### PR TITLE
hotfix(v2.3): cors issue

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/formancehq/go-libs/v3/api"
 	"github.com/formancehq/go-libs/v3/bun/bunpaginate"
 	"github.com/formancehq/go-libs/v3/otlp"
@@ -10,7 +12,6 @@ import (
 	"github.com/formancehq/ledger/internal/controller/system"
 	"go.opentelemetry.io/otel/trace"
 	nooptracer "go.opentelemetry.io/otel/trace/noop"
-	"net/http"
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
@@ -43,6 +44,7 @@ func NewRouter(
 				return true
 			},
 			AllowCredentials: true,
+			AllowedHeaders:   []string{"*"},
 			ExposedHeaders:   []string{"Count"},
 		}).Handler,
 		common.LogID(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CORS to allow all headers and expose the Count header so browser clients can reliably call the API. Also backports small API improvements for idempotency and time filters.

- **Bug Fixes**
  - CORS: add AllowedHeaders "*" and ExposedHeaders "Count".
  - Transactions filters: support startTime/endTime (with fallback to start_time/end_time) and use the correct timestamp column.

- **New Features**
  - Add Idempotency-Hit response header on write endpoints when a request reuses an idempotency key.
  - Add PUT /v2/exporters/{exporterID} to update exporter configuration, with GRPC support.
  - Pulumi: support custom image registry/repository/tag and a configurable Postgres chart version.

<sup>Written for commit e7029fb1a9d9d99699e986db349689f41288172a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

