### PR TITLE
feat(tracing): add accounts attribute to single-account controller spans

### DIFF
--- a/internal/controller/ledger/controller_with_traces.go
+++ b/internal/controller/ledger/controller_with_traces.go
@@ -3,11 +3,14 @@ package ledger
 import (
 	"context"
 	"database/sql"
+	"slices"
 
 	"github.com/uptrace/bun"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/formancehq/go-libs/v5/pkg/query"
 	"github.com/formancehq/go-libs/v5/pkg/storage/bun/paginate"
 	"github.com/formancehq/go-libs/v5/pkg/storage/migrations"
 
@@ -16,6 +19,58 @@ import (
 	"github.com/formancehq/ledger/internal/storage/common"
 	"github.com/formancehq/ledger/internal/tracing"
 )
+
+// accountsFromQuery extracts every concrete account address a query is scoped
+// to through `address` (or `account`) filters, handling both exact (`$match`)
+// and set (`$in`) operators across the whole expression tree. Pattern operators
+// such as `$like` are ignored as they do not designate a concrete account. It
+// returns nil when the query does not constrain the account set.
+func accountsFromQuery(builder query.Builder) []string {
+	if builder == nil {
+		return nil
+	}
+
+	var accounts []string
+	_ = builder.Walk(func(operator, key string, value *any) error {
+		if key != "address" && key != "account" {
+			return nil
+		}
+		switch operator {
+		case "$match":
+			if s, ok := (*value).(string); ok {
+				accounts = append(accounts, s)
+			}
+		case "$in":
+			switch v := (*value).(type) {
+			case []string:
+				accounts = append(accounts, v...)
+			case []any:
+				for _, item := range v {
+					if s, ok := item.(string); ok {
+						accounts = append(accounts, s)
+					}
+				}
+			}
+		}
+		return nil
+	})
+
+	// Dedupe so overlapping filters (e.g. `address` and `account` aliases, or
+	// repeated/overlapping `$in` sets) do not inflate the span attribute.
+	slices.Sort(accounts)
+	return slices.Compact(accounts)
+}
+
+// setAccountsAttribute tags the current span with the accounts it operates on.
+// The value is emitted under the same `accounts` slice attribute used by bulk
+// operations, so a single query can surface every span involving an account
+// regardless of whether the operation targets one or several accounts.
+func setAccountsAttribute(ctx context.Context, accounts []string) {
+	if len(accounts) == 0 {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.StringSlice("accounts", accounts))
+}
 
 type ControllerWithTraces struct {
 	underlying Controller
@@ -305,6 +360,7 @@ func (c *ControllerWithTraces) GetAccount(ctx context.Context, q common.Resource
 		c.tracer,
 		c.getAccountHistogram,
 		func(ctx context.Context) (*ledger.Account, error) {
+			setAccountsAttribute(ctx, accountsFromQuery(q.Builder))
 			return c.underlying.GetAccount(ctx, q)
 		},
 	)
@@ -317,6 +373,7 @@ func (c *ControllerWithTraces) GetAggregatedBalances(ctx context.Context, q comm
 		c.tracer,
 		c.getAggregatedBalancesHistogram,
 		func(ctx context.Context) (ledger.BalancesByAssets, error) {
+			setAccountsAttribute(ctx, accountsFromQuery(q.Builder))
 			return c.underlying.GetAggregatedBalances(ctx, q)
 		},
 	)
@@ -377,6 +434,9 @@ func (c *ControllerWithTraces) GetVolumesWithBalances(ctx context.Context, q com
 		c.tracer,
 		c.getVolumesWithBalancesHistogram,
 		func(ctx context.Context) (*paginate.Cursor[ledger.VolumesWithBalanceByAssetByAccount], error) {
+			if rq, ok := common.ResourceQueryFromPaginatedQuery[ledger.GetVolumesOptions](q); ok {
+				setAccountsAttribute(ctx, accountsFromQuery(rq.Builder))
+			}
 			return c.underlying.GetVolumesWithBalances(ctx, q)
 		},
 	)
@@ -464,6 +524,7 @@ func (c *ControllerWithTraces) SaveAccountMetadata(ctx context.Context, paramete
 		c.tracer,
 		c.saveAccountMetadataHistogram,
 		func(ctx context.Context) (*ledger.Log, error) {
+			setAccountsAttribute(ctx, []string{parameters.Input.Address})
 			log, idempotencyHit, err = c.underlying.SaveAccountMetadata(ctx, parameters)
 			return nil, err
 		},
@@ -510,6 +571,7 @@ func (c *ControllerWithTraces) DeleteAccountMetadata(ctx context.Context, parame
 		c.tracer,
 		c.deleteAccountMetadataHistogram,
 		func(ctx context.Context) (*ledger.Log, error) {
+			setAccountsAttribute(ctx, []string{parameters.Input.Address})
 			log, idempotencyHit, err = c.underlying.DeleteAccountMetadata(ctx, parameters)
 			return nil, err
 		},

--- a/internal/controller/ledger/controller_with_traces_test.go
+++ b/internal/controller/ledger/controller_with_traces_test.go
@@ -1,0 +1,124 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/query"
+
+	ledger "github.com/formancehq/ledger/internal"
+	"github.com/formancehq/ledger/internal/storage/common"
+)
+
+func TestAccountsFromQuery(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name             string
+		builder          query.Builder
+		expectedAccounts []string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:             "nil builder",
+			builder:          nil,
+			expectedAccounts: nil,
+		},
+		{
+			name:             "single address match",
+			builder:          query.Match("address", "users:001"),
+			expectedAccounts: []string{"users:001"},
+		},
+		{
+			name:             "single account match",
+			builder:          query.Match("account", "users:001"),
+			expectedAccounts: []string{"users:001"},
+		},
+		{
+			name:             "address match alongside other filters",
+			builder:          query.And(query.Match("address", "users:001"), query.Match("balance", 100)),
+			expectedAccounts: []string{"users:001"},
+		},
+		{
+			name:             "no address filter",
+			builder:          query.Match("balance", 100),
+			expectedAccounts: nil,
+		},
+		{
+			name:             "several address matches",
+			builder:          query.Or(query.Match("address", "users:001"), query.Match("address", "users:002")),
+			expectedAccounts: []string{"users:001", "users:002"},
+		},
+		{
+			name:             "in operator with several accounts",
+			builder:          query.In("address", []any{"users:001", "users:002"}),
+			expectedAccounts: []string{"users:001", "users:002"},
+		},
+		{
+			name:             "duplicates across aliases are deduped and sorted",
+			builder:          query.Or(query.Match("account", "users:002"), query.Match("address", "users:002"), query.Match("address", "users:001")),
+			expectedAccounts: []string{"users:001", "users:002"},
+		},
+		{
+			name:             "address match with non-string value",
+			builder:          query.Match("address", 42),
+			expectedAccounts: nil,
+		},
+		{
+			name:             "address with pattern operator is ignored",
+			builder:          query.Like("address", "users:%"),
+			expectedAccounts: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expectedAccounts, accountsFromQuery(tc.builder))
+		})
+	}
+}
+
+func TestResourceQueryFromPaginatedQuery(t *testing.T) {
+	t.Parallel()
+
+	builder := query.Match("address", "users:001")
+
+	for _, tc := range []struct {
+		name  string
+		query common.PaginatedQuery[ledger.GetVolumesOptions]
+	}{
+		{
+			name: "initial",
+			query: common.InitialPaginatedQuery[ledger.GetVolumesOptions]{
+				Options: common.ResourceQuery[ledger.GetVolumesOptions]{Builder: builder},
+			},
+		},
+		{
+			name: "offset",
+			query: common.OffsetPaginatedQuery[ledger.GetVolumesOptions]{
+				InitialPaginatedQuery: common.InitialPaginatedQuery[ledger.GetVolumesOptions]{
+					Options: common.ResourceQuery[ledger.GetVolumesOptions]{Builder: builder},
+				},
+			},
+		},
+		{
+			name: "column",
+			query: common.ColumnPaginatedQuery[ledger.GetVolumesOptions]{
+				InitialPaginatedQuery: common.InitialPaginatedQuery[ledger.GetVolumesOptions]{
+					Options: common.ResourceQuery[ledger.GetVolumesOptions]{Builder: builder},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rq, ok := common.ResourceQueryFromPaginatedQuery[ledger.GetVolumesOptions](tc.query)
+			require.True(t, ok)
+
+			require.Equal(t, []string{"users:001"}, accountsFromQuery(rq.Builder))
+		})
+	}
+}

--- a/internal/storage/common/pagination.go
+++ b/internal/storage/common/pagination.go
@@ -37,6 +37,30 @@ type (
 
 func (i InitialPaginatedQuery[OptionsType]) isPaginatedQuery() {}
 
+// ResourceQueryFromPaginatedQuery returns the underlying ResourceQuery carried
+// by a PaginatedQuery, whatever its concrete pagination strategy. The second
+// return value is false when the query does not match any known type. Both
+// value and pointer forms are handled, as the marker interface is satisfied by
+// either.
+func ResourceQueryFromPaginatedQuery[OptionsType any](q PaginatedQuery[OptionsType]) (ResourceQuery[OptionsType], bool) {
+	switch v := any(q).(type) {
+	case InitialPaginatedQuery[OptionsType]:
+		return v.Options, true
+	case *InitialPaginatedQuery[OptionsType]:
+		return v.Options, true
+	case OffsetPaginatedQuery[OptionsType]:
+		return v.Options, true
+	case *OffsetPaginatedQuery[OptionsType]:
+		return v.Options, true
+	case ColumnPaginatedQuery[OptionsType]:
+		return v.Options, true
+	case *ColumnPaginatedQuery[OptionsType]:
+		return v.Options, true
+	default:
+		return ResourceQuery[OptionsType]{}, false
+	}
+}
+
 var _ PaginatedQuery[any] = (*InitialPaginatedQuery[any])(nil)
 
 var _ PaginatedQuery[any] = (*OffsetPaginatedQuery[any])(nil)


### PR DESCRIPTION
## What

Adds an `accounts` OpenTelemetry span attribute to the controller trace spans that operate on accounts, so traces can be filtered/grouped by account in Signoz.

Covered operations:
- `GetAccount`, `GetAggregatedBalances`, `GetVolumesWithBalances` — accounts extracted from the query builder (`$match` / `$in` on `address` / `account`).
- `SaveAccountMetadata`, `DeleteAccountMetadata` — account taken from the explicit `Input.Address`.

The value is emitted under the **same `accounts` `StringSlice` key** already used by the bulk storage operations (`storage/ledger/accounts.go`), so one query (`accounts CONTAINS "users:001"`) surfaces every span involving an account — single-account or bulk — without type collisions.

## How

- `accountsFromQuery(query.Builder) []string` walks the query expression tree, collecting concrete account addresses from `$match` and `$in` filters (pattern operators like `$like` are ignored), then **dedupes** (`slices.Sort` + `slices.Compact`).
- `setAccountsAttribute(ctx, accounts)` guards against empty slices and sets the `accounts` `StringSlice` attribute on the current span.
- `common.ResourceQueryFromPaginatedQuery[…]` extracts the underlying `ResourceQuery` (and thus the `Builder`) from any `PaginatedQuery` strategy (handles both value and pointer forms).

## Tests

- `TestAccountsFromQuery` — single/multiple matches, `$in`, alias dedup+sort, non-string values, `$like` exclusion, nil builder.
- `TestResourceQueryFromPaginatedQuery` — extraction across Initial / Offset / Column pagination.
- `go build ./internal/...`, `go vet`, and the controller/common test suites pass.

## Known limitations (intentional, best-effort)

- **`$not` negation**: `query.Builder.Walk` exposes no negation context, so a `$not`-wrapped address filter would still be tagged. Acceptable for best-effort observability tagging; flagged here for reviewers.
- **List/aggregate ops**: on `GetVolumesWithBalances` / `GetAggregatedBalances` an address filter can be a segment prefix (e.g. `users:`) rather than a concrete account, so the attribute reflects the *filter*, not necessarily exact accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)