### PR TITLE
chore: drop remaining ledger-v3-poc references

### DIFF
--- a/.claude/skills/antithesis-run/SKILL.md
+++ b/.claude/skills/antithesis-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: antithesis-run
-description: Trigger an Antithesis cloud run for ledger-v3-poc by building and pushing per-branch tagged images to ECR and POSTing to the Antithesis launch API. Default mode is k8s (`just k8s-run`, duration in hours, exercises the operator); compose mode (`just run`, duration in minutes) is available on request. Use this skill when the user wants to "lance un run antithesis", "trigger antithesis", "fire antithesis", "test sur antithesis", or any phrasing about kicking off a cloud Antithesis test for this repo.
+description: Trigger an Antithesis cloud run for ledger by building and pushing per-branch tagged images to ECR and POSTing to the Antithesis launch API. Default mode is k8s (`just k8s-run`, duration in hours, exercises the operator); compose mode (`just run`, duration in minutes) is available on request. Use this skill when the user wants to "lance un run antithesis", "trigger antithesis", "fire antithesis", "test sur antithesis", or any phrasing about kicking off a cloud Antithesis test for this repo.
 ---
 
 # /antithesis-run — Launch an Antithesis cloud run

--- a/misc/operator/e2e/tests/additional-labels/ledgerservice-drift.yaml
+++ b/misc/operator/e2e/tests/additional-labels/ledgerservice-drift.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   image:
-    repository: ledger-v3-poc
+    repository: ledger
     tag: e2e
     pullPolicy: Never
   additionalLabels:

--- a/misc/operator/e2e/tests/additional-labels/ledgerservice.yaml
+++ b/misc/operator/e2e/tests/additional-labels/ledgerservice.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   image:
-    repository: ledger-v3-poc
+    repository: ledger
     tag: e2e
     pullPolicy: Never
   additionalLabels:

--- a/misc/operator/e2e/tests/pvc-deletion-protection/ledgerservice.yaml
+++ b/misc/operator/e2e/tests/pvc-deletion-protection/ledgerservice.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   image:
-    repository: ledger-v3-poc
+    repository: ledger
     tag: e2e
     pullPolicy: Never
   persistence:


### PR DESCRIPTION
## Summary

Final cleanup of `ledger-v3-poc` string references on `release/v3.0`:

- `.claude/skills/antithesis-run/SKILL.md` — skill description text.
- `misc/operator/e2e/tests/additional-labels/ledgerservice.yaml`
- `misc/operator/e2e/tests/additional-labels/ledgerservice-drift.yaml`
- `misc/operator/e2e/tests/pvc-deletion-protection/ledgerservice.yaml`
  (image `repository: ledger-v3-poc` → `repository: ledger` to match the other e2e manifests.)

## Notes

- `tests/antithesis/workload/first_default_ledger` (committed binary) still embeds the old Go module path (`github.com/formancehq/ledger-v3-poc/...`) in its protobuf descriptors. It needs to be regenerated from sources — left out of this PR.
- After this PR, `git grep ledger-v3-poc` on `release/v3.0` only matches the binary above.

## Test plan

- [ ] CI green on `release/v3.0` PR
- [ ] `git grep -l ledger-v3-poc` returns only `tests/antithesis/workload/first_default_ledger`