### PR TITLE
fix(storage): prevent empty WHERE clause in query builder

### DIFF
--- a/internal/storage/common/resource.go
+++ b/internal/storage/common/resource.go
@@ -176,10 +176,12 @@ func (r *ResourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q R
 		if err != nil {
 			return nil, err
 		}
-		if len(args) > 0 {
-			dataset = dataset.Where(where, args...)
-		} else {
-			dataset = dataset.Where(where)
+		if where != "" {
+			if len(args) > 0 {
+				dataset = dataset.Where(where, args...)
+			} else {
+				dataset = dataset.Where(where)
+			}
 		}
 	}
 

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -42,6 +42,10 @@ func filterAccountAddress(address, key string) string {
 		parts = append(parts, fmt.Sprintf("%s = '%s'", key, address))
 	}
 
+	if len(parts) == 0 {
+		return "1 = 1"
+	}
+
 	return strings.Join(parts, " and ")
 }
 


### PR DESCRIPTION
## Summary
- Guard `dataset.Where()` call behind a `where != ""` check in `buildFilteredDataset` to prevent generating invalid SQL (`WHERE  LIMIT 16`) when the query builder resolves to an empty condition string
- Make `filterAccountAddress` return `"1 = 1"` instead of `""` when no address segments match (inputs like `""`, `":"`, `"::"`)

## Context
A client listing accounts triggered a malformed SQL query:
```sql
... dataset WHERE  LIMIT 16
```
The root cause: when `q.Builder` is non-nil but `Build()` returns an empty string, bun's `.Where("")` emits the `WHERE` keyword with no condition.

## Test plan
- [ ] Verify `GET /{ledger}/accounts` without filters still works
- [ ] Verify `GET /{ledger}/accounts` with `{"$match": {"address": ""}}` no longer produces invalid SQL
- [ ] Verify `GET /{ledger}/accounts` with valid address filters still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)