### PR TITLE
fix(storage): run bucket migration before inserting ledger row

### DIFF
--- a/internal/storage/driver/driver.go
+++ b/internal/storage/driver/driver.go
@@ -42,16 +42,9 @@ func (d *Driver) CreateLedger(ctx context.Context, l *ledger.Ledger) (*ledgersto
 
 	var ret *ledgerstore.Store
 	err := d.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		systemStore := d.systemStoreFactory.Create(tx)
-
-		if err := systemStore.CreateLedger(ctx, l); err != nil {
-			if errors.Is(postgres.ResolveError(err), postgres.ErrConstraintsFailed{}) {
-				return systemstore.ErrLedgerAlreadyExists
-			}
-			return postgres.ResolveError(err)
-		}
-
 		b := d.bucketFactory.Create(l.Bucket)
+
+		// Bring the bucket up to date before inserting the _system.ledgers row.
 		isInitialized, err := b.IsInitialized(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("checking if bucket is initialized: %w", err)
@@ -65,14 +58,22 @@ func (d *Driver) CreateLedger(ctx context.Context, l *ledger.Ledger) (*ledgersto
 			if !upToDate {
 				return ErrBucketOutdated
 			}
-
-			if err := b.AddLedger(ctx, tx, *l); err != nil {
-				return fmt.Errorf("adding ledger to bucket: %w", err)
-			}
 		} else {
 			if err := b.Migrate(ctx, tx); err != nil {
 				return fmt.Errorf("migrating bucket: %w", err)
 			}
+		}
+
+		systemStore := d.systemStoreFactory.Create(tx)
+		if err := systemStore.CreateLedger(ctx, l); err != nil {
+			if errors.Is(postgres.ResolveError(err), postgres.ErrConstraintsFailed{}) {
+				return systemstore.ErrLedgerAlreadyExists
+			}
+			return postgres.ResolveError(err)
+		}
+
+		if err := b.AddLedger(ctx, tx, *l); err != nil {
+			return fmt.Errorf("adding ledger to bucket: %w", err)
 		}
 
 		count, err := systemStore.CountLedgersInBucket(ctx, l.Bucket)

--- a/test/e2e/api_ledgers_create_test.go
+++ b/test/e2e/api_ledgers_create_test.go
@@ -3,8 +3,12 @@
 package test_suite
 
 import (
+	"fmt"
+	"math/big"
 	"strings"
+	"sync"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -187,6 +191,68 @@ var _ = Context("Ledger engine tests", func() {
 				})
 				It("should be ok", func() {
 					Expect(err).To(BeNil())
+				})
+			})
+
+			// Regression test: concurrent CreateLedger calls into a brand-new
+			// bucket used to leave losers of the migrator advisory-lock race
+			// without their per-ledger sequences (transaction_id_<id> /
+			// log_id_<id>), because migration 11's DO block only saw the
+			// winner's uncommitted _system.ledgers row under READ COMMITTED.
+			// The first write to a loser then 500'd with
+			// `relation "<bucket>.transaction_id_N" does not exist`.
+			Context("concurrent creation into a fresh bucket", func() {
+				It("should set up per-ledger sequences for every ledger", func(specContext SpecContext) {
+					const n = 10
+					bucket := "race-" + uuid.NewString()[:8]
+
+					names := make([]string, n)
+					for i := range names {
+						names[i] = fmt.Sprintf("ledger-%d", i)
+					}
+
+					start := make(chan struct{})
+					wg := sync.WaitGroup{}
+					errs := make([]error, n)
+					for i := 0; i < n; i++ {
+						wg.Add(1)
+						go func(i int) {
+							defer GinkgoRecover()
+							defer wg.Done()
+							<-start
+							_, errs[i] = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateLedger(ctx,
+								operations.V2CreateLedgerRequest{
+									Ledger: names[i],
+									V2CreateLedgerRequest: components.V2CreateLedgerRequest{
+										Bucket: pointer.For(bucket),
+									},
+								})
+						}(i)
+					}
+					close(start)
+					wg.Wait()
+
+					for i, err := range errs {
+						Expect(err).To(BeNil(), "CreateLedger failed for %s: %v", names[i], err)
+					}
+
+					// Force the initializing→in-use state transition that
+					// runs setval on the per-ledger sequence.
+					for _, name := range names {
+						_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx,
+							operations.V2CreateTransactionRequest{
+								Ledger: name,
+								V2PostTransaction: components.V2PostTransaction{
+									Postings: []components.V2Posting{{
+										Source:      "world",
+										Destination: "alice",
+										Amount:      big.NewInt(1),
+										Asset:       "USD",
+									}},
+								},
+							})
+						Expect(err).To(BeNil(), "CreateTransaction failed for %s: %v", name, err)
+					}
 				})
 			})
 		})


### PR DESCRIPTION
Concurrent CreateLedger calls into a brand-new bucket could leave losers of the migrator's advisory-lock race without their per-ledger sequences (transaction_id_<id>, log_id_<id>) and triggers.

The _system.ledgers row was inserted before b.Migrate ran. Under READ COMMITTED, migration 11's DO block (which iterates _system.ledgers to create per-ledger resources) only saw the winner's uncommitted row. Concurrent losers got ErrAlreadyUpToDate from Migrate and took the else branch, which did not call AddLedger, so their sequences were never created. The first write to such a ledger failed with `relation "<bucket>.transaction_id_N" does not exist` on the initializing→in-use state transition.

Reorder: migrate or verify the bucket first, then insert the _system.ledgers row, then call AddLedger. AddLedger is now the sole owner of per-ledger setup for newly-created ledgers and runs on a freshly minted unique id, so there is no collision with the DO block and no race between concurrent creates.

Add an e2e regression test that fires 10 concurrent CreateLedger calls at a fresh bucket and posts a transaction on each; reliably fails on the pre-fix code with the exact error observed in Antithesis.