### PR TITLE
refactor(state): decode raft proposals once at the applier boundary

### DIFF
--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -19,7 +19,6 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/pkg/futures"
 	"github.com/formancehq/ledger/v3/internal/pkg/worker"
-	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/spool"
@@ -844,21 +843,41 @@ func (a *Applier) GetSyncProgress() *state.SyncProgress {
 // futures. Used by replay paths (spool, WAL) that do not need pipelining.
 //
 // Callers must ensure no checkpoint trigger appears mid-slice; use
-// applyReplayEntries when iterating an arbitrary slice.
-func (a *Applier) applyEntriesAndResolveCommands(ctx context.Context, entries ...raftpb.Entry) (*state.ApplyEntriesResult, error) {
+// applyReplayEntries when iterating an arbitrary slice. The caller owns
+// the lifetime of decoded[].Proposal — this method does not release them.
+func (a *Applier) applyEntriesAndResolveCommands(ctx context.Context, decoded ...state.DecodedEntry) (*state.ApplyEntriesResult, error) {
 	start := time.Now()
 
-	result, err := a.fsm.ApplyEntries(ctx, a.store, entries...)
+	pb, err := a.fsm.PrepareDecodedEntries(ctx, a.store, decoded...)
 	if err != nil {
-		return nil, fmt.Errorf("applying entries to Machine: %w", err)
+		return nil, fmt.Errorf("preparing entries on Machine: %w", err)
 	}
+
+	if err := a.fsm.CommitPreparedBatch(ctx, pb); err != nil {
+		return nil, fmt.Errorf("committing entries on Machine: %w", err)
+	}
+
+	result := pb.Result
 
 	a.applyEntriesHistogram.Record(ctx, time.Since(start).Microseconds())
 	a.applyEntriesBatchSizeCounter.Add(ctx, int64(len(result.Results)))
 	a.applyEntriesBatchSizeHistogram.Record(ctx, int64(len(result.Results)))
 
 	a.resolveFutures(result)
-	a.sweepBelowTerm(entries)
+
+	// sweepBelowTerm needs only entry terms; compute the max in-place
+	// instead of materializing a []raftpb.Entry slice from decoded.
+	var maxTerm uint64
+
+	for i := range decoded {
+		if decoded[i].Entry.Term > maxTerm {
+			maxTerm = decoded[i].Entry.Term
+		}
+	}
+
+	if maxTerm > 0 {
+		a.FailFuturesBelowTerm(maxTerm, ErrLeadershipLost)
+	}
 
 	return result, nil
 }
@@ -869,15 +888,19 @@ func (a *Applier) applyEntriesAndResolveCommands(ctx context.Context, entries ..
 // (createReplayCheckpoint / createMainStoreCheckpoint) before continuing.
 // Cascading checkpoints in the same slice are handled by the loop.
 func (a *Applier) applyReplayEntries(ctx context.Context, entries []raftpb.Entry) error {
-	for offset := 0; offset < len(entries); {
-		boundary, err := findCheckpointBoundary(entries[offset:])
-		if err != nil {
-			return fmt.Errorf("classifying replay batch: %w", err)
-		}
+	decoded, err := state.DecodeEntries(entries)
+	if err != nil {
+		return fmt.Errorf("decoding replay entries: %w", err)
+	}
+
+	defer state.ReleaseDecodedEntries(decoded)
+
+	for offset := 0; offset < len(decoded); {
+		boundary := findCheckpointBoundaryDecoded(decoded[offset:])
 
 		end := offset + boundary
 
-		result, err := a.applyEntriesAndResolveCommands(ctx, entries[offset:end]...)
+		result, err := a.applyEntriesAndResolveCommands(ctx, decoded[offset:end]...)
 		if err != nil {
 			return err
 		}
@@ -992,10 +1015,13 @@ func (a *Applier) runCommitter(ctx context.Context) {
 // applyEntriesPipelined prepares entries (CPU-bound) and starts the commit
 // asynchronously. The previous batch's commit runs concurrently with this
 // batch's prepare. Used by the hot path in Run (statusNormal).
-func (a *Applier) applyEntriesPipelined(ctx context.Context, entries ...raftpb.Entry) (*state.ApplyEntriesResult, error) {
+//
+// The caller (applyEntriesToFSM) owns the lifetime of decoded[].Proposal
+// pointers — this method does not release them.
+func (a *Applier) applyEntriesPipelined(ctx context.Context, decoded ...state.DecodedEntry) (*state.ApplyEntriesResult, error) {
 	prepareStart := time.Now()
 
-	pb, err := a.fsm.PrepareEntries(ctx, a.store, entries...)
+	pb, err := a.fsm.PrepareDecodedEntries(ctx, a.store, decoded...)
 	if err != nil {
 		_ = a.waitPendingCommit(ctx)
 
@@ -1025,9 +1051,9 @@ func (a *Applier) applyEntriesPipelined(ctx context.Context, entries ...raftpb.E
 	// (issue #172). Computed once and reused below.
 	var maxTerm uint64
 
-	for i := range entries {
-		if entries[i].Term > maxTerm {
-			maxTerm = entries[i].Term
+	for i := range decoded {
+		if decoded[i].Entry.Term > maxTerm {
+			maxTerm = decoded[i].Entry.Term
 		}
 	}
 
@@ -1079,15 +1105,22 @@ func (a *Applier) resolveFutures(result *state.ApplyEntriesResult) {
 // batches; dropping it produces an "entry index gap detected" panic in the
 // next PrepareEntries call. Hence the loop.
 func (a *Applier) applyEntriesToFSM(ctx context.Context, confState *raftpb.ConfState, entries ...raftpb.Entry) error {
-	for offset := 0; offset < len(entries); {
-		boundary, err := findCheckpointBoundary(entries[offset:])
-		if err != nil {
-			return fmt.Errorf("classifying checkpoint boundary: %w", err)
-		}
+	// Decode once at the applier boundary so every downstream stage
+	// (checkpoint boundary scan, FSM apply, position validation) reads the
+	// already-decoded proposal instead of re-unmarshalling the raw payload.
+	decoded, err := state.DecodeEntries(entries)
+	if err != nil {
+		return fmt.Errorf("decoding entries: %w", err)
+	}
+
+	defer state.ReleaseDecodedEntries(decoded)
+
+	for offset := 0; offset < len(decoded); {
+		boundary := findCheckpointBoundaryDecoded(decoded[offset:])
 
 		end := offset + boundary
-		head := entries[offset:end]
-		tail := entries[end:]
+		head := decoded[offset:end]
+		tail := decoded[end:]
 
 		result, err := a.applyEntriesPipelined(ctx, head...)
 		if err != nil {
@@ -1109,19 +1142,34 @@ func (a *Applier) applyEntriesToFSM(ctx context.Context, confState *raftpb.ConfS
 		// agnostic of "leftover entries" and makes the pre-split contract
 		// explicit at the call site.
 		if len(tail) > 0 {
-			if err := a.spool.AppendCommittedEntries(ctx, tail...); err != nil {
+			if err := a.spool.AppendCommittedEntries(ctx, rawEntriesFromDecoded(tail)...); err != nil {
 				return fmt.Errorf("spooling entries past checkpoint trigger: %w", err)
 			}
 		}
 
+		headRaw := rawEntriesFromDecoded(head)
+
 		if result.QueryCheckpointID > 0 {
-			return a.handleQueryCheckpointRequired(ctx, head, result)
+			return a.handleQueryCheckpointRequired(ctx, headRaw, result)
 		}
 
-		return a.handleCheckpointRequired(ctx, head, result)
+		return a.handleCheckpointRequired(ctx, headRaw, result)
 	}
 
 	return nil
+}
+
+// rawEntriesFromDecoded extracts the underlying raftpb.Entry values from a
+// slice of DecodedEntry for APIs that take raw entries (spool, replay
+// fallbacks, maintenance handoff). The returned slice is freshly allocated
+// and does not share storage with the input.
+func rawEntriesFromDecoded(decoded []state.DecodedEntry) []raftpb.Entry {
+	out := make([]raftpb.Entry, len(decoded))
+	for i := range decoded {
+		out[i] = decoded[i].Entry
+	}
+
+	return out
 }
 
 // findCheckpointBoundary returns the length of the prefix of entries that
@@ -1132,37 +1180,33 @@ func (a *Applier) applyEntriesToFSM(ctx context.Context, confState *raftpb.ConfS
 //
 // Returns len(entries) when no trigger is present (apply the whole slice as
 // one batch).
+//
+// Convenience wrapper around findCheckpointBoundaryDecoded: decodes
+// entries, scans, and releases. Hot-path callers should decode once at the
+// applier boundary and use findCheckpointBoundaryDecoded directly so the
+// pipeline never re-unmarshals the same payload.
 func findCheckpointBoundary(entries []raftpb.Entry) (int, error) {
-	for i := range entries {
-		hasTrigger, err := entryRequiresCheckpoint(&entries[i])
-		if err != nil {
-			return 0, fmt.Errorf("inspecting entry index %d: %w", entries[i].Index, err)
-		}
-
-		if hasTrigger {
-			return i + 1, nil
-		}
+	decoded, err := state.DecodeEntries(entries)
+	if err != nil {
+		return 0, err
 	}
 
-	return len(entries), nil
+	defer state.ReleaseDecodedEntries(decoded)
+
+	return findCheckpointBoundaryDecoded(decoded), nil
 }
 
-// entryRequiresCheckpoint reports whether the proposal carried by entry
-// contains a checkpoint trigger order. Returns false for non-normal entries
-// (raftpb.EntryConfChange*, empty entries) which never carry a proposal.
-func entryRequiresCheckpoint(entry *raftpb.Entry) (bool, error) {
-	if entry.Type != raftpb.EntryNormal || len(entry.Data) == 0 {
-		return false, nil
+// findCheckpointBoundaryDecoded is the no-unmarshal variant used on the
+// hot path. It mirrors findCheckpointBoundary but operates on entries that
+// have already been decoded once at the applier boundary.
+func findCheckpointBoundaryDecoded(decoded []state.DecodedEntry) int {
+	for i := range decoded {
+		if state.DecodedEntryRequiresCheckpoint(decoded[i]) {
+			return i + 1
+		}
 	}
 
-	cmd := raftcmdpb.ProposalFromVTPool()
-	defer cmd.ReturnToVTPool()
-
-	if err := cmd.UnmarshalVT(entry.Data); err != nil {
-		return false, fmt.Errorf("unmarshaling proposal: %w", err)
-	}
-
-	return state.ProposalRequiresCheckpoint(cmd), nil
+	return len(decoded)
 }
 
 // maintenanceTask is the body of a gated maintenance task. It receives the

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -369,18 +369,36 @@ func (a *Applier) FailFuturesBelowTerm(threshold uint64, err error) {
 	})
 }
 
-// sweepBelowTerm computes the max term across the supplied raft entries and
-// fails every pending future whose stored term is strictly smaller. Callers
-// should invoke this AFTER per-commandID resolution for the same batch, so
-// committed older-term entries get their futures resolved first.
-func (a *Applier) sweepBelowTerm(entries []raftpb.Entry) {
-	var maxTerm uint64
-
-	for i := range entries {
-		if entries[i].Term > maxTerm {
-			maxTerm = entries[i].Term
-		}
+// batchMaxTerm returns the highest Raft term in entries.
+//
+// Within any batch of committed entries delivered by raft, terms are
+// monotonically non-decreasing: raft delivers entries in log order, and a
+// new leader can only append at a term strictly higher than any preceding
+// entry's. The last entry's term is therefore the max. Returns 0 for an
+// empty slice — callers skip the sweep when maxTerm == 0.
+func batchMaxTerm(entries []raftpb.Entry) uint64 {
+	if len(entries) == 0 {
+		return 0
 	}
+
+	return entries[len(entries)-1].Term
+}
+
+// batchMaxTermDecoded is the DecodedEntry variant of batchMaxTerm.
+func batchMaxTermDecoded(decoded []state.DecodedEntry) uint64 {
+	if len(decoded) == 0 {
+		return 0
+	}
+
+	return decoded[len(decoded)-1].Entry.Term
+}
+
+// sweepBelowTerm fails every pending future whose stored term is strictly
+// smaller than the max term in entries. Callers should invoke this AFTER
+// per-commandID resolution for the same batch, so committed older-term
+// entries get their futures resolved first.
+func (a *Applier) sweepBelowTerm(entries []raftpb.Entry) {
+	maxTerm := batchMaxTerm(entries)
 
 	if maxTerm > 0 {
 		a.FailFuturesBelowTerm(maxTerm, ErrLeadershipLost)
@@ -865,17 +883,7 @@ func (a *Applier) applyEntriesAndResolveCommands(ctx context.Context, decoded ..
 
 	a.resolveFutures(result)
 
-	// sweepBelowTerm needs only entry terms; compute the max in-place
-	// instead of materializing a []raftpb.Entry slice from decoded.
-	var maxTerm uint64
-
-	for i := range decoded {
-		if decoded[i].Entry.Term > maxTerm {
-			maxTerm = decoded[i].Entry.Term
-		}
-	}
-
-	if maxTerm > 0 {
+	if maxTerm := batchMaxTermDecoded(decoded); maxTerm > 0 {
 		a.FailFuturesBelowTerm(maxTerm, ErrLeadershipLost)
 	}
 
@@ -1048,14 +1056,8 @@ func (a *Applier) applyEntriesPipelined(ctx context.Context, decoded ...state.De
 	pfs := a.extractBatchFutures(pb.Result)
 
 	// Highest term seen in this batch, used by the post-resolve sweep
-	// (issue #172). Computed once and reused below.
-	var maxTerm uint64
-
-	for i := range decoded {
-		if decoded[i].Entry.Term > maxTerm {
-			maxTerm = decoded[i].Entry.Term
-		}
-	}
+	// (issue #172). See batchMaxTermDecoded for the monotonic-term shortcut.
+	maxTerm := batchMaxTermDecoded(decoded)
 
 	// Send to the committer goroutine. Futures are resolved when the
 	// commit completes. No need to wait for the next batch.

--- a/internal/infra/state/checkpoint_orders.go
+++ b/internal/infra/state/checkpoint_orders.go
@@ -116,3 +116,33 @@ func ValidateCheckpointEntryPositions(entries []raftpb.Entry) error {
 
 	return nil
 }
+
+// ValidateCheckpointEntryPositionsDecoded is the no-unmarshal variant of
+// ValidateCheckpointEntryPositions used on the hot path: it inspects the
+// pre-decoded proposals attached to each DecodedEntry instead of decoding
+// raw entry.Data. Same semantics as ValidateCheckpointEntryPositions: an
+// error if any non-last entry carries a checkpoint-trigger order.
+func ValidateCheckpointEntryPositionsDecoded(decoded []DecodedEntry) error {
+	if len(decoded) == 0 {
+		return nil
+	}
+
+	last := len(decoded) - 1
+
+	for i := range last {
+		if decoded[i].Proposal == nil {
+			continue
+		}
+
+		if ClassifyCheckpointOrderPosition(decoded[i].Proposal.GetOrders()) == CheckpointOrderAbsent {
+			continue
+		}
+
+		return fmt.Errorf(
+			"checkpoint trigger entry at position %d/%d (raft index %d) — applier must pre-split",
+			i, len(decoded), decoded[i].Entry.Index,
+		)
+	}
+
+	return nil
+}

--- a/internal/infra/state/decoded_entry.go
+++ b/internal/infra/state/decoded_entry.go
@@ -1,0 +1,88 @@
+package state
+
+import (
+	"fmt"
+
+	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// DecodedEntry pairs a Raft entry with its already-unmarshalled Proposal.
+//
+// Proposal is nil for entries that carry no proposal payload (config-change
+// entries, empty entries). Pre-decoding at the applier boundary lets the
+// downstream stages (checkpoint boundary detection, position validation,
+// FSM apply loop) read the proposal directly instead of re-unmarshalling
+// the raw entry.Data at every step.
+//
+// Ownership and lifetime: the producer of a DecodedEntry slice (typically
+// the applier) owns every non-nil Proposal and MUST return them to the VT
+// pool by calling ReleaseDecodedEntries once the slice is no longer used.
+// After release, Proposal pointers are invalid and must not be read again.
+// The FSM apply path may keep references only for the duration of a single
+// PrepareDecodedEntries call — the returned *PreparedBatch deliberately
+// does not retain any Proposal pointer.
+type DecodedEntry struct {
+	Entry    raftpb.Entry
+	Proposal *raftcmdpb.Proposal
+}
+
+// DecodeEntries unmarshals every normal entry's Data into a pooled
+// *raftcmdpb.Proposal. Non-normal entries (raftpb.EntryConfChange*) and
+// entries with empty Data get a nil Proposal so the slice keeps positional
+// alignment with the source entries.
+//
+// On error, any proposals already decoded are returned to the pool and a
+// nil slice is returned so callers need not call ReleaseDecodedEntries
+// themselves.
+func DecodeEntries(entries []raftpb.Entry) ([]DecodedEntry, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	decoded := make([]DecodedEntry, len(entries))
+
+	for i := range entries {
+		decoded[i].Entry = entries[i]
+
+		if entries[i].Type != raftpb.EntryNormal || len(entries[i].Data) == 0 {
+			continue
+		}
+
+		cmd := raftcmdpb.ProposalFromVTPool()
+		if err := cmd.UnmarshalVT(entries[i].Data); err != nil {
+			cmd.ReturnToVTPool()
+			ReleaseDecodedEntries(decoded[:i])
+
+			return nil, fmt.Errorf("unmarshaling proposal at raft index %d: %w", entries[i].Index, err)
+		}
+
+		decoded[i].Proposal = cmd
+	}
+
+	return decoded, nil
+}
+
+// ReleaseDecodedEntries returns every non-nil Proposal in decoded back to
+// the VT pool. Safe to call with a nil or empty slice. After this call no
+// DecodedEntry.Proposal pointer in the slice may be accessed.
+func ReleaseDecodedEntries(decoded []DecodedEntry) {
+	for i := range decoded {
+		if decoded[i].Proposal != nil {
+			decoded[i].Proposal.ReturnToVTPool()
+			decoded[i].Proposal = nil
+		}
+	}
+}
+
+// DecodedEntryRequiresCheckpoint reports whether d carries a checkpoint-
+// triggering order. Mirrors ProposalRequiresCheckpoint but reads the
+// pre-decoded proposal so the hot path never re-unmarshals.
+func DecodedEntryRequiresCheckpoint(d DecodedEntry) bool {
+	if d.Proposal == nil {
+		return false
+	}
+
+	return ProposalRequiresCheckpoint(d.Proposal)
+}

--- a/internal/infra/state/decoded_entry_test.go
+++ b/internal/infra/state/decoded_entry_test.go
@@ -1,0 +1,280 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// marshalProposal builds a Proposal with one ledger-apply order and returns
+// its wire bytes — the smallest valid payload DecodeEntries will accept.
+func marshalProposal(t *testing.T, id uint64) []byte {
+	t.Helper()
+	cmd := &raftcmdpb.Proposal{
+		Id: id,
+		Orders: []*raftcmdpb.Order{{Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger:  "l",
+				Payload: &raftcmdpb.LedgerScopedOrder_Apply{Apply: &raftcmdpb.LedgerApplyOrder{}},
+			},
+		}}},
+	}
+	data, err := cmd.MarshalVT()
+	require.NoError(t, err)
+
+	return data
+}
+
+// marshalCheckpointProposal builds a Proposal whose only order triggers a
+// checkpoint (CreateQueryCheckpoint).
+func marshalCheckpointProposal(t *testing.T, id uint64) []byte {
+	t.Helper()
+	cmd := &raftcmdpb.Proposal{
+		Id: id,
+		Orders: []*raftcmdpb.Order{{Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_CreateQueryCheckpoint{
+					CreateQueryCheckpoint: &raftcmdpb.CreateQueryCheckpointOrder{},
+				},
+			},
+		}}},
+	}
+	data, err := cmd.MarshalVT()
+	require.NoError(t, err)
+
+	return data
+}
+
+func TestDecodeEntries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+		decoded, err := DecodeEntries(nil)
+		require.NoError(t, err)
+		require.Nil(t, decoded)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
+		decoded, err := DecodeEntries([]raftpb.Entry{})
+		require.NoError(t, err)
+		require.Nil(t, decoded)
+	})
+
+	t.Run("mixed: normal, conf-change, empty-data", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 1)},
+			{Index: 2, Term: 1, Type: raftpb.EntryConfChange, Data: []byte("ignored payload")},
+			{Index: 3, Term: 1, Type: raftpb.EntryNormal /* empty Data */},
+			{Index: 4, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 4)},
+		}
+
+		decoded, err := DecodeEntries(entries)
+		require.NoError(t, err)
+		require.Len(t, decoded, 4, "DecodeEntries preserves positional alignment")
+
+		defer ReleaseDecodedEntries(decoded)
+
+		require.NotNil(t, decoded[0].Proposal, "normal entry decodes")
+		require.Equal(t, uint64(1), decoded[0].Proposal.GetId())
+
+		require.Nil(t, decoded[1].Proposal, "EntryConfChange carries no proposal payload")
+		require.Equal(t, raftpb.EntryConfChange, decoded[1].Entry.Type)
+
+		require.Nil(t, decoded[2].Proposal, "EntryNormal with empty Data carries no proposal payload")
+
+		require.NotNil(t, decoded[3].Proposal)
+		require.Equal(t, uint64(4), decoded[3].Proposal.GetId())
+	})
+
+	t.Run("malformed payload returns error and nil slice", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 10, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 10)},
+			{Index: 11, Term: 1, Type: raftpb.EntryNormal, Data: []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}}, // not a valid Proposal wire form
+		}
+
+		decoded, err := DecodeEntries(entries)
+		require.Error(t, err, "malformed Data must surface as error")
+		require.Contains(t, err.Error(), "raft index 11")
+		require.Nil(t, decoded, "on error, no slice is returned (already-decoded proposals are released internally)")
+	})
+
+	t.Run("malformed payload at first position", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 20, Term: 1, Type: raftpb.EntryNormal, Data: []byte{0xff, 0xff, 0xff}},
+			{Index: 21, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 21)},
+		}
+
+		decoded, err := DecodeEntries(entries)
+		require.Error(t, err)
+		require.Nil(t, decoded)
+	})
+}
+
+func TestReleaseDecodedEntries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil slice is a no-op", func(t *testing.T) {
+		t.Parallel()
+		require.NotPanics(t, func() { ReleaseDecodedEntries(nil) })
+	})
+
+	t.Run("empty slice is a no-op", func(t *testing.T) {
+		t.Parallel()
+		require.NotPanics(t, func() { ReleaseDecodedEntries([]DecodedEntry{}) })
+	})
+
+	t.Run("nils out Proposal pointers so double-release is safe", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 1)},
+			{Index: 2, Term: 1, Type: raftpb.EntryConfChange},
+			{Index: 3, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 3)},
+		}
+
+		decoded, err := DecodeEntries(entries)
+		require.NoError(t, err)
+		require.NotNil(t, decoded[0].Proposal)
+		require.Nil(t, decoded[1].Proposal)
+		require.NotNil(t, decoded[2].Proposal)
+
+		ReleaseDecodedEntries(decoded)
+
+		// After release, every Proposal pointer is nil — a second release
+		// is a no-op rather than a double pool return.
+		for i := range decoded {
+			require.Nil(t, decoded[i].Proposal, "Proposal at %d must be nil after release", i)
+		}
+
+		require.NotPanics(t, func() { ReleaseDecodedEntries(decoded) },
+			"second release must be safe (idempotent)")
+	})
+}
+
+func TestDecodedEntryRequiresCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil proposal", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, DecodedEntryRequiresCheckpoint(DecodedEntry{}))
+	})
+
+	t.Run("apply-only proposal", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, 1)},
+		}
+		decoded, err := DecodeEntries(entries)
+		require.NoError(t, err)
+
+		defer ReleaseDecodedEntries(decoded)
+
+		require.False(t, DecodedEntryRequiresCheckpoint(decoded[0]))
+	})
+
+	t.Run("checkpoint-trigger proposal", func(t *testing.T) {
+		t.Parallel()
+		entries := []raftpb.Entry{
+			{Index: 1, Term: 1, Type: raftpb.EntryNormal, Data: marshalCheckpointProposal(t, 1)},
+		}
+		decoded, err := DecodeEntries(entries)
+		require.NoError(t, err)
+
+		defer ReleaseDecodedEntries(decoded)
+
+		require.True(t, DecodedEntryRequiresCheckpoint(decoded[0]))
+	})
+}
+
+func TestValidateCheckpointEntryPositionsDecoded(t *testing.T) {
+	t.Parallel()
+
+	apply := func(t *testing.T, idx uint64) raftpb.Entry {
+		t.Helper()
+
+		return raftpb.Entry{Index: idx, Term: 1, Type: raftpb.EntryNormal, Data: marshalProposal(t, idx)}
+	}
+	chkpt := func(t *testing.T, idx uint64) raftpb.Entry {
+		t.Helper()
+
+		return raftpb.Entry{Index: idx, Term: 1, Type: raftpb.EntryNormal, Data: marshalCheckpointProposal(t, idx)}
+	}
+
+	confChange := raftpb.Entry{Index: 99, Term: 1, Type: raftpb.EntryConfChange}
+	emptyData := raftpb.Entry{Index: 99, Term: 1, Type: raftpb.EntryNormal}
+
+	decode := func(t *testing.T, entries []raftpb.Entry) []DecodedEntry {
+		t.Helper()
+
+		d, err := DecodeEntries(entries)
+		require.NoError(t, err)
+		t.Cleanup(func() { ReleaseDecodedEntries(d) })
+
+		return d
+	}
+
+	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(nil))
+	})
+
+	t.Run("no trigger", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{apply(t, 1), apply(t, 2)}),
+		))
+	})
+
+	t.Run("trigger last", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{apply(t, 1), chkpt(t, 2)}),
+		))
+	})
+
+	t.Run("single trigger", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{chkpt(t, 1)}),
+		))
+	})
+
+	t.Run("trigger first", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{chkpt(t, 1), apply(t, 2)}),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "applier must pre-split")
+	})
+
+	t.Run("trigger middle", func(t *testing.T) {
+		t.Parallel()
+		err := ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{apply(t, 1), chkpt(t, 2), apply(t, 3)}),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("conf-change and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{confChange, emptyData, chkpt(t, 100)}),
+		))
+	})
+
+	t.Run("nil-proposal entry then trigger last", func(t *testing.T) {
+		t.Parallel()
+		// emptyData has no Proposal; the trailing chkpt is last, so this is valid.
+		require.NoError(t, ValidateCheckpointEntryPositionsDecoded(
+			decode(t, []raftpb.Entry{apply(t, 1), emptyData, chkpt(t, 100)}),
+		))
+	})
+}

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -397,18 +397,43 @@ func (fsm *Machine) WaitForApplied(ctx context.Context, targetIndex uint64) erro
 	return nil
 }
 
-// PrepareEntries processes Raft entries and builds a Pebble batch without
-// committing it. All in-memory state (cache, KeyStore, counters) is updated.
-// The caller must either call CommitPreparedBatch or PreparedBatch.Close.
-//
-// This is the first half of the pipelining split: PrepareEntries is CPU-bound
-// and can run while a previous batch's commit is in-flight.
+// PrepareEntries decodes the raw Raft entries and delegates to
+// PrepareDecodedEntries. Convenience wrapper for callers (tests, replay)
+// that do not already hold decoded proposals. Hot-path callers should
+// decode once at the applier boundary and call PrepareDecodedEntries
+// directly so the apply pipeline never re-unmarshals the same payload.
 func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessionFactory, entries ...raftpb.Entry) (*PreparedBatch, error) {
+	decoded, err := DecodeEntries(entries)
+	if err != nil {
+		return nil, err
+	}
+
+	// Safe to release after PrepareDecodedEntries returns: the returned
+	// *PreparedBatch does not retain any Proposal pointer — every per-entry
+	// effect is captured by-value into ApplyResult / WriteSession during
+	// the apply loop. See the post-loop assembly of pb below.
+	defer ReleaseDecodedEntries(decoded)
+
+	return fsm.PrepareDecodedEntries(ctx, sessions, decoded...)
+}
+
+// PrepareDecodedEntries processes pre-decoded Raft entries and builds a
+// Pebble batch without committing it. All in-memory state (cache,
+// KeyStore, counters) is updated. The caller must either call
+// CommitPreparedBatch or PreparedBatch.Close.
+//
+// This is the first half of the pipelining split: PrepareDecodedEntries
+// is CPU-bound and can run while a previous batch's commit is in-flight.
+//
+// The caller owns the lifetime of decoded[].Proposal pointers and must
+// keep them valid for the duration of this call; they may be released
+// immediately after return (see PrepareEntries for the canonical pattern).
+func (fsm *Machine) PrepareDecodedEntries(ctx context.Context, sessions dal.WriteSessionFactory, decoded ...DecodedEntry) (*PreparedBatch, error) {
 	// Validate checkpoint trigger positions BEFORE taking the lock or mutating
 	// any in-memory state. A malformed batch (trigger not last) is rejected
 	// here so the FSM cannot be left with lastAppliedIndex bumped and proposal
 	// side effects applied for an entry that will never be committed.
-	if err := ValidateCheckpointEntryPositions(entries); err != nil {
+	if err := ValidateCheckpointEntryPositionsDecoded(decoded); err != nil {
 		return nil, err
 	}
 
@@ -428,17 +453,17 @@ func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessio
 	// With pipelining, lastPersistedIndex may lag lastAppliedIndex by one batch
 	// (the pending commit). This is expected and safe.
 	persistedIdx := fsm.lastPersistedIndex.Load()
-	if persistedIdx != fsm.State.LastAppliedIndex && len(entries) > 0 && fsm.logger.Enabled(logging.TraceLevel) {
+	if persistedIdx != fsm.State.LastAppliedIndex && len(decoded) > 0 && fsm.logger.Enabled(logging.TraceLevel) {
 		fsm.logger.WithFields(map[string]any{
 			"lastPersistedIndex": persistedIdx,
 			"lastAppliedIndex":   fsm.State.LastAppliedIndex,
 			"snapshotIndex":      fsm.State.SnapshotIndex,
-			"entryCount":         len(entries),
-			"firstEntryIndex":    entries[0].Index,
+			"entryCount":         len(decoded),
+			"firstEntryIndex":    decoded[0].Entry.Index,
 			"gen0":               fsm.Registry.Cache.BaseIndex.Gen0,
 			"gen1":               fsm.Registry.Cache.BaseIndex.Gen1,
 			"currentGeneration":  fsm.Registry.Cache.CurrentGeneration(),
-		}).Tracef("PrepareEntries: lastPersistedIndex lags (pending commit in-flight)")
+		}).Tracef("PrepareDecodedEntries: lastPersistedIndex lags (pending commit in-flight)")
 	}
 
 	if fsm.State.SnapshotIndex > fsm.State.LastAppliedIndex {
@@ -455,18 +480,18 @@ func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessio
 
 	batch := sessions.OpenWriteSession()
 
-	cmd := raftcmdpb.ProposalFromVTPool()
-	defer func() { cmd.ReturnToVTPool() }()
-
 	ret := &ApplyEntriesResult{
-		Results: make([]ApplyResult, 0, len(entries)),
+		Results: make([]ApplyResult, 0, len(decoded)),
 	}
 	sinkConfigChanged := false
 	mirrorConfigChanged := false
 	needsArchiveDispatch := false
 	needsColdCompaction := false
 
-	for i, entry := range entries {
+	for i := range decoded {
+		entry := decoded[i].Entry
+		cmd := decoded[i].Proposal
+
 		if entry.Index <= fsm.State.LastAppliedIndex {
 			ret.Results = append(ret.Results, ApplyResult{})
 
@@ -552,13 +577,18 @@ func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessio
 			continue
 		}
 
-		cmd.ReturnToVTPool()
-		cmd = raftcmdpb.ProposalFromVTPool()
+		// cmd was set from decoded[i].Proposal at the top of the iteration:
+		// DecodeEntries unmarshalled it once at the applier boundary, so the
+		// hot path never re-decodes the same raft payload. The caller owns
+		// the *Proposal lifetime (VT pool); the FSM only reads from it.
+		if cmd == nil {
+			assert.Unreachable("normal entry with non-empty Data but nil Proposal", map[string]any{
+				"raftIndex": entry.Index,
+			})
 
-		if err := cmd.UnmarshalVT(entry.Data); err != nil {
 			_ = batch.Cancel()
 
-			return nil, err
+			return nil, fmt.Errorf("invariant: decoded entry at raft index %d has nil Proposal", entry.Index)
 		}
 
 		if len(cmd.GetOrders()) == 0 && len(cmd.GetTechnicalUpdates()) == 0 {
@@ -633,19 +663,19 @@ func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessio
 		sealReqBase := fsm.checkCloseChapter(result)
 		queryCheckpointCreated := result.QueryCheckpointCreated > 0
 
-		if (sealReqBase != nil || queryCheckpointCreated) && i != len(entries)-1 {
+		if (sealReqBase != nil || queryCheckpointCreated) && i != len(decoded)-1 {
 			assert.Unreachable("checkpoint trigger entry not last in PrepareEntries batch", map[string]any{
 				"raftIndex":  entry.Index,
 				"proposalID": cmd.GetId(),
 				"position":   i,
-				"entryCount": len(entries),
+				"entryCount": len(decoded),
 			})
 
 			_ = batch.Cancel()
 
 			return nil, fmt.Errorf(
 				"checkpoint trigger entry at position %d/%d in PrepareEntries batch (raft index %d) — applier must pre-split",
-				i, len(entries), entry.Index,
+				i, len(decoded), entry.Index,
 			)
 		}
 
@@ -689,7 +719,7 @@ func (fsm *Machine) PrepareEntries(ctx context.Context, sessions dal.WriteSessio
 		needsColdCompaction:  needsColdCompaction,
 		sinkConfigChanged:    sinkConfigChanged,
 		mirrorConfigChanged:  mirrorConfigChanged,
-		entryCount:           len(entries),
+		entryCount:           len(decoded),
 	}
 
 	// Capture sentinel data before releasing the lock.

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -664,7 +664,7 @@ func (fsm *Machine) PrepareDecodedEntries(ctx context.Context, sessions dal.Writ
 		queryCheckpointCreated := result.QueryCheckpointCreated > 0
 
 		if (sealReqBase != nil || queryCheckpointCreated) && i != len(decoded)-1 {
-			assert.Unreachable("checkpoint trigger entry not last in PrepareEntries batch", map[string]any{
+			assert.Unreachable("checkpoint trigger entry not last in PrepareDecodedEntries batch", map[string]any{
 				"raftIndex":  entry.Index,
 				"proposalID": cmd.GetId(),
 				"position":   i,
@@ -674,7 +674,7 @@ func (fsm *Machine) PrepareDecodedEntries(ctx context.Context, sessions dal.Writ
 			_ = batch.Cancel()
 
 			return nil, fmt.Errorf(
-				"checkpoint trigger entry at position %d/%d in PrepareEntries batch (raft index %d) — applier must pre-split",
+				"checkpoint trigger entry at position %d/%d in PrepareDecodedEntries batch (raft index %d) — applier must pre-split",
 				i, len(decoded), entry.Index,
 			)
 		}


### PR DESCRIPTION
## Summary

The FSM apply pipeline used to `UnmarshalVT` the same `entry.Data` up to **three times** per Raft entry:

1. `applier.findCheckpointBoundary` — scan to find the checkpoint pre-split boundary
2. `state.ValidateCheckpointEntryPositions` — defensive validator called at the top of `PrepareEntries`
3. `state.Machine.PrepareEntries` main loop — the actual apply decode

For a batch of `N` entries that meant ~`3N` decodes of the same payload. This PR moves the decode to the **applier boundary** so it happens once per entry, and threads the decoded form through every downstream stage.

## What changed

- **New** `internal/infra/state/decoded_entry.go`: `DecodedEntry` (entry + pre-decoded `*raftcmdpb.Proposal`), `DecodeEntries`, `ReleaseDecodedEntries`, `DecodedEntryRequiresCheckpoint`.
- **State**: `PrepareEntries(...raftpb.Entry)` is now a thin wrapper that decodes → delegates → releases. The hot path core is `PrepareDecodedEntries(...DecodedEntry)` — no `UnmarshalVT` in the apply loop. Added `ValidateCheckpointEntryPositionsDecoded` (no-unmarshal sibling kept for parity with the raw variant).
- **Applier**: `applyEntriesToFSM` and `applyReplayEntries` decode once at the top (`defer state.ReleaseDecodedEntries(decoded)`), then pass the `[]state.DecodedEntry` through `findCheckpointBoundaryDecoded` → `applyEntriesPipelined` / `applyEntriesAndResolveCommands` → `PrepareDecodedEntries`. Helper `rawEntriesFromDecoded` for the few sites that need `[]raftpb.Entry` back (spool tail append, checkpoint maintenance handoff).

## Cost per batch of N entries

| Stage | Before | After |
|---|---|---|
| `findCheckpointBoundary` | 1 unmarshal / entry | 0 |
| `ValidateCheckpointEntryPositions` | 1 unmarshal / (N-1) | 0 |
| `PrepareEntries` apply loop | 1 unmarshal / entry | 0 |
| `DecodeEntries` at applier boundary | — | **1 unmarshal / entry** |
| **Total** | **~3N** | **1N** |

## Lifetime and safety

The applier owns each `*raftcmdpb.Proposal`'s lifetime via `defer state.ReleaseDecodedEntries(decoded)`. The returned `*PreparedBatch` retains no pointer into the proposal — every per-entry effect is captured by value into `ApplyResult` during apply. This matches the invariant already implicit in the previous single-`cmd` VT-pool recycling pattern.

## Backward compatibility

Public signatures preserved as wrappers (`PrepareEntries`, `ApplyEntries`, `findCheckpointBoundary`, `ValidateCheckpointEntryPositions`) — no test file needed to change. ~30+ call sites across `internal/infra/state/*_test.go` and `internal/infra/node/checkpoint_boundary_test.go` continue to work as-is.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/...` (state + node + all other internals)
- [x] `golangci-lint run --new-from-rev=HEAD~ ./internal/infra/state/... ./internal/infra/node/...` — 0 issues
- [ ] CI green on this PR
- [ ] Antithesis run (optional sanity check given hot-path nature)