### PR TITLE
chore: make operator-docker-build image overridable via env var

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,6 +43,11 @@ all_tags := "kafka,nats,clickhouse,databricks,s3,azure,pyroscope"
 # `formancehq/ledger` published image.
 image_repository := env_var_or_default("IMAGE_REPOSITORY", "ghcr.io/formancehq/ledger")
 
+# Operator Docker image repository (registry + name). Override via env var
+# to push to a different GHCR location. Default targets the canonical
+# `formancehq/ledger-operator` published image.
+operator_image_repository := env_var_or_default("OPERATOR_IMAGE_REPOSITORY", "ghcr.io/formancehq/ledger-operator")
+
 # Build the server application (light: no optional deps)
 build:
     go build -o ./build/ledger-server .
@@ -362,7 +367,7 @@ operator-pre-commit: operator-generate
 operator-docker-build tag='':
     #!/bin/bash
     set -euo pipefail
-    image=ghcr.io/formancehq/ledger-operator
+    image='{{ operator_image_repository }}'
     if [ -n "{{ tag }}" ]; then
         docker buildx build -t "${image}:{{ tag }}" -t "${image}:latest" \
             --platform linux/amd64,linux/arm64 --push misc/operator


### PR DESCRIPTION
## Summary

- Lift the hardcoded `ghcr.io/formancehq/ledger-operator` tag out of `operator-docker-build` into a new `operator_image_repository` justfile variable, mirroring the existing `image_repository` / `IMAGE_REPOSITORY` pattern already in place for the server image.
- Default is unchanged (`ghcr.io/formancehq/ledger-operator`), so existing callers keep working.
- Override via env var: `OPERATOR_IMAGE_REPOSITORY=my.registry/foo just operator-docker-build`.

> Originally also covered the server image, but `main` already introduced `image_repository` / `IMAGE_REPOSITORY` for that — this PR now only carries the operator-side override after rebase.

## Test plan

- [ ] `just operator-docker-build` still targets `ghcr.io/formancehq/ledger-operator` (default unchanged).
- [ ] `OPERATOR_IMAGE_REPOSITORY=my.registry/foo just operator-docker-build` targets the override.

---
_Migrated from formancehq/ledger-v3-poc#582 on 2026-06-29._