### PR TITLE
feat: remove one UPDATE sql query in case of metadata usage

### DIFF
--- a/internal/controller/ledger/controller_default_test.go
+++ b/internal/controller/ledger/controller_default_test.go
@@ -52,7 +52,7 @@ func TestCreateTransaction(t *testing.T) {
 		}, nil)
 
 	store.EXPECT().
-		CommitTransaction(gomock.Any(), gomock.Any()).
+		CommitTransaction(gomock.Any(), gomock.Any(), nil).
 		Return(nil)
 
 	store.EXPECT().
@@ -101,7 +101,7 @@ func TestRevertTransaction(t *testing.T) {
 		Return(map[string]map[string]*big.Int{}, nil)
 
 	store.EXPECT().
-		CommitTransaction(gomock.Any(), gomock.Any()).
+		CommitTransaction(gomock.Any(), gomock.Any(), nil).
 		Return(nil)
 
 	store.EXPECT().

--- a/internal/controller/ledger/store.go
+++ b/internal/controller/ledger/store.go
@@ -34,7 +34,7 @@ type Store interface {
 
 	// GetBalances must returns balance and lock account until the end of the TX
 	GetBalances(ctx context.Context, query BalanceQuery) (Balances, error)
-	CommitTransaction(ctx context.Context, transaction *ledger.Transaction) error
+	CommitTransaction(ctx context.Context, transaction *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error
 	// RevertTransaction revert the transaction with identifier id
 	// It returns :
 	//  * the reverted transaction

--- a/internal/controller/ledger/store_generated_test.go
+++ b/internal/controller/ledger/store_generated_test.go
@@ -101,17 +101,17 @@ func (mr *MockStoreMockRecorder) Commit() *gomock.Call {
 }
 
 // CommitTransaction mocks base method.
-func (m *MockStore) CommitTransaction(ctx context.Context, transaction *ledger.Transaction) error {
+func (m *MockStore) CommitTransaction(ctx context.Context, transaction *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitTransaction", ctx, transaction)
+	ret := m.ctrl.Call(m, "CommitTransaction", ctx, transaction, accountMetadata)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitTransaction indicates an expected call of CommitTransaction.
-func (mr *MockStoreMockRecorder) CommitTransaction(ctx, transaction any) *gomock.Call {
+func (mr *MockStoreMockRecorder) CommitTransaction(ctx, transaction, accountMetadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTransaction", reflect.TypeOf((*MockStore)(nil).CommitTransaction), ctx, transaction)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTransaction", reflect.TypeOf((*MockStore)(nil).CommitTransaction), ctx, transaction, accountMetadata)
 }
 
 // DeleteAccountMetadata mocks base method.

--- a/internal/storage/ledger/accounts_test.go
+++ b/internal/storage/ledger/accounts_test.go
@@ -32,7 +32,7 @@ func TestAccountsList(t *testing.T) {
 	err := store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now).
-		WithInsertedAt(now)))
+		WithInsertedAt(now)), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
@@ -56,19 +56,19 @@ func TestAccountsList(t *testing.T) {
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(4*time.Minute)).
-		WithInsertedAt(now.Add(100*time.Millisecond))))
+		WithInsertedAt(now.Add(100*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(3*time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	t.Run("list all", func(t *testing.T) {
@@ -306,7 +306,7 @@ func TestAccountsGet(t *testing.T) {
 	tx1 := pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(100)),
 	).WithTimestamp(now))
-	err := store.CommitTransaction(ctx, tx1)
+	err := store.CommitTransaction(ctx, tx1, nil)
 	require.NoError(t, err)
 
 	// sleep for at least the time precision to ensure the next transaction is inserted with a different timestamp
@@ -321,7 +321,7 @@ func TestAccountsGet(t *testing.T) {
 	tx2 := pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(0)),
 	).WithTimestamp(now.Add(-time.Minute)))
-	err = store.CommitTransaction(ctx, tx2)
+	err = store.CommitTransaction(ctx, tx2, nil)
 	require.NoError(t, err)
 
 	t.Run("find account", func(t *testing.T) {
@@ -447,7 +447,7 @@ func TestAccountsCount(t *testing.T) {
 
 	err := store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "central_bank", "USD/2", big.NewInt(100)),
-	)))
+	)), nil)
 	require.NoError(t, err)
 
 	countAccounts, err := store.Accounts().Count(ctx, ledgercontroller.ResourceQuery[any]{})

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -199,7 +199,7 @@ func TestBalancesAggregates(t *testing.T) {
 		).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
@@ -210,7 +210,7 @@ func TestBalancesAggregates(t *testing.T) {
 		).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{

--- a/internal/storage/ledger/legacy/accounts_test.go
+++ b/internal/storage/ledger/legacy/accounts_test.go
@@ -29,7 +29,7 @@ func TestGetAccounts(t *testing.T) {
 	err := store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now).
-		WithInsertedAt(now)))
+		WithInsertedAt(now)), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.newStore.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
@@ -53,19 +53,19 @@ func TestGetAccounts(t *testing.T) {
 	err = store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(4*time.Minute)).
-		WithInsertedAt(now.Add(100*time.Millisecond))))
+		WithInsertedAt(now.Add(100*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(3*time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	t.Run("list all", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestGetAccount(t *testing.T) {
 
 	err := store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(100)),
-	).WithTimestamp(now)))
+	).WithTimestamp(now)), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.newStore.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
@@ -233,7 +233,7 @@ func TestGetAccount(t *testing.T) {
 
 	err = store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(0)),
-	).WithTimestamp(now.Add(-time.Minute))))
+	).WithTimestamp(now.Add(-time.Minute))), nil)
 	require.NoError(t, err)
 
 	t.Run("find account", func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestCountAccounts(t *testing.T) {
 
 	err := store.newStore.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "central_bank", "USD/2", big.NewInt(100)),
-	)))
+	)), nil)
 	require.NoError(t, err)
 
 	countAccounts, err := store.CountAccounts(ctx, ledgerstore.NewListAccountsQuery(ledgercontroller.NewPaginatedQueryOptions(ledgerstore.PITFilterWithVolumes{})))

--- a/internal/storage/ledger/legacy/adapters.go
+++ b/internal/storage/ledger/legacy/adapters.go
@@ -264,8 +264,8 @@ func (d *DefaultStoreAdapter) GetBalances(ctx context.Context, query ledgercontr
 	return d.newStore.GetBalances(ctx, query)
 }
 
-func (d *DefaultStoreAdapter) CommitTransaction(ctx context.Context, transaction *ledger.Transaction) error {
-	return d.newStore.CommitTransaction(ctx, transaction)
+func (d *DefaultStoreAdapter) CommitTransaction(ctx context.Context, transaction *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error {
+	return d.newStore.CommitTransaction(ctx, transaction, accountMetadata)
 }
 
 func (d *DefaultStoreAdapter) RevertTransaction(ctx context.Context, id int, at time.Time) (*ledger.Transaction, bool, error) {

--- a/internal/storage/ledger/legacy/balances_test.go
+++ b/internal/storage/ledger/legacy/balances_test.go
@@ -35,7 +35,7 @@ func TestGetBalancesAggregated(t *testing.T) {
 		).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err := store.newStore.CommitTransaction(ctx, &tx1)
+	err := store.newStore.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
@@ -46,7 +46,7 @@ func TestGetBalancesAggregated(t *testing.T) {
 		).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx2)
+	err = store.newStore.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.newStore.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{

--- a/internal/storage/ledger/legacy/transactions_test.go
+++ b/internal/storage/ledger/legacy/transactions_test.go
@@ -35,7 +35,7 @@ func TestGetTransactionWithVolumes(t *testing.T) {
 		).
 		WithReference("tx1").
 		WithTimestamp(now.Add(-3 * time.Hour))
-	err := store.newStore.CommitTransaction(ctx, &tx1)
+	err := store.newStore.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
@@ -44,7 +44,7 @@ func TestGetTransactionWithVolumes(t *testing.T) {
 		).
 		WithReference("tx2").
 		WithTimestamp(now.Add(-2 * time.Hour))
-	err = store.newStore.CommitTransaction(ctx, &tx2)
+	err = store.newStore.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx, err := store.GetTransactionWithVolumes(ctx, ledgerstore.NewGetTransactionQuery(*tx1.ID).
@@ -101,7 +101,7 @@ func TestCountTransactions(t *testing.T) {
 		tx := ledger.NewTransaction().WithPostings(
 			ledger.NewPosting("world", fmt.Sprintf("account%d", i), "USD", big.NewInt(100)),
 		)
-		err := store.newStore.CommitTransaction(ctx, &tx)
+		err := store.newStore.CommitTransaction(ctx, &tx, nil)
 		require.NoError(t, err)
 	}
 
@@ -122,7 +122,7 @@ func TestGetTransactions(t *testing.T) {
 		).
 		WithMetadata(metadata.Metadata{"category": "1"}).
 		WithTimestamp(now.Add(-3 * time.Hour))
-	err := store.newStore.CommitTransaction(ctx, &tx1)
+	err := store.newStore.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
@@ -131,7 +131,7 @@ func TestGetTransactions(t *testing.T) {
 		).
 		WithMetadata(metadata.Metadata{"category": "2"}).
 		WithTimestamp(now.Add(-2 * time.Hour))
-	err = store.newStore.CommitTransaction(ctx, &tx2)
+	err = store.newStore.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3BeforeRevert := ledger.NewTransaction().
@@ -140,7 +140,7 @@ func TestGetTransactions(t *testing.T) {
 		).
 		WithMetadata(metadata.Metadata{"category": "3"}).
 		WithTimestamp(now.Add(-time.Hour))
-	err = store.newStore.CommitTransaction(ctx, &tx3BeforeRevert)
+	err = store.newStore.CommitTransaction(ctx, &tx3BeforeRevert, nil)
 	require.NoError(t, err)
 
 	_, hasBeenReverted, err := store.newStore.RevertTransaction(ctx, *tx3BeforeRevert.ID, time.Time{})
@@ -148,7 +148,7 @@ func TestGetTransactions(t *testing.T) {
 	require.True(t, hasBeenReverted)
 
 	tx4 := tx3BeforeRevert.Reverse().WithTimestamp(now)
-	err = store.newStore.CommitTransaction(ctx, &tx4)
+	err = store.newStore.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	_, _, err = store.newStore.UpdateTransactionMetadata(ctx, *tx3BeforeRevert.ID, metadata.Metadata{
@@ -171,7 +171,7 @@ func TestGetTransactions(t *testing.T) {
 			ledger.NewPosting("users:marley", "sellers:amazon", "USD", big.NewInt(100)),
 		).
 		WithTimestamp(now)
-	err = store.newStore.CommitTransaction(ctx, &tx5)
+	err = store.newStore.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	type testCase struct {

--- a/internal/storage/ledger/legacy/volumes_test.go
+++ b/internal/storage/ledger/legacy/volumes_test.go
@@ -47,56 +47,56 @@ func TestVolumesList(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now.Add(4 * time.Minute))
-	err := store.newStore.CommitTransaction(ctx, &tx1)
+	err := store.newStore.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute)).
 		WithInsertedAt(now.Add(3 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx2)
+	err = store.newStore.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute)).
 		WithInsertedAt(now.Add(2 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx3)
+	err = store.newStore.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx4)
+	err = store.newStore.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err = store.newStore.CommitTransaction(ctx, &tx5)
+	err = store.newStore.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute)).
 		WithInsertedAt(now.Add(-time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx6)
+	err = store.newStore.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:2", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(2 * time.Minute)).
 		WithInsertedAt(now.Add(-2 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx7)
+	err = store.newStore.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	tx8 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute)).
 		WithInsertedAt(now.Add(-3 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx8)
+	err = store.newStore.CommitTransaction(ctx, &tx8, nil)
 	require.NoError(t, err)
 
 	t.Run("Get all volumes with balance for insertion date", func(t *testing.T) {
@@ -414,43 +414,43 @@ func TestVolumesAggregate(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1:2", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now)
-	err := store.newStore.CommitTransaction(ctx, &tx1)
+	err := store.newStore.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:1", "EUR", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx2)
+	err = store.newStore.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:2", "EUR", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx3)
+	err = store.newStore.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:3", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx4)
+	err = store.newStore.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:1", "USD", big.NewInt(50))).
 		WithTimestamp(now)
-	err = store.newStore.CommitTransaction(ctx, &tx5)
+	err = store.newStore.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx6)
+	err = store.newStore.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:3", "EUR", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute))
-	err = store.newStore.CommitTransaction(ctx, &tx7)
+	err = store.newStore.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.newStore.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{

--- a/internal/storage/ledger/moves_test.go
+++ b/internal/storage/ledger/moves_test.go
@@ -157,7 +157,7 @@ func TestMovesInsert(t *testing.T) {
 					tx := ledger.NewTransaction().WithPostings(
 						ledger.NewPosting(src, dst, "USD", big.NewInt(1)),
 					)
-					err = storeCP.CommitTransaction(ctx, &tx)
+					err = storeCP.CommitTransaction(ctx, &tx, nil)
 					if errors.Is(err, postgres.ErrDeadlockDetected) {
 						require.NoError(t, sqlTx.Rollback())
 						continue

--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -34,7 +34,10 @@ var (
 	metadataRegex = regexp.MustCompile(`metadata\[(.+)]`)
 )
 
-func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transaction) error {
+func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error {
+	if accountMetadata == nil {
+		accountMetadata = make(map[string]metadata.Metadata)
+	}
 
 	postCommitVolumes, err := store.UpdateVolumes(ctx, tx.VolumeUpdates()...)
 	if err != nil {
@@ -51,7 +54,7 @@ func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transactio
 		return &ledger.Account{
 			Address:       address,
 			FirstUsage:    tx.Timestamp,
-			Metadata:      make(metadata.Metadata),
+			Metadata:      accountMetadata[address],
 			InsertionDate: tx.InsertedAt,
 			UpdatedAt:     tx.InsertedAt,
 		}

--- a/internal/storage/ledger/volumes_test.go
+++ b/internal/storage/ledger/volumes_test.go
@@ -51,56 +51,56 @@ func TestVolumesList(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now.Add(4 * time.Minute))
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute)).
 		WithInsertedAt(now.Add(3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute)).
 		WithInsertedAt(now.Add(2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx3)
+	err = store.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.CommitTransaction(ctx, &tx4)
+	err = store.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err = store.CommitTransaction(ctx, &tx5)
+	err = store.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute)).
 		WithInsertedAt(now.Add(-time.Minute))
-	err = store.CommitTransaction(ctx, &tx6)
+	err = store.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:2", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(2 * time.Minute)).
 		WithInsertedAt(now.Add(-2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx7)
+	err = store.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	tx8 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute)).
 		WithInsertedAt(now.Add(-3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx8)
+	err = store.CommitTransaction(ctx, &tx8, nil)
 	require.NoError(t, err)
 
 	t.Run("Get all volumes with balance for insertion date", func(t *testing.T) {
@@ -439,43 +439,43 @@ func TestVolumesAggregate(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1:2", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now)
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:1", "EUR", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:2", "EUR", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx3)
+	err = store.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:3", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute))
-	err = store.CommitTransaction(ctx, &tx4)
+	err = store.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:1", "USD", big.NewInt(50))).
 		WithTimestamp(now)
-	err = store.CommitTransaction(ctx, &tx5)
+	err = store.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx6)
+	err = store.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:3", "EUR", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx7)
+	err = store.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{


### PR DESCRIPTION
Backport of #793 