### PR TITLE
fix: save & overdraft interaction + world var error

### DIFF
--- a/internal/machine/vm/machine.go
+++ b/internal/machine/vm/machine.go
@@ -516,7 +516,7 @@ func (m *Machine) ResolveBalances(ctx context.Context, store Store) error {
 		}
 		accountAddress := (*account).(machine.AccountAddress)
 		if string(accountAddress) == "world" {
-			return machine.NewErrInvalidVars("`@world` can only be used as a variable in the experimental interpreter")
+			return machine.NewErrInvalidVars("`@world` can only be used as a variable in the experimental interpreter, or if it is never used as a source")
 		}
 
 		// for every asset, register the query


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes save + overdraft interaction and enforces proper @world handling. Save no longer hides negative balances or touches missing balances, so overdraft limits work as expected.

- **Bug Fixes**
  - OP_SAVE only updates known balances:
    - Asset: zeroed only if current balance > 0.
    - Monetary: subtracts only when the asset balance exists.
  - `@world` as a variable now errors when used as a source (allowed as destination) with a clearer message.
  - Added tests for “save all” with overdraft and `@world` variable behavior; tweaked error assertion formatting.

<sup>Written for commit c0f3f4bc79a75a6673745cd9986eaa2eca45d98e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





