### PR TITLE
fix: remove duplicate error recording in TraceWithMetric

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -112,7 +112,7 @@ func TraceWithMetric[RET any](
 		now := time.Now()
 		ret, err := fn(ctx)
 		if err != nil {
-			otlp.RecordError(ctx, err)
+			// Error is already recorded by Trace(), no need to record it here
 			return zeroRet, err
 		}
 


### PR DESCRIPTION
## Summary
- Remove duplicate error recording in OpenTelemetry traces
- The error was being recorded twice: once in TraceWithMetric and once in Trace()
- This caused duplicate stacktraces in traces for the same error

## Test plan
- [x] Cherry-picked from fix/duplicate-otel-error-recording branch
- [ ] Verify traces no longer show duplicate errors