### PR TITLE
fix(deps): add replace directives for charmbracelet modules migrated to charm.land

### DIFF
--- a/deployments/pulumi/go.mod
+++ b/deployments/pulumi/go.mod
@@ -190,3 +190,9 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	lukechampine.com/frand v1.5.1 // indirect
 )
+
+replace (
+	github.com/charmbracelet/bubbles/v2 => charm.land/bubbles/v2 v2.0.0
+	github.com/charmbracelet/bubbletea/v2 => charm.land/bubbletea/v2 v2.0.2
+	github.com/charmbracelet/lipgloss/v2 => charm.land/lipgloss/v2 v2.0.2
+)


### PR DESCRIPTION
## Summary

- PR #1302 (security updates) bumped `pulumi-aws/sdk` from v6 to v7, which pulled in charmbracelet v2 modules (`bubbles/v2`, `bubbletea/v2`, `lipgloss/v2`)
- These modules have migrated their Go module paths from `github.com/charmbracelet/*` to `charm.land/*`, breaking `go mod tidy`
- Adds `replace` directives in `deployments/pulumi/go.mod` to map the old paths to the new ones

## Test plan

- [ ] `go mod tidy` passes in `deployments/pulumi/`
- [ ] CI Dirty check passes