### PR TITLE
chore: run deploy job on github runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
           push-to-registry: true
 
   Deploy:
-    runs-on: "shipfox-2vcpu-ubuntu-2404"
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     environment: staging
     needs:


### PR DESCRIPTION
Because tailscale does not work with --accept-dns=true on shipfox runners.