### PR TITLE
chore: sync release/v3.0 with old ledger-v3-poc main

### DIFF
--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -95,6 +95,83 @@ spec:
 | `replicaCount` | `1` | Operator replicas |
 | `leaderElection` | `true` | Enable HA leader election |
 | `watchNamespace` | `""` | Namespace to watch (empty = all) |
+| `pvcProtection.enabled` | `false` | Install the cluster-scoped ValidatingAdmissionPolicy that can block accidental deletion of ledger PVCs/PVs (requires Kubernetes >= 1.30). Arming only — a ledger opts in per-CR via `spec.persistence.deletionProtection` |
+| `pvcProtection.allowDeletionAnnotation` | `formance.com/allow-deletion` | Annotation key whose value `true` opts a volume out of deletion protection |
+| `pvcProtection.additionalExemptServiceAccounts` | `[]` | Extra ServiceAccount usernames (`system:serviceaccount:<ns>:<name>`) exempt from the policies — sibling operator releases managing protected ledgers, or managed workload/GitOps controllers |
+
+## Volume Deletion Protection
+
+Deletion protection has three independent layers, so the choice of *which*
+ledgers are protected lives with the ledger owner (per-CR), while *whether the
+mechanism exists at all* stays a cluster-admin decision:
+
+1. **`pvcProtection.enabled` (Helm value, cluster-admin consent).** Installs two
+   cluster-scoped `ValidatingAdmissionPolicy` objects (`failurePolicy: Fail`) that
+   reject `DELETE` of selected ledger PVCs/PVs. Off by default and **requires
+   Kubernetes >= 1.30** (ValidatingAdmissionPolicy GA); enabling it on an older
+   cluster fails the install. Installing the policy does **not** protect anything
+   on its own — the policy bindings only select volumes carrying the
+   `ledger.formance.com/deletion-protection: enabled` label.
+
+   The policy is a **cluster-wide singleton** — enable `pvcProtection.enabled` on
+   **at most one** operator release per cluster. The cluster-scoped policy objects
+   have fixed, release-independent names, so a second release with
+   `pvcProtection.enabled=true` fails its `helm install`/`upgrade` with an ownership
+   conflict by design, rather than installing a second policy that would cross-apply
+   to and block legitimate deletes on the first release's volumes. In a multi-release
+   cluster where *other* releases also manage ledgers with `deletionProtection: true`,
+   list those releases' operator ServiceAccounts in `pvcProtection.additionalExemptServiceAccounts`
+   on the owning release, so their operators' scale-down deletes are not blocked by the
+   singleton policy.
+2. **`spec.persistence.deletionProtection` (per-LedgerService opt-in, default
+   `false`).** When `true`, the operator stamps that label on the ledger's PVCs and
+   their bound PVs, so the cluster policy starts selecting them; setting it back to
+   `false` removes the label and lifts protection. This is versioned alongside the
+   ledger and toggleable without a `helm upgrade`.
+3. **`formance.com/allow-deletion=true` annotation (per-volume override).** A
+   protected volume can still be deleted on purpose by annotating it first.
+
+To delete a protected volume on purpose:
+
+```bash
+kubectl annotate pvc <name> formance.com/allow-deletion=true --overwrite
+kubectl delete pvc <name>
+```
+
+If a LedgerService sets `deletionProtection: true` while no cluster-scoped protection
+policy is installed on the cluster, the label is still stamped but no policy acts on it;
+the operator surfaces this as a `DeletionProtectionInactive` warning event and status
+condition on the CR rather than silently leaving the volumes unprotected. The operator
+detects this by probing for the policy's `ValidatingAdmissionPolicyBinding` directly, so
+the condition stays correct in a multi-release cluster: a sibling release with
+`pvcProtection.enabled=false` whose ledgers are protected by the owning release's
+singleton policy is **not** falsely warned.
+
+Exemptions: the operator ServiceAccount (its own raft scale-down deletes) and the
+kube-controller-manager garbage collector are exempt, so the StatefulSet
+`retentionPolicy: Delete` path (`persistence.retentionPolicy.whenScaled` /
+`whenDeleted=Delete`) continues to work with protection enabled.
+
+No other identity is exempt. A workload/GitOps controller (ArgoCD, Flux, Velero
+restore, etc.) that deletes a protected `LedgerService` **and** its PVCs/PVs in a
+single managed teardown runs under its own ServiceAccount, so once
+`pvcProtection.enabled=true` those deletes are blocked just like a manual one. To
+allow such a teardown, either annotate the volumes with the allow-deletion key
+first (as above) or, for a recurring controller, add its ServiceAccount username to
+`pvcProtection.additionalExemptServiceAccounts` (full form
+`system:serviceaccount:<namespace>:<name>`), which appends it to the policies'
+`matchConditions` exemptions.
+
+The PV policy only protects **Bound** PVs (volumes holding live ledger data). Once
+a PVC is deleted — which itself goes through the PVC policy above — its PV becomes
+`Released` and the reclaim path proceeds normally: with `persistentVolumeReclaimPolicy:
+Delete` (the default for most cloud StorageClasses) the PV controller / CSI
+external-provisioner deletes the volume without being blocked, and with `Retain` an
+admin can delete the orphaned `Released` PV directly. Deleting a live, Bound PV by
+hand is still rejected unless it carries the allow-deletion annotation. (A PV that is
+orphaned in the `Released` state keeps the protection label it last held, because the
+operator only reconciles the label on live PVCs; this is harmless since the policy
+guards Bound PVs only.)
 
 ## kubectl Plugin
 

--- a/misc/operator/api/v1alpha1/ledger_types.go
+++ b/misc/operator/api/v1alpha1/ledger_types.go
@@ -1085,6 +1085,19 @@ type PersistenceSpec struct {
 	// RetentionPolicy for PVCs.
 	// +optional
 	RetentionPolicy *RetentionPolicySpec `json:"retentionPolicy,omitempty"`
+
+	// DeletionProtection opts this ledger's PVCs and bound PVs into the
+	// cluster-scoped volume deletion-protection admission policy. When true, the
+	// operator stamps the `ledger.formance.com/deletion-protection: enabled`
+	// label on the volumes so the policy selects them and rejects accidental
+	// DELETEs unless the object carries the allow-deletion annotation; when set
+	// back to false the label is removed and protection is lifted. The policy
+	// itself must be installed cluster-wide by an admin via the Helm value
+	// `pvcProtection.enabled` — otherwise this flag has no effect and the
+	// operator emits a DeletionProtectionInactive warning on the CR.
+	// +kubebuilder:default=false
+	// +optional
+	DeletionProtection bool `json:"deletionProtection,omitempty"`
 }
 
 // VolumeSpec defines a volume configuration.

--- a/misc/operator/cmd/operator/main.go
+++ b/misc/operator/cmd/operator/main.go
@@ -87,6 +87,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Config:    cfg,
 		Clientset: clientset,
+		Recorder:  mgr.GetEventRecorderFor("ledgerservice-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LedgerService")
 		os.Exit(1)

--- a/misc/operator/config/crd/bases/ledger.formance.com_ledgerservices.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_ledgerservices.yaml
@@ -2488,6 +2488,19 @@ spec:
                           Mutually exclusive with hostPath.
                         type: string
                     type: object
+                  deletionProtection:
+                    default: false
+                    description: |-
+                      DeletionProtection opts this ledger's PVCs and bound PVs into the
+                      cluster-scoped volume deletion-protection admission policy. When true, the
+                      operator stamps the `ledger.formance.com/deletion-protection: enabled`
+                      label on the volumes so the policy selects them and rejects accidental
+                      DELETEs unless the object carries the allow-deletion annotation; when set
+                      back to false the label is removed and protection is lifted. The policy
+                      itself must be installed cluster-wide by an admin via the Helm value
+                      `pvcProtection.enabled` — otherwise this flag has no effect and the
+                      operator emits a DeletionProtectionInactive warning on the CR.
+                    type: boolean
                   retentionPolicy:
                     description: RetentionPolicy for PVCs.
                     properties:

--- a/misc/operator/config/rbac/role.yaml
+++ b/misc/operator/config/rbac/role.yaml
@@ -22,10 +22,27 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - delete
+  - get
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -46,6 +63,14 @@ rules:
   - pods/log
   verbs:
   - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/misc/operator/e2e/tests/pvc-deletion-protection/chainsaw-test.yaml
+++ b/misc/operator/e2e/tests/pvc-deletion-protection/chainsaw-test.yaml
@@ -1,0 +1,138 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pvc-deletion-protection
+# Requires the operator installed with pvcProtection.enabled=true and Kubernetes >= 1.30.
+spec:
+  timeouts:
+    assert: 5m
+  steps:
+    # 1. Deploy a single-replica ledger so its PVCs/PVs are provisioned.
+    - name: Deploy 1-replica cluster
+      try:
+        - apply:
+            file: ledgerservice.yaml
+        - assert:
+            resource:
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: ledger-protect-vol
+              status:
+                readyReplicas: 1
+
+    # 2. Wait until the operator has stamped the per-CR deletion-protection label
+    #    on the bound PV (driven by spec.persistence.deletionProtection=true).
+    - name: Wait for PV label stamping
+      try:
+        - script:
+            content: |
+              for i in $(seq 1 30); do
+                PV=$(kubectl get pvc data-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.spec.volumeName}')
+                if [ -n "$PV" ]; then
+                  LABEL=$(kubectl get pv "$PV" -o jsonpath='{.metadata.labels.ledger\.formance\.com/deletion-protection}')
+                  echo "Attempt $i: pv=$PV deletion-protection-label=$LABEL"
+                  [ "$LABEL" = "enabled" ] && exit 0
+                fi
+                sleep 5
+              done
+              echo "FAIL: PV was not stamped with ledger.formance.com/deletion-protection=enabled"
+              exit 1
+            timeout: 180s
+
+    # 3. PV DELETE without the annotation must also be rejected (the PV-level
+    #    policy, scoped to the label stamped in step 2). Tested while the PV is
+    #    still Bound, before the PVC is touched below.
+    - name: Delete PV without annotation is blocked
+      try:
+        - script:
+            content: |
+              PV=$(kubectl get pvc data-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.spec.volumeName}')
+              [ -n "$PV" ] || { echo "FAIL: PVC has no bound volume"; exit 1; }
+              if kubectl delete pv "$PV" --timeout=30s 2>err.txt; then
+                echo "FAIL: PV deletion succeeded but should have been blocked"
+                cat err.txt
+                exit 1
+              fi
+              echo "PV deletion correctly blocked:"
+              cat err.txt
+              grep -q "allow-deletion" err.txt
+            timeout: 60s
+
+    # 4. After opting in via the annotation, the PV DELETE is admitted. The PV is
+    #    still bound, so the kubernetes.io/pv-protection finalizer keeps it
+    #    Terminating — we assert the request was ADMITTED (deletionTimestamp set).
+    - name: Delete PV with annotation is admitted
+      try:
+        - script:
+            content: |
+              set -e
+              PV=$(kubectl get pvc data-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.spec.volumeName}')
+              [ -n "$PV" ] || { echo "FAIL: PVC has no bound volume"; exit 1; }
+              kubectl annotate pv "$PV" formance.com/allow-deletion=true --overwrite
+              kubectl delete pv "$PV" --wait=false
+              TS=$(kubectl get pv "$PV" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+              echo "deletionTimestamp=$TS"
+              [ -n "$TS" ]
+            timeout: 60s
+
+    # 5. PVC DELETE without the annotation must be rejected by the admission policy.
+    - name: Delete PVC without annotation is blocked
+      try:
+        - script:
+            content: |
+              if kubectl delete pvc data-ledger-protect-vol-0 -n $NAMESPACE --timeout=30s 2>err.txt; then
+                echo "FAIL: PVC deletion succeeded but should have been blocked"
+                cat err.txt
+                exit 1
+              fi
+              echo "PVC deletion correctly blocked:"
+              cat err.txt
+              grep -q "allow-deletion" err.txt
+            timeout: 60s
+
+    # 6. After opting in via the annotation, the PVC DELETE is admitted.
+    #    The PVC is in use by pod-0, so the kubernetes.io/pvc-protection finalizer
+    #    keeps it Terminating until the pod unmounts — we assert the request was
+    #    ADMITTED (deletionTimestamp set), not that the object is fully gone.
+    - name: Delete PVC with annotation is admitted
+      try:
+        - script:
+            content: |
+              set -e
+              kubectl annotate pvc data-ledger-protect-vol-0 -n $NAMESPACE formance.com/allow-deletion=true --overwrite
+              kubectl delete pvc data-ledger-protect-vol-0 -n $NAMESPACE --wait=false
+              TS=$(kubectl get pvc data-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+              echo "deletionTimestamp=$TS"
+              [ -n "$TS" ]
+            timeout: 60s
+
+    # 7. Toggle path: setting spec.persistence.deletionProtection back to false must
+    #    make the operator remove the label from the volumes, lifting protection so a
+    #    PVC DELETE without the annotation is admitted. This guards the remove path in
+    #    reconcileVolumeProtection — protection that stays stuck on after the owner
+    #    turns it off would be a silent regression. Run last (disabling is CR-wide) and
+    #    against the so-far-untouched wal volume, since the data PVC/PV are already
+    #    Terminating from the steps above.
+    - name: Disabling deletionProtection lifts protection
+      try:
+        - script:
+            content: |
+              set -e
+              kubectl patch ledgerservice protect-vol -n $NAMESPACE \
+                --type merge -p '{"spec":{"persistence":{"deletionProtection":false}}}'
+              for i in $(seq 1 30); do
+                PVC_LABEL=$(kubectl get pvc wal-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.metadata.labels.ledger\.formance\.com/deletion-protection}')
+                PV=$(kubectl get pvc wal-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.spec.volumeName}')
+                PV_LABEL=""
+                [ -n "$PV" ] && PV_LABEL=$(kubectl get pv "$PV" -o jsonpath='{.metadata.labels.ledger\.formance\.com/deletion-protection}')
+                echo "Attempt $i: pvc-label='$PVC_LABEL' pv=$PV pv-label='$PV_LABEL'"
+                [ -z "$PVC_LABEL" ] && [ -z "$PV_LABEL" ] && break
+                sleep 5
+              done
+              [ -z "$PVC_LABEL" ] && [ -z "$PV_LABEL" ] || { echo "FAIL: label not removed after disabling protection"; exit 1; }
+              kubectl delete pvc wal-ledger-protect-vol-0 -n $NAMESPACE --wait=false
+              TS=$(kubectl get pvc wal-ledger-protect-vol-0 -n $NAMESPACE -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+              echo "deletionTimestamp=$TS"
+              [ -n "$TS" ]
+            timeout: 180s

--- a/misc/operator/e2e/tests/pvc-deletion-protection/ledgerservice.yaml
+++ b/misc/operator/e2e/tests/pvc-deletion-protection/ledgerservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: ledger.formance.com/v1alpha1
+kind: LedgerService
+metadata:
+  name: protect-vol
+spec:
+  replicas: 1
+  image:
+    repository: ledger-v3-poc
+    tag: e2e
+    pullPolicy: Never
+  persistence:
+    # Opt this ledger into the cluster-scoped deletion-protection policy
+    # (installed via Helm pvcProtection.enabled=true in e2e-cluster-up).
+    deletionProtection: true

--- a/misc/operator/helm/crds/templates/ledger.formance.com_ledgerservices.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_ledgerservices.yaml
@@ -2488,6 +2488,19 @@ spec:
                           Mutually exclusive with hostPath.
                         type: string
                     type: object
+                  deletionProtection:
+                    default: false
+                    description: |-
+                      DeletionProtection opts this ledger's PVCs and bound PVs into the
+                      cluster-scoped volume deletion-protection admission policy. When true, the
+                      operator stamps the `ledger.formance.com/deletion-protection: enabled`
+                      label on the volumes so the policy selects them and rejects accidental
+                      DELETEs unless the object carries the allow-deletion annotation; when set
+                      back to false the label is removed and protection is lifted. The policy
+                      itself must be installed cluster-wide by an admin via the Helm value
+                      `pvcProtection.enabled` — otherwise this flag has no effect and the
+                      operator emits a DeletionProtectionInactive warning on the CR.
+                    type: boolean
                   retentionPolicy:
                     description: RetentionPolicy for PVCs.
                     properties:

--- a/misc/operator/helm/operator/templates/clusterrole.yaml
+++ b/misc/operator/helm/operator/templates/clusterrole.yaml
@@ -23,10 +23,27 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - delete
+  - get
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -47,6 +64,14 @@ rules:
   - pods/log
   verbs:
   - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/misc/operator/helm/operator/templates/validatingadmissionpolicy.yaml
+++ b/misc/operator/helm/operator/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,149 @@
+{{- if .Values.pvcProtection.enabled }}
+{{- $sa := printf "system:serviceaccount:%s:%s" .Release.Namespace (include "ledger-operator.serviceAccountName" .) }}
+{{- $annotation := .Values.pvcProtection.allowDeletionAnnotation }}
+{{- /* Validate as a Kubernetes annotation key: an optional lowercase DNS-1123
+       subdomain prefix (<=253 chars) before '/', then a name segment of
+       alphanumerics/'-'/'_'/'.' (mixed case allowed, <=63 chars). A single regex
+       can't express the differing case rules and length caps, so split on '/'.
+       Enforcing this at render time turns an API-server VAP rejection at apply
+       time into a clear Helm error. */}}
+{{- $parts := splitList "/" $annotation }}
+{{- $name := $annotation }}
+{{- if gt (len $parts) 2 }}
+{{- fail (printf "pvcProtection.allowDeletionAnnotation %q is not a valid Kubernetes annotation key (at most one '/' separator)" $annotation) }}
+{{- end }}
+{{- if eq (len $parts) 2 }}
+{{- $prefix := index $parts 0 }}
+{{- $name = index $parts 1 }}
+{{- if gt (len $prefix) 253 }}
+{{- fail (printf "pvcProtection.allowDeletionAnnotation %q: prefix must be at most 253 characters" $annotation) }}
+{{- end }}
+{{- /* DNS-1123 subdomain: validate each dot-separated label so consecutive dots,
+       empty leading/trailing labels, and >63-char labels are caught in Helm rather
+       than rejected later by the API server. */}}
+{{- range $label := splitList "." $prefix }}
+{{- if or (not (regexMatch "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" $label)) (gt (len $label) 63) }}
+{{- fail (printf "pvcProtection.allowDeletionAnnotation %q: each prefix DNS label must be a non-empty lowercase alphanumeric/'-' segment (start/end alphanumeric) of at most 63 characters" $annotation) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if or (not (regexMatch "^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$" $name)) (gt (len $name) 63) }}
+{{- fail (printf "pvcProtection.allowDeletionAnnotation %q: name segment must be alphanumerics, '-', '_' or '.' (start/end alphanumeric) of at most 63 characters" $annotation) }}
+{{- end }}
+{{- /* The kube-controller-manager garbage collector reaps PVCs when retentionPolicy
+       whenScaled/whenDeleted=Delete removes their owner refs; exempt it so that path
+       composes with protection (the operator SA covers its own scale-down deletes). */}}
+{{- $gc := "system:serviceaccount:kube-system:generic-garbage-collector" }}
+{{- /* Extra ServiceAccount usernames the admin wants exempt (sibling operator releases
+       in a multi-release cluster, or managed workload/GitOps controllers). Each entry is
+       interpolated into the single-quoted CEL matchConditions below, so validate the full
+       system:serviceaccount:<namespace>:<name> shape (both segments are DNS-1123 labels)
+       at render time. A strict shape check rejects single quotes and any other
+       CEL-breaking character, so a malformed entry fails the render rather than breaking
+       policy installation or neutralizing a matchCondition. */}}
+{{- range $extra := .Values.pvcProtection.additionalExemptServiceAccounts }}
+{{- if not (regexMatch "^system:serviceaccount:[a-z0-9]([a-z0-9-]*[a-z0-9])?:[a-z0-9]([a-z0-9-]*[a-z0-9])?$" $extra) }}
+{{- fail (printf "pvcProtection.additionalExemptServiceAccounts entry %q must be a ServiceAccount username of the form system:serviceaccount:<namespace>:<name>" $extra) }}
+{{- end }}
+{{- end }}
+{{- /* These cluster-scoped objects use fixed, release-independent names on purpose:
+       volume deletion protection is a cluster-wide admin singleton. A second operator
+       release that also sets pvcProtection.enabled=true would render the same names and
+       fail its helm install/upgrade with an ownership conflict, rather than silently
+       installing a second policy that cross-applies to (and blocks legitimate deletes
+       on) the first release's volumes. Enable it on at most one release per cluster. */}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: ledger-volume-protection-pvc
+  labels:
+    {{- include "ledger-operator.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["DELETE"]
+        resources: ["persistentvolumeclaims"]
+  matchConditions:
+    - name: not-operator-sa
+      expression: "request.userInfo.username != '{{ $sa }}'"
+    - name: not-gc-sa
+      expression: "request.userInfo.username != '{{ $gc }}'"
+    {{- range $i, $extra := .Values.pvcProtection.additionalExemptServiceAccounts }}
+    - name: {{ printf "not-extra-sa-%d" $i }}
+      expression: "request.userInfo.username != '{{ $extra }}'"
+    {{- end }}
+  validations:
+    - expression: >-
+        has(oldObject.metadata.annotations) &&
+        '{{ $annotation }}' in oldObject.metadata.annotations &&
+        oldObject.metadata.annotations['{{ $annotation }}'] == 'true'
+      message: "Deletion blocked: set annotation {{ $annotation }}=true to permit deleting this ledger volume."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: ledger-volume-protection-pvc
+  labels:
+    {{- include "ledger-operator.labels" . | nindent 4 }}
+spec:
+  policyName: ledger-volume-protection-pvc
+  validationActions: ["Deny"]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        ledger.formance.com/deletion-protection: enabled
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: ledger-volume-protection-pv
+  labels:
+    {{- include "ledger-operator.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["DELETE"]
+        resources: ["persistentvolumes"]
+  matchConditions:
+    - name: not-operator-sa
+      expression: "request.userInfo.username != '{{ $sa }}'"
+    - name: not-gc-sa
+      expression: "request.userInfo.username != '{{ $gc }}'"
+    {{- range $i, $extra := .Values.pvcProtection.additionalExemptServiceAccounts }}
+    - name: {{ printf "not-extra-sa-%d" $i }}
+      expression: "request.userInfo.username != '{{ $extra }}'"
+    {{- end }}
+    {{- /* Only protect live (Bound) PVs. Once the PVC is gone the PV goes Released and
+           is reclaimed by the PV controller / CSI external-provisioner (reclaimPolicy:
+           Delete) — a non-exempt identity. Gating on Bound lets that reclaim proceed
+           without leaking storage, and the deletion of live data is still blocked at the
+           PVC gate. This also lets an admin clean up an orphaned Released (Retain) PV. */}}
+    - name: pv-still-bound
+      expression: "has(oldObject.status) && oldObject.status.phase == 'Bound'"
+  validations:
+    - expression: >-
+        has(oldObject.metadata.annotations) &&
+        '{{ $annotation }}' in oldObject.metadata.annotations &&
+        oldObject.metadata.annotations['{{ $annotation }}'] == 'true'
+      message: "Deletion blocked: set annotation {{ $annotation }}=true to permit deleting this ledger volume."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: ledger-volume-protection-pv
+  labels:
+    {{- include "ledger-operator.labels" . | nindent 4 }}
+spec:
+  policyName: ledger-volume-protection-pv
+  validationActions: ["Deny"]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        ledger.formance.com/deletion-protection: enabled
+{{- end }}

--- a/misc/operator/helm/operator/values.yaml
+++ b/misc/operator/helm/operator/values.yaml
@@ -34,3 +34,29 @@ tolerations: []
 
 nameOverride: ""
 fullnameOverride: ""
+
+# -- Volume deletion protection (cluster-admin consent layer). When enabled,
+# installs the cluster-scoped ValidatingAdmissionPolicy that rejects DELETE of
+# ledger PVCs/PVs unless they carry the allow-deletion annotation. This only
+# arms the policy — a ledger is protected only once it also opts in per-CR via
+# spec.persistence.deletionProtection (the operator then stamps the
+# `ledger.formance.com/deletion-protection: enabled` label the policy selects on).
+# Requires Kubernetes >= 1.30. The operator ServiceAccount (scale-down deletes)
+# and the kube-controller-manager garbage collector (retentionPolicy
+# whenScaled/whenDeleted=Delete) are exempt, so both deletion paths keep working.
+# allowDeletionAnnotation must be a valid Kubernetes annotation key (render fails
+# otherwise). The installed policy is a cluster-wide singleton: enable it on at most
+# one operator release per cluster. A second release with pvcProtection.enabled=true
+# renders the same fixed-name cluster-scoped objects and fails to install (Helm
+# ownership conflict) by design. See the operator README "Volume deletion protection".
+pvcProtection:
+  enabled: false
+  allowDeletionAnnotation: formance.com/allow-deletion
+  # Extra ServiceAccount usernames to exempt from the deletion-protection policies,
+  # beyond this release's operator SA and the kube-controller-manager GC. Entries must
+  # be full SA usernames (system:serviceaccount:<namespace>:<name>); a malformed entry
+  # fails the render. Use this on the release that owns the cluster-wide singleton to
+  # exempt (a) other operator releases' SAs that manage protected ledgers, and (b)
+  # managed workload/GitOps controllers (ArgoCD, Flux, Velero) that legitimately delete
+  # protected volumes during a teardown.
+  additionalExemptServiceAccounts: []

--- a/misc/operator/internal/controller/deletion_protection_test.go
+++ b/misc/operator/internal/controller/deletion_protection_test.go
@@ -1,0 +1,44 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestDeletionProtectionPolicyInstalled verifies the controller decides whether
+// deletion protection is active by probing the actual cluster-scoped
+// ValidatingAdmissionPolicyBinding, not a release-local flag — so it stays correct
+// in a multi-release setup where a sibling release relies on the owning release's
+// singleton policy.
+func TestDeletionProtectionPolicyInstalled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("binding present", func(t *testing.T) {
+		t.Parallel()
+
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: volumeProtectionPVCBindingName},
+		}
+		r := &LedgerServiceReconciler{Clientset: fake.NewClientset(binding)}
+
+		installed, err := r.deletionProtectionPolicyInstalled(context.Background())
+		require.NoError(t, err)
+		assert.True(t, installed, "binding exists, so protection is active")
+	})
+
+	t.Run("binding absent", func(t *testing.T) {
+		t.Parallel()
+
+		r := &LedgerServiceReconciler{Clientset: fake.NewClientset()}
+
+		installed, err := r.deletionProtectionPolicyInstalled(context.Background())
+		require.NoError(t, err)
+		assert.False(t, installed, "no binding, so protection is inactive")
+	})
+}

--- a/misc/operator/internal/controller/hash.go
+++ b/misc/operator/internal/controller/hash.go
@@ -29,6 +29,11 @@ func computeSpecHash(spec *ledgerv1alpha1.LedgerServiceSpec) string {
 	cp.NetworkPolicy = nil
 	cp.DNSEndpoint = nil
 
+	// DeletionProtection only drives PVC/PV label patches (reconcileVolumeProtection);
+	// it has no pod-template effect, so toggling it must not roll the StatefulSet.
+	// Persistence is a value field, so zeroing it on the shallow copy is safe.
+	cp.Persistence.DeletionProtection = false
+
 	data, _ := json.Marshal(&cp) //nolint:errchkjson // spec is always serializable
 
 	return fmt.Sprintf("%x", sha256.Sum256(data))

--- a/misc/operator/internal/controller/hash_test.go
+++ b/misc/operator/internal/controller/hash_test.go
@@ -41,6 +41,12 @@ func TestComputeSpecHash_ExcludesNonPodFields(t *testing.T) {
 	replicas := int32(5)
 	withReplicas.Replicas = &replicas
 	assert.Equal(t, baseHash, computeSpecHash(withReplicas), "Replicas change should not affect hash")
+
+	// Toggling Persistence.DeletionProtection should NOT change the hash: it only
+	// drives PVC/PV label patches, not the pod template, so it must not roll pods.
+	withDeletionProtection := base.DeepCopy()
+	withDeletionProtection.Persistence.DeletionProtection = true
+	assert.Equal(t, baseHash, computeSpecHash(withDeletionProtection), "DeletionProtection change should not affect hash")
 }
 
 func TestComputeSpecHash_IncludesPodFields(t *testing.T) {

--- a/misc/operator/internal/controller/labels.go
+++ b/misc/operator/internal/controller/labels.go
@@ -10,6 +10,25 @@ const (
 	labelName              = "app.kubernetes.io/name"
 	annotationSpecHash     = "ledger.formance.com/spec-hash"
 	annotationAuthKeysHash = "ledger.formance.com/auth-keys-hash"
+
+	// labelDeletionProtection (set to labelDeletionProtectionValue) is stamped on
+	// the PVCs and bound PVs of a LedgerService whose spec.persistence.deletionProtection
+	// is true. The volume deletion-protection ValidatingAdmissionPolicyBinding scopes
+	// itself to this label, so a ledger opts in or out per-CR without touching the
+	// cluster-scoped policy. PVs are cluster-scoped and don't inherit PVC labels, so
+	// the operator stamps both sides explicitly.
+	labelDeletionProtection      = "ledger.formance.com/deletion-protection"
+	labelDeletionProtectionValue = "enabled"
+
+	// volumeProtectionPVCBindingName is the fixed, release-independent name of the
+	// PVC ValidatingAdmissionPolicyBinding rendered by the chart when
+	// pvcProtection.enabled=true (see helm/operator/templates/validatingadmissionpolicy.yaml).
+	// The controller probes it to tell whether deletion protection is actually
+	// active cluster-wide — which is what matters in a multi-release setup where a
+	// sibling release owns the singleton — rather than trusting this release's own
+	// Helm flag. The PV binding is installed in the same bundle, so the PVC binding's
+	// presence is a sufficient proxy for the whole policy.
+	volumeProtectionPVCBindingName = "ledger-volume-protection-pvc"
 )
 
 // selectorLabels returns the labels used to select pods owned by this LedgerService.

--- a/misc/operator/internal/controller/ledger_controller.go
+++ b/misc/operator/internal/controller/ledger_controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -33,6 +34,7 @@ type LedgerServiceReconciler struct {
 	Scheme    *runtime.Scheme
 	Config    *rest.Config
 	Clientset kubernetes.Interface
+	Recorder  record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=ledger.formance.com,resources=ledgerservices,verbs=get;list;watch;create;update;patch;delete
@@ -43,12 +45,15 @@ type LedgerServiceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=delete;list
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=delete;get;list;patch
+// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;patch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=externaldns.k8s.io,resources=dnsendpoints,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicybindings,verbs=get;list;watch
 
 // Reconcile handles the reconciliation loop for LedgerService resources.
 func (r *LedgerServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -156,6 +161,41 @@ func (r *LedgerServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		meta.RemoveStatusCondition(&ledger.Status.Conditions, "HostPathSchedulingWarning")
 	}
 
+	// Warn when a ledger opts into deletion protection but no cluster-scoped
+	// protection policy is installed. The operator still stamps the label, but
+	// with no policy selecting it the volumes are not actually protected — surface
+	// that instead of silently no-op'ing. We detect "installed" by probing the
+	// actual ValidatingAdmissionPolicyBinding rather than this release's own Helm
+	// flag: in a multi-release setup a sibling release (pvcProtection.enabled=false)
+	// still stamps the label and the owning release's cluster-wide binding protects
+	// it, so keying off the local flag would falsely report unprotected.
+	if r.Clientset != nil {
+		inactive := false
+		if ledger.Spec.Persistence.DeletionProtection {
+			installed, err := r.deletionProtectionPolicyInstalled(ctx)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("checking volume deletion-protection policy: %w", err)
+			}
+			inactive = !installed
+		}
+
+		if inactive {
+			meta.SetStatusCondition(&ledger.Status.Conditions, metav1.Condition{
+				Type:               "DeletionProtectionInactive",
+				Status:             metav1.ConditionTrue,
+				Reason:             "ClusterPolicyNotInstalled",
+				Message:            "spec.persistence.deletionProtection is set but no cluster-scoped volume protection policy is installed (Helm pvcProtection.enabled on no release); volumes are NOT protected",
+				ObservedGeneration: ledger.Generation,
+			})
+			if r.Recorder != nil {
+				r.Recorder.Event(ledger, corev1.EventTypeWarning, "DeletionProtectionInactive",
+					"deletion protection requested but no cluster policy is installed; volumes are NOT protected")
+			}
+		} else {
+			meta.RemoveStatusCondition(&ledger.Status.Conditions, "DeletionProtectionInactive")
+		}
+	}
+
 	// Compute spec hash for rolling updates
 	specHash := computeSpecHash(&ledger.Spec)
 
@@ -220,13 +260,34 @@ func (r *LedgerServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// StatefulSet needs the specHash and agent info
-	if err := r.reconcileStatefulSet(ctx, ledger, specHash, agents); err != nil {
+	result, err := r.reconcileStatefulSet(ctx, ledger, specHash, agents)
+	if err != nil {
 		logger.Error(err, "failed to reconcile StatefulSet")
 
 		return ctrl.Result{}, fmt.Errorf("reconciling StatefulSet: %w", err)
 	}
 
-	return ctrl.Result{}, nil
+	return result, nil
+}
+
+// deletionProtectionPolicyInstalled reports whether the cluster-scoped volume
+// deletion-protection policy is installed, by probing for the fixed-name PVC
+// ValidatingAdmissionPolicyBinding. This reflects actual cluster state regardless
+// of which operator release owns the singleton, so it stays correct in the
+// documented multi-release setup where a sibling release (pvcProtection.enabled=false)
+// relies on the owning release's binding to protect its volumes.
+func (r *LedgerServiceReconciler) deletionProtectionPolicyInstalled(ctx context.Context) (bool, error) {
+	_, err := r.Clientset.AdmissionregistrationV1().
+		ValidatingAdmissionPolicyBindings().
+		Get(ctx, volumeProtectionPVCBindingName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("getting ValidatingAdmissionPolicyBinding %s: %w", volumeProtectionPVCBindingName, err)
+	}
+
+	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -253,11 +314,14 @@ func (r *LedgerServiceReconciler) updateStatus(ctx context.Context, ledger *ledg
 		return err
 	}
 
-	// Carry over conditions accumulated during reconciliation on the
-	// in-memory ledger object.
-	for _, c := range ledger.Status.Conditions {
-		meta.SetStatusCondition(&latest.Status.Conditions, c)
-	}
+	// ledger was fetched fresh at the top of Reconcile and this reconciler is the
+	// sole writer of LedgerService status conditions, so ledger.Status.Conditions is
+	// the authoritative desired set after this pass — including conditions removed
+	// during reconcile (e.g. DeletionProtectionInactive once the cluster policy is
+	// installed or protection is disabled). Assign it onto the freshly-fetched latest
+	// so those removals are persisted; an additive SetStatusCondition merge would
+	// leave stale conditions in .status.conditions forever.
+	latest.Status.Conditions = ledger.Status.Conditions
 
 	// Preserve the phase set during reconciliation (e.g. "Degraded" from
 	// validation failure) before we try to recompute from StatefulSet state.

--- a/misc/operator/internal/controller/pv_protection.go
+++ b/misc/operator/internal/controller/pv_protection.go
@@ -1,0 +1,154 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// reconcileVolumeProtection brings the deletion-protection label on this
+// LedgerService's PVCs and their bound PVs in line with the desired protect
+// state (spec.persistence.deletionProtection). When protect is true the
+// `ledger.formance.com/deletion-protection: enabled` label is stamped so the
+// volume deletion-protection ValidatingAdmissionPolicyBinding selects the
+// volumes; when protect is false the label is removed and protection is lifted.
+//
+// It is a full reconcile, not an idempotent add: flipping deletionProtection
+// off must actually unselect the volumes. The work is eventually consistent —
+// PVCs that are absent or not yet bound (empty spec.VolumeName) are skipped and
+// picked up on a later reconcile once the volume binds.
+//
+// PVs are cluster-scoped and do not inherit PVC labels, so both sides are
+// stamped explicitly. A PV is only touched when its spec.claimRef still points
+// at the PVC we resolved it through, so a PV rebound to a different claim is
+// never (mis)labeled. Labels are applied with a JSON merge patch (a null value
+// removes the key) to avoid clobbering concurrent writes from CSI / the PV
+// controller and to sidestep update conflicts.
+//
+// Note: a PV orphaned after PVC/CR deletion (Released phase) keeps whatever
+// label it last carried, because the reconcile only walks live PVCs. That is
+// harmless: the PV policy guards Bound PVs only, so a Released orphan is not
+// protected regardless of the label, and the reclaim path proceeds.
+//
+// It returns pending=true when at least one desired PVC is not yet created
+// (either direction — a new PVC must be stamped when protecting, or unstamped
+// when not, since a scale-out PVC born from a still-labeled immutable VCT after
+// an opt-out would otherwise stay protected), or when a PVC is not yet bound and
+// protection is on so its PV is still to stamp once it binds. The caller requeues
+// on that signal — the controller does not watch PVC/PV binding events, so this
+// is what makes reconciliation to the desired label state deterministic.
+func reconcileVolumeProtection(ctx context.Context, clientset kubernetes.Interface,
+	namespace, stsName string, replicas int32, volumeNames []string, protect bool,
+) (bool, error) {
+	logger := log.FromContext(ctx)
+	pvcClient := clientset.CoreV1().PersistentVolumeClaims(namespace)
+	pvClient := clientset.CoreV1().PersistentVolumes()
+
+	pending := false
+	for ordinal := range replicas {
+		for _, vol := range volumeNames {
+			pvcName := fmt.Sprintf("%s-%s-%d", vol, stsName, ordinal)
+			pvc, err := pvcClient.Get(ctx, pvcName, metav1.GetOptions{})
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					// Expected to be created by the StatefulSet controller. Requeue
+					// regardless of direction so the PVC is reconciled to the desired
+					// label state once it appears: when protecting, the new PVC (and
+					// its PV) must be stamped; when not, a PVC born from a still-labeled
+					// (immutable) VCT after an opt-out scale-out must be unstamped, or it
+					// stays selected by the policy and its deletion is wrongly blocked.
+					pending = true
+
+					continue
+				}
+
+				return false, fmt.Errorf("getting PVC %s: %w", pvcName, err)
+			}
+
+			patch, err := protectionLabelPatch(pvc.Labels, protect)
+			if err != nil {
+				return false, fmt.Errorf("building deletion-protection patch for PVC %s: %w", pvcName, err)
+			}
+			if patch != nil {
+				if _, err := pvcClient.Patch(ctx, pvcName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+					return false, fmt.Errorf("patching deletion-protection label on PVC %s: %w", pvcName, err)
+				}
+				logger.Info("reconciled deletion-protection label on PVC", "pvc", pvcName, "protect", protect)
+			}
+
+			if pvc.Spec.VolumeName == "" {
+				// Not yet bound: the PV to stamp does not exist yet. Signal pending
+				// so the caller requeues until it binds (only matters when we want
+				// the eventual PV protected).
+				pending = pending || protect
+
+				continue
+			}
+
+			pv, err := pvClient.Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					continue
+				}
+
+				return false, fmt.Errorf("getting PV %s: %w", pvc.Spec.VolumeName, err)
+			}
+
+			// Only touch a PV that is still claimed by this PVC; a PV rebound to
+			// another claim must neither inherit nor lose our protection label.
+			if ref := pv.Spec.ClaimRef; ref == nil || ref.Namespace != namespace || ref.Name != pvcName {
+				continue
+			}
+
+			pvPatch, err := protectionLabelPatch(pv.Labels, protect)
+			if err != nil {
+				return false, fmt.Errorf("building deletion-protection patch for PV %s: %w", pv.Name, err)
+			}
+			if pvPatch != nil {
+				if _, err := pvClient.Patch(ctx, pv.Name, types.MergePatchType, pvPatch, metav1.PatchOptions{}); err != nil {
+					return false, fmt.Errorf("patching deletion-protection label on PV %s: %w", pv.Name, err)
+				}
+				logger.Info("reconciled deletion-protection label on bound PV", "pv", pv.Name, "pvc", pvcName, "protect", protect)
+			}
+		}
+	}
+
+	return pending, nil
+}
+
+// protectionLabelPatch returns a JSON merge patch that adds (protect) or removes
+// (!protect) the deletion-protection label, or nil when the current labels are
+// already in the desired state. A null value in a merge patch deletes the key.
+func protectionLabelPatch(current map[string]string, protect bool) ([]byte, error) {
+	hasDesiredValue := current[labelDeletionProtection] == labelDeletionProtectionValue
+	_, present := current[labelDeletionProtection]
+
+	var value any
+	switch {
+	case protect && hasDesiredValue:
+		return nil, nil // already stamped
+	case !protect && !present:
+		return nil, nil // already absent
+	case protect:
+		value = labelDeletionProtectionValue
+	default:
+		value = nil // remove the key
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{labelDeletionProtection: value},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling deletion-protection label patch: %w", err)
+	}
+
+	return patch, nil
+}

--- a/misc/operator/internal/controller/pv_protection_test.go
+++ b/misc/operator/internal/controller/pv_protection_test.go
@@ -1,0 +1,195 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// stsName mirrors the prefixed StatefulSet name the reconciler passes
+// (resourceName(ledger.Name)); the PVC names derive from it as
+// <volume>-<stsName>-<ordinal>.
+const (
+	testStsName = "ledger-my-ledger"
+	testPVCName = "data-ledger-my-ledger-0"
+)
+
+func boundPVCAndPV(pvcName, pvName, namespace string) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName, Namespace: namespace},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: pvName},
+	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: pvName},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{Namespace: namespace, Name: pvcName},
+		},
+	}
+
+	return pvc, pv
+}
+
+func countPatches(cs *fake.Clientset, resource string) *int {
+	n := 0
+	cs.PrependReactor("patch", resource, func(clienttesting.Action) (bool, runtime.Object, error) {
+		n++
+
+		return false, nil, nil
+	})
+
+	return &n
+}
+
+func TestReconcileVolumeProtection_StampsBoundPVCAndPV(t *testing.T) {
+	t.Parallel()
+
+	boundPVC, boundPV := boundPVCAndPV(testPVCName, "pv-0", "ns")
+	cs := fake.NewClientset(boundPVC, boundPV)
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, true)
+	require.NoError(t, err)
+	require.False(t, pending, "a bound PVC leaves nothing pending")
+
+	gotPVC, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), testPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, labelDeletionProtectionValue, gotPVC.Labels[labelDeletionProtection])
+
+	gotPV, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, labelDeletionProtectionValue, gotPV.Labels[labelDeletionProtection])
+}
+
+func TestReconcileVolumeProtection_UnstampsWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	boundPVC, boundPV := boundPVCAndPV(testPVCName, "pv-0", "ns")
+	boundPVC.Labels = map[string]string{labelDeletionProtection: labelDeletionProtectionValue}
+	boundPV.Labels = map[string]string{labelDeletionProtection: labelDeletionProtectionValue}
+	cs := fake.NewClientset(boundPVC, boundPV)
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, false)
+	require.NoError(t, err)
+	require.False(t, pending, "disabling protection never requeues")
+
+	gotPVC, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), testPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, gotPVC.Labels, labelDeletionProtection)
+
+	gotPV, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, gotPV.Labels, labelDeletionProtection)
+}
+
+func TestReconcileVolumeProtection_SkipsPVBoundToDifferentClaim(t *testing.T) {
+	t.Parallel()
+
+	boundPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: "ns"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "pv-0"},
+	}
+	// PV reused by an unrelated claim: must not inherit ledger protection labels.
+	rebound := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-0"},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{Namespace: "other", Name: "someone-else-0"},
+		},
+	}
+	cs := fake.NewClientset(boundPVC, rebound)
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, true)
+	require.NoError(t, err)
+	require.False(t, pending, "a bound PVC leaves nothing pending even when its PV is rebound elsewhere")
+
+	gotPV, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotContains(t, gotPV.Labels, labelDeletionProtection)
+}
+
+func TestReconcileVolumeProtection_NoOpWhenAlreadyInDesiredState(t *testing.T) {
+	t.Parallel()
+
+	boundPVC, boundPV := boundPVCAndPV(testPVCName, "pv-0", "ns")
+	boundPVC.Labels = map[string]string{labelDeletionProtection: labelDeletionProtectionValue}
+	boundPV.Labels = map[string]string{labelDeletionProtection: labelDeletionProtectionValue}
+	cs := fake.NewClientset(boundPVC, boundPV)
+
+	pvcPatches := countPatches(cs, "persistentvolumeclaims")
+	pvPatches := countPatches(cs, "persistentvolumes")
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, true)
+	require.NoError(t, err)
+	require.False(t, pending)
+	require.Zero(t, *pvcPatches, "already-stamped PVC must not be patched")
+	require.Zero(t, *pvPatches, "already-stamped PV must not be patched")
+}
+
+func TestReconcileVolumeProtection_NoOpWhenDisabledAndUnlabeled(t *testing.T) {
+	t.Parallel()
+
+	boundPVC, boundPV := boundPVCAndPV(testPVCName, "pv-0", "ns")
+	cs := fake.NewClientset(boundPVC, boundPV)
+
+	pvcPatches := countPatches(cs, "persistentvolumeclaims")
+	pvPatches := countPatches(cs, "persistentvolumes")
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, false)
+	require.NoError(t, err)
+	require.False(t, pending)
+	require.Zero(t, *pvcPatches, "unlabeled PVC must not be patched when protection is off")
+	require.Zero(t, *pvPatches, "unlabeled PV must not be patched when protection is off")
+}
+
+func TestReconcileVolumeProtection_StampsUnboundPVCAndReportsPending(t *testing.T) {
+	t.Parallel()
+
+	unboundPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: "ns"},
+		// no Spec.VolumeName -> not yet bound
+	}
+	cs := fake.NewClientset(unboundPVC)
+
+	// ordinal 0 PVC is unbound (PVC stamped, PV skipped); ordinal 1 PVC does not
+	// exist yet -> both leave a PV to stamp once they bind, so pending is true.
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 2, []string{"data"}, true)
+	require.NoError(t, err)
+	require.True(t, pending, "an unbound/absent PVC under protection must requeue")
+
+	got, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), testPVCName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, labelDeletionProtectionValue, got.Labels[labelDeletionProtection])
+}
+
+func TestReconcileVolumeProtection_UnboundPVCNotPendingWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	unboundPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: "ns"},
+	}
+	cs := fake.NewClientset(unboundPVC)
+
+	// replicas=1 so the only ordinal is the existing unbound PVC (no absent ordinal).
+	// Protection off: its future PV is born without our label (the provisioner does
+	// not copy PVC labels), so there is nothing to unstamp and no need to requeue.
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, false)
+	require.NoError(t, err)
+	require.False(t, pending, "with protection off an unbound PVC must not requeue")
+}
+
+func TestReconcileVolumeProtection_RequeuesAbsentPVCWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	// No PVC exists yet. With protection off we must still requeue: a PVC born from
+	// a still-labeled (immutable) VCT after an opt-out scale-out has to be unstamped,
+	// otherwise it stays selected by the policy and its deletion is wrongly blocked.
+	cs := fake.NewClientset()
+
+	pending, err := reconcileVolumeProtection(context.Background(), cs, "ns", testStsName, 1, []string{"data"}, false)
+	require.NoError(t, err)
+	require.True(t, pending, "an absent PVC must requeue even when protection is off, to unstamp stale-VCT scale-out PVCs")
+}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -20,7 +22,14 @@ import (
 	ledgerv1alpha1 "github.com/formance/ledger/operator/api/v1alpha1"
 )
 
-func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledger *ledgerv1alpha1.LedgerService, specHash string, agents []agentKeyInfo) error {
+// volumeBindRequeueInterval is how soon to requeue while a ledger's PVC is still
+// awaiting binding, so the deletion-protection label lands on the PV promptly
+// once it binds. The controller does not watch PVC/PV binding events, so this
+// poll is what makes stamping deterministic rather than dependent on incidental
+// StatefulSet status churn.
+const volumeBindRequeueInterval = 10 * time.Second
+
+func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledger *ledgerv1alpha1.LedgerService, specHash string, agents []agentKeyInfo) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	name := resourceName(ledger.Name)
 
@@ -30,7 +39,7 @@ func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledg
 	// only exposes a boolean.
 	existingForTLS, err := r.fetchExistingStatefulSet(ctx, ledger)
 	if err != nil {
-		return fmt.Errorf("fetching StatefulSet for TLS state: %w", err)
+		return ctrl.Result{}, fmt.Errorf("fetching StatefulSet for TLS state: %w", err)
 	}
 
 	targetTLSMode := computeTargetTLSMode(
@@ -91,7 +100,7 @@ func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledg
 			})
 			ledger.Spec.Replicas = savedReplicas
 			if err != nil {
-				return fmt.Errorf("updating StatefulSet spec before scale-down: %w", err)
+				return ctrl.Result{}, fmt.Errorf("updating StatefulSet spec before scale-down: %w", err)
 			}
 
 			logger.Info("scale-down detected, removing Raft nodes",
@@ -103,7 +112,7 @@ func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledg
 			// started, so pod-0's gRPC server is still on the old TLS_MODE.
 			runningTLSMode := currentTLSModeFromStatefulSet(existingForTLS)
 			if err := raftScaleDown(ctx, r.Config, r.Clientset, ledger, previousReplicas, desiredReplicas, runningTLSMode); err != nil {
-				return fmt.Errorf("removing Raft nodes before scale-down: %w", err)
+				return ctrl.Result{}, fmt.Errorf("removing Raft nodes before scale-down: %w", err)
 			}
 		}
 	}
@@ -127,11 +136,11 @@ func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledg
 			if err := r.Delete(ctx, existing, &client.DeleteOptions{
 				PropagationPolicy: &orphan,
 			}); err != nil {
-				return fmt.Errorf("deleting StatefulSet for VolumeClaimTemplate change: %w", err)
+				return ctrl.Result{}, fmt.Errorf("deleting StatefulSet for VolumeClaimTemplate change: %w", err)
 			}
-			// Return nil to requeue — next reconciliation will create the new StatefulSet
-			// and the orphaned pods will be adopted.
-			return nil
+			// Returning here requeues via the owned-StatefulSet delete event — the next
+			// reconciliation creates the new StatefulSet and the orphaned pods are adopted.
+			return ctrl.Result{}, nil
 		}
 	}
 
@@ -155,18 +164,43 @@ func (r *LedgerServiceReconciler) reconcileStatefulSet(ctx context.Context, ledg
 		return controllerutil.SetControllerReference(ledger, sts, r.Scheme)
 	})
 	if err != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	// After the StatefulSet is updated (pods terminated), delete orphaned PVCs.
 	if scalingDown && r.Clientset != nil {
 		volNames := pvcVolumeNames(&ledger.Spec.Persistence)
 		if err := deleteScaledDownPVCs(ctx, r.Clientset, ledger.Namespace, name, previousReplicas, desiredReplicas, volNames); err != nil {
-			return fmt.Errorf("deleting PVCs after scale-down: %w", err)
+			return ctrl.Result{}, fmt.Errorf("deleting PVCs after scale-down: %w", err)
 		}
 	}
 
-	return nil
+	// Reconcile the deletion-protection label on this ledger's PVCs and bound
+	// PVs to match spec.persistence.deletionProtection, so the opt-in volume
+	// protection admission policy selects (or stops selecting) the volumes per-CR.
+	// PVs are cluster-scoped and don't inherit PVC labels. This is the last step
+	// of the pass, so returning the error skips nothing and makes controller-runtime
+	// requeue with backoff. The requeue matters: the controller does not watch
+	// PVC/PV events, so without it a transient failure after the StatefulSet has
+	// settled would leave the label out of sync until the next full resync.
+	//
+	// We requeue on a short interval whenever a desired PVC is not yet created or
+	// (when protecting) not yet bound, so the label reaches the right state promptly
+	// rather than relying on an incidental later StatefulSet status change — in both
+	// directions: stamping a freshly scaled-out PVC/PV when protection is on, and
+	// unstamping a PVC born from a still-labeled immutable VCT after an opt-out.
+	if r.Clientset != nil {
+		volNames := pvcVolumeNames(&ledger.Spec.Persistence)
+		pending, err := reconcileVolumeProtection(ctx, r.Clientset, ledger.Namespace, name, desiredReplicas, volNames, ledger.Spec.Persistence.DeletionProtection)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("reconciling volume deletion-protection labels: %w", err)
+		}
+		if pending {
+			return ctrl.Result{RequeueAfter: volumeBindRequeueInterval}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func buildStatefulSetSpec(ledger *ledgerv1alpha1.LedgerService, specHash string, agents []agentKeyInfo, targetTLSMode string) appsv1.StatefulSetSpec {
@@ -596,8 +630,29 @@ func buildVolumeClaimTemplates(ledger *ledgerv1alpha1.LedgerService) []corev1.Pe
 			size = resource.MustParse(d.dflt)
 		}
 
+		// When deletion protection is on, stamp the label directly on the VCT so
+		// the PVCs the StatefulSet controller provisions carry it from creation,
+		// closing the window before reconcileVolumeProtection's first stamp pass.
+		//
+		// VCTs are immutable, so this born-labels PVCs only for newly-created
+		// StatefulSets, and the template label cannot be changed after creation in
+		// either direction. On a false->true toggle the VCT stays unlabeled; on a
+		// true->false toggle it stays labeled. Existing PVCs are relabeled (or
+		// unlabeled) by reconcileVolumeProtection, but PVCs born from a later
+		// scale-out inherit the stale template label. reconcileVolumeProtection runs
+		// in the same reconcile that bumps replicas and requeues every
+		// volumeBindRequeueInterval until the new PVCs appear, then stamps/unstamps
+		// them to the desired state, so the residual scale-out window is small and
+		// self-healing in both directions. We accept it deliberately: closing it
+		// fully would mean recreating the StatefulSet just to re-emit templates,
+		// which is too disruptive for a running Raft cluster.
+		var labels map[string]string
+		if ledger.Spec.Persistence.DeletionProtection {
+			labels = map[string]string{labelDeletionProtection: labelDeletionProtectionValue}
+		}
+
 		pvc := corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: d.name},
+			ObjectMeta: metav1.ObjectMeta{Name: d.name, Labels: labels},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{accessMode},
 				Resources: corev1.VolumeResourceRequirements{

--- a/misc/operator/internal/controller/reconcile_statefulset_test.go
+++ b/misc/operator/internal/controller/reconcile_statefulset_test.go
@@ -27,3 +27,35 @@ func TestBuildStatefulSetSpec_ExplicitRollingUpdate(t *testing.T) {
 	assert.Equal(t, int32(0), *spec.UpdateStrategy.RollingUpdate.Partition,
 		"Partition=0 ensures all pods are rolled when the template hash changes")
 }
+
+func TestBuildVolumeClaimTemplates_DeletionProtectionLabel(t *testing.T) {
+	t.Parallel()
+
+	newLedger := func(protect bool) *ledgerv1alpha1.LedgerService {
+		return &ledgerv1alpha1.LedgerService{
+			ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "default"},
+			Spec: ledgerv1alpha1.LedgerServiceSpec{
+				Persistence: ledgerv1alpha1.PersistenceSpec{DeletionProtection: protect},
+			},
+		}
+	}
+
+	// When protection is on, every PVC-backed template carries the label so the
+	// PVCs the StatefulSet controller provisions are protected from creation,
+	// closing the window before the first stamp reconcile.
+	protected := buildVolumeClaimTemplates(newLedger(true))
+	require.NotEmpty(t, protected)
+	for _, tmpl := range protected {
+		assert.Equal(t, labelDeletionProtectionValue, tmpl.Labels[labelDeletionProtection],
+			"VCT %q must carry the deletion-protection label when protection is on", tmpl.Name)
+	}
+
+	// When protection is off, the label must be absent so disabled ledgers are
+	// not selected by the admission policy.
+	unprotected := buildVolumeClaimTemplates(newLedger(false))
+	require.NotEmpty(t, unprotected)
+	for _, tmpl := range unprotected {
+		_, present := tmpl.Labels[labelDeletionProtection]
+		assert.False(t, present, "VCT %q must not carry the deletion-protection label when protection is off", tmpl.Name)
+	}
+}

--- a/misc/operator/internal/controller/suite_test.go
+++ b/misc/operator/internal/controller/suite_test.go
@@ -74,8 +74,9 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := (&LedgerServiceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("ledgerservice-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		panic(fmt.Sprintf("setting up LedgerService controller: %v", err))
 	}

--- a/misc/operator/internal/controller/update_status_test.go
+++ b/misc/operator/internal/controller/update_status_test.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ledgerv1alpha1 "github.com/formance/ledger/operator/api/v1alpha1"
+)
+
+// TestUpdateStatus_RemovesStaleConditions verifies that a condition removed from
+// the in-memory ledger during reconcile is actually cleared from the persisted
+// status, not merely dropped from the in-memory copy. Regression test for the
+// additive-merge bug that left DeletionProtectionInactive (and any other
+// conditionally-removed condition) stuck in .status.conditions forever.
+func TestUpdateStatus_RemovesStaleConditions(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, ledgerv1alpha1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	// Persisted object already carries a stale DeletionProtectionInactive warning
+	// plus an unrelated condition that must survive the update.
+	replicas := int32(1)
+	persisted := &ledgerv1alpha1.LedgerService{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "default"},
+		Spec:       ledgerv1alpha1.LedgerServiceSpec{Replicas: &replicas},
+		Status: ledgerv1alpha1.LedgerServiceStatus{
+			Conditions: []metav1.Condition{
+				{Type: "DeletionProtectionInactive", Status: metav1.ConditionTrue, Reason: "ClusterPolicyNotInstalled"},
+				{Type: "ConfigValid", Status: metav1.ConditionTrue, Reason: "Valid"},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(persisted).
+		WithStatusSubresource(&ledgerv1alpha1.LedgerService{}).
+		Build()
+
+	r := &LedgerServiceReconciler{Client: c, Scheme: scheme}
+
+	// In-memory ledger after a reconcile in which protection became active: the
+	// warning was removed from the slice; ConfigValid remains.
+	inMemory := &ledgerv1alpha1.LedgerService{
+		ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "default"},
+		Status: ledgerv1alpha1.LedgerServiceStatus{
+			Conditions: []metav1.Condition{
+				{Type: "ConfigValid", Status: metav1.ConditionTrue, Reason: "Valid"},
+			},
+		},
+	}
+
+	require.NoError(t, r.updateStatus(context.Background(), inMemory))
+
+	got := &ledgerv1alpha1.LedgerService{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "ls", Namespace: "default"}, got))
+
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, "DeletionProtectionInactive"),
+		"stale condition removed in-memory must be cleared from persisted status")
+	assert.NotNil(t, meta.FindStatusCondition(got.Status.Conditions, "ConfigValid"),
+		"conditions still present in-memory must be retained")
+}

--- a/misc/operator/justfile
+++ b/misc/operator/justfile
@@ -62,6 +62,7 @@ e2e-cluster-up: _e2e-build-ledger
         --set image.tag=e2e \
         --set image.pullPolicy=Never \
         --set leaderElection=false \
+        --set pvcProtection.enabled=true \
         --kube-context kind-ledger-e2e --wait --timeout 120s
 
 # Build the ledger image from the local working tree (with S3 support).


### PR DESCRIPTION
## Context

The `formancehq/ledger-v3-poc` repository is being retired. Its `main` branch was previously snapshot-pushed to `release/v3.0` on this repo, but one commit landed on the old `main` after that snapshot:

- `d86dbc776 feat(EN-1353): protect ledger PVC/PV from accidental deletion (#567)`

This PR brings that commit forward so `release/v3.0` matches the final state of the old `main`. All other open PRs from the old repo are about to be recreated against `release/v3.0`; this sync ensures their diffs stay clean instead of each carrying the EN-1353 commit as noise.

## Test plan

- [x] Local fast-forward verified (`git merge-base --is-ancestor 6066233ff2 d86dbc7762`)
- [x] Single-commit diff confirmed (operator-only changes: PVC/PV protection)
- [ ] CI green on `release/v3.0` after merge