### PR TITLE
Add GetTransaction Endpoints

### DIFF
--- a/api/controllers/config_controller.go
+++ b/api/controllers/config_controller.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"github.com/swaggo/swag"
 	"net/http"
+
+	"github.com/swaggo/swag"
 
 	"github.com/gin-gonic/gin"
 	"github.com/numary/ledger/config"
@@ -22,6 +23,8 @@ func NewConfigController() ConfigController {
 
 // GetInfo godoc
 // @Summary Server Info
+// @Description Show server informations
+// @Tags server
 // @Schemes
 // @Accept json
 // @Produce json

--- a/api/controllers/ledger_controller.go
+++ b/api/controllers/ledger_controller.go
@@ -18,7 +18,9 @@ func NewLedgerController() LedgerController {
 }
 
 // GetStats godoc
-// @Summary Get ledger stats (aggregate metrics on accounts and transactions)
+// @Summary Get Stats
+// @Description Get ledger stats (aggregate metrics on accounts and transactions)
+// @Tags stats
 // @Schemes
 // @Description The stats for account
 // @Accept json

--- a/api/controllers/script_controller.go
+++ b/api/controllers/script_controller.go
@@ -23,7 +23,9 @@ func NewScriptController() ScriptController {
 }
 
 // PostScript godoc
-// @Summary Execute a Numscript and commit transaction if any
+// @Summary Execute Numscript
+// @Description Execute a Numscript and create the transaction if any
+// @Tags script
 // @Schemes
 // @Param ledger path string true "ledger"
 // @Param script body core.Script true "script"

--- a/api/controllers/transaction_controller.go
+++ b/api/controllers/transaction_controller.go
@@ -82,18 +82,45 @@ func (ctl *TransactionController) PostTransaction(c *gin.Context) {
 	)
 }
 
+// GetTransaction godoc
+// @Summary Revert transaction
+// @Schemes
+// @Param ledger path string true "ledger"
+// @Param txid path string true "txid"
+// @Accept json
+// @Produce json
+// @Success 200 {object} controllers.BaseResponse
+// @Router /{ledger}/transactions/{txid} [get]
+func (ctl *TransactionController) GetTransaction(c *gin.Context) {
+	l, _ := c.Get("ledger")
+	tx, err := l.(*ledger.Ledger).GetTransaction(c.Param("txid"))
+	if err != nil {
+		ctl.responseError(
+			c,
+			http.StatusInternalServerError,
+			err,
+		)
+		return
+	}
+	ctl.response(
+		c,
+		http.StatusOK,
+		tx,
+	)
+}
+
 // RevertTransaction godoc
 // @Summary Revert transaction
 // @Schemes
 // @Param ledger path string true "ledger"
-// @Param transactionId path string true "transactionId"
+// @Param txid path string true "txid"
 // @Accept json
 // @Produce json
 // @Success 200 {object} controllers.BaseResponse
-// @Router /{ledger}/transactions/{transactionId}/revert [post]
+// @Router /{ledger}/transactions/{txid}/revert [post]
 func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 	l, _ := c.Get("ledger")
-	err := l.(*ledger.Ledger).RevertTransaction(c.Param("transactionId"))
+	err := l.(*ledger.Ledger).RevertTransaction(c.Param("txid"))
 	if err != nil {
 		ctl.responseError(
 			c,
@@ -113,11 +140,11 @@ func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 // @Summary Set metadata on transaction
 // @Schemes
 // @Param ledger path string true "ledger"
-// @Param reference path string true "reference"
+// @Param txid path string true "txid"
 // @Accept json
 // @Produce json
 // @Success 200 {object} controllers.BaseResponse
-// @Router /{ledger}/transactions/{reference}/metadata [post]
+// @Router /{ledger}/transactions/{txid}/metadata [post]
 func (ctl *TransactionController) PostTransactionMetadata(c *gin.Context) {
 	l, _ := c.Get("ledger")
 
@@ -126,7 +153,7 @@ func (ctl *TransactionController) PostTransactionMetadata(c *gin.Context) {
 
 	err := l.(*ledger.Ledger).SaveMeta(
 		"transaction",
-		c.Param("transactionId"),
+		c.Param("txid"),
 		m,
 	)
 	if err != nil {

--- a/api/controllers/transaction_controller.go
+++ b/api/controllers/transaction_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,6 +22,8 @@ func NewTransactionController() TransactionController {
 
 // GetTransactions godoc
 // @Summary Get Transactions
+// @Description Get all ledger transactions
+// @Tags transactions
 // @Schemes
 // @Description List transactions
 // @Param ledger path string true "ledger"
@@ -51,7 +54,9 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 }
 
 // PostTransactions godoc
-// @Summary Commit a new transaction to the ledger
+// @Summary Create Transaction
+// @Description Create a new ledger transaction
+// @Tags transactions
 // @Schemes
 // @Description Commit a new transaction to the ledger
 // @Param ledger path string true "ledger"
@@ -83,13 +88,16 @@ func (ctl *TransactionController) PostTransaction(c *gin.Context) {
 }
 
 // GetTransaction godoc
-// @Summary Revert transaction
+// @Summary Revert Transaction
+// @Description Get transaction by transaction id
+// @Tags transactions
 // @Schemes
 // @Param ledger path string true "ledger"
 // @Param txid path string true "txid"
 // @Accept json
 // @Produce json
 // @Success 200 {object} controllers.BaseResponse
+// @Failure 404 {object} controllers.BaseResponse
 // @Router /{ledger}/transactions/{txid} [get]
 func (ctl *TransactionController) GetTransaction(c *gin.Context) {
 	l, _ := c.Get("ledger")
@@ -102,6 +110,14 @@ func (ctl *TransactionController) GetTransaction(c *gin.Context) {
 		)
 		return
 	}
+	if tx.Postings == nil {
+		ctl.responseError(
+			c,
+			http.StatusNotFound,
+			errors.New("transaction not found"),
+		)
+		return
+	}
 	ctl.response(
 		c,
 		http.StatusOK,
@@ -110,7 +126,9 @@ func (ctl *TransactionController) GetTransaction(c *gin.Context) {
 }
 
 // RevertTransaction godoc
-// @Summary Revert transaction
+// @Summary Revert Transaction
+// @Description Revert a ledger transaction by transaction id
+// @Tags transactions
 // @Schemes
 // @Param ledger path string true "ledger"
 // @Param txid path string true "txid"
@@ -137,7 +155,9 @@ func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 }
 
 // PostTransactionMetadata godoc
-// @Summary Set metadata on transaction
+// @Summary Set Transaction Metadata
+// @Description Set a new metadata to a ledger transaction by transaction id
+// @Tags transactions
 // @Schemes
 // @Param ledger path string true "ledger"
 // @Param txid path string true "txid"

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -74,8 +74,9 @@ func (r *Routes) Engine(cc cors.Config) *gin.Engine {
 		// TransactionController
 		ledger.GET("/transactions", r.transactionController.GetTransactions)
 		ledger.POST("/transactions", r.transactionController.PostTransaction)
-		ledger.POST("/transactions/:transactionId/revert", r.transactionController.RevertTransaction)
-		ledger.POST("/transactions/:transactionId/metadata", r.transactionController.PostTransactionMetadata)
+		ledger.GET("/transactions/:txid", r.transactionController.GetTransaction)
+		ledger.POST("/transactions/:txid/revert", r.transactionController.RevertTransaction)
+		ledger.POST("/transactions/:txid/metadata", r.transactionController.PostTransactionMetadata)
 
 		// AccountController
 		ledger.GET("/accounts", r.accountController.GetAccounts)

--- a/storage/sqlite/transactions.go
+++ b/storage/sqlite/transactions.go
@@ -234,7 +234,7 @@ func (s *SQLiteStore) SaveTransactions(ts []core.Transaction) error {
 	return tx.Commit()
 }
 
-func (s *SQLiteStore) GetTransaction(id string) (core.Transaction, error) {
+func (s *SQLiteStore) GetTransaction(txid string) (tx core.Transaction, err error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(
 		"t.id",
@@ -247,7 +247,7 @@ func (s *SQLiteStore) GetTransaction(id string) (core.Transaction, error) {
 		"p.asset",
 	)
 	sb.From(sb.As("transactions", "t"))
-	sb.Where(sb.Equal("t.id", id))
+	sb.Where(sb.Equal("t.id", txid))
 	sb.JoinWithOption(sqlbuilder.LeftJoin, sb.As("postings", "p"), "p.txid = t.id")
 	sb.OrderBy("p.id asc")
 
@@ -255,8 +255,6 @@ func (s *SQLiteStore) GetTransaction(id string) (core.Transaction, error) {
 	if viper.GetBool("debug") {
 		fmt.Println(sqlq, args)
 	}
-
-	tx := core.Transaction{}
 
 	rows, err := s.db.Query(
 		sqlq,
@@ -267,17 +265,15 @@ func (s *SQLiteStore) GetTransaction(id string) (core.Transaction, error) {
 		return tx, err
 	}
 
-	txFieldsSet := false
-
 	for rows.Next() {
 		var txid int64
 		var ts string
 		var thash string
-		var tref string
+		var tref interface{}
 
 		posting := core.Posting{}
 
-		rows.Scan(
+		err := rows.Scan(
 			&txid,
 			&ts,
 			&thash,
@@ -287,16 +283,16 @@ func (s *SQLiteStore) GetTransaction(id string) (core.Transaction, error) {
 			&posting.Amount,
 			&posting.Asset,
 		)
+		if err != nil {
+			return tx, err
+		}
 
-		if !txFieldsSet {
-			tx.ID = txid
-			tx.Postings = []core.Posting{}
-			tx.Timestamp = ts
-			tx.Hash = thash
-			tx.Reference = tref
-			tx.Metadata = core.Metadata{}
-
-			txFieldsSet = true
+		tx.ID = txid
+		tx.Timestamp = ts
+		tx.Hash = thash
+		tx.Metadata = core.Metadata{}
+		if tref != nil {
+			tx.Reference = tref.(string)
 		}
 
 		tx.AppendPosting(posting)


### PR DESCRIPTION
### New GetTransaction API Endpoint

Retrieve a ledger transaction by transaction ID (txid).
Also linked to issue #30 

### Endpoint

`GET /:ledger/transactions/:txid`

### API Responses

**@Succcess** Return the transaction data as:

```
{
    "data": {
        "txid": 1,
        "postings": [
            {
                "source": "world",
                "destination": "central_bank",
                "amount": 100,
                "asset": "GEM"
            },
            {
                "source": "central_bank",
                "destination": "users:001",
                "amount": 100,
                "asset": "GEM"
            }
        ],
        "reference": "",
        "timestamp": "2021-12-05T12:51:48+09:00",
        "hash": "b9be72a8f237fea355c4705fc76a9af01fb5ea8763689a18d9636c3af02acae7",
        "metadata": {}
    },
    "ok": true
}
```

**@Failure** Return 404 as:

```
{
    "error": true,
    "error_code": 404,
    "error_message": "transaction not found",
    "ok": false
}
```