### PR TITLE
feat: Add configuration for image registries

### DIFF
--- a/deployments/pulumi/pkg/api/deployment.go
+++ b/deployments/pulumi/pkg/api/deployment.go
@@ -153,7 +153,7 @@ func createDeployment(ctx *pulumi.Context, args createDeploymentArgs, resourceOp
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:            pulumi.String("ledger-api"),
-							Image:           utils.GetMainImage(args.Tag),
+							Image:           utils.GetMainImage(args.ImageConfiguration),
 							ImagePullPolicy: args.ImagePullPolicy.ToOutput(ctx.Context()).Untyped().(pulumi.StringOutput),
 							Args: pulumi.StringArray{
 								pulumi.String("serve"),

--- a/deployments/pulumi/pkg/common/common.go
+++ b/deployments/pulumi/pkg/common/common.go
@@ -2,14 +2,15 @@ package common
 
 import (
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/monitoring"
+	"github.com/formancehq/ledger/deployments/pulumi/pkg/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
 type CommonArgs struct {
+	utils.ImageConfiguration
 	Namespace       pulumix.Input[string]
 	Monitoring      *monitoring.Args
-	Tag             pulumix.Input[string]
 	ImagePullPolicy pulumix.Input[string]
 	Debug           pulumix.Input[bool]
 }
@@ -37,4 +38,5 @@ func (args *CommonArgs) SetDefaults() {
 	if args.Monitoring != nil {
 		args.Monitoring.SetDefaults()
 	}
+	args.ImageConfiguration.SetDefaults()
 }

--- a/deployments/pulumi/pkg/generator/component.go
+++ b/deployments/pulumi/pkg/generator/component.go
@@ -3,6 +3,10 @@ package generator
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/api"
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/common"
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/utils"
@@ -12,9 +16,6 @@ import (
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 type Component struct {
@@ -48,15 +49,6 @@ type Args struct {
 }
 
 func (a *Args) SetDefaults() {
-	if a.GeneratorVersion == nil {
-		a.GeneratorVersion = pulumix.Val("")
-	}
-	a.GeneratorVersion = pulumix.Apply(a.GeneratorVersion, func(generatorVersion string) string {
-		if generatorVersion == "" {
-			return "latest"
-		}
-		return generatorVersion
-	})
 	if a.Ledgers == nil {
 		a.Ledgers = make(map[string]LedgerConfiguration)
 	}
@@ -149,12 +141,10 @@ func NewComponent(ctx *pulumi.Context, name string, args ComponentArgs, opts ...
 				corev1.ContainerArgs{
 					Name: pulumi.String("generator"),
 					Args: generatorArgs.ToOutput(ctx.Context()).Untyped().(pulumi.StringArrayOutput),
-					Image: utils.GetImage(pulumi.String("ledger-generator"), pulumix.Apply2(args.GeneratorVersion, args.Tag, func(generatorVersion string, ledgerVersion string) string {
-						if generatorVersion == "" {
-							return ledgerVersion
-						}
-						return generatorVersion
-					})),
+					Image: utils.GetImage(
+						args.ImageConfiguration.WithFallbackTag(args.GeneratorVersion),
+						pulumi.String("ledger-generator"),
+					),
 					ImagePullPolicy: pulumi.String("Always"),
 					VolumeMounts: corev1.VolumeMountArray{
 						corev1.VolumeMountArgs{

--- a/deployments/pulumi/pkg/provision/component.go
+++ b/deployments/pulumi/pkg/provision/component.go
@@ -2,6 +2,7 @@ package provision
 
 import (
 	"fmt"
+
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/api"
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/common"
 	"github.com/formancehq/ledger/deployments/pulumi/pkg/utils"
@@ -24,7 +25,7 @@ type LedgerConfigArgs struct {
 }
 
 type Args struct {
-	ProvisionerVersion pulumi.String
+	ProvisionerVersion pulumix.Input[string]
 	Ledgers            map[string]LedgerConfigArgs `json:"ledgers"`
 }
 
@@ -126,12 +127,10 @@ func NewComponent(ctx *pulumi.Context, name string, args ComponentArgs, opts ...
 								pulumi.String("--state-store"),
 								pulumi.Sprintf("k8s:///%s/provisioner", args.Namespace),
 							},
-							Image: utils.GetImage(pulumi.String("ledger-provisioner"), pulumix.Apply2(args.Tag, args.ProvisionerVersion, func(ledgerVersion, provisionerVersion string) string {
-								if provisionerVersion != "" {
-									return provisionerVersion
-								}
-								return ledgerVersion
-							})),
+							Image: utils.GetImage(
+								args.ImageConfiguration.WithFallbackTag(args.ProvisionerVersion),
+								pulumi.String("ledger-provisioner"),
+							),
 							VolumeMounts: corev1.VolumeMountArray{
 								corev1.VolumeMountArgs{
 									Name:      pulumi.String("config"),

--- a/deployments/pulumi/pkg/storage/migrate.go
+++ b/deployments/pulumi/pkg/storage/migrate.go
@@ -38,7 +38,7 @@ func runMigrateJob(ctx *pulumi.Context, args migrationArgs, opts ...pulumi.Resou
 							Args: pulumi.StringArray{
 								pulumi.String("migrate"),
 							},
-							Image:           utils.GetMainImage(args.Tag),
+							Image:           utils.GetMainImage(args.ImageConfiguration),
 							ImagePullPolicy: args.ImagePullPolicy.ToOutput(ctx.Context()).Untyped().(pulumi.StringOutput),
 							Env:             envVars,
 						},

--- a/deployments/pulumi/pkg/utils/convert.go
+++ b/deployments/pulumi/pkg/utils/convert.go
@@ -5,17 +5,33 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumix"
 )
 
-func GetMainImage(tag pulumix.Input[string]) pulumi.StringOutput {
-	return GetImage(pulumi.String("ledger"), tag)
+func GetMainImage(imageConfiguration ImageConfiguration) pulumi.StringOutput {
+	return GetImage(imageConfiguration, pulumi.String("ledger"))
 }
 
-func GetImage(component, tag pulumix.Input[string]) pulumi.StringOutput {
-	return pulumi.Sprintf("ghcr.io/formancehq/%s:%s", component, pulumix.Apply(tag, func(version string) string {
-		if version == "" {
-			return "latest"
-		}
-		return version
-	}))
+func GetImage(imageConfiguration ImageConfiguration, component pulumix.Input[string]) pulumi.StringOutput {
+	return pulumi.Sprintf(
+		"%s/%s/%s:%s",
+		pulumix.Apply(imageConfiguration.Registry, func(registry string) string {
+			if registry == "" {
+				return "ghcr.io"
+			}
+			return registry
+		}),
+		pulumix.Apply(imageConfiguration.Repository, func(repository string) string {
+			if repository == "" {
+				return "formancehq"
+			}
+			return repository
+		}),
+		component,
+		pulumix.Apply(imageConfiguration.Tag, func(version string) string {
+			if version == "" {
+				return "latest"
+			}
+			return version
+		}),
+	)
 }
 
 func BoolToString(output pulumix.Input[bool]) pulumix.Output[string] {
@@ -25,4 +41,55 @@ func BoolToString(output pulumix.Input[bool]) pulumix.Output[string] {
 		}
 		return "false"
 	})
+}
+
+type ImageConfiguration struct {
+	Registry   pulumix.Input[string]
+	Repository pulumix.Input[string]
+	Tag        pulumix.Input[string]
+}
+
+func (args ImageConfiguration) WithFallbackTag(input pulumix.Input[string]) ImageConfiguration {
+	args.Tag = pulumix.Apply2(args.Tag, input, func(providedVersion, fallbackVersion string) string {
+		if providedVersion == "" {
+			return fallbackVersion
+		}
+		return providedVersion
+	})
+	return args
+}
+
+func (args *ImageConfiguration) SetDefaults() {
+	if args.Registry == nil {
+		args.Registry = pulumi.String("ghcr.io")
+	} else {
+		args.Registry = pulumix.Apply(args.Registry, func(registry string) string {
+			if registry == "" {
+				return "ghcr.io"
+			}
+			return registry
+		})
+	}
+
+	if args.Repository == nil {
+		args.Repository = pulumi.String("formancehq")
+	} else {
+		args.Repository = pulumix.Apply(args.Repository, func(repository string) string {
+			if repository == "" {
+				return "formancehq"
+			}
+			return repository
+		})
+	}
+
+	if args.Tag == nil {
+		args.Tag = pulumi.String("latest")
+	} else {
+		args.Tag = pulumix.Apply(args.Tag, func(tag string) string {
+			if tag == "" {
+				return "latest"
+			}
+			return tag
+		})
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds configurable image registry, repository, and version for all ledger components, replacing the fixed GHCR defaults. Keeps existing version config working as a fallback, so no breaking changes.

- **New Features**
  - Introduced image configuration (registry, repository, version) via config.image.
  - Applied across ledger, generator, provisioner, and migrate job.
  - Defaults to ghcr.io/formancehq:latest when not set.
  - Deprecated Common.Tag and Generator.GeneratorVersion; still used as fallback.
  - Updated image helpers to use the new ImageConfiguration with clean defaults.

- **Migration**
  - No changes required if you use the existing version field.
  - To use a custom registry or repository, set config.image.registry and config.image.repository; set config.image.version to pin a version.
  - You can still override generator/provisioner versions; they now fall back to config.image.version when unspecified.

<sup>Written for commit 67db4f6cdb9ad560bb5567d9d8b6c98d507e4218. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

