### PR TITLE
refactor: volumes aggregation

### DIFF
--- a/pkg/api/controllers/transaction_controller.go
+++ b/pkg/api/controllers/transaction_controller.go
@@ -170,7 +170,7 @@ func (ctl *TransactionController) PostTransaction(c *gin.Context) {
 		status = http.StatusNotModified
 	}
 
-	respondWithData[[]core.ExpandedTransaction](c, status, res.GeneratedTransactions)
+	respondWithData[[]core.ExpandedTransaction](c, status, res)
 }
 
 func (ctl *TransactionController) GetTransaction(c *gin.Context) {
@@ -259,5 +259,5 @@ func (ctl *TransactionController) PostTransactionsBatch(c *gin.Context) {
 		return
 	}
 
-	respondWithData[[]core.ExpandedTransaction](c, http.StatusOK, res.GeneratedTransactions)
+	respondWithData[[]core.ExpandedTransaction](c, http.StatusOK, res)
 }

--- a/pkg/bus/monitor.go
+++ b/pkg/bus/monitor.go
@@ -37,14 +37,15 @@ func LedgerMonitorModule() fx.Option {
 	)
 }
 
-func (l *ledgerMonitor) CommittedTransactions(ctx context.Context, ledger string, res *ledger.CommitResult) {
+func (l *ledgerMonitor) CommittedTransactions(ctx context.Context, ledger string, txs ...core.ExpandedTransaction) {
+	postCommitVolumes := core.AggregatePostCommitVolumes(txs...)		
 	l.publish(ctx, EventTypeCommittedTransactions,
 		newEventCommittedTransactions(CommittedTransactions{
 			Ledger:            ledger,
-			Transactions:      res.GeneratedTransactions,
-			Volumes:           res.PostCommitVolumes,
-			PostCommitVolumes: res.PostCommitVolumes,
-			PreCommitVolumes:  res.PreCommitVolumes,
+			Transactions:      txs,
+			Volumes:           postCommitVolumes,
+			PostCommitVolumes: postCommitVolumes,
+			PreCommitVolumes:  core.AggregatePreCommitVolumes(txs...),
 		}))
 }
 

--- a/pkg/bus/monitor_test.go
+++ b/pkg/bus/monitor_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 	"github.com/numary/go-libs/sharedpublish"
-	"github.com/numary/ledger/pkg/ledger"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,7 +28,7 @@ func TestMonitor(t *testing.T) {
 		"*": "testing",
 	})
 	m := NewLedgerMonitor(p)
-	go m.CommittedTransactions(context.Background(), uuid.New(), &ledger.CommitResult{})
+	go m.CommittedTransactions(context.Background(), uuid.New())
 
 	select {
 	case m := <-messages:

--- a/pkg/ledger/executor.go
+++ b/pkg/ledger/executor.go
@@ -133,7 +133,7 @@ func (l *Ledger) Execute(ctx context.Context, script core.Script) (*core.Expande
 		return nil, err
 	}
 
-	return &res.GeneratedTransactions[0], nil
+	return &res[0], nil
 }
 
 func (l *Ledger) ExecutePreview(ctx context.Context, script core.Script) (*core.ExpandedTransaction, error) {
@@ -147,5 +147,5 @@ func (l *Ledger) ExecutePreview(ctx context.Context, script core.Script) (*core.
 		return nil, err
 	}
 
-	return &res.GeneratedTransactions[0], nil
+	return &res[0], nil
 }

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -303,8 +303,10 @@ func TestTransactionExpectedVolumes(t *testing.T) {
 		}
 
 		res, err := l.Commit(context.Background(), batch)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.NotNil(t, res)
 
+		postCommitVolumes := core.AggregatePostCommitVolumes(res...)
 		assert.EqualValues(t, core.AccountsAssetsVolumes{
 			"world": core.AssetsVolumes{
 				"USD": {
@@ -332,7 +334,7 @@ func TestTransactionExpectedVolumes(t *testing.T) {
 					Output: core.NewMonetaryInt(0),
 				},
 			},
-		}, res.PostCommitVolumes)
+		}, postCommitVolumes)
 	})
 }
 
@@ -565,7 +567,7 @@ func TestRevertTransaction(t *testing.T) {
 
 		originalBal := world.Balances["COIN"]
 
-		revertTx, err := l.RevertTransaction(context.Background(), res.GeneratedTransactions[0].ID)
+		revertTx, err := l.RevertTransaction(context.Background(), res[0].ID)
 		require.NoError(t, err)
 
 		require.Equal(t, core.Postings{
@@ -577,10 +579,10 @@ func TestRevertTransaction(t *testing.T) {
 			},
 		}, revertTx.TransactionData.Postings)
 
-		require.EqualValues(t, fmt.Sprintf("%d", res.GeneratedTransactions[0].ID),
+		require.EqualValues(t, fmt.Sprintf("%d", res[0].ID),
 			revertTx.Metadata[core.RevertMetadataSpecKey()])
 
-		tx, err := l.GetTransaction(context.Background(), res.GeneratedTransactions[0].ID)
+		tx, err := l.GetTransaction(context.Background(), res[0].ID)
 		require.NoError(t, err)
 
 		v := core.RevertedMetadataSpecValue{}

--- a/pkg/ledger/monitor.go
+++ b/pkg/ledger/monitor.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Monitor interface {
-	CommittedTransactions(ctx context.Context, ledger string, res *CommitResult)
+	CommittedTransactions(ctx context.Context, ledger string, res ...core.ExpandedTransaction)
 	SavedMetadata(ctx context.Context, ledger, targetType, id string, metadata core.Metadata)
 	UpdatedMapping(ctx context.Context, ledger string, mapping core.Mapping)
 	RevertedTransaction(ctx context.Context, ledger string, reverted, revert *core.ExpandedTransaction)
@@ -17,8 +17,8 @@ type noOpMonitor struct{}
 
 var _ Monitor = &noOpMonitor{}
 
-func (n noOpMonitor) CommittedTransactions(context.Context, string, *CommitResult)         {}
-func (n noOpMonitor) SavedMetadata(context.Context, string, string, string, core.Metadata) {}
-func (n noOpMonitor) UpdatedMapping(context.Context, string, core.Mapping)                 {}
+func (n noOpMonitor) CommittedTransactions(context.Context, string, ...core.ExpandedTransaction) {}
+func (n noOpMonitor) SavedMetadata(context.Context, string, string, string, core.Metadata)       {}
+func (n noOpMonitor) UpdatedMapping(context.Context, string, core.Mapping)                       {}
 func (n noOpMonitor) RevertedTransaction(context.Context, string, *core.ExpandedTransaction, *core.ExpandedTransaction) {
 }

--- a/pkg/ledger/process_test.go
+++ b/pkg/ledger/process_test.go
@@ -136,8 +136,10 @@ func TestLedger_processTx(t *testing.T) {
 				res, err := l.processTx(context.Background(), txsData)
 				assert.NoError(t, err)
 
-				assert.Equal(t, expectedPreCommitVol, res.PreCommitVolumes)
-				assert.Equal(t, expectedPostCommitVol, res.PostCommitVolumes)
+				preCommitVolumes := core.AggregatePreCommitVolumes(res...)
+				postCommitVolumes := core.AggregatePostCommitVolumes(res...)
+				assert.Equal(t, expectedPreCommitVol, preCommitVolumes)
+				assert.Equal(t, expectedPostCommitVol, postCommitVolumes)
 
 				expectedTxs := []core.ExpandedTransaction{{
 					Transaction: core.Transaction{
@@ -147,7 +149,7 @@ func TestLedger_processTx(t *testing.T) {
 					PreCommitVolumes:  expectedPreCommitVol,
 					PostCommitVolumes: expectedPostCommitVol,
 				}}
-				assert.Equal(t, expectedTxs, res.GeneratedTransactions)
+				assert.Equal(t, expectedTxs, res)
 			})
 
 			t.Run("multi transactions single postings", func(t *testing.T) {
@@ -182,8 +184,10 @@ func TestLedger_processTx(t *testing.T) {
 				res, err := l.processTx(context.Background(), txsData)
 				assert.NoError(t, err)
 
-				assert.Equal(t, expectedPreCommitVol, res.PreCommitVolumes)
-				assert.Equal(t, expectedPostCommitVol, res.PostCommitVolumes)
+				preCommitVolumes := core.AggregatePreCommitVolumes(res...)
+				postCommitVolumes := core.AggregatePostCommitVolumes(res...)
+				assert.Equal(t, expectedPreCommitVol, preCommitVolumes)
+				assert.Equal(t, expectedPostCommitVol, postCommitVolumes)
 
 				expectedTxs := []core.ExpandedTransaction{
 					{
@@ -288,18 +292,14 @@ func TestLedger_processTx(t *testing.T) {
 					},
 				}
 
-				assert.Equal(t, expectedTxs, res.GeneratedTransactions)
+				assert.Equal(t, expectedTxs, res)
 			})
 		})
 
 		t.Run("no transactions", func(t *testing.T) {
 			result, err := l.processTx(context.Background(), []core.TransactionData{})
 			assert.NoError(t, err)
-			assert.Equal(t, &CommitResult{
-				PreCommitVolumes:      core.AccountsAssetsVolumes{},
-				PostCommitVolumes:     core.AccountsAssetsVolumes{},
-				GeneratedTransactions: []core.ExpandedTransaction{},
-			}, result)
+			assert.Equal(t, []core.ExpandedTransaction{}, result)
 		})
 
 		t.Run("date in the past", func(t *testing.T) {

--- a/pkg/ledger/volume_agg_test.go
+++ b/pkg/ledger/volume_agg_test.go
@@ -140,7 +140,7 @@ func TestVolumeAggregator(t *testing.T) {
 							Output: core.NewMonetaryInt(0),
 						},
 					},
-				}, firstTx.postCommitVolumes())
+				}, firstTx.postCommitVolumes)
 				require.Equal(t, core.AccountsAssetsVolumes{
 					"bob": core.AssetsVolumes{
 						"USD": {
@@ -160,7 +160,7 @@ func TestVolumeAggregator(t *testing.T) {
 							Output: core.NewMonetaryInt(0),
 						},
 					},
-				}, firstTx.preCommitVolumes())
+				}, firstTx.preCommitVolumes)
 
 				secondTx := volumeAggregator.nextTx()
 				require.NoError(t, secondTx.transfer(context.Background(), "alice", "fred", "USD", core.NewMonetaryInt(50)))
@@ -184,7 +184,7 @@ func TestVolumeAggregator(t *testing.T) {
 							Output: core.NewMonetaryInt(0),
 						},
 					},
-				}, secondTx.postCommitVolumes())
+				}, secondTx.postCommitVolumes)
 				require.Equal(t, core.AccountsAssetsVolumes{
 					"bob": core.AssetsVolumes{
 						"USD": {
@@ -204,63 +204,7 @@ func TestVolumeAggregator(t *testing.T) {
 							Output: core.NewMonetaryInt(0),
 						},
 					},
-				}, secondTx.preCommitVolumes())
-
-				aggregatedPostVolumes := volumeAggregator.aggregatedPostCommitVolumes()
-				require.Equal(t, core.AccountsAssetsVolumes{
-					"bob": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(0),
-							Output: core.NewMonetaryInt(275),
-						},
-					},
-					"alice": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(200),
-							Output: core.NewMonetaryInt(50),
-						},
-					},
-					"fred": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(75),
-							Output: core.NewMonetaryInt(0),
-						},
-					},
-					"zoro": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(50),
-							Output: core.NewMonetaryInt(0),
-						},
-					},
-				}, aggregatedPostVolumes)
-
-				aggregatedPreVolumes := volumeAggregator.aggregatedPreCommitVolumes()
-				require.Equal(t, core.AccountsAssetsVolumes{
-					"bob": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(0),
-							Output: core.NewMonetaryInt(100),
-						},
-					},
-					"alice": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(100),
-							Output: core.NewMonetaryInt(0),
-						},
-					},
-					"fred": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(0),
-							Output: core.NewMonetaryInt(0),
-						},
-					},
-					"zoro": core.AssetsVolumes{
-						"USD": {
-							Input:  core.NewMonetaryInt(0),
-							Output: core.NewMonetaryInt(0),
-						},
-					},
-				}, aggregatedPreVolumes)
+				}, secondTx.preCommitVolumes)
 
 				return nil
 			},


### PR DESCRIPTION
Remove post commit volumes and pre commit volumes calculation from transaction batches.
Aggregation is provided by the core using functions AggregatePostCommitVolumes() and AggregatePreCommitVolumes().
This simplify a bit the transaction processing and remove duplicate codes.