### PR TITLE
fix(EN-1409): scan checkpoints dir on cleanup to reclaim crash orphans

### DIFF
--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -50,7 +50,11 @@ const (
 	checkpointsDir          = "checkpoints"
 	temporaryCheckpointsDir = "tmp"
 	baselineCheckpointsDir  = "baseline"
-	incomingRestoreDir      = "incoming" // inside checkpointsDir, non-numeric to avoid ID collision
+	// incomingCheckpointDir sits at the dataDir top level (sibling of
+	// checkpointsDir) so that checkpointsDir contains only numbered
+	// checkpoint dirs. Same filesystem → ActivateIncomingRestore's
+	// Rename(incoming, checkpoints/<id>) stays atomic.
+	incomingCheckpointDir = "incoming-checkpoint"
 )
 
 // ScanLatestCheckpointID scans the checkpoints directory and returns the highest
@@ -74,7 +78,10 @@ func ScanLatestCheckpointID(dataDir string) (latestID uint64, found bool, err er
 
 		id, err := strconv.ParseUint(entry.Name(), 10, 64)
 		if err != nil {
-			continue // skip non-numeric dirs (e.g. "incoming")
+			// Defensive: no producer writes non-numeric children to
+			// checkpointsDir, but tolerate foreign artifacts (.DS_Store,
+			// editor scratch files) instead of failing boot.
+			continue
 		}
 
 		if !found || id > latestID {
@@ -728,8 +735,9 @@ func (s *Store) CreateSnapshot() (uint64, error) {
 // exit otherwise preserves the live checkpoint set as untouchable orphans,
 // permanently leaking `maxCheckpoints * checkpoint_size` per crash.
 //
-// Non-numeric child dirs (e.g. "incoming" used by follower sync) are
-// skipped; only positive-integer dirs are considered checkpoints.
+// Non-numeric children are skipped defensively (no producer writes them
+// after the layout split that moved follower-sync staging out of
+// checkpointsDir); only numeric dirs are considered checkpoints.
 func (s *Store) cleanupOldCheckpoints() error {
 	newCheckpoint := s.currentCheckPoint + 1
 
@@ -742,12 +750,12 @@ func (s *Store) cleanupOldCheckpoints() error {
 	oldestToKeep := newCheckpoint - uint64(s.maxCheckpoints) + 1
 	checkpointsPath := filepath.Join(s.dataDir, checkpointsDir)
 
+	// cleanupOldCheckpoints runs only after CreateSnapshot's db.Checkpoint()
+	// has succeeded, which (re)creates the checkpoints/ parent — so ENOENT
+	// here would signal filesystem tampering or a broken invariant, not a
+	// benign empty state. Per CLAUDE.md invariant #7, surface it loudly.
 	entries, err := os.ReadDir(checkpointsPath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-
 		return fmt.Errorf("listing checkpoints directory: %w", err)
 	}
 
@@ -758,7 +766,7 @@ func (s *Store) cleanupOldCheckpoints() error {
 
 		id, err := strconv.ParseUint(entry.Name(), 10, 64)
 		if err != nil {
-			continue // skip non-numeric children (e.g. "incoming")
+			continue // defensive: see ScanLatestCheckpointID
 		}
 
 		if id >= oldestToKeep {
@@ -936,14 +944,23 @@ func (s *Store) cleanupTemporaryCheckpoints() {
 // cleanupIncomingRestore removes the incoming restore directory on startup.
 // A partial incoming checkpoint can be left if the node crashed during follower sync
 // (between PrepareIncomingRestore and RestoreCheckpoint). It is safe to delete.
+//
+// Also drops the legacy path (dataDir/checkpoints/incoming) used by older
+// builds that placed staging inside checkpointsDir; migration is one-way
+// because the dir is always volatile staging.
 func (s *Store) cleanupIncomingRestore() {
-	path := filepath.Join(s.dataDir, checkpointsDir, incomingRestoreDir)
+	paths := []string{
+		filepath.Join(s.dataDir, incomingCheckpointDir),
+		filepath.Join(s.dataDir, checkpointsDir, "incoming"),
+	}
 
-	err := os.RemoveAll(path)
-	if err != nil {
-		s.logger.WithFields(map[string]any{
-			"error": err,
-		}).Errorf("Failed to clean up incoming restore directory")
+	for _, path := range paths {
+		if err := os.RemoveAll(path); err != nil {
+			s.logger.WithFields(map[string]any{
+				"path":  path,
+				"error": err,
+			}).Errorf("Failed to clean up incoming restore directory")
+		}
 	}
 }
 
@@ -968,11 +985,12 @@ func (s *Store) PrepareCheckpointRestore(checkpointID uint64) (string, error) {
 }
 
 // PrepareIncomingRestore creates a staging directory for an incoming checkpoint
-// from a leader. The directory is "checkpoints/incoming/" — a non-numeric name
-// that cannot collide with the numbered checkpoints created by CreateSnapshot
-// or the background checkpoint goroutine.
+// from a leader. The directory lives outside checkpointsDir so that
+// checkpointsDir holds only numbered checkpoints and the staging path cannot
+// collide with the numbered checkpoints created by CreateSnapshot or the
+// background checkpoint goroutine.
 func (s *Store) PrepareIncomingRestore() (string, error) {
-	dir := filepath.Join(s.dataDir, checkpointsDir, incomingRestoreDir)
+	dir := filepath.Join(s.dataDir, incomingCheckpointDir)
 
 	if err := os.RemoveAll(dir); err != nil {
 		return "", fmt.Errorf("removing existing incoming directory: %w", err)
@@ -993,8 +1011,17 @@ func (s *Store) ActivateIncomingRestore() (uint64, error) {
 	defer s.snapshotMu.Unlock()
 
 	newID := s.currentCheckPoint + 1
-	incomingDir := filepath.Join(s.dataDir, checkpointsDir, incomingRestoreDir)
-	targetDir := filepath.Join(s.dataDir, checkpointsDir, strconv.FormatUint(newID, 10))
+	incomingDir := filepath.Join(s.dataDir, incomingCheckpointDir)
+	targetParent := filepath.Join(s.dataDir, checkpointsDir)
+	targetDir := filepath.Join(targetParent, strconv.FormatUint(newID, 10))
+
+	// Ensure the checkpoints parent exists. Before the staging-dir split it
+	// was created as a side effect of PrepareIncomingRestore; now staging
+	// lives elsewhere and the parent may not exist on a freshly initialised
+	// follower whose first checkpoint comes from the leader.
+	if err := os.MkdirAll(targetParent, 0755); err != nil {
+		return 0, fmt.Errorf("creating checkpoints directory: %w", err)
+	}
 
 	if err := os.RemoveAll(targetDir); err != nil {
 		return 0, fmt.Errorf("removing target checkpoint directory: %w", err)

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -720,32 +720,58 @@ func (s *Store) CreateSnapshot() (uint64, error) {
 	return newCheckpointID, nil
 }
 
-// cleanupOldCheckpoints removes checkpoints older than the configured maximum.
-// It keeps the most recent maxCheckpoints checkpoints.
+// cleanupOldCheckpoints removes every checkpoint dir whose ID falls below
+// (currentCheckPoint + 1) - maxCheckpoints + 1. It scans the checkpoints
+// directory on disk rather than iterating from an in-memory tracker so it
+// also reclaims fossil checkpoints left by a previous crash that fall
+// outside the running tracker's window (see EN-1409). Each non-graceful
+// exit otherwise preserves the live checkpoint set as untouchable orphans,
+// permanently leaking `maxCheckpoints * checkpoint_size` per crash.
+//
+// Non-numeric child dirs (e.g. "incoming" used by follower sync) are
+// skipped; only positive-integer dirs are considered checkpoints.
 func (s *Store) cleanupOldCheckpoints() error {
 	newCheckpoint := s.currentCheckPoint + 1
 
-	// Calculate the oldest checkpoint to keep
-	// If newCheckpoint is 15 and maxCheckpoints is 10, we keep checkpoints 6-15
-	// So we delete anything older than (newCheckpoint - maxCheckpoints + 1)
+	// If we haven't reached maxCheckpoints yet there's nothing to keep
+	// below 0; skip the scan.
 	if newCheckpoint < uint64(s.maxCheckpoints) {
-		// Not enough checkpoints yet, nothing to delete
 		return nil
 	}
 
 	oldestToKeep := newCheckpoint - uint64(s.maxCheckpoints) + 1
+	checkpointsPath := filepath.Join(s.dataDir, checkpointsDir)
 
-	// Delete checkpoints from oldestCheckpoint up to (but not including) oldestToKeep
-	for i := s.oldestCheckpoint; i < oldestToKeep; i++ {
-		checkpointPath := filepath.Join(s.dataDir, checkpointsDir, strconv.FormatUint(i, 10))
+	entries, err := os.ReadDir(checkpointsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 
-		err := os.RemoveAll(checkpointPath)
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("removing old checkpoint %d: %w", i, err)
+		return fmt.Errorf("listing checkpoints directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		id, err := strconv.ParseUint(entry.Name(), 10, 64)
+		if err != nil {
+			continue // skip non-numeric children (e.g. "incoming")
+		}
+
+		if id >= oldestToKeep {
+			continue
+		}
+
+		if err := os.RemoveAll(filepath.Join(checkpointsPath, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing old checkpoint %d: %w", id, err)
 		}
 	}
 
-	// Update the oldest checkpoint tracker
+	// Tracker is informational only after this change, but keep it
+	// consistent with the new floor so external readers don't drift.
 	s.oldestCheckpoint = oldestToKeep
 
 	return nil

--- a/internal/storage/dal/store_operations_test.go
+++ b/internal/storage/dal/store_operations_test.go
@@ -398,6 +398,39 @@ func TestStore_PrepareIncomingRestoreLocation(t *testing.T) {
 	require.True(t, info.IsDir())
 }
 
+// TestStore_ActivateIncomingRestore_FreshFollower pins the safety net that
+// makes follower-sync work when the follower has never taken a local
+// snapshot: the leader delivers the first checkpoint before `checkpoints/`
+// exists on disk, so ActivateIncomingRestore must MkdirAll the parent
+// before renaming staging into place. A refactor that drops the MkdirAll
+// would silently reintroduce the fresh-follower failure — this test
+// catches it.
+func TestStore_ActivateIncomingRestore_FreshFollower(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	// Precondition: checkpoints/ must not exist on a fresh store.
+	_, err := os.Stat(filepath.Join(s.DataDir(), "checkpoints"))
+	require.True(t, os.IsNotExist(err), "fresh store must not have a checkpoints/ dir yet")
+
+	stagingDir, err := s.PrepareIncomingRestore()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stagingDir, "marker"), []byte("leader-data"), 0o644))
+
+	checkpointID, err := s.ActivateIncomingRestore()
+	require.NoError(t, err, "must succeed even without a pre-existing checkpoints/ parent")
+	require.Equal(t, uint64(1), checkpointID)
+
+	// Staging dir was renamed (not copied) into checkpoints/<id>/.
+	marker, err := os.ReadFile(filepath.Join(s.DataDir(), "checkpoints", "1", "marker"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("leader-data"), marker)
+
+	_, err = os.Stat(stagingDir)
+	require.True(t, os.IsNotExist(err), "staging dir must be renamed away, not left behind")
+}
+
 func TestStore_IterateColdKVPairs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/dal/store_operations_test.go
+++ b/internal/storage/dal/store_operations_test.go
@@ -293,6 +293,68 @@ func TestStore_CleanupOldCheckpoints(t *testing.T) {
 	require.LessOrEqual(t, len(entries), 4, "should have at most 4 checkpoint dirs")
 }
 
+// TestStore_CleanupOldCheckpoints_RemovesOrphansBelowTracker is the
+// EN-1409 regression test. Before the fix, cleanupOldCheckpoints iterated
+// from an in-memory tracker initialised at boot via arithmetic
+// (latestID - maxCheckpoints + 1), so any checkpoint dir whose ID was
+// below that floor at boot time -- left there by a previous non-graceful
+// exit -- was permanently unreachable to cleanup and leaked
+// `maxCheckpoints * checkpoint_size` per crash forever.
+//
+// The fix scans the checkpoints directory on every cleanup and removes
+// any numeric dir below `oldestToKeep`, regardless of the tracker, so
+// orphans are reclaimed on the first snapshot after restart.
+func TestStore_CleanupOldCheckpoints_RemovesOrphansBelowTracker(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	meter := noop.NewMeterProvider().Meter("test")
+
+	dataDir := t.TempDir()
+	checkpointsPath := filepath.Join(dataDir, "checkpoints")
+
+	// Simulate fossil pairs left by previous crashes plus the live pair
+	// that survived the most recent crash. With maxCheckpoints=2 and
+	// latestID=101, the buggy init would compute oldestCheckpoint=100,
+	// leaving {5, 6} permanently unreachable.
+	for _, id := range []string{"5", "6", "100", "101"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(checkpointsPath, id), 0o755))
+	}
+
+	cfg := DefaultConfig()
+	cfg.MaxCheckpoints = 2
+
+	s, err := NewStore(dataDir, logger, meter, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// One snapshot is enough to fire the new scan-based cleanup.
+	batch := s.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte("k"), []byte("v")))
+	require.NoError(t, batch.Commit())
+
+	_, err = s.CreateSnapshot()
+	require.NoError(t, err)
+
+	// After cleanup, only the last maxCheckpoints (=2) checkpoints should
+	// remain on disk: the just-created 102 and the previous 101. The
+	// fossil pair {5, 6} and the now-aged 100 must be gone.
+	entries, err := os.ReadDir(checkpointsPath)
+	require.NoError(t, err)
+
+	remaining := map[string]bool{}
+	for _, e := range entries {
+		remaining[e.Name()] = true
+	}
+
+	require.NotContains(t, remaining, "5", "fossil orphan 5 must be reclaimed")
+	require.NotContains(t, remaining, "6", "fossil orphan 6 must be reclaimed")
+	require.NotContains(t, remaining, "100", "aged-out 100 must be reclaimed")
+	require.Contains(t, remaining, "101", "previous-live 101 must be kept")
+	require.Contains(t, remaining, "102", "newly-created 102 must be kept")
+}
+
 func TestStore_IterateColdKVPairs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/dal/store_operations_test.go
+++ b/internal/storage/dal/store_operations_test.go
@@ -355,6 +355,49 @@ func TestStore_CleanupOldCheckpoints_RemovesOrphansBelowTracker(t *testing.T) {
 	require.Contains(t, remaining, "102", "newly-created 102 must be kept")
 }
 
+// TestStore_LegacyIncomingMigration asserts the boot-time cleanup of the
+// legacy follower-sync staging path (dataDir/checkpoints/incoming) used by
+// older builds. Newer builds stage at dataDir/incoming-checkpoint; the
+// legacy path is volatile-only so it can be removed unconditionally.
+func TestStore_LegacyIncomingMigration(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	meter := noop.NewMeterProvider().Meter("test")
+
+	dataDir := t.TempDir()
+	legacyIncoming := filepath.Join(dataDir, "checkpoints", "incoming")
+	require.NoError(t, os.MkdirAll(legacyIncoming, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyIncoming, "junk"), []byte("x"), 0o644))
+
+	s, err := NewStore(dataDir, logger, meter, DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, err = os.Stat(legacyIncoming)
+	require.True(t, os.IsNotExist(err), "legacy checkpoints/incoming must be removed at boot")
+
+	_, err = os.Stat(filepath.Join(dataDir, "incoming-checkpoint"))
+	require.True(t, os.IsNotExist(err), "new staging path must not be pre-created")
+}
+
+// TestStore_PrepareIncomingRestoreLocation pins the new staging path so a
+// future move is caught by tests, not by surprise on production restore.
+func TestStore_PrepareIncomingRestoreLocation(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	dir, err := s.PrepareIncomingRestore()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(s.DataDir(), "incoming-checkpoint"), dir)
+
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
 func TestStore_IterateColdKVPairs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`cleanupOldCheckpoints` iterated from an in-memory tracker
(`s.oldestCheckpoint`) initialised at boot by arithmetic
(`latestCheckpointID - maxCheckpoints + 1`). After any non-graceful exit,
the previous live checkpoint set was preserved on disk and fell inside the
newly-computed window, so cleanup never touched it. As subsequent
snapshots advanced the tracker, those fossils dropped out of the window
forever — the loop only iterates upward from the tracker, never below.

Net effect: every crash permanently leaked
`maxCheckpoints * checkpoint_size` of disk.

Observed on `blockchains` LedgerService on `eks-acme-dev-euw1-01`:
93.4 GiB of orphan checkpoint dirs accumulated in ~14h, saturating the
data PVC and triggering `ResourceExhausted` ("writes blocked: disk usage
exceeds threshold") in connect's batch applies. The disk layout shows
the fossil pairs explicitly — six `(X, X+1)` pairs separated by gaps
where normal rotation did clean up:

```
checkpoints/23   7.7G  + 24  1.9G    (fossil)
checkpoints/161  12.1G + 162 241M    (fossil)
checkpoints/194  12.7G + 195 481M    (fossil)
checkpoints/224  13.8G + 225 480M    (fossil)
checkpoints/256  16.3G + 257 481M    (fossil)
checkpoints/309  17.2G + 310 246M    (fossil)
checkpoints/316  20.4G + 317 1.6G    (live)
```

## Fix

Replace the incremental loop with a directory scan: read `checkpointsDir`,
parse every numeric child as a checkpoint ID, and `RemoveAll` anything
below `oldestToKeep`. Non-numeric children are skipped (defensive — see
follow-up commit).

`s.oldestCheckpoint` is kept as an informational floor but is no longer
authoritative for what gets deleted.

## Follow-up commit: layout split + loud-fail on missing parent

The first commit fixed the leak but left two rough edges. The follow-up
commit addresses both:

1. **Loud-fail invariant on missing `checkpoints/`** (addresses
   paul-nicolas's Medium review): `cleanupOldCheckpoints` runs only
   after `db.Checkpoint()` has succeeded, which (re)creates the
   `checkpoints/` parent. `ENOENT` from `os.ReadDir` here is impossible
   by design — per CLAUDE.md invariant #7 we surface it instead of
   silently no-oping.

2. **Move follower-sync staging out of `checkpoints/`**: was
   `dataDir/checkpoints/incoming/`, becomes `dataDir/incoming-checkpoint/`
   (top-level sibling). Reasons:
   - `checkpointsDir` now holds only numbered checkpoint dirs; the
     "skip non-numeric" branch becomes pure defense for foreign
     artifacts (.DS_Store etc) rather than load-bearing logic.
   - Same filesystem → `ActivateIncomingRestore`'s
     `Rename(staging, checkpoints/<id>)` stays atomic.
   - `ActivateIncomingRestore` now `MkdirAll`s `checkpoints/` explicitly
     (before the split it was a side effect of `PrepareIncomingRestore`).
   - `cleanupIncomingRestore` at boot wipes both the new staging path
     and the legacy `checkpoints/incoming/` path. One-way migration is
     safe — the staging dir is always volatile.

## Test plan

- [x] `go test ./internal/storage/dal/ -run TestStore_CleanupOldCheckpoints`
- [x] `TestStore_CleanupOldCheckpoints_RemovesOrphansBelowTracker`
      pre-populates `{5, 6, 100, 101}`, runs `NewStore` + one
      `CreateSnapshot`, and asserts `{5, 6, 100}` are gone and
      `{101, 102}` remain. Before the fix, the assertion on the missing
      fossils fails because the tracker-bounded loop never visits IDs
      below the boot-computed floor.
- [x] `TestStore_LegacyIncomingMigration` pins the boot-time cleanup
      of `dataDir/checkpoints/incoming/`.
- [x] `TestStore_PrepareIncomingRestoreLocation` pins the new staging
      path so a future move is caught by tests, not by surprise on
      production restores.
- [x] `go test ./internal/storage/dal/ ./internal/infra/state/ ./internal/infra/node/`
      green — follower-sync flow (PrepareIncomingRestore → write →
      ActivateIncomingRestore → RestoreCheckpoint) still works with
      the new staging location.
- [ ] Validate live on `blockchains` after merge + image deploy: orphan
      pairs should be reclaimed on the next snapshot tick after restart.

Jira: [EN-1409](https://formance-team.atlassian.net/browse/EN-1409).

[EN-1409]: https://formance-team.atlassian.net/browse/EN-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
_Migrated from formancehq/ledger-v3-poc#585 on 2026-06-29._
