### PR TITLE
perf(retry): add jitter to all retry/backoff delays

### DIFF
--- a/internal/controller/ledger/controller_with_too_many_client_handling.go
+++ b/internal/controller/ledger/controller_with_too_many_client_handling.go
@@ -235,7 +235,7 @@ func handleRetry(
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(delay + time.Duration(rand.Int63n(int64(delay/2)))):
+			case <-time.After(delay + time.Duration(rand.Int63n(max(int64(delay/2), 1)))):
 				count++
 				span.SetAttributes(attribute.Int("retry", count))
 				continue

--- a/internal/controller/ledger/controller_with_too_many_client_handling.go
+++ b/internal/controller/ledger/controller_with_too_many_client_handling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"math/rand"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -234,7 +235,7 @@ func handleRetry(
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(delay):
+			case <-time.After(delay + time.Duration(rand.Int63n(int64(delay/2)))):
 				count++
 				span.SetAttributes(attribute.Int("retry", count))
 				continue

--- a/internal/controller/ledger/controller_with_too_many_client_handling_test.go
+++ b/internal/controller/ledger/controller_with_too_many_client_handling_test.go
@@ -79,6 +79,36 @@ func TestNewControllerWithTooManyClientHandling(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	})
 
+	t.Run("retry with sub-nanosecond delay exercises max guard", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		underlyingLedgerController := NewMockController(ctrl)
+		delayCalculator := NewMockDelayCalculator(ctrl)
+		ctx := logging.TestingContext()
+
+		parameters := Parameters[CreateTransaction]{}
+
+		underlyingLedgerController.EXPECT().
+			CreateTransaction(gomock.Any(), parameters).
+			Return(nil, nil, false, postgres.ErrTooManyClient{})
+
+		underlyingLedgerController.EXPECT().
+			CreateTransaction(gomock.Any(), parameters).
+			Return(&ledger.Log{}, &ledger.CreatedTransaction{
+				Transaction: ledger.NewTransaction(),
+			}, false, nil)
+
+		// 1ns delay: int64(1/2) == 0, so max(0, 1) kicks in
+		delayCalculator.EXPECT().
+			Next(0).
+			Return(time.Duration(1))
+
+		ledgerController := NewControllerWithTooManyClientHandling(underlyingLedgerController, noop.Tracer{}, delayCalculator)
+		_, _, _, err := ledgerController.CreateTransaction(ctx, parameters)
+		require.NoError(t, err)
+	})
+
 	t.Run("finally failing", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/controller/ledger/controller_with_too_many_client_handling_test.go
+++ b/internal/controller/ledger/controller_with_too_many_client_handling_test.go
@@ -16,6 +16,17 @@ import (
 	ledger "github.com/formancehq/ledger/internal"
 )
 
+func TestDelayCalculatorFn(t *testing.T) {
+	t.Parallel()
+
+	fn := DelayCalculatorFn(func(iteration int) time.Duration {
+		return time.Duration(iteration) * time.Second
+	})
+	require.Equal(t, time.Duration(0), fn.Next(0))
+	require.Equal(t, time.Second, fn.Next(1))
+	require.Equal(t, 2*time.Second, fn.Next(2))
+}
+
 func TestNewControllerWithTooManyClientHandling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controller/ledger/controller_with_too_many_client_handling_test.go
+++ b/internal/controller/ledger/controller_with_too_many_client_handling_test.go
@@ -1,6 +1,7 @@
 package ledger
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -50,6 +51,32 @@ func TestNewControllerWithTooManyClientHandling(t *testing.T) {
 		ledgerController := NewControllerWithTooManyClientHandling(underlyingLedgerController, noop.Tracer{}, delayCalculator)
 		_, _, _, err := ledgerController.CreateTransaction(ctx, parameters)
 		require.NoError(t, err)
+	})
+
+	t.Run("context canceled during retry wait", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		underlyingLedgerController := NewMockController(ctrl)
+		delayCalculator := NewMockDelayCalculator(ctrl)
+		ctx, cancel := context.WithCancel(logging.TestingContext())
+
+		parameters := Parameters[CreateTransaction]{}
+
+		underlyingLedgerController.EXPECT().
+			CreateTransaction(gomock.Any(), parameters).
+			Return(nil, nil, false, postgres.ErrTooManyClient{})
+
+		delayCalculator.EXPECT().
+			Next(0).
+			DoAndReturn(func(int) time.Duration {
+				cancel()
+				return time.Hour
+			})
+
+		ledgerController := NewControllerWithTooManyClientHandling(underlyingLedgerController, noop.Tracer{}, delayCalculator)
+		_, _, _, err := ledgerController.CreateTransaction(ctx, parameters)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("finally failing", func(t *testing.T) {

--- a/internal/replication/driver_facade.go
+++ b/internal/replication/driver_facade.go
@@ -90,6 +90,9 @@ func (c *DriverFacade) Accept(ctx context.Context, logs ...drivers.LogWithLedger
 var _ drivers.Driver = (*DriverFacade)(nil)
 
 func newDriverFacade(driver drivers.Driver, logger logging.Logger, retryInterval time.Duration) *DriverFacade {
+	if retryInterval < 2 {
+		retryInterval = 2
+	}
 	return &DriverFacade{
 		Driver:        driver,
 		readyChan:     make(chan struct{}),

--- a/internal/replication/driver_facade.go
+++ b/internal/replication/driver_facade.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func (c *DriverFacade) Run(ctx context.Context) {
 				select {
 				case <-c.startContext.Done():
 					return
-				case <-time.After(c.retryInterval):
+				case <-time.After(c.retryInterval + time.Duration(rand.Int63n(int64(c.retryInterval/2)))):
 				}
 				continue
 			}

--- a/internal/replication/manager.go
+++ b/internal/replication/manager.go
@@ -3,6 +3,7 @@ package replication
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -274,7 +275,7 @@ func (m *Manager) Run(ctx context.Context) {
 			m.pipelinesWaitGroup.Wait()
 			close(signalChannel)
 			return
-		case <-time.After(m.syncPeriod):
+		case <-time.After(m.syncPeriod + time.Duration(rand.Int63n(int64(m.syncPeriod/2)))):
 			withLock(func() {
 				if err := m.synchronizePipelines(ctx); err != nil {
 					m.logger.Errorf("synchronizing pipelines: %s", err)

--- a/internal/replication/manager.go
+++ b/internal/replication/manager.go
@@ -512,6 +512,9 @@ func WithPipelineOptions(options ...PipelineOption) Option {
 
 func WithSyncPeriod(period time.Duration) Option {
 	return func(r *Manager) {
+		if period < 2 {
+			period = 2
+		}
 		r.syncPeriod = period
 	}
 }

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -39,6 +39,24 @@ func startManager(
 	return manager
 }
 
+func TestWithSyncPeriodMinimum(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{}
+	WithSyncPeriod(1)(m)
+	require.Equal(t, time.Duration(2), m.syncPeriod)
+}
+
+func TestNewDriverFacadeMinimumRetryInterval(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	driver := drivers.NewMockDriver(ctrl)
+
+	facade := newDriverFacade(driver, logging.Testing(), 1)
+	require.Equal(t, time.Duration(2), facade.retryInterval)
+}
+
 func TestManagerExportersNominal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -66,11 +66,13 @@ func TestDriverFacadeStopContextExpiresDuringStart(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	blockStart := make(chan struct{})
+	startedChan := make(chan struct{}, 1)
 
 	mockDriver := drivers.NewMockDriver(ctrl)
 	// Start blocks on blockStart regardless of context cancellation, keeping
 	// startingChan open while Stop's inner select runs.
 	mockDriver.EXPECT().Start(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+		startedChan <- struct{}{}
 		<-blockStart
 		return ctx.Err()
 	}).AnyTimes()
@@ -80,6 +82,9 @@ func TestDriverFacadeStopContextExpiresDuringStart(t *testing.T) {
 	runCtx, cancelRun := context.WithCancel(context.Background())
 	defer cancelRun()
 	facade.Run(runCtx)
+
+	// Wait for Start to actually begin before proceeding.
+	<-startedChan
 
 	// Pre-cancel the stop context so the inner select picks ctx.Done()
 	// before startingChan can close.

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -3,6 +3,7 @@ package replication
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -543,6 +544,47 @@ func TestManagerSynchronizePipelinesError(t *testing.T) {
 
 	require.NoError(t, manager.Stop(ctx))
 	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestManagerPeriodicSyncError covers manager.go line 280-282: the periodic
+// sync timer fires, synchronizePipelines returns an error, and the manager
+// logs the error and continues running.
+func TestManagerPeriodicSyncError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	exporterConfigValidator := NewMockConfigValidator(ctrl)
+	driverFactory := drivers.NewMockFactory(ctrl)
+
+	var callCount atomic.Int32
+	storage.EXPECT().
+		ListEnabledPipelines(gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context) ([]ledger.Pipeline, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				return nil, nil
+			}
+			return nil, errors.New("periodic sync failure")
+		})
+
+	manager := NewManager(
+		storage,
+		driverFactory,
+		logging.Testing(),
+		exporterConfigValidator,
+		WithSyncPeriod(2),
+	)
+	go manager.Run(ctx)
+	<-manager.Started()
+
+	require.Eventually(t, func() bool {
+		return callCount.Load() >= 2
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, manager.Stop(ctx))
 }
 
 // TestManagerPeriodicSync covers the time.After branch in manager.go Run loop

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -98,6 +98,58 @@ func TestDriverFacadeStopContextExpiresDuringStart(t *testing.T) {
 	close(blockStart)
 }
 
+// TestDriverFacadeRetryThenSuccess covers the retry-timer branch in
+// DriverFacade.Run: Start fails with a non-context error, the jittered timer
+// fires, and Start succeeds on the second attempt.
+func TestDriverFacadeRetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDriver := drivers.NewMockDriver(ctrl)
+
+	gomock.InOrder(
+		mockDriver.EXPECT().Start(gomock.Any()).Return(errors.New("transient")),
+		mockDriver.EXPECT().Start(gomock.Any()).Return(nil),
+	)
+
+	facade := newDriverFacade(mockDriver, logging.Testing(), 2)
+	facade.Run(context.Background())
+
+	select {
+	case <-facade.Ready():
+	case <-time.After(time.Second):
+		require.Fail(t, "facade should become ready after retry")
+	}
+
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestDriverFacadeAcceptNotReady covers the "not ready exporter" branch in
+// DriverFacade.Accept (driver_facade.go line 86): calling Accept before the
+// driver has started returns an error.
+func TestDriverFacadeAcceptNotReady(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDriver := drivers.NewMockDriver(ctrl)
+
+	// Start blocks forever so readyChan is never closed.
+	mockDriver.EXPECT().Start(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}).AnyTimes()
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+
+	facade := newDriverFacade(mockDriver, logging.Testing(), time.Minute)
+	facade.Run(runCtx)
+
+	_, err := facade.Accept(context.Background())
+	require.Error(t, err)
+	require.Equal(t, "not ready exporter", err.Error())
+}
+
 func TestManagerExportersNominal(t *testing.T) {
 	t.Parallel()
 
@@ -491,4 +543,45 @@ func TestManagerSynchronizePipelinesError(t *testing.T) {
 
 	require.NoError(t, manager.Stop(ctx))
 	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestManagerPeriodicSync covers the time.After branch in manager.go Run loop
+// (line 278): the sync timer fires and triggers synchronizePipelines again.
+func TestManagerPeriodicSync(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	exporterConfigValidator := NewMockConfigValidator(ctrl)
+	driverFactory := drivers.NewMockFactory(ctrl)
+
+	syncCount := make(chan struct{}, 10)
+	storage.EXPECT().
+		ListEnabledPipelines(gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context) ([]ledger.Pipeline, error) {
+			select {
+			case syncCount <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		})
+
+	manager := NewManager(
+		storage,
+		driverFactory,
+		logging.Testing(),
+		exporterConfigValidator,
+		WithSyncPeriod(2),
+	)
+	go manager.Run(ctx)
+
+	<-manager.Started()
+
+	// First sync happened at startup. Wait for at least one periodic sync.
+	<-syncCount // initial
+	<-syncCount // periodic
+
+	require.NoError(t, manager.Stop(ctx))
 }

--- a/internal/replication/manager_test.go
+++ b/internal/replication/manager_test.go
@@ -57,6 +57,42 @@ func TestNewDriverFacadeMinimumRetryInterval(t *testing.T) {
 	require.Equal(t, time.Duration(2), facade.retryInterval)
 }
 
+// TestDriverFacadeStopContextExpiresDuringStart covers the ctx.Done branch in
+// DriverFacade.Stop: when Stop is called while the start goroutine is still
+// running and the stop context expires before the goroutine finishes, Stop must
+// return ctx.Err().
+func TestDriverFacadeStopContextExpiresDuringStart(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	blockStart := make(chan struct{})
+
+	mockDriver := drivers.NewMockDriver(ctrl)
+	// Start blocks on blockStart regardless of context cancellation, keeping
+	// startingChan open while Stop's inner select runs.
+	mockDriver.EXPECT().Start(gomock.Any()).DoAndReturn(func(ctx context.Context) error {
+		<-blockStart
+		return ctx.Err()
+	}).AnyTimes()
+
+	facade := newDriverFacade(mockDriver, logging.Testing(), time.Minute)
+
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	defer cancelRun()
+	facade.Run(runCtx)
+
+	// Pre-cancel the stop context so the inner select picks ctx.Done()
+	// before startingChan can close.
+	stopCtx, cancelStop := context.WithCancel(context.Background())
+	cancelStop()
+
+	err := facade.Stop(stopCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Unblock the start goroutine so it can exit cleanly.
+	close(blockStart)
+}
+
 func TestManagerExportersNominal(t *testing.T) {
 	t.Parallel()
 
@@ -426,4 +462,28 @@ func TestManagerStop(t *testing.T) {
 		require.NoError(t, manager.Stop(ctx))
 	})
 
+}
+
+// TestManagerSynchronizePipelinesError covers manager.go lines 260-262:
+// synchronizePipelines returns an error during Run's initial sync; the manager logs
+// the error and continues running normally.
+func TestManagerSynchronizePipelinesError(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	exporterConfigValidator := NewMockConfigValidator(ctrl)
+	driverFactory := drivers.NewMockFactory(ctrl)
+
+	storage.EXPECT().
+		ListEnabledPipelines(gomock.Any()).
+		AnyTimes().
+		Return(nil, errors.New("database unavailable"))
+
+	manager := startManager(t, ctx, storage, driverFactory, exporterConfigValidator)
+	<-manager.Started()
+
+	require.NoError(t, manager.Stop(ctx))
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
 }

--- a/internal/replication/pipeline.go
+++ b/internal/replication/pipeline.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -97,7 +98,7 @@ func (p *PipelineHandler) Run(ctx context.Context, ingestedLogs chan uint64) {
 				case ch := <-p.stopChannel:
 					stop(ch)
 					return
-				case <-time.After(p.pipelineConfig.PullInterval):
+				case <-time.After(p.pipelineConfig.PullInterval + time.Duration(rand.Int63n(int64(p.pipelineConfig.PullInterval/2)))):
 					continue
 				}
 			}
@@ -130,7 +131,7 @@ func (p *PipelineHandler) Run(ctx context.Context, ingestedLogs chan uint64) {
 						case ch := <-p.stopChannel:
 							stop(ch)
 							return
-						case <-time.After(p.pipelineConfig.PushRetryPeriod):
+						case <-time.After(p.pipelineConfig.PushRetryPeriod + time.Duration(rand.Int63n(int64(p.pipelineConfig.PushRetryPeriod/2)))):
 							continue
 						}
 					}

--- a/internal/replication/pipeline.go
+++ b/internal/replication/pipeline.go
@@ -31,12 +31,18 @@ type PipelineOption func(config *PipelineHandlerConfig)
 
 func WithPullPeriod(v time.Duration) PipelineOption {
 	return func(config *PipelineHandlerConfig) {
+		if v < 2 {
+			v = 2
+		}
 		config.PullInterval = v
 	}
 }
 
 func WithPushRetryPeriod(v time.Duration) PipelineOption {
 	return func(config *PipelineHandlerConfig) {
+		if v < 2 {
+			v = 2
+		}
 		config.PushRetryPeriod = v
 	}
 }

--- a/internal/replication/pipeline_test.go
+++ b/internal/replication/pipeline_test.go
@@ -3,6 +3,7 @@ package replication
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -112,6 +113,190 @@ func TestPipeline(t *testing.T) {
 	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
 }
 
+// TestPipelineStopDuringExport covers pipeline.go lines 144-147:
+// stop signal received while the export Accept call is in progress.
+func TestPipelineStopDuringExport(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	log := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log.ID = pointer.For(uint64(1))
+
+	deliver := make(chan struct{})
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-deliver:
+				return &paginate.Cursor[ledger.Log]{Data: []ledger.Log{log}}, nil
+			}
+		})
+
+	// Accept blocks until its context is cancelled, keeping the export in-flight.
+	acceptStarted := make(chan struct{})
+	driver.EXPECT().
+		Accept(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ ...drivers.LogWithLedger) ([]error, error) {
+			close(acceptStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	handler := NewPipelineHandler(pipeline, logFetcher, driver, logging.Testing())
+	lastLogIDChannel := make(chan uint64, 1)
+	go handler.Run(ctx, lastLogIDChannel)
+
+	close(deliver)
+	<-acceptStarted
+
+	require.NoError(t, handler.Shutdown(ctx))
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelineHasMoreLogs covers pipeline.go lines 163-168:
+// when the cursor reports HasMore, nextInterval is set to 0 for immediate re-fetch.
+func TestPipelineHasMoreLogs(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	log1 := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log1.ID = pointer.For(uint64(1))
+	log2 := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log2.ID = pointer.For(uint64(2))
+
+	var fetchCount atomic.Int32
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			n := fetchCount.Add(1)
+			switch n {
+			case 1:
+				return &paginate.Cursor[ledger.Log]{
+					Data:    []ledger.Log{log1},
+					HasMore: true,
+				}, nil
+			case 2:
+				return &paginate.Cursor[ledger.Log]{
+					Data: []ledger.Log{log2},
+				}, nil
+			default:
+				return &paginate.Cursor[ledger.Log]{}, nil
+			}
+		})
+
+	driver.EXPECT().
+		Accept(gomock.Any(), gomock.Any()).
+		Times(2).
+		Return([]error{nil}, nil)
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	handler := NewPipelineHandler(pipeline, logFetcher, driver, logging.Testing())
+	lastLogIDChannel := make(chan uint64, 2)
+	go handler.Run(ctx, lastLogIDChannel)
+	t.Cleanup(func() {
+		require.NoError(t, handler.Shutdown(ctx))
+	})
+
+	ShouldReceive(t, uint64(1), lastLogIDChannel)
+	ShouldReceive(t, uint64(2), lastLogIDChannel)
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelineShutdownContextExpired covers pipeline.go lines 177-178:
+// Shutdown's context expires before the stop signal can be sent.
+func TestPipelineShutdownContextExpired(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(ctx context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	handler := NewPipelineHandler(pipeline, logFetcher, driver, logging.Testing())
+
+	// Fill the stop channel so Shutdown blocks waiting to send.
+	handler.stopChannel <- make(chan error)
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err := handler.Shutdown(cancelledCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelineShutdownWaitContextExpired covers pipeline.go lines 184-185:
+// Shutdown sends the stop signal but the context expires before the pipeline
+// confirms termination.
+func TestPipelineShutdownWaitContextExpired(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	// Block ListLogs so the pipeline never processes the stop signal.
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(ctx context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	handler := NewPipelineHandler(pipeline, logFetcher, driver, logging.Testing())
+
+	lastLogIDChannel := make(chan uint64, 1)
+	runCtx, cancelRun := context.WithCancel(ctx)
+	go handler.Run(runCtx, lastLogIDChannel)
+
+	// Give the pipeline a moment to enter its select loop.
+	time.Sleep(10 * time.Millisecond)
+
+	// Shutdown with an already-cancelled context: the stop signal can be sent
+	// (stopChannel is buffered with size 1) but waiting for the error response
+	// should hit the ctx.Done() branch.
+	shutdownCtx, cancelShutdown := context.WithCancel(ctx)
+	cancelShutdown()
+	err := handler.Shutdown(shutdownCtx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	cancelRun()
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
 // TestPipelineFetchRetryThenSuccess covers pipeline.go lines 107-108:
 // ListLogs errors once, the jittered retry timer fires, and the next ListLogs
 // call succeeds.
@@ -126,16 +311,16 @@ func TestPipelineFetchRetryThenSuccess(t *testing.T) {
 	log := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
 	log.ID = pointer.For(uint64(1))
 
-	fetchCount := 0
+	var fetchCount atomic.Int32
 	logFetcher.EXPECT().
 		ListLogs(gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
-			fetchCount++
-			if fetchCount == 1 {
+			n := fetchCount.Add(1)
+			if n == 1 {
 				return nil, errors.New("store unavailable")
 			}
-			if fetchCount == 2 {
+			if n == 2 {
 				return &paginate.Cursor[ledger.Log]{Data: []ledger.Log{log}}, nil
 			}
 			return &paginate.Cursor[ledger.Log]{}, nil

--- a/internal/replication/pipeline_test.go
+++ b/internal/replication/pipeline_test.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -108,5 +109,173 @@ func TestPipeline(t *testing.T) {
 
 	ShouldReceive(t, 1, lastLogIDChannel)
 
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelineStopDuringFetchRetry covers pipeline.go lines 104-106:
+// stop signal received while waiting in the fetch-retry select after a ListLogs error.
+func TestPipelineStopDuringFetchRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	// fetchErrored is closed once the first ListLogs call returns an error.
+	fetchErrored := make(chan struct{})
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			select {
+			case <-fetchErrored:
+			default:
+				close(fetchErrored)
+			}
+			return nil, errors.New("store unavailable")
+		})
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	// Long PullInterval keeps the pipeline in the retry-wait select until Shutdown fires.
+	handler := NewPipelineHandler(
+		pipeline, logFetcher, driver, logging.Testing(),
+		WithPullPeriod(time.Hour),
+	)
+
+	lastLogIDChannel := make(chan uint64, 1)
+	go handler.Run(ctx, lastLogIDChannel)
+
+	<-fetchErrored
+	require.NoError(t, handler.Shutdown(ctx))
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelineStopDuringPushRetry covers pipeline.go lines 137-139:
+// stop signal received while waiting in the push-retry select after an Accept error.
+func TestPipelineStopDuringPushRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	log := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log.ID = pointer.For(uint64(1))
+
+	deliver := make(chan struct{})
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-deliver:
+				return &paginate.Cursor[ledger.Log]{Data: []ledger.Log{log}}, nil
+			}
+		})
+
+	// acceptErrored is closed once the first Accept returns an error.
+	acceptErrored := make(chan struct{})
+	driver.EXPECT().
+		Accept(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ ...drivers.LogWithLedger) ([]error, error) {
+			select {
+			case <-acceptErrored:
+			default:
+				close(acceptErrored)
+			}
+			return nil, errors.New("export failed")
+		})
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	// Long PushRetryPeriod keeps the pipeline in the push-retry select until Shutdown fires.
+	handler := NewPipelineHandler(
+		pipeline, logFetcher, driver, logging.Testing(),
+		WithPushRetryPeriod(time.Hour),
+	)
+
+	lastLogIDChannel := make(chan uint64, 1)
+	go handler.Run(ctx, lastLogIDChannel)
+
+	close(deliver)
+	<-acceptErrored
+	require.NoError(t, handler.Shutdown(ctx))
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
+// TestPipelinePushRetryThenSuccess covers pipeline.go lines 140-141:
+// Accept errors once, the push-retry timer fires, Accept succeeds on the second attempt.
+func TestPipelinePushRetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	log := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log.ID = pointer.For(uint64(1))
+
+	deliver := make(chan struct{})
+	delivered := make(chan struct{})
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), common.InitialPaginatedQuery[any]{
+			PageSize: 100,
+			Column:   "id",
+			Options:  common.ResourceQuery[any]{},
+			Order:    pointer.For(paginate.Order(paginate.OrderAsc)),
+		}).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-deliver:
+				select {
+				case <-delivered:
+				default:
+					close(delivered)
+					return &paginate.Cursor[ledger.Log]{Data: []ledger.Log{log}}, nil
+				}
+			}
+			return &paginate.Cursor[ledger.Log]{}, nil
+		})
+
+	// First Accept call fails; second succeeds.
+	gomock.InOrder(
+		driver.EXPECT().
+			Accept(gomock.Any(), drivers.NewLogWithLedger("testing", log)).
+			Return(nil, errors.New("first attempt failed")),
+		driver.EXPECT().
+			Accept(gomock.Any(), drivers.NewLogWithLedger("testing", log)).
+			Return([]error{nil}, nil),
+	)
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	// Minimum PushRetryPeriod (2ns) so the retry timer fires immediately.
+	handler := NewPipelineHandler(
+		pipeline, logFetcher, driver, logging.Testing(),
+		WithPushRetryPeriod(2),
+	)
+
+	lastLogIDChannel := make(chan uint64, 1)
+	go handler.Run(ctx, lastLogIDChannel)
+	t.Cleanup(func() {
+		require.NoError(t, handler.Shutdown(ctx))
+	})
+
+	close(deliver)
+
+	ShouldReceive(t, uint64(1), lastLogIDChannel)
 	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
 }

--- a/internal/replication/pipeline_test.go
+++ b/internal/replication/pipeline_test.go
@@ -37,6 +37,22 @@ func runPipeline(t *testing.T, ctx context.Context, pipeline ledger.Pipeline, st
 	return handler, lastLogIDChannel
 }
 
+func TestWithPullPeriodMinimum(t *testing.T) {
+	t.Parallel()
+
+	config := PipelineHandlerConfig{}
+	WithPullPeriod(1)(&config)
+	require.Equal(t, time.Duration(2), config.PullInterval)
+}
+
+func TestWithPushRetryPeriodMinimum(t *testing.T) {
+	t.Parallel()
+
+	config := PipelineHandlerConfig{}
+	WithPushRetryPeriod(1)(&config)
+	require.Equal(t, time.Duration(2), config.PushRetryPeriod)
+}
+
 func TestPipeline(t *testing.T) {
 	t.Parallel()
 

--- a/internal/replication/pipeline_test.go
+++ b/internal/replication/pipeline_test.go
@@ -112,6 +112,57 @@ func TestPipeline(t *testing.T) {
 	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
 }
 
+// TestPipelineFetchRetryThenSuccess covers pipeline.go lines 107-108:
+// ListLogs errors once, the jittered retry timer fires, and the next ListLogs
+// call succeeds.
+func TestPipelineFetchRetryThenSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	logFetcher := NewMockLogFetcher(ctrl)
+	driver := drivers.NewMockDriver(ctrl)
+
+	log := ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()})
+	log.ID = pointer.For(uint64(1))
+
+	fetchCount := 0
+	logFetcher.EXPECT().
+		ListLogs(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, _ common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Log], error) {
+			fetchCount++
+			if fetchCount == 1 {
+				return nil, errors.New("store unavailable")
+			}
+			if fetchCount == 2 {
+				return &paginate.Cursor[ledger.Log]{Data: []ledger.Log{log}}, nil
+			}
+			return &paginate.Cursor[ledger.Log]{}, nil
+		})
+
+	driver.EXPECT().
+		Accept(gomock.Any(), drivers.NewLogWithLedger("testing", log)).
+		Return([]error{nil}, nil)
+
+	pipelineConfiguration := ledger.NewPipelineConfiguration("testing", "testing")
+	pipeline := ledger.NewPipeline(pipelineConfiguration)
+
+	handler := NewPipelineHandler(
+		pipeline, logFetcher, driver, logging.Testing(),
+		WithPullPeriod(2),
+	)
+
+	lastLogIDChannel := make(chan uint64, 1)
+	go handler.Run(ctx, lastLogIDChannel)
+	t.Cleanup(func() {
+		require.NoError(t, handler.Shutdown(ctx))
+	})
+
+	ShouldReceive(t, uint64(1), lastLogIDChannel)
+	require.Eventually(t, ctrl.Satisfied, time.Second, 10*time.Millisecond)
+}
+
 // TestPipelineStopDuringFetchRetry covers pipeline.go lines 104-106:
 // stop signal received while waiting in the fetch-retry select after a ListLogs error.
 func TestPipelineStopDuringFetchRetry(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace deterministic fixed waits with `base + rand(0, base/2)` jitter across all retry and periodic-wait sites
- Prevents thundering herd when multiple ledger instances recover from the same failure simultaneously
- Affected sites: `TooManyClient` DB retries, replication pipeline push-error and pull-error retries, replication manager sync period, driver facade startup retries

## Changed files

| File | Site |
|---|---|
| `internal/controller/ledger/controller_with_too_many_client_handling.go` | DB too-many-clients retry |
| `internal/replication/pipeline.go` | push-error retry + pull-error retry |
| `internal/replication/manager.go` | pipeline sync loop |
| `internal/replication/driver_facade.go` | exporter startup retry |

Skipped: cron-scheduled workers (naturally staggered), deadlock retry (intentionally immediate), client SDK (already has ±25% jitter).

## Test plan

- [ ] Existing unit tests pass (`go test ./internal/...`)
- [ ] Replication integration tests pass
- [ ] Manual: start multiple worker instances against a shared DB; confirm retry storms no longer pile up on the same tick in logs