### PR TITLE
ci: add Earthfile target for CI and update GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,6 @@ jobs:
   Earthly:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: 'actions/checkout@v4'
-        with:
-          fetch-depth: 0
       - name: Setup Env
         uses: ./.github/actions/env
         with:
@@ -39,19 +36,20 @@ jobs:
           --allow-privileged
           --secret SPEAKEASY_API_KEY=$SPEAKEASY_API_KEY
           ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') && '--no-cache' || '' }}
-          +ci
+          github.com/formancehq/earthly+run-ci --project=ledger --commit=$COMMIT
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-      - name: Get changed files
-        id: changed-files
-        shell: bash
-        run: |
-          hasChanged=$(git status --porcelain) 
-          if (( $(echo ${#hasChanged}) != 0 )); then
-            git status
-            echo "There are changes in the repository"
-            exit 1
-          fi
+          COMMIT: ${{ github.sha }}
+#      - name: Get changed files
+#        id: changed-files
+#        shell: bash
+#        run: |
+#          hasChanged=$(git status --porcelain)
+#          if (( $(echo ${#hasChanged}) != 0 )); then
+#            git status
+#            echo "There are changes in the repository"
+#            exit 1
+#          fi
 
   GoReleaser:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  Dirty:
+  Earthly:
     runs-on: "ubuntu-latest"
     steps:
       - uses: 'actions/checkout@v4'
@@ -39,7 +39,7 @@ jobs:
           --allow-privileged
           --secret SPEAKEASY_API_KEY=$SPEAKEASY_API_KEY
           ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') && '--no-cache' || '' }}
-          +pre-commit
+          +ci
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
       - name: Get changed files
@@ -53,33 +53,9 @@ jobs:
             exit 1
           fi
 
-  Tests:
-    runs-on: "ubuntu-latest"
-    needs:
-      - Dirty
-    steps:
-      - uses: 'actions/checkout@v4'
-        with:
-          fetch-depth: 0
-      - name: Setup Env
-        uses: ./.github/actions/env
-        with:
-          token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - run: >
-          earthly
-          --no-output
-          --allow-privileged
-          --secret SPEAKEASY_API_KEY=$SPEAKEASY_API_KEY
-          ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') && '--no-cache' || '' }}
-          +tests
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-
   GoReleaser:
     runs-on: "ubuntu-latest"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
-    needs:
-      - Dirty
     steps:
       - uses: earthly/actions-setup@v1
         with:
@@ -120,7 +96,7 @@ jobs:
     environment: staging
     needs:
       - GoReleaser
-      - Tests
+      - Earthly
     steps:
       - uses: earthly/actions-setup@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
   Earthly:
     runs-on: "ubuntu-latest"
     steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
       - name: Setup Env
         uses: ./.github/actions/env
         with:


### PR DESCRIPTION
- Add `ci` target to Earthfile for local builds and tests
- Rename workflow job `Dirty` to `Earthly`
- Replace `+pre-commit` with `+ci` in GitHub workflow
- Remove separate `Tests` job in GitHub workflow
- Update job dependencies in GitHub workflow