### PR TITLE
fix: POST /transactions without any postings

### DIFF
--- a/pkg/api/controllers/transaction_controller_test.go
+++ b/pkg/api/controllers/transaction_controller_test.go
@@ -425,6 +425,21 @@ func TestPostTransactions(t *testing.T) {
 			},
 		},
 		{
+			name: "script failure with no postings",
+			payload: []controllers.PostTransaction{{
+				Script: core.Script{
+					Plain: `
+					set_account_meta(@bar, "foo", "bar")
+					`,
+				},
+			}},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedErr: apierrors.ErrorResponse{
+				ErrorCode:    apierrors.ErrValidation,
+				ErrorMessage: "transaction has no postings",
+			},
+		},
+		{
 			name: "postings and script",
 			payload: []controllers.PostTransaction{{
 				Postings: core.Postings{

--- a/pkg/ledger/executor.go
+++ b/pkg/ledger/executor.go
@@ -23,6 +23,13 @@ func (l *Ledger) Execute(ctx context.Context, preview bool, scripts ...core.Scri
 		return []core.ExpandedTransaction{}, err
 	}
 
+	for _, txData := range txsData {
+		if len(txData.Postings) == 0 {
+			return []core.ExpandedTransaction{},
+				NewValidationError("transaction has no postings")
+		}
+	}
+
 	txs, err := l.Commit(ctx, preview, addOps, txsData...)
 	if err != nil {
 		return []core.ExpandedTransaction{}, err


### PR DESCRIPTION
Fixing a specific case where the payload of POST /transaction shouldn't be committed:
- no postings
- a script that hasn't any `send` instructions