### PR TITLE
feature/gin error

### DIFF
--- a/cmd/container.go
+++ b/cmd/container.go
@@ -159,15 +159,7 @@ func NewContainer(v *viper.Viper, options ...fx.Option) *fx.App {
 		var writer io.Writer = os.Stderr
 		if viper.GetBool(otelTracesFlag) {
 			writer = ioutil.Discard
-			res = append(res, func(context *gin.Context) {
-				defer func() {
-					for _, e := range context.Errors {
-						trace.SpanFromContext(context.Request.Context()).
-							RecordError(e)
-					}
-				}()
-				context.Next()
-			})
+			res = append(res, opentelemetrytraces.Middleware())
 		}
 		res = append(res, gin.CustomRecoveryWithWriter(writer, func(c *gin.Context, err interface{}) {
 			switch eerr := err.(type) {

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -160,10 +160,13 @@ func NewContainer(v *viper.Viper, options ...fx.Option) *fx.App {
 		if viper.GetBool(otelTracesFlag) {
 			writer = ioutil.Discard
 			res = append(res, func(context *gin.Context) {
-				for _, e := range context.Errors {
-					trace.SpanFromContext(context.Request.Context()).
-						RecordError(e)
-				}
+				defer func() {
+					for _, e := range context.Errors {
+						trace.SpanFromContext(context.Request.Context()).
+							RecordError(e)
+					}
+				}()
+				context.Next()
 			})
 		}
 		res = append(res, gin.CustomRecoveryWithWriter(writer, func(c *gin.Context, err interface{}) {

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -167,8 +167,12 @@ func NewContainer(v *viper.Viper, options ...fx.Option) *fx.App {
 			})
 		}
 		res = append(res, gin.CustomRecoveryWithWriter(writer, func(c *gin.Context, err interface{}) {
-			eerr := fmt.Errorf("%s", err)
-			c.AbortWithError(http.StatusInternalServerError, eerr)
+			switch eerr := err.(type) {
+			case error:
+				c.AbortWithError(http.StatusInternalServerError, eerr)
+			default:
+				c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("%s", err))
+			}
 		}))
 		res = append(res, middlewares.Auth(viper.GetString(serverHttpBasicAuthFlag)))
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,6 +31,12 @@ func TestServer(t *testing.T) {
 	for _, tc := range []testCase{
 		{
 			name: "default",
+			env: []env{
+				{
+					key:   "NUMARY_STORAGE_DRIVER",
+					value: "sqlite",
+				},
+			},
 		},
 		{
 			name: "pg",

--- a/main.go
+++ b/main.go
@@ -4,12 +4,6 @@ import (
 	"github.com/numary/ledger/cmd"
 )
 
-// @title Ledger API
-// @version 1.0
-
-// @host localhost:3068
-// @schemes http https
-
 func main() {
 	cmd.Execute()
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/numary/ledger/pkg/api/routes"
 	"github.com/numary/ledger/pkg/core"
 	"github.com/numary/ledger/pkg/ledger"
+	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
-	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
@@ -33,7 +33,7 @@ func withNewModule(t *testing.T, options ...fx.Option) {
 		module,
 		ledger.ResolveModule(),
 		storage.DefaultModule(),
-		sqlstorage.TestingModule(),
+		ledgertesting.TestingModule(),
 		logging.LogrusModule(),
 		fx.NopLogger,
 	}, options...)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -33,7 +33,7 @@ func withNewModule(t *testing.T, options ...fx.Option) {
 		module,
 		ledger.ResolveModule(),
 		storage.DefaultModule(),
-		ledgertesting.TestingModule(),
+		ledgertesting.StorageModule(),
 		logging.LogrusModule(),
 		fx.NopLogger,
 	}, options...)

--- a/pkg/api/controllers/account_controller.go
+++ b/pkg/api/controllers/account_controller.go
@@ -27,7 +27,7 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 		query.After(c.Query("after")),
 	)
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.response(
@@ -41,7 +41,7 @@ func (ctl *AccountController) GetAccount(c *gin.Context) {
 	l, _ := c.Get("ledger")
 	acc, err := l.(*ledger.Ledger).GetAccount(c.Request.Context(), c.Param("address"))
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.response(
@@ -58,7 +58,7 @@ func (ctl *AccountController) PostAccountMetadata(c *gin.Context) {
 
 	addr := c.Param("address")
 	if !core.ValidateAddress(addr) {
-		ctl.responseError(c, http.StatusBadRequest, ErrValidation, errors.New("invalid address"))
+		ResponseError(c, errors.New("invalid address"))
 		return
 	}
 
@@ -69,7 +69,7 @@ func (ctl *AccountController) PostAccountMetadata(c *gin.Context) {
 		m,
 	)
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.noContent(c)

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -2,9 +2,9 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"github.com/numary/ledger/pkg/ledger"
 	"github.com/numary/ledger/pkg/storage"
+	"github.com/pkg/errors"
 	"net/http"
 	"reflect"
 
@@ -63,10 +63,10 @@ func coreErrorToErrorCode(err error) (int, string) {
 		return http.StatusBadRequest, ErrInsufficientFund
 	case ledger.IsValidationError(err):
 		return http.StatusBadRequest, ErrValidation
-	case storage.IsError(err):
-		return http.StatusServiceUnavailable, ErrStore
 	case errors.Is(err, context.Canceled):
 		return http.StatusInternalServerError, ErrContextCancelled
+	case storage.IsError(err):
+		return http.StatusServiceUnavailable, ErrStore
 	default:
 		return http.StatusInternalServerError, ErrInternal
 	}

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -38,6 +38,8 @@ const (
 	ErrInsufficientFund = "INSUFFICIENT_FUND"
 	ErrValidation       = "VALIDATION"
 	ErrNotFound         = "NOT_FOUND"
+
+	errorCodeKey = "_errorCode"
 )
 
 type ErrorResponse struct {
@@ -72,6 +74,10 @@ func coreErrorToErrorCode(err error) (int, string) {
 	}
 }
 
+func ErrorCode(c *gin.Context) string {
+	return c.GetString(errorCodeKey)
+}
+
 func ResponseError(c *gin.Context, err error) {
 	c.Error(err)
 	status, code := coreErrorToErrorCode(err)
@@ -79,6 +85,7 @@ func ResponseError(c *gin.Context, err error) {
 	if code != ErrInternal {
 		message = err.Error()
 	}
+	c.Set(errorCodeKey, code)
 	c.AbortWithStatusJSON(status, ErrorResponse{
 		ErrorCode:    code,
 		ErrorMessage: message,

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -49,7 +49,7 @@ func (ctl *BaseController) noContent(c *gin.Context) {
 }
 
 func (ctl *BaseController) responseError(c *gin.Context, status int, code string, err error) {
-	c.Abort()
+	c.Error(err)
 	c.AbortWithStatusJSON(status, ErrorResponse{
 		ErrorCode:    code,
 		ErrorMessage: err.Error(),

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -75,8 +75,12 @@ func coreErrorToErrorCode(err error) (int, string) {
 func ResponseError(c *gin.Context, err error) {
 	c.Error(err)
 	status, code := coreErrorToErrorCode(err)
+	message := ""
+	if code != ErrInternal {
+		message = err.Error()
+	}
 	c.AbortWithStatusJSON(status, ErrorResponse{
 		ErrorCode:    code,
-		ErrorMessage: err.Error(),
+		ErrorMessage: message,
 	})
 }

--- a/pkg/api/controllers/base_controller.go
+++ b/pkg/api/controllers/base_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/numary/ledger/pkg/ledger"
+	"github.com/numary/ledger/pkg/storage"
 	"net/http"
 	"reflect"
 
@@ -40,7 +41,7 @@ const (
 	ErrInsufficientFund = "INSUFFICIENT_FUND"
 	ErrValidation       = "VALIDATION"
 	ErrContextCancelled = "CONTEXT_CANCELLED"
-	ErrUnavailableStore = "UNAVAILABLE_STORE"
+	ErrStore            = "STORE"
 
 	errorCodeKey = "_errorCode"
 )
@@ -62,8 +63,8 @@ func coreErrorToErrorCode(err error) (int, string) {
 		return http.StatusBadRequest, ErrInsufficientFund
 	case ledger.IsValidationError(err):
 		return http.StatusBadRequest, ErrValidation
-	case ledger.IsUnavailableStoreError(err):
-		return http.StatusServiceUnavailable, ErrUnavailableStore
+	case storage.IsError(err):
+		return http.StatusServiceUnavailable, ErrStore
 	case errors.Is(err, context.Canceled):
 		return http.StatusInternalServerError, ErrContextCancelled
 	default:

--- a/pkg/api/controllers/ledger_controller.go
+++ b/pkg/api/controllers/ledger_controller.go
@@ -22,7 +22,7 @@ func (ctl *LedgerController) GetStats(c *gin.Context) {
 
 	stats, err := l.(*ledger.Ledger).Stats(c.Request.Context())
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.response(c, http.StatusOK, stats)

--- a/pkg/api/controllers/mapping_controller.go
+++ b/pkg/api/controllers/mapping_controller.go
@@ -21,13 +21,13 @@ func (ctl *MappingController) PutMapping(c *gin.Context) {
 	mapping := &core.Mapping{}
 	err := c.ShouldBind(mapping)
 	if err != nil {
-		ctl.responseError(c, http.StatusBadRequest, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 
 	err = l.(*ledger.Ledger).SaveMapping(c.Request.Context(), *mapping)
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.response(c, http.StatusOK, mapping)
@@ -38,7 +38,7 @@ func (ctl *MappingController) GetMapping(c *gin.Context) {
 
 	mapping, err := l.(*ledger.Ledger).LoadMapping(c.Request.Context())
 	if err != nil {
-		ctl.responseError(c, http.StatusInternalServerError, ErrInternal, err)
+		ResponseError(c, err)
 		return
 	}
 	ctl.response(c, http.StatusOK, mapping)

--- a/pkg/api/controllers/transaction_controller.go
+++ b/pkg/api/controllers/transaction_controller.go
@@ -124,9 +124,9 @@ func (ctl *TransactionController) PostTransactionsBatch(c *gin.Context) {
 					Transaction: tx.Transaction,
 				}
 				if tx.Err != nil {
-					var exposeMessage bool
-					_, v.ErrorCode, exposeMessage = coreErrorToErrorCode(tx.Err)
-					if exposeMessage {
+					var status int
+					status, v.ErrorCode = coreErrorToErrorCode(tx.Err)
+					if status < 500 {
 						v.ErrorMessage = tx.Err.Error()
 					}
 				}

--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"os"
 	"testing"
 )
 
@@ -283,6 +284,9 @@ func TestTooManyClient(t *testing.T) {
 	internal.RunTest(t, func(api *api.API, factory storage.Factory) {
 
 		if ledgertesting.StorageDriverName() != "postgres" {
+			return
+		}
+		if os.Getenv("NUMARY_STORAGE_POSTGRES_CONN_STRING") != "" { // Use of external server, ignore this test
 			return
 		}
 

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/numary/ledger/pkg/api"
@@ -159,7 +158,7 @@ func WithNewModule(t *testing.T, options ...fx.Option) {
 		module,
 		ledger.ResolveModule(),
 		storage.DefaultModule(),
-		ledgertesting.TestingModule(),
+		ledgertesting.StorageModule(),
 		logging.LogrusModule(),
 		fx.NopLogger,
 	}, options...)
@@ -168,9 +167,6 @@ func WithNewModule(t *testing.T, options ...fx.Option) {
 	}))
 
 	app := fx.New(options...)
-	err := app.Start(context.Background())
-	assert.NoError(t, err)
-	defer app.Stop(context.Background())
 
 	select {
 	case <-ch:

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 	"io"
@@ -20,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 )
+
+var testingLedger string
 
 func Encode(t *testing.T, v interface{}) []byte {
 	data, err := json.Marshal(v)
@@ -78,61 +81,61 @@ func NewRequest(method, path string, body io.Reader) (*http.Request, *httptest.R
 }
 
 func PostTransaction(t *testing.T, handler http.Handler, tx core.TransactionData) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodPost, "/quickstart/transactions", Buffer(t, tx))
+	req, rec := NewRequest(http.MethodPost, "/"+testingLedger+"/transactions", Buffer(t, tx))
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func PostTransactionMetadata(t *testing.T, handler http.Handler, id int64, m core.Metadata) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodPost, fmt.Sprintf("/quickstart/transactions/%d/metadata", id), Buffer(t, m))
+	req, rec := NewRequest(http.MethodPost, fmt.Sprintf("/"+testingLedger+"/transactions/%d/metadata", id), Buffer(t, m))
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func GetTransactions(handler http.Handler) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, "/quickstart/transactions", nil)
+	req, rec := NewRequest(http.MethodGet, "/"+testingLedger+"/transactions", nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func GetTransaction(handler http.Handler, id int64) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, fmt.Sprintf("/quickstart/transactions/%d", id), nil)
+	req, rec := NewRequest(http.MethodGet, fmt.Sprintf("/"+testingLedger+"/transactions/%d", id), nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func GetAccounts(handler http.Handler) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, "/quickstart/accounts", nil)
+	req, rec := NewRequest(http.MethodGet, "/"+testingLedger+"/accounts", nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func GetAccount(handler http.Handler, addr string) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, "/quickstart/accounts/"+addr, nil)
+	req, rec := NewRequest(http.MethodGet, "/"+testingLedger+"/accounts/"+addr, nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func PostAccountMetadata(t *testing.T, handler http.Handler, addr string, m core.Metadata) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodPost, fmt.Sprintf("/quickstart/accounts/%s/metadata", addr), Buffer(t, m))
+	req, rec := NewRequest(http.MethodPost, fmt.Sprintf("/"+testingLedger+"/accounts/%s/metadata", addr), Buffer(t, m))
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func GetStats(handler http.Handler) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, "/quickstart/stats", nil)
+	req, rec := NewRequest(http.MethodGet, "/"+testingLedger+"/stats", nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func LoadMapping(handler http.Handler) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodGet, "/quickstart/mapping", nil)
+	req, rec := NewRequest(http.MethodGet, "/"+testingLedger+"/mapping", nil)
 	handler.ServeHTTP(rec, req)
 	return rec
 }
 
 func SaveMapping(t *testing.T, handler http.Handler, m core.Mapping) *httptest.ResponseRecorder {
-	req, rec := NewRequest(http.MethodPut, "/quickstart/mapping", Buffer(t, m))
+	req, rec := NewRequest(http.MethodPut, "/"+testingLedger+"/mapping", Buffer(t, m))
 	handler.ServeHTTP(rec, req)
 	return rec
 }
@@ -144,6 +147,7 @@ func GetInfo(handler http.Handler) *httptest.ResponseRecorder {
 }
 
 func WithNewModule(t *testing.T, options ...fx.Option) {
+	testingLedger = uuid.New()
 	module := api.Module(api.Config{
 		StorageDriver: "sqlite",
 		LedgerLister: controllers.LedgerListerFn(func(r *http.Request) []string {

--- a/pkg/api/internal/testing.go
+++ b/pkg/api/internal/testing.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/numary/ledger/pkg/api"
@@ -9,9 +10,9 @@ import (
 	"github.com/numary/ledger/pkg/core"
 	"github.com/numary/ledger/pkg/ledger"
 	"github.com/numary/ledger/pkg/ledger/query"
+	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
-	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 	"io"
@@ -158,7 +159,7 @@ func WithNewModule(t *testing.T, options ...fx.Option) {
 		module,
 		ledger.ResolveModule(),
 		storage.DefaultModule(),
-		sqlstorage.TestingModule(),
+		ledgertesting.TestingModule(),
 		logging.LogrusModule(),
 		fx.NopLogger,
 	}, options...)
@@ -167,6 +168,10 @@ func WithNewModule(t *testing.T, options ...fx.Option) {
 	}))
 
 	app := fx.New(options...)
+	err := app.Start(context.Background())
+	assert.NoError(t, err)
+	defer app.Stop(context.Background())
+
 	select {
 	case <-ch:
 	default:

--- a/pkg/api/middlewares/ledger_middleware.go
+++ b/pkg/api/middlewares/ledger_middleware.go
@@ -2,8 +2,10 @@ package middlewares
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/numary/ledger/pkg/api/controllers"
 	"github.com/numary/ledger/pkg/ledger"
 	"github.com/numary/ledger/pkg/logging"
+	"net/http"
 )
 
 // LedgerMiddleware struct
@@ -34,11 +36,16 @@ func (m *LedgerMiddleware) LedgerMiddleware() gin.HandlerFunc {
 
 		l, err := m.resolver.GetLedger(c.Request.Context(), name)
 		if err != nil {
-			c.JSON(400, gin.H{
-				"error":         true,
-				"error_code":    400,
-				"error_message": err.Error(),
-			})
+			statusCode := http.StatusBadRequest
+			res := controllers.ErrorResponse{
+				ErrorCode:    controllers.ErrInternal,
+				ErrorMessage: err.Error(),
+			}
+			switch {
+			case ledger.IsUnavailableStoreError(err):
+				statusCode = http.StatusServiceUnavailable
+			}
+			c.AbortWithStatusJSON(statusCode, res)
 			return
 		}
 		defer func() {

--- a/pkg/api/middlewares/ledger_middleware.go
+++ b/pkg/api/middlewares/ledger_middleware.go
@@ -5,7 +5,6 @@ import (
 	"github.com/numary/ledger/pkg/api/controllers"
 	"github.com/numary/ledger/pkg/ledger"
 	"github.com/numary/ledger/pkg/logging"
-	"net/http"
 )
 
 // LedgerMiddleware struct
@@ -36,16 +35,7 @@ func (m *LedgerMiddleware) LedgerMiddleware() gin.HandlerFunc {
 
 		l, err := m.resolver.GetLedger(c.Request.Context(), name)
 		if err != nil {
-			statusCode := http.StatusBadRequest
-			res := controllers.ErrorResponse{
-				ErrorCode:    controllers.ErrInternal,
-				ErrorMessage: err.Error(),
-			}
-			switch {
-			case ledger.IsUnavailableStoreError(err):
-				statusCode = http.StatusServiceUnavailable
-			}
-			c.AbortWithStatusJSON(statusCode, res)
+			controllers.ResponseError(c, err)
 			return
 		}
 		defer func() {

--- a/pkg/api/middlewares/ledger_middleware.go
+++ b/pkg/api/middlewares/ledger_middleware.go
@@ -39,6 +39,7 @@ func (m *LedgerMiddleware) LedgerMiddleware() gin.HandlerFunc {
 				"error_code":    400,
 				"error_message": err.Error(),
 			})
+			return
 		}
 		defer func() {
 			err := l.Close(c.Request.Context())

--- a/pkg/ledger/error.go
+++ b/pkg/ledger/error.go
@@ -7,9 +7,40 @@ import (
 
 var ErrCommitError = errors.New("commit error")
 
+type UnavailableStoreError struct {
+	Err error
+}
+
+func (e UnavailableStoreError) Error() string {
+	return fmt.Sprintf("unavailable store: %s", e.Err)
+}
+
+func (e UnavailableStoreError) Unwrap() error {
+	return e.Err
+}
+
+func (e UnavailableStoreError) Is(err error) bool {
+	_, ok := err.(*UnavailableStoreError)
+	return ok
+}
+
+func NewUnavailableStoreError(err error) *UnavailableStoreError {
+	return &UnavailableStoreError{
+		Err: err,
+	}
+}
+
+func IsUnavailableStoreError(err error) bool {
+	return errors.Is(err, &UnavailableStoreError{})
+}
+
 type TransactionCommitError struct {
 	TXIndex int   `json:"index"`
 	Err     error `json:"error"`
+}
+
+func (e TransactionCommitError) Unwrap() error {
+	return e.Err
 }
 
 func (e TransactionCommitError) Error() string {

--- a/pkg/ledger/error.go
+++ b/pkg/ledger/error.go
@@ -47,11 +47,20 @@ func (e TransactionCommitError) Error() string {
 	return errors.Wrapf(e.Err, "processing tx %d", e.TXIndex).Error()
 }
 
+func (e TransactionCommitError) Is(err error) bool {
+	_, ok := err.(*TransactionCommitError)
+	return ok
+}
+
 func NewTransactionCommitError(txIndex int, err error) *TransactionCommitError {
 	return &TransactionCommitError{
 		TXIndex: txIndex,
 		Err:     err,
 	}
+}
+
+func IsTransactionCommitError(err error) bool {
+	return errors.Is(err, &TransactionCommitError{})
 }
 
 type InsufficientFundError struct {
@@ -62,10 +71,19 @@ func (e InsufficientFundError) Error() string {
 	return fmt.Sprintf("balance.insufficient.%s", e.Asset)
 }
 
+func (e InsufficientFundError) Is(err error) bool {
+	_, ok := err.(*InsufficientFundError)
+	return ok
+}
+
 func NewInsufficientFundError(asset string) *InsufficientFundError {
 	return &InsufficientFundError{
 		Asset: asset,
 	}
+}
+
+func IsInsufficientFundError(err error) bool {
+	return errors.Is(err, &InsufficientFundError{})
 }
 
 type ValidationError struct {
@@ -76,10 +94,19 @@ func (v ValidationError) Error() string {
 	return v.Msg
 }
 
+func (v ValidationError) Is(err error) bool {
+	_, ok := err.(*ValidationError)
+	return ok
+}
+
 func NewValidationError(msg string) *ValidationError {
 	return &ValidationError{
 		Msg: msg,
 	}
+}
+
+func IsValidationError(err error) bool {
+	return errors.Is(err, &ValidationError{})
 }
 
 type ConflictError struct {
@@ -90,8 +117,17 @@ func (e ConflictError) Error() string {
 	return fmt.Sprintf("conflict error on reference '%s'", e.Reference)
 }
 
+func (e ConflictError) Is(err error) bool {
+	_, ok := err.(*ConflictError)
+	return ok
+}
+
 func NewConflictError(ref string) *ConflictError {
 	return &ConflictError{
 		Reference: ref,
 	}
+}
+
+func IsConflictError(err error) bool {
+	return errors.Is(err, &ConflictError{})
 }

--- a/pkg/ledger/error.go
+++ b/pkg/ledger/error.go
@@ -7,33 +7,6 @@ import (
 
 var ErrCommitError = errors.New("commit error")
 
-type UnavailableStoreError struct {
-	Err error
-}
-
-func (e UnavailableStoreError) Error() string {
-	return fmt.Sprintf("unavailable store: %s", e.Err)
-}
-
-func (e UnavailableStoreError) Unwrap() error {
-	return e.Err
-}
-
-func (e UnavailableStoreError) Is(err error) bool {
-	_, ok := err.(*UnavailableStoreError)
-	return ok
-}
-
-func NewUnavailableStoreError(err error) *UnavailableStoreError {
-	return &UnavailableStoreError{
-		Err: err,
-	}
-}
-
-func IsUnavailableStoreError(err error) bool {
-	return errors.Is(err, &UnavailableStoreError{})
-}
-
 type TransactionCommitError struct {
 	TXIndex int   `json:"index"`
 	Err     error `json:"error"`

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -67,15 +67,15 @@ func (l *Ledger) Commit(ctx context.Context, ts []core.TransactionData) (Balance
 	}
 	defer unlock(ctx)
 
-	count, err := l.store.CountTransactions(ctx)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "counting transactions")
-	}
 	timestamp := time.Now().Format(time.RFC3339)
 
+	startId := int64(0)
 	last, err := l.store.LastTransaction(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading last transaction")
+	}
+	if last != nil {
+		startId = last.ID + 1
 	}
 
 	mapping, err := l.store.LoadMapping(ctx)
@@ -102,7 +102,7 @@ txLoop:
 			TransactionData: ts[i],
 		}
 
-		tx.ID = count + int64(i)
+		tx.ID = startId + int64(i)
 		tx.Timestamp = timestamp
 
 		tx.Hash = core.Hash(last, &tx)

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -67,7 +67,10 @@ func (l *Ledger) Commit(ctx context.Context, ts []core.TransactionData) (Balance
 	}
 	defer unlock(ctx)
 
-	count, _ := l.store.CountTransactions(ctx)
+	count, err := l.store.CountTransactions(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
 	timestamp := time.Now().Format(time.RFC3339)
 
 	last, err := l.store.LastTransaction(ctx)

--- a/pkg/ledger/ledger.go
+++ b/pkg/ledger/ledger.go
@@ -69,18 +69,18 @@ func (l *Ledger) Commit(ctx context.Context, ts []core.TransactionData) (Balance
 
 	count, err := l.store.CountTransactions(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "counting transactions")
 	}
 	timestamp := time.Now().Format(time.RFC3339)
 
 	last, err := l.store.LastTransaction(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "loading last transaction")
 	}
 
 	mapping, err := l.store.LoadMapping(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "loading mapping")
 	}
 
 	contracts := make([]core.Contract, 0)
@@ -220,7 +220,7 @@ txLoop:
 			}
 			return nil, ret, ErrCommitError
 		default:
-			return nil, nil, err
+			return nil, nil, errors.Wrap(err, "committing transactions")
 		}
 	}
 	return aggregatedBalances, ret, nil

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -60,7 +60,6 @@ func with(f func(l *Ledger)) {
 	go app.Start(context.Background())
 
 	select {
-	case <-time.After(5 * time.Second):
 	case <-done:
 	}
 	if app.Err() != nil {

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/numary/ledger/pkg/core"
@@ -26,48 +27,58 @@ import (
 var driver storage.Driver
 
 func with(f func(l *Ledger)) {
+	done := make(chan struct{})
 	app := fx.New(
 		fx.NopLogger,
 		fx.Provide(func() storage.Driver {
 			return driver
 		}),
-		fx.Invoke(func(d storage.Driver) error {
-			return d.Initialize(context.Background())
+		fx.Invoke(func(lc fx.Lifecycle, d storage.Driver) {
+			lc.Append(fx.Hook{
+				OnStop:  d.Close,
+				OnStart: d.Initialize,
+			})
 		}),
 		fx.Provide(storage.NewDefaultFactory),
-		fx.Provide(
-			func(storageFactory storage.Factory) (*Ledger, error) {
-				store, err := storageFactory.GetStore("test")
-				if err != nil {
-					return nil, err
-				}
-				err = store.Initialize(context.Background())
-				if err != nil {
-					return nil, err
-				}
-				l, err := NewLedger("test", store, NewInMemoryLocker())
-				if err != nil {
-					panic(err)
-				}
-				return l, nil
-			},
-		),
-		fx.Invoke(f),
-		fx.Invoke(func(l *Ledger) {
-			err := l.Close(context.Background())
-			if err != nil {
-				logging.Error(context.Background(), "%s", err)
-			}
+		fx.Invoke(func(lc fx.Lifecycle, storageFactory storage.Factory) {
+			lc.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					defer func() {
+						close(done)
+					}()
+					store, err := storageFactory.GetStore("test")
+					if err != nil {
+						return err
+					}
+					err = store.Initialize(context.Background())
+					if err != nil {
+						return err
+					}
+					l, err := NewLedger("test", store, NewInMemoryLocker())
+					if err != nil {
+						panic(err)
+					}
+					lc.Append(fx.Hook{
+						OnStop: l.Close,
+					})
+					f(l)
+					return nil
+				},
+			})
 		}),
-		// Closing the driver after each test cause a test to fail
-		// Tests seems not independent
-		//fx.Invoke(func(d storage.Driver) error {
-		//	return d.Close(context.Background())
-		//}),
 	)
+	go app.Start(context.Background())
+
+	select {
+	case <-time.After(5 * time.Second):
+	case <-done:
+	}
 	if app.Err() != nil {
 		panic(app.Err())
 	}
+	ctx, _ := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	app.Stop(ctx)
+
 }
 
 func TestMain(m *testing.M) {
@@ -391,6 +402,7 @@ func TestLast(t *testing.T) {
 
 func TestAccountMetadata(t *testing.T) {
 	with(func(l *Ledger) {
+
 		err := l.SaveMeta(context.Background(), "account", "users:001", core.Metadata{
 			"a random metadata": json.RawMessage(`"old value"`),
 		})
@@ -410,9 +422,8 @@ func TestAccountMetadata(t *testing.T) {
 			if meta, ok := acc.Metadata["a random metadata"]; ok {
 				var value string
 				err := json.Unmarshal(meta, &value)
-				if err != nil {
-					t.Fatal(err)
-				}
+				assert.NoError(t, err)
+
 				if value != "new value" {
 					t.Fatalf("metadata entry did not match in get: expected \"new value\", got %v", value)
 				}
@@ -420,10 +431,23 @@ func TestAccountMetadata(t *testing.T) {
 		}
 
 		{
+			// We have to create at least one transaction to retrieve an account from FindAccounts store method
+			_, _, err := l.Commit(context.Background(), []core.TransactionData{
+				{
+					Postings: core.Postings{
+						{
+							Source:      "world",
+							Amount:      100,
+							Asset:       "USD",
+							Destination: "users:001",
+						},
+					},
+				},
+			})
+			assert.NoError(t, err)
+
 			cursor, err := l.FindAccounts(context.Background(), query.Account("users:001"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NoError(t, err)
 
 			accounts, ok := cursor.Data.([]core.Account)
 			if !ok {

--- a/pkg/ledger/resolver.go
+++ b/pkg/ledger/resolver.go
@@ -73,7 +73,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 
 	store, err := r.storageFactory.GetStore(name)
 	if err != nil {
-		return nil, NewUnavailableStoreError(err)
+		return nil, errors.Wrap(err, "retrieving ledger store")
 	}
 
 	r.lock.RLock()
@@ -90,7 +90,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 	if !ok {
 		err = store.Initialize(ctx)
 		if err != nil {
-			return nil, NewUnavailableStoreError(err)
+			return nil, errors.Wrap(err, "initializing ledger store")
 		}
 		r.initializedStores[name] = struct{}{}
 	}

--- a/pkg/ledger/resolver.go
+++ b/pkg/ledger/resolver.go
@@ -2,7 +2,6 @@ package ledger
 
 import (
 	"context"
-	"fmt"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
 	"github.com/numary/ledger/pkg/storage/sqlstorage"
@@ -74,7 +73,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 
 	store, err := r.storageFactory.GetStore(name)
 	if err != nil {
-		return nil, err
+		return nil, NewUnavailableStoreError(err)
 	}
 
 	r.lock.RLock()
@@ -91,9 +90,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 	if !ok {
 		err = store.Initialize(ctx)
 		if err != nil {
-			err = fmt.Errorf("failed to initialize store: %w", err)
-			r.logger.Debug(ctx, "%s", err)
-			return nil, err
+			return nil, NewUnavailableStoreError(err)
 		}
 		r.initializedStores[name] = struct{}{}
 	}

--- a/pkg/ledgertesting/db.go
+++ b/pkg/ledgertesting/db.go
@@ -13,7 +13,7 @@ import (
 	"path"
 )
 
-func TestingModule() fx.Option {
+func StorageModule() fx.Option {
 	return fx.Options(
 		fx.Provide(func(logger logging.Logger, lifecycle fx.Lifecycle) (storage.Driver, error) {
 			var driver storage.Driver
@@ -48,19 +48,14 @@ func TestingModule() fx.Option {
 			if driver == nil {
 				return nil, errors.New("not found driver")
 			}
-			return driver, nil
-		}),
-		fx.Invoke(func(driver storage.Driver, lifecycle fx.Lifecycle) error {
-			err := driver.Initialize(context.Background())
-			if err != nil {
-				return err
-			}
 			lifecycle.Append(fx.Hook{
-				OnStop: func(ctx context.Context) error {
-					return driver.Close(ctx)
+				OnStart: func(ctx context.Context) error {
+					fmt.Println("init driver")
+					return driver.Initialize(ctx)
 				},
+				OnStop: driver.Close,
 			})
-			return nil
+			return driver, nil
 		}),
 	)
 }

--- a/pkg/ledgertesting/db.go
+++ b/pkg/ledgertesting/db.go
@@ -1,0 +1,66 @@
+package ledgertesting
+
+import (
+	"context"
+	"fmt"
+	"github.com/numary/ledger/pkg/logging"
+	"github.com/numary/ledger/pkg/storage"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
+	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
+	"go.uber.org/fx"
+	"os"
+	"path"
+)
+
+func TestingModule() fx.Option {
+	return fx.Options(
+		fx.Provide(func(logger logging.Logger, lifecycle fx.Lifecycle) (storage.Driver, error) {
+			var driver storage.Driver
+			id := uuid.New()
+			switch os.Getenv("NUMARY_STORAGE_DRIVER") {
+			case "sqlite", "":
+				driver = sqlstorage.NewOpenCloseDBDriver(logger, "sqlite", sqlstorage.SQLite, func(name string) string {
+					return sqlstorage.SQLiteFileConnString(path.Join(
+						os.TempDir(),
+						fmt.Sprintf("%s_%s.db", id, name),
+					))
+				})
+			case "postgres":
+				pgServer, err := PostgresServer()
+				if err != nil {
+					return nil, err
+				}
+				lifecycle.Append(fx.Hook{
+					OnStop: func(ctx context.Context) error {
+						return pgServer.Close()
+					},
+				})
+				driver = sqlstorage.NewOpenCloseDBDriver(
+					logger,
+					"postgres",
+					sqlstorage.PostgreSQL,
+					func(name string) string {
+						return pgServer.ConnString()
+					},
+				)
+			}
+			if driver == nil {
+				return nil, errors.New("not found driver")
+			}
+			return driver, nil
+		}),
+		fx.Invoke(func(driver storage.Driver, lifecycle fx.Lifecycle) error {
+			err := driver.Initialize(context.Background())
+			if err != nil {
+				return err
+			}
+			lifecycle.Append(fx.Hook{
+				OnStop: func(ctx context.Context) error {
+					return driver.Close(ctx)
+				},
+			})
+			return nil
+		}),
+	)
+}

--- a/pkg/opentelemetry/opentelemetrytraces/middleware.go
+++ b/pkg/opentelemetry/opentelemetrytraces/middleware.go
@@ -1,0 +1,26 @@
+package opentelemetrytraces
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/numary/ledger/pkg/api/controllers"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Middleware() func(context *gin.Context) {
+	return func(context *gin.Context) {
+		defer func() {
+			span := trace.SpanFromContext(context.Request.Context())
+			for _, e := range context.Errors {
+				span.RecordError(e)
+			}
+			if code := controllers.ErrorCode(context); code != "" {
+				span.SetAttributes(attribute.KeyValue{
+					Key:   "http.error_code",
+					Value: attribute.StringValue(code),
+				})
+			}
+		}()
+		context.Next()
+	}
+}

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -31,7 +31,6 @@ func (s *Store) findAccounts(ctx context.Context, exec executor, q query.Query) 
 	sqlq, args := sb.BuildWithFlavor(s.flavor)
 
 	rows, err := exec.QueryContext(ctx, sqlq, args...)
-
 	if err != nil {
 		return c, s.error(err)
 	}
@@ -56,6 +55,9 @@ func (s *Store) findAccounts(ctx context.Context, exec executor, q query.Query) 
 		account.Metadata = meta
 
 		results = append(results, account)
+	}
+	if rows.Err() != nil {
+		return query.Cursor{}, s.error(rows.Err())
 	}
 
 	c.PageSize = q.Limit - 1

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/numary/ledger/pkg/ledger/query"
 )
 
-func (s *Store) FindAccounts(ctx context.Context, q query.Query) (query.Cursor, error) {
+func (s *Store) findAccounts(ctx context.Context, exec executor, q query.Query) (query.Cursor, error) {
 	// We fetch an additional account to know if we have more documents
 	q.Limit = int(math.Max(-1, math.Min(float64(q.Limit), 100))) + 1
 
@@ -30,11 +30,7 @@ func (s *Store) FindAccounts(ctx context.Context, q query.Query) (query.Cursor, 
 
 	sqlq, args := sb.BuildWithFlavor(s.flavor)
 
-	rows, err := s.db.QueryContext(
-		ctx,
-		sqlq,
-		args...,
-	)
+	rows, err := exec.QueryContext(ctx, sqlq, args...)
 
 	if err != nil {
 		return c, s.error(err)
@@ -53,7 +49,7 @@ func (s *Store) FindAccounts(ctx context.Context, q query.Query) (query.Cursor, 
 			Address: address,
 		}
 
-		meta, err := s.GetMeta(ctx, "account", account.Address)
+		meta, err := s.getMeta(ctx, exec, "account", account.Address)
 		if err != nil {
 			return c, err
 		}
@@ -70,8 +66,12 @@ func (s *Store) FindAccounts(ctx context.Context, q query.Query) (query.Cursor, 
 	}
 	c.Data = results
 
-	total, _ := s.CountAccounts(ctx)
+	total, _ := s.countAccounts(ctx, exec)
 	c.Total = total
 
 	return c, nil
+}
+
+func (s *Store) FindAccounts(ctx context.Context, q query.Query) (query.Cursor, error) {
+	return s.findAccounts(ctx, s.db, q)
 }

--- a/pkg/storage/sqlstorage/aggregations.go
+++ b/pkg/storage/sqlstorage/aggregations.go
@@ -133,6 +133,9 @@ func (s *Store) aggregateVolumes(ctx context.Context, exec executor, address str
 			volumes[row.asset]["input"] += row.amount
 		}
 	}
+	if rows.Err() != nil {
+		return nil, s.error(rows.Err())
+	}
 
 	return volumes, nil
 }

--- a/pkg/storage/sqlstorage/aggregations.go
+++ b/pkg/storage/sqlstorage/aggregations.go
@@ -5,7 +5,7 @@ import (
 	"github.com/huandu/go-sqlbuilder"
 )
 
-func (s *Store) CountTransactions(ctx context.Context) (int64, error) {
+func (s *Store) countTransactions(ctx context.Context, exec executor) (int64, error) {
 	var count int64
 
 	sb := sqlbuilder.NewSelectBuilder()
@@ -14,29 +14,35 @@ func (s *Store) CountTransactions(ctx context.Context) (int64, error) {
 
 	sqlq, args := sb.Build()
 
-	err := s.db.QueryRowContext(ctx, sqlq, args...).Scan(&count)
+	err := exec.QueryRowContext(ctx, sqlq, args...).Scan(&count)
 
 	return count, s.error(err)
 }
 
-func (s *Store) CountAccounts(ctx context.Context) (int64, error) {
+func (s *Store) CountTransactions(ctx context.Context) (int64, error) {
+	return s.countTransactions(ctx, s.db)
+}
+
+func (s *Store) countAccounts(ctx context.Context, exec executor) (int64, error) {
 	var count int64
 
 	sb := sqlbuilder.NewSelectBuilder()
-
 	sb.
 		Select("count(*)").
 		From(s.table("addresses")).
 		BuildWithFlavor(s.flavor)
 
 	sqlq, args := sb.Build()
-
-	err := s.db.QueryRowContext(ctx, sqlq, args...).Scan(&count)
+	err := exec.QueryRowContext(ctx, sqlq, args...).Scan(&count)
 
 	return count, s.error(err)
 }
 
-func (s *Store) CountMeta(ctx context.Context) (int64, error) {
+func (s *Store) CountAccounts(ctx context.Context) (int64, error) {
+	return s.countAccounts(ctx, s.db)
+}
+
+func (s *Store) countMeta(ctx context.Context, exec executor) (int64, error) {
 	var count int64
 
 	sb := sqlbuilder.NewSelectBuilder()
@@ -47,17 +53,20 @@ func (s *Store) CountMeta(ctx context.Context) (int64, error) {
 
 	sqlq, args := sb.BuildWithFlavor(s.flavor)
 
-	q := s.db.QueryRowContext(ctx, sqlq, args...)
+	q := exec.QueryRowContext(ctx, sqlq, args...)
 	err := q.Scan(&count)
 
 	return count, s.error(err)
 }
 
-func (s *Store) AggregateBalances(ctx context.Context, address string) (map[string]int64, error) {
+func (s *Store) CountMeta(ctx context.Context) (int64, error) {
+	return s.countMeta(ctx, s.db)
+}
+
+func (s *Store) aggregateBalances(ctx context.Context, exec executor, address string) (map[string]int64, error) {
 	balances := map[string]int64{}
 
-	volumes, err := s.AggregateVolumes(ctx, address)
-
+	volumes, err := s.aggregateVolumes(ctx, exec, address)
 	if err != nil {
 		return balances, s.error(err)
 	}
@@ -69,7 +78,11 @@ func (s *Store) AggregateBalances(ctx context.Context, address string) (map[stri
 	return balances, nil
 }
 
-func (s *Store) AggregateVolumes(ctx context.Context, address string) (map[string]map[string]int64, error) {
+func (s *Store) AggregateBalances(ctx context.Context, address string) (map[string]int64, error) {
+	return s.aggregateBalances(ctx, s.db, address)
+}
+
+func (s *Store) aggregateVolumes(ctx context.Context, exec executor, address string) (map[string]map[string]int64, error) {
 	volumes := map[string]map[string]int64{}
 
 	agg1 := sqlbuilder.NewSelectBuilder()
@@ -91,8 +104,7 @@ func (s *Store) AggregateVolumes(ctx context.Context, address string) (map[strin
 	sb.From(sb.BuilderAs(union, "assets"))
 
 	sqlq, args := sb.BuildWithFlavor(s.flavor)
-
-	rows, err := s.db.QueryContext(ctx, sqlq, args...)
+	rows, err := exec.QueryContext(ctx, sqlq, args...)
 
 	if err != nil {
 		return volumes, s.error(err)
@@ -123,4 +135,8 @@ func (s *Store) AggregateVolumes(ctx context.Context, address string) (map[strin
 	}
 
 	return volumes, nil
+}
+
+func (s *Store) AggregateVolumes(ctx context.Context, address string) (map[string]map[string]int64, error) {
+	return s.aggregateVolumes(ctx, s.db, address)
 }

--- a/pkg/storage/sqlstorage/driver.go
+++ b/pkg/storage/sqlstorage/driver.go
@@ -3,11 +3,11 @@ package sqlstorage
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
+	"github.com/pkg/errors"
 )
 
 var sqlDrivers = map[Flavor]struct {
@@ -94,6 +94,10 @@ func (s *cachedDBDriver) Name() string {
 
 func (s *cachedDBDriver) Initialize(ctx context.Context) error {
 
+	if s.db != nil {
+		return errors.New("database already initialized")
+	}
+
 	cfg, ok := sqlDrivers[s.flavor]
 	if !ok {
 		return errors.New("unknown flavor")
@@ -117,7 +121,9 @@ func (d *cachedDBDriver) Close(ctx context.Context) error {
 	if d.db == nil {
 		return nil
 	}
-	return d.db.Close()
+	err := d.db.Close()
+	d.db = nil
+	return err
 }
 
 const SQLiteMemoryConnString = "file::memory:?cache=shared"

--- a/pkg/storage/sqlstorage/flavor.go
+++ b/pkg/storage/sqlstorage/flavor.go
@@ -75,7 +75,7 @@ func init() {
 					return storage.NewError(storage.TooManyClient, err)
 				}
 			}
-			return err
+			return storage.NewError(storage.Unknown, err)
 		}
 
 		unwrappedError := errors.Unwrap(err)

--- a/pkg/storage/sqlstorage/flavor.go
+++ b/pkg/storage/sqlstorage/flavor.go
@@ -1,6 +1,7 @@
 package sqlstorage
 
 import (
+	"errors"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/jackc/pgconn"
 	"github.com/numary/ledger/pkg/storage"
@@ -63,14 +64,25 @@ func errorFromFlavor(f Flavor, err error) error {
 
 func init() {
 	errorHandlers[PostgreSQL] = func(err error) error {
-		eerr, ok := err.(*pgconn.PgError)
-		if !ok {
+
+		handleError := func(err error) error {
+			switch eerr := err.(type) {
+			case *pgconn.PgError:
+				switch eerr.Code {
+				case "23505":
+					return storage.NewError(storage.ConstraintFailed, err)
+				case "53300":
+					return storage.NewError(storage.TooManyClient, err)
+				}
+			}
 			return err
 		}
-		switch eerr.Code {
-		case "23505":
-			return storage.NewError(storage.ConstraintFailed, err)
+
+		unwrappedError := errors.Unwrap(err)
+		if unwrappedError != nil {
+			return handleError(unwrappedError)
+		} else {
+			return handleError(err)
 		}
-		return err
 	}
 }

--- a/pkg/storage/sqlstorage/flavor_sqlite.go
+++ b/pkg/storage/sqlstorage/flavor_sqlite.go
@@ -16,7 +16,7 @@ func init() {
 	errorHandlers[SQLite] = func(err error) error {
 		eerr, ok := err.(sqlite3.Error)
 		if !ok {
-			return err
+			return storage.NewError(storage.Unknown, err)
 		}
 		if eerr.Code == sqlite3.ErrConstraint {
 			return storage.NewError(storage.ConstraintFailed, err)

--- a/pkg/storage/sqlstorage/mapping.go
+++ b/pkg/storage/sqlstorage/mapping.go
@@ -25,6 +25,9 @@ func (s *Store) loadMapping(ctx context.Context, exec executor) (*core.Mapping, 
 		return nil, s.error(err)
 	}
 	if !rows.Next() {
+		if rows.Err() != nil {
+			return nil, s.error(rows.Err())
+		}
 		return nil, nil
 	}
 

--- a/pkg/storage/sqlstorage/mapping.go
+++ b/pkg/storage/sqlstorage/mapping.go
@@ -11,7 +11,7 @@ import (
 // We have only one mapping for a ledger, so hardcode the id
 const mappingId = "0000"
 
-func (s *Store) LoadMapping(ctx context.Context) (*core.Mapping, error) {
+func (s *Store) loadMapping(ctx context.Context, exec executor) (*core.Mapping, error) {
 
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.
@@ -20,11 +20,7 @@ func (s *Store) LoadMapping(ctx context.Context) (*core.Mapping, error) {
 
 	sqlq, args := sb.BuildWithFlavor(s.flavor)
 
-	rows, err := s.db.QueryContext(
-		ctx,
-		sqlq,
-		args...,
-	)
+	rows, err := exec.QueryContext(ctx, sqlq, args...)
 	if err != nil {
 		return nil, s.error(err)
 	}
@@ -50,11 +46,11 @@ func (s *Store) LoadMapping(ctx context.Context) (*core.Mapping, error) {
 	return m, nil
 }
 
-func (s *Store) SaveMapping(ctx context.Context, mapping core.Mapping) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return s.error(err)
-	}
+func (s *Store) LoadMapping(ctx context.Context) (*core.Mapping, error) {
+	return s.loadMapping(ctx, s.db)
+}
+
+func (s *Store) saveMapping(ctx context.Context, exec executor, mapping core.Mapping) error {
 
 	data, err := json.Marshal(mapping)
 	if err != nil {
@@ -81,11 +77,10 @@ func (s *Store) SaveMapping(ctx context.Context, mapping core.Mapping) error {
 
 	logrus.Debugln(sqlq, args)
 
-	_, err = tx.ExecContext(ctx, sqlq, args...)
-	if err != nil {
-		tx.Rollback()
+	_, err = exec.ExecContext(ctx, sqlq, args...)
+	return s.error(err)
+}
 
-		return s.error(err)
-	}
-	return tx.Commit()
+func (s *Store) SaveMapping(ctx context.Context, mapping core.Mapping) error {
+	return s.saveMapping(ctx, s.db, mapping)
 }

--- a/pkg/storage/sqlstorage/metadata.go
+++ b/pkg/storage/sqlstorage/metadata.go
@@ -63,6 +63,9 @@ func (s *Store) getMeta(ctx context.Context, exec executor, ty string, id string
 
 		meta[metaKey] = value
 	}
+	if rows.Err() != nil {
+		return nil, s.error(rows.Err())
+	}
 
 	return meta, nil
 }

--- a/pkg/storage/sqlstorage/metadata.go
+++ b/pkg/storage/sqlstorage/metadata.go
@@ -98,8 +98,6 @@ func (s *Store) SaveMeta(ctx context.Context, id int64, timestamp, targetType, t
 
 	_, err = tx.ExecContext(ctx, sqlq, args...)
 	if err != nil {
-		tx.Rollback()
-
 		return s.error(err)
 	}
 

--- a/pkg/storage/sqlstorage/module.go
+++ b/pkg/storage/sqlstorage/module.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
-	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/fx"
-	"os"
 	"path"
 )
 
@@ -73,16 +71,4 @@ func DriverModule(cfg ModuleConfig) fx.Option {
 		return nil
 	}))
 	return fx.Options(options...)
-}
-
-func TestingModule() fx.Option {
-	return fx.Options(
-		DriverModule(ModuleConfig{
-			StorageDriver: "sqlite",
-			SQLiteConfig: &SQLiteConfig{
-				Dir:    os.TempDir(),
-				DBName: uuid.New(),
-			},
-		}),
-	)
 }

--- a/pkg/storage/sqlstorage/queryable.go
+++ b/pkg/storage/sqlstorage/queryable.go
@@ -1,0 +1,12 @@
+package sqlstorage
+
+import (
+	"context"
+	"database/sql"
+)
+
+type executor interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}

--- a/pkg/storage/sqlstorage/store.go
+++ b/pkg/storage/sqlstorage/store.go
@@ -40,6 +40,9 @@ func (s *Store) DB() *sql.DB {
 }
 
 func (s *Store) error(err error) error {
+	if err == nil {
+		return nil
+	}
 	return errorFromFlavor(Flavor(s.flavor), err)
 }
 

--- a/pkg/storage/sqlstorage/store.go
+++ b/pkg/storage/sqlstorage/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/ledger/pkg/logging"
+	"github.com/pkg/errors"
 	"path"
 	"strings"
 
@@ -88,11 +89,10 @@ func (s *Store) Initialize(ctx context.Context) error {
 	for i, statement := range statements {
 		s.logger.Debug(ctx, "running statement: %s", statement)
 		_, err = s.db.ExecContext(ctx, statement)
-
 		if err != nil {
-			err = fmt.Errorf("failed to run statement %d: %w", i, err)
+			err = errors.Wrapf(s.error(err), "failed to run statement %d", i)
 			s.logger.Error(ctx, "%s", err)
-			return s.error(err)
+			return err
 		}
 	}
 

--- a/pkg/storage/sqlstorage/store.go
+++ b/pkg/storage/sqlstorage/store.go
@@ -34,6 +34,10 @@ func (s *Store) table(name string) string {
 	}
 }
 
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
 func (s *Store) error(err error) error {
 	return errorFromFlavor(Flavor(s.flavor), err)
 }

--- a/pkg/storage/sqlstorage/store_bench_test.go
+++ b/pkg/storage/sqlstorage/store_bench_test.go
@@ -1,4 +1,4 @@
-package sqlstorage
+package sqlstorage_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"github.com/numary/ledger/pkg/ledger/query"
 	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/logging"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -30,14 +31,14 @@ func BenchmarkStore(b *testing.B) {
 
 	type driverConfig struct {
 		driver     string
-		connString ConnStringResolver
+		connString sqlstorage.ConnStringResolver
 		flavor     sqlbuilder.Flavor
 	}
 	var drivers = []driverConfig{
 		{
 			driver: "sqlite3",
 			connString: func(name string) string {
-				return SQLiteFileConnString(path.Join(os.TempDir(), name))
+				return sqlstorage.SQLiteFileConnString(path.Join(os.TempDir(), name))
 			},
 			flavor: sqlbuilder.SQLite,
 		},
@@ -52,7 +53,7 @@ func BenchmarkStore(b *testing.B) {
 
 	type testingFunction struct {
 		name string
-		fn   func(b *testing.B, store *Store)
+		fn   func(b *testing.B, store *sqlstorage.Store)
 	}
 
 	for _, driver := range drivers {
@@ -91,7 +92,7 @@ func BenchmarkStore(b *testing.B) {
 					break
 				}
 
-				store, err := NewStore(ledger, driver.flavor, db, logging.DefaultLogger(), func(ctx context.Context) error {
+				store, err := sqlstorage.NewStore(ledger, driver.flavor, db, logging.DefaultLogger(), func(ctx context.Context) error {
 					return db.Close()
 				})
 				assert.NoError(b, err)
@@ -108,7 +109,7 @@ func BenchmarkStore(b *testing.B) {
 	}
 }
 
-func testBenchmarkFindTransactions(b *testing.B, store *Store) {
+func testBenchmarkFindTransactions(b *testing.B, store *sqlstorage.Store) {
 	datas := make([]core.Transaction, 0)
 	for i := 0; i < 1000; i++ {
 		datas = append(datas, core.Transaction{
@@ -148,7 +149,7 @@ func testBenchmarkFindTransactions(b *testing.B, store *Store) {
 
 }
 
-func testBenchmarkLastTransaction(b *testing.B, store *Store) {
+func testBenchmarkLastTransaction(b *testing.B, store *sqlstorage.Store) {
 	datas := make([]core.Transaction, 0)
 	count := 1000
 	for i := 0; i < count; i++ {
@@ -185,7 +186,7 @@ func testBenchmarkLastTransaction(b *testing.B, store *Store) {
 
 }
 
-func testBenchmarkAggregateVolumes(b *testing.B, store *Store) {
+func testBenchmarkAggregateVolumes(b *testing.B, store *sqlstorage.Store) {
 	datas := make([]core.Transaction, 0)
 	count := 1000
 	for i := 0; i < count; i++ {

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
+	"os"
 	"testing"
 	"time"
 )
@@ -571,6 +572,11 @@ func testGetTransaction(t *testing.T, store *sqlstorage.Store) {
 }
 
 func testTooManyClient(t *testing.T, store *sqlstorage.Store) {
+
+	if os.Getenv("NUMARY_STORAGE_POSTGRES_CONN_STRING") != "" { // Use of external server, ignore this test
+		return
+	}
+
 	for i := 0; i < ledgertesting.MaxConnections; i++ {
 		tx, err := store.DB().BeginTx(context.Background(), nil)
 		assert.NoError(t, err)

--- a/pkg/storage/sqlstorage/store_test.go
+++ b/pkg/storage/sqlstorage/store_test.go
@@ -1,4 +1,4 @@
-package sqlstorage
+package sqlstorage_test
 
 import (
 	"context"
@@ -16,6 +16,7 @@ import (
 	"github.com/numary/ledger/pkg/ledgertesting"
 	"github.com/numary/ledger/pkg/logging"
 	"github.com/numary/ledger/pkg/storage"
+	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -33,14 +34,14 @@ func TestStore(t *testing.T) {
 
 	type driverConfig struct {
 		driver     string
-		connString ConnStringResolver
+		connString sqlstorage.ConnStringResolver
 		flavor     sqlbuilder.Flavor
 	}
 	var drivers = []driverConfig{
 		{
 			driver: "sqlite3",
 			connString: func(name string) string {
-				return SQLiteFileConnString(path.Join(os.TempDir(), name))
+				return sqlstorage.SQLiteFileConnString(path.Join(os.TempDir(), name))
 			},
 			flavor: sqlbuilder.SQLite,
 		},
@@ -53,13 +54,19 @@ func TestStore(t *testing.T) {
 		},
 	}
 
-	type testingFunction struct {
-		name string
-		fn   func(t *testing.T, store storage.Store)
+	type testCase struct {
+		name       string
+		onlyDriver string
+		fn         func(t *testing.T, store *sqlstorage.Store)
 	}
 
 	for _, driver := range drivers {
-		for _, tf := range []testingFunction{
+		for _, tf := range []testCase{
+			{
+				name:       "TooManyClient",
+				fn:         testTooManyClient,
+				onlyDriver: "pgx",
+			},
 			{
 				name: "SaveTransactions",
 				fn:   testSaveTransaction,
@@ -121,11 +128,18 @@ func TestStore(t *testing.T) {
 				fn:   testMapping,
 			},
 		} {
+			if tf.onlyDriver != "" && tf.onlyDriver != driver.driver {
+				continue
+			}
 			t.Run(fmt.Sprintf("%s/%s", driver.driver, tf.name), func(t *testing.T) {
+
 				ledger := uuid.New()
 
 				db, err := sql.Open(driver.driver, driver.connString(ledger))
 				assert.NoError(t, err)
+				defer func() {
+					assert.NoError(t, db.Close())
+				}()
 
 				counter := 0
 				for {
@@ -136,13 +150,13 @@ func TestStore(t *testing.T) {
 							<-time.After(time.Second)
 							continue
 						}
-						assert.Fail(t, "timeout waiting database: %s", err)
+						assert.Fail(t, "timeout waiting database", err)
 						return
 					}
 					break
 				}
 
-				store, err := NewStore(ledger, driver.flavor, db, logging.DefaultLogger(), func(ctx context.Context) error {
+				store, err := sqlstorage.NewStore(ledger, driver.flavor, db, logging.DefaultLogger(), func(ctx context.Context) error {
 					return db.Close()
 				})
 				assert.NoError(t, err)
@@ -157,7 +171,7 @@ func TestStore(t *testing.T) {
 	}
 }
 
-func testSaveTransaction(t *testing.T, store storage.Store) {
+func testSaveTransaction(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -178,7 +192,7 @@ func testSaveTransaction(t *testing.T, store storage.Store) {
 	assert.NoError(t, err)
 }
 
-func testDuplicatedTransaction(t *testing.T, store storage.Store) {
+func testDuplicatedTransaction(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -202,13 +216,13 @@ func testDuplicatedTransaction(t *testing.T, store storage.Store) {
 	assert.Equal(t, storage.ConstraintFailed, ret[0].(*storage.Error).Code)
 }
 
-func testSaveMeta(t *testing.T, store storage.Store) {
+func testSaveMeta(t *testing.T, store *sqlstorage.Store) {
 	err := store.SaveMeta(context.Background(), 1, time.Now().Format(time.RFC3339),
 		"transaction", "1", "firstname", "\"YYY\"")
 	assert.NoError(t, err)
 }
 
-func testGetMeta(t *testing.T, store storage.Store) {
+func testGetMeta(t *testing.T, store *sqlstorage.Store) {
 	var (
 		firstname = "\"John\""
 		lastname  = "\"Doe\""
@@ -228,7 +242,7 @@ func testGetMeta(t *testing.T, store storage.Store) {
 	}, meta)
 }
 
-func testLastTransaction(t *testing.T, store storage.Store) {
+func testLastTransaction(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 0,
@@ -262,7 +276,7 @@ func testLastTransaction(t *testing.T, store storage.Store) {
 
 }
 
-func testLastMetaID(t *testing.T, store storage.Store) {
+func testLastMetaID(t *testing.T, store *sqlstorage.Store) {
 	err := store.SaveMeta(context.Background(), 0, time.Now().Format(time.RFC3339),
 		"transaction", "1", "firstname", "\"YYY\"")
 	assert.NoError(t, err)
@@ -272,7 +286,7 @@ func testLastMetaID(t *testing.T, store storage.Store) {
 	assert.EqualValues(t, 0, lastMetaId)
 }
 
-func testCountAccounts(t *testing.T, store storage.Store) {
+func testCountAccounts(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -297,7 +311,7 @@ func testCountAccounts(t *testing.T, store storage.Store) {
 
 }
 
-func testAggregateBalances(t *testing.T, store storage.Store) {
+func testAggregateBalances(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -323,7 +337,7 @@ func testAggregateBalances(t *testing.T, store storage.Store) {
 	assert.EqualValues(t, 100, balances["USD"])
 }
 
-func testAggregateVolumes(t *testing.T, store storage.Store) {
+func testAggregateVolumes(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -350,7 +364,7 @@ func testAggregateVolumes(t *testing.T, store storage.Store) {
 	assert.EqualValues(t, 100, volumes["USD"]["input"])
 }
 
-func testFindAccounts(t *testing.T, store storage.Store) {
+func testFindAccounts(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -388,7 +402,7 @@ func testFindAccounts(t *testing.T, store storage.Store) {
 	assert.Equal(t, 1, accounts.PageSize)
 }
 
-func testCountMeta(t *testing.T, store storage.Store) {
+func testCountMeta(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -420,7 +434,7 @@ func testCountMeta(t *testing.T, store storage.Store) {
 	assert.EqualValues(t, 2, countMeta)
 }
 
-func testCountTransactions(t *testing.T, store storage.Store) {
+func testCountTransactions(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 1,
@@ -448,7 +462,7 @@ func testCountTransactions(t *testing.T, store storage.Store) {
 	assert.EqualValues(t, 1, countTransactions)
 }
 
-func testFindTransactions(t *testing.T, store storage.Store) {
+func testFindTransactions(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID: 0,
@@ -512,7 +526,7 @@ func testFindTransactions(t *testing.T, store storage.Store) {
 
 }
 
-func testMapping(t *testing.T, store storage.Store) {
+func testMapping(t *testing.T, store *sqlstorage.Store) {
 
 	m := core.Mapping{
 		Contracts: []core.Contract{
@@ -544,7 +558,7 @@ func testMapping(t *testing.T, store storage.Store) {
 	assert.Len(t, mapping.Contracts, 0)
 }
 
-func testGetTransaction(t *testing.T, store storage.Store) {
+func testGetTransaction(t *testing.T, store *sqlstorage.Store) {
 	txs := []core.Transaction{
 		{
 			ID:        0,
@@ -585,5 +599,16 @@ func testGetTransaction(t *testing.T, store storage.Store) {
 	tx, err := store.GetTransaction(context.Background(), "1")
 	assert.NoError(t, err)
 	assert.Equal(t, txs[1], tx)
+}
 
+func testTooManyClient(t *testing.T, store *sqlstorage.Store) {
+	for i := 0; i < ledgertesting.MaxConnections; i++ {
+		tx, err := store.DB().BeginTx(context.Background(), nil)
+		assert.NoError(t, err)
+		defer tx.Rollback()
+	}
+	_, err := store.CountTransactions(context.Background())
+	assert.Error(t, err)
+	assert.IsType(t, new(storage.Error), err)
+	assert.Equal(t, storage.TooManyClient, err.(*storage.Error).Code)
 }

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -106,6 +106,9 @@ func (s *Store) findTransactions(ctx context.Context, exec executor, q query.Que
 		t.AppendPosting(posting)
 		transactions[txid] = t
 	}
+	if rows.Err() != nil {
+		return query.Cursor{}, s.error(rows.Err())
+	}
 
 	for _, t := range transactions {
 		meta, err := s.getMeta(ctx, exec, "transaction", fmt.Sprintf("%d", t.ID))
@@ -282,6 +285,9 @@ func (s *Store) getTransaction(ctx context.Context, exec executor, txid string) 
 
 		tx.AppendPosting(posting)
 	}
+	if rows.Err() != nil {
+		return tx, s.error(rows.Err())
+	}
 
 	meta, err := s.getMeta(ctx, exec, "transaction", fmt.Sprintf("%d", tx.ID))
 	if err != nil {
@@ -339,6 +345,9 @@ func (s *Store) lastTransaction(ctx context.Context, exec executor) (*core.Trans
 		}
 		tx.Reference = ref.String
 		tx.AppendPosting(posting)
+	}
+	if rows.Err() != nil {
+		return nil, s.error(rows.Err())
 	}
 
 	if len(tx.Postings) == 0 {

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -235,10 +235,7 @@ txLoop:
 	}
 
 	if mustRollback {
-		err = tx.Rollback()
-		if err != nil {
-			return nil, err
-		}
+		tx.Rollback()
 		return ret, storage.ErrAborted
 	}
 

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -316,7 +316,7 @@ func (s *Store) lastTransaction(ctx context.Context, exec executor) (*core.Trans
 	s.logger.Debug(ctx, sqlq)
 	rows, err := exec.QueryContext(ctx, sqlq, args...)
 	if err != nil {
-		return nil, err
+		return nil, s.error(err)
 	}
 
 	tx := core.Transaction{}
@@ -335,7 +335,7 @@ func (s *Store) lastTransaction(ctx context.Context, exec executor) (*core.Trans
 			&posting.Asset,
 		)
 		if err != nil {
-			return nil, err
+			return nil, s.error(err)
 		}
 		tx.Reference = ref.String
 		tx.AppendPosting(posting)
@@ -347,7 +347,7 @@ func (s *Store) lastTransaction(ctx context.Context, exec executor) (*core.Trans
 
 	meta, err := s.getMeta(ctx, exec, "transaction", fmt.Sprintf("%d", tx.ID))
 	if err != nil {
-		return nil, s.error(err)
+		return nil, err
 	}
 	tx.Metadata = meta
 

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -135,7 +135,10 @@ func (s *Store) FindTransactions(ctx context.Context, q query.Query) (query.Curs
 	}
 	c.Data = results
 
-	total, _ := s.CountTransactions(ctx)
+	total, err := s.CountTransactions(ctx)
+	if err != nil {
+		return c, err
+	}
 	c.Total = total
 
 	return c, nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -22,6 +22,14 @@ type Error struct {
 	OriginalError error
 }
 
+func (e Error) Is(err error) bool {
+	eerr, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+	return eerr.Code == e.Code
+}
+
 func (e Error) Error() string {
 	return fmt.Sprintf("%s [%s]", e.OriginalError, e.Code)
 }
@@ -31,6 +39,16 @@ func NewError(code Code, originalError error) *Error {
 		Code:          code,
 		OriginalError: originalError,
 	}
+}
+
+func IsError(err error, code Code) bool {
+	return errors.Is(err, &Error{
+		Code: code,
+	})
+}
+
+func IsTooManyClientError(err error) bool {
+	return IsError(err, TooManyClient)
 }
 
 type Store interface {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,6 +12,7 @@ type Code string
 
 const (
 	ConstraintFailed Code = "CONSTRAINT_FAILED"
+	TooManyClient    Code = "TOO_MANY_CLIENT"
 )
 
 var ErrAborted = errors.New("aborted transactions")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -13,6 +13,7 @@ type Code string
 const (
 	ConstraintFailed Code = "CONSTRAINT_FAILED"
 	TooManyClient    Code = "TOO_MANY_CLIENT"
+	Unknown          Code = "UNKNOWN"
 )
 
 var ErrAborted = errors.New("aborted transactions")

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -27,6 +27,9 @@ func (e Error) Is(err error) bool {
 	if !ok {
 		return false
 	}
+	if eerr.Code == "" {
+		return true
+	}
 	return eerr.Code == e.Code
 }
 
@@ -41,14 +44,18 @@ func NewError(code Code, originalError error) *Error {
 	}
 }
 
-func IsError(err error, code Code) bool {
+func IsError(err error) bool {
+	return IsErrorCode(err, "")
+}
+
+func IsErrorCode(err error, code Code) bool {
 	return errors.Is(err, &Error{
 		Code: code,
 	})
 }
 
 func IsTooManyClientError(err error) bool {
-	return IsError(err, TooManyClient)
+	return IsErrorCode(err, TooManyClient)
 }
 
 type Store interface {


### PR DESCRIPTION
- Register gin errors on BaseResponse.responseError() function. It allow opentelemetry middleware to register errors.
- Add error records on opentelemetry after a request.
- Better error handling.
- Fix error.
- Fix not handled error.
- Some error handling.
- Use common storage testing module to test ledger package.
- Allow storage test to choose the right sql engine.
- Fix tests with postgres.
- Refine errors management.
- Factorize api error management. Also convert database connection error to 503 status code.
- Show error message on api only for non internal errors.
- Add opentelemetry http.error_code allowing filter responses.
- Handle context.Cancelled errors and clean code.
- Prevent error message to be send over http response if status >= 500
- Better handle storage errors.
- Make sql storage always return storage.Error{} errors.
- Ignore rollback error.
- Refactor sql storage driver. For some methods, sql storage call itself to gain additional data. It is the case for SaveTransactions() method which call CountMeta() to generate metadata ids. But the CountMeta() was made outside of the main transaction, causing potentiel inconsistent data (mitigate by the lock on the ledger), and failed transactions.
- Optimize.
- Make context cancelled prioritary over store errors.
- Fix not handled storage error.
