### PR TITLE
feat(storage): add config to disable alone-in-bucket query optimization

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -65,6 +65,8 @@ type ServeCommandConfig struct {
 	AuditAsyncEnabled       bool   `mapstructure:"audit-async-enabled"`
 	AuditAsyncQueueCapacity int    `mapstructure:"audit-async-queue-capacity"`
 	AuditAsyncWorkerCount   int    `mapstructure:"audit-async-worker-count"`
+
+	DisableLedgerScopeOptimization bool `mapstructure:"disable-ledger-scope-optimization"`
 }
 
 const (
@@ -84,6 +86,8 @@ const (
 	AuditAsyncEnabledFlag       = "audit-async-enabled"
 	AuditAsyncQueueCapacityFlag = "audit-async-queue-capacity"
 	AuditAsyncWorkerCountFlag   = "audit-async-worker-count"
+
+	DisableLedgerScopeOptimizationFlag = "disable-ledger-scope-optimization"
 )
 
 func NewServeCommand() *cobra.Command {
@@ -114,7 +118,8 @@ func NewServeCommand() *cobra.Command {
 				fx.Supply(connectionOptions),
 				storagefx.BunConnectModule(*connectionOptions, service.IsDebug(cmd)),
 				storage.NewFXModule(storage.ModuleConfig{
-					AutoUpgrade: cfg.AutoUpgrade,
+					AutoUpgrade:                     cfg.AutoUpgrade,
+					DisableScopedSelectOptimization: cfg.DisableLedgerScopeOptimization,
 				}),
 				drivers.NewFXModule(),
 				fx.Invoke(alldrivers.Register),
@@ -216,6 +221,7 @@ func NewServeCommand() *cobra.Command {
 	cmd.Flags().Bool(AuditAsyncEnabledFlag, true, "Publish HTTP audit events asynchronously")
 	cmd.Flags().Int(AuditAsyncQueueCapacityFlag, api.DefaultAuditAsyncQueueCapacity, "HTTP audit async publish queue capacity")
 	cmd.Flags().Int(AuditAsyncWorkerCountFlag, api.DefaultAuditAsyncWorkerCount, "HTTP audit async publish worker count")
+	cmd.Flags().Bool(DisableLedgerScopeOptimizationFlag, false, "Always emit the `ledger = ?` predicate on read queries, disabling the alone-in-bucket optimization that skips it when a ledger is the only one in its bucket")
 
 	addWorkerFlags(cmd)
 	connect.AddFlags(cmd.Flags())

--- a/internal/storage/driver/module.go
+++ b/internal/storage/driver/module.go
@@ -16,7 +16,13 @@ import (
 	systemstore "github.com/formancehq/ledger/internal/storage/system"
 )
 
-func NewFXModule() fx.Option {
+type ModuleConfig struct {
+	// DisableScopedSelectOptimization disables the alone-in-bucket optimization,
+	// forcing the `ledger = ?` predicate to always be emitted on scoped selects.
+	DisableScopedSelectOptimization bool
+}
+
+func NewFXModule(config ModuleConfig) fx.Option {
 	return fx.Options(
 		fx.Provide(fx.Annotate(func(tracerProvider trace.TracerProvider) bucket.Factory {
 			return bucket.NewDefaultFactory(bucket.WithTracer(tracerProvider.Tracer("store")))
@@ -44,6 +50,7 @@ func NewFXModule() fx.Option {
 			if params.MeterProvider != nil {
 				options = append(options, ledgerstore.WithMeter(params.MeterProvider.Meter("store")))
 			}
+			options = append(options, ledgerstore.WithDisableScopedSelectOptimization(config.DisableScopedSelectOptimization))
 			return ledgerstore.NewFactory(params.DB, options...)
 		}),
 		fx.Provide(func(

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -34,6 +34,11 @@ type Store struct {
 	// (e.g. when a new ledger is created) immediately affects all stores.
 	aloneInBucket *atomic.Bool
 
+	// disableScopedSelectOptimization, when true, forces newScopedSelect to always
+	// emit the `ledger = ?` predicate, ignoring the aloneInBucket hint. It is a
+	// kill switch for the alone-in-bucket optimization (see newScopedSelect).
+	disableScopedSelectOptimization bool
+
 	tracer                             trace.Tracer
 	meter                              metric.Meter
 	checkBucketSchemaHistogram         metric.Int64Histogram
@@ -199,9 +204,12 @@ func (store *Store) LockLedger(ctx context.Context) (*Store, bun.IDB, func() err
 // name to use the composite index (ledger, id) efficiently.
 //
 // This relies on aloneInBucket being up to date (shared across the bucket).
+//
+// When disableScopedSelectOptimization is set, the optimization is bypassed and
+// the `ledger = ?` predicate is always emitted.
 func (store *Store) newScopedSelect() *bun.SelectQuery {
 	q := store.db.NewSelect()
-	if store.aloneInBucket == nil || !store.aloneInBucket.Load() {
+	if store.disableScopedSelectOptimization || store.aloneInBucket == nil || !store.aloneInBucket.Load() {
 		q = q.Where("ledger = ?", store.ledger.Name)
 	}
 	return q
@@ -343,6 +351,15 @@ func WithMeter(meter metric.Meter) Option {
 func WithTracer(tracer trace.Tracer) Option {
 	return func(s *Store) {
 		s.tracer = tracer
+	}
+}
+
+// WithDisableScopedSelectOptimization, when set to true, forces every scoped
+// select to emit the `ledger = ?` predicate, disabling the alone-in-bucket
+// optimization (see newScopedSelect).
+func WithDisableScopedSelectOptimization(disable bool) Option {
+	return func(s *Store) {
+		s.disableScopedSelectOptimization = disable
 	}
 }
 

--- a/internal/storage/ledger/store_scoped_select_test.go
+++ b/internal/storage/ledger/store_scoped_select_test.go
@@ -1,0 +1,78 @@
+package ledger
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+
+	ledger "github.com/formancehq/ledger/internal"
+)
+
+// renderScopedSelect builds the scoped select for a freshly created store and
+// renders it to SQL using the pg dialect (no live connection required).
+func renderScopedSelect(t *testing.T, store *Store) string {
+	t.Helper()
+
+	q := store.newScopedSelect().Table("transactions")
+	sql, err := q.AppendQuery(store.db.(*bun.DB).QueryGen(), nil)
+	require.NoError(t, err)
+	return string(sql)
+}
+
+func newTestStore(disableOptimization bool) *Store {
+	db := bun.NewDB(nil, pgdialect.New())
+	return &Store{
+		db:                              db,
+		ledger:                          ledger.Ledger{Name: "ledger0"},
+		disableScopedSelectOptimization: disableOptimization,
+	}
+}
+
+func TestNewScopedSelect_AloneInBucketSkipsPredicate(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(false)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(true)
+
+	require.NotContains(t, renderScopedSelect(t, store), `ledger =`,
+		"alone-in-bucket optimization should skip the ledger predicate")
+}
+
+func TestNewScopedSelect_NotAloneEmitsPredicate(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(false)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(false)
+
+	require.Contains(t, renderScopedSelect(t, store), `ledger = 'ledger0'`,
+		"a ledger sharing its bucket must be filtered by name")
+}
+
+func TestNewScopedSelect_DisableOptimizationAlwaysEmitsPredicate(t *testing.T) {
+	t.Parallel()
+
+	// Even when the store is flagged as alone in its bucket, disabling the
+	// optimization must force the predicate to be emitted.
+	store := newTestStore(true)
+	store.aloneInBucket = &atomic.Bool{}
+	store.aloneInBucket.Store(true)
+
+	require.Contains(t, renderScopedSelect(t, store), `ledger = 'ledger0'`,
+		"disabling the optimization must always emit the ledger predicate")
+}
+
+func TestWithDisableScopedSelectOptimization(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{}
+	WithDisableScopedSelectOptimization(true)(store)
+	require.True(t, store.disableScopedSelectOptimization)
+
+	WithDisableScopedSelectOptimization(false)(store)
+	require.False(t, store.disableScopedSelectOptimization)
+}

--- a/internal/storage/module.go
+++ b/internal/storage/module.go
@@ -20,6 +20,9 @@ const HealthCheckName = `storage-driver-up-to-date`
 
 type ModuleConfig struct {
 	AutoUpgrade bool
+	// DisableScopedSelectOptimization disables the alone-in-bucket optimization,
+	// forcing the `ledger = ?` predicate to always be emitted on scoped selects.
+	DisableScopedSelectOptimization bool
 }
 
 func NewFXModule(config ModuleConfig) fx.Option {
@@ -28,7 +31,9 @@ func NewFXModule(config ModuleConfig) fx.Option {
 		fx.Provide(func(store *systemstore.DefaultStore) driver.SystemStore {
 			return store
 		}),
-		driver.NewFXModule(),
+		driver.NewFXModule(driver.ModuleConfig{
+			DisableScopedSelectOptimization: config.DisableScopedSelectOptimization,
+		}),
 		servicefx.ProvideHealthCheck(func(driver *driver.Driver, tracer trace.TracerProvider) health.NamedCheck {
 			hasReachedMinimalVersion := false
 			return health.NewNamedCheck(HealthCheckName, health.CheckFn(func(ctx context.Context) error {


### PR DESCRIPTION
Forward-port of `81a2cc6` (originally landed on `hotfix/v2.3/disable-ledger-predicate-optimization`) to `main`.

## What

`newScopedSelect` skips the `ledger = ?` predicate when a ledger is the only one in its bucket, to avoid a degraded ~100%-selectivity seq scan. This adds a `--disable-ledger-scope-optimization` serve flag that forces the predicate to always be emitted, as a performance/safety escape hatch. The config threads from the serve flag through `storage.ModuleConfig` and `driver.ModuleConfig` down to a new `ledgerstore` store option. Default keeps current behavior (optimization enabled).

## Forward-port notes

- `cmd/serve.go` and `internal/storage/module.go` had conflicts: kept `main`'s newer content (audit flags, `servicefx.ProvideHealthCheck`) and layered the new flag/config on top.
- `store_scoped_select_test.go`: adapted to bun `v1.2.18` (`main`) — `(*bun.DB).Formatter()` was removed; switched the unit test to `(*bun.DB).QueryGen()`, which matches `SelectQuery.AppendQuery`'s new `schema.QueryGen` signature.

## Verification

- `go build ./cmd/... ./internal/storage/...` ✅
- `go test ./internal/storage/ledger/ -run 'TestNewScopedSelect|TestWithDisableScopedSelectOptimization'` ✅