### PR TITLE
fix(metrics): emit ledger as a datapoint label, not a scope attribute

### DIFF
--- a/internal/controller/system/controller.go
+++ b/internal/controller/system/controller.go
@@ -148,9 +148,24 @@ func (ctrl *DefaultController) GetLedgerController(ctx context.Context, name str
 			attribute.String("ledger", name),
 		}
 
-		meter := ctrl.meterProvider.Meter("ledger", metric.WithInstrumentationAttributes(
+		// The ledger name is injected as a datapoint attribute (a real metric
+		// label) via tracing.MeterWithAttributes, NOT as a metrics
+		// instrumentation-scope attribute. Scope attributes are dropped by the
+		// OTLP -> Prometheus/VictoriaMetrics translation (not promoted to labels),
+		// which collapsed every ledger's per-operation histogram (e.g.
+		// controller.create_transaction -> CreateTransaction) into a single series
+		// holding the conflicting cumulative values of many ledgers; VM read the
+		// downward jumps as counter resets and turned rate() into garbage.
+		//
+		// The underlying meter is intentionally created without instrumentation
+		// attributes: a single shared "ledger" meter is reused across all ledgers
+		// (the per-ledger identity rides on the datapoint), which avoids retaining
+		// a distinct meter + instrument set per ledger in memory and removes any
+		// double-label risk should scope-attribute promotion ever be enabled.
+		meter := tracing.MeterWithAttributes(
+			ctrl.meterProvider.Meter("ledger"),
 			instrumentationAttributes...,
-		))
+		)
 		tracer := ctrl.tracerProvider.Tracer("ledger", trace.WithInstrumentationAttributes(
 			instrumentationAttributes...,
 		))

--- a/internal/tracing/meter.go
+++ b/internal/tracing/meter.go
@@ -1,0 +1,199 @@
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// MeterWithAttributes wraps a metric.Meter so that the given attributes are
+// injected as *datapoint* attributes (i.e. real metric labels) on every
+// measurement recorded by the synchronous instruments it creates. Caller-
+// supplied attributes on each Record/Add are preserved and take precedence on
+// key conflicts.
+//
+// Why this exists: OpenTelemetry instrumentation-scope attributes are dropped
+// by the OTLP -> Prometheus/VictoriaMetrics translation (they are not promoted
+// to labels). Carrying per-ledger identity only on the meter scope therefore
+// collapsed every ledger's series into one, so a single time series ended up
+// holding the conflicting cumulative values of many ledgers. VictoriaMetrics
+// read the downward jumps as counter resets, which made rate() on cumulative
+// series such as CreateTransaction_count produce garbage. Promoting the
+// identity to a datapoint attribute turns it into a proper label, yielding one
+// monotonic series per (ledger, operation).
+//
+// Coverage: all synchronous instruments (Int64/Float64 Counter,
+// UpDownCounter, Histogram, Gauge) inject the attributes. Asynchronous
+// (observable) instruments are NOT covered: their callbacks would have to apply
+// the attributes at observation time, which this wrapper cannot do. If a future
+// metric needs the labels on an observable instrument, attach them explicitly
+// in its callback.
+func MeterWithAttributes(meter metric.Meter, attrs ...attribute.KeyValue) metric.Meter {
+	return attrMeter{
+		Meter: meter,
+		opt:   metric.WithAttributeSet(attribute.NewSet(attrs...)),
+	}
+}
+
+// attrMeter embeds metric.Meter so it satisfies the full interface (including
+// the embedded.Meter compatibility marker); it overrides the synchronous
+// instrument constructors to wrap the returned instruments. Asynchronous
+// constructors fall through to the wrapped meter unchanged.
+type attrMeter struct {
+	metric.Meter
+	opt metric.MeasurementOption
+}
+
+func (m attrMeter) Int64Counter(name string, options ...metric.Int64CounterOption) (metric.Int64Counter, error) {
+	i, err := m.Meter.Int64Counter(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrInt64Counter{Int64Counter: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Int64UpDownCounter(name string, options ...metric.Int64UpDownCounterOption) (metric.Int64UpDownCounter, error) {
+	i, err := m.Meter.Int64UpDownCounter(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrInt64UpDownCounter{Int64UpDownCounter: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Int64Histogram(name string, options ...metric.Int64HistogramOption) (metric.Int64Histogram, error) {
+	i, err := m.Meter.Int64Histogram(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrInt64Histogram{Int64Histogram: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Int64Gauge(name string, options ...metric.Int64GaugeOption) (metric.Int64Gauge, error) {
+	i, err := m.Meter.Int64Gauge(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrInt64Gauge{Int64Gauge: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Float64Counter(name string, options ...metric.Float64CounterOption) (metric.Float64Counter, error) {
+	i, err := m.Meter.Float64Counter(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrFloat64Counter{Float64Counter: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Float64UpDownCounter(name string, options ...metric.Float64UpDownCounterOption) (metric.Float64UpDownCounter, error) {
+	i, err := m.Meter.Float64UpDownCounter(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrFloat64UpDownCounter{Float64UpDownCounter: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Float64Histogram(name string, options ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	i, err := m.Meter.Float64Histogram(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrFloat64Histogram{Float64Histogram: i, opt: m.opt}, nil
+}
+
+func (m attrMeter) Float64Gauge(name string, options ...metric.Float64GaugeOption) (metric.Float64Gauge, error) {
+	i, err := m.Meter.Float64Gauge(name, options...)
+	if err != nil {
+		return i, err
+	}
+	return attrFloat64Gauge{Float64Gauge: i, opt: m.opt}, nil
+}
+
+// recordOpts prepends the injected option so caller options (applied later)
+// win on key conflicts. The len==0 fast path avoids an allocation on the hot
+// path, which is the common case for these instruments.
+func recordOpts(opt metric.MeasurementOption, options []metric.RecordOption) []metric.RecordOption {
+	if len(options) == 0 {
+		return []metric.RecordOption{opt}
+	}
+	return append([]metric.RecordOption{opt}, options...)
+}
+
+func addOpts(opt metric.MeasurementOption, options []metric.AddOption) []metric.AddOption {
+	if len(options) == 0 {
+		return []metric.AddOption{opt}
+	}
+	return append([]metric.AddOption{opt}, options...)
+}
+
+type attrInt64Counter struct {
+	metric.Int64Counter
+	opt metric.MeasurementOption
+}
+
+func (c attrInt64Counter) Add(ctx context.Context, incr int64, options ...metric.AddOption) {
+	c.Int64Counter.Add(ctx, incr, addOpts(c.opt, options)...)
+}
+
+type attrInt64UpDownCounter struct {
+	metric.Int64UpDownCounter
+	opt metric.MeasurementOption
+}
+
+func (c attrInt64UpDownCounter) Add(ctx context.Context, incr int64, options ...metric.AddOption) {
+	c.Int64UpDownCounter.Add(ctx, incr, addOpts(c.opt, options)...)
+}
+
+type attrInt64Histogram struct {
+	metric.Int64Histogram
+	opt metric.MeasurementOption
+}
+
+func (h attrInt64Histogram) Record(ctx context.Context, incr int64, options ...metric.RecordOption) {
+	h.Int64Histogram.Record(ctx, incr, recordOpts(h.opt, options)...)
+}
+
+type attrInt64Gauge struct {
+	metric.Int64Gauge
+	opt metric.MeasurementOption
+}
+
+func (g attrInt64Gauge) Record(ctx context.Context, value int64, options ...metric.RecordOption) {
+	g.Int64Gauge.Record(ctx, value, recordOpts(g.opt, options)...)
+}
+
+type attrFloat64Counter struct {
+	metric.Float64Counter
+	opt metric.MeasurementOption
+}
+
+func (c attrFloat64Counter) Add(ctx context.Context, incr float64, options ...metric.AddOption) {
+	c.Float64Counter.Add(ctx, incr, addOpts(c.opt, options)...)
+}
+
+type attrFloat64UpDownCounter struct {
+	metric.Float64UpDownCounter
+	opt metric.MeasurementOption
+}
+
+func (c attrFloat64UpDownCounter) Add(ctx context.Context, incr float64, options ...metric.AddOption) {
+	c.Float64UpDownCounter.Add(ctx, incr, addOpts(c.opt, options)...)
+}
+
+type attrFloat64Histogram struct {
+	metric.Float64Histogram
+	opt metric.MeasurementOption
+}
+
+func (h attrFloat64Histogram) Record(ctx context.Context, incr float64, options ...metric.RecordOption) {
+	h.Float64Histogram.Record(ctx, incr, recordOpts(h.opt, options)...)
+}
+
+type attrFloat64Gauge struct {
+	metric.Float64Gauge
+	opt metric.MeasurementOption
+}
+
+func (g attrFloat64Gauge) Record(ctx context.Context, value float64, options ...metric.RecordOption) {
+	g.Float64Gauge.Record(ctx, value, recordOpts(g.opt, options)...)
+}

--- a/internal/tracing/meter_test.go
+++ b/internal/tracing/meter_test.go
@@ -1,0 +1,155 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// histogramDatapoints returns the int64 histogram datapoints for the named
+// metric, aggregated across every scope so the helper does not depend on the
+// metric living in a single instrumentation scope.
+func histogramDatapoints(t *testing.T, rdr *sdkmetric.ManualReader, name string) []metricdata.HistogramDataPoint[int64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, rdr.Collect(context.Background(), &rm))
+	var dps []metricdata.HistogramDataPoint[int64]
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != name {
+				continue
+			}
+			h, ok := md.Data.(metricdata.Histogram[int64])
+			require.True(t, ok)
+			dps = append(dps, h.DataPoints...)
+			found = true
+		}
+	}
+	require.True(t, found, "metric %q not found", name)
+	return dps
+}
+
+// Without the wrapper the per-ledger identity lives only on the scope, so the
+// datapoint has no ledger label. With MeterWithAttributes it becomes a real
+// label, which is what keeps each ledger's cumulative series distinct.
+func TestMeterWithAttributes_InjectsLedgerLabel(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr))
+
+	meter := MeterWithAttributes(mp.Meter("ledger"), attribute.String("ledger", "deriv"))
+	h, err := meter.Int64Histogram("controller.create_transaction")
+	require.NoError(t, err)
+	h.Record(context.Background(), 5)
+	h.Record(context.Background(), 7)
+
+	dps := histogramDatapoints(t, rdr, "controller.create_transaction")
+	require.Len(t, dps, 1)
+	require.Equal(t, uint64(2), dps[0].Count)
+	v, ok := dps[0].Attributes.Value("ledger")
+	require.True(t, ok, "ledger label must be present as a datapoint attribute")
+	require.Equal(t, "deriv", v.AsString())
+}
+
+// Two ledgers must yield two distinct series (no collapse).
+func TestMeterWithAttributes_SeparatesLedgers(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr))
+
+	for _, name := range []string{"main", "treasury"} {
+		meter := MeterWithAttributes(mp.Meter("ledger"), attribute.String("ledger", name))
+		h, err := meter.Int64Histogram("controller.create_transaction")
+		require.NoError(t, err)
+		h.Record(context.Background(), 1)
+	}
+
+	dps := histogramDatapoints(t, rdr, "controller.create_transaction")
+	require.Len(t, dps, 2, "each ledger must keep its own series")
+}
+
+// Caller-supplied attributes (e.g. the deadlock counter's "operation") must be
+// preserved alongside the injected ledger label.
+func TestMeterWithAttributes_MergesCallerAttributes(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr))
+
+	meter := MeterWithAttributes(mp.Meter("ledger"), attribute.String("ledger", "deriv"))
+	c, err := meter.Int64Counter("controller.deadlocks")
+	require.NoError(t, err)
+	c.Add(context.Background(), 1, metric.WithAttributes(attribute.String("operation", "CreateTransaction")))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, rdr.Collect(context.Background(), &rm))
+	var got attribute.Set
+	for _, sm := range rm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != "controller.deadlocks" {
+				continue
+			}
+			sum, ok := md.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			got = sum.DataPoints[0].Attributes
+		}
+	}
+	ledger, ok := got.Value("ledger")
+	require.True(t, ok)
+	require.Equal(t, "deriv", ledger.AsString())
+	op, ok := got.Value("operation")
+	require.True(t, ok)
+	require.Equal(t, "CreateTransaction", op.AsString())
+}
+
+// A caller that supplies the same key as the injected attribute must win: the
+// injected option is prepended and OTel applies options in order, last value
+// taking precedence on conflict.
+func TestMeterWithAttributes_CallerOverridesInjected(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr))
+
+	meter := MeterWithAttributes(mp.Meter("ledger"), attribute.String("ledger", "deriv"))
+	h, err := meter.Int64Histogram("controller.create_transaction")
+	require.NoError(t, err)
+	h.Record(context.Background(), 1, metric.WithAttributes(attribute.String("ledger", "override")))
+
+	dps := histogramDatapoints(t, rdr, "controller.create_transaction")
+	require.Len(t, dps, 1)
+	v, ok := dps[0].Attributes.Value("ledger")
+	require.True(t, ok)
+	require.Equal(t, "override", v.AsString(), "caller attribute must take precedence")
+}
+
+// Float64 instruments are wrapped too, so a future Float64 metric does not
+// silently lose the label.
+func TestMeterWithAttributes_Float64InstrumentsLabelled(t *testing.T) {
+	rdr := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(rdr))
+
+	meter := MeterWithAttributes(mp.Meter("ledger"), attribute.String("ledger", "deriv"))
+	c, err := meter.Float64Counter("controller.some_float_counter")
+	require.NoError(t, err)
+	c.Add(context.Background(), 1.5)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, rdr.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != "controller.some_float_counter" {
+				continue
+			}
+			sum, ok := md.Data.(metricdata.Sum[float64])
+			require.True(t, ok)
+			require.Len(t, sum.DataPoints, 1)
+			v, ok := sum.DataPoints[0].Attributes.Value("ledger")
+			require.True(t, ok, "Float64Counter must carry the injected label")
+			require.Equal(t, "deriv", v.AsString())
+			return
+		}
+	}
+	t.Fatal("controller.some_float_counter not found")
+}


### PR DESCRIPTION
## Problem

Per-ledger controller metrics (e.g. `CreateTransaction_count`) carried the ledger name **only as an OpenTelemetry instrumentation-scope attribute**. The OTLP → Prometheus/VictoriaMetrics translation **drops scope attributes** (they are not promoted to labels), so every ledger's series collapsed into a single series holding the conflicting cumulative values of many ledgers. VictoriaMetrics read the downward jumps as counter resets, turning `rate()` into garbage — observed as "holes" on stacks running many ledgers. Stacks with few ledgers were unaffected because there was nothing to collapse.

## Fix

Inject the ledger identity as a **datapoint attribute** (a real metric label) via a `metric.Meter` wrapper, `tracing.MeterWithAttributes`, so it becomes a proper label — yielding one monotonic series per `(ledger, operation)`. `rate()` then works directly.

- The metrics meter is now a single **shared** `"ledger"` meter with **no scope attributes**; the per-ledger identity rides on the datapoint. This also avoids retaining a distinct meter + instrument set per ledger in memory.
- The scope attribute is **kept on the tracer**, where per-ledger identity is useful and not subject to metric aggregation/cardinality.
- The wrapper covers all **synchronous** instruments (Int64/Float64 Counter, UpDownCounter, Histogram, Gauge); asynchronous/observable instruments are documented as not covered.

## Alternatives considered

- **Thread the label through `TraceWithMetric` at ~30 call sites** — rejected: churn, and easy to forget on new metrics.
- **Promote scope attributes in the OTLP collector** — rejected: makes application correctness depend on external infra config, with a global cardinality blast radius.

## ⚠️ Cardinality note

This turns `ledger` into a real label across ~27 controller histograms (~500 series/ledger/pod with default buckets). Per-ledger cardinality grows with ledger count. The in-process cost is unchanged (the per-ledger meter scope already created these aggregations; VM was just collapsing them). If a stack runs **very many** ledgers, consider gating this behind a flag or dropping the per-ledger dimension instead of promoting it.

## Tests

```
go build ./...
go test -race ./internal/tracing/... ./internal/controller/system/... ./internal/controller/ledger/...  → all pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)