### PR TITLE
fix(storage): make logs_blocks primary key composite (ledger, previous)

### DIFF
--- a/internal/storage/bucket/migrations/53-fix-logs-blocks-pkey-collision/notes.yaml
+++ b/internal/storage/bucket/migrations/53-fix-logs-blocks-pkey-collision/notes.yaml
@@ -1,0 +1,1 @@
+name: Fix logs_blocks primary key to be composite (ledger, previous) to allow multiple ledgers in the same bucket

--- a/internal/storage/bucket/migrations/53-fix-logs-blocks-pkey-collision/up.sql
+++ b/internal/storage/bucket/migrations/53-fix-logs-blocks-pkey-collision/up.sql
@@ -1,0 +1,8 @@
+do $$
+	begin
+		set search_path = '{{ .Schema }}';
+
+		alter table logs_blocks drop constraint logs_blocks_pkey;
+		alter table logs_blocks add primary key (ledger, previous);
+	end
+$$;

--- a/test/e2e/app_logs_blocks_async_test.go
+++ b/test/e2e/app_logs_blocks_async_test.go
@@ -108,3 +108,100 @@ var _ = Context("Logs block async hashing", func() {
 		})
 	})
 })
+
+var _ = Context("Logs block async hashing with multiple ledgers in the same bucket", func() {
+	var (
+		db                = UseTemplatedDatabase()
+		connectionOptions = DeferMap(db, (*pgtesting.Database).ConnectionOptions)
+		ctx               = logging.TestingContext()
+	)
+
+	const (
+		blockSize    = 10
+		nbBlock      = 2
+		txCount      = blockSize * nbBlock
+		sharedBucket = "shared"
+	)
+
+	ledgerNames := []string{"ledger-a", "ledger-b"}
+
+	testServer := ginkgo.DeferTestServer(
+		connectionOptions,
+		testservice.WithInstruments(
+			testservice.DebugInstrumentation(debug),
+			testservice.OutputInstrumentation(GinkgoWriter),
+			ExperimentalFeaturesInstrumentation(),
+		),
+		testservice.WithLogger(GinkgoT()),
+	)
+
+	ginkgo.DeferTestWorker(connectionOptions, testservice.WithInstruments(
+		LogsHashBlockCRONSpecInstrumentation("* * * * * *"),
+		LogsHashBlockMaxSizeInstrumentation(blockSize),
+	))
+
+	JustBeforeEach(func(specContext SpecContext) {
+		for _, name := range ledgerNames {
+			_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+				Ledger: name,
+				V2CreateLedgerRequest: components.V2CreateLedgerRequest{
+					Bucket:   pointer.For(sharedBucket),
+					Features: features.MinimalFeatureSet.With(features.FeatureHashLogs, "ASYNC"),
+				},
+			})
+			Expect(err).To(BeNil())
+		}
+	})
+
+	When(fmt.Sprintf("creating %d transactions on each ledger", txCount), func() {
+		JustBeforeEach(func(specContext SpecContext) {
+			for _, name := range ledgerNames {
+				requestBody := make([]components.V2BulkElement, 0, txCount)
+				for i := 0; i < txCount; i++ {
+					requestBody = append(requestBody, components.CreateV2BulkElementCreateTransaction(
+						components.V2BulkElementCreateTransaction{
+							Data: &components.V2PostTransaction{
+								Metadata: map[string]string{},
+								Postings: []components.V2Posting{{
+									Amount:      big.NewInt(100),
+									Asset:       "USD",
+									Source:      "world",
+									Destination: "bank",
+								}},
+							},
+						},
+					))
+				}
+
+				_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+					Ledger:      name,
+					RequestBody: requestBody,
+					Atomic:      pointer.For(true),
+				})
+				Expect(err).To(BeNil())
+			}
+		})
+		It(fmt.Sprintf("should generate %d blocks per ledger without primary key collisions", nbBlock), func() {
+			db := ConnectToDatabase(ctx, connectionOptions)
+			Eventually(func(g Gomega) bool {
+				for _, name := range ledgerNames {
+					ret := make([]map[string]any, 0)
+					err := db.NewSelect().
+						Model(&ret).
+						ModelTableExpr(fmt.Sprintf("%s.logs_blocks", sharedBucket)).
+						Where("ledger = ?", name).
+						Scan(ctx)
+					g.Expect(err).To(BeNil())
+					g.Expect(ret).To(HaveLen(nbBlock))
+					for _, block := range ret {
+						g.Expect(block["hash"]).NotTo(BeEmpty())
+					}
+				}
+
+				return true
+			}).
+				WithTimeout(10 * time.Second).
+				Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Adds bucket migration `53-fix-logs-blocks-pkey-collision` that swaps the `logs_blocks` primary key from `(previous)` to `(ledger, previous)`, allowing multiple ledgers in the same bucket to each own their own chain head (`previous=0`).
- Adds an e2e test that reproduces the production collision (two async-hashed ledgers in the same bucket).

## Context

Fixes [EN-1246](https://formance-team.atlassian.net/browse/EN-1246). Forward port of #1412 (hotfix branched on `release/v2.4`).

`internal/storage/bucket/migrations/38-logs-async-hash-procedure/up.sql:5` declares `previous bigint primary key` on `logs_blocks`. The `create_blocks` procedure initializes the first block of every ledger with ``previous_block = (0, 0, null)::block``, so the very first insert for any ledger writes `previous = 0`. As soon as two ledgers share the same bucket, the second one fails with `logs_blocks_pkey` SQLSTATE 23505.

Confirmed in production via Signoz on `prod-us-east-1-deriv` (ledger `test_brand` colliding with `deriv` in bucket `_default`) and `prod-eu-west-1-hosting` (ledger `payflip-monoledger-async` colliding with `stress-test-ledger-async`). Rate is rock-steady at 120 err/h (us-east-1) and 60 err/h (eu-west-1) over 48h, with zero recovery. Single-pod worker per cluster — no parallel-worker contributor.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test -tags it ./internal/storage/bucket/...` — migration applies cleanly on a bucket created at migration 38
- [ ] `go test -tags it ./test/e2e/... -run "Logs block async hashing with multiple ledgers"` — new e2e covers the two-ledger collision
- [ ] Existing `Logs block async hashing` single-ledger e2e still passes

[EN-1246]: https://formance-team.atlassian.net/browse/EN-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ