### PR TITLE
chore: add mailmap to clean git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Alessandro Scandone <alessandro@formance.com> <alescandone@gmail.com>
+Alix Bott <alix@formance.com> <bott.alix@gmail.com>
+Brieuc Caillot <brieuc@formance.com> <22858504+BrieucCaillot@users.noreply.github.com>
+Clément Salaün <clem@formance.com> <salaun.clement@gmail.com>
+David Ragot <david@formance.com> <35502263+Dav-14@users.noreply.github.com>
+Don Goodman <don@formance.com> <don@uncanny.bingo>
+Geoffrey Ragot <geoffrey@formance.com> <geoffrey.ragot@gmail.com>
+Jules Dupas <jules@formance.com> <106673437+jdupas22@users.noreply.github.com>
+Maxence Maireaux <maxence@formance.com> <maxence@maireaux.fr>
+NumaryBot <numarybot@formance.com> <91949389+NumaryBot@users.noreply.github.com>
+Reslene Bahloul <reslene@formance.com> <93119071+reslene@users.noreply.github.com>
+Sylvain Rabot <sylvain@formance.com> <sylvain@abstraction.fr>
+Thierry Coopman <thierry@formance.com> <44340976+thierrycoopman@users.noreply.github.com>


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a .mailmap to unify contributor emails and produce a clean git shortlog.

<sup>Written for commit b5dbcac9b478110b57be4b3c719c9a375b8aafa2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



