### PR TITLE
fix: prevent nil map panic in OP_SAVE when using unbounded overdraft

### DIFF
--- a/internal/machine/vm/machine_test.go
+++ b/internal/machine/vm/machine_test.go
@@ -2334,6 +2334,90 @@ func TestSaveFromAccount(t *testing.T) {
 		}
 		test(t, tc)
 	})
+
+	// Regression test: save with unbounded overdraft must not panic
+	// This reproduces the exact scenario from production where OP_SAVE panicked
+	// because balances were not fetched when 'save' was followed by 'send' with 'allowing unbounded overdraft'
+	t.Run("save with unbounded overdraft", func(t *testing.T) {
+		script := `
+			save [EUR/4 1500000] from @source
+
+			send [EUR/4 240000] (
+				source = @source allowing unbounded overdraft
+				destination = @destination
+			)`
+		tc := NewTestCase()
+		tc.compile(t, script)
+		tc.setBalance("source", "EUR/4", 2000000)
+		tc.expected = CaseResult{
+			Printed: []machine.Value{},
+			Postings: []Posting{
+				{
+					Asset:       "EUR/4",
+					Amount:      machine.NewMonetaryInt(240000),
+					Source:      "source",
+					Destination: "destination",
+				},
+			},
+			Error: nil,
+		}
+		test(t, tc)
+	})
+
+	// Regression test: save all with unbounded overdraft
+	t.Run("save all with unbounded overdraft", func(t *testing.T) {
+		script := `
+			save [EUR/4 *] from @source
+
+			send [EUR/4 100] (
+				source = @source allowing unbounded overdraft
+				destination = @destination
+			)`
+		tc := NewTestCase()
+		tc.compile(t, script)
+		tc.setBalance("source", "EUR/4", 500)
+		tc.expected = CaseResult{
+			Printed: []machine.Value{},
+			Postings: []Posting{
+				{
+					Asset:       "EUR/4",
+					Amount:      machine.NewMonetaryInt(100),
+					Source:      "source",
+					Destination: "destination",
+				},
+			},
+			Error: nil,
+		}
+		test(t, tc)
+	})
+
+	// Regression test: save from account not in send statement
+	// This ensures balances are fetched even when the save account is different from send source
+	t.Run("save from different account with unbounded overdraft", func(t *testing.T) {
+		script := `
+			save [USD 100] from @blocked
+
+			send [USD 50] (
+				source = @source allowing unbounded overdraft
+				destination = @destination
+			)`
+		tc := NewTestCase()
+		tc.compile(t, script)
+		tc.setBalance("blocked", "USD", 200)
+		tc.expected = CaseResult{
+			Printed: []machine.Value{},
+			Postings: []Posting{
+				{
+					Asset:       "USD",
+					Amount:      machine.NewMonetaryInt(50),
+					Source:      "source",
+					Destination: "destination",
+				},
+			},
+			Error: nil,
+		}
+		test(t, tc)
+	})
 }
 
 func TestUseDifferentAssetsWithSameSourceAccount(t *testing.T) {


### PR DESCRIPTION
## Summary

Cherry-pick of #1214 for main branch.

Fixes a panic in the VM when executing `save` operations combined with `allowing unbounded overdraft` in send statements.

**Root cause:** The `save` operation in the compiler was not calling `setNeededBalances`, so when followed by a `send` with `unbounded overdraft` (which skips balance fetching by design), the account's balances map was never initialized.

**Note:** The VM code on main already has defensive checks (`if ok` pattern), so only the compiler fix and tests are needed here.

## Changes

1. **Compiler (`compiler.go`)**: Added `setNeededBalances` call in `VisitSaveFromAccount`
2. **Tests (`machine_test.go`)**: Added 3 regression tests

## Test plan

- [x] All `TestSaveFromAccount` tests pass (including new regression tests)