### PR TITLE
fix(ledger): backport single DB transaction for forgeLog hot path

### DIFF
--- a/internal/controller/ledger/log_process.go
+++ b/internal/controller/ledger/log_process.go
@@ -89,16 +89,53 @@ func (lp *logProcessor[INPUT, OUTPUT]) forgeLog(
 	parameters Parameters[INPUT],
 	fn func(ctx context.Context, store Store, parameters Parameters[INPUT]) (*OUTPUT, error),
 ) (*ledger.Log, *OUTPUT, bool, error) {
+	txStore, _, err := store.BeginTX(ctx, nil)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to start transaction: %w", err)
+	}
+
 	if parameters.IdempotencyKey != "" {
-		log, output, err := lp.fetchLogWithIK(ctx, store, parameters)
-		if err != nil {
-			return nil, nil, false, err
-		}
-		if output != nil {
+		log, output, err := lp.fetchLogWithIK(ctx, txStore, parameters)
+		if err != nil || output != nil {
+			if rollbackErr := txStore.Rollback(); rollbackErr != nil {
+				logging.FromContext(ctx).Errorf("failed to rollback transaction: %v", rollbackErr)
+			}
+			if err != nil {
+				return nil, nil, false, err
+			}
 			return log, output, true, nil
 		}
 	}
 
+	log, output, err := lp.runLog(ctx, txStore, parameters, fn)
+	if err != nil {
+		if rollbackErr := txStore.Rollback(); rollbackErr != nil {
+			logging.FromContext(ctx).Errorf("failed to rollback transaction: %v", rollbackErr)
+		}
+		if errors.Is(err, postgres.ErrDeadlockDetected) || errors.Is(err, ledgerstore.ErrIdempotencyKeyConflict{}) {
+			return lp.forgeLogRetry(ctx, store, parameters, fn)
+		}
+		return nil, nil, false, fmt.Errorf("unexpected error while forging log: %w", err)
+	}
+
+	if parameters.DryRun {
+		if rollbackErr := txStore.Rollback(); rollbackErr != nil {
+			logging.FromContext(ctx).Errorf("failed to rollback transaction: %v", rollbackErr)
+		}
+		return log, output, false, nil
+	}
+	if err := txStore.Commit(); err != nil {
+		return nil, nil, false, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return log, output, false, nil
+}
+
+func (lp *logProcessor[INPUT, OUTPUT]) forgeLogRetry(
+	ctx context.Context,
+	store Store,
+	parameters Parameters[INPUT],
+	fn func(ctx context.Context, store Store, parameters Parameters[INPUT]) (*OUTPUT, error),
+) (*ledger.Log, *OUTPUT, bool, error) {
 	for {
 		log, output, err := lp.runTx(ctx, store, parameters, fn)
 		if err != nil {

--- a/internal/controller/ledger/log_process_test.go
+++ b/internal/controller/ledger/log_process_test.go
@@ -21,10 +21,20 @@ func TestForgeLogWithIKConflict(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := NewMockStore(ctrl)
 
+	// Hot path: single transaction
+	store.EXPECT().
+		BeginTX(gomock.Any(), gomock.Any()).
+		Return(store, &bun.Tx{}, nil)
+
 	store.EXPECT().
 		ReadLogWithIdempotencyKey(gomock.Any(), "foo").
 		Return(nil, postgres.ErrNotFound)
 
+	store.EXPECT().
+		Rollback().
+		Return(nil)
+
+	// Retry path after ErrIdempotencyKeyConflict
 	store.EXPECT().
 		BeginTX(gomock.Any(), gomock.Any()).
 		Return(store, &bun.Tx{}, nil)


### PR DESCRIPTION
## Summary
- Backport of #1262 onto `release/v2.3`
- Runs `fetchLogWithIK` and `runLog` (fn + InsertLog) in the same transaction on the happy path to avoid acquiring two connections under load
- On retriable errors (deadlock, idempotency conflict) delegates to `forgeLogRetry` which runs the existing `runTx` loop

## Test plan
- [ ] CI passes on backported changes
- [ ] Verify idempotency key fetch + log creation uses a single transaction under normal conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)