### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -94,6 +94,7 @@ func NewServeCommand() *cobra.Command {
 
 			options := []fx.Option{
 				fx.NopLogger,
+				fx.Supply(connectionOptions),
 				otlpModule(cmd, cfg.commonConfig),
 				publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
 				auth.FXModuleFromFlags(cmd),


### PR DESCRIPTION
Supply `*bunconnect.ConnectionOptions` to fx container to resolve Circuit Breaker DB connection dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-572711f1-a174-408f-8e88-74dfabfbe081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-572711f1-a174-408f-8e88-74dfabfbe081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

