### PR TITLE
fix(sdk): fix generation by reverting openapi specification version upgrade

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   title: Ledger API
   contact: {}


### PR DESCRIPTION
# SDK generation

A previous PR upgraded the openapi specification version, breaking sdk generation.
We should later investigate on the issue to be able to upgrade versions.
But, right now, just revert the change.