### PR TITLE
fix(ledger): use AST analysis for lateral filter safety instead of string matching

### DIFF
--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -22,6 +22,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) Schema() queries.EntitySche
 func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.RepositoryHandlerBuildContext[ledger.GetAggregatedVolumesOptions]) (*bun.SelectQuery, error) {
 
 	allAddresses, needAddressSegments := collectAddressFilters(query)
+	canPushLateral := canPushAddressFilterToLateral(query.Builder)
 
 	if query.UsePIT() {
 		ret := h.store.newScopedSelect().
@@ -52,7 +53,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 				Column("address_array").
 				Where("accounts.address = accounts_address")
 
-			subQuery = applyLateralAddressFilter(subQuery, allAddresses, query.Builder)
+			subQuery = applyLateralAddressFilter(subQuery, allAddresses, canPushLateral)
 
 			ret = ret.
 				ColumnExpr("accounts.address_array as accounts_address_array").
@@ -88,7 +89,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 			if query.UseFilter("address") {
 				subQuery = subQuery.ColumnExpr("address_array as accounts_address_array")
 				ret = ret.Column("accounts_address_array")
-				subQuery = applyLateralAddressFilter(subQuery, allAddresses, query.Builder)
+				subQuery = applyLateralAddressFilter(subQuery, allAddresses, canPushLateral)
 			}
 			if query.UseFilter("metadata") {
 				subQuery = subQuery.ColumnExpr("metadata")

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -26,6 +26,7 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 	var selectVolumes *bun.SelectQuery
 
 	allAddresses, needAddressSegments := collectAddressFilters(query)
+	canPushLateral := canPushAddressFilterToLateral(query.Builder)
 	if !query.UsePIT() && !query.UseOOT() {
 		selectVolumes = h.store.newScopedSelect().
 			Column("asset", "input", "output").
@@ -43,7 +44,7 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 			if needAddressSegments {
 				accountsQuery = accountsQuery.ColumnExpr("address_array as account_array")
 				selectVolumes = selectVolumes.Column("account_array")
-				accountsQuery = applyLateralAddressFilter(accountsQuery, allAddresses, query.Builder)
+				accountsQuery = applyLateralAddressFilter(accountsQuery, allAddresses, canPushLateral)
 			}
 			if query.UseFilter("metadata") {
 				accountsQuery = accountsQuery.ColumnExpr("metadata")
@@ -93,7 +94,7 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 			if needAddressSegments {
 				accountsQuery = accountsQuery.ColumnExpr("address_array")
 				selectVolumes = selectVolumes.ColumnExpr("(array_agg(accounts.address_array))[1] as account_array")
-				accountsQuery = applyLateralAddressFilter(accountsQuery, allAddresses, query.Builder)
+				accountsQuery = applyLateralAddressFilter(accountsQuery, allAddresses, canPushLateral)
 			}
 			if query.UseFilter("first_usage") {
 				accountsQuery = accountsQuery.ColumnExpr("first_usage")

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -71,9 +71,9 @@ func collectAddressFilters(q interface {
 }
 
 // applyLateralAddressFilter conditionally pushes the address filter into a
-// LATERAL join subquery when it is safe to do so.
-func applyLateralAddressFilter(subQuery *bun.SelectQuery, addresses []string, builder query.Builder) *bun.SelectQuery {
-	if len(addresses) > 0 && canPushAddressFilterToLateral(builder) {
+// LATERAL join subquery when canPush is true and there are addresses to filter.
+func applyLateralAddressFilter(subQuery *bun.SelectQuery, addresses []string, canPush bool) *bun.SelectQuery {
+	if len(addresses) > 0 && canPush {
 		subQuery = subQuery.Where(buildAddressFilterForLateral(addresses))
 	}
 	return subQuery
@@ -83,14 +83,16 @@ func applyLateralAddressFilter(subQuery *bun.SelectQuery, addresses []string, bu
 // filter into the LATERAL join by inspecting the query builder's JSON AST.
 //
 // The optimization is UNSAFE when:
-//   - $not is present: the lateral keeps matching rows, but the outer WHERE
-//     negates them → 0 results.
-//   - $or is present: the lateral excludes rows that don't match the address
-//     filter, but those rows might match another branch of the $or (e.g.
-//     a balance or metadata condition) → missing results.
+//   - An address filter is inside a $not (at any depth): the lateral keeps
+//     matching rows, but the outer WHERE negates them → 0 results.
+//   - An address filter is inside a $or that also has branches without address
+//     filters: the lateral excludes rows matching the non-address branch → missing results.
 //
-// With pure $and queries, the optimization is safe because all conditions
-// must be true, so pre-filtering by address is a valid subset operation.
+// The optimization is SAFE when:
+//   - $not only wraps non-address filters (e.g. metadata)
+//   - $or wraps a single item (no-op wrapper)
+//   - $or branches all contain address filters
+//   - Pure $and at any depth
 func canPushAddressFilterToLateral(builder query.Builder) bool {
 	if builder == nil {
 		return true
@@ -99,8 +101,149 @@ func canPushAddressFilterToLateral(builder query.Builder) bool {
 	if err != nil {
 		return false
 	}
-	s := string(data)
-	return !strings.Contains(s, `"$not":`) && !strings.Contains(s, `"$or":`)
+	var node map[string]any
+	if err := json.Unmarshal(data, &node); err != nil {
+		return false
+	}
+	return isNodeSafeForLateral(node, false)
+}
+
+// isAddressKey returns true if the key refers to an address/account field.
+func isAddressKey(key string) bool {
+	return key == "address" || key == "account"
+}
+
+// isLeafOperator returns true for query leaf operators ($match, $gt, etc).
+// Must match leaf operators in go-libs/v3/query/expression.go (mapMapToExpression).
+func isLeafOperator(op string) bool {
+	switch op {
+	case "$match", "$gt", "$gte", "$lt", "$lte", "$like", "$exists", "$in":
+		return true
+	}
+	return false
+}
+
+// nodeContainsAddressFilter checks whether a JSON AST subtree contains
+// any filter on an address/account field.
+func nodeContainsAddressFilter(node map[string]any) bool {
+	for op, value := range node {
+		switch {
+		case isLeafOperator(op):
+			if m, ok := value.(map[string]any); ok {
+				for key := range m {
+					if isAddressKey(key) {
+						return true
+					}
+				}
+			}
+		case op == "$not":
+			if child, ok := value.(map[string]any); ok {
+				if nodeContainsAddressFilter(child) {
+					return true
+				}
+			}
+		case op == "$and" || op == "$or":
+			if items, ok := value.([]any); ok {
+				for _, item := range items {
+					if child, ok := item.(map[string]any); ok {
+						if nodeContainsAddressFilter(child) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isNodeSafeForLateral walks the JSON AST and checks whether pushing the
+// address filter into the LATERAL join would produce correct results.
+// insideNot tracks whether we are inside a $not ancestor.
+func isNodeSafeForLateral(node map[string]any, insideNot bool) bool {
+	for op, value := range node {
+		switch {
+		case isLeafOperator(op):
+			// Address filter inside $not → unsafe
+			if insideNot {
+				if m, ok := value.(map[string]any); ok {
+					for key := range m {
+						if isAddressKey(key) {
+							return false
+						}
+					}
+				}
+			}
+
+		case op == "$not":
+			if child, ok := value.(map[string]any); ok {
+				if !isNodeSafeForLateral(child, true) {
+					return false
+				}
+			}
+
+		case op == "$and":
+			if items, ok := value.([]any); ok {
+				for _, item := range items {
+					if child, ok := item.(map[string]any); ok {
+						if !isNodeSafeForLateral(child, insideNot) {
+							return false
+						}
+					}
+				}
+			}
+
+		case op == "$or":
+			items, ok := value.([]any)
+			if !ok {
+				continue
+			}
+
+			if insideNot {
+				// NOT(A OR B) = NOT A AND NOT B — if any branch contains
+				// an address filter, that becomes a negated address → unsafe.
+				// nodeContainsAddressFilter already checks the full subtree,
+				// so no further recursion is needed.
+				for _, item := range items {
+					if child, ok := item.(map[string]any); ok {
+						if nodeContainsAddressFilter(child) {
+							return false
+						}
+					}
+				}
+				continue
+			}
+
+			if len(items) > 1 {
+				// $or with multiple branches: unsafe if it mixes branches
+				// that contain address filters with branches that don't.
+				hasAddr := false
+				hasNonAddr := false
+				for _, item := range items {
+					if child, ok := item.(map[string]any); ok {
+						if nodeContainsAddressFilter(child) {
+							hasAddr = true
+						} else {
+							hasNonAddr = true
+						}
+					}
+				}
+				if hasAddr && hasNonAddr {
+					return false
+				}
+			}
+
+			// Recurse into children for nested issues
+			for _, item := range items {
+				if child, ok := item.(map[string]any); ok {
+					if !isNodeSafeForLateral(child, insideNot) {
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
 }
 
 // buildAddressFilterForLateral builds an OR condition of all address filters

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -3,9 +3,10 @@ package ledger
 import (
 	"testing"
 
-	"github.com/formancehq/go-libs/v4/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v4/query"
 )
 
 func TestCanPushAddressFilterToLateral(t *testing.T) {

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -1,0 +1,215 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/formancehq/go-libs/v4/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanPushAddressFilterToLateral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		builder  query.Builder
+		expected bool
+	}{
+		{
+			name:     "nil builder",
+			builder:  nil,
+			expected: true,
+		},
+		{
+			name:     "simple $match on address",
+			builder:  query.Match("address", "users:"),
+			expected: true,
+		},
+		{
+			name:     "simple $match on account alias",
+			builder:  query.Match("account", "users:"),
+			expected: true,
+		},
+		{
+			name:     "$and with address and metadata",
+			builder:  query.And(query.Match("address", "users:"), query.Match("metadata[category]", "premium")),
+			expected: true,
+		},
+		{
+			name:     "$not with address - unsafe",
+			builder:  query.Not(query.Match("address", "users:")),
+			expected: false,
+		},
+		{
+			name:     "$not with metadata only - safe",
+			builder:  query.Not(query.Match("metadata[x]", "y")),
+			expected: true,
+		},
+		{
+			name:     "$or with two addresses - safe (all branches have address)",
+			builder:  query.Or(query.Match("address", "users:"), query.Match("address", "world")),
+			expected: true,
+		},
+		{
+			name:     "$or single item - safe (no-op wrapper)",
+			builder:  query.Or(query.Match("address", "users:")),
+			expected: true,
+		},
+		{
+			name:     "$or with address and balance - unsafe (mixed)",
+			builder:  query.Or(query.Match("address", "users:"), query.Lte("balance[USD]", 0)),
+			expected: false,
+		},
+		{
+			name:     "$and with address and $not on metadata - safe (production case)",
+			builder:  query.And(query.And(query.Or(query.Match("account", "xxx:")), query.Not(query.Match("metadata[wallet_transaction_method]", "hold_settlement")))),
+			expected: true,
+		},
+		{
+			name:     "$and with address and $not on address - unsafe",
+			builder:  query.And(query.Match("address", "users:"), query.Not(query.Match("address", "world"))),
+			expected: false,
+		},
+		{
+			name:     "nested $not on metadata inside $and - safe",
+			builder:  query.And(query.Match("address", "users:"), query.Not(query.Match("metadata[x]", "y"))),
+			expected: true,
+		},
+		{
+			name:     "nested $or on metadata inside $and - safe (no address in $or)",
+			builder:  query.And(query.Match("address", "users:"), query.Or(query.Match("metadata[x]", "y"), query.Match("metadata[z]", "w"))),
+			expected: true,
+		},
+		{
+			name:     "$not wrapping $or with address - unsafe",
+			builder:  query.Not(query.Or(query.Match("address", "a:"), query.Match("address", "b:"))),
+			expected: false,
+		},
+		{
+			name:     "$not wrapping $and with address - unsafe",
+			builder:  query.Not(query.And(query.Match("address", "a:"), query.Match("metadata[x]", "y"))),
+			expected: false,
+		},
+		{
+			name:     "$not wrapping $or without address - safe",
+			builder:  query.Not(query.Or(query.Match("metadata[x]", "y"), query.Match("metadata[z]", "w"))),
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := canPushAddressFilterToLateral(tc.builder)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildAddressFilterForLateral(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single exact address", func(t *testing.T) {
+		t.Parallel()
+		result := buildAddressFilterForLateral([]string{"world"})
+		assert.Equal(t, "address = 'world'", result)
+	})
+
+	t.Run("single partial address", func(t *testing.T) {
+		t.Parallel()
+		result := buildAddressFilterForLateral([]string{"users:"})
+		assert.Contains(t, result, "address_array @@")
+	})
+
+	t.Run("single partial address with fixed segment", func(t *testing.T) {
+		t.Parallel()
+		result := buildAddressFilterForLateral([]string{"system:cashier:"})
+		assert.Contains(t, result, `address_array @@ ('$[0] == "system"')::jsonpath`)
+		assert.Contains(t, result, `address_array @@ ('$[1] == "cashier"')::jsonpath`)
+	})
+
+	t.Run("multiple addresses joined with OR", func(t *testing.T) {
+		t.Parallel()
+		result := buildAddressFilterForLateral([]string{"world", "users:"})
+		assert.Contains(t, result, "(address = 'world')")
+		assert.Contains(t, result, " OR ")
+		assert.Contains(t, result, "address_array @@")
+	})
+}
+
+func TestCollectAddressFilters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no address filter", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockUseFilter{filters: map[string][]any{}}
+		addresses, needSegments := collectAddressFilters(mock)
+		assert.Empty(t, addresses)
+		assert.False(t, needSegments)
+	})
+
+	t.Run("single exact address", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockUseFilter{filters: map[string][]any{
+			"address": {"world"},
+		}}
+		addresses, needSegments := collectAddressFilters(mock)
+		require.Len(t, addresses, 1)
+		assert.Equal(t, "world", addresses[0])
+		assert.False(t, needSegments)
+	})
+
+	t.Run("single partial address", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockUseFilter{filters: map[string][]any{
+			"address": {"users:"},
+		}}
+		addresses, needSegments := collectAddressFilters(mock)
+		require.Len(t, addresses, 1)
+		assert.Equal(t, "users:", addresses[0])
+		assert.True(t, needSegments)
+	})
+
+	t.Run("mixed exact and partial addresses", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockUseFilter{filters: map[string][]any{
+			"address": {"world", "users:"},
+		}}
+		addresses, needSegments := collectAddressFilters(mock)
+		require.Len(t, addresses, 2)
+		assert.Equal(t, "world", addresses[0])
+		assert.Equal(t, "users:", addresses[1])
+		assert.True(t, needSegments)
+	})
+}
+
+// mockUseFilter implements the interface expected by collectAddressFilters.
+// It simulates RepositoryHandlerBuildContext.UseFilter behavior:
+// iterates all values for the given key and calls each matcher.
+type mockUseFilter struct {
+	filters map[string][]any
+}
+
+func (m *mockUseFilter) UseFilter(key string, matchers ...func(any) bool) bool {
+	values, ok := m.filters[key]
+	if !ok {
+		return false
+	}
+	if len(matchers) == 0 {
+		return true
+	}
+	for _, value := range values {
+		allMatch := true
+		for _, matcher := range matchers {
+			if !matcher(value) {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Cherry-pick of #1296 to main. Replaces naive string matching with proper JSON AST walking for lateral filter safety detection. Fixes production case where $and(address, $not(metadata)) was incorrectly skipping the GIN index optimization.