### PR TITLE
fix(ledger): tx reversion handles empty middle accounts

### DIFF
--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -406,6 +406,13 @@ func (ctrl *DefaultController) revertTransaction(ctx context.Context, store Stor
 				balances[posting.Source][posting.Asset],
 				big.NewInt(0).Neg(posting.Amount),
 			)
+			if _, ok := balances[posting.Destination]; ok {
+				// if destination is also a source in some posting, since balances should only contain posting sources
+				balances[posting.Destination][posting.Asset] = balances[posting.Destination][posting.Asset].Add(
+					balances[posting.Destination][posting.Asset],
+					posting.Amount,
+				)
+			}
 		}
 
 		for account, forAccount := range balances {


### PR DESCRIPTION
Suppose we have three accounts:

`account_one` with balance 10
`account_two` with balance 0
`world`

If we create a transaction with postings
`account_one -5-> account_two`
`account_two -5-> world`

we will end up with final balances

`account_one` with balance 5
`account_two` with balance 0
`world`

When trying to revert this transaction, we will:

1. Get balances for destination accounts, in this case `account_one` and `account_two` [line 388]
2. Reverse our postings so our sources are `world` and `account_two` [line 395]
3. Iterating over postings, we will deduct `posting.Amount` from each of `world` and `account 2` [line 405]
4. Verify that all three accounts are non negative [line 415]

In this example, because `account_two` has no balance we will deduct `5` credits from it and end up with `-5`, thus the reversion is failed. However, this only occurs because we account for the credits being removed from `account_two` and not the credits being added.

The solution is to track both the source and destination when adjusting credits on line 405 so we can add in the five credits that _will_ be added to `account_two` from `world` so they exist in order to be deducted via the reversion