### PR TITLE
implement account and transaction filtering by metadata

### DIFF
--- a/api/controllers/account_controller.go
+++ b/api/controllers/account_controller.go
@@ -31,6 +31,8 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 	l, _ := c.Get("ledger")
 	cursor, err := l.(*ledger.Ledger).FindAccounts(
 		query.After(c.Query("after")),
+		query.Metakey(c.Query("meta_key")),
+		query.Metavalue(c.Query("meta_value")),
 	)
 	if err != nil {
 		ctl.responseError(

--- a/api/controllers/transaction_controller.go
+++ b/api/controllers/transaction_controller.go
@@ -34,6 +34,8 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 		query.After(c.Query("after")),
 		query.Reference(c.Query("reference")),
 		query.Account(c.Query("account")),
+		query.Metakey(c.Query("meta_key")),
+		query.Metavalue(c.Query("meta_value")),
 	)
 	if err != nil {
 		ctl.responseError(

--- a/ledger/query/query.go
+++ b/ledger/query/query.go
@@ -80,3 +80,15 @@ func Reference(v string) func(*Query) {
 		q.Params["reference"] = v
 	}
 }
+
+func Metakey(v string) func(*Query) {
+	return func(q *Query) {
+		q.Params["meta_key"] = v
+	}
+}
+
+func Metavalue(v string) func(*Query) {
+	return func(q *Query) {
+		q.Params["meta_value"] = v
+	}
+}

--- a/storage/postgres/accounts.go
+++ b/storage/postgres/accounts.go
@@ -64,7 +64,7 @@ func (s *PGStore) FindAccounts(q query.Query) (query.Cursor, error) {
 		queryAcc.JoinWithOption(
 			sqlbuilder.LeftJoin,
 			queryAcc.As("metadata", "m"),
-			"m.meta_target_id = t.id",
+			"m.meta_target_id = address",
 		)
 		queryAcc.Where(
 			queryAcc.Equal("m.meta_key", q.Params["meta_key"]),

--- a/storage/postgres/accounts.go
+++ b/storage/postgres/accounts.go
@@ -60,6 +60,23 @@ func (s *PGStore) FindAccounts(q query.Query) (query.Cursor, error) {
 		queryAcc.Where(queryAcc.LessThan("address", q.After))
 	}
 
+	if q.HasParam("meta_key") {
+		queryAcc.JoinWithOption(
+			sqlbuilder.LeftJoin,
+			queryAcc.As("metadata", "m"),
+			"m.meta_target_id = t.id",
+		)
+		queryAcc.Where(
+			queryAcc.Equal("m.meta_key", q.Params["meta_key"]),
+			queryAcc.Equal("m.meta_target_type", "account"),
+		)
+		if q.HasParam("meta_value") {
+			queryAcc.Where(
+				queryAcc.Equal("m.meta_value", q.Params["meta_value"]),
+			)
+		}
+	}
+
 	sqlAcc, args := queryAcc.BuildWithFlavor(sqlbuilder.PostgreSQL)
 
 	rows, err := s.Conn().Query(
@@ -71,6 +88,8 @@ func (s *PGStore) FindAccounts(q query.Query) (query.Cursor, error) {
 	if err != nil {
 		return c, err
 	}
+
+	defer rows.Close()
 
 	for rows.Next() {
 		var address string

--- a/storage/postgres/transactions.go
+++ b/storage/postgres/transactions.go
@@ -163,6 +163,23 @@ func (s *PGStore) FindTransactions(q query.Query) (query.Cursor, error) {
 		)
 	}
 
+	if q.HasParam("meta_key") {
+		in.JoinWithOption(
+			sqlbuilder.LeftJoin,
+			in.As("metadata", "m"),
+			"m.meta_target_id = t.id",
+		)
+		in.Where(
+			in.Equal("m.meta_key", q.Params["meta_key"]),
+			in.Equal("m.meta_target_type", "transaction"),
+		)
+		if q.HasParam("meta_value") {
+			in.Where(
+				in.Equal("m.meta_value", q.Params["meta_value"]),
+			)
+		}
+	}
+
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(
 		"t.id",

--- a/storage/sqlite/accounts.go
+++ b/storage/sqlite/accounts.go
@@ -32,7 +32,7 @@ func (s *SQLiteStore) FindAccounts(q query.Query) (query.Cursor, error) {
 		sb.JoinWithOption(
 			sqlbuilder.LeftJoin,
 			sb.As("metadata", "m"),
-			"m.meta_target_id = t.id",
+			"m.meta_target_id = address",
 		)
 		sb.Where(
 			sb.Equal("m.meta_key", q.Params["meta_key"]),


### PR DESCRIPTION
Signed-off-by: Henry Jackson <34102861+henry-jackson@users.noreply.github.com>

Closes #68 

Transaction and account objects can be retrieved by providing a meta_key + meta_value pair, or with just a meta_key.

Implementation:
`GET /:ledger/transactions?meta_key=foo` 
`GET /:ledger/transactions?meta_key=foo&meta_value=\"bar\"`
`GET /:ledger/accounts?meta_key=foo`
`GET /:ledger/accounts?meta_key=foo&meta_value=\"bar\"` 

Sample transaction filter query using only the meta_key string:
```
▶ curl -X GET -H "Content-Type: application/json" http://localhost:3068/quickstart/transactions\?meta_key\=x | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   649  100   649    0     0  52283      0 --:--:-- --:--:-- --:--:--  126k
{
  "cursor": {
    "page_size": 15,
    "has_more": false,
    "total": 6,
    "remaining_results": 0,
    "data": [
      {
        "txid": 0,
        "postings": [
          {
            "source": "world",
            "destination": "payments:001",
            "amount": 599,
            "asset": "USD/2"
          },
          {
            "source": "payments:001",
            "destination": "rides:0234",
            "amount": 599,
            "asset": "USD/2"
          },
          {
            "source": "rides:0234",
            "destination": "drivers:042",
            "amount": 510,
            "asset": "USD/2"
          },
          {
            "source": "rides:0234",
            "destination": "platform:fees",
            "amount": 89,
            "asset": "USD/2"
          }
        ],
        "reference": "",
        "timestamp": "2021-11-06T10:44:30-04:00",
        "hash": "df99e6f426514499761d24c77bfbab332e72fd97a6ab18a1880573ec7bba5dc3",
        "metadata": {
          "ride-type": "standard",
          "transaction-type": "driver-payout",
          "x": "y"
        }
      }
    ]
  },
  "ok": true
}
```

Sample transaction filter query using a meta_key and URL-encoded meta_value:
```
▶ curl -X GET -H "Content-Type: application/json" http://localhost:3068/quickstart/accounts\?meta_key\=car-type\&meta_value\=\"sedan\" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   174  100   174    0     0  13519      0 --:--:-- --:--:-- --:--:-- 34800
{
  "cursor": {
    "page_size": 15,
    "has_more": false,
    "total": 6,
    "remaining_results": 0,
    "data": [
      {
        "address": "drivers:042",
        "contract": "default",
        "metadata": {
          "car-type": "sedan"
        }
      }
    ]
  },
  "ok": true
}```