### PR TITLE
fix(auth): bound OIDC JWKS reads and drop the inert go-libs JWT module

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net/http"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -21,7 +20,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	auth "github.com/formancehq/go-libs/v5/pkg/authn/jwt"
-	"github.com/formancehq/go-libs/v5/pkg/fx/authnfx"
 	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
 	otlp "github.com/formancehq/go-libs/v5/pkg/observe"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -192,11 +190,11 @@ func NewRunCommand() *cobra.Command {
 	runCmd.Flags().String("auth-scope-mapping-file", "", "Path to JSON file mapping virtual scopes (e.g. ledger:read) to granular scopes")
 	runCmd.Flags().String("auth-anonymous-scopes", "", "Comma-separated granular scopes granted to requests without a bearer token (e.g. \"*:read\" for writes-only mode). Wildcards: *:read, *:write")
 
-	// OIDC discovery + JWKS HTTP timeout. A slow or blackholed issuer would
-	// otherwise hang startup indefinitely (go-libs supplies http.DefaultClient
-	// with no Timeout and discovery uses context.Background()). 0 keeps the
-	// legacy unbounded behavior for operators that need it.
-	runCmd.Flags().Duration("auth-discovery-timeout", 10*time.Second, "Bound the HTTP calls used for OIDC discovery and JWKS fetches at startup (0 = unbounded)")
+	// OIDC discovery + JWKS HTTP timeout, applied in buildAuthConfig: a context
+	// deadline bounds oidc.Discover and the keyset's http.Client.Timeout bounds
+	// JWKS fetches, so both share one operator-controlled ceiling. 0 leaves them
+	// unbounded for operators that need it.
+	runCmd.Flags().Duration("auth-discovery-timeout", 10*time.Second, "Bound the HTTP calls used for OIDC discovery and JWKS fetches (0 = unbounded)")
 
 	// Idempotency TTL and eviction
 	runCmd.Flags().Duration("idempotency-ttl", 24*time.Hour, "Idempotency key time-to-live (0 = never expire)")
@@ -322,40 +320,17 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		appModule = bootstrap.Module()
 	}
 
-	// Build authentication module.
-	// Only use go-libs OIDC module when an issuer is configured; otherwise
-	// skip OIDC discovery to avoid a crash on empty issuer URL.
-	// Ed25519-only auth works without OIDC (the KeySet parameter in
-	// buildAuthConfig is optional).
-	//
-	// fx.Decorate replaces the http.DefaultClient that authnfx.JWTModule
-	// supplies (no Timeout — would hang startup on a slow/blackholed issuer)
-	// with one bounded by cfg.AuthConfig.OIDCDiscoveryTimeout. go-libs'
-	// NewKeySets receives this client and feeds it to oidc client.Discover
-	// and NewRemoteKeySet, so both discovery and JWKS fetches are bounded.
-	var authModule fx.Option
-	if cfg.AuthConfig.Issuer != "" {
-		discoveryTimeout := cfg.AuthConfig.OIDCDiscoveryTimeout
-		authModule = fx.Options(
-			authnfx.JWTModuleFromFlags(cmd),
-			fx.Decorate(func(*http.Client) *http.Client {
-				return bootstrap.TimeoutHTTPClient(discoveryTimeout)
-			}),
-		)
-	} else {
-		authModule = fx.Module("auth")
-	}
-
 	info := version.Get()
 
-	// Create fx application options
+	// Auth (OIDC discovery + JWKS reads, bounded by OIDCDiscoveryTimeout) is built in
+	// bootstrap.buildAuthConfig; there is no auth fx module. The go-libs authnfx JWT
+	// module is intentionally not wired in: nothing in this service consumes its
+	// map[string]oidc.KeySet or Authenticator, so its providers would never run.
 	opts := []fx.Option{
 		// Provide configuration
 		fx.Supply(*cfg),
 		// Provide build metadata for version reporting
 		fx.Supply(info),
-		// Add authentication module (OIDC discovery when issuer is configured)
-		authModule,
 		// Add OpenTelemetry modules from go-libs (using flags)
 		observefx.ResourceModuleFromFlags(cmd, otlp.WithServiceVersion(fmt.Sprintf("%s-%s", info.Version, info.Commit))),
 		observefx.TracesModuleFromFlags(cmd),

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4233,7 +4233,7 @@ on/off TLS toggle workflow.
 |------|------|---------|-------------|
 | `--auth-scope-mapping-file` | string | `""` | Path to JSON file mapping virtual scopes (e.g. `ledger:read`) to granular scopes |
 | `--auth-anonymous-scopes` | string | `""` | Comma-separated granular scopes (or `*:read` / `*:write` wildcards) granted to requests that arrive without a bearer token |
-| `--auth-discovery-timeout` | duration | `10s` | Bound the HTTP calls used for OIDC discovery and JWKS fetches at startup (`0` = unbounded). Prevents a slow or blackholed issuer from hanging the process indefinitely. |
+| `--auth-discovery-timeout` | duration | `10s` | Bound the HTTP calls used for OIDC discovery and JWKS fetches (`0` = unbounded). Applies one operator-controlled timeout to both the discovery call and later JWKS key fetches. |
 
 Allows expanding virtual scopes into fine-grained scopes. For example, mapping `ledger:read` to a set of more specific scopes. The mapping can also be provided via the `AUTH_SCOPE_MAPPING` environment variable (JSON string).
 

--- a/internal/bootstrap/auth_discovery_timeout_test.go
+++ b/internal/bootstrap/auth_discovery_timeout_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/require"
 
+	oidcclient "github.com/formancehq/go-libs/v5/pkg/authn/oidc/client"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
@@ -99,4 +101,44 @@ func TestDiscoveryContext(t *testing.T) {
 		cancel()
 		require.ErrorIs(t, ctx.Err(), context.Canceled)
 	})
+}
+
+// TestRemoteKeySet_JWKSReadRespectsTimeout verifies that the OIDC remote keyset
+// buildAuthConfig constructs — via TimeoutHTTPClient(OIDCDiscoveryTimeout) — bounds
+// its lazy JWKS fetch by that timeout: a blackholed JWKS endpoint makes token
+// verification fail quickly rather than stall on the goroutine that fetches keys.
+func TestRemoteKeySet_JWKSReadRespectsTimeout(t *testing.T) {
+	t.Parallel()
+
+	// The handler blocks until the client gives up; the request context is
+	// cancelled when the client's Timeout fires, letting srv.Close proceed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	timeout := 500 * time.Millisecond
+	keySet := oidcclient.NewRemoteKeySet(TimeoutHTTPClient(timeout), srv.URL)
+
+	// Any signed token forces a remote JWKS fetch, since the key cache is empty.
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: []byte("0123456789abcdef0123456789abcdef")}, nil)
+	require.NoError(t, err)
+	jws, err := signer.Sign([]byte("{}"))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, verr := keySet.VerifySignature(context.Background(), jws)
+		done <- verr
+	}()
+
+	select {
+	case verr := <-done:
+		require.Error(t, verr, "a blackholed JWKS endpoint must fail, not hang")
+		require.Less(t, time.Since(start), 2*timeout,
+			"JWKS fetch should return inside ~timeout (%s)", timeout)
+	case <-time.After(3 * time.Second):
+		t.Fatal("VerifySignature did not respect the JWKS read timeout")
+	}
 }

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -30,12 +30,10 @@ type AuthFlagConfig struct {
 	// writes require a valid token. Empty (default) preserves the historical
 	// strict behavior where every request must authenticate.
 	AnonymousScopes string
-	// OIDCDiscoveryTimeout bounds the OIDC discovery + JWKS HTTP calls made
-	// during startup. A slow or blackholed issuer would otherwise hang the
-	// process indefinitely (the go-libs path injects http.DefaultClient with
-	// no Timeout, and the local fallback calls oidc.Discover with
-	// context.Background()). 0 keeps the legacy unbounded behavior; the
-	// default (set in cmd/server/server.go) is 10s.
+	// OIDCDiscoveryTimeout bounds OIDC discovery (via a context deadline) and the
+	// keyset's JWKS fetches (via the HTTP client timeout) under one
+	// operator-controlled ceiling. 0 leaves them unbounded; the default (set in
+	// cmd/server/server.go) is 10s.
 	OIDCDiscoveryTimeout time.Duration
 }
 

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -1572,10 +1572,8 @@ func discoveryContext(timeout time.Duration) (context.Context, context.CancelFun
 }
 
 // TimeoutHTTPClient returns an *http.Client with Timeout set when timeout > 0,
-// otherwise http.DefaultClient (which has no timeout). Used by cmd/server to
-// shadow — via fx.Decorate — the http.DefaultClient that go-libs'
-// authnfx.JWTModule injects into NewKeySets, so OIDC discovery + JWKS reads
-// don't hang startup on a slow issuer.
+// otherwise http.DefaultClient (which has no timeout). buildAuthConfig uses it
+// to bound the JWKS reads performed by the OIDC remote keyset.
 func TimeoutHTTPClient(timeout time.Duration) *http.Client {
 	if timeout <= 0 {
 		return http.DefaultClient
@@ -1597,10 +1595,10 @@ func buildAuthConfig(cfg Config, logger logging.Logger, oidcKeySet oidc.KeySet) 
 	}
 
 	// When auth is enabled and an issuer is configured but no external KeySet was injected,
-	// discover the OIDC configuration and create a remote KeySet. The
-	// discovery HTTP call uses http.DefaultClient (no Timeout) inside go-libs,
-	// so a slow or blackholed issuer would otherwise hang startup forever —
-	// bound it via a context deadline derived from cfg.AuthConfig.OIDCDiscoveryTimeout.
+	// discover the OIDC configuration and create a remote KeySet. Both the discovery
+	// call and the keyset's JWKS reads are bounded by OIDCDiscoveryTimeout so a slow or
+	// blackholed issuer cannot hang the process: the context deadline bounds
+	// oidc.Discover, and the keyset's http.Client.Timeout bounds JWKS fetches.
 	if oidcKeySet == nil && cfg.AuthConfig.Enabled && cfg.AuthConfig.Issuer != "" {
 		ctx, cancel := discoveryContext(cfg.AuthConfig.OIDCDiscoveryTimeout)
 		discovery, err := oidc.Discover(ctx, cfg.AuthConfig.Issuer, oidc.DiscoveryEndpoint)
@@ -1609,7 +1607,7 @@ func buildAuthConfig(cfg Config, logger logging.Logger, oidcKeySet oidc.KeySet) 
 			return authCfg, fmt.Errorf("discovering OIDC configuration for issuer %q: %w", cfg.AuthConfig.Issuer, err)
 		}
 
-		oidcKeySet = oidcclient.NewRemoteKeySet(nil, discovery.JwksURI)
+		oidcKeySet = oidcclient.NewRemoteKeySet(TimeoutHTTPClient(cfg.AuthConfig.OIDCDiscoveryTimeout), discovery.JwksURI)
 
 		logger.WithFields(map[string]any{
 			"issuer":   cfg.AuthConfig.Issuer,


### PR DESCRIPTION
The server exposes `--auth-discovery-timeout` (default `10s`), applied in `buildAuthConfig`, which already bounds the OIDC discovery HTTP call via a context deadline. This PR extends that same bound to the JWKS reads and removes an inert auth fx module.

### Changes

**1. Bound the JWKS read client**

`buildAuthConfig` bounded `oidc.Discover` with a context deadline, but built the remote keyset with `NewRemoteKeySet(nil, …)`:

```go
oidcKeySet = oidcclient.NewRemoteKeySet(nil, discovery.JwksURI)
```

The keyset here is go-libs' `oidc/client` (`authn/oidc/client`), not zitadel directly. On a `nil` client it does **not** use `http.DefaultClient` — it falls back to the package's `DefaultHTTPClient`, which carries a hardcoded **30s** timeout:

```go
// go-libs/v5/pkg/authn/oidc/client/jwks.go
func NewRemoteKeySet(client *http.Client, jwksURL string, ...) oidc.KeySet {
	if client == nil {
		client = httphelper.DefaultHTTPClient   // &http.Client{Timeout: 30 * time.Second}
	}
	...
}
```

So JWKS key fetches (lazy, on first token verification) were bounded — but at a fixed 30s, ignoring `--auth-discovery-timeout`. This passes the configured client so discovery and JWKS reads share one operator-controlled ceiling:

```go
oidcKeySet = oidcclient.NewRemoteKeySet(TimeoutHTTPClient(cfg.AuthConfig.OIDCDiscoveryTimeout), discovery.JwksURI)
```

`TimeoutHTTPClient(0)` returns `http.DefaultClient` (no timeout), so `--auth-discovery-timeout=0` now makes JWKS reads truly unbounded too, matching the documented `0 = unbounded` opt-out (the previous 30s floor on JWKS is intentionally removed in that case).

**2. Drop the inert `authnfx` JWT module + its no-op `fx.Decorate`**

`cmd/server` wired `authnfx.JWTModuleFromFlags(cmd)` plus an `fx.Decorate` to bound the `*http.Client` fed to `NewKeySets`. That wiring is dead:

- `jwt.NewKeySets` returns `map[string]oidc.KeySet` and `jwt.NewAuthenticatorFromConfig` returns an `Authenticator` — nothing in this service consumes either.
- `buildAuthConfig`'s injected `oidcKeySet` is a *singular* `oidc.KeySet` (`optional:"true"`, `module.go:530`) that the module never provides, so it's always `nil` and the local discovery path always runs.
- fx providers are lazy: with no consumer of the module's outputs, `NewKeySets` never runs, the decorated `*http.Client` is never requested, and the decorator never fires.

So `buildAuthConfig` is already the sole, fully-bounded discovery path. The wiring is removed entirely (no leftover `fx.Module("auth")` marker), and the now-unused `authnfx` / `net/http` imports are dropped. Auth flags remain registered independently via `auth.AddFlags`.

### Testing

- `go build ./...`, `go vet ./cmd/server/... ./internal/bootstrap/...`, `gofmt -l` — clean
- `go test ./internal/bootstrap/ -run 'AuthConfig|TimeoutHTTPClient|DiscoveryContext|HangingIssuer|RemoteKeySet_JWKSRead'` — pass
- Adds `TestRemoteKeySet_JWKSReadRespectsTimeout`: builds the keyset exactly as `buildAuthConfig` does (`TimeoutHTTPClient(timeout)`), points it at a blackholed `/jwks` handler, and asserts `VerifySignature` returns an error inside ~2×timeout instead of stalling — covering the line this PR changes.

### Files

- `cmd/server/server.go` — remove the `authnfx` module + `fx.Decorate`
- `internal/bootstrap/module.go` — pass `TimeoutHTTPClient(...)` to `NewRemoteKeySet`; refresh comments
- `internal/bootstrap/config.go` — refresh the `OIDCDiscoveryTimeout` doc comment
- `internal/bootstrap/auth_discovery_timeout_test.go` — add the JWKS-bound test
- `docs/ops/cli.md` — update the `--auth-discovery-timeout` description

### Notes for reviewers

- Change 2 removes the `authnfx` module and its decorator. It's verified safe (zero consumers of its outputs in this service). If a future feature needs the go-libs `Authenticator`, the module can be re-added with a real consumer.
