### PR TITLE
perf(storage): remove row_number() window function from list paginator (backport v2.3)

### DIFF
--- a/internal/storage/common/paginator.go
+++ b/internal/storage/common/paginator.go
@@ -8,4 +8,5 @@ import (
 type Paginator[ResourceType any] interface {
 	Paginate(selectQuery *bun.SelectQuery) (*bun.SelectQuery, error)
 	BuildCursor(ret []ResourceType) (*bunpaginate.Cursor[ResourceType], error)
+	OrderExpression() string
 }

--- a/internal/storage/common/paginator_column.go
+++ b/internal/storage/common/paginator_column.go
@@ -35,7 +35,7 @@ func (o columnPaginator[ResourceType, OptionsType]) Paginate(sb *bun.SelectQuery
 		order = order.Reverse()
 	}
 	orderExpression := fmt.Sprintf("%s %s", paginationColumn, order)
-	sb = sb.ColumnExpr("row_number() OVER (ORDER BY " + orderExpression + ")")
+	sb = sb.Order(orderExpression)
 
 	if o.query.PaginationID != nil {
 		paginationID := convertPaginationIDToSQLType(o.fieldType, o.query.PaginationID)
@@ -132,6 +132,15 @@ func (o columnPaginator[ResourceType, OptionsType]) BuildCursor(ret []ResourceTy
 	}, nil
 }
 
+//nolint:unused
+func (o columnPaginator[ResourceType, OptionsType]) OrderExpression() string {
+	order := *o.query.Order
+	if o.query.Reverse {
+		order = order.Reverse()
+	}
+	return fmt.Sprintf("%s %s", o.fieldName, order)
+}
+
 var _ Paginator[any] = &columnPaginator[any, any]{}
 
 //nolint:unused
@@ -148,7 +157,7 @@ func findPaginationFieldPath(v any, paginationColumn string) []reflect.StructFie
 		//     *AnotherObject
 		// }
 		for {
-			if field.Type.Kind() == reflect.Ptr {
+			if field.Type.Kind() == reflect.Pointer {
 				fieldType = field.Type.Elem()
 			}
 			break

--- a/internal/storage/common/paginator_offset.go
+++ b/internal/storage/common/paginator_offset.go
@@ -18,7 +18,7 @@ func (o OffsetPaginator[ResourceType, OptionsType]) Paginate(sb *bun.SelectQuery
 	originalOrder := *o.query.Order
 
 	orderExpression := fmt.Sprintf("%s %s", paginationColumn, originalOrder)
-	sb = sb.ColumnExpr("row_number() OVER (ORDER BY " + orderExpression + ")")
+	sb = sb.Order(orderExpression)
 
 	if o.query.Offset > math.MaxInt32 {
 		return nil, fmt.Errorf("offset value exceeds maximum allowed value")
@@ -68,6 +68,11 @@ func (o OffsetPaginator[ResourceType, OptionsType]) BuildCursor(ret []ResourceTy
 		Next:     encodeCursor[OptionsType, OffsetPaginatedQuery[OptionsType]](next),
 		Data:     ret,
 	}, nil
+}
+
+//nolint:unused
+func (o OffsetPaginator[ResourceType, OptionsType]) OrderExpression() string {
+	return fmt.Sprintf("%s %s", o.query.Column, *o.query.Order)
 }
 
 var _ Paginator[any] = &OffsetPaginator[any, any]{}

--- a/internal/storage/common/resource.go
+++ b/internal/storage/common/resource.go
@@ -353,7 +353,12 @@ func (r *PaginatedResourceRepository[ResourceType, OptionsType]) Paginate(
 	if err != nil {
 		return nil, fmt.Errorf("expanding results: %w", err)
 	}
-	finalQuery = finalQuery.Order("row_number")
+	// Qualify the sort column with "dataset." so that LEFT JOINed expand CTEs
+	// cannot introduce an ambiguous column name (e.g. a future expand that also
+	// selects "id"). No expand today conflicts, but this makes it safe by construction.
+	orderExpr := paginator.OrderExpression()
+	col, dir, _ := strings.Cut(orderExpr, " ")
+	finalQuery = finalQuery.Order(fmt.Sprintf("dataset.%s %s", col, dir))
 
 	ret := make([]ResourceType, 0)
 	err = finalQuery.Model(&ret).Scan(ctx)


### PR DESCRIPTION
Backport of #1351 to `release/v2.3` (N-1 maintenance branch). Mirrors the v2.4 backport #1359.

## What

Replace `row_number() OVER (ORDER BY ...)` wrapping with a plain `ORDER BY` in the column and offset paginators, and propagate the sort through the outer CTE wrapper in `resource.go` via a new `Paginator.OrderExpression()` method.

The window function forced PostgreSQL to materialise every row matching the `WHERE` clause before applying `LIMIT`, preventing early-exit on the index scan. With a plain `ORDER BY`, the planner pushes `LIMIT` directly onto the `Index Scan Backward` node — O(page_size) instead of O(matching_rows). On large production ledgers this was the source of 30–50 s list-transactions queries.

The `dataset.` qualification on the final `ORDER BY` keeps it safe by construction against future expand CTEs introducing an ambiguous column name.

## Backport notes

`release/v2.3` is on `go-libs/v3` and predates the `internal/queries` refactor present on v2.4, so a clean cherry-pick of #1359 / the #1351 commits is not possible (conflicts confined to import blocks and `FieldType` qualifiers). The four **functional** hunks are identical and were applied by hand; the new `OrderExpression()` methods reference only fields already present on v2.3.

Diff is functionally identical to #1359.

## Verification

- `go build ./...` ✅
- `go vet ./internal/storage/common/... ./internal/storage/ledger/... ./internal/storage/system/...` ✅ (test packages compile against the new interface)
- No remaining `row_number()` in `internal/storage/common/` ✅
- Integration tests not run locally (no Docker) — covered by CI.

Refs #1351, #1359