### PR TITLE
fix(storage): return TRUE for degenerate address filter patterns

### DIFF
--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -44,6 +44,9 @@ func filterAccountAddress(address, key string) string {
 		parts = append(parts, fmt.Sprintf("%s = '%s'", key, address))
 	}
 
+	if len(parts) == 0 {
+		return "TRUE"
+	}
 	return strings.Join(parts, " and ")
 }
 


### PR DESCRIPTION
## Summary

- `filterAccountAddress` returns an empty string `""` for patterns like `:`, `::`, or `...` where every segment is either empty or the wildcard `...`
- `bun.Where("")` then generates invalid SQL, producing a 500 on the volumes and accounts endpoints
- The fix returns `"TRUE"` when `parts` is empty, making the filter a no-op (matches all rows) rather than crashing
- This only activates for degenerate patterns — all valid filters like `:foo`, `foo:`, `account:user1` build a non-empty `parts` slice and are unaffected

## Test plan

- [ ] Filter volumes/accounts with address `:` — should return all results, no 500
- [ ] Filter volumes/accounts with address `:foo` — should still filter to matching accounts
- [ ] Existing test suite passes