### PR TITLE
fix(v2.1): create transaction compatibility

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -119,7 +119,7 @@ pre-commit:
     WAIT
         BUILD +openapi
     END
-    BUILD +generate-client
+    #BUILD +generate-client
 
 bench:
     FROM core+builder-image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     - postgres:/data/postgres
 
   ledger:
-    image: golang:1.19-alpine
+    image: golang:1.22-alpine
     entrypoint: go run main.go serve
     volumes:
     - .:/src

--- a/internal/api/v2/utils.go
+++ b/internal/api/v2/utils.go
@@ -47,18 +47,18 @@ func getPITOOTFilter(r *http.Request) (*ledgerstore.PITFilter, error) {
 func getPITFilter(r *http.Request) (*ledgerstore.PITFilter, error) {
 	pitString := r.URL.Query().Get("pit")
 
-	pit := time.Now()
+	var pit *time.Time
 
 	if pitString != "" {
-		var err error
-		pit, err = time.ParseTime(pitString)
+		parsedPit, err := time.ParseTime(pitString)
 		if err != nil {
 			return nil, err
 		}
+		pit = &parsedPit
 	}
 
 	return &ledgerstore.PITFilter{
-		PIT: &pit,
+		PIT: pit,
 	}, nil
 }
 

--- a/internal/script.go
+++ b/internal/script.go
@@ -32,7 +32,12 @@ func (s ScriptV1) ToCore() Script {
 		case string:
 			s.Script.Vars[k] = v
 		case map[string]any:
-			s.Script.Vars[k] = fmt.Sprintf("%s %v", v["asset"], v["amount"])
+			switch amount := v["amount"].(type) {
+			case string:
+				s.Script.Vars[k] = fmt.Sprintf("%s %s", v["asset"], amount)
+			case float64:
+				s.Script.Vars[k] = fmt.Sprintf("%s %d", v["asset"], int(amount))
+			}
 		default:
 			s.Script.Vars[k] = fmt.Sprint(v)
 		}

--- a/internal/script_test.go
+++ b/internal/script_test.go
@@ -1,0 +1,64 @@
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertScriptV1(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name      string
+		inputVars map[string]any
+		expected  map[string]string
+	}
+
+	testCases := []testCase{
+		{
+			name: "float64 conversion",
+			inputVars: map[string]any{
+				"amount": map[string]any{
+					"asset":  "USD",
+					"amount": float64(999999999999999),
+				},
+			},
+			expected: map[string]string{
+				"amount": "USD 999999999999999",
+			},
+		},
+		{
+			name: "big int conversion",
+			inputVars: map[string]any{
+				"amount": map[string]any{
+					"asset": "USD",
+					"amount": func() string {
+						ret, _ := big.NewInt(0).SetString("9999999999999999999999999999999999999999", 10)
+						return ret.String()
+					}(),
+				},
+			},
+			expected: map[string]string{
+				"amount": "USD 9999999999999999999999999999999999999999",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			script := ScriptV1{
+				Script: Script{
+					Plain: ``,
+				},
+				Vars: tc.inputVars,
+			}
+
+			converted := script.ToCore()
+			require.Equal(t, tc.expected, converted.Vars)
+		})
+	}
+}

--- a/internal/storage/ledgerstore/accounts.go
+++ b/internal/storage/ledgerstore/accounts.go
@@ -132,6 +132,8 @@ func (store *Store) accountQueryContext(qb query.Builder, q GetAccountsQuery) (s
 			}
 
 			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil
+		case key == "first_usage":
+			return fmt.Sprintf("%s %s ?", key, query.DefaultComparisonOperatorsMapping[operator]), []any{value}, nil
 		default:
 			return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 		}

--- a/internal/storage/ledgerstore/accounts_test.go
+++ b/internal/storage/ledgerstore/accounts_test.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/formancehq/go-libs/pointer"
+
 	"github.com/formancehq/go-libs/time"
 
 	"github.com/formancehq/go-libs/logging"
@@ -155,6 +157,7 @@ func TestGetAccounts(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, accounts.Data, 3)
 	})
+
 	t.Run("list using filter on multiple address", func(t *testing.T) {
 		t.Parallel()
 		accounts, err := store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{}).
@@ -183,6 +186,18 @@ func TestGetAccounts(t *testing.T) {
 		require.Len(t, accounts.Data, 2)
 		require.Equal(t, "account:1", accounts.Data[0].Account.Address)
 		require.Equal(t, "bank", accounts.Data[1].Account.Address)
+	})
+	t.Run("list using filter on balances and pit", func(t *testing.T) {
+		t.Parallel()
+		accounts, err := store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{
+			PITFilter: PITFilter{
+				PIT: pointer.For(now.Add(100 * time.Millisecond)),
+			},
+		}).
+			WithQueryBuilder(query.Lt("balance[USD]", 0)),
+		))
+		require.NoError(t, err)
+		require.Len(t, accounts.Data, 1) // world
 	})
 
 	t.Run("list using filter on exists metadata", func(t *testing.T) {

--- a/internal/storage/ledgerstore/balances.go
+++ b/internal/storage/ledgerstore/balances.go
@@ -157,8 +157,11 @@ func (store *Store) GetBalance(ctx context.Context, address, asset string) (*big
 			Order("seq desc").
 			Limit(1)
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, sqlutils.ErrNotFound) {
 		return nil, err
+	}
+	if errors.Is(err, sqlutils.ErrNotFound) {
+		v.Balance = big.NewInt(0)
 	}
 
 	return v.Balance, nil

--- a/internal/storage/ledgerstore/balances_test.go
+++ b/internal/storage/ledgerstore/balances_test.go
@@ -18,6 +18,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetBalances(t *testing.T) {
+	t.Parallel()
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+
+	t.Run("get balance from account not existing", func(t *testing.T) {
+		t.Parallel()
+		balance, err := store.GetBalance(ctx, "account_not_existing", "USD/2")
+		require.NoError(t, err)
+		require.Equal(t, big.NewInt(0), balance)
+	})
+}
+
 func TestGetBalancesAggregated(t *testing.T) {
 	t.Parallel()
 	store := newLedgerStore(t)


### PR DESCRIPTION
- **fix: missing filter (#560)**
- **feat: replace get_account_balance sql function call by inline query (#669)**
- **fix(ledgerstore): return zero balance for non-existing accounts (#674)**
- **fix: invalid balance filter when using pit**
- **fix: incompatibility between v1 and v2 api format when using numbers with more than 7 digits**
