### PR TITLE
Improve swagger typing.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -144,7 +144,7 @@ var doc = `{
                                 {
                                     "type": "object",
                                     "properties": {
-                                        "account": {
+                                        "data": {
                                             "$ref": "#/definitions/core.Account"
                                         }
                                     }
@@ -181,11 +181,8 @@ var doc = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
-                        }
+                    "204": {
+                        "description": "Empty response"
                     },
                     "400": {
                         "description": ""
@@ -219,13 +216,19 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/core.Mapping"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -249,19 +252,34 @@ var doc = `{
                         "name": "ledger",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "mapping",
+                        "name": "mapping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/core.Mapping"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/core.Mapping"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -302,7 +320,9 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
+==== BASE ====
                             "$ref": "#/definitions/controllers.ScriptResponse"
+==== BASE ====
                         }
                     }
                 }
@@ -334,7 +354,19 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ledger.Stats"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/ledger.Stats"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -442,7 +474,7 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/core.Transaction"
+                            "$ref": "#/definitions/core.TransactionData"
                         }
                     }
                 ],
@@ -450,7 +482,19 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/core.Transaction"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
@@ -503,7 +547,22 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/core.Transaction"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "400": {
@@ -545,7 +604,19 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/controllers.BaseResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/core.Transaction"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -587,11 +658,8 @@ var doc = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
-                        }
+                    "204": {
+                        "description": "Empty response"
                     }
                 }
             }
@@ -626,11 +694,8 @@ var doc = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/controllers.BaseResponse"
-                        }
+                    "204": {
+                        "description": "Empty response"
                     }
                 }
             }
@@ -672,50 +737,9 @@ var doc = `{
             }
         },
         "controllers.BaseResponse": {
-            "type": "object",
-            "properties": {
-                "cursor": {},
-                "data": {}
-            }
-        },
-        "controllers.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error_code": {
-                    "type": "string",
-                    "enum": [
-                        "INTERNAL",
-                        "CONFLICT",
-                        "INSUFFICIENT_FUND",
-                        "VALIDATION",
-                        "NOT_FOUND"
-                    ]
-                },
-                "error_message": {
-                    "type": "string"
-                }
-            }
-        },
-        "controllers.ScriptResponse": {
-            "type": "object",
-            "properties": {
-                "details": {
-                    "type": "string"
-                },
-                "error_code": {
-                    "type": "string",
-                    "enum": [
-                        "INTERNAL",
-                        "CONFLICT",
-                        "INSUFFICIENT_FUND",
-                        "VALIDATION",
-                        "NOT_FOUND"
-                    ]
-                },
-                "error_message": {
-                    "type": "string"
-                }
-            }
+==== BASE ====
+            "type": "object"
+==== BASE ====
         },
         "core.Account": {
             "type": "object",
@@ -747,6 +771,26 @@ var doc = `{
                         "additionalProperties": {
                             "type": "integer"
                         }
+                    }
+                }
+            }
+        },
+        "core.Contract": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string"
+                },
+                "expr": {}
+            }
+        },
+        "core.Mapping": {
+            "type": "object",
+            "properties": {
+                "contracts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/core.Contract"
                     }
                 }
             }
@@ -802,6 +846,23 @@ var doc = `{
                 }
             }
         },
+        "core.TransactionData": {
+            "type": "object",
+            "properties": {
+                "metadata": {
+                    "type": "object"
+                },
+                "postings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/core.Posting"
+                    }
+                },
+                "reference": {
+                    "type": "string"
+                }
+            }
+        },
         "core.Transactions": {
             "type": "object",
             "required": [
@@ -811,7 +872,7 @@ var doc = `{
                 "transactions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/core.Transaction"
+                        "$ref": "#/definitions/core.TransactionData"
                     }
                 }
             }

--- a/pkg/api/controllers/account_controller.go
+++ b/pkg/api/controllers/account_controller.go
@@ -53,7 +53,7 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 // @Param accountId path string true "accountId"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse{account=core.Account}
+// @Success 200 {object} controllers.BaseResponse{data=core.Account}
 // @Router /{ledger}/accounts/{accountId} [get]
 func (ctl *AccountController) GetAccount(c *gin.Context) {
 	l, _ := c.Get("ledger")
@@ -76,7 +76,7 @@ func (ctl *AccountController) GetAccount(c *gin.Context) {
 // @Param accountId path string true "accountId"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 204 "Empty response"
 // @Failure 400
 // @Router /{ledger}/accounts/{accountId}/metadata [post]
 func (ctl *AccountController) PostAccountMetadata(c *gin.Context) {
@@ -100,5 +100,5 @@ func (ctl *AccountController) PostAccountMetadata(c *gin.Context) {
 		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
 		return
 	}
-	ctl.response(c, http.StatusOK, nil)
+	ctl.noContent(c)
 }

--- a/pkg/api/controllers/account_controller_test.go
+++ b/pkg/api/controllers/account_controller_test.go
@@ -14,7 +14,7 @@ func TestGetAccounts(t *testing.T) {
 
 	internal.RunTest(t, func(h *api.API) {
 
-		rsp := internal.PostTransaction(t, h, core.Transaction{
+		rsp := internal.PostTransaction(t, h, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -26,7 +26,7 @@ func TestGetAccounts(t *testing.T) {
 		})
 		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 
-		rsp = internal.PostTransaction(t, h, core.Transaction{
+		rsp = internal.PostTransaction(t, h, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -49,7 +49,7 @@ func TestGetAccounts(t *testing.T) {
 
 func TestGetAccount(t *testing.T) {
 	internal.RunTest(t, func(h *api.API) {
-		rsp := internal.PostTransaction(t, h, core.Transaction{
+		rsp := internal.PostTransaction(t, h, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -64,7 +64,7 @@ func TestGetAccount(t *testing.T) {
 		rsp = internal.PostAccountMetadata(t, h, "alice", core.Metadata{
 			"foo": json.RawMessage(`"bar"`),
 		})
-		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
+		assert.Equal(t, http.StatusNoContent, rsp.Result().StatusCode)
 
 		rsp = internal.GetAccount(h, "alice")
 		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"net/http"
 	"reflect"
 
 	"github.com/gin-gonic/gin"
@@ -11,8 +12,8 @@ import (
 type BaseController struct{}
 
 type BaseResponse struct {
-	Cursor interface{} `json:"cursor,omitempty"`
 	Data   interface{} `json:"data,omitempty"`
+	Cursor interface{} `json:"cursor,omitempty"`
 }
 
 func (ctl *BaseController) response(c *gin.Context, status int, data interface{}) {
@@ -41,6 +42,10 @@ const (
 type ErrorResponse struct {
 	ErrorCode    string `json:"error_code,omitempty" enums:"INTERNAL,CONFLICT,INSUFFICIENT_FUND,VALIDATION,NOT_FOUND"`
 	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+func (ctl *BaseController) noContent(c *gin.Context) {
+	c.Status(http.StatusNoContent)
 }
 
 func (ctl *BaseController) responseError(c *gin.Context, status int, code string, err error) {

--- a/pkg/api/controllers/ledger_controller.go
+++ b/pkg/api/controllers/ledger_controller.go
@@ -26,7 +26,7 @@ func NewLedgerController() LedgerController {
 // @Accept json
 // @Produce json
 // @Param ledger path string true "ledger"
-// @Success 200 {object} ledger.Stats{}
+// @Success 200 {object} controllers.BaseResponse{data=ledger.Stats}
 // @Router /{ledger}/stats [get]
 func (ctl *LedgerController) GetStats(c *gin.Context) {
 	l, _ := c.Get("ledger")

--- a/pkg/api/controllers/ledger_controller_test.go
+++ b/pkg/api/controllers/ledger_controller_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetStats(t *testing.T) {
 	internal.RunTest(t, func(h *api.API) {
-		rsp := internal.PostTransaction(t, h, core.Transaction{
+		rsp := internal.PostTransaction(t, h, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -24,7 +24,7 @@ func TestGetStats(t *testing.T) {
 		})
 		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 
-		rsp = internal.PostTransaction(t, h, core.Transaction{
+		rsp = internal.PostTransaction(t, h, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",

--- a/pkg/api/controllers/mapping_controller.go
+++ b/pkg/api/controllers/mapping_controller.go
@@ -21,10 +21,10 @@ func NewMappingController() MappingController {
 // @Tags mapping
 // @Schemes
 // @Param ledger path string true "ledger"
+// @Param mapping body core.Mapping true "mapping"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
-// @Failure 404 {object} controllers.BaseResponse
+// @Success 200 {object} controllers.BaseResponse{data=core.Mapping}
 // @Router /{ledger}/mapping [put]
 func (ctl *MappingController) PutMapping(c *gin.Context) {
 	l, _ := c.Get("ledger")
@@ -52,8 +52,7 @@ func (ctl *MappingController) PutMapping(c *gin.Context) {
 // @Param ledger path string true "ledger"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
-// @Failure 404 {object} controllers.BaseResponse
+// @Success 200 {object} controllers.BaseResponse{data=core.Mapping}
 // @Router /{ledger}/mapping [get]
 func (ctl *MappingController) GetMapping(c *gin.Context) {
 	l, _ := c.Get("ledger")

--- a/pkg/api/controllers/transaction_controller.go
+++ b/pkg/api/controllers/transaction_controller.go
@@ -65,27 +65,27 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 	)
 }
 
-// PostTransactions godoc
+// PostTransaction godoc
 // @Summary Create Transaction
 // @Description Create a new ledger transaction
 // @Tags transactions
 // @Schemes
 // @Description Commit a new transaction to the ledger
 // @Param ledger path string true "ledger"
-// @Param transaction body core.Transaction true "transaction"
+// @Param transaction body core.TransactionData true "transaction"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 200 {object} controllers.BaseResponse{data=core.Transaction}
 // @Failure 400 {object} controllers.ErrorResponse
 // @Failure 409 {object} controllers.ErrorResponse
 // @Router /{ledger}/transactions [post]
 func (ctl *TransactionController) PostTransaction(c *gin.Context) {
 	l, _ := c.Get("ledger")
 
-	var t core.Transaction
+	var t core.TransactionData
 	c.ShouldBind(&t)
 
-	_, result, err := l.(*ledger.Ledger).Commit(c.Request.Context(), []core.Transaction{t})
+	_, result, err := l.(*ledger.Ledger).Commit(c.Request.Context(), []core.TransactionData{t})
 	if err != nil {
 		switch err {
 		case ledger.ErrCommitError:
@@ -108,7 +108,7 @@ func (ctl *TransactionController) PostTransaction(c *gin.Context) {
 // @Param txid path string true "txid"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 200 {object} controllers.BaseResponse{data=core.Transaction}
 // @Failure 404 {object} controllers.BaseResponse
 // @Router /{ledger}/transactions/{txid} [get]
 func (ctl *TransactionController) GetTransaction(c *gin.Context) {
@@ -134,7 +134,7 @@ func (ctl *TransactionController) GetTransaction(c *gin.Context) {
 // @Param txid path string true "txid"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 204 "Empty response"
 // @Router /{ledger}/transactions/{txid}/revert [post]
 func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 	l, _ := c.Get("ledger")
@@ -148,7 +148,7 @@ func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 		}
 		return
 	}
-	ctl.response(c, http.StatusOK, nil)
+	ctl.noContent(c)
 }
 
 // PostTransactionMetadata godoc
@@ -160,7 +160,7 @@ func (ctl *TransactionController) RevertTransaction(c *gin.Context) {
 // @Param txid path string true "txid"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 204 "Empty response"
 // @Router /{ledger}/transactions/{txid}/metadata [post]
 func (ctl *TransactionController) PostTransactionMetadata(c *gin.Context) {
 	l, _ := c.Get("ledger")
@@ -178,7 +178,7 @@ func (ctl *TransactionController) PostTransactionMetadata(c *gin.Context) {
 		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
 		return
 	}
-	ctl.response(c, http.StatusOK, nil)
+	ctl.noContent(c)
 }
 
 // PostTransactionsBatch godoc
@@ -191,7 +191,7 @@ func (ctl *TransactionController) PostTransactionMetadata(c *gin.Context) {
 // @Param transactions body core.Transactions true "transactions"
 // @Accept json
 // @Produce json
-// @Success 200 {object} controllers.BaseResponse
+// @Success 200 {object} controllers.BaseResponse{data=[]core.Transaction}
 // @Failure 400
 // @Router /{ledger}/transactions/batch [post]
 func (ctl *TransactionController) PostTransactionsBatch(c *gin.Context) {

--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -15,7 +15,7 @@ func TestCommitTransaction(t *testing.T) {
 
 	type testCase struct {
 		name               string
-		transactions       []core.Transaction
+		transactions       []core.TransactionData
 		expectedStatusCode int
 		expectedErrorCode  string
 	}
@@ -23,7 +23,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			name:               "nominal",
 			expectedStatusCode: http.StatusOK,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -39,7 +39,7 @@ func TestCommitTransaction(t *testing.T) {
 		{
 			name:               "no-postings",
 			expectedStatusCode: http.StatusBadRequest,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{},
 				},
@@ -50,7 +50,7 @@ func TestCommitTransaction(t *testing.T) {
 			name:               "negative-amount",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  controllers.ErrValidation,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -67,7 +67,7 @@ func TestCommitTransaction(t *testing.T) {
 			name:               "wrong-asset",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  controllers.ErrValidation,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -84,7 +84,7 @@ func TestCommitTransaction(t *testing.T) {
 			name:               "bad-address",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  controllers.ErrValidation,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -101,7 +101,7 @@ func TestCommitTransaction(t *testing.T) {
 			name:               "missing-funds",
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrorCode:  controllers.ErrInsufficientFund,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -118,7 +118,7 @@ func TestCommitTransaction(t *testing.T) {
 			name:               "reference-conflict",
 			expectedStatusCode: http.StatusConflict,
 			expectedErrorCode:  controllers.ErrConflict,
-			transactions: []core.Transaction{
+			transactions: []core.TransactionData{
 				{
 					Postings: core.Postings{
 						{
@@ -159,7 +159,7 @@ func TestCommitTransaction(t *testing.T) {
 
 func TestGetTransaction(t *testing.T) {
 	internal.RunTest(t, func(api *api.API) {
-		rsp := internal.PostTransaction(t, api, core.Transaction{
+		rsp := internal.PostTransaction(t, api, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -203,7 +203,7 @@ func TestNotFoundTransaction(t *testing.T) {
 
 func TestGetTransactions(t *testing.T) {
 	internal.RunTest(t, func(api *api.API) {
-		rsp := internal.PostTransaction(t, api, core.Transaction{
+		rsp := internal.PostTransaction(t, api, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -215,7 +215,7 @@ func TestGetTransactions(t *testing.T) {
 		})
 		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 
-		rsp = internal.PostTransaction(t, api, core.Transaction{
+		rsp = internal.PostTransaction(t, api, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -243,7 +243,7 @@ func TestGetTransactions(t *testing.T) {
 
 func TestPostTransactionMetadata(t *testing.T) {
 	internal.RunTest(t, func(api *api.API) {
-		rsp := internal.PostTransaction(t, api, core.Transaction{
+		rsp := internal.PostTransaction(t, api, core.TransactionData{
 			Postings: core.Postings{
 				{
 					Source:      "world",
@@ -260,7 +260,7 @@ func TestPostTransactionMetadata(t *testing.T) {
 		rsp = internal.PostTransactionMetadata(t, api, tx.ID, core.Metadata{
 			"foo": json.RawMessage(`"bar"`),
 		})
-		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
+		assert.Equal(t, http.StatusNoContent, rsp.Result().StatusCode)
 
 		rsp = internal.GetTransaction(api, 0)
 		assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -77,7 +77,7 @@ func NewRequest(method, path string, body io.Reader) (*http.Request, *httptest.R
 	return req, rec
 }
 
-func PostTransaction(t *testing.T, handler http.Handler, tx core.Transaction) *httptest.ResponseRecorder {
+func PostTransaction(t *testing.T, handler http.Handler, tx core.TransactionData) *httptest.ResponseRecorder {
 	req, rec := NewRequest(http.MethodPost, "/quickstart/transactions", Buffer(t, tx))
 	handler.ServeHTTP(rec, req)
 	return rec
@@ -160,6 +160,7 @@ func WithNewModule(t *testing.T, options ...fx.Option) {
 		storage.DefaultModule(),
 		sqlstorage.TestingModule(),
 		logging.LogrusModule(),
+		fx.NopLogger,
 	}, options...)
 	options = append(options, fx.Invoke(func() {
 		close(ch)

--- a/pkg/core/transaction.go
+++ b/pkg/core/transaction.go
@@ -8,27 +8,31 @@ import (
 
 // Transactions struct
 type Transactions struct {
-	Transactions []Transaction `json:"transactions" binding:"required,dive"`
+	Transactions []TransactionData `json:"transactions" binding:"required,dive"`
+}
+
+type TransactionData struct {
+	Postings  Postings `json:"postings"`
+	Reference string   `json:"reference"`
+	Metadata  Metadata `json:"metadata" swaggertype:"object"`
 }
 
 type Transaction struct {
-	ID        int64    `json:"txid"`
-	Postings  Postings `json:"postings"`
-	Reference string   `json:"reference"`
-	Timestamp string   `json:"timestamp"`
-	Hash      string   `json:"hash" swaggerignore:"true"`
-	Metadata  Metadata `json:"metadata" swaggertype:"object"`
+	TransactionData
+	ID        int64  `json:"txid"`
+	Timestamp string `json:"timestamp"`
+	Hash      string `json:"hash" swaggerignore:"true"`
 }
 
 func (t *Transaction) AppendPosting(p Posting) {
 	t.Postings = append(t.Postings, p)
 }
 
-func (t *Transaction) Reverse() Transaction {
+func (t *Transaction) Reverse() TransactionData {
 	postings := t.Postings
 	postings.Reverse()
 
-	ret := Transaction{
+	ret := TransactionData{
 		Postings: postings,
 	}
 	if t.Reference != "" {

--- a/pkg/core/transaction_test.go
+++ b/pkg/core/transaction_test.go
@@ -9,62 +9,68 @@ import (
 func TestHash(t *testing.T) {
 	a := Transaction{
 		ID: 0,
-		Postings: []Posting{
-			{
-				Source:      "world",
-				Destination: "users:001",
-				Amount:      100,
-				Asset:       "COIN",
+		TransactionData: TransactionData{
+			Postings: []Posting{
+				{
+					Source:      "world",
+					Destination: "users:001",
+					Amount:      100,
+					Asset:       "COIN",
+				},
 			},
 		},
 	}
 
 	b := Transaction{
 		ID: 1,
-		Postings: []Posting{
-			{
-				Source:      "world",
-				Destination: "users:001",
-				Amount:      100,
-				Asset:       "COIN",
+		TransactionData: TransactionData{
+			Postings: []Posting{
+				{
+					Source:      "world",
+					Destination: "users:001",
+					Amount:      100,
+					Asset:       "COIN",
+				},
 			},
 		},
 	}
 
 	h1 := Hash(nil, &a)
 
-	if h1 != "3d60910b8f0aab20d17e3e8aa71ca9fe54634fe03466ec7ca49822bc4c5cac7f" {
+	if h1 != "57618464a7b23bf22a4fce5c5943e8677ace7197c6c90bd7ad684d0769708bb2" {
 		t.Fail()
 	}
 
 	a.Hash = h1
 	h2 := Hash(&a, &b)
 
-	if h2 != "b604e920f4f0d20fd2a2b09038ab9fc21d5761f05cdbd33148000a3f2ab7e65c" {
+	if h2 != "dbcced909e105f24754724d5c6da62a82aa88b05b85cc424baed51ad59cbbdd1" {
 		t.Fail()
 	}
 }
 
 func TestReverseTransaction(t *testing.T) {
 	tx := &Transaction{
-		Postings: Postings{
-			{
-				Source:      "world",
-				Destination: "users:001",
-				Amount:      100,
-				Asset:       "COIN",
+		TransactionData: TransactionData{
+			Postings: Postings{
+				{
+					Source:      "world",
+					Destination: "users:001",
+					Amount:      100,
+					Asset:       "COIN",
+				},
+				{
+					Source:      "users:001",
+					Destination: "payments:001",
+					Amount:      100,
+					Asset:       "COIN",
+				},
 			},
-			{
-				Source:      "users:001",
-				Destination: "payments:001",
-				Amount:      100,
-				Asset:       "COIN",
-			},
+			Reference: "foo",
 		},
-		Reference: "foo",
 	}
 
-	expected := Transaction{
+	expected := TransactionData{
 		Postings: Postings{
 			{
 				Source:      "payments:001",

--- a/pkg/ledger/executor.go
+++ b/pkg/ledger/executor.go
@@ -94,11 +94,11 @@ func (l *Ledger) Execute(ctx context.Context, script core.Script) error {
 		}
 	}
 
-	t := core.Transaction{
+	t := core.TransactionData{
 		Postings: m.Postings,
 	}
 
-	_, ret, err := l.Commit(ctx, []core.Transaction{t})
+	_, ret, err := l.Commit(ctx, []core.TransactionData{t})
 	switch err {
 	case ErrCommitError:
 		return ret[0].Err

--- a/pkg/ledger/executor_test.go
+++ b/pkg/ledger/executor_test.go
@@ -124,7 +124,7 @@ func TestEnoughFunds(t *testing.T) {
 	with(func(l *Ledger) {
 		defer l.Close(context.Background())
 
-		tx := core.Transaction{
+		tx := core.TransactionData{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -135,7 +135,7 @@ func TestEnoughFunds(t *testing.T) {
 			},
 		}
 
-		_, _, err := l.Commit(context.Background(), []core.Transaction{tx})
+		_, _, err := l.Commit(context.Background(), []core.TransactionData{tx})
 
 		if err != nil {
 			t.Error(err)
@@ -166,7 +166,7 @@ func TestNotEnoughFunds(t *testing.T) {
 	with(func(l *Ledger) {
 		defer l.Close(context.Background())
 
-		tx := core.Transaction{
+		tx := core.TransactionData{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -177,7 +177,7 @@ func TestNotEnoughFunds(t *testing.T) {
 			},
 		}
 
-		_, _, err := l.Commit(context.Background(), []core.Transaction{tx})
+		_, _, err := l.Commit(context.Background(), []core.TransactionData{tx})
 
 		if err != nil {
 			t.Error(err)
@@ -204,7 +204,7 @@ func TestMetadata(t *testing.T) {
 	with(func(l *Ledger) {
 		defer l.Close(context.Background())
 
-		tx := core.Transaction{
+		tx := core.TransactionData{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -215,7 +215,7 @@ func TestMetadata(t *testing.T) {
 			},
 		}
 
-		_, _, err := l.Commit(context.Background(), []core.Transaction{tx})
+		_, _, err := l.Commit(context.Background(), []core.TransactionData{tx})
 
 		l.SaveMeta(context.Background(), "account", "sales:042", core.Metadata{
 			"seller": json.RawMessage(`{

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -112,14 +112,14 @@ func TestTransaction(t *testing.T) {
 	with(func(l *Ledger) {
 		testsize := 1e4
 		total := 0
-		batch := []core.Transaction{}
+		batch := []core.TransactionData{}
 
 		for i := 1; i <= int(testsize); i++ {
 			user := fmt.Sprintf("users:%03d", 1+rand.Intn(100))
 			amount := 100
 			total += amount
 
-			batch = append(batch, core.Transaction{
+			batch = append(batch, core.TransactionData{
 				Postings: []core.Posting{
 					{
 						Source:      "world",
@@ -146,7 +146,7 @@ func TestTransaction(t *testing.T) {
 				t.Error(err)
 			}
 
-			batch = []core.Transaction{}
+			batch = []core.TransactionData{}
 		}
 
 		world, err := l.GetAccount(context.Background(), "world")
@@ -170,7 +170,7 @@ func TestTransaction(t *testing.T) {
 
 func TestTransactionBatchWithIntermediateWrongState(t *testing.T) {
 	with(func(l *Ledger) {
-		batch := []core.Transaction{
+		batch := []core.TransactionData{
 			{
 				Postings: []core.Posting{
 					{
@@ -218,7 +218,7 @@ func TestTransactionBatchWithIntermediateWrongState(t *testing.T) {
 
 func TestTransactionBatchWithConflictingReference(t *testing.T) {
 	with(func(l *Ledger) {
-		batch := []core.Transaction{
+		batch := []core.TransactionData{
 			{
 				Postings: []core.Posting{
 					{
@@ -269,7 +269,7 @@ func TestTransactionBatchWithConflictingReference(t *testing.T) {
 
 func TestTransactionExpectedBalances(t *testing.T) {
 	with(func(l *Ledger) {
-		batch := []core.Transaction{
+		batch := []core.TransactionData{
 			{
 				Postings: []core.Posting{
 					{
@@ -330,7 +330,7 @@ func TestTransactionExpectedBalances(t *testing.T) {
 
 func TestBalance(t *testing.T) {
 	with(func(l *Ledger) {
-		_, _, err := l.Commit(context.Background(), []core.Transaction{
+		_, _, err := l.Commit(context.Background(), []core.TransactionData{
 			{
 				Postings: []core.Posting{
 					{
@@ -353,7 +353,7 @@ func TestBalance(t *testing.T) {
 
 func TestReference(t *testing.T) {
 	with(func(l *Ledger) {
-		tx := core.Transaction{
+		tx := core.TransactionData{
 			Reference: "payment_processor_id_01",
 			Postings: []core.Posting{
 				{
@@ -365,13 +365,13 @@ func TestReference(t *testing.T) {
 			},
 		}
 
-		_, _, err := l.Commit(context.Background(), []core.Transaction{tx})
+		_, _, err := l.Commit(context.Background(), []core.TransactionData{tx})
 
 		if err != nil {
 			t.Error(err)
 		}
 
-		_, _, err = l.Commit(context.Background(), []core.Transaction{tx})
+		_, _, err = l.Commit(context.Background(), []core.TransactionData{tx})
 
 		if err == nil {
 			t.Fail()
@@ -449,7 +449,7 @@ func TestAccountMetadata(t *testing.T) {
 
 func TestTransactionMetadata(t *testing.T) {
 	with(func(l *Ledger) {
-		l.Commit(context.Background(), []core.Transaction{{
+		l.Commit(context.Background(), []core.TransactionData{{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -493,7 +493,7 @@ func TestTransactionMetadata(t *testing.T) {
 func TestSaveTransactionMetadata(t *testing.T) {
 	with(func(l *Ledger) {
 
-		l.Commit(context.Background(), []core.Transaction{{
+		l.Commit(context.Background(), []core.TransactionData{{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -527,7 +527,7 @@ func TestSaveTransactionMetadata(t *testing.T) {
 
 func TestGetTransaction(t *testing.T) {
 	with(func(l *Ledger) {
-		l.Commit(context.Background(), []core.Transaction{{
+		l.Commit(context.Background(), []core.TransactionData{{
 			Reference: "bar",
 			Postings: []core.Posting{
 				{
@@ -557,7 +557,7 @@ func TestGetTransaction(t *testing.T) {
 
 func TestFindTransactions(t *testing.T) {
 	with(func(l *Ledger) {
-		tx := core.Transaction{
+		tx := core.TransactionData{
 			Postings: []core.Posting{
 				{
 					Source:      "world",
@@ -568,7 +568,7 @@ func TestFindTransactions(t *testing.T) {
 			},
 		}
 
-		l.Commit(context.Background(), []core.Transaction{tx})
+		l.Commit(context.Background(), []core.TransactionData{tx})
 
 		res, err := l.FindTransactions(context.Background())
 
@@ -588,7 +588,7 @@ func TestRevertTransaction(t *testing.T) {
 	with(func(l *Ledger) {
 		revertAmt := int64(100)
 
-		_, txs, err := l.Commit(context.Background(), []core.Transaction{{
+		_, txs, err := l.Commit(context.Background(), []core.TransactionData{{
 			Reference: "foo",
 			Postings: []core.Posting{
 				{
@@ -647,9 +647,9 @@ func TestRevertTransaction(t *testing.T) {
 func BenchmarkTransaction1(b *testing.B) {
 	with(func(l *Ledger) {
 		for n := 0; n < b.N; n++ {
-			txs := []core.Transaction{}
+			txs := []core.TransactionData{}
 
-			txs = append(txs, core.Transaction{
+			txs = append(txs, core.TransactionData{
 				Postings: []core.Posting{
 					{
 						Source:      "world",
@@ -669,10 +669,10 @@ func BenchmarkTransaction_20_1k(b *testing.B) {
 	with(func(l *Ledger) {
 		for n := 0; n < b.N; n++ {
 			for i := 0; i < 20; i++ {
-				txs := []core.Transaction{}
+				txs := []core.TransactionData{}
 
 				for j := 0; j < 1e3; j++ {
-					txs = append(txs, core.Transaction{
+					txs = append(txs, core.TransactionData{
 						Postings: []core.Posting{
 							{
 								Source:      "world",

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -160,12 +160,14 @@ func testSaveTransaction(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -179,10 +181,12 @@ func testDuplicatedTransaction(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{},
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{},
+				},
+				Reference: "foo",
 			},
-			Reference: "foo",
 		},
 	}
 	_, err := store.SaveTransactions(context.Background(), txs)
@@ -227,12 +231,14 @@ func testLastTransaction(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -245,10 +251,12 @@ func testLastTransaction(t *testing.T, store storage.Store) {
 	assert.NoError(t, err)
 	assert.NotNil(t, lastTx)
 	assert.Equal(t, core.Transaction{
+		TransactionData: core.TransactionData{
+			Postings: txs[0].Postings,
+			Metadata: map[string]json.RawMessage{},
+		},
 		ID:        txs[0].ID,
-		Postings:  txs[0].Postings,
 		Timestamp: txs[0].Timestamp,
-		Metadata:  map[string]json.RawMessage{},
 	}, *lastTx)
 
 }
@@ -267,12 +275,14 @@ func testCountAccounts(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -290,12 +300,14 @@ func testAggregateBalances(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -314,12 +326,14 @@ func testAggregateVolumes(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -339,12 +353,14 @@ func testFindAccounts(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -375,16 +391,18 @@ func testCountMeta(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
-			},
-			Metadata: map[string]json.RawMessage{
-				"lastname": json.RawMessage(`"XXX"`),
+				Metadata: map[string]json.RawMessage{
+					"lastname": json.RawMessage(`"XXX"`),
+				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
 		},
@@ -405,16 +423,18 @@ func testCountTransactions(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
-			},
-			Metadata: map[string]json.RawMessage{
-				"lastname": json.RawMessage(`"XXX"`),
+				Metadata: map[string]json.RawMessage{
+					"lastname": json.RawMessage(`"XXX"`),
+				},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
 		},
@@ -431,29 +451,33 @@ func testFindTransactions(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 0,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
+				Reference: "tx1",
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
-			Reference: "tx1",
 		},
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
+				Reference: "tx2",
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
-			Reference: "tx2",
 		},
 	}
 	_, err := store.SaveTransactions(context.Background(), txs)
@@ -522,32 +546,36 @@ func testMapping(t *testing.T, store storage.Store) {
 func testGetTransaction(t *testing.T, store storage.Store) {
 	txs := []core.Transaction{
 		{
-			ID: 0,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			ID:        0,
+			Timestamp: time.Now().Format(time.RFC3339),
+			TransactionData: core.TransactionData{
+				Reference: "tx1",
+				Metadata:  core.Metadata{},
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
 			},
-			Timestamp: time.Now().Format(time.RFC3339),
-			Reference: "tx1",
-			Metadata:  core.Metadata{},
 		},
 		{
 			ID: 1,
-			Postings: []core.Posting{
-				{
-					Source:      "world",
-					Destination: "central_bank",
-					Amount:      100,
-					Asset:       "USD",
+			TransactionData: core.TransactionData{
+				Postings: []core.Posting{
+					{
+						Source:      "world",
+						Destination: "central_bank",
+						Amount:      100,
+						Asset:       "USD",
+					},
 				},
+				Reference: "tx2",
+				Metadata:  core.Metadata{},
 			},
 			Timestamp: time.Now().Format(time.RFC3339),
-			Reference: "tx2",
-			Metadata:  core.Metadata{},
 		},
 	}
 	_, err := store.SaveTransactions(context.Background(), txs)

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -97,12 +97,14 @@ func (s *Store) FindTransactions(ctx context.Context, q query.Query) (query.Curs
 
 		if _, ok := transactions[txid]; !ok {
 			transactions[txid] = core.Transaction{
-				ID:        txid,
-				Postings:  []core.Posting{},
+				ID: txid,
+				TransactionData: core.TransactionData{
+					Postings:  []core.Posting{},
+					Reference: ref.String,
+					Metadata:  core.Metadata{},
+				},
 				Timestamp: ts,
 				Hash:      thash,
-				Reference: ref.String,
-				Metadata:  core.Metadata{},
 			}
 		}
 


### PR DESCRIPTION
The main change is the introduction of TransactionData structure which hold user provided data (postings, metadata, and reference).
Now, ledger.Commit accept a slice of TransactionData and return a slice of Transaction.
