### PR TITLE
chore(ci): migrate runners from Shipfox to Namespace.so

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -24,4 +24,4 @@ runs:
     - name: Install earthly
       uses: earthly/actions-setup@v1
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Dirty:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
+    env:
+      GOPATH: /tmp/go
+      GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/env
         with:
@@ -55,11 +59,14 @@ jobs:
           fi
 
   Tests:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-8vcpu"
+    env:
+      GOPATH: /tmp/go
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/env
         with:
@@ -79,7 +86,10 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   GoReleaser:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
+    permissions:
+      id-token: write
+      attestations: write
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     needs:
       - Dirty
@@ -88,13 +98,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: 'actions/checkout@v4'
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
+          dissociate: true
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: Setup Env
         uses: ./.github/actions/env
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,20 +8,18 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-8vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v4'
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-      - uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ inputs.token }}
-          version: "latest"
-          use-cache: true
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/env
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Backport of #1336 to this release branch.

Migrates CI runners from Shipfox to Namespace.so so that hotfix builds on this release branch use the same infrastructure as `main`. Composite action (`.github/actions/default`) does not exist on this release branch — only the runs-on, checkout, QEMU/buildx swaps from #1336 apply.