### PR TITLE
Add support of claim 'scope' (https://datatracker.ietf.org/doc/html/rfc8693)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,4 @@ jobs:
             APP_SHA=${{ github.sha }}
             VERSION=${{ github.event.release.tag_name }}
             SEGMENT_WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY_OSS }}
+      - name:

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -197,6 +197,7 @@ func NewContainer(v *viper.Viper, userOptions ...fx.Option) *fx.App {
 	options = append(options, api.Module(api.Config{
 		StorageDriver: v.GetString(storageDriverFlag),
 		Version:       Version,
+		UseScopes:     viper.GetBool(authBearerUseScopesFlag),
 	}))
 
 	// Handle storage driver
@@ -248,18 +249,23 @@ func NewContainer(v *viper.Viper, userOptions ...fx.Option) *fx.App {
 		methods := make([]sharedauth.Method, 0)
 		if basicAuth := v.GetStringSlice(authBasicCredentialsFlag); len(basicAuth) > 0 &&
 			(!v.IsSet(authBasicEnabledFlag) || v.GetBool(authBasicEnabledFlag)) { // Keep compatibility, we disable the feature only if the flag is explicitely set to false
-			credentials := make(map[string]string)
+			credentials := sharedauth.Credentials{}
 			for _, kv := range basicAuth {
 				parts := strings.SplitN(kv, ":", 2)
-				credentials[parts[0]] = parts[1]
+				credentials[parts[0]] = sharedauth.Credential{
+					Password: parts[1],
+					Scopes:   routes.AllScopes,
+				}
 			}
 			methods = append(methods, sharedauth.NewHTTPBasicMethod(credentials))
 		}
 		if v.GetBool(authBearerEnabledFlag) {
 			methods = append(methods, sharedauth.NewHttpBearerMethod(
-				oauth2introspect.NewIntrospecter(v.GetString(authBearerIntrospectUrlFlag)),
-				v.GetBool(authBearerAudiencesWildcardFlag),
-				v.GetStringSlice(authBearerAudienceFlag)...,
+				sharedauth.NewIntrospectionValidator(
+					oauth2introspect.NewIntrospecter(v.GetString(authBearerIntrospectUrlFlag)),
+					v.GetBool(authBearerAudiencesWildcardFlag),
+					v.GetStringSlice(authBearerAudienceFlag)...,
+				),
 			))
 		}
 		if len(methods) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ const (
 	authBearerIntrospectUrlFlag          = "auth-bearer-introspect-url"
 	authBearerAudienceFlag               = "auth-bearer-audience"
 	authBearerAudiencesWildcardFlag      = "auth-bearer-audiences-wildcard"
+	authBearerUseScopesFlag              = "auth-bearer-use-scopes"
 
 	segmentEnabledFlag       = "segment-enabled"
 	segmentWriteKey          = "segment-write-key"
@@ -169,6 +170,7 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().String(authBearerIntrospectUrlFlag, "", "OAuth2 introspect URL")
 	root.PersistentFlags().StringSlice(authBearerAudienceFlag, []string{}, "Allowed audiences")
 	root.PersistentFlags().Bool(authBearerAudiencesWildcardFlag, false, "Don't check audience")
+	root.PersistentFlags().Bool(authBearerUseScopesFlag, false, "Use scopes as defined by rfc https://datatracker.ietf.org/doc/html/rfc8693")
 	root.PersistentFlags().Bool(segmentEnabledFlag, true, "Is segment enabled")
 	root.PersistentFlags().String(segmentApplicationId, "", "Segment application id")
 	root.PersistentFlags().String(segmentWriteKey, DefaultSegmentWriteKey, "Segment write key")

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/go-redis/redismock/v8 v8.0.6
-	github.com/numary/go-libs v0.0.0-20220424155450-f2a5122cde41
+	github.com/numary/go-libs v0.0.0-20220511113055-4f47b504fa62
 	github.com/uptrace/opentelemetry-go-extra/otellogrus v0.1.12
 	github.com/xdg-go/scram v1.1.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.sum
+++ b/go.sum
@@ -696,6 +696,10 @@ github.com/numary/go-libs v0.0.0-20220422182305-6598727372a6 h1:KozADR0nMPNpg/u1
 github.com/numary/go-libs v0.0.0-20220422182305-6598727372a6/go.mod h1:Kdz30gnijNv6cdZyB64ipJsa9gm9hFEu8XMGULwogc8=
 github.com/numary/go-libs v0.0.0-20220424155450-f2a5122cde41 h1:zFaCXPmstdDxn3BYdlejrFrEmBzvbEM7Jq3YwGRQzHQ=
 github.com/numary/go-libs v0.0.0-20220424155450-f2a5122cde41/go.mod h1:7StJNTZ3QbU2uBWpOeryPaHD6xMYUN8AWXWTjP67kv0=
+github.com/numary/go-libs v0.0.0-20220511093922-3a351dedf00c h1:8dH7Gg+iNL7VEGcydF4rw/WFb7y94yTjNTdVbNjYTfA=
+github.com/numary/go-libs v0.0.0-20220511093922-3a351dedf00c/go.mod h1:7StJNTZ3QbU2uBWpOeryPaHD6xMYUN8AWXWTjP67kv0=
+github.com/numary/go-libs v0.0.0-20220511113055-4f47b504fa62 h1:Wc4FFjF9veiiBTnuqpeSqnX09Ek39zxgta1RceZZaOw=
+github.com/numary/go-libs v0.0.0-20220511113055-4f47b504fa62/go.mod h1:7StJNTZ3QbU2uBWpOeryPaHD6xMYUN8AWXWTjP67kv0=
 github.com/numary/ledger v0.0.0-20210702172952-a5bd30e551d0/go.mod h1:u2K28z9TDYd6id1qeD2uv7JDlajuRZ0fvOnCeDZmDxk=
 github.com/numary/ledger v0.0.0-20211227131550-dc7b78f85b5b/go.mod h1:uovuDsK7Gs7duqKQ9PgaFulJnPTDftGdR/n3rBRzNIs=
 github.com/numary/machine v0.0.0-20210702091459-23a82555adbf/go.mod h1:WAFvefAGYNjdDmPtDoZ305F58QDtUJyB0QWN3vzSZao=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -34,6 +34,7 @@ func NewAPI(
 type Config struct {
 	StorageDriver string
 	Version       string
+	UseScopes     bool
 }
 
 func Module(cfg Config) fx.Option {
@@ -45,5 +46,6 @@ func Module(cfg Config) fx.Option {
 		routes.Module,
 		controllers.Module,
 		fx.Provide(NewAPI),
+		fx.Supply(routes.UseScopes(cfg.UseScopes)),
 	)
 }


### PR DESCRIPTION
This introduce following scopes :
* transactions:read
* transactions:write
* accounts:read
* accounts:write
* mapping:read
* mapping:write
* stats

The feature has to be enabled.
If enabled, the server will search for claim 'scope' inside jwt access token. It will reject the requests if scopes are insufficients.
