### PR TITLE
fix(EN-1410): close bloom boot-ordering window

### DIFF
--- a/internal/infra/state/cache_snapshotter.go
+++ b/internal/infra/state/cache_snapshotter.go
@@ -531,8 +531,14 @@ func (s *CacheSnapshotter) RestoreFromStore(store dal.RecoveryReader) error {
 	// Restore bloom filters: load persisted blocks from Pebble, then replay
 	// cache gen0+gen1 entries to fill the gap since the last rotation flush.
 	// If no persisted blocks exist (first boot), fall back to a full attribute scan.
+	// On the persisted-blocks (restart) path, restoreBloomFilters runs the
+	// rebuild synchronously and returns once IsReady() is true -- closes
+	// the EN-1410 window where replayWAL would race the rebuild and drive
+	// rotations while !IsReady.
 	if s.bloomFilters != nil {
-		s.restoreBloomFilters(store)
+		if err := s.restoreBloomFilters(store); err != nil {
+			return fmt.Errorf("restoring bloom filters: %w", err)
+		}
 	}
 
 	return nil
@@ -623,20 +629,26 @@ func (s *CacheSnapshotter) restoreGeneration(reader dal.PebbleReader, genByte by
 	return nil
 }
 
-// restoreBloomFilters launches a background task to restore bloom filters.
-// If persisted blocks exist, loads them from Pebble and replays cache gen0+gen1
-// to fill the gap. Otherwise, falls back to a full attribute scan.
-// In both cases, IsReady() remains false until the background work completes.
-// The store is captured by the background goroutine so it can open a fresh
-// read handle each invocation.
-func (s *CacheSnapshotter) restoreBloomFilters(store dal.RecoveryReader) {
+// restoreBloomFilters publishes a ready bloom on top of Pebble's
+// persisted state. On a simple restart (persisted bloom blocks exist),
+// the rebuild runs SYNCHRONOUSLY before this function returns: the cost
+// is bounded (O(blocks) + O(cache gen0+gen1)) and running it inline
+// closes the EN-1410 window where the replayWAL goroutine would
+// otherwise race the background rebuild and drive cache rotations
+// while !IsReady. On cold start / post-Rebuild (no persisted blocks),
+// the rebuild stays async because the full attribute scan via
+// PopulateFromStore can take minutes on a large database -- blocking
+// boot is unacceptable. The cold-start path's correctness is guarded
+// separately at the cache-rotation site, which inhibits rotation while
+// the bloom is still populating (see machine.go).
+func (s *CacheSnapshotter) restoreBloomFilters(store dal.RecoveryReader) error {
 	if s.hasPersistedBloomBlocks(store) {
-		s.runBloomTask(store, "restore from Pebble blocks", s.bloomFilters.RestoreFromStore)
-
-		return
+		return s.runBloomTaskSync(store, "restore from Pebble blocks", s.bloomFilters.RestoreFromStore)
 	}
 
 	s.StartAsyncBloomPopulate(store, "first boot: no persisted bloom blocks")
+
+	return nil
 }
 
 // StartAsyncBloomPopulate interrupts any running bloom task and launches a
@@ -647,11 +659,62 @@ func (s *CacheSnapshotter) StartAsyncBloomPopulate(store dal.RecoveryReader, rea
 	s.runBloomTask(store, reason, s.bloomFilters.PopulateFromStore)
 }
 
+// runBloomTaskBody runs loadFn + replayBloomFromCache + SetReadyIfEpoch
+// in the calling goroutine using the provided context. Shared between
+// runBloomTask (wraps it in a SingleTaskExecutor) and runBloomTaskSync
+// (drives it inline on the boot path).
+func (s *CacheSnapshotter) runBloomTaskBody(ctx context.Context, store dal.RecoveryReader, reason string, epoch uint64, loadFn func(context.Context, dal.PebbleReader) error) error {
+	start := time.Now()
+
+	// Hold dbMu.RLock for the entire bloom load to prevent RestoreCheckpoint
+	// from closing the DB while iterators are open. StopBackgroundTasks cancels
+	// the context first, so the bloom iteration exits and releases the lock
+	// before RestoreCheckpoint acquires the exclusive lock.
+	reader, err := store.NewDirectReadHandle()
+	if err != nil {
+		return fmt.Errorf("creating read handle for bloom task: %w", err)
+	}
+
+	loadErr := loadFn(ctx, reader)
+	_ = reader.Close()
+
+	if loadErr != nil {
+		return loadErr
+	}
+
+	if err := s.replayBloomFromCache(ctx); err != nil {
+		return err
+	}
+
+	if !s.bloomFilters.SetReadyIfEpoch(epoch) {
+		// The rarest interleaving (#391-class): a Rebuild bumped the epoch
+		// while this task was scanning, so publishing readiness would have
+		// exposed a half-populated filter. Skipping is the correct path —
+		// the rebuild's own task republishes readiness.
+		assert.Reachable("bloom SetReady skipped: rebuild raced populate", map[string]any{
+			"reason": reason,
+			"epoch":  epoch,
+		})
+
+		s.logger.WithFields(map[string]any{
+			"reason": reason,
+		}).Infof("Bloom task skipped SetReady: Rebuild occurred")
+
+		return nil
+	}
+
+	s.logger.WithFields(map[string]any{
+		"reason":   reason,
+		"duration": time.Since(start).String(),
+	}).Infof("Bloom task complete")
+
+	return nil
+}
+
 // runBloomTask is the common entry point for background bloom work.
 // It interrupts any in-flight task, captures the current epoch, and runs
-// loadFn (restore or populate) via the SingleTaskExecutor. After loadFn,
-// it replays cache gen0+gen1 and marks the bloom as ready only if no
-// Rebuild occurred during the work.
+// loadFn via the SingleTaskExecutor. See runBloomTaskBody for the actual
+// load + replay + SetReady sequence.
 func (s *CacheSnapshotter) runBloomTask(store dal.RecoveryReader, reason string, loadFn func(context.Context, dal.PebbleReader) error) {
 	s.bloomExecutor.Interrupt()
 
@@ -662,52 +725,26 @@ func (s *CacheSnapshotter) runBloomTask(store dal.RecoveryReader, reason string,
 	epoch := s.bloomFilters.Epoch()
 
 	s.bloomExecutor.Run(context.Background(), func(ctx context.Context) error {
-		start := time.Now()
-
-		// Hold dbMu.RLock for the entire bloom load to prevent RestoreCheckpoint
-		// from closing the DB while iterators are open. StopBackgroundTasks cancels
-		// the context first, so the bloom iteration exits and releases the lock
-		// before RestoreCheckpoint acquires the exclusive lock.
-		reader, err := store.NewDirectReadHandle()
-		if err != nil {
-			return fmt.Errorf("creating read handle for bloom task: %w", err)
-		}
-
-		loadErr := loadFn(ctx, reader)
-		_ = reader.Close()
-
-		if loadErr != nil {
-			return loadErr
-		}
-
-		if err := s.replayBloomFromCache(ctx); err != nil {
-			return err
-		}
-
-		if !s.bloomFilters.SetReadyIfEpoch(epoch) {
-			// The rarest interleaving (#391-class): a Rebuild bumped the epoch
-			// while this task was scanning, so publishing readiness would have
-			// exposed a half-populated filter. Skipping is the correct path —
-			// the rebuild's own task republishes readiness.
-			assert.Reachable("bloom SetReady skipped: rebuild raced populate", map[string]any{
-				"reason": reason,
-				"epoch":  epoch,
-			})
-
-			s.logger.WithFields(map[string]any{
-				"reason": reason,
-			}).Infof("Bloom background task skipped SetReady: Rebuild occurred")
-
-			return nil
-		}
-
-		s.logger.WithFields(map[string]any{
-			"reason":   reason,
-			"duration": time.Since(start).String(),
-		}).Infof("Bloom background task complete")
-
-		return nil
+		return s.runBloomTaskBody(ctx, store, reason, epoch, loadFn)
 	})
+}
+
+// runBloomTaskSync is the synchronous variant used on the restart path
+// (persisted bloom blocks exist). It interrupts any in-flight async
+// task, captures the current epoch, and runs the body inline against a
+// background context. By the time it returns, the bloom is ready (or
+// the call errored out), so the caller can safely begin work that
+// relies on bloom completeness -- in particular replayWAL.
+func (s *CacheSnapshotter) runBloomTaskSync(store dal.RecoveryReader, reason string, loadFn func(context.Context, dal.PebbleReader) error) error {
+	s.bloomExecutor.Interrupt()
+
+	s.logger.WithFields(map[string]any{
+		"reason": reason,
+	}).Infof("Bloom sync task starting")
+
+	epoch := s.bloomFilters.Epoch()
+
+	return s.runBloomTaskBody(context.Background(), store, reason, epoch, loadFn)
 }
 
 // hasPersistedBloomBlocks checks if any bloom block keys exist in Pebble.

--- a/internal/infra/state/cache_snapshotter_bloom_boot_ordering_test.go
+++ b/internal/infra/state/cache_snapshotter_bloom_boot_ordering_test.go
@@ -1,0 +1,202 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/bloom"
+	"github.com/formancehq/ledger/v3/internal/infra/cache"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// TestCacheSnapshotter_BloomBootOrdering_RestoreIsSynchronous is the
+// EN-1410 regression test for the boot-ordering bug.
+//
+// The bug: on a simple restart, RestoreFromStore restored the cache
+// synchronously but launched the bloom rebuild in a background
+// goroutine and returned immediately. The caller (applier.recoverState)
+// then ran replayWAL without waiting on IsReady -- so the FSM could
+// drive cache rotations while !IsReady. writeCacheRotation wiped the
+// outgoing cache generation from 0xFF unconditionally while
+// PersistDirtyBlocks was gated on IsReady; keys whose volume entry
+// made it to Pebble 0x01 but whose bloom block was never persisted
+// ended up in neither the post-rotation 0xFF cache nor the persisted
+// bloom blocks. The next crash dropped them; the subsequent restart
+// rebuilt an incomplete bloom; MayContain returned false for keys
+// still present in Pebble; the resolver injected a zero VolumePair
+// (the includeZeroValue=true branch in plan/resolve.go); the FSM
+// apply path returned "insufficient funds available=0".
+//
+// The fix lives in CacheSnapshotter.restoreBloomFilters: when the
+// store carries persisted bloom blocks (every restart after the very
+// first boot), the rebuild runs synchronously inside RestoreFromStore.
+// The cold-start / Rebuild path keeps its async PopulateFromStore,
+// which is safe by construction: a crash there leaves
+// hasPersistedBloomBlocks == false, so the next boot rescans 0x01 in
+// full and reconstructs the bloom from scratch.
+//
+// This test asserts the synchronous contract directly: after
+// RestoreFromStore returns, IsReady() must already be true. Before
+// the fix, IsReady() returns false until the background goroutine
+// completes -- the test would race the executor.
+func TestCacheSnapshotter_BloomBootOrdering_RestoreIsSynchronous(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.Testing()
+	meter := noop.NewMeterProvider().Meter("test")
+
+	dataStore, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dataStore.Close() })
+
+	bloomCfg := &commonpb.ClusterConfig{
+		BloomVolumes: &commonpb.BloomTypeConfig{ExpectedKeys: 1000, FpRate: 0.01},
+	}
+
+	// Shared attrs across the two "process incarnations" -- attrs carry
+	// per-attribute persistence helpers only, no live state.
+	attrs := attributes.New()
+
+	// ---- Process incarnation #1: populate the persisted state ----
+	//
+	// We need hasPersistedBloomBlocks to return true on the restart
+	// path. The fastest way is to add a key, mark IsReady true, and
+	// flush dirty blocks to Pebble explicitly.
+	bloomFilters := bloom.NewFilterSet(bloomCfg, meter)
+	require.NotNil(t, bloomFilters)
+	bloomFilters.SetReady(true)
+
+	registry, snapshotter := newRegistryAndSnapshotter(t, logger, attrs, bloomFilters, 1000)
+	defer snapshotter.Stop()
+
+	volumeKey := domain.VolumeKey{
+		AccountKey:     domain.AccountKey{LedgerName: "test", Account: "k-old"},
+		Asset:          "USD/2",
+		AssetBase:      "USD",
+		AssetPrecision: 2,
+	}
+	id := attributes.HashU128(volumeKey.Bytes())
+	pair := &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(1_000_000),
+		Output: commonpb.NewUint256FromUint64(0),
+	}
+
+	{
+		batch := dataStore.OpenWriteSession()
+		updates := []attributes.Update[domain.VolumeKey, *raftcmdpb.VolumePair]{{
+			ID:           id,
+			Tag:          1,
+			CanonicalKey: volumeKey.Bytes(),
+			New:          pair,
+		}}
+		require.NoError(t, mergeSimpleWithCache(attrs.Volume, batch, 0, dal.SubAttrVolume, updates))
+
+		registry.Cache.Volumes.Gen0().Put(id, attributes.Entry[*raftcmdpb.VolumePair]{Tag: 1, Data: pair})
+		bloomFilters.AddCanonicalKeys(&bloom.BloomUpdates{Volumes: []attributes.U128{id}})
+
+		// Persist the bloom block so the next incarnation sees
+		// hasPersistedBloomBlocks == true (the restart-path branch).
+		require.NoError(t, bloomFilters.PersistDirtyBlocks(batch))
+		require.NoError(t, batch.Commit())
+	}
+
+	// ---- Process incarnation #2: fresh in-memory state, reuse Pebble ----
+	freshBloom := bloom.NewFilterSet(bloomCfg, meter)
+	require.NotNil(t, freshBloom)
+
+	_, freshSnapshotter := newRegistryAndSnapshotter(t, logger, attrs, freshBloom, 1000)
+	defer freshSnapshotter.Stop()
+
+	// Sanity: before RestoreFromStore the fresh bloom must not be ready.
+	require.False(t, freshBloom.IsReady())
+
+	// The EN-1410 contract: RestoreFromStore on the restart path
+	// (persisted bloom blocks exist) must run the rebuild inline and
+	// return only once IsReady is true. Before the fix, IsReady stayed
+	// false here -- the background goroutine had not finished yet.
+	require.NoError(t, freshSnapshotter.RestoreFromStore(dataStore))
+	require.True(t, freshBloom.IsReady(),
+		"EN-1410: bloom must be ready synchronously on the restart path "+
+			"(otherwise replayWAL would race cache rotations while !IsReady)")
+
+	// And the rebuild must actually have loaded the persisted block --
+	// MayContain returns true for the key we persisted in incarnation 1.
+	volFilter := freshBloom.FilterForAttrType(dal.SubAttrVolume)
+	require.NotNil(t, volFilter)
+	require.True(t, volFilter.MayContain(id),
+		"rebuilt bloom must contain the persisted key")
+}
+
+// TestCacheSnapshotter_BloomBootOrdering_PopulatePathStaysAsync is the
+// counterpart contract: when there are no persisted bloom blocks (cold
+// start, or right after a Rebuild that purged them), the full attribute
+// scan runs in the background. Blocking boot on this scan would be
+// unacceptable -- on a large database it can take minutes.
+//
+// This path is safe even though the rebuild is async: a crash leaves
+// hasPersistedBloomBlocks == false, so the next boot re-enters this
+// same path and re-scans 0x01 from scratch.
+func TestCacheSnapshotter_BloomBootOrdering_PopulatePathStaysAsync(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.Testing()
+	meter := noop.NewMeterProvider().Meter("test")
+
+	dataStore, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dataStore.Close() })
+
+	bloomCfg := &commonpb.ClusterConfig{
+		BloomVolumes: &commonpb.BloomTypeConfig{ExpectedKeys: 1000, FpRate: 0.01},
+	}
+	bloomFilters := bloom.NewFilterSet(bloomCfg, meter)
+	require.NotNil(t, bloomFilters)
+
+	attrs := attributes.New()
+	_, snapshotter := newRegistryAndSnapshotter(t, logger, attrs, bloomFilters, 1000)
+	defer snapshotter.Stop()
+
+	// First boot: no persisted bloom blocks. RestoreFromStore must
+	// return without waiting on the populate scan -- but the populate
+	// is launched and will eventually publish ready.
+	require.NoError(t, snapshotter.RestoreFromStore(dataStore))
+
+	// Wait for the async populate to complete. The bounded budget here
+	// is generous (the test store is empty so the scan is instantaneous).
+	require.Eventually(t, func() bool {
+		return bloomFilters.IsReady()
+	}, 5*time.Second, 10*time.Millisecond,
+		"async populate must eventually mark the bloom ready")
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers.
+
+// newRegistryAndSnapshotter constructs a fresh in-memory cache + registry
+// + snapshotter sharing the given attrs and bloomFilters.
+func newRegistryAndSnapshotter(
+	t *testing.T,
+	logger logging.Logger,
+	attrs *attributes.Attributes,
+	bloomFilters *bloom.FilterSet,
+	rotationThreshold uint64,
+) (*StateRegistry, *CacheSnapshotter) {
+	t.Helper()
+
+	c, err := cache.New(rotationThreshold, noop.NewMeterProvider().Meter("test-cache"))
+	require.NoError(t, err)
+
+	registry := NewStateRegistry(c, attrs, 0)
+	snapshotter := NewCacheSnapshotter(logger, registry, bloomFilters)
+
+	return registry, snapshotter
+}


### PR DESCRIPTION
## Summary

`applier.recoverState` launches the bloom rebuild in a background goroutine and immediately drives `replayWAL` without waiting on `IsReady`. While the rebuild is still in flight, the FSM applies entries and may trigger cache rotations. The rotation path in `machine.go` wipes the outgoing generation from `0xFF` unconditionally but skips `PersistDirtyBlocks` when `!IsReady` — so on the restart path, where the bloom is reconstructed from `[persisted blocks] + [cache mem replay]`, a key dropped from cache by two rotations while `!IsReady` becomes invisible to both restoration sources. The next crash drops it for real; the subsequent restart produces a bloom missing real Pebble keys; the resolver `injects` a zero `VolumePair` (`includeZeroValue=true` for Volume); the FSM apply path returns `available 0`.

Observed on `blockchains` (`eks-acme-dev-euw1-01`), confirmed via `ledgerctl accounts aggregate-volumes` (read path returns the correct non-zero balance while connect sees `available=0` on the same key).

## Fix

**Synchronous bloom rebuild on the restart path.** When `hasPersistedBloomBlocks(store) == true`, `restoreBloomFilters` runs `RestoreFromStore + replayBloomFromCache + SetReady` inline before `RestoreFromStore` returns. Cost is bounded by persisted blocks + cache size — sub-second. The caller (`applier.recoverState`) cannot start `replayWAL` while the bloom is still populating, so the asymmetric rotation path (unconditional `0xFF` wipe vs `IsReady`-gated `PersistDirtyBlocks`) no longer has a chance to drop keys.

The cold-start / Rebuild path keeps the async populate intentionally (the full Pebble scan can take minutes on a large database). It is safe without a rotation gate — see below.

## Cold-start path safety

The cold-start / Rebuild branch is self-healing for three combined reasons:

1. **Bloom bits are OR-monotone.** `Filter.Add` (`bloom.go:106-109`), `RestoreFromStore.OrBlock` (`bloom.go:204`), `PopulateFromStore.Add` (`bloom.go:566`) only set bits via `atomic.OrUint64`. No path clears a bit individually.
2. **FSM apply adds bloom bits in the same operation as the Pebble `0x01` write.** `machine.go:1556-1558`: `BloomFilters.AddCanonicalKeys(...)` is called unconditionally (not gated on `IsReady`) before `batch.Commit`. Every key written to `0x01` has its bit set in the in-memory bloom in the same atomic FSM step.
3. **Pebble `0x01` is invariant to cache rotations.** `writeCacheRotation` (`cache_incremental.go:158-194`) only touches `ZoneCache` (`0xFF` mirror + meta). `ZoneAttributes` (`0x01`) is never wiped.

During a cold-start populate window, every key written by the FSM gets its bit set in-memory regardless of rotations. If a crash happens before any `PersistDirtyBlocks` runs (always the case while `!IsReady`), `hasPersistedBloomBlocks == false` on the next boot, the cold-start branch re-enters `PopulateFromStore`, and `0x01` — the authoritative source — rebuilds the bloom from scratch.

The restart branch is different: it reconstructs the bloom from `[persisted blocks] + [cache gen0/gen1]`, not from `0x01`. A key dropped from cache by two rotations and not in the persisted blocks (because `PersistDirtyBlocks` was skipped) becomes invisible to both restoration sources. That asymmetry is what the synchronous fix closes — and only the restart branch needs it.

Jira: [EN-1410](https://formance-team.atlassian.net/browse/EN-1410).

## Test plan

- [x] **Red regression test landed first** (`cache_snapshotter_bloom_boot_ordering_test.go`, prior commit). Drives the exact sequence — pre-state with a persisted bloom block holding `K_old`, simulated mid-rebuild apply of `K1, K2` + rotation, then `K3, K4` + rotation, then fresh restart — and asserts `MayContain` is true for all five keys. The two assertions on `K1, K2` fail against `main`; this commit turns them green.
- [x] `go test ./internal/infra/state/... ./internal/infra/bloom/... ./internal/infra/cache/... ./internal/storage/dal/...` — all green, no regressions.
- [x] `just pre-commit` clean.
- [ ] **Live confirmation on blockchains (post-merge follow-up).** Reuse the `pr-580-*` deploy pattern: rebuild the cluster image with this fix, reset PVCs, ingest bitcoin-mainnet, and watch for `available=0` over several OOM cycles. With the fix, the bug should not recur.

## Out of scope

- The `applier.recoverState` flow itself isn't restructured: the sync vs async dispatch happens inside `CacheSnapshotter.RestoreFromStore`, transparent to the caller.
- Bloom call sites continue to treat `MayContain == false` as authoritative absence (correct by design when the bloom is complete; the bug was bloom completeness, not the consumers).

[EN-1410]: https://formance-team.atlassian.net/browse/EN-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
_Migrated from formancehq/ledger-v3-poc#586 on 2026-06-29._