### PR TITLE
perf(storage): conditional MATERIALIZED CTE fence for ListTransactions (backport v2.4)

### DIFF
--- a/internal/controller/ledger/mocks_test.go
+++ b/internal/controller/ledger/mocks_test.go
@@ -156,6 +156,44 @@ func (mr *MockRepositoryHandlerMockRecorder[Opts]) Schema() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Schema", reflect.TypeOf((*MockRepositoryHandler[Opts])(nil).Schema))
 }
 
+// MockDatasetFencer is a mock of DatasetFencer interface.
+type MockDatasetFencer[Opts any] struct {
+	ctrl     *gomock.Controller
+	recorder *MockDatasetFencerMockRecorder[Opts]
+	isgomock struct{}
+}
+
+// MockDatasetFencerMockRecorder is the mock recorder for MockDatasetFencer.
+type MockDatasetFencerMockRecorder[Opts any] struct {
+	mock *MockDatasetFencer[Opts]
+}
+
+// NewMockDatasetFencer creates a new mock instance.
+func NewMockDatasetFencer[Opts any](ctrl *gomock.Controller) *MockDatasetFencer[Opts] {
+	mock := &MockDatasetFencer[Opts]{ctrl: ctrl}
+	mock.recorder = &MockDatasetFencerMockRecorder[Opts]{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDatasetFencer[Opts]) EXPECT() *MockDatasetFencerMockRecorder[Opts] {
+	return m.recorder
+}
+
+// ShouldFenceDataset mocks base method.
+func (m *MockDatasetFencer[Opts]) ShouldFenceDataset(ctx common.RepositoryHandlerBuildContext[Opts]) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldFenceDataset", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldFenceDataset indicates an expected call of ShouldFenceDataset.
+func (mr *MockDatasetFencerMockRecorder[Opts]) ShouldFenceDataset(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldFenceDataset", reflect.TypeOf((*MockDatasetFencer[Opts])(nil).ShouldFenceDataset), ctx)
+}
+
 // MockResource is a mock of Resource interface.
 type MockResource[ResourceType any, OptionsType any] struct {
 	ctrl     *gomock.Controller

--- a/internal/storage/common/paginator.go
+++ b/internal/storage/common/paginator.go
@@ -10,4 +10,13 @@ type Paginator[ResourceType any] interface {
 	Paginate(selectQuery *bun.SelectQuery) (*bun.SelectQuery, error)
 	BuildCursor(ret []ResourceType) (*paginate.Cursor[ResourceType], error)
 	OrderExpression() string
+	// ApplyCursorPredicate adds only the page-position predicate that belongs to "the filtered
+	// set" — for column pagination the keyset WHERE (id <=/>=/... cursor); for offset pagination
+	// nothing (the offset is applied as part of the page window). Used by the MATERIALIZED-CTE
+	// fence path, where this predicate must stay inside the fenced dataset CTE.
+	ApplyCursorPredicate(selectQuery *bun.SelectQuery) *bun.SelectQuery
+	// ApplyWindow adds only LIMIT (and OFFSET for offset pagination) — it does NOT add ORDER BY.
+	// The caller must have already applied the paginator's order (see OrderExpression) to the
+	// select. Used by the fence path to attach the page window to the outer select.
+	ApplyWindow(selectQuery *bun.SelectQuery) (*bun.SelectQuery, error)
 }

--- a/internal/storage/common/paginator_column.go
+++ b/internal/storage/common/paginator_column.go
@@ -25,42 +25,55 @@ type columnPaginator[ResourceType, OptionsType any] struct {
 func (o columnPaginator[ResourceType, OptionsType]) Paginate(sb *bun.SelectQuery) (*bun.SelectQuery, error) {
 
 	paginationColumn := o.fieldName
-	originalOrder := *o.query.Order
 
+	order := *o.query.Order
+	if o.query.Reverse {
+		order = order.Reverse()
+	}
+	orderExpression := fmt.Sprintf("%s %s", paginationColumn, order)
+
+	sb = o.ApplyCursorPredicate(sb)
+	sb = sb.Order(orderExpression)
+	return o.ApplyWindow(sb)
+}
+
+//nolint:unused
+func (o columnPaginator[ResourceType, OptionsType]) ApplyCursorPredicate(sb *bun.SelectQuery) *bun.SelectQuery {
+
+	if o.query.PaginationID == nil {
+		return sb
+	}
+
+	paginationColumn := o.fieldName
+	originalOrder := *o.query.Order
+	paginationID := convertPaginationIDToSQLType(o.fieldType, o.query.PaginationID)
+	if o.query.Reverse {
+		switch originalOrder {
+		case paginate.OrderAsc:
+			sb = sb.Where(fmt.Sprintf("%s < ?", paginationColumn), paginationID)
+		case paginate.OrderDesc:
+			sb = sb.Where(fmt.Sprintf("%s > ?", paginationColumn), paginationID)
+		}
+	} else {
+		switch originalOrder {
+		case paginate.OrderAsc:
+			sb = sb.Where(fmt.Sprintf("%s >= ?", paginationColumn), paginationID)
+		case paginate.OrderDesc:
+			sb = sb.Where(fmt.Sprintf("%s <= ?", paginationColumn), paginationID)
+		}
+	}
+
+	return sb
+}
+
+//nolint:unused
+func (o columnPaginator[ResourceType, OptionsType]) ApplyWindow(sb *bun.SelectQuery) (*bun.SelectQuery, error) {
 	pageSize := o.query.PageSize
 	if pageSize == 0 {
 		pageSize = paginate.QueryDefaultPageSize
 	}
 
-	sb = sb.Limit(int(pageSize) + 1) // Fetch one additional item to find the next token
-
-	order := originalOrder
-	if o.query.Reverse {
-		order = order.Reverse()
-	}
-	orderExpression := fmt.Sprintf("%s %s", paginationColumn, order)
-	sb = sb.Order(orderExpression)
-
-	if o.query.PaginationID != nil {
-		paginationID := convertPaginationIDToSQLType(o.fieldType, o.query.PaginationID)
-		if o.query.Reverse {
-			switch originalOrder {
-			case paginate.OrderAsc:
-				sb = sb.Where(fmt.Sprintf("%s < ?", paginationColumn), paginationID)
-			case paginate.OrderDesc:
-				sb = sb.Where(fmt.Sprintf("%s > ?", paginationColumn), paginationID)
-			}
-		} else {
-			switch originalOrder {
-			case paginate.OrderAsc:
-				sb = sb.Where(fmt.Sprintf("%s >= ?", paginationColumn), paginationID)
-			case paginate.OrderDesc:
-				sb = sb.Where(fmt.Sprintf("%s <= ?", paginationColumn), paginationID)
-			}
-		}
-	}
-
-	return sb, nil
+	return sb.Limit(int(pageSize) + 1), nil // Fetch one additional item to find the next token
 }
 
 //nolint:unused

--- a/internal/storage/common/paginator_offset.go
+++ b/internal/storage/common/paginator_offset.go
@@ -22,6 +22,19 @@ func (o OffsetPaginator[ResourceType, OptionsType]) Paginate(sb *bun.SelectQuery
 	orderExpression := fmt.Sprintf("%s %s", paginationColumn, originalOrder)
 	sb = sb.Order(orderExpression)
 
+	return o.ApplyWindow(sb)
+}
+
+// ApplyCursorPredicate is a no-op for offset pagination: the position is expressed as OFFSET,
+// which is part of the page window (see ApplyWindow), not a predicate on the filtered set.
+//
+//nolint:unused
+func (o OffsetPaginator[ResourceType, OptionsType]) ApplyCursorPredicate(sb *bun.SelectQuery) *bun.SelectQuery {
+	return sb
+}
+
+//nolint:unused
+func (o OffsetPaginator[ResourceType, OptionsType]) ApplyWindow(sb *bun.SelectQuery) (*bun.SelectQuery, error) {
 	if o.query.Offset > math.MaxInt32 {
 		return nil, fmt.Errorf("offset value exceeds maximum allowed value")
 	}

--- a/internal/storage/common/resource.go
+++ b/internal/storage/common/resource.go
@@ -220,18 +220,13 @@ func (r *ResourceRepository[ResourceType, OptionsType]) buildFilteredDataset(bui
 	return r.resourceHandler.Project(q, dataset)
 }
 
-// expand wraps the filtered dataset as a "dataset" CTE and left-joins any requested expand CTEs.
-// When materialized is true the CTE is emitted as "WITH dataset AS MATERIALIZED (...)", an
-// optimization fence that forces the planner to evaluate the filtered set once instead of
-// inlining it (which would let an outer LIMIT leak back onto the scan). See DatasetFencer.
-func (r *ResourceRepository[ResourceType, OptionsType]) expand(dataset *bun.SelectQuery, q ResourceQuery[OptionsType], materialized bool) (*bun.SelectQuery, error) {
-	outer := dataset.NewSelect()
-	if materialized {
-		outer = outer.WithQuery(bun.NewWithQuery("dataset", dataset).Materialized())
-	} else {
-		outer = outer.With("dataset", dataset)
-	}
-	dataset = outer.
+// expand wraps the given select as the "dataset" CTE and left-joins any requested expand CTEs,
+// which reference it via "select ... from dataset". The MATERIALIZED fence (when fencing) lives one
+// level deeper, inside the select passed here (see Paginate), so the expands always join against the
+// page rather than the full filtered set.
+func (r *ResourceRepository[ResourceType, OptionsType]) expand(dataset *bun.SelectQuery, q ResourceQuery[OptionsType]) (*bun.SelectQuery, error) {
+	dataset = dataset.NewSelect().
+		With("dataset", dataset).
 		ModelTableExpr("dataset").
 		ColumnExpr("*")
 
@@ -274,7 +269,7 @@ func (r *ResourceRepository[ResourceType, OptionsType]) GetOne(ctx context.Conte
 		return nil, err
 	}
 
-	finalQuery, err = r.expand(finalQuery, query, false)
+	finalQuery, err = r.expand(finalQuery, query)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +406,25 @@ func (r *PaginatedResourceRepository[ResourceType, OptionsType]) Paginate(
 	if fence {
 		// The cursor/offset predicate is part of "the filtered set", so it stays inside the fence.
 		finalQuery = paginator.ApplyCursorPredicate(finalQuery)
-		finalQuery, err = r.expand(finalQuery, resourceQuery, true)
+
+		// Fence the filtered set in a MATERIALIZED CTE ("filtered"), then take the page
+		// (ORDER BY + LIMIT/OFFSET) in the "dataset" select that wraps it. The page window lives
+		// here — between the fence and the expand joins — so expand CTEs that reference
+		// "select id from dataset" see only the page, not the whole filtered set. The plan benefit
+		// is preserved: the LIMIT is outside the *materialized* CTE, so the planner still evaluates
+		// "filtered" once via the GIN BitmapOr and the page is a cheap top-N over that result.
+		paged := finalQuery.NewSelect().
+			WithQuery(bun.NewWithQuery("filtered", finalQuery).Materialized()).
+			ModelTableExpr("filtered").
+			ColumnExpr("*").
+			Order(paginator.OrderExpression())
+		paged, err = paginator.ApplyWindow(paged)
+		if err != nil {
+			return nil, fmt.Errorf("applying page window: %w", err)
+		}
+
+		// expand wraps the paged select as the "dataset" CTE the expands join against.
+		finalQuery, err = r.expand(paged, resourceQuery)
 		if err != nil {
 			return nil, fmt.Errorf("expanding results: %w", err)
 		}
@@ -420,7 +433,7 @@ func (r *PaginatedResourceRepository[ResourceType, OptionsType]) Paginate(
 		if err != nil {
 			return nil, fmt.Errorf("paginating request: %w", err)
 		}
-		finalQuery, err = r.expand(finalQuery, resourceQuery, false)
+		finalQuery, err = r.expand(finalQuery, resourceQuery)
 		if err != nil {
 			return nil, fmt.Errorf("expanding results: %w", err)
 		}
@@ -428,20 +441,11 @@ func (r *PaginatedResourceRepository[ResourceType, OptionsType]) Paginate(
 	// Qualify the sort column with "dataset." so that LEFT JOINed expand CTEs
 	// cannot introduce an ambiguous column name (e.g. a future expand that also
 	// selects "id"). No expand today conflicts, but this makes it safe by construction.
-	// This is the single source of the final ORDER BY for both paths; in the fenced path it
-	// is the only ORDER BY, and it must be applied before the page window below.
+	// This is the final ORDER BY over the joined result for both paths; in the fenced path the
+	// page LIMIT already lives inside the "dataset" CTE, so the outer select carries no LIMIT.
 	orderExpr := paginator.OrderExpression()
 	col, dir, _ := strings.Cut(orderExpr, " ")
 	finalQuery = finalQuery.Order(fmt.Sprintf("dataset.%s %s", col, dir))
-
-	if fence {
-		// In the fenced shape the LIMIT (+ OFFSET) live on the outer select, applied after the
-		// outer ORDER BY above.
-		finalQuery, err = paginator.ApplyWindow(finalQuery)
-		if err != nil {
-			return nil, fmt.Errorf("applying page window: %w", err)
-		}
-	}
 
 	ret := make([]ResourceType, 0)
 	err = finalQuery.Model(&ret).Scan(ctx)

--- a/internal/storage/common/resource.go
+++ b/internal/storage/common/resource.go
@@ -113,6 +113,24 @@ type RepositoryHandler[Opts any] interface {
 	Expand(query ResourceQuery[Opts], property string) (*bun.SelectQuery, *JoinCondition, error)
 }
 
+// DatasetFencer is an optional interface a RepositoryHandler may implement to request a
+// MATERIALIZED CTE fence around the filtered dataset when the resolved filter is selective
+// enough that an abort-early "ORDER BY ... LIMIT" index walk would scan most of the table.
+//
+// When ShouldFenceDataset returns true, the paginated query is generated as:
+//
+//	WITH dataset AS MATERIALIZED (<filter + PIT + keyset>)
+//	SELECT * FROM dataset [expand joins] ORDER BY dataset.<col> <dir> LIMIT pageSize+1
+//
+// i.e. the ORDER BY + LIMIT move outside the fence so the planner can pick a GIN BitmapOr
+// over the filtered set instead of walking the pagination index. The decision is static
+// (filter-shape based); see internal/storage/ledger/resource_transactions.go for the rule.
+//
+// Handlers that do not implement this interface keep the default, non-materialized shape.
+type DatasetFencer[Opts any] interface {
+	ShouldFenceDataset(ctx RepositoryHandlerBuildContext[Opts]) bool
+}
+
 type ResourceRepository[ResourceType, OptionsType any] struct {
 	resourceHandler RepositoryHandler[OptionsType]
 }
@@ -155,17 +173,26 @@ func (r *ResourceRepository[ResourceType, OptionsType]) validateFilters(builder 
 	return ret, nil
 }
 
-func (r *ResourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q ResourceQuery[OptionsType]) (*bun.SelectQuery, error) {
-
+// resolveBuildContext validates the query's filters and returns the build context shared by
+// BuildDataset and the optional DatasetFencer decision. Kept separate from buildFilteredDataset
+// so the paginated path can inspect the resolved filter shape before deciding whether to fence.
+func (r *ResourceRepository[ResourceType, OptionsType]) resolveBuildContext(q ResourceQuery[OptionsType]) (RepositoryHandlerBuildContext[OptionsType], error) {
 	filters, err := r.validateFilters(q.Builder)
 	if err != nil {
-		return nil, err
+		return RepositoryHandlerBuildContext[OptionsType]{}, err
 	}
 
-	dataset, err := r.resourceHandler.BuildDataset(RepositoryHandlerBuildContext[OptionsType]{
+	return RepositoryHandlerBuildContext[OptionsType]{
 		ResourceQuery: q,
 		filters:       filters,
-	})
+	}, nil
+}
+
+func (r *ResourceRepository[ResourceType, OptionsType]) buildFilteredDataset(buildCtx RepositoryHandlerBuildContext[OptionsType]) (*bun.SelectQuery, error) {
+
+	q := buildCtx.ResourceQuery
+
+	dataset, err := r.resourceHandler.BuildDataset(buildCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -193,9 +220,18 @@ func (r *ResourceRepository[ResourceType, OptionsType]) buildFilteredDataset(q R
 	return r.resourceHandler.Project(q, dataset)
 }
 
-func (r *ResourceRepository[ResourceType, OptionsType]) expand(dataset *bun.SelectQuery, q ResourceQuery[OptionsType]) (*bun.SelectQuery, error) {
-	dataset = dataset.NewSelect().
-		With("dataset", dataset).
+// expand wraps the filtered dataset as a "dataset" CTE and left-joins any requested expand CTEs.
+// When materialized is true the CTE is emitted as "WITH dataset AS MATERIALIZED (...)", an
+// optimization fence that forces the planner to evaluate the filtered set once instead of
+// inlining it (which would let an outer LIMIT leak back onto the scan). See DatasetFencer.
+func (r *ResourceRepository[ResourceType, OptionsType]) expand(dataset *bun.SelectQuery, q ResourceQuery[OptionsType], materialized bool) (*bun.SelectQuery, error) {
+	outer := dataset.NewSelect()
+	if materialized {
+		outer = outer.WithQuery(bun.NewWithQuery("dataset", dataset).Materialized())
+	} else {
+		outer = outer.With("dataset", dataset)
+	}
+	dataset = outer.
 		ModelTableExpr("dataset").
 		ColumnExpr("*")
 
@@ -228,12 +264,17 @@ func (r *ResourceRepository[ResourceType, OptionsType]) expand(dataset *bun.Sele
 
 func (r *ResourceRepository[ResourceType, OptionsType]) GetOne(ctx context.Context, query ResourceQuery[OptionsType]) (*ResourceType, error) {
 
-	finalQuery, err := r.buildFilteredDataset(query)
+	buildCtx, err := r.resolveBuildContext(query)
 	if err != nil {
 		return nil, err
 	}
 
-	finalQuery, err = r.expand(finalQuery, query)
+	finalQuery, err := r.buildFilteredDataset(buildCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	finalQuery, err = r.expand(finalQuery, query, false)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +295,12 @@ func (r *ResourceRepository[ResourceType, OptionsType]) GetOne(ctx context.Conte
 
 func (r *ResourceRepository[ResourceType, OptionsType]) Count(ctx context.Context, query ResourceQuery[OptionsType]) (int, error) {
 
-	finalQuery, err := r.buildFilteredDataset(query)
+	buildCtx, err := r.resolveBuildContext(query)
+	if err != nil {
+		return 0, err
+	}
+
+	finalQuery, err := r.buildFilteredDataset(buildCtx)
 	if err != nil {
 		return 0, err
 	}
@@ -344,26 +390,58 @@ func (r *PaginatedResourceRepository[ResourceType, OptionsType]) Paginate(
 		panic("should not happen")
 	}
 
-	finalQuery, err := r.buildFilteredDataset(resourceQuery)
+	buildCtx, err := r.resolveBuildContext(resourceQuery)
+	if err != nil {
+		return nil, fmt.Errorf("resolving build context: %w", err)
+	}
+
+	// A handler may opt into a MATERIALIZED CTE fence when its resolved filter is selective.
+	// Fenced, the keyset predicate stays inside the CTE and ORDER BY + LIMIT move to the outer
+	// select; unfenced keeps the historical shape (order + limit inside the dataset select).
+	fence := false
+	if fencer, ok := r.resourceHandler.(DatasetFencer[OptionsType]); ok {
+		fence = fencer.ShouldFenceDataset(buildCtx)
+	}
+
+	finalQuery, err := r.buildFilteredDataset(buildCtx)
 	if err != nil {
 		return nil, fmt.Errorf("building filtered dataset: %w", err)
 	}
 
-	finalQuery, err = paginator.Paginate(finalQuery)
-	if err != nil {
-		return nil, fmt.Errorf("paginating request: %w", err)
-	}
-
-	finalQuery, err = r.expand(finalQuery, resourceQuery)
-	if err != nil {
-		return nil, fmt.Errorf("expanding results: %w", err)
+	if fence {
+		// The cursor/offset predicate is part of "the filtered set", so it stays inside the fence.
+		finalQuery = paginator.ApplyCursorPredicate(finalQuery)
+		finalQuery, err = r.expand(finalQuery, resourceQuery, true)
+		if err != nil {
+			return nil, fmt.Errorf("expanding results: %w", err)
+		}
+	} else {
+		finalQuery, err = paginator.Paginate(finalQuery)
+		if err != nil {
+			return nil, fmt.Errorf("paginating request: %w", err)
+		}
+		finalQuery, err = r.expand(finalQuery, resourceQuery, false)
+		if err != nil {
+			return nil, fmt.Errorf("expanding results: %w", err)
+		}
 	}
 	// Qualify the sort column with "dataset." so that LEFT JOINed expand CTEs
 	// cannot introduce an ambiguous column name (e.g. a future expand that also
 	// selects "id"). No expand today conflicts, but this makes it safe by construction.
+	// This is the single source of the final ORDER BY for both paths; in the fenced path it
+	// is the only ORDER BY, and it must be applied before the page window below.
 	orderExpr := paginator.OrderExpression()
 	col, dir, _ := strings.Cut(orderExpr, " ")
 	finalQuery = finalQuery.Order(fmt.Sprintf("dataset.%s %s", col, dir))
+
+	if fence {
+		// In the fenced shape the LIMIT (+ OFFSET) live on the outer select, applied after the
+		// outer ORDER BY above.
+		finalQuery, err = paginator.ApplyWindow(finalQuery)
+		if err != nil {
+			return nil, fmt.Errorf("applying page window: %w", err)
+		}
+	}
 
 	ret := make([]ResourceType, 0)
 	err = finalQuery.Model(&ret).Scan(ctx)

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -158,6 +158,32 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 	}
 }
 
+// ShouldFenceDataset opts ListTransactions into a MATERIALIZED CTE fence when the filter targets a
+// specific account/source/destination address or metadata value. These compile to indexed JSONB/array
+// containment ("needle") predicates that are usually highly selective; without the fence the
+// "ORDER BY id DESC LIMIT n" pagination triggers an abort-early walk of transactions_id_desc that can
+// scan most of the table before collecting a page. Fenced, the planner uses the GIN BitmapOr over the
+// filtered set and the LIMIT becomes a trivial top-N. Broad/range-only filters (id/timestamp/reference/
+// reverted) are intentionally left unfenced, where abort-early is the faster plan.
+//
+// The decision is static and correctness-safe (see DatasetFencer): edge cases such as a negated
+// containment (NOT metadata @> {x}) or a non-selective needle value like account="world" may fence
+// without benefit, but never change the result.
+func (h transactionsResourceHandler) ShouldFenceDataset(ctx common.RepositoryHandlerBuildContext[any]) bool {
+	return shouldFenceTransactionsDataset(ctx)
+}
+
+// shouldFenceTransactionsDataset holds the static needle-filter rule, taking the minimal UseFilter
+// interface so it can be unit-tested with a mock (see resource_transactions_test.go).
+func shouldFenceTransactionsDataset(q interface {
+	UseFilter(string, ...func(any) bool) bool
+}) bool {
+	return q.UseFilter("account") ||
+		q.UseFilter("source") ||
+		q.UseFilter("destination") ||
+		q.UseFilter("metadata")
+}
+
 func (h transactionsResourceHandler) Project(_ common.ResourceQuery[any], selectQuery *bun.SelectQuery) (*bun.SelectQuery, error) {
 	return selectQuery.ColumnExpr("*"), nil
 }

--- a/internal/storage/ledger/resource_transactions_fence_test.go
+++ b/internal/storage/ledger/resource_transactions_fence_test.go
@@ -1,0 +1,263 @@
+//go:build it
+
+package ledger_test
+
+import (
+	"context"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/query"
+	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
+	"github.com/formancehq/go-libs/v5/pkg/types/time"
+
+	ledger "github.com/formancehq/ledger/internal"
+	"github.com/formancehq/ledger/internal/storage/common"
+)
+
+// sqlRecorder is a bun.QueryHook that captures the formatted SQL of executed queries while enabled.
+// It is process-wide (bun has no hook removal), so it filters nothing itself — callers isolate their
+// queries by the unique per-test ledger name.
+type sqlRecorder struct {
+	enabled atomic.Bool
+	mu      sync.Mutex
+	queries []string
+}
+
+func (r *sqlRecorder) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.Context {
+	return ctx
+}
+
+func (r *sqlRecorder) AfterQuery(_ context.Context, e *bun.QueryEvent) {
+	if !r.enabled.Load() {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.queries = append(r.queries, e.Query)
+}
+
+func (r *sqlRecorder) snapshotLen() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.queries)
+}
+
+func (r *sqlRecorder) since(from int) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.queries[from:]...)
+}
+
+// TestListTransactionsMaterializedFence asserts that a selective ("needle") filter emits a
+// MATERIALIZED dataset CTE, while an unfiltered list keeps the historical non-materialized shape
+// (acceptance criterion 2 regression guard + non-fence shape preservation).
+func TestListTransactionsMaterializedFence(t *testing.T) {
+	// Not parallel: relies on a process-wide query hook with a recording window.
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	rec := &sqlRecorder{}
+	defaultBunDB.GetValue().AddQueryHook(rec)
+	t.Cleanup(func() { rec.enabled.Store(false) })
+
+	tx := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"wallet_id": "w1"}).
+		WithTimestamp(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+
+	// capture runs fn with recording enabled and returns the dataset queries it produced. This test
+	// is intentionally NOT parallel: a non-parallel test runs while all t.Parallel siblings are
+	// paused, so the process-wide recorder only sees this test's queries during the window, and
+	// matching on the "dataset" CTE is enough to pick out the transactions list query.
+	capture := func(fn func()) []string {
+		from := rec.snapshotLen()
+		rec.enabled.Store(true)
+		fn()
+		rec.enabled.Store(false)
+
+		var out []string
+		for _, q := range rec.since(from) {
+			if strings.Contains(q, "dataset") {
+				out = append(out, q)
+			}
+		}
+		return out
+	}
+
+	containsMaterialized := func(queries []string) bool {
+		for _, q := range queries {
+			if strings.Contains(q, "AS MATERIALIZED") {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("selective account filter is fenced", func(t *testing.T) {
+		queries := capture(func() {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				PageSize: 10,
+				Options:  common.ResourceQuery[any]{Builder: query.Match("account", "alice")},
+			})
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, queries, "expected to capture the list query")
+		require.True(t, containsMaterialized(queries),
+			"selective filter should emit a MATERIALIZED CTE, got: %v", queries)
+	})
+
+	t.Run("metadata filter is fenced", func(t *testing.T) {
+		queries := capture(func() {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				PageSize: 10,
+				Options:  common.ResourceQuery[any]{Builder: query.Match("metadata[wallet_id]", "w1")},
+			})
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, queries)
+		require.True(t, containsMaterialized(queries),
+			"metadata filter should emit a MATERIALIZED CTE, got: %v", queries)
+	})
+
+	t.Run("unfiltered list is not fenced", func(t *testing.T) {
+		queries := capture(func() {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				PageSize: 10,
+			})
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, queries)
+		require.False(t, containsMaterialized(queries),
+			"unfiltered list must keep the non-materialized shape, got: %v", queries)
+	})
+
+	t.Run("range-only (timestamp) filter is not fenced", func(t *testing.T) {
+		queries := capture(func() {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				PageSize: 10,
+				Options:  common.ResourceQuery[any]{Builder: query.Lte("timestamp", now.Format(time.RFC3339Nano))},
+			})
+			require.NoError(t, err)
+		})
+		require.NotEmpty(t, queries)
+		require.False(t, containsMaterialized(queries),
+			"range-only filter must not be fenced, got: %v", queries)
+	})
+}
+
+// TestListTransactionsFencedPagination walks next/previous pages under a fenced (selective) filter
+// with a page size of 1, confirming cursor pagination, HasMore overfetch, and ordering are correct
+// when ORDER BY + LIMIT live on the outer select and the keyset predicate stays inside the fence.
+func TestListTransactionsFencedPagination(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	// Three transactions all touching "alice" (so the account filter is a needle => fenced),
+	// at increasing timestamps so the default id/timestamp DESC order is tx3, tx2, tx1.
+	var ids []uint64
+	for i := 0; i < 3; i++ {
+		tx := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithTimestamp(now.Add(time.Duration(i) * time.Minute))
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+		ids = append(ids, *tx.ID)
+	}
+	// Descending id order is the default.
+	wantDesc := []uint64{ids[2], ids[1], ids[0]}
+
+	filter := common.InitialPaginatedQuery[any]{
+		PageSize: 1,
+		Options:  common.ResourceQuery[any]{Builder: query.Match("account", "alice")},
+	}
+
+	// Forward traversal collects one transaction per page following Next until exhausted.
+	var forward []uint64
+	var q common.PaginatedQuery[any] = filter
+	for {
+		cursor, err := store.Transactions().Paginate(ctx, q)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(cursor.Data), 1)
+		for _, tx := range cursor.Data {
+			forward = append(forward, *tx.ID)
+		}
+		if cursor.Next == "" {
+			break
+		}
+		q, err = common.UnmarshalCursor[any](cursor.Next)
+		require.NoError(t, err)
+		require.Less(t, len(forward), 10, "pagination did not terminate")
+	}
+	require.Equal(t, wantDesc, forward, "fenced forward pagination must return all rows in order")
+
+	// From the last page, walk Previous back to the start and confirm we revisit the same rows.
+	last, err := store.Transactions().Paginate(ctx, filter)
+	require.NoError(t, err)
+	require.NotEmpty(t, last.Next)
+	// advance to the 2nd page so a Previous link exists
+	second, err := common.UnmarshalCursor[any](last.Next)
+	require.NoError(t, err)
+	secondCursor, err := store.Transactions().Paginate(ctx, second)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{wantDesc[1]}, idsOf(secondCursor.Data))
+	require.NotEmpty(t, secondCursor.Previous)
+	prev, err := common.UnmarshalCursor[any](secondCursor.Previous)
+	require.NoError(t, err)
+	prevCursor, err := store.Transactions().Paginate(ctx, prev)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{wantDesc[0]}, idsOf(prevCursor.Data))
+}
+
+// TestListTransactionsFencedWithEffectiveVolumes guards the expand interaction: under the fence the
+// dataset CTE holds the full filtered set (no inner LIMIT), and the effectiveVolumes expand CTE
+// references "select id from dataset". The page must still come back correct with its volumes.
+func TestListTransactionsFencedWithEffectiveVolumes(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		tx := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithTimestamp(now.Add(time.Duration(i) * time.Minute))
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+	}
+
+	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		PageSize: 2,
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("account", "alice"),
+			Expand:  []string{"volumes", "effectiveVolumes"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, cursor.Data, 2, "page size honored under fence")
+	require.True(t, cursor.HasMore, "third row should be detected via overfetch")
+	for _, tx := range cursor.Data {
+		require.NotEmpty(t, tx.PostCommitEffectiveVolumes,
+			"effective volumes must be populated for each page row under the fence")
+		require.Equal(t, tx.PostCommitVolumes, tx.PostCommitEffectiveVolumes)
+	}
+}
+
+func idsOf(txs []ledger.Transaction) []uint64 {
+	out := make([]uint64, 0, len(txs))
+	for _, tx := range txs {
+		out = append(out, *tx.ID)
+	}
+	return out
+}

--- a/internal/storage/ledger/resource_transactions_fence_test.go
+++ b/internal/storage/ledger/resource_transactions_fence_test.go
@@ -153,6 +153,41 @@ func TestListTransactionsMaterializedFence(t *testing.T) {
 		require.False(t, containsMaterialized(queries),
 			"range-only filter must not be fenced, got: %v", queries)
 	})
+
+	// Regression guard for the nested-CTE shape: when fenced with effectiveVolumes, the page LIMIT
+	// must live inside the "dataset" CTE so the expand's "select id from dataset" sees only the page,
+	// not the whole materialized filtered set. Otherwise effectiveVolumes aggregates over the entire
+	// matched history to return one page.
+	t.Run("fenced + effectiveVolumes pages before the expand reads dataset", func(t *testing.T) {
+		queries := capture(func() {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				PageSize: 5,
+				Options: common.ResourceQuery[any]{
+					Builder: query.Match("account", "alice"),
+					Expand:  []string{"effectiveVolumes"},
+				},
+			})
+			require.NoError(t, err)
+		})
+
+		var main string
+		for _, q := range queries {
+			if strings.Contains(q, "AS MATERIALIZED") {
+				main = q
+				break
+			}
+		}
+		require.NotEmpty(t, main, "expected a fenced list query, got: %v", queries)
+
+		low := strings.ToLower(main)
+		expandRef := strings.Index(low, "select id from dataset")
+		limitIdx := strings.Index(low, "limit")
+		require.GreaterOrEqual(t, expandRef, 0, "effectiveVolumes expand should reference dataset: %s", main)
+		require.GreaterOrEqual(t, limitIdx, 0, "fenced query should carry a page LIMIT: %s", main)
+		require.Less(t, limitIdx, expandRef,
+			"page LIMIT must live inside the dataset CTE (before the expand reads from dataset), "+
+				"so effectiveVolumes aggregates over the page, not the whole filtered set: %s", main)
+	})
 }
 
 // TestListTransactionsFencedPagination walks next/previous pages under a fenced (selective) filter

--- a/internal/storage/ledger/resource_transactions_test.go
+++ b/internal/storage/ledger/resource_transactions_test.go
@@ -1,0 +1,79 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldFenceTransactionsDataset(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		filters map[string][]any
+		expect  bool
+	}{
+		{
+			name:    "no filter",
+			filters: map[string][]any{},
+			expect:  false,
+		},
+		{
+			name:    "account needle",
+			filters: map[string][]any{"account": {"users:alice"}},
+			expect:  true,
+		},
+		{
+			name:    "source needle",
+			filters: map[string][]any{"source": {"world"}},
+			expect:  true,
+		},
+		{
+			name:    "destination needle",
+			filters: map[string][]any{"destination": {"bank"}},
+			expect:  true,
+		},
+		{
+			name:    "metadata needle",
+			filters: map[string][]any{"metadata": {map[string]any{"wallet_id": "x"}}},
+			expect:  true,
+		},
+		{
+			name:    "id only is not a needle",
+			filters: map[string][]any{"id": {uint64(42)}},
+			expect:  false,
+		},
+		{
+			name:    "timestamp only is not a needle",
+			filters: map[string][]any{"timestamp": {"2026-06-11T00:00:00Z"}},
+			expect:  false,
+		},
+		{
+			name:    "reference only is not a needle",
+			filters: map[string][]any{"reference": {"tx1"}},
+			expect:  false,
+		},
+		{
+			name:    "reverted only is not a needle",
+			filters: map[string][]any{"reverted": {true}},
+			expect:  false,
+		},
+		{
+			name: "needle combined with range still fences",
+			filters: map[string][]any{
+				"account":   {"users:alice"},
+				"timestamp": {"2026-06-11T00:00:00Z"},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockUseFilter{filters: tc.filters}
+			assert.Equal(t, tc.expect, shouldFenceTransactionsDataset(mock))
+		})
+	}
+}

--- a/internal/storage/ledger/resource_transactions_test.go
+++ b/internal/storage/ledger/resource_transactions_test.go
@@ -36,7 +36,7 @@ func TestShouldFenceTransactionsDataset(t *testing.T) {
 		},
 		{
 			name:    "metadata needle",
-			filters: map[string][]any{"metadata": {map[string]any{"wallet_id": "x"}}},
+			filters: map[string][]any{"metadata": {"wallet_id"}},
 			expect:  true,
 		},
 		{


### PR DESCRIPTION
Backport of #1409 to `release/v2.4`.

## Problem

A selective wallet-history `ListTransactions` attached `ORDER BY id DESC LIMIT n` to the same select as a JSONB `@>` filter, so the planner chose an abort-early `transactions_id_desc` index walk that scanned ~2.3M rows (**16.1s**) to return 16.

## Fix

Wrap the filtered dataset in a **`MATERIALIZED`** CTE and move `ORDER BY id DESC LIMIT n` to the **outer** select, so the planner uses the GIN `BitmapOr` (**~7.7ms**, ~2,000×). The fence is **conditional** — applied only when the filter contains a "needle" containment predicate (`account`/`source`/`destination`/`metadata`) via the opt-in `DatasetFencer` interface; unfiltered/range-only lists keep the historical shape. No schema change (GIN indexes already exist).

## Backport notes

- Cherry-picked cleanly from `main` (PR #1409, commit `801a5619`); the only auto-merge was context in `paginator.go`.
- Verified on the v2.4 base: `go build`, `go vet`, and the fence integration tests (`TestListTransactionsMaterializedFence`, `TestListTransactionsFencedPagination`, `TestListTransactionsFencedWithEffectiveVolumes`, `TestShouldFenceTransactionsDataset`) all pass.

See #1409 for full details and the tri-model review.