### PR TITLE
fix(http): enforce bulk per-element scopes when auth is enabled (#474)

### DIFF
--- a/internal/adapter/http/handler.go
+++ b/internal/adapter/http/handler.go
@@ -66,7 +66,7 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 	)
 
 	// Create server instance for handlers
-	server := NewServer(logger, backend, defaultBulkMaxSize)
+	server := NewServer(logger, backend, authCfg, defaultBulkMaxSize)
 
 	// Ops routes: not versioned (K8s probes, monitoring, profiling).
 	// /health, /livez, /readyz, /_info are also exempted from auth in

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -36,9 +36,12 @@ func (s *Server) handleBulk(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Per-element scope check: verify the caller has the required scope for each element.
-	effective := internalauth.ExpandedScopesFromContext(r.Context())
-	if effective != nil {
+	// Per-element scope check: each element may require a different granular
+	// scope. Enforcement keys off auth being enabled — same as RequireScope and
+	// the gRPC Apply handler — so an anonymous request with an empty or nil scope
+	// set is denied by HasScope rather than skipped.
+	if s.authCfg.Enabled {
+		effective := internalauth.ExpandedScopesFromContext(r.Context())
 		authPresented := internalauth.AuthPresentedFromContext(r.Context())
 
 		for i, elem := range elements {

--- a/internal/adapter/http/handlers_bulk_test.go
+++ b/internal/adapter/http/handlers_bulk_test.go
@@ -11,9 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
+
+// bulkWriteBody is a single-element bulk payload whose action (CREATE_TRANSACTION)
+// requires the transactions:write granular scope.
+const bulkWriteBody = `[{"action":"CREATE_TRANSACTION","data":{"postings":[{"source":"world","destination":"bank","amount":100,"asset":"USD/2"}]}}]`
 
 func TestHandleBulk_InvalidBody(t *testing.T) {
 	t.Parallel()
@@ -181,4 +189,50 @@ func TestRunBulkSequential_ContinueOnFailure(t *testing.T) {
 	require.Len(t, results, 2)
 	require.Error(t, results[0].err)
 	require.NoError(t, results[1].err)
+}
+
+// TestHandleBulk_AuthEnabled_NoToken_Unauthorized covers the unauthenticated
+// write path: auth is enabled with the default mapping (no anonymous scopes),
+// the request carries no bearer token, and a write element must be rejected with
+// 401 before reaching the backend. The mock backend has no Apply expectation, so
+// any call to it fails the test.
+func TestHandleBulk_AuthEnabled_NoToken_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	authCfg := internalauth.AuthConfig{
+		Enabled:      true,
+		ScopeMapping: internalauth.DefaultMapping("ledger"),
+	}
+	handler := NewHandler(logging.Testing(), backend, authCfg, version.Info{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v3/ledger1/bulk", strings.NewReader(bulkWriteBody))
+
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Equal(t, "UNAUTHENTICATED", decodeResponse[bulkResponse](t, w).ErrorCode)
+}
+
+// TestHandleBulk_AuthDisabled_NoToken_Allowed is the control for the case above:
+// with auth disabled the same no-token write must pass through to the backend.
+func TestHandleBulk_AuthDisabled_NoToken_Allowed(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			return []*commonpb.Log{
+				{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{}}}}},
+			}, nil
+		}).Times(1)
+	handler := NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v3/ledger1/bulk", strings.NewReader(bulkWriteBody))
+
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -1138,7 +1138,7 @@ func TestNewServer(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	srv := NewServer(logging.Testing(), backend, 100)
+	srv := NewServer(logging.Testing(), backend, internalauth.AuthConfig{}, 100)
 
 	require.NotNil(t, srv)
 	require.Equal(t, 100, srv.bulkMaxSize)

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -5,6 +5,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
@@ -15,14 +16,16 @@ import (
 type Server struct {
 	logger      logging.Logger
 	backend     Backend
+	authCfg     internalauth.AuthConfig
 	bulkMaxSize int
 }
 
 // NewServer creates a new server instance (used by handlers).
-func NewServer(logger logging.Logger, backend Backend, bulkMaxSize int) *Server {
+func NewServer(logger logging.Logger, backend Backend, authCfg internalauth.AuthConfig, bulkMaxSize int) *Server {
 	return &Server{
 		logger:      logger,
 		backend:     backend,
+		authCfg:     authCfg,
 		bulkMaxSize: bulkMaxSize,
 	}
 }

--- a/internal/adapter/http/test_helpers_test.go
+++ b/internal/adapter/http/test_helpers_test.go
@@ -11,6 +11,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 )
 
@@ -18,14 +19,14 @@ import (
 func newTestServer(t *testing.T, backend Backend) *Server {
 	t.Helper()
 
-	return NewServer(logging.Testing(), backend, 0)
+	return NewServer(logging.Testing(), backend, internalauth.AuthConfig{}, 0)
 }
 
 // newTestServerWithBulkLimit creates a Server with a mock backend and bulk limit for testing.
 func newTestServerWithBulkLimit(t *testing.T, backend Backend, bulkMaxSize int) *Server {
 	t.Helper()
 
-	return NewServer(logging.Testing(), backend, bulkMaxSize)
+	return NewServer(logging.Testing(), backend, internalauth.AuthConfig{}, bulkMaxSize)
 }
 
 // newRequest creates an http.Request with chi URL params.


### PR DESCRIPTION
## Summary

Fixes a **critical unauthenticated write bypass** on the `/{ledger}/bulk` and
`/{ledger}/_bulk` endpoints. With auth enabled, no bearer token, and the default
scope mapping, a caller could run bulk transaction and metadata writes with zero
authorization.

Closes #474.

## Root cause

The bulk handler gated its per-element scope check on `if effective != nil`,
using the nil-ness of the expanded-scopes map as a proxy for "auth enforcement
active". Two distinct states both produce a nil map there, and the handler
couldn't tell them apart:

- **Auth disabled** — the middleware returns early and never sets the scope key,
  so `ExpandedScopesFromContext` returns a nil map. *(correct to skip)*
- **Auth enabled, no token, default mapping** — the middleware stores
  `cfg.ScopeMapping.AnonymousScopes()`, which is `nil` because `DefaultMapping`
  has no `"anonymous"` key. *(should be denied)*

In Go a nil map compares equal to `nil`, so `effective != nil` was `false` in
both cases — the per-element loop was skipped entirely and control fell through
to `runBulk → applyUnsigned → backend.Apply`, which performs no scope check.

Notably, `HasScope(nil, transactions:write)` would have correctly returned
`false` — the bug is that the check was never reached.

## Fix

Gate the loop on `s.authCfg.Enabled` instead, exactly as `RequireScope`
(`http_middleware.go`) and the gRPC `Apply` handler (`server_bucket.go`) already
do. An anonymous request now reaches `HasScope` with a nil/empty scope set,
which denies with **401**; auth-disabled requests still bypass the check as
before. This required threading `AuthConfig` into the HTTP `Server` struct — the
same field-on-the-struct + gate-on-`Enabled` shape the gRPC servers already use.

This was the only `effective != nil` enforcement guard in the codebase; every
other site already keys off `cfg.Enabled`, so no other path changes.

## Testing

- `TestHandleBulk_AuthEnabled_NoToken_Unauthorized` — full path through
  `NewHandler` (real middleware), auth enabled + default mapping, no token, a
  `CREATE_TRANSACTION` element → asserts **401 `UNAUTHENTICATED`**. The mock
  backend has no `Apply` expectation, so it also proves the write never reaches
  the backend.
- `TestHandleBulk_AuthDisabled_NoToken_Allowed` — control: the same request with
  auth disabled still reaches the backend and returns 200.

Verified the regression test fails on the original code (the unauthenticated
write reaching `backend.Apply`) and passes with the fix. `go build ./...`,
`go vet`, the `internal/adapter/http` + `internal/adapter/auth` test suites,
`gofmt`, and `golangci-lint run` on both packages are all clean.
