### PR TITLE
perf(EN-1403): dethash zero-alloc sorted-keys via sync.Pool

### DIFF
--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -6,7 +6,7 @@ package auditpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	sort "sort"
+	slices "slices"
 	sync "sync"
 )
 
@@ -184,7 +184,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		for k := range m.Context {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Context[k]
 			baseI := i

--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_audit_String = sync.Pool{
+	_dethashKeyPoolAuditString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -179,7 +179,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Context) > 0 {
-		keysPtr := _dethashKeyPool_audit_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolAuditString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Context {
 			keys = append(keys, k)
@@ -204,7 +204,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_audit_String.Put(keysPtr)
+		_dethashKeyPoolAuditString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)

--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolAuditString = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoAuditpbAuditString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -179,7 +179,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Context) > 0 {
-		keysPtr := _dethashKeyPoolAuditString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoAuditpbAuditString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Context {
 			keys = append(keys, k)
@@ -204,7 +204,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolAuditString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoAuditpbAuditString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)

--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolAuditString = sync.Pool{
+	_dethashKeyPool_audit_String = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -179,7 +179,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Context) > 0 {
-		keysPtr := _dethashKeyPoolAuditString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_audit_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Context {
 			keys = append(keys, k)
@@ -204,7 +204,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolAuditString.Put(keysPtr)
+		_dethashKeyPool_audit_String.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)

--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -6,8 +6,20 @@ package auditpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
-	slices "slices"
+	sort "sort"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolString = sync.Pool{
+		New: func() any { s := make([]string, 0, 16); return &s },
+	}
 )
 
 func (m *AuditEntry) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -167,7 +179,13 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Context) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Context)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Context {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Context[k]
 			baseI := i
 			i -= len(v)
@@ -184,6 +202,8 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)

--- a/internal/proto/auditpb/audit_dethash.pb.go
+++ b/internal/proto/auditpb/audit_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolString = sync.Pool{
+	_dethashKeyPoolAuditString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -179,7 +179,7 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Context) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolAuditString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Context {
 			keys = append(keys, k)
@@ -202,8 +202,9 @@ func (m *AuditFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, er
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolAuditString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)

--- a/internal/proto/clusterpb/cluster_dethash.pb.go
+++ b/internal/proto/clusterpb/cluster_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolClusterUint64 = sync.Pool{
+	_dethashKeyPool_cluster_Uint64 = sync.Pool{
 		New: func() any { s := make([]uint64, 0, 16); return &s },
 	}
 )
@@ -81,7 +81,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x49
 	}
 	if len(m.Progress) > 0 {
-		keysPtr := _dethashKeyPoolClusterUint64.Get().(*[]uint64)
+		keysPtr := _dethashKeyPool_cluster_Uint64.Get().(*[]uint64)
 		keys := (*keysPtr)[:0]
 		for k := range m.Progress {
 			keys = append(keys, k)
@@ -103,7 +103,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			dAtA[i] = 0x42
 		}
 		*keysPtr = keys
-		_dethashKeyPoolClusterUint64.Put(keysPtr)
+		_dethashKeyPool_cluster_Uint64.Put(keysPtr)
 	}
 	if m.Vote != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vote))

--- a/internal/proto/clusterpb/cluster_dethash.pb.go
+++ b/internal/proto/clusterpb/cluster_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolClusterUint64 = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoClusterpbClusterUint64 = sync.Pool{
 		New: func() any { s := make([]uint64, 0, 16); return &s },
 	}
 )
@@ -81,7 +81,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x49
 	}
 	if len(m.Progress) > 0 {
-		keysPtr := _dethashKeyPoolClusterUint64.Get().(*[]uint64)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoClusterpbClusterUint64.Get().(*[]uint64)
 		keys := (*keysPtr)[:0]
 		for k := range m.Progress {
 			keys = append(keys, k)
@@ -103,7 +103,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			dAtA[i] = 0x42
 		}
 		*keysPtr = keys
-		_dethashKeyPoolClusterUint64.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoClusterpbClusterUint64.Put(keysPtr)
 	}
 	if m.Vote != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vote))

--- a/internal/proto/clusterpb/cluster_dethash.pb.go
+++ b/internal/proto/clusterpb/cluster_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_cluster_Uint64 = sync.Pool{
+	_dethashKeyPoolClusterUint64 = sync.Pool{
 		New: func() any { s := make([]uint64, 0, 16); return &s },
 	}
 )
@@ -81,7 +81,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x49
 	}
 	if len(m.Progress) > 0 {
-		keysPtr := _dethashKeyPool_cluster_Uint64.Get().(*[]uint64)
+		keysPtr := _dethashKeyPoolClusterUint64.Get().(*[]uint64)
 		keys := (*keysPtr)[:0]
 		for k := range m.Progress {
 			keys = append(keys, k)
@@ -103,7 +103,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			dAtA[i] = 0x42
 		}
 		*keysPtr = keys
-		_dethashKeyPool_cluster_Uint64.Put(keysPtr)
+		_dethashKeyPoolClusterUint64.Put(keysPtr)
 	}
 	if m.Vote != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vote))

--- a/internal/proto/clusterpb/cluster_dethash.pb.go
+++ b/internal/proto/clusterpb/cluster_dethash.pb.go
@@ -6,8 +6,20 @@ package clusterpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
 	slices "slices"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolUint64 = sync.Pool{
+		New: func() any { s := make([]uint64, 0, 16); return &s },
+	}
 )
 
 func (m *GetClusterStateRequest) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -69,7 +81,13 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x49
 	}
 	if len(m.Progress) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Progress)) {
+		keysPtr := _dethashKeyPoolUint64.Get().(*[]uint64)
+		keys := (*keysPtr)[:0]
+		for k := range m.Progress {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+		for _, k := range keys {
 			v := m.Progress[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -84,6 +102,8 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0x42
 		}
+		*keysPtr = keys
+		_dethashKeyPoolUint64.Put(keysPtr)
 	}
 	if m.Vote != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vote))

--- a/internal/proto/clusterpb/cluster_dethash.pb.go
+++ b/internal/proto/clusterpb/cluster_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolUint64 = sync.Pool{
+	_dethashKeyPoolClusterUint64 = sync.Pool{
 		New: func() any { s := make([]uint64, 0, 16); return &s },
 	}
 )
@@ -81,7 +81,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x49
 	}
 	if len(m.Progress) > 0 {
-		keysPtr := _dethashKeyPoolUint64.Get().(*[]uint64)
+		keysPtr := _dethashKeyPoolClusterUint64.Get().(*[]uint64)
 		keys := (*keysPtr)[:0]
 		for k := range m.Progress {
 			keys = append(keys, k)
@@ -103,7 +103,7 @@ func (m *RaftStatus) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			dAtA[i] = 0x42
 		}
 		*keysPtr = keys
-		_dethashKeyPoolUint64.Put(keysPtr)
+		_dethashKeyPoolClusterUint64.Put(keysPtr)
 	}
 	if m.Vote != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Vote))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -6,8 +6,20 @@ package commonpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
-	slices "slices"
+	sort "sort"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolString = sync.Pool{
+		New: func() any { s := make([]string, 0, 16); return &s },
+	}
 )
 
 func (m *Timestamp) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -63,7 +75,13 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Values) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Values)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Values {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Values[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -80,6 +98,8 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -188,7 +208,13 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -205,6 +231,8 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -245,7 +273,13 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 	}
 	if len(m.Vars) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Vars)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Vars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
 			i -= len(v)
@@ -262,6 +296,8 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Plain) > 0 {
 		i -= len(m.Plain)
@@ -315,7 +351,13 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Volumes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Volumes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Volumes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -332,6 +374,8 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -356,7 +400,13 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.VolumesByAccount) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.VolumesByAccount)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.VolumesByAccount {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.VolumesByAccount[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -373,6 +423,8 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -397,7 +449,13 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Volumes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Volumes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Volumes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -414,6 +472,8 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 			i--
 			dAtA[i] = 0x32
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.UpdatedAt != nil {
 		size, _ := m.UpdatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -437,7 +497,13 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -454,6 +520,8 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
@@ -518,7 +586,13 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.LedgerFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.LedgerFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.LedgerFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -535,9 +609,17 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.TransactionFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.TransactionFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.TransactionFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -554,9 +636,17 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -573,6 +663,8 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -1152,7 +1244,13 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1169,6 +1267,8 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1397,7 +1497,13 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountTypes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountTypes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1414,6 +1520,8 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 			i--
 			dAtA[i] = 0x32
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -1746,7 +1854,13 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		dAtA[i] = 0x19
 	}
 	if len(m.AccountMetadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountMetadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountMetadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1763,6 +1877,8 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Transaction != nil {
 		size, _ := m.Transaction.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1836,7 +1952,13 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1853,6 +1975,8 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2043,7 +2167,13 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x68
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -2060,6 +2190,8 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0x62
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.DefaultEnforcementMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DefaultEnforcementMode))
@@ -2067,7 +2199,13 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x58
 	}
 	if len(m.AccountTypes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountTypes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -2084,6 +2222,8 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0x52
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.MirrorSyncProgress != nil {
 		size, _ := m.MirrorSyncProgress.MarshalToSizedBufferVT(dAtA[:i])
@@ -2155,7 +2295,13 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -2172,6 +2318,8 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2221,7 +2369,13 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -2238,6 +2392,8 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.RevertedByTransaction != 0 {
 		i -= 8
@@ -2332,7 +2488,13 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			i -= len(v)
@@ -2349,6 +2511,8 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)
@@ -2451,7 +2615,13 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.SegmentTypes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.SegmentTypes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.SegmentTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.SegmentTypes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -2468,6 +2638,8 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Persistence != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Persistence))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolCommonString = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -75,7 +75,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Values) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Values {
 			keys = append(keys, k)
@@ -100,7 +100,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -209,7 +209,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -234,7 +234,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -275,7 +275,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -300,7 +300,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.Plain) > 0 {
 		i -= len(m.Plain)
@@ -354,7 +354,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -379,7 +379,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -404,7 +404,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.VolumesByAccount) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.VolumesByAccount {
 			keys = append(keys, k)
@@ -429,7 +429,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -454,7 +454,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -479,7 +479,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.UpdatedAt != nil {
 		size, _ := m.UpdatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -503,7 +503,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -528,7 +528,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
@@ -593,7 +593,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -618,10 +618,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -646,10 +646,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -674,7 +674,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -1254,7 +1254,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1279,7 +1279,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1508,7 +1508,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -1533,7 +1533,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -1866,7 +1866,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		dAtA[i] = 0x19
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1891,7 +1891,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.Transaction != nil {
 		size, _ := m.Transaction.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1965,7 +1965,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1990,7 +1990,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2181,7 +2181,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x68
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2206,7 +2206,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.DefaultEnforcementMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DefaultEnforcementMode))
@@ -2214,7 +2214,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x58
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -2239,7 +2239,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.MirrorSyncProgress != nil {
 		size, _ := m.MirrorSyncProgress.MarshalToSizedBufferVT(dAtA[:i])
@@ -2311,7 +2311,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2336,7 +2336,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2386,7 +2386,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2411,7 +2411,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.RevertedByTransaction != 0 {
 		i -= 8
@@ -2506,7 +2506,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2531,7 +2531,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)
@@ -2634,7 +2634,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.SegmentTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.SegmentTypes {
 			keys = append(keys, k)
@@ -2659,7 +2659,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoCommonpbCommonString.Put(keysPtr)
 	}
 	if m.Persistence != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Persistence))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolCommonString = sync.Pool{
+	_dethashKeyPool_common_String = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -75,7 +75,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Values) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Values {
 			keys = append(keys, k)
@@ -100,7 +100,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -209,7 +209,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -234,7 +234,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -275,7 +275,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -300,7 +300,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.Plain) > 0 {
 		i -= len(m.Plain)
@@ -354,7 +354,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -379,7 +379,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -404,7 +404,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.VolumesByAccount) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.VolumesByAccount {
 			keys = append(keys, k)
@@ -429,7 +429,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -454,7 +454,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -479,7 +479,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.UpdatedAt != nil {
 		size, _ := m.UpdatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -503,7 +503,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -528,7 +528,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
@@ -593,7 +593,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -618,10 +618,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -646,10 +646,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -674,7 +674,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -1254,7 +1254,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1279,7 +1279,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1508,7 +1508,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -1533,7 +1533,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -1866,7 +1866,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		dAtA[i] = 0x19
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1891,7 +1891,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.Transaction != nil {
 		size, _ := m.Transaction.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1965,7 +1965,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1990,7 +1990,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2181,7 +2181,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x68
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2206,7 +2206,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.DefaultEnforcementMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DefaultEnforcementMode))
@@ -2214,7 +2214,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x58
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -2239,7 +2239,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.MirrorSyncProgress != nil {
 		size, _ := m.MirrorSyncProgress.MarshalToSizedBufferVT(dAtA[:i])
@@ -2311,7 +2311,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2336,7 +2336,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2386,7 +2386,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2411,7 +2411,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.RevertedByTransaction != 0 {
 		i -= 8
@@ -2506,7 +2506,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2531,7 +2531,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)
@@ -2634,7 +2634,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.SegmentTypes) > 0 {
-		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.SegmentTypes {
 			keys = append(keys, k)
@@ -2659,7 +2659,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolCommonString.Put(keysPtr)
+		_dethashKeyPool_common_String.Put(keysPtr)
 	}
 	if m.Persistence != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Persistence))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_common_String = sync.Pool{
+	_dethashKeyPoolCommonString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -75,7 +75,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Values) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Values {
 			keys = append(keys, k)
@@ -100,7 +100,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -209,7 +209,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -234,7 +234,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -275,7 +275,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -300,7 +300,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Plain) > 0 {
 		i -= len(m.Plain)
@@ -354,7 +354,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -379,7 +379,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -404,7 +404,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.VolumesByAccount) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.VolumesByAccount {
 			keys = append(keys, k)
@@ -429,7 +429,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -454,7 +454,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -479,7 +479,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.UpdatedAt != nil {
 		size, _ := m.UpdatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -503,7 +503,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -528,7 +528,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
@@ -593,7 +593,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -618,10 +618,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -646,10 +646,10 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -674,7 +674,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -1254,7 +1254,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1279,7 +1279,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1508,7 +1508,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -1533,7 +1533,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -1866,7 +1866,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		dAtA[i] = 0x19
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1891,7 +1891,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Transaction != nil {
 		size, _ := m.Transaction.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1965,7 +1965,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1990,7 +1990,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2181,7 +2181,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x68
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2206,7 +2206,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.DefaultEnforcementMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DefaultEnforcementMode))
@@ -2214,7 +2214,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x58
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -2239,7 +2239,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.MirrorSyncProgress != nil {
 		size, _ := m.MirrorSyncProgress.MarshalToSizedBufferVT(dAtA[:i])
@@ -2311,7 +2311,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2336,7 +2336,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2386,7 +2386,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2411,7 +2411,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.RevertedByTransaction != 0 {
 		i -= 8
@@ -2506,7 +2506,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2531,7 +2531,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)
@@ -2634,7 +2634,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.SegmentTypes) > 0 {
-		keysPtr := _dethashKeyPool_common_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.SegmentTypes {
 			keys = append(keys, k)
@@ -2659,7 +2659,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_common_String.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Persistence != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Persistence))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolString = sync.Pool{
+	_dethashKeyPoolCommonString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -75,7 +75,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Values) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Values {
 			keys = append(keys, k)
@@ -98,8 +98,9 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -208,7 +209,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -231,8 +232,9 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -273,7 +275,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -296,8 +298,9 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Plain) > 0 {
 		i -= len(m.Plain)
@@ -351,7 +354,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -374,8 +377,9 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -400,7 +404,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.VolumesByAccount) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.VolumesByAccount {
 			keys = append(keys, k)
@@ -423,8 +427,9 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -449,7 +454,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Volumes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Volumes {
 			keys = append(keys, k)
@@ -472,8 +477,9 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 			i--
 			dAtA[i] = 0x32
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.UpdatedAt != nil {
 		size, _ := m.UpdatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -497,7 +503,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		dAtA[i] = 0x1a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -520,8 +526,9 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Address) > 0 {
 		i -= len(m.Address)
@@ -586,7 +593,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -609,11 +616,12 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -636,11 +644,12 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -663,8 +672,9 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -1244,7 +1254,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1267,8 +1277,9 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1497,7 +1508,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -1520,8 +1531,9 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 			i--
 			dAtA[i] = 0x32
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -1854,7 +1866,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		dAtA[i] = 0x19
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1877,8 +1889,9 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Transaction != nil {
 		size, _ := m.Transaction.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1952,7 +1965,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1975,8 +1988,9 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2167,7 +2181,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x68
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2190,8 +2204,9 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0x62
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.DefaultEnforcementMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DefaultEnforcementMode))
@@ -2199,7 +2214,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		dAtA[i] = 0x58
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -2222,8 +2237,9 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0x52
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.MirrorSyncProgress != nil {
 		size, _ := m.MirrorSyncProgress.MarshalToSizedBufferVT(dAtA[:i])
@@ -2295,7 +2311,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2318,8 +2334,9 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -2369,7 +2386,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2392,8 +2409,9 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.RevertedByTransaction != 0 {
 		i -= 8
@@ -2488,7 +2506,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -2511,8 +2529,9 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if len(m.Message) > 0 {
 		i -= len(m.Message)
@@ -2615,7 +2634,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.SegmentTypes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolCommonString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.SegmentTypes {
 			keys = append(keys, k)
@@ -2638,8 +2657,9 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolCommonString.Put(keysPtr)
 	}
 	if m.Persistence != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Persistence))

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -6,7 +6,7 @@ package commonpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	sort "sort"
+	slices "slices"
 	sync "sync"
 )
 
@@ -80,7 +80,7 @@ func (m *MetadataMap) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		for k := range m.Values {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Values[k]
 			baseI := i
@@ -213,7 +213,7 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -278,7 +278,7 @@ func (m *Script) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		for k := range m.Vars {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
@@ -356,7 +356,7 @@ func (m *VolumesByAssets) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		for k := range m.Volumes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Volumes[k]
 			baseI := i
@@ -405,7 +405,7 @@ func (m *PostCommitVolumes) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		for k := range m.VolumesByAccount {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.VolumesByAccount[k]
 			baseI := i
@@ -454,7 +454,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		for k := range m.Volumes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Volumes[k]
 			baseI := i
@@ -502,7 +502,7 @@ func (m *Account) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) 
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -591,7 +591,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.LedgerFields[k]
 			baseI := i
@@ -618,7 +618,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.TransactionFields[k]
 			baseI := i
@@ -645,7 +645,7 @@ func (m *MetadataSchema) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		for k := range m.AccountFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountFields[k]
 			baseI := i
@@ -1249,7 +1249,7 @@ func (m *SavedLedgerMetadataLog) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1502,7 +1502,7 @@ func (m *CreatedLedgerLog) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
@@ -1859,7 +1859,7 @@ func (m *CreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
@@ -1957,7 +1957,7 @@ func (m *SavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, e
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -2172,7 +2172,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -2204,7 +2204,7 @@ func (m *LedgerInfo) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, erro
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
@@ -2300,7 +2300,7 @@ func (m *SaveMetadataCommand) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -2374,7 +2374,7 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -2493,7 +2493,7 @@ func (m *IdempotencyFailure) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -2620,7 +2620,7 @@ func (m *AccountType) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		for k := range m.SegmentTypes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.SegmentTypes[k]
 			baseI := i

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -6,8 +6,20 @@ package proposalpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
-	slices "slices"
+	sort "sort"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolString = sync.Pool{
+		New: func() any { s := make([]string, 0, 16); return &s },
+	}
 )
 
 func (m *AppliedProposal) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -30,7 +42,13 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.TransientVolumes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.TransientVolumes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.TransientVolumes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.TransientVolumes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -47,6 +65,8 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.MaxLogSequence != 0 {
 		i -= 8

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_proposal_String = sync.Pool{
+	_dethashKeyPoolProposalString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -42,7 +42,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.TransientVolumes) > 0 {
-		keysPtr := _dethashKeyPool_proposal_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolProposalString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransientVolumes {
 			keys = append(keys, k)
@@ -67,7 +67,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_proposal_String.Put(keysPtr)
+		_dethashKeyPoolProposalString.Put(keysPtr)
 	}
 	if m.MaxLogSequence != 0 {
 		i -= 8

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolString = sync.Pool{
+	_dethashKeyPoolProposalString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -42,7 +42,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.TransientVolumes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolProposalString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransientVolumes {
 			keys = append(keys, k)
@@ -65,8 +65,9 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolProposalString.Put(keysPtr)
 	}
 	if m.MaxLogSequence != 0 {
 		i -= 8

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolProposalString = sync.Pool{
+	_dethashKeyPool_proposal_String = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -42,7 +42,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.TransientVolumes) > 0 {
-		keysPtr := _dethashKeyPoolProposalString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_proposal_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransientVolumes {
 			keys = append(keys, k)
@@ -67,7 +67,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolProposalString.Put(keysPtr)
+		_dethashKeyPool_proposal_String.Put(keysPtr)
 	}
 	if m.MaxLogSequence != 0 {
 		i -= 8

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolProposalString = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoProposalpbProposalString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -42,7 +42,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.TransientVolumes) > 0 {
-		keysPtr := _dethashKeyPoolProposalString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoProposalpbProposalString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransientVolumes {
 			keys = append(keys, k)
@@ -67,7 +67,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolProposalString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoProposalpbProposalString.Put(keysPtr)
 	}
 	if m.MaxLogSequence != 0 {
 		i -= 8

--- a/internal/proto/proposalpb/proposal_dethash.pb.go
+++ b/internal/proto/proposalpb/proposal_dethash.pb.go
@@ -6,7 +6,7 @@ package proposalpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	sort "sort"
+	slices "slices"
 	sync "sync"
 )
 
@@ -47,7 +47,7 @@ func (m *AppliedProposal) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		for k := range m.TransientVolumes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.TransientVolumes[k]
 			baseI := i

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolString = sync.Pool{
+	_dethashKeyPoolRaftCmdString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -474,7 +474,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		dAtA[i] = 0x28
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -497,8 +497,9 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -654,7 +655,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -677,8 +678,9 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x32
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -695,7 +697,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -718,8 +720,9 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -759,7 +762,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -782,8 +785,9 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -822,7 +826,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -845,8 +849,9 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.ReversePostings) > 0 {
 		for iNdEx := len(m.ReversePostings) - 1; iNdEx >= 0; iNdEx-- {
@@ -1159,7 +1164,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1182,11 +1187,12 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x32
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1209,8 +1215,9 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x2a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1265,7 +1272,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1288,8 +1295,9 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1328,7 +1336,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1351,8 +1359,9 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -1403,7 +1412,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1426,8 +1435,9 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1489,7 +1499,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1512,8 +1522,9 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -6,8 +6,20 @@ package raftcmdpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
-	slices "slices"
+	sort "sort"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolString = sync.Pool{
+		New: func() any { s := make([]string, 0, 16); return &s },
+	}
 )
 
 func (m *Order) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -462,7 +474,13 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		dAtA[i] = 0x28
 	}
 	if len(m.AccountTypes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountTypes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -479,6 +497,8 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -634,7 +654,13 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.AccountMetadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountMetadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountMetadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -651,6 +677,8 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x32
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -667,7 +695,13 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -684,6 +718,8 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -723,7 +759,13 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -740,6 +782,8 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -778,7 +822,13 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -795,6 +845,8 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.ReversePostings) > 0 {
 		for iNdEx := len(m.ReversePostings) - 1; iNdEx >= 0; iNdEx-- {
@@ -1107,7 +1159,13 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountMetadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountMetadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1124,9 +1182,17 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x32
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1143,6 +1209,8 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x2a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1197,7 +1265,13 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Vars)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Vars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
 			i -= len(v)
@@ -1214,6 +1288,8 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1252,7 +1328,13 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1269,6 +1351,8 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -1319,7 +1403,13 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1336,6 +1426,8 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1397,7 +1489,13 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1414,6 +1512,8 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -6,7 +6,7 @@ package raftcmdpb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	sort "sort"
+	slices "slices"
 	sync "sync"
 )
 
@@ -479,7 +479,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
@@ -659,7 +659,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
@@ -700,7 +700,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -764,7 +764,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -827,7 +827,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1164,7 +1164,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
@@ -1191,7 +1191,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1270,7 +1270,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		for k := range m.Vars {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
@@ -1333,7 +1333,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1408,7 +1408,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1494,7 +1494,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolRaftCmdString = sync.Pool{
+	_dethashKeyPool_raft_cmd_String = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -474,7 +474,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		dAtA[i] = 0x28
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -499,7 +499,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -655,7 +655,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -680,7 +680,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -697,7 +697,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -722,7 +722,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -762,7 +762,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -787,7 +787,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -826,7 +826,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -851,7 +851,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.ReversePostings) > 0 {
 		for iNdEx := len(m.ReversePostings) - 1; iNdEx >= 0; iNdEx-- {
@@ -1164,7 +1164,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1189,10 +1189,10 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1217,7 +1217,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1272,7 +1272,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1297,7 +1297,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1336,7 +1336,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1361,7 +1361,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -1412,7 +1412,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1437,7 +1437,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1499,7 +1499,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1524,7 +1524,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_raft_cmd_String = sync.Pool{
+	_dethashKeyPoolRaftCmdString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -474,7 +474,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		dAtA[i] = 0x28
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -499,7 +499,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -655,7 +655,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -680,7 +680,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -697,7 +697,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -722,7 +722,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -762,7 +762,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -787,7 +787,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -826,7 +826,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -851,7 +851,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.ReversePostings) > 0 {
 		for iNdEx := len(m.ReversePostings) - 1; iNdEx >= 0; iNdEx-- {
@@ -1164,7 +1164,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1189,10 +1189,10 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1217,7 +1217,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1272,7 +1272,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1297,7 +1297,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1336,7 +1336,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1361,7 +1361,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -1412,7 +1412,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1437,7 +1437,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1499,7 +1499,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_raft_cmd_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1524,7 +1524,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_raft_cmd_String.Put(keysPtr)
+		_dethashKeyPoolRaftCmdString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolRaftCmdString = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -474,7 +474,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		dAtA[i] = 0x28
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -499,7 +499,7 @@ func (m *CreateLedgerOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -655,7 +655,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -680,7 +680,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -697,7 +697,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x22
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -722,7 +722,7 @@ func (m *MirrorCreatedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
@@ -762,7 +762,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -787,7 +787,7 @@ func (m *MirrorSavedMetadata) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -826,7 +826,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -851,7 +851,7 @@ func (m *MirrorRevertedTransaction) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.ReversePostings) > 0 {
 		for iNdEx := len(m.ReversePostings) - 1; iNdEx >= 0; iNdEx-- {
@@ -1164,7 +1164,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1189,10 +1189,10 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1217,7 +1217,7 @@ func (m *CreateTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1272,7 +1272,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1297,7 +1297,7 @@ func (m *NumscriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (i
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1336,7 +1336,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1361,7 +1361,7 @@ func (m *SaveMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte) (in
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if m.Target != nil {
 		size, _ := m.Target.MarshalToSizedBufferVT(dAtA[:i])
@@ -1412,7 +1412,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1437,7 +1437,7 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1499,7 +1499,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolRaftCmdString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1524,7 +1524,7 @@ func (m *SaveLedgerMetadataOrder) MarshalToSizedBufferDeterministicVT(dAtA []byt
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolRaftCmdString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolBucketString = sync.Pool{
+	_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -127,7 +127,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		dAtA[i] = 0x30
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -152,7 +152,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -746,7 +746,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -771,7 +771,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1056,7 +1056,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1081,7 +1081,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1235,7 +1235,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1260,10 +1260,10 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1288,7 +1288,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1360,7 +1360,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1385,7 +1385,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1947,7 +1947,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -1972,10 +1972,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -2000,10 +2000,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -2028,7 +2028,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -2329,7 +2329,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		dAtA[i] = 0x20
 	}
 	if len(m.Parameters) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Parameters {
 			keys = append(keys, k)
@@ -2354,7 +2354,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoServicepbBucketString.Put(keysPtr)
 	}
 	if len(m.QueryName) > 0 {
 		i -= len(m.QueryName)

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -6,7 +6,7 @@ package servicepb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	sort "sort"
+	slices "slices"
 	sync "sync"
 )
 
@@ -132,7 +132,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
@@ -750,7 +750,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1059,7 +1059,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		for k := range m.Vars {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
@@ -1237,7 +1237,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
@@ -1264,7 +1264,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1360,7 +1360,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		for k := range m.Metadata {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
@@ -1946,7 +1946,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.LedgerFields[k]
 			baseI := i
@@ -1973,7 +1973,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.TransactionFields[k]
 			baseI := i
@@ -2000,7 +2000,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		for k := range m.AccountFields {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.AccountFields[k]
 			baseI := i
@@ -2325,7 +2325,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		for k := range m.Parameters {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
 			v := m.Parameters[k]
 			baseI := i

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -6,8 +6,20 @@ package servicepb
 import (
 	binary "encoding/binary"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
-	maps "maps"
-	slices "slices"
+	sort "sort"
+	sync "sync"
+)
+
+// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that
+// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,
+// sorts it in place, and returns it. Steady-state allocations are zero:
+// the pool reuses the slice across marshal calls. The first marshal of
+// a given kind warms the pool with a 16-cap slice; larger maps grow it
+// once and the grown capacity persists.
+var (
+	_dethashKeyPoolString = sync.Pool{
+		New: func() any { s := make([]string, 0, 16); return &s },
+	}
 )
 
 func (m *GetAccountRequest) MarshalDeterministicVT(dAtA []byte) []byte {
@@ -115,7 +127,13 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		dAtA[i] = 0x30
 	}
 	if len(m.AccountTypes) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountTypes)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountTypes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountTypes[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -132,6 +150,8 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x2a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -725,7 +745,13 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -742,6 +768,8 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1026,7 +1054,13 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Vars)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Vars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Vars[k]
 			baseI := i
 			i -= len(v)
@@ -1043,6 +1077,8 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1196,7 +1232,13 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountMetadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountMetadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountMetadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])
@@ -1213,9 +1255,17 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x32
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1232,6 +1282,8 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x2a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1303,7 +1355,13 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Metadata)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Metadata[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1320,6 +1378,8 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x22
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1881,7 +1941,13 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.LedgerFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.LedgerFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.LedgerFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1898,9 +1964,17 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.TransactionFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.TransactionFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.TransactionFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1917,9 +1991,17 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0x12
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.AccountFields)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.AccountFields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.AccountFields[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -1936,6 +2018,8 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0xa
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -2236,7 +2320,13 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		dAtA[i] = 0x20
 	}
 	if len(m.Parameters) > 0 {
-		for _, k := range slices.Sorted(maps.Keys(m.Parameters)) {
+		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keys := (*keysPtr)[:0]
+		for k := range m.Parameters {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			v := m.Parameters[k]
 			baseI := i
 			size, _ := v.MarshalToSizedBufferVT(dAtA[:i])
@@ -2253,6 +2343,8 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 			i--
 			dAtA[i] = 0x1a
 		}
+		*keysPtr = keys
+		_dethashKeyPoolString.Put(keysPtr)
 	}
 	if len(m.QueryName) > 0 {
 		i -= len(m.QueryName)

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolBucketString = sync.Pool{
+	_dethashKeyPool_bucket_String = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -127,7 +127,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		dAtA[i] = 0x30
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -152,7 +152,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -746,7 +746,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -771,7 +771,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1056,7 +1056,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1081,7 +1081,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1235,7 +1235,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1260,10 +1260,10 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1288,7 +1288,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1360,7 +1360,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1385,7 +1385,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1947,7 +1947,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -1972,10 +1972,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -2000,10 +2000,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -2028,7 +2028,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -2329,7 +2329,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		dAtA[i] = 0x20
 	}
 	if len(m.Parameters) > 0 {
-		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
+		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Parameters {
 			keys = append(keys, k)
@@ -2354,7 +2354,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolBucketString.Put(keysPtr)
+		_dethashKeyPool_bucket_String.Put(keysPtr)
 	}
 	if len(m.QueryName) > 0 {
 		i -= len(m.QueryName)

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPool_bucket_String = sync.Pool{
+	_dethashKeyPoolBucketString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -127,7 +127,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		dAtA[i] = 0x30
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -152,7 +152,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -746,7 +746,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -771,7 +771,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1056,7 +1056,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1081,7 +1081,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1235,7 +1235,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1260,10 +1260,10 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1288,7 +1288,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1360,7 +1360,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1385,7 +1385,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1947,7 +1947,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -1972,10 +1972,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -2000,10 +2000,10 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -2028,7 +2028,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -2329,7 +2329,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		dAtA[i] = 0x20
 	}
 	if len(m.Parameters) > 0 {
-		keysPtr := _dethashKeyPool_bucket_String.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Parameters {
 			keys = append(keys, k)
@@ -2354,7 +2354,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		}
 		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPool_bucket_String.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.QueryName) > 0 {
 		i -= len(m.QueryName)

--- a/internal/proto/servicepb/bucket_dethash.pb.go
+++ b/internal/proto/servicepb/bucket_dethash.pb.go
@@ -17,7 +17,7 @@ import (
 // a given kind warms the pool with a 16-cap slice; larger maps grow it
 // once and the grown capacity persists.
 var (
-	_dethashKeyPoolString = sync.Pool{
+	_dethashKeyPoolBucketString = sync.Pool{
 		New: func() any { s := make([]string, 0, 16); return &s },
 	}
 )
@@ -127,7 +127,7 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 		dAtA[i] = 0x30
 	}
 	if len(m.AccountTypes) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountTypes {
 			keys = append(keys, k)
@@ -150,8 +150,9 @@ func (m *CreateLedgerRequest) MarshalToSizedBufferDeterministicVT(dAtA []byte) (
 			i--
 			dAtA[i] = 0x2a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if m.MirrorSource != nil {
 		size, _ := m.MirrorSource.MarshalToSizedBufferVT(dAtA[:i])
@@ -745,7 +746,7 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -768,8 +769,9 @@ func (m *SaveLedgerMetadataRequest) MarshalToSizedBufferDeterministicVT(dAtA []b
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Ledger) > 0 {
 		i -= len(m.Ledger)
@@ -1054,7 +1056,7 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.Vars) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Vars {
 			keys = append(keys, k)
@@ -1077,8 +1079,9 @@ func (m *ScriptReference) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int,
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Version) > 0 {
 		i -= len(m.Version)
@@ -1232,7 +1235,7 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x38
 	}
 	if len(m.AccountMetadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountMetadata {
 			keys = append(keys, k)
@@ -1255,11 +1258,12 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x32
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1282,8 +1286,9 @@ func (m *CreateTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x2a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.Reference) > 0 {
 		i -= len(m.Reference)
@@ -1355,7 +1360,7 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 		dAtA[i] = 0x2a
 	}
 	if len(m.Metadata) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Metadata {
 			keys = append(keys, k)
@@ -1378,8 +1383,9 @@ func (m *RevertTransactionPayload) MarshalToSizedBufferDeterministicVT(dAtA []by
 			i--
 			dAtA[i] = 0x22
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if m.AtEffectiveDate {
 		i--
@@ -1941,7 +1947,7 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if len(m.LedgerFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.LedgerFields {
 			keys = append(keys, k)
@@ -1964,11 +1970,12 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.TransactionFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.TransactionFields {
 			keys = append(keys, k)
@@ -1991,11 +1998,12 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0x12
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.AccountFields) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.AccountFields {
 			keys = append(keys, k)
@@ -2018,8 +2026,9 @@ func (m *GetMetadataSchemaStatusResponse) MarshalToSizedBufferDeterministicVT(dA
 			i--
 			dAtA[i] = 0xa
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	return len(dAtA) - i, nil
 }
@@ -2320,7 +2329,7 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 		dAtA[i] = 0x20
 	}
 	if len(m.Parameters) > 0 {
-		keysPtr := _dethashKeyPoolString.Get().(*[]string)
+		keysPtr := _dethashKeyPoolBucketString.Get().(*[]string)
 		keys := (*keysPtr)[:0]
 		for k := range m.Parameters {
 			keys = append(keys, k)
@@ -2343,8 +2352,9 @@ func (m *ExecutePreparedQueryRequest) MarshalToSizedBufferDeterministicVT(dAtA [
 			i--
 			dAtA[i] = 0x1a
 		}
+		clear(keys)
 		*keysPtr = keys
-		_dethashKeyPoolString.Put(keysPtr)
+		_dethashKeyPoolBucketString.Put(keysPtr)
 	}
 	if len(m.QueryName) > 0 {
 		i -= len(m.QueryName)

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	slicesPkg       = protogen.GoImportPath("slices")
-	sortPkg         = protogen.GoImportPath("sort")
 	syncPkg         = protogen.GoImportPath("sync")
 	protohelpersPkg = protogen.GoImportPath("github.com/planetscale/vtprotobuf/protohelpers")
 	binaryPkg       = protogen.GoImportPath("encoding/binary")
@@ -45,8 +44,12 @@ type keyKindInfo struct {
 
 // supportedKeyKinds maps every map-key kind the plugin accepts to its
 // pool/sort recipe. The kinds match the panic guard in genMapMarshal.
+// `slices.Sort` is used uniformly (Go 1.21+ pdqsort generic) — measured
+// marginally faster than `sort.Strings` on strings of any size and the
+// fastest std-lib option on ints; using a single sort function avoids
+// pulling the `sort` package into the generated file.
 var supportedKeyKinds = map[protoreflect.Kind]keyKindInfo{
-	protoreflect.StringKind: {goType: "string", pkgVar: "_dethashKeyPoolString", sortPkg: sortPkg, sortFunc: "Strings"},
+	protoreflect.StringKind: {goType: "string", pkgVar: "_dethashKeyPoolString", sortPkg: slicesPkg, sortFunc: "Sort"},
 	protoreflect.Int32Kind:  {goType: "int32", pkgVar: "_dethashKeyPoolInt32", sortPkg: slicesPkg, sortFunc: "Sort"},
 	protoreflect.Uint32Kind: {goType: "uint32", pkgVar: "_dethashKeyPoolUint32", sortPkg: slicesPkg, sortFunc: "Sort"},
 	protoreflect.Int64Kind:  {goType: "int64", pkgVar: "_dethashKeyPoolInt64", sortPkg: slicesPkg, sortFunc: "Sort"},

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -18,11 +18,40 @@ import (
 
 var (
 	slicesPkg       = protogen.GoImportPath("slices")
-	mapsPkg         = protogen.GoImportPath("maps")
+	sortPkg         = protogen.GoImportPath("sort")
+	syncPkg         = protogen.GoImportPath("sync")
 	protohelpersPkg = protogen.GoImportPath("github.com/planetscale/vtprotobuf/protohelpers")
 	binaryPkg       = protogen.GoImportPath("encoding/binary")
 	mathPkg         = protogen.GoImportPath("math")
 )
+
+// keyKindInfo describes how to declare a sync.Pool of sorted keys for a
+// supported map-key kind. The generated marshaler grabs a *[]K from the pool,
+// fills it, sorts it in place, and returns it to the pool after the map has
+// been encoded — replacing the previous `slices.Sorted(maps.Keys(...))` call
+// that allocated a fresh slice on every marshal.
+type keyKindInfo struct {
+	// goType is the Go literal for the key slice element (e.g. "string",
+	// "int64").
+	goType string
+	// pkgVar is the unique package-level variable name for this kind's pool,
+	// e.g. "_dethashKeyPoolString".
+	pkgVar string
+	// sortCall is the sort statement applied to a `keys` slice of this type.
+	// Generated as `<package>.<call>(keys)` so the import is tracked.
+	sortPkg  protogen.GoImportPath
+	sortFunc string
+}
+
+// supportedKeyKinds maps every map-key kind the plugin accepts to its
+// pool/sort recipe. The kinds match the panic guard in genMapMarshal.
+var supportedKeyKinds = map[protoreflect.Kind]keyKindInfo{
+	protoreflect.StringKind: {goType: "string", pkgVar: "_dethashKeyPoolString", sortPkg: sortPkg, sortFunc: "Strings"},
+	protoreflect.Int32Kind:  {goType: "int32", pkgVar: "_dethashKeyPoolInt32", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Uint32Kind: {goType: "uint32", pkgVar: "_dethashKeyPoolUint32", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Int64Kind:  {goType: "int64", pkgVar: "_dethashKeyPoolInt64", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Uint64Kind: {goType: "uint64", pkgVar: "_dethashKeyPoolUint64", sortPkg: slicesPkg, sortFunc: "Sort"},
+}
 
 func main() {
 	protogen.Options{}.Run(func(gen *protogen.Plugin) error {
@@ -81,9 +110,86 @@ func generateFile(gen *protogen.Plugin, file *protogen.File, hasMap map[string]b
 	g.P()
 	g.P("package ", file.GoPackageName)
 
+	// First, find every map-key kind used in this file so we can emit one
+	// sync.Pool per kind. The pool reuses the sorted-keys slice across
+	// marshal calls, replacing the per-call `slices.Sorted(maps.Keys(m))`
+	// allocation. The pool is package-private so it does not leak into
+	// the public API.
+	usedKeyKinds := map[protoreflect.Kind]bool{}
+	for _, msg := range file.Messages {
+		collectMapKeyKinds(msg, usedKeyKinds)
+	}
+
+	emitKeyPools(g, usedKeyKinds)
+
 	for _, msg := range file.Messages {
 		walkMessages(g, msg, hasMap)
 	}
+}
+
+// collectMapKeyKinds walks msg + every nested message and records the kind
+// of every map<K, V> field's key. Limited to the kinds supported by
+// genMapMarshal — anything else would have panicked the plugin elsewhere.
+func collectMapKeyKinds(msg *protogen.Message, out map[protoreflect.Kind]bool) {
+	if msg.Desc.IsMapEntry() {
+		return
+	}
+
+	for _, f := range msg.Fields {
+		if f.Desc.IsMap() {
+			keyKind := f.Message.Fields[0].Desc.Kind()
+			if _, ok := supportedKeyKinds[keyKind]; ok {
+				out[keyKind] = true
+			}
+		}
+	}
+
+	for _, nested := range msg.Messages {
+		collectMapKeyKinds(nested, out)
+	}
+}
+
+// emitKeyPools writes one sync.Pool per used map-key kind, plus a small
+// initial slice capacity tuned for the typical metadata-style map (~16
+// entries — beyond that the pool's slice grows once and stays grown,
+// which is exactly the behaviour we want).
+func emitKeyPools(g *protogen.GeneratedFile, used map[protoreflect.Kind]bool) {
+	if len(used) == 0 {
+		return
+	}
+
+	// Iterate in a deterministic order so the generated file is stable
+	// across plugin runs (map iteration would otherwise reshuffle the
+	// declarations, producing useless diffs).
+	ordered := []protoreflect.Kind{
+		protoreflect.StringKind,
+		protoreflect.Int32Kind,
+		protoreflect.Uint32Kind,
+		protoreflect.Int64Kind,
+		protoreflect.Uint64Kind,
+	}
+
+	g.P()
+	g.P("// Map-key scratch pools. Each MarshalToSizedBufferDeterministicVT that")
+	g.P("// encodes a map<K, V> grabs a *[]K from the matching pool, fills it,")
+	g.P("// sorts it in place, and returns it. Steady-state allocations are zero:")
+	g.P("// the pool reuses the slice across marshal calls. The first marshal of")
+	g.P("// a given kind warms the pool with a 16-cap slice; larger maps grow it")
+	g.P("// once and the grown capacity persists.")
+	g.P("var (")
+
+	for _, kind := range ordered {
+		if !used[kind] {
+			continue
+		}
+
+		info := supportedKeyKinds[kind]
+		g.P("  ", info.pkgVar, " = ", syncPkg.Ident("Pool"), "{")
+		g.P("    New: func() any { s := make([]", info.goType, ", 0, 16); return &s },")
+		g.P("  }")
+	}
+
+	g.P(")")
 }
 
 func walkMessages(g *protogen.GeneratedFile, msg *protogen.Message, hasMap map[string]bool) {
@@ -264,9 +370,24 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 	valField := f.Message.Fields[1]
 	fieldNum := f.Desc.Number()
 	tag := encodeTag(fieldNum, 2)
+	keyField := f.Message.Fields[0]
+	keyKind := keyField.Desc.Kind()
 
+	info, ok := supportedKeyKinds[keyKind]
+	if !ok {
+		panic(fmt.Sprintf("protoc-gen-dethash: unsupported map key type %s in field %s", keyKind, f.Desc.FullName()))
+	}
+
+	// Borrow a sorted-keys scratch slice from the file-scoped pool, fill it,
+	// sort it in place, and return it after the loop. Steady-state zero alloc.
 	g.P("  if len(m.", goName, ") > 0 {")
-	g.P("    for _, k := range ", slicesPkg.Ident("Sorted"), "(", mapsPkg.Ident("Keys"), "(m.", goName, ")) {")
+	g.P("    keysPtr := ", info.pkgVar, ".Get().(*[]", info.goType, ")")
+	g.P("    keys := (*keysPtr)[:0]")
+	g.P("    for k := range m.", goName, " {")
+	g.P("      keys = append(keys, k)")
+	g.P("    }")
+	g.P("    ", info.sortPkg.Ident(info.sortFunc), "(keys)")
+	g.P("    for _, k := range keys {")
 	g.P("      v := m.", goName, "[k]")
 	g.P("      baseI := i")
 
@@ -298,8 +419,7 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 	}
 
 	// Write key (field 1)
-	keyField := f.Message.Fields[0]
-	switch keyField.Desc.Kind() {
+	switch keyKind {
 	case protoreflect.StringKind:
 		g.P("      i -= len(k)")
 		g.P("      copy(dAtA[i:], k)")
@@ -311,7 +431,7 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 		g.P("      i--")
 		g.P("      dAtA[i] = 0x8") // field 1, wire type varint
 	default:
-		panic(fmt.Sprintf("protoc-gen-dethash: unsupported map key type %s in field %s", keyField.Desc.Kind(), f.Desc.FullName()))
+		panic(fmt.Sprintf("protoc-gen-dethash: unsupported map key type %s in field %s", keyKind, f.Desc.FullName()))
 	}
 
 	// Write entry length + outer tag
@@ -319,6 +439,11 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 	writeTag(g, tag)
 
 	g.P("    }")
+	// Return the (possibly grown) scratch slice to the pool. The pool keeps
+	// the underlying capacity, so the next marshal that needs at most that
+	// many keys hits zero allocation.
+	g.P("    *keysPtr = keys")
+	g.P("    ", info.pkgVar, ".Put(keysPtr)")
 	g.P("  }")
 }
 

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -68,48 +69,46 @@ var supportedKeyKinds = map[protoreflect.Kind]keyKindInfo{
 }
 
 // poolVarName builds the unique package-level pool variable name for a
-// given (file, kind) pair. The file segment prevents collisions when two
+// given (file, kind) pair. The file suffix prevents collisions when two
 // .proto files share the same `go_package` — each generated file would
 // otherwise emit the same `_dethashKeyPool<Kind>` identifier, producing
 // a "redeclared in this block" compile error.
 func poolVarName(filePoolPrefix string, kind protoreflect.Kind) string {
-	return "_dethashKeyPool_" + filePoolPrefix + "_" + supportedKeyKinds[kind].kindSuffix
+	return "_dethashKeyPool" + filePoolPrefix + supportedKeyKinds[kind].kindSuffix
 }
 
-// filePoolPrefix returns the .proto file's basename (path stripped, ".proto"
-// extension already stripped by protogen) verbatim, after validating that
-// every rune is Go-identifier-safe. It is embedded literally into pool
-// variable names — preserving underscores rather than collapsing them —
-// so two distinct proto basenames produce two distinct pool identifiers.
-//
-// Earlier revisions sanitized non-alphanumeric runes (dropping them or
-// folding them into capitalization), but any lossy mapping re-introduces
-// the very collision the per-file scheme is meant to prevent — e.g.
-// `foo-bar.proto` and `foo_bar.proto` collapsing onto the same prefix.
-// The filesystem already guarantees basenames are unique inside a
-// directory; preserving them verbatim makes pool identifier uniqueness
-// rely on that single guarantee, with no fuzzy sanitization step in
-// between. Basenames containing runes outside [A-Za-z0-9_] (or a leading
-// digit) are rejected here at generate time so the failure is immediate
-// and obvious instead of silently producing invalid Go.
+// filePoolPrefix derives a Go-identifier-safe, capitalized suffix from a
+// proto file's GeneratedFilenamePrefix (which is the proto file path
+// minus its extension, e.g. "common" or "misc/proto/common"). It is used
+// as a per-file disambiguator in pool variable names. Non-alphanumeric
+// runes are replaced with '_'; the result is title-cased so the final
+// pool identifier reads as `_dethashKeyPool<File><Kind>`.
 func filePoolPrefix(file *protogen.File) string {
 	base := path.Base(file.GeneratedFilenamePrefix)
-	if base == "" {
-		panic(fmt.Sprintf("protoc-gen-dethash: empty file base name for %q", file.Desc.Path()))
-	}
 
-	for i, r := range base {
-		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
-		isDigit := r >= '0' && r <= '9'
-		isUnderscore := r == '_'
-		if !isLetter && !isUnderscore && !(isDigit && i > 0) {
-			panic(fmt.Sprintf(
-				"protoc-gen-dethash: proto file %q basename %q contains rune %q at offset %d outside [A-Za-z0-9_] (leading digits not allowed); rename the file or extend filePoolPrefix to encode it unambiguously",
-				file.Desc.Path(), base, r, i,
-			))
+	var b strings.Builder
+	b.Grow(len(base) + 1)
+	upper := true
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			if upper {
+				r -= 'a' - 'A'
+				upper = false
+			}
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9':
+			b.WriteRune(r)
+			upper = false
+		default:
+			// Non-identifier rune (e.g. '-' in a hypothetical "my-proto"
+			// file). Drop and re-capitalize the next letter so we don't
+			// emit '_' inside what is otherwise a CamelCase identifier.
+			upper = true
 		}
 	}
-	return base
+
+	return b.String()
 }
 
 func main() {

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -11,7 +11,6 @@ package main
 import (
 	"fmt"
 	"path"
-	"strings"
 
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -69,46 +68,48 @@ var supportedKeyKinds = map[protoreflect.Kind]keyKindInfo{
 }
 
 // poolVarName builds the unique package-level pool variable name for a
-// given (file, kind) pair. The file suffix prevents collisions when two
+// given (file, kind) pair. The file segment prevents collisions when two
 // .proto files share the same `go_package` — each generated file would
 // otherwise emit the same `_dethashKeyPool<Kind>` identifier, producing
 // a "redeclared in this block" compile error.
 func poolVarName(filePoolPrefix string, kind protoreflect.Kind) string {
-	return "_dethashKeyPool" + filePoolPrefix + supportedKeyKinds[kind].kindSuffix
+	return "_dethashKeyPool_" + filePoolPrefix + "_" + supportedKeyKinds[kind].kindSuffix
 }
 
-// filePoolPrefix derives a Go-identifier-safe, capitalized suffix from a
-// proto file's GeneratedFilenamePrefix (which is the proto file path
-// minus its extension, e.g. "common" or "misc/proto/common"). It is used
-// as a per-file disambiguator in pool variable names. Non-alphanumeric
-// runes are replaced with '_'; the result is title-cased so the final
-// pool identifier reads as `_dethashKeyPool<File><Kind>`.
+// filePoolPrefix returns the .proto file's basename (path stripped, ".proto"
+// extension already stripped by protogen) verbatim, after validating that
+// every rune is Go-identifier-safe. It is embedded literally into pool
+// variable names — preserving underscores rather than collapsing them —
+// so two distinct proto basenames produce two distinct pool identifiers.
+//
+// Earlier revisions sanitized non-alphanumeric runes (dropping them or
+// folding them into capitalization), but any lossy mapping re-introduces
+// the very collision the per-file scheme is meant to prevent — e.g.
+// `foo-bar.proto` and `foo_bar.proto` collapsing onto the same prefix.
+// The filesystem already guarantees basenames are unique inside a
+// directory; preserving them verbatim makes pool identifier uniqueness
+// rely on that single guarantee, with no fuzzy sanitization step in
+// between. Basenames containing runes outside [A-Za-z0-9_] (or a leading
+// digit) are rejected here at generate time so the failure is immediate
+// and obvious instead of silently producing invalid Go.
 func filePoolPrefix(file *protogen.File) string {
 	base := path.Base(file.GeneratedFilenamePrefix)
-
-	var b strings.Builder
-	b.Grow(len(base) + 1)
-	upper := true
-	for _, r := range base {
-		switch {
-		case r >= 'a' && r <= 'z':
-			if upper {
-				r -= 'a' - 'A'
-				upper = false
-			}
-			b.WriteRune(r)
-		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9':
-			b.WriteRune(r)
-			upper = false
-		default:
-			// Non-identifier rune (e.g. '-' in a hypothetical "my-proto"
-			// file). Drop and re-capitalize the next letter so we don't
-			// emit '_' inside what is otherwise a CamelCase identifier.
-			upper = true
-		}
+	if base == "" {
+		panic(fmt.Sprintf("protoc-gen-dethash: empty file base name for %q", file.Desc.Path()))
 	}
 
-	return b.String()
+	for i, r := range base {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		isUnderscore := r == '_'
+		if !isLetter && !isUnderscore && !(isDigit && i > 0) {
+			panic(fmt.Sprintf(
+				"protoc-gen-dethash: proto file %q basename %q contains rune %q at offset %d outside [A-Za-z0-9_] (leading digits not allowed); rename the file or extend filePoolPrefix to encode it unambiguously",
+				file.Desc.Path(), base, r, i,
+			))
+		}
+	}
+	return base
 }
 
 func main() {

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -10,6 +10,8 @@ package main
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -33,10 +35,20 @@ type keyKindInfo struct {
 	// goType is the Go literal for the key slice element (e.g. "string",
 	// "int64").
 	goType string
-	// pkgVar is the unique package-level variable name for this kind's pool,
-	// e.g. "_dethashKeyPoolString".
-	pkgVar string
-	// sortCall is the sort statement applied to a `keys` slice of this type.
+	// kindSuffix is the capitalized kind name appended to the pool variable
+	// (e.g. "String", "Uint64"). The full per-file variable name is built
+	// by poolVarName so that two .proto files sharing the same Go package
+	// don't collide on a single `_dethashKeyPool<Kind>` identifier.
+	kindSuffix string
+	// pointerContaining is true when the key type embeds Go pointers (today
+	// only `string`, whose header points at the underlying bytes). The
+	// generated code must `clear(keys)` before returning the slice to the
+	// pool — otherwise the backing array keeps those pointers reachable
+	// until the pool slot is overwritten or evicted, effectively trading
+	// the per-marshal allocation for unbounded heap retention on
+	// many-unique-key workloads (e.g. churn over metadata maps).
+	pointerContaining bool
+	// sortPkg/sortFunc is the sort statement applied to the keys slice.
 	// Generated as `<package>.<call>(keys)` so the import is tracked.
 	sortPkg  protogen.GoImportPath
 	sortFunc string
@@ -49,11 +61,54 @@ type keyKindInfo struct {
 // fastest std-lib option on ints; using a single sort function avoids
 // pulling the `sort` package into the generated file.
 var supportedKeyKinds = map[protoreflect.Kind]keyKindInfo{
-	protoreflect.StringKind: {goType: "string", pkgVar: "_dethashKeyPoolString", sortPkg: slicesPkg, sortFunc: "Sort"},
-	protoreflect.Int32Kind:  {goType: "int32", pkgVar: "_dethashKeyPoolInt32", sortPkg: slicesPkg, sortFunc: "Sort"},
-	protoreflect.Uint32Kind: {goType: "uint32", pkgVar: "_dethashKeyPoolUint32", sortPkg: slicesPkg, sortFunc: "Sort"},
-	protoreflect.Int64Kind:  {goType: "int64", pkgVar: "_dethashKeyPoolInt64", sortPkg: slicesPkg, sortFunc: "Sort"},
-	protoreflect.Uint64Kind: {goType: "uint64", pkgVar: "_dethashKeyPoolUint64", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.StringKind: {goType: "string", kindSuffix: "String", pointerContaining: true, sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Int32Kind:  {goType: "int32", kindSuffix: "Int32", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Uint32Kind: {goType: "uint32", kindSuffix: "Uint32", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Int64Kind:  {goType: "int64", kindSuffix: "Int64", sortPkg: slicesPkg, sortFunc: "Sort"},
+	protoreflect.Uint64Kind: {goType: "uint64", kindSuffix: "Uint64", sortPkg: slicesPkg, sortFunc: "Sort"},
+}
+
+// poolVarName builds the unique package-level pool variable name for a
+// given (file, kind) pair. The file suffix prevents collisions when two
+// .proto files share the same `go_package` — each generated file would
+// otherwise emit the same `_dethashKeyPool<Kind>` identifier, producing
+// a "redeclared in this block" compile error.
+func poolVarName(filePoolPrefix string, kind protoreflect.Kind) string {
+	return "_dethashKeyPool" + filePoolPrefix + supportedKeyKinds[kind].kindSuffix
+}
+
+// filePoolPrefix derives a Go-identifier-safe, capitalized suffix from a
+// proto file's GeneratedFilenamePrefix (which is the proto file path
+// minus its extension, e.g. "common" or "misc/proto/common"). It is used
+// as a per-file disambiguator in pool variable names. Non-alphanumeric
+// runes are replaced with '_'; the result is title-cased so the final
+// pool identifier reads as `_dethashKeyPool<File><Kind>`.
+func filePoolPrefix(file *protogen.File) string {
+	base := path.Base(file.GeneratedFilenamePrefix)
+
+	var b strings.Builder
+	b.Grow(len(base) + 1)
+	upper := true
+	for _, r := range base {
+		switch {
+		case r >= 'a' && r <= 'z':
+			if upper {
+				r -= 'a' - 'A'
+				upper = false
+			}
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z' || r >= '0' && r <= '9':
+			b.WriteRune(r)
+			upper = false
+		default:
+			// Non-identifier rune (e.g. '-' in a hypothetical "my-proto"
+			// file). Drop and re-capitalize the next letter so we don't
+			// emit '_' inside what is otherwise a CamelCase identifier.
+			upper = true
+		}
+	}
+
+	return b.String()
 }
 
 func main() {
@@ -74,6 +129,7 @@ func main() {
 			}
 			generateFile(gen, f, hasMapTransitive)
 		}
+
 		return nil
 	})
 }
@@ -88,15 +144,18 @@ func computeHasMap(msg *protogen.Message, cache map[string]bool) bool {
 	for _, f := range msg.Fields {
 		if f.Desc.IsMap() {
 			cache[key] = true
+
 			return true
 		}
 		if f.Desc.Kind() == protoreflect.MessageKind && f.Message != nil && !f.Message.Desc.IsMapEntry() {
 			if computeHasMap(f.Message, cache) {
 				cache[key] = true
+
 				return true
 			}
 		}
 	}
+
 	return cache[key]
 }
 
@@ -116,17 +175,19 @@ func generateFile(gen *protogen.Plugin, file *protogen.File, hasMap map[string]b
 	// First, find every map-key kind used in this file so we can emit one
 	// sync.Pool per kind. The pool reuses the sorted-keys slice across
 	// marshal calls, replacing the per-call `slices.Sorted(maps.Keys(m))`
-	// allocation. The pool is package-private so it does not leak into
-	// the public API.
+	// allocation. Pool variables are named per-file (`_dethashKeyPool<File><Kind>`)
+	// so two .proto files sharing a single Go package never collide on the
+	// same identifier.
 	usedKeyKinds := map[protoreflect.Kind]bool{}
 	for _, msg := range file.Messages {
 		collectMapKeyKinds(msg, usedKeyKinds)
 	}
 
-	emitKeyPools(g, usedKeyKinds)
+	poolPrefix := filePoolPrefix(file)
+	emitKeyPools(g, usedKeyKinds, poolPrefix)
 
 	for _, msg := range file.Messages {
-		walkMessages(g, msg, hasMap)
+		walkMessages(g, msg, hasMap, poolPrefix)
 	}
 }
 
@@ -156,7 +217,7 @@ func collectMapKeyKinds(msg *protogen.Message, out map[protoreflect.Kind]bool) {
 // initial slice capacity tuned for the typical metadata-style map (~16
 // entries — beyond that the pool's slice grows once and stays grown,
 // which is exactly the behaviour we want).
-func emitKeyPools(g *protogen.GeneratedFile, used map[protoreflect.Kind]bool) {
+func emitKeyPools(g *protogen.GeneratedFile, used map[protoreflect.Kind]bool, poolPrefix string) {
 	if len(used) == 0 {
 		return
 	}
@@ -187,7 +248,7 @@ func emitKeyPools(g *protogen.GeneratedFile, used map[protoreflect.Kind]bool) {
 		}
 
 		info := supportedKeyKinds[kind]
-		g.P("  ", info.pkgVar, " = ", syncPkg.Ident("Pool"), "{")
+		g.P("  ", poolVarName(poolPrefix, kind), " = ", syncPkg.Ident("Pool"), "{")
 		g.P("    New: func() any { s := make([]", info.goType, ", 0, 16); return &s },")
 		g.P("  }")
 	}
@@ -195,17 +256,17 @@ func emitKeyPools(g *protogen.GeneratedFile, used map[protoreflect.Kind]bool) {
 	g.P(")")
 }
 
-func walkMessages(g *protogen.GeneratedFile, msg *protogen.Message, hasMap map[string]bool) {
+func walkMessages(g *protogen.GeneratedFile, msg *protogen.Message, hasMap map[string]bool, poolPrefix string) {
 	if msg.Desc.IsMapEntry() {
 		return
 	}
-	generateMessage(g, msg, hasMap)
+	generateMessage(g, msg, hasMap, poolPrefix)
 	for _, nested := range msg.Messages {
-		walkMessages(g, nested, hasMap)
+		walkMessages(g, nested, hasMap, poolPrefix)
 	}
 }
 
-func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message, hasMap map[string]bool) {
+func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message, hasMap map[string]bool, poolPrefix string) {
 	key := string(msg.Desc.FullName())
 
 	g.P()
@@ -243,7 +304,7 @@ func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message, hasMap ma
 			if f.Oneof != nil && !f.Oneof.Desc.IsSynthetic() {
 				continue
 			}
-			genFieldMarshal(g, f, hasMap)
+			genFieldMarshal(g, f, hasMap, poolPrefix)
 		}
 
 		// Oneofs in reverse
@@ -274,6 +335,7 @@ func genOneofMarshal(g *protogen.GeneratedFile, msg *protogen.Message, oo *proto
 		if f.Desc.Kind() == protoreflect.MessageKind && f.Message != nil {
 			if hasMap[string(f.Message.Desc.FullName())] {
 				anyHasMap = true
+
 				break
 			}
 		}
@@ -329,19 +391,21 @@ func marshalOneofField(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[
 
 // ---------- field ----------
 
-func genFieldMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[string]bool) {
+func genFieldMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[string]bool, poolPrefix string) {
 	goName := f.GoName
 	kind := f.Desc.Kind()
 	fieldNum := f.Desc.Number()
 	access := "m." + goName
 
 	if f.Desc.IsMap() {
-		genMapMarshal(g, f, hasMap)
+		genMapMarshal(g, f, hasMap, poolPrefix)
+
 		return
 	}
 
 	if f.Desc.IsList() {
 		genRepeatedMarshal(g, f, hasMap)
+
 		return
 	}
 
@@ -349,6 +413,7 @@ func genFieldMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[st
 		g.P("  if ", access, " != nil {")
 		marshalMessageField(g, access, f, fieldNum, hasMap)
 		g.P("  }")
+
 		return
 	}
 
@@ -358,6 +423,7 @@ func genFieldMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[st
 		g.P("  if ", access, " != nil {")
 		marshalScalarField(g, "*"+access, kind, fieldNum, wireType)
 		g.P("  }")
+
 		return
 	}
 
@@ -368,7 +434,7 @@ func genFieldMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[st
 
 // ---------- map ----------
 
-func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[string]bool) {
+func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[string]bool, poolPrefix string) {
 	goName := f.GoName
 	valField := f.Message.Fields[1]
 	fieldNum := f.Desc.Number()
@@ -380,11 +446,12 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 	if !ok {
 		panic(fmt.Sprintf("protoc-gen-dethash: unsupported map key type %s in field %s", keyKind, f.Desc.FullName()))
 	}
+	poolVar := poolVarName(poolPrefix, keyKind)
 
 	// Borrow a sorted-keys scratch slice from the file-scoped pool, fill it,
 	// sort it in place, and return it after the loop. Steady-state zero alloc.
 	g.P("  if len(m.", goName, ") > 0 {")
-	g.P("    keysPtr := ", info.pkgVar, ".Get().(*[]", info.goType, ")")
+	g.P("    keysPtr := ", poolVar, ".Get().(*[]", info.goType, ")")
 	g.P("    keys := (*keysPtr)[:0]")
 	g.P("    for k := range m.", goName, " {")
 	g.P("      keys = append(keys, k)")
@@ -396,7 +463,8 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 
 	// Write value (field 2 of map entry)
 	valKind := valField.Desc.Kind()
-	if valKind == protoreflect.MessageKind {
+	switch valKind {
+	case protoreflect.MessageKind:
 		key := string(valField.Message.Desc.FullName())
 		if hasMap[key] {
 			g.P("      size, _ := v.MarshalToSizedBufferDeterministicVT(dAtA[:i])")
@@ -407,17 +475,17 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 		g.P("      i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(size))")
 		g.P("      i--")
 		g.P("      dAtA[i] = 0x12")
-	} else if valKind == protoreflect.StringKind {
+	case protoreflect.StringKind:
 		g.P("      i -= len(v)")
 		g.P("      copy(dAtA[i:], v)")
 		g.P("      i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(len(v)))")
 		g.P("      i--")
 		g.P("      dAtA[i] = 0x12")
-	} else if valKind == protoreflect.EnumKind || valKind == protoreflect.Int32Kind || valKind == protoreflect.Uint32Kind || valKind == protoreflect.Int64Kind || valKind == protoreflect.Uint64Kind {
+	case protoreflect.EnumKind, protoreflect.Int32Kind, protoreflect.Uint32Kind, protoreflect.Int64Kind, protoreflect.Uint64Kind:
 		g.P("      i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(v))")
 		g.P("      i--")
 		g.P("      dAtA[i] = 0x10") // field 2, wire type varint
-	} else {
+	default:
 		panic(fmt.Sprintf("protoc-gen-dethash: unsupported map value type %s in field %s", valKind, f.Desc.FullName()))
 	}
 
@@ -445,8 +513,17 @@ func genMapMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map[stri
 	// Return the (possibly grown) scratch slice to the pool. The pool keeps
 	// the underlying capacity, so the next marshal that needs at most that
 	// many keys hits zero allocation.
+	//
+	// For pointer-containing key kinds (today: string headers), zero the
+	// slice elements first. Without this, the backing array keeps the last
+	// marshal's keys reachable until the pool slot is overwritten or
+	// evicted — turning the per-call allocation saved into unbounded heap
+	// retention of user metadata on many-unique-key workloads.
+	if info.pointerContaining {
+		g.P("    clear(keys)")
+	}
 	g.P("    *keysPtr = keys")
-	g.P("    ", info.pkgVar, ".Put(keysPtr)")
+	g.P("    ", poolVar, ".Put(keysPtr)")
 	g.P("  }")
 }
 
@@ -459,11 +536,12 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 
 	g.P("  if len(m.", goName, ") > 0 {")
 
-	if kind == protoreflect.MessageKind || kind == protoreflect.GroupKind {
+	switch kind {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
 		g.P("    for iNdEx := len(m.", goName, ") - 1; iNdEx >= 0; iNdEx-- {")
 		marshalMessageField(g, "m."+goName+"[iNdEx]", f, fieldNum, hasMap)
 		g.P("    }")
-	} else if kind == protoreflect.StringKind {
+	case protoreflect.StringKind:
 		tag := encodeTag(fieldNum, 2)
 		g.P("    for iNdEx := len(m.", goName, ") - 1; iNdEx >= 0; iNdEx-- {")
 		g.P("      i -= len(m.", goName, "[iNdEx])")
@@ -471,7 +549,7 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 		g.P("      i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(len(m.", goName, "[iNdEx])))")
 		writeTag(g, tag)
 		g.P("    }")
-	} else if kind == protoreflect.BytesKind {
+	case protoreflect.BytesKind:
 		tag := encodeTag(fieldNum, 2)
 		g.P("    for iNdEx := len(m.", goName, ") - 1; iNdEx >= 0; iNdEx-- {")
 		g.P("      i -= len(m.", goName, "[iNdEx])")
@@ -479,7 +557,7 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 		g.P("      i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(len(m.", goName, "[iNdEx])))")
 		writeTag(g, tag)
 		g.P("    }")
-	} else if kind == protoreflect.Uint64Kind || kind == protoreflect.Int64Kind || kind == protoreflect.Uint32Kind || kind == protoreflect.Int32Kind || kind == protoreflect.EnumKind {
+	case protoreflect.Uint64Kind, protoreflect.Int64Kind, protoreflect.Uint32Kind, protoreflect.Int32Kind, protoreflect.EnumKind:
 		// Packed encoding for varint types
 		tag := encodeTag(fieldNum, 2) // packed = wire type LEN
 		g.P("    var pkBuf [10]byte")
@@ -491,7 +569,7 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 		g.P("    }")
 		g.P("    i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(start-i))")
 		writeTag(g, tag)
-	} else if kind == protoreflect.Fixed64Kind || kind == protoreflect.Sfixed64Kind || kind == protoreflect.DoubleKind {
+	case protoreflect.Fixed64Kind, protoreflect.Sfixed64Kind, protoreflect.DoubleKind:
 		tag := encodeTag(fieldNum, 2)
 		g.P("    i -= 8 * len(m.", goName, ")")
 		g.P("    for iNdEx, v := range m.", goName, " {")
@@ -503,7 +581,7 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 		g.P("    }")
 		g.P("    i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(8*len(m.", goName, ")))")
 		writeTag(g, tag)
-	} else if kind == protoreflect.Fixed32Kind || kind == protoreflect.Sfixed32Kind || kind == protoreflect.FloatKind {
+	case protoreflect.Fixed32Kind, protoreflect.Sfixed32Kind, protoreflect.FloatKind:
 		tag := encodeTag(fieldNum, 2)
 		g.P("    i -= 4 * len(m.", goName, ")")
 		g.P("    for iNdEx, v := range m.", goName, " {")
@@ -515,7 +593,7 @@ func genRepeatedMarshal(g *protogen.GeneratedFile, f *protogen.Field, hasMap map
 		g.P("    }")
 		g.P("    i = ", protohelpersPkg.Ident("EncodeVarint"), "(dAtA, i, uint64(4*len(m.", goName, ")))")
 		writeTag(g, tag)
-	} else if kind == protoreflect.BoolKind {
+	case protoreflect.BoolKind:
 		tag := encodeTag(fieldNum, 2)
 		g.P("    i -= len(m.", goName, ")")
 		g.P("    for iNdEx, v := range m.", goName, " {")
@@ -617,7 +695,7 @@ func zeroGuard(access string, kind protoreflect.Kind) string {
 	case protoreflect.StringKind, protoreflect.BytesKind:
 		return fmt.Sprintf("len(%s) > 0", access)
 	default:
-		return fmt.Sprintf("%s != 0", access)
+		return access + " != 0"
 	}
 }
 

--- a/tools/protoc-gen-dethash/main.go
+++ b/tools/protoc-gen-dethash/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"google.golang.org/protobuf/compiler/protogen"
@@ -78,18 +77,27 @@ func poolVarName(filePoolPrefix string, kind protoreflect.Kind) string {
 }
 
 // filePoolPrefix derives a Go-identifier-safe, capitalized suffix from a
-// proto file's GeneratedFilenamePrefix (which is the proto file path
-// minus its extension, e.g. "common" or "misc/proto/common"). It is used
-// as a per-file disambiguator in pool variable names. Non-alphanumeric
-// runes are replaced with '_'; the result is title-cased so the final
-// pool identifier reads as `_dethashKeyPool<File><Kind>`.
+// proto file's GeneratedFilenamePrefix (the proto file path minus its
+// extension, e.g. "common" with `protoc -I misc/proto` or
+// "misc/proto/common" with `protoc -I .`). The full prefix is consumed —
+// not just the basename — so two .proto files that happen to share a
+// basename in different directories (e.g. `a/common.proto` and
+// `b/common.proto`) but compile into the same go_package still produce
+// distinct pool identifiers (`ACommon` vs `BCommon`). Stripping to
+// `path.Base` first would re-introduce the per-file collision the
+// per-file scheme exists to prevent.
+//
+// Non-identifier runes (including the path separator `/`) are dropped
+// and the next letter is re-capitalized, yielding a CamelCase suffix
+// that reads naturally inside the final `_dethashKeyPool<File><Kind>`
+// pool variable name.
 func filePoolPrefix(file *protogen.File) string {
-	base := path.Base(file.GeneratedFilenamePrefix)
+	prefix := file.GeneratedFilenamePrefix
 
 	var b strings.Builder
-	b.Grow(len(base) + 1)
+	b.Grow(len(prefix) + 1)
 	upper := true
-	for _, r := range base {
+	for _, r := range prefix {
 		switch {
 		case r >= 'a' && r <= 'z':
 			if upper {


### PR DESCRIPTION
[EN-1403](https://formance-team.atlassian.net/browse/EN-1403)

## Why

The `protoc-gen-dethash` plugin generated `MarshalToSizedBufferDeterministicVT` methods that allocated a fresh sorted-keys slice on every marshal via `slices.Sorted(maps.Keys(m))`. For typical metadata-bearing messages this dominated the cost of the deterministic marshal — a `TransactionState` with 500 metadata entries paid ~18.8 KB across 13 allocations every time. A `LedgerInfo` with two maps (Metadata + AccountTypes, 500/100 entries) paid ~23 KB across 24 allocations.

Surfaced while benchmarking the FSM cross-node digest opt-in (PR #574). The non-deterministic encoder is 0-alloc; the deterministic encoder shouldn't have a worse allocation profile by design.

## What

Replace the per-marshal `slices.Sorted(maps.Keys(m))` call with a `sync.Pool` of `*[]K` per map-key kind, declared once at the top of each generated dethash file:

- Plugin scans every file's messages, collects which map-key kinds are actually used (string, int32, uint32, int64, uint64), and emits one `sync.Pool` per used kind. Files with no maps emit no pool (and no `sync` import).
- `genMapMarshal` now generates a Get / fill / sort / Put pattern around the existing inner marshal loop.
- Steady-state allocations fall to zero; the underlying capacity persists across calls and grows once on the first marshal that exceeds 16 keys.
- Pool is package-private (`_dethash` prefix), no public API change.

## Benchmark (Apple M5 Pro, marshal-only)

| Case | Before | After |
|---|---|---|
| TransactionState metadata=5 | 290 ns, 304 B, 7 alloc | **166 ns, 0 B, 0 alloc** |
| TransactionState metadata=50 | 2531 ns, 2.2 KB, 10 alloc | **1956 ns, 0 B, 0 alloc** |
| TransactionState metadata=500 | 41.6 µs, 18.8 KB, 13 alloc | **38.0 µs, 0 B, 0 alloc** |
| LedgerInfo meta=5_acct=3 | 496 ns, 480 B, 13 alloc | **288 ns, 0 B, 0 alloc** |
| LedgerInfo meta=500_acct=100 | 49.2 µs, 23 KB, 24 alloc | **44.0 µs, 0 B, 0 alloc** |
| Transaction post=100_meta=100 | 7.7 µs, 4.5 KB, 11 alloc | **6.5 µs, 0 B, 0 alloc** |

Surcoût vs the non-deterministic baseline drops to 1.1x-1.4x for typical metadata-size maps (≤ 20 entries), tops out at ~2.5x for huge 500-entry maps. The residual is the sort O(n log n) itself — inherent to the determinism contract.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Pre-commit clean (`just pre-commit`: 0 lint issues)
- [x] Generated dethash code visually inspected: pool decl at top, Get/Put pattern around the marshal loop, no `slices.Sorted` / `maps.Keys` left in the generated code.
- [x] Bench from PR #574's `internal/storage/dal/marshal_bench_test.go` confirms 0 alloc / latency drop across all map-bearing shapes.

## Notes

This PR ships with `feat/dethash-zero-alloc-keys`; PR #574 (cross-node FSM digest) is rebased on top.

[EN-1403]: https://formance-team.atlassian.net/browse/EN-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---
_Migrated from formancehq/ledger-v3-poc#579 on 2026-06-29._