### PR TITLE
chore: improve golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,17 @@ linters:
     - unparam
     - unused
     - unconvert
+    - errcheck
+    - errchkjson
+    - godox
   settings:
+    godox:
+      # Report any comments starting with keywords
+      keywords:
+        - BUG
+        - FIXME
+        - OPTIMIZE
+        - HACK
     gocyclo:
       # Minimal code complexity to report.
       # Default: 30 (but we recommend 10-20)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,9 @@ linters:
     - gosec
     - tagliatelle
     - gocyclo
+    - unparam
+    - unused
+    - unconvert
   settings:
     gocyclo:
       # Minimal code complexity to report.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,16 @@ linters:
     - errchkjson
     - godox
     - tparallel
+    - usetesting
   settings:
+    usetesting:
+      os-create-temp: true
+      os-mkdir-temp: true
+      os-setenv: true
+      os-temp-dir: true
+      os-chdir: true
+      context-background: true
+      context-todo: true
     godox:
       # Report any comments starting with keywords
       keywords:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,11 +18,25 @@ formatters:
 run:
   timeout: 5m
 
+exclusions:
+  paths:
+    - pkg/client # Generated SDK code
+
 linters:
   enable:
     - unused
     - gosec
+    - tagliatelle
   settings:
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+          yaml: goCamel
+          xml: goCamel
+          bson: goCamel
+          env: upperSnake
+          envconfig: upperSnake
     errcheck:
       exclude-functions:
         - (io.Closer).Close

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - errcheck
     - errchkjson
     - godox
+    - tparallel
   settings:
     godox:
       # Report any comments starting with keywords

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,12 @@ linters:
     - unused
     - gosec
     - tagliatelle
+    - gocyclo
   settings:
+    gocyclo:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 30
     tagliatelle:
       case:
         rules:

--- a/internal/README.md
+++ b/internal/README.md
@@ -673,7 +673,7 @@ func (p CreatedTransaction) ValidateWithSchema(schema Schema) error
 ```go
 type DeletedMetadata struct {
     TargetType string `json:"targetType"`
-    TargetID   any    `json:"targetId"`
+    TargetID   any    `json:"targetId"` //nolint:tagliatelle
     Key        string `json:"key"`
 }
 ```
@@ -1587,7 +1587,7 @@ const (
 ```go
 type SavedMetadata struct {
     TargetType string            `json:"targetType"`
-    TargetID   any               `json:"targetId"`
+    TargetID   any               `json:"targetId"` //nolint:tagliatelle
     Metadata   metadata.Metadata `json:"metadata"`
 }
 ```

--- a/internal/api/bulking/elements.go
+++ b/internal/api/bulking/elements.go
@@ -79,7 +79,7 @@ type BulkElementResult struct {
 
 type AddMetadataRequest struct {
 	TargetType string            `json:"targetType"`
-	TargetID   json.RawMessage   `json:"targetId"`
+	TargetID   json.RawMessage   `json:"targetId"` //nolint:tagliatelle
 	Metadata   metadata.Metadata `json:"metadata"`
 }
 
@@ -92,7 +92,7 @@ type RevertTransactionRequest struct {
 
 type DeleteMetadataRequest struct {
 	TargetType string          `json:"targetType"`
-	TargetID   json.RawMessage `json:"targetId"`
+	TargetID   json.RawMessage `json:"targetId"` //nolint:tagliatelle
 	Key        string          `json:"key"`
 }
 

--- a/internal/api/v1/controllers_accounts_add_metadata_test.go
+++ b/internal/api/v1/controllers_accounts_add_metadata_test.go
@@ -83,6 +83,7 @@ func TestAccountsAddMetadata(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v1/controllers_accounts_count_test.go
+++ b/internal/api/v1/controllers_accounts_count_test.go
@@ -104,6 +104,7 @@ func TestAccountsCount(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v1/controllers_accounts_list_test.go
+++ b/internal/api/v1/controllers_accounts_list_test.go
@@ -152,6 +152,7 @@ func TestAccountsList(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/api/v1/controllers_accounts_read_test.go
+++ b/internal/api/v1/controllers_accounts_read_test.go
@@ -78,6 +78,7 @@ func TestAccountsRead(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusOK

--- a/internal/api/v1/controllers_balances_aggregates_test.go
+++ b/internal/api/v1/controllers_balances_aggregates_test.go
@@ -54,6 +54,7 @@ func TestBalancesAggregates(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			expectedBalances := ledger.BalancesByAssets{
 				"world": big.NewInt(-100),

--- a/internal/api/v1/controllers_logs_list_test.go
+++ b/internal/api/v1/controllers_logs_list_test.go
@@ -99,6 +99,7 @@ func TestGetLogs(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/api/v1/controllers_transactions_count_test.go
+++ b/internal/api/v1/controllers_transactions_count_test.go
@@ -140,6 +140,7 @@ func TestCountTransactions(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v1/controllers_transactions_list_test.go
+++ b/internal/api/v1/controllers_transactions_list_test.go
@@ -269,6 +269,7 @@ func TestTransactionsList(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_accounts_add_metadata_test.go
+++ b/internal/api/v2/controllers_accounts_add_metadata_test.go
@@ -55,6 +55,7 @@ func TestAccountsAddMetadata(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v2/controllers_accounts_count_test.go
+++ b/internal/api/v2/controllers_accounts_count_test.go
@@ -129,6 +129,7 @@ func TestAccountsCount(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v2/controllers_accounts_list_test.go
+++ b/internal/api/v2/controllers_accounts_list_test.go
@@ -228,6 +228,7 @@ func TestAccountsList(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_accounts_read_test.go
+++ b/internal/api/v2/controllers_accounts_read_test.go
@@ -82,6 +82,7 @@ func TestAccountsRead(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_balances_test.go
+++ b/internal/api/v2/controllers_balances_test.go
@@ -91,6 +91,7 @@ func TestBalancesAggregates(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			expectedBalances := ledger.BalancesByAssets{
 				"world": big.NewInt(-100),

--- a/internal/api/v2/controllers_logs_export_test.go
+++ b/internal/api/v2/controllers_logs_export_test.go
@@ -42,6 +42,7 @@ func TestLogsExport(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_logs_import_test.go
+++ b/internal/api/v2/controllers_logs_import_test.go
@@ -43,6 +43,7 @@ func TestLogsImport(t *testing.T) {
 	for _, testCase := range testCases {
 		tc := testCase
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusNoContent

--- a/internal/api/v2/controllers_logs_list_test.go
+++ b/internal/api/v2/controllers_logs_list_test.go
@@ -171,6 +171,7 @@ func TestLogsList(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_transactions_add_metadata_test.go
+++ b/internal/api/v2/controllers_transactions_add_metadata_test.go
@@ -77,6 +77,7 @@ func TestTransactionsAddMetadata(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusNoContent

--- a/internal/api/v2/controllers_transactions_count_test.go
+++ b/internal/api/v2/controllers_transactions_count_test.go
@@ -154,6 +154,7 @@ func TestTransactionsCount(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.expectStatusCode == 0 {
 				tc.expectStatusCode = http.StatusNoContent

--- a/internal/api/v2/controllers_transactions_list_test.go
+++ b/internal/api/v2/controllers_transactions_list_test.go
@@ -252,6 +252,7 @@ func TestTransactionsList(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/api/v2/controllers_volumes_test.go
+++ b/internal/api/v2/controllers_volumes_test.go
@@ -136,6 +136,7 @@ func TestVolumesList(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
 			if testCase.expectStatusCode == 0 {
 				testCase.expectStatusCode = http.StatusOK

--- a/internal/bus/listener_test.go
+++ b/internal/bus/listener_test.go
@@ -1,7 +1,6 @@
 package bus
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -24,13 +23,13 @@ func TestMonitor(t *testing.T) {
 		},
 		watermill.NewStdLogger(os.Getenv("DEBUG") == "true", os.Getenv("DEBUG") == "true"),
 	)
-	messages, err := pubSub.Subscribe(context.Background(), "testing")
+	messages, err := pubSub.Subscribe(t.Context(), "testing")
 	require.NoError(t, err)
 	p := topicmapper.NewPublisherDecorator(pubSub, map[string]string{
 		"*": "testing",
 	})
 	m := NewLedgerListener(p)
-	go m.CommittedTransactions(context.Background(), uuid.New(), ledger.Transaction{}, nil)
+	go m.CommittedTransactions(t.Context(), uuid.New(), ledger.Transaction{}, nil)
 
 	select {
 	case m := <-messages:

--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -68,7 +68,7 @@ func (ctrl *DefaultController) insertSchema(ctx context.Context, store Store, _s
 	}
 
 	for id, template := range schema.Transactions {
-		parser := ctrl.getParser(ledger.RuntimeType(template.Runtime))
+		parser := ctrl.getParser(template.Runtime)
 		_, err := parser.Parse(template.Script)
 		if err != nil {
 			return nil, ledger.NewErrInvalidSchema(fmt.Errorf("invalid template %s: %w", id, err))

--- a/internal/controller/ledger/controller_default_test.go
+++ b/internal/controller/ledger/controller_default_test.go
@@ -75,7 +75,7 @@ func TestCreateTransactionWithoutSchema(t *testing.T) {
 			return log
 		})
 
-	_, _, _, err := l.CreateTransaction(context.Background(), Parameters[CreateTransaction]{
+	_, _, _, err := l.CreateTransaction(t.Context(), Parameters[CreateTransaction]{
 		Input: CreateTransaction{
 			RunScript: runScript,
 		},
@@ -156,7 +156,7 @@ send [EUR/2 100] (
 			return log
 		})
 
-	_, _, _, err := l.InsertSchema(context.Background(), Parameters[InsertSchema]{
+	_, _, _, err := l.InsertSchema(t.Context(), Parameters[InsertSchema]{
 		Input: InsertSchema{
 			Version: schema.Version,
 			Data:    schema.SchemaData,
@@ -212,7 +212,7 @@ send [EUR/2 100] (
 			return log
 		})
 
-	_, _, _, err = l.CreateTransaction(context.Background(), Parameters[CreateTransaction]{
+	_, _, _, err = l.CreateTransaction(t.Context(), Parameters[CreateTransaction]{
 		SchemaVersion: schemaVersion,
 		Input: CreateTransaction{
 			RunScript: runScript,

--- a/internal/controller/ledger/controller_with_events.go
+++ b/internal/controller/ledger/controller_with_events.go
@@ -27,6 +27,7 @@ func NewControllerWithEvents(ledger ledger.Ledger, underlying Controller, listen
 	}
 }
 
+//nolint:unparam // ctx is propagated recursively to parent handlers
 func (c *ControllerWithEvents) handleEvent(ctx context.Context, fn func()) {
 	if !c.hasTx {
 		fn()

--- a/internal/log.go
+++ b/internal/log.go
@@ -265,7 +265,7 @@ var _ Memento = (*CreatedTransaction)(nil)
 
 type SavedMetadata struct {
 	TargetType string            `json:"targetType"`
-	TargetID   any               `json:"targetId"`
+	TargetID   any               `json:"targetId"` //nolint:tagliatelle
 	Metadata   metadata.Metadata `json:"metadata"`
 }
 
@@ -285,7 +285,7 @@ var _ LogPayload = (*SavedMetadata)(nil)
 func (s *SavedMetadata) UnmarshalJSON(data []byte) error {
 	type X struct {
 		TargetType string            `json:"targetType"`
-		TargetID   json.RawMessage   `json:"targetId"`
+		TargetID   json.RawMessage   `json:"targetId"` //nolint:tagliatelle
 		Metadata   metadata.Metadata `json:"metadata"`
 	}
 	x := X{}
@@ -317,7 +317,7 @@ func (s *SavedMetadata) UnmarshalJSON(data []byte) error {
 
 type DeletedMetadata struct {
 	TargetType string `json:"targetType"`
-	TargetID   any    `json:"targetId"`
+	TargetID   any    `json:"targetId"` //nolint:tagliatelle
 	Key        string `json:"key"`
 }
 
@@ -337,7 +337,7 @@ var _ LogPayload = (*DeletedMetadata)(nil)
 func (s *DeletedMetadata) UnmarshalJSON(data []byte) error {
 	type X struct {
 		TargetType string          `json:"targetType"`
-		TargetID   json.RawMessage `json:"targetId"`
+		TargetID   json.RawMessage `json:"targetId"` //nolint:tagliatelle
 		Key        string          `json:"key"`
 	}
 	x := X{}

--- a/internal/machine/script/compiler/source.go
+++ b/internal/machine/script/compiler/source.go
@@ -120,6 +120,8 @@ func (p parseVisitor) isOverdraftUnbounded(overdraftCtx parser.ISourceAccountOve
 // VisitSource returns the resource addresses of all the accounts,
 // the addresses of accounts already emptied,
 // and possibly a fallback account if the source has an unbounded overdraft allowance or contains @world
+//
+//nolint:gocyclo // AST visitor pattern, each branch handles a distinct source node type
 func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), isAll bool) (map[machine.Address]struct{}, map[machine.Address]struct{}, *FallbackAccount, *CompileError) {
 	neededAccounts := map[machine.Address]struct{}{}
 	emptiedAccounts := map[machine.Address]struct{}{}

--- a/internal/machine/vm/machine.go
+++ b/internal/machine/vm/machine.go
@@ -136,6 +136,7 @@ func (m *Machine) withdrawAll(account machine.AccountAddress, asset machine.Asse
 	return nil, fmt.Errorf("missing %v balance from %v", asset, account)
 }
 
+//nolint:unparam // error return kept for consistency with withdrawAll signature
 func (m *Machine) withdrawAlways(account machine.AccountAddress, mon machine.Monetary) (*machine.Funding, error) {
 	if accBalance, ok := m.Balances[account]; ok {
 		if balance, ok := accBalance[mon.Asset]; ok {

--- a/internal/machine/vm/machine.go
+++ b/internal/machine/vm/machine.go
@@ -184,6 +184,7 @@ func (m *Machine) repay(funding machine.Funding) {
 	}
 }
 
+//nolint:gocyclo // Bytecode interpreter loop, each case handles a distinct opcode
 func (m *Machine) tick() (bool, error) {
 	op := m.Program.Instructions[m.P]
 

--- a/internal/machine/vm/machine_test.go
+++ b/internal/machine/vm/machine_test.go
@@ -1748,6 +1748,7 @@ func TestWorldNonSourceVariable(t *testing.T) {
 }
 
 func TestSetVarsFromJSON(t *testing.T) {
+	t.Parallel()
 
 	type testCase struct {
 		name          string
@@ -1787,6 +1788,7 @@ func TestSetVarsFromJSON(t *testing.T) {
 }
 
 func TestResolveResources(t *testing.T) {
+	t.Parallel()
 
 	type testCase struct {
 		name          string
@@ -1831,6 +1833,7 @@ func TestResolveResources(t *testing.T) {
 }
 
 func TestResolveBalances(t *testing.T) {
+	t.Parallel()
 
 	type testCase struct {
 		name          string

--- a/internal/machine/vm/machine_test.go
+++ b/internal/machine/vm/machine_test.go
@@ -1134,7 +1134,7 @@ func TestSetTxMeta(t *testing.T) {
 	assert.Equal(t, 6, len(resMeta))
 
 	for key, val := range resMeta {
-		assert.Equal(t, string(expectedMeta[key]), val)
+		assert.Equal(t, expectedMeta[key], val)
 	}
 }
 
@@ -1223,7 +1223,7 @@ func TestSetAccountMeta(t *testing.T) {
 			assert.Equal(t, "test", acc)
 			assert.Equal(t, 1, len(meta))
 			for key, val := range meta {
-				assert.Equal(t, string(expectedMeta[key]), val)
+				assert.Equal(t, expectedMeta[key], val)
 			}
 		}
 	})

--- a/internal/machine/vm/machine_test.go
+++ b/internal/machine/vm/machine_test.go
@@ -101,12 +101,12 @@ func test(t *testing.T, testCase TestCase) {
 			}
 		}
 
-		err := m.ResolveResources(context.Background(), store)
+		err := m.ResolveResources(t.Context(), store)
 		if err != nil {
 			return err
 		}
 
-		err = m.ResolveBalances(context.Background(), store)
+		err = m.ResolveBalances(t.Context(), store)
 		if err != nil {
 			return err
 		}
@@ -1010,11 +1010,11 @@ func TestNeededBalances(t *testing.T) {
 	if err != nil {
 		t.Fatalf("did not expect error on SetVars, got: %v", err)
 	}
-	err = m.ResolveResources(context.Background(), EmptyStore)
+	err = m.ResolveResources(t.Context(), EmptyStore)
 	require.NoError(t, err)
 
 	store := mockStore{}
-	err = m.ResolveBalances(context.Background(), &store)
+	err = m.ResolveBalances(t.Context(), &store)
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"a", "b", "bounded"}, store.GetRequestedAccounts())
@@ -1037,7 +1037,7 @@ func TestNeededBalances2(t *testing.T) {
 	}
 
 	m := NewMachine(*p)
-	err = m.ResolveResources(context.Background(), EmptyStore)
+	err = m.ResolveResources(t.Context(), EmptyStore)
 	require.NoError(t, err)
 }
 
@@ -1056,11 +1056,11 @@ send $balance (
 	}
 
 	m := NewMachine(*p)
-	err = m.ResolveResources(context.Background(), EmptyStore)
+	err = m.ResolveResources(t.Context(), EmptyStore)
 	require.NoError(t, err)
 
 	store := mockStore{}
-	err = m.ResolveBalances(context.Background(), &store)
+	err = m.ResolveBalances(t.Context(), &store)
 	require.NoError(t, err)
 	require.Equal(t, []string{"a", "acc"}, store.GetRequestedAccounts())
 }
@@ -1091,11 +1091,11 @@ send [COIN 1] (
 			Balances: map[string]*big.Int{},
 		},
 	}
-	err = m.ResolveResources(context.Background(), staticStore)
+	err = m.ResolveResources(t.Context(), staticStore)
 	require.NoError(t, err)
 
 	store := mockStore{}
-	err = m.ResolveBalances(context.Background(), &store)
+	err = m.ResolveBalances(t.Context(), &store)
 	require.NoError(t, err)
 	require.Equal(t, []string{"src"}, store.GetRequestedAccounts())
 }
@@ -1113,9 +1113,9 @@ func TestSetTxMeta(t *testing.T) {
 
 	m := NewMachine(*p)
 
-	err = m.ResolveResources(context.Background(), EmptyStore)
+	err = m.ResolveResources(t.Context(), EmptyStore)
 	require.NoError(t, err)
-	err = m.ResolveBalances(context.Background(), EmptyStore)
+	err = m.ResolveBalances(t.Context(), EmptyStore)
 	require.NoError(t, err)
 
 	err = m.Execute()
@@ -1153,10 +1153,10 @@ func TestSetAccountMeta(t *testing.T) {
 
 		m := NewMachine(*p)
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
-		err = m.ResolveBalances(context.Background(), EmptyStore)
+		err = m.ResolveBalances(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
 		err = m.Execute()
@@ -1203,10 +1203,10 @@ func TestSetAccountMeta(t *testing.T) {
 			"acc": "test",
 		}))
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
-		err = m.ResolveBalances(context.Background(), EmptyStore)
+		err = m.ResolveBalances(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
 		err = m.Execute()
@@ -1223,7 +1223,7 @@ func TestSetAccountMeta(t *testing.T) {
 			assert.Equal(t, "test", acc)
 			assert.Equal(t, 1, len(meta))
 			for key, val := range meta {
-				assert.Equal(t, expectedMeta[key], val)
+				assert.Equal(t, string(expectedMeta[key]), val) //nolint:unconvert
 			}
 		}
 	})
@@ -1821,7 +1821,7 @@ func TestResolveResources(t *testing.T) {
 
 			m := NewMachine(*p)
 			require.NoError(t, m.SetVarsFromJSON(tc.vars))
-			err = m.ResolveResources(context.Background(), EmptyStore)
+			err = m.ResolveResources(t.Context(), EmptyStore)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				require.True(t, errors.Is(err, tc.expectedError))
@@ -1875,7 +1875,7 @@ func TestResolveBalances(t *testing.T) {
 
 			m := NewMachine(*p)
 			require.NoError(t, m.SetVarsFromJSON(tc.vars))
-			err = m.ResolveResources(context.Background(), EmptyStore)
+			err = m.ResolveResources(t.Context(), EmptyStore)
 			require.NoError(t, err)
 
 			store := tc.store
@@ -1883,7 +1883,7 @@ func TestResolveBalances(t *testing.T) {
 				store = EmptyStore
 			}
 
-			err = m.ResolveBalances(context.Background(), store)
+			err = m.ResolveBalances(t.Context(), store)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				require.True(t, errors.Is(err, tc.expectedError))
@@ -1914,10 +1914,10 @@ func TestMachine(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
-		err = m.ResolveBalances(context.Background(), EmptyStore)
+		err = m.ResolveBalances(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
 		err = m.Execute()
@@ -1938,7 +1938,7 @@ func TestMachine(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
 		err = m.Execute()
@@ -1953,17 +1953,17 @@ func TestMachine(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.NoError(t, err)
 
-		err := m.ResolveResources(context.Background(), EmptyStore)
+		err := m.ResolveResources(t.Context(), EmptyStore)
 		require.ErrorContains(t, err, "tried to call ResolveResources twice")
 	})
 
 	t.Run("err missing var", func(t *testing.T) {
 		m := NewMachine(*p)
 
-		err = m.ResolveResources(context.Background(), EmptyStore)
+		err = m.ResolveResources(t.Context(), EmptyStore)
 		require.Error(t, err)
 	})
 }

--- a/internal/machine/vm/run_test.go
+++ b/internal/machine/vm/run_test.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -432,9 +431,9 @@ func TestRun(t *testing.T) {
 			m := NewMachine(*program)
 			require.NoError(t, m.SetVarsFromJSON(tc.vars))
 
-			err = m.ResolveResources(context.Background(), tc.store)
+			err = m.ResolveResources(t.Context(), tc.store)
 			require.NoError(t, err)
-			require.NoError(t, m.ResolveBalances(context.Background(), tc.store))
+			require.NoError(t, m.ResolveBalances(t.Context(), tc.store))
 
 			result, err := Run(m, RunScript{
 				Script: Script{

--- a/internal/machine/vm/run_test.go
+++ b/internal/machine/vm/run_test.go
@@ -420,6 +420,7 @@ func TestRun(t *testing.T) {
 	for _, tc := range runTestCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			if tc.store == nil {
 				tc.store = StaticStore{}

--- a/internal/replication/drivers/batcher_test.go
+++ b/internal/replication/drivers/batcher_test.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -62,7 +61,7 @@ func TestBatcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	driver := NewMockDriver(ctrl)
 	logger := logging.Testing()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	log := NewLogWithLedger("module1", ledger.Log{})
 

--- a/internal/replication/drivers/batcher_test.go
+++ b/internal/replication/drivers/batcher_test.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -77,7 +78,8 @@ func TestBatcher(t *testing.T) {
 	}, logger)
 	require.NoError(t, batcher.Start(ctx))
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Stop(ctx))
+		//nolint:usetesting // t.Context() is already canceled when cleanup runs, which would cause Stop to fail
+		require.NoError(t, batcher.Stop(context.Background()))
 	})
 
 	itemsErrors, err := batcher.Accept(ctx, log)

--- a/internal/replication/drivers/clickhouse/driver_test.go
+++ b/internal/replication/drivers/clickhouse/driver_test.go
@@ -24,7 +24,7 @@ import (
 func TestClickhouseDriver(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	// Start a new clickhouse server
 	dockerPool := docker.NewPool(t, logging.Testing())

--- a/internal/replication/drivers/elasticsearch/driver.go
+++ b/internal/replication/drivers/elasticsearch/driver.go
@@ -109,6 +109,9 @@ type DocID struct {
 }
 
 func (docID DocID) String() string {
-	rawID, _ := json.Marshal(docID)
+	rawID, err := json.Marshal(docID)
+	if err != nil {
+		panic(err)
+	}
 	return base64.URLEncoding.EncodeToString(rawID)
 }

--- a/internal/replication/drivers/elasticsearch/driver_test.go
+++ b/internal/replication/drivers/elasticsearch/driver_test.go
@@ -3,7 +3,6 @@
 package elasticsearch
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -25,7 +24,7 @@ func TestElasticSearchDriver(t *testing.T) {
 	dockerPool := docker.NewPool(t, logging.Testing())
 	srv := elastictesting.CreateServer(dockerPool, elastictesting.WithTimeout(2*time.Minute))
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	esConfig := Config{
 		Endpoint: srv.Endpoint(),
 	}

--- a/internal/replication/drivers/http/driver_test.go
+++ b/internal/replication/drivers/http/driver_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +49,7 @@ func TestHTTPDriver(t *testing.T) {
 	}
 
 	// Send all logs to the driver
-	itemsErrors, err := driver.Accept(context.TODO(), logs...)
+	itemsErrors, err := driver.Accept(t.Context(), logs...)
 	require.NoError(t, err)
 	require.Len(t, itemsErrors, numberOfLogs)
 	for index := range logs {

--- a/internal/replication/drivers/noop/driver_test.go
+++ b/internal/replication/drivers/noop/driver_test.go
@@ -1,7 +1,6 @@
 package noop
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 func TestNoOpDriver(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	// Create our driver
 	driver, err := NewDriver(struct{}{}, logging.Testing())

--- a/internal/replication/drivers/stdout/driver_test.go
+++ b/internal/replication/drivers/stdout/driver_test.go
@@ -1,7 +1,6 @@
 package stdout
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -17,7 +16,7 @@ import (
 func TestStdoutDriver(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	// Create our driver
 	driver, err := NewDriver(struct{}{}, logging.Testing())

--- a/internal/replication/manager.go
+++ b/internal/replication/manager.go
@@ -93,6 +93,7 @@ func (m *Manager) StartPipeline(ctx context.Context, pipelineID string) error {
 	return err
 }
 
+//nolint:unparam // PipelineHandler return kept for future callers
 func (m *Manager) startPipeline(ctx context.Context, pipeline ledger.Pipeline) (*PipelineHandler, error) {
 	m.logger.Infof("initializing pipeline")
 	_, ok := m.pipelines[pipeline.ID]

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -260,6 +260,8 @@ func TestManagerStop(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nominal", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := logging.TestingContext()
 		ctrl := gomock.NewController(t)
 		storage := NewMockStorage(ctrl)
@@ -343,6 +345,8 @@ func TestManagerStop(t *testing.T) {
 		require.NoError(t, manager.Stop(ctx))
 	})
 	t.Run("error on driver initialization", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := logging.TestingContext()
 		ctrl := gomock.NewController(t)
 		storage := NewMockStorage(ctrl)

--- a/internal/storage/ledger/accounts_test.go
+++ b/internal/storage/ledger/accounts_test.go
@@ -3,7 +3,6 @@
 package ledger_test
 
 import (
-	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -325,7 +324,7 @@ func TestAccountsUpdateMetadata(t *testing.T) {
 		"bank": m,
 	}, time.Time{}))
 
-	account, err := store.Accounts().GetOne(context.Background(), common.ResourceQuery[any]{
+	account, err := store.Accounts().GetOne(t.Context(), common.ResourceQuery[any]{
 		Builder: query.Match("address", "bank"),
 	})
 	require.NoError(t, err, "account retrieval should not fail")

--- a/internal/storage/ledger/logs_test.go
+++ b/internal/storage/ledger/logs_test.go
@@ -3,7 +3,6 @@
 package ledger_test
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"math/big"
@@ -202,7 +201,7 @@ func TestLogsReadWithIdempotencyKey(t *testing.T) {
 	err := store.InsertLog(ctx, &log)
 	require.NoError(t, err)
 
-	lastLog, err := store.ReadLogWithIdempotencyKey(context.Background(), "test")
+	lastLog, err := store.ReadLogWithIdempotencyKey(t.Context(), "test")
 	require.NoError(t, err)
 	require.NotNil(t, lastLog)
 	require.Equal(t, log, *lastLog)
@@ -225,14 +224,14 @@ func TestLogsList(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	cursor, err := store.Logs().Paginate(context.Background(), common.InitialPaginatedQuery[any]{})
+	cursor, err := store.Logs().Paginate(t.Context(), common.InitialPaginatedQuery[any]{})
 	require.NoError(t, err)
 	require.Equal(t, bunpaginate.QueryDefaultPageSize, cursor.PageSize)
 
 	require.Equal(t, 3, len(cursor.Data))
 	require.EqualValues(t, 3, *cursor.Data[0].ID)
 
-	cursor, err = store.Logs().Paginate(context.Background(), common.InitialPaginatedQuery[any]{
+	cursor, err = store.Logs().Paginate(t.Context(), common.InitialPaginatedQuery[any]{
 		PageSize: 1,
 	})
 	require.NoError(t, err)
@@ -240,7 +239,7 @@ func TestLogsList(t *testing.T) {
 	require.Equal(t, 1, cursor.PageSize)
 	require.EqualValues(t, 3, *cursor.Data[0].ID)
 
-	cursor, err = store.Logs().Paginate(context.Background(), common.InitialPaginatedQuery[any]{
+	cursor, err = store.Logs().Paginate(t.Context(), common.InitialPaginatedQuery[any]{
 		PageSize: 10,
 		Options: common.ResourceQuery[any]{
 			Builder: query.And(
@@ -256,7 +255,7 @@ func TestLogsList(t *testing.T) {
 	require.Len(t, cursor.Data, 1)
 	require.EqualValues(t, 2, *cursor.Data[0].ID)
 
-	cursor, err = store.Logs().Paginate(context.Background(), common.InitialPaginatedQuery[any]{
+	cursor, err = store.Logs().Paginate(t.Context(), common.InitialPaginatedQuery[any]{
 		PageSize: 10,
 		Options: common.ResourceQuery[any]{
 			Builder: query.Lt("id", 3),

--- a/internal/storage/ledger/logs_test.go
+++ b/internal/storage/ledger/logs_test.go
@@ -30,6 +30,8 @@ func TestLogsInsert(t *testing.T) {
 	ctx := logging.TestingContext()
 
 	t.Run("check hash against core", func(t *testing.T) {
+		t.Parallel()
+
 		// Insert a first tx (we don't have any previous hash to use at this moment)
 		store := newLedgerStore(t)
 		log1 := ledger.NewLog(ledger.CreatedTransaction{
@@ -75,6 +77,8 @@ func TestLogsInsert(t *testing.T) {
 	})
 
 	t.Run("duplicate IK", func(t *testing.T) {
+		t.Parallel()
+
 		// Insert a first tx (we don't have any previous hash to use at this moment)
 		store := newLedgerStore(t)
 		logTx := ledger.NewLog(ledger.CreatedTransaction{
@@ -101,6 +105,8 @@ func TestLogsInsert(t *testing.T) {
 	})
 
 	t.Run("hash consistency over high concurrency", func(t *testing.T) {
+		t.Parallel()
+
 		errGroup, _ := errgroup.WithContext(ctx)
 		store := newLedgerStore(t)
 		const countLogs = 50

--- a/internal/storage/ledger/main_test.go
+++ b/internal/storage/ledger/main_test.go
@@ -78,6 +78,7 @@ type T interface {
 	Cleanup(func())
 }
 
+//nolint:unparam // variadic opts kept for test flexibility
 func newLedgerStore(t T, opts ...func(cfg *ledger.Configuration)) *ledgerstore.Store {
 	t.Helper()
 

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/go-libs/v3/time"
 )
 
+//nolint:gocyclo // Simple string mapping table, no real logic complexity
 func LegacyMetricsName(operationName string) string {
 	switch operationName {
 	case "controller.numscript_run":

--- a/pkg/accounts/account_test.go
+++ b/pkg/accounts/account_test.go
@@ -86,6 +86,8 @@ func TestValidateAddress(t *testing.T) {
 	for _, testCase := range testsCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			require.Equal(t, testCase.shouldBeOk, ValidateAddress(testCase.address))
 		})
 	}

--- a/pkg/events/message.go
+++ b/pkg/events/message.go
@@ -27,7 +27,7 @@ func NewEventCommittedTransactions(txs CommittedTransactions) publish.EventMessa
 type SavedMetadata struct {
 	Ledger     string            `json:"ledger"`
 	TargetType string            `json:"targetType"`
-	TargetID   string            `json:"targetId"`
+	TargetID   string            `json:"targetId"` //nolint:tagliatelle
 	Metadata   metadata.Metadata `json:"metadata"`
 }
 
@@ -60,7 +60,7 @@ func NewEventRevertedTransaction(revertedTransaction RevertedTransaction) publis
 type DeletedMetadata struct {
 	Ledger     string `json:"ledger"`
 	TargetType string `json:"targetType"`
-	TargetID   any    `json:"targetId"`
+	TargetID   any    `json:"targetId"` //nolint:tagliatelle
 	Key        string `json:"key"`
 }
 

--- a/test/performance/pkg/read/read_test.go
+++ b/test/performance/pkg/read/read_test.go
@@ -141,7 +141,7 @@ func BenchmarkRead(b *testing.B) {
 		b.Fatalf("Failed to decode configuration file: %s", err)
 	}
 
-	env := env.Factory.Create(context.Background(), b)
+	env := env.Factory.Create(b.Context(), b)
 	ctx := logging.TestingContext()
 
 	for _, query := range cfg.Queries {


### PR DESCRIPTION
## Summary

- Configure **tagliatelle** linter with `goCamel` convention following Effective Go naming rules (json, yaml, xml, bson, env tags)
- Exclude `pkg/client` (generated SDK code) from linting
- Suppress **gocyclo** false positives on string mapping table, AST visitor, and bytecode interpreter
- Fix **unconvert** unnecessary type conversions
- Add **nolint:unparam** directives where parameters are intentionally kept for API consistency
- Fix **errchkjson** unchecked `json.Marshal` error
- Add missing **t.Parallel()** calls to satisfy tparallel linter (27 test functions)
- Enable **usetesting** linter and replace `context.Background()`/`context.TODO()` with `t.Context()` in tests

## Test plan

- [x] `just lint` passes with 0 issues
- [x] `go test -race ./...` passes all unit tests