### PR TITLE
fix: ledger lock

### DIFF
--- a/cmd/container.go
+++ b/cmd/container.go
@@ -120,10 +120,6 @@ func NewContainer(v *viper.Viper, userOptions ...fx.Option) *fx.App {
 	}
 
 	switch v.GetString(lockStrategyFlag) {
-	case "memory":
-		options = append(options, ledger.MemoryLockModule())
-	case "none":
-		options = append(options, ledger.NoLockModule())
 	case "redis":
 		var tlsConfig *tls.Config
 		if v.GetBool(lockStrategyRedisTLSEnabledFlag) {

--- a/cmd/container_test.go
+++ b/cmd/container_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/numary/go-libs/sharedotlp/pkg/sharedotlpmetrics"
 	"github.com/numary/go-libs/sharedotlp/pkg/sharedotlptraces"
 	"github.com/numary/ledger/internal/pgtesting"
+	"github.com/numary/ledger/pkg/api/middlewares"
 	"github.com/numary/ledger/pkg/bus"
 	"github.com/numary/ledger/pkg/core"
 	"github.com/numary/ledger/pkg/ledger"
+	"github.com/numary/ledger/pkg/redis"
 	"github.com/numary/ledger/pkg/storage"
 	"github.com/numary/ledger/pkg/storage/sqlstorage"
 	"github.com/pborman/uuid"
@@ -200,17 +202,10 @@ func TestContainers(t *testing.T) {
 				v.Set(lockStrategyRedisUrlFlag, "redis://redis:6789")
 			},
 			options: []fx.Option{
-				fx.Invoke(func(lc fx.Lifecycle, resolver *ledger.Resolver) {
+				fx.Invoke(func(lc fx.Lifecycle, resolver *ledger.Resolver, locker middlewares.Locker) {
 					lc.Append(fx.Hook{
 						OnStart: func(ctx context.Context) error {
-							l, err := resolver.GetLedger(ctx, uuid.New())
-							if err != nil {
-								return err
-							}
-							_, err = l.Commit(ctx, nil)
-							if !ledger.IsLockError(err) { // No redis in test, it should trigger a lock error
-								return err
-							}
+							require.IsType(t, locker, &redis.Lock{})
 							return nil
 						},
 					})

--- a/pkg/api/middlewares/lock.go
+++ b/pkg/api/middlewares/lock.go
@@ -1,4 +1,4 @@
-package ledger
+package middlewares
 
 import (
 	"context"

--- a/pkg/api/middlewares/module.go
+++ b/pkg/api/middlewares/module.go
@@ -6,4 +6,7 @@ import (
 
 var Module = fx.Options(
 	fx.Provide(NewLedgerMiddleware),
+	fx.Provide(func() Locker {
+		return NewInMemoryLocker()
+	}),
 )

--- a/pkg/ledger/ledger_test.go
+++ b/pkg/ledger/ledger_test.go
@@ -70,7 +70,7 @@ func runOnLedger(f func(l *ledger.Ledger), ledgerOptions ...ledger.LedgerOption)
 				if err != nil {
 					return err
 				}
-				l, err := ledger.NewLedger(store, ledger.NewInMemoryLocker(), ledger.NewNoOpMonitor(), ledgerOptions...)
+				l, err := ledger.NewLedger(store, ledger.NewNoOpMonitor(), ledgerOptions...)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/redis/lock.go
+++ b/pkg/redis/lock.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/numary/go-libs/sharedlogging"
-	"github.com/numary/ledger/pkg/ledger"
+	"github.com/numary/ledger/pkg/api/middlewares"
 	"github.com/pkg/errors"
 )
 
@@ -41,7 +41,7 @@ type Lock struct {
 	retry        time.Duration
 }
 
-func (l Lock) tryLock(ctx context.Context, name string) (bool, ledger.Unlock, error) {
+func (l Lock) tryLock(ctx context.Context, name string) (bool, middlewares.Unlock, error) {
 	rv, err := randomString()
 	if err != nil {
 		return false, nil, errors.Wrap(err, "generating random string")
@@ -77,7 +77,7 @@ func (l Lock) tryLock(ctx context.Context, name string) (bool, ledger.Unlock, er
 	}, nil
 }
 
-func (l Lock) Lock(ctx context.Context, name string) (ledger.Unlock, error) {
+func (l Lock) Lock(ctx context.Context, name string) (middlewares.Unlock, error) {
 	for {
 		ok, unlock, err := l.tryLock(ctx, name)
 		if err != nil {
@@ -95,7 +95,7 @@ func (l Lock) Lock(ctx context.Context, name string) (ledger.Unlock, error) {
 	}
 }
 
-var _ ledger.Locker = &Lock{}
+var _ middlewares.Locker = &Lock{}
 
 func NewLock(client Client, lockDuration, retry time.Duration) *Lock {
 	return &Lock{

--- a/pkg/redis/module.go
+++ b/pkg/redis/module.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/numary/ledger/pkg/ledger"
+	"github.com/numary/ledger/pkg/api/middlewares"
 	"go.uber.org/fx"
 )
 
@@ -39,12 +39,12 @@ func Module(cfg Config) fx.Option {
 			options.TLSConfig = cfg.TLSConfig
 			return redis.NewClient(options), nil
 		}),
-		ledger.ProvideResolverOption(func(redisClient Client) ledger.ResolverOption {
-			return ledger.WithLocker(NewLock(
+		fx.Decorate(func(redisClient Client) middlewares.Locker {
+			return NewLock(
 				redisClient,
 				cfg.LockDuration,
 				cfg.LockRetry,
-			))
+			)
 		}),
 	)
 }

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/go-libs/sharedapi"
 	"github.com/numary/go-libs/sharedlogging"
@@ -331,6 +332,7 @@ func (s *Store) insertTransactions(ctx context.Context, txs ...core.ExpandedTran
 				sources, destinations)
 		}
 		query, args = ib.BuildWithFlavor(s.schema.Flavor())
+		spew.Dump(query, args)
 	case sqlbuilder.PostgreSQL:
 		ids := make([]uint64, len(txs))
 		timestamps := make([]time.Time, len(txs))
@@ -415,11 +417,13 @@ func (s *Store) insertTransactions(ctx context.Context, txs ...core.ExpandedTran
 
 	sharedlogging.GetLogger(ctx).Debugf("ExecContext: %s %s", query, args)
 
+	fmt.Println("get provider")
 	executor, err := s.executorProvider(ctx)
 	if err != nil {
 		return err
 	}
 
+	fmt.Println(query, args)
 	_, err = executor.ExecContext(ctx, query, args...)
 	if err != nil {
 		return s.error(err)

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/numary/go-libs/sharedapi"
 	"github.com/numary/go-libs/sharedlogging"
@@ -332,7 +331,6 @@ func (s *Store) insertTransactions(ctx context.Context, txs ...core.ExpandedTran
 				sources, destinations)
 		}
 		query, args = ib.BuildWithFlavor(s.schema.Flavor())
-		spew.Dump(query, args)
 	case sqlbuilder.PostgreSQL:
 		ids := make([]uint64, len(txs))
 		timestamps := make([]time.Time, len(txs))
@@ -417,13 +415,11 @@ func (s *Store) insertTransactions(ctx context.Context, txs ...core.ExpandedTran
 
 	sharedlogging.GetLogger(ctx).Debugf("ExecContext: %s %s", query, args)
 
-	fmt.Println("get provider")
 	executor, err := s.executorProvider(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(query, args)
 	_, err = executor.ExecContext(ctx, query, args...)
 	if err != nil {
 		return s.error(err)


### PR DESCRIPTION
Due to new idempotency feature, sql transactions has been moved at upper level (request).
So, the lock used by the ledger to lock writes was released before sql transaction commit.

This changes invert that by moving the ledger lock at api level.
