### PR TITLE
fix(EN-1416): map nodeForwarder 'node not reachable' to codes.Unavailable

### DIFF
--- a/internal/adapter/grpc/errors_test.go
+++ b/internal/adapter/grpc/errors_test.go
@@ -555,6 +555,38 @@ func TestConvertToGRPCError_BackupInProgress(t *testing.T) {
 	}
 }
 
+// TestConvertToGRPCError_NodeNotReachable pins EN-1416: when the forwarder
+// fails to resolve a peer (conn-pool entry missing during a partition or
+// pod restart), the error must surface as codes.Unavailable so client
+// retry logic and the antithesis IsTransient predicate cover it the same
+// way as the other peer-transport transients. Before the fix the bare
+// fmt.Errorf("node N not reachable") fell through to the codes.Unknown
+// sanitizer and looked like a permanent server bug.
+func TestConvertToGRPCError_NodeNotReachable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"sentinel raw", ErrNodeNotReachable},
+		{"wrapped from resolve", fmt.Errorf("%w: node 3", ErrNodeNotReachable)},
+		{"wrapped twice", fmt.Errorf("forward: %w", fmt.Errorf("%w: node 7", ErrNodeNotReachable))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			grpcErr := convertToGRPCError(tt.err, testLogger())
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			require.Equal(t, codes.Unavailable, st.Code(),
+				"ErrNodeNotReachable must surface as Unavailable, not %v", st.Code())
+		})
+	}
+}
+
 func TestConvertToGRPCError_MissingSignature(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/grpc/forward.go
+++ b/internal/adapter/grpc/forward.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc"
@@ -8,6 +9,14 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/node"
 	"github.com/formancehq/ledger/v3/internal/infra/transport"
 )
+
+// ErrNodeNotReachable is returned by nodeForwarder.resolve when the requested
+// peer has no entry in the service-connection pool — typically a network
+// partition / pod restart in flight, recoverable as soon as the pool
+// re-converges. convertToGRPCError maps it to codes.Unavailable so SDK
+// clients (and the antithesis workload's IsTransient predicate) retry it
+// the same way as the other peer-transport transients.
+var ErrNodeNotReachable = errors.New("node not reachable")
 
 // nodeForwarder resolves a target node ID to either local handling or a gRPC
 // connection for forwarding the request to a peer.
@@ -25,7 +34,7 @@ func (f *nodeForwarder) resolve(nodeID uint32) (*grpc.ClientConn, error) {
 
 	conn := f.servicePool.GetConnection(uint64(nodeID))
 	if conn == nil {
-		return nil, fmt.Errorf("node %d not reachable", nodeID)
+		return nil, fmt.Errorf("%w: node %d", ErrNodeNotReachable, nodeID)
 	}
 
 	return conn, nil

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -495,12 +495,16 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 	// ErrTransferLeaderTimeout: leadership transfer did not complete in time.
 	// ErrNoLeader: target peer doesn't know who the leader is yet (election
 	// still in progress, or it just joined and hasn't received the heartbeat).
+	// ErrNodeNotReachable: forwarder lost its conn-pool entry for the target
+	// peer (network partition / pod restart in flight). Recovers as soon as
+	// the pool re-converges.
 	if errors.Is(err, raft.ErrProposalDropped) ||
 		errors.Is(err, node.ErrLeadershipLost) ||
 		errors.Is(err, node.ErrNotLeader) ||
 		errors.Is(err, node.ErrNodeSyncing) ||
 		errors.Is(err, node.ErrTransferLeaderTimeout) ||
-		errors.Is(err, commonpb.ErrNoLeader) {
+		errors.Is(err, commonpb.ErrNoLeader) ||
+		errors.Is(err, ErrNodeNotReachable) {
 		return status.Error(codes.Unavailable, err.Error())
 	}
 


### PR DESCRIPTION
Closes [EN-1416](https://formance-team.atlassian.net/browse/EN-1416).

## Summary

`nodeForwarder.resolve` returned a bare `fmt.Errorf("node %d not reachable")` when the conn pool had no entry for the target peer — typically a network partition or pod restart in flight. Without a typed sentinel and without a gRPC code, `convertToGRPCError` fell through to the `codes.Unknown` sanitizer (originally there to mask Pebble strings / invariant messages), so the wire was reporting an "unknown server error" for what is semantically a `codes.Unavailable` transient.

This was caught by the antithesis classify interceptor added in formancehq/ledger#1430 during a `network restore ALL` fault recovery window. Server-side log for the same correlation ID:

```
ERROR  Unmapped gRPC handler error: node 1 not reachable
       {"node-id": 2, "correlation_id": "8e5a13d286419655"}
ERROR  gRPC call failed
       {"code": "Unknown", "method": "/cluster.ClusterService/GetClusterState"}
```

The mis-classification is doubly bad: SDK clients and the antithesis `IsTransient` predicate both only retry the transient set, so a recoverable network blip looks definitive at the call site, and the *next* call surfaces a spurious "unknown server error".

## Change

- New typed sentinel `ErrNodeNotReachable` in `internal/adapter/grpc/forward.go`, wrapped with the node ID via `%w` so `errors.Is` matches while the message still tells you which peer was missing.
- New branch in `convertToGRPCError`'s Raft-transient `errors.Is` chain that maps `ErrNodeNotReachable` to `codes.Unavailable` — same semantics as `node.ErrNoLeader` / `node.ErrNotLeader` / `node.ErrNodeSyncing` already there.
- `TestConvertToGRPCError_NodeNotReachable` pins the mapping for raw, single-wrap and double-wrap variants. Follows the existing `TestConvertToGRPCError_BackupInProgress` pattern.

No workload change needed: with the wire code now `Unavailable`, the antithesis `IsTransient` predicate covers it automatically.

## Test plan

- [x] \`GOROOT= go build ./...\` clean
- [x] \`go test -run TestConvertToGRPCError_NodeNotReachable ./internal/adapter/grpc/...\` passes
- [ ] Next antithesis run should no longer flag this code path via the classify interceptor

[EN-1416]: https://formance-team.atlassian.net/browse/EN-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ