### PR TITLE
fix(cors): missing allowed headers

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -52,6 +52,7 @@ func NewRouter(
 				return true
 			},
 			AllowCredentials: true,
+			AllowedHeaders:   []string{"*"},
 			ExposedHeaders:   []string{"Count"},
 		}).Handler,
 		common.LogID(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix CORS preflight failures by allowing all request headers. This unblocks browser requests that send custom headers like Authorization and Content-Type.

- **Bug Fixes**
  - Set AllowedHeaders to "*" in the CORS middleware to return Access-Control-Allow-Headers for any header.

<sup>Written for commit 7b7060a025d48ab33630c8dbec08298c1cafe04f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

