### PR TITLE
fix(storage): restore transaction address array indexes

### DIFF
--- a/internal/storage/bucket/migrations/51-add-transactions-sources-array-index/notes.yaml
+++ b/internal/storage/bucket/migrations/51-add-transactions-sources-array-index/notes.yaml
@@ -1,0 +1,1 @@
+name: Add transactions sources array index

--- a/internal/storage/bucket/migrations/51-add-transactions-sources-array-index/up.sql
+++ b/internal/storage/bucket/migrations/51-add-transactions-sources-array-index/up.sql
@@ -1,0 +1,2 @@
+create index {{ if not .Transactional }}concurrently{{end}} if not exists transactions_sources_arrays_gin
+on "{{.Schema}}".transactions using gin (sources_arrays jsonb_path_ops);

--- a/internal/storage/bucket/migrations/52-add-transactions-destinations-array-index/notes.yaml
+++ b/internal/storage/bucket/migrations/52-add-transactions-destinations-array-index/notes.yaml
@@ -1,0 +1,1 @@
+name: Add transactions destinations array index

--- a/internal/storage/bucket/migrations/52-add-transactions-destinations-array-index/up.sql
+++ b/internal/storage/bucket/migrations/52-add-transactions-destinations-array-index/up.sql
@@ -1,0 +1,2 @@
+create index {{ if not .Transactional }}concurrently{{end}} if not exists transactions_destinations_arrays_gin
+on "{{.Schema}}".transactions using gin (destinations_arrays jsonb_path_ops);


### PR DESCRIPTION
## Summary
- add migration 51 to recreate the GIN index on transactions.sources_arrays
- add migration 52 to recreate the GIN index on transactions.destinations_arrays
- use IF NOT EXISTS and the existing concurrent-index template pattern
- keep MinimalSchemaVersion at 50 because these indexes are not mandatory for the minimal schema

## Tests
- go test -tags it ./internal/storage/bucket
- git diff --check