### PR TITLE
fix(check): verify live idempotency entries frozen by archived audit entries

### DIFF
--- a/cmd/ledgerctl/store/bootstrap.go
+++ b/cmd/ledgerctl/store/bootstrap.go
@@ -424,8 +424,9 @@ func runBootstrapValidation(ctx context.Context, stagingDir string, logger loggi
 	attrs := attributes.New()
 	// No cold reader on this path: it validates a local staging store from a
 	// backup, so the idempotency pass keeps the post-archive boundary as its
-	// verification floor.
-	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, logger)
+	// verification floor. nil TTL: no trusted runtime config for a foreign
+	// backup, so the pass falls back to the backup's persisted TTL.
+	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, nil, logger)
 
 	pterm.Info.Println("Validating backup integrity...")
 

--- a/cmd/ledgerctl/store/bootstrap.go
+++ b/cmd/ledgerctl/store/bootstrap.go
@@ -422,7 +422,10 @@ func runBootstrapValidation(ctx context.Context, stagingDir string, logger loggi
 	}
 
 	attrs := attributes.New()
-	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), logger)
+	// No cold reader on this path: it validates a local staging store from a
+	// backup, so the idempotency pass keeps the post-archive boundary as its
+	// verification floor.
+	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, logger)
 
 	pterm.Info.Println("Validating backup integrity...")
 

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -1047,7 +1047,7 @@ func (impl *BucketServiceServerImpl) CheckStore(_ *servicepb.CheckStoreRequest, 
 		return err
 	}
 
-	checker := check.NewChecker(impl.store, impl.attrs, impl.clusterID, impl.logger)
+	checker := check.NewChecker(impl.store, impl.attrs, impl.clusterID, impl.localCtrl.ColdReader(), impl.logger)
 
 	return checker.Check(stream.Context(), func(event *servicepb.CheckStoreEvent) {
 		_ = stream.Send(event)

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -65,12 +65,13 @@ type BucketServiceServerImpl struct {
 	authCfg               internalauth.AuthConfig
 	queryProfileThreshold time.Duration
 	clusterID             string
+	idempotencyTTL        time.Duration
 	info                  version.Info
 	applyDuration         metric.Int64Histogram
 	forwarder             nodeForwarder
 }
 
-func NewBucketServiceServer(logger logging.Logger, c ctrl.Controller, localCtrl *ctrl.DefaultController, s *dal.Store, rs *readstore.Store, attrs *attributes.Attributes, sharedState *state.SharedState, receiptSigner *receipt.Signer, responseSigner *signing.ResponseSigner, authCfg internalauth.AuthConfig, queryProfileThreshold time.Duration, clusterID string, meterProvider metric.MeterProvider, n *node.Node, servicePool *transport.ConnectionPool, info version.Info) servicepb.BucketServiceServer {
+func NewBucketServiceServer(logger logging.Logger, c ctrl.Controller, localCtrl *ctrl.DefaultController, s *dal.Store, rs *readstore.Store, attrs *attributes.Attributes, sharedState *state.SharedState, receiptSigner *receipt.Signer, responseSigner *signing.ResponseSigner, authCfg internalauth.AuthConfig, queryProfileThreshold time.Duration, clusterID string, idempotencyTTL time.Duration, meterProvider metric.MeterProvider, n *node.Node, servicePool *transport.ConnectionPool, info version.Info) servicepb.BucketServiceServer {
 	meter := meterProvider.Meter("grpc")
 	applyDuration, _ := meter.Int64Histogram("grpc.apply.duration",
 		metric.WithUnit("us"),
@@ -93,6 +94,7 @@ func NewBucketServiceServer(logger logging.Logger, c ctrl.Controller, localCtrl 
 		authCfg:               authCfg,
 		queryProfileThreshold: queryProfileThreshold,
 		clusterID:             clusterID,
+		idempotencyTTL:        idempotencyTTL,
 		info:                  info,
 		applyDuration:         applyDuration,
 		forwarder:             nodeForwarder{node: n, servicePool: servicePool},
@@ -1047,7 +1049,7 @@ func (impl *BucketServiceServerImpl) CheckStore(_ *servicepb.CheckStoreRequest, 
 		return err
 	}
 
-	checker := check.NewChecker(impl.store, impl.attrs, impl.clusterID, impl.localCtrl.ColdReader(), impl.logger)
+	checker := check.NewChecker(impl.store, impl.attrs, impl.clusterID, impl.localCtrl.ColdReader(), &impl.idempotencyTTL, impl.logger)
 
 	return checker.Check(stream.Context(), func(event *servicepb.CheckStoreEvent) {
 		_ = stream.Send(event)

--- a/internal/adapter/grpc/server_restore.go
+++ b/internal/adapter/grpc/server_restore.go
@@ -219,7 +219,9 @@ func (s *RestoreServiceServerImpl) ValidateRestore(_ *restorepb.ValidateRestoreR
 	attrs := attributes.New()
 	// No cold reader on this path: it validates a staged backup store, so the
 	// idempotency pass keeps the post-archive boundary as its verification floor.
-	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, s.logger)
+	// nil TTL: there is no trusted runtime config for a foreign backup, so the
+	// pass falls back to the backup's persisted TTL.
+	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, nil, s.logger)
 
 	return checker.Check(stream.Context(), func(event *servicepb.CheckStoreEvent) {
 		var restoreEvent restorepb.ValidateRestoreEvent

--- a/internal/adapter/grpc/server_restore.go
+++ b/internal/adapter/grpc/server_restore.go
@@ -217,7 +217,9 @@ func (s *RestoreServiceServerImpl) ValidateRestore(_ *restorepb.ValidateRestoreR
 	}
 
 	attrs := attributes.New()
-	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), s.logger)
+	// No cold reader on this path: it validates a staged backup store, so the
+	// idempotency pass keeps the post-archive boundary as its verification floor.
+	checker := check.NewChecker(store, attrs, persisted.GetClusterId(), nil, s.logger)
 
 	return checker.Check(stream.Context(), func(event *servicepb.CheckStoreEvent) {
 		var restoreEvent restorepb.ValidateRestoreEvent

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sort"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/zeebo/blake3"
@@ -21,6 +22,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	domainreplay "github.com/formancehq/ledger/v3/internal/domain/replay"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
@@ -40,18 +42,26 @@ type Checker struct {
 	attrs     *attributes.Attributes
 	logger    logging.Logger
 	clusterID string
+	// coldReader gives the idempotency pass read access to archived audit
+	// entries so a still-live frozen outcome whose freezing entry has been
+	// archived can be re-derived rather than skipped. nil when cold storage
+	// is not configured (e.g. the CLI / restore call sites) — the pass then
+	// keeps the post-archive boundary as its verification floor.
+	coldReader *coldstorage.ColdReader
 }
 
 // NewChecker creates a new Checker. clusterID is used to derive the
 // per-cluster key for verifying audit-hash chain entries — it must match
 // the value the FSM used when writing those entries (enforced via
-// PersistedConfig immutability).
-func NewChecker(store *dal.Store, attrs *attributes.Attributes, clusterID string, logger logging.Logger) *Checker {
+// PersistedConfig immutability). coldReader may be nil when cold storage is
+// not configured.
+func NewChecker(store *dal.Store, attrs *attributes.Attributes, clusterID string, coldReader *coldstorage.ColdReader, logger logging.Logger) *Checker {
 	return &Checker{
-		store:     store,
-		attrs:     attrs,
-		logger:    logger,
-		clusterID: clusterID,
+		store:      store,
+		attrs:      attrs,
+		logger:     logger,
+		clusterID:  clusterID,
+		coldReader: coldReader,
 	}
 }
 
@@ -139,10 +149,33 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 
 	defer func() { _ = replay.Close() }()
 
+	// Lower bound of the idempotency TTL window: an entry frozen before this
+	// timestamp can no longer be live (it is past its TTL relative to the
+	// latest applied HLC timestamp), so it never needs cold-storage
+	// re-derivation. Read from the same snapshot so the window is
+	// deterministic for this run. A nil/zero TTL config yields a cutoff at
+	// lastApplied, disabling the cold extension (no entry counts as live).
+	persisted, err := query.ReadPersistedConfig(snap)
+	if err != nil {
+		return fmt.Errorf("reading persisted config: %w", err)
+	}
+
+	lastAppliedTs, err := query.ReadLastAppliedTimestamp(snap)
+	if err != nil {
+		return fmt.Errorf("reading last applied timestamp: %w", err)
+	}
+
+	ttlMicros := persisted.GetIdempotencyTtlSeconds() * 1_000_000
+
+	var idempotencyTTLCutoff uint64
+	if lastAppliedTs > ttlMicros {
+		idempotencyTTLCutoff = lastAppliedTs - ttlMicros
+	}
+
 	// Verify the audit hash chain before log replay.
 	// This iterates all non-archived audit entries and recomputes each hash
 	// from the stored orders, chaining from archiveLastAuditHash.
-	if err := c.verifyAuditHashChain(ctx, snap, chapters, archiveLastAuditHash, callback); err != nil {
+	if err := c.verifyAuditHashChain(ctx, snap, chapters, archiveLastAuditHash, idempotencyTTLCutoff, callback); err != nil {
 		return fmt.Errorf("verifying audit hash chain: %w", err)
 	}
 
@@ -1458,6 +1491,7 @@ func (c *Checker) verifyAuditHashChain(
 	reader dal.PebbleReader,
 	chapters []*commonpb.Chapter,
 	archiveLastAuditHash []byte,
+	idempotencyTTLCutoff uint64,
 	callback func(*servicepb.CheckStoreEvent),
 ) error {
 	// Find the last archived audit sequence to start iteration after it.
@@ -1495,10 +1529,10 @@ func (c *Checker) verifyAuditHashChain(
 		// from each verified audit entry and compared to SubIdempKeys below.
 		expectedIdem = make(map[idemExpectedKey]expectedIdempotency)
 		// Timestamp of the first (lowest-sequence) verified entry — the archive
-		// boundary. HLC timestamps are monotonic with sequence, so every freeze
-		// in the verified range is at/after it; a stored idempotency entry that
-		// claims a created_at >= this but matches no expected freeze is tampered
-		// or fabricated (see compareIdempotencyOutcomes). 0 = no verified entry.
+		// boundary. HLC timestamps are monotonic with sequence, so the verified
+		// range always re-derives every freeze at/after it; it is the default
+		// idempotency report floor (see the idemReportFloor computation below).
+		// 0 = no verified entry.
 		verifiedRangeStartTs uint64
 	)
 
@@ -1615,7 +1649,24 @@ func (c *Checker) verifyAuditHashChain(
 		c.logger.Infof("Audit hash chain verified: %d entries checked", checked)
 	}
 
-	if err := c.compareIdempotencyOutcomes(reader, expectedIdem, verifiedRangeStartTs, callback); err != nil {
+	// idemReportFloor is the lowest created_at at/above which `expectedIdem` is
+	// complete, so an unmatched stored entry there is tampering rather than an
+	// un-re-derivable archived freeze. The post-archive (verified) range always
+	// covers [verifiedRangeStartTs, ∞). When the TTL window reaches before that
+	// boundary, the still-live archived freezes in [ttlCutoff, boundary) are
+	// re-derived from cold storage; if that succeeds the floor drops to
+	// ttlCutoff. If cold storage is unavailable the floor stays at the boundary
+	// — the residual gap, not a false positive.
+	idemReportFloor := verifiedRangeStartTs
+	if verifiedRangeStartTs != 0 && idempotencyTTLCutoff < verifiedRangeStartTs {
+		if c.reDeriveArchivedIdempotency(ctx, chapters, idempotencyTTLCutoff, expectedIdem) {
+			idemReportFloor = idempotencyTTLCutoff
+		} else {
+			c.logger.Info("idempotency TTL window extends before the archive boundary but archived audit entries are not readable; verifying only the post-archive range")
+		}
+	}
+
+	if err := c.compareIdempotencyOutcomes(reader, expectedIdem, idemReportFloor, callback); err != nil {
 		return err
 	}
 
@@ -1701,33 +1752,173 @@ func recomputeProposalHash(items []*auditpb.AuditItem) []byte {
 	return processing.HashOrders(orders)
 }
 
+// reDeriveArchivedIdempotency extends `expected` with the frozen idempotency
+// outcomes re-derived from ARCHIVED audit entries whose timestamp is within the
+// TTL window [ttlCutoff, ∞) — the only archived freezes that can still be live.
+// It returns true when every archived chapter that could hold such a freeze was
+// read, so the caller may lower its report floor to ttlCutoff; false when cold
+// storage is unavailable or a read failed, in which case the caller keeps the
+// post-archive boundary and leaves the residual gap rather than risk a false
+// positive.
+//
+// Unlike the post-archive range, these cold entries are NOT re-verified against
+// the hash chain here. Cold storage sits outside the follower-disk threat model
+// this pass targets (see compareIdempotencyOutcomes), so the archived entry is
+// taken as the trusted source and only the live SubIdempKeys projection is
+// checked against it. Widening the threat model to cover cold-storage tampering
+// would require re-walking the chain over this same bounded window.
+//
+// The read is bounded by the TTL window, not by history: chapters are visited
+// newest-first and the scan stops at the first one whose newest entry predates
+// ttlCutoff.
+func (c *Checker) reDeriveArchivedIdempotency(
+	ctx context.Context,
+	chapters []*commonpb.Chapter,
+	ttlCutoff uint64,
+	expected map[idemExpectedKey]expectedIdempotency,
+) bool {
+	archived := make([]*commonpb.Chapter, 0, len(chapters))
+
+	for _, ch := range chapters {
+		if ch.GetStatus() == commonpb.ChapterStatus_CHAPTER_ARCHIVED {
+			archived = append(archived, ch)
+		}
+	}
+
+	// No archived data: the verified (hot) range already spans the whole audit
+	// history, so coverage extends down to ttlCutoff without any cold read.
+	if len(archived) == 0 {
+		return true
+	}
+
+	if c.coldReader == nil {
+		return false
+	}
+
+	sort.Slice(archived, func(i, j int) bool {
+		return archived[i].GetCloseAuditSequence() > archived[j].GetCloseAuditSequence()
+	})
+
+	for _, ch := range archived {
+		coldPebble, err := c.coldReader.GetReader(ctx, ch.GetId())
+		if err != nil {
+			c.logger.Infof("reading archived chapter %d for idempotency window failed: %v", ch.GetId(), err)
+
+			return false
+		}
+
+		last, err := query.ReadLastAuditEntry(coldPebble)
+		if err != nil {
+			c.logger.Infof("reading last audit entry of archived chapter %d failed: %v", ch.GetId(), err)
+
+			return false
+		}
+
+		// This chapter (and, by audit-sequence order, every older one) is
+		// entirely below the TTL window — nothing here can still be live.
+		if last == nil || last.GetTimestamp().GetData() < ttlCutoff {
+			break
+		}
+
+		windowStartsHere, err := c.collectChapterIdempotency(ctx, coldPebble, ttlCutoff, expected)
+		if err != nil {
+			c.logger.Infof("re-deriving idempotency from archived chapter %d failed: %v", ch.GetId(), err)
+
+			return false
+		}
+
+		if windowStartsHere {
+			break
+		}
+	}
+
+	return true
+}
+
+// collectChapterIdempotency scans one archived chapter's audit entries (read
+// from cold storage), re-derives the frozen idempotency outcome for every keyed
+// entry at/after ttlCutoff, and merges it into expected. It returns true when
+// the chapter's oldest entry predates ttlCutoff — the window starts inside this
+// chapter, so older chapters need not be read.
+func (c *Checker) collectChapterIdempotency(
+	ctx context.Context,
+	coldPebble dal.PebbleReader,
+	ttlCutoff uint64,
+	expected map[idemExpectedKey]expectedIdempotency,
+) (bool, error) {
+	cur, err := query.ReadAuditEntries(ctx, coldPebble, nil)
+	if err != nil {
+		return false, fmt.Errorf("reading archived audit entries: %w", err)
+	}
+
+	defer func() { _ = cur.Close() }()
+
+	windowStartsHere := false
+
+	for {
+		entry, err := cur.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return false, fmt.Errorf("reading archived audit entry: %w", err)
+		}
+
+		ts := entry.GetTimestamp().GetData()
+		if ts < ttlCutoff {
+			windowStartsHere = true
+
+			continue
+		}
+
+		key := entry.GetIdempotency().GetKey()
+		if key == "" {
+			continue
+		}
+
+		items, err := query.ReadAuditItems(ctx, coldPebble, entry.GetSequence())
+		if err != nil {
+			return false, fmt.Errorf("reading archived audit items for sequence %d: %w", entry.GetSequence(), err)
+		}
+
+		if exp, ok := expectedIdempotencyOutcome(entry, items); ok {
+			expected[idemExpectedKey{
+				keyHash:   state.HashIdempotencyKey(key),
+				createdAt: ts,
+			}] = exp
+		}
+	}
+
+	return windowStartsHere, nil
+}
+
 // compareIdempotencyOutcomes scans the frozen idempotency entries
 // (SubIdempKeys) and verifies each against the outcome re-derived from the
 // hash-chained audit entry that wrote it. A divergence is a tampered replay
 // cache — left unchecked, a duplicate caller would replay an arbitrary error or
 // wrong log range while Check() passed.
 //
-// Entries are matched by (key hash, created_at). A miss is classified by
-// verifiedRangeStartTs (the archive boundary): an entry whose created_at is
-// at/after the boundary must have its freeze in the verified range, so a miss
-// there is tampered created_at or a fabricated entry and is reported; an entry
-// before the boundary was frozen by an already-archived entry that is no longer
-// re-derivable here, so it is skipped — the same scoping the hash-chain
-// verification uses. This closes the gap where tampering the created_at of a
-// live, post-boundary entry would otherwise dodge the lookup and skip
-// verification entirely. (When verifiedRangeStartTs is 0 — no verified entries —
-// nothing is re-derivable, so all entries are skipped.)
+// Entries are matched by (key hash, created_at). `expected` is built to be
+// complete at/above idemReportFloor: the post-archive range is always
+// re-derived, and the still-live slice frozen by archived entries within the
+// idempotency TTL window ([ttlCutoff, boundary)) is re-derived from cold storage
+// when available (see reDeriveArchivedIdempotency). A stored entry whose
+// created_at is at/above the floor but matches no freeze is therefore a tampered
+// created_at or a fabricated entry and is reported. Below the floor the freezing
+// audit entry is older than the TTL window — no longer live, and not
+// re-derived — so the entry is skipped. (idemReportFloor == 0 means nothing was
+// re-derivable, e.g. an empty audit log, so all entries are skipped.)
 //
-// Residual limitation: a stored entry created before the boundary is skipped
-// even when it is still live — reachable only when the idempotency TTL outlives
-// the age at which chapters are archived. In that window a tampered outcome on
-// such an entry goes undetected here; fully closing it requires re-deriving the
-// archived freezes from cold storage (the same boundary that already scopes the
-// hash-chain verification).
+// Threat model: the check targets an actor with direct disk/Pebble write access
+// to a follower's store, which is where SubIdempKeys lives. The post-archive
+// audit entries that anchor the live range are hash-chain-verified above; the
+// archived entries used for the TTL window are trusted as-is because cold
+// storage is outside that follower-disk reach (see reDeriveArchivedIdempotency).
 func (c *Checker) compareIdempotencyOutcomes(
 	reader dal.PebbleReader,
 	expected map[idemExpectedKey]expectedIdempotency,
-	verifiedRangeStartTs uint64,
+	idemReportFloor uint64,
 	callback func(*servicepb.CheckStoreEvent),
 ) error {
 	iter, err := reader.NewIter(&pebble.IterOptions{
@@ -1756,14 +1947,15 @@ func (c *Checker) compareIdempotencyOutcomes(
 			createdAt: stored.GetCreatedAt(),
 		}]
 		if !ok {
-			// No matching freeze. If the entry claims a created_at at/after the
-			// archive boundary, its freeze must be in the verified range — its
-			// absence is tampering or fabrication. Older entries are archived
-			// (not re-derivable here) and are skipped.
-			if verifiedRangeStartTs != 0 && stored.GetCreatedAt() >= verifiedRangeStartTs {
+			// No matching freeze. `expected` is complete at/above the report
+			// floor, so a miss there is a tampered created_at or a fabricated
+			// entry. Below the floor the freezing entry is older than the TTL
+			// window (or pre-archive when cold storage was unavailable) and is
+			// not re-derived, so the entry is skipped rather than flagged.
+			if idemReportFloor != 0 && stored.GetCreatedAt() >= idemReportFloor {
 				callback(errorEvent(
 					servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH,
-					fmt.Sprintf("frozen idempotency outcome (created_at=%d) has no matching audit entry in the verified range — tampered created_at or fabricated entry",
+					fmt.Sprintf("frozen idempotency outcome (created_at=%d) has no matching audit entry — tampered created_at or fabricated entry",
 						stored.GetCreatedAt()),
 					0, "", "", "",
 				))

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/big"
 	"slices"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/zeebo/blake3"
@@ -49,20 +50,29 @@ type Checker struct {
 	// is not configured (e.g. the CLI / restore call sites) — the pass then
 	// keeps the post-archive boundary as its verification floor.
 	coldReader *coldstorage.ColdReader
+	// idempotencyTTL is the boot-validated runtime idempotency TTL, used to
+	// size the cold re-derivation window. It is preferred over the persisted
+	// projection because it lives in process memory (not on the audited disk),
+	// so a disk-tampered PersistedConfig cannot shrink the window. nil where no
+	// trusted runtime config exists (CLI / restore backup validation) — the
+	// pass then falls back to the persisted TTL.
+	idempotencyTTL *time.Duration
 }
 
 // NewChecker creates a new Checker. clusterID is used to derive the
 // per-cluster key for verifying audit-hash chain entries — it must match
 // the value the FSM used when writing those entries (enforced via
 // PersistedConfig immutability). coldReader may be nil when cold storage is
-// not configured.
-func NewChecker(store *dal.Store, attrs *attributes.Attributes, clusterID string, coldReader *coldstorage.ColdReader, logger logging.Logger) *Checker {
+// not configured. idempotencyTTL may be nil when no trusted runtime config is
+// available (the pass then falls back to the persisted TTL).
+func NewChecker(store *dal.Store, attrs *attributes.Attributes, clusterID string, coldReader *coldstorage.ColdReader, idempotencyTTL *time.Duration, logger logging.Logger) *Checker {
 	return &Checker{
-		store:      store,
-		attrs:      attrs,
-		logger:     logger,
-		clusterID:  clusterID,
-		coldReader: coldReader,
+		store:          store,
+		attrs:          attrs,
+		logger:         logger,
+		clusterID:      clusterID,
+		coldReader:     coldReader,
+		idempotencyTTL: idempotencyTTL,
 	}
 }
 
@@ -151,23 +161,22 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	defer func() { _ = replay.Close() }()
 
 	// Idempotency TTL, in microseconds, used by the hash-chain pass to bound the
-	// cold re-derivation window. The TTL is a Pebble projection (not chain-
-	// bound); "now" for the window is NOT read from a projection — it is the
-	// highest timestamp the hash chain verifies in this same run (see
-	// verifyAuditHashChain), so a tampered lastAppliedTimestamp cannot shift the
-	// window. nil = PersistedConfig absent: the window is unknown, so the cold
-	// pass is skipped rather than guessed.
+	// cold re-derivation window. Prefer the boot-validated runtime config (in
+	// process memory, off the audited disk) over the persisted projection, so a
+	// disk-tampered PersistedConfig cannot shrink the window; fall back to the
+	// persisted value where no runtime config exists (CLI / restore). nil (no
+	// runtime config and no persisted config) means the window is unknown, so
+	// the cold pass is skipped rather than guessed.
+	//
+	// "now" for the window is NOT a projection either — it is the highest
+	// timestamp the hash chain verifies in this same run (see
+	// verifyAuditHashChain), so a tampered lastAppliedTimestamp cannot shift it.
 	persisted, err := query.ReadPersistedConfig(snap)
 	if err != nil {
 		return fmt.Errorf("reading persisted config: %w", err)
 	}
 
-	var idempotencyTTLMicros *uint64
-
-	if persisted != nil {
-		micros := persisted.GetIdempotencyTtlSeconds() * 1_000_000
-		idempotencyTTLMicros = &micros
-	}
+	idempotencyTTLMicros := resolveIdempotencyTTLMicros(c.idempotencyTTL, persisted)
 
 	// Verify the audit hash chain before log replay.
 	// This iterates all non-archived audit entries and recomputes each hash
@@ -1696,6 +1705,28 @@ func (c *Checker) verifyAuditHashChain(
 	return nil
 }
 
+// resolveIdempotencyTTLMicros picks the TTL (in microseconds) that bounds the
+// cold re-derivation window. The boot-validated runtime config is preferred
+// because it is not read from the audited store; the persisted projection is
+// the fallback for paths with no runtime config (CLI / restore backup
+// validation). Returns nil when neither is available — the window is then
+// unknown and the cold pass is skipped.
+func resolveIdempotencyTTLMicros(runtime *time.Duration, persisted *commonpb.PersistedConfig) *uint64 {
+	if runtime != nil {
+		micros := uint64(runtime.Microseconds())
+
+		return &micros
+	}
+
+	if persisted != nil {
+		micros := persisted.GetIdempotencyTtlSeconds() * 1_000_000
+
+		return &micros
+	}
+
+	return nil
+}
+
 // idempotencyWindowCutoff returns the lower bound of the idempotency TTL window
 // given the hash-chain-verified "now" and the configured TTL. A ttlMicros of 0
 // (idempotency-ttl=0, never expire) or a ledger younger than its TTL yields 0 —
@@ -1978,12 +2009,13 @@ func (c *Checker) collectChapterIdempotency(
 // chain:
 //   - "now" (verifiedRangeEndTs) is the highest hash-chain-verified timestamp,
 //     NOT a projection — a tampered lastAppliedTimestamp cannot move the floor.
-//   - the idempotency TTL comes from PersistedConfig, a Pebble projection that
-//     is NOT chain-bound. An on-disk TTL shrink moves the floor up and makes
-//     entries just below it tamper-safe until the next boot, when config
-//     validation catches the mismatch. Binding the TTL to the chain would close
-//     this but is a larger design change (invariant #8 trusts projections
-//     between reboots).
+//   - the idempotency TTL is taken from the boot-validated runtime config when
+//     available (in process memory, off the audited disk), falling back to the
+//     PersistedConfig projection only where no runtime config exists (CLI /
+//     restore backup validation). On those fallback paths a disk-tampered TTL
+//     could move the floor up until the next boot revalidates config; the TTL
+//     is boot config, not an audit projection, so the checker cannot re-derive
+//     it from the chain.
 func (c *Checker) compareIdempotencyOutcomes(
 	reader dal.PebbleReader,
 	expected map[idemExpectedKey]expectedIdempotency,

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -150,11 +150,15 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	defer func() { _ = replay.Close() }()
 
 	// Lower bound of the idempotency TTL window: an entry frozen before this
-	// timestamp can no longer be live (it is past its TTL relative to the
-	// latest applied HLC timestamp), so it never needs cold-storage
-	// re-derivation. Read from the same snapshot so the window is
-	// deterministic for this run. A nil/zero TTL config yields a cutoff at
-	// lastApplied, disabling the cold extension (no entry counts as live).
+	// timestamp can no longer be live (past its TTL relative to the latest
+	// applied HLC timestamp), so it never needs cold-storage re-derivation.
+	// Read from the same snapshot so the window is deterministic for this run.
+	//
+	// A cutoff of 0 means an unbounded window — every frozen entry can still be
+	// live, so the cold pass scans the whole archived history. This is the
+	// configured behaviour for idempotency-ttl=0 (never expire; see
+	// cmd/server "0 = never expire") and also holds for a ledger younger than
+	// its TTL.
 	persisted, err := query.ReadPersistedConfig(snap)
 	if err != nil {
 		return fmt.Errorf("reading persisted config: %w", err)
@@ -165,11 +169,13 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 		return fmt.Errorf("reading last applied timestamp: %w", err)
 	}
 
-	ttlMicros := persisted.GetIdempotencyTtlSeconds() * 1_000_000
-
 	var idempotencyTTLCutoff uint64
-	if lastAppliedTs > ttlMicros {
-		idempotencyTTLCutoff = lastAppliedTs - ttlMicros
+
+	if ttlSeconds := persisted.GetIdempotencyTtlSeconds(); ttlSeconds != 0 {
+		ttlMicros := ttlSeconds * 1_000_000
+		if lastAppliedTs > ttlMicros {
+			idempotencyTTLCutoff = lastAppliedTs - ttlMicros
+		}
 	}
 
 	// Verify the audit hash chain before log replay.
@@ -1651,18 +1657,26 @@ func (c *Checker) verifyAuditHashChain(
 
 	// idemReportFloor is the lowest created_at at/above which `expectedIdem` is
 	// complete, so an unmatched stored entry there is tampering rather than an
-	// un-re-derivable archived freeze. The post-archive (verified) range always
-	// covers [verifiedRangeStartTs, ∞). When the TTL window reaches before that
-	// boundary, the still-live archived freezes in [ttlCutoff, boundary) are
-	// re-derived from cold storage; if that succeeds the floor drops to
-	// ttlCutoff. If cold storage is unavailable the floor stays at the boundary
-	// — the residual gap, not a false positive.
-	idemReportFloor := verifiedRangeStartTs
-	if verifiedRangeStartTs != 0 && idempotencyTTLCutoff < verifiedRangeStartTs {
-		if c.reDeriveArchivedIdempotency(ctx, chapters, idempotencyTTLCutoff, expectedIdem) {
-			idemReportFloor = idempotencyTTLCutoff
-		} else {
-			c.logger.Info("idempotency TTL window extends before the archive boundary but archived audit entries are not readable; verifying only the post-archive range")
+	// un-re-derivable archived freeze. It is a pointer so a floor of 0 ("the TTL
+	// window is unbounded — report every entry") is distinct from "no verified
+	// range at all" (nil — report nothing).
+	//
+	// The post-archive (verified) range always covers [verifiedRangeStartTs, ∞).
+	// When the TTL window reaches before that boundary, the still-live archived
+	// freezes in [ttlCutoff, boundary) are re-derived from cold storage; if that
+	// succeeds the floor drops to ttlCutoff. If cold storage is unavailable the
+	// floor stays at the boundary — the residual gap, not a false positive.
+	var idemReportFloor *uint64
+
+	if verifiedRangeStartTs != 0 {
+		idemReportFloor = &verifiedRangeStartTs
+
+		if idempotencyTTLCutoff < verifiedRangeStartTs {
+			if c.reDeriveArchivedIdempotency(ctx, chapters, idempotencyTTLCutoff, expectedIdem) {
+				idemReportFloor = &idempotencyTTLCutoff
+			} else {
+				c.logger.Info("idempotency TTL window extends before the archive boundary but archived audit entries are not readable; verifying only the post-archive range")
+			}
 		}
 	}
 
@@ -1795,6 +1809,13 @@ func (c *Checker) reDeriveArchivedIdempotency(
 		return false
 	}
 
+	// ttlCutoff == 0 means never-expire (idempotency-ttl=0): the window spans
+	// all history, so every archived chapter is read. Flag it — the read is
+	// O(history) by configuration, not a bug.
+	if ttlCutoff == 0 {
+		c.logger.Infof("idempotency-ttl is never-expire; scanning all %d archived chapters to verify frozen outcomes", len(archived))
+	}
+
 	sort.Slice(archived, func(i, j int) bool {
 		return archived[i].GetCloseAuditSequence() > archived[j].GetCloseAuditSequence()
 	})
@@ -1907,8 +1928,17 @@ func (c *Checker) collectChapterIdempotency(
 // created_at is at/above the floor but matches no freeze is therefore a tampered
 // created_at or a fabricated entry and is reported. Below the floor the freezing
 // audit entry is older than the TTL window — no longer live, and not
-// re-derived — so the entry is skipped. (idemReportFloor == 0 means nothing was
-// re-derivable, e.g. an empty audit log, so all entries are skipped.)
+// re-derived — so the entry is skipped. A nil floor means nothing was
+// re-derivable (no verified range), so all entries are skipped; a non-nil floor
+// of 0 means the window is unbounded (never-expire), so every entry is checked.
+//
+// This pass verifies the INTEGRITY of the entries that are stored — it does not
+// detect a DELETED entry. A frozen outcome that is simply absent cannot be
+// distinguished from one legitimately evicted at its TTL: eviction is applied by
+// IdempotencyEviction, which writes no audit record (see applyIdempotencyEviction),
+// so the audit log cannot prove an entry "should still be there". Detecting a
+// deleted entry (which would let a retry re-execute instead of replay) is a
+// separate concern out of scope here.
 //
 // Threat model: the check targets an actor with direct disk/Pebble write access
 // to a follower's store, which is where SubIdempKeys lives. The post-archive
@@ -1918,7 +1948,7 @@ func (c *Checker) collectChapterIdempotency(
 func (c *Checker) compareIdempotencyOutcomes(
 	reader dal.PebbleReader,
 	expected map[idemExpectedKey]expectedIdempotency,
-	idemReportFloor uint64,
+	idemReportFloor *uint64,
 	callback func(*servicepb.CheckStoreEvent),
 ) error {
 	iter, err := reader.NewIter(&pebble.IterOptions{
@@ -1952,7 +1982,7 @@ func (c *Checker) compareIdempotencyOutcomes(
 			// entry. Below the floor the freezing entry is older than the TTL
 			// window (or pre-archive when cold storage was unavailable) and is
 			// not re-derived, so the entry is skipped rather than flagged.
-			if idemReportFloor != 0 && stored.GetCreatedAt() >= idemReportFloor {
+			if idemReportFloor != nil && stored.GetCreatedAt() >= *idemReportFloor {
 				callback(errorEvent(
 					servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH,
 					fmt.Sprintf("frozen idempotency outcome (created_at=%d) has no matching audit entry — tampered created_at or fabricated entry",

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -2,13 +2,14 @@ package check
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"math/big"
-	"sort"
+	"slices"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/zeebo/blake3"
@@ -149,39 +150,29 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 
 	defer func() { _ = replay.Close() }()
 
-	// Lower bound of the idempotency TTL window: an entry frozen before this
-	// timestamp can no longer be live (past its TTL relative to the latest
-	// applied HLC timestamp), so it never needs cold-storage re-derivation.
-	// Read from the same snapshot so the window is deterministic for this run.
-	//
-	// A cutoff of 0 means an unbounded window — every frozen entry can still be
-	// live, so the cold pass scans the whole archived history. This is the
-	// configured behaviour for idempotency-ttl=0 (never expire; see
-	// cmd/server "0 = never expire") and also holds for a ledger younger than
-	// its TTL.
+	// Idempotency TTL, in microseconds, used by the hash-chain pass to bound the
+	// cold re-derivation window. The TTL is a Pebble projection (not chain-
+	// bound); "now" for the window is NOT read from a projection — it is the
+	// highest timestamp the hash chain verifies in this same run (see
+	// verifyAuditHashChain), so a tampered lastAppliedTimestamp cannot shift the
+	// window. nil = PersistedConfig absent: the window is unknown, so the cold
+	// pass is skipped rather than guessed.
 	persisted, err := query.ReadPersistedConfig(snap)
 	if err != nil {
 		return fmt.Errorf("reading persisted config: %w", err)
 	}
 
-	lastAppliedTs, err := query.ReadLastAppliedTimestamp(snap)
-	if err != nil {
-		return fmt.Errorf("reading last applied timestamp: %w", err)
-	}
+	var idempotencyTTLMicros *uint64
 
-	var idempotencyTTLCutoff uint64
-
-	if ttlSeconds := persisted.GetIdempotencyTtlSeconds(); ttlSeconds != 0 {
-		ttlMicros := ttlSeconds * 1_000_000
-		if lastAppliedTs > ttlMicros {
-			idempotencyTTLCutoff = lastAppliedTs - ttlMicros
-		}
+	if persisted != nil {
+		micros := persisted.GetIdempotencyTtlSeconds() * 1_000_000
+		idempotencyTTLMicros = &micros
 	}
 
 	// Verify the audit hash chain before log replay.
 	// This iterates all non-archived audit entries and recomputes each hash
 	// from the stored orders, chaining from archiveLastAuditHash.
-	if err := c.verifyAuditHashChain(ctx, snap, chapters, archiveLastAuditHash, idempotencyTTLCutoff, callback); err != nil {
+	if err := c.verifyAuditHashChain(ctx, snap, chapters, archiveLastAuditHash, idempotencyTTLMicros, callback); err != nil {
 		return fmt.Errorf("verifying audit hash chain: %w", err)
 	}
 
@@ -1497,7 +1488,7 @@ func (c *Checker) verifyAuditHashChain(
 	reader dal.PebbleReader,
 	chapters []*commonpb.Chapter,
 	archiveLastAuditHash []byte,
-	idempotencyTTLCutoff uint64,
+	idempotencyTTLMicros *uint64,
 	callback func(*servicepb.CheckStoreEvent),
 ) error {
 	// Find the last archived audit sequence to start iteration after it.
@@ -1534,12 +1525,16 @@ func (c *Checker) verifyAuditHashChain(
 		// Frozen idempotency outcomes the projection should hold, re-derived
 		// from each verified audit entry and compared to SubIdempKeys below.
 		expectedIdem = make(map[idemExpectedKey]expectedIdempotency)
-		// Timestamp of the first (lowest-sequence) verified entry — the archive
-		// boundary. HLC timestamps are monotonic with sequence, so the verified
-		// range always re-derives every freeze at/after it; it is the default
-		// idempotency report floor (see the idemReportFloor computation below).
-		// 0 = no verified entry.
+		// hasVerifiedRange records whether any entry was verified; a dedicated
+		// bool rather than a 0-sentinel, since HLC timestamp 0 is a legitimate
+		// value (mirrors the *uint64 idemReportFloor tri-state below).
+		hasVerifiedRange bool
+		// Timestamps of the first (lowest-sequence) and last (highest-sequence)
+		// verified entries. HLC timestamps are monotonic with sequence, so the
+		// first is the archive boundary (default idempotency report floor) and
+		// the last is the hash-chain-verified "now" used to size the TTL window.
 		verifiedRangeStartTs uint64
+		verifiedRangeEndTs   uint64
 	)
 
 	for {
@@ -1556,9 +1551,14 @@ func (c *Checker) verifyAuditHashChain(
 			return fmt.Errorf("reading audit entry for hash chain verification: %w", err)
 		}
 
-		if verifiedRangeStartTs == 0 {
+		if !hasVerifiedRange {
+			hasVerifiedRange = true
 			verifiedRangeStartTs = entry.GetTimestamp().GetData()
 		}
+
+		// Entries arrive in ascending sequence (hence ascending HLC), so the
+		// last one seen carries the highest verified timestamp.
+		verifiedRangeEndTs = entry.GetTimestamp().GetData()
 
 		// `items` on the stored AuditEntry value is reserved for
 		// GetAuditEntry response shaping — the apply path forces it
@@ -1663,17 +1663,26 @@ func (c *Checker) verifyAuditHashChain(
 	//
 	// The post-archive (verified) range always covers [verifiedRangeStartTs, ∞).
 	// When the TTL window reaches before that boundary, the still-live archived
-	// freezes in [ttlCutoff, boundary) are re-derived from cold storage; if that
-	// succeeds the floor drops to ttlCutoff. If cold storage is unavailable the
+	// freezes in [cutoff, boundary) are re-derived from cold storage; if that
+	// succeeds the floor drops to cutoff. If cold storage is unavailable the
 	// floor stays at the boundary — the residual gap, not a false positive.
+	//
+	// "now" is verifiedRangeEndTs — the highest hash-chain-verified timestamp —
+	// not a Pebble projection, so a tampered lastAppliedTimestamp cannot shrink
+	// the window. The TTL itself is still a projection (see idempotencyTTLMicros).
 	var idemReportFloor *uint64
 
-	if verifiedRangeStartTs != 0 {
+	if hasVerifiedRange {
 		idemReportFloor = &verifiedRangeStartTs
 
-		if idempotencyTTLCutoff < verifiedRangeStartTs {
-			if c.reDeriveArchivedIdempotency(ctx, chapters, idempotencyTTLCutoff, expectedIdem) {
-				idemReportFloor = &idempotencyTTLCutoff
+		if idempotencyTTLMicros == nil {
+			// PersistedConfig absent: the window is unknown. Skip the cold pass
+			// rather than treat it as never-expire — distinct from a genuine
+			// cold-storage read failure below.
+			c.logger.Debug("persisted idempotency TTL unavailable; verifying only the post-archive idempotency range")
+		} else if cutoff := idempotencyWindowCutoff(verifiedRangeEndTs, *idempotencyTTLMicros); cutoff < verifiedRangeStartTs {
+			if c.reDeriveArchivedIdempotency(ctx, chapters, cutoff, expectedIdem) {
+				idemReportFloor = &cutoff
 			} else {
 				c.logger.Info("idempotency TTL window extends before the archive boundary but archived audit entries are not readable; verifying only the post-archive range")
 			}
@@ -1685,6 +1694,18 @@ func (c *Checker) verifyAuditHashChain(
 	}
 
 	return nil
+}
+
+// idempotencyWindowCutoff returns the lower bound of the idempotency TTL window
+// given the hash-chain-verified "now" and the configured TTL. A ttlMicros of 0
+// (idempotency-ttl=0, never expire) or a ledger younger than its TTL yields 0 —
+// an unbounded window that re-derives the whole archived history.
+func idempotencyWindowCutoff(now, ttlMicros uint64) uint64 {
+	if ttlMicros != 0 && now > ttlMicros {
+		return now - ttlMicros
+	}
+
+	return 0
 }
 
 // idemExpectedKey identifies the frozen idempotency entry an audit outcome
@@ -1809,15 +1830,17 @@ func (c *Checker) reDeriveArchivedIdempotency(
 		return false
 	}
 
-	// ttlCutoff == 0 means never-expire (idempotency-ttl=0): the window spans
-	// all history, so every archived chapter is read. Flag it — the read is
-	// O(history) by configuration, not a bug.
+	// ttlCutoff == 0 means an unbounded window (idempotency-ttl=0 never-expire,
+	// or a ledger younger than its TTL): the whole archived history is read.
+	// Flag it — the O(history) read is by configuration, not a bug.
 	if ttlCutoff == 0 {
-		c.logger.Infof("idempotency-ttl is never-expire; scanning all %d archived chapters to verify frozen outcomes", len(archived))
+		c.logger.Infof("idempotency TTL window is unbounded; scanning all %d archived chapters to verify frozen outcomes", len(archived))
 	}
 
-	sort.Slice(archived, func(i, j int) bool {
-		return archived[i].GetCloseAuditSequence() > archived[j].GetCloseAuditSequence()
+	// Newest first, so the scan can stop at the first chapter whose newest entry
+	// predates the cutoff.
+	slices.SortFunc(archived, func(a, b *commonpb.Chapter) int {
+		return cmp.Compare(b.GetCloseAuditSequence(), a.GetCloseAuditSequence())
 	})
 
 	for _, ch := range archived {
@@ -1861,6 +1884,11 @@ func (c *Checker) reDeriveArchivedIdempotency(
 // entry at/after ttlCutoff, and merges it into expected. It returns true when
 // the chapter's oldest entry predates ttlCutoff — the window starts inside this
 // chapter, so older chapters need not be read.
+//
+// Scan order does not matter here: every in-window keyed entry is added
+// regardless of direction, and windowStartsHere only needs to observe whether
+// any entry predates the cutoff — so this is correct even if ReadAuditEntries'
+// ordering ever changes.
 func (c *Checker) collectChapterIdempotency(
 	ctx context.Context,
 	coldPebble dal.PebbleReader,
@@ -1945,6 +1973,17 @@ func (c *Checker) collectChapterIdempotency(
 // audit entries that anchor the live range are hash-chain-verified above; the
 // archived entries used for the TTL window are trusted as-is because cold
 // storage is outside that follower-disk reach (see reDeriveArchivedIdempotency).
+//
+// Coverage frontier — the report floor depends on two inputs beyond the audit
+// chain:
+//   - "now" (verifiedRangeEndTs) is the highest hash-chain-verified timestamp,
+//     NOT a projection — a tampered lastAppliedTimestamp cannot move the floor.
+//   - the idempotency TTL comes from PersistedConfig, a Pebble projection that
+//     is NOT chain-bound. An on-disk TTL shrink moves the floor up and makes
+//     entries just below it tamper-safe until the next boot, when config
+//     validation catches the mismatch. Binding the TTL to the chain would close
+//     this but is a larger design change (invariant #8 trusts projections
+//     between reboots).
 func (c *Checker) compareIdempotencyOutcomes(
 	reader dal.PebbleReader,
 	expected map[idemExpectedKey]expectedIdempotency,

--- a/internal/application/check/checker_idempotency_cold_test.go
+++ b/internal/application/check/checker_idempotency_cold_test.go
@@ -1,0 +1,232 @@
+package check
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2/bloom"
+	"github.com/cockroachdb/pebble/v2/sstable"
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow covers the
+// completeness gap closed by reDeriveArchivedIdempotency: a frozen idempotency
+// entry whose freezing audit entry has been ARCHIVED but is still within the
+// idempotency TTL window is re-derived from cold storage and verified, while an
+// entry frozen by an archived audit entry OLDER than the window is skipped (no
+// false positive). Bounding is asserted by leaving a fully-below-window archived
+// chapter's SST absent: if the pass read it, the cold read would fail, the floor
+// would fall back to the archive boundary, and the in-window tamper would no
+// longer be flagged.
+func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterID = "idem-cold-cluster"
+		bucketID  = "test-bucket"
+
+		liveKey    = "live-key"    // frozen by an archived entry inside the TTL window
+		expiredKey = "expired-key" // frozen by an archived entry older than the window
+
+		ttlCutoff = 2000 // lower bound of the TTL window
+		tsExpired = 1500 // archived freeze below the window
+		tsLive    = 3000 // archived freeze inside the window
+		tsHot     = 5000 // surviving post-archive entry => verifiedRangeStartTs
+
+		chapterNewer = 7 // archived chapter holding audit seq 3-4 (straddles the cutoff)
+		chapterOlder = 3 // archived chapter holding audit seq 1-2 (entirely below the window)
+	)
+
+	store := createTestStore(t)
+
+	// One real order shared by every freeze; its serialized form drives the
+	// proposal hash both in the audit items and in the stored projection.
+	orders := []*raftcmdpb.Order{{}}
+	serialized := orders[0].MarshalDeterministicVT(nil)
+	proposalHash := processing.HashOrders(orders)
+
+	failure := func(message string, ctx map[string]string) *auditpb.AuditEntry_Failure {
+		return &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{
+			Reason:  commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS,
+			Message: message,
+			Context: ctx,
+		}}
+	}
+
+	// Archived audit entries, both living in the newer chapter's SST: seq 3 is
+	// below the cutoff (skipped), seq 4 is inside the window (re-derived).
+	coldEntries := []*auditpb.AuditEntry{
+		{
+			Sequence: 3, Timestamp: &commonpb.Timestamp{Data: tsExpired}, ProposalId: 1, OrderCount: 1,
+			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+			Idempotency: &commonpb.Idempotency{Key: expiredKey},
+			Outcome:     failure("old", map[string]string{"a": "1"}),
+		},
+		{
+			Sequence: 4, Timestamp: &commonpb.Timestamp{Data: tsLive}, ProposalId: 2, OrderCount: 1,
+			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+			Idempotency: &commonpb.Idempotency{Key: liveKey},
+			Outcome:     failure("balance too low", map[string]string{"account": "bank"}),
+		},
+	}
+	coldItems := map[uint64][]*auditpb.AuditItem{
+		3: {{OrderIndex: 0, SerializedOrder: serialized}},
+		4: {{OrderIndex: 0, SerializedOrder: serialized}},
+	}
+
+	// Upload only the newer chapter's archive; the older chapter is deliberately
+	// missing so any attempt to read it surfaces as a cold-read failure.
+	fs := coldstorage.NewFilesystemStorage(t.TempDir())
+	sstBytes := buildColdAuditSST(t, coldEntries, coldItems)
+
+	checksum, err := coldstorage.ComputeSHA256(bytes.NewReader(sstBytes))
+	require.NoError(t, err)
+	require.NoError(t, fs.Archive(context.Background(), bucketID, chapterNewer, bytes.NewReader(sstBytes), checksum))
+
+	coldReader := coldstorage.NewColdReader(fs, bucketID, t.TempDir(), 4, 0, logging.Testing())
+	t.Cleanup(func() { _ = coldReader.Close() })
+
+	// A surviving post-archive entry anchors the verified range (seq after both
+	// chapters' close audit sequence). archiveLastAuditHash is nil, so its hash
+	// chains from a nil seed — matching persistAuditEntry.
+	hot := &auditpb.AuditEntry{
+		Sequence: 5, Timestamp: &commonpb.Timestamp{Data: tsHot}, ProposalId: 9,
+		HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+		Outcome:     failure("unrelated", nil),
+	}
+	persistAuditEntry(t, store, hot, nil, clusterID)
+
+	chapters := []*commonpb.Chapter{
+		{Id: chapterNewer, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED, StartAuditSequence: 3, CloseAuditSequence: 4},
+		{Id: chapterOlder, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED, StartAuditSequence: 1, CloseAuditSequence: 2},
+	}
+
+	collectMismatches := func() []*servicepb.CheckStoreError {
+		checker := NewChecker(store, attributes.New(), clusterID, coldReader, logging.Testing())
+
+		handle, err := store.NewReadHandle()
+		require.NoError(t, err)
+
+		defer func() { _ = handle.Close() }()
+
+		var got []*servicepb.CheckStoreError
+
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, ttlCutoff,
+			func(event *servicepb.CheckStoreEvent) {
+				if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
+					e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
+					got = append(got, e.Error)
+				}
+			}))
+
+		return got
+	}
+
+	// expiredKey's freeze (created_at=1500) is older than the window — it has no
+	// re-derived expectation and must be skipped, not flagged.
+	writeIdempotencyEntry(t, store, expiredKey, &commonpb.IdempotencyKeyValue{
+		CreatedAt: tsExpired,
+		Hash:      proposalHash,
+		Failure:   &commonpb.IdempotencyFailure{Reason: commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS, Message: "old", Metadata: map[string]string{"a": "1"}},
+	})
+
+	faithfulLive := &commonpb.IdempotencyKeyValue{
+		CreatedAt: tsLive,
+		Hash:      proposalHash,
+		Failure:   &commonpb.IdempotencyFailure{Reason: commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS, Message: "balance too low", Metadata: map[string]string{"account": "bank"}},
+	}
+	writeIdempotencyEntry(t, store, liveKey, faithfulLive)
+
+	require.Empty(t, collectMismatches(),
+		"a faithful entry frozen by an archived-but-in-window audit entry must pass, and an older-than-window entry must be skipped")
+
+	tampered := faithfulLive.CloneVT()
+	tampered.Failure.Message = "you have plenty of money"
+	writeIdempotencyEntry(t, store, liveKey, tampered)
+
+	got := collectMismatches()
+	require.NotEmpty(t, got,
+		"a tampered outcome on a live entry whose freeze is archived within the TTL window must be flagged")
+	require.Contains(t, got[0].GetMessage(), "3000",
+		"the flagged mismatch should reference the in-window created_at")
+}
+
+// buildColdAuditSST builds the SST an archived chapter would hold for the given
+// audit entries and items, keyed exactly as the live store keys them so the
+// query helpers read them back unchanged from a ColdReader.
+func buildColdAuditSST(t *testing.T, entries []*auditpb.AuditEntry, items map[uint64][]*auditpb.AuditItem) []byte {
+	t.Helper()
+
+	type kv struct{ k, v []byte }
+
+	var kvs []kv
+
+	for _, e := range entries {
+		key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdAudit).PutUint64(e.GetSequence()).Build()
+
+		val, err := e.MarshalVT()
+		require.NoError(t, err)
+
+		kvs = append(kvs, kv{key, val})
+	}
+
+	for seq, list := range items {
+		for _, it := range list {
+			key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdAuditItem).PutUint64(seq).PutUint32(it.GetOrderIndex()).Build()
+
+			val, err := it.MarshalVT()
+			require.NoError(t, err)
+
+			kvs = append(kvs, kv{key, val})
+		}
+	}
+
+	sort.Slice(kvs, func(i, j int) bool { return bytes.Compare(kvs[i].k, kvs[j].k) < 0 })
+
+	var buf bytes.Buffer
+
+	w := sstable.NewWriter(newSSTBufWritable(&buf), sstable.WriterOptions{
+		Compression:  sstable.SnappyCompression,
+		FilterPolicy: bloom.FilterPolicy(10),
+	})
+
+	for _, p := range kvs {
+		require.NoError(t, w.Set(p.k, p.v))
+	}
+
+	require.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+// sstBufWritable adapts a bytes.Buffer to the objstorage.Writable interface
+// sstable.NewWriter expects.
+type sstBufWritable struct {
+	buf *bytes.Buffer
+}
+
+func newSSTBufWritable(buf *bytes.Buffer) *sstBufWritable {
+	return &sstBufWritable{buf: buf}
+}
+
+func (w *sstBufWritable) Write(p []byte) error {
+	_, err := w.buf.Write(p)
+
+	return err
+}
+
+func (w *sstBufWritable) Finish() error { return nil }
+func (w *sstBufWritable) Abort()        {}

--- a/internal/application/check/checker_idempotency_cold_test.go
+++ b/internal/application/check/checker_idempotency_cold_test.go
@@ -58,14 +58,6 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 	serialized := orders[0].MarshalDeterministicVT(nil)
 	proposalHash := processing.HashOrders(orders)
 
-	failure := func(message string, ctx map[string]string) *auditpb.AuditEntry_Failure {
-		return &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{
-			Reason:  commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS,
-			Message: message,
-			Context: ctx,
-		}}
-	}
-
 	// Archived audit entries, both living in the newer chapter's SST: seq 3 is
 	// below the cutoff (skipped), seq 4 is inside the window (re-derived).
 	coldEntries := []*auditpb.AuditEntry{
@@ -73,13 +65,13 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 			Sequence: 3, Timestamp: &commonpb.Timestamp{Data: tsExpired}, ProposalId: 1, OrderCount: 1,
 			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
 			Idempotency: &commonpb.Idempotency{Key: expiredKey},
-			Outcome:     failure("old", map[string]string{"a": "1"}),
+			Outcome:     idemAuditFailure("old", map[string]string{"a": "1"}),
 		},
 		{
 			Sequence: 4, Timestamp: &commonpb.Timestamp{Data: tsLive}, ProposalId: 2, OrderCount: 1,
 			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
 			Idempotency: &commonpb.Idempotency{Key: liveKey},
-			Outcome:     failure("balance too low", map[string]string{"account": "bank"}),
+			Outcome:     idemAuditFailure("balance too low", map[string]string{"account": "bank"}),
 		},
 	}
 	coldItems := map[uint64][]*auditpb.AuditItem{
@@ -105,7 +97,7 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 	hot := &auditpb.AuditEntry{
 		Sequence: 5, Timestamp: &commonpb.Timestamp{Data: tsHot}, ProposalId: 9,
 		HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
-		Outcome:     failure("unrelated", nil),
+		Outcome:     idemAuditFailure("unrelated", nil),
 	}
 	persistAuditEntry(t, store, hot, nil, clusterID)
 
@@ -162,6 +154,124 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 		"a tampered outcome on a live entry whose freeze is archived within the TTL window must be flagged")
 	require.Contains(t, got[0].GetMessage(), "3000",
 		"the flagged mismatch should reference the in-window created_at")
+}
+
+// TestCompareIdempotencyOutcomes_NeverExpireScansFullArchivedHistory pins the
+// idempotency-ttl=0 (never expire) behavior: the cold re-derivation scans the
+// full archived history (ttlCutoff 0), so even a freeze far older than any
+// finite window is verified, and the report floor of 0 reports every unmatched
+// entry. It also pins the documented non-goal: a frozen key with no stored
+// entry (a deletion) is not flagged, because eviction is unaudited and a missing
+// entry can't be told apart from a legitimately evicted one.
+func TestCompareIdempotencyOutcomes_NeverExpireScansFullArchivedHistory(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterID  = "idem-never-expire-cluster"
+		bucketID   = "test-bucket"
+		ancientKey = "ancient-key"
+
+		tsAncient = 500  // far below any finite TTL window
+		tsHot     = 5000 // surviving post-archive entry => verifiedRangeStartTs
+
+		chapterAncient = 11
+	)
+
+	store := createTestStore(t)
+
+	orders := []*raftcmdpb.Order{{}}
+	serialized := orders[0].MarshalDeterministicVT(nil)
+	proposalHash := processing.HashOrders(orders)
+
+	coldEntries := []*auditpb.AuditEntry{
+		{
+			Sequence: 1, Timestamp: &commonpb.Timestamp{Data: tsAncient}, ProposalId: 1, OrderCount: 1,
+			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+			Idempotency: &commonpb.Idempotency{Key: ancientKey},
+			Outcome:     idemAuditFailure("ancient", map[string]string{"k": "v"}),
+		},
+	}
+	coldItems := map[uint64][]*auditpb.AuditItem{1: {{OrderIndex: 0, SerializedOrder: serialized}}}
+
+	fs := coldstorage.NewFilesystemStorage(t.TempDir())
+	sstBytes := buildColdAuditSST(t, coldEntries, coldItems)
+
+	checksum, err := coldstorage.ComputeSHA256(bytes.NewReader(sstBytes))
+	require.NoError(t, err)
+	require.NoError(t, fs.Archive(context.Background(), bucketID, chapterAncient, bytes.NewReader(sstBytes), checksum))
+
+	coldReader := coldstorage.NewColdReader(fs, bucketID, t.TempDir(), 4, 0, logging.Testing())
+	t.Cleanup(func() { _ = coldReader.Close() })
+
+	hot := &auditpb.AuditEntry{
+		Sequence: 5, Timestamp: &commonpb.Timestamp{Data: tsHot}, ProposalId: 9,
+		HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+		Outcome:     idemAuditFailure("unrelated", nil),
+	}
+	persistAuditEntry(t, store, hot, nil, clusterID)
+
+	chapters := []*commonpb.Chapter{
+		{Id: chapterAncient, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED, StartAuditSequence: 1, CloseAuditSequence: 2},
+	}
+
+	collectMismatches := func() []*servicepb.CheckStoreError {
+		checker := NewChecker(store, attributes.New(), clusterID, coldReader, logging.Testing())
+
+		handle, err := store.NewReadHandle()
+		require.NoError(t, err)
+
+		defer func() { _ = handle.Close() }()
+
+		var got []*servicepb.CheckStoreError
+
+		// ttlCutoff == 0 is the never-expire window: the cold pass scans the
+		// full archived history.
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, 0,
+			func(event *servicepb.CheckStoreEvent) {
+				if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
+					e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
+					got = append(got, e.Error)
+				}
+			}))
+
+		return got
+	}
+
+	// Deletion non-goal: the audit froze ancientKey, but with no stored entry
+	// the pass reports nothing — a missing entry is indistinguishable from a
+	// legitimately evicted one.
+	require.Empty(t, collectMismatches(),
+		"a frozen key with no stored entry must not be flagged (deletion is out of scope)")
+
+	faithful := &commonpb.IdempotencyKeyValue{
+		CreatedAt: tsAncient,
+		Hash:      proposalHash,
+		Failure:   &commonpb.IdempotencyFailure{Reason: commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS, Message: "ancient", Metadata: map[string]string{"k": "v"}},
+	}
+	writeIdempotencyEntry(t, store, ancientKey, faithful)
+
+	require.Empty(t, collectMismatches(),
+		"never-expire must scan the full archived history and pass a faithful ancient entry")
+
+	tampered := faithful.CloneVT()
+	tampered.Failure.Message = "tampered"
+	writeIdempotencyEntry(t, store, ancientKey, tampered)
+
+	got := collectMismatches()
+	require.NotEmpty(t, got,
+		"never-expire must scan the full archived history and flag a tampered ancient entry")
+	require.Contains(t, got[0].GetMessage(), "500",
+		"the flagged mismatch should reference the ancient created_at")
+}
+
+// idemAuditFailure builds a freezable-failure outcome for an archived audit
+// entry under test.
+func idemAuditFailure(message string, ctx map[string]string) *auditpb.AuditEntry_Failure {
+	return &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{
+		Reason:  commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS,
+		Message: message,
+		Context: ctx,
+	}}
 }
 
 // buildColdAuditSST builds the SST an archived chapter would hold for the given

--- a/internal/application/check/checker_idempotency_cold_test.go
+++ b/internal/application/check/checker_idempotency_cold_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2/bloom"
 	"github.com/cockroachdb/pebble/v2/sstable"
@@ -112,7 +113,7 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 	}
 
 	collectMismatches := func() []*servicepb.CheckStoreError {
-		checker := NewChecker(store, attributes.New(), clusterID, coldReader, logging.Testing())
+		checker := NewChecker(store, attributes.New(), clusterID, coldReader, nil, logging.Testing())
 
 		handle, err := store.NewReadHandle()
 		require.NoError(t, err)
@@ -221,7 +222,7 @@ func TestCompareIdempotencyOutcomes_NeverExpireScansFullArchivedHistory(t *testi
 	}
 
 	collectMismatches := func() []*servicepb.CheckStoreError {
-		checker := NewChecker(store, attributes.New(), clusterID, coldReader, logging.Testing())
+		checker := NewChecker(store, attributes.New(), clusterID, coldReader, nil, logging.Testing())
 
 		handle, err := store.NewReadHandle()
 		require.NoError(t, err)
@@ -290,14 +291,14 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 	t.Run("no archived chapters is fully covered without a cold reader", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewChecker(store, attributes.New(), "x", nil, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", nil, nil, logging.Testing())
 		require.True(t, c.reDeriveArchivedIdempotency(ctx, nil, 0, map[idemExpectedKey]expectedIdempotency{}))
 	})
 
 	t.Run("archived data with no cold reader is not covered", func(t *testing.T) {
 		t.Parallel()
 
-		c := NewChecker(store, attributes.New(), "x", nil, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", nil, nil, logging.Testing())
 		require.False(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(1, 2)}, 0, map[idemExpectedKey]expectedIdempotency{}))
 	})
 
@@ -306,7 +307,7 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 
 		// Cold reader over an empty store: GetReader fails for the chapter.
 		reader := coldReaderWithChapters(t, bucketID, nil)
-		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", reader, nil, logging.Testing())
 		require.False(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(99, 2)}, 0, map[idemExpectedKey]expectedIdempotency{}))
 	})
 
@@ -330,7 +331,7 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 		}, map[uint64][]*auditpb.AuditItem{4: {{OrderIndex: 0, SerializedOrder: serialized}}})
 
 		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{20: newer, 10: older})
-		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", reader, nil, logging.Testing())
 
 		expected := map[idemExpectedKey]expectedIdempotency{}
 		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(20, 6), archived(10, 4)}, cutoff, expected))
@@ -355,7 +356,7 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 		}, map[uint64][]*auditpb.AuditItem{5: {{OrderIndex: 0, SerializedOrder: serialized}}})
 
 		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{30: sst})
-		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", reader, nil, logging.Testing())
 
 		expected := map[idemExpectedKey]expectedIdempotency{}
 		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(30, 5)}, 2000, expected))
@@ -376,7 +377,7 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 		sst := writeSSTBytes(t, [][2][]byte{{logKey, []byte("x")}})
 
 		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{40: sst})
-		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+		c := NewChecker(store, attributes.New(), "x", reader, nil, logging.Testing())
 
 		expected := map[idemExpectedKey]expectedIdempotency{}
 		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(40, 2)}, 2000, expected))
@@ -407,6 +408,46 @@ func TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig(t *testing.T) {
 
 	require.Empty(t, collectCheckErrors(t, engine.store, engine.attrs),
 		"a clean store with a persisted idempotency TTL must pass Check")
+}
+
+// TestResolveIdempotencyTTLMicros pins the TTL-source precedence: the trusted
+// runtime config wins over the persisted projection, the persisted value is the
+// fallback, an explicit never-expire (0) runtime TTL is preserved (not confused
+// with "unset"), and nil is returned when neither source exists.
+func TestResolveIdempotencyTTLMicros(t *testing.T) {
+	t.Parallel()
+
+	dur := func(d time.Duration) *time.Duration { return &d }
+
+	t.Run("runtime config wins over persisted", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolveIdempotencyTTLMicros(dur(2*time.Second), &commonpb.PersistedConfig{IdempotencyTtlSeconds: 99})
+		require.NotNil(t, got)
+		require.Equal(t, uint64(2_000_000), *got)
+	})
+
+	t.Run("runtime never-expire (0) wins and is preserved", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolveIdempotencyTTLMicros(dur(0), &commonpb.PersistedConfig{IdempotencyTtlSeconds: 99})
+		require.NotNil(t, got)
+		require.Equal(t, uint64(0), *got, "an explicit runtime TTL of 0 must not fall back to persisted")
+	})
+
+	t.Run("falls back to persisted when no runtime config", func(t *testing.T) {
+		t.Parallel()
+
+		got := resolveIdempotencyTTLMicros(nil, &commonpb.PersistedConfig{IdempotencyTtlSeconds: 3})
+		require.NotNil(t, got)
+		require.Equal(t, uint64(3_000_000), *got)
+	})
+
+	t.Run("nil when neither is available", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, resolveIdempotencyTTLMicros(nil, nil))
+	})
 }
 
 // writePersistedConfig stores the PersistedConfig at its Global-zone key, the

--- a/internal/application/check/checker_idempotency_cold_test.go
+++ b/internal/application/check/checker_idempotency_cold_test.go
@@ -3,7 +3,6 @@ package check
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"sort"
 	"testing"
 
@@ -43,10 +42,14 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 		liveKey    = "live-key"    // frozen by an archived entry inside the TTL window
 		expiredKey = "expired-key" // frozen by an archived entry older than the window
 
-		ttlCutoff = 2000 // lower bound of the TTL window
+		ttlCutoff = 2000 // desired lower bound of the TTL window
 		tsExpired = 1500 // archived freeze below the window
 		tsLive    = 3000 // archived freeze inside the window
-		tsHot     = 5000 // surviving post-archive entry => verifiedRangeStartTs
+		tsHot     = 5000 // surviving post-archive entry => verified "now"
+
+		// verifyAuditHashChain derives the cutoff as (verified now − TTL); with
+		// a single hot entry, verified now == tsHot, so this TTL yields ttlCutoff.
+		ttlMicros = tsHot - ttlCutoff
 
 		chapterNewer = 7 // archived chapter holding audit seq 3-4 (straddles the cutoff)
 		chapterOlder = 3 // archived chapter holding audit seq 1-2 (entirely below the window)
@@ -118,7 +121,8 @@ func TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow(t *testing.T) 
 
 		var got []*servicepb.CheckStoreError
 
-		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, ttlCutoff,
+		ttl := uint64(ttlMicros)
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, &ttl,
 			func(event *servicepb.CheckStoreEvent) {
 				if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
 					e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
@@ -226,9 +230,10 @@ func TestCompareIdempotencyOutcomes_NeverExpireScansFullArchivedHistory(t *testi
 
 		var got []*servicepb.CheckStoreError
 
-		// ttlCutoff == 0 is the never-expire window: the cold pass scans the
-		// full archived history.
-		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, 0,
+		// TTL 0 is never-expire: the derived cutoff is 0, so the cold pass scans
+		// the full archived history.
+		neverExpire := uint64(0)
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, chapters, nil, &neverExpire,
 			func(event *servicepb.CheckStoreEvent) {
 				if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
 					e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
@@ -336,12 +341,54 @@ func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
 		_, ok := expected[idemExpectedKey{keyHash: state.HashIdempotencyKey("k"), createdAt: 3000}]
 		require.True(t, ok, "the in-window keyed entry must be re-derived")
 	})
+
+	t.Run("success outcomes are re-derived from cold storage", func(t *testing.T) {
+		t.Parallel()
+
+		serialized := (&raftcmdpb.Order{}).MarshalDeterministicVT(nil)
+
+		sst := buildColdAuditSST(t, []*auditpb.AuditEntry{
+			{
+				Sequence: 5, Timestamp: &commonpb.Timestamp{Data: 3000}, Idempotency: &commonpb.Idempotency{Key: "s"},
+				Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{MinLogSequence: 10, MaxLogSequence: 12}},
+			},
+		}, map[uint64][]*auditpb.AuditItem{5: {{OrderIndex: 0, SerializedOrder: serialized}}})
+
+		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{30: sst})
+		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+
+		expected := map[idemExpectedKey]expectedIdempotency{}
+		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(30, 5)}, 2000, expected))
+
+		got, ok := expected[idemExpectedKey{keyHash: state.HashIdempotencyKey("s"), createdAt: 3000}]
+		require.True(t, ok, "the success freeze must be re-derived")
+		require.False(t, got.failure)
+		require.Equal(t, uint64(10), got.firstLog)
+		require.Equal(t, uint32(3), got.logCount, "log count is max−min+1")
+	})
+
+	t.Run("a chapter with no audit entries is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		// SST holds only a (non-audit) log key, so ReadLastAuditEntry returns
+		// nil and the chapter is skipped without error.
+		logKey := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdLog).PutUint64(1).Build()
+		sst := writeSSTBytes(t, [][2][]byte{{logKey, []byte("x")}})
+
+		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{40: sst})
+		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+
+		expected := map[idemExpectedKey]expectedIdempotency{}
+		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(40, 2)}, 2000, expected))
+		require.Empty(t, expected)
+	})
 }
 
 // TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig exercises the
-// end-to-end path in Check that reads the persisted idempotency TTL and the
-// last-applied timestamp and computes the window cutoff. A clean store with a
-// non-zero TTL configured must still pass.
+// end-to-end path in Check that reads the persisted idempotency TTL and passes
+// it to the hash-chain pass, which derives the window cutoff from the verified
+// "now". A short TTL keeps the cutoff bounded (verified now − TTL > 0). A clean
+// store must still pass.
 func TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig(t *testing.T) {
 	t.Parallel()
 
@@ -350,12 +397,12 @@ func TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig(t *testing.T) {
 	engine.processAndCommit(createTransactionOrder("test", true,
 		newPosting("world", "user:alice", "USD", 100)))
 
-	// Non-zero TTL + a last-applied timestamp ahead of it, so Check computes a
-	// bounded (non-zero) cutoff.
-	writeGlobalUint64(t, engine.store, dal.SubGlobLastAppliedTimestamp, 1_700_000_100_000_000)
+	// A 1s TTL is well below the engine's audit timestamps, so the derived
+	// cutoff is non-zero (exercises the bounded-window branch). "now" comes from
+	// the verified chain, not a persisted last-applied timestamp.
 	writePersistedConfig(t, engine.store, &commonpb.PersistedConfig{
 		ClusterId:             engine.clusterID,
-		IdempotencyTtlSeconds: 3600,
+		IdempotencyTtlSeconds: 1,
 	})
 
 	require.Empty(t, collectCheckErrors(t, engine.store, engine.attrs),
@@ -372,19 +419,6 @@ func writePersistedConfig(t *testing.T, store *dal.Store, cfg *commonpb.Persiste
 
 	batch := store.OpenWriteSession()
 	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig}, data))
-	require.NoError(t, batch.Commit())
-}
-
-// writeGlobalUint64 stores a big-endian uint64 under a Global-zone sub-key, the
-// encoding dal.ReadUint64 expects.
-func writeGlobalUint64(t *testing.T, store *dal.Store, sub byte, v uint64) {
-	t.Helper()
-
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, v)
-
-	batch := store.OpenWriteSession()
-	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, sub}, buf))
 	require.NoError(t, batch.Commit())
 }
 
@@ -423,9 +457,7 @@ func idemAuditFailure(message string, ctx map[string]string) *auditpb.AuditEntry
 func buildColdAuditSST(t *testing.T, entries []*auditpb.AuditEntry, items map[uint64][]*auditpb.AuditItem) []byte {
 	t.Helper()
 
-	type kv struct{ k, v []byte }
-
-	var kvs []kv
+	var kvs [][2][]byte
 
 	for _, e := range entries {
 		key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdAudit).PutUint64(e.GetSequence()).Build()
@@ -433,7 +465,7 @@ func buildColdAuditSST(t *testing.T, entries []*auditpb.AuditEntry, items map[ui
 		val, err := e.MarshalVT()
 		require.NoError(t, err)
 
-		kvs = append(kvs, kv{key, val})
+		kvs = append(kvs, [2][]byte{key, val})
 	}
 
 	for seq, list := range items {
@@ -443,11 +475,19 @@ func buildColdAuditSST(t *testing.T, entries []*auditpb.AuditEntry, items map[ui
 			val, err := it.MarshalVT()
 			require.NoError(t, err)
 
-			kvs = append(kvs, kv{key, val})
+			kvs = append(kvs, [2][]byte{key, val})
 		}
 	}
 
-	sort.Slice(kvs, func(i, j int) bool { return bytes.Compare(kvs[i].k, kvs[j].k) < 0 })
+	return writeSSTBytes(t, kvs)
+}
+
+// writeSSTBytes writes an SST (sorted by key) with the given key/value pairs and
+// returns its bytes.
+func writeSSTBytes(t *testing.T, kvs [][2][]byte) []byte {
+	t.Helper()
+
+	sort.Slice(kvs, func(i, j int) bool { return bytes.Compare(kvs[i][0], kvs[j][0]) < 0 })
 
 	var buf bytes.Buffer
 
@@ -456,8 +496,8 @@ func buildColdAuditSST(t *testing.T, entries []*auditpb.AuditEntry, items map[ui
 		FilterPolicy: bloom.FilterPolicy(10),
 	})
 
-	for _, p := range kvs {
-		require.NoError(t, w.Set(p.k, p.v))
+	for _, kv := range kvs {
+		require.NoError(t, w.Set(kv[0], kv[1]))
 	}
 
 	require.NoError(t, w.Close())

--- a/internal/application/check/checker_idempotency_cold_test.go
+++ b/internal/application/check/checker_idempotency_cold_test.go
@@ -3,6 +3,7 @@ package check
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"sort"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
@@ -262,6 +264,147 @@ func TestCompareIdempotencyOutcomes_NeverExpireScansFullArchivedHistory(t *testi
 		"never-expire must scan the full archived history and flag a tampered ancient entry")
 	require.Contains(t, got[0].GetMessage(), "500",
 		"the flagged mismatch should reference the ancient created_at")
+}
+
+// TestReDeriveArchivedIdempotency_Bounds exercises the branch behaviour of the
+// cold re-derivation directly: coverage of archived data, the no-cold-reader and
+// failed-read fallbacks, the newest-first scan stopping at the first chapter
+// entirely below the window, and skipping non-keyed entries.
+func TestReDeriveArchivedIdempotency_Bounds(t *testing.T) {
+	t.Parallel()
+
+	const bucketID = "test-bucket"
+
+	store := createTestStore(t)
+	ctx := context.Background()
+
+	archived := func(id, closeAuditSeq uint64) *commonpb.Chapter {
+		return &commonpb.Chapter{Id: id, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED, CloseAuditSequence: closeAuditSeq}
+	}
+
+	t.Run("no archived chapters is fully covered without a cold reader", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewChecker(store, attributes.New(), "x", nil, logging.Testing())
+		require.True(t, c.reDeriveArchivedIdempotency(ctx, nil, 0, map[idemExpectedKey]expectedIdempotency{}))
+	})
+
+	t.Run("archived data with no cold reader is not covered", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewChecker(store, attributes.New(), "x", nil, logging.Testing())
+		require.False(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(1, 2)}, 0, map[idemExpectedKey]expectedIdempotency{}))
+	})
+
+	t.Run("a missing archive is a read failure, not coverage", func(t *testing.T) {
+		t.Parallel()
+
+		// Cold reader over an empty store: GetReader fails for the chapter.
+		reader := coldReaderWithChapters(t, bucketID, nil)
+		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+		require.False(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(99, 2)}, 0, map[idemExpectedKey]expectedIdempotency{}))
+	})
+
+	t.Run("scan stops at the first chapter below the window and skips non-keyed entries", func(t *testing.T) {
+		t.Parallel()
+
+		const cutoff = 2000
+
+		serialized := (&raftcmdpb.Order{}).MarshalDeterministicVT(nil)
+
+		// Newer chapter: one keyed entry in-window + one non-keyed entry.
+		newer := buildColdAuditSST(t, []*auditpb.AuditEntry{
+			{Sequence: 5, Timestamp: &commonpb.Timestamp{Data: 3000}, Idempotency: &commonpb.Idempotency{Key: "k"}, Outcome: idemAuditFailure("m", nil)},
+			{Sequence: 6, Timestamp: &commonpb.Timestamp{Data: 4000}, Outcome: idemAuditFailure("no-key", nil)},
+		}, map[uint64][]*auditpb.AuditItem{5: {{OrderIndex: 0, SerializedOrder: serialized}}})
+
+		// Older chapter: entirely below the cutoff — must not be scanned for items.
+		older := buildColdAuditSST(t, []*auditpb.AuditEntry{
+			{Sequence: 3, Timestamp: &commonpb.Timestamp{Data: 500}, Idempotency: &commonpb.Idempotency{Key: "old"}, Outcome: idemAuditFailure("x", nil)},
+			{Sequence: 4, Timestamp: &commonpb.Timestamp{Data: 1000}, Idempotency: &commonpb.Idempotency{Key: "old2"}, Outcome: idemAuditFailure("y", nil)},
+		}, map[uint64][]*auditpb.AuditItem{4: {{OrderIndex: 0, SerializedOrder: serialized}}})
+
+		reader := coldReaderWithChapters(t, bucketID, map[uint64][]byte{20: newer, 10: older})
+		c := NewChecker(store, attributes.New(), "x", reader, logging.Testing())
+
+		expected := map[idemExpectedKey]expectedIdempotency{}
+		require.True(t, c.reDeriveArchivedIdempotency(ctx, []*commonpb.Chapter{archived(20, 6), archived(10, 4)}, cutoff, expected))
+
+		// Only the in-window keyed entry was re-derived: the non-keyed entry was
+		// skipped, and the older chapter (below the window) was never scanned.
+		require.Len(t, expected, 1)
+		_, ok := expected[idemExpectedKey{keyHash: state.HashIdempotencyKey("k"), createdAt: 3000}]
+		require.True(t, ok, "the in-window keyed entry must be re-derived")
+	})
+}
+
+// TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig exercises the
+// end-to-end path in Check that reads the persisted idempotency TTL and the
+// last-applied timestamp and computes the window cutoff. A clean store with a
+// non-zero TTL configured must still pass.
+func TestCheck_DerivesIdempotencyTTLWindowFromPersistedConfig(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestEngine(t)
+	engine.processAndCommit(createLedgerOrder("test"))
+	engine.processAndCommit(createTransactionOrder("test", true,
+		newPosting("world", "user:alice", "USD", 100)))
+
+	// Non-zero TTL + a last-applied timestamp ahead of it, so Check computes a
+	// bounded (non-zero) cutoff.
+	writeGlobalUint64(t, engine.store, dal.SubGlobLastAppliedTimestamp, 1_700_000_100_000_000)
+	writePersistedConfig(t, engine.store, &commonpb.PersistedConfig{
+		ClusterId:             engine.clusterID,
+		IdempotencyTtlSeconds: 3600,
+	})
+
+	require.Empty(t, collectCheckErrors(t, engine.store, engine.attrs),
+		"a clean store with a persisted idempotency TTL must pass Check")
+}
+
+// writePersistedConfig stores the PersistedConfig at its Global-zone key, the
+// layout query.ReadPersistedConfig reads.
+func writePersistedConfig(t *testing.T, store *dal.Store, cfg *commonpb.PersistedConfig) {
+	t.Helper()
+
+	data, err := cfg.MarshalVT()
+	require.NoError(t, err)
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig}, data))
+	require.NoError(t, batch.Commit())
+}
+
+// writeGlobalUint64 stores a big-endian uint64 under a Global-zone sub-key, the
+// encoding dal.ReadUint64 expects.
+func writeGlobalUint64(t *testing.T, store *dal.Store, sub byte, v uint64) {
+	t.Helper()
+
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, v)
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, sub}, buf))
+	require.NoError(t, batch.Commit())
+}
+
+// coldReaderWithChapters builds a ColdReader backed by a filesystem store
+// holding the given chapter SSTs (chapterID -> SST bytes).
+func coldReaderWithChapters(t *testing.T, bucketID string, sstByChapter map[uint64][]byte) *coldstorage.ColdReader {
+	t.Helper()
+
+	fs := coldstorage.NewFilesystemStorage(t.TempDir())
+
+	for id, sst := range sstByChapter {
+		checksum, err := coldstorage.ComputeSHA256(bytes.NewReader(sst))
+		require.NoError(t, err)
+		require.NoError(t, fs.Archive(context.Background(), bucketID, id, bytes.NewReader(sst), checksum))
+	}
+
+	reader := coldstorage.NewColdReader(fs, bucketID, t.TempDir(), 8, 0, logging.Testing())
+	t.Cleanup(func() { _ = reader.Close() })
+
+	return reader
 }
 
 // idemAuditFailure builds a freezable-failure outcome for an archived audit

--- a/internal/application/check/checker_tamper_test.go
+++ b/internal/application/check/checker_tamper_test.go
@@ -282,7 +282,7 @@ func TestVerifyAuditHashChain_DetectsIdempotencyOutcomeTampering(t *testing.T) {
 
 	collectIdempotencyMismatches := func(store *dal.Store) []*servicepb.CheckStoreError {
 		attrs := attributes.New()
-		checker := NewChecker(store, attrs, clusterID, nil, logging.Testing())
+		checker := NewChecker(store, attrs, clusterID, nil, nil, logging.Testing())
 
 		handle, err := store.NewReadHandle()
 		require.NoError(t, err)
@@ -407,7 +407,7 @@ func runChainVerifier(t *testing.T, store *dal.Store, clusterID string) []*servi
 	t.Helper()
 
 	attrs := attributes.New()
-	checker := NewChecker(store, attrs, clusterID, nil, logging.Testing())
+	checker := NewChecker(store, attrs, clusterID, nil, nil, logging.Testing())
 
 	handle, err := store.NewReadHandle()
 	require.NoError(t, err)

--- a/internal/application/check/checker_tamper_test.go
+++ b/internal/application/check/checker_tamper_test.go
@@ -282,7 +282,7 @@ func TestVerifyAuditHashChain_DetectsIdempotencyOutcomeTampering(t *testing.T) {
 
 	collectIdempotencyMismatches := func(store *dal.Store) []*servicepb.CheckStoreError {
 		attrs := attributes.New()
-		checker := NewChecker(store, attrs, clusterID, logging.Testing())
+		checker := NewChecker(store, attrs, clusterID, nil, logging.Testing())
 
 		handle, err := store.NewReadHandle()
 		require.NoError(t, err)
@@ -291,7 +291,10 @@ func TestVerifyAuditHashChain_DetectsIdempotencyOutcomeTampering(t *testing.T) {
 
 		var got []*servicepb.CheckStoreError
 
-		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, nil, nil, func(event *servicepb.CheckStoreEvent) {
+		// Cutoff == the single entry's timestamp keeps the report floor at the
+		// archive boundary (no cold TTL-window extension), isolating the
+		// post-boundary guard this test exercises.
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, nil, nil, createdAt, func(event *servicepb.CheckStoreEvent) {
 			if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
 				e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
 				got = append(got, e.Error)
@@ -404,7 +407,7 @@ func runChainVerifier(t *testing.T, store *dal.Store, clusterID string) []*servi
 	t.Helper()
 
 	attrs := attributes.New()
-	checker := NewChecker(store, attrs, clusterID, logging.Testing())
+	checker := NewChecker(store, attrs, clusterID, nil, logging.Testing())
 
 	handle, err := store.NewReadHandle()
 	require.NoError(t, err)
@@ -412,7 +415,8 @@ func runChainVerifier(t *testing.T, store *dal.Store, clusterID string) []*servi
 
 	var mismatches []*servicepb.CheckStoreError
 
-	err = checker.verifyAuditHashChain(context.Background(), handle, nil, nil, func(event *servicepb.CheckStoreEvent) {
+	// This test isolates HASH_MISMATCH; the idempotency cutoff is irrelevant.
+	err = checker.verifyAuditHashChain(context.Background(), handle, nil, nil, 0, func(event *servicepb.CheckStoreEvent) {
 		if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok && e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_HASH_MISMATCH {
 			mismatches = append(mismatches, e.Error)
 		}

--- a/internal/application/check/checker_tamper_test.go
+++ b/internal/application/check/checker_tamper_test.go
@@ -291,10 +291,10 @@ func TestVerifyAuditHashChain_DetectsIdempotencyOutcomeTampering(t *testing.T) {
 
 		var got []*servicepb.CheckStoreError
 
-		// Cutoff == the single entry's timestamp keeps the report floor at the
-		// archive boundary (no cold TTL-window extension), isolating the
+		// A nil TTL (PersistedConfig absent) skips the cold extension entirely,
+		// keeping the report floor at the archive boundary and isolating the
 		// post-boundary guard this test exercises.
-		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, nil, nil, createdAt, func(event *servicepb.CheckStoreEvent) {
+		require.NoError(t, checker.verifyAuditHashChain(context.Background(), handle, nil, nil, nil, func(event *servicepb.CheckStoreEvent) {
 			if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
 				e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH {
 				got = append(got, e.Error)
@@ -415,8 +415,8 @@ func runChainVerifier(t *testing.T, store *dal.Store, clusterID string) []*servi
 
 	var mismatches []*servicepb.CheckStoreError
 
-	// This test isolates HASH_MISMATCH; the idempotency cutoff is irrelevant.
-	err = checker.verifyAuditHashChain(context.Background(), handle, nil, nil, 0, func(event *servicepb.CheckStoreEvent) {
+	// This test isolates HASH_MISMATCH; the idempotency TTL is irrelevant.
+	err = checker.verifyAuditHashChain(context.Background(), handle, nil, nil, nil, func(event *servicepb.CheckStoreEvent) {
 		if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok && e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_HASH_MISMATCH {
 			mismatches = append(mismatches, e.Error)
 		}

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -852,7 +852,7 @@ func deleteAccountMetadataOrder(ledger, account, key string) *raftcmdpb.Order {
 func collectCheckErrors(t *testing.T, store *dal.Store, attrs *attributes.Attributes) []*servicepb.CheckStoreError {
 	t.Helper()
 
-	checker := NewChecker(store, attrs, "test-cluster", logging.Testing())
+	checker := NewChecker(store, attrs, "test-cluster", nil, logging.Testing())
 
 	var errors []*servicepb.CheckStoreError
 
@@ -1124,7 +1124,7 @@ func TestCheckerProgressEvents(t *testing.T) {
 		))
 	}
 
-	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, logging.Testing())
+	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, logging.Testing())
 
 	var progressEvents []*servicepb.CheckStoreProgress
 
@@ -1459,7 +1459,7 @@ func TestCheckerSurfacesCorruptAuditEntry(t *testing.T) {
 	require.NoError(t, batch.SetBytes(auditKey, []byte{0xFF, 0xFF, 0xFF, 0xFF}))
 	require.NoError(t, batch.Commit())
 
-	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, logging.Testing())
+	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, logging.Testing())
 	err := checker.Check(context.Background(), func(_ *servicepb.CheckStoreEvent) {})
 
 	// Before the fix: Check returned nil; the cursor break swallowed the
@@ -1844,7 +1844,7 @@ func indexCheckerFor(t *testing.T, stored map[domain.IndexKey]*commonpb.Index) (
 
 	ctx := logging.TestingContext()
 
-	return NewChecker(store, attrs, "test-cluster", logging.FromContext(ctx)), store
+	return NewChecker(store, attrs, "test-cluster", nil, logging.FromContext(ctx)), store
 }
 
 // TestCompareIndexes_Identical pins the happy path: when the SubAttrIndex

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -852,7 +852,7 @@ func deleteAccountMetadataOrder(ledger, account, key string) *raftcmdpb.Order {
 func collectCheckErrors(t *testing.T, store *dal.Store, attrs *attributes.Attributes) []*servicepb.CheckStoreError {
 	t.Helper()
 
-	checker := NewChecker(store, attrs, "test-cluster", nil, logging.Testing())
+	checker := NewChecker(store, attrs, "test-cluster", nil, nil, logging.Testing())
 
 	var errors []*servicepb.CheckStoreError
 
@@ -1124,7 +1124,7 @@ func TestCheckerProgressEvents(t *testing.T) {
 		))
 	}
 
-	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, logging.Testing())
+	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, nil, logging.Testing())
 
 	var progressEvents []*servicepb.CheckStoreProgress
 
@@ -1459,7 +1459,7 @@ func TestCheckerSurfacesCorruptAuditEntry(t *testing.T) {
 	require.NoError(t, batch.SetBytes(auditKey, []byte{0xFF, 0xFF, 0xFF, 0xFF}))
 	require.NoError(t, batch.Commit())
 
-	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, logging.Testing())
+	checker := NewChecker(engine.store, engine.attrs, engine.clusterID, nil, nil, logging.Testing())
 	err := checker.Check(context.Background(), func(_ *servicepb.CheckStoreEvent) {})
 
 	// Before the fix: Check returned nil; the cursor break swallowed the
@@ -1844,7 +1844,7 @@ func indexCheckerFor(t *testing.T, stored map[domain.IndexKey]*commonpb.Index) (
 
 	ctx := logging.TestingContext()
 
-	return NewChecker(store, attrs, "test-cluster", nil, logging.FromContext(ctx)), store
+	return NewChecker(store, attrs, "test-cluster", nil, nil, logging.FromContext(ctx)), store
 }
 
 // TestCompareIndexes_Identical pins the happy path: when the SubAttrIndex

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -136,6 +136,13 @@ func NewDefaultController(
 	}
 }
 
+// ColdReader returns the cold-storage reader, or nil when cold storage is not
+// configured. The gRPC layer passes it to the store checker so the idempotency
+// pass can re-derive frozen outcomes from archived audit entries.
+func (ctrl *DefaultController) ColdReader() *coldstorage.ColdReader {
+	return ctrl.coldReader
+}
+
 // ListLedgers returns a cursor over all active (non-deleted) ledgers.
 func (ctrl *DefaultController) ListLedgers(ctx context.Context) (cursor.Cursor[*commonpb.LedgerInfo], error) {
 	handle, err := ctrl.store.NewReadHandle()

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -529,7 +529,7 @@ func Module() fx.Option {
 			// Provide a single AuthConfig used by gRPC and HTTP handlers.
 			fx.Annotate(buildAuthConfig, fx.ParamTags(``, ``, `optional:"true"`)),
 			fx.Annotate(func(cfg Config, logger logging.Logger, c ctrl.Controller, localCtrl *ctrl.DefaultController, s *dal.Store, rs *readstore.Store, attrs *attributes.Attributes, ss *state.SharedState, signer *receipt.Signer, respSigner *signing.ResponseSigner, authCfg internalauth.AuthConfig, meterProvider metric.MeterProvider, n *node.Node, servicePool *transport.ConnectionPool, info version.Info) servicepb.BucketServiceServer {
-				return grpcadp.NewBucketServiceServer(logger, c, localCtrl, s, rs, attrs, ss, signer, respSigner, authCfg, cfg.QueryProfileThreshold, cfg.ClusterID, meterProvider, n, servicePool, info)
+				return grpcadp.NewBucketServiceServer(logger, c, localCtrl, s, rs, attrs, ss, signer, respSigner, authCfg, cfg.QueryProfileThreshold, cfg.ClusterID, cfg.IdempotencyTTL, meterProvider, n, servicePool, info)
 			}, fx.ParamTags(``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, `name:"service"`, ``)),
 			func(cfg Config, logger logging.Logger, s *dal.Store, fsm *state.Machine) snapshotpb.SnapshotServiceServer {
 				return grpcadp.NewSnapshotServiceServer(logger, s, cfg.SnapshotSyncConfig.SessionTTL, fsm.WaitForApplied)


### PR DESCRIPTION
## Summary

`checker.compareIdempotencyOutcomes` verifies each frozen idempotency entry (`SubIdempKeys`) against the outcome re-derived from the hash-chained `AuditEntry` that wrote it. Until now it only re-derived entries from the **verified (post-archive) audit range**, so a stored entry whose freezing audit entry had been **archived** was skipped — and if that entry was still *live*, its outcome (proposal hash, failure reason/message/metadata, or success log range) went unverified.

This PR makes `expected` complete across the archive boundary by re-deriving the archived freezes that can still be live (those within the idempotency TTL window), then reports any unmatched live entry bidirectionally — the standard the other projection passes adopted in #347.

## Background

The recent guard (`327b5a38`) closed the dangerous part: a tampered `created_at` on a *post-boundary* entry is reported rather than silently skipped. The **residual gap** was a still-live entry whose `created_at` is *before* the archive boundary — reachable only when the idempotency TTL outlives the age at which chapters are archived. In that window a tampered outcome replayed to a duplicate caller while `Check()` passed. This was the only `Check()` projection pass not complete across the archive boundary.

Threat model is unchanged: an actor with direct disk/Pebble write access to a follower's store (invariant #8).

## What changed

- **TTL window.** `Check()` reads the persisted `idempotency-ttl` and the latest applied HLC timestamp from the same snapshot and computes `ttlCutoff = lastApplied − ttl`. Only entries at/after this can still be live, so the cold read is **bounded by the TTL window, not by history**.
- **Cold re-derivation** (`reDeriveArchivedIdempotency`). After building `expected` from the hot range, the checker reads archived chapters **newest-first** from cold storage and re-derives the frozen outcome for every keyed entry `≥ ttlCutoff`. It stops at the first chapter whose newest entry predates the cutoff — never re-walks the full archive.
- **Report floor.** The single `verifiedRangeStartTs` boundary is replaced by `idemReportFloor`: it drops to `ttlCutoff` when the cold window was fully read, and falls back to the post-archive boundary when cold storage is unavailable (e.g. the CLI/restore validation paths) — preserving the prior no-false-positive behavior, with the residual gap remaining only there.
- **Plumbing.** Only a `*coldstorage.ColdReader` is threaded into `Checker` (TTL and timestamp are read in-`Check`). Added a `ColdReader()` accessor on `DefaultController`; the gRPC `CheckStore` handler passes it. The CLI-bootstrap and restore-validation call sites pass `nil`.

## Design note: cold entries are trusted, not re-hashed

Archived entries used for the TTL window are **re-derived, not re-hash-chained**. Cold storage sits outside the follower-disk threat model this pass targets, so the archived entry is the trusted source and only the live `SubIdempKeys` projection is checked against it. The hot range that anchors the live entries is still fully hash-chain-verified. The doc comments mark exactly where cold-chain verification would go if the threat model is ever widened.

## Testing

- New `TestCompareIdempotencyOutcomes_ArchivedFreezeWithinTTLWindow`: a live entry frozen by an archived-but-in-window audit entry passes when faithful and is flagged (`CHECK_STORE_ERROR_TYPE_IDEMPOTENCY_MISMATCH`) when its outcome is tampered; an entry frozen by an archived entry older than the window is skipped (no false positive). Bounding is asserted by leaving a fully-below-window chapter's SST absent — if the pass read it, the cold read would fail, the floor would rise, and the in-window tamper would no longer flag.
- Existing idempotency/hash-chain tamper tests updated for the new signature; all pass.
- `go build ./...`, `go vet ./...`, `go test -race` (check package), and `golangci-lint` on all changed packages: clean.

## Acceptance criteria

- [x] A frozen entry whose freezing audit entry is archived but within the TTL window is verified against its cold-storage audit source; a tampered outcome is reported.
- [x] No false positives for entries frozen by archived entries older than the TTL window.
- [x] Cold-storage reads bounded by the TTL window.
- [x] Test coverage for live + archived-freeze + tampered → flagged; older-than-TTL → skipped.

## References

- Prior guard: `327b5a38` (`fix(check): flag tampered created_at on live frozen idempotency entries`)
- Bidirectional / no-silent-skip standard: #347 (`compareTransactions`)
- Invariant #8 (audit log is the only source of truth — every projection must be verified)
