### PR TITLE
perf(ledger): add index on transactions(id desc) for pagination

### DIFF
--- a/internal/storage/bucket/migrations/50-add-transactions-id-desc-index/notes.yaml
+++ b/internal/storage/bucket/migrations/50-add-transactions-id-desc-index/notes.yaml
@@ -1,0 +1,1 @@
+name: Add transactions id desc index for pagination performance

--- a/internal/storage/bucket/migrations/50-add-transactions-id-desc-index/up.sql
+++ b/internal/storage/bucket/migrations/50-add-transactions-id-desc-index/up.sql
@@ -1,0 +1,1 @@
+create index {{ if not .Transactional }}concurrently{{end}} transactions_id_desc on "{{.Schema}}".transactions (id desc);


### PR DESCRIPTION
## Summary

Cherry-pick of #1310 to `main`.

- Adds a new migration (`50-add-transactions-id-desc-index`) that creates an index on `transactions(id DESC)` per bucket schema
- Uses `CONCURRENTLY` for non-transactional contexts (production) to avoid locking the table

## Problem

Listing transactions via `GET /v2/{ledger}/transactions` without filters causes a **full sequential scan + on-disk sort** of all rows before applying `LIMIT`. On large ledgers (12M+ rows), this results in **~200s response times**.

## Fix

The `(id DESC)` index allows PostgreSQL to use an **Index Scan Backward** for the default `ORDER BY id DESC` pagination, reducing response time from ~200s to milliseconds.

## Test plan

- [ ] Migration applies cleanly on a fresh database
- [ ] Migration applies cleanly on an existing database with data
- [ ] `EXPLAIN ANALYZE` on `SELECT ... FROM transactions ORDER BY id DESC LIMIT 16` shows Index Scan instead of Seq Scan