### PR TITLE
fix: remove duplicate error recording in TraceWithMetric

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -24,7 +24,7 @@ func TraceWithMetric[RET any](
 		now := time.Now()
 		ret, err := fn(ctx)
 		if err != nil {
-			otlp.RecordError(ctx, err)
+			// Error is already recorded by Trace(), no need to record it here
 			return zeroRet, err
 		}
 


### PR DESCRIPTION
## Summary
- Remove duplicate `otlp.RecordError` call in `TraceWithMetric` function
- The error was being recorded twice in OpenTelemetry traces, causing duplicate stacktraces

<img width="444" height="678" alt="CleanShot 2025-12-29 at 10 52 13" src="https://github.com/user-attachments/assets/da63978e-0e05-41f4-a714-d817da3c8d84" />


## Problem
When an error occurred in a function wrapped by `TraceWithMetric`, it was recorded twice:
1. First in the `TraceWithMetric` callback (line 27)
2. Then again in the `Trace` function after the callback returns (line 55)

This caused duplicate exception stacktraces in OpenTelemetry traces for the same error event.

## Solution
Remove the redundant `otlp.RecordError` call in `TraceWithMetric` since `Trace()` already handles error recording.

## Test plan
- [x] Verify that errors are still recorded in OpenTelemetry traces (via `Trace()`)
- [x] Confirm no duplicate stacktraces appear for the same error