### PR TITLE
fix(storage): escape address filter values to prevent SQL injection

### DIFF
--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -294,11 +294,12 @@ func filterAccountAddressOnTransactions(address string, source, destination bool
 			panic(err)
 		}
 
+		escaped := escapeSQL(string(data))
 		if source {
-			parts = append(parts, fmt.Sprintf("sources_arrays @> '%s'", string(data)))
+			parts = append(parts, fmt.Sprintf("sources_arrays @> '%s'", escaped))
 		}
 		if destination {
-			parts = append(parts, fmt.Sprintf("destinations_arrays @> '%s'", string(data)))
+			parts = append(parts, fmt.Sprintf("destinations_arrays @> '%s'", escaped))
 		}
 		return strings.Join(parts, " or ")
 	}
@@ -308,12 +309,13 @@ func filterAccountAddressOnTransactions(address string, source, destination bool
 		panic(err)
 	}
 
+	escaped := escapeSQL(string(data))
 	parts := make([]string, 0)
 	if source {
-		parts = append(parts, fmt.Sprintf("sources @> '%s'", string(data)))
+		parts = append(parts, fmt.Sprintf("sources @> '%s'", escaped))
 	}
 	if destination {
-		parts = append(parts, fmt.Sprintf("destinations @> '%s'", string(data)))
+		parts = append(parts, fmt.Sprintf("destinations @> '%s'", escaped))
 	}
 	return strings.Join(parts, " or ")
 }

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -25,6 +25,19 @@ func isPartialAddress(address string) bool {
 	return false
 }
 
+// escapeSQL escapes a value for safe embedding in a SQL single-quoted string literal.
+func escapeSQL(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// escapeJSONPath escapes a value for safe embedding in a JSONPath double-quoted
+// string that itself lives inside a SQL single-quoted literal.
+func escapeJSONPath(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`) // must be first
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return escapeSQL(s)
+}
+
 func filterAccountAddress(address, key string) string {
 	parts := make([]string, 0)
 
@@ -38,10 +51,10 @@ func filterAccountAddress(address, key string) string {
 			if len(segment) == 0 || segment == "..." {
 				continue
 			}
-			parts = append(parts, fmt.Sprintf("%s_array @@ ('$[%d] == \"%s\"')::jsonpath", key, i, segment))
+			parts = append(parts, fmt.Sprintf("%s_array @@ ('$[%d] == \"%s\"')::jsonpath", key, i, escapeJSONPath(segment)))
 		}
 	} else {
-		parts = append(parts, fmt.Sprintf("%s = '%s'", key, address))
+		parts = append(parts, fmt.Sprintf("%s = '%s'", key, escapeSQL(address)))
 	}
 
 	return strings.Join(parts, " and ")

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -185,6 +185,125 @@ func TestCollectAddressFilters(t *testing.T) {
 	})
 }
 
+func TestEscapeSQL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"world", "world"},
+		{"it's", "it''s"},
+		{"a'b'c", "a''b''c"},
+		{"no quotes here", "no quotes here"},
+		{"' OR '1'='1", "'' OR ''1''=''1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, escapeSQL(tc.input))
+		})
+	}
+}
+
+func TestEscapeJSONPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain segment", "foo", "foo"},
+		{"double quote", `fo"o`, `fo\"o`},
+		{"backslash", `fo\o`, `fo\\o`},
+		{"backslash then double quote", `\""`, `\\\"` + `\"`},
+		{"single quote", "fo'o", "fo''o"},
+		{"double quote and single quote", `f"o'b`, `f\"o''b`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, escapeJSONPath(tc.input))
+		})
+	}
+}
+
+func TestFilterAccountAddress_SQLInjection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact address with single quote is escaped", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("it's:me", "address")
+		// Must not contain an unescaped lone single quote that would break the literal
+		assert.Contains(t, result, "''s")
+		assert.NotContains(t, result, "address = 'it's")
+	})
+
+	t.Run("injection payload in exact address is neutralised", func(t *testing.T) {
+		t.Parallel()
+		payload := "doesnt_exist' OR '1'='1"
+		result := filterAccountAddress(payload, "address")
+		assert.Equal(t, "address = 'doesnt_exist'' OR ''1''=''1'", result)
+	})
+
+	t.Run("partial address segment with double quote is escaped in jsonpath", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress(`users:"admin":`, "address")
+		assert.Contains(t, result, `$[1] == "\"admin\""`)
+	})
+
+	t.Run("partial address segment with backslash is escaped", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress(`users:\foo:`, "address")
+		assert.Contains(t, result, `$[1] == "\\foo"`)
+	})
+
+	t.Run("partial address segment with single quote is escaped", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("users:it's:", "address")
+		assert.Contains(t, result, "''s")
+	})
+}
+
+func TestFilterAccountAddressOnTransactions_SQLInjection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact address with single quote is escaped", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("it's", true, true)
+		assert.NotContains(t, result, `'it's'`)
+		assert.Contains(t, result, `it''s`)
+	})
+
+	t.Run("injection payload in exact address is neutralised", func(t *testing.T) {
+		t.Parallel()
+		payload := "world' OR '1'='1"
+		result := filterAccountAddressOnTransactions(payload, true, false)
+		assert.NotContains(t, result, "OR '1'='1")
+		assert.Contains(t, result, `''`)
+	})
+
+	t.Run("partial address segment with single quote is escaped", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("users:it's:", true, false)
+		assert.NotContains(t, result, `'it's'`)
+		assert.Contains(t, result, `it''s`)
+	})
+
+	t.Run("injection payload in partial address segment is neutralised", func(t *testing.T) {
+		t.Parallel()
+		// The single quote that would close the SQL string literal must be doubled.
+		// The text may still appear inside the (now-safe) JSON string value.
+		payload := "users:x' OR '1'='1:"
+		result := filterAccountAddressOnTransactions(payload, true, false)
+		// Unescaped closing-quote pattern must not appear
+		assert.NotContains(t, result, "' OR '1'='1")
+		// But the escaped form must be present
+		assert.Contains(t, result, `'' OR ''1''=''1`)
+	})
+}
+
 // mockUseFilter implements the interface expected by collectAddressFilters.
 // It simulates RepositoryHandlerBuildContext.UseFilter behavior:
 // iterates all values for the given key and calls each matcher.

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -229,6 +229,78 @@ func TestEscapeJSONPath(t *testing.T) {
 	}
 }
 
+func TestFilterAccountAddress_NormalCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact address produces equality condition", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("world", "address")
+		assert.Equal(t, "address = 'world'", result)
+	})
+
+	t.Run("two-segment exact address", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("users:alice", "address")
+		assert.Equal(t, "address = 'users:alice'", result)
+	})
+
+	t.Run("partial address with trailing colon matches on segment", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("users:", "address")
+		assert.Equal(t, `address_array @@ ('$[0] == "users"')::jsonpath`, result)
+	})
+
+	t.Run("partial address with two fixed segments", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("users:alice:", "address")
+		assert.Contains(t, result, `$[0] == "users"`)
+		assert.Contains(t, result, `$[1] == "alice"`)
+	})
+
+	t.Run("wildcard suffix constrains length and segment", func(t *testing.T) {
+		t.Parallel()
+		// "users:..." means exactly 2 segments with "users" at position 0
+		result := filterAccountAddress("users:...", "address")
+		assert.Contains(t, result, "jsonb_array_length(address_array) = 2")
+		assert.Contains(t, result, `$[0] == "users"`)
+	})
+
+	t.Run("key prefix is applied correctly", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddress("world", "destination")
+		assert.Equal(t, "destination = 'world'", result)
+	})
+}
+
+func TestFilterAccountAddressOnTransactions_NormalCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact address source only", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("world", true, false)
+		assert.Equal(t, `sources @> '["world"]'`, result)
+	})
+
+	t.Run("exact address destination only", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("world", false, true)
+		assert.Equal(t, `destinations @> '["world"]'`, result)
+	})
+
+	t.Run("exact address source and destination joined with or", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("world", true, true)
+		assert.Equal(t, `sources @> '["world"]' or destinations @> '["world"]'`, result)
+	})
+
+	t.Run("partial address uses array containment", func(t *testing.T) {
+		t.Parallel()
+		result := filterAccountAddressOnTransactions("users:", true, false)
+		assert.Contains(t, result, "sources_arrays @> '")
+		assert.NotContains(t, result, "sources @> '")
+	})
+}
+
 func TestFilterAccountAddress_SQLInjection(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`filterAccountAddress` was interpolating user-supplied address filter values directly into SQL string literals using `fmt.Sprintf`, with no escaping. This allowed SQL injection via single-quote characters in filter values passed to the accounts and volumes endpoints.

**Confirmed via testing:**
- `{"$match": {"address": "doesnt_exist' OR '1'='1"}}` returned all accounts in the ledger instead of zero results

**Blast radius (low):** injection is constrained to the authenticated user's ledger scope (table-level isolation holds) and the Go PostgreSQL driver blocks multi-statement execution, so no writes are possible. The risk is an authenticated user reading all account data/metadata within their ledger, bypassing any address-based filtering.

## Fix

Added two helpers:
- `escapeSQL` — escapes `'` → `''` for safe embedding in SQL string literals
- `escapeJSONPath` — additionally escapes `\` and `"` for safe embedding in JSONPath double-quoted strings inside SQL literals

Applied to both injection points in `filterAccountAddress`:
- Exact address path: `address = '%s'` → uses `escapeSQL`
- Partial address / JSONPath path: `$[i] == "%s"` → uses `escapeJSONPath`

## Test plan

- [ ] `{"$match": {"address": "doesnt_exist' OR '1'='1"}}` now returns 0 results
- [ ] Valid partial filters like `{"$match": {"address": ":foo"}}` still work correctly
- [ ] Existing test suite passes