### PR TITLE
feat: faster timestamp queries

### DIFF
--- a/pkg/storage/sqlstorage/migrates/21-optimized-temporal/postgres.sql
+++ b/pkg/storage/sqlstorage/migrates/21-optimized-temporal/postgres.sql
@@ -1,0 +1,2 @@
+--statement
+CREATE INDEX IF NOT EXISTS transactions_ts_desc ON "VAR_LEDGER_NAME".transactions ("timestamp" DESC);

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -122,6 +122,22 @@ func (s *Store) buildTransactionsQuery(flavor Flavor, p ledger.TransactionsQuery
 	}
 	if !endTime.IsZero() {
 		sb.Where(sb.L("timestamp", endTime.UTC()))
+
+		// We nudge the query planner in the right direction,
+		// by reducing the search space according to the end time.
+		// We have to use a raw query as the sqlbuilder
+		// does not support LTE+subqueries in the where clause.
+		sb.SQL(fmt.Sprintf(`
+			AND "id" <= (
+				SELECT "id"
+				FROM "%s".transactions
+				WHERE "timestamp" < '%s'::timestamptz
+				ORDER BY "timestamp" DESC, "id" DESC
+				LIMIT 1
+			)`,
+			s.schema.Name(),
+			endTime.UTC().Format(time.RFC3339),
+		))
 		t.EndTime = endTime
 	}
 

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -123,7 +123,7 @@ func (s *Store) buildTransactionsQuery(flavor Flavor, p ledger.TransactionsQuery
 	if !endTime.IsZero() {
 		sb.Where(sb.L("timestamp", endTime.UTC()))
 
-		if p.PageSize == 1 {
+		if flavor == PostgreSQL {
 			// We nudge the query planner in the right direction,
 			// by reducing the search space according to the end time.
 			// We have to use a raw query as the sqlbuilder

--- a/pkg/storage/sqlstorage/transactions.go
+++ b/pkg/storage/sqlstorage/transactions.go
@@ -461,7 +461,7 @@ func (s *Store) insertTransactions(ctx context.Context, txs ...core.ExpandedTran
                                pre_commit_volumes,
                                post_commit_volumes) (SELECT * FROM unnest(
                                    $1::int[],
-                                   $2::timestamp[],
+                                   $2::timestamptz[],
                                    $3::varchar[],
                                    $4::jsonb[],
                                    $5::jsonb[],

--- a/pkg/storage/sqlstorage/transactions_test.go
+++ b/pkg/storage/sqlstorage/transactions_test.go
@@ -354,7 +354,7 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		require.Equal(t, 1, cursor.PageSize)
 
 		// Transaction timestamp fetched should be equal to the timestamp of the committed transaction.
-		require.Equal(t, cursor.Data[0].Timestamp, tx3.Timestamp.Format(time.RFC3339))
+		require.True(t, cursor.Data[0].Timestamp.Equal(tx3.Timestamp))
 
 		cursor, err = store.GetTransactions(context.Background(), ledger.TransactionsQuery{
 			AfterTxID: cursor.Data[0].ID,

--- a/pkg/storage/sqlstorage/transactions_test.go
+++ b/pkg/storage/sqlstorage/transactions_test.go
@@ -353,6 +353,9 @@ func testTransactions(t *testing.T, store *sqlstorage.Store) {
 		// Should get only the first transaction.
 		require.Equal(t, 1, cursor.PageSize)
 
+		// Transaction timestamp fetched should be equal to the timestamp of the committed transaction.
+		require.Equal(t, cursor.Data[0].Timestamp, tx3.Timestamp.Format(time.RFC3339))
+
 		cursor, err = store.GetTransactions(context.Background(), ledger.TransactionsQuery{
 			AfterTxID: cursor.Data[0].ID,
 			PageSize:  1,


### PR DESCRIPTION
This pull request introduces some improvements on temporal queries on transactions, by reviewing the way the `endTime` parameter is compiled.

We leverage the property on v1 stating that `∀A,B, (A.timestamp > B.timestamp) ⇒ (A.txid > B.txid)` to reduce the search space with an upper-bounded txid.

An index is added on the transactions table, to efficiently sort and query timestamps.

-----
Internal: Fixes ENG-573