### PR TITLE
feat: optimize volume selection with partial address filtering

### DIFF
--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -413,18 +413,18 @@ func TestBalancesAggregates(t *testing.T) {
 	t.Run("$or with partial address and exact address", func(t *testing.T) {
 		t.Parallel()
 
-		// Query: accounts matching "users::" OR exact address "world"
+		// Query: accounts matching "users:" (2 segments) OR exact address "world"
 		// Expected: users:1, users:2, world (NOT xxx - it doesn't match either condition)
 		ret, err := store.AggregatedVolumes().GetOne(ctx, ledgercontroller.ResourceQuery[ledgercontroller.GetAggregatedVolumesOptions]{
 			PIT: pointer.For(now.Add(time.Minute)),
 			Builder: query.Or(
-				query.Match("address", "users::"),
+				query.Match("address", "users:"),
 				query.Match("address", "world"),
 			),
 		})
 		require.NoError(t, err)
 		// Should return aggregated volumes for users:1, users:2, and world
-		// Note: xxx is NOT included as it doesn't match "users::" or "world"
+		// Note: xxx is NOT included as it doesn't match "users:" or "world"
 		// For EUR: only world has EUR Output (sending to xxx), xxx has EUR Input but is excluded
 		RequireEqual(t, ledger.AggregatedVolumes{
 			Aggregated: ledger.VolumesByAssets{
@@ -449,14 +449,14 @@ func TestBalancesAggregates(t *testing.T) {
 	t.Run("$not with partial address", func(t *testing.T) {
 		t.Parallel()
 
-		// Query: accounts NOT matching "users::"
+		// Query: accounts NOT matching "users:" (2 segments)
 		// Expected: world, xxx
 		ret, err := store.AggregatedVolumes().GetOne(ctx, ledgercontroller.ResourceQuery[ledgercontroller.GetAggregatedVolumesOptions]{
 			PIT: pointer.For(now.Add(time.Minute)),
-			Builder: query.Not(query.Match("address", "users::")),
+			Builder: query.Not(query.Match("address", "users:")),
 		})
 		require.NoError(t, err)
-		// Should return aggregated volumes for world and xxx (not matching users::)
+		// Should return aggregated volumes for world and xxx (not matching users:)
 		RequireEqual(t, ledger.AggregatedVolumes{
 			Aggregated: ledger.VolumesByAssets{
 				"USD": ledger.Volumes{

--- a/internal/storage/ledger/resource.go
+++ b/internal/storage/ledger/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/formancehq/go-libs/v2/bun/bunpaginate"
 	"github.com/formancehq/go-libs/v2/platform/postgres"
@@ -64,6 +65,9 @@ type filter struct {
 type repositoryHandlerBuildContext[Opts any] struct {
 	ledgercontroller.ResourceQuery[Opts]
 	filters map[string][]any
+	// hasComplexQuery indicates if the query contains $or or $not operators
+	// which make address optimization unsafe
+	hasComplexQuery bool
 }
 
 func (ctx repositoryHandlerBuildContext[Opts]) useFilter(v string, matchers ...func(value any) bool) bool {
@@ -152,6 +156,16 @@ func (r *resourceRepository[ResourceType, OptionsType]) validateFilters(builder 
 	return ret, nil
 }
 
+// hasComplexQueryOperators analyzes the WHERE clause to detect $or or $not operators
+// which make address pre-filtering optimization unsafe
+func hasComplexQueryOperators(where string) bool {
+	// The query builder generates:
+	// - "not (...)" for $not operators
+	// - "(...) or (...)" for $or operators
+	// We check for these patterns in the generated WHERE clause
+	return strings.Contains(where, "not (") || strings.Contains(where, ") or (")
+}
+
 func (r *resourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q ledgercontroller.ResourceQuery[OptionsType]) (*bun.SelectQuery, error) {
 
 	filters, err := r.validateFilters(q.Builder)
@@ -159,9 +173,25 @@ func (r *resourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q l
 		return nil, err
 	}
 
+	// Analyze the WHERE clause to detect complex query operators ($or, $not)
+	// that would make address optimization unsafe
+	var hasComplexQuery bool
+	var where string
+	var args []any
+	if q.Builder != nil {
+		where, args, err = q.Builder.Build(query.ContextFn(func(key, operator string, value any) (string, []any, error) {
+			return r.resourceHandler.resolveFilter(r.store, q, operator, key, value)
+		}))
+		if err != nil {
+			return nil, err
+		}
+		hasComplexQuery = hasComplexQueryOperators(where)
+	}
+
 	dataset, err := r.resourceHandler.buildDataset(r.store, repositoryHandlerBuildContext[OptionsType]{
-		ResourceQuery: q,
-		filters:       filters,
+		ResourceQuery:   q,
+		filters:         filters,
+		hasComplexQuery: hasComplexQuery,
 	})
 	if err != nil {
 		return nil, err
@@ -171,13 +201,6 @@ func (r *resourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q l
 		ModelTableExpr("(?) dataset", dataset)
 
 	if q.Builder != nil {
-		// Convert filters to where clause
-		where, args, err := q.Builder.Build(query.ContextFn(func(key, operator string, value any) (string, []any, error) {
-			return r.resourceHandler.resolveFilter(r.store, q, operator, key, value)
-		}))
-		if err != nil {
-			return nil, err
-		}
 		if len(args) > 0 {
 			dataset = dataset.Where(where, args...)
 		} else {

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -3,6 +3,8 @@ package ledger
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	ledger "github.com/formancehq/ledger/internal"
 	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
 	"github.com/formancehq/ledger/pkg/features"
@@ -49,53 +51,99 @@ func (h aggregatedBalancesResourceRepositoryHandler) filters() []filter {
 func (h aggregatedBalancesResourceRepositoryHandler) buildDataset(store *Store, query repositoryHandlerBuildContext[ledgercontroller.GetAggregatedVolumesOptions]) (*bun.SelectQuery, error) {
 
 	if query.UsePIT() {
-		ret := store.newScopedSelect().
-			ModelTableExpr(store.GetPrefixedRelationName("moves")).
-			DistinctOn("accounts_address, asset").
-			Column("accounts_address", "asset")
+		needAddressSegments := query.useFilter("address", isPartialAddress)
+
+		dateFilterColumn := "effective_date"
 		if query.Opts.UseInsertionDate {
 			if !store.ledger.HasFeature(features.FeatureMovesHistory, "ON") {
 				return nil, ledgercontroller.NewErrMissingFeature(features.FeatureMovesHistory)
 			}
-
-			ret = ret.
-				ColumnExpr("first_value(post_commit_volumes) over (partition by (accounts_address, asset) order by seq desc) as volumes").
-				Where("insertion_date <= ?", query.PIT)
+			dateFilterColumn = "insertion_date"
 		} else {
 			if !store.ledger.HasFeature(features.FeatureMovesHistoryPostCommitEffectiveVolumes, "SYNC") {
 				return nil, ledgercontroller.NewErrMissingFeature(features.FeatureMovesHistoryPostCommitEffectiveVolumes)
 			}
-
-			ret = ret.
-				ColumnExpr("first_value(post_commit_effective_volumes) over (partition by (accounts_address, asset) order by effective_date desc, seq desc) as volumes").
-				Where("effective_date <= ?", query.PIT)
 		}
 
-		if query.useFilter("address", isPartialAddress) {
-			subQuery := store.newScopedSelect().
+		// Optimization: when filtering on address segments, first identify eligible accounts
+		// then INNER JOIN with moves. This is more efficient than LATERAL JOIN + filtering after.
+		if needAddressSegments {
+			// Build eligible accounts subquery with address filters pre-applied
+			eligibleAccounts := store.newScopedSelect().
 				TableExpr(store.GetPrefixedRelationName("accounts")).
-				Column("address_array").
-				Where("accounts.address = accounts_address")
+				Column("address", "address_array")
 
-			ret = ret.
-				ColumnExpr("accounts.address_array as accounts_address_array").
-				Join(`join lateral (?) accounts on true`, subQuery)
+			// Apply address filters directly on the accounts table
+			// Multiple filters are combined with OR (user wants accounts matching ANY of the patterns)
+			if addressFilters, ok := query.filters["address"]; ok {
+				var orConditions []string
+				for _, addrFilter := range addressFilters {
+					addrStr := addrFilter.(string)
+					if isPartialAddress(addrStr) {
+						orConditions = append(orConditions, "("+filterAccountAddress(addrStr, "address")+")")
+					}
+				}
+				if len(orConditions) > 0 {
+					eligibleAccounts = eligibleAccounts.Where(strings.Join(orConditions, " OR "))
+				}
+			}
+
+			ret := store.newScopedSelect().
+				ModelTableExpr(store.GetPrefixedRelationName("moves")+" moves").
+				DistinctOn("moves.accounts_address, moves.asset").
+				Column("moves.accounts_address", "moves.asset").
+				ColumnExpr("eligible_accounts.address_array as accounts_address_array").
+				Join("inner join (?) eligible_accounts on eligible_accounts.address = moves.accounts_address", eligibleAccounts).
+				Where("moves."+dateFilterColumn+" <= ?", query.PIT)
+
+			if query.Opts.UseInsertionDate {
+				ret = ret.ColumnExpr("first_value(moves.post_commit_volumes) over (partition by (moves.accounts_address, moves.asset) order by moves.seq desc) as volumes")
+			} else {
+				ret = ret.ColumnExpr("first_value(moves.post_commit_effective_volumes) over (partition by (moves.accounts_address, moves.asset) order by moves.effective_date desc, moves.seq desc) as volumes")
+			}
+
+			if query.useFilter("metadata") {
+				subQuery := store.newScopedSelect().
+					DistinctOn("accounts_address").
+					ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
+					ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
+					Where("accounts_metadata.accounts_address = moves.accounts_address").
+					Where("date <= ?", query.PIT)
+
+				ret = ret.
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
+					Column("metadata")
+			}
+
+			return ret, nil
+		} else {
+			ret := store.newScopedSelect().
+				ModelTableExpr(store.GetPrefixedRelationName("moves")).
+				DistinctOn("accounts_address, asset").
+				Column("accounts_address", "asset").
+				Where(dateFilterColumn+" <= ?", query.PIT)
+
+			if query.Opts.UseInsertionDate {
+				ret = ret.ColumnExpr("first_value(post_commit_volumes) over (partition by (accounts_address, asset) order by seq desc) as volumes")
+			} else {
+				ret = ret.ColumnExpr("first_value(post_commit_effective_volumes) over (partition by (accounts_address, asset) order by effective_date desc, seq desc) as volumes")
+			}
+
+			if query.useFilter("metadata") {
+				subQuery := store.newScopedSelect().
+					DistinctOn("accounts_address").
+					ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
+					ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
+					Where("accounts_metadata.accounts_address = moves.accounts_address").
+					Where("date <= ?", query.PIT)
+
+				ret = ret.
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
+					Column("metadata")
+			}
+
+			return ret, nil
 		}
-
-		if query.useFilter("metadata") {
-			subQuery := store.newScopedSelect().
-				DistinctOn("accounts_address").
-				ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
-				ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
-				Where("accounts_metadata.accounts_address = moves.accounts_address").
-				Where("date <= ?", query.PIT)
-
-			ret = ret.
-				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-				Column("metadata")
-		}
-
-		return ret, nil
 	} else {
 		ret := store.newScopedSelect().
 			ModelTableExpr(store.GetPrefixedRelationName("accounts_volumes")).

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -65,20 +65,17 @@ func (h aggregatedBalancesResourceRepositoryHandler) buildDataset(store *Store, 
 			}
 		}
 
-		// Optimization: when filtering on a SINGLE partial address (no other filter types),
-		// first identify eligible accounts then INNER JOIN with moves.
-		// This is more efficient than LATERAL JOIN + filtering after.
+		// Optimization: when filtering on partial addresses, first identify eligible accounts
+		// then INNER JOIN with moves. This is more efficient than LATERAL JOIN + filtering after.
 		//
-		// IMPORTANT: Only use this optimization when there is exactly ONE partial address filter
-		// and NO other filters (metadata). This is because:
+		// IMPORTANT: Only use this optimization when the query does NOT contain $or or $not operators.
+		// These operators make pre-filtering unsafe because:
 		// - $or(partial, other) would exclude accounts matching "other" but not the partial address
 		// - $not(partial) would exclude all accounts after pre-filtering
-		// - Multiple address filters might be in $or and need different handling
 		//
-		// Note: PIT/OOT (endTime) filters are OK as they are global time filters, not $or-able filters.
-		addressFilters := query.filters["address"]
-		hasSinglePartialAddress := len(addressFilters) == 1 && isPartialAddress(addressFilters[0])
-		useAddressOptimization := hasSinglePartialAddress && !query.useFilter("metadata")
+		// The hasComplexQuery flag is set by analyzing the generated WHERE clause for these patterns.
+		// PIT/OOT (endTime) filters are OK as they are global time filters, not $or-able filters.
+		useAddressOptimization := needAddressSegments && !query.hasComplexQuery
 		if useAddressOptimization {
 			// Build eligible accounts subquery with address filters pre-applied
 			eligibleAccounts := store.newScopedSelect().

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -3,11 +3,12 @@ package ledger
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	ledger "github.com/formancehq/ledger/internal"
 	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
 	"github.com/formancehq/ledger/pkg/features"
 	"github.com/uptrace/bun"
-	"strings"
 )
 
 type volumesResourceHandler struct{}
@@ -90,50 +91,95 @@ func (h volumesResourceHandler) buildDataset(store *Store, query repositoryHandl
 			return nil, ledgercontroller.NewErrMissingFeature(features.FeatureMovesHistory)
 		}
 
-		selectVolumes = store.newScopedSelect().
-			Column("asset").
-			ColumnExpr("accounts_address as account").
-			ColumnExpr("sum(case when not is_source then amount else 0 end) as input").
-			ColumnExpr("sum(case when is_source then amount else 0 end) as output").
-			ColumnExpr("sum(case when not is_source then amount else -amount end) as balance").
-			ModelTableExpr(store.GetPrefixedRelationName("moves")).
-			GroupExpr("accounts_address, asset").
-			Order("accounts_address", "asset")
-
 		dateFilterColumn := "effective_date"
 		if query.Opts.UseInsertionDate {
 			dateFilterColumn = "insertion_date"
 		}
 
-		if query.UsePIT() {
-			selectVolumes = selectVolumes.Where(dateFilterColumn+" <= ?", query.PIT)
-		}
-
-		if query.UseOOT() {
-			selectVolumes = selectVolumes.Where(dateFilterColumn+" >= ?", query.OOT)
-		}
-
+		// Optimization: when filtering on address segments, first identify eligible accounts
+		// then INNER JOIN with moves. This is more efficient than LATERAL JOIN + filtering after.
 		if needAddressSegments {
-			subQuery := store.newScopedSelect().
+			// Build eligible accounts subquery with address filters pre-applied
+			eligibleAccounts := store.newScopedSelect().
 				TableExpr(store.GetPrefixedRelationName("accounts")).
-				Column("address_array").
-				Where("accounts.address = accounts_address")
+				Column("address", "address_array")
 
-			selectVolumes.
-				ColumnExpr("(array_agg(accounts.address_array))[1] as account_array").
-				Join(`join lateral (?) accounts on true`, subQuery)
-		}
+			// Apply address filters directly on the accounts table
+			// Multiple filters are combined with OR (user wants accounts matching ANY of the patterns)
+			if addressFilters, ok := query.filters["address"]; ok {
+				var orConditions []string
+				for _, addrFilter := range addressFilters {
+					addrStr := addrFilter.(string)
+					if isPartialAddress(addrStr) {
+						orConditions = append(orConditions, "("+filterAccountAddress(addrStr, "address")+")")
+					}
+				}
+				if len(orConditions) > 0 {
+					eligibleAccounts = eligibleAccounts.Where(strings.Join(orConditions, " OR "))
+				}
+			}
 
-		if query.useFilter("metadata") {
-			subQuery := store.newScopedSelect().
-				DistinctOn("accounts_address").
-				ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
-				ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
-				Where("accounts_metadata.accounts_address = moves.accounts_address")
+			selectVolumes = store.newScopedSelect().
+				Column("moves.asset").
+				ColumnExpr("moves.accounts_address as account").
+				ColumnExpr("sum(case when not moves.is_source then moves.amount else 0 end) as input").
+				ColumnExpr("sum(case when moves.is_source then moves.amount else 0 end) as output").
+				ColumnExpr("sum(case when not moves.is_source then moves.amount else -moves.amount end) as balance").
+				ColumnExpr("(array_agg(eligible_accounts.address_array))[1] as account_array").
+				ModelTableExpr(store.GetPrefixedRelationName("moves")+" moves").
+				Join("inner join (?) eligible_accounts on eligible_accounts.address = moves.accounts_address", eligibleAccounts).
+				GroupExpr("moves.accounts_address, moves.asset").
+				Order("moves.accounts_address", "moves.asset")
 
-			selectVolumes = selectVolumes.
-				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-				ColumnExpr("(array_agg(metadata))[1] as metadata")
+			if query.UsePIT() {
+				selectVolumes = selectVolumes.Where("moves."+dateFilterColumn+" <= ?", query.PIT)
+			}
+
+			if query.UseOOT() {
+				selectVolumes = selectVolumes.Where("moves."+dateFilterColumn+" >= ?", query.OOT)
+			}
+
+			if query.useFilter("metadata") {
+				subQuery := store.newScopedSelect().
+					DistinctOn("accounts_address").
+					ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
+					ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
+					Where("accounts_metadata.accounts_address = moves.accounts_address")
+
+				selectVolumes = selectVolumes.
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
+					ColumnExpr("(array_agg(accounts_metadata.metadata))[1] as metadata")
+			}
+		} else {
+			selectVolumes = store.newScopedSelect().
+				Column("asset").
+				ColumnExpr("accounts_address as account").
+				ColumnExpr("sum(case when not is_source then amount else 0 end) as input").
+				ColumnExpr("sum(case when is_source then amount else 0 end) as output").
+				ColumnExpr("sum(case when not is_source then amount else -amount end) as balance").
+				ModelTableExpr(store.GetPrefixedRelationName("moves")).
+				GroupExpr("accounts_address, asset").
+				Order("accounts_address", "asset")
+
+			if query.UsePIT() {
+				selectVolumes = selectVolumes.Where(dateFilterColumn+" <= ?", query.PIT)
+			}
+
+			if query.UseOOT() {
+				selectVolumes = selectVolumes.Where(dateFilterColumn+" >= ?", query.OOT)
+			}
+
+			if query.useFilter("metadata") {
+				subQuery := store.newScopedSelect().
+					DistinctOn("accounts_address").
+					ModelTableExpr(store.GetPrefixedRelationName("accounts_metadata")).
+					ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
+					Where("accounts_metadata.accounts_address = moves.accounts_address")
+
+				selectVolumes = selectVolumes.
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
+					ColumnExpr("(array_agg(metadata))[1] as metadata")
+			}
 		}
 	}
 

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -96,13 +96,21 @@ func (h volumesResourceHandler) buildDataset(store *Store, query repositoryHandl
 			dateFilterColumn = "insertion_date"
 		}
 
-		// Optimization: when filtering ONLY on address segments (no other filter types),
+		// Optimization: when filtering on a SINGLE partial address (no other filter types),
 		// first identify eligible accounts then INNER JOIN with moves.
 		// This is more efficient than LATERAL JOIN + filtering after.
-		// IMPORTANT: Do NOT use this optimization when other filters (like metadata) are present,
-		// because they might be in a $or clause with the address filter, and pre-filtering
-		// on addresses would exclude accounts that match the other filters but not the address.
-		useAddressOptimization := needAddressSegments && !query.useFilter("metadata")
+		//
+		// IMPORTANT: Only use this optimization when there is exactly ONE partial address filter
+		// and NO other filters (metadata, balance, exact addresses). This is because:
+		// - $or(partial, other) would exclude accounts matching "other" but not the partial address
+		// - $not(partial) would exclude all accounts after pre-filtering
+		// - Multiple address filters might be in $or and need different handling
+		//
+		// Note: PIT/OOT (endTime) filters are OK as they are global time filters, not $or-able filters.
+		addressFilters := query.filters["address"]
+		hasSinglePartialAddress := len(addressFilters) == 1 && isPartialAddress(addressFilters[0])
+		hasOtherFilters := query.useFilter("metadata") || query.useFilter(`balance(\[.*])?`)
+		useAddressOptimization := hasSinglePartialAddress && !hasOtherFilters
 		if useAddressOptimization {
 			// Build eligible accounts subquery with address filters pre-applied
 			eligibleAccounts := store.newScopedSelect().

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -157,7 +157,7 @@ func (h volumesResourceHandler) buildDataset(store *Store, query repositoryHandl
 				ColumnExpr("sum(case when not is_source then amount else 0 end) as input").
 				ColumnExpr("sum(case when is_source then amount else 0 end) as output").
 				ColumnExpr("sum(case when not is_source then amount else -amount end) as balance").
-				ModelTableExpr(store.GetPrefixedRelationName("moves")).
+				ModelTableExpr(store.GetPrefixedRelationName("moves") + " moves").
 				GroupExpr("accounts_address, asset").
 				Order("accounts_address", "asset")
 

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -22,7 +22,37 @@ func filterAccountAddress(address, key string) string {
 
 	if isPartialAddress(address) {
 		src := strings.Split(address, ":")
-		parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, len(src)))
+		// Fix trailing empty segment handling for patterns ending with "::"
+		// strings.Split("users::", ":") gives ["users", "", ""] (3 elements)
+		// but "users::" should match addresses with 2 segments like "users:alice"
+		//
+		// The rule: if the address ends with "::" (double colon), the last empty
+		// element is an artifact of Split and should be removed.
+		// But only if there's nothing but empty segments after the last non-empty one.
+		//
+		// Examples:
+		// - "users::" -> ["users", "", ""] -> expectedLen = 2 (match users:X)
+		// - "users::products::" -> ["users", "", "products", "", ""] -> expectedLen = 5 (match users:X:products:Y:Z)
+		// - "users:" -> ["users", ""] -> expectedLen = 2 (match users:X)
+		expectedLen := len(src)
+		// Only trim if the pattern ends with "::" AND the last two are empty AND
+		// there's no non-empty segment between them
+		if expectedLen >= 2 && src[expectedLen-1] == "" && src[expectedLen-2] == "" {
+			// Check if this is a "simple ending" pattern like "users::" vs "users::products::"
+			// For "users::", we want to trim. For "users::products::", we don't.
+			// The difference: in "users::", there are only empty segments after the first non-empty
+			hasNonEmptyAfterFirst := false
+			for i := 1; i < expectedLen-1; i++ {
+				if src[i] != "" {
+					hasNonEmptyAfterFirst = true
+					break
+				}
+			}
+			if !hasNonEmptyAfterFirst {
+				expectedLen--
+			}
+		}
+		parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, expectedLen))
 
 		for i, segment := range src {
 			if len(segment) == 0 {

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -22,37 +22,11 @@ func filterAccountAddress(address, key string) string {
 
 	if isPartialAddress(address) {
 		src := strings.Split(address, ":")
-		// Fix trailing empty segment handling for patterns ending with "::"
-		// strings.Split("users::", ":") gives ["users", "", ""] (3 elements)
-		// but "users::" should match addresses with 2 segments like "users:alice"
-		//
-		// The rule: if the address ends with "::" (double colon), the last empty
-		// element is an artifact of Split and should be removed.
-		// But only if there's nothing but empty segments after the last non-empty one.
-		//
-		// Examples:
-		// - "users::" -> ["users", "", ""] -> expectedLen = 2 (match users:X)
-		// - "users::products::" -> ["users", "", "products", "", ""] -> expectedLen = 5 (match users:X:products:Y:Z)
-		// - "users:" -> ["users", ""] -> expectedLen = 2 (match users:X)
-		expectedLen := len(src)
-		// Only trim if the pattern ends with "::" AND the last two are empty AND
-		// there's no non-empty segment between them
-		if expectedLen >= 2 && src[expectedLen-1] == "" && src[expectedLen-2] == "" {
-			// Check if this is a "simple ending" pattern like "users::" vs "users::products::"
-			// For "users::", we want to trim. For "users::products::", we don't.
-			// The difference: in "users::", there are only empty segments after the first non-empty
-			hasNonEmptyAfterFirst := false
-			for i := 1; i < expectedLen-1; i++ {
-				if src[i] != "" {
-					hasNonEmptyAfterFirst = true
-					break
-				}
-			}
-			if !hasNonEmptyAfterFirst {
-				expectedLen--
-			}
-		}
-		parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, expectedLen))
+		// Pattern semantics:
+		// - "users:" = ["users", ""] = 2 segments = match "users:X"
+		// - "users::" = ["users", "", ""] = 3 segments = match "users:X:Y"
+		// - "users::alice" = ["users", "", "alice"] = 3 segments = match "users:X:alice"
+		parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, len(src)))
 
 		for i, segment := range src {
 			if len(segment) == 0 {

--- a/internal/storage/ledger/volumes_test.go
+++ b/internal/storage/ledger/volumes_test.go
@@ -704,6 +704,24 @@ func TestVolumesAggregate(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, volumes.Data, 1)
 	})
+
+	t.Run("filter using PIT and metadata without partial address filter", func(t *testing.T) {
+		t.Parallel()
+
+		// This test reproduces the bug where the 'moves' table alias is missing
+		// when using PIT/OOT with metadata filter but WITHOUT partial address filter.
+		// The query references moves.accounts_address but the table has no alias.
+		volumes, err := store.Volumes().Paginate(ctx,
+			ledgercontroller.OffsetPaginatedQuery[ledgercontroller.GetVolumesOptions]{
+				Options: ledgercontroller.ResourceQuery[ledgercontroller.GetVolumesOptions]{
+					PIT:     &pit,
+					Builder: query.Match("metadata[foo]", "bar"),
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, volumes.Data, 1)
+	})
 }
 
 func TestVolumesWithPartialAddressAndPIT(t *testing.T) {


### PR DESCRIPTION
- Introduced a more efficient method for filtering accounts based on address segments by using INNER JOIN instead of LATERAL JOIN.
- Enhanced the query logic to support multiple OR conditions for partial address filters.
- Added comprehensive tests for various scenarios involving partial address filters, including PIT and OOT conditions.