### PR TITLE
fix: update cli arg name

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -45,7 +45,7 @@ const (
 	BulkMaxSizeFlag                 = "bulk-max-size"
 	BulkParallelFlag                = "bulk-parallel"
 	NumscriptInterpreterFlag        = "experimental-numscript-interpreter"
-	NumscriptInterpreterFlagsToPass = "numscript-interpreter-flags"
+	NumscriptInterpreterFlagsToPass = "experimental-numscript-interpreter-flags"
 	DefaultPageSizeFlag             = "default-page-size"
 	MaxPageSizeFlag                 = "max-page-size"
 )


### PR DESCRIPTION
tested with:
```
EXPERIMENTAL_NUMSCRIPT_INTERPRETER=true EXPERIMENTAL_NUMSCRIPT_INTERPRETER_FLAGS='experimental-overdraft-function experimental-mid-script-function-call experimental-oneof' go run . serve
```
and by running this script:
```
{"script":{"plain":"vars { } \nsend [USD/2 100] (\n  source = oneof {\n    @x\n    @world\n  }\n  destination = @alice\n)\n"}}
```
which run successfully 