### PR TITLE
feat: added numscript feature flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"net/http"
 	"net/http/pprof"
-	"strings"
 	"time"
 
 	"github.com/formancehq/go-libs/v2/logging"
@@ -68,7 +67,7 @@ func NewServeCommand() *cobra.Command {
 				return err
 			}
 			numscriptInterpreter, _ := cmd.Flags().GetBool(NumscriptInterpreterFlag)
-			numscriptInterpreterFlags, _ := cmd.Flags().GetString(NumscriptInterpreterFlagsToPass)
+			numscriptInterpreterFlags, _ := cmd.Flags().GetStringSlice(NumscriptInterpreterFlagsToPass)
 
 			bulkMaxSize, err := cmd.Flags().GetInt(BulkMaxSizeFlag)
 			if err != nil {
@@ -91,11 +90,8 @@ func NewServeCommand() *cobra.Command {
 			}
 
 			interpreterFlags := make(map[string]struct{})
-			for _, flag := range strings.Split(numscriptInterpreterFlags, ",") {
-				flag = strings.Trim(flag, " ")
-				if flag != "" {
-					interpreterFlags[flag] = struct{}{}
-				}
+			for _, flag := range numscriptInterpreterFlags {
+				interpreterFlags[flag] = struct{}{}
 			}
 
 			options := []fx.Option{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -89,11 +89,6 @@ func NewServeCommand() *cobra.Command {
 				return err
 			}
 
-			interpreterFlags := make(map[string]struct{})
-			for _, flag := range numscriptInterpreterFlags {
-				interpreterFlags[flag] = struct{}{}
-			}
-
 			options := []fx.Option{
 				fx.NopLogger,
 				otlp.FXModuleFromFlags(cmd),
@@ -105,7 +100,7 @@ func NewServeCommand() *cobra.Command {
 				storage.NewFXModule(serveConfiguration.autoUpgrade),
 				systemcontroller.NewFXModule(systemcontroller.ModuleConfiguration{
 					NumscriptInterpreter:      numscriptInterpreter,
-					NumscriptInterpreterFlags: interpreterFlags,
+					NumscriptInterpreterFlags: numscriptInterpreterFlags,
 					NSCacheConfiguration: ledgercontroller.CacheConfiguration{
 						MaxCount: serveConfiguration.numscriptCacheMaxCount,
 					},

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -170,6 +170,7 @@ func NewServeCommand() *cobra.Command {
 	cmd.Flags().Int(BulkMaxSizeFlag, api.DefaultBulkMaxSize, "Bulk max size (default 100)")
 	cmd.Flags().Int(BulkParallelFlag, 10, "Bulk max parallelism")
 	cmd.Flags().Bool(NumscriptInterpreterFlag, false, "Enable experimental numscript rewrite")
+	cmd.Flags().String(NumscriptInterpreterFlagsToPass, "", "Feature flags to pass to the experimental numscript interpreter")
 	cmd.Flags().Uint64(MaxPageSizeFlag, 100, "Max page size")
 	cmd.Flags().Uint64(DefaultPageSizeFlag, 15, "Default page size")
 

--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/big"
+	"reflect"
+
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/go-libs/v2/time"
 	"github.com/formancehq/ledger/pkg/features"
-	"math/big"
-	"reflect"
 
 	. "github.com/formancehq/go-libs/v2/collectionutils"
 	"go.opentelemetry.io/otel/metric"
@@ -291,7 +292,7 @@ func (ctrl *DefaultController) Export(ctx context.Context, w ExportWriter) error
 		ctx,
 		ColumnPaginatedQuery[any]{
 			PageSize: 100,
-			Order: pointer.For(bunpaginate.Order(bunpaginate.OrderAsc)),
+			Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderAsc)),
 		},
 		func(ctx context.Context, q ColumnPaginatedQuery[any]) (*bunpaginate.Cursor[ledger.Log], error) {
 			return ctrl.store.Logs().Paginate(ctx, q)

--- a/internal/controller/ledger/numscript_parser.go
+++ b/internal/controller/ledger/numscript_parser.go
@@ -33,7 +33,7 @@ func NewDefaultNumscriptParser() *DefaultNumscriptParser {
 
 var _ NumscriptParser = (*DefaultNumscriptParser)(nil)
 
-type InterpreterNumscriptParser struct{ featureFlags map[string]struct{} }
+type InterpreterNumscriptParser struct{ featureFlags []string }
 
 func (n *InterpreterNumscriptParser) Parse(script string) (NumscriptRuntime, error) {
 	result := numscript.Parse(script)
@@ -44,10 +44,15 @@ func (n *InterpreterNumscriptParser) Parse(script string) (NumscriptRuntime, err
 			Errors: errs,
 		}
 	}
-	return NewDefaultInterpreterMachineAdapter(result, n.featureFlags), nil
+
+	interpreterFlags := make(map[string]struct{})
+	for _, flag := range n.featureFlags {
+		interpreterFlags[flag] = struct{}{}
+	}
+	return NewDefaultInterpreterMachineAdapter(result, interpreterFlags), nil
 }
 
-func NewInterpreterNumscriptParser(featureFlags map[string]struct{}) *InterpreterNumscriptParser {
+func NewInterpreterNumscriptParser(featureFlags []string) *InterpreterNumscriptParser {
 	return &InterpreterNumscriptParser{
 		featureFlags: featureFlags,
 	}

--- a/internal/controller/ledger/numscript_parser.go
+++ b/internal/controller/ledger/numscript_parser.go
@@ -33,7 +33,7 @@ func NewDefaultNumscriptParser() *DefaultNumscriptParser {
 
 var _ NumscriptParser = (*DefaultNumscriptParser)(nil)
 
-type InterpreterNumscriptParser struct{}
+type InterpreterNumscriptParser struct{ featureFlags map[string]struct{} }
 
 func (n *InterpreterNumscriptParser) Parse(script string) (NumscriptRuntime, error) {
 	result := numscript.Parse(script)
@@ -44,11 +44,13 @@ func (n *InterpreterNumscriptParser) Parse(script string) (NumscriptRuntime, err
 			Errors: errs,
 		}
 	}
-	return NewDefaultInterpreterMachineAdapter(result), nil
+	return NewDefaultInterpreterMachineAdapter(result, n.featureFlags), nil
 }
 
-func NewInterpreterNumscriptParser() *InterpreterNumscriptParser {
-	return &InterpreterNumscriptParser{}
+func NewInterpreterNumscriptParser(featureFlags map[string]struct{}) *InterpreterNumscriptParser {
+	return &InterpreterNumscriptParser{
+		featureFlags: featureFlags,
+	}
 }
 
 var _ NumscriptParser = (*InterpreterNumscriptParser)(nil)

--- a/internal/controller/ledger/numscript_runtime.go
+++ b/internal/controller/ledger/numscript_runtime.go
@@ -90,17 +90,19 @@ var _ NumscriptRuntime = (*MachineNumscriptRuntimeAdapter)(nil)
 var _ NumscriptRuntime = (*DefaultInterpreterMachineAdapter)(nil)
 
 type DefaultInterpreterMachineAdapter struct {
-	parseResult numscript.ParseResult
+	parseResult  numscript.ParseResult
+	featureFlags map[string]struct{}
 }
 
-func NewDefaultInterpreterMachineAdapter(parseResult numscript.ParseResult) *DefaultInterpreterMachineAdapter {
+func NewDefaultInterpreterMachineAdapter(parseResult numscript.ParseResult, featureFlags map[string]struct{}) *DefaultInterpreterMachineAdapter {
 	return &DefaultInterpreterMachineAdapter{
-		parseResult: parseResult,
+		parseResult:  parseResult,
+		featureFlags: featureFlags,
 	}
 }
 
 func (d *DefaultInterpreterMachineAdapter) Execute(ctx context.Context, store Store, vars map[string]string) (*NumscriptExecutionResult, error) {
-	execResult, err := d.parseResult.Run(ctx, vars, newNumscriptRewriteAdapter(store))
+	execResult, err := d.parseResult.RunWithFeatureFlags(ctx, vars, newNumscriptRewriteAdapter(store), d.featureFlags)
 	if err != nil {
 		return nil, ErrRuntime{
 			Source: d.parseResult.GetSource(),

--- a/internal/controller/system/module.go
+++ b/internal/controller/system/module.go
@@ -19,6 +19,8 @@ type ModuleConfiguration struct {
 	DatabaseRetryConfiguration DatabaseRetryConfiguration
 	EnableFeatures             bool
 	NumscriptInterpreter       bool
+	// Ignored whenever NumscriptInterpreter is set to false
+	NumscriptInterpreterFlags map[string]struct{}
 }
 
 func NewFXModule(configuration ModuleConfiguration) fx.Option {
@@ -34,7 +36,7 @@ func NewFXModule(configuration ModuleConfiguration) fx.Option {
 		) *DefaultController {
 			var parser ledgercontroller.NumscriptParser = ledgercontroller.NewDefaultNumscriptParser()
 			if configuration.NumscriptInterpreter {
-				parser = ledgercontroller.NewInterpreterNumscriptParser()
+				parser = ledgercontroller.NewInterpreterNumscriptParser(configuration.NumscriptInterpreterFlags)
 			}
 
 			if configuration.NSCacheConfiguration.MaxCount != 0 {

--- a/internal/controller/system/module.go
+++ b/internal/controller/system/module.go
@@ -20,7 +20,7 @@ type ModuleConfiguration struct {
 	EnableFeatures             bool
 	NumscriptInterpreter       bool
 	// Ignored whenever NumscriptInterpreter is set to false
-	NumscriptInterpreterFlags map[string]struct{}
+	NumscriptInterpreterFlags []string
 }
 
 func NewFXModule(configuration ModuleConfiguration) fx.Option {

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/nats-io/nats.go"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/nats-io/nats.go"
 
 	"github.com/formancehq/go-libs/v2/otlp"
 	"github.com/formancehq/go-libs/v2/otlp/otlpmetrics"
@@ -48,8 +49,8 @@ type Configuration struct {
 	DisableAutoUpgrade           bool
 	BulkMaxSize                  int
 	ExperimentalNumscriptRewrite bool
-	MaxPageSize uint64
-	DefaultPageSize uint64
+	MaxPageSize                  uint64
+	DefaultPageSize              uint64
 }
 
 type Logger interface {


### PR DESCRIPTION
This PR allows to pass feature flags to the numscript interpreter (which is, in turn, under a feature flags)
Values must be comma-separated
The flags are ignored whenever `--experimental-numscript-interpreter is not passed`

For example:
```
--experimental-numscript-interpreter --numscript-interpreter-flags=experimental-oneof-combinator,experimental-if-expression
```