### PR TITLE
fix: SQLite: GetTransactions account filters should be a ^{...}$ regex

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -473,20 +473,20 @@ paths:
             example: ref:001
         - name: account
           in: query
-          description: Find transactions with postings involving given account, either
-            as source or destination.
+          description: Filter transactions with postings involving given account, either
+            as source or destination (regular expression placed between ^ and $).
           schema:
             type: string
             example: users:001
         - name: source
           in: query
-          description: Find transactions with postings involving given account at source.
+          description: Filter transactions with postings involving given account at source (regular expression placed between ^ and $).
           schema:
             type: string
             example: users:001
         - name: destination
           in: query
-          description: Find transactions with postings involving given account at destination.
+          description: Filter transactions with postings involving given account at destination (regular expression placed between ^ and $).
           schema:
             type: string
             example: users:001

--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -554,13 +554,22 @@ func TestGetTransactions(t *testing.T) {
 					require.Equal(t, cursor.Data[1].ID, uint64(0))
 				})
 
-				t.Run("account filter should be exact", func(t *testing.T) {
+				t.Run("account no result", func(t *testing.T) {
 					rsp = internal.GetTransactions(api, url.Values{
 						"account": []string{"central"},
 					})
 					require.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.ExpandedTransaction](t, rsp.Body)
 					require.Len(t, cursor.Data, 0)
+				})
+
+				t.Run("account regex expr", func(t *testing.T) {
+					rsp = internal.GetTransactions(api, url.Values{
+						"account": []string{"central.*"},
+					})
+					require.Equal(t, http.StatusOK, rsp.Result().StatusCode)
+					cursor := internal.DecodeCursorResponse[core.ExpandedTransaction](t, rsp.Body)
+					require.Len(t, cursor.Data, 3)
 				})
 
 				t.Run("time range", func(t *testing.T) {

--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -554,6 +554,15 @@ func TestGetTransactions(t *testing.T) {
 					require.Equal(t, cursor.Data[1].ID, uint64(0))
 				})
 
+				t.Run("account filter should be exact", func(t *testing.T) {
+					rsp = internal.GetTransactions(api, url.Values{
+						"account": []string{"central"},
+					})
+					require.Equal(t, http.StatusOK, rsp.Result().StatusCode)
+					cursor := internal.DecodeCursorResponse[core.ExpandedTransaction](t, rsp.Body)
+					require.Len(t, cursor.Data, 0)
+				})
+
 				t.Run("time range", func(t *testing.T) {
 					rsp = internal.GetTransactions(api, url.Values{
 						"start_time": []string{tx1Timestamp.Format(time.RFC3339)},

--- a/pkg/storage/sqlstorage/sqlite.go
+++ b/pkg/storage/sqlstorage/sqlite.go
@@ -56,13 +56,17 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account", func(v string, act string) (bool, error) {
+				r, err := regexp.Compile("^" + act + "$")
+				if err != nil {
+					return false, err
+				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if act == p.Source || act == p.Destination {
+					if r.MatchString(p.Source) || r.MatchString(p.Destination) {
 						return true, nil
 					}
 				}
@@ -72,13 +76,17 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account_as_source", func(v string, act string) (bool, error) {
+				r, err := regexp.Compile("^" + act + "$")
+				if err != nil {
+					return false, err
+				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if act == p.Source {
+					if r.MatchString(p.Source) {
 						return true, nil
 					}
 				}
@@ -88,13 +96,17 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account_as_destination", func(v string, act string) (bool, error) {
+				r, err := regexp.Compile("^" + act + "$")
+				if err != nil {
+					return false, err
+				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if act == p.Destination {
+					if r.MatchString(p.Destination) {
 						return true, nil
 					}
 				}

--- a/pkg/storage/sqlstorage/sqlite.go
+++ b/pkg/storage/sqlstorage/sqlite.go
@@ -56,17 +56,13 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account", func(v string, act string) (bool, error) {
-				r, err := regexp.Compile(act)
-				if err != nil {
-					return false, err
-				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if r.MatchString(p.Source) || r.MatchString(p.Destination) {
+					if act == p.Source || act == p.Destination {
 						return true, nil
 					}
 				}
@@ -76,17 +72,13 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account_as_source", func(v string, act string) (bool, error) {
-				r, err := regexp.Compile(act)
-				if err != nil {
-					return false, err
-				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if r.MatchString(p.Source) {
+					if act == p.Source {
 						return true, nil
 					}
 				}
@@ -96,17 +88,13 @@ func init() {
 				return err
 			}
 			err = conn.RegisterFunc("use_account_as_destination", func(v string, act string) (bool, error) {
-				r, err := regexp.Compile(act)
-				if err != nil {
-					return false, err
-				}
 				postings := core.Postings{}
 				err = json.Unmarshal([]byte(v), &postings)
 				if err != nil {
 					return false, nil
 				}
 				for _, p := range postings {
-					if r.MatchString(p.Destination) {
+					if act == p.Destination {
 						return true, nil
 					}
 				}

--- a/pkg/storage/sqlstorage/store_ledger_test.go
+++ b/pkg/storage/sqlstorage/store_ledger_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/numary/go-libs/sharedlogging"
 	"github.com/numary/go-libs/sharedlogging/sharedlogginglogrus"
 	"github.com/numary/ledger/internal/pgtesting"
@@ -288,7 +287,6 @@ func testIKS(t *testing.T, store *sqlstorage.Store) {
 	})
 	t.Run("Not found", func(t *testing.T) {
 		_, err := store.ReadIK(context.Background(), uuid.New())
-		spew.Dump(err)
 		require.Equal(t, idempotency.ErrIKNotFound, err)
 	})
 }


### PR DESCRIPTION
# fix: SQLite: GetTransactions account filters should be a ^{...}$ regex

Postgres is using ^{...}$ regex for its account filters, but not SQLite.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Technical debt