### PR TITLE
fix(storage): scope ledger queries with bucket hint

### DIFF
--- a/internal/storage/driver/store.go
+++ b/internal/storage/driver/store.go
@@ -16,6 +16,7 @@ type SystemStore interface {
 	//ListLedgers(ctx context.Context, q systemstore.ListLedgersQuery) (*bunpaginate.Cursor[ledger.Ledger], error)
 	GetLedger(ctx context.Context, name string) (*ledger.Ledger, error)
 	GetDistinctBuckets(ctx context.Context) ([]string, error)
+	CountLedgersInBucket(ctx context.Context, bucket string) (int, error)
 
 	Migrate(ctx context.Context, options ...migrations.Option) error
 	GetMigrator(options ...migrations.Option) *migrations.Migrator

--- a/internal/storage/driver/store_generated_test.go
+++ b/internal/storage/driver/store_generated_test.go
@@ -41,6 +41,21 @@ func (m *MockSystemStore) EXPECT() *MockSystemStoreMockRecorder {
 	return m.recorder
 }
 
+// CountLedgersInBucket mocks base method.
+func (m *MockSystemStore) CountLedgersInBucket(ctx context.Context, bucket string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountLedgersInBucket", ctx, bucket)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountLedgersInBucket indicates an expected call of CountLedgersInBucket.
+func (mr *MockSystemStoreMockRecorder) CountLedgersInBucket(ctx, bucket any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountLedgersInBucket", reflect.TypeOf((*MockSystemStore)(nil).CountLedgersInBucket), ctx, bucket)
+}
+
 // CreateLedger mocks base method.
 func (m *MockSystemStore) CreateLedger(ctx context.Context, l *ledger.Ledger) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

Backport of #1250 onto `release/v2.3`.

- Add `CountLedgersInBucket` to the system store interface and implementation
- Replace the dynamic `_system.ledgers` subquery in `newScopedSelect()` with a pre-computed `isAloneInBucket` boolean flag
- Set the flag at store creation (`CreateLedger`) and opening (`OpenLedger`) time
- Add safety comment about cache invalidation for the flag

This avoids degraded PostgreSQL query plans when a ledger is alone in its bucket, and guards against potential cross-ledger reads if the store is cached without proper invalidation.

## Files changed

- `internal/storage/system/store.go` — new `CountLedgersInBucket` method
- `internal/storage/driver/store.go` — `SystemStore` interface update
- `internal/storage/driver/driver.go` — flag initialization in `CreateLedger` and `OpenLedger`
- `internal/storage/ledger/store.go` — `isAloneInBucket` field, simplified `newScopedSelect()`, `SetAloneInBucket` method
- `internal/storage/driver/store_generated_test.go` — regenerated mock

## Test plan

- [x] `go build ./...` passes
- [ ] `go test -tags it ./internal/storage/ledger ./internal/storage/driver` (requires Postgres)