### PR TITLE
fix: consider PIT in /volumes account metadata filter

### DIFF
--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -114,6 +114,10 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 				ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
 				Where("accounts_metadata.accounts_address = moves.accounts_address")
 
+			if query.UsePIT() {
+				subQuery = subQuery.Where("date <= ?", query.PIT)
+			}
+
 			selectVolumes = selectVolumes.
 				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
 				ColumnExpr("(array_agg(metadata))[1] as metadata")


### PR DESCRIPTION
Makes sure volumes are returned only for accounts with matching metadata at the given PIT