### PR TITLE
fix: invalid offset

### DIFF
--- a/internal/storage/bucket/migrations/19-transactions-fill-pcv/up.sql
+++ b/internal/storage/bucket/migrations/19-transactions-fill-pcv/up.sql
@@ -42,7 +42,7 @@ do $$
 				select transactions_seq, volumes
 				from moves_view
 				-- play better than offset/limit
-				where transactions_seq >= _offset and transactions_seq < _offset + _batch_size
+				where transactions_seq > _offset and transactions_seq <= _offset + _batch_size
 			)
 			update transactions
 			set post_commit_volumes = data.volumes

--- a/internal/storage/bucket/migrations/28-fix-pcv-missing-asset/up.sql
+++ b/internal/storage/bucket/migrations/28-fix-pcv-missing-asset/up.sql
@@ -42,7 +42,7 @@ do $$
 			with data as (
 				select transactions_seq, volumes
 				from moves_view
-				where row_number >= _offset and row_number < _offset + _batch_size
+				where row_number > _offset and row_number <= _offset + _batch_size
 			)
 			update transactions
 			set post_commit_volumes = data.volumes

--- a/internal/storage/bucket/migrations/29-fix-invalid-metadata-on-reverts/up.sql
+++ b/internal/storage/bucket/migrations/29-fix-invalid-metadata-on-reverts/up.sql
@@ -37,7 +37,7 @@ do $$
 			with data as (
 				select ledger, reversedTransactionID, revertedTransactionID, revertedAt
 				from txs_view
-				where row_number >= _offset and row_number < _offset + _batch_size
+				where row_number > _offset and row_number <= _offset + _batch_size
 			)
 			update transactions
 			set

--- a/internal/storage/bucket/migrations/31-fix-transaction-updated-at/up.sql
+++ b/internal/storage/bucket/migrations/31-fix-transaction-updated-at/up.sql
@@ -26,7 +26,7 @@ do $$
 			with data as (
 				select *
 				from txs_view
-				where row_number >= _offset and row_number < _offset+_batch_size
+				where row_number > _offset and row_number <= _offset+_batch_size
 			)
 			update transactions
 			set updated_at = transactions.inserted_at

--- a/internal/storage/bucket/migrations/34-fix-memento-format/up.sql
+++ b/internal/storage/bucket/migrations/34-fix-memento-format/up.sql
@@ -15,7 +15,7 @@ do $$
 			with data as (
 				select *
 				from logs
-				where seq >= _offset and seq < _offset + _batch_size
+				where seq > _offset and seq <= _offset + _batch_size
 				order by seq
 			)
 			update logs

--- a/internal/storage/bucket/migrations/43-fix-missing-inserted-at-in-log-data/up.sql
+++ b/internal/storage/bucket/migrations/43-fix-missing-inserted-at-in-log-data/up.sql
@@ -17,7 +17,7 @@ do $$
 			with _rows as (
 				select id, ledger, row_number
 				from logs_view
-				where row_number >= _offset and row_number < _offset + _batch_size
+				where row_number > _offset and row_number <= _offset + _batch_size
 			)
 			update logs
 			set data = jsonb_set(data, '{transaction, insertedAt}', to_jsonb(to_jsonb(date)#>>'{}' || 'Z'))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix batch offset boundaries in several database migrations to prevent off-by-one errors. Queries now use > _offset and <= _offset + _batch_size to avoid skipping or duplicating rows during backfills.

- **Bug Fixes**
  - Updated WHERE clauses in migrations 19, 28, 29, 31, 34, and 43 to use an exclusive lower bound and inclusive upper bound.
  - Applies to transactions_seq, row_number, and seq to ensure consistent batching when resuming migrations.

<sup>Written for commit 37f83e11c652115c29f3c6681def88c335a556d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

