### PR TITLE
fix: provide database connection options to fx container for circuit breaker

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -94,6 +94,7 @@ func NewServeCommand() *cobra.Command {
 				publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
 				auth.FXModuleFromFlags(cmd),
 				bunconnect.Module(*connectionOptions, service.IsDebug(cmd)),
+				fx.Supply(connectionOptions),
 				storage.NewFXModule(serveConfiguration.autoUpgrade),
 				systemcontroller.NewFXModule(systemcontroller.ModuleConfiguration{
 					NumscriptInterpreter: numscriptInterpreter,


### PR DESCRIPTION
Supply connection options to the fx container to resolve a missing dependency for the Circuit Breaker storage module.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c3ec0fe-b8e7-4234-84bc-a198fc829f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c3ec0fe-b8e7-4234-84bc-a198fc829f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

