### PR TITLE
chore(ci): migrate runners from Shipfox to Namespace.so

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -21,12 +21,9 @@ runs:
       shell: bash
       run: |
         nix develop --command bash -c "go env | sed -E \"s/^([^=]+)='(.*)'\$/\1=\2/\"" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v5
+    - uses: namespacelabs/nscloud-cache-action@v1
       with:
         path: |
           ${{ steps.go-env.outputs.GOCACHE }}
           ${{ steps.go-env.outputs.GOMODCACHE }}
           ~/.cache/golangci-lint
-        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-go-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:
@@ -59,10 +59,10 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:
@@ -91,10 +91,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: Setup Env
         uses: ./.github/actions/default

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,10 +83,6 @@ jobs:
       attestations: write
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
       - uses: earthly/actions-setup@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,10 +96,8 @@ jobs:
         uses: ./.github/actions/default
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Dirty:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     env:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
@@ -55,7 +55,7 @@ jobs:
           fi
 
   Tests:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-8vcpu"
     env:
       GOPATH: /tmp/go
     steps:
@@ -77,7 +77,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,10 +18,8 @@ jobs:
         uses: ./.github/actions/default
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -10,10 +10,10 @@ jobs:
   GoReleaser:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions runners from Shipfox to Namespace.so
- `shipfox-4vcpu-ubuntu-2404` → `namespace-profile-linux-amd64-4vcpu` (jobs: Dirty, GoReleaser in main, Release GoReleaser)
- `shipfox-8vcpu-ubuntu-2404` → `namespace-profile-linux-amd64-8vcpu` (job: Tests)
- `ubuntu-latest` (PR Title check) and `ubuntu-24.04` (Deploy) left unchanged

## Test plan
- [ ] PR triggers `Dirty` job on Namespace 4vcpu runner
- [ ] `Tests` job runs successfully on Namespace 8vcpu runner
- [ ] `GoReleaser` job builds on Namespace 4vcpu runner
- [ ] Release workflow validated on next tag push