### PR TITLE
fix(storage): scope ledger queries with bucket hint

### DIFF
--- a/internal/storage/driver/store.go
+++ b/internal/storage/driver/store.go
@@ -18,6 +18,7 @@ type SystemStore interface {
 	//ListLedgers(ctx context.Context, q systemstore.ListLedgersQuery) (*bunpaginate.Cursor[ledger.Ledger], error)
 	GetLedger(ctx context.Context, name string) (*ledger.Ledger, error)
 	GetDistinctBuckets(ctx context.Context) ([]string, error)
+	CountLedgersInBucket(ctx context.Context, bucket string) (int, error)
 
 	Migrate(ctx context.Context, options ...migrations.Option) error
 	GetMigrator(options ...migrations.Option) *migrations.Migrator

--- a/internal/storage/driver/store_generated_test.go
+++ b/internal/storage/driver/store_generated_test.go
@@ -41,6 +41,21 @@ func (m *MockSystemStore) EXPECT() *MockSystemStoreMockRecorder {
 	return m.recorder
 }
 
+// CountLedgersInBucket mocks base method.
+func (m *MockSystemStore) CountLedgersInBucket(ctx context.Context, bucket string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountLedgersInBucket", ctx, bucket)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountLedgersInBucket indicates an expected call of CountLedgersInBucket.
+func (mr *MockSystemStoreMockRecorder) CountLedgersInBucket(ctx, bucket any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountLedgersInBucket", reflect.TypeOf((*MockSystemStore)(nil).CountLedgersInBucket), ctx, bucket)
+}
+
 // CreateLedger mocks base method.
 func (m *MockSystemStore) CreateLedger(ctx context.Context, l *ledger.Ledger) error {
 	m.ctrl.T.Helper()

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -27,6 +27,11 @@ type Store struct {
 	bucket bucket.Bucket
 	ledger ledger.Ledger
 
+	// isAloneInBucket is a point-in-time hint indicating whether this ledger is the only one in its bucket.
+	// It must be refreshed if bucket membership changes.
+	// WARNING: if the store is cached without invalidation, a stale value may cause cross-ledger reads.
+	isAloneInBucket bool
+
 	tracer                             trace.Tracer
 	meter                              metric.Meter
 	checkBucketSchemaHistogram         metric.Int64Histogram
@@ -188,25 +193,17 @@ func (store *Store) LockLedger(ctx context.Context) (*Store, bun.IDB, func() err
 
 // newScopedSelect creates a new select query scoped to the current ledger.
 // notes(gfyrag): The "WHERE ledger = 'XXX'" condition can cause degraded postgres plan.
-// To avoid that, we use a WHERE OR to separate the two cases:
-// 1. Check if the ledger is the only one in the bucket
-// 2. Otherwise, filter by ledger name
+// When the ledger is alone in its bucket we skip the filter entirely.
 func (store *Store) newScopedSelect() *bun.SelectQuery {
 	q := store.db.NewSelect()
-	checkLedgerAlone := store.db.NewSelect().
-		TableExpr("_system.ledgers").
-		ColumnExpr("count = 1").
-		Join("JOIN (?) AS counters ON _system.ledgers.bucket = counters.bucket",
-			store.db.NewSelect().
-				TableExpr("_system.ledgers").
-				ColumnExpr("bucket").
-				ColumnExpr("COUNT(*) AS count").
-				Group("bucket"),
-		).
-		Where("_system.ledgers.name = ?", store.ledger.Name)
+	if !store.isAloneInBucket {
+		q = q.Where("ledger = ?", store.ledger.Name)
+	}
+	return q
+}
 
-	return q.
-		Where("((?) or ledger = ?)", checkLedgerAlone, store.ledger.Name)
+func (store *Store) SetAloneInBucket(alone bool) {
+	store.isAloneInBucket = alone
 }
 
 func New(db bun.IDB, bucket bucket.Bucket, l ledger.Ledger, opts ...Option) *Store {

--- a/internal/storage/system/store.go
+++ b/internal/storage/system/store.go
@@ -28,6 +28,7 @@ type Store interface {
 	Ledgers() common.PaginatedResource[ledger.Ledger, ListLedgersQueryPayload]
 	GetLedger(ctx context.Context, name string) (*ledger.Ledger, error)
 	GetDistinctBuckets(ctx context.Context) ([]string, error)
+	CountLedgersInBucket(ctx context.Context, bucket string) (int, error)
 	DeleteBucket(ctx context.Context, bucket string) error
 	RestoreBucket(ctx context.Context, bucket string) error
 	GetDeletedBucketsOlderThan(ctx context.Context, olderThan time.Time) ([]string, error)
@@ -67,6 +68,17 @@ func (d *DefaultStore) GetDistinctBuckets(ctx context.Context) ([]string, error)
 	}
 
 	return buckets, nil
+}
+
+func (d *DefaultStore) CountLedgersInBucket(ctx context.Context, bucket string) (int, error) {
+	count, err := d.db.NewSelect().
+		Model((*ledger.Ledger)(nil)).
+		Where("bucket = ?", bucket).
+		Count(ctx)
+	if err != nil {
+		return 0, postgres.ResolveError(err)
+	}
+	return count, nil
 }
 
 func (d *DefaultStore) CreateLedger(ctx context.Context, l *ledger.Ledger) error {


### PR DESCRIPTION
## Summary
- scope ledger reads with a cached `isAloneInBucket` hint set at store open/create time
- add `CountLedgersInBucket` to system store and wire it in driver create/open flows
- document the cache invalidation constraint to prevent cross-ledger data exposure when caching stores

## Validation
- go test ./internal/storage/ledger ./internal/storage/driver
