### PR TITLE
chore(direnv): source .envrc.local if exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
+source_env_if_exists ".envrc.local"
 use flake --impure
 dotenv

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ worktrees
 dumps
 .env
 !.envrc
+.envrc.*
 Pulumi.*.yaml
 coverage.txt


### PR DESCRIPTION
This allows to source an optional and unversioned .envrc.local file which could be used to source secrets from 1Password:

```
source_url "https://github.com/tmatilai/direnv-1password/raw/v1.0.1/1password.sh" "sha256-4dmKkmlPBNXimznxeehplDfiV+CvJiIzg7H1Pik4oqY="
from_op GORELEASER_KEY=op://Shared/Goreleaser/password
```