### PR TITLE
chore: add example in the description for metadata filter

### DIFF
--- a/pkg/api/controllers/swagger.yaml
+++ b/pkg/api/controllers/swagger.yaml
@@ -75,7 +75,7 @@ paths:
             example: users:.+
         - name: metadata
           in: query
-          description: Filter accounts by metadata key value pairs. Nested objects can be used as seen in the example below.
+          description: Filter accounts by metadata key value pairs. Can be used like this metadata[key]=value1&metadata[a.nested.key]=value2
           style: deepObject
           explode: true
           schema:


### PR DESCRIPTION
This PR adds an example on how to use the metadata filter for the GET /transactions route.
For whatever reason our swagger has decided not to display it in the example area so here we are