### PR TITLE
fix: support startTime/endTime parameters and correct database column

### DIFF
--- a/internal/api/v1/controllers_transactions.go
+++ b/internal/api/v1/controllers_transactions.go
@@ -59,11 +59,22 @@ func buildGetTransactionsQuery(r *http.Request) query.Builder {
 		clauses = append(clauses, query.Lt("id", after))
 	}
 
-	if startTime := r.URL.Query().Get("start_time"); startTime != "" {
-		clauses = append(clauses, query.Gte("date", startTime))
+	// Support both startTime (new) and start_time (deprecated) parameters
+	startTime := r.URL.Query().Get("startTime")
+	if startTime == "" {
+		startTime = r.URL.Query().Get("start_time") // fallback to deprecated parameter
 	}
-	if endTime := r.URL.Query().Get("end_time"); endTime != "" {
-		clauses = append(clauses, query.Lt("date", endTime))
+	if startTime != "" {
+		clauses = append(clauses, query.Gte("timestamp", startTime))
+	}
+
+	// Support both endTime (new) and end_time (deprecated) parameters  
+	endTime := r.URL.Query().Get("endTime")
+	if endTime == "" {
+		endTime = r.URL.Query().Get("end_time") // fallback to deprecated parameter
+	}
+	if endTime != "" {
+		clauses = append(clauses, query.Lt("timestamp", endTime))
 	}
 
 	if reference := r.URL.Query().Get("reference"); reference != "" {

--- a/internal/api/v1/controllers_transactions_count_test.go
+++ b/internal/api/v1/controllers_transactions_count_test.go
@@ -45,19 +45,57 @@ func TestCountTransactions(t *testing.T) {
 		{
 			name: "using startTime",
 			queryParams: url.Values{
-				"start_time": []string{now.Format(time.DateFormat)},
+				"startTime": []string{now.Format(time.DateFormat)},
 			},
 			expectQuery: storagecommon.ResourceQuery[any]{
-				Builder: query.Gte("date", now.Format(time.DateFormat)),
+				Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
 			},
 		},
 		{
 			name: "using endTime",
 			queryParams: url.Values{
+				"endTime": []string{now.Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.ResourceQuery[any]{
+				Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
+			},
+		},
+		{
+			name: "using deprecated start_time",
+			queryParams: url.Values{
+				"start_time": []string{now.Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.ResourceQuery[any]{
+				Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
+			},
+		},
+		{
+			name: "using deprecated end_time",
+			queryParams: url.Values{
 				"end_time": []string{now.Format(time.DateFormat)},
 			},
 			expectQuery: storagecommon.ResourceQuery[any]{
-				Builder: query.Lt("date", now.Format(time.DateFormat)),
+				Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
+			},
+		},
+		{
+			name: "startTime takes precedence over start_time",
+			queryParams: url.Values{
+				"startTime":  []string{now.Format(time.DateFormat)},
+				"start_time": []string{now.Add(-time.Hour).Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.ResourceQuery[any]{
+				Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
+			},
+		},
+		{
+			name: "endTime takes precedence over end_time",
+			queryParams: url.Values{
+				"endTime":  []string{now.Format(time.DateFormat)},
+				"end_time": []string{now.Add(-time.Hour).Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.ResourceQuery[any]{
+				Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
 			},
 		},
 		{

--- a/internal/api/v1/controllers_transactions_list_test.go
+++ b/internal/api/v1/controllers_transactions_list_test.go
@@ -63,6 +63,36 @@ func TestTransactionsList(t *testing.T) {
 		{
 			name: "using startTime",
 			queryParams: url.Values{
+				"startTime": []string{now.Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.InitialPaginatedQuery[any]{
+				PageSize: DefaultPageSize,
+				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
+				Column:   "id",
+				Options: storagecommon.ResourceQuery[any]{
+					Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
+					Expand:  []string{"volumes"},
+				},
+			},
+		},
+		{
+			name: "using endTime",
+			queryParams: url.Values{
+				"endTime": []string{now.Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.InitialPaginatedQuery[any]{
+				PageSize: DefaultPageSize,
+				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
+				Column:   "id",
+				Options: storagecommon.ResourceQuery[any]{
+					Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
+					Expand:  []string{"volumes"},
+				},
+			},
+		},
+		{
+			name: "using deprecated start_time",
+			queryParams: url.Values{
 				"start_time": []string{now.Format(time.DateFormat)},
 			},
 			expectQuery: storagecommon.InitialPaginatedQuery[any]{
@@ -70,13 +100,13 @@ func TestTransactionsList(t *testing.T) {
 				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
 				Column:   "id",
 				Options: storagecommon.ResourceQuery[any]{
-					Builder: query.Gte("date", now.Format(time.DateFormat)),
+					Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
 					Expand:  []string{"volumes"},
 				},
 			},
 		},
 		{
-			name: "using endTime",
+			name: "using deprecated end_time",
 			queryParams: url.Values{
 				"end_time": []string{now.Format(time.DateFormat)},
 			},
@@ -85,7 +115,39 @@ func TestTransactionsList(t *testing.T) {
 				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
 				Column:   "id",
 				Options: storagecommon.ResourceQuery[any]{
-					Builder: query.Lt("date", now.Format(time.DateFormat)),
+					Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
+					Expand:  []string{"volumes"},
+				},
+			},
+		},
+		{
+			name: "startTime takes precedence over start_time",
+			queryParams: url.Values{
+				"startTime":  []string{now.Format(time.DateFormat)},
+				"start_time": []string{now.Add(-time.Hour).Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.InitialPaginatedQuery[any]{
+				PageSize: DefaultPageSize,
+				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
+				Column:   "id",
+				Options: storagecommon.ResourceQuery[any]{
+					Builder: query.Gte("timestamp", now.Format(time.DateFormat)),
+					Expand:  []string{"volumes"},
+				},
+			},
+		},
+		{
+			name: "endTime takes precedence over end_time",
+			queryParams: url.Values{
+				"endTime":  []string{now.Format(time.DateFormat)},
+				"end_time": []string{now.Add(-time.Hour).Format(time.DateFormat)},
+			},
+			expectQuery: storagecommon.InitialPaginatedQuery[any]{
+				PageSize: DefaultPageSize,
+				Order:    pointer.For(bunpaginate.Order(bunpaginate.OrderDesc)),
+				Column:   "id",
+				Options: storagecommon.ResourceQuery[any]{
+					Builder: query.Lt("timestamp", now.Format(time.DateFormat)),
 					Expand:  []string{"volumes"},
 				},
 			},


### PR DESCRIPTION
Fixes #491

- Add support for new `startTime` parameter as specified in OpenAPI v1.yaml
- Add support for new `endTime` parameter (similar issue)
- Maintain backward compatibility with deprecated `start_time`/`end_time`
- Fix incorrect database column reference from `date` to `timestamp`
- Query now correctly filters transactions by timestamp range

Changes:
- Support both camelCase (startTime/endTime) and snake_case (start_time/end_time) parameters
- Use correct `timestamp` column name matching database schema
- Prioritize new parameter names over deprecated ones

