### PR TITLE
Bind cobra flags on viper.

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"runtime"
 
-	"github.com/numary/ledger/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,8 +35,6 @@ func openuri(uri string) bool {
 var UICmd = &cobra.Command{
 	Use: "ui",
 	Run: func(cmd *cobra.Command, args []string) {
-		config.Init()
-
 		addr := viper.GetString("ui.http.bind_address")
 
 		handler := http.FileServer(http.FS(uipath))

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,9 @@ package config
 
 import (
 	"github.com/sirupsen/logrus"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
-
 	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
 )
 
 // ConfigInfo struct
@@ -28,44 +25,6 @@ type LedgerStorage struct {
 	Ledgers interface{} `json:"ledgers"`
 }
 
-var home string
-
-func init() {
-	var err error
-	home, err = os.UserHomeDir()
-	if err != nil {
-		home = "/root"
-	}
-}
-
-func Init() {
-	err := os.MkdirAll(path.Join(home, ".numary", "data"), 0700)
-	if err != nil {
-		panic(err)
-	}
-
-	viper.SetDefault("debug", false)
-	viper.SetDefault("storage.driver", "sqlite")
-	viper.SetDefault("storage.dir", path.Join(home, ".numary/data"))
-	viper.SetDefault("storage.sqlite.db_name", "numary")
-	viper.SetDefault("storage.postgres.conn_string", "postgresql://localhost/postgres")
-	viper.SetDefault("storage.cache", false)
-	viper.SetDefault("server.http.bind_address", "localhost:3068")
-	viper.SetDefault("ui.http.bind_address", "localhost:3078")
-	viper.SetDefault("ledgers", []string{"quickstart"})
-
-	viper.SetConfigName("numary")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath("$HOME/.numary")
-	// TODO: Path not writeable if not root, should be removed?
-	viper.AddConfigPath("/etc/numary")
-	viper.ReadInConfig()
-
-	viper.SetEnvPrefix("numary")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.AutomaticEnv()
-}
-
 func Remember(ledger string) {
 	ledgers := viper.GetStringSlice("ledgers")
 
@@ -73,6 +32,11 @@ func Remember(ledger string) {
 		if ledger == v {
 			return
 		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/root"
 	}
 
 	writeTo := ""
@@ -92,7 +56,7 @@ func Remember(ledger string) {
 	}
 
 	viper.Set("ledgers", append(ledgers, ledger))
-	err := viper.WriteConfig()
+	err = viper.WriteConfig()
 	if err != nil {
 		logrus.Errorf("failed to write config: ledger %s will not be remembered\n",
 			ledger)

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/numary/ledger/storage"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/numary/ledger/config"
 	"github.com/numary/ledger/core"
 	"github.com/numary/ledger/ledger/query"
 	"github.com/numary/ledger/storage/postgres"
@@ -63,8 +62,6 @@ func TestMain(m *testing.M) {
 	if testing.Verbose() {
 		logrus.StandardLogger().Level = logrus.DebugLevel
 	}
-
-	config.Init()
 
 	switch os.Getenv("NUMARY_STORAGE_DRIVER") {
 	case "sqlite":


### PR DESCRIPTION
Before: 
```
$ go run main.go -h
Numary

Usage:
  numary [command]

Available Commands:
  check
  config
  exec
  help        Help about any command
  server
  stickers
  storage
  ui
  version     Get version

Flags:
  -h, --help   help for numary

Use "numary [command] --help" for more information about a command.
```

After: 
```
$ go run main.go -h
Numary

Usage:
  numary [command]

Available Commands:
  check
  config
  exec
  help        Help about any command
  server
  stickers
  storage
  ui
  version     Get version

Flags:
      --debug                                 Debug mode
  -h, --help                                  help for numary
      --ledgers strings                       Ledgers (default [quickstart])
      --server.http.bind_address string       API bind address (default "localhost:3068")
      --storage.dir string                    Storage directory (for sqlite) (default "/home/gfyrag/.numary/data")
      --storage.driver string                 Storage driver (default "sqlite")
      --storage.postgres.conn_string string   Postgre connection string (default "postgresql://localhost/postgres")
      --storage.sqlite.db_name string         SQLite database name (default "numary")
      --ui.http.bind_address string           UI bind address (default "localhost:3068")

Use "numary [command] --help" for more information about a command.
```