### PR TITLE
fix: add connection options dependency to fx container

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -97,6 +97,7 @@ func NewServeCommand() *cobra.Command {
 				otlpModule(cmd, cfg.commonConfig),
 				publish.FXModuleFromFlags(cmd, service.IsDebug(cmd)),
 				auth.FXModuleFromFlags(cmd),
+				fx.Supply(connectionOptions),
 				bunconnect.Module(*connectionOptions, service.IsDebug(cmd)),
 				storage.NewFXModule(storage.ModuleConfig{
 					AutoUpgrade: cfg.AutoUpgrade,


### PR DESCRIPTION
The circuit breaker storage module requires *bunconnect.ConnectionOptions as a dependency but it was not provided to the fx container. This fix adds fx.Supply(connectionOptions) to make the dependency available for injection.