### PR TITLE
feat: Add configuration for image registries

### DIFF
--- a/deployments/pulumi/pkg/api/deployment.go
+++ b/deployments/pulumi/pkg/api/deployment.go
@@ -169,7 +169,7 @@ func createDeployment(ctx *pulumi.Context, args createDeploymentArgs, resourceOp
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:            pulumi.String("ledger-api"),
-							Image:           utils.GetMainImage(args.Tag),
+							Image:           utils.GetMainImage(args.ImageConfiguration),
 							ImagePullPolicy: args.ImagePullPolicy.ToOutput(ctx.Context()).Untyped().(pulumi.StringOutput),
 							Args: pulumi.StringArray{
 								pulumi.String("serve"),

--- a/deployments/pulumi/pkg/common/common.go
+++ b/deployments/pulumi/pkg/common/common.go
@@ -1,16 +1,16 @@
 package common
 
 import (
+	"github.com/formancehq/ledger/deployments/pulumi/pkg/monitoring"
+	"github.com/formancehq/ledger/deployments/pulumi/pkg/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-
-	"github.com/formancehq/ledger/deployments/pulumi/pkg/monitoring"
 )
 
 type CommonArgs struct {
+	utils.ImageConfiguration
 	Namespace       pulumix.Input[string]
 	Monitoring      *monitoring.Args
-	Tag             pulumix.Input[string]
 	ImagePullPolicy pulumix.Input[string]
 	Debug           pulumix.Input[bool]
 }
@@ -38,4 +38,5 @@ func (args *CommonArgs) SetDefaults() {
 	if args.Monitoring != nil {
 		args.Monitoring.SetDefaults()
 	}
+	args.ImageConfiguration.SetDefaults()
 }

--- a/deployments/pulumi/pkg/config/config.go
+++ b/deployments/pulumi/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/formancehq/ledger/deployments/pulumi/pkg/utils"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/rds"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
@@ -186,8 +187,8 @@ func (a *PostgresDatabase) toInput() *storage.PostgresDatabaseArgs {
 
 	return &storage.PostgresDatabaseArgs{
 		Install: &storage.PostgresInstallArgs{
-			Username: pulumix.Val(a.Install.Username),
-			Password: pulumix.Val(a.Install.Password),
+			Username:     pulumix.Val(a.Install.Username),
+			Password:     pulumix.Val(a.Install.Password),
 			ChartVersion: pulumix.Val(a.Install.ChartVersion),
 		},
 	}
@@ -575,7 +576,11 @@ type Common struct {
 	Monitoring *Monitoring `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
 
 	// Tag is the version tag for the ledger
+	// deprecated
 	Tag string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	// Image configuration
+	Image *ImageConfiguration `json:"image"`
 
 	// ImagePullPolicy is the image pull policy for the ledger
 	ImagePullPolicy string `json:"image-pull-policy,omitempty" yaml:"image-pull-policy,omitempty"`
@@ -586,11 +591,11 @@ type Common struct {
 
 func (c Common) toInput() common.CommonArgs {
 	return common.CommonArgs{
-		Namespace:       pulumix.Val(c.Namespace),
-		Monitoring:      c.Monitoring.ToInput(),
-		Tag:             pulumix.Val(c.Tag),
-		ImagePullPolicy: pulumix.Val(c.ImagePullPolicy),
-		Debug:           pulumix.Val(c.Debug),
+		Namespace:          pulumix.Val(c.Namespace),
+		Monitoring:         c.Monitoring.ToInput(),
+		ImageConfiguration: imageConfigurationOrTag(c.Image, c.Tag),
+		ImagePullPolicy:    pulumix.Val(c.ImagePullPolicy),
+		Debug:              pulumix.Val(c.Debug),
 	}
 }
 
@@ -665,6 +670,7 @@ func (g GeneratorLedgerConfiguration) toInput() generator.LedgerConfiguration {
 
 type Generator struct {
 	// GeneratorVersion is the version of the generator
+	// deprecated
 	GeneratorVersion string `json:"generator-version" yaml:"generator-version"`
 
 	// Ledgers are the ledgers to run the generator against
@@ -726,6 +732,12 @@ func (cfg Config) ToInput() pulumi_ledger.ComponentArgs {
 		Exporters:     cfg.Exporters.toInput(),
 		Generator:     cfg.Generator.toInput(),
 	}
+}
+
+type ImageConfiguration struct {
+	Registry   string `json:"registry" yaml:"registry"`
+	Repository string `json:"repository" yaml:"repository"`
+	Tag        string `json:"version" yaml:"version"`
 }
 
 func Load(ctx *pulumi.Context) (*Config, error) {
@@ -798,6 +810,13 @@ func Load(ctx *pulumi.Context) (*Config, error) {
 		generator = nil
 	}
 
+	image := &ImageConfiguration{}
+	if err := cfg.TryObject("image", image); err != nil {
+		if !errors.Is(err, config.ErrMissingVar) {
+			return nil, fmt.Errorf("error reading generator config: %w", err)
+		}
+	}
+
 	namespace := cfg.Get("namespace")
 	if namespace == "" {
 		namespace = ctx.Stack()
@@ -810,6 +829,7 @@ func Load(ctx *pulumi.Context) (*Config, error) {
 			Namespace:       namespace,
 			Tag:             cfg.Get("version"),
 			Monitoring:      monitoring,
+			Image:           image,
 			ImagePullPolicy: cfg.Get("image-pull-policy"),
 		},
 		InstallDevBox: cfg.GetBool("install-dev-box"),
@@ -821,4 +841,22 @@ func Load(ctx *pulumi.Context) (*Config, error) {
 		Provision:     provision,
 		Generator:     generator,
 	}, nil
+}
+
+func imageConfigurationOrTag(configuration *ImageConfiguration, tag string) utils.ImageConfiguration {
+	if configuration == nil {
+		return utils.ImageConfiguration{
+			Tag: pulumix.Val(tag),
+		}
+	}
+
+	if configuration.Tag != "" {
+		tag = configuration.Tag
+	}
+
+	return utils.ImageConfiguration{
+		Registry:   pulumix.Val(configuration.Registry),
+		Repository: pulumix.Val(configuration.Repository),
+		Tag:        pulumix.Val(tag),
+	}
 }

--- a/deployments/pulumi/pkg/provision/component.go
+++ b/deployments/pulumi/pkg/provision/component.go
@@ -2,7 +2,6 @@ package provision
 
 import (
 	"fmt"
-
 	batchv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/batch/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
@@ -28,7 +27,7 @@ type LedgerConfigArgs struct {
 }
 
 type Args struct {
-	ProvisionerVersion pulumi.String
+	ProvisionerVersion pulumix.Input[string]
 	Ledgers            map[string]LedgerConfigArgs `json:"ledgers"`
 }
 
@@ -131,12 +130,10 @@ func NewComponent(ctx *pulumi.Context, name string, args ComponentArgs, opts ...
 								pulumi.String("--state-store"),
 								pulumi.Sprintf("k8s:///%s/provisioner", args.Namespace),
 							},
-							Image: utils.GetImage(pulumi.String("ledger-provisioner"), pulumix.Apply2(args.Tag, args.ProvisionerVersion, func(ledgerVersion, provisionerVersion string) string {
-								if provisionerVersion != "" {
-									return provisionerVersion
-								}
-								return ledgerVersion
-							})),
+							Image: utils.GetImage(
+								args.WithFallbackTag(args.ProvisionerVersion),
+								pulumi.String("ledger-provisioner"),
+							),
 							VolumeMounts: corev1.VolumeMountArray{
 								corev1.VolumeMountArgs{
 									Name:      pulumi.String("config"),

--- a/deployments/pulumi/pkg/storage/migrate.go
+++ b/deployments/pulumi/pkg/storage/migrate.go
@@ -39,7 +39,7 @@ func runMigrateJob(ctx *pulumi.Context, args migrationArgs, opts ...pulumi.Resou
 							Args: pulumi.StringArray{
 								pulumi.String("migrate"),
 							},
-							Image:           utils.GetMainImage(args.Tag),
+							Image:           utils.GetMainImage(args.ImageConfiguration),
 							ImagePullPolicy: args.ImagePullPolicy.ToOutput(ctx.Context()).Untyped().(pulumi.StringOutput),
 							Env:             envVars,
 						},

--- a/deployments/pulumi/pkg/utils/convert.go
+++ b/deployments/pulumi/pkg/utils/convert.go
@@ -5,17 +5,33 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
-func GetMainImage(tag pulumix.Input[string]) pulumi.StringOutput {
-	return GetImage(pulumi.String("ledger"), tag)
+func GetMainImage(imageConfiguration ImageConfiguration) pulumi.StringOutput {
+	return GetImage(imageConfiguration, pulumi.String("ledger"))
 }
 
-func GetImage(component, tag pulumix.Input[string]) pulumi.StringOutput {
-	return pulumi.Sprintf("ghcr.io/formancehq/%s:%s", component, pulumix.Apply(tag, func(version string) string {
-		if version == "" {
-			return "latest"
-		}
-		return version
-	}))
+func GetImage(imageConfiguration ImageConfiguration, component pulumix.Input[string]) pulumi.StringOutput {
+	return pulumi.Sprintf(
+		"%s/%s/%s:%s",
+		pulumix.Apply(imageConfiguration.Registry, func(registry string) string {
+			if registry == "" {
+				return "ghcr.io"
+			}
+			return registry
+		}),
+		pulumix.Apply(imageConfiguration.Repository, func(repository string) string {
+			if repository == "" {
+				return "formancehq"
+			}
+			return repository
+		}),
+		component,
+		pulumix.Apply(imageConfiguration.Tag, func(version string) string {
+			if version == "" {
+				return "latest"
+			}
+			return version
+		}),
+	)
 }
 
 func BoolToString(output pulumix.Input[bool]) pulumix.Output[string] {
@@ -25,4 +41,55 @@ func BoolToString(output pulumix.Input[bool]) pulumix.Output[string] {
 		}
 		return "false"
 	})
+}
+
+type ImageConfiguration struct {
+	Registry   pulumix.Input[string]
+	Repository pulumix.Input[string]
+	Tag        pulumix.Input[string]
+}
+
+func (args ImageConfiguration) WithFallbackTag(input pulumix.Input[string]) ImageConfiguration {
+	args.Tag = pulumix.Apply2(args.Tag, input, func(providedVersion, fallbackVersion string) string {
+		if providedVersion == "" {
+			return fallbackVersion
+		}
+		return providedVersion
+	})
+	return args
+}
+
+func (args *ImageConfiguration) SetDefaults() {
+	if args.Registry == nil {
+		args.Registry = pulumi.String("ghcr.io")
+	} else {
+		args.Registry = pulumix.Apply(args.Registry, func(registry string) string {
+			if registry == "" {
+				return "ghcr.io"
+			}
+			return registry
+		})
+	}
+
+	if args.Repository == nil {
+		args.Repository = pulumi.String("formancehq")
+	} else {
+		args.Repository = pulumix.Apply(args.Repository, func(repository string) string {
+			if repository == "" {
+				return "formancehq"
+			}
+			return repository
+		})
+	}
+
+	if args.Tag == nil {
+		args.Tag = pulumi.String("latest")
+	} else {
+		args.Tag = pulumix.Apply(args.Tag, func(tag string) string {
+			if tag == "" {
+				return "latest"
+			}
+			return tag
+		})
+	}
 }

--- a/deployments/pulumi/pkg/worker/deployment.go
+++ b/deployments/pulumi/pkg/worker/deployment.go
@@ -46,7 +46,7 @@ func createDeployment(ctx *pulumi.Context, args ComponentArgs, resourceOptions .
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:            pulumi.String("worker"),
-							Image:           utils.GetMainImage(args.Tag),
+							Image:           utils.GetMainImage(args.ImageConfiguration),
 							ImagePullPolicy: args.ImagePullPolicy.ToOutput(ctx.Context()).Untyped().(pulumi.StringOutput),
 							Args: pulumi.StringArray{
 								pulumi.String("worker"),

--- a/internal/replication/manager.go
+++ b/internal/replication/manager.go
@@ -217,7 +217,11 @@ func (m *Manager) synchronizePipelines(ctx context.Context) error {
 	for _, pipeline := range pipelines {
 		m.logger.Debugf("restoring pipeline %s", pipeline.ID)
 		if _, err := m.startPipeline(ctx, pipeline); err != nil {
-			return err
+			switch {
+			case errors.Is(err, ledger.ErrAlreadyStarted("")):
+			default:
+				return err
+			}
 		}
 	}
 

--- a/internal/replication/pipeline.go
+++ b/internal/replication/pipeline.go
@@ -68,6 +68,7 @@ func (p *PipelineHandler) Run(ctx context.Context, ingestedLogs chan uint64) {
 	for {
 		select {
 		case ch := <-p.stopChannel:
+			p.logger.Debugf("Pipeline terminated.")
 			close(ch)
 			return
 		case <-time.After(nextInterval):
@@ -93,6 +94,7 @@ func (p *PipelineHandler) Run(ctx context.Context, ingestedLogs chan uint64) {
 				}
 			}
 
+			p.logger.Debugf("Got %d items", len(logs.Data))
 			if len(logs.Data) == 0 {
 				nextInterval = p.pipelineConfig.PullInterval
 				continue
@@ -118,6 +120,7 @@ func (p *PipelineHandler) Run(ctx context.Context, ingestedLogs chan uint64) {
 			}
 
 			lastLogID := logs.Data[len(logs.Data)-1].ID
+			p.logger.Debugf("Move last log id to %d", lastLogID)
 			p.pipeline.LastLogID = lastLogID
 
 			select {

--- a/tools/provisioner/Dockerfile
+++ b/tools/provisioner/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.25-alpine AS compiler
 WORKDIR /src
 COPY --from=root pkg pkg


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds configurable image registry, repository, and version for all Pulumi-ledger components, replacing hardcoded GHCR paths while keeping backward compatibility with the existing tag. This lets deployments pull images from custom registries and repos.

- **New Features**
  - Introduced ImageConfiguration (registry, repository, tag) with sane defaults and SetDefaults().
  - Updated image helpers (GetImage, GetMainImage) and added WithFallbackTag for per-component version overrides.
  - Switched API, worker, migrate, generator, and provisioner to use ImageConfiguration when building image names.

- **Migration**
  - Optional config block: image.registry, image.repository, image.version. If omitted, behavior falls back to ghcr.io/formancehq with the existing version tag.
  - version (Tag) is now deprecated; prefer image.version.
  - generator-version is deprecated; generator and provisioner use ImageConfiguration with per-component tag fallback.

<sup>Written for commit e6fe0d6a38d0eb39a4ef4756bccb16fe0a5e16c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

