### PR TITLE
feat: change runtime field name

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -502,7 +502,7 @@ Accept: application/json
           "user": "users:042"
         }
       },
-      "runtime": "interpreter",
+      "runtime": "experimental-interpreter",
       "reference": "ref:001",
       "metadata": {
         "admin": "true"
@@ -1315,7 +1315,7 @@ Idempotency-Key: string
       "user": "users:042"
     }
   },
-  "runtime": "interpreter",
+  "runtime": "experimental-interpreter",
   "reference": "ref:001",
   "metadata": {
     "admin": "true"
@@ -2707,7 +2707,7 @@ Authorization ( Scopes: ledger:write )
       "user": "users:042"
     }
   },
-  "runtime": "interpreter",
+  "runtime": "experimental-interpreter",
   "reference": "ref:001",
   "metadata": {
     "admin": "true"
@@ -2744,7 +2744,7 @@ Authorization ( Scopes: ledger:write )
 
 |Property|Value|
 |---|---|
-|runtime|interpreter|
+|runtime|experimental-interpreter|
 |runtime|machine|
 
 <h2 id="tocS_V2Stats">V2Stats</h2>
@@ -3429,7 +3429,7 @@ Authorization ( Scopes: ledger:write )
           "user": "users:042"
         }
       },
-      "runtime": "interpreter",
+      "runtime": "experimental-interpreter",
       "reference": "ref:001",
       "metadata": {
         "admin": "true"
@@ -3503,7 +3503,7 @@ Authorization ( Scopes: ledger:write )
         "user": "users:042"
       }
     },
-    "runtime": "interpreter",
+    "runtime": "experimental-interpreter",
     "reference": "ref:001",
     "metadata": {
       "admin": "true"
@@ -3574,7 +3574,7 @@ xor
         "user": "users:042"
       }
     },
-    "runtime": "interpreter",
+    "runtime": "experimental-interpreter",
     "reference": "ref:001",
     "metadata": {
       "admin": "true"

--- a/internal/controller/ledger/controller.go
+++ b/internal/controller/ledger/controller.go
@@ -86,8 +86,8 @@ type ScriptV1 = vm.ScriptV1
 type RuntimeType string
 
 const (
-	RuntimeInterpreter RuntimeType = "experimental-interpreter"
-	RuntimeMachine     RuntimeType = "machine"
+	RuntimeExperimentalInterpreter RuntimeType = "experimental-interpreter"
+	RuntimeMachine                 RuntimeType = "machine"
 )
 
 type CreateTransaction struct {

--- a/internal/controller/ledger/controller.go
+++ b/internal/controller/ledger/controller.go
@@ -86,7 +86,7 @@ type ScriptV1 = vm.ScriptV1
 type RuntimeType string
 
 const (
-	RuntimeInterpreter RuntimeType = "interpreter"
+	RuntimeInterpreter RuntimeType = "experimental-interpreter"
 	RuntimeMachine     RuntimeType = "machine"
 )
 

--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -317,7 +317,7 @@ func (ctrl *DefaultController) Export(ctx context.Context, w ExportWriter) error
 
 func (ctrl *DefaultController) getParser(tx CreateTransaction) NumscriptParser {
 	switch tx.Runtime {
-	case RuntimeInterpreter:
+	case RuntimeExperimentalInterpreter:
 		return ctrl.interpreterParser
 	case RuntimeMachine:
 		return ctrl.machineParser

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3478,7 +3478,7 @@ components:
           description: The numscript runtime used to execute the script. Uses "machine" by default, unless the "--experimental-numscript-interpreter" feature flag is passed.
           type: string
           enum:
-            - interpreter
+            - experimental-interpreter
             - machine
         reference:
           type: string

--- a/openapi/v2.yaml
+++ b/openapi/v2.yaml
@@ -1635,7 +1635,7 @@ components:
           description: The numscript runtime used to execute the script. Uses "machine" by default, unless the "--experimental-numscript-interpreter" feature flag is passed.
           type: string
           enum:
-            - interpreter
+            - experimental-interpreter
             - machine
         reference:
           type: string

--- a/pkg/client/.speakeasy/gen.lock
+++ b/pkg/client/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: a9ac79e1-e429-4ee3-96c4-ec973f19bec3
 management:
-  docChecksum: 88b3f676d965468d58f248ede6b8adf0
+  docChecksum: ba1cd35a327e7c3ca6b907a3a850d1ac
   docVersion: v2
   speakeasyVersion: 1.517.3
   generationVersion: 2.548.6

--- a/pkg/client/docs/models/components/runtime.md
+++ b/pkg/client/docs/models/components/runtime.md
@@ -5,7 +5,7 @@ The numscript runtime used to execute the script. Uses "machine" by default, unl
 
 ## Values
 
-| Name                 | Value                |
-| -------------------- | -------------------- |
-| `RuntimeInterpreter` | interpreter          |
-| `RuntimeMachine`     | machine              |
+| Name                             | Value                            |
+| -------------------------------- | -------------------------------- |
+| `RuntimeExperimentalInterpreter` | experimental-interpreter         |
+| `RuntimeMachine`                 | machine                          |

--- a/pkg/client/models/components/v2posttransaction.go
+++ b/pkg/client/models/components/v2posttransaction.go
@@ -32,8 +32,8 @@ func (o *V2PostTransactionScript) GetVars() map[string]string {
 type Runtime string
 
 const (
-	RuntimeInterpreter Runtime = "interpreter"
-	RuntimeMachine     Runtime = "machine"
+	RuntimeExperimentalInterpreter Runtime = "experimental-interpreter"
+	RuntimeMachine                 Runtime = "machine"
 )
 
 func (e Runtime) ToPointer() *Runtime {
@@ -45,7 +45,7 @@ func (e *Runtime) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch v {
-	case "interpreter":
+	case "experimental-interpreter":
 		fallthrough
 	case "machine":
 		*e = Runtime(v)

--- a/test/e2e/api_transactions_create_test.go
+++ b/test/e2e/api_transactions_create_test.go
@@ -310,7 +310,7 @@ var _ = Context("Ledger transactions create API tests", func() {
 							IdempotencyKey: pointer.For("testing"),
 							Ledger:         "default",
 							V2PostTransaction: components.V2PostTransaction{
-								Runtime:  pointer.For(components.RuntimeInterpreter),
+								Runtime:  pointer.For(components.RuntimeExperimentalInterpreter),
 								Metadata: map[string]string{},
 								Script: &components.V2PostTransactionScript{
 									// note that we're missing newlines here,


### PR DESCRIPTION
Follow-up of this pr: https://github.com/formancehq/ledger/pull/878
changes the field name from "interpreter" to "experimental-interpreter"