### PR TITLE
feat(EN-1305): honor ListOptions.filter on the audit trail

### DIFF
--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -141,11 +141,21 @@ func buildAuditFilter(expr string, failuresOnly bool, ledger string) (*commonpb.
 		parts = append(parts, f)
 	}
 	if ledger != "" {
-		f, err := filterexpr.Parse(fmt.Sprintf("audit[ledger] == %q", ledger))
-		if err != nil {
-			return nil, err
-		}
-		parts = append(parts, f)
+		// Build the proto directly instead of round-tripping through the DSL
+		// string. The filterexpr String grammar has no escape handling, so a
+		// ledger name containing a quote or backslash (both valid per
+		// domain.ValidateLedgerName) cannot survive
+		// Parse(fmt.Sprintf("audit[ledger] == %q", ledger)).
+		parts = append(parts, &commonpb.QueryFilter{
+			Filter: &commonpb.QueryFilter_Audit{Audit: &commonpb.AuditCondition{
+				Field: commonpb.AuditField_AUDIT_FIELD_LEDGER,
+				Condition: &commonpb.AuditCondition_StringCond{
+					StringCond: &commonpb.StringCondition{
+						Value: &commonpb.StringCondition_Hardcoded{Hardcoded: ledger},
+					},
+				},
+			}},
+		})
 	}
 
 	switch len(parts) {

--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
@@ -32,7 +33,9 @@ func NewListCommand() *cobra.Command {
 	cmdutil.AddPaginationFlags(cmd, cmdutil.PaginationOptions{})
 	cmdutil.AddMinLogSequenceFlag(cmd)
 	cmdutil.AddOutputFlags(cmd)
-	cmd.Flags().Bool("failures-only", false, "Show only failed entries")
+	cmdutil.AddFilterFlags(cmd, cmdutil.FilterOptions{})
+	cmd.Flags().Bool("failures-only", false, "Shorthand for --filter 'audit[outcome] == failure'")
+	cmd.Flags().String("ledger", "", "Shorthand for --filter 'audit[ledger] == <name>'")
 	cmd.Flags().Duration("timeout", cmdutil.DefaultTimeout, "Request timeout")
 	cmd.Flags().Bool("expand", false, "Expand orders within each audit entry")
 
@@ -50,14 +53,20 @@ func runList(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
+	failuresOnly, _ := cmd.Flags().GetBool("failures-only")
+	ledger, _ := cmd.Flags().GetString("ledger")
 	expand, _ := cmd.Flags().GetBool("expand")
 	minLogSeq, _ := cmd.Flags().GetUint64("min-log-sequence")
 	pgn := cmdutil.GetPaginationFlags(cmd)
+	ff := cmdutil.GetFilterFlags(cmd)
 
-	// NOTE(EN-1305): the failures-only filter now flows through
-	// options.filter; the CLI flag wiring is completed in a follow-up task.
+	filter, err := buildAuditFilter(ff.Expr, failuresOnly, ledger)
+	if err != nil {
+		return err
+	}
+
 	stream, err := client.ListAuditEntries(ctx, &servicepb.ListAuditEntriesRequest{
-		Options: cmdutil.BuildListOptions(pgn, cmdutil.ConsistencyFlags{MinLogSequence: minLogSeq}, nil),
+		Options: cmdutil.BuildListOptions(pgn, cmdutil.ConsistencyFlags{MinLogSequence: minLogSeq}, filter),
 	})
 	if err != nil {
 		return cmdutil.FormatGRPCError("failed to list audit entries", err)
@@ -110,6 +119,43 @@ func runList(cmd *cobra.Command, _ []string) error {
 	cmdutil.EmitNextCursorHint(cmd, nextCursor)
 
 	return nil
+}
+
+// buildAuditFilter combines --filter with the --failures-only / --ledger
+// shorthands into a single QueryFilter (AND-combined). Returns nil when empty.
+func buildAuditFilter(expr string, failuresOnly bool, ledger string) (*commonpb.QueryFilter, error) {
+	var parts []*commonpb.QueryFilter
+
+	if expr != "" {
+		parsed, err := filterexpr.Parse(expr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filter expression: %w", err)
+		}
+		parts = append(parts, parsed)
+	}
+	if failuresOnly {
+		f, err := filterexpr.Parse(`audit[outcome] == failure`)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, f)
+	}
+	if ledger != "" {
+		f, err := filterexpr.Parse(fmt.Sprintf("audit[ledger] == %q", ledger))
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, f)
+	}
+
+	switch len(parts) {
+	case 0:
+		return nil, nil
+	case 1:
+		return parts[0], nil
+	default:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: parts}}}, nil
+	}
 }
 
 // printAuditEntry prints a single audit entry in a human-readable format.

--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -50,14 +50,14 @@ func runList(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	failuresOnly, _ := cmd.Flags().GetBool("failures-only")
 	expand, _ := cmd.Flags().GetBool("expand")
 	minLogSeq, _ := cmd.Flags().GetUint64("min-log-sequence")
 	pgn := cmdutil.GetPaginationFlags(cmd)
 
+	// NOTE(EN-1305): the failures-only filter now flows through
+	// options.filter; the CLI flag wiring is completed in a follow-up task.
 	stream, err := client.ListAuditEntries(ctx, &servicepb.ListAuditEntriesRequest{
-		Options:      cmdutil.BuildListOptions(pgn, cmdutil.ConsistencyFlags{MinLogSequence: minLogSeq}, nil),
-		FailuresOnly: failuresOnly,
+		Options: cmdutil.BuildListOptions(pgn, cmdutil.ConsistencyFlags{MinLogSequence: minLogSeq}, nil),
 	})
 	if err != nil {
 		return cmdutil.FormatGRPCError("failed to list audit entries", err)

--- a/cmd/ledgerctl/audit/list_test.go
+++ b/cmd/ledgerctl/audit/list_test.go
@@ -1,0 +1,52 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// The --ledger shorthand must carry the raw ledger name through to the proto
+// filter. Building the proto directly (rather than round-tripping through the
+// filterexpr DSL string) is what lets names containing characters the no-escape
+// String grammar cannot represent — quotes and backslashes, both valid per
+// domain.ValidateLedgerName — survive verbatim.
+func TestBuildAuditFilter_LedgerShorthandPreservesSpecialChars(t *testing.T) {
+	t.Parallel()
+
+	for _, ledger := range []string{`a"b`, `a\b`, `plain`, `a"b\c`} {
+		filter, err := buildAuditFilter("", false, ledger)
+		require.NoError(t, err, "ledger: %q", ledger)
+
+		audit := filter.GetAudit()
+		require.NotNil(t, audit, "ledger: %q", ledger)
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_LEDGER, audit.GetField(), "ledger: %q", ledger)
+		require.Equal(t, ledger, audit.GetStringCond().GetHardcoded(), "ledger: %q", ledger)
+	}
+}
+
+func TestBuildAuditFilter_Combinations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		t.Parallel()
+		filter, err := buildAuditFilter("", false, "")
+		require.NoError(t, err)
+		require.Nil(t, filter)
+	})
+
+	t.Run("ledger and failures-only AND-combine", func(t *testing.T) {
+		t.Parallel()
+		filter, err := buildAuditFilter("", true, "main")
+		require.NoError(t, err)
+		require.Len(t, filter.GetAnd().GetFilters(), 2)
+	})
+
+	t.Run("invalid expr surfaces error", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildAuditFilter("this is not valid !!", false, "")
+		require.Error(t, err)
+	})
+}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -2211,7 +2211,7 @@ The `--filter` flag accepts a boolean expression using `audit[field]` conditions
 | `proposal_id` | Proposal ID | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
 | `timestamp` | Entry timestamp (Unix nanoseconds) | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
 | `log_seq` | Overlaps the produced log-sequence range | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
-| `outcome` | `success` or `failure` | string | `==` |
+| `outcome` | `success` or `failure` | string | `==`, `!=`, `in` |
 | `error_type` | Failure error type (e.g. `INSUFFICIENT_FUNDS`) | string | `==`, `!=`, `in` |
 | `caller.subject` | Caller subject | string | `==`, `!=`, `in` |
 | `caller.scope` | Caller scope (match-any) | string | `==`, `!=`, `in` |

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -2221,6 +2221,8 @@ The `--filter` flag accepts a boolean expression using `audit[field]` conditions
 
 Multiple conditions can be combined with `and`. Unsupported conditions are rejected with gRPC `InvalidArgument`.
 
+> **`order_type` values vs. displayed labels:** `order_type` matches the proposal's *outer* order payload variant (`apply`, `create_ledger`, `delete_ledger`, `save_numscript`, `register_signing_key`, `seal_chapter`, …). This differs from the per-order label printed by `--expand`, which shows the *inner* operation (`CreateTransaction`, `RevertTransaction`, …). All ledger transaction operations are `apply` orders, so to match transactions use `audit[order_type] == apply` (not `== create_transaction`).
+
 **Examples:**
 
 ```bash

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -2149,10 +2149,12 @@ ledgerctl audit list [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--failures-only` | `false` | Show only failed entries |
+| `--filter` | | Boolean filter expression targeting the audit log (see [Audit Filter Expressions](#audit-filter-expressions) below) |
+| `--failures-only` | `false` | Shorthand for `--filter 'audit[outcome] == failure'`; show only failed entries |
+| `--ledger` | | Shorthand for `--filter 'audit[ledger] == <name>'`; show entries for a specific ledger |
 | `--expand` | `false` | Expand orders within each audit entry |
 
-Also honors the [Shared Flag Contract](#shared-flag-contract) (`--page-size`, `--cursor`, `--min-log-sequence`, `--json`, `--yaml`, `--timeout`).
+`--failures-only` and `--ledger` combine with `--filter` via AND when all are provided. Also honors the [Shared Flag Contract](#shared-flag-contract) (`--page-size`, `--cursor`, `--min-log-sequence`, `--json`, `--yaml`, `--timeout`).
 
 **Behavior:**
 - Streams audit entries from the server
@@ -2164,6 +2166,7 @@ Also honors the [Shared Flag Contract](#shared-flag-contract) (`--page-size`, `-
   - Consecutive identical orders are grouped compactly (e.g. `MirrorIngest x500`)
 - If audit is disabled on the server, a warning message is displayed instead of an error
 - When `--page-size N` is set and more entries exist, the command prints `More results available — resume with --cursor <token>` so the listing can be chained
+- Filters are evaluated as **scan-time predicates** on the sequential cold-zone audit log — there is no audit index. Filtering by `order_type` additionally loads each candidate entry's AuditItems lazily (only when the condition is evaluated). Unsupported conditions are rejected with gRPC `InvalidArgument`.
 
 **Example:**
 
@@ -2171,8 +2174,20 @@ Also honors the [Shared Flag Contract](#shared-flag-contract) (`--page-size`, `-
 # List audit entries
 ledgerctl audit list
 
-# Show only failures
+# Show only failures (shorthand)
 ledgerctl audit list --failures-only
+
+# Show entries for a specific ledger (shorthand)
+ledgerctl audit list --ledger my-ledger
+
+# Combine shorthands with an explicit filter
+ledgerctl audit list --failures-only --ledger my-ledger
+
+# Filter using the DSL directly
+ledgerctl audit list --filter 'audit[outcome] == failure'
+ledgerctl audit list --filter 'audit[caller.subject] == "alice" and audit[ledger] == "main"'
+ledgerctl audit list --filter 'audit[order_type] in (apply, save_numscript)'
+ledgerctl audit list --filter 'audit[seq] between 1000 and 2000'
 
 # Resume after a previous page
 ledgerctl audit list --page-size 20 --cursor <token>
@@ -2182,6 +2197,47 @@ ledgerctl audit list --expand
 
 # Output as JSON
 ledgerctl audit list --json
+```
+
+#### Audit Filter Expressions
+
+The `--filter` flag accepts a boolean expression using `audit[field]` conditions. All conditions are evaluated as scan-time predicates; there is no dedicated audit index.
+
+**Supported fields:**
+
+| DSL key | Meaning | Value kind | Supported operators |
+|---|---|---|---|
+| `seq` | Audit sequence number | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
+| `proposal_id` | Proposal ID | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
+| `timestamp` | Entry timestamp (Unix nanoseconds) | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
+| `log_seq` | Overlaps the produced log-sequence range | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
+| `outcome` | `success` or `failure` | string | `==` |
+| `error_type` | Failure error type (e.g. `INSUFFICIENT_FUNDS`) | string | `==`, `!=`, `in` |
+| `caller.subject` | Caller subject | string | `==`, `!=`, `in` |
+| `caller.scope` | Caller scope (match-any) | string | `==`, `!=`, `in` |
+| `caller.god` | Caller god flag | bool | `== true` / `== false` |
+| `ledger` | Targeted ledger name (match-any) | string | `==`, `!=`, `in` |
+| `order_type` | Order payload variant, e.g. `apply`, `create_ledger`, `save_numscript` (match-any) | string | `==`, `!=`, `in` |
+
+Multiple conditions can be combined with `and`. Unsupported conditions are rejected with gRPC `InvalidArgument`.
+
+**Examples:**
+
+```bash
+# All failures
+--filter 'audit[outcome] == failure'
+
+# A specific caller on a specific ledger
+--filter 'audit[caller.subject] == "alice" and audit[ledger] == "main"'
+
+# Multiple order types
+--filter 'audit[order_type] in (apply, save_numscript)'
+
+# Sequence range
+--filter 'audit[seq] between 1000 and 2000'
+
+# Specific error type
+--filter 'audit[error_type] == INSUFFICIENT_FUNDS'
 ```
 
 **Sample output:**

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -2209,7 +2209,7 @@ The `--filter` flag accepts a boolean expression using `audit[field]` conditions
 |---|---|---|---|
 | `seq` | Audit sequence number | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
 | `proposal_id` | Proposal ID | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
-| `timestamp` | Entry timestamp (Unix nanoseconds) | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
+| `timestamp` | Entry timestamp (Unix microseconds) | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
 | `log_seq` | Overlaps the produced log-sequence range | uint | `==`, `!=`, `>`, `>=`, `<`, `<=`, `between` |
 | `outcome` | `success` or `failure` | string | `==`, `!=`, `in` |
 | `error_type` | Failure error type (e.g. `INSUFFICIENT_FUNDS`) | string | `==`, `!=`, `in` |

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -712,7 +712,7 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `ListNumscripts` | List all saved numscripts | ✅ |
 | `Apply(CloseChapter)` | Close the current open chapter | ✅ |
 | `ListChapters` | Stream all chapters | ✅ |
-| `ListAuditEntries` | Stream audit log entries (success + failure) | ✅ |
+| `ListAuditEntries` | Stream audit log entries (success + failure); honors `options.filter` with the `QUERY_TARGET_AUDIT` DSL (seq, proposal_id, timestamp, log_seq, outcome, error_type, caller.subject, caller.scope, caller.god, ledger, order_type). Dedicated `failures_only` / `ledger` request fields removed in favor of the filter. Unsupported conditions rejected with `InvalidArgument`. | ✅ |
 | `GetAuditEntry` | Get a single audit entry by sequence number | ✅ |
 | `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination) | ✅ |
 | `GetLog` | Get a single system log by sequence number | ✅ |

--- a/internal/adapter/grpc/client_bucket.go
+++ b/internal/adapter/grpc/client_bucket.go
@@ -184,7 +184,7 @@ func (g *BucketGrpcClient) GetLedgerByName(ctx context.Context, name string) (*c
 	})
 }
 
-func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	var cursorStr string
 	if afterSequence != nil {
 		cursorStr = strconv.FormatUint(*afterSequence, 10)
@@ -194,9 +194,8 @@ func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, afterSequence *
 		Options: &commonpb.ListOptions{
 			PageSize: pageSize,
 			Cursor:   cursorStr,
+			Filter:   filter,
 		},
-		FailuresOnly: failuresOnly,
-		Ledger:       ledger,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/adapter/grpc/client_bucket_test.go
+++ b/internal/adapter/grpc/client_bucket_test.go
@@ -317,7 +317,7 @@ func TestListAuditEntries_Success(t *testing.T) {
 
 	client := NewLedgerGrpcClient(mock)
 	seq := uint64(5)
-	cursor, err := client.ListAuditEntries(context.Background(), &seq, true, 10, "")
+	cursor, err := client.ListAuditEntries(context.Background(), &seq, 10, nil)
 	require.NoError(t, err)
 
 	entry, err := cursor.Next()
@@ -333,7 +333,7 @@ func TestListAuditEntries_StreamError(t *testing.T) {
 	mock.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any()).Return(nil, errors.New("audit error"))
 
 	client := NewLedgerGrpcClient(mock)
-	_, err := client.ListAuditEntries(context.Background(), nil, false, 10, "")
+	_, err := client.ListAuditEntries(context.Background(), nil, 10, nil)
 	require.Error(t, err)
 }
 

--- a/internal/adapter/grpc/controller_generated_test.go
+++ b/internal/adapter/grpc/controller_generated_test.go
@@ -746,18 +746,18 @@ func (c *MockControllerListAccountsCall) DoAndReturn(f func(context.Context, str
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, failuresOnly, pageSize, ledger)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, pageSize, filter)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, failuresOnly, pageSize, ledger any) *MockControllerListAuditEntriesCall {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, pageSize, filter any) *MockControllerListAuditEntriesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, failuresOnly, pageSize, ledger)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, pageSize, filter)
 	return &MockControllerListAuditEntriesCall{Call: call}
 }
 
@@ -773,13 +773,13 @@ func (c *MockControllerListAuditEntriesCall) Return(arg0 cursor.Cursor[*auditpb.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerListAuditEntriesCall) Do(f func(context.Context, *uint64, bool, uint32, string) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
+func (c *MockControllerListAuditEntriesCall) Do(f func(context.Context, *uint64, uint32, *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerListAuditEntriesCall) DoAndReturn(f func(context.Context, *uint64, bool, uint32, string) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
+func (c *MockControllerListAuditEntriesCall) DoAndReturn(f func(context.Context, *uint64, uint32, *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -1072,9 +1072,9 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 
 	opts := req.GetOptions()
 
-	// The audit controller does not yet honor filter / reverse /
-	// checkpoint_id — see #436 for the alignment work.
-	if err := ValidateListOptions(opts, ListOptionsSupport{}); err != nil {
+	// Audit honors filter (scan-time predicates over the cold-zone audit log).
+	// reverse / checkpoint_id are not supported — see #436.
+	if err := ValidateListOptions(opts, ListOptionsSupport{Filter: true}); err != nil {
 		return err
 	}
 
@@ -1094,7 +1094,7 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 		afterSeqPtr = &afterSeq
 	}
 
-	c, err := impl.ctrl.ListAuditEntries(ctx, afterSeqPtr, req.GetFailuresOnly(), pageSizePlusOne(pageSize), req.GetLedger())
+	c, err := impl.ctrl.ListAuditEntries(ctx, afterSeqPtr, pageSizePlusOne(pageSize), opts.GetFilter())
 	if err != nil {
 		return fmt.Errorf("listing audit entries: %w", err)
 	}

--- a/internal/adapter/grpc/server_bucket_list_test.go
+++ b/internal/adapter/grpc/server_bucket_list_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl/ctrlmock"
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -268,8 +269,8 @@ func TestListAuditEntries(t *testing.T) {
 		t.Parallel()
 
 		impl, mockCtrl := newListHandlerHarness(t)
-		// ListAuditEntries(ctx, afterSeq*uint64, failuresOnly, pageSize, ledger)
-		mockCtrl.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), false, uint32(3), "").
+		// ListAuditEntries(ctx, afterSeq *uint64, pageSize, filter)
+		mockCtrl.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), uint32(3), gomock.Any()).
 			Return(page(
 				&auditpb.AuditEntry{Sequence: 1},
 				&auditpb.AuditEntry{Sequence: 2},
@@ -282,6 +283,50 @@ func TestListAuditEntries(t *testing.T) {
 		require.NoError(t, impl.ListAuditEntries(req, stream))
 		require.Equal(t, "2", stream.trailerCursor())
 	})
+}
+
+// TestListAuditEntries_ForwardsFilter asserts the handler threads
+// options.filter through to the controller unchanged.
+func TestListAuditEntries_ForwardsFilter(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl := newListHandlerHarness(t)
+
+	filter, err := filterexpr.Parse("audit[outcome] == failure")
+	require.NoError(t, err)
+
+	var captured *commonpb.QueryFilter
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
+		DoAndReturn(func(_ context.Context, _ *uint64, _ uint32, f *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
+			captured = f
+			return page[auditpb.AuditEntry](), nil
+		})
+
+	stream := newFakeServerStream[auditpb.AuditEntry](t)
+	req := &servicepb.ListAuditEntriesRequest{
+		Options: &commonpb.ListOptions{PageSize: 2, Filter: filter},
+	}
+
+	require.NoError(t, impl.ListAuditEntries(req, stream))
+	require.NotNil(t, captured)
+}
+
+// TestListAuditEntries_RejectsReverse asserts the handler rejects the
+// unsupported reverse option with InvalidArgument before touching the
+// controller.
+func TestListAuditEntries_RejectsReverse(t *testing.T) {
+	t.Parallel()
+
+	impl, _ := newListHandlerHarness(t)
+
+	stream := newFakeServerStream[auditpb.AuditEntry](t)
+	req := &servicepb.ListAuditEntriesRequest{
+		Options: &commonpb.ListOptions{PageSize: 2, Reverse: true},
+	}
+
+	err := impl.ListAuditEntries(req, stream)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestListChapters covers chapter listing — the cursor is the chapter id.

--- a/internal/adapter/grpc/server_bucket_list_test.go
+++ b/internal/adapter/grpc/server_bucket_list_test.go
@@ -300,6 +300,7 @@ func TestListAuditEntries_ForwardsFilter(t *testing.T) {
 		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil())).
 		DoAndReturn(func(_ context.Context, _ *uint64, _ uint32, f *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			captured = f
+
 			return page[auditpb.AuditEntry](), nil
 		})
 

--- a/internal/adapter/http/backend_generated_test.go
+++ b/internal/adapter/http/backend_generated_test.go
@@ -900,18 +900,18 @@ func (c *MockBackendListAccountsCall) DoAndReturn(f func(context.Context, string
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockBackend) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockBackend) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, failuresOnly, pageSize, ledger)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, pageSize, filter)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockBackendMockRecorder) ListAuditEntries(ctx, afterSequence, failuresOnly, pageSize, ledger any) *MockBackendListAuditEntriesCall {
+func (mr *MockBackendMockRecorder) ListAuditEntries(ctx, afterSequence, pageSize, filter any) *MockBackendListAuditEntriesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockBackend)(nil).ListAuditEntries), ctx, afterSequence, failuresOnly, pageSize, ledger)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockBackend)(nil).ListAuditEntries), ctx, afterSequence, pageSize, filter)
 	return &MockBackendListAuditEntriesCall{Call: call}
 }
 
@@ -927,13 +927,13 @@ func (c *MockBackendListAuditEntriesCall) Return(arg0 cursor.Cursor[*auditpb.Aud
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendListAuditEntriesCall) Do(f func(context.Context, *uint64, bool, uint32, string) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
+func (c *MockBackendListAuditEntriesCall) Do(f func(context.Context, *uint64, uint32, *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendListAuditEntriesCall) DoAndReturn(f func(context.Context, *uint64, bool, uint32, string) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
+func (c *MockBackendListAuditEntriesCall) DoAndReturn(f func(context.Context, *uint64, uint32, *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/application/admission/validate_order.go
+++ b/internal/application/admission/validate_order.go
@@ -214,8 +214,11 @@ func validateOrderPreparedQuery(order *raftcmdpb.Order) domain.Describable {
 		if q == nil {
 			return domain.ErrPreparedQueryRequired
 		}
+		if err := domain.ValidatePreparedQueryName(q.GetName()); err != nil {
+			return err
+		}
 
-		return domain.ValidatePreparedQueryName(q.GetName())
+		return domain.ValidatePreparedQueryTarget(q.GetTarget())
 	case *raftcmdpb.LedgerScopedOrder_UpdatePreparedQuery:
 		return domain.ValidatePreparedQueryName(p.UpdatePreparedQuery.GetName())
 	case *raftcmdpb.LedgerScopedOrder_DeletePreparedQuery:

--- a/internal/application/admission/validate_order_test.go
+++ b/internal/application/admission/validate_order_test.go
@@ -206,6 +206,39 @@ func TestValidateOrder_PreparedQueryPayload(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "create rejects the audit target",
+			order: &raftcmdpb.Order{
+				Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+					Ledger: "l",
+					Payload: &raftcmdpb.LedgerScopedOrder_CreatePreparedQuery{
+						CreatePreparedQuery: &raftcmdpb.CreatePreparedQueryOrder{
+							Query: &commonpb.PreparedQuery{
+								Name:   "ok",
+								Target: commonpb.QueryTarget_QUERY_TARGET_AUDIT,
+							},
+						},
+					},
+				}},
+			},
+			wantErr: domain.ErrPreparedQueryAuditTargetUnsupported,
+		},
+		{
+			name: "create accepts a non-audit target",
+			order: &raftcmdpb.Order{
+				Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+					Ledger: "l",
+					Payload: &raftcmdpb.LedgerScopedOrder_CreatePreparedQuery{
+						CreatePreparedQuery: &raftcmdpb.CreatePreparedQueryOrder{
+							Query: &commonpb.PreparedQuery{
+								Name:   "ok",
+								Target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+							},
+						},
+					},
+				}},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/application/ctrl/controller.go
+++ b/internal/application/ctrl/controller.go
@@ -33,7 +33,7 @@ type Controller interface {
 	GetLog(ctx context.Context, sequence uint64) (*commonpb.Log, error)
 
 	// Audit operations
-	ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error)
+	ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error)
 	GetAuditEntry(ctx context.Context, sequence uint64) (*auditpb.AuditEntry, error)
 
 	// Chapter operations

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1136,7 +1136,7 @@ func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, afterSequen
 			items = its
 		}
 
-		return pred(entry, items), nil
+		return pred(entry, items)
 	})
 
 	// Always cap audit-entry materialization (pagination via AfterSequence).

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -1105,8 +1104,14 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 	return cursor.NewClosingCursor(c, handle), nil
 }
 
-// ListAuditEntries returns a cursor over audit entries, applying optional filters.
-func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+// ListAuditEntries returns a cursor over audit entries, applying an optional
+// scan-time filter compiled from the QueryFilter DSL.
+func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	pred, needsItems, err := query.CompileAuditPredicate(filter)
+	if err != nil {
+		return nil, domain.WrapCompileError(err)
+	}
+
 	handle, err := ctrl.store.NewReadHandle()
 	if err != nil {
 		return nil, fmt.Errorf("creating read handle: %w", err)
@@ -1119,32 +1124,23 @@ func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, afterSequen
 		return nil, fmt.Errorf("listing audit entries: %w", err)
 	}
 
-	var result = cursor.NewClosingCursor(c, handle)
+	base := cursor.NewClosingCursor(c, handle)
 
-	if ledger != "" {
-		result = cursor.NewFilteredCursor(result, func(entry *auditpb.AuditEntry) bool {
-			return auditEntryTargetsLedger(entry, ledger)
-		})
-	}
+	filtered := cursor.NewFilteredCursorE(base, func(entry *auditpb.AuditEntry) (bool, error) {
+		var items []*auditpb.AuditItem
+		if needsItems {
+			its, itErr := query.ReadAuditItems(ctx, handle, entry.GetSequence())
+			if itErr != nil {
+				return false, fmt.Errorf("loading audit items for entry %d: %w", entry.GetSequence(), itErr)
+			}
+			items = its
+		}
 
-	if failuresOnly {
-		result = cursor.NewFilteredCursor(result, func(entry *auditpb.AuditEntry) bool {
-			return entry.GetFailure() != nil
-		})
-	}
+		return pred(entry, items), nil
+	})
 
-	// Always cap audit-entry materialization. A caller that needs more than
-	// MaxPageSize entries paginates by passing the previous page's last
-	// AfterSequence — there is no "unlimited" option at the public boundary.
-	result = cursor.NewLimitedCursor(result, ClampFetchSize(pageSize))
-
-	return result, nil
-}
-
-// auditEntryTargetsLedger returns true if the audit entry targets the given ledger.
-// Uses the pre-computed ledgers field stored on the entry header.
-func auditEntryTargetsLedger(entry *auditpb.AuditEntry, ledger string) bool {
-	return slices.Contains(entry.GetLedgers(), ledger)
+	// Always cap audit-entry materialization (pagination via AfterSequence).
+	return cursor.NewLimitedCursor(filtered, ClampFetchSize(pageSize)), nil
 }
 
 // GetLog returns a single system log by sequence number.

--- a/internal/application/ctrl/controller_generated_test.go
+++ b/internal/application/ctrl/controller_generated_test.go
@@ -314,18 +314,18 @@ func (mr *MockControllerMockRecorder) ListAccounts(ctx, ledgerName, pageSize, af
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, failuresOnly, pageSize, ledger)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, pageSize, filter)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, failuresOnly, pageSize, ledger any) *gomock.Call {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, pageSize, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, failuresOnly, pageSize, ledger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, pageSize, filter)
 }
 
 // ListChapters mocks base method.

--- a/internal/application/ctrl/ctrlmock/controller_generated.go
+++ b/internal/application/ctrl/ctrlmock/controller_generated.go
@@ -314,18 +314,18 @@ func (mr *MockControllerMockRecorder) ListAccounts(ctx, ledgerName, pageSize, af
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, failuresOnly, pageSize, ledger)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, afterSequence, pageSize, filter)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, failuresOnly, pageSize, ledger any) *gomock.Call {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, afterSequence, pageSize, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, failuresOnly, pageSize, ledger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, afterSequence, pageSize, filter)
 }
 
 // ListChapters mocks base method.

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -212,13 +212,13 @@ func (b *RoutedController) GetLog(ctx context.Context, sequence uint64) (*common
 	return c.GetLog(ctx, sequence)
 }
 
-func (b *RoutedController) ListAuditEntries(ctx context.Context, afterSequence *uint64, failuresOnly bool, pageSize uint32, ledger string) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (b *RoutedController) ListAuditEntries(ctx context.Context, afterSequence *uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	c, _, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ListAuditEntries(ctx, afterSequence, failuresOnly, pageSize, ledger)
+	return c.ListAuditEntries(ctx, afterSequence, pageSize, filter)
 }
 
 func (b *RoutedController) GetAuditEntry(ctx context.Context, sequence uint64) (*auditpb.AuditEntry, error) {

--- a/internal/domain/processing/processor_prepared_query.go
+++ b/internal/domain/processing/processor_prepared_query.go
@@ -42,6 +42,10 @@ func processCreatePreparedQuery(ledger string, order *raftcmdpb.CreatePreparedQu
 		return nil, err
 	}
 
+	if err := domain.ValidatePreparedQueryTarget(q.GetTarget()); err != nil {
+		return nil, err
+	}
+
 	if _, loadErr := loadLedger(s, ledger); loadErr != nil {
 		return nil, loadErr
 	}

--- a/internal/domain/validation.go
+++ b/internal/domain/validation.go
@@ -36,24 +36,25 @@ const maxAccountAddressLength = 1024
 // Storage-safety validation sentinels. All are Describable so they flow
 // through BusinessError with Kind=KindValidation.
 var (
-	ErrLedgerNameContainsNullByte    = newValidationSentinel("ledger name must not contain null bytes")
-	ErrLedgerNameInvalidChar         = newValidationSentinel("ledger name must contain only printable ASCII (0x20–0x7E)")
-	ErrLedgerNameTooLong             = newValidationSentinel(fmt.Sprintf("ledger name exceeds maximum length of %d bytes", maxLedgerNameLength))
-	ErrNumscriptNameInvalidChar      = newValidationSentinel("numscript name must contain only printable ASCII (0x20–0x7E)")
-	ErrNumscriptNameTooLong          = newValidationSentinel(fmt.Sprintf("numscript name exceeds maximum length of %d bytes", maxNumscriptNameLength))
-	ErrPreparedQueryNameRequired     = newValidationSentinel("prepared query name is required")
-	ErrPreparedQueryNameInvalidChar  = newValidationSentinel("prepared query name must contain only printable ASCII (0x20–0x7E)")
-	ErrPreparedQueryNameTooLong      = newValidationSentinel(fmt.Sprintf("prepared query name exceeds maximum length of %d bytes", maxPreparedQueryNameLength))
-	ErrPreparedQueryRequired         = newValidationSentinel("prepared query payload is required")
-	ErrSigningKeyIDRequired          = newValidationSentinel("signing key id is required")
-	ErrSigningKeyIDInvalidChar       = newValidationSentinel("signing key id must contain only printable ASCII (0x20–0x7E)")
-	ErrSigningKeyIDTooLong           = newValidationSentinel(fmt.Sprintf("signing key id exceeds maximum length of %d bytes", maxSigningKeyIDLength))
-	ErrMetadataKeyContainsNullByte   = newValidationSentinel("metadata key must not contain null bytes")
-	ErrMetadataKeyEmpty              = newValidationSentinel("metadata key must not be empty")
-	ErrMetadataValueContainsNullByte = newValidationSentinel("metadata value must not contain null bytes")
-	ErrAccountAddressEmpty           = newValidationSentinel("account address must not be empty")
-	ErrAccountAddressInvalidChar     = newValidationSentinel("account address must contain only letters, digits, colons, underscores, and hyphens")
-	ErrAccountAddressTooLong         = newValidationSentinel(fmt.Sprintf("account address exceeds maximum length of %d bytes", maxAccountAddressLength))
+	ErrLedgerNameContainsNullByte          = newValidationSentinel("ledger name must not contain null bytes")
+	ErrLedgerNameInvalidChar               = newValidationSentinel("ledger name must contain only printable ASCII (0x20–0x7E)")
+	ErrLedgerNameTooLong                   = newValidationSentinel(fmt.Sprintf("ledger name exceeds maximum length of %d bytes", maxLedgerNameLength))
+	ErrNumscriptNameInvalidChar            = newValidationSentinel("numscript name must contain only printable ASCII (0x20–0x7E)")
+	ErrNumscriptNameTooLong                = newValidationSentinel(fmt.Sprintf("numscript name exceeds maximum length of %d bytes", maxNumscriptNameLength))
+	ErrPreparedQueryNameRequired           = newValidationSentinel("prepared query name is required")
+	ErrPreparedQueryNameInvalidChar        = newValidationSentinel("prepared query name must contain only printable ASCII (0x20–0x7E)")
+	ErrPreparedQueryNameTooLong            = newValidationSentinel(fmt.Sprintf("prepared query name exceeds maximum length of %d bytes", maxPreparedQueryNameLength))
+	ErrPreparedQueryRequired               = newValidationSentinel("prepared query payload is required")
+	ErrPreparedQueryAuditTargetUnsupported = newValidationSentinel("prepared queries do not support the audit target; query the audit trail via ListAuditEntries")
+	ErrSigningKeyIDRequired                = newValidationSentinel("signing key id is required")
+	ErrSigningKeyIDInvalidChar             = newValidationSentinel("signing key id must contain only printable ASCII (0x20–0x7E)")
+	ErrSigningKeyIDTooLong                 = newValidationSentinel(fmt.Sprintf("signing key id exceeds maximum length of %d bytes", maxSigningKeyIDLength))
+	ErrMetadataKeyContainsNullByte         = newValidationSentinel("metadata key must not contain null bytes")
+	ErrMetadataKeyEmpty                    = newValidationSentinel("metadata key must not be empty")
+	ErrMetadataValueContainsNullByte       = newValidationSentinel("metadata value must not contain null bytes")
+	ErrAccountAddressEmpty                 = newValidationSentinel("account address must not be empty")
+	ErrAccountAddressInvalidChar           = newValidationSentinel("account address must contain only letters, digits, colons, underscores, and hyphens")
+	ErrAccountAddressTooLong               = newValidationSentinel(fmt.Sprintf("account address exceeds maximum length of %d bytes", maxAccountAddressLength))
 
 	ErrAssetInvalid = newValidationSentinel("asset must match [A-Z][A-Z0-9]{0,16}(_[A-Z]{1,16})?(/[1-9][0-9]{0,2})? with precision in [1, 255]")
 )
@@ -139,6 +140,21 @@ func ValidatePreparedQueryName(name string) Describable {
 
 	if len(name) > maxPreparedQueryNameLength {
 		return ErrPreparedQueryNameTooLong
+	}
+
+	return nil
+}
+
+// ValidatePreparedQueryTarget rejects QUERY_TARGET_AUDIT. The audit trail is
+// served only through ListAuditEntries (which compiles QueryFilter_Audit via
+// query.CompileAuditPredicate); the prepared-query execution path does not
+// dispatch on the audit target, so an audit-targeted prepared query would
+// otherwise be admitted and silently return an empty cursor. The enum value
+// still exists for parity with the other targets (see misc/proto/common.proto),
+// so it is rejected at admission/FSM rather than removed from the wire.
+func ValidatePreparedQueryTarget(target commonpb.QueryTarget) Describable {
+	if target == commonpb.QueryTarget_QUERY_TARGET_AUDIT {
+		return ErrPreparedQueryAuditTargetUnsupported
 	}
 
 	return nil

--- a/internal/pkg/cursor/cursor.go
+++ b/internal/pkg/cursor/cursor.go
@@ -77,6 +77,41 @@ func NewFilteredCursor[T any](inner Cursor[T], predicate func(T) bool) Cursor[T]
 	return &FilteredCursor[T]{inner: inner, predicate: predicate}
 }
 
+// FilteredCursorE wraps a cursor and filters items based on a predicate that may
+// return an error. A predicate error aborts iteration and is returned from Next.
+type FilteredCursorE[T any] struct {
+	inner     Cursor[T]
+	predicate func(T) (bool, error)
+}
+
+func (c *FilteredCursorE[T]) Next() (T, error) {
+	for {
+		item, err := c.inner.Next()
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		ok, perr := c.predicate(item)
+		if perr != nil {
+			var zero T
+			return zero, perr
+		}
+		if ok {
+			return item, nil
+		}
+	}
+}
+
+func (c *FilteredCursorE[T]) Close() error { return c.inner.Close() }
+
+var _ Cursor[any] = (*FilteredCursorE[any])(nil)
+
+// NewFilteredCursorE creates a filtering cursor whose predicate may fail; the
+// failure is surfaced from Next rather than silently dropping the item.
+func NewFilteredCursorE[T any](inner Cursor[T], predicate func(T) (bool, error)) Cursor[T] {
+	return &FilteredCursorE[T]{inner: inner, predicate: predicate}
+}
+
 // LimitedCursor wraps a cursor and limits the number of items returned.
 type LimitedCursor[T any] struct {
 	inner    Cursor[T]

--- a/internal/pkg/cursor/cursor.go
+++ b/internal/pkg/cursor/cursor.go
@@ -89,11 +89,13 @@ func (c *FilteredCursorE[T]) Next() (T, error) {
 		item, err := c.inner.Next()
 		if err != nil {
 			var zero T
+
 			return zero, err
 		}
 		ok, perr := c.predicate(item)
 		if perr != nil {
 			var zero T
+
 			return zero, perr
 		}
 		if ok {

--- a/internal/pkg/cursor/cursor_test.go
+++ b/internal/pkg/cursor/cursor_test.go
@@ -1,6 +1,7 @@
 package cursor
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -171,4 +172,37 @@ func TestLimitedCursor_Close(t *testing.T) {
 	inner := NewSliceCursor([]int{1, 2, 3})
 	cursor := NewLimitedCursor(inner, 2)
 	require.NoError(t, cursor.Close())
+}
+
+func TestNewFilteredCursorE_PropagatesError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("boom")
+	inner := NewSliceCursor([]int{1, 2, 3})
+	c := NewFilteredCursorE(inner, func(v int) (bool, error) {
+		if v == 2 {
+			return false, sentinel
+		}
+		return true, nil
+	})
+	got, err := c.Next()
+	require.NoError(t, err)
+	require.Equal(t, 1, got)
+
+	_, err = c.Next()
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestNewFilteredCursorE_Filters(t *testing.T) {
+	t.Parallel()
+	c := NewFilteredCursorE(NewSliceCursor([]int{1, 2, 3, 4}), func(v int) (bool, error) {
+		return v%2 == 0, nil
+	})
+	got, err := c.Next()
+	require.NoError(t, err)
+	require.Equal(t, 2, got)
+	got, err = c.Next()
+	require.NoError(t, err)
+	require.Equal(t, 4, got)
+	_, err = c.Next()
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/internal/pkg/cursor/cursor_test.go
+++ b/internal/pkg/cursor/cursor_test.go
@@ -182,6 +182,7 @@ func TestNewFilteredCursorE_PropagatesError(t *testing.T) {
 		if v == 2 {
 			return false, sentinel
 		}
+
 		return true, nil
 	})
 	got, err := c.Next()

--- a/internal/pkg/filterexpr/format.go
+++ b/internal/pkg/filterexpr/format.go
@@ -43,6 +43,8 @@ func formatFilter(f *commonpb.QueryFilter) (string, int) {
 		return formatNot(v.Not)
 	case *commonpb.QueryFilter_AccountHasAsset:
 		return formatAccountHasAsset(v.AccountHasAsset), precLeaf
+	case *commonpb.QueryFilter_Audit:
+		return formatAuditCondition(v.Audit), precLeaf
 	default:
 		return "<unknown filter>", precLeaf
 	}
@@ -57,6 +59,79 @@ func formatAccountHasAsset(c *commonpb.AccountHasAssetCondition) string {
 	}
 
 	return fmt.Sprintf("has asset %s/%d", c.GetAssetBase(), c.GetPrecision())
+}
+
+// auditFieldNames is the inverse of auditFieldKeys (parser.go): enum -> DSL key.
+// Keep it in sync with auditFieldKeys — it is the single source of truth for the
+// DSL key strings.
+var auditFieldNames = func() map[commonpb.AuditField]string {
+	m := make(map[commonpb.AuditField]string, len(auditFieldKeys))
+	for key, spec := range auditFieldKeys {
+		m[spec.field] = key
+	}
+
+	return m
+}()
+
+func formatAuditCondition(ac *commonpb.AuditCondition) string {
+	key, ok := auditFieldNames[ac.GetField()]
+	if !ok {
+		return "<unknown audit field>"
+	}
+
+	switch cond := ac.GetCondition().(type) {
+	case *commonpb.AuditCondition_StringCond:
+		return fmt.Sprintf("audit[%s] == %s", key, formatStringCondValue(cond.StringCond))
+	case *commonpb.AuditCondition_UintCond:
+		return fmt.Sprintf("audit[%s] %s", key, formatAuditUintCond(cond.UintCond))
+	case *commonpb.AuditCondition_BoolCond:
+		return fmt.Sprintf("audit[%s] == %s", key, formatBoolCondValue(cond.BoolCond))
+	default:
+		return fmt.Sprintf("audit[%s] <unknown>", key)
+	}
+}
+
+// formatAuditUintCond renders the operator+value tail of an audit uint condition
+// (everything after the `audit[key] ` prefix). It mirrors formatUintCondition's
+// equality/single-bound/range logic but without the metadata key prefix, so it
+// can be reused under the `audit[...]` lead.
+func formatAuditUintCond(uc *commonpb.UintCondition) string {
+	// Equality: min == max, both set, no exclusion.
+	if uc.Min != nil && uc.Max != nil && uc.GetMin() == uc.GetMax() && !uc.GetMinExclusive() && !uc.GetMaxExclusive() {
+		return fmt.Sprintf("== %d", uc.GetMin())
+	}
+
+	hasLow := uc.Min != nil || uc.GetParamMin() != ""
+	hasHigh := uc.Max != nil || uc.GetParamMax() != ""
+
+	if hasLow && hasHigh {
+		return fmt.Sprintf("between %s and %s", formatUintLowInclusive(uc), formatUintHighInclusive(uc))
+	}
+
+	if hasLow {
+		op := ">="
+		if uc.GetMinExclusive() {
+			op = ">"
+		}
+		if uc.GetParamMin() != "" {
+			return fmt.Sprintf("%s $%s", op, uc.GetParamMin())
+		}
+
+		return fmt.Sprintf("%s %d", op, uc.GetMin())
+	}
+	if hasHigh {
+		op := "<="
+		if uc.GetMaxExclusive() {
+			op = "<"
+		}
+		if uc.GetParamMax() != "" {
+			return fmt.Sprintf("%s $%s", op, uc.GetParamMax())
+		}
+
+		return fmt.Sprintf("%s %d", op, uc.GetMax())
+	}
+
+	return "<uint?>"
 }
 
 // formatWithPrec formats a child filter, wrapping it in parentheses if its

--- a/internal/pkg/filterexpr/format_test.go
+++ b/internal/pkg/filterexpr/format_test.go
@@ -667,7 +667,6 @@ func TestFormat_AuditRoundTrip(t *testing.T) {
 		`audit[order_type] == apply`,
 	}
 	for _, in := range inputs {
-		in := in
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
 			f, err := Parse(in)

--- a/internal/pkg/filterexpr/format_test.go
+++ b/internal/pkg/filterexpr/format_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -652,4 +653,29 @@ func TestFormatIntConditionEdgeCases(t *testing.T) {
 		f := intField("x", &commonpb.IntCondition{})
 		assert.Equal(t, "metadata[x] <int?>", Format(f))
 	})
+}
+
+func TestFormat_AuditRoundTrip(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		`audit[outcome] == failure`,
+		`audit[ledger] == "main"`,
+		`audit[caller.god] == true`,
+		`audit[seq] >= 5000`,
+		`audit[proposal_id] between 100 and 200`,
+		`audit[error_type] == "insufficient_funds"`,
+		`audit[order_type] == apply`,
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			f, err := Parse(in)
+			require.NoError(t, err)
+			out := Format(f)
+			reparsed, err := Parse(out)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(f, reparsed), "round-trip mismatch: %q -> %q", in, out)
+		})
+	}
 }

--- a/internal/pkg/filterexpr/parser.go
+++ b/internal/pkg/filterexpr/parser.go
@@ -408,6 +408,7 @@ func (a *AuditCond) toProto() (*commonpb.QueryFilter, error) {
 
 func auditQF(field commonpb.AuditField, cond *commonpb.AuditCondition) *commonpb.QueryFilter {
 	cond.Field = field
+
 	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: cond}}
 }
 
@@ -423,6 +424,7 @@ func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 		if err != nil {
 			return 0, fmt.Errorf("audit field %q requires an unsigned integer, got %q", a.Field, v.resolve())
 		}
+
 		return n, nil
 	}
 	switch {
@@ -437,8 +439,8 @@ func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 		if err != nil {
 			return nil, err
 		}
-		min, max := n, n
-		eq := auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_UintCond{UintCond: &commonpb.UintCondition{Min: &min, Max: &max}}})
+		eq := auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_UintCond{UintCond: &commonpb.UintCondition{Min: &n, Max: &n}}})
+
 		return auditNot(eq), nil
 	case op.Gt != nil:
 		n, err := parse(op.Gt)
@@ -477,6 +479,7 @@ func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 	default:
 		return nil, fmt.Errorf("audit field %q does not support this operator", a.Field)
 	}
+
 	return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_UintCond{UintCond: uc}}), nil
 }
 
@@ -497,6 +500,7 @@ func (a *AuditCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFil
 		for i, v := range op.In {
 			filters[i] = mk(v)
 		}
+
 		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: filters}}}, nil
 	default:
 		return nil, fmt.Errorf("audit field %q only supports ==, != and in", a.Field)
@@ -511,6 +515,7 @@ func (a *AuditCond) boolToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 	if raw != "true" && raw != "false" {
 		return nil, fmt.Errorf("audit field %q requires true or false, got %q", a.Field, raw)
 	}
+
 	return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_BoolCond{
 		BoolCond: &commonpb.BoolCondition{Value: &commonpb.BoolCondition_Hardcoded{Hardcoded: raw == "true"}},
 	}}), nil

--- a/internal/pkg/filterexpr/parser.go
+++ b/internal/pkg/filterexpr/parser.go
@@ -49,7 +49,7 @@ var filterLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Dollar", Pattern: `\$`},
 	{Name: "String", Pattern: `"[^"]*"|'[^']*'`},
 	{Name: "Comma", Pattern: `,`},
-	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|exists|true|false)\b`},
+	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|audit|exists|true|false)\b`},
 	{Name: "Number", Pattern: `-?[0-9]+`},
 	{Name: "Ident", Pattern: `[a-zA-Z_][a-zA-Z0-9_:.\-/]*`},
 })
@@ -182,6 +182,7 @@ func (p *Primary) toProto() (*commonpb.QueryFilter, error) {
 type Condition struct {
 	Asset    *AssetCond    `parser:"  @@"`
 	Metadata *MetadataCond `parser:"| @@"`
+	Audit    *AuditCond    `parser:"| @@"`
 	Address  *AddressCond  `parser:"| @@"`
 	Ledger   *LedgerCond   `parser:"| @@"`
 }
@@ -193,6 +194,10 @@ func (c *Condition) toProto() (*commonpb.QueryFilter, error) {
 
 	if c.Metadata != nil {
 		return c.Metadata.toProto()
+	}
+
+	if c.Audit != nil {
+		return c.Audit.toProto()
 	}
 
 	if c.Ledger != nil {
@@ -344,6 +349,171 @@ func (l *LedgerCond) toProto() (*commonpb.QueryFilter, error) {
 			Ledger: &commonpb.LedgerCondition{Cond: cond},
 		},
 	}, nil
+}
+
+// --- Audit conditions ---
+
+type AuditCond struct {
+	Field string      `parser:"'audit' '[' @(Ident | Keyword) ']'"`
+	Op    *MetadataOp `parser:"@@"`
+}
+
+type auditFieldKind int
+
+const (
+	auditKindUint auditFieldKind = iota
+	auditKindString
+	auditKindBool
+)
+
+type auditFieldSpec struct {
+	field commonpb.AuditField
+	kind  auditFieldKind
+}
+
+// auditFieldKeys maps the DSL field key to its enum + value kind.
+var auditFieldKeys = map[string]auditFieldSpec{
+	"seq":            {commonpb.AuditField_AUDIT_FIELD_SEQUENCE, auditKindUint},
+	"proposal_id":    {commonpb.AuditField_AUDIT_FIELD_PROPOSAL_ID, auditKindUint},
+	"timestamp":      {commonpb.AuditField_AUDIT_FIELD_TIMESTAMP, auditKindUint},
+	"log_seq":        {commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, auditKindUint},
+	"outcome":        {commonpb.AuditField_AUDIT_FIELD_OUTCOME, auditKindString},
+	"error_type":     {commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, auditKindString},
+	"caller.subject": {commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, auditKindString},
+	"caller.scope":   {commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE, auditKindString},
+	"caller.god":     {commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, auditKindBool},
+	"ledger":         {commonpb.AuditField_AUDIT_FIELD_LEDGER, auditKindString},
+	"order_type":     {commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, auditKindString},
+}
+
+func (a *AuditCond) toProto() (*commonpb.QueryFilter, error) {
+	spec, ok := auditFieldKeys[a.Field]
+	if !ok {
+		return nil, fmt.Errorf("unknown audit field %q", a.Field)
+	}
+	if a.Op == nil {
+		return nil, fmt.Errorf("audit field %q requires an operator", a.Field)
+	}
+	switch spec.kind {
+	case auditKindUint:
+		return a.uintToProto(spec.field)
+	case auditKindString:
+		return a.stringToProto(spec.field)
+	case auditKindBool:
+		return a.boolToProto(spec.field)
+	default:
+		return nil, fmt.Errorf("unhandled audit field kind for %q", a.Field)
+	}
+}
+
+func auditQF(field commonpb.AuditField, cond *commonpb.AuditCondition) *commonpb.QueryFilter {
+	cond.Field = field
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: cond}}
+}
+
+func auditNot(inner *commonpb.QueryFilter) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{Filter: inner}}}
+}
+
+func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+	op := a.Op
+	uc := &commonpb.UintCondition{}
+	parse := func(v *Value) (uint64, error) {
+		n, err := strconv.ParseUint(v.resolve(), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("audit field %q requires an unsigned integer, got %q", a.Field, v.resolve())
+		}
+		return n, nil
+	}
+	switch {
+	case op.Eq != nil:
+		n, err := parse(op.Eq)
+		if err != nil {
+			return nil, err
+		}
+		uc.Min, uc.Max = &n, &n
+	case op.Ne != nil:
+		n, err := parse(op.Ne)
+		if err != nil {
+			return nil, err
+		}
+		min, max := n, n
+		eq := auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_UintCond{UintCond: &commonpb.UintCondition{Min: &min, Max: &max}}})
+		return auditNot(eq), nil
+	case op.Gt != nil:
+		n, err := parse(op.Gt)
+		if err != nil {
+			return nil, err
+		}
+		uc.Min, uc.MinExclusive = &n, true
+	case op.Gte != nil:
+		n, err := parse(op.Gte)
+		if err != nil {
+			return nil, err
+		}
+		uc.Min = &n
+	case op.Lt != nil:
+		n, err := parse(op.Lt)
+		if err != nil {
+			return nil, err
+		}
+		uc.Max, uc.MaxExclusive = &n, true
+	case op.Lte != nil:
+		n, err := parse(op.Lte)
+		if err != nil {
+			return nil, err
+		}
+		uc.Max = &n
+	case op.Between != nil:
+		lo, err := parse(op.Between.Low)
+		if err != nil {
+			return nil, err
+		}
+		hi, err := parse(op.Between.High)
+		if err != nil {
+			return nil, err
+		}
+		uc.Min, uc.Max = &lo, &hi
+	default:
+		return nil, fmt.Errorf("audit field %q does not support this operator", a.Field)
+	}
+	return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_UintCond{UintCond: uc}}), nil
+}
+
+func (a *AuditCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+	op := a.Op
+	mk := func(v *Value) *commonpb.QueryFilter {
+		return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_StringCond{
+			StringCond: &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: v.resolve()}},
+		}})
+	}
+	switch {
+	case op.Eq != nil:
+		return mk(op.Eq), nil
+	case op.Ne != nil:
+		return auditNot(mk(op.Ne)), nil
+	case len(op.In) > 0:
+		filters := make([]*commonpb.QueryFilter, len(op.In))
+		for i, v := range op.In {
+			filters[i] = mk(v)
+		}
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: filters}}}, nil
+	default:
+		return nil, fmt.Errorf("audit field %q only supports ==, != and in", a.Field)
+	}
+}
+
+func (a *AuditCond) boolToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+	if a.Op.Eq == nil {
+		return nil, fmt.Errorf("audit field %q only supports ==", a.Field)
+	}
+	raw := a.Op.Eq.resolve()
+	if raw != "true" && raw != "false" {
+		return nil, fmt.Errorf("audit field %q requires true or false, got %q", a.Field, raw)
+	}
+	return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_BoolCond{
+		BoolCond: &commonpb.BoolCondition{Value: &commonpb.BoolCondition_Hardcoded{Hardcoded: raw == "true"}},
+	}}), nil
 }
 
 // --- Address conditions ---

--- a/internal/pkg/filterexpr/parser.go
+++ b/internal/pkg/filterexpr/parser.go
@@ -49,7 +49,7 @@ var filterLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Dollar", Pattern: `\$`},
 	{Name: "String", Pattern: `"[^"]*"|'[^']*'`},
 	{Name: "Comma", Pattern: `,`},
-	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|audit|exists|true|false)\b`},
+	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|exists|true|false)\b`},
 	{Name: "Number", Pattern: `-?[0-9]+`},
 	{Name: "Ident", Pattern: `[a-zA-Z_][a-zA-Z0-9_:.\-/]*`},
 })

--- a/internal/pkg/filterexpr/parser.go
+++ b/internal/pkg/filterexpr/parser.go
@@ -485,20 +485,36 @@ func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 
 func (a *AuditCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
 	op := a.Op
-	mk := func(v *Value) *commonpb.QueryFilter {
+	// Audit filters are evaluated at scan time with no parameter-resolution
+	// context, so a $param value cannot be honored — reject it rather than
+	// letting it degrade to a match against the empty string.
+	mk := func(v *Value) (*commonpb.QueryFilter, error) {
+		if v.Param != "" {
+			return nil, fmt.Errorf("audit field %q does not support parameters", a.Field)
+		}
+
 		return auditQF(field, &commonpb.AuditCondition{Condition: &commonpb.AuditCondition_StringCond{
 			StringCond: &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: v.resolve()}},
-		}})
+		}}), nil
 	}
 	switch {
 	case op.Eq != nil:
-		return mk(op.Eq), nil
+		return mk(op.Eq)
 	case op.Ne != nil:
-		return auditNot(mk(op.Ne)), nil
+		inner, err := mk(op.Ne)
+		if err != nil {
+			return nil, err
+		}
+
+		return auditNot(inner), nil
 	case len(op.In) > 0:
 		filters := make([]*commonpb.QueryFilter, len(op.In))
 		for i, v := range op.In {
-			filters[i] = mk(v)
+			f, err := mk(v)
+			if err != nil {
+				return nil, err
+			}
+			filters[i] = f
 		}
 
 		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: filters}}}, nil

--- a/internal/pkg/filterexpr/parser_test.go
+++ b/internal/pkg/filterexpr/parser_test.go
@@ -1055,3 +1055,71 @@ func TestParse_HasAssetKeywordsNotReserved(t *testing.T) {
 		assert.Equal(t, "has:wallet", f.GetAddress().GetHardcodedPrefix())
 	})
 }
+
+func TestParse_Audit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("outcome string", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[outcome] == failure`)
+		require.NoError(t, err)
+		ac := f.GetAudit()
+		require.NotNil(t, ac)
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_OUTCOME, ac.GetField())
+		require.Equal(t, "failure", ac.GetStringCond().GetHardcoded())
+	})
+
+	t.Run("uint range between", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[proposal_id] between 100 and 200`)
+		require.NoError(t, err)
+		ac := f.GetAudit()
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_PROPOSAL_ID, ac.GetField())
+		require.Equal(t, uint64(100), ac.GetUintCond().GetMin())
+		require.Equal(t, uint64(200), ac.GetUintCond().GetMax())
+	})
+
+	t.Run("uint gte", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[seq] >= 5000`)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5000), f.GetAudit().GetUintCond().GetMin())
+		require.False(t, f.GetAudit().GetUintCond().GetMinExclusive())
+	})
+
+	t.Run("bool god", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[caller.god] == true`)
+		require.NoError(t, err)
+		require.True(t, f.GetAudit().GetBoolCond().GetHardcoded())
+	})
+
+	t.Run("order_type in", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[order_type] in (apply, save_numscript)`)
+		require.NoError(t, err)
+		require.NotNil(t, f.GetOr())
+		require.Len(t, f.GetOr().GetFilters(), 2)
+		require.Equal(t, "apply", f.GetOr().GetFilters()[0].GetAudit().GetStringCond().GetHardcoded())
+	})
+
+	t.Run("ne becomes not", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[error_type] != "x"`)
+		require.NoError(t, err)
+		require.NotNil(t, f.GetNot())
+		require.Equal(t, "x", f.GetNot().GetFilter().GetAudit().GetStringCond().GetHardcoded())
+	})
+
+	t.Run("unknown field rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse(`audit[bogus] == 1`)
+		require.Error(t, err)
+	})
+
+	t.Run("string range rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := Parse(`audit[outcome] >= 1`)
+		require.Error(t, err)
+	})
+}

--- a/internal/pkg/filterexpr/parser_test.go
+++ b/internal/pkg/filterexpr/parser_test.go
@@ -1122,4 +1122,18 @@ func TestParse_Audit(t *testing.T) {
 		_, err := Parse(`audit[outcome] >= 1`)
 		require.Error(t, err)
 	})
+
+	t.Run("parameterized string field rejected", func(t *testing.T) {
+		t.Parallel()
+		// Audit filters are evaluated at scan time with no parameter context,
+		// so a $param must be rejected rather than degrade to an empty match.
+		for _, expr := range []string{
+			`audit[caller.subject] == $user`,
+			`audit[ledger] != $l`,
+			`audit[order_type] in (apply, $other)`,
+		} {
+			_, err := Parse(expr)
+			require.Error(t, err, "expr: %s", expr)
+		}
+	})
 }

--- a/internal/pkg/filterexpr/parser_test.go
+++ b/internal/pkg/filterexpr/parser_test.go
@@ -1137,3 +1137,33 @@ func TestParse_Audit(t *testing.T) {
 		}
 	})
 }
+
+// TestParse_AuditNotReservedAsBareValue guards against reserving "audit" as a
+// global keyword. The audit condition leader is matched as a grammar literal
+// (which participle matches against an Ident token), so "audit" must stay usable
+// as a bare value in metadata/address filters, e.g. metadata[type] == audit.
+func TestParse_AuditNotReservedAsBareValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata bare audit value", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`metadata[type] == audit`)
+		require.NoError(t, err)
+		require.Equal(t, "audit", f.GetField().GetStringCond().GetHardcoded())
+	})
+
+	t.Run("address bare audit value", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`address == audit`)
+		require.NoError(t, err)
+		require.Equal(t, "audit", f.GetAddress().GetHardcodedExact())
+	})
+
+	t.Run("audit condition still parses", func(t *testing.T) {
+		t.Parallel()
+		f, err := Parse(`audit[seq] == 1`)
+		require.NoError(t, err)
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_SEQUENCE, f.GetAudit().GetField())
+		require.Equal(t, uint64(1), f.GetAudit().GetUintCond().GetMin())
+	})
+}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -8752,8 +8752,14 @@ func (x *AccountHasAssetCondition) GetPrecision() uint32 {
 }
 
 // AuditCondition filters audit entries by a single audit field. Mirrors
-// BuiltinUintCondition's (field-enum x condition) shape. Only valid under
-// QUERY_TARGET_AUDIT; rejected with InvalidArgument on any other target.
+// BuiltinUintCondition's (field-enum x condition) shape. Enforcement is
+// structural, not via QueryTarget: the audit predicate compiler
+// (query.CompileAuditPredicate) accepts only Audit/And/Or/Not nodes and
+// rejects every other condition with InvalidArgument, while the index
+// compiler (query.Compile, used for accounts/transactions/logs) never lists
+// QueryFilter_Audit in its switch and so rejects it there. QUERY_TARGET_AUDIT
+// exists for parity with the other targets (e.g. prepared-query metadata); the
+// scan-time audit path does not dispatch on it.
 type AuditCondition struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Field AuditField             `protobuf:"varint,1,opt,name=field,proto3,enum=common.AuditField" json:"field,omitempty"`

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -947,7 +947,7 @@ const (
 	AuditField_AUDIT_FIELD_UNSPECIFIED    AuditField = 0
 	AuditField_AUDIT_FIELD_SEQUENCE       AuditField = 1  // uint   -> AuditEntry.sequence
 	AuditField_AUDIT_FIELD_PROPOSAL_ID    AuditField = 2  // uint   -> AuditEntry.proposal_id
-	AuditField_AUDIT_FIELD_TIMESTAMP      AuditField = 3  // uint   -> AuditEntry.timestamp.data (unix nanos)
+	AuditField_AUDIT_FIELD_TIMESTAMP      AuditField = 3  // uint   -> AuditEntry.timestamp.data (unix micros)
 	AuditField_AUDIT_FIELD_LOG_SEQUENCE   AuditField = 4  // uint   -> overlaps [success.min,max]_log_sequence
 	AuditField_AUDIT_FIELD_OUTCOME        AuditField = 5  // string in {success, failure}
 	AuditField_AUDIT_FIELD_ERROR_TYPE     AuditField = 6  // string -> failure.error_type

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -941,6 +941,82 @@ func (AccountTypePersistence) EnumDescriptor() ([]byte, []int) {
 	return file_common_proto_rawDescGZIP(), []int{13}
 }
 
+type AuditField int32
+
+const (
+	AuditField_AUDIT_FIELD_UNSPECIFIED    AuditField = 0
+	AuditField_AUDIT_FIELD_SEQUENCE       AuditField = 1  // uint   -> AuditEntry.sequence
+	AuditField_AUDIT_FIELD_PROPOSAL_ID    AuditField = 2  // uint   -> AuditEntry.proposal_id
+	AuditField_AUDIT_FIELD_TIMESTAMP      AuditField = 3  // uint   -> AuditEntry.timestamp.data (unix nanos)
+	AuditField_AUDIT_FIELD_LOG_SEQUENCE   AuditField = 4  // uint   -> overlaps [success.min,max]_log_sequence
+	AuditField_AUDIT_FIELD_OUTCOME        AuditField = 5  // string in {success, failure}
+	AuditField_AUDIT_FIELD_ERROR_TYPE     AuditField = 6  // string -> failure.error_type
+	AuditField_AUDIT_FIELD_CALLER_SUBJECT AuditField = 7  // string -> caller_snapshot.identity.subject
+	AuditField_AUDIT_FIELD_CALLER_SCOPE   AuditField = 8  // string -> caller_snapshot.scopes (contains)
+	AuditField_AUDIT_FIELD_CALLER_GOD     AuditField = 9  // bool   -> caller_snapshot.god
+	AuditField_AUDIT_FIELD_LEDGER         AuditField = 10 // string -> AuditEntry.ledgers (contains)
+	AuditField_AUDIT_FIELD_ORDER_TYPE     AuditField = 11 // string -> order payload variant (contains, lazy)
+)
+
+// Enum value maps for AuditField.
+var (
+	AuditField_name = map[int32]string{
+		0:  "AUDIT_FIELD_UNSPECIFIED",
+		1:  "AUDIT_FIELD_SEQUENCE",
+		2:  "AUDIT_FIELD_PROPOSAL_ID",
+		3:  "AUDIT_FIELD_TIMESTAMP",
+		4:  "AUDIT_FIELD_LOG_SEQUENCE",
+		5:  "AUDIT_FIELD_OUTCOME",
+		6:  "AUDIT_FIELD_ERROR_TYPE",
+		7:  "AUDIT_FIELD_CALLER_SUBJECT",
+		8:  "AUDIT_FIELD_CALLER_SCOPE",
+		9:  "AUDIT_FIELD_CALLER_GOD",
+		10: "AUDIT_FIELD_LEDGER",
+		11: "AUDIT_FIELD_ORDER_TYPE",
+	}
+	AuditField_value = map[string]int32{
+		"AUDIT_FIELD_UNSPECIFIED":    0,
+		"AUDIT_FIELD_SEQUENCE":       1,
+		"AUDIT_FIELD_PROPOSAL_ID":    2,
+		"AUDIT_FIELD_TIMESTAMP":      3,
+		"AUDIT_FIELD_LOG_SEQUENCE":   4,
+		"AUDIT_FIELD_OUTCOME":        5,
+		"AUDIT_FIELD_ERROR_TYPE":     6,
+		"AUDIT_FIELD_CALLER_SUBJECT": 7,
+		"AUDIT_FIELD_CALLER_SCOPE":   8,
+		"AUDIT_FIELD_CALLER_GOD":     9,
+		"AUDIT_FIELD_LEDGER":         10,
+		"AUDIT_FIELD_ORDER_TYPE":     11,
+	}
+)
+
+func (x AuditField) Enum() *AuditField {
+	p := new(AuditField)
+	*p = x
+	return p
+}
+
+func (x AuditField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AuditField) Descriptor() protoreflect.EnumDescriptor {
+	return file_common_proto_enumTypes[14].Descriptor()
+}
+
+func (AuditField) Type() protoreflect.EnumType {
+	return &file_common_proto_enumTypes[14]
+}
+
+func (x AuditField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AuditField.Descriptor instead.
+func (AuditField) EnumDescriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{14}
+}
+
 type AddressRole int32
 
 const (
@@ -974,11 +1050,11 @@ func (x AddressRole) String() string {
 }
 
 func (AddressRole) Descriptor() protoreflect.EnumDescriptor {
-	return file_common_proto_enumTypes[14].Descriptor()
+	return file_common_proto_enumTypes[15].Descriptor()
 }
 
 func (AddressRole) Type() protoreflect.EnumType {
-	return &file_common_proto_enumTypes[14]
+	return &file_common_proto_enumTypes[15]
 }
 
 func (x AddressRole) Number() protoreflect.EnumNumber {
@@ -987,7 +1063,7 @@ func (x AddressRole) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AddressRole.Descriptor instead.
 func (AddressRole) EnumDescriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{14}
+	return file_common_proto_rawDescGZIP(), []int{15}
 }
 
 type QueryTarget int32
@@ -996,6 +1072,7 @@ const (
 	QueryTarget_QUERY_TARGET_ACCOUNTS     QueryTarget = 0
 	QueryTarget_QUERY_TARGET_TRANSACTIONS QueryTarget = 1
 	QueryTarget_QUERY_TARGET_LOGS         QueryTarget = 2
+	QueryTarget_QUERY_TARGET_AUDIT        QueryTarget = 3
 )
 
 // Enum value maps for QueryTarget.
@@ -1004,11 +1081,13 @@ var (
 		0: "QUERY_TARGET_ACCOUNTS",
 		1: "QUERY_TARGET_TRANSACTIONS",
 		2: "QUERY_TARGET_LOGS",
+		3: "QUERY_TARGET_AUDIT",
 	}
 	QueryTarget_value = map[string]int32{
 		"QUERY_TARGET_ACCOUNTS":     0,
 		"QUERY_TARGET_TRANSACTIONS": 1,
 		"QUERY_TARGET_LOGS":         2,
+		"QUERY_TARGET_AUDIT":        3,
 	}
 )
 
@@ -1023,11 +1102,11 @@ func (x QueryTarget) String() string {
 }
 
 func (QueryTarget) Descriptor() protoreflect.EnumDescriptor {
-	return file_common_proto_enumTypes[15].Descriptor()
+	return file_common_proto_enumTypes[16].Descriptor()
 }
 
 func (QueryTarget) Type() protoreflect.EnumType {
-	return &file_common_proto_enumTypes[15]
+	return &file_common_proto_enumTypes[16]
 }
 
 func (x QueryTarget) Number() protoreflect.EnumNumber {
@@ -1036,7 +1115,7 @@ func (x QueryTarget) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use QueryTarget.Descriptor instead.
 func (QueryTarget) EnumDescriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{15}
+	return file_common_proto_rawDescGZIP(), []int{16}
 }
 
 type QueryMode int32
@@ -1069,11 +1148,11 @@ func (x QueryMode) String() string {
 }
 
 func (QueryMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_common_proto_enumTypes[16].Descriptor()
+	return file_common_proto_enumTypes[17].Descriptor()
 }
 
 func (QueryMode) Type() protoreflect.EnumType {
-	return &file_common_proto_enumTypes[16]
+	return &file_common_proto_enumTypes[17]
 }
 
 func (x QueryMode) Number() protoreflect.EnumNumber {
@@ -1082,7 +1161,7 @@ func (x QueryMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use QueryMode.Descriptor instead.
 func (QueryMode) EnumDescriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{16}
+	return file_common_proto_rawDescGZIP(), []int{17}
 }
 
 type Timestamp struct {
@@ -8148,6 +8227,7 @@ type QueryFilter struct {
 	//	*QueryFilter_LogId
 	//	*QueryFilter_LogBuiltinUint
 	//	*QueryFilter_AccountHasAsset
+	//	*QueryFilter_Audit
 	Filter        isQueryFilter_Filter `protobuf_oneof:"filter"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -8289,6 +8369,15 @@ func (x *QueryFilter) GetAccountHasAsset() *AccountHasAssetCondition {
 	return nil
 }
 
+func (x *QueryFilter) GetAudit() *AuditCondition {
+	if x != nil {
+		if x, ok := x.Filter.(*QueryFilter_Audit); ok {
+			return x.Audit
+		}
+	}
+	return nil
+}
+
 type isQueryFilter_Filter interface {
 	isQueryFilter_Filter()
 }
@@ -8337,6 +8426,10 @@ type QueryFilter_AccountHasAsset struct {
 	AccountHasAsset *AccountHasAssetCondition `protobuf:"bytes,11,opt,name=account_has_asset,json=accountHasAsset,proto3,oneof"`
 }
 
+type QueryFilter_Audit struct {
+	Audit *AuditCondition `protobuf:"bytes,12,opt,name=audit,proto3,oneof"`
+}
+
 func (*QueryFilter_Field) isQueryFilter_Filter() {}
 
 func (*QueryFilter_Address) isQueryFilter_Filter() {}
@@ -8358,6 +8451,8 @@ func (*QueryFilter_LogId) isQueryFilter_Filter() {}
 func (*QueryFilter_LogBuiltinUint) isQueryFilter_Filter() {}
 
 func (*QueryFilter_AccountHasAsset) isQueryFilter_Filter() {}
+
+func (*QueryFilter_Audit) isQueryFilter_Filter() {}
 
 // ReferenceCondition filters transactions by reference (exact match).
 type ReferenceCondition struct {
@@ -8656,6 +8751,115 @@ func (x *AccountHasAssetCondition) GetPrecision() uint32 {
 	return 0
 }
 
+// AuditCondition filters audit entries by a single audit field. Mirrors
+// BuiltinUintCondition's (field-enum x condition) shape. Only valid under
+// QUERY_TARGET_AUDIT; rejected with InvalidArgument on any other target.
+type AuditCondition struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Field AuditField             `protobuf:"varint,1,opt,name=field,proto3,enum=common.AuditField" json:"field,omitempty"`
+	// Types that are valid to be assigned to Condition:
+	//
+	//	*AuditCondition_StringCond
+	//	*AuditCondition_UintCond
+	//	*AuditCondition_BoolCond
+	Condition     isAuditCondition_Condition `protobuf_oneof:"condition"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditCondition) Reset() {
+	*x = AuditCondition{}
+	mi := &file_common_proto_msgTypes[109]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditCondition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditCondition) ProtoMessage() {}
+
+func (x *AuditCondition) ProtoReflect() protoreflect.Message {
+	mi := &file_common_proto_msgTypes[109]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditCondition.ProtoReflect.Descriptor instead.
+func (*AuditCondition) Descriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{109}
+}
+
+func (x *AuditCondition) GetField() AuditField {
+	if x != nil {
+		return x.Field
+	}
+	return AuditField_AUDIT_FIELD_UNSPECIFIED
+}
+
+func (x *AuditCondition) GetCondition() isAuditCondition_Condition {
+	if x != nil {
+		return x.Condition
+	}
+	return nil
+}
+
+func (x *AuditCondition) GetStringCond() *StringCondition {
+	if x != nil {
+		if x, ok := x.Condition.(*AuditCondition_StringCond); ok {
+			return x.StringCond
+		}
+	}
+	return nil
+}
+
+func (x *AuditCondition) GetUintCond() *UintCondition {
+	if x != nil {
+		if x, ok := x.Condition.(*AuditCondition_UintCond); ok {
+			return x.UintCond
+		}
+	}
+	return nil
+}
+
+func (x *AuditCondition) GetBoolCond() *BoolCondition {
+	if x != nil {
+		if x, ok := x.Condition.(*AuditCondition_BoolCond); ok {
+			return x.BoolCond
+		}
+	}
+	return nil
+}
+
+type isAuditCondition_Condition interface {
+	isAuditCondition_Condition()
+}
+
+type AuditCondition_StringCond struct {
+	StringCond *StringCondition `protobuf:"bytes,2,opt,name=string_cond,json=stringCond,proto3,oneof"`
+}
+
+type AuditCondition_UintCond struct {
+	UintCond *UintCondition `protobuf:"bytes,3,opt,name=uint_cond,json=uintCond,proto3,oneof"`
+}
+
+type AuditCondition_BoolCond struct {
+	BoolCond *BoolCondition `protobuf:"bytes,4,opt,name=bool_cond,json=boolCond,proto3,oneof"`
+}
+
+func (*AuditCondition_StringCond) isAuditCondition_Condition() {}
+
+func (*AuditCondition_UintCond) isAuditCondition_Condition() {}
+
+func (*AuditCondition_BoolCond) isAuditCondition_Condition() {}
+
 type AndFilter struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Filters       []*QueryFilter         `protobuf:"bytes,1,rep,name=filters,proto3" json:"filters,omitempty"`
@@ -8665,7 +8869,7 @@ type AndFilter struct {
 
 func (x *AndFilter) Reset() {
 	*x = AndFilter{}
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8677,7 +8881,7 @@ func (x *AndFilter) String() string {
 func (*AndFilter) ProtoMessage() {}
 
 func (x *AndFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8690,7 +8894,7 @@ func (x *AndFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AndFilter.ProtoReflect.Descriptor instead.
 func (*AndFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{109}
+	return file_common_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *AndFilter) GetFilters() []*QueryFilter {
@@ -8709,7 +8913,7 @@ type OrFilter struct {
 
 func (x *OrFilter) Reset() {
 	*x = OrFilter{}
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8721,7 +8925,7 @@ func (x *OrFilter) String() string {
 func (*OrFilter) ProtoMessage() {}
 
 func (x *OrFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8734,7 +8938,7 @@ func (x *OrFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OrFilter.ProtoReflect.Descriptor instead.
 func (*OrFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{110}
+	return file_common_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *OrFilter) GetFilters() []*QueryFilter {
@@ -8753,7 +8957,7 @@ type NotFilter struct {
 
 func (x *NotFilter) Reset() {
 	*x = NotFilter{}
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8765,7 +8969,7 @@ func (x *NotFilter) String() string {
 func (*NotFilter) ProtoMessage() {}
 
 func (x *NotFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8778,7 +8982,7 @@ func (x *NotFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotFilter.ProtoReflect.Descriptor instead.
 func (*NotFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{111}
+	return file_common_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *NotFilter) GetFilter() *QueryFilter {
@@ -8800,7 +9004,7 @@ type FieldRef struct {
 
 func (x *FieldRef) Reset() {
 	*x = FieldRef{}
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8812,7 +9016,7 @@ func (x *FieldRef) String() string {
 func (*FieldRef) ProtoMessage() {}
 
 func (x *FieldRef) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8825,7 +9029,7 @@ func (x *FieldRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldRef.ProtoReflect.Descriptor instead.
 func (*FieldRef) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{112}
+	return file_common_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *FieldRef) GetMetadata() string {
@@ -8853,7 +9057,7 @@ type FieldCondition struct {
 
 func (x *FieldCondition) Reset() {
 	*x = FieldCondition{}
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8865,7 +9069,7 @@ func (x *FieldCondition) String() string {
 func (*FieldCondition) ProtoMessage() {}
 
 func (x *FieldCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8878,7 +9082,7 @@ func (x *FieldCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldCondition.ProtoReflect.Descriptor instead.
 func (*FieldCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{113}
+	return file_common_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *FieldCondition) GetField() *FieldRef {
@@ -8987,7 +9191,7 @@ type StringCondition struct {
 
 func (x *StringCondition) Reset() {
 	*x = StringCondition{}
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8999,7 +9203,7 @@ func (x *StringCondition) String() string {
 func (*StringCondition) ProtoMessage() {}
 
 func (x *StringCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9012,7 +9216,7 @@ func (x *StringCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringCondition.ProtoReflect.Descriptor instead.
 func (*StringCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{114}
+	return file_common_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *StringCondition) GetValue() isStringCondition_Value {
@@ -9070,7 +9274,7 @@ type IntCondition struct {
 
 func (x *IntCondition) Reset() {
 	*x = IntCondition{}
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9082,7 +9286,7 @@ func (x *IntCondition) String() string {
 func (*IntCondition) ProtoMessage() {}
 
 func (x *IntCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9095,7 +9299,7 @@ func (x *IntCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntCondition.ProtoReflect.Descriptor instead.
 func (*IntCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{115}
+	return file_common_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *IntCondition) GetMin() int64 {
@@ -9154,7 +9358,7 @@ type UintCondition struct {
 
 func (x *UintCondition) Reset() {
 	*x = UintCondition{}
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9166,7 +9370,7 @@ func (x *UintCondition) String() string {
 func (*UintCondition) ProtoMessage() {}
 
 func (x *UintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9179,7 +9383,7 @@ func (x *UintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UintCondition.ProtoReflect.Descriptor instead.
 func (*UintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{116}
+	return file_common_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *UintCondition) GetMin() uint64 {
@@ -9237,7 +9441,7 @@ type BoolCondition struct {
 
 func (x *BoolCondition) Reset() {
 	*x = BoolCondition{}
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9249,7 +9453,7 @@ func (x *BoolCondition) String() string {
 func (*BoolCondition) ProtoMessage() {}
 
 func (x *BoolCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9262,7 +9466,7 @@ func (x *BoolCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoolCondition.ProtoReflect.Descriptor instead.
 func (*BoolCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{117}
+	return file_common_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *BoolCondition) GetValue() isBoolCondition_Value {
@@ -9315,7 +9519,7 @@ type ExistsCondition struct {
 
 func (x *ExistsCondition) Reset() {
 	*x = ExistsCondition{}
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9327,7 +9531,7 @@ func (x *ExistsCondition) String() string {
 func (*ExistsCondition) ProtoMessage() {}
 
 func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9340,7 +9544,7 @@ func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExistsCondition.ProtoReflect.Descriptor instead.
 func (*ExistsCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{118}
+	return file_common_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ExistsCondition) GetIncludeNull() bool {
@@ -9366,7 +9570,7 @@ type AddressMatch struct {
 
 func (x *AddressMatch) Reset() {
 	*x = AddressMatch{}
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9378,7 +9582,7 @@ func (x *AddressMatch) String() string {
 func (*AddressMatch) ProtoMessage() {}
 
 func (x *AddressMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9391,7 +9595,7 @@ func (x *AddressMatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddressMatch.ProtoReflect.Descriptor instead.
 func (*AddressMatch) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{119}
+	return file_common_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *AddressMatch) GetMatch() isAddressMatch_Match {
@@ -9487,7 +9691,7 @@ type PreparedQuery struct {
 
 func (x *PreparedQuery) Reset() {
 	*x = PreparedQuery{}
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9499,7 +9703,7 @@ func (x *PreparedQuery) String() string {
 func (*PreparedQuery) ProtoMessage() {}
 
 func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9512,7 +9716,7 @@ func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQuery.ProtoReflect.Descriptor instead.
 func (*PreparedQuery) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{120}
+	return file_common_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *PreparedQuery) GetName() string {
@@ -9548,7 +9752,7 @@ type AggregatedVolume struct {
 
 func (x *AggregatedVolume) Reset() {
 	*x = AggregatedVolume{}
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9560,7 +9764,7 @@ func (x *AggregatedVolume) String() string {
 func (*AggregatedVolume) ProtoMessage() {}
 
 func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9573,7 +9777,7 @@ func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregatedVolume.ProtoReflect.Descriptor instead.
 func (*AggregatedVolume) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{121}
+	return file_common_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AggregatedVolume) GetAsset() string {
@@ -9608,7 +9812,7 @@ type AggregateResult struct {
 
 func (x *AggregateResult) Reset() {
 	*x = AggregateResult{}
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9620,7 +9824,7 @@ func (x *AggregateResult) String() string {
 func (*AggregateResult) ProtoMessage() {}
 
 func (x *AggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9633,7 +9837,7 @@ func (x *AggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregateResult.ProtoReflect.Descriptor instead.
 func (*AggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{122}
+	return file_common_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AggregateResult) GetVolumes() []*AggregatedVolume {
@@ -9661,7 +9865,7 @@ type GroupedAggregateResult struct {
 
 func (x *GroupedAggregateResult) Reset() {
 	*x = GroupedAggregateResult{}
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9673,7 +9877,7 @@ func (x *GroupedAggregateResult) String() string {
 func (*GroupedAggregateResult) ProtoMessage() {}
 
 func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9686,7 +9890,7 @@ func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupedAggregateResult.ProtoReflect.Descriptor instead.
 func (*GroupedAggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{123}
+	return file_common_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *GroupedAggregateResult) GetPrefix() string {
@@ -9718,7 +9922,7 @@ type PreparedQueryCursor struct {
 
 func (x *PreparedQueryCursor) Reset() {
 	*x = PreparedQueryCursor{}
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9730,7 +9934,7 @@ func (x *PreparedQueryCursor) String() string {
 func (*PreparedQueryCursor) ProtoMessage() {}
 
 func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9743,7 +9947,7 @@ func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQueryCursor.ProtoReflect.Descriptor instead.
 func (*PreparedQueryCursor) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{124}
+	return file_common_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *PreparedQueryCursor) GetPageSize() uint32 {
@@ -9807,7 +10011,7 @@ type LedgerStats struct {
 
 func (x *LedgerStats) Reset() {
 	*x = LedgerStats{}
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9819,7 +10023,7 @@ func (x *LedgerStats) String() string {
 func (*LedgerStats) ProtoMessage() {}
 
 func (x *LedgerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9832,7 +10036,7 @@ func (x *LedgerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerStats.ProtoReflect.Descriptor instead.
 func (*LedgerStats) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{125}
+	return file_common_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *LedgerStats) GetTransactionCount() uint64 {
@@ -9920,7 +10124,7 @@ type PersistedConfig struct {
 
 func (x *PersistedConfig) Reset() {
 	*x = PersistedConfig{}
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9932,7 +10136,7 @@ func (x *PersistedConfig) String() string {
 func (*PersistedConfig) ProtoMessage() {}
 
 func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9945,7 +10149,7 @@ func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistedConfig.ProtoReflect.Descriptor instead.
 func (*PersistedConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{126}
+	return file_common_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *PersistedConfig) GetNodeId() uint64 {
@@ -9998,7 +10202,7 @@ type CallerIdentity struct {
 
 func (x *CallerIdentity) Reset() {
 	*x = CallerIdentity{}
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10010,7 +10214,7 @@ func (x *CallerIdentity) String() string {
 func (*CallerIdentity) ProtoMessage() {}
 
 func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10023,7 +10227,7 @@ func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerIdentity.ProtoReflect.Descriptor instead.
 func (*CallerIdentity) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{127}
+	return file_common_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *CallerIdentity) GetSubject() string {
@@ -10094,7 +10298,7 @@ type CallerSnapshot struct {
 
 func (x *CallerSnapshot) Reset() {
 	*x = CallerSnapshot{}
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10106,7 +10310,7 @@ func (x *CallerSnapshot) String() string {
 func (*CallerSnapshot) ProtoMessage() {}
 
 func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10119,7 +10323,7 @@ func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerSnapshot.ProtoReflect.Descriptor instead.
 func (*CallerSnapshot) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{128}
+	return file_common_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *CallerSnapshot) GetIdentity() *CallerIdentity {
@@ -10157,7 +10361,7 @@ type S3StorageConfig struct {
 
 func (x *S3StorageConfig) Reset() {
 	*x = S3StorageConfig{}
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10169,7 +10373,7 @@ func (x *S3StorageConfig) String() string {
 func (*S3StorageConfig) ProtoMessage() {}
 
 func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10182,7 +10386,7 @@ func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3StorageConfig.ProtoReflect.Descriptor instead.
 func (*S3StorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{129}
+	return file_common_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *S3StorageConfig) GetBucket() string {
@@ -10233,7 +10437,7 @@ type AzureStorageConfig struct {
 
 func (x *AzureStorageConfig) Reset() {
 	*x = AzureStorageConfig{}
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10245,7 +10449,7 @@ func (x *AzureStorageConfig) String() string {
 func (*AzureStorageConfig) ProtoMessage() {}
 
 func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10258,7 +10462,7 @@ func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureStorageConfig.ProtoReflect.Descriptor instead.
 func (*AzureStorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{130}
+	return file_common_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *AzureStorageConfig) GetAccountName() string {
@@ -10305,7 +10509,7 @@ type BackupStorage struct {
 
 func (x *BackupStorage) Reset() {
 	*x = BackupStorage{}
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10317,7 +10521,7 @@ func (x *BackupStorage) String() string {
 func (*BackupStorage) ProtoMessage() {}
 
 func (x *BackupStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10330,7 +10534,7 @@ func (x *BackupStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupStorage.ProtoReflect.Descriptor instead.
 func (*BackupStorage) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{131}
+	return file_common_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *BackupStorage) GetProvider() isBackupStorage_Provider {
@@ -10393,7 +10597,7 @@ type ReadOptions struct {
 
 func (x *ReadOptions) Reset() {
 	*x = ReadOptions{}
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10405,7 +10609,7 @@ func (x *ReadOptions) String() string {
 func (*ReadOptions) ProtoMessage() {}
 
 func (x *ReadOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10418,7 +10622,7 @@ func (x *ReadOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadOptions.ProtoReflect.Descriptor instead.
 func (*ReadOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{132}
+	return file_common_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *ReadOptions) GetCheckpointId() uint64 {
@@ -10470,7 +10674,7 @@ type ListOptions struct {
 
 func (x *ListOptions) Reset() {
 	*x = ListOptions{}
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10482,7 +10686,7 @@ func (x *ListOptions) String() string {
 func (*ListOptions) ProtoMessage() {}
 
 func (x *ListOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10495,7 +10699,7 @@ func (x *ListOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOptions.ProtoReflect.Descriptor instead.
 func (*ListOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{133}
+	return file_common_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *ListOptions) GetRead() *ReadOptions {
@@ -11086,7 +11290,7 @@ const file_common_proto_rawDesc = "" +
 	"\x15RemovedAccountTypeLog\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"k\n" +
 	" UpdatedDefaultEnforcementModeLog\x12G\n" +
-	"\x10enforcement_mode\x18\x01 \x01(\x0e2\x1c.common.ChartEnforcementModeR\x0fenforcementMode\"\xeb\x04\n" +
+	"\x10enforcement_mode\x18\x01 \x01(\x0e2\x1c.common.ChartEnforcementModeR\x0fenforcementMode\"\x9b\x05\n" +
 	"\vQueryFilter\x12.\n" +
 	"\x05field\x18\x01 \x01(\v2\x16.common.FieldConditionH\x00R\x05field\x120\n" +
 	"\aaddress\x18\x02 \x01(\v2\x14.common.AddressMatchH\x00R\aaddress\x12%\n" +
@@ -11099,7 +11303,8 @@ const file_common_proto_rawDesc = "" +
 	"\x06log_id\x18\t \x01(\v2\x16.common.LogIdConditionH\x00R\x05logId\x12K\n" +
 	"\x10log_builtin_uint\x18\n" +
 	" \x01(\v2\x1f.common.LogBuiltinUintConditionH\x00R\x0elogBuiltinUint\x12N\n" +
-	"\x11account_has_asset\x18\v \x01(\v2 .common.AccountHasAssetConditionH\x00R\x0faccountHasAssetB\b\n" +
+	"\x11account_has_asset\x18\v \x01(\v2 .common.AccountHasAssetConditionH\x00R\x0faccountHasAsset\x12.\n" +
+	"\x05audit\x18\f \x01(\v2\x16.common.AuditConditionH\x00R\x05auditB\b\n" +
 	"\x06filter\"A\n" +
 	"\x12ReferenceCondition\x12+\n" +
 	"\x04cond\x18\x01 \x01(\v2\x17.common.StringConditionR\x04cond\">\n" +
@@ -11116,7 +11321,14 @@ const file_common_proto_rawDesc = "" +
 	"\x18AccountHasAssetCondition\x12\x1d\n" +
 	"\n" +
 	"asset_base\x18\x01 \x01(\tR\tassetBase\x12\x1c\n" +
-	"\tprecision\x18\x02 \x01(\rR\tprecision\":\n" +
+	"\tprecision\x18\x02 \x01(\rR\tprecision\"\xef\x01\n" +
+	"\x0eAuditCondition\x12(\n" +
+	"\x05field\x18\x01 \x01(\x0e2\x12.common.AuditFieldR\x05field\x12:\n" +
+	"\vstring_cond\x18\x02 \x01(\v2\x17.common.StringConditionH\x00R\n" +
+	"stringCond\x124\n" +
+	"\tuint_cond\x18\x03 \x01(\v2\x15.common.UintConditionH\x00R\buintCond\x124\n" +
+	"\tbool_cond\x18\x04 \x01(\v2\x15.common.BoolConditionH\x00R\bboolCondB\v\n" +
+	"\tcondition\":\n" +
 	"\tAndFilter\x12-\n" +
 	"\afilters\x18\x01 \x03(\v2\x13.common.QueryFilterR\afilters\"9\n" +
 	"\bOrFilter\x12-\n" +
@@ -11376,15 +11588,31 @@ const file_common_proto_rawDesc = "" +
 	"\x16AccountTypePersistence\x12\x17\n" +
 	"\x13ACCOUNT_TYPE_NORMAL\x10\x00\x12\x1a\n" +
 	"\x16ACCOUNT_TYPE_EPHEMERAL\x10\x01\x12\x1a\n" +
-	"\x16ACCOUNT_TYPE_TRANSIENT\x10\x02*Z\n" +
+	"\x16ACCOUNT_TYPE_TRANSIENT\x10\x02*\xdc\x02\n" +
+	"\n" +
+	"AuditField\x12\x1b\n" +
+	"\x17AUDIT_FIELD_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14AUDIT_FIELD_SEQUENCE\x10\x01\x12\x1b\n" +
+	"\x17AUDIT_FIELD_PROPOSAL_ID\x10\x02\x12\x19\n" +
+	"\x15AUDIT_FIELD_TIMESTAMP\x10\x03\x12\x1c\n" +
+	"\x18AUDIT_FIELD_LOG_SEQUENCE\x10\x04\x12\x17\n" +
+	"\x13AUDIT_FIELD_OUTCOME\x10\x05\x12\x1a\n" +
+	"\x16AUDIT_FIELD_ERROR_TYPE\x10\x06\x12\x1e\n" +
+	"\x1aAUDIT_FIELD_CALLER_SUBJECT\x10\a\x12\x1c\n" +
+	"\x18AUDIT_FIELD_CALLER_SCOPE\x10\b\x12\x1a\n" +
+	"\x16AUDIT_FIELD_CALLER_GOD\x10\t\x12\x16\n" +
+	"\x12AUDIT_FIELD_LEDGER\x10\n" +
+	"\x12\x1a\n" +
+	"\x16AUDIT_FIELD_ORDER_TYPE\x10\v*Z\n" +
 	"\vAddressRole\x12\x14\n" +
 	"\x10ADDRESS_ROLE_ANY\x10\x00\x12\x17\n" +
 	"\x13ADDRESS_ROLE_SOURCE\x10\x01\x12\x1c\n" +
-	"\x18ADDRESS_ROLE_DESTINATION\x10\x02*^\n" +
+	"\x18ADDRESS_ROLE_DESTINATION\x10\x02*v\n" +
 	"\vQueryTarget\x12\x19\n" +
 	"\x15QUERY_TARGET_ACCOUNTS\x10\x00\x12\x1d\n" +
 	"\x19QUERY_TARGET_TRANSACTIONS\x10\x01\x12\x15\n" +
-	"\x11QUERY_TARGET_LOGS\x10\x02*B\n" +
+	"\x11QUERY_TARGET_LOGS\x10\x02\x12\x16\n" +
+	"\x12QUERY_TARGET_AUDIT\x10\x03*B\n" +
 	"\tQueryMode\x12\x13\n" +
 	"\x0fQUERY_MODE_LIST\x10\x00\x12 \n" +
 	"\x1cQUERY_MODE_AGGREGATE_VOLUMES\x10\x01B9Z7github.com/formancehq/ledger/v3/internal/proto/commonpbb\x06proto3"
@@ -11401,8 +11629,8 @@ func file_common_proto_rawDescGZIP() []byte {
 	return file_common_proto_rawDescData
 }
 
-var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
-var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 154)
+var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 18)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 155)
 var file_common_proto_goTypes = []any{
 	(TargetType)(0),                           // 0: common.TargetType
 	(MetadataType)(0),                         // 1: common.MetadataType
@@ -11418,398 +11646,405 @@ var file_common_proto_goTypes = []any{
 	(ErrorReason)(0),                          // 11: common.ErrorReason
 	(ChartEnforcementMode)(0),                 // 12: common.ChartEnforcementMode
 	(AccountTypePersistence)(0),               // 13: common.AccountTypePersistence
-	(AddressRole)(0),                          // 14: common.AddressRole
-	(QueryTarget)(0),                          // 15: common.QueryTarget
-	(QueryMode)(0),                            // 16: common.QueryMode
-	(*Timestamp)(nil),                         // 17: common.Timestamp
-	(*NullValue)(nil),                         // 18: common.NullValue
-	(*MetadataValue)(nil),                     // 19: common.MetadataValue
-	(*MetadataMap)(nil),                       // 20: common.MetadataMap
-	(*ParameterValue)(nil),                    // 21: common.ParameterValue
-	(*Uint256)(nil),                           // 22: common.Uint256
-	(*Posting)(nil),                           // 23: common.Posting
-	(*Transaction)(nil),                       // 24: common.Transaction
-	(*Script)(nil),                            // 25: common.Script
-	(*Volumes)(nil),                           // 26: common.Volumes
-	(*VolumesWithBalance)(nil),                // 27: common.VolumesWithBalance
-	(*VolumesByAssets)(nil),                   // 28: common.VolumesByAssets
-	(*PostCommitVolumes)(nil),                 // 29: common.PostCommitVolumes
-	(*Account)(nil),                           // 30: common.Account
-	(*TargetAccount)(nil),                     // 31: common.TargetAccount
-	(*Target)(nil),                            // 32: common.Target
-	(*MetadataFieldSchema)(nil),               // 33: common.MetadataFieldSchema
-	(*MetadataSchema)(nil),                    // 34: common.MetadataSchema
-	(*SetMetadataFieldTypeCommand)(nil),       // 35: common.SetMetadataFieldTypeCommand
-	(*MetadataIndexID)(nil),                   // 36: common.MetadataIndexID
-	(*IndexID)(nil),                           // 37: common.IndexID
-	(*Index)(nil),                             // 38: common.Index
-	(*Idempotency)(nil),                       // 39: common.Idempotency
-	(*IdempotencyEntry)(nil),                  // 40: common.IdempotencyEntry
-	(*Log)(nil),                               // 41: common.Log
-	(*LogPayload)(nil),                        // 42: common.LogPayload
-	(*PromotedLedgerLog)(nil),                 // 43: common.PromotedLedgerLog
-	(*RegisteredSigningKeyLog)(nil),           // 44: common.RegisteredSigningKeyLog
-	(*RevokedSigningKeyLog)(nil),              // 45: common.RevokedSigningKeyLog
-	(*SigningKey)(nil),                        // 46: common.SigningKey
-	(*SetSigningConfigLog)(nil),               // 47: common.SetSigningConfigLog
-	(*AddedEventsSinkLog)(nil),                // 48: common.AddedEventsSinkLog
-	(*RemovedEventsSinkLog)(nil),              // 49: common.RemovedEventsSinkLog
-	(*SetMaintenanceModeLog)(nil),             // 50: common.SetMaintenanceModeLog
-	(*BloomTypeConfig)(nil),                   // 51: common.BloomTypeConfig
-	(*ClusterConfig)(nil),                     // 52: common.ClusterConfig
-	(*PersistedClusterState)(nil),             // 53: common.PersistedClusterState
-	(*SetChapterScheduleLog)(nil),             // 54: common.SetChapterScheduleLog
-	(*DeletedChapterScheduleLog)(nil),         // 55: common.DeletedChapterScheduleLog
-	(*CreatedPreparedQueryLog)(nil),           // 56: common.CreatedPreparedQueryLog
-	(*UpdatedPreparedQueryLog)(nil),           // 57: common.UpdatedPreparedQueryLog
-	(*DeletedPreparedQueryLog)(nil),           // 58: common.DeletedPreparedQueryLog
-	(*SavedLedgerMetadataLog)(nil),            // 59: common.SavedLedgerMetadataLog
-	(*DeletedLedgerMetadataLog)(nil),          // 60: common.DeletedLedgerMetadataLog
-	(*NumscriptInfo)(nil),                     // 61: common.NumscriptInfo
-	(*SavedNumscriptLog)(nil),                 // 62: common.SavedNumscriptLog
-	(*DeletedNumscriptLog)(nil),               // 63: common.DeletedNumscriptLog
-	(*SetQueryCheckpointScheduleLog)(nil),     // 64: common.SetQueryCheckpointScheduleLog
-	(*DeletedQueryCheckpointScheduleLog)(nil), // 65: common.DeletedQueryCheckpointScheduleLog
-	(*CreatedQueryCheckpointLog)(nil),         // 66: common.CreatedQueryCheckpointLog
-	(*DeletedQueryCheckpointLog)(nil),         // 67: common.DeletedQueryCheckpointLog
-	(*SinkConfig)(nil),                        // 68: common.SinkConfig
-	(*SinkStatus)(nil),                        // 69: common.SinkStatus
-	(*SinkError)(nil),                         // 70: common.SinkError
-	(*NatsSinkConfig)(nil),                    // 71: common.NatsSinkConfig
-	(*ClickHouseSinkConfig)(nil),              // 72: common.ClickHouseSinkConfig
-	(*KafkaSinkConfig)(nil),                   // 73: common.KafkaSinkConfig
-	(*HttpSinkConfig)(nil),                    // 74: common.HttpSinkConfig
-	(*DatabricksSinkConfig)(nil),              // 75: common.DatabricksSinkConfig
-	(*DatabricksOAuthM2M)(nil),                // 76: common.DatabricksOAuthM2M
-	(*CreatedLedgerLog)(nil),                  // 77: common.CreatedLedgerLog
-	(*DeletedLedgerLog)(nil),                  // 78: common.DeletedLedgerLog
-	(*ApplyLedgerLog)(nil),                    // 79: common.ApplyLedgerLog
-	(*LedgerLog)(nil),                         // 80: common.LedgerLog
-	(*TouchedVolume)(nil),                     // 81: common.TouchedVolume
-	(*LedgerLogPayload)(nil),                  // 82: common.LedgerLogPayload
-	(*CreatedIndexLog)(nil),                   // 83: common.CreatedIndexLog
-	(*DroppedIndexLog)(nil),                   // 84: common.DroppedIndexLog
-	(*FilledGapLog)(nil),                      // 85: common.FilledGapLog
-	(*CreatedTransaction)(nil),                // 86: common.CreatedTransaction
-	(*RevertedTransaction)(nil),               // 87: common.RevertedTransaction
-	(*SavedMetadata)(nil),                     // 88: common.SavedMetadata
-	(*DeletedMetadata)(nil),                   // 89: common.DeletedMetadata
-	(*SetMetadataFieldTypeLog)(nil),           // 90: common.SetMetadataFieldTypeLog
-	(*RemovedMetadataFieldTypeLog)(nil),       // 91: common.RemovedMetadataFieldTypeLog
-	(*Chapter)(nil),                           // 92: common.Chapter
-	(*ClosedChapterLog)(nil),                  // 93: common.ClosedChapterLog
-	(*SealedChapterLog)(nil),                  // 94: common.SealedChapterLog
-	(*ArchivedChapterLog)(nil),                // 95: common.ArchivedChapterLog
-	(*ConfirmedArchiveChapterLog)(nil),        // 96: common.ConfirmedArchiveChapterLog
-	(*MirrorSourceConfig)(nil),                // 97: common.MirrorSourceConfig
-	(*HttpMirrorSourceConfig)(nil),            // 98: common.HttpMirrorSourceConfig
-	(*OAuth2ClientCredentials)(nil),           // 99: common.OAuth2ClientCredentials
-	(*PostgresMirrorSourceConfig)(nil),        // 100: common.PostgresMirrorSourceConfig
-	(*MirrorSyncError)(nil),                   // 101: common.MirrorSyncError
-	(*MirrorSyncProgress)(nil),                // 102: common.MirrorSyncProgress
-	(*LedgerInfo)(nil),                        // 103: common.LedgerInfo
-	(*SaveMetadataCommand)(nil),               // 104: common.SaveMetadataCommand
-	(*DeleteMetadataCommand)(nil),             // 105: common.DeleteMetadataCommand
-	(*TransactionState)(nil),                  // 106: common.TransactionState
-	(*IdempotencyKeyValue)(nil),               // 107: common.IdempotencyKeyValue
-	(*IdempotencyFailure)(nil),                // 108: common.IdempotencyFailure
-	(*TransactionReferenceValue)(nil),         // 109: common.TransactionReferenceValue
-	(*NumscriptVersionValue)(nil),             // 110: common.NumscriptVersionValue
-	(*SegmentType)(nil),                       // 111: common.SegmentType
-	(*UUIDConstraint)(nil),                    // 112: common.UUIDConstraint
-	(*Uint64Constraint)(nil),                  // 113: common.Uint64Constraint
-	(*BytesConstraint)(nil),                   // 114: common.BytesConstraint
-	(*AccountType)(nil),                       // 115: common.AccountType
-	(*AddedAccountTypeLog)(nil),               // 116: common.AddedAccountTypeLog
-	(*RemovedAccountTypeLog)(nil),             // 117: common.RemovedAccountTypeLog
-	(*UpdatedDefaultEnforcementModeLog)(nil),  // 118: common.UpdatedDefaultEnforcementModeLog
-	(*QueryFilter)(nil),                       // 119: common.QueryFilter
-	(*ReferenceCondition)(nil),                // 120: common.ReferenceCondition
-	(*LedgerCondition)(nil),                   // 121: common.LedgerCondition
-	(*LogIdCondition)(nil),                    // 122: common.LogIdCondition
-	(*BuiltinUintCondition)(nil),              // 123: common.BuiltinUintCondition
-	(*LogBuiltinUintCondition)(nil),           // 124: common.LogBuiltinUintCondition
-	(*AccountHasAssetCondition)(nil),          // 125: common.AccountHasAssetCondition
-	(*AndFilter)(nil),                         // 126: common.AndFilter
-	(*OrFilter)(nil),                          // 127: common.OrFilter
-	(*NotFilter)(nil),                         // 128: common.NotFilter
-	(*FieldRef)(nil),                          // 129: common.FieldRef
-	(*FieldCondition)(nil),                    // 130: common.FieldCondition
-	(*StringCondition)(nil),                   // 131: common.StringCondition
-	(*IntCondition)(nil),                      // 132: common.IntCondition
-	(*UintCondition)(nil),                     // 133: common.UintCondition
-	(*BoolCondition)(nil),                     // 134: common.BoolCondition
-	(*ExistsCondition)(nil),                   // 135: common.ExistsCondition
-	(*AddressMatch)(nil),                      // 136: common.AddressMatch
-	(*PreparedQuery)(nil),                     // 137: common.PreparedQuery
-	(*AggregatedVolume)(nil),                  // 138: common.AggregatedVolume
-	(*AggregateResult)(nil),                   // 139: common.AggregateResult
-	(*GroupedAggregateResult)(nil),            // 140: common.GroupedAggregateResult
-	(*PreparedQueryCursor)(nil),               // 141: common.PreparedQueryCursor
-	(*LedgerStats)(nil),                       // 142: common.LedgerStats
-	(*PersistedConfig)(nil),                   // 143: common.PersistedConfig
-	(*CallerIdentity)(nil),                    // 144: common.CallerIdentity
-	(*CallerSnapshot)(nil),                    // 145: common.CallerSnapshot
-	(*S3StorageConfig)(nil),                   // 146: common.S3StorageConfig
-	(*AzureStorageConfig)(nil),                // 147: common.AzureStorageConfig
-	(*BackupStorage)(nil),                     // 148: common.BackupStorage
-	(*ReadOptions)(nil),                       // 149: common.ReadOptions
-	(*ListOptions)(nil),                       // 150: common.ListOptions
-	nil,                                       // 151: common.MetadataMap.ValuesEntry
-	nil,                                       // 152: common.Transaction.MetadataEntry
-	nil,                                       // 153: common.Script.VarsEntry
-	nil,                                       // 154: common.VolumesByAssets.VolumesEntry
-	nil,                                       // 155: common.PostCommitVolumes.VolumesByAccountEntry
-	nil,                                       // 156: common.Account.MetadataEntry
-	nil,                                       // 157: common.Account.VolumesEntry
-	nil,                                       // 158: common.MetadataSchema.AccountFieldsEntry
-	nil,                                       // 159: common.MetadataSchema.TransactionFieldsEntry
-	nil,                                       // 160: common.MetadataSchema.LedgerFieldsEntry
-	nil,                                       // 161: common.SavedLedgerMetadataLog.MetadataEntry
-	nil,                                       // 162: common.CreatedLedgerLog.AccountTypesEntry
-	nil,                                       // 163: common.CreatedTransaction.AccountMetadataEntry
-	nil,                                       // 164: common.SavedMetadata.MetadataEntry
-	nil,                                       // 165: common.LedgerInfo.AccountTypesEntry
-	nil,                                       // 166: common.LedgerInfo.MetadataEntry
-	nil,                                       // 167: common.SaveMetadataCommand.MetadataEntry
-	nil,                                       // 168: common.TransactionState.MetadataEntry
-	nil,                                       // 169: common.IdempotencyFailure.MetadataEntry
-	nil,                                       // 170: common.AccountType.SegmentTypesEntry
-	(*signaturepb.SignedLog)(nil),             // 171: signature.SignedLog
+	(AuditField)(0),                           // 14: common.AuditField
+	(AddressRole)(0),                          // 15: common.AddressRole
+	(QueryTarget)(0),                          // 16: common.QueryTarget
+	(QueryMode)(0),                            // 17: common.QueryMode
+	(*Timestamp)(nil),                         // 18: common.Timestamp
+	(*NullValue)(nil),                         // 19: common.NullValue
+	(*MetadataValue)(nil),                     // 20: common.MetadataValue
+	(*MetadataMap)(nil),                       // 21: common.MetadataMap
+	(*ParameterValue)(nil),                    // 22: common.ParameterValue
+	(*Uint256)(nil),                           // 23: common.Uint256
+	(*Posting)(nil),                           // 24: common.Posting
+	(*Transaction)(nil),                       // 25: common.Transaction
+	(*Script)(nil),                            // 26: common.Script
+	(*Volumes)(nil),                           // 27: common.Volumes
+	(*VolumesWithBalance)(nil),                // 28: common.VolumesWithBalance
+	(*VolumesByAssets)(nil),                   // 29: common.VolumesByAssets
+	(*PostCommitVolumes)(nil),                 // 30: common.PostCommitVolumes
+	(*Account)(nil),                           // 31: common.Account
+	(*TargetAccount)(nil),                     // 32: common.TargetAccount
+	(*Target)(nil),                            // 33: common.Target
+	(*MetadataFieldSchema)(nil),               // 34: common.MetadataFieldSchema
+	(*MetadataSchema)(nil),                    // 35: common.MetadataSchema
+	(*SetMetadataFieldTypeCommand)(nil),       // 36: common.SetMetadataFieldTypeCommand
+	(*MetadataIndexID)(nil),                   // 37: common.MetadataIndexID
+	(*IndexID)(nil),                           // 38: common.IndexID
+	(*Index)(nil),                             // 39: common.Index
+	(*Idempotency)(nil),                       // 40: common.Idempotency
+	(*IdempotencyEntry)(nil),                  // 41: common.IdempotencyEntry
+	(*Log)(nil),                               // 42: common.Log
+	(*LogPayload)(nil),                        // 43: common.LogPayload
+	(*PromotedLedgerLog)(nil),                 // 44: common.PromotedLedgerLog
+	(*RegisteredSigningKeyLog)(nil),           // 45: common.RegisteredSigningKeyLog
+	(*RevokedSigningKeyLog)(nil),              // 46: common.RevokedSigningKeyLog
+	(*SigningKey)(nil),                        // 47: common.SigningKey
+	(*SetSigningConfigLog)(nil),               // 48: common.SetSigningConfigLog
+	(*AddedEventsSinkLog)(nil),                // 49: common.AddedEventsSinkLog
+	(*RemovedEventsSinkLog)(nil),              // 50: common.RemovedEventsSinkLog
+	(*SetMaintenanceModeLog)(nil),             // 51: common.SetMaintenanceModeLog
+	(*BloomTypeConfig)(nil),                   // 52: common.BloomTypeConfig
+	(*ClusterConfig)(nil),                     // 53: common.ClusterConfig
+	(*PersistedClusterState)(nil),             // 54: common.PersistedClusterState
+	(*SetChapterScheduleLog)(nil),             // 55: common.SetChapterScheduleLog
+	(*DeletedChapterScheduleLog)(nil),         // 56: common.DeletedChapterScheduleLog
+	(*CreatedPreparedQueryLog)(nil),           // 57: common.CreatedPreparedQueryLog
+	(*UpdatedPreparedQueryLog)(nil),           // 58: common.UpdatedPreparedQueryLog
+	(*DeletedPreparedQueryLog)(nil),           // 59: common.DeletedPreparedQueryLog
+	(*SavedLedgerMetadataLog)(nil),            // 60: common.SavedLedgerMetadataLog
+	(*DeletedLedgerMetadataLog)(nil),          // 61: common.DeletedLedgerMetadataLog
+	(*NumscriptInfo)(nil),                     // 62: common.NumscriptInfo
+	(*SavedNumscriptLog)(nil),                 // 63: common.SavedNumscriptLog
+	(*DeletedNumscriptLog)(nil),               // 64: common.DeletedNumscriptLog
+	(*SetQueryCheckpointScheduleLog)(nil),     // 65: common.SetQueryCheckpointScheduleLog
+	(*DeletedQueryCheckpointScheduleLog)(nil), // 66: common.DeletedQueryCheckpointScheduleLog
+	(*CreatedQueryCheckpointLog)(nil),         // 67: common.CreatedQueryCheckpointLog
+	(*DeletedQueryCheckpointLog)(nil),         // 68: common.DeletedQueryCheckpointLog
+	(*SinkConfig)(nil),                        // 69: common.SinkConfig
+	(*SinkStatus)(nil),                        // 70: common.SinkStatus
+	(*SinkError)(nil),                         // 71: common.SinkError
+	(*NatsSinkConfig)(nil),                    // 72: common.NatsSinkConfig
+	(*ClickHouseSinkConfig)(nil),              // 73: common.ClickHouseSinkConfig
+	(*KafkaSinkConfig)(nil),                   // 74: common.KafkaSinkConfig
+	(*HttpSinkConfig)(nil),                    // 75: common.HttpSinkConfig
+	(*DatabricksSinkConfig)(nil),              // 76: common.DatabricksSinkConfig
+	(*DatabricksOAuthM2M)(nil),                // 77: common.DatabricksOAuthM2M
+	(*CreatedLedgerLog)(nil),                  // 78: common.CreatedLedgerLog
+	(*DeletedLedgerLog)(nil),                  // 79: common.DeletedLedgerLog
+	(*ApplyLedgerLog)(nil),                    // 80: common.ApplyLedgerLog
+	(*LedgerLog)(nil),                         // 81: common.LedgerLog
+	(*TouchedVolume)(nil),                     // 82: common.TouchedVolume
+	(*LedgerLogPayload)(nil),                  // 83: common.LedgerLogPayload
+	(*CreatedIndexLog)(nil),                   // 84: common.CreatedIndexLog
+	(*DroppedIndexLog)(nil),                   // 85: common.DroppedIndexLog
+	(*FilledGapLog)(nil),                      // 86: common.FilledGapLog
+	(*CreatedTransaction)(nil),                // 87: common.CreatedTransaction
+	(*RevertedTransaction)(nil),               // 88: common.RevertedTransaction
+	(*SavedMetadata)(nil),                     // 89: common.SavedMetadata
+	(*DeletedMetadata)(nil),                   // 90: common.DeletedMetadata
+	(*SetMetadataFieldTypeLog)(nil),           // 91: common.SetMetadataFieldTypeLog
+	(*RemovedMetadataFieldTypeLog)(nil),       // 92: common.RemovedMetadataFieldTypeLog
+	(*Chapter)(nil),                           // 93: common.Chapter
+	(*ClosedChapterLog)(nil),                  // 94: common.ClosedChapterLog
+	(*SealedChapterLog)(nil),                  // 95: common.SealedChapterLog
+	(*ArchivedChapterLog)(nil),                // 96: common.ArchivedChapterLog
+	(*ConfirmedArchiveChapterLog)(nil),        // 97: common.ConfirmedArchiveChapterLog
+	(*MirrorSourceConfig)(nil),                // 98: common.MirrorSourceConfig
+	(*HttpMirrorSourceConfig)(nil),            // 99: common.HttpMirrorSourceConfig
+	(*OAuth2ClientCredentials)(nil),           // 100: common.OAuth2ClientCredentials
+	(*PostgresMirrorSourceConfig)(nil),        // 101: common.PostgresMirrorSourceConfig
+	(*MirrorSyncError)(nil),                   // 102: common.MirrorSyncError
+	(*MirrorSyncProgress)(nil),                // 103: common.MirrorSyncProgress
+	(*LedgerInfo)(nil),                        // 104: common.LedgerInfo
+	(*SaveMetadataCommand)(nil),               // 105: common.SaveMetadataCommand
+	(*DeleteMetadataCommand)(nil),             // 106: common.DeleteMetadataCommand
+	(*TransactionState)(nil),                  // 107: common.TransactionState
+	(*IdempotencyKeyValue)(nil),               // 108: common.IdempotencyKeyValue
+	(*IdempotencyFailure)(nil),                // 109: common.IdempotencyFailure
+	(*TransactionReferenceValue)(nil),         // 110: common.TransactionReferenceValue
+	(*NumscriptVersionValue)(nil),             // 111: common.NumscriptVersionValue
+	(*SegmentType)(nil),                       // 112: common.SegmentType
+	(*UUIDConstraint)(nil),                    // 113: common.UUIDConstraint
+	(*Uint64Constraint)(nil),                  // 114: common.Uint64Constraint
+	(*BytesConstraint)(nil),                   // 115: common.BytesConstraint
+	(*AccountType)(nil),                       // 116: common.AccountType
+	(*AddedAccountTypeLog)(nil),               // 117: common.AddedAccountTypeLog
+	(*RemovedAccountTypeLog)(nil),             // 118: common.RemovedAccountTypeLog
+	(*UpdatedDefaultEnforcementModeLog)(nil),  // 119: common.UpdatedDefaultEnforcementModeLog
+	(*QueryFilter)(nil),                       // 120: common.QueryFilter
+	(*ReferenceCondition)(nil),                // 121: common.ReferenceCondition
+	(*LedgerCondition)(nil),                   // 122: common.LedgerCondition
+	(*LogIdCondition)(nil),                    // 123: common.LogIdCondition
+	(*BuiltinUintCondition)(nil),              // 124: common.BuiltinUintCondition
+	(*LogBuiltinUintCondition)(nil),           // 125: common.LogBuiltinUintCondition
+	(*AccountHasAssetCondition)(nil),          // 126: common.AccountHasAssetCondition
+	(*AuditCondition)(nil),                    // 127: common.AuditCondition
+	(*AndFilter)(nil),                         // 128: common.AndFilter
+	(*OrFilter)(nil),                          // 129: common.OrFilter
+	(*NotFilter)(nil),                         // 130: common.NotFilter
+	(*FieldRef)(nil),                          // 131: common.FieldRef
+	(*FieldCondition)(nil),                    // 132: common.FieldCondition
+	(*StringCondition)(nil),                   // 133: common.StringCondition
+	(*IntCondition)(nil),                      // 134: common.IntCondition
+	(*UintCondition)(nil),                     // 135: common.UintCondition
+	(*BoolCondition)(nil),                     // 136: common.BoolCondition
+	(*ExistsCondition)(nil),                   // 137: common.ExistsCondition
+	(*AddressMatch)(nil),                      // 138: common.AddressMatch
+	(*PreparedQuery)(nil),                     // 139: common.PreparedQuery
+	(*AggregatedVolume)(nil),                  // 140: common.AggregatedVolume
+	(*AggregateResult)(nil),                   // 141: common.AggregateResult
+	(*GroupedAggregateResult)(nil),            // 142: common.GroupedAggregateResult
+	(*PreparedQueryCursor)(nil),               // 143: common.PreparedQueryCursor
+	(*LedgerStats)(nil),                       // 144: common.LedgerStats
+	(*PersistedConfig)(nil),                   // 145: common.PersistedConfig
+	(*CallerIdentity)(nil),                    // 146: common.CallerIdentity
+	(*CallerSnapshot)(nil),                    // 147: common.CallerSnapshot
+	(*S3StorageConfig)(nil),                   // 148: common.S3StorageConfig
+	(*AzureStorageConfig)(nil),                // 149: common.AzureStorageConfig
+	(*BackupStorage)(nil),                     // 150: common.BackupStorage
+	(*ReadOptions)(nil),                       // 151: common.ReadOptions
+	(*ListOptions)(nil),                       // 152: common.ListOptions
+	nil,                                       // 153: common.MetadataMap.ValuesEntry
+	nil,                                       // 154: common.Transaction.MetadataEntry
+	nil,                                       // 155: common.Script.VarsEntry
+	nil,                                       // 156: common.VolumesByAssets.VolumesEntry
+	nil,                                       // 157: common.PostCommitVolumes.VolumesByAccountEntry
+	nil,                                       // 158: common.Account.MetadataEntry
+	nil,                                       // 159: common.Account.VolumesEntry
+	nil,                                       // 160: common.MetadataSchema.AccountFieldsEntry
+	nil,                                       // 161: common.MetadataSchema.TransactionFieldsEntry
+	nil,                                       // 162: common.MetadataSchema.LedgerFieldsEntry
+	nil,                                       // 163: common.SavedLedgerMetadataLog.MetadataEntry
+	nil,                                       // 164: common.CreatedLedgerLog.AccountTypesEntry
+	nil,                                       // 165: common.CreatedTransaction.AccountMetadataEntry
+	nil,                                       // 166: common.SavedMetadata.MetadataEntry
+	nil,                                       // 167: common.LedgerInfo.AccountTypesEntry
+	nil,                                       // 168: common.LedgerInfo.MetadataEntry
+	nil,                                       // 169: common.SaveMetadataCommand.MetadataEntry
+	nil,                                       // 170: common.TransactionState.MetadataEntry
+	nil,                                       // 171: common.IdempotencyFailure.MetadataEntry
+	nil,                                       // 172: common.AccountType.SegmentTypesEntry
+	(*signaturepb.SignedLog)(nil),             // 173: signature.SignedLog
 }
 var file_common_proto_depIdxs = []int32{
-	18,  // 0: common.MetadataValue.null_value:type_name -> common.NullValue
-	151, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
-	22,  // 2: common.Posting.amount:type_name -> common.Uint256
-	23,  // 3: common.Transaction.postings:type_name -> common.Posting
-	152, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
-	17,  // 5: common.Transaction.timestamp:type_name -> common.Timestamp
-	17,  // 6: common.Transaction.inserted_at:type_name -> common.Timestamp
-	17,  // 7: common.Transaction.updated_at:type_name -> common.Timestamp
-	17,  // 8: common.Transaction.reverted_at:type_name -> common.Timestamp
-	153, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
-	154, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
-	155, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
-	156, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
-	17,  // 13: common.Account.first_usage:type_name -> common.Timestamp
-	17,  // 14: common.Account.insertion_date:type_name -> common.Timestamp
-	17,  // 15: common.Account.updated_at:type_name -> common.Timestamp
-	157, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
-	31,  // 17: common.Target.account:type_name -> common.TargetAccount
+	19,  // 0: common.MetadataValue.null_value:type_name -> common.NullValue
+	153, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
+	23,  // 2: common.Posting.amount:type_name -> common.Uint256
+	24,  // 3: common.Transaction.postings:type_name -> common.Posting
+	154, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
+	18,  // 5: common.Transaction.timestamp:type_name -> common.Timestamp
+	18,  // 6: common.Transaction.inserted_at:type_name -> common.Timestamp
+	18,  // 7: common.Transaction.updated_at:type_name -> common.Timestamp
+	18,  // 8: common.Transaction.reverted_at:type_name -> common.Timestamp
+	155, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
+	156, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
+	157, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
+	158, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
+	18,  // 13: common.Account.first_usage:type_name -> common.Timestamp
+	18,  // 14: common.Account.insertion_date:type_name -> common.Timestamp
+	18,  // 15: common.Account.updated_at:type_name -> common.Timestamp
+	159, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
+	32,  // 17: common.Target.account:type_name -> common.TargetAccount
 	1,   // 18: common.MetadataFieldSchema.type:type_name -> common.MetadataType
-	158, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
-	159, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
-	160, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
+	160, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
+	161, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
+	162, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
 	0,   // 22: common.SetMetadataFieldTypeCommand.target_type:type_name -> common.TargetType
 	1,   // 23: common.SetMetadataFieldTypeCommand.type:type_name -> common.MetadataType
 	0,   // 24: common.MetadataIndexID.target:type_name -> common.TargetType
 	3,   // 25: common.IndexID.tx_builtin:type_name -> common.TransactionBuiltinIndex
 	5,   // 26: common.IndexID.log_builtin:type_name -> common.LogBuiltinIndex
 	4,   // 27: common.IndexID.account_builtin:type_name -> common.AccountBuiltinIndex
-	36,  // 28: common.IndexID.metadata:type_name -> common.MetadataIndexID
-	37,  // 29: common.Index.id:type_name -> common.IndexID
+	37,  // 28: common.IndexID.metadata:type_name -> common.MetadataIndexID
+	38,  // 29: common.Index.id:type_name -> common.IndexID
 	2,   // 30: common.Index.build_status:type_name -> common.IndexBuildStatus
-	17,  // 31: common.Index.created_at:type_name -> common.Timestamp
-	17,  // 32: common.Index.last_built_at:type_name -> common.Timestamp
-	42,  // 33: common.Log.payload:type_name -> common.LogPayload
-	171, // 34: common.Log.response_signature:type_name -> signature.SignedLog
-	77,  // 35: common.LogPayload.create_ledger:type_name -> common.CreatedLedgerLog
-	78,  // 36: common.LogPayload.delete_ledger:type_name -> common.DeletedLedgerLog
-	79,  // 37: common.LogPayload.apply:type_name -> common.ApplyLedgerLog
-	44,  // 38: common.LogPayload.register_signing_key:type_name -> common.RegisteredSigningKeyLog
-	45,  // 39: common.LogPayload.revoke_signing_key:type_name -> common.RevokedSigningKeyLog
-	47,  // 40: common.LogPayload.set_signing_config:type_name -> common.SetSigningConfigLog
-	48,  // 41: common.LogPayload.added_events_sink:type_name -> common.AddedEventsSinkLog
-	49,  // 42: common.LogPayload.removed_events_sink:type_name -> common.RemovedEventsSinkLog
-	93,  // 43: common.LogPayload.close_chapter:type_name -> common.ClosedChapterLog
-	94,  // 44: common.LogPayload.seal_chapter:type_name -> common.SealedChapterLog
-	95,  // 45: common.LogPayload.archive_chapter:type_name -> common.ArchivedChapterLog
-	96,  // 46: common.LogPayload.confirm_archive_chapter:type_name -> common.ConfirmedArchiveChapterLog
-	50,  // 47: common.LogPayload.set_maintenance_mode:type_name -> common.SetMaintenanceModeLog
-	54,  // 48: common.LogPayload.set_chapter_schedule:type_name -> common.SetChapterScheduleLog
-	55,  // 49: common.LogPayload.delete_chapter_schedule:type_name -> common.DeletedChapterScheduleLog
-	43,  // 50: common.LogPayload.promote_ledger:type_name -> common.PromotedLedgerLog
-	56,  // 51: common.LogPayload.created_prepared_query:type_name -> common.CreatedPreparedQueryLog
-	57,  // 52: common.LogPayload.updated_prepared_query:type_name -> common.UpdatedPreparedQueryLog
-	58,  // 53: common.LogPayload.deleted_prepared_query:type_name -> common.DeletedPreparedQueryLog
-	62,  // 54: common.LogPayload.saved_numscript:type_name -> common.SavedNumscriptLog
-	63,  // 55: common.LogPayload.deleted_numscript:type_name -> common.DeletedNumscriptLog
-	66,  // 56: common.LogPayload.created_query_checkpoint:type_name -> common.CreatedQueryCheckpointLog
-	67,  // 57: common.LogPayload.deleted_query_checkpoint:type_name -> common.DeletedQueryCheckpointLog
-	64,  // 58: common.LogPayload.set_query_checkpoint_schedule:type_name -> common.SetQueryCheckpointScheduleLog
-	65,  // 59: common.LogPayload.delete_query_checkpoint_schedule:type_name -> common.DeletedQueryCheckpointScheduleLog
-	59,  // 60: common.LogPayload.saved_ledger_metadata:type_name -> common.SavedLedgerMetadataLog
-	60,  // 61: common.LogPayload.deleted_ledger_metadata:type_name -> common.DeletedLedgerMetadataLog
-	68,  // 62: common.AddedEventsSinkLog.config:type_name -> common.SinkConfig
-	51,  // 63: common.ClusterConfig.bloom_volumes:type_name -> common.BloomTypeConfig
-	51,  // 64: common.ClusterConfig.bloom_metadata:type_name -> common.BloomTypeConfig
-	51,  // 65: common.ClusterConfig.bloom_references:type_name -> common.BloomTypeConfig
-	51,  // 66: common.ClusterConfig.bloom_ledgers:type_name -> common.BloomTypeConfig
-	51,  // 67: common.ClusterConfig.bloom_boundaries:type_name -> common.BloomTypeConfig
-	51,  // 68: common.ClusterConfig.bloom_transactions:type_name -> common.BloomTypeConfig
-	51,  // 69: common.ClusterConfig.bloom_sink_configs:type_name -> common.BloomTypeConfig
-	51,  // 70: common.ClusterConfig.bloom_numscript_versions:type_name -> common.BloomTypeConfig
-	51,  // 71: common.ClusterConfig.bloom_numscript_contents:type_name -> common.BloomTypeConfig
+	18,  // 31: common.Index.created_at:type_name -> common.Timestamp
+	18,  // 32: common.Index.last_built_at:type_name -> common.Timestamp
+	43,  // 33: common.Log.payload:type_name -> common.LogPayload
+	173, // 34: common.Log.response_signature:type_name -> signature.SignedLog
+	78,  // 35: common.LogPayload.create_ledger:type_name -> common.CreatedLedgerLog
+	79,  // 36: common.LogPayload.delete_ledger:type_name -> common.DeletedLedgerLog
+	80,  // 37: common.LogPayload.apply:type_name -> common.ApplyLedgerLog
+	45,  // 38: common.LogPayload.register_signing_key:type_name -> common.RegisteredSigningKeyLog
+	46,  // 39: common.LogPayload.revoke_signing_key:type_name -> common.RevokedSigningKeyLog
+	48,  // 40: common.LogPayload.set_signing_config:type_name -> common.SetSigningConfigLog
+	49,  // 41: common.LogPayload.added_events_sink:type_name -> common.AddedEventsSinkLog
+	50,  // 42: common.LogPayload.removed_events_sink:type_name -> common.RemovedEventsSinkLog
+	94,  // 43: common.LogPayload.close_chapter:type_name -> common.ClosedChapterLog
+	95,  // 44: common.LogPayload.seal_chapter:type_name -> common.SealedChapterLog
+	96,  // 45: common.LogPayload.archive_chapter:type_name -> common.ArchivedChapterLog
+	97,  // 46: common.LogPayload.confirm_archive_chapter:type_name -> common.ConfirmedArchiveChapterLog
+	51,  // 47: common.LogPayload.set_maintenance_mode:type_name -> common.SetMaintenanceModeLog
+	55,  // 48: common.LogPayload.set_chapter_schedule:type_name -> common.SetChapterScheduleLog
+	56,  // 49: common.LogPayload.delete_chapter_schedule:type_name -> common.DeletedChapterScheduleLog
+	44,  // 50: common.LogPayload.promote_ledger:type_name -> common.PromotedLedgerLog
+	57,  // 51: common.LogPayload.created_prepared_query:type_name -> common.CreatedPreparedQueryLog
+	58,  // 52: common.LogPayload.updated_prepared_query:type_name -> common.UpdatedPreparedQueryLog
+	59,  // 53: common.LogPayload.deleted_prepared_query:type_name -> common.DeletedPreparedQueryLog
+	63,  // 54: common.LogPayload.saved_numscript:type_name -> common.SavedNumscriptLog
+	64,  // 55: common.LogPayload.deleted_numscript:type_name -> common.DeletedNumscriptLog
+	67,  // 56: common.LogPayload.created_query_checkpoint:type_name -> common.CreatedQueryCheckpointLog
+	68,  // 57: common.LogPayload.deleted_query_checkpoint:type_name -> common.DeletedQueryCheckpointLog
+	65,  // 58: common.LogPayload.set_query_checkpoint_schedule:type_name -> common.SetQueryCheckpointScheduleLog
+	66,  // 59: common.LogPayload.delete_query_checkpoint_schedule:type_name -> common.DeletedQueryCheckpointScheduleLog
+	60,  // 60: common.LogPayload.saved_ledger_metadata:type_name -> common.SavedLedgerMetadataLog
+	61,  // 61: common.LogPayload.deleted_ledger_metadata:type_name -> common.DeletedLedgerMetadataLog
+	69,  // 62: common.AddedEventsSinkLog.config:type_name -> common.SinkConfig
+	52,  // 63: common.ClusterConfig.bloom_volumes:type_name -> common.BloomTypeConfig
+	52,  // 64: common.ClusterConfig.bloom_metadata:type_name -> common.BloomTypeConfig
+	52,  // 65: common.ClusterConfig.bloom_references:type_name -> common.BloomTypeConfig
+	52,  // 66: common.ClusterConfig.bloom_ledgers:type_name -> common.BloomTypeConfig
+	52,  // 67: common.ClusterConfig.bloom_boundaries:type_name -> common.BloomTypeConfig
+	52,  // 68: common.ClusterConfig.bloom_transactions:type_name -> common.BloomTypeConfig
+	52,  // 69: common.ClusterConfig.bloom_sink_configs:type_name -> common.BloomTypeConfig
+	52,  // 70: common.ClusterConfig.bloom_numscript_versions:type_name -> common.BloomTypeConfig
+	52,  // 71: common.ClusterConfig.bloom_numscript_contents:type_name -> common.BloomTypeConfig
 	6,   // 72: common.ClusterConfig.hash_algorithm:type_name -> common.HashAlgorithm
-	51,  // 73: common.ClusterConfig.bloom_ledger_metadata:type_name -> common.BloomTypeConfig
-	51,  // 74: common.ClusterConfig.bloom_prepared_queries:type_name -> common.BloomTypeConfig
-	51,  // 75: common.ClusterConfig.bloom_indexes:type_name -> common.BloomTypeConfig
-	52,  // 76: common.PersistedClusterState.config:type_name -> common.ClusterConfig
-	137, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
-	119, // 78: common.UpdatedPreparedQueryLog.previous_filter:type_name -> common.QueryFilter
-	119, // 79: common.UpdatedPreparedQueryLog.new_filter:type_name -> common.QueryFilter
-	161, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
-	17,  // 81: common.NumscriptInfo.created_at:type_name -> common.Timestamp
-	61,  // 82: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
-	71,  // 83: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
-	72,  // 84: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
-	73,  // 85: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
-	74,  // 86: common.SinkConfig.http:type_name -> common.HttpSinkConfig
-	75,  // 87: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
+	52,  // 73: common.ClusterConfig.bloom_ledger_metadata:type_name -> common.BloomTypeConfig
+	52,  // 74: common.ClusterConfig.bloom_prepared_queries:type_name -> common.BloomTypeConfig
+	52,  // 75: common.ClusterConfig.bloom_indexes:type_name -> common.BloomTypeConfig
+	53,  // 76: common.PersistedClusterState.config:type_name -> common.ClusterConfig
+	139, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
+	120, // 78: common.UpdatedPreparedQueryLog.previous_filter:type_name -> common.QueryFilter
+	120, // 79: common.UpdatedPreparedQueryLog.new_filter:type_name -> common.QueryFilter
+	163, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
+	18,  // 81: common.NumscriptInfo.created_at:type_name -> common.Timestamp
+	62,  // 82: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
+	72,  // 83: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
+	73,  // 84: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
+	74,  // 85: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
+	75,  // 86: common.SinkConfig.http:type_name -> common.HttpSinkConfig
+	76,  // 87: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
 	7,   // 88: common.SinkConfig.event_types:type_name -> common.EventType
-	70,  // 89: common.SinkStatus.error:type_name -> common.SinkError
-	17,  // 90: common.SinkError.occurred_at:type_name -> common.Timestamp
-	76,  // 91: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
-	17,  // 92: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
-	34,  // 93: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
+	71,  // 89: common.SinkStatus.error:type_name -> common.SinkError
+	18,  // 90: common.SinkError.occurred_at:type_name -> common.Timestamp
+	77,  // 91: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
+	18,  // 92: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
+	35,  // 93: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
 	9,   // 94: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
-	97,  // 95: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
-	162, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
+	98,  // 95: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
+	164, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
 	12,  // 97: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	17,  // 98: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
-	80,  // 99: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
-	82,  // 100: common.LedgerLog.data:type_name -> common.LedgerLogPayload
-	17,  // 101: common.LedgerLog.date:type_name -> common.Timestamp
-	81,  // 102: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
-	86,  // 103: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
-	87,  // 104: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
-	88,  // 105: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
-	89,  // 106: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
-	90,  // 107: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
-	91,  // 108: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
-	85,  // 109: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
-	83,  // 110: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
-	84,  // 111: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
-	116, // 112: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
-	117, // 113: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
-	118, // 114: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
-	37,  // 115: common.CreatedIndexLog.id:type_name -> common.IndexID
-	37,  // 116: common.DroppedIndexLog.id:type_name -> common.IndexID
-	24,  // 117: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	163, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
-	29,  // 119: common.CreatedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
-	24,  // 120: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
-	29,  // 121: common.RevertedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
-	32,  // 122: common.SavedMetadata.target:type_name -> common.Target
-	164, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
-	32,  // 124: common.DeletedMetadata.target:type_name -> common.Target
+	18,  // 98: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
+	81,  // 99: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
+	83,  // 100: common.LedgerLog.data:type_name -> common.LedgerLogPayload
+	18,  // 101: common.LedgerLog.date:type_name -> common.Timestamp
+	82,  // 102: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
+	87,  // 103: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
+	88,  // 104: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
+	89,  // 105: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
+	90,  // 106: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
+	91,  // 107: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
+	92,  // 108: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
+	86,  // 109: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
+	84,  // 110: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
+	85,  // 111: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
+	117, // 112: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
+	118, // 113: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
+	119, // 114: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
+	38,  // 115: common.CreatedIndexLog.id:type_name -> common.IndexID
+	38,  // 116: common.DroppedIndexLog.id:type_name -> common.IndexID
+	25,  // 117: common.CreatedTransaction.transaction:type_name -> common.Transaction
+	165, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	30,  // 119: common.CreatedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
+	25,  // 120: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
+	30,  // 121: common.RevertedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
+	33,  // 122: common.SavedMetadata.target:type_name -> common.Target
+	166, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	33,  // 124: common.DeletedMetadata.target:type_name -> common.Target
 	0,   // 125: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
 	1,   // 126: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
 	0,   // 127: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	37,  // 128: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
-	17,  // 129: common.Chapter.start:type_name -> common.Timestamp
-	17,  // 130: common.Chapter.end:type_name -> common.Timestamp
+	38,  // 128: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
+	18,  // 129: common.Chapter.start:type_name -> common.Timestamp
+	18,  // 130: common.Chapter.end:type_name -> common.Timestamp
 	8,   // 131: common.Chapter.status:type_name -> common.ChapterStatus
-	92,  // 132: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
-	92,  // 133: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
-	92,  // 134: common.SealedChapterLog.chapter:type_name -> common.Chapter
-	92,  // 135: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
-	92,  // 136: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
-	98,  // 137: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
-	100, // 138: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
-	99,  // 139: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
-	17,  // 140: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
+	93,  // 132: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
+	93,  // 133: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
+	93,  // 134: common.SealedChapterLog.chapter:type_name -> common.Chapter
+	93,  // 135: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
+	93,  // 136: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
+	99,  // 137: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
+	101, // 138: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
+	100, // 139: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
+	18,  // 140: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
 	10,  // 141: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
-	101, // 142: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
-	17,  // 143: common.LedgerInfo.created_at:type_name -> common.Timestamp
-	17,  // 144: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
-	34,  // 145: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
+	102, // 142: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
+	18,  // 143: common.LedgerInfo.created_at:type_name -> common.Timestamp
+	18,  // 144: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
+	35,  // 145: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
 	9,   // 146: common.LedgerInfo.mode:type_name -> common.LedgerMode
-	97,  // 147: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
-	102, // 148: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	165, // 149: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	98,  // 147: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
+	103, // 148: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
+	167, // 149: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
 	12,  // 150: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	166, // 151: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
-	32,  // 152: common.SaveMetadataCommand.target:type_name -> common.Target
-	167, // 153: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
-	32,  // 154: common.DeleteMetadataCommand.target:type_name -> common.Target
-	168, // 155: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
-	17,  // 156: common.TransactionState.timestamp:type_name -> common.Timestamp
-	108, // 157: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	168, // 151: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	33,  // 152: common.SaveMetadataCommand.target:type_name -> common.Target
+	169, // 153: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	33,  // 154: common.DeleteMetadataCommand.target:type_name -> common.Target
+	170, // 155: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	18,  // 156: common.TransactionState.timestamp:type_name -> common.Timestamp
+	109, // 157: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
 	11,  // 158: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	169, // 159: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	112, // 160: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	113, // 161: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	114, // 162: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	171, // 159: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	113, // 160: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	114, // 161: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	115, // 162: common.SegmentType.bytes:type_name -> common.BytesConstraint
 	13,  // 163: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	170, // 164: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	115, // 165: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	172, // 164: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	116, // 165: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
 	12,  // 166: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	130, // 167: common.QueryFilter.field:type_name -> common.FieldCondition
-	136, // 168: common.QueryFilter.address:type_name -> common.AddressMatch
-	126, // 169: common.QueryFilter.and:type_name -> common.AndFilter
-	127, // 170: common.QueryFilter.or:type_name -> common.OrFilter
-	128, // 171: common.QueryFilter.not:type_name -> common.NotFilter
-	120, // 172: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	123, // 173: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	121, // 174: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	122, // 175: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	124, // 176: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	125, // 177: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	131, // 178: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	131, // 179: common.LedgerCondition.cond:type_name -> common.StringCondition
-	133, // 180: common.LogIdCondition.cond:type_name -> common.UintCondition
-	3,   // 181: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	133, // 182: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	5,   // 183: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	133, // 184: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	119, // 185: common.AndFilter.filters:type_name -> common.QueryFilter
-	119, // 186: common.OrFilter.filters:type_name -> common.QueryFilter
-	119, // 187: common.NotFilter.filter:type_name -> common.QueryFilter
-	129, // 188: common.FieldCondition.field:type_name -> common.FieldRef
-	131, // 189: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	132, // 190: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	133, // 191: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	134, // 192: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	135, // 193: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 194: common.AddressMatch.role:type_name -> common.AddressRole
-	119, // 195: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 196: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 197: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 198: common.AggregatedVolume.output:type_name -> common.Uint256
-	138, // 199: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	140, // 200: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	138, // 201: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	30,  // 202: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 203: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	144, // 204: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	146, // 205: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	147, // 206: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	149, // 207: common.ListOptions.read:type_name -> common.ReadOptions
-	119, // 208: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 209: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 210: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	26,  // 211: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
-	28,  // 212: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 213: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	27,  // 214: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
-	33,  // 215: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 216: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 217: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 218: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	115, // 219: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 220: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 221: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	115, // 222: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 223: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 224: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 225: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	111, // 226: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	227, // [227:227] is the sub-list for method output_type
-	227, // [227:227] is the sub-list for method input_type
-	227, // [227:227] is the sub-list for extension type_name
-	227, // [227:227] is the sub-list for extension extendee
-	0,   // [0:227] is the sub-list for field type_name
+	132, // 167: common.QueryFilter.field:type_name -> common.FieldCondition
+	138, // 168: common.QueryFilter.address:type_name -> common.AddressMatch
+	128, // 169: common.QueryFilter.and:type_name -> common.AndFilter
+	129, // 170: common.QueryFilter.or:type_name -> common.OrFilter
+	130, // 171: common.QueryFilter.not:type_name -> common.NotFilter
+	121, // 172: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	124, // 173: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	122, // 174: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	123, // 175: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	125, // 176: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	126, // 177: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	127, // 178: common.QueryFilter.audit:type_name -> common.AuditCondition
+	133, // 179: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	133, // 180: common.LedgerCondition.cond:type_name -> common.StringCondition
+	135, // 181: common.LogIdCondition.cond:type_name -> common.UintCondition
+	3,   // 182: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	135, // 183: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	5,   // 184: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	135, // 185: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	14,  // 186: common.AuditCondition.field:type_name -> common.AuditField
+	133, // 187: common.AuditCondition.string_cond:type_name -> common.StringCondition
+	135, // 188: common.AuditCondition.uint_cond:type_name -> common.UintCondition
+	136, // 189: common.AuditCondition.bool_cond:type_name -> common.BoolCondition
+	120, // 190: common.AndFilter.filters:type_name -> common.QueryFilter
+	120, // 191: common.OrFilter.filters:type_name -> common.QueryFilter
+	120, // 192: common.NotFilter.filter:type_name -> common.QueryFilter
+	131, // 193: common.FieldCondition.field:type_name -> common.FieldRef
+	133, // 194: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	134, // 195: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	135, // 196: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	136, // 197: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	137, // 198: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	15,  // 199: common.AddressMatch.role:type_name -> common.AddressRole
+	120, // 200: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	16,  // 201: common.PreparedQuery.target:type_name -> common.QueryTarget
+	23,  // 202: common.AggregatedVolume.input:type_name -> common.Uint256
+	23,  // 203: common.AggregatedVolume.output:type_name -> common.Uint256
+	140, // 204: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	142, // 205: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	140, // 206: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	31,  // 207: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	25,  // 208: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	146, // 209: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	148, // 210: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	149, // 211: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	151, // 212: common.ListOptions.read:type_name -> common.ReadOptions
+	120, // 213: common.ListOptions.filter:type_name -> common.QueryFilter
+	20,  // 214: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	20,  // 215: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	27,  // 216: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
+	29,  // 217: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	20,  // 218: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	28,  // 219: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
+	34,  // 220: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	34,  // 221: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	34,  // 222: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	20,  // 223: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	116, // 224: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	21,  // 225: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	20,  // 226: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	116, // 227: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 228: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	20,  // 229: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	20,  // 230: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	112, // 231: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	232, // [232:232] is the sub-list for method output_type
+	232, // [232:232] is the sub-list for method input_type
+	232, // [232:232] is the sub-list for extension type_name
+	232, // [232:232] is the sub-list for extension extendee
+	0,   // [0:232] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }
@@ -11917,35 +12152,41 @@ func file_common_proto_init() {
 		(*QueryFilter_LogId)(nil),
 		(*QueryFilter_LogBuiltinUint)(nil),
 		(*QueryFilter_AccountHasAsset)(nil),
+		(*QueryFilter_Audit)(nil),
 	}
-	file_common_proto_msgTypes[113].OneofWrappers = []any{
+	file_common_proto_msgTypes[109].OneofWrappers = []any{
+		(*AuditCondition_StringCond)(nil),
+		(*AuditCondition_UintCond)(nil),
+		(*AuditCondition_BoolCond)(nil),
+	}
+	file_common_proto_msgTypes[114].OneofWrappers = []any{
 		(*FieldCondition_StringCond)(nil),
 		(*FieldCondition_IntCond)(nil),
 		(*FieldCondition_UintCond)(nil),
 		(*FieldCondition_BoolCond)(nil),
 		(*FieldCondition_ExistsCond)(nil),
 	}
-	file_common_proto_msgTypes[114].OneofWrappers = []any{
+	file_common_proto_msgTypes[115].OneofWrappers = []any{
 		(*StringCondition_Hardcoded)(nil),
 		(*StringCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[115].OneofWrappers = []any{}
 	file_common_proto_msgTypes[116].OneofWrappers = []any{}
-	file_common_proto_msgTypes[117].OneofWrappers = []any{
+	file_common_proto_msgTypes[117].OneofWrappers = []any{}
+	file_common_proto_msgTypes[118].OneofWrappers = []any{
 		(*BoolCondition_Hardcoded)(nil),
 		(*BoolCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[119].OneofWrappers = []any{
+	file_common_proto_msgTypes[120].OneofWrappers = []any{
 		(*AddressMatch_HardcodedPrefix)(nil),
 		(*AddressMatch_HardcodedExact)(nil),
 		(*AddressMatch_ParamPrefix)(nil),
 		(*AddressMatch_ParamExact)(nil),
 	}
-	file_common_proto_msgTypes[127].OneofWrappers = []any{
+	file_common_proto_msgTypes[128].OneofWrappers = []any{
 		(*CallerIdentity_Issuer)(nil),
 		(*CallerIdentity_KeyId)(nil),
 	}
-	file_common_proto_msgTypes[131].OneofWrappers = []any{
+	file_common_proto_msgTypes[132].OneofWrappers = []any{
 		(*BackupStorage_S3)(nil),
 		(*BackupStorage_Azure)(nil),
 	}
@@ -11954,8 +12195,8 @@ func file_common_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_common_proto_rawDesc), len(file_common_proto_rawDesc)),
-			NumEnums:      17,
-			NumMessages:   154,
+			NumEnums:      18,
+			NumMessages:   155,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -2619,6 +2619,17 @@ func (m *AccountHasAssetCondition) MarshalDeterministicVT(dAtA []byte) []byte {
 	return append(dAtA, b...)
 }
 
+func (m *AuditCondition) MarshalDeterministicVT(dAtA []byte) []byte {
+	if m == nil {
+		return dAtA
+	}
+	b, err := m.MarshalVT()
+	if err != nil {
+		panic("MarshalDeterministicVT: " + err.Error())
+	}
+	return append(dAtA, b...)
+}
+
 func (m *AndFilter) MarshalDeterministicVT(dAtA []byte) []byte {
 	if m == nil {
 		return dAtA

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -9017,6 +9017,78 @@ func NewAccountHasAssetConditionListReader(s []*AccountHasAssetCondition) Accoun
 	return accountHasAssetConditionListReadonly(s)
 }
 
+// AuditConditionReader provides read-only access to AuditCondition.
+// Call Mutate() to obtain a mutable clone.
+type AuditConditionReader interface {
+	GetField() AuditField
+	GetCondition() isAuditCondition_Condition
+	Mutate() *AuditCondition
+}
+
+type auditConditionReadonly struct{ v *AuditCondition }
+
+func (r *auditConditionReadonly) GetField() AuditField {
+	return r.v.GetField()
+}
+
+func (r *auditConditionReadonly) GetCondition() isAuditCondition_Condition {
+	return r.v.GetCondition()
+}
+
+func (r *auditConditionReadonly) Mutate() *AuditCondition {
+	return r.v.CloneVT()
+}
+
+// AsReader returns a read-only view of this AuditCondition.
+func (m *AuditCondition) AsReader() AuditConditionReader {
+	if m == nil {
+		return nil
+	}
+	return &auditConditionReadonly{v: m}
+}
+
+// Mutate returns a mutable deep clone of this AuditCondition.
+func (m *AuditCondition) Mutate() *AuditCondition {
+	return m.CloneVT()
+}
+
+// AuditConditionListReader provides read-only iteration over []*AuditCondition.
+type AuditConditionListReader interface {
+	Len() int
+	Get(i int) AuditConditionReader
+	Range(yield func(int, AuditConditionReader) bool)
+}
+
+type auditConditionListReadonly []*AuditCondition
+
+func (l auditConditionListReadonly) Len() int { return len(l) }
+
+func (l auditConditionListReadonly) Get(i int) AuditConditionReader {
+	v := l[i]
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
+}
+
+func (l auditConditionListReadonly) Range(yield func(int, AuditConditionReader) bool) {
+	for i, v := range l {
+		var r AuditConditionReader
+		if v != nil {
+			r = v.AsReader()
+		}
+		if !yield(i, r) {
+			return
+		}
+	}
+}
+
+// NewAuditConditionListReader wraps s for read-only iteration. The returned
+// view aliases the underlying slice; do not mutate s afterwards.
+func NewAuditConditionListReader(s []*AuditCondition) AuditConditionListReader {
+	return auditConditionListReadonly(s)
+}
+
 // AndFilterReader provides read-only access to AndFilter.
 // Call Mutate() to obtain a mutable clone.
 type AndFilterReader interface {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -2855,6 +2855,15 @@ func (m *QueryFilter_AccountHasAsset) CloneVT() isQueryFilter_Filter {
 	return r
 }
 
+func (m *QueryFilter_Audit) CloneVT() isQueryFilter_Filter {
+	if m == nil {
+		return (*QueryFilter_Audit)(nil)
+	}
+	r := new(QueryFilter_Audit)
+	r.Audit = m.Audit.CloneVT()
+	return r
+}
+
 func (m *ReferenceCondition) CloneVT() *ReferenceCondition {
 	if m == nil {
 		return (*ReferenceCondition)(nil)
@@ -2958,6 +2967,55 @@ func (m *AccountHasAssetCondition) CloneVT() *AccountHasAssetCondition {
 
 func (m *AccountHasAssetCondition) CloneMessageVT() proto.Message {
 	return m.CloneVT()
+}
+
+func (m *AuditCondition) CloneVT() *AuditCondition {
+	if m == nil {
+		return (*AuditCondition)(nil)
+	}
+	r := new(AuditCondition)
+	r.Field = m.Field
+	if m.Condition != nil {
+		r.Condition = m.Condition.(interface {
+			CloneVT() isAuditCondition_Condition
+		}).CloneVT()
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *AuditCondition) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *AuditCondition_StringCond) CloneVT() isAuditCondition_Condition {
+	if m == nil {
+		return (*AuditCondition_StringCond)(nil)
+	}
+	r := new(AuditCondition_StringCond)
+	r.StringCond = m.StringCond.CloneVT()
+	return r
+}
+
+func (m *AuditCondition_UintCond) CloneVT() isAuditCondition_Condition {
+	if m == nil {
+		return (*AuditCondition_UintCond)(nil)
+	}
+	r := new(AuditCondition_UintCond)
+	r.UintCond = m.UintCond.CloneVT()
+	return r
+}
+
+func (m *AuditCondition_BoolCond) CloneVT() isAuditCondition_Condition {
+	if m == nil {
+		return (*AuditCondition_BoolCond)(nil)
+	}
+	r := new(AuditCondition_BoolCond)
+	r.BoolCond = m.BoolCond.CloneVT()
+	return r
 }
 
 func (m *AndFilter) CloneVT() *AndFilter {
@@ -8428,6 +8486,31 @@ func (this *QueryFilter_AccountHasAsset) EqualVT(thatIface isQueryFilter_Filter)
 	return true
 }
 
+func (this *QueryFilter_Audit) EqualVT(thatIface isQueryFilter_Filter) bool {
+	that, ok := thatIface.(*QueryFilter_Audit)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.Audit, that.Audit; p != q {
+		if p == nil {
+			p = &AuditCondition{}
+		}
+		if q == nil {
+			q = &AuditCondition{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
 func (this *ReferenceCondition) EqualVT(that *ReferenceCondition) bool {
 	if this == that {
 		return true
@@ -8551,6 +8634,112 @@ func (this *AccountHasAssetCondition) EqualMessageVT(thatMsg proto.Message) bool
 	}
 	return this.EqualVT(that)
 }
+func (this *AuditCondition) EqualVT(that *AuditCondition) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Condition == nil && that.Condition != nil {
+		return false
+	} else if this.Condition != nil {
+		if that.Condition == nil {
+			return false
+		}
+		if !this.Condition.(interface {
+			EqualVT(isAuditCondition_Condition) bool
+		}).EqualVT(that.Condition) {
+			return false
+		}
+	}
+	if this.Field != that.Field {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *AuditCondition) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*AuditCondition)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *AuditCondition_StringCond) EqualVT(thatIface isAuditCondition_Condition) bool {
+	that, ok := thatIface.(*AuditCondition_StringCond)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.StringCond, that.StringCond; p != q {
+		if p == nil {
+			p = &StringCondition{}
+		}
+		if q == nil {
+			q = &StringCondition{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *AuditCondition_UintCond) EqualVT(thatIface isAuditCondition_Condition) bool {
+	that, ok := thatIface.(*AuditCondition_UintCond)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.UintCond, that.UintCond; p != q {
+		if p == nil {
+			p = &UintCondition{}
+		}
+		if q == nil {
+			q = &UintCondition{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *AuditCondition_BoolCond) EqualVT(thatIface isAuditCondition_Condition) bool {
+	that, ok := thatIface.(*AuditCondition_BoolCond)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.BoolCond, that.BoolCond; p != q {
+		if p == nil {
+			p = &BoolCondition{}
+		}
+		if q == nil {
+			q = &BoolCondition{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
 func (this *AndFilter) EqualVT(that *AndFilter) bool {
 	if this == that {
 		return true
@@ -16844,6 +17033,25 @@ func (m *QueryFilter_AccountHasAsset) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	}
 	return len(dAtA) - i, nil
 }
+func (m *QueryFilter_Audit) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *QueryFilter_Audit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Audit != nil {
+		size, err := m.Audit.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x62
+	}
+	return len(dAtA) - i, nil
+}
 func (m *ReferenceCondition) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -17114,6 +17322,110 @@ func (m *AccountHasAssetCondition) MarshalToSizedBufferVT(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *AuditCondition) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AuditCondition) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AuditCondition) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if vtmsg, ok := m.Condition.(interface {
+		MarshalToSizedBufferVT([]byte) (int, error)
+	}); ok {
+		size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+	}
+	if m.Field != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Field))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *AuditCondition_StringCond) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AuditCondition_StringCond) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.StringCond != nil {
+		size, err := m.StringCond.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
+}
+func (m *AuditCondition_UintCond) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AuditCondition_UintCond) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.UintCond != nil {
+		size, err := m.UintCond.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *AuditCondition_BoolCond) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AuditCondition_BoolCond) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.BoolCond != nil {
+		size, err := m.BoolCond.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	return len(dAtA) - i, nil
+}
 func (m *AndFilter) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -21906,6 +22218,18 @@ func (m *QueryFilter_AccountHasAsset) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *QueryFilter_Audit) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Audit != nil {
+		l = m.Audit.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	return n
+}
 func (m *ReferenceCondition) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -21999,6 +22323,58 @@ func (m *AccountHasAssetCondition) SizeVT() (n int) {
 	return n
 }
 
+func (m *AuditCondition) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Field != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Field))
+	}
+	if vtmsg, ok := m.Condition.(interface{ SizeVT() int }); ok {
+		n += vtmsg.SizeVT()
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *AuditCondition_StringCond) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.StringCond != nil {
+		l = m.StringCond.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	return n
+}
+func (m *AuditCondition_UintCond) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.UintCond != nil {
+		l = m.UintCond.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	return n
+}
+func (m *AuditCondition_BoolCond) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BoolCond != nil {
+		l = m.BoolCond.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	return n
+}
 func (m *AndFilter) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -40170,6 +40546,47 @@ func (m *QueryFilter) UnmarshalVT(dAtA []byte) error {
 				m.Filter = &QueryFilter_AccountHasAsset{AccountHasAsset: v}
 			}
 			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Audit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Filter.(*QueryFilter_Audit); ok {
+				if err := oneof.Audit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &AuditCondition{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Filter = &QueryFilter_Audit{Audit: v}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -40745,6 +41162,199 @@ func (m *AccountHasAssetCondition) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AuditCondition) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AuditCondition: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AuditCondition: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Field", wireType)
+			}
+			m.Field = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Field |= AuditField(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StringCond", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Condition.(*AuditCondition_StringCond); ok {
+				if err := oneof.StringCond.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &StringCondition{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Condition = &AuditCondition_StringCond{StringCond: v}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UintCond", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Condition.(*AuditCondition_UintCond); ok {
+				if err := oneof.UintCond.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &UintCondition{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Condition = &AuditCondition_UintCond{UintCond: v}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BoolCond", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Condition.(*AuditCondition_BoolCond); ok {
+				if err := oneof.BoolCond.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &BoolCondition{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Condition = &AuditCondition_BoolCond{BoolCond: v}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -5568,12 +5568,8 @@ func (x *CheckStoreProgress) GetTotalLogs() uint64 {
 }
 
 type ListAuditEntriesRequest struct {
-	state   protoimpl.MessageState `protogen:"open.v1"`
-	Options *commonpb.ListOptions  `protobuf:"bytes,1,opt,name=options,proto3" json:"options,omitempty"`
-	// failures_only filters audit entries to only those carrying a failure status.
-	FailuresOnly bool `protobuf:"varint,2,opt,name=failures_only,json=failuresOnly,proto3" json:"failures_only,omitempty"`
-	// ledger filters audit entries to only those containing orders targeting this ledger.
-	Ledger        string `protobuf:"bytes,3,opt,name=ledger,proto3" json:"ledger,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Options       *commonpb.ListOptions  `protobuf:"bytes,1,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5613,20 +5609,6 @@ func (x *ListAuditEntriesRequest) GetOptions() *commonpb.ListOptions {
 		return x.Options
 	}
 	return nil
-}
-
-func (x *ListAuditEntriesRequest) GetFailuresOnly() bool {
-	if x != nil {
-		return x.FailuresOnly
-	}
-	return false
-}
-
-func (x *ListAuditEntriesRequest) GetLedger() string {
-	if x != nil {
-		return x.Ledger
-	}
-	return ""
 }
 
 type GetAuditEntryRequest struct {
@@ -9063,11 +9045,9 @@ const file_bucket_proto_rawDesc = "" +
 	"\x12CheckStoreProgress\x12!\n" +
 	"\flogs_checked\x18\x01 \x01(\x06R\vlogsChecked\x12\x1d\n" +
 	"\n" +
-	"total_logs\x18\x02 \x01(\x06R\ttotalLogs\"\x85\x01\n" +
+	"total_logs\x18\x02 \x01(\x06R\ttotalLogs\"k\n" +
 	"\x17ListAuditEntriesRequest\x12-\n" +
-	"\aoptions\x18\x01 \x01(\v2\x13.common.ListOptionsR\aoptions\x12#\n" +
-	"\rfailures_only\x18\x02 \x01(\bR\ffailuresOnly\x12\x16\n" +
-	"\x06ledger\x18\x03 \x01(\tR\x06ledger\"2\n" +
+	"\aoptions\x18\x01 \x01(\v2\x13.common.ListOptionsR\aoptionsJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\rfailures_onlyR\x06ledger\"2\n" +
 	"\x14GetAuditEntryRequest\x12\x1a\n" +
 	"\bsequence\x18\x01 \x01(\x06R\bsequence\"\xa2\x01\n" +
 	"\x0fListLogsRequest\x12\x16\n" +

--- a/internal/proto/servicepb/bucket_reader.pb.go
+++ b/internal/proto/servicepb/bucket_reader.pb.go
@@ -6221,8 +6221,6 @@ func NewCheckStoreProgressListReader(s []*CheckStoreProgress) CheckStoreProgress
 // Call Mutate() to obtain a mutable clone.
 type ListAuditEntriesRequestReader interface {
 	GetOptions() commonpb.ListOptionsReader
-	GetFailuresOnly() bool
-	GetLedger() string
 	Mutate() *ListAuditEntriesRequest
 }
 
@@ -6234,14 +6232,6 @@ func (r *listAuditEntriesRequestReadonly) GetOptions() commonpb.ListOptionsReade
 		return nil
 	}
 	return v.AsReader()
-}
-
-func (r *listAuditEntriesRequestReadonly) GetFailuresOnly() bool {
-	return r.v.GetFailuresOnly()
-}
-
-func (r *listAuditEntriesRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
 }
 
 func (r *listAuditEntriesRequestReadonly) Mutate() *ListAuditEntriesRequest {

--- a/internal/proto/servicepb/bucket_vtproto.pb.go
+++ b/internal/proto/servicepb/bucket_vtproto.pb.go
@@ -1987,8 +1987,6 @@ func (m *ListAuditEntriesRequest) CloneVT() *ListAuditEntriesRequest {
 	}
 	r := new(ListAuditEntriesRequest)
 	r.Options = m.Options.CloneVT()
-	r.FailuresOnly = m.FailuresOnly
-	r.Ledger = m.Ledger
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6316,12 +6314,6 @@ func (this *ListAuditEntriesRequest) EqualVT(that *ListAuditEntriesRequest) bool
 		return false
 	}
 	if !this.Options.EqualVT(that.Options) {
-		return false
-	}
-	if this.FailuresOnly != that.FailuresOnly {
-		return false
-	}
-	if this.Ledger != that.Ledger {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -13115,23 +13107,6 @@ func (m *ListAuditEntriesRequest) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.Ledger) > 0 {
-		i -= len(m.Ledger)
-		copy(dAtA[i:], m.Ledger)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Ledger)))
-		i--
-		dAtA[i] = 0x1a
-	}
-	if m.FailuresOnly {
-		i--
-		if m.FailuresOnly {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x10
-	}
 	if m.Options != nil {
 		size, err := m.Options.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -18066,13 +18041,6 @@ func (m *ListAuditEntriesRequest) SizeVT() (n int) {
 	_ = l
 	if m.Options != nil {
 		l = m.Options.SizeVT()
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	if m.FailuresOnly {
-		n += 2
-	}
-	l = len(m.Ledger)
-	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -30582,58 +30550,6 @@ func (m *ListAuditEntriesRequest) UnmarshalVT(dAtA []byte) error {
 			if err := m.Options.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			iNdEx = postIndex
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FailuresOnly", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.FailuresOnly = bool(v != 0)
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Ledger", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Ledger = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -196,8 +196,8 @@ func matchUintBounds(b resolvedUintBounds, v uint64) bool {
 }
 
 // logSequencePredicate matches when the entry's produced log range
-// [min,max] overlaps the requested bounds. Failures produce no logs and never
-// match a positive log-sequence filter.
+// [min,max] overlaps the requested bounds. Failures and no-log successes (an
+// all-idempotent batch) produce no logs and never match a log-sequence filter.
 func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
 	uc := cond.GetUintCond()
 	if uc == nil {
@@ -211,6 +211,14 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
 		s := e.GetSuccess()
 		if s == nil {
+			return false, nil
+		}
+		// A no-log success (all-idempotent batch) produced no log range:
+		// extractLogSequenceRange records (0,0) and MaxLogSequence == 0 is the
+		// canonical "no logs touched" sentinel (see applied_proposal_sync /
+		// checker / rebuild). Treating (0,0) as a real range would wrongly match
+		// upper-bounded filters (e.g. log_seq <= 100), so skip it like failures.
+		if s.GetMaxLogSequence() == 0 {
 			return false, nil
 		}
 		if bounds.empty {

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -230,20 +230,22 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 }
 
 // hardcodedAuditString extracts the hardcoded value of cond's StringCondition.
-// It rejects a missing condition and a parameterized ($param) value: audit
-// filters are evaluated at scan time and have no parameter-resolution context,
-// so a Param would otherwise read as GetHardcoded() == "" and silently match
-// the empty string.
+// Like hardcodedAuditBool, it rejects a missing condition and any non-hardcoded
+// value (a $param, or an unset oneof): audit filters are evaluated at scan time
+// with no parameter-resolution context, so a Param — or an unset value, which
+// reads as GetHardcoded() == "" — would otherwise silently match the empty
+// string instead of returning InvalidArgument.
 func hardcodedAuditString(cond *commonpb.AuditCondition, field string) (string, error) {
 	sc := cond.GetStringCond()
 	if sc == nil {
 		return "", domain.NewFilterCompilationError("audit field %s requires a string condition", field)
 	}
-	if _, ok := sc.GetValue().(*commonpb.StringCondition_Param); ok {
+	hc, ok := sc.GetValue().(*commonpb.StringCondition_Hardcoded)
+	if !ok {
 		return "", domain.NewFilterCompilationError("audit field %s does not support parameterized conditions", field)
 	}
 
-	return sc.GetHardcoded(), nil
+	return hc.Hardcoded, nil
 }
 
 // hardcodedAuditBool extracts the hardcoded value of cond's BoolCondition.

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -193,7 +193,20 @@ func resolveAuditUintBounds(uc *commonpb.UintCondition, field string) (resolvedU
 		return resolvedUintBounds{}, domain.NewFilterCompilationError("audit field %s requires at least one uint bound", field)
 	}
 
-	return resolveUintBounds(uc, nil)
+	bounds, err := resolveUintBounds(uc, nil)
+	if err != nil {
+		return resolvedUintBounds{}, err
+	}
+	// An inverted range (min >= max after exclusivity adjustment, e.g.
+	// `between 10 and 5` → [10,6)) can never match. Mark it empty so both
+	// matchUintBounds and the log_seq overlap check short-circuit to false,
+	// instead of the overlap test spuriously matching an entry whose log range
+	// straddles the inverted bounds. Equality (min==v, max==v+1) is unaffected.
+	if bounds.hasMin && bounds.hasMax && bounds.min >= bounds.max {
+		bounds.empty = true
+	}
+
+	return bounds, nil
 }
 
 func matchUintBounds(b resolvedUintBounds, v uint64) bool {

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -83,6 +83,14 @@ func (c *auditCompiler) compileAnd(and *commonpb.AndFilter, depth int) (AuditPre
 		preds = append(preds, p)
 	}
 
+	// An empty AND matches nothing, mirroring the index compiler (compile.go's
+	// compileAnd returns an empty iterator for zero children). The DSL never
+	// emits this; a malformed proto request must not widen the result set to
+	// every entry by evaluating a vacuous AND as true.
+	if len(preds) == 0 {
+		return func(*auditpb.AuditEntry, []*auditpb.AuditItem) (bool, error) { return false, nil }, nil
+	}
+
 	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error) {
 		for _, p := range preds {
 			ok, err := p(e, items)

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -1,9 +1,9 @@
 package query
 
 import (
+	"fmt"
 	"slices"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
@@ -15,7 +15,9 @@ import (
 // AuditPredicate decides whether an audit entry matches a compiled filter.
 // items is non-nil only when the filter references AUDIT_FIELD_ORDER_TYPE
 // (see CompileAuditPredicate's needsItems return); other fields ignore it.
-type AuditPredicate func(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) bool
+// The error return surfaces per-entry data faults (e.g. an audit order that
+// fails to unmarshal) instead of silently dropping the entry.
+type AuditPredicate func(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error)
 
 // CompileAuditPredicate turns a QueryFilter into a scan-time predicate over
 // audit entries. needsItems is true iff the filter references ORDER_TYPE, so the
@@ -24,7 +26,7 @@ type AuditPredicate func(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) 
 // FilterCompilationError (mapped to gRPC InvalidArgument).
 func CompileAuditPredicate(filter *commonpb.QueryFilter) (AuditPredicate, bool, error) {
 	if filter == nil {
-		return func(*auditpb.AuditEntry, []*auditpb.AuditItem) bool { return true }, false, nil
+		return func(*auditpb.AuditEntry, []*auditpb.AuditItem) (bool, error) { return true, nil }, false, nil
 	}
 
 	c := &auditCompiler{}
@@ -58,7 +60,14 @@ func (c *auditCompiler) compile(filter *commonpb.QueryFilter, depth int) (AuditP
 			return nil, err
 		}
 
-		return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool { return !inner(e, items) }, nil
+		return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error) {
+			ok, err := inner(e, items)
+			if err != nil {
+				return false, err
+			}
+
+			return !ok, nil
+		}, nil
 	default:
 		return nil, domain.NewFilterCompilationError("unsupported condition for audit target: %T", filter.GetFilter())
 	}
@@ -74,14 +83,18 @@ func (c *auditCompiler) compileAnd(and *commonpb.AndFilter, depth int) (AuditPre
 		preds = append(preds, p)
 	}
 
-	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error) {
 		for _, p := range preds {
-			if !p(e, items) {
-				return false
+			ok, err := p(e, items)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
 			}
 		}
 
-		return true
+		return true, nil
 	}, nil
 }
 
@@ -95,14 +108,18 @@ func (c *auditCompiler) compileOr(or *commonpb.OrFilter, depth int) (AuditPredic
 		preds = append(preds, p)
 	}
 
-	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error) {
 		for _, p := range preds {
-			if p(e, items) {
-				return true
+			ok, err := p(e, items)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
 			}
 		}
 
-		return false
+		return false, nil
 	}, nil
 }
 
@@ -159,8 +176,8 @@ func uintFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 		return nil, err
 	}
 
-	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
-		return matchUintBounds(bounds, get(e))
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
+		return matchUintBounds(bounds, get(e)), nil
 	}, nil
 }
 
@@ -191,40 +208,56 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 		return nil, err
 	}
 
-	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
 		s := e.GetSuccess()
 		if s == nil {
-			return false
+			return false, nil
 		}
 		if bounds.empty {
-			return false
+			return false, nil
 		}
 		lo, hi := s.GetMinLogSequence(), s.GetMaxLogSequence()
 		// Overlap of [lo,hi] with half-open [min,max).
 		if bounds.hasMin && hi < bounds.min {
-			return false
+			return false, nil
 		}
 		if bounds.hasMax && lo >= bounds.max {
-			return false
+			return false, nil
 		}
 
-		return true
+		return true, nil
 	}, nil
+}
+
+// hardcodedAuditString extracts the hardcoded value of cond's StringCondition.
+// It rejects a missing condition and a parameterized ($param) value: audit
+// filters are evaluated at scan time and have no parameter-resolution context,
+// so a Param would otherwise read as GetHardcoded() == "" and silently match
+// the empty string.
+func hardcodedAuditString(cond *commonpb.AuditCondition, field string) (string, error) {
+	sc := cond.GetStringCond()
+	if sc == nil {
+		return "", domain.NewFilterCompilationError("audit field %s requires a string condition", field)
+	}
+	if _, ok := sc.GetValue().(*commonpb.StringCondition_Param); ok {
+		return "", domain.NewFilterCompilationError("audit field %s does not support parameterized conditions", field)
+	}
+
+	return sc.GetHardcoded(), nil
 }
 
 // outcomePredicate matches a string condition whose value is "success" or
 // "failure".
 func outcomePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
-	sc := cond.GetStringCond()
-	if sc == nil {
-		return nil, domain.NewFilterCompilationError("audit field outcome requires a string condition")
+	want, err := hardcodedAuditString(cond, "outcome")
+	if err != nil {
+		return nil, err
 	}
-	want := sc.GetHardcoded()
 	switch want {
 	case "success":
-		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool { return e.GetSuccess() != nil }, nil
+		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) { return e.GetSuccess() != nil, nil }, nil
 	case "failure":
-		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool { return e.GetFailure() != nil }, nil
+		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) { return e.GetFailure() != nil, nil }, nil
 	default:
 		return nil, domain.NewFilterCompilationError("audit field outcome must be \"success\" or \"failure\", got %q", want)
 	}
@@ -233,14 +266,13 @@ func outcomePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
 // stringFieldPredicate matches a hardcoded StringCondition against one or more
 // string values from the entry (match-any: success against ANY value).
 func stringFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEntry) []string) (AuditPredicate, error) {
-	sc := cond.GetStringCond()
-	if sc == nil {
-		return nil, domain.NewFilterCompilationError("audit field %v requires a string condition", cond.GetField())
+	want, err := hardcodedAuditString(cond, cond.GetField().String())
+	if err != nil {
+		return nil, err
 	}
-	want := sc.GetHardcoded()
 
-	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
-		return slices.Contains(get(e), want)
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
+		return slices.Contains(get(e), want), nil
 	}, nil
 }
 
@@ -251,8 +283,8 @@ func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 	}
 	want := bc.GetHardcoded()
 
-	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
-		return get(e) == want
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
+		return get(e) == want, nil
 	}, nil
 }
 
@@ -261,24 +293,27 @@ func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 // is not on the audit header, so the caller must supply the entry's AuditItems
 // (see CompileAuditPredicate's needsItems return).
 func orderTypePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
-	sc := cond.GetStringCond()
-	if sc == nil {
-		return nil, domain.NewFilterCompilationError("audit field order_type requires a string condition")
+	want, err := hardcodedAuditString(cond, "order_type")
+	if err != nil {
+		return nil, err
 	}
-	want := sc.GetHardcoded()
 
-	return func(_ *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+	return func(_ *auditpb.AuditEntry, items []*auditpb.AuditItem) (bool, error) {
 		for _, it := range items {
 			order := &raftcmdpb.Order{}
-			if err := proto.Unmarshal(it.GetSerializedOrder(), order); err != nil {
-				continue // unreadable order bytes cannot match a positive filter
+			if err := order.UnmarshalVT(it.GetSerializedOrder()); err != nil {
+				// The audit zone is the cryptographic source of truth; order
+				// bytes that fail to unmarshal indicate corruption/tampering,
+				// not an expected runtime condition. Surface it loudly through
+				// the error-capable cursor rather than silently dropping it.
+				return false, fmt.Errorf("unmarshalling audit order (index %d): %w", it.GetOrderIndex(), err)
 			}
 			if orderTypeName(order) == want {
-				return true
+				return true, nil
 			}
 		}
 
-		return false
+		return false, nil
 	}, nil
 }
 

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -57,6 +57,7 @@ func (c *auditCompiler) compile(filter *commonpb.QueryFilter, depth int) (AuditP
 		if err != nil {
 			return nil, err
 		}
+
 		return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool { return !inner(e, items) }, nil
 	default:
 		return nil, domain.NewFilterCompilationError("unsupported condition for audit target: %T", filter.GetFilter())
@@ -72,12 +73,14 @@ func (c *auditCompiler) compileAnd(and *commonpb.AndFilter, depth int) (AuditPre
 		}
 		preds = append(preds, p)
 	}
+
 	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
 		for _, p := range preds {
 			if !p(e, items) {
 				return false
 			}
 		}
+
 		return true
 	}, nil
 }
@@ -91,12 +94,14 @@ func (c *auditCompiler) compileOr(or *commonpb.OrFilter, depth int) (AuditPredic
 		}
 		preds = append(preds, p)
 	}
+
 	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
 		for _, p := range preds {
 			if p(e, items) {
 				return true
 			}
 		}
+
 		return false
 	}, nil
 }
@@ -118,6 +123,7 @@ func (c *auditCompiler) compileCondition(cond *commonpb.AuditCondition) (AuditPr
 			if e.GetFailure() == nil {
 				return nil
 			}
+
 			return []string{domain.ReasonString(e.GetFailure().GetReason())}
 		})
 	case commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT:
@@ -134,6 +140,7 @@ func (c *auditCompiler) compileCondition(cond *commonpb.AuditCondition) (AuditPr
 		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string { return e.GetLedgers() })
 	case commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE:
 		c.needsItems = true
+
 		return orderTypePredicate(cond)
 	default:
 		return nil, domain.NewFilterCompilationError("unsupported audit field: %v", cond.GetField())
@@ -151,6 +158,7 @@ func uintFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 	if err != nil {
 		return nil, err
 	}
+
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
 		return matchUintBounds(bounds, get(e))
 	}, nil
@@ -166,6 +174,7 @@ func matchUintBounds(b resolvedUintBounds, v uint64) bool {
 	if b.hasMax && v >= b.max { // max is exclusive (half-open)
 		return false
 	}
+
 	return true
 }
 
@@ -181,6 +190,7 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
 		s := e.GetSuccess()
 		if s == nil {
@@ -197,6 +207,7 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 		if bounds.hasMax && lo >= bounds.max {
 			return false
 		}
+
 		return true
 	}, nil
 }
@@ -227,6 +238,7 @@ func stringFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.Audit
 		return nil, domain.NewFilterCompilationError("audit field %v requires a string condition", cond.GetField())
 	}
 	want := sc.GetHardcoded()
+
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
 		return slices.Contains(get(e), want)
 	}, nil
@@ -238,6 +250,7 @@ func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 		return nil, domain.NewFilterCompilationError("audit field %v requires a bool condition", cond.GetField())
 	}
 	want := bc.GetHardcoded()
+
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
 		return get(e) == want
 	}, nil
@@ -253,6 +266,7 @@ func orderTypePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
 		return nil, domain.NewFilterCompilationError("audit field order_type requires a string condition")
 	}
 	want := sc.GetHardcoded()
+
 	return func(_ *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
 		for _, it := range items {
 			order := &raftcmdpb.Order{}
@@ -263,6 +277,7 @@ func orderTypePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
 				return true
 			}
 		}
+
 		return false
 	}, nil
 }
@@ -291,5 +306,6 @@ func activeOneofName(m protoreflect.Message, oneof protoreflect.Name) string {
 	if fd == nil {
 		return ""
 	}
+
 	return string(fd.Name())
 }

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -3,9 +3,13 @@ package query
 import (
 	"slices"
 
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
 // AuditPredicate decides whether an audit entry matches a compiled filter.
@@ -239,7 +243,53 @@ func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 	}, nil
 }
 
-// orderTypePredicate is a temporary stub replaced in Task 3.
+// orderTypePredicate matches (match-any) when any order in the proposal has the
+// requested payload variant name (e.g. "apply", "save_numscript"). Order type
+// is not on the audit header, so the caller must supply the entry's AuditItems
+// (see CompileAuditPredicate's needsItems return).
 func orderTypePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
-	return nil, domain.NewFilterCompilationError("order_type filtering not yet implemented")
+	sc := cond.GetStringCond()
+	if sc == nil {
+		return nil, domain.NewFilterCompilationError("audit field order_type requires a string condition")
+	}
+	want := sc.GetHardcoded()
+	return func(_ *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+		for _, it := range items {
+			order := &raftcmdpb.Order{}
+			if err := proto.Unmarshal(it.GetSerializedOrder(), order); err != nil {
+				continue // unreadable order bytes cannot match a positive filter
+			}
+			if orderTypeName(order) == want {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// orderTypeName returns the proto field name of the active order payload oneof
+// (e.g. "apply", "create_ledger", "register_signing_key"), or "" if unset.
+// Derived via protoreflect so the full variant set is sourced from the proto,
+// not a hand-maintained switch.
+func orderTypeName(order *raftcmdpb.Order) string {
+	switch t := order.GetType().(type) {
+	case *raftcmdpb.Order_LedgerScoped:
+		return activeOneofName(t.LedgerScoped.ProtoReflect(), "payload")
+	case *raftcmdpb.Order_SystemScoped:
+		return activeOneofName(t.SystemScoped.ProtoReflect(), "payload")
+	default:
+		return ""
+	}
+}
+
+func activeOneofName(m protoreflect.Message, oneof protoreflect.Name) string {
+	od := m.Descriptor().Oneofs().ByName(oneof)
+	if od == nil {
+		return ""
+	}
+	fd := m.WhichOneof(od)
+	if fd == nil {
+		return ""
+	}
+	return string(fd.Name())
 }

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -118,7 +118,7 @@ func (c *auditCompiler) compileCondition(cond *commonpb.AuditCondition) (AuditPr
 			if e.GetFailure() == nil {
 				return nil
 			}
-			return []string{e.GetFailure().GetErrorType()}
+			return []string{domain.ReasonString(e.GetFailure().GetReason())}
 		})
 	case commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT:
 		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string {

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -1,0 +1,245 @@
+package query
+
+import (
+	"slices"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// AuditPredicate decides whether an audit entry matches a compiled filter.
+// items is non-nil only when the filter references AUDIT_FIELD_ORDER_TYPE
+// (see CompileAuditPredicate's needsItems return); other fields ignore it.
+type AuditPredicate func(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) bool
+
+// CompileAuditPredicate turns a QueryFilter into a scan-time predicate over
+// audit entries. needsItems is true iff the filter references ORDER_TYPE, so the
+// caller only pays the per-entry AuditItem load when required. Unsupported
+// QueryFilter variants and field/condition mismatches return a
+// FilterCompilationError (mapped to gRPC InvalidArgument).
+func CompileAuditPredicate(filter *commonpb.QueryFilter) (AuditPredicate, bool, error) {
+	if filter == nil {
+		return func(*auditpb.AuditEntry, []*auditpb.AuditItem) bool { return true }, false, nil
+	}
+
+	c := &auditCompiler{}
+	pred, err := c.compile(filter, 0)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return pred, c.needsItems, nil
+}
+
+type auditCompiler struct {
+	needsItems bool
+}
+
+func (c *auditCompiler) compile(filter *commonpb.QueryFilter, depth int) (AuditPredicate, error) {
+	if depth >= MaxFilterDepth {
+		return nil, ErrFilterTooDeep
+	}
+
+	switch f := filter.GetFilter().(type) {
+	case *commonpb.QueryFilter_Audit:
+		return c.compileCondition(f.Audit)
+	case *commonpb.QueryFilter_And:
+		return c.compileAnd(f.And, depth)
+	case *commonpb.QueryFilter_Or:
+		return c.compileOr(f.Or, depth)
+	case *commonpb.QueryFilter_Not:
+		inner, err := c.compile(f.Not.GetFilter(), depth+1)
+		if err != nil {
+			return nil, err
+		}
+		return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool { return !inner(e, items) }, nil
+	default:
+		return nil, domain.NewFilterCompilationError("unsupported condition for audit target: %T", filter.GetFilter())
+	}
+}
+
+func (c *auditCompiler) compileAnd(and *commonpb.AndFilter, depth int) (AuditPredicate, error) {
+	preds := make([]AuditPredicate, 0, len(and.GetFilters()))
+	for _, sub := range and.GetFilters() {
+		p, err := c.compile(sub, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		preds = append(preds, p)
+	}
+	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+		for _, p := range preds {
+			if !p(e, items) {
+				return false
+			}
+		}
+		return true
+	}, nil
+}
+
+func (c *auditCompiler) compileOr(or *commonpb.OrFilter, depth int) (AuditPredicate, error) {
+	preds := make([]AuditPredicate, 0, len(or.GetFilters()))
+	for _, sub := range or.GetFilters() {
+		p, err := c.compile(sub, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		preds = append(preds, p)
+	}
+	return func(e *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+		for _, p := range preds {
+			if p(e, items) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+func (c *auditCompiler) compileCondition(cond *commonpb.AuditCondition) (AuditPredicate, error) {
+	switch cond.GetField() {
+	case commonpb.AuditField_AUDIT_FIELD_SEQUENCE:
+		return uintFieldPredicate(cond, func(e *auditpb.AuditEntry) uint64 { return e.GetSequence() })
+	case commonpb.AuditField_AUDIT_FIELD_PROPOSAL_ID:
+		return uintFieldPredicate(cond, func(e *auditpb.AuditEntry) uint64 { return e.GetProposalId() })
+	case commonpb.AuditField_AUDIT_FIELD_TIMESTAMP:
+		return uintFieldPredicate(cond, func(e *auditpb.AuditEntry) uint64 { return e.GetTimestamp().GetData() })
+	case commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE:
+		return logSequencePredicate(cond)
+	case commonpb.AuditField_AUDIT_FIELD_OUTCOME:
+		return outcomePredicate(cond)
+	case commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE:
+		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string {
+			if e.GetFailure() == nil {
+				return nil
+			}
+			return []string{e.GetFailure().GetErrorType()}
+		})
+	case commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT:
+		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string {
+			return []string{e.GetCallerSnapshot().GetIdentity().GetSubject()}
+		})
+	case commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE:
+		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string {
+			return e.GetCallerSnapshot().GetScopes()
+		})
+	case commonpb.AuditField_AUDIT_FIELD_CALLER_GOD:
+		return boolFieldPredicate(cond, func(e *auditpb.AuditEntry) bool { return e.GetCallerSnapshot().GetGod() })
+	case commonpb.AuditField_AUDIT_FIELD_LEDGER:
+		return stringFieldPredicate(cond, func(e *auditpb.AuditEntry) []string { return e.GetLedgers() })
+	case commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE:
+		c.needsItems = true
+		return orderTypePredicate(cond)
+	default:
+		return nil, domain.NewFilterCompilationError("unsupported audit field: %v", cond.GetField())
+	}
+}
+
+// uintFieldPredicate evaluates a UintCondition against a single uint64 getter,
+// reusing the same bounds semantics as the index compiler (half-open [min,max)).
+func uintFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEntry) uint64) (AuditPredicate, error) {
+	uc := cond.GetUintCond()
+	if uc == nil {
+		return nil, domain.NewFilterCompilationError("audit field %v requires a uint condition", cond.GetField())
+	}
+	bounds, err := resolveUintBounds(uc, nil)
+	if err != nil {
+		return nil, err
+	}
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
+		return matchUintBounds(bounds, get(e))
+	}, nil
+}
+
+func matchUintBounds(b resolvedUintBounds, v uint64) bool {
+	if b.empty {
+		return false
+	}
+	if b.hasMin && v < b.min {
+		return false
+	}
+	if b.hasMax && v >= b.max { // max is exclusive (half-open)
+		return false
+	}
+	return true
+}
+
+// logSequencePredicate matches when the entry's produced log range
+// [min,max] overlaps the requested bounds. Failures produce no logs and never
+// match a positive log-sequence filter.
+func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
+	uc := cond.GetUintCond()
+	if uc == nil {
+		return nil, domain.NewFilterCompilationError("audit field log_seq requires a uint condition")
+	}
+	bounds, err := resolveUintBounds(uc, nil)
+	if err != nil {
+		return nil, err
+	}
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
+		s := e.GetSuccess()
+		if s == nil {
+			return false
+		}
+		if bounds.empty {
+			return false
+		}
+		lo, hi := s.GetMinLogSequence(), s.GetMaxLogSequence()
+		// Overlap of [lo,hi] with half-open [min,max).
+		if bounds.hasMin && hi < bounds.min {
+			return false
+		}
+		if bounds.hasMax && lo >= bounds.max {
+			return false
+		}
+		return true
+	}, nil
+}
+
+// outcomePredicate matches a string condition whose value is "success" or
+// "failure".
+func outcomePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
+	sc := cond.GetStringCond()
+	if sc == nil {
+		return nil, domain.NewFilterCompilationError("audit field outcome requires a string condition")
+	}
+	want := sc.GetHardcoded()
+	switch want {
+	case "success":
+		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool { return e.GetSuccess() != nil }, nil
+	case "failure":
+		return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool { return e.GetFailure() != nil }, nil
+	default:
+		return nil, domain.NewFilterCompilationError("audit field outcome must be \"success\" or \"failure\", got %q", want)
+	}
+}
+
+// stringFieldPredicate matches a hardcoded StringCondition against one or more
+// string values from the entry (match-any: success against ANY value).
+func stringFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEntry) []string) (AuditPredicate, error) {
+	sc := cond.GetStringCond()
+	if sc == nil {
+		return nil, domain.NewFilterCompilationError("audit field %v requires a string condition", cond.GetField())
+	}
+	want := sc.GetHardcoded()
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
+		return slices.Contains(get(e), want)
+	}, nil
+}
+
+func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEntry) bool) (AuditPredicate, error) {
+	bc := cond.GetBoolCond()
+	if bc == nil {
+		return nil, domain.NewFilterCompilationError("audit field %v requires a bool condition", cond.GetField())
+	}
+	want := bc.GetHardcoded()
+	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) bool {
+		return get(e) == want
+	}, nil
+}
+
+// orderTypePredicate is a temporary stub replaced in Task 3.
+func orderTypePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
+	return nil, domain.NewFilterCompilationError("order_type filtering not yet implemented")
+}

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -171,7 +171,7 @@ func uintFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 	if uc == nil {
 		return nil, domain.NewFilterCompilationError("audit field %v requires a uint condition", cond.GetField())
 	}
-	bounds, err := resolveUintBounds(uc, nil)
+	bounds, err := resolveAuditUintBounds(uc, cond.GetField().String())
 	if err != nil {
 		return nil, err
 	}
@@ -179,6 +179,21 @@ func uintFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEn
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
 		return matchUintBounds(bounds, get(e)), nil
 	}, nil
+}
+
+// resolveAuditUintBounds validates and resolves an audit UintCondition. Audit
+// filters are evaluated at scan time, and — unlike the index path — a
+// UintCondition with no bound set must be rejected rather than compiled to an
+// unbounded range that silently matches every entry (mirrors
+// hardcodedAuditString/hardcodedAuditBool). The four input fields are checked
+// directly (not the resolved bounds) so the legitimate `field <= MaxUint64`
+// shape, which resolves to no upper bound, is not falsely rejected.
+func resolveAuditUintBounds(uc *commonpb.UintCondition, field string) (resolvedUintBounds, error) {
+	if uc.GetParamMin() == "" && uc.Min == nil && uc.GetParamMax() == "" && uc.Max == nil {
+		return resolvedUintBounds{}, domain.NewFilterCompilationError("audit field %s requires at least one uint bound", field)
+	}
+
+	return resolveUintBounds(uc, nil)
 }
 
 func matchUintBounds(b resolvedUintBounds, v uint64) bool {
@@ -203,7 +218,7 @@ func logSequencePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error)
 	if uc == nil {
 		return nil, domain.NewFilterCompilationError("audit field log_seq requires a uint condition")
 	}
-	bounds, err := resolveUintBounds(uc, nil)
+	bounds, err := resolveAuditUintBounds(uc, "log_seq")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -246,6 +246,25 @@ func hardcodedAuditString(cond *commonpb.AuditCondition, field string) (string, 
 	return sc.GetHardcoded(), nil
 }
 
+// hardcodedAuditBool extracts the hardcoded value of cond's BoolCondition.
+// Like hardcodedAuditString, it rejects a missing condition and any
+// non-hardcoded value (a $param, or an unset oneof): audit filters are
+// evaluated at scan time with no parameter-resolution context, so a Param
+// would otherwise read as GetHardcoded() == false and silently match against
+// false instead of returning InvalidArgument.
+func hardcodedAuditBool(cond *commonpb.AuditCondition) (bool, error) {
+	bc := cond.GetBoolCond()
+	if bc == nil {
+		return false, domain.NewFilterCompilationError("audit field %v requires a bool condition", cond.GetField())
+	}
+	hc, ok := bc.GetValue().(*commonpb.BoolCondition_Hardcoded)
+	if !ok {
+		return false, domain.NewFilterCompilationError("audit field %v does not support parameterized conditions", cond.GetField())
+	}
+
+	return hc.Hardcoded, nil
+}
+
 // outcomePredicate matches a string condition whose value is "success" or
 // "failure".
 func outcomePredicate(cond *commonpb.AuditCondition) (AuditPredicate, error) {
@@ -277,11 +296,10 @@ func stringFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.Audit
 }
 
 func boolFieldPredicate(cond *commonpb.AuditCondition, get func(*auditpb.AuditEntry) bool) (AuditPredicate, error) {
-	bc := cond.GetBoolCond()
-	if bc == nil {
-		return nil, domain.NewFilterCompilationError("audit field %v requires a bool condition", cond.GetField())
+	want, err := hardcodedAuditBool(cond)
+	if err != nil {
+		return nil, err
 	}
-	want := bc.GetHardcoded()
 
 	return func(e *auditpb.AuditEntry, _ []*auditpb.AuditItem) (bool, error) {
 		return get(e) == want, nil

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -1,0 +1,138 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func uintEq(v uint64) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Min: &v, Max: &v}
+}
+
+func auditFilter(field commonpb.AuditField, cond any) *commonpb.QueryFilter {
+	ac := &commonpb.AuditCondition{Field: field}
+	switch c := cond.(type) {
+	case *commonpb.UintCondition:
+		ac.Condition = &commonpb.AuditCondition_UintCond{UintCond: c}
+	case *commonpb.StringCondition:
+		ac.Condition = &commonpb.AuditCondition_StringCond{StringCond: c}
+	case *commonpb.BoolCondition:
+		ac.Condition = &commonpb.AuditCondition_BoolCond{BoolCond: c}
+	}
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: ac}}
+}
+
+func strEq(v string) *commonpb.StringCondition {
+	return &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: v}}
+}
+
+func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
+	t.Parallel()
+
+	success := &auditpb.AuditEntry{
+		Sequence:   7,
+		ProposalId: 42,
+		Timestamp:  &commonpb.Timestamp{Data: 1700000000000000000},
+		Outcome:    &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{MinLogSequence: 100, MaxLogSequence: 105}},
+		Ledgers:    []string{"main", "treasury"},
+		CallerSnapshot: &commonpb.CallerSnapshot{
+			Identity: &commonpb.CallerIdentity{Subject: "alice"},
+			Scopes:   []string{"ledger:read", "ledger:write"},
+			God:      true,
+		},
+	}
+	failure := &auditpb.AuditEntry{
+		Sequence: 8,
+		Outcome:  &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{ErrorType: "insufficient_funds"}},
+	}
+
+	tests := []struct {
+		name   string
+		filter *commonpb.QueryFilter
+		entry  *auditpb.AuditEntry
+		want   bool
+	}{
+		{"seq match", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, uintEq(7)), success, true},
+		{"seq miss", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, uintEq(9)), success, false},
+		{"proposal id", auditFilter(commonpb.AuditField_AUDIT_FIELD_PROPOSAL_ID, uintEq(42)), success, true},
+		{"timestamp", auditFilter(commonpb.AuditField_AUDIT_FIELD_TIMESTAMP, uintEq(1700000000000000000)), success, true},
+		{"outcome success", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("success")), success, true},
+		{"outcome failure on success", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("failure")), success, false},
+		{"error type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("insufficient_funds")), failure, true},
+		{"error type on success", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("insufficient_funds")), success, false},
+		{"caller subject", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, strEq("alice")), success, true},
+		{"caller scope contains", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE, strEq("ledger:write")), success, true},
+		{"caller scope miss", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE, strEq("admin")), success, false},
+		{"caller god", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, &commonpb.BoolCondition{Value: &commonpb.BoolCondition_Hardcoded{Hardcoded: true}}), success, true},
+		{"ledger contains", auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("treasury")), success, true},
+		{"ledger miss", auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("other")), success, false},
+		{"log seq overlap", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), success, true},
+		{"log seq outside", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(200)), success, false},
+		{"log seq on failure", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), failure, false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pred, needsItems, err := CompileAuditPredicate(tc.filter)
+			require.NoError(t, err)
+			require.False(t, needsItems)
+			require.Equal(t, tc.want, pred(tc.entry, nil))
+		})
+	}
+}
+
+func TestCompileAuditPredicate_NilMatchesAll(t *testing.T) {
+	t.Parallel()
+	pred, needsItems, err := CompileAuditPredicate(nil)
+	require.NoError(t, err)
+	require.False(t, needsItems)
+	require.True(t, pred(&auditpb.AuditEntry{}, nil))
+}
+
+func TestCompileAuditPredicate_Composition(t *testing.T) {
+	t.Parallel()
+	entry := &auditpb.AuditEntry{
+		Outcome: &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{ErrorType: "x"}},
+		Ledgers: []string{"main"},
+	}
+	and := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("failure")),
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("main")),
+	}}}}
+	pred, _, err := CompileAuditPredicate(and)
+	require.NoError(t, err)
+	require.True(t, pred(entry, nil))
+
+	not := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+		Filter: auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("success")),
+	}}}
+	predNot, _, err := CompileAuditPredicate(not)
+	require.NoError(t, err)
+	require.True(t, predNot(entry, nil))
+}
+
+func TestCompileAuditPredicate_Rejections(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		filter *commonpb.QueryFilter
+	}{
+		{"non-audit variant", &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Ledger{Ledger: &commonpb.LedgerCondition{Cond: strEq("x")}}}},
+		{"field/type mismatch", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, strEq("x"))},
+		{"unspecified field", auditFilter(commonpb.AuditField_AUDIT_FIELD_UNSPECIFIED, uintEq(1))},
+		{"bad outcome value", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("maybe"))},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := CompileAuditPredicate(tc.filter)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -49,7 +49,7 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 	}
 	failure := &auditpb.AuditEntry{
 		Sequence: 8,
-		Outcome:  &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{ErrorType: "insufficient_funds"}},
+		Outcome:  &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{Reason: commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS}},
 	}
 
 	tests := []struct {
@@ -64,8 +64,8 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 		{"timestamp", auditFilter(commonpb.AuditField_AUDIT_FIELD_TIMESTAMP, uintEq(1700000000000000000)), success, true},
 		{"outcome success", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("success")), success, true},
 		{"outcome failure on success", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("failure")), success, false},
-		{"error type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("insufficient_funds")), failure, true},
-		{"error type on success", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("insufficient_funds")), success, false},
+		{"error type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("INSUFFICIENT_FUNDS")), failure, true},
+		{"error type on success", auditFilter(commonpb.AuditField_AUDIT_FIELD_ERROR_TYPE, strEq("INSUFFICIENT_FUNDS")), success, false},
 		{"caller subject", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, strEq("alice")), success, true},
 		{"caller scope contains", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE, strEq("ledger:write")), success, true},
 		{"caller scope miss", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SCOPE, strEq("admin")), success, false},
@@ -99,7 +99,7 @@ func TestCompileAuditPredicate_NilMatchesAll(t *testing.T) {
 func TestCompileAuditPredicate_Composition(t *testing.T) {
 	t.Parallel()
 	entry := &auditpb.AuditEntry{
-		Outcome: &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{ErrorType: "x"}},
+		Outcome: &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{Reason: commonpb.ErrorReason_ERROR_REASON_VALIDATION}},
 		Ledgers: []string{"main"},
 	}
 	and := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -171,6 +171,9 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 		{"parameterized order_type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strParam("t"))},
 		{"parameterized caller.god", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, boolParam("g"))},
 		{"unset bool oneof caller.god", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, &commonpb.BoolCondition{})},
+		{"unset string oneof caller.subject", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, &commonpb.StringCondition{})},
+		{"unset string oneof outcome", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, &commonpb.StringCondition{})},
+		{"unset string oneof order_type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, &commonpb.StringCondition{})},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
 func uintEq(v uint64) *commonpb.UintCondition {
@@ -135,4 +137,43 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func itemWithOrder(t *testing.T, order *raftcmdpb.Order) *auditpb.AuditItem {
+	t.Helper()
+	b, err := proto.Marshal(order)
+	require.NoError(t, err)
+	return &auditpb.AuditItem{SerializedOrder: b}
+}
+
+func TestCompileAuditPredicate_OrderType(t *testing.T) {
+	t.Parallel()
+
+	applyOrder := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{
+		LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+			Ledger:  "main",
+			Payload: &raftcmdpb.LedgerScopedOrder_Apply{Apply: &raftcmdpb.LedgerApplyOrder{}},
+		},
+	}}
+	numscriptOrder := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{
+		LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+			Ledger:  "main",
+			Payload: &raftcmdpb.LedgerScopedOrder_SaveNumscript{SaveNumscript: &raftcmdpb.SaveNumscriptOrder{}},
+		},
+	}}
+
+	entry := &auditpb.AuditEntry{Sequence: 1}
+	items := []*auditpb.AuditItem{itemWithOrder(t, applyOrder), itemWithOrder(t, numscriptOrder)}
+
+	pred, needsItems, err := CompileAuditPredicate(
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strEq("apply")))
+	require.NoError(t, err)
+	require.True(t, needsItems)
+	require.True(t, pred(entry, items))      // match-any: apply present
+	require.False(t, pred(entry, items[1:])) // only numscript -> no match
+
+	predMiss, _, err := CompileAuditPredicate(
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strEq("create_ledger")))
+	require.NoError(t, err)
+	require.False(t, predMiss(entry, items))
 }

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -116,6 +116,25 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	predNot, _, err := CompileAuditPredicate(not)
 	require.NoError(t, err)
 	require.True(t, predNot(entry, nil))
+
+	// Or is the lowered form of `audit[ledger] in (other, main)`: matches when
+	// any branch matches.
+	or := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("other")),
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("main")),
+	}}}}
+	predOr, _, err := CompileAuditPredicate(or)
+	require.NoError(t, err)
+	require.True(t, predOr(entry, nil))
+
+	// Or with no matching branch is false.
+	orMiss := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("other")),
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_LEDGER, strEq("nope")),
+	}}}}
+	predOrMiss, _, err := CompileAuditPredicate(orMiss)
+	require.NoError(t, err)
+	require.False(t, predOrMiss(entry, nil))
 }
 
 func TestCompileAuditPredicate_Rejections(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -191,6 +191,8 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 		{"unset string oneof caller.subject", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, &commonpb.StringCondition{})},
 		{"unset string oneof outcome", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, &commonpb.StringCondition{})},
 		{"unset string oneof order_type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, &commonpb.StringCondition{})},
+		{"unset uint oneof sequence", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, &commonpb.UintCondition{})},
+		{"unset uint oneof log_seq", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, &commonpb.UintCondition{})},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -37,6 +37,10 @@ func strParam(p string) *commonpb.StringCondition {
 	return &commonpb.StringCondition{Value: &commonpb.StringCondition_Param{Param: p}}
 }
 
+func boolParam(p string) *commonpb.BoolCondition {
+	return &commonpb.BoolCondition{Value: &commonpb.BoolCondition_Param{Param: p}}
+}
+
 // mustMatch runs pred and fails the test on a predicate error, returning the
 // match result. Predicates only error on per-entry data faults (e.g. a corrupt
 // audit order), which the dedicated tests assert explicitly.
@@ -165,6 +169,8 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 		{"parameterized string field", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, strParam("user"))},
 		{"parameterized outcome", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strParam("o"))},
 		{"parameterized order_type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strParam("t"))},
+		{"parameterized caller.god", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, boolParam("g"))},
+		{"unset bool oneof caller.god", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_GOD, &commonpb.BoolCondition{})},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -179,6 +179,18 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	predOrMiss, _, err := CompileAuditPredicate(orMiss)
 	require.NoError(t, err)
 	require.False(t, mustMatch(t, predOrMiss, entry, nil))
+
+	// An empty AND/OR (only reachable from a malformed proto request, never the
+	// DSL) matches nothing, mirroring the index compiler's empty-iterator result.
+	emptyAnd := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{}}}
+	predEmptyAnd, _, err := CompileAuditPredicate(emptyAnd)
+	require.NoError(t, err)
+	require.False(t, mustMatch(t, predEmptyAnd, entry, nil))
+
+	emptyOr := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{}}}
+	predEmptyOr, _, err := CompileAuditPredicate(emptyOr)
+	require.NoError(t, err)
+	require.False(t, mustMatch(t, predEmptyOr, entry, nil))
 }
 
 func TestCompileAuditPredicate_InvertedLogSeqRange(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -33,6 +33,21 @@ func strEq(v string) *commonpb.StringCondition {
 	return &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: v}}
 }
 
+func strParam(p string) *commonpb.StringCondition {
+	return &commonpb.StringCondition{Value: &commonpb.StringCondition_Param{Param: p}}
+}
+
+// mustMatch runs pred and fails the test on a predicate error, returning the
+// match result. Predicates only error on per-entry data faults (e.g. a corrupt
+// audit order), which the dedicated tests assert explicitly.
+func mustMatch(t *testing.T, pred AuditPredicate, entry *auditpb.AuditEntry, items []*auditpb.AuditItem) bool {
+	t.Helper()
+	ok, err := pred(entry, items)
+	require.NoError(t, err)
+
+	return ok
+}
+
 func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 	t.Parallel()
 
@@ -83,7 +98,7 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 			pred, needsItems, err := CompileAuditPredicate(tc.filter)
 			require.NoError(t, err)
 			require.False(t, needsItems)
-			require.Equal(t, tc.want, pred(tc.entry, nil))
+			require.Equal(t, tc.want, mustMatch(t, pred, tc.entry, nil))
 		})
 	}
 }
@@ -93,7 +108,7 @@ func TestCompileAuditPredicate_NilMatchesAll(t *testing.T) {
 	pred, needsItems, err := CompileAuditPredicate(nil)
 	require.NoError(t, err)
 	require.False(t, needsItems)
-	require.True(t, pred(&auditpb.AuditEntry{}, nil))
+	require.True(t, mustMatch(t, pred, &auditpb.AuditEntry{}, nil))
 }
 
 func TestCompileAuditPredicate_Composition(t *testing.T) {
@@ -108,14 +123,14 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	}}}}
 	pred, _, err := CompileAuditPredicate(and)
 	require.NoError(t, err)
-	require.True(t, pred(entry, nil))
+	require.True(t, mustMatch(t, pred, entry, nil))
 
 	not := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
 		Filter: auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("success")),
 	}}}
 	predNot, _, err := CompileAuditPredicate(not)
 	require.NoError(t, err)
-	require.True(t, predNot(entry, nil))
+	require.True(t, mustMatch(t, predNot, entry, nil))
 
 	// Or is the lowered form of `audit[ledger] in (other, main)`: matches when
 	// any branch matches.
@@ -125,7 +140,7 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	}}}}
 	predOr, _, err := CompileAuditPredicate(or)
 	require.NoError(t, err)
-	require.True(t, predOr(entry, nil))
+	require.True(t, mustMatch(t, predOr, entry, nil))
 
 	// Or with no matching branch is false.
 	orMiss := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
@@ -134,7 +149,7 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	}}}}
 	predOrMiss, _, err := CompileAuditPredicate(orMiss)
 	require.NoError(t, err)
-	require.False(t, predOrMiss(entry, nil))
+	require.False(t, mustMatch(t, predOrMiss, entry, nil))
 }
 
 func TestCompileAuditPredicate_Rejections(t *testing.T) {
@@ -147,6 +162,9 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 		{"field/type mismatch", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, strEq("x"))},
 		{"unspecified field", auditFilter(commonpb.AuditField_AUDIT_FIELD_UNSPECIFIED, uintEq(1))},
 		{"bad outcome value", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("maybe"))},
+		{"parameterized string field", auditFilter(commonpb.AuditField_AUDIT_FIELD_CALLER_SUBJECT, strParam("user"))},
+		{"parameterized outcome", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strParam("o"))},
+		{"parameterized order_type", auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strParam("t"))},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -188,11 +206,27 @@ func TestCompileAuditPredicate_OrderType(t *testing.T) {
 		auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strEq("apply")))
 	require.NoError(t, err)
 	require.True(t, needsItems)
-	require.True(t, pred(entry, items))      // match-any: apply present
-	require.False(t, pred(entry, items[1:])) // only numscript -> no match
+	require.True(t, mustMatch(t, pred, entry, items))      // match-any: apply present
+	require.False(t, mustMatch(t, pred, entry, items[1:])) // only numscript -> no match
 
 	predMiss, _, err := CompileAuditPredicate(
 		auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strEq("create_ledger")))
 	require.NoError(t, err)
-	require.False(t, predMiss(entry, items))
+	require.False(t, mustMatch(t, predMiss, entry, items))
+}
+
+// A corrupt SerializedOrder in the audit zone (the cryptographic source of
+// truth) must surface as an error from the predicate, not be silently dropped.
+func TestCompileAuditPredicate_OrderTypeCorruptBytesSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	pred, needsItems, err := CompileAuditPredicate(
+		auditFilter(commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, strEq("apply")))
+	require.NoError(t, err)
+	require.True(t, needsItems)
+
+	// Tag 0 (field number 0) is illegal in protobuf, so UnmarshalVT fails.
+	corrupt := []*auditpb.AuditItem{{SerializedOrder: []byte{0x00}}}
+	_, perr := pred(&auditpb.AuditEntry{Sequence: 1}, corrupt)
+	require.Error(t, perr)
 }

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -25,6 +25,7 @@ func auditFilter(field commonpb.AuditField, cond any) *commonpb.QueryFilter {
 	case *commonpb.BoolCondition:
 		ac.Condition = &commonpb.AuditCondition_BoolCond{BoolCond: c}
 	}
+
 	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: ac}}
 }
 
@@ -77,7 +78,6 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 		{"log seq on failure", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), failure, false},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			pred, needsItems, err := CompileAuditPredicate(tc.filter)
@@ -130,7 +130,6 @@ func TestCompileAuditPredicate_Rejections(t *testing.T) {
 		{"bad outcome value", auditFilter(commonpb.AuditField_AUDIT_FIELD_OUTCOME, strEq("maybe"))},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, _, err := CompileAuditPredicate(tc.filter)
@@ -143,6 +142,7 @@ func itemWithOrder(t *testing.T, order *raftcmdpb.Order) *auditpb.AuditItem {
 	t.Helper()
 	b, err := proto.Marshal(order)
 	require.NoError(t, err)
+
 	return &auditpb.AuditItem{SerializedOrder: b}
 }
 

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -22,6 +22,12 @@ func uintMax(v uint64) *commonpb.UintCondition {
 	return &commonpb.UintCondition{Max: &v}
 }
 
+// uintBetween builds an inclusive [lo,hi] range. Passing lo > hi produces an
+// inverted (impossible) range, used to assert it matches nothing.
+func uintBetween(lo, hi uint64) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Min: &lo, Max: &hi}
+}
+
 func auditFilter(field commonpb.AuditField, cond any) *commonpb.QueryFilter {
 	ac := &commonpb.AuditCondition{Field: field}
 	switch c := cond.(type) {
@@ -112,6 +118,8 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 		// Equality and (the regression-exposing) upper-bounded filters both miss.
 		{"log seq on no-log success", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), noLogSuccess, false},
 		{"log seq upper bound on no-log success", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintMax(100)), noLogSuccess, false},
+		// An inverted range is impossible and must match nothing on a point field.
+		{"seq inverted range", auditFilter(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, uintBetween(10, 5)), success, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -171,6 +179,20 @@ func TestCompileAuditPredicate_Composition(t *testing.T) {
 	predOrMiss, _, err := CompileAuditPredicate(orMiss)
 	require.NoError(t, err)
 	require.False(t, mustMatch(t, predOrMiss, entry, nil))
+}
+
+func TestCompileAuditPredicate_InvertedLogSeqRange(t *testing.T) {
+	t.Parallel()
+	// A success whose produced log range [1,20] straddles the inverted filter
+	// range `between 10 and 5` (resolved to the empty half-open [10,6)). Without
+	// the empty-range guard the overlap check fired neither bound and spuriously
+	// matched this unrelated entry.
+	straddling := &auditpb.AuditEntry{
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{MinLogSequence: 1, MaxLogSequence: 20}},
+	}
+	pred, _, err := CompileAuditPredicate(auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintBetween(10, 5)))
+	require.NoError(t, err)
+	require.False(t, mustMatch(t, pred, straddling, nil))
 }
 
 func TestCompileAuditPredicate_Rejections(t *testing.T) {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -15,6 +15,13 @@ func uintEq(v uint64) *commonpb.UintCondition {
 	return &commonpb.UintCondition{Min: &v, Max: &v}
 }
 
+// uintMax builds an upper-bounded-only condition (half-open: matches
+// `log_seq < v`), the shape that exposes the no-log-success regression: with no
+// Min set the overlap check reduces to the exclusive Max comparison.
+func uintMax(v uint64) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Max: &v}
+}
+
 func auditFilter(field commonpb.AuditField, cond any) *commonpb.QueryFilter {
 	ac := &commonpb.AuditCondition{Field: field}
 	switch c := cond.(type) {
@@ -71,6 +78,12 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 		Sequence: 8,
 		Outcome:  &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{Reason: commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS}},
 	}
+	// A successful all-idempotent batch produced no logs: extractLogSequenceRange
+	// records (0,0), so MaxLogSequence == 0 is the "no logs touched" sentinel.
+	noLogSuccess := &auditpb.AuditEntry{
+		Sequence: 9,
+		Outcome:  &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{MinLogSequence: 0, MaxLogSequence: 0}},
+	}
 
 	tests := []struct {
 		name   string
@@ -95,6 +108,10 @@ func TestCompileAuditPredicate_HeaderFields(t *testing.T) {
 		{"log seq overlap", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), success, true},
 		{"log seq outside", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(200)), success, false},
 		{"log seq on failure", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), failure, false},
+		// No-log success: its (0,0) sentinel must not be treated as a real range.
+		// Equality and (the regression-exposing) upper-bounded filters both miss.
+		{"log seq on no-log success", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintEq(103)), noLogSuccess, false},
+		{"log seq upper bound on no-log success", auditFilter(commonpb.AuditField_AUDIT_FIELD_LOG_SEQUENCE, uintMax(100)), noLogSuccess, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -758,10 +758,10 @@ message CheckStoreProgress {
 
 message ListAuditEntriesRequest {
   common.ListOptions options = 1;
-  // failures_only filters audit entries to only those carrying a failure status.
-  bool failures_only = 2;
-  // ledger filters audit entries to only those containing orders targeting this ledger.
-  string ledger = 3;
+  // Field 2 (failures_only) and 3 (ledger) folded into options.filter
+  // (audit[outcome]==failure, audit[ledger]==X) — EN-1305.
+  reserved 2, 3;
+  reserved "failures_only", "ledger";
 }
 
 message GetAuditEntryRequest {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1085,8 +1085,14 @@ message AccountHasAssetCondition {
 }
 
 // AuditCondition filters audit entries by a single audit field. Mirrors
-// BuiltinUintCondition's (field-enum x condition) shape. Only valid under
-// QUERY_TARGET_AUDIT; rejected with InvalidArgument on any other target.
+// BuiltinUintCondition's (field-enum x condition) shape. Enforcement is
+// structural, not via QueryTarget: the audit predicate compiler
+// (query.CompileAuditPredicate) accepts only Audit/And/Or/Not nodes and
+// rejects every other condition with InvalidArgument, while the index
+// compiler (query.Compile, used for accounts/transactions/logs) never lists
+// QueryFilter_Audit in its switch and so rejects it there. QUERY_TARGET_AUDIT
+// exists for parity with the other targets (e.g. prepared-query metadata); the
+// scan-time audit path does not dispatch on it.
 message AuditCondition {
   AuditField field = 1;
   oneof condition {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1106,7 +1106,7 @@ enum AuditField {
   AUDIT_FIELD_UNSPECIFIED    = 0;
   AUDIT_FIELD_SEQUENCE       = 1;  // uint   -> AuditEntry.sequence
   AUDIT_FIELD_PROPOSAL_ID    = 2;  // uint   -> AuditEntry.proposal_id
-  AUDIT_FIELD_TIMESTAMP      = 3;  // uint   -> AuditEntry.timestamp.data (unix nanos)
+  AUDIT_FIELD_TIMESTAMP      = 3;  // uint   -> AuditEntry.timestamp.data (unix micros)
   AUDIT_FIELD_LOG_SEQUENCE   = 4;  // uint   -> overlaps [success.min,max]_log_sequence
   AUDIT_FIELD_OUTCOME        = 5;  // string in {success, failure}
   AUDIT_FIELD_ERROR_TYPE     = 6;  // string -> failure.error_type

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1044,6 +1044,7 @@ message QueryFilter {
     LogIdCondition log_id = 9;
     LogBuiltinUintCondition log_builtin_uint = 10;
     AccountHasAssetCondition account_has_asset = 11;
+    AuditCondition audit = 12;
   }
 }
 
@@ -1081,6 +1082,33 @@ message LogBuiltinUintCondition {
 message AccountHasAssetCondition {
   string asset_base = 1;
   uint32 precision = 2;
+}
+
+// AuditCondition filters audit entries by a single audit field. Mirrors
+// BuiltinUintCondition's (field-enum x condition) shape. Only valid under
+// QUERY_TARGET_AUDIT; rejected with InvalidArgument on any other target.
+message AuditCondition {
+  AuditField field = 1;
+  oneof condition {
+    StringCondition string_cond = 2;
+    UintCondition   uint_cond   = 3;
+    BoolCondition   bool_cond   = 4;
+  }
+}
+
+enum AuditField {
+  AUDIT_FIELD_UNSPECIFIED    = 0;
+  AUDIT_FIELD_SEQUENCE       = 1;  // uint   -> AuditEntry.sequence
+  AUDIT_FIELD_PROPOSAL_ID    = 2;  // uint   -> AuditEntry.proposal_id
+  AUDIT_FIELD_TIMESTAMP      = 3;  // uint   -> AuditEntry.timestamp.data (unix nanos)
+  AUDIT_FIELD_LOG_SEQUENCE   = 4;  // uint   -> overlaps [success.min,max]_log_sequence
+  AUDIT_FIELD_OUTCOME        = 5;  // string in {success, failure}
+  AUDIT_FIELD_ERROR_TYPE     = 6;  // string -> failure.error_type
+  AUDIT_FIELD_CALLER_SUBJECT = 7;  // string -> caller_snapshot.identity.subject
+  AUDIT_FIELD_CALLER_SCOPE   = 8;  // string -> caller_snapshot.scopes (contains)
+  AUDIT_FIELD_CALLER_GOD     = 9;  // bool   -> caller_snapshot.god
+  AUDIT_FIELD_LEDGER         = 10; // string -> AuditEntry.ledgers (contains)
+  AUDIT_FIELD_ORDER_TYPE     = 11; // string -> order payload variant (contains, lazy)
 }
 
 message AndFilter {
@@ -1170,6 +1198,7 @@ enum QueryTarget {
   QUERY_TARGET_ACCOUNTS = 0;
   QUERY_TARGET_TRANSACTIONS = 1;
   QUERY_TARGET_LOGS = 2;
+  QUERY_TARGET_AUDIT = 3;
 }
 
 enum QueryMode {

--- a/pkg/actions/read.go
+++ b/pkg/actions/read.go
@@ -3,11 +3,13 @@ package actions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -329,10 +331,24 @@ func AggregateVolumes(ctx context.Context, client servicepb.BucketServiceClient,
 	})
 }
 
-// ListAuditEntries collects all audit entries from the streaming RPC.
+// ListAuditEntries collects all audit entries from the streaming RPC. When
+// failuresOnly is set, it scopes the scan to failed orders via the audit
+// outcome filter (the server-side FailuresOnly field was replaced by the
+// generic options.filter — see EN-1305).
 func ListAuditEntries(ctx context.Context, client servicepb.BucketServiceClient, failuresOnly bool) ([]*auditpb.AuditEntry, error) {
+	var filter *commonpb.QueryFilter
+	if failuresOnly {
+		parsed, err := filterexpr.Parse("audit[outcome] == failure")
+		if err != nil {
+			return nil, fmt.Errorf("building audit failures filter: %w", err)
+		}
+		filter = parsed
+	}
+
 	return ListAuditEntriesWithRequest(ctx, client, &servicepb.ListAuditEntriesRequest{
-		FailuresOnly: failuresOnly,
+		Options: &commonpb.ListOptions{
+			Filter: filter,
+		},
 	})
 }
 
@@ -347,17 +363,17 @@ func ListAuditEntriesWithRequest(ctx context.Context, client servicepb.BucketSer
 	// messages embed a sync.Mutex (in MessageState) so value copy trips
 	// govet (copylocks). We only need the request fields used by the
 	// underlying RPC; the per-page cursor is updated below.
-	// Preserve the caller's Read (min_log_sequence, checkpoint_id) on every
-	// page request — dropping it would silently turn a freshness-gated audit
-	// scan into a stale read against a lagging follower.
+	// Preserve the caller's Read (min_log_sequence, checkpoint_id) and Filter
+	// on every page request — dropping Read would silently turn a
+	// freshness-gated audit scan into a stale read against a lagging follower,
+	// and dropping Filter would widen the scan past the caller's predicate.
 	page := &servicepb.ListAuditEntriesRequest{
 		Options: &commonpb.ListOptions{
 			Read:     req.GetOptions().GetRead(),
 			PageSize: listAllPageSize,
 			Cursor:   req.GetOptions().GetCursor(),
+			Filter:   req.GetOptions().GetFilter(),
 		},
-		FailuresOnly: req.GetFailuresOnly(),
-		Ledger:       req.GetLedger(),
 	}
 
 	var entries []*auditpb.AuditEntry

--- a/tests/e2e/business/audit_test.go
+++ b/tests/e2e/business/audit_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"math/big"
 	"strconv"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
@@ -26,6 +28,18 @@ import (
 // collectAuditEntries collects all audit entries from the streaming RPC.
 func collectAuditEntries(ctx context.Context, client servicepb.BucketServiceClient, req *servicepb.ListAuditEntriesRequest) ([]*auditpb.AuditEntry, error) {
 	return actions.ListAuditEntriesWithRequest(ctx, client, req)
+}
+
+// auditFilterRequest builds a ListAuditEntriesRequest carrying the given filter
+// DSL expression in options.filter (EN-1305: server-side audit narrowing now
+// flows exclusively through the generic filter, not bespoke request fields).
+func auditFilterRequest(expr string) *servicepb.ListAuditEntriesRequest {
+	parsed, err := filterexpr.Parse(expr)
+	Expect(err).To(Succeed())
+
+	return &servicepb.ListAuditEntriesRequest{
+		Options: &commonpb.ListOptions{Filter: parsed},
+	}
 }
 
 // decodeOrder unmarshals AuditItem.serialized_order back into a typed Order.
@@ -106,9 +120,8 @@ var _ = Describe("Audit Log", Ordered, func() {
 		Expect(err).To(Succeed())
 
 		// Filter by the original ledger — should not include the second ledger's entries
-		filtered, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{
-			Ledger: ledgerName,
-		})
+		filtered, err := collectAuditEntries(sharedCtx, sharedClient,
+			auditFilterRequest(`audit[ledger] == "`+ledgerName+`"`))
 		Expect(err).To(Succeed())
 
 		for _, entry := range filtered {
@@ -124,9 +137,8 @@ var _ = Describe("Audit Log", Ordered, func() {
 		}
 
 		// Filter by the other ledger — should include at least 2 entries (create + transaction)
-		otherFiltered, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{
-			Ledger: otherLedger,
-		})
+		otherFiltered, err := collectAuditEntries(sharedCtx, sharedClient,
+			auditFilterRequest(`audit[ledger] == "`+otherLedger+`"`))
 		Expect(err).To(Succeed())
 		Expect(len(otherFiltered)).To(BeNumerically(">=", 2))
 	})
@@ -145,9 +157,8 @@ var _ = Describe("Audit Log", Ordered, func() {
 		Expect(err).To(HaveOccurred())
 
 		// Get failures only — every returned entry must be a failure
-		failures, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{
-			FailuresOnly: true,
-		})
+		failures, err := collectAuditEntries(sharedCtx, sharedClient,
+			auditFilterRequest(`audit[outcome] == failure`))
 		Expect(err).To(Succeed())
 		Expect(failures).NotTo(BeEmpty())
 		for _, entry := range failures {
@@ -321,9 +332,8 @@ var _ = Describe("Audit Log", Ordered, func() {
 		}, nil, nil)))
 		Expect(err).To(HaveOccurred())
 
-		entries, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{
-			FailuresOnly: true,
-		})
+		entries, err := collectAuditEntries(sharedCtx, sharedClient,
+			auditFilterRequest(`audit[outcome] == failure`))
 		Expect(err).To(Succeed())
 		Expect(entries).NotTo(BeEmpty())
 
@@ -408,9 +418,8 @@ var _ = Describe("Audit Log", Ordered, func() {
 	})
 
 	It("Should have ledgers field populated on list entries when filtering by ledger", func() {
-		filtered, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{
-			Ledger: ledgerName,
-		})
+		filtered, err := collectAuditEntries(sharedCtx, sharedClient,
+			auditFilterRequest(`audit[ledger] == "`+ledgerName+`"`))
 		Expect(err).To(Succeed())
 		Expect(filtered).NotTo(BeEmpty())
 
@@ -443,5 +452,171 @@ var _ = Describe("Audit Log", Ordered, func() {
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.NotFound))
+	})
+})
+
+// This suite proves the options.filter DSL narrows audit results server-side
+// (CompileAuditPredicate runs in the controller scan, not client-side) and
+// rejects conditions that do not target the audit log. It runs on a dedicated
+// single node so sequence numbers and per-filter counts are deterministic,
+// uncontaminated by the shared suite's accumulated entries.
+var _ = Describe("Audit Log filter DSL", Ordered, func() {
+	const (
+		ledgerA = "audit-filter-a"
+		ledgerB = "audit-filter-b"
+	)
+
+	var (
+		filterCtx    context.Context
+		filterClient servicepb.BucketServiceClient
+	)
+
+	// listFiltered scans audit entries through the options.filter DSL.
+	listFiltered := func(expr string) []*auditpb.AuditEntry {
+		entries, err := collectAuditEntries(filterCtx, filterClient, auditFilterRequest(expr))
+		Expect(err).To(Succeed())
+
+		return entries
+	}
+
+	BeforeAll(func() {
+		filterCtx, filterClient, _ = testutil.SetupSingleNode(9110, 8110)
+
+		// Two ledgers created in separate Apply calls so each audit entry targets
+		// exactly one ledger (a single multi-ledger batch would produce one entry
+		// whose Ledgers slice contains both, which would defeat the leak check).
+		_, err := filterClient.Apply(filterCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerA, nil)))
+		Expect(err).To(Succeed())
+
+		_, err = filterClient.Apply(filterCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerB, nil)))
+		Expect(err).To(Succeed())
+
+		// ... a successful transaction on ledgerA (success entry) ...
+		_, err = filterClient.Apply(filterCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateTransactionAction(ledgerA, []*commonpb.Posting{
+				actions.NewPosting("world", "bank", big.NewInt(1000), "USD"),
+			}, nil, nil),
+		))
+		Expect(err).To(Succeed())
+
+		// ... and a failing transaction on ledgerB (failure entry).
+		_, err = filterClient.Apply(filterCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateTransactionAction(ledgerB, []*commonpb.Posting{
+				actions.NewPosting("empty:account", "bank", big.NewInt(99999), "USD"),
+			}, nil, nil),
+		))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("narrows to failures only via audit[outcome] == failure", func() {
+		failures := listFiltered(`audit[outcome] == failure`)
+		Expect(failures).NotTo(BeEmpty())
+		for _, e := range failures {
+			Expect(e.GetFailure()).NotTo(BeNil(), "expected only failure entries")
+			Expect(e.GetSuccess()).To(BeNil())
+		}
+
+		successes := listFiltered(`audit[outcome] == success`)
+		Expect(successes).NotTo(BeEmpty())
+		for _, e := range successes {
+			Expect(e.GetSuccess()).NotTo(BeNil(), "expected only success entries")
+		}
+	})
+
+	It("narrows by targeted ledger via audit[ledger] == X", func() {
+		onA := listFiltered(`audit[ledger] == "` + ledgerA + `"`)
+		Expect(onA).NotTo(BeEmpty())
+		for _, e := range onA {
+			Expect(e.GetLedgers()).To(ContainElement(ledgerA))
+			Expect(e.GetLedgers()).NotTo(ContainElement(ledgerB),
+				"ledgerA filter must not leak ledgerB-only entries")
+		}
+
+		onB := listFiltered(`audit[ledger] == "` + ledgerB + `"`)
+		Expect(onB).NotTo(BeEmpty())
+		for _, e := range onB {
+			Expect(e.GetLedgers()).To(ContainElement(ledgerB))
+		}
+	})
+
+	It("narrows by sequence range via audit[seq] between A and B", func() {
+		all := listFiltered(`audit[seq] >= 0`)
+		Expect(len(all)).To(BeNumerically(">=", 3))
+
+		// Pick a window strictly inside the populated range so we prove the
+		// bound is honored (not just that everything comes back).
+		lo := all[0].GetSequence()
+		hi := all[len(all)-1].GetSequence()
+		Expect(hi).To(BeNumerically(">", lo))
+
+		windowed := listFiltered(fmt.Sprintf("audit[seq] between %d and %d", lo+1, hi))
+		Expect(windowed).NotTo(BeEmpty())
+		Expect(len(windowed)).To(BeNumerically("<", len(all)),
+			"a sub-range must return fewer entries than the full scan")
+		for _, e := range windowed {
+			Expect(e.GetSequence()).To(BeNumerically(">=", lo+1))
+			Expect(e.GetSequence()).To(BeNumerically("<=", hi))
+		}
+	})
+
+	It("narrows by order payload type via audit[order_type] == apply", func() {
+		// Apply (create transaction) entries exist; create_ledger entries exist
+		// too. The order_type filter loads AuditItems per entry to match, so a
+		// non-empty, correct result proves the needsItems path works server-side.
+		applies := listFiltered(`audit[order_type] == apply`)
+		Expect(applies).NotTo(BeEmpty(), "expected at least the success/failure tx entries")
+		for _, e := range applies {
+			full, err := filterClient.GetAuditEntry(filterCtx, &servicepb.GetAuditEntryRequest{
+				Sequence: e.GetSequence(),
+			})
+			Expect(err).To(Succeed())
+
+			hasApply := false
+			for _, item := range full.GetItems() {
+				if decodeOrder(item).GetLedgerScoped().GetApply() != nil {
+					hasApply = true
+
+					break
+				}
+			}
+			Expect(hasApply).To(BeTrue(), "order_type=apply entry must contain an apply order")
+		}
+
+		creates := listFiltered(`audit[order_type] == create_ledger`)
+		Expect(creates).NotTo(BeEmpty())
+		for _, e := range creates {
+			full, err := filterClient.GetAuditEntry(filterCtx, &servicepb.GetAuditEntryRequest{
+				Sequence: e.GetSequence(),
+			})
+			Expect(err).To(Succeed())
+
+			hasCreate := false
+			for _, item := range full.GetItems() {
+				if decodeOrder(item).GetLedgerScoped().GetCreateLedger() != nil {
+					hasCreate = true
+
+					break
+				}
+			}
+			Expect(hasCreate).To(BeTrue(), "order_type=create_ledger entry must contain a create_ledger order")
+		}
+	})
+
+	It("rejects an unsupported (non-audit) condition with InvalidArgument", func() {
+		// metadata[...] is a transaction/account predicate, not an audit field.
+		// CompileAuditPredicate must reject it and the gRPC boundary must map
+		// the FilterCompilationError to InvalidArgument.
+		parsed, err := filterexpr.Parse("metadata[k] == v")
+		Expect(err).To(Succeed())
+
+		stream, err := filterClient.ListAuditEntries(filterCtx, &servicepb.ListAuditEntriesRequest{
+			Options: &commonpb.ListOptions{Filter: parsed},
+		})
+		Expect(err).To(Succeed())
+
+		_, recvErr := stream.Recv()
+		Expect(recvErr).To(HaveOccurred())
+		Expect(status.Code(recvErr)).To(Equal(codes.InvalidArgument),
+			"unsupported audit condition must surface as InvalidArgument")
 	})
 })


### PR DESCRIPTION
## Summary

`ListAuditEntries` advertised the full `ListOptions.filter` envelope on the wire but ignored it — the only server-side narrowing was the bespoke `failures_only` / `ledger` request fields. This PR makes the audit trail queryable server-side through the shared `QueryFilter` DSL, for a new `QUERY_TARGET_AUDIT`.

Jira: https://formance-team.atlassian.net/browse/EN-1305

Fixes #506

## Approach

The audit log is a sequential cold-zone scan with **no index**, so filtering is implemented as **scan-time predicates** (consistent with how `failures_only` / `ledger` already worked), not through the index-backed `query.Compile` path. The shared `QueryFilter` oneof gains a single grouped `AuditCondition` variant; a dedicated `query.CompileAuditPredicate` turns a filter into a `func(*AuditEntry, []*AuditItem) bool` applied during the scan.

The dedicated `failures_only` / `ledger` request fields are removed and folded into the filter; the CLI keeps `--failures-only` / `--ledger` as convenience shorthands that build the equivalent filter client-side.

## What changed

- **Proto**: `QUERY_TARGET_AUDIT`, `QueryFilter.audit` (`AuditCondition` = `AuditField` enum × string/uint/bool condition); `failures_only`/`ledger` reserved on `ListAuditEntriesRequest`.
- **Predicate compiler** (`internal/query/audit_filter.go`): header fields evaluated directly (sequence, proposal_id, timestamp, log_seq overlap, outcome, error_type, caller subject/scope/god, ledger — match-any for repeated fields); `order_type` lazily loads `AuditItem`s and matches the order payload variant via protoreflect, gated by `needsItems`. Reuses the existing half-open `resolveUintBounds`. Non-audit conditions and field/type mismatches → `InvalidArgument`.
- **Error-returning cursor** (`cursor.NewFilteredCursorE`): surfaces per-entry item-load errors instead of silently dropping them.
- **Filter grammar** (`internal/pkg/filterexpr`): `audit[field] op value` term + formatter round-trip.
- **Wiring**: `DefaultController.ListAuditEntries(ctx, afterSeq, pageSize, filter)`; gRPC handler passes `opts.GetFilter()` with `ListOptionsSupport{Filter: true}`; updated the other `Controller` implementers (`BucketGrpcClient`, `RoutedController`) and `pkg/actions/read.go`.
- **CLI**: `ledgerctl audit list --filter / --ledger / --failures-only`.
- **Docs**: `docs/ops/cli.md` (audit filter fields/operators, scan-time strategy note, `order_type` value vs. display clarification), `api-comparison.md`.

## Supported audit filter DSL

```
audit[outcome] == failure
audit[caller.subject] == "alice" and audit[ledger] == "main"
audit[order_type] in (apply, save_numscript)
audit[seq] between 1000 and 2000
```

Fields: `seq`, `proposal_id`, `timestamp`, `log_seq` (uint); `outcome`, `error_type`, `caller.subject`, `caller.scope`, `ledger`, `order_type` (string); `caller.god` (bool).

## Acceptance criteria

- [x] `ListAuditEntries` applies `options.filter`; unsupported conditions rejected with `InvalidArgument`.
- [x] Supported audit conditions documented (fields/operators).
- [x] Index/scan strategy noted (sequential cold-zone scan, scan-time predicates, lazy item load for `order_type`, no audit index).
- [x] Docs (`cli.md` / API comparison) and `ledgerctl audit list` flags updated.

## Testing

- Unit: `internal/query/audit_filter_test.go` (per-field semantics, composition, rejections, order-type match-any + `needsItems` gating), `internal/pkg/cursor` error-cursor, `filterexpr` parser + format round-trip.
- E2E (`tests/e2e/business/audit_test.go`): outcome / ledger / seq-range / order_type filtering and `InvalidArgument` rejection against a real server via the gRPC client.
- `just pre-commit` and `just test` green.

## Invariants

Purely read-side: no Pebble writes, no FSM/hot-path involvement, and **no new persisted projection** (Invariant #8) — nothing to add to the checker.

## Follow-ups (non-blocking, from review)

- Controller-level regression test asserting header-only filters do not call `ReadAuditItems` (`needsItems == false`).
- Consider aligning `order_type` values with the `--expand` display labels (currently matches the outer payload variant, e.g. `apply`; documented).



---
_Migrated from formancehq/ledger-v3-poc#558 onto `release/v3.0`._
