### PR TITLE
fix: parameterize ledger address filters

### DIFF
--- a/internal/storage/ledger/resource_accounts.go
+++ b/internal/storage/ledger/resource_accounts.go
@@ -63,7 +63,8 @@ func (h accountsResourceHandler) ResolveFilter(opts common.ResourceQuery[any], o
 
 			return "address IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			return filterAccountAddress(value.(string), "address"), nil, nil
+			filter, args := filterAccountAddress(value.(string), "address")
+			return filter, args, nil
 		}
 
 	case property == "first_usage" || property == "insertion_date" || property == "updated_at":

--- a/internal/storage/ledger/resource_accounts.go
+++ b/internal/storage/ledger/resource_accounts.go
@@ -63,8 +63,8 @@ func (h accountsResourceHandler) ResolveFilter(opts common.ResourceQuery[any], o
 
 			return "address IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			filter, args := filterAccountAddress(value.(string), "address")
-			return filter, args, nil
+			where, args := filterAccountAddress(value.(string), "address")
+			return where, args, nil
 		}
 
 	case property == "first_usage" || property == "insertion_date" || property == "updated_at":

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -116,7 +116,8 @@ func (h aggregatedBalancesResourceRepositoryHandler) ResolveFilter(_ common.Reso
 
 			return "accounts_address IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			return filterAccountAddress(value.(string), "accounts_address"), nil, nil
+			filter, args := filterAccountAddress(value.(string), "accounts_address")
+			return filter, args, nil
 		}
 	case common.MetadataRegex.Match([]byte(property)) || property == "metadata":
 		if property == "metadata" {

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -116,8 +116,8 @@ func (h aggregatedBalancesResourceRepositoryHandler) ResolveFilter(_ common.Reso
 
 			return "accounts_address IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			filter, args := filterAccountAddress(value.(string), "accounts_address")
-			return filter, args, nil
+			where, args := filterAccountAddress(value.(string), "accounts_address")
+			return where, args, nil
 		}
 	case common.MetadataRegex.Match([]byte(property)) || property == "metadata":
 		if property == "metadata" {

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -107,7 +107,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 
 			return "sources \\?| " + placeholder + " OR destinations \\?| " + placeholder, args, nil
 		default:
-			return filterAccountAddressOnTransactions(value.(string), true, true), nil, nil
+			filter, args := filterAccountAddressOnTransactions(value.(string), true, true)
+			return filter, args, nil
 		}
 	case property == "source":
 		switch operator {
@@ -121,7 +122,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 
 			return "sources \\?| " + placeholder, args, nil
 		default:
-			return filterAccountAddressOnTransactions(value.(string), true, false), nil, nil
+			filter, args := filterAccountAddressOnTransactions(value.(string), true, false)
+			return filter, args, nil
 		}
 	case property == "destination":
 		switch operator {
@@ -134,7 +136,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			placeholder, args := stringArrayToPostgresArray(addresses)
 			return "destinations \\?| " + placeholder, args, nil
 		default:
-			return filterAccountAddressOnTransactions(value.(string), false, true), nil, nil
+			filter, args := filterAccountAddressOnTransactions(value.(string), false, true)
+			return filter, args, nil
 		}
 	case common.MetadataRegex.Match([]byte(property)):
 		match := common.MetadataRegex.FindAllStringSubmatch(property, 3)

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -107,8 +107,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 
 			return "sources \\?| " + placeholder + " OR destinations \\?| " + placeholder, args, nil
 		default:
-			filter, args := filterAccountAddressOnTransactions(value.(string), true, true)
-			return filter, args, nil
+			where, args := filterAccountAddressOnTransactions(value.(string), true, true)
+			return where, args, nil
 		}
 	case property == "source":
 		switch operator {
@@ -122,8 +122,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 
 			return "sources \\?| " + placeholder, args, nil
 		default:
-			filter, args := filterAccountAddressOnTransactions(value.(string), true, false)
-			return filter, args, nil
+			where, args := filterAccountAddressOnTransactions(value.(string), true, false)
+			return where, args, nil
 		}
 	case property == "destination":
 		switch operator {
@@ -136,8 +136,8 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			placeholder, args := stringArrayToPostgresArray(addresses)
 			return "destinations \\?| " + placeholder, args, nil
 		default:
-			filter, args := filterAccountAddressOnTransactions(value.(string), false, true)
-			return filter, args, nil
+			where, args := filterAccountAddressOnTransactions(value.(string), false, true)
+			return where, args, nil
 		}
 	case common.MetadataRegex.Match([]byte(property)):
 		match := common.MetadataRegex.FindAllStringSubmatch(property, 3)

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -140,7 +140,8 @@ func (h volumesResourceHandler) ResolveFilter(
 
 			return "account IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			return filterAccountAddress(value.(string), "account"), nil, nil
+			filter, args := filterAccountAddress(value.(string), "account")
+			return filter, args, nil
 		}
 	case property == "first_usage":
 		return fmt.Sprintf("first_usage %s ?", common.ConvertOperatorToSQL(operator)), []any{value}, nil

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -140,8 +140,8 @@ func (h volumesResourceHandler) ResolveFilter(
 
 			return "account IN (?)", []any{bun.In(addresses)}, nil
 		default:
-			filter, args := filterAccountAddress(value.(string), "account")
-			return filter, args, nil
+			where, args := filterAccountAddress(value.(string), "account")
+			return where, args, nil
 		}
 	case property == "first_usage":
 		return fmt.Sprintf("first_usage %s ?", common.ConvertOperatorToSQL(operator)), []any{value}, nil

--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -269,12 +269,13 @@ func (store *Store) DeleteTransactionMetadata(ctx context.Context, id uint64, ke
 	return tx, modified, err
 }
 
-func filterAccountAddressOnTransactions(address string, source, destination bool) string {
+func filterAccountAddressOnTransactions(address string, source, destination bool) (string, []any) {
 	src := strings.Split(address, ":")
 
 	if isPartialAddress(address) {
 		m := map[string]any{}
 		parts := make([]string, 0)
+		args := make([]any, 0, 2)
 
 		for i, segment := range src {
 			if len(segment) == 0 {
@@ -295,12 +296,14 @@ func filterAccountAddressOnTransactions(address string, source, destination bool
 		}
 
 		if source {
-			parts = append(parts, fmt.Sprintf("sources_arrays @> '%s'", string(data)))
+			parts = append(parts, "sources_arrays @> ?::jsonb")
+			args = append(args, string(data))
 		}
 		if destination {
-			parts = append(parts, fmt.Sprintf("destinations_arrays @> '%s'", string(data)))
+			parts = append(parts, "destinations_arrays @> ?::jsonb")
+			args = append(args, string(data))
 		}
-		return strings.Join(parts, " or ")
+		return strings.Join(parts, " or "), args
 	}
 
 	data, err := json.Marshal([]string{address})
@@ -309,13 +312,16 @@ func filterAccountAddressOnTransactions(address string, source, destination bool
 	}
 
 	parts := make([]string, 0)
+	args := make([]any, 0, 2)
 	if source {
-		parts = append(parts, fmt.Sprintf("sources @> '%s'", string(data)))
+		parts = append(parts, "sources @> ?::jsonb")
+		args = append(args, string(data))
 	}
 	if destination {
-		parts = append(parts, fmt.Sprintf("destinations @> '%s'", string(data)))
+		parts = append(parts, "destinations @> ?::jsonb")
+		args = append(args, string(data))
 	}
-	return strings.Join(parts, " or ")
+	return strings.Join(parts, " or "), args
 }
 
 func assetAddressArray(v any) ([]string, error) {

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -40,12 +40,8 @@ func filterAccountAddress(address, key string) (string, []any) {
 			if len(segment) == 0 || segment == "..." {
 				continue
 			}
-			encodedSegment, err := json.Marshal(segment)
-			if err != nil {
-				panic(err)
-			}
-			parts = append(parts, fmt.Sprintf("%s_array @@ (?)::jsonpath", key))
-			args = append(args, fmt.Sprintf("$[%d] == %s", i, encodedSegment))
+			parts = append(parts, fmt.Sprintf("%s_array @@ ?::jsonpath", key))
+			args = append(args, fmt.Sprintf("$[%d] == %s", i, jsonString(segment)))
 		}
 	} else {
 		parts = append(parts, fmt.Sprintf("%s = ?", key))
@@ -57,6 +53,14 @@ func filterAccountAddress(address, key string) (string, []any) {
 	}
 
 	return strings.Join(parts, " and "), args
+}
+
+func jsonString(value string) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }
 
 // collectAddressFilters visits all address filter values (without short-circuiting)
@@ -86,8 +90,8 @@ func collectAddressFilters(q interface {
 // LATERAL join subquery when canPush is true and there are addresses to filter.
 func applyLateralAddressFilter(subQuery *bun.SelectQuery, addresses []string, canPush bool) *bun.SelectQuery {
 	if len(addresses) > 0 && canPush {
-		filter, args := buildAddressFilterForLateral(addresses)
-		subQuery = subQuery.Where(filter, args...)
+		where, args := buildAddressFilterForLateral(addresses)
+		subQuery = subQuery.Where(where, args...)
 	}
 	return subQuery
 }
@@ -268,9 +272,9 @@ func buildAddressFilterForLateral(addresses []string) (string, []any) {
 	conditions := make([]string, len(addresses))
 	args := make([]any, 0, len(addresses))
 	for i, addr := range addresses {
-		condition, conditionArgs := filterAccountAddress(addr, "address")
-		conditions[i] = "(" + condition + ")"
-		args = append(args, conditionArgs...)
+		where, whereArgs := filterAccountAddress(addr, "address")
+		conditions[i] = "(" + where + ")"
+		args = append(args, whereArgs...)
 	}
 	return strings.Join(conditions, " OR "), args
 }

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -25,30 +25,38 @@ func isPartialAddress(address string) bool {
 	return false
 }
 
-func filterAccountAddress(address, key string) string {
+func filterAccountAddress(address, key string) (string, []any) {
 	parts := make([]string, 0)
+	args := make([]any, 0)
 
 	if isPartialAddress(address) {
 		src := strings.Split(address, ":")
 		if src[len(src)-1] != "" {
-			parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, len(src)))
+			parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = ?", key))
+			args = append(args, len(src))
 		}
 
 		for i, segment := range src {
 			if len(segment) == 0 || segment == "..." {
 				continue
 			}
-			parts = append(parts, fmt.Sprintf("%s_array @@ ('$[%d] == \"%s\"')::jsonpath", key, i, segment))
+			encodedSegment, err := json.Marshal(segment)
+			if err != nil {
+				panic(err)
+			}
+			parts = append(parts, fmt.Sprintf("%s_array @@ (?)::jsonpath", key))
+			args = append(args, fmt.Sprintf("$[%d] == %s", i, encodedSegment))
 		}
 	} else {
-		parts = append(parts, fmt.Sprintf("%s = '%s'", key, address))
+		parts = append(parts, fmt.Sprintf("%s = ?", key))
+		args = append(args, address)
 	}
 
 	if len(parts) == 0 {
-		return "1 = 1"
+		return "1 = 1", nil
 	}
 
-	return strings.Join(parts, " and ")
+	return strings.Join(parts, " and "), args
 }
 
 // collectAddressFilters visits all address filter values (without short-circuiting)
@@ -78,7 +86,8 @@ func collectAddressFilters(q interface {
 // LATERAL join subquery when canPush is true and there are addresses to filter.
 func applyLateralAddressFilter(subQuery *bun.SelectQuery, addresses []string, canPush bool) *bun.SelectQuery {
 	if len(addresses) > 0 && canPush {
-		subQuery = subQuery.Where(buildAddressFilterForLateral(addresses))
+		filter, args := buildAddressFilterForLateral(addresses)
+		subQuery = subQuery.Where(filter, args...)
 	}
 	return subQuery
 }
@@ -252,15 +261,18 @@ func isNodeSafeForLateral(node map[string]any, insideNot bool) bool {
 
 // buildAddressFilterForLateral builds an OR condition of all address filters
 // to push into a LATERAL join, allowing Postgres to use the GIN index on address_array.
-func buildAddressFilterForLateral(addresses []string) string {
+func buildAddressFilterForLateral(addresses []string) (string, []any) {
 	if len(addresses) == 1 {
 		return filterAccountAddress(addresses[0], "address")
 	}
 	conditions := make([]string, len(addresses))
+	args := make([]any, 0, len(addresses))
 	for i, addr := range addresses {
-		conditions[i] = "(" + filterAccountAddress(addr, "address") + ")"
+		condition, conditionArgs := filterAccountAddress(addr, "address")
+		conditions[i] = "(" + condition + ")"
+		args = append(args, conditionArgs...)
 	}
-	return strings.Join(conditions, " OR ")
+	return strings.Join(conditions, " OR "), args
 }
 
 func explodeAddress(address string) map[string]any {

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -121,14 +121,14 @@ func TestBuildAddressFilterForLateral(t *testing.T) {
 	t.Run("single partial address", func(t *testing.T) {
 		t.Parallel()
 		result, args := buildAddressFilterForLateral([]string{"users:"})
-		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Contains(t, result, "address_array @@ ?::jsonpath")
 		assert.Equal(t, []any{`$[0] == "users"`}, args)
 	})
 
 	t.Run("single partial address with fixed segment", func(t *testing.T) {
 		t.Parallel()
 		result, args := buildAddressFilterForLateral([]string{"system:cashier:"})
-		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Contains(t, result, "address_array @@ ?::jsonpath")
 		assert.Equal(t, []any{`$[0] == "system"`, `$[1] == "cashier"`}, args)
 	})
 
@@ -137,7 +137,7 @@ func TestBuildAddressFilterForLateral(t *testing.T) {
 		result, args := buildAddressFilterForLateral([]string{"world", "users:"})
 		assert.Contains(t, result, "(address = ?)")
 		assert.Contains(t, result, " OR ")
-		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Contains(t, result, "address_array @@ ?::jsonpath")
 		assert.Equal(t, []any{"world", `$[0] == "users"`}, args)
 	})
 
@@ -146,6 +146,22 @@ func TestBuildAddressFilterForLateral(t *testing.T) {
 		result, args := buildAddressFilterForLateral([]string{`users:\"') OR TRUE --:`})
 		assert.NotContains(t, result, `OR TRUE`)
 		assert.Equal(t, []any{`$[0] == "users"`, `$[1] == "\\\"') OR TRUE --"`}, args)
+	})
+
+	t.Run("malicious address remains bound parameter", func(t *testing.T) {
+		t.Parallel()
+		payload := "' OR 1=1 --"
+		result, args := buildAddressFilterForLateral([]string{payload})
+		assert.Equal(t, "address = ?", result)
+		assert.Equal(t, []any{payload}, args)
+	})
+
+	t.Run("malicious partial segment remains bound jsonpath", func(t *testing.T) {
+		t.Parallel()
+		payload := `users:evil" || true || "`
+		result, args := buildAddressFilterForLateral([]string{payload + ":"})
+		assert.Contains(t, result, "address_array @@ ?::jsonpath")
+		assert.Equal(t, []any{"$[0] == \"users\"", "$[1] == " + jsonString(`evil" || true || "`)}, args)
 	})
 }
 
@@ -242,4 +258,14 @@ func TestFilterAccountAddressOnTransactions(t *testing.T) {
 		assert.NotContains(t, result, "OR TRUE")
 		assert.Equal(t, []any{"[{\"0\":\"users\",\"1\":\"\\\"') OR TRUE --\",\"3\":null}]"}, args)
 	})
+}
+
+func TestFilterAccountAddressOnTransactionsBindsAddressJSON(t *testing.T) {
+	t.Parallel()
+
+	payload := "bank' OR true --"
+	where, args := filterAccountAddressOnTransactions(payload, true, true)
+
+	assert.Equal(t, "sources @> ?::jsonb or destinations @> ?::jsonb", where)
+	assert.Equal(t, []any{`["bank' OR true --"]`, `["bank' OR true --"]`}, args)
 }

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -113,29 +113,39 @@ func TestBuildAddressFilterForLateral(t *testing.T) {
 
 	t.Run("single exact address", func(t *testing.T) {
 		t.Parallel()
-		result := buildAddressFilterForLateral([]string{"world"})
-		assert.Equal(t, "address = 'world'", result)
+		result, args := buildAddressFilterForLateral([]string{"world"})
+		assert.Equal(t, "address = ?", result)
+		assert.Equal(t, []any{"world"}, args)
 	})
 
 	t.Run("single partial address", func(t *testing.T) {
 		t.Parallel()
-		result := buildAddressFilterForLateral([]string{"users:"})
-		assert.Contains(t, result, "address_array @@")
+		result, args := buildAddressFilterForLateral([]string{"users:"})
+		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Equal(t, []any{`$[0] == "users"`}, args)
 	})
 
 	t.Run("single partial address with fixed segment", func(t *testing.T) {
 		t.Parallel()
-		result := buildAddressFilterForLateral([]string{"system:cashier:"})
-		assert.Contains(t, result, `address_array @@ ('$[0] == "system"')::jsonpath`)
-		assert.Contains(t, result, `address_array @@ ('$[1] == "cashier"')::jsonpath`)
+		result, args := buildAddressFilterForLateral([]string{"system:cashier:"})
+		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Equal(t, []any{`$[0] == "system"`, `$[1] == "cashier"`}, args)
 	})
 
 	t.Run("multiple addresses joined with OR", func(t *testing.T) {
 		t.Parallel()
-		result := buildAddressFilterForLateral([]string{"world", "users:"})
-		assert.Contains(t, result, "(address = 'world')")
+		result, args := buildAddressFilterForLateral([]string{"world", "users:"})
+		assert.Contains(t, result, "(address = ?)")
 		assert.Contains(t, result, " OR ")
-		assert.Contains(t, result, "address_array @@")
+		assert.Contains(t, result, "address_array @@ (?)::jsonpath")
+		assert.Equal(t, []any{"world", `$[0] == "users"`}, args)
+	})
+
+	t.Run("escapes malicious segments through arguments", func(t *testing.T) {
+		t.Parallel()
+		result, args := buildAddressFilterForLateral([]string{`users:\"') OR TRUE --:`})
+		assert.NotContains(t, result, `OR TRUE`)
+		assert.Equal(t, []any{`$[0] == "users"`, `$[1] == "\\\"') OR TRUE --"`}, args)
 	})
 }
 
@@ -213,4 +223,23 @@ func (m *mockUseFilter) UseFilter(key string, matchers ...func(any) bool) bool {
 		}
 	}
 	return false
+}
+
+func TestFilterAccountAddressOnTransactions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact account uses jsonb argument", func(t *testing.T) {
+		t.Parallel()
+		result, args := filterAccountAddressOnTransactions("world", true, true)
+		assert.Equal(t, "sources @> ?::jsonb or destinations @> ?::jsonb", result)
+		assert.Equal(t, []any{`["world"]`, `["world"]`}, args)
+	})
+
+	t.Run("malicious partial account is not interpolated", func(t *testing.T) {
+		t.Parallel()
+		result, args := filterAccountAddressOnTransactions(`users:"') OR TRUE --:`, true, false)
+		assert.Equal(t, "sources_arrays @> ?::jsonb", result)
+		assert.NotContains(t, result, "OR TRUE")
+		assert.Equal(t, []any{"[{\"0\":\"users\",\"1\":\"\\\"') OR TRUE --\",\"3\":null}]"}, args)
+	})
 }


### PR DESCRIPTION
## Summary
- Parameterize ledger account address filters instead of interpolating address values into SQL
- Bind JSONB and JSONPath filter values through query args for accounts, volumes, transactions, and aggregated balances
- Add regression tests for malicious exact and partial address inputs

## Tests
- go test ./internal/storage/ledger -run 'TestBuildAddressFilterForLateral|TestFilterAccountAddressOnTransactions|TestFilterAccountAddressOnTransactionsBindsAddressJSON'
- go test ./internal/storage/ledger
- go test -race ./internal/storage/ledger
- go test ./...

## Note
- just tests was also run, but the full recipe failed only on TestElasticSearchDriver because the local Elasticsearch service healthcheck timed out with connection refused.