### PR TITLE
feat: remove one UPDATE sql query in case of metadata usage

### DIFF
--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"reflect"
 
-	. "github.com/formancehq/go-libs/v2/collectionutils"
 	"github.com/formancehq/go-libs/v2/pointer"
 	"github.com/formancehq/go-libs/v2/time"
 	"github.com/formancehq/ledger/pkg/features"
@@ -199,17 +198,10 @@ func (ctrl *DefaultController) importLog(ctx context.Context, log ledger.Log) er
 	switch payload := log.Data.(type) {
 	case ledger.CreatedTransaction:
 		logging.FromContext(ctx).Debugf("Importing transaction %d", *payload.Transaction.ID)
-		if err := ctrl.store.CommitTransaction(ctx, &payload.Transaction); err != nil {
+		if err := ctrl.store.CommitTransaction(ctx, &payload.Transaction, payload.AccountMetadata); err != nil {
 			return fmt.Errorf("failed to commit transaction: %w", err)
 		}
 		logging.FromContext(ctx).Debugf("Imported transaction %d", *payload.Transaction.ID)
-
-		if len(payload.AccountMetadata) > 0 {
-			logging.FromContext(ctx).Debugf("Importing metadata of accounts '%s'", Keys(payload.AccountMetadata))
-			if err := ctrl.store.UpdateAccountsMetadata(ctx, payload.AccountMetadata); err != nil {
-				return fmt.Errorf("updating metadata of accounts '%s': %w", Keys(payload.AccountMetadata), err)
-			}
-		}
 	case ledger.RevertedTransaction:
 		logging.FromContext(ctx).Debugf("Reverting transaction %d", *payload.RevertedTransaction.ID)
 		_, _, err := ctrl.store.RevertTransaction(
@@ -220,7 +212,7 @@ func (ctrl *DefaultController) importLog(ctx context.Context, log ledger.Log) er
 		if err != nil {
 			return fmt.Errorf("failed to revert transaction: %w", err)
 		}
-		if err := ctrl.store.CommitTransaction(ctx, &payload.RevertTransaction); err != nil {
+		if err := ctrl.store.CommitTransaction(ctx, &payload.RevertTransaction, nil); err != nil {
 			return fmt.Errorf("failed to commit transaction: %w", err)
 		}
 	case ledger.SavedMetadata:
@@ -332,15 +324,9 @@ func (ctrl *DefaultController) createTransaction(ctx context.Context, store Stor
 		WithMetadata(finalMetadata).
 		WithTimestamp(parameters.Input.Timestamp).
 		WithReference(parameters.Input.Reference)
-	err = store.CommitTransaction(ctx, &transaction)
+	err = store.CommitTransaction(ctx, &transaction, result.AccountMetadata)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(result.AccountMetadata) > 0 {
-		if err := store.UpdateAccountsMetadata(ctx, result.AccountMetadata); err != nil {
-			return nil, fmt.Errorf("updating metadata of account '%s': %w", Keys(result.AccountMetadata), err)
-		}
 	}
 
 	return &ledger.CreatedTransaction{
@@ -407,7 +393,7 @@ func (ctrl *DefaultController) revertTransaction(ctx context.Context, store Stor
 		}
 	}
 
-	err = store.CommitTransaction(ctx, &reversedTx)
+	err = store.CommitTransaction(ctx, &reversedTx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert transaction: %w", err)
 	}

--- a/internal/controller/ledger/controller_default_test.go
+++ b/internal/controller/ledger/controller_default_test.go
@@ -52,7 +52,7 @@ func TestCreateTransaction(t *testing.T) {
 		}, nil)
 
 	store.EXPECT().
-		CommitTransaction(gomock.Any(), gomock.Any()).
+		CommitTransaction(gomock.Any(), gomock.Any(), nil).
 		Return(nil)
 
 	store.EXPECT().
@@ -101,7 +101,7 @@ func TestRevertTransaction(t *testing.T) {
 		Return(map[string]map[string]*big.Int{}, nil)
 
 	store.EXPECT().
-		CommitTransaction(gomock.Any(), gomock.Any()).
+		CommitTransaction(gomock.Any(), gomock.Any(), nil).
 		Return(nil)
 
 	store.EXPECT().

--- a/internal/controller/ledger/store.go
+++ b/internal/controller/ledger/store.go
@@ -34,7 +34,7 @@ type Store interface {
 
 	// GetBalances must returns balance and lock account until the end of the TX
 	GetBalances(ctx context.Context, query BalanceQuery) (Balances, error)
-	CommitTransaction(ctx context.Context, transaction *ledger.Transaction) error
+	CommitTransaction(ctx context.Context, transaction *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error
 	// RevertTransaction revert the transaction with identifier id
 	// It returns :
 	//  * the reverted transaction

--- a/internal/controller/ledger/store_generated_test.go
+++ b/internal/controller/ledger/store_generated_test.go
@@ -104,17 +104,17 @@ func (mr *MockStoreMockRecorder) Commit() *gomock.Call {
 }
 
 // CommitTransaction mocks base method.
-func (m *MockStore) CommitTransaction(ctx context.Context, transaction *ledger.Transaction) error {
+func (m *MockStore) CommitTransaction(ctx context.Context, transaction *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitTransaction", ctx, transaction)
+	ret := m.ctrl.Call(m, "CommitTransaction", ctx, transaction, accountMetadata)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitTransaction indicates an expected call of CommitTransaction.
-func (mr *MockStoreMockRecorder) CommitTransaction(ctx, transaction any) *gomock.Call {
+func (mr *MockStoreMockRecorder) CommitTransaction(ctx, transaction, accountMetadata any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTransaction", reflect.TypeOf((*MockStore)(nil).CommitTransaction), ctx, transaction)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTransaction", reflect.TypeOf((*MockStore)(nil).CommitTransaction), ctx, transaction, accountMetadata)
 }
 
 // DeleteAccountMetadata mocks base method.

--- a/internal/storage/ledger/accounts_test.go
+++ b/internal/storage/ledger/accounts_test.go
@@ -31,7 +31,7 @@ func TestAccountsList(t *testing.T) {
 	err := store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now).
-		WithInsertedAt(now)))
+		WithInsertedAt(now)), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
@@ -55,19 +55,19 @@ func TestAccountsList(t *testing.T) {
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(4*time.Minute)).
-		WithInsertedAt(now.Add(100*time.Millisecond))))
+		WithInsertedAt(now.Add(100*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(3*time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	err = store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
-		WithInsertedAt(now.Add(200*time.Millisecond))))
+		WithInsertedAt(now.Add(200*time.Millisecond))), nil)
 	require.NoError(t, err)
 
 	t.Run("list all", func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestAccountsGet(t *testing.T) {
 	tx1 := pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(100)),
 	).WithTimestamp(now))
-	err := store.CommitTransaction(ctx, tx1)
+	err := store.CommitTransaction(ctx, tx1, nil)
 	require.NoError(t, err)
 
 	// sleep for at least the time precision to ensure the next transaction is inserted with a different timestamp
@@ -320,7 +320,7 @@ func TestAccountsGet(t *testing.T) {
 	tx2 := pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "multi", "USD/2", big.NewInt(0)),
 	).WithTimestamp(now.Add(-time.Minute)))
-	err = store.CommitTransaction(ctx, tx2)
+	err = store.CommitTransaction(ctx, tx2, nil)
 	require.NoError(t, err)
 
 	t.Run("find account", func(t *testing.T) {
@@ -446,7 +446,7 @@ func TestAccountsCount(t *testing.T) {
 
 	err := store.CommitTransaction(ctx, pointer.For(ledger.NewTransaction().WithPostings(
 		ledger.NewPosting("world", "central_bank", "USD/2", big.NewInt(100)),
-	)))
+	)), nil)
 	require.NoError(t, err)
 
 	countAccounts, err := store.Accounts().Count(ctx, ledgercontroller.ResourceQuery[any]{})

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -174,7 +174,7 @@ func TestBalancesAggregates(t *testing.T) {
 		).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
@@ -185,7 +185,7 @@ func TestBalancesAggregates(t *testing.T) {
 		).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{

--- a/internal/storage/ledger/moves_test.go
+++ b/internal/storage/ledger/moves_test.go
@@ -157,7 +157,7 @@ func TestMovesInsert(t *testing.T) {
 					tx := ledger.NewTransaction().WithPostings(
 						ledger.NewPosting(src, dst, "USD", big.NewInt(1)),
 					)
-					err = storeCP.CommitTransaction(ctx, &tx)
+					err = storeCP.CommitTransaction(ctx, &tx, nil)
 					if errors.Is(err, postgres.ErrDeadlockDetected) {
 						require.NoError(t, sqlTx.Rollback())
 						continue

--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -34,7 +34,10 @@ var (
 	metadataRegex = regexp.MustCompile(`metadata\[(.+)]`)
 )
 
-func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transaction) error {
+func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transaction, accountMetadata map[string]metadata.Metadata) error {
+	if accountMetadata == nil {
+		accountMetadata = make(map[string]metadata.Metadata)
+	}
 
 	postCommitVolumes, err := store.UpdateVolumes(ctx, tx.VolumeUpdates()...)
 	if err != nil {
@@ -51,7 +54,7 @@ func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transactio
 		return &ledger.Account{
 			Address:       address,
 			FirstUsage:    tx.Timestamp,
-			Metadata:      make(metadata.Metadata),
+			Metadata:      accountMetadata[address],
 			InsertionDate: tx.InsertedAt,
 			UpdatedAt:     tx.InsertedAt,
 		}

--- a/internal/storage/ledger/volumes_test.go
+++ b/internal/storage/ledger/volumes_test.go
@@ -51,56 +51,56 @@ func TestVolumesList(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now.Add(4 * time.Minute))
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute)).
 		WithInsertedAt(now.Add(3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:1", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute)).
 		WithInsertedAt(now.Add(2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx3)
+	err = store.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute)).
 		WithInsertedAt(now.Add(time.Minute))
-	err = store.CommitTransaction(ctx, &tx4)
+	err = store.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	err = store.CommitTransaction(ctx, &tx5)
+	err = store.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute)).
 		WithInsertedAt(now.Add(-time.Minute))
-	err = store.CommitTransaction(ctx, &tx6)
+	err = store.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("account:2", "bank", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(2 * time.Minute)).
 		WithInsertedAt(now.Add(-2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx7)
+	err = store.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	tx8 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2", "USD", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute)).
 		WithInsertedAt(now.Add(-3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx8)
+	err = store.CommitTransaction(ctx, &tx8, nil)
 	require.NoError(t, err)
 
 	t.Run("Get all volumes with first account usage filter", func(t *testing.T) {
@@ -498,43 +498,43 @@ func TestVolumesAggregate(t *testing.T) {
 		WithPostings(ledger.NewPosting("world", "account:1:2", "USD", big.NewInt(100))).
 		WithTimestamp(now.Add(-4 * time.Minute)).
 		WithInsertedAt(now)
-	err := store.CommitTransaction(ctx, &tx1)
+	err := store.CommitTransaction(ctx, &tx1, nil)
 	require.NoError(t, err)
 
 	tx2 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:1", "EUR", big.NewInt(100))).
 		WithTimestamp(now.Add(-3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx2)
+	err = store.CommitTransaction(ctx, &tx2, nil)
 	require.NoError(t, err)
 
 	tx3 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:2", "EUR", big.NewInt(50))).
 		WithTimestamp(now.Add(-2 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx3)
+	err = store.CommitTransaction(ctx, &tx3, nil)
 	require.NoError(t, err)
 
 	tx4 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:1:3", "USD", big.NewInt(0))).
 		WithTimestamp(now.Add(-time.Minute))
-	err = store.CommitTransaction(ctx, &tx4)
+	err = store.CommitTransaction(ctx, &tx4, nil)
 	require.NoError(t, err)
 
 	tx5 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:1", "USD", big.NewInt(50))).
 		WithTimestamp(now)
-	err = store.CommitTransaction(ctx, &tx5)
+	err = store.CommitTransaction(ctx, &tx5, nil)
 	require.NoError(t, err)
 
 	tx6 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:2", "USD", big.NewInt(50))).
 		WithTimestamp(now.Add(1 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx6)
+	err = store.CommitTransaction(ctx, &tx6, nil)
 	require.NoError(t, err)
 
 	tx7 := ledger.NewTransaction().
 		WithPostings(ledger.NewPosting("world", "account:2:3", "EUR", big.NewInt(25))).
 		WithTimestamp(now.Add(3 * time.Minute))
-	err = store.CommitTransaction(ctx, &tx7)
+	err = store.CommitTransaction(ctx, &tx7, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{


### PR DESCRIPTION
Backport of #793 