### PR TITLE
fix: vars type can be more than string, should be object

### DIFF
--- a/openapi/v2.yaml
+++ b/openapi/v2.yaml
@@ -1606,8 +1606,7 @@ components:
             vars:
               type: object
               properties: {}
-              additionalProperties:
-                type: string
+              additionalProperties: true
               example:
                 user: users:042
           required:


### PR DESCRIPTION
* Generated (Java) SDK doesn't accept any vars other than String type (i.e. generated map is `Map<String, String>`), it should be `Map<String, Object>` type. I.e. if you have a script with monetary variable, you need a nested map to reflect the asset and amount parts.

As mentioned on [Slack](https://formance-community.slack.com/archives/C042BME2UQZ/p1739449099173399)