### PR TITLE
feat: add task to handle OpenAPI artifact in Earthfile

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -72,3 +72,9 @@ export-database-schema:
     END
     SAVE ARTIFACT docs/database/_system/diagrams AS LOCAL docs/database/_system/diagrams
     SAVE ARTIFACT docs/database/_default/diagrams AS LOCAL docs/database/_default/diagrams
+
+openapi:
+    FROM core+base-image
+    WORKDIR /src
+    COPY openapi.yaml openapi.yaml
+    SAVE ARTIFACT ./openapi.yaml


### PR DESCRIPTION
Added a new task `openapi` to manage OpenAPI specification by copying `openapi.yaml` and saving it as an artifact. This enhances automation and ensures consistent handling of OpenAPI files.