### PR TITLE
fix(EN-1242): tombstone both cache generations on metadata delete

### DIFF
--- a/internal/infra/attributes/key_store.go
+++ b/internal/infra/attributes/key_store.go
@@ -158,10 +158,14 @@ func (s *KeyStore[K, T]) GetEntry(canonical []byte) (Entry[T], bool) {
 	return entry, true
 }
 
-// Delete marks the entry as a tombstone instead of removing it.
+// Delete marks the entry as a tombstone in the underlying store.
+// On the dual-generation cache the tombstone is written to every generation
+// (cache.AttributeCache.Del), mirroring the 0xFF zone the FSM writes in the
+// same batch, so the in-memory cache equals disk for the same applied index.
 // The entry stays in the cache (surviving MirrorTouch during pipelined
-// proposals) but reads via Get return nil. Tombstones age out naturally
-// via cache generation rotation.
+// proposals) and reads via Get return ErrNotFound. Tombstones age out naturally
+// via cache generation rotation. A single-map kv.KV (tests) removes the entry,
+// which Get also reports as not found.
 func (s *KeyStore[K, T]) Delete(canonical []byte) (id U128, tag uint64, err error) {
 	id, tag = s.hasher.MakeKey(canonical)
 
@@ -174,8 +178,7 @@ func (s *KeyStore[K, T]) Delete(canonical []byte) (id U128, tag uint64, err erro
 		return id, tag, newErrCollisionDetected(canonical, entry.Tag, tag)
 	}
 
-	entry.Deleted = true
-	s.M.Put(id, entry)
+	s.M.Del(id)
 
 	return id, tag, nil
 }

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -74,33 +74,42 @@ func (a *AttributeCache[T]) GetAndPut(k attributes.U128, v attributes.Entry[T]) 
 	return a.gen1.Load().Get(k)
 }
 
-// Del marks the entry as a tombstone in both Gen0 and Gen1 instead of
-// removing it. This prevents pipelined MirrorTouch from failing when
-// the leader admitted a touch before the FSM processed the deletion —
-// admission relies on the tombstone being present in the cache to
-// distinguish "deleted" from "cache miss". Tombstones age out naturally
-// via rotation.
+// Del marks the key as a tombstone in both Gen0 and Gen1: the entry stays in
+// the cache with Deleted set so CheckCache/MirrorTouch still see the key and a
+// pipelined touch admitted before the FSM processed the deletion does not fail.
+// Writing both generations mirrors state.writeCacheTombstone, which stamps a
+// tombstone at both gen bytes in the 0xFF zone, keeping the in-memory cache
+// equal to disk for the same applied index (the cache-mirror invariant). A
+// generation that lacks the key borrows the tag from the one that has it.
 //
-// Data is reset to the zero value: a tombstone's payload is unreadable
-// by contract (every consumer checks Deleted first and returns
-// ErrNotFound), so retaining the pre-delete value yields zombie state
-// that has historically caused snapshot/restore foot-guns (see EN-1377
-// — the persist path used to marshal entry.Data unconditionally and
-// resurrect the deleted key on restore).
+// Data is reset to the zero value: a tombstone's payload is unreadable by
+// contract (every consumer checks Deleted first and returns ErrNotFound), and
+// retaining it risks snapshot/restore resurrection of the deleted key (EN-1377).
+//
+// Tombstones age out naturally via rotation. Called only from the FSM goroutine.
 func (a *AttributeCache[T]) Del(k attributes.U128) {
 	var zero T
 
-	if entry, ok := a.gen0.Load().Get(k); ok {
-		entry.Deleted = true
-		entry.Data = zero
-		a.gen0.Load().Put(k, entry)
+	e0, ok0 := a.gen0.Load().Get(k)
+	e1, ok1 := a.gen1.Load().Get(k)
+	if !ok0 && !ok1 {
+		return
 	}
 
-	if entry, ok := a.gen1.Load().Get(k); ok {
-		entry.Deleted = true
-		entry.Data = zero
-		a.gen1.Load().Put(k, entry)
+	if !ok0 {
+		e0 = e1
 	}
+
+	if !ok1 {
+		e1 = e0
+	}
+
+	e0.Deleted = true
+	e0.Data = zero
+	e1.Deleted = true
+	e1.Data = zero
+	a.gen0.Load().Put(k, e0)
+	a.gen1.Load().Put(k, e1)
 }
 
 func (a *AttributeCache[T]) Size() uint64 {

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -169,9 +169,23 @@ func TestAttributeCache_Del(t *testing.T) {
 	assert.True(t, ok)
 	assert.True(t, result.Deleted)
 	// Data is reset to the zero value: a tombstone's payload is unreadable by
-	// contract, and retaining it has historically caused snapshot/restore
-	// foot-guns (EN-1377).
+	// contract, and retaining it risks snapshot/restore resurrection (EN-1377).
 	assert.Nil(t, result.Data, "Del must reset entry.Data to the zero value")
+
+	// Del tombstones both generations, borrowing the tag for the gen that
+	// lacked the key (here Gen1), so the in-memory cache mirrors the dual-gen
+	// 0xFF tombstone.
+	gen0Entry, ok := ac.Gen0().Get(key)
+	require.True(t, ok)
+	assert.True(t, gen0Entry.Deleted)
+	assert.Equal(t, uint64(123), gen0Entry.Tag)
+	assert.Nil(t, gen0Entry.Data)
+
+	gen1Entry, ok := ac.Gen1().Get(key)
+	require.True(t, ok)
+	assert.True(t, gen1Entry.Deleted)
+	assert.Equal(t, uint64(123), gen1Entry.Tag)
+	assert.Nil(t, gen1Entry.Data)
 }
 
 func TestAttributeCache_DelResetsDataAcrossGenerations(t *testing.T) {

--- a/internal/infra/cache/keystore_delete_test.go
+++ b/internal/infra/cache/keystore_delete_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// TestKeyStoreDelete_TombstonesAllGenerations is the EN-1242 regression: a
+// delete on a key whose live entry sits in Gen1 (post-rotation) must tombstone
+// BOTH generations, matching the dual-gen tombstone the FSM writes to the 0xFF
+// zone in the same batch. A Gen0-only write leaves Gen1 holding the live entry
+// — hidden from Get (which reads Gen0 first) yet diverging from disk until a
+// restart rehydrates Gen1 as a tombstone.
+func TestKeyStoreDelete_TombstonesAllGenerations(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(10, nil)
+	require.NoError(t, err)
+
+	ac := c.LedgerMetadata
+	ks := attributes.NewKeyStore[domain.LedgerMetadataKey, *commonpb.MetadataValue](ac)
+
+	canonical := domain.LedgerMetadataKey{LedgerName: "l", Key: "k"}.Bytes()
+
+	_, idWithTag, err := ks.Put(canonical, commonpb.NewStringValue("v"))
+	require.NoError(t, err)
+	id := idWithTag.ID
+
+	// Rotate: the live entry moves Gen0 -> Gen1, Gen0 is fresh and empty.
+	ac.Rotate()
+
+	_, gen0Has := ac.Gen0().Get(id)
+	require.False(t, gen0Has, "precondition: Gen0 empty after rotation")
+	live, gen1Has := ac.Gen1().Get(id)
+	require.True(t, gen1Has)
+	require.False(t, live.Deleted, "precondition: live entry in Gen1")
+
+	_, _, err = ks.Delete(canonical)
+	require.NoError(t, err)
+
+	gen0Entry, ok := ac.Gen0().Get(id)
+	require.True(t, ok, "Gen0 must hold a tombstone after delete")
+	require.True(t, gen0Entry.Deleted)
+
+	gen1Entry, ok := ac.Gen1().Get(id)
+	require.True(t, ok)
+	require.True(t, gen1Entry.Deleted, "Gen1 live entry must become a tombstone")
+
+	_, _, err = ks.Get(canonical)
+	require.ErrorIs(t, err, domain.ErrNotFound)
+}


### PR DESCRIPTION
# fix(cache): tombstone both generations on metadata delete (EN-1242)

## Context

The in-memory `AttributeCache` is dual-generation (`gen0` = current, `gen1` =
previous, rotated on each generation boundary). The 0xFF Pebble zone mirrors
both generations for restart recovery, and the invariant is that **the
in-memory cache equals the 0xFF zone for the same applied index**.

When the FSM applies a metadata delete, two writes happen in the same Pebble
batch:

1. **In memory** — `KeyStore.Delete` tombstoned the entry via `s.M.Put(id, entry)`,
   and `AttributeCache.Put` writes **gen0 only**.
2. **On disk** — `writeCacheTombstone` stamps a tombstone at **both** gen bytes
   in the 0xFF zone.

So immediately after a delete on a key whose live entry sat in `gen1`
(post-rotation), the two sides disagreed:

| Location | gen0 | gen1 |
|---|---|---|
| in-memory `AttributeCache` | tombstone | **live entry** |
| Pebble 0xFF | tombstone | tombstone |

It was invisible at runtime because `AttributeCache.Get` reads gen0 first and
returns the tombstone, and a restart rehydrates `gen1` from disk as a tombstone
— but the cache-mirror invariant was broken between the delete and the next
restart. Any code that consults `gen1` directly (or any memory-vs-disk
consistency check) would see the mismatch.

## Fix

`AttributeCache.Del` already documented that it "marks the entry as a tombstone
in **both Gen0 and Gen1**", but its implementation only tombstoned generations
that already held the key, and `KeyStore.Delete` never called it (it used
`Put`, hitting gen0 only).

This change makes `Del` honor its contract and routes the delete through it:

- **`AttributeCache.Del`** now tombstones **both** generations and resets the
  entry's `Data` to zero (the tombstone-payload reset EN-1377 introduced). When a
  generation lacks the key it borrows the tag from the one that has it (a delete
  always has the key in at least one gen); the borrow only fires for an empty
  target generation, so it never clobbers a colliding entry, and it matches what
  `writeCacheTombstone` does on disk.
- **`KeyStore.Delete`** validates existence + tag (unchanged) and then calls
  `s.M.Del(id)` — reusing the existing `kv.KV.Del` interface method instead of a
  bespoke gen0-only `Put`. For a single-map `kv.KV` (test stores) `Del` removes
  the entry, which `Get` also reports as not found.

Net result: after a metadata delete, both in-memory generations carry the
tombstone, matching the 0xFF zone for the same applied index.

## Tests

- `TestKeyStoreDelete_TombstonesAllGenerations` (cache) — write → rotate (entry
  now gen1-only) → delete → asserts **both** generations are tombstones and
  `Get` returns `ErrNotFound`. This is the EN-1242 acceptance scenario.
- `TestAttributeCache_Del` (cache) — strengthened to assert `Del` tombstones
  both generations (with `Data` reset), including the borrowed-tag path for the
  generation that lacked the key.

Both fail against the pre-fix code (gen1 stays live) and pass with the fix.

## Relationship to EN-1377

EN-1377 (explicit on-disk tombstone flag byte, `persistLeanProtoEntries`
hardening, and `AttributeCache.Del` resetting `Data`) is **already merged** into
the base. The two are complementary halves of the same cache-mirror story:

- **EN-1377** makes the in-memory↔disk mapping unambiguous — an out-of-band flag
  byte, so a presence-only / all-default proto no longer round-trips as a
  tombstone.
- **EN-1242** (this PR) makes the in-memory `Deleted` flag correct across **both**
  generations, so `gen1` never keeps a live entry after a `gen0`-only delete.

Both reworked `AttributeCache.Del`, so this branch's `Del` reconciles them: it
tombstones both generations (EN-1242) **and** resets `Data` to zero (EN-1377).

## Verification

- `just pre-commit` passes (go generate, go mod tidy, golangci-lint).
- `go build ./...`, `go vet`, and the `cache` / `attributes` / `state` package
  suites pass.
- Rebased onto `formancehq/ledger` `release/v3.0`; the change touches no files
  modified by the rest of that branch.

## Files changed

- `internal/infra/cache/cache.go` — `Del` tombstones both generations.
- `internal/infra/attributes/key_store.go` — `Delete` routes through `s.M.Del`.
- `internal/infra/cache/cache_test.go` — strengthened `TestAttributeCache_Del`.
- `internal/infra/cache/keystore_delete_test.go` — new EN-1242 regression test.
