### PR TITLE
fix: prevent nil map panic in OP_SAVE when using unbounded overdraft

### DIFF
--- a/internal/machine/vm/machine.go
+++ b/internal/machine/vm/machine.go
@@ -433,10 +433,17 @@ func (m *Machine) tick() (bool, error) {
 	case program.OP_SAVE:
 		a := pop[machine.AccountAddress](m)
 		v := m.popValue()
+		// Ensure the account's balance map is initialized to prevent nil map panic
+		if m.Balances[a] == nil {
+			m.Balances[a] = make(map[machine.Asset]*machine.MonetaryInt)
+		}
 		switch v := v.(type) {
 		case machine.Asset:
 			m.Balances[a][v] = machine.Zero
 		case machine.Monetary:
+			if m.Balances[a][v.Asset] == nil {
+				m.Balances[a][v.Asset] = machine.NewMonetaryInt(0)
+			}
 			m.Balances[a][v.Asset] = m.Balances[a][v.Asset].Sub(v.Amount)
 		default:
 			panic(fmt.Errorf("invalid value type: %T", v))


### PR DESCRIPTION
## Summary

Fixes a panic in the VM when executing `save` operations combined with `allowing unbounded overdraft` in send statements.

**Root cause:** The `save` operation in the compiler was not calling `setNeededBalances`, so when followed by a `send` with `unbounded overdraft` (which skips balance fetching by design), the account's balances map was never initialized, causing a nil map assignment panic in `OP_SAVE`.

**Example script that triggered the panic:**
```numscript
save [EUR/4 1500000] from @118131

send [EUR/4 240000] (
    source = @118131 allowing unbounded overdraft
    destination = @118131:blocked
)
```

## Changes

1. **Compiler (`compiler.go`)**: Added `setNeededBalances` call in `VisitSaveFromAccount` to ensure the account's balances are fetched before execution
2. **VM (`machine.go`)**: Added defensive nil check in `OP_SAVE` to prevent panic if balances map is not initialized (belt and suspenders approach)
3. **Tests (`machine_test.go`)**: Added 3 regression tests for save operations with unbounded overdraft

## Test plan

- [x] All existing `TestSaveFromAccount` tests pass
- [x] New regression tests pass:
  - `TestSaveFromAccount/save_with_unbounded_overdraft`
  - `TestSaveFromAccount/save_all_with_unbounded_overdraft`
  - `TestSaveFromAccount/save_from_different_account_with_unbounded_overdraft`