### PR TITLE
chore: Deprecate query params and switch to camelCase

### DIFF
--- a/pkg/api/controllers/account_controller.go
+++ b/pkg/api/controllers/account_controller.go
@@ -46,8 +46,10 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 			c.Query("address") != "" ||
 			len(c.QueryMap("metadata")) > 0 ||
 			c.Query("balance") != "" ||
-			c.Query("balance_operator") != "" ||
-			c.Query("page_size") != "" {
+			c.Query(QueryKeyBalanceOperator) != "" ||
+			c.Query(QueryKeyBalanceOperatorDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursor)))
 			return
@@ -81,8 +83,10 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 			c.Query("address") != "" ||
 			len(c.QueryMap("metadata")) > 0 ||
 			c.Query("balance") != "" ||
-			c.Query("balance_operator") != "" ||
-			c.Query("page_size") != "" {
+			c.Query(QueryKeyBalanceOperator) != "" ||
+			c.Query(QueryKeyBalanceOperatorDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursorDeprecated)))
 			return
@@ -121,14 +125,10 @@ func (ctl *AccountController) GetAccounts(c *gin.Context) {
 			}
 		}
 
-		var balanceOperator = ledger.DefaultBalanceOperator
-		if balanceOperatorStr := c.Query("balance_operator"); balanceOperatorStr != "" {
-			var ok bool
-			if balanceOperator, ok = ledger.NewBalanceOperator(balanceOperatorStr); !ok {
-				apierrors.ResponseError(c, ledger.NewValidationError(
-					"invalid parameter 'balance_operator', should be one of 'e, gt, gte, lt, lte'"))
-				return
-			}
+		balanceOperator, err := getBalanceOperator(c)
+		if err != nil {
+			apierrors.ResponseError(c, err)
+			return
 		}
 
 		pageSize, err := getPageSize(c)

--- a/pkg/api/controllers/account_controller_test.go
+++ b/pkg/api/controllers/account_controller_test.go
@@ -168,13 +168,6 @@ func TestGetAccounts(t *testing.T) {
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				})
 
-				t.Run(fmt.Sprintf("valid empty %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetAccounts(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
-					})
-					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
-				})
-
 				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
 						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
@@ -189,23 +182,6 @@ func TestGetAccounts(t *testing.T) {
 						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
 						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
-					}, err)
-				})
-
-				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetAccounts(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
-						"after":                              []string{"bob"},
-					})
-					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
-
-					err := sharedapi.ErrorResponse{}
-					internal.Decode(t, rsp.Body, &err)
-					assert.EqualValues(t, sharedapi.ErrorResponse{
-						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
-						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 
@@ -225,22 +201,6 @@ func TestGetAccounts(t *testing.T) {
 					}, err)
 				})
 
-				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetAccounts(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{"invalid"},
-					})
-					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
-
-					err := sharedapi.ErrorResponse{}
-					internal.Decode(t, rsp.Body, &err)
-					assert.EqualValues(t, sharedapi.ErrorResponse{
-						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
-						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
-					}, err)
-				})
-
 				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
 						controllers.QueryKeyCursor: []string{"\n*@"},
@@ -254,22 +214,6 @@ func TestGetAccounts(t *testing.T) {
 						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
 						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
-					}, err)
-				})
-
-				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetAccounts(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{"\n*@"},
-					})
-					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
-
-					err := sharedapi.ErrorResponse{}
-					internal.Decode(t, rsp.Body, &err)
-					assert.EqualValues(t, sharedapi.ErrorResponse{
-						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
-						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 
@@ -296,8 +240,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance >= 50", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"50"},
-						"balance_operator": []string{"gte"},
+						"balance":                           []string{"50"},
+						controllers.QueryKeyBalanceOperator: []string{"gte"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -308,8 +252,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance >= 120", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"120"},
-						"balance_operator": []string{"gte"},
+						"balance":                           []string{"120"},
+						controllers.QueryKeyBalanceOperator: []string{"gte"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -319,8 +263,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance > 120", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"120"},
-						"balance_operator": []string{"gt"},
+						"balance":                           []string{"120"},
+						controllers.QueryKeyBalanceOperator: []string{"gt"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -330,8 +274,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance < 0", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"0"},
-						"balance_operator": []string{"lt"},
+						"balance":                           []string{"0"},
+						controllers.QueryKeyBalanceOperator: []string{"lt"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -341,8 +285,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance < 100", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"100"},
-						"balance_operator": []string{"lt"},
+						"balance":                           []string{"100"},
+						controllers.QueryKeyBalanceOperator: []string{"lt"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -352,8 +296,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance <= 100", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"100"},
-						"balance_operator": []string{"lte"},
+						"balance":                           []string{"100"},
+						controllers.QueryKeyBalanceOperator: []string{"lte"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -364,8 +308,8 @@ func TestGetAccounts(t *testing.T) {
 
 				t.Run("filter by balance = 100", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"100"},
-						"balance_operator": []string{"e"},
+						"balance":                           []string{"100"},
+						controllers.QueryKeyBalanceOperator: []string{"e"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -376,8 +320,8 @@ func TestGetAccounts(t *testing.T) {
 				// test filter by balance != 100
 				t.Run("filter by balance != 100", func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"balance":          []string{"100"},
-						"balance_operator": []string{"ne"},
+						"balance":                           []string{"100"},
+						controllers.QueryKeyBalanceOperator: []string{"ne"},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor := internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -402,10 +346,10 @@ func TestGetAccounts(t *testing.T) {
 					}, err)
 				})
 
-				t.Run("invalid balance_operator", func(t *testing.T) {
+				t.Run("invalid balance operator", func(t *testing.T) {
 					rsp := internal.GetAccounts(api, url.Values{
-						"balance":          []string{"100"},
-						"balance_operator": []string{"toto"},
+						"balance":                           []string{"100"},
+						controllers.QueryKeyBalanceOperator: []string{"toto"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode)
 
@@ -413,9 +357,9 @@ func TestGetAccounts(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					assert.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid parameter 'balance_operator', should be one of 'e, gt, gte, lt, lte'",
+						ErrorMessage:           controllers.ErrInvalidBalanceOperator.Error(),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid parameter 'balance_operator', should be one of 'e, gt, gte, lt, lte'",
+						ErrorMessageDeprecated: controllers.ErrInvalidBalanceOperator.Error(),
 					}, err)
 				})
 
@@ -440,7 +384,7 @@ func TestGetAccountsWithPageSize(t *testing.T) {
 
 				t.Run("invalid page size", func(t *testing.T) {
 					rsp := internal.GetAccounts(api, url.Values{
-						"page_size": []string{"nan"},
+						controllers.QueryKeyPageSize: []string{"nan"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -455,7 +399,7 @@ func TestGetAccountsWithPageSize(t *testing.T) {
 				})
 				t.Run("page size over maximum", func(t *testing.T) {
 					httpResponse := internal.GetAccounts(api, url.Values{
-						"page_size": []string{fmt.Sprintf("%d", 2*controllers.MaxPageSize)},
+						controllers.QueryKeyPageSize: []string{fmt.Sprintf("%d", 2*controllers.MaxPageSize)},
 					})
 					assert.Equal(t, http.StatusOK, httpResponse.Result().StatusCode, httpResponse.Body.String())
 
@@ -467,8 +411,8 @@ func TestGetAccountsWithPageSize(t *testing.T) {
 				})
 				t.Run("with page size greater than max count", func(t *testing.T) {
 					httpResponse := internal.GetAccounts(api, url.Values{
-						"page_size": []string{fmt.Sprintf("%d", controllers.MaxPageSize)},
-						"after":     []string{fmt.Sprintf("accounts:%06d", controllers.MaxPageSize-100)},
+						controllers.QueryKeyPageSize: []string{fmt.Sprintf("%d", controllers.MaxPageSize)},
+						"after":                      []string{fmt.Sprintf("accounts:%06d", controllers.MaxPageSize-100)},
 					})
 					assert.Equal(t, http.StatusOK, httpResponse.Result().StatusCode, httpResponse.Body.String())
 
@@ -480,7 +424,7 @@ func TestGetAccountsWithPageSize(t *testing.T) {
 				})
 				t.Run("with page size lower than max count", func(t *testing.T) {
 					httpResponse := internal.GetAccounts(api, url.Values{
-						"page_size": []string{fmt.Sprintf("%d", controllers.MaxPageSize/10)},
+						controllers.QueryKeyPageSize: []string{fmt.Sprintf("%d", controllers.MaxPageSize/10)},
 					})
 					assert.Equal(t, http.StatusOK, httpResponse.Result().StatusCode, httpResponse.Body.String())
 

--- a/pkg/api/controllers/account_controller_test.go
+++ b/pkg/api/controllers/account_controller_test.go
@@ -160,17 +160,25 @@ func TestGetAccounts(t *testing.T) {
 				to := sqlstorage.AccPaginationToken{}
 				raw, err := json.Marshal(to)
 				require.NoError(t, err)
-				t.Run("valid empty pagination_token", func(t *testing.T) {
+
+				t.Run(fmt.Sprintf("valid empty %s", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"pagination_token": []string{base64.RawURLEncoding.EncodeToString(raw)},
+						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				})
 
-				t.Run("valid empty pagination_token with any other param is forbidden", func(t *testing.T) {
+				t.Run(fmt.Sprintf("valid empty %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"pagination_token": []string{base64.RawURLEncoding.EncodeToString(raw)},
-						"after":            []string{"bob"},
+						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
+					})
+					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
+				})
+
+				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursor), func(t *testing.T) {
+					rsp = internal.GetAccounts(api, url.Values{
+						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
+						"after":                    []string{"bob"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -178,15 +186,16 @@ func TestGetAccounts(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					assert.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "no other query params can be set with 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "no other query params can be set with 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
 					}, err)
 				})
 
-				t.Run("invalid pagination_token", func(t *testing.T) {
+				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"pagination_token": []string{"invalid"},
+						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
+						"after":                              []string{"bob"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -194,15 +203,15 @@ func TestGetAccounts(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					assert.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 
-				t.Run("invalid pagination_token not base64", func(t *testing.T) {
+				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp = internal.GetAccounts(api, url.Values{
-						"pagination_token": []string{"\n*@"},
+						controllers.QueryKeyCursor: []string{"invalid"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -210,9 +219,57 @@ func TestGetAccounts(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					assert.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
+					rsp = internal.GetAccounts(api, url.Values{
+						controllers.QueryKeyCursorDeprecated: []string{"invalid"},
+					})
+					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					assert.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursor), func(t *testing.T) {
+					rsp = internal.GetAccounts(api, url.Values{
+						controllers.QueryKeyCursor: []string{"\n*@"},
+					})
+					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					assert.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
+					rsp = internal.GetAccounts(api, url.Values{
+						controllers.QueryKeyCursorDeprecated: []string{"\n*@"},
+					})
+					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					assert.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 

--- a/pkg/api/controllers/balance_controller.go
+++ b/pkg/api/controllers/balance_controller.go
@@ -42,7 +42,8 @@ func (ctl *BalanceController) GetBalances(c *gin.Context) {
 	if c.Query(QueryKeyCursor) != "" {
 		if c.Query("after") != "" ||
 			c.Query("address") != "" ||
-			c.Query("page_size") != "" {
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursor)))
 			return
@@ -71,7 +72,8 @@ func (ctl *BalanceController) GetBalances(c *gin.Context) {
 	} else if c.Query(QueryKeyCursorDeprecated) != "" {
 		if c.Query("after") != "" ||
 			c.Query("address") != "" ||
-			c.Query("page_size") != "" {
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursorDeprecated)))
 			return

--- a/pkg/api/controllers/balance_controller.go
+++ b/pkg/api/controllers/balance_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,16 +22,10 @@ func NewBalanceController() BalanceController {
 func (ctl *BalanceController) GetBalancesAggregated(c *gin.Context) {
 	l, _ := c.Get("ledger")
 
-	var balances core.AssetsBalances
-	var err error
-
-	balancesQuery := ledger.NewBalancesQuery().WithAddressFilter(c.Query("address"))
-
-	balances, err = l.(*ledger.Ledger).GetBalancesAggregated(
-		c.Request.Context(),
-		*balancesQuery,
-	)
-
+	balancesQuery := ledger.NewBalancesQuery().
+		WithAddressFilter(c.Query("address"))
+	balances, err := l.(*ledger.Ledger).GetBalancesAggregated(
+		c.Request.Context(), *balancesQuery)
 	if err != nil {
 		apierrors.ResponseError(c, err)
 		return
@@ -44,26 +39,55 @@ func (ctl *BalanceController) GetBalances(c *gin.Context) {
 
 	balancesQuery := ledger.NewBalancesQuery()
 
-	if c.Query("pagination_token") != "" {
+	if c.Query(QueryKeyCursor) != "" {
 		if c.Query("after") != "" ||
 			c.Query("address") != "" ||
 			c.Query("page_size") != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
-				"no other query params can be set with 'pagination_token'"))
+				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursor)))
 			return
 		}
 
-		res, decErr := base64.RawURLEncoding.DecodeString(c.Query("pagination_token"))
-		if decErr != nil {
+		res, err := base64.RawURLEncoding.DecodeString(c.Query(QueryKeyCursor))
+		if err != nil {
 			apierrors.ResponseError(c, ledger.NewValidationError(
-				"invalid query value 'pagination_token'"))
+				fmt.Sprintf("invalid '%s' query param", QueryKeyCursor)))
 			return
 		}
 
 		token := sqlstorage.BalancesPaginationToken{}
 		if err := json.Unmarshal(res, &token); err != nil {
 			apierrors.ResponseError(c, ledger.NewValidationError(
-				"invalid query value 'pagination_token'"))
+				fmt.Sprintf("invalid '%s' query param", QueryKeyCursor)))
+			return
+		}
+
+		balancesQuery = balancesQuery.
+			WithOffset(token.Offset).
+			WithAfterAddress(token.AfterAddress).
+			WithAddressFilter(token.AddressRegexpFilter).
+			WithPageSize(token.PageSize)
+
+	} else if c.Query(QueryKeyCursorDeprecated) != "" {
+		if c.Query("after") != "" ||
+			c.Query("address") != "" ||
+			c.Query("page_size") != "" {
+			apierrors.ResponseError(c, ledger.NewValidationError(
+				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursorDeprecated)))
+			return
+		}
+
+		res, err := base64.RawURLEncoding.DecodeString(c.Query(QueryKeyCursorDeprecated))
+		if err != nil {
+			apierrors.ResponseError(c, ledger.NewValidationError(
+				fmt.Sprintf("invalid '%s' query param", QueryKeyCursorDeprecated)))
+			return
+		}
+
+		token := sqlstorage.BalancesPaginationToken{}
+		if err := json.Unmarshal(res, &token); err != nil {
+			apierrors.ResponseError(c, ledger.NewValidationError(
+				fmt.Sprintf("invalid '%s' query param", QueryKeyCursorDeprecated)))
 			return
 		}
 
@@ -74,7 +98,6 @@ func (ctl *BalanceController) GetBalances(c *gin.Context) {
 			WithPageSize(token.PageSize)
 
 	} else {
-
 		pageSize, err := getPageSize(c)
 		if err != nil {
 			apierrors.ResponseError(c, err)
@@ -88,7 +111,6 @@ func (ctl *BalanceController) GetBalances(c *gin.Context) {
 	}
 
 	cursor, err := l.(*ledger.Ledger).GetBalances(c.Request.Context(), *balancesQuery)
-
 	if err != nil {
 		apierrors.ResponseError(c, err)
 		return

--- a/pkg/api/controllers/balance_controller_test.go
+++ b/pkg/api/controllers/balance_controller_test.go
@@ -143,25 +143,10 @@ func TestGetBalances(t *testing.T) {
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				})
 
-				t.Run("valid empty "+controllers.QueryKeyCursorDeprecated, func(t *testing.T) {
-					rsp = internal.GetBalances(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
-					})
-					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
-				})
-
 				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp = internal.GetBalances(api, url.Values{
 						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
 						"after":                    []string{"bob"},
-					})
-					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
-				})
-
-				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetBalances(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
-						"after":                              []string{"bob"},
 					})
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 				})
@@ -174,16 +159,6 @@ func TestGetBalances(t *testing.T) {
 					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 					assert.Contains(t, rsp.Body.String(),
 						fmt.Sprintf(`"invalid '%s' query param"`, controllers.QueryKeyCursor))
-				})
-
-				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
-					rsp = internal.GetBalances(api, url.Values{
-						controllers.QueryKeyCursorDeprecated: []string{"invalid"},
-					})
-
-					assert.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
-					assert.Contains(t, rsp.Body.String(),
-						fmt.Sprintf(`"invalid '%s' query param"`, controllers.QueryKeyCursorDeprecated))
 				})
 
 				t.Run("all", func(t *testing.T) {

--- a/pkg/api/controllers/info.go
+++ b/pkg/api/controllers/info.go
@@ -1,1 +1,0 @@
-package controllers

--- a/pkg/api/controllers/ledger_controller.go
+++ b/pkg/api/controllers/ledger_controller.go
@@ -65,8 +65,13 @@ func (ctl *LedgerController) GetLogs(c *gin.Context) {
 	logsQuery := ledger.NewLogsQuery()
 
 	if c.Query(QueryKeyCursor) != "" {
-		if c.Query("after") != "" || c.Query("start_time") != "" ||
-			c.Query("end_time") != "" || c.Query("page_size") != "" {
+		if c.Query("after") != "" ||
+			c.Query(QueryKeyStartTime) != "" ||
+			c.Query(QueryKeyStartTimeDeprecated) != "" ||
+			c.Query(QueryKeyEndTime) != "" ||
+			c.Query(QueryKeyEndTimeDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursor)))
 			return
@@ -93,8 +98,13 @@ func (ctl *LedgerController) GetLogs(c *gin.Context) {
 			WithPageSize(token.PageSize)
 
 	} else if c.Query(QueryKeyCursorDeprecated) != "" {
-		if c.Query("after") != "" || c.Query("start_time") != "" ||
-			c.Query("end_time") != "" || c.Query("page_size") != "" {
+		if c.Query("after") != "" ||
+			c.Query(QueryKeyStartTime) != "" ||
+			c.Query(QueryKeyStartTimeDeprecated) != "" ||
+			c.Query(QueryKeyEndTime) != "" ||
+			c.Query(QueryKeyEndTimeDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursorDeprecated)))
 			return
@@ -133,20 +143,32 @@ func (ctl *LedgerController) GetLogs(c *gin.Context) {
 		}
 
 		var startTimeParsed, endTimeParsed time.Time
-		if c.Query("start_time") != "" {
-			startTimeParsed, err = time.Parse(time.RFC3339, c.Query("start_time"))
+		if c.Query(QueryKeyStartTime) != "" {
+			startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTime))
 			if err != nil {
-				apierrors.ResponseError(c, ledger.NewValidationError(
-					"invalid 'start_time' query param"))
+				apierrors.ResponseError(c, ErrInvalidStartTime)
+				return
+			}
+		}
+		if c.Query(QueryKeyStartTimeDeprecated) != "" {
+			startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTimeDeprecated))
+			if err != nil {
+				apierrors.ResponseError(c, ErrInvalidStartTimeDeprecated)
 				return
 			}
 		}
 
-		if c.Query("end_time") != "" {
-			endTimeParsed, err = time.Parse(time.RFC3339, c.Query("end_time"))
+		if c.Query(QueryKeyEndTime) != "" {
+			endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTime))
 			if err != nil {
-				apierrors.ResponseError(c, ledger.NewValidationError(
-					"invalid 'end_time' query param"))
+				apierrors.ResponseError(c, ErrInvalidEndTime)
+				return
+			}
+		}
+		if c.Query(QueryKeyEndTimeDeprecated) != "" {
+			endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTimeDeprecated))
+			if err != nil {
+				apierrors.ResponseError(c, ErrInvalidEndTimeDeprecated)
 				return
 			}
 		}

--- a/pkg/api/controllers/ledger_controller_test.go
+++ b/pkg/api/controllers/ledger_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -178,9 +179,9 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'after'",
+						ErrorMessage:           "invalid 'after' query param",
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'after'",
+						ErrorMessageDeprecated: "invalid 'after' query param",
 					}, err)
 				})
 
@@ -223,9 +224,9 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'start_time'",
+						ErrorMessage:           "invalid 'start_time' query param",
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'start_time'",
+						ErrorMessageDeprecated: "invalid 'start_time' query param",
 					}, err)
 				})
 
@@ -239,26 +240,34 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'end_time'",
+						ErrorMessage:           "invalid 'end_time' query param",
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'end_time'",
+						ErrorMessageDeprecated: "invalid 'end_time' query param",
 					}, err)
 				})
 
 				to := sqlstorage.LogsPaginationToken{}
 				raw, err := json.Marshal(to)
 				require.NoError(t, err)
-				t.Run("valid empty pagination_token", func(t *testing.T) {
+
+				t.Run(fmt.Sprintf("valid empty %s", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp := internal.GetLedgerLogs(api, url.Values{
-						"pagination_token": []string{base64.RawURLEncoding.EncodeToString(raw)},
+						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
 					})
 					require.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				})
 
-				t.Run("valid empty pagination_token with any other param is forbidden", func(t *testing.T) {
+				t.Run(fmt.Sprintf("valid empty %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
 					rsp := internal.GetLedgerLogs(api, url.Values{
-						"pagination_token": []string{base64.RawURLEncoding.EncodeToString(raw)},
-						"after":            []string{"1"},
+						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
+					})
+					require.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
+				})
+
+				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursor), func(t *testing.T) {
+					rsp := internal.GetLedgerLogs(api, url.Values{
+						controllers.QueryKeyCursor: []string{base64.RawURLEncoding.EncodeToString(raw)},
+						"after":                    []string{"1"},
 					})
 					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -266,15 +275,16 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "no other query params can be set with 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "no other query params can be set with 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursor),
 					}, err)
 				})
 
-				t.Run("invalid pagination_token", func(t *testing.T) {
+				t.Run(fmt.Sprintf("valid empty %s with any other param is forbidden", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
 					rsp := internal.GetLedgerLogs(api, url.Values{
-						"pagination_token": []string{"invalid"},
+						controllers.QueryKeyCursorDeprecated: []string{base64.RawURLEncoding.EncodeToString(raw)},
+						"after":                              []string{"1"},
 					})
 					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -282,15 +292,15 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("no other query params can be set with '%s'", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 
-				t.Run("invalid pagination_token not base64", func(t *testing.T) {
+				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursor), func(t *testing.T) {
 					rsp := internal.GetLedgerLogs(api, url.Values{
-						"pagination_token": []string{"@!/"},
+						controllers.QueryKeyCursor: []string{"invalid"},
 					})
 					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
 
@@ -298,9 +308,57 @@ func TestGetLogs(t *testing.T) {
 					internal.Decode(t, rsp.Body, &err)
 					require.EqualValues(t, sharedapi.ErrorResponse{
 						ErrorCode:              apierrors.ErrValidation,
-						ErrorMessage:           "invalid query value 'pagination_token'",
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
 						ErrorCodeDeprecated:    apierrors.ErrValidation,
-						ErrorMessageDeprecated: "invalid query value 'pagination_token'",
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
+					rsp := internal.GetLedgerLogs(api, url.Values{
+						controllers.QueryKeyCursorDeprecated: []string{"invalid"},
+					})
+					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					require.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursor), func(t *testing.T) {
+					rsp := internal.GetLedgerLogs(api, url.Values{
+						controllers.QueryKeyCursor: []string{"@!/"},
+					})
+					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					require.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursor),
+					}, err)
+				})
+
+				t.Run(fmt.Sprintf("invalid %s not base64", controllers.QueryKeyCursorDeprecated), func(t *testing.T) {
+					rsp := internal.GetLedgerLogs(api, url.Values{
+						controllers.QueryKeyCursorDeprecated: []string{"@!/"},
+					})
+					require.Equal(t, http.StatusBadRequest, rsp.Result().StatusCode, rsp.Body.String())
+
+					err := sharedapi.ErrorResponse{}
+					internal.Decode(t, rsp.Body, &err)
+					require.EqualValues(t, sharedapi.ErrorResponse{
+						ErrorCode:              apierrors.ErrValidation,
+						ErrorMessage:           fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
+						ErrorCodeDeprecated:    apierrors.ErrValidation,
+						ErrorMessageDeprecated: fmt.Sprintf("invalid '%s' query param", controllers.QueryKeyCursorDeprecated),
 					}, err)
 				})
 

--- a/pkg/api/controllers/mapping_controller.go
+++ b/pkg/api/controllers/mapping_controller.go
@@ -19,14 +19,12 @@ func (ctl *MappingController) PutMapping(c *gin.Context) {
 	l, _ := c.Get("ledger")
 
 	mapping := &core.Mapping{}
-	err := c.ShouldBind(mapping)
-	if err != nil {
+	if err := c.ShouldBind(mapping); err != nil {
 		apierrors.ResponseError(c, err)
 		return
 	}
 
-	err = l.(*ledger.Ledger).SaveMapping(c.Request.Context(), *mapping)
-	if err != nil {
+	if err := l.(*ledger.Ledger).SaveMapping(c.Request.Context(), *mapping); err != nil {
 		apierrors.ResponseError(c, err)
 		return
 	}

--- a/pkg/api/controllers/pagination_test.go
+++ b/pkg/api/controllers/pagination_test.go
@@ -84,7 +84,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 				values := url.Values{}
 				if paginationToken == "" {
-					values.Set("page_size", fmt.Sprintf("%d", pageSize))
+					values.Set(controllers.QueryKeyPageSize, fmt.Sprintf("%d", pageSize))
 				} else {
 					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
@@ -167,7 +167,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 				values := url.Values{}
 				if paginationToken == "" {
-					values.Set("page_size", fmt.Sprintf("%d", pageSize))
+					values.Set(controllers.QueryKeyPageSize, fmt.Sprintf("%d", pageSize))
 				} else {
 					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
@@ -265,7 +265,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 				values := url.Values{}
 				if paginationToken == "" {
-					values.Set("page_size", fmt.Sprintf("%d", pageSize))
+					values.Set(controllers.QueryKeyPageSize, fmt.Sprintf("%d", pageSize))
 				} else {
 					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
@@ -359,7 +359,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 				values := url.Values{}
 				if paginationToken == "" {
-					values.Set("page_size", fmt.Sprintf("%d", pageSize))
+					values.Set(controllers.QueryKeyPageSize, fmt.Sprintf("%d", pageSize))
 				} else {
 					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}

--- a/pkg/api/controllers/pagination_test.go
+++ b/pkg/api/controllers/pagination_test.go
@@ -9,6 +9,7 @@ import (
 
 	sharedapi "github.com/formancehq/go-libs/api"
 	"github.com/numary/ledger/pkg/api"
+	"github.com/numary/ledger/pkg/api/controllers"
 	"github.com/numary/ledger/pkg/api/internal"
 	"github.com/numary/ledger/pkg/core"
 	"github.com/stretchr/testify/assert"
@@ -85,7 +86,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				if paginationToken == "" {
 					values.Set("page_size", fmt.Sprintf("%d", pageSize))
 				} else {
-					values.Set("pagination_token", paginationToken)
+					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
 
 				rsp = internal.GetTransactions(api, values)
@@ -107,7 +108,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 			if additionalTxs > 0 {
 				rsp = internal.GetTransactions(api, url.Values{
-					"pagination_token": []string{paginationToken},
+					controllers.QueryKeyCursor: []string{paginationToken},
 				})
 				assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				cursor = internal.DecodeCursorResponse[core.ExpandedTransaction](t, rsp.Body)
@@ -131,7 +132,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				for cursor.Previous != "" {
 					paginationToken = cursor.Previous
 					rsp = internal.GetTransactions(api, url.Values{
-						"pagination_token": []string{paginationToken},
+						controllers.QueryKeyCursor: []string{paginationToken},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor = internal.DecodeCursorResponse[core.ExpandedTransaction](t, rsp.Body)
@@ -168,7 +169,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				if paginationToken == "" {
 					values.Set("page_size", fmt.Sprintf("%d", pageSize))
 				} else {
-					values.Set("pagination_token", paginationToken)
+					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
 
 				rsp = internal.GetAccounts(api, values)
@@ -197,7 +198,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 			if additionalAccs > 0 {
 				rsp = internal.GetAccounts(api, url.Values{
-					"pagination_token": []string{paginationToken},
+					controllers.QueryKeyCursor: []string{paginationToken},
 				})
 				assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				cursor = internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -228,7 +229,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				for cursor.Previous != "" {
 					paginationToken = cursor.Previous
 					rsp = internal.GetAccounts(api, url.Values{
-						"pagination_token": []string{paginationToken},
+						controllers.QueryKeyCursor: []string{paginationToken},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 					cursor = internal.DecodeCursorResponse[core.Account](t, rsp.Body)
@@ -266,7 +267,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				if paginationToken == "" {
 					values.Set("page_size", fmt.Sprintf("%d", pageSize))
 				} else {
-					values.Set("pagination_token", paginationToken)
+					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
 
 				rsp = internal.GetBalances(api, values)
@@ -295,7 +296,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 			if additionalAccs > 0 {
 				rsp = internal.GetBalances(api, url.Values{
-					"pagination_token": []string{paginationToken},
+					controllers.QueryKeyCursor: []string{paginationToken},
 				})
 				assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				cursor = internal.DecodeCursorResponse[core.AccountsBalances](t, rsp.Body)
@@ -324,7 +325,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				for cursor.Previous != "" {
 					paginationToken = cursor.Previous
 					rsp = internal.GetBalances(api, url.Values{
-						"pagination_token": []string{paginationToken},
+						controllers.QueryKeyCursor: []string{paginationToken},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 					cursor = internal.DecodeCursorResponse[core.AccountsBalances](t, rsp.Body)
@@ -360,7 +361,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				if paginationToken == "" {
 					values.Set("page_size", fmt.Sprintf("%d", pageSize))
 				} else {
-					values.Set("pagination_token", paginationToken)
+					values.Set(controllers.QueryKeyCursor, paginationToken)
 				}
 
 				rsp = internal.GetLedgerLogs(api, values)
@@ -382,7 +383,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 
 			if additionalTxs > 0 {
 				rsp = internal.GetLedgerLogs(api, url.Values{
-					"pagination_token": []string{paginationToken},
+					controllers.QueryKeyCursor: []string{paginationToken},
 				})
 				assert.Equal(t, http.StatusOK, rsp.Result().StatusCode, rsp.Body.String())
 				cursor = internal.DecodeCursorResponse[core.Log](t, rsp.Body)
@@ -406,7 +407,7 @@ func testGetPagination(t *testing.T, api *api.API, txsPages, additionalTxs int) 
 				for cursor.Previous != "" {
 					paginationToken = cursor.Previous
 					rsp = internal.GetLedgerLogs(api, url.Values{
-						"pagination_token": []string{paginationToken},
+						controllers.QueryKeyCursor: []string{paginationToken},
 					})
 					assert.Equal(t, http.StatusOK, rsp.Result().StatusCode)
 					cursor = internal.DecodeCursorResponse[core.Log](t, rsp.Body)

--- a/pkg/api/controllers/query.go
+++ b/pkg/api/controllers/query.go
@@ -10,28 +10,30 @@ import (
 const (
 	MaxPageSize     = 1000
 	DefaultPageSize = ledger.QueryDefaultPageSize
+
+	QueryKeyCursor = "cursor"
+	// Deprecated
+	QueryKeyCursorDeprecated = "pagination_token"
 )
 
 var (
-	ErrInvalidPageSize = ledger.NewValidationError("invalid query value 'page_size'")
+	ErrInvalidPageSize = ledger.NewValidationError("invalid 'page_size' query param")
 )
 
 func getPageSize(c *gin.Context) (uint, error) {
-	var (
-		pageSize uint64
-		err      error
-	)
-	if pageSizeParam := c.Query("page_size"); pageSizeParam != "" {
-		pageSize, err = strconv.ParseUint(pageSizeParam, 10, 32)
-		if err != nil {
-			return 0, ErrInvalidPageSize
-		}
-
-		if pageSize > MaxPageSize {
-			pageSize = MaxPageSize
-		}
-	} else {
-		pageSize = DefaultPageSize
+	pageSizeParam := c.Query("page_size")
+	if pageSizeParam == "" {
+		return DefaultPageSize, nil
 	}
+
+	pageSize, err := strconv.ParseUint(pageSizeParam, 10, 32)
+	if err != nil {
+		return 0, ErrInvalidPageSize
+	}
+
+	if pageSize > MaxPageSize {
+		return MaxPageSize, nil
+	}
+
 	return uint(pageSize), nil
 }

--- a/pkg/api/controllers/query.go
+++ b/pkg/api/controllers/query.go
@@ -14,21 +14,63 @@ const (
 	QueryKeyCursor = "cursor"
 	// Deprecated
 	QueryKeyCursorDeprecated = "pagination_token"
+
+	QueryKeyPageSize = "pageSize"
+	// Deprecated
+	QueryKeyPageSizeDeprecated = "page_size"
+
+	QueryKeyBalanceOperator = "balanceOperator"
+	// Deprecated
+	QueryKeyBalanceOperatorDeprecated = "balance_operator"
+
+	QueryKeyStartTime = "startTime"
+	// Deprecated
+	QueryKeyStartTimeDeprecated = "start_time"
+
+	QueryKeyEndTime = "endTime"
+	// Deprecated
+	QueryKeyEndTimeDeprecated = "end_time"
 )
 
 var (
-	ErrInvalidPageSize = ledger.NewValidationError("invalid 'page_size' query param")
+	ErrInvalidPageSize = ledger.NewValidationError("invalid 'pageSize' query param")
+	// Deprecated
+	ErrInvalidPageSizeDeprecated = ledger.NewValidationError("invalid 'page_size' query param")
+
+	ErrInvalidBalanceOperator = ledger.NewValidationError(
+		"invalid parameter 'balanceOperator', should be one of 'e, ne, gt, gte, lt, lte'")
+	// Deprecated
+	ErrInvalidBalanceOperatorDeprecated = ledger.NewValidationError(
+		"invalid parameter 'balance_operator', should be one of 'e, ne, gt, gte, lt, lte'")
+
+	ErrInvalidStartTime = ledger.NewValidationError("invalid 'startTime' query param")
+	// Deprecated
+	ErrInvalidStartTimeDeprecated = ledger.NewValidationError("invalid 'start_time' query param")
+
+	ErrInvalidEndTime = ledger.NewValidationError("invalid 'endTime' query param")
+	// Deprecated
+	ErrInvalidEndTimeDeprecated = ledger.NewValidationError("invalid 'end_time' query param")
 )
 
 func getPageSize(c *gin.Context) (uint, error) {
-	pageSizeParam := c.Query("page_size")
-	if pageSizeParam == "" {
+	pageSizeParam := c.Query(QueryKeyPageSize)
+	pageSizeParamDeprecated := c.Query(QueryKeyPageSizeDeprecated)
+	if pageSizeParam == "" && pageSizeParamDeprecated == "" {
 		return DefaultPageSize, nil
 	}
 
-	pageSize, err := strconv.ParseUint(pageSizeParam, 10, 32)
-	if err != nil {
-		return 0, ErrInvalidPageSize
+	var pageSize uint64
+	var err error
+	if pageSizeParam != "" {
+		pageSize, err = strconv.ParseUint(pageSizeParam, 10, 32)
+		if err != nil {
+			return 0, ErrInvalidPageSize
+		}
+	} else if pageSizeParamDeprecated != "" {
+		pageSize, err = strconv.ParseUint(pageSizeParamDeprecated, 10, 32)
+		if err != nil {
+			return 0, ErrInvalidPageSizeDeprecated
+		}
 	}
 
 	if pageSize > MaxPageSize {
@@ -36,4 +78,23 @@ func getPageSize(c *gin.Context) (uint, error) {
 	}
 
 	return uint(pageSize), nil
+}
+
+func getBalanceOperator(c *gin.Context) (ledger.BalanceOperator, error) {
+	balanceOperator := ledger.DefaultBalanceOperator
+	balanceOperatorStr := c.Query(QueryKeyBalanceOperator)
+	balanceOperatorStrDeprecated := c.Query(QueryKeyBalanceOperatorDeprecated)
+	if balanceOperatorStr != "" {
+		var ok bool
+		if balanceOperator, ok = ledger.NewBalanceOperator(balanceOperatorStr); !ok {
+			return "", ErrInvalidBalanceOperator
+		}
+	} else if balanceOperatorStrDeprecated != "" {
+		var ok bool
+		if balanceOperator, ok = ledger.NewBalanceOperator(balanceOperatorStrDeprecated); !ok {
+			return "", ErrInvalidBalanceOperatorDeprecated
+		}
+	}
+
+	return balanceOperator, nil
 }

--- a/pkg/api/controllers/script_controller.go
+++ b/pkg/api/controllers/script_controller.go
@@ -14,7 +14,6 @@ import (
 
 type ScriptResponse struct {
 	api.ErrorResponse
-	Details     string                    `json:"details,omitempty"`
 	Transaction *core.ExpandedTransaction `json:"transaction,omitempty"`
 }
 

--- a/pkg/api/controllers/script_controller_test.go
+++ b/pkg/api/controllers/script_controller_test.go
@@ -58,10 +58,10 @@ func TestPostScript(t *testing.T) {
 				ErrorResponse: sharedapi.ErrorResponse{
 					ErrorCode:              apierrors.ErrInsufficientFund,
 					ErrorMessage:           "account had insufficient funds",
+					Details:                apierrors.EncodeLink("account had insufficient funds"),
 					ErrorCodeDeprecated:    apierrors.ErrInsufficientFund,
 					ErrorMessageDeprecated: "account had insufficient funds",
 				},
-				Details: apierrors.EncodeLink("account had insufficient funds"),
 			},
 		},
 		{
@@ -84,10 +84,10 @@ func TestPostScript(t *testing.T) {
 				ErrorResponse: sharedapi.ErrorResponse{
 					ErrorCode:              ledger.ScriptErrorMetadataOverride,
 					ErrorMessage:           "cannot override metadata from script",
+					Details:                apierrors.EncodeLink("cannot override metadata from script"),
 					ErrorCodeDeprecated:    ledger.ScriptErrorMetadataOverride,
 					ErrorMessageDeprecated: "cannot override metadata from script",
 				},
-				Details: apierrors.EncodeLink("cannot override metadata from script"),
 			},
 		},
 	}

--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -10,7 +10,7 @@ paths:
     get:
       tags:
         - Server
-      summary: Show server information.
+      summary: Show server information
       operationId: getInfo
       responses:
         "200":
@@ -28,7 +28,7 @@ paths:
 
   /{ledger}/_info:
     get:
-      summary: Get information about a ledger.
+      summary: Get information about a ledger
       operationId: getLedgerInfo
       tags:
         - Ledger
@@ -56,7 +56,7 @@ paths:
 
   /{ledger}/accounts:
     head:
-      summary: Count the accounts from a ledger.
+      summary: Count the accounts from a ledger
       operationId: countAccounts
       tags:
         - Accounts
@@ -100,7 +100,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
     get:
-      summary: List accounts from a ledger.
+      summary: List accounts from a ledger
       description: List accounts from a ledger, sorted by address in descending order.
       operationId: listAccounts
       tags:
@@ -113,9 +113,10 @@ paths:
           schema:
             type: string
             example: ledger001
-        - name: page_size
+        - name: pageSize
           in: query
-          description: 'The maximum number of results to return per page'
+          description: |
+            The maximum number of results to return per page.
           example: 100
           schema:
             type: integer
@@ -123,6 +124,19 @@ paths:
             minimum: 1
             maximum: 1000
             default: 15
+        - name: page_size
+          in: query
+          description: |
+            The maximum number of results to return per page.
+            Deprecated, please use `pageSize` instead.
+          example: 100
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 1000
+            default: 15
+          deprecated: true
         - name: after
           in: query
           description: Pagination cursor, will return accounts after given address, in descending order.
@@ -152,13 +166,24 @@ paths:
             format: int64
             minimum: 0
             example: 2400
-        - name: balance_operator
+        - name: balanceOperator
           in: query
-          description: Operator used for the filtering of balances can be greater than/equal, less than/equal, greater than, less than, or equal
+          description: |
+            Operator used for the filtering of balances can be greater than/equal, less than/equal, greater than, less than, equal or not.
           schema:
             type: string
             enum: [gte, lte, gt, lt, e, ne]
             example: gte
+        - name: balance_operator
+          in: query
+          description: |
+            Operator used for the filtering of balances can be greater than/equal, less than/equal, greater than, less than, equal or not.
+            Deprecated, please use `balanceOperator` instead.
+          schema:
+            type: string
+            enum: [gte, lte, gt, lt, e, ne]
+            example: gte
+          deprecated: true
         - name: cursor
           in: query
           description: |
@@ -176,7 +201,7 @@ paths:
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
             No other parameters can be set when this parameter is set.
-            Deprecated: Use cursor instead.
+            Deprecated, please use `cursor` instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
@@ -197,7 +222,7 @@ paths:
 
   /{ledger}/accounts/{address}:
     get:
-      summary: Get account by its address.
+      summary: Get account by its address
       operationId: getAccount
       tags:
         - Accounts
@@ -236,7 +261,7 @@ paths:
 
   /{ledger}/accounts/{address}/metadata:
     post:
-      summary: Add metadata to an account.
+      summary: Add metadata to an account
       operationId: addMetadataToAccount
       tags:
         - Accounts
@@ -282,7 +307,7 @@ paths:
       tags:
         - Mapping
       operationId: getMapping
-      summary: Get the mapping of a ledger.
+      summary: Get the mapping of a ledger
       parameters:
         - name: ledger
           in: path
@@ -309,7 +334,7 @@ paths:
       tags:
         - Mapping
       operationId: updateMapping
-      summary: Update the mapping of a ledger.
+      summary: Update the mapping of a ledger
       parameters:
         - name: ledger
           in: path
@@ -344,7 +369,7 @@ paths:
       tags:
         - Script
       operationId: runScript
-      summary: Execute a Numscript.
+      summary: Execute a Numscript
       description: >
         This route is deprecated, and has been merged into `POST /{ledger}/transactions`.
       parameters:
@@ -387,7 +412,7 @@ paths:
       tags:
         - Stats
       operationId: readStats
-      summary: Get statistics from a ledger.
+      summary: Get statistics from a ledger
       description: |
         Get statistics from a ledger. (aggregate metrics on accounts and transactions)
       parameters:
@@ -416,7 +441,7 @@ paths:
     head:
       tags:
         - Transactions
-      summary: Count the transactions from a ledger.
+      summary: Count the transactions from a ledger
       operationId: countTransactions
       parameters:
         - name: ledger
@@ -451,21 +476,42 @@ paths:
           schema:
             type: string
             example: users:001
+        - name: startTime
+          in: query
+          description: |
+            Filter transactions that occurred after this timestamp.
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: start_time
           in: query
           description: |
             Filter transactions that occurred after this timestamp.
-            The format is RFC3339 and is inclusive (for example, 12:00:01 includes the first second of the minute).
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+            Deprecated, please use `startTime` instead.
           schema:
             type: string
-            example:
+            format: date-time
+          deprecated: true
+        - name: endTime
+          in: query
+          description: |
+            Filter transactions that occurred before this timestamp.
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: end_time
           in: query
           description: |
             Filter transactions that occurred before this timestamp.
-            The format is RFC3339 and is exclusive (for example, 12:00:01 excludes the first second of the minute).
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+            Deprecated, please use `endTime` instead.
           schema:
             type: string
+            format: date-time
+          deprecated: true
         - name: metadata
           in: query
           description: Filter transactions by metadata key value pairs. Nested objects can be used as seen in the example below.
@@ -494,7 +540,7 @@ paths:
     get:
       tags:
         - Transactions
-      summary: List transactions from a ledger.
+      summary: List transactions from a ledger
       description: List transactions from a ledger, sorted by txid in descending order.
       operationId: listTransactions
       parameters:
@@ -505,15 +551,30 @@ paths:
           schema:
             type: string
             example: ledger001
-        - name: page_size
+        - name: pageSize
           in: query
-          description: 'The maximum number of results to return per page'
+          description: |
+            The maximum number of results to return per page.
+          example: 100
           schema:
             type: integer
             format: int64
             minimum: 1
             maximum: 1000
             default: 15
+        - name: page_size
+          in: query
+          description: |
+            The maximum number of results to return per page.
+            Deprecated, please use `pageSize` instead.
+          example: 100
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 1000
+            default: 15
+          deprecated: true
         - name: after
           in: query
           description: Pagination cursor, will return transactions after given txid
@@ -546,21 +607,42 @@ paths:
           schema:
             type: string
             example: users:001
+        - name: startTime
+          in: query
+          description: |
+            Filter transactions that occurred after this timestamp.
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: start_time
           in: query
           description: |
             Filter transactions that occurred after this timestamp.
-            The format is RFC3339 and is inclusive (for example, 12:00:01 includes the first second of the minute).
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+            Deprecated, please use `startTime` instead.
           schema:
             type: string
-            example:
+            format: date-time
+          deprecated: true
+        - name: endTime
+          in: query
+          description: |
+            Filter transactions that occurred before this timestamp.
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: end_time
           in: query
           description: |
             Filter transactions that occurred before this timestamp.
-            The format is RFC3339 and is exclusive (for example, 12:00:01 excludes the first second of the minute).
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+            Deprecated, please use `endTime` instead.
           schema:
             type: string
+            format: date-time
+          deprecated: true
         - name: cursor
           in: query
           description: |
@@ -578,7 +660,7 @@ paths:
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
             No other parameters can be set when this parameter is set.
-            Deprecated: Use cursor instead.
+            Deprecated, please use `cursor` instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
@@ -609,7 +691,7 @@ paths:
     post:
       tags:
         - Transactions
-      summary: Create a new transaction to a ledger.
+      summary: Create a new transaction to a ledger
       operationId: createTransaction
       parameters:
         - name: ledger
@@ -653,7 +735,7 @@ paths:
     get:
       tags:
         - Transactions
-      summary: Get transaction from a ledger by its ID.
+      summary: Get transaction from a ledger by its ID
       operationId: getTransaction
       parameters:
         - name: ledger
@@ -690,7 +772,7 @@ paths:
     post:
       tags:
         - Transactions
-      summary: Set the metadata of a transaction by its ID.
+      summary: Set the metadata of a transaction by its ID
       operationId: addMetadataOnTransaction
       parameters:
         - name: ledger
@@ -731,7 +813,7 @@ paths:
       tags:
         - Transactions
       operationId: revertTransaction
-      summary: Revert a ledger transaction by its ID.
+      summary: Revert a ledger transaction by its ID
       parameters:
         - name: ledger
           in: path
@@ -767,7 +849,7 @@ paths:
     post:
       tags:
         - Transactions
-      summary: Create a new batch of transactions to a ledger.
+      summary: Create a new batch of transactions to a ledger
       operationId: CreateTransactions
       parameters:
         - name: ledger
@@ -840,7 +922,7 @@ paths:
             Parameter used in pagination requests.
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
-            Deprecated: Use cursor instead.
+            Deprecated, please use `cursor` instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
@@ -898,7 +980,7 @@ paths:
     get:
       tags:
         - Logs
-      summary: List the logs from a ledger.
+      summary: List the logs from a ledger
       description: List the logs from a ledger, sorted by ID in descending order.
       operationId: listLogs
       parameters:
@@ -909,15 +991,30 @@ paths:
           schema:
             type: string
             example: ledger001
-        - name: page_size
+        - name: pageSize
           in: query
-          description: 'The maximum number of results to return per page'
+          description: |
+            The maximum number of results to return per page.
+          example: 100
           schema:
             type: integer
             format: int64
             minimum: 1
             maximum: 1000
             default: 15
+        - name: page_size
+          in: query
+          description: |
+            The maximum number of results to return per page.
+            Deprecated, please use `pageSize` instead.
+          example: 100
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 1000
+            default: 15
+          deprecated: true
         - name: after
           in: query
           description: Pagination cursor, will return the logs after a given ID.
@@ -925,21 +1022,42 @@ paths:
           schema:
             type: string
             example: 1234
+        - name: startTime
+          in: query
+          description: |
+            Filter transactions that occurred after this timestamp.
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: start_time
           in: query
           description: |
-            Filter logs that occurred after this timestamp.
-            The format is RFC3339 and is inclusive (for example, 12:00:01 includes the first second of the minute).
+            Filter transactions that occurred after this timestamp.
+            The format is RFC3339 and is inclusive (for example, "2023-01-02T15:04:01Z" includes the first second of 4th minute).
+            Deprecated, please use `startTime` instead.
           schema:
             type: string
-            example:
+            format: date-time
+          deprecated: true
+        - name: endTime
+          in: query
+          description: |
+            Filter transactions that occurred before this timestamp.
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+          schema:
+            type: string
+            format: date-time
         - name: end_time
           in: query
           description: |
-            Filter logs that occurred before this timestamp.
-            The format is RFC3339 and is exclusive (for example, 12:00:01 excludes the first second of the minute).
+            Filter transactions that occurred before this timestamp.
+            The format is RFC3339 and is exclusive (for example, "2023-01-02T15:04:01Z" excludes the first second of 4th minute).
+            Deprecated, please use `endTime` instead.
           schema:
             type: string
+            format: date-time
+          deprecated: true
         - name: cursor
           in: query
           description: |
@@ -957,7 +1075,7 @@ paths:
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
             No other parameters can be set when this parameter is set.
-            Deprecated: Use cursor instead.
+            Deprecated, please use `cursor` instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==

--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -140,16 +140,28 @@ paths:
             type: string
             enum: [gte, lte, gt, lt, e, ne]
             example: gte
+        - name: cursor
+          in: query
+          description: |
+            Parameter used in pagination requests. Maximum page size is set to 15.
+            Set to the value of next for the next page of results.
+            Set to the value of previous for the previous page of results.
+            No other parameters can be set when this parameter is set.
+          schema:
+            type: string
+            example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
         - name: pagination_token
           in: query
           description: |
             Parameter used in pagination requests. Maximum page size is set to 15.
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
-            No other parameters can be set when the pagination token is set.
+            No other parameters can be set when this parameter is set.
+            Deprecated: Use cursor instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
+          deprecated: true
       responses:
         "200":
           description: OK
@@ -522,16 +534,28 @@ paths:
             The format is RFC3339 and is exclusive (for example, 12:00:01 excludes the first second of the minute).
           schema:
             type: string
+        - name: cursor
+          in: query
+          description: |
+            Parameter used in pagination requests. Maximum page size is set to 15.
+            Set to the value of next for the next page of results.
+            Set to the value of previous for the previous page of results.
+            No other parameters can be set when this parameter is set.
+          schema:
+            type: string
+            example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
         - name: pagination_token
           in: query
           description: |
             Parameter used in pagination requests. Maximum page size is set to 15.
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
-            No other parameters can be set when the pagination token is set.
+            No other parameters can be set when this parameter is set.
+            Deprecated: Use cursor instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
+          deprecated: true
         - name: metadata
           in: query
           description: Filter transactions by metadata key value pairs. Nested objects can be used as seen in the example below.
@@ -816,15 +840,27 @@ paths:
           schema:
             type: string
             example: users:003
+        - name: cursor
+          in: query
+          description: |
+            Parameter used in pagination requests. Maximum page size is set to 15.
+            Set to the value of next for the next page of results.
+            Set to the value of previous for the previous page of results.
+            No other parameters can be set when this parameter is set.
+          schema:
+            type: string
+            example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
         - name: pagination_token
           in: query
           description: |-
             Parameter used in pagination requests.
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
+            Deprecated: Use cursor instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
+          deprecated: true
       responses:
         "200":
           description: OK
@@ -940,16 +976,28 @@ paths:
             The format is RFC3339 and is exclusive (for example, 12:00:01 excludes the first second of the minute).
           schema:
             type: string
+        - name: cursor
+          in: query
+          description: |
+            Parameter used in pagination requests. Maximum page size is set to 15.
+            Set to the value of next for the next page of results.
+            Set to the value of previous for the previous page of results.
+            No other parameters can be set when this parameter is set.
+          schema:
+            type: string
+            example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
         - name: pagination_token
           in: query
           description: |
             Parameter used in pagination requests. Maximum page size is set to 15.
             Set to the value of next for the next page of results.
             Set to the value of previous for the previous page of results.
-            No other parameters can be set when the pagination token is set.
+            No other parameters can be set when this parameter is set.
+            Deprecated: Use cursor instead.
           schema:
             type: string
             example: aHR0cHM6Ly9nLnBhZ2UvTmVrby1SYW1lbj9zaGFyZQ==
+          deprecated: true
       responses:
         "200":
           description: OK
@@ -1462,15 +1510,9 @@ components:
         name:
           type: string
           example: ledger001
-        version:
-          type: string
-          example: v1.8.1
         storage:
           type: object
           properties:
-            driver:
-              type: string
-              example: postgres
             migrations:
               type: array
               items:
@@ -1484,6 +1526,9 @@ components:
           format: int64
           minimum: 0
           example: 11
+        name:
+          type: string
+          example: migrations:001
         date:
           type: string
           format: date-time

--- a/pkg/api/controllers/transaction_controller.go
+++ b/pkg/api/controllers/transaction_controller.go
@@ -27,18 +27,32 @@ func (ctl *TransactionController) CountTransactions(c *gin.Context) {
 
 	var startTimeParsed, endTimeParsed time.Time
 	var err error
-	if c.Query("start_time") != "" {
-		startTimeParsed, err = time.Parse(time.RFC3339, c.Query("start_time"))
+	if c.Query(QueryKeyStartTime) != "" {
+		startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTime))
 		if err != nil {
-			apierrors.ResponseError(c, ledger.NewValidationError("invalid 'start_time' query param"))
+			apierrors.ResponseError(c, ErrInvalidStartTime)
+			return
+		}
+	}
+	if c.Query(QueryKeyStartTimeDeprecated) != "" {
+		startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTimeDeprecated))
+		if err != nil {
+			apierrors.ResponseError(c, ErrInvalidStartTimeDeprecated)
 			return
 		}
 	}
 
-	if c.Query("end_time") != "" {
-		endTimeParsed, err = time.Parse(time.RFC3339, c.Query("end_time"))
+	if c.Query(QueryKeyEndTime) != "" {
+		endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTime))
 		if err != nil {
-			apierrors.ResponseError(c, ledger.NewValidationError("invalid 'end_time' query param"))
+			apierrors.ResponseError(c, ErrInvalidEndTime)
+			return
+		}
+	}
+	if c.Query(QueryKeyEndTimeDeprecated) != "" {
+		endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTimeDeprecated))
+		if err != nil {
+			apierrors.ResponseError(c, ErrInvalidEndTimeDeprecated)
 			return
 		}
 	}
@@ -51,10 +65,7 @@ func (ctl *TransactionController) CountTransactions(c *gin.Context) {
 		WithStartTimeFilter(startTimeParsed).
 		WithEndTimeFilter(endTimeParsed)
 
-	count, err := l.(*ledger.Ledger).CountTransactions(
-		c.Request.Context(),
-		*txQuery,
-	)
+	count, err := l.(*ledger.Ledger).CountTransactions(c.Request.Context(), *txQuery)
 	if err != nil {
 		apierrors.ResponseError(c, err)
 		return
@@ -69,10 +80,17 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 	txQuery := ledger.NewTransactionsQuery()
 
 	if c.Query(QueryKeyCursor) != "" {
-		if c.Query("after") != "" || c.Query("reference") != "" ||
-			c.Query("account") != "" || c.Query("source") != "" ||
-			c.Query("destination") != "" || c.Query("start_time") != "" ||
-			c.Query("end_time") != "" || c.Query("page_size") != "" {
+		if c.Query("after") != "" ||
+			c.Query("reference") != "" ||
+			c.Query("account") != "" ||
+			c.Query("source") != "" ||
+			c.Query("destination") != "" ||
+			c.Query(QueryKeyStartTime) != "" ||
+			c.Query(QueryKeyStartTimeDeprecated) != "" ||
+			c.Query(QueryKeyEndTime) != "" ||
+			c.Query(QueryKeyEndTimeDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursor)))
 			return
@@ -104,10 +122,17 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 			WithPageSize(token.PageSize)
 
 	} else if c.Query(QueryKeyCursorDeprecated) != "" {
-		if c.Query("after") != "" || c.Query("reference") != "" ||
-			c.Query("account") != "" || c.Query("source") != "" ||
-			c.Query("destination") != "" || c.Query("start_time") != "" ||
-			c.Query("end_time") != "" || c.Query("page_size") != "" {
+		if c.Query("after") != "" ||
+			c.Query("reference") != "" ||
+			c.Query("account") != "" ||
+			c.Query("source") != "" ||
+			c.Query("destination") != "" ||
+			c.Query(QueryKeyStartTime) != "" ||
+			c.Query(QueryKeyStartTimeDeprecated) != "" ||
+			c.Query(QueryKeyEndTime) != "" ||
+			c.Query(QueryKeyEndTimeDeprecated) != "" ||
+			c.Query(QueryKeyPageSize) != "" ||
+			c.Query(QueryKeyPageSizeDeprecated) != "" {
 			apierrors.ResponseError(c, ledger.NewValidationError(
 				fmt.Sprintf("no other query params can be set with '%s'", QueryKeyCursorDeprecated)))
 			return
@@ -151,20 +176,32 @@ func (ctl *TransactionController) GetTransactions(c *gin.Context) {
 		}
 
 		var startTimeParsed, endTimeParsed time.Time
-		if c.Query("start_time") != "" {
-			startTimeParsed, err = time.Parse(time.RFC3339, c.Query("start_time"))
+		if c.Query(QueryKeyStartTime) != "" {
+			startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTime))
 			if err != nil {
-				apierrors.ResponseError(c, ledger.NewValidationError(
-					"invalid 'start_time' query param"))
+				apierrors.ResponseError(c, ErrInvalidStartTime)
+				return
+			}
+		}
+		if c.Query(QueryKeyStartTimeDeprecated) != "" {
+			startTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyStartTimeDeprecated))
+			if err != nil {
+				apierrors.ResponseError(c, ErrInvalidStartTimeDeprecated)
 				return
 			}
 		}
 
-		if c.Query("end_time") != "" {
-			endTimeParsed, err = time.Parse(time.RFC3339, c.Query("end_time"))
+		if c.Query(QueryKeyEndTime) != "" {
+			endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTime))
 			if err != nil {
-				apierrors.ResponseError(c, ledger.NewValidationError(
-					"invalid 'end_time' query param"))
+				apierrors.ResponseError(c, ErrInvalidEndTime)
+				return
+			}
+		}
+		if c.Query(QueryKeyEndTimeDeprecated) != "" {
+			endTimeParsed, err = time.Parse(time.RFC3339, c.Query(QueryKeyEndTimeDeprecated))
+			if err != nil {
+				apierrors.ResponseError(c, ErrInvalidEndTimeDeprecated)
 				return
 			}
 		}

--- a/pkg/storage/sqlstorage/accounts.go
+++ b/pkg/storage/sqlstorage/accounts.go
@@ -79,7 +79,7 @@ func (s *Store) buildAccountsQuery(p ledger.AccountsQuery) (*sqlbuilder.SelectBu
 				sb.Where(sb.NotEqual(balanceOperation, balanceValue))
 			default:
 				// parameter is validated in the controller for now
-				panic("invalid balance_operator parameter")
+				panic("invalid balance operator parameter")
 			}
 		} else { // if no operator is given, default to gte
 			sb.Where(sb.GreaterEqualThan(balanceOperation, balanceValue))

--- a/pkg/storage/sqlstorage/accounts_test.go
+++ b/pkg/storage/sqlstorage/accounts_test.go
@@ -56,8 +56,8 @@ func TestAccounts(t *testing.T) {
 			}, "invalid balance in storage should panic")
 	})
 
-	t.Run("panic invalid balance_operator", func(t *testing.T) {
-		assert.PanicsWithValue(t, "invalid balance_operator parameter", func() {
+	t.Run("panic invalid balance operator", func(t *testing.T) {
+		assert.PanicsWithValue(t, "invalid balance operator parameter", func() {
 			q := ledger.AccountsQuery{
 				PageSize: 10,
 				Filters: ledger.AccountsQueryFilters{
@@ -70,7 +70,7 @@ func TestAccounts(t *testing.T) {
 		}, "invalid balance operator in storage should panic")
 	})
 
-	t.Run("success balance_operator", func(t *testing.T) {
+	t.Run("success balance operator", func(t *testing.T) {
 		q := ledger.AccountsQuery{
 			PageSize: 10,
 			Filters: ledger.AccountsQueryFilters{
@@ -80,6 +80,6 @@ func TestAccounts(t *testing.T) {
 		}
 
 		_, err := store.GetAccounts(context.Background(), q)
-		assert.NoError(t, err, "balance_operator filter should not fail")
+		assert.NoError(t, err, "balance operator filter should not fail")
 	})
 }

--- a/pkg/storage/sqlstorage/pagination.go
+++ b/pkg/storage/sqlstorage/pagination.go
@@ -12,24 +12,24 @@ type TxsPaginationToken struct {
 	AccountFilter     string            `json:"account,omitempty"`
 	SourceFilter      string            `json:"source,omitempty"`
 	DestinationFilter string            `json:"destination,omitempty"`
-	StartTime         time.Time         `json:"start_time,omitempty"`
-	EndTime           time.Time         `json:"end_time,omitempty"`
+	StartTime         time.Time         `json:"startTime,omitempty"`
+	EndTime           time.Time         `json:"endTime,omitempty"`
 	MetadataFilter    map[string]string `json:"metadata,omitempty"`
-	PageSize          uint              `json:"page_size,omitempty"`
+	PageSize          uint              `json:"pageSize,omitempty"`
 }
 
 type AccPaginationToken struct {
-	PageSize              uint                   `json:"page_size"`
+	PageSize              uint                   `json:"pageSize"`
 	Offset                uint                   `json:"offset"`
 	AfterAddress          string                 `json:"after,omitempty"`
 	AddressRegexpFilter   string                 `json:"address,omitempty"`
 	MetadataFilter        map[string]string      `json:"metadata,omitempty"`
 	BalanceFilter         string                 `json:"balance,omitempty"`
-	BalanceOperatorFilter ledger.BalanceOperator `json:"balance_operator,omitempty"`
+	BalanceOperatorFilter ledger.BalanceOperator `json:"balanceOperator,omitempty"`
 }
 
 type BalancesPaginationToken struct {
-	PageSize            uint   `json:"page_size"`
+	PageSize            uint   `json:"pageSize"`
 	Offset              uint   `json:"offset"`
 	AfterAddress        string `json:"after,omitempty"`
 	AddressRegexpFilter string `json:"address,omitempty"`
@@ -37,7 +37,7 @@ type BalancesPaginationToken struct {
 
 type LogsPaginationToken struct {
 	AfterID   uint64    `json:"after"`
-	PageSize  uint      `json:"page_size,omitempty"`
-	StartTime time.Time `json:"start_time,omitempty"`
-	EndTime   time.Time `json:"end_time,omitempty"`
+	PageSize  uint      `json:"pageSize,omitempty"`
+	StartTime time.Time `json:"startTime,omitempty"`
+	EndTime   time.Time `json:"endTime,omitempty"`
 }


### PR DESCRIPTION
- deprecate `pagination_token` and add `cursor` query param
- deprecate `page_size` and add `pageSize` query param
- deprecate `start_time` and add `startTime` query param
- deprecate `end_time` and add `endTime` query param
- deprecate `balance_operator` and add `balanceOperator` query param
- fix {ledger}/_info response
- fix ScriptResponse duplicate details field