### PR TITLE
fix(docker-compose): cannot start control ui

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   control:
     image: "ghcr.io/formancehq/ledger:latest"
-    command: numary ui
+    command: ui
     depends_on:
       ledger:
         condition: service_healthy


### PR DESCRIPTION
It was executing `numary numary ui` whereas the correct command is `numary ui`