### PR TITLE
fix: prevent nil map assignment panic in volumes handling

### DIFF
--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -82,7 +82,7 @@ func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transactio
 				Asset:             posting.Asset,
 				InsertionDate:     tx.InsertedAt,
 				EffectiveDate:     tx.Timestamp,
-				PostCommitVolumes: pointer.For(postCommitVolumes[posting.Destination][posting.Asset].Copy()),
+				PostCommitVolumes: pointer.For(postCommitVolumes.Get(posting.Destination, posting.Asset).Copy()),
 				TransactionID:     *tx.ID,
 			})
 			postCommitVolumes.AddInput(posting.Destination, posting.Asset, new(big.Int).Neg(posting.Amount))
@@ -94,7 +94,7 @@ func (store *Store) CommitTransaction(ctx context.Context, tx *ledger.Transactio
 				Asset:             posting.Asset,
 				InsertionDate:     tx.InsertedAt,
 				EffectiveDate:     tx.Timestamp,
-				PostCommitVolumes: pointer.For(postCommitVolumes[posting.Source][posting.Asset].Copy()),
+				PostCommitVolumes: pointer.For(postCommitVolumes.Get(posting.Source, posting.Asset).Copy()),
 				TransactionID:     *tx.ID,
 			})
 			postCommitVolumes.AddOutput(posting.Source, posting.Asset, new(big.Int).Neg(posting.Amount))

--- a/internal/volumes.go
+++ b/internal/volumes.go
@@ -117,6 +117,18 @@ func (v VolumesByAssets) copy() VolumesByAssets {
 
 type PostCommitVolumes map[string]VolumesByAssets
 
+// Get returns the volumes for the given account and asset, creating empty volumes if they don't exist.
+// This method is safe to call even if the account or asset doesn't exist in the map.
+func (a PostCommitVolumes) Get(account, asset string) Volumes {
+	if _, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{}
+	}
+	if _, ok := a[account][asset]; !ok {
+		a[account][asset] = NewEmptyVolumes()
+	}
+	return a[account][asset]
+}
+
 func (a PostCommitVolumes) AddInput(account, asset string, input *big.Int) {
 	if _, ok := a[account]; !ok {
 		a[account] = map[string]Volumes{}

--- a/internal/volumes.go
+++ b/internal/volumes.go
@@ -118,12 +118,24 @@ func (v VolumesByAssets) copy() VolumesByAssets {
 type PostCommitVolumes map[string]VolumesByAssets
 
 func (a PostCommitVolumes) AddInput(account, asset string, input *big.Int) {
+	if _, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{}
+	}
+	if _, ok := a[account][asset]; !ok {
+		a[account][asset] = NewEmptyVolumes()
+	}
 	volumes := a[account][asset].Copy()
 	volumes.Input.Add(volumes.Input, input)
 	a[account][asset] = volumes
 }
 
 func (a PostCommitVolumes) AddOutput(account, asset string, output *big.Int) {
+	if _, ok := a[account]; !ok {
+		a[account] = map[string]Volumes{}
+	}
+	if _, ok := a[account][asset]; !ok {
+		a[account][asset] = NewEmptyVolumes()
+	}
 	volumes := a[account][asset].Copy()
 	volumes.Output.Add(volumes.Output, output)
 	a[account][asset] = volumes

--- a/internal/volumes_test.go
+++ b/internal/volumes_test.go
@@ -1,0 +1,164 @@
+package ledger
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostCommitVolumes_AddInput_WithExistingAccount verifies normal behavior
+func TestPostCommitVolumes_AddInput_WithExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewVolumesInt64(100, 50),
+		},
+	}
+
+	volumes.AddInput("existing_account", "USD", big.NewInt(100))
+
+	require.Equal(t, big.NewInt(200), volumes["existing_account"]["USD"].Input)
+	require.Equal(t, big.NewInt(50), volumes["existing_account"]["USD"].Output)
+}
+
+// TestPostCommitVolumes_AddInput_WithNonExistingAccount verifies that AddInput
+// creates the account if it doesn't exist (fix for "assignment to entry in nil map")
+func TestPostCommitVolumes_AddInput_WithNonExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewEmptyVolumes(),
+		},
+	}
+
+	// Should NOT panic - account should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddInput("new_account", "USD", big.NewInt(100))
+	})
+
+	// Verify the account and asset were created with correct values
+	require.Contains(t, volumes, "new_account")
+	require.Contains(t, volumes["new_account"], "USD")
+	require.Equal(t, big.NewInt(100), volumes["new_account"]["USD"].Input)
+	require.Equal(t, big.NewInt(0), volumes["new_account"]["USD"].Output)
+}
+
+// TestPostCommitVolumes_AddOutput_WithExistingAccount verifies normal behavior
+func TestPostCommitVolumes_AddOutput_WithExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewVolumesInt64(100, 50),
+		},
+	}
+
+	volumes.AddOutput("existing_account", "USD", big.NewInt(25))
+
+	require.Equal(t, big.NewInt(100), volumes["existing_account"]["USD"].Input)
+	require.Equal(t, big.NewInt(75), volumes["existing_account"]["USD"].Output)
+}
+
+// TestPostCommitVolumes_AddOutput_WithNonExistingAccount verifies that AddOutput
+// creates the account if it doesn't exist (fix for "assignment to entry in nil map")
+func TestPostCommitVolumes_AddOutput_WithNonExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewEmptyVolumes(),
+		},
+	}
+
+	// Should NOT panic - account should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddOutput("new_account", "USD", big.NewInt(100))
+	})
+
+	// Verify the account and asset were created with correct values
+	require.Contains(t, volumes, "new_account")
+	require.Contains(t, volumes["new_account"], "USD")
+	require.Equal(t, big.NewInt(0), volumes["new_account"]["USD"].Input)
+	require.Equal(t, big.NewInt(100), volumes["new_account"]["USD"].Output)
+}
+
+// TestPostCommitVolumes_AddInput_WithNonExistingAsset verifies that AddInput
+// creates the asset if it doesn't exist for an existing account
+func TestPostCommitVolumes_AddInput_WithNonExistingAsset(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewEmptyVolumes(),
+		},
+	}
+
+	// Should NOT panic - asset should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddInput("existing_account", "EUR", big.NewInt(100))
+	})
+
+	// Verify the asset was created with correct values
+	require.Contains(t, volumes["existing_account"], "EUR")
+	require.Equal(t, big.NewInt(100), volumes["existing_account"]["EUR"].Input)
+	require.Equal(t, big.NewInt(0), volumes["existing_account"]["EUR"].Output)
+}
+
+// TestPostCommitVolumes_AddOutput_WithNonExistingAsset verifies that AddOutput
+// creates the asset if it doesn't exist for an existing account
+func TestPostCommitVolumes_AddOutput_WithNonExistingAsset(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewEmptyVolumes(),
+		},
+	}
+
+	// Should NOT panic - asset should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddOutput("existing_account", "EUR", big.NewInt(100))
+	})
+
+	// Verify the asset was created with correct values
+	require.Contains(t, volumes["existing_account"], "EUR")
+	require.Equal(t, big.NewInt(0), volumes["existing_account"]["EUR"].Input)
+	require.Equal(t, big.NewInt(100), volumes["existing_account"]["EUR"].Output)
+}
+
+// TestPostCommitVolumes_AddInput_OnEmptyMap verifies that AddInput works on empty map
+func TestPostCommitVolumes_AddInput_OnEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{}
+
+	// Should NOT panic - account and asset should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddInput("any_account", "USD", big.NewInt(100))
+	})
+
+	// Verify the account and asset were created
+	require.Contains(t, volumes, "any_account")
+	require.Contains(t, volumes["any_account"], "USD")
+	require.Equal(t, big.NewInt(100), volumes["any_account"]["USD"].Input)
+}
+
+// TestPostCommitVolumes_AddOutput_OnEmptyMap verifies that AddOutput works on empty map
+func TestPostCommitVolumes_AddOutput_OnEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{}
+
+	// Should NOT panic - account and asset should be created automatically
+	require.NotPanics(t, func() {
+		volumes.AddOutput("any_account", "USD", big.NewInt(100))
+	})
+
+	// Verify the account and asset were created
+	require.Contains(t, volumes, "any_account")
+	require.Contains(t, volumes["any_account"], "USD")
+	require.Equal(t, big.NewInt(100), volumes["any_account"]["USD"].Output)
+}

--- a/internal/volumes_test.go
+++ b/internal/volumes_test.go
@@ -162,3 +162,65 @@ func TestPostCommitVolumes_AddOutput_OnEmptyMap(t *testing.T) {
 	require.Contains(t, volumes["any_account"], "USD")
 	require.Equal(t, big.NewInt(100), volumes["any_account"]["USD"].Output)
 }
+
+// TestPostCommitVolumes_Get_WithExistingAccount verifies Get returns existing volumes
+func TestPostCommitVolumes_Get_WithExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewVolumesInt64(100, 50),
+		},
+	}
+
+	result := volumes.Get("existing_account", "USD")
+
+	require.Equal(t, big.NewInt(100), result.Input)
+	require.Equal(t, big.NewInt(50), result.Output)
+}
+
+// TestPostCommitVolumes_Get_WithNonExistingAccount verifies Get creates empty volumes
+func TestPostCommitVolumes_Get_WithNonExistingAccount(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{
+		"existing_account": {
+			"USD": NewEmptyVolumes(),
+		},
+	}
+
+	// Should NOT panic - account should be created automatically
+	var result Volumes
+	require.NotPanics(t, func() {
+		result = volumes.Get("new_account", "USD")
+	})
+
+	// Verify empty volumes are returned
+	require.Equal(t, big.NewInt(0), result.Input)
+	require.Equal(t, big.NewInt(0), result.Output)
+
+	// Verify the account and asset were created in the map
+	require.Contains(t, volumes, "new_account")
+	require.Contains(t, volumes["new_account"], "USD")
+}
+
+// TestPostCommitVolumes_Get_OnEmptyMap verifies Get works on empty map
+func TestPostCommitVolumes_Get_OnEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	volumes := PostCommitVolumes{}
+
+	// Should NOT panic - account and asset should be created automatically
+	var result Volumes
+	require.NotPanics(t, func() {
+		result = volumes.Get("any_account", "USD")
+	})
+
+	// Verify empty volumes are returned
+	require.Equal(t, big.NewInt(0), result.Input)
+	require.Equal(t, big.NewInt(0), result.Output)
+
+	// Verify the account and asset were created
+	require.Contains(t, volumes, "any_account")
+	require.Contains(t, volumes["any_account"], "USD")
+}


### PR DESCRIPTION
## Summary
- Fix "assignment to entry in nil map" panic when accessing `PostCommitVolumes`
- Add defensive checks in `AddInput()` and `AddOutput()` methods
- **Add safe `Get()` method** that creates empty volumes if account/asset doesn't exist
- **Fix direct volume access in `CommitTransaction`** (when `FeatureMovesHistory` is ON)

## Root Cause Analysis
The panic occurred in `CommitTransaction` (transactions.go:85,97) when:
1. `FeatureMovesHistory` feature is **ON**
2. Code accesses `postCommitVolumes[account][asset]` directly
3. The account/asset combination doesn't exist in the map

The direct access happened **before** the `AddInput`/`AddOutput` calls that could create the entries.

## Changes
1. `internal/volumes.go`:
   - Add `Get(account, asset)` method that safely returns volumes (creates if missing)
   - `AddInput()` and `AddOutput()` now initialize account/asset if they don't exist

2. `internal/storage/ledger/transactions.go`:
   - Use `postCommitVolumes.Get()` instead of direct `postCommitVolumes[account][asset]` access

3. `internal/volumes_test.go`:
   - Add tests for all edge cases (existing account, non-existing account, non-existing asset, empty map)
   - Add tests for new `Get()` method

## Test plan
- [x] All existing tests pass
- [x] New unit tests cover edge cases
- [x] Build succeeds