### PR TITLE
test(EN-1410): antithesis detector + dev-loop workload filter

### DIFF
--- a/internal/infra/node/applier_test.go
+++ b/internal/infra/node/applier_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -78,13 +79,23 @@ type testApplierSetup struct {
 	store     *dal.Store
 	wal       wal.WAL
 	spool     *spool.Default
+	spoolDir  string
 	fsm       *state.Machine
 	stop      chan struct{}
 	confState *raftpb.ConfState
 }
 
-// newTestApplierSetup creates a minimal Applier with real infrastructure (Pebble, WAL, spool, FSM).
+// newTestApplierSetup creates a minimal Applier with real infrastructure (Pebble, WAL, spool, FSM)
+// using the default spool config (large segments — entries rarely roll).
 func newTestApplierSetup(t *testing.T) *testApplierSetup {
+	return newTestApplierSetupWithSpool(t, spool.DefaultSpoolConfig{})
+}
+
+// newTestApplierSetupWithSpool is the variant that lets a test pin the spool
+// segment size (typically a few KiB) so that submitting a handful of entries
+// reliably rolls 2+ segments — required to exercise the unspoolAndResume +
+// Prune reclamation path.
+func newTestApplierSetupWithSpool(t *testing.T, spoolCfg spool.DefaultSpoolConfig) *testApplierSetup {
 	t.Helper()
 
 	logger := logging.Testing()
@@ -98,7 +109,8 @@ func newTestApplierSetup(t *testing.T) *testApplierSetup {
 	w, err := wal.New(walDir, logger, meter)
 	require.NoError(t, err)
 
-	defaultSpool, err := spool.NewDefault(spool.DefaultSpoolConfig{Dir: spoolDir})
+	spoolCfg.Dir = spoolDir
+	defaultSpool, err := spool.NewDefault(spoolCfg)
 	require.NoError(t, err)
 
 	pebbleStore, err := dal.NewStore(dataDir, logger, meter, dal.DefaultConfig())
@@ -146,6 +158,7 @@ func newTestApplierSetup(t *testing.T) *testApplierSetup {
 		store:     pebbleStore,
 		wal:       w,
 		spool:     defaultSpool,
+		spoolDir:  spoolDir,
 		fsm:       fsm,
 		stop:      stop,
 		confState: &confState,
@@ -1008,4 +1021,86 @@ func TestStartMaintenanceTaskReportsFailureOnTaskError(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	require.ErrorIs(t, err, taskErr)
+}
+
+// TestApplierUnspoolAndResumeReclaimsFullyAppliedSegments pins the
+// `spool pruned after resync` Antithesis Sometimes assertion in
+// unspoolAndResume (applier.go:1418). Production runs depend on a workload
+// large enough to roll multiple spool segments AND a gated window long
+// enough to spool entries that survive to Prune — Antithesis filtered runs
+// rarely match both conditions, so the Sometimes is fragile. Pin it here
+// deterministically: shrink SegmentMaxBytes so a handful of CreateLedger
+// entries roll 2+ segments while OutOfSync, then drive unspoolAndResume
+// (replay drains the spool, Prune reclaims the sealed segments) and assert
+// at least one sealed segment was removed from disk.
+//
+// The assertion in production is on pruneStats.SegmentsRemoved > 0; the
+// on-disk segment file count is the side-effect that proves the same thing
+// without exposing internal stats to the test surface.
+func TestApplierUnspoolAndResumeReclaimsFullyAppliedSegments(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	setup := newTestApplierSetupWithSpool(t, spool.DefaultSpoolConfig{
+		// 1 KiB → a CreateLedger record (~200 B per entry once protobuf
+		// + record header is counted) rolls a new segment every ~5 entries.
+		SegmentMaxBytes: 1024,
+	})
+
+	// Force spooling: while OutOfSync, Submitted entries are written to the
+	// spool instead of being applied to Pebble — the production state the
+	// gated-window machinery enters during snapshot install / sync.
+	setup.applier.setOutOfSync()
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- setup.applier.Run(ctx, setup.stop) }()
+
+	const entryCount = 30
+	for i := uint64(1); i <= entryCount; i++ {
+		entry, _ := makeCreateLedgerEntry(t, i, fmt.Sprintf("ledger-%d", i))
+		setup.applier.Submit([]raftpb.Entry{entry}, nil, setup.stop)
+	}
+	setup.applier.Drain(setup.stop)
+
+	beforePrune, err := countSpoolSegments(setup.spoolDir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, beforePrune, 2,
+		"expected ≥2 spool segments after rolling under 1 KiB cap, got %d", beforePrune)
+
+	// Verify entries are spooled, not applied (negative control).
+	for i := uint64(1); i <= entryCount; i++ {
+		require.False(t, listLedgerContains(setup.store, fmt.Sprintf("ledger-%d", i)),
+			"ledger-%d should still be spooled at this point", i)
+	}
+
+	// Stop the Run goroutine so unspoolAndResume runs without contention.
+	close(setup.stop)
+	require.NoError(t, <-runDone)
+
+	// Drive the production path: replay drains the spool into the FSM,
+	// status flips to Normal, Prune reclaims the sealed segments.
+	require.NoError(t, setup.applier.unspoolAndResume(ctx))
+
+	// Replay should have fully applied every entry.
+	for i := uint64(1); i <= entryCount; i++ {
+		require.True(t, listLedgerContains(setup.store, fmt.Sprintf("ledger-%d", i)),
+			"ledger-%d should be applied after unspoolAndResume", i)
+	}
+
+	afterPrune, err := countSpoolSegments(setup.spoolDir)
+	require.NoError(t, err)
+	require.Less(t, afterPrune, beforePrune,
+		"Prune should remove ≥1 sealed fully-applied segment (before=%d, after=%d)",
+		beforePrune, afterPrune)
+}
+
+// countSpoolSegments returns the number of segment files in the spool dir.
+// Default spool writes one file per segment; comparing the count before and
+// after Prune is a cheap proxy for pruneStats.SegmentsRemoved.
+func countSpoolSegments(dir string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, err
+	}
+	return len(entries), nil
 }

--- a/tests/antithesis/Justfile
+++ b/tests/antithesis/Justfile
@@ -11,8 +11,12 @@ ledger_image_name := env_var_or_default("LEDGER_IMAGE_NAME", "ledger")
 
 # --- Docker Compose mode (legacy) ---
 
-run duration description='ledger-v3 manual run' *ARGS:
-    just push-images {{ARGS}}
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image. Empty ships every driver (the default). Use the
+# filtered mode for dev-loop runs where the Antithesis composer should focus
+# on a specific subset (e.g. "main/parallel_driver_bulk,main/first_default_ledger").
+run duration description='ledger-v3 manual run' include='' *ARGS:
+    just push-images {{quote(include)}} {{ARGS}}
     curl --fail \
         --user "formance:$ANTITHESIS_PASSWORD" \
         -X POST https://formance.antithesis.com/api/v1/launch/basic_test -d '{ \
@@ -39,10 +43,10 @@ build-images:
         -t "$ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}" \
         ../../
 
-push-images *ARGS:
+push-images include='' *ARGS:
     just build-images
     just --justfile config/Justfile -d config push {{ARGS}}
-    just --justfile workload/Justfile -d workload push
+    just --justfile workload/Justfile -d workload push {{quote(include)}}
     docker push $ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}
     docker push $ANTITHESIS_REPOSITORY/etcd:v3.5.9
 
@@ -62,8 +66,12 @@ deploy-local: build-images
 
 # Launch a test run on Antithesis using the k8s environment.
 # Duration is in hours (converted to minutes for the Antithesis API).
-k8s-run duration_hours description='ledger-v3 k8s run' *ARGS:
-    just k8s-push-images {{ARGS}}
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image. Empty ships every driver. Use the filtered mode for
+# dev-loop runs where the composer should focus on a specific subset (e.g.
+# "main/parallel_driver_bulk,main/first_default_ledger").
+k8s-run duration_hours description='ledger-v3 k8s run' include='' *ARGS:
+    just k8s-push-images {{quote(include)}} {{ARGS}}
     curl --fail \
         --user "formance:$ANTITHESIS_PASSWORD" \
         -X POST https://formance.antithesis.com/api/v1/launch/basic_k8s_test -d '{ \
@@ -93,9 +101,9 @@ k8s-build-images:
         ../../misc/operator
 
 # Push all images for k8s mode.
-k8s-push-images *ARGS:
+k8s-push-images include='' *ARGS:
     just k8s-build-images
     just --justfile k8s/Justfile -d k8s push {{ARGS}}
-    just --justfile workload/Justfile -d workload push
+    just --justfile workload/Justfile -d workload push {{quote(include)}}
     docker push $ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}
     docker push $ANTITHESIS_REPOSITORY/ledger-operator:{{tag}}

--- a/tests/antithesis/workload/Dockerfile
+++ b/tests/antithesis/workload/Dockerfile
@@ -31,12 +31,29 @@ RUN mkdir -p /cmds
 # compile the unique main.go (~117 LOC each).
 RUN go build -race ./internal/...
 
+# Optional dev-loop filter: when INCLUDED_DRIVERS is a non-empty comma-separated
+# list of <template>/<driver> paths (e.g. "main/parallel_driver_bulk,main/first_default_ledger"),
+# only those binaries are built and shipped. The Antithesis composer then has
+# no choice but to schedule them — useful for iterating on a targeted fix
+# without waiting for the global composer to randomly pick the driver under
+# test. Leave empty (default) for full-coverage runs.
+ARG INCLUDED_DRIVERS=""
+
 # Build all workload binaries in parallel, preserving the
 # bin/cmds/<template>/<command> layout so each command lands in its own test
 # template directory. The shared dependency cache is warm from the previous step,
 # so each build only compiles main.go.
-RUN find ./bin/cmds -mindepth 2 -maxdepth 2 -type d \
-        | sed 's|^\./bin/cmds/||' \
+RUN set -e; \
+    find ./bin/cmds -mindepth 2 -maxdepth 2 -type d | sed 's|^\./bin/cmds/||' > /tmp/all-drivers.txt; \
+    if [ -n "$INCLUDED_DRIVERS" ]; then \
+        echo "$INCLUDED_DRIVERS" | tr ',' '\n' > /tmp/include.txt; \
+        grep -Fx -f /tmp/include.txt /tmp/all-drivers.txt > /tmp/targets.txt; \
+        echo "Filtered build ($(wc -l < /tmp/targets.txt) of $(wc -l < /tmp/all-drivers.txt) drivers):"; \
+        cat /tmp/targets.txt; \
+    else \
+        cp /tmp/all-drivers.txt /tmp/targets.txt; \
+    fi; \
+    cat /tmp/targets.txt \
         | xargs -P"$(nproc)" -I{} sh -c 'mkdir -p "/cmds/$(dirname "$1")" && go build -race -o "/cmds/$1" "./bin/cmds/$1"' _ {}
 
 # Runner

--- a/tests/antithesis/workload/Justfile
+++ b/tests/antithesis/workload/Justfile
@@ -1,7 +1,11 @@
 tag := 'antithesis'
 
-build:
-	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image (e.g. "main/parallel_driver_bulk,main/first_default_ledger").
+# Empty (default) ships every driver. Use the filtered mode for dev-loop runs
+# where the Antithesis composer should focus on a specific subset.
+build include='':
+	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
 
-push: build
+push include='': (build include)
 	docker push "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}"

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
@@ -1,140 +1,206 @@
+// parallel_driver_insufficient_funds is the EN-1410 detector: it stresses
+// the exact-balance transfer path on a long-lived pool of accounts, so an
+// account funded by a past iteration can be picked up by a future iteration
+// after restarts, snapshots, and cache rotations have had time to fire.
+//
+// The bug it targets (EN-1410 bloom boot-ordering): a cache rotation that
+// runs while the bloom rebuild is still !IsReady wipes Pebble 0xFF for the
+// outgoing generation but skips PersistDirtyBlocks. A later crash loses the
+// in-memory bloom; the next boot's rebuild reads only persisted blocks +
+// cache 0xFF, both of which are now missing the key. MayContain returns
+// false, the FSM injects a zero VolumePair, and an exact-balance transfer
+// is rejected with INSUFFICIENT_FUNDS even though the account's volume cell
+// still sits in Pebble 0x01.
+//
+// The asymmetry the driver exploits: the read-side index (GetAccount) and
+// the FSM cache (apply-time CheckBalance) are independent. The read-side
+// sees the funded balance; the FSM bloom-gated cache may not. A spurious
+// INSUFFICIENT_FUNDS on an account whose read-side balance is non-zero is
+// the bug's signature.
+//
+// Iteration:
+//  1. Create the shared ledger idempotently (every iteration races; only
+//     one CreateLedger succeeds, the rest see AlreadyExists).
+//  2. Pick a random account from a fixed pool of accountPoolSize cells.
+//  3. Read the account's balance via the read-side. If unknown / empty,
+//     fund it (Force=true) and exit — the next iteration to pick this
+//     cell will see balance > 0 and attempt the transfer.
+//  4. If balance > 0, attempt an exact-balance transfer back to world
+//     without Force. The two assertions:
+//       - Sometimes: campaign coverage — at least once the transfer must
+//         succeed (proves the path is reachable in steady state).
+//       - AlwaysOrUnreachable: per-iteration safety — INSUFFICIENT_FUNDS
+//         is unreachable; firing it is the EN-1410 signature.
+//
+// The pool is shared across every instance of the driver: accounts funded
+// in past iterations survive restarts and snapshots, so a balance > 0
+// observed today may have been written hours ago — that's the time window
+// during which a bloom-vs-Pebble desync would have formed.
 package main
 
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/holiman/uint256"
+
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
+const (
+	// sharedLedger is shared across every instance of the driver so accounts
+	// outlive any single iteration; without this the bug cannot surface —
+	// fund and transfer happen too close together in time for a !IsReady
+	// rotation to fall between them.
+	sharedLedger = "insuf-shared"
+
+	// accountPoolSize bounds the address space the driver cycles through.
+	// Small enough that repeat picks happen across many iterations (so a
+	// post-restart pick lands on a previously funded cell), large enough
+	// that consecutive iterations rarely collide on the same cell.
+	accountPoolSize = 50
+
+	// fundAmount is the fixed credit applied to an empty pool account. The
+	// driver always transfers the exact read-side balance back, so the
+	// precise amount does not need to be remembered between iterations.
+	fundAmount = 1000
+
+	asset = "USD/2"
+)
+
 func main() {
 	internal.RunDriver("parallel_driver_insufficient_funds", func(ctx context.Context, client servicepb.BucketServiceClient, _ string) {
 		r := internal.Rand()
 
-		// Use a dedicated ledger to control account balances precisely.
-		ledger := fmt.Sprintf("insuf-%d", r.Uint64()%1_000_000)
-		if err := internal.CreateLedger(ctx, client, ledger); err != nil {
+		// Race-create the shared ledger. AlreadyExists is the steady state
+		// once any prior iteration has won the race.
+		if err := internal.CreateLedger(ctx, client, sharedLedger); err != nil &&
+			!internal.IsAlreadyExists(err) && !internal.IsTransient(err) {
 			return
 		}
 
-		// Use a dedicated account prefix so other drivers (e.g. audit) that post
-		// to "users:N" on random ledgers cannot interfere with balance assumptions.
-		account := fmt.Sprintf("insuf-users:%d", r.Uint64()%internal.UserAccountCount)
-		asset := "USD/2"
-		fundAmount := r.Uint64()%10000 + 100
-		details := internal.Details{"ledger": ledger, "account": account, "asset": asset, "fundAmount": fundAmount}
+		account := fmt.Sprintf("insuf-users:%d", r.Uint64()%accountPoolSize)
+		details := internal.Details{
+			"ledger":  sharedLedger,
+			"account": account,
+			"asset":   asset,
+		}
 
-		// 1. Fund the account from world with a known amount.
-		resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
-			Type: &servicepb.Request_Apply{
-				Apply: &servicepb.LedgerApplyRequest{
-					Ledger: ledger,
-					Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
-						CreateTransaction: &servicepb.CreateTransactionPayload{
-							Postings: []*commonpb.Posting{{
-								Source:      "world",
-								Destination: account,
-								Amount:      commonpb.NewUint256FromUint64(fundAmount),
-								Asset:       asset,
-							}},
-							Force:         true,
-							ExpandVolumes: true,
-						},
-					}},
-				},
-			},
-		}))
+		balance, err := readBalance(ctx, client, sharedLedger, account)
 		if err != nil {
-			if internal.IsTransient(err) {
-				return
-			}
-
-			assert.Unreachable("funding should not fail", details.With(internal.Details{"error": err}))
-
+			// Read-side temporarily unavailable or account not yet visible
+			// to the read-side index; nothing to assert this round.
 			return
 		}
 
-		if ct := internal.ExtractCreatedTransaction(resp); ct != nil {
-			internal.CheckPostCommitVolumes(ct.PostCommitVolumes, details)
-		}
-
-		// 2. Attempt exact balance transfer (should succeed without Force).
-		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
-			Type: &servicepb.Request_Apply{
-				Apply: &servicepb.LedgerApplyRequest{
-					Ledger: ledger,
-					Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
-						CreateTransaction: &servicepb.CreateTransactionPayload{
-							Postings: []*commonpb.Posting{{
-								Source:      account,
-								Destination: "world",
-								Amount:      commonpb.NewUint256FromUint64(fundAmount),
-								Asset:       asset,
-							}},
-							ExpandVolumes: true,
-						},
-					}},
-				},
-			},
-		}))
-
-		assert.Sometimes(err == nil || internal.IsTransient(err),
-			"exact balance transfer should succeed",
-			details.With(internal.Details{"error": err}))
-
-		// EN-1410: a bloom miss on a key still present in Pebble — caused by a
-		// rotation that wiped 0xFF while !IsReady, without persisting bloom
-		// blocks — surfaces here as a spurious INSUFFICIENT_FUNDS on a transfer
-		// whose source was funded earlier in this driver. The exact-balance
-		// transfer must NEVER be rejected with INSUFFICIENT_FUNDS: that would
-		// mean the bloom diverged from Pebble.
-		isSpuriousInsuf := internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds)
-		assert.AlwaysOrUnreachable(!isSpuriousInsuf,
-			"exact balance transfer must not be rejected as INSUFFICIENT_FUNDS — bloom must reflect persisted Pebble state",
-			details.With(internal.Details{"error": err}))
-
-		if err != nil {
+		if balance.Sign() == 0 {
+			fund(ctx, client, account, details)
 			return
 		}
 
-		// 3. Now the balance is 0. Attempt to send 1 unit — must get INSUFFICIENT_FUNDS.
-		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
-			Type: &servicepb.Request_Apply{
-				Apply: &servicepb.LedgerApplyRequest{
-					Ledger: ledger,
-					Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
-						CreateTransaction: &servicepb.CreateTransactionPayload{
-							Postings: []*commonpb.Posting{{
-								Source:      account,
-								Destination: "world",
-								Amount:      commonpb.NewUint256FromUint64(1),
-								Asset:       asset,
-							}},
-						},
-					}},
-				},
-			},
-		}))
-
-		if err == nil {
-			assert.Unreachable("overdraft without Force should fail", details)
-
-			return
-		}
-
-		if internal.IsTransient(err) {
-			return
-		}
-
-		isInsufficient := internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds)
-		assert.AlwaysOrUnreachable(isInsufficient,
-			"overdraft should return INSUFFICIENT_FUNDS",
-			details.With(internal.Details{"error": err}))
-
-		assert.Reachable("insufficient funds path exercised", details)
+		transferAll(ctx, client, account, balance, details)
 	})
+}
+
+// readBalance returns the (input - output) balance for (account, asset) via
+// the read-side. NotFound is mapped to zero so brand-new pool cells are
+// distinguishable from the "account exists with zero balance" steady state
+// only by the next write — both legitimately route to the fund branch.
+func readBalance(ctx context.Context, client servicepb.BucketServiceClient, ledger, account string) (*big.Int, error) {
+	resp, err := client.GetAccount(ctx, &servicepb.GetAccountRequest{
+		Ledger:  ledger,
+		Address: account,
+	})
+	if err != nil {
+		if internal.IsNotFound(err) {
+			return new(big.Int), nil
+		}
+		return nil, err
+	}
+
+	vol, ok := resp.GetVolumes()[asset]
+	if !ok {
+		return new(big.Int), nil
+	}
+
+	bal, ok := new(big.Int).SetString(vol.GetBalance(), 10)
+	if !ok {
+		return new(big.Int), nil
+	}
+	return bal, nil
+}
+
+func fund(ctx context.Context, client servicepb.BucketServiceClient, account string, details internal.Details) {
+	_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: sharedLedger,
+				Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
+					CreateTransaction: &servicepb.CreateTransactionPayload{
+						Postings: []*commonpb.Posting{{
+							Source:      "world",
+							Destination: account,
+							Amount:      commonpb.NewUint256FromUint64(fundAmount),
+							Asset:       asset,
+						}},
+						Force:         true,
+						ExpandVolumes: true,
+					},
+				}},
+			},
+		},
+	}))
+	if err != nil && !internal.IsTransient(err) {
+		assert.Unreachable("funding should not fail", details.With(internal.Details{"error": err}))
+	}
+}
+
+func transferAll(ctx context.Context, client servicepb.BucketServiceClient, account string, balance *big.Int, details internal.Details) {
+	amount, overflow := uint256.FromBig(balance)
+	if overflow {
+		// Pool balances never exceed fundAmount per cell so overflow is
+		// impossible in normal operation; an overflow here would mean
+		// something other than this driver wrote into the pool address
+		// space — skip rather than mis-assert.
+		return
+	}
+
+	_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: sharedLedger,
+				Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
+					CreateTransaction: &servicepb.CreateTransactionPayload{
+						Postings: []*commonpb.Posting{{
+							Source:      account,
+							Destination: "world",
+							Amount:      commonpb.NewUint256(amount),
+							Asset:       asset,
+						}},
+						ExpandVolumes: true,
+					},
+				}},
+			},
+		},
+	}))
+
+	withErr := details.With(internal.Details{"error": err, "amount": balance.String()})
+
+	assert.Sometimes(err == nil || internal.IsTransient(err),
+		"exact balance transfer should succeed", withErr)
+
+	// EN-1410: the read-side just returned balance > 0 for this cell, so the
+	// FSM cache injecting a zero VolumePair (the only path to spurious
+	// INSUFFICIENT_FUNDS on a non-overdraft transfer) means the bloom no
+	// longer admits a key whose volume still lives in Pebble — the
+	// boot-ordering desync. Every iteration that observes it is the bug.
+	isSpuriousInsuf := internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds)
+	assert.AlwaysOrUnreachable(!isSpuriousInsuf,
+		"exact balance transfer must not be rejected as INSUFFICIENT_FUNDS — bloom must reflect persisted Pebble state",
+		withErr)
 }

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
@@ -194,13 +194,30 @@ func transferAll(ctx context.Context, client servicepb.BucketServiceClient, acco
 	assert.Sometimes(err == nil || internal.IsTransient(err),
 		"exact balance transfer should succeed", withErr)
 
-	// EN-1410: the read-side just returned balance > 0 for this cell, so the
-	// FSM cache injecting a zero VolumePair (the only path to spurious
-	// INSUFFICIENT_FUNDS on a non-overdraft transfer) means the bloom no
-	// longer admits a key whose volume still lives in Pebble — the
-	// boot-ordering desync. Every iteration that observes it is the bug.
-	isSpuriousInsuf := internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds)
-	assert.AlwaysOrUnreachable(!isSpuriousInsuf,
+	// EN-1410 detection. The naive "INSUFFICIENT_FUNDS implies bug" check is
+	// racy because parallel_driver_ spawns many concurrent instances that
+	// may pick the same pool cell between their GetAccount and their Apply.
+	// One wins; the others observe a legitimate INSUFFICIENT_FUNDS even
+	// though the bloom is healthy. Disambiguate by re-reading the balance
+	// after the failure: the bug's signature is "FSM apply rejected on
+	// available=0 while the read-side still shows balance > 0", because
+	// the only path that produces available=0 on a cell with non-zero
+	// volumes in Pebble is the FSM-side cache injecting a zero VolumePair
+	// — i.e. the bloom dropped a key whose volume Pebble still holds.
+	//
+	// The re-read itself is racy too (the read-side can lag, a concurrent
+	// fund can re-credit the cell, etc.). We accept those: a confirmed
+	// bug requires the conjunction (apply rejected available=0 AND
+	// read-side balance > 0 after the fact). A miss in either direction
+	// is the safe answer.
+	confirmed := false
+	if internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds) {
+		if confirm, rerr := readBalance(ctx, client, sharedLedger, account); rerr == nil && confirm.Sign() > 0 {
+			confirmed = true
+			withErr = withErr.With(internal.Details{"reReadBalance": confirm.String()})
+		}
+	}
+	assert.AlwaysOrUnreachable(!confirmed,
 		"exact balance transfer must not be rejected as INSUFFICIENT_FUNDS — bloom must reflect persisted Pebble state",
 		withErr)
 }

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/main.go
@@ -85,6 +85,18 @@ func main() {
 		assert.Sometimes(err == nil || internal.IsTransient(err),
 			"exact balance transfer should succeed",
 			details.With(internal.Details{"error": err}))
+
+		// EN-1410: a bloom miss on a key still present in Pebble — caused by a
+		// rotation that wiped 0xFF while !IsReady, without persisting bloom
+		// blocks — surfaces here as a spurious INSUFFICIENT_FUNDS on a transfer
+		// whose source was funded earlier in this driver. The exact-balance
+		// transfer must NEVER be rejected with INSUFFICIENT_FUNDS: that would
+		// mean the bloom diverged from Pebble.
+		isSpuriousInsuf := internal.HasErrorReason(err, domain.ErrReasonInsufficientFunds)
+		assert.AlwaysOrUnreachable(!isSpuriousInsuf,
+			"exact balance transfer must not be rejected as INSUFFICIENT_FUNDS — bloom must reflect persisted Pebble state",
+			details.With(internal.Details{"error": err}))
+
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary
- Adds an Antithesis red detector for EN-1410 (spurious `INSUFFICIENT_FUNDS` caused by bloom diverging from Pebble after a `!IsReady` cache rotation).
- Adds a dev-loop driver filter on the workload image so iterating on a targeted bug doesn't depend on waiting for the test composer to randomly pick the relevant driver out of ~40 parallel_driver_*.

## Why
EN-1410 surfaces as a non-deterministic race: a cache rotation that fires while the bloom rebuild is still `!IsReady` wipes Pebble `0xFF` (outgoing gen1) but skips `PersistDirtyBlocks`. A subsequent crash loses the in-memory bloom; on the next boot the rebuild has neither the persisted block nor the cache `0xFF` entry. The FSM injects zero on the next read, and an exact-balance transfer fails `INSUFFICIENT_FUNDS` even though the read-side index still shows the balance. This is the exact signature on the `blockchains` dev cluster (`ledgerctl accounts aggregate-volumes` shows balance > 0, the ingester is stuck on `INSUFFICIENT_FUNDS` retries on the same address).

## Detector — `parallel_driver_insufficient_funds`

Rewritten from a fresh-ledger-per-iteration shape (which could never expose the bug — fund and transfer were too close in time for a `!IsReady` rotation to fall between them) to a pattern that matches the blockchains usage:

- Long-lived shared ledger `insuf-shared` + fixed pool of 50 accounts that survive restarts, snapshots, and rotations.
- Each iteration:
  1. Pick a random pool cell.
  2. Read balance via `GetAccount` (read-side index — ground truth, NOT the FSM cache the bug lives in).
  3. If balance == 0 → fund with `Force=true` and exit (next iteration to pick the cell will do the transfer).
  4. If balance > 0 → attempt exact-balance transfer back to `world` with `Force=false`.
- After an `INSUFFICIENT_FUNDS` response, re-read the balance: only fire the assertion if read-side still shows > 0. This disambiguates the bug from concurrent-drain races between parallel instances (caught the v2 run on `insuf-users:11` — succeed at `t+181.441` then fail at `t+181.442` from another instance that had read the same balance).
- `AlwaysOrUnreachable` fires only when the conjunction holds: apply rejected on `available=0` AND read-side proves balance > 0 after the fact. The only path producing that is the FSM cache injecting a zero `VolumePair` on a key Pebble still holds — i.e. the bloom dropped it.

## Dev-loop filter — `INCLUDED_DRIVERS`

Antithesis's test composer ranking is opaque to users (per the test_composer reference, no user-configurable weighting). Untargeted runs spend most of the slot budget on whichever drivers the composer judges interesting — `parallel_driver_insufficient_funds` was scheduled zero times in the first 1h run.

New build-arg on the workload image: when set to a comma-separated list of `<template>/<driver>` paths, only those binaries are shipped to `/opt/antithesis/test/v1/`. The composer then has nothing else to schedule.

Plumbed through every Justfile recipe that builds + pushes the workload:

```bash
just antithesis::k8s-run 1 "EN-1410 red" \
    "main/first_default_ledger,main/parallel_driver_insufficient_funds,main/singleton_driver_config_change,..."
```

Always include `main/first_default_ledger` — without an initial ledger, every `parallel_driver_*` call to `GetRandomLedger` blocks until the 10 min timeout.

Empty (default) preserves the existing full-coverage behaviour for nightly runs.

## Status

- v1 run: confirmed the assertion is reachable, but the driver was scheduled 0 times — motivated the filter.
- v2 run with filter + pool refactor: assertion fired once (insuf-users:11), confirmed as a concurrent-drain race via the 1 ms gap — motivated the re-read confirm.
- v3 run (`943c0b33a482752ae813b0e30935af8a-56-17`) with the re-read fix in flight as of this PR. Report by email when 1h elapsed.

Intentionally NOT rebased on top of the fix PR #1432 — the first goal is to confirm the detector catches the bug on un-fixed `release/v3.0`. Once confirmed, a follow-up run on top of the fix should show the assertion no longer fires.

## Test plan
- [ ] v3 Antithesis run shows the assertion does NOT fire after the re-read confirm patch (= no real bug observed in this run, or the re-read filtered remaining false positives)
- [ ] Follow-up: rebase on top of `fix/EN-1410-bloom-boot-ordering` (#1432) and re-run to confirm the fix closes the window
- [x] Local build: `GOROOT= go build ./tests/antithesis/workload/bin/cmds/main/parallel_driver_insufficient_funds/` passes
- [x] `just antithesis::k8s-run` with filter and full driver lists both work (dry-run + live)