### PR TITLE
fix(storage): handle PIT + metadata filter on aggregated balances when ACCOUNT_METADATA_HISTORY is disabled (v2.3)

### DIFF
--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -403,7 +403,7 @@ func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
 		).
 		WithTimestamp(now).
 		WithInsertedAt(now)
-	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+	require.NoError(t, store.CommitTransaction(ctx, &tx, nil))
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
 		"merchant:m1:held": {
@@ -438,7 +438,7 @@ func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
 	})
 
 	t.Run("with pit and partial address filter", func(t *testing.T) {
-		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledger.GetAggregatedVolumesOptions]{
+		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledgerstore.GetAggregatedVolumesOptions]{
 			PIT: pointer.For(now.Add(time.Minute)),
 			Builder: query.And(
 				query.Match("address", "merchant:"),

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -436,4 +436,16 @@ func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
 		require.NoError(t, err)
 		RequireEqual(t, expected, *ret)
 	})
+
+	t.Run("with pit and partial address filter", func(t *testing.T) {
+		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledger.GetAggregatedVolumesOptions]{
+			PIT: pointer.For(now.Add(time.Minute)),
+			Builder: query.And(
+				query.Match("address", "merchant:"),
+				query.Match("metadata[trust]", "true"),
+			),
+		})
+		require.NoError(t, err)
+		RequireEqual(t, expected, *ret)
+	})
 }

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"github.com/formancehq/ledger/internal/storage/common"
 	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
+	"github.com/formancehq/ledger/pkg/features"
 	"math/big"
 	"testing"
 
@@ -377,5 +378,62 @@ func TestBalancesAggregates(t *testing.T) {
 				},
 			},
 		}, *ret)
+	})
+}
+
+// Regression test for https://github.com/formancehq/ledger/issues/1416:
+// /aggregate/balances with PIT + metadata filter used to silently return an
+// empty result when ACCOUNT_METADATA_HISTORY was DISABLED because the query
+// joined the unpopulated accounts_metadata history table. When the feature is
+// off we must fall back to the current accounts.metadata column.
+func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t, func(cfg *ledger.Configuration) {
+		cfg.Features = features.DefaultFeatures.With(features.FeatureAccountMetadataHistory, "DISABLED")
+	})
+	now := time.Now()
+	ctx := logging.TestingContext()
+
+	amount := big.NewInt(350)
+
+	tx := ledger.NewTransaction().
+		WithPostings(
+			ledger.NewPosting("world", "merchant:m1:held", "USD/2", amount),
+		).
+		WithTimestamp(now).
+		WithInsertedAt(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+
+	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
+		"merchant:m1:held": {
+			"trust": "true",
+		},
+	}, time.Time{}))
+
+	expected := ledger.AggregatedVolumes{
+		Aggregated: ledger.VolumesByAssets{
+			"USD/2": ledger.Volumes{
+				Input:  amount,
+				Output: new(big.Int),
+			},
+		},
+	}
+
+	t.Run("without pit", func(t *testing.T) {
+		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledgerstore.GetAggregatedVolumesOptions]{
+			Builder: query.Match("metadata[trust]", "true"),
+		})
+		require.NoError(t, err)
+		RequireEqual(t, expected, *ret)
+	})
+
+	t.Run("with pit", func(t *testing.T) {
+		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledgerstore.GetAggregatedVolumesOptions]{
+			PIT:     pointer.For(now.Add(time.Minute)),
+			Builder: query.Match("metadata[trust]", "true"),
+		})
+		require.NoError(t, err)
+		RequireEqual(t, expected, *ret)
 	})
 }

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -62,16 +62,27 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 		}
 
 		if query.UseFilter("metadata") {
-			subQuery := h.store.newScopedSelect().
-				DistinctOn("accounts_address").
-				ModelTableExpr(h.store.GetPrefixedRelationName("accounts_metadata")).
-				ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
-				Where("accounts_metadata.accounts_address = moves.accounts_address").
-				Where("date <= ?", query.PIT)
+			if h.store.ledger.HasFeature(features.FeatureAccountMetadataHistory, "SYNC") {
+				subQuery := h.store.newScopedSelect().
+					DistinctOn("accounts_address").
+					ModelTableExpr(h.store.GetPrefixedRelationName("accounts_metadata")).
+					ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
+					Where("accounts_metadata.accounts_address = moves.accounts_address").
+					Where("date <= ?", query.PIT)
 
-			ret = ret.
-				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-				Column("metadata")
+				ret = ret.
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
+					Column("metadata")
+			} else {
+				subQuery := h.store.newScopedSelect().
+					TableExpr(h.store.GetPrefixedRelationName("accounts")).
+					ColumnExpr("metadata").
+					Where("accounts.address = moves.accounts_address")
+
+				ret = ret.
+					Join(`left join lateral (?) accounts on true`, subQuery).
+					Column("metadata")
+			}
 		}
 
 		return ret, nil

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -80,7 +80,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 					Where("accounts.address = moves.accounts_address")
 
 				ret = ret.
-					Join(`left join lateral (?) accounts on true`, subQuery).
+					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
 					Column("metadata")
 			}
 		}


### PR DESCRIPTION
## Summary

Backport of #1421 to `release/v2.3`.

- `/aggregate/balances?pit=…` with a metadata `\$match` filter silently returned `{"data":{}}` on ledgers configured with `ACCOUNT_METADATA_HISTORY: DISABLED`, because the PIT path joined the `accounts_metadata` history table that is never populated under that feature flag value.
- Gate the history join on `FeatureAccountMetadataHistory=SYNC` and fall back to the current `accounts.metadata` column otherwise — matching the pattern already used in `resource_accounts.go`.
- Adds a regression test (`TestBalancesAggregatesPITWithMetadataHistoryDisabled`) covering with-PIT, without-PIT, and the combined metadata + partial address filter case on a ledger configured with `ACCOUNT_METADATA_HISTORY: DISABLED`.

Notes on the backport:
- Import conflict resolved in `balances_test.go`.
- v2.3's `CommitTransaction` already upserts accounts internally, so the `commitTransactionAndUpsertAccounts` helper from main is unnecessary — the regression test was adapted to call `store.CommitTransaction(ctx, &tx, nil)` directly (separate adjustment commit).

Fixes #1416

## Test plan

- [ ] CI green on this branch