### PR TITLE
feat(storage): add config to disable alone-in-bucket query optimization

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-use flake --impure
+use flake . --impure
 dotenv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - uses: namespacelabs/nscloud-checkout-action@v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -59,7 +59,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - uses: namespacelabs/nscloud-checkout-action@v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -87,7 +87,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - uses: namespacelabs/nscloud-checkout-action@v9
         with:
           fetch-depth: 0
           dissociate: true

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -10,7 +10,7 @@ jobs:
   GoReleaser:
     runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - uses: namespacelabs/nscloud-checkout-action@v9
         with:
           fetch-depth: 0
           dissociate: true

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -56,6 +56,8 @@ type ServeCommandConfig struct {
 	MaxPageSize            uint64 `mapstructure:"max-page-size"`
 	WorkerEnabled          bool   `mapstructure:"worker"`
 	WorkerAddress          string `mapstructure:"worker-grpc-address"`
+
+	DisableLedgerScopeOptimization bool `mapstructure:"disable-ledger-scope-optimization"`
 }
 
 const (
@@ -69,6 +71,8 @@ const (
 	DefaultPageSizeFlag = "default-page-size"
 	MaxPageSizeFlag     = "max-page-size"
 	WorkerEnabledFlag   = "worker"
+
+	DisableLedgerScopeOptimizationFlag = "disable-ledger-scope-optimization"
 )
 
 func NewServeCommand() *cobra.Command {
@@ -97,7 +101,8 @@ func NewServeCommand() *cobra.Command {
 				auth.FXModuleFromFlags(cmd),
 				bunconnect.Module(*connectionOptions, service.IsDebug(cmd)),
 				storage.NewFXModule(storage.ModuleConfig{
-					AutoUpgrade: cfg.AutoUpgrade,
+					AutoUpgrade:                     cfg.AutoUpgrade,
+					DisableScopedSelectOptimization: cfg.DisableLedgerScopeOptimization,
 				}),
 				drivers.NewFXModule(),
 				fx.Invoke(alldrivers.Register),
@@ -186,6 +191,7 @@ func NewServeCommand() *cobra.Command {
 	cmd.Flags().Bool(NumscriptInterpreterFlag, false, "Enable experimental numscript rewrite")
 	cmd.Flags().StringSlice(NumscriptInterpreterFlagsToPass, nil, "Feature flags to pass to the experimental numscript interpreter")
 	cmd.Flags().String(WorkerGRPCAddressFlag, "localhost:8081", "GRPC address")
+	cmd.Flags().Bool(DisableLedgerScopeOptimizationFlag, false, "Always emit the `ledger = ?` predicate on read queries, disabling the alone-in-bucket optimization that skips it when a ledger is the only one in its bucket")
 
 	addWorkerFlags(cmd)
 	bunconnect.AddFlags(cmd.Flags())

--- a/internal/storage/driver/module.go
+++ b/internal/storage/driver/module.go
@@ -15,7 +15,13 @@ import (
 	"go.uber.org/fx"
 )
 
-func NewFXModule() fx.Option {
+type ModuleConfig struct {
+	// DisableScopedSelectOptimization disables the alone-in-bucket optimization,
+	// forcing the `ledger = ?` predicate to always be emitted on scoped selects.
+	DisableScopedSelectOptimization bool
+}
+
+func NewFXModule(config ModuleConfig) fx.Option {
 	return fx.Options(
 		fx.Provide(fx.Annotate(func(tracerProvider trace.TracerProvider) bucket.Factory {
 			return bucket.NewDefaultFactory(bucket.WithTracer(tracerProvider.Tracer("store")))
@@ -43,6 +49,7 @@ func NewFXModule() fx.Option {
 			if params.MeterProvider != nil {
 				options = append(options, ledgerstore.WithMeter(params.MeterProvider.Meter("store")))
 			}
+			options = append(options, ledgerstore.WithDisableScopedSelectOptimization(config.DisableScopedSelectOptimization))
 			return ledgerstore.NewFactory(params.DB, options...)
 		}),
 		fx.Provide(func(

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -32,6 +32,11 @@ type Store struct {
 	// (e.g. when a new ledger is created) immediately affects all stores.
 	aloneInBucket *atomic.Bool
 
+	// disableScopedSelectOptimization, when true, forces newScopedSelect to always
+	// emit the `ledger = ?` predicate, ignoring the aloneInBucket hint. It is a
+	// kill switch for the alone-in-bucket optimization (see newScopedSelect).
+	disableScopedSelectOptimization bool
+
 	tracer                             trace.Tracer
 	meter                              metric.Meter
 	checkBucketSchemaHistogram         metric.Int64Histogram
@@ -177,9 +182,12 @@ func (store *Store) LockLedger(ctx context.Context) (*Store, bun.IDB, func() err
 // name to use the composite index (ledger, id) efficiently.
 //
 // This relies on aloneInBucket being up to date (shared across the bucket).
+//
+// When disableScopedSelectOptimization is set, the optimization is bypassed and
+// the `ledger = ?` predicate is always emitted.
 func (store *Store) newScopedSelect() *bun.SelectQuery {
 	q := store.db.NewSelect()
-	if store.aloneInBucket == nil || !store.aloneInBucket.Load() {
+	if store.disableScopedSelectOptimization || store.aloneInBucket == nil || !store.aloneInBucket.Load() {
 		q = q.Where("ledger = ?", store.ledger.Name)
 	}
 	return q
@@ -306,6 +314,15 @@ func WithMeter(meter metric.Meter) Option {
 func WithTracer(tracer trace.Tracer) Option {
 	return func(s *Store) {
 		s.tracer = tracer
+	}
+}
+
+// WithDisableScopedSelectOptimization, when set to true, forces every scoped
+// select to emit the `ledger = ?` predicate, disabling the alone-in-bucket
+// optimization (see newScopedSelect).
+func WithDisableScopedSelectOptimization(disable bool) Option {
+	return func(s *Store) {
+		s.disableScopedSelectOptimization = disable
 	}
 }
 

--- a/internal/storage/ledger/store_scoped_select_test.go
+++ b/internal/storage/ledger/store_scoped_select_test.go
@@ -1,0 +1,77 @@
+package ledger
+
+import (
+	"sync/atomic"
+	"testing"
+
+	ledger "github.com/formancehq/ledger/internal"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+// renderScopedSelect builds the scoped select for a freshly created store and
+// renders it to SQL using the pg dialect (no live connection required).
+func renderScopedSelect(t *testing.T, store *Store) string {
+	t.Helper()
+
+	q := store.newScopedSelect().Table("transactions")
+	sql, err := q.AppendQuery(store.db.(*bun.DB).Formatter(), nil)
+	require.NoError(t, err)
+	return string(sql)
+}
+
+func newTestStore(disableOptimization bool) *Store {
+	db := bun.NewDB(nil, pgdialect.New())
+	return &Store{
+		db:                              db,
+		ledger:                          ledger.Ledger{Name: "ledger0"},
+		disableScopedSelectOptimization: disableOptimization,
+	}
+}
+
+func TestNewScopedSelect_AloneInBucketSkipsPredicate(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(false)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(true)
+
+	require.NotContains(t, renderScopedSelect(t, store), `ledger =`,
+		"alone-in-bucket optimization should skip the ledger predicate")
+}
+
+func TestNewScopedSelect_NotAloneEmitsPredicate(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(false)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(false)
+
+	require.Contains(t, renderScopedSelect(t, store), `ledger = 'ledger0'`,
+		"a ledger sharing its bucket must be filtered by name")
+}
+
+func TestNewScopedSelect_DisableOptimizationAlwaysEmitsPredicate(t *testing.T) {
+	t.Parallel()
+
+	// Even when the store is flagged as alone in its bucket, disabling the
+	// optimization must force the predicate to be emitted.
+	store := newTestStore(true)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(true)
+
+	require.Contains(t, renderScopedSelect(t, store), `ledger = 'ledger0'`,
+		"disabling the optimization must always emit the ledger predicate")
+}
+
+func TestWithDisableScopedSelectOptimization(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{}
+	WithDisableScopedSelectOptimization(true)(store)
+	require.True(t, store.disableScopedSelectOptimization)
+
+	WithDisableScopedSelectOptimization(false)(store)
+	require.False(t, store.disableScopedSelectOptimization)
+}

--- a/internal/storage/module.go
+++ b/internal/storage/module.go
@@ -16,6 +16,9 @@ const HealthCheckName = `storage-driver-up-to-date`
 
 type ModuleConfig struct {
 	AutoUpgrade bool
+	// DisableScopedSelectOptimization disables the alone-in-bucket optimization,
+	// forcing the `ledger = ?` predicate to always be emitted on scoped selects.
+	DisableScopedSelectOptimization bool
 }
 
 func NewFXModule(config ModuleConfig) fx.Option {
@@ -24,7 +27,9 @@ func NewFXModule(config ModuleConfig) fx.Option {
 		fx.Provide(func(store *systemstore.DefaultStore) driver.SystemStore {
 			return store
 		}),
-		driver.NewFXModule(),
+		driver.NewFXModule(driver.ModuleConfig{
+			DisableScopedSelectOptimization: config.DisableScopedSelectOptimization,
+		}),
 		health.ProvideHealthCheck(func(driver *driver.Driver, tracer trace.TracerProvider) health.NamedCheck {
 			hasReachedMinimalVersion := false
 			return health.NewNamedCheck(HealthCheckName, health.CheckFn(func(ctx context.Context) error {


### PR DESCRIPTION
newScopedSelect skips the `ledger = ?` predicate when a ledger is the only one in its bucket, to avoid a degraded ~100%-selectivity seq scan. Add a --disable-ledger-scope-optimization serve flag that forces the predicate to always be emitted, as a performance/safety escape hatch.

The config threads from the serve flag through storage.ModuleConfig and driver.ModuleConfig down to a new ledgerstore store option. Default keeps current behavior (optimization enabled).

Constraint: disabling must only ever force the always-correct scoped query, never remove the predicate
Rejected: gate on aloneInBucket hint alone | operators need a deterministic override independent of bucket population
Confidence: high
Scope-risk: narrow
Directive: optimization is wired only into `serve`; worker/buckets-upgrade keep it on (correctness-neutral)
Not-tested: end-to-end fx wiring of the flag (covered by unit-level SQL rendering + build)