### PR TITLE
fix: 'account' filter on GET /transactions using old method

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -746,6 +746,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
+github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -45,12 +45,7 @@ func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder
 		"post_commit_volumes",
 	).Distinct()
 	sb.From(s.schema.Table("transactions"))
-	if account != "" {
-		arg := sb.Args.Add(account)
-		sb.Where(s.schema.Table("use_account") + "(postings, " + arg + ")")
-		t.AccountFilter = account
-	}
-	if (source != "" || destination != "") && s.schema.Flavor() == sqlbuilder.PostgreSQL {
+	if (source != "" || destination != "" || account != "") && s.schema.Flavor() == sqlbuilder.PostgreSQL {
 		// new wildcard handling
 		sb.Join(fmt.Sprintf(
 			"%s postings on postings.txid = %s.id",
@@ -96,6 +91,26 @@ func (s *Store) buildTransactionsQuery(p storage.TransactionsQuery) (*sqlbuilder
 
 				arg := sb.Args.Add(segment)
 				sb.Where(fmt.Sprintf("postings.destination @@ ('$[%d] == \"' || %s::text || '\"')::jsonpath", i, arg))
+			}
+		}
+	}
+	if account != "" {
+		if !addressQueryRegexp.MatchString(account) || s.schema.Flavor() == sqlbuilder.SQLite {
+			// deprecated regex handling
+			arg := sb.Args.Add(account)
+			sb.Where(s.schema.Table("use_account") + "(postings, " + arg + ")")
+			t.AccountFilter = account
+		} else {
+			// new wildcard handling
+			dst := strings.Split(account, ":")
+			sb.Where(fmt.Sprintf("(jsonb_array_length(postings.destination) = %d OR jsonb_array_length(postings.source) = %d)", len(dst), len(dst)))
+			for i, segment := range dst {
+				if segment == ".*" || segment == "*" || segment == "" {
+					continue
+				}
+
+				arg := sb.Args.Add(segment)
+				sb.Where(fmt.Sprintf("(postings.source @@ ('$[%d] == \"' || %s::text || '\"')::jsonpath OR postings.destination @@ ('$[%d] == \"' || %s::text || '\"')::jsonpath)", i, arg, i, arg))
 			}
 		}
 	}


### PR DESCRIPTION
# Fix missing filter

A previous PR had a new way to filter accounts which improved performances when querying the /transactions endpoint using 'source' and 'destination' filters.
This PR add the same mechanism for 'account' filter.
