### PR TITLE
feat(admission): reject when cache horizon exceeds 2 generations

### DIFF
--- a/docs/technical/architecture/core/admission-cache-horizon.md
+++ b/docs/technical/architecture/core/admission-cache-horizon.md
@@ -1,0 +1,100 @@
+# Admission Cache Horizon
+
+**Status:** Implemented
+**Scope:** admission-side rejection of proposals whose cache prediction cannot be honored at FSM apply
+**Related:** [fsm-cache-layers.md](fsm-cache-layers.md), [deterministic-fsm.md](deterministic-fsm.md)
+
+## What it is
+
+When admission builds a proposal's preload plan, it queries the dual-generation
+cache (`AttributeCache.CheckCache(at, key)`) to decide, per key, whether to
+emit a `Declare`, a `Touch`, or a `Preload`. The decision compares the
+predicted apply-time generation `Gen(at, threshold)` against the FSM's current
+applied generation:
+
+| `Gen(at) − currentGen` | `CheckCache` result | Plan emitted |
+|---|---|---|
+| 0 | `CacheGuaranteed` / `CacheNeedsTouch` / `CacheMiss` | `Declare` / `Touch` / `Preload` |
+| 1 | `CacheGuaranteed` / `CacheMiss` | `Declare` / `Preload` |
+| **≥ 2** | **`CacheUnreachable`** | **proposal rejected at admission** |
+
+The ≥ 2 case is the "cache horizon exceeded" condition this document is about.
+
+## Why we reject instead of preload
+
+In the ≥ 2 regime, two cache rotations are predicted to fire on the FSM side
+between this proposal's propose-time and its apply-time. Each rotation does
+the canonical `gen0 → gen1, drop old gen1, gen0 := ∅` move. So any value
+loaded *now* and emitted in a `MirrorPreload` plan would land in `gen0` and
+then:
+
+1. First rotation: `gen0` (with the preloaded value) becomes `gen1`.
+2. Second rotation: `gen1` (still holding the preloaded value) is **dropped**.
+
+By the time the order applies, the cache has no record of the preload —
+reads would miss the value the proposer guaranteed. The FSM-side coverage
+gate (`Plan.CheckCoverage`) would still admit the read, but the underlying
+`KeyStore.Get` would return `ErrNotFound` for a key admission promised would
+be available. This is the class of bug invariant #1 ("cache is the source of
+authority") is designed to make impossible.
+
+Returning `CacheUnreachable` and rejecting the proposal at admission keeps
+the contract honest: the proposal never enters Raft, no audit trail is owed,
+and the client retries against a fresh admission snapshot. By the time the
+retry lands, the FSM has caught up and the predicted horizon is within reach.
+
+## Why this is not a domain error
+
+The rejection is **not** a business outcome — the user-submitted operation
+might be perfectly valid. It is an *operational* signal that admission's
+view is too far behind FSM apply for the system to safely admit any new
+proposal whose preload would target keys this stale.
+
+Consequently the error lives in `internal/infra/plan/` as
+`plan.ErrCacheHorizonExceeded`, **not** in `internal/domain/`. The gRPC
+adapter (`internal/adapter/grpc/server.go`) maps it to `codes.Unavailable`
+so existing client-side retry interceptors handle it transparently. No
+`AuditFailure` is recorded — the system explicitly declined to take
+responsibility for this proposal.
+
+## When can it fire?
+
+Under a correctly tuned rotation threshold (`--cache-rotation-threshold`,
+default 1000) and an FSM apply rate that keeps up with proposals, the
+≥ 2-generation horizon should never be reached: admission's `nextIndex`
+would have to sit at least `2 × threshold` indices past the FSM's
+last-applied index. In a healthy single-leader cluster that means
+**2000+ in-flight proposals** between admit and apply — well outside
+the normal operating envelope.
+
+Recurring `ErrCacheHorizonExceeded` is therefore an *operational* signal:
+
+- The rotation threshold is too low for the workload (raise it).
+- FSM apply is falling behind admission (overload — check apply latency,
+  disk, GC).
+- A transient backlog after a leadership transfer, snapshot restore, or
+  bloom rebuild (self-resolves; clients retry).
+
+Use `lifecycle.SendEvent` / metric counters at the rejection site (TODO
+follow-up) to make this observable to SREs.
+
+## Implementation
+
+- `internal/infra/cache/cache.go` — `CacheUnreachable` constant, the
+  default branch of `CheckCache`.
+- `internal/infra/plan/errors.go` — `ErrCacheHorizonExceeded` sentinel.
+- `internal/infra/plan/resolve.go` — short-circuit on
+  `CacheUnreachable`, return `ErrCacheHorizonExceeded`.
+- `internal/adapter/grpc/server.go` — `convertToGRPCError` maps
+  `ErrCacheHorizonExceeded` to `codes.Unavailable`.
+- `internal/application/admission/admission.go` — already wraps the
+  builder error and returns it to the gRPC layer (no new code).
+
+## Tests
+
+- `cache_test.go` / `TestAttributeCache_IsGuaranteedInCache_TwoGenerationsAhead`
+  — `CheckCache` returns `CacheUnreachable` for the default case (both with
+  and without a stored value).
+- `builder_test.go` / `TestBuildPreloads_RejectsCacheHorizonExceeded` —
+  end-to-end resolver short-circuits with `ErrCacheHorizonExceeded` when
+  the tracker is pinned past the second generation boundary.

--- a/docs/technical/architecture/core/fsm-cache-layers.md
+++ b/docs/technical/architecture/core/fsm-cache-layers.md
@@ -173,5 +173,6 @@ If you find yourself wanting to bypass a layer (e.g. read from Pebble inside a h
 ## Related
 
 - [deterministic-fsm.md](deterministic-fsm.md) — generation rotation, Preload building (admission side), AttributeLoader concurrency
+- [admission-cache-horizon.md](admission-cache-horizon.md) — admission-side rejection when ≥ 2 generations are predicted between propose and apply
 - [attributes.md](../storage/attributes.md) — Pebble layout (0xF1 attribute zone, 0xFF cache mirror)
 - [attribute-key-hashing.md](../storage/attribute-key-hashing.md) — U128 derivation and collision tag scheme

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/crypto/signing"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/infra/plan"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/infra/transport"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -504,6 +505,7 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 		errors.Is(err, node.ErrNodeSyncing) ||
 		errors.Is(err, node.ErrTransferLeaderTimeout) ||
 		errors.Is(err, commonpb.ErrNoLeader) ||
+		errors.Is(err, plan.ErrCacheHorizonExceeded) ||
 		errors.Is(err, ErrNodeNotReachable) {
 		return status.Error(codes.Unavailable, err.Error())
 	}

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/plan"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -52,6 +53,19 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, commonpb.ErrNoLeader) {
 		w.Header().Set("Retry-After", "1")
 		writeErrorResponse(w, http.StatusServiceUnavailable, "NO_LEADER", err)
+
+		return
+	}
+
+	// plan.ErrCacheHorizonExceeded is an infrastructure-level admission
+	// rejection (not a domain business outcome, hence not a Describable):
+	// admission predicted 2+ cache rotations between propose and apply so
+	// any preload would be discarded before FSM read. Retry against a fresh
+	// admission snapshot. Mirrors the gRPC adapter's codes.Unavailable
+	// mapping (see internal/adapter/grpc/server.go).
+	if errors.Is(err, plan.ErrCacheHorizonExceeded) {
+		w.Header().Set("Retry-After", "1")
+		writeErrorResponse(w, http.StatusServiceUnavailable, "CACHE_HORIZON_EXCEEDED", err)
 
 		return
 	}

--- a/internal/adapter/http/error_handler_test.go
+++ b/internal/adapter/http/error_handler_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/plan"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -32,6 +34,20 @@ func TestHandleError(t *testing.T) {
 			err:            commonpb.ErrNoLeader,
 			expectedStatus: http.StatusServiceUnavailable,
 			expectedCode:   "NO_LEADER",
+			checkRetry:     true,
+		},
+		{
+			name:           "cache horizon exceeded — infrastructure rejection, retryable",
+			err:            plan.ErrCacheHorizonExceeded,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedCode:   "CACHE_HORIZON_EXCEEDED",
+			checkRetry:     true,
+		},
+		{
+			name:           "cache horizon exceeded wrapped by admission",
+			err:            fmt.Errorf("building preloads: %w", plan.ErrCacheHorizonExceeded),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedCode:   "CACHE_HORIZON_EXCEEDED",
 			checkRetry:     true,
 		},
 		{

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -177,13 +177,18 @@ const (
 // raft index `at`. Takes a read lock on the cache to ensure a consistent view
 // of currentGeneration and the gen0/gen1 data during the check.
 func (a *AttributeCache[T]) CheckCache(at uint64, k attributes.U128) CacheStatus {
+	a.Cache.mu.RLock()
+	defer a.Cache.mu.RUnlock()
+
+	// Threshold + currentGeneration are read INSIDE the RLock so a concurrent
+	// ResetWithThreshold (write-lock holder) cannot bump one between our
+	// reads and leave us with a (threshold=old, currentGeneration=new)
+	// snapshot. Such a torn view would classify a valid admission as
+	// CacheUnreachable during the threshold-change transition window.
 	threshold := a.Cache.GenerationThreshold()
 	if threshold == 0 {
 		return CacheMiss
 	}
-
-	a.Cache.mu.RLock()
-	defer a.Cache.mu.RUnlock()
 
 	actualGeneration := a.Cache.currentGeneration.Load()
 	futureGeneration := Gen(at, threshold)

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -188,6 +188,17 @@ func (a *AttributeCache[T]) CheckCache(at uint64, k attributes.U128) CacheStatus
 	actualGeneration := a.Cache.currentGeneration.Load()
 	futureGeneration := Gen(at, threshold)
 
+	// Stale-behind build: an admission build sampled `at` before the FSM
+	// applied entries past that index, so its `at` maps to a generation the
+	// FSM has already left behind. Not a horizon violation — the higher-level
+	// staleness guard (checkStaleProposal / AcquireProposalGuard) will
+	// reject or rebuild. Report CacheMiss so the caller loads from store and
+	// the concurrent apply resolves the outcome; do NOT let the uint64
+	// subtraction underflow into the CacheUnreachable default branch.
+	if futureGeneration < actualGeneration {
+		return CacheMiss
+	}
+
 	switch futureGeneration - actualGeneration {
 	case 0:
 		// Same generation — no rotation expected.

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -355,11 +355,21 @@ func (c *Cache) Reset() {
 // caller-provided raftIndex is the entry the FSM is applying, so
 // Gen(raftIndex, threshold) is the correct post-reset horizon.
 //
-// Callers that persist the reset to Pebble must read the returned tuple
-// (or Cache.CurrentGeneration + Cache.BaseIndex.{Gen0,Gen1}) so the
-// on-disk sentinels reflect the same in-memory state a RestoreFromStore
-// would reconstruct.
+// A zero threshold is a config invariant violation — cache.New already
+// rejects it, and every code path that reaches this method has validated
+// the config upstream. Panics loudly rather than silently disabling
+// rotations, which would leave currentGeneration frozen at 0 forever and
+// break the CacheUnreachable / CheckRotationNeeded contracts.
+//
+// Callers that persist the reset to Pebble must read
+// Cache.CurrentGeneration + Cache.BaseIndex.{Gen0,Gen1} after the call so
+// the on-disk sentinels reflect the same in-memory state a
+// RestoreFromStore would reconstruct.
 func (c *Cache) ResetWithThreshold(threshold, raftIndex uint64) {
+	if threshold == 0 {
+		panic("cache.ResetWithThreshold: threshold must be > 0 (invariant enforced by cache.New)")
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -367,13 +377,9 @@ func (c *Cache) ResetWithThreshold(threshold, raftIndex uint64) {
 	c.epoch.Add(1)
 	c.generationThreshold.Store(threshold)
 
-	// Skip the alignment when the threshold is 0 (rotations disabled) or
-	// the target generation is 0 (raftIndex within the first gen — the
-	// post-clearLocked state already matches).
-	if threshold == 0 {
-		return
-	}
-
+	// clearLocked already set currentGeneration=0 and BaseIndex={0,0}. If
+	// raftIndex falls inside the first generation, that's the final state.
+	// Otherwise realign under the same lock.
 	if g := Gen(raftIndex, threshold); g != 0 {
 		boundary := genEndIndex(g-1, threshold)
 		c.rotateLocked(boundary, g)

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -342,17 +342,42 @@ func (c *Cache) Reset() {
 	c.clearLocked()
 }
 
-// ResetWithThreshold atomically resets the cache, increments the epoch, and
-// sets a new generation threshold. Called by the FSM when a cluster config
-// change is applied — the epoch increment is deterministic (all nodes apply
-// the same Raft entry).
-func (c *Cache) ResetWithThreshold(threshold uint64) {
+// ResetWithThreshold atomically resets the cache, increments the epoch, sets
+// a new generation threshold, AND realigns currentGeneration + BaseIndex to
+// the generation that raftIndex falls into under the new threshold. Called
+// by the FSM when a cluster config change is applied.
+//
+// The epoch increment is deterministic (all nodes apply the same Raft
+// entry). Realigning currentGeneration and BaseIndex in the same critical
+// section closes the race window where admission's CheckCache would
+// otherwise observe currentGeneration=0 against the new threshold and
+// falsely trip the CacheUnreachable horizon (2+ predicted rotations); the
+// caller-provided raftIndex is the entry the FSM is applying, so
+// Gen(raftIndex, threshold) is the correct post-reset horizon.
+//
+// Callers that persist the reset to Pebble must read the returned tuple
+// (or Cache.CurrentGeneration + Cache.BaseIndex.{Gen0,Gen1}) so the
+// on-disk sentinels reflect the same in-memory state a RestoreFromStore
+// would reconstruct.
+func (c *Cache) ResetWithThreshold(threshold, raftIndex uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.clearLocked()
 	c.epoch.Add(1)
 	c.generationThreshold.Store(threshold)
+
+	// Skip the alignment when the threshold is 0 (rotations disabled) or
+	// the target generation is 0 (raftIndex within the first gen — the
+	// post-clearLocked state already matches).
+	if threshold == 0 {
+		return
+	}
+
+	if g := Gen(raftIndex, threshold); g != 0 {
+		boundary := genEndIndex(g-1, threshold)
+		c.rotateLocked(boundary, g)
+	}
 }
 
 // clearLocked clears all cache data without incrementing the epoch.

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -149,6 +149,15 @@ const (
 	CacheNeedsTouch
 	// CacheMiss means the key is not in cache at all — a full preload from store is needed.
 	CacheMiss
+	// CacheUnreachable means the target index is 2+ generations ahead of the
+	// current FSM-applied generation: any preload value computed now would be
+	// invalidated by the rotations that must run before apply (gen0 -> gen1 ->
+	// discarded). The admission cannot guarantee that the proposal will read a
+	// consistent cache horizon, so the order must be rejected and re-admitted
+	// once the FSM apply has caught up. This is an operational signal — under
+	// a correctly tuned rotation threshold and a healthy apply rate it should
+	// not occur.
+	CacheUnreachable
 )
 
 // CheckCache determines whether a key will survive in cache until the future raft
@@ -205,8 +214,12 @@ func (a *AttributeCache[T]) CheckCache(at uint64, k attributes.U128) CacheStatus
 
 		return CacheMiss
 	default:
-		// 2+ generations ahead — data will be lost regardless.
-		return CacheMiss
+		// 2+ generations ahead — any preload value computed now would be
+		// rotated out (gen0 -> gen1 -> discarded) before apply. Signal an
+		// unreachable horizon so admission can reject the proposal with a
+		// transient error; the client retries and admission re-admits with
+		// a fresh prediction once the FSM apply has caught up.
+		return CacheUnreachable
 	}
 }
 

--- a/internal/infra/cache/cache.go
+++ b/internal/infra/cache/cache.go
@@ -185,11 +185,11 @@ func (a *AttributeCache[T]) CheckCache(at uint64, k attributes.U128) CacheStatus
 	// reads and leave us with a (threshold=old, currentGeneration=new)
 	// snapshot. Such a torn view would classify a valid admission as
 	// CacheUnreachable during the threshold-change transition window.
+	//
+	// threshold > 0 is a cluster-wide invariant: cache.New rejects 0 and
+	// ResetWithThreshold panics on 0 — no legitimate call path can observe
+	// threshold=0 here.
 	threshold := a.Cache.GenerationThreshold()
-	if threshold == 0 {
-		return CacheMiss
-	}
-
 	actualGeneration := a.Cache.currentGeneration.Load()
 	futureGeneration := Gen(at, threshold)
 
@@ -416,10 +416,9 @@ func (c *Cache) clearLocked() {
 // and performs it atomically if necessary.
 // Returns whether a rotation occurred and the old Gen1 base index (compaction threshold).
 func (c *Cache) CheckRotationNeeded(index uint64) (rotated bool, oldGen1BaseIndex uint64) {
+	// threshold > 0 is a cluster-wide invariant (see CheckCache / New /
+	// ResetWithThreshold) — no dead-code guard here.
 	threshold := c.generationThreshold.Load()
-	if threshold == 0 {
-		return false, 0
-	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -533,7 +532,12 @@ func (c *Cache) GenerationThreshold() uint64 {
 }
 
 // SetGenerationThreshold updates the cache rotation threshold atomically.
+// Panics on 0 — threshold > 0 is a cluster-wide invariant enforced by
+// cache.New and ResetWithThreshold.
 func (c *Cache) SetGenerationThreshold(v uint64) {
+	if v == 0 {
+		panic("cache.SetGenerationThreshold: threshold must be > 0 (invariant enforced by cache.New)")
+	}
 	c.generationThreshold.Store(v)
 }
 

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -375,11 +375,32 @@ func TestCache_ResetWithThresholdIncrementsEpoch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cache.Epoch())
 
-	cache.ResetWithThreshold(200)
+	cache.ResetWithThreshold(200, 0)
 	assert.Equal(t, uint64(2), cache.Epoch())
 
-	cache.ResetWithThreshold(300)
+	cache.ResetWithThreshold(300, 0)
 	assert.Equal(t, uint64(3), cache.Epoch())
+}
+
+// TestCache_ResetWithThresholdAtNonZeroIndex covers the atomic realignment
+// path: when the caller passes a raftIndex that falls into a non-zero
+// generation under the new threshold, ResetWithThreshold must set
+// currentGeneration and BaseIndex accordingly in the SAME critical section
+// so admission's next CheckCache never observes a transient
+// (currentGeneration=0, threshold=new) window.
+func TestCache_ResetWithThresholdAtNonZeroIndex(t *testing.T) {
+	t.Parallel()
+
+	cache, err := New(100, nil)
+	require.NoError(t, err)
+
+	// raftIndex=25 with newThreshold=10 → Gen=2, BaseIndex.Gen0=genEndIndex(1, 10)=20.
+	cache.ResetWithThreshold(10, 25)
+
+	assert.Equal(t, uint64(2), cache.CurrentGeneration())
+	assert.Equal(t, uint64(20), cache.BaseIndex.Gen0)
+	assert.Equal(t, uint64(0), cache.BaseIndex.Gen1)
+	assert.Equal(t, uint64(2), cache.Epoch())
 }
 
 func TestCache_CheckRotationNeeded_SameGeneration(t *testing.T) {

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -403,6 +403,26 @@ func TestCache_ResetWithThresholdAtNonZeroIndex(t *testing.T) {
 	assert.Equal(t, uint64(2), cache.Epoch())
 }
 
+// TestAttributeCache_CheckCache_StaleBehindReportsMiss: when the caller's
+// nextIndex maps to a generation the FSM has already left behind
+// (actualGeneration > futureGeneration), the uint64 subtraction would
+// otherwise underflow into the CacheUnreachable default branch. Guard
+// against that: report CacheMiss so higher-level staleness checks
+// (checkStaleProposal / AcquireProposalGuard) handle the actual mismatch,
+// instead of falsely returning a horizon violation.
+func TestAttributeCache_CheckCache_StaleBehindReportsMiss(t *testing.T) {
+	t.Parallel()
+
+	c, err := New(10, nil)
+	require.NoError(t, err)
+	c.SetCurrentGeneration(5) // FSM already at gen 5
+
+	// nextIndex=15 → Gen(15, 10) = 1 (behind actualGeneration=5). Would
+	// underflow: 1 - 5 = huge → default branch → CacheUnreachable.
+	assert.Equal(t, CacheMiss, c.Volumes.CheckCache(15, attributes.NewU128(1, 1)),
+		"stale-behind build must report CacheMiss, not underflow into CacheUnreachable")
+}
+
 // TestCache_ResetWithThresholdRejectsZero: threshold=0 is a config invariant
 // violation — cache.New rejects it up front, and no legitimate call path can
 // reach ResetWithThreshold with 0. Panicking makes the violation impossible

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -403,6 +403,23 @@ func TestCache_ResetWithThresholdAtNonZeroIndex(t *testing.T) {
 	assert.Equal(t, uint64(2), cache.Epoch())
 }
 
+// TestCache_ResetWithThresholdRejectsZero: threshold=0 is a config invariant
+// violation — cache.New rejects it up front, and no legitimate call path can
+// reach ResetWithThreshold with 0. Panicking makes the violation impossible
+// to silently mask by disabling rotations (which would freeze
+// currentGeneration=0 forever and break the CacheUnreachable contract).
+func TestCache_ResetWithThresholdRejectsZero(t *testing.T) {
+	t.Parallel()
+
+	cache, err := New(100, nil)
+	require.NoError(t, err)
+
+	require.PanicsWithValue(t,
+		"cache.ResetWithThreshold: threshold must be > 0 (invariant enforced by cache.New)",
+		func() { cache.ResetWithThreshold(0, 0) },
+	)
+}
+
 func TestCache_CheckRotationNeeded_SameGeneration(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -334,9 +334,20 @@ func TestAttributeCache_IsGuaranteedInCache_TwoGenerationsAhead(t *testing.T) {
 	key := attributes.NewU128(1, 1)
 	ac.Put(key, attributes.Entry[*raftcmdpb.VolumePair]{})
 
-	// Index 25 is in generation 2 (two generations ahead)
-	// Data will be lost after two rotations -> false
+	// Index 25 is in generation 2 (two generations ahead): any preload
+	// computed now would be rotated out before apply. CheckCache surfaces
+	// this as CacheUnreachable so admission can reject the proposal with a
+	// transient error — Guaranteed must be false and the explicit status
+	// must be CacheUnreachable (not CacheMiss, which would mistakenly drive
+	// a stale preload).
 	assert.False(t, ac.IsGuaranteedInCache(25, key))
+	assert.Equal(t, CacheUnreachable, ac.CheckCache(25, key),
+		"≥2 generations ahead must report CacheUnreachable")
+
+	// Same regime for a key absent from the cache: still Unreachable; the
+	// admission-level reject takes precedence over the per-key miss path.
+	absent := attributes.NewU128(9, 9)
+	assert.Equal(t, CacheUnreachable, ac.CheckCache(25, absent))
 }
 
 func TestCache_NewCache(t *testing.T) {

--- a/internal/infra/cache/cache_test.go
+++ b/internal/infra/cache/cache_test.go
@@ -614,32 +614,20 @@ func TestAttributeCache_Gen0Gen1_Accessors(t *testing.T) {
 	require.NotSame(t, ac.Gen0(), ac.Gen1())
 }
 
-func TestCache_CheckRotationNeeded_ZeroThreshold(t *testing.T) {
-	t.Parallel()
-
-	// Create a cache and forcibly set threshold to 0
-	cache, err := New(10, nil)
-	require.NoError(t, err)
-
-	cache.SetGenerationThreshold(0)
-
-	rotated, _ := cache.CheckRotationNeeded(100)
-	assert.False(t, rotated)
-}
-
-func TestAttributeCache_IsGuaranteedInCache_ZeroThreshold(t *testing.T) {
+// TestCache_SetGenerationThresholdRejectsZero locks the invariant that a
+// running cache never observes threshold=0. cache.New rejects it, and every
+// setter (SetGenerationThreshold, ResetWithThreshold) panics loudly rather
+// than silently disabling rotations.
+func TestCache_SetGenerationThresholdRejectsZero(t *testing.T) {
 	t.Parallel()
 
 	cache, err := New(10, nil)
 	require.NoError(t, err)
 
-	cache.SetGenerationThreshold(0)
-
-	key := attributes.NewU128(1, 1)
-	cache.Volumes.Put(key, attributes.Entry[*raftcmdpb.VolumePair]{})
-
-	// Should return false when threshold is 0
-	assert.False(t, cache.Volumes.IsGuaranteedInCache(5, key))
+	require.PanicsWithValue(t,
+		"cache.SetGenerationThreshold: threshold must be > 0 (invariant enforced by cache.New)",
+		func() { cache.SetGenerationThreshold(0) },
+	)
 }
 
 func TestAttributeCache_Touch_DoesNotOverwriteGen0(t *testing.T) {

--- a/internal/infra/plan/builder_test.go
+++ b/internal/infra/plan/builder_test.go
@@ -325,3 +325,44 @@ func TestBuildPreloads_DeclaresAbsentNonZeroKey(t *testing.T) {
 	expectedID, _ := attributes.MakeKey(refKey.Bytes())
 	require.Equal(t, expectedID[:], plan.GetId().GetId())
 }
+
+// TestBuildPreloads_RejectsCacheHorizonExceeded covers the admission-level
+// guard against ≥2 cache rotations between propose and apply. With a low
+// rotation threshold (10) and the tracker pinned past two boundaries, the
+// resolver must short-circuit and surface ErrCacheHorizonExceeded so the
+// proposal never reaches Raft (and the audit log records nothing — it is a
+// system-level rejection, not a business outcome).
+func TestBuildPreloads_RejectsCacheHorizonExceeded(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	meter := noop.NewMeterProvider().Meter("test")
+
+	store, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	attrs := attributes.New()
+	// Threshold 10: every 10 indices crosses a generation. Tracker starts
+	// past the second boundary so Gen(nextIndex) - currentGeneration >= 2.
+	c, err := cache.New(10, meter)
+	require.NoError(t, err)
+	c.SetCurrentGeneration(0)
+
+	// Tracker at index 25 → Gen(25, 10) = 2, two rotations ahead of
+	// currentGeneration (0) → CheckCache returns CacheUnreachable.
+	tracker := node.NewIndexTracker(25)
+	p := NewBuilder(tracker, c, attrs, store, nil, logger, 0)
+
+	refKey := domain.TransactionReferenceKey{LedgerName: "test", Reference: "ref"}
+	needs := NewNeeds()
+	needs.References[refKey] = struct{}{}
+
+	build, buildErr := p.Build([]WriteOperation{{Needs: needs}})
+	defer build.ReleaseLoaders()
+
+	require.Error(t, buildErr, "admission must reject when 2+ rotations are predicted")
+	require.ErrorIs(t, buildErr, ErrCacheHorizonExceeded,
+		"reject must surface ErrCacheHorizonExceeded so the gRPC adapter maps to codes.Unavailable")
+}

--- a/internal/infra/plan/errors.go
+++ b/internal/infra/plan/errors.go
@@ -1,0 +1,26 @@
+package plan
+
+import "errors"
+
+// ErrCacheHorizonExceeded is returned by Builder.Build when admission predicts
+// 2+ cache generation rotations will fire on the FSM side between this
+// proposal's propose-time and its apply-time (cache.CheckCache → CacheUnreachable).
+//
+// In that regime, any preload value resolved now would be discarded by the
+// rotations before the FSM apply reads it: a preload landed in gen0 is rotated
+// into gen1 by the first rotation and dropped by the second. The proposal's
+// reads would then miss the preloaded data, producing inconsistent results.
+//
+// Admission rejects the proposal so it never enters Raft. The client retries
+// — by then admission's snapshot is fresh again and CheckCache returns a usable
+// status. The audit log is *not* an issue here: the order never landed, so no
+// audit entry is owed (this is a system-level rejection, not a user-domain
+// business outcome).
+//
+// Under a correctly tuned rotation-threshold and a healthy FSM apply rate, this
+// error should not fire. Recurring occurrences indicate either a too-low
+// rotation threshold or FSM apply falling behind admission (overload).
+//
+// Mapped to gRPC codes.Unavailable in adapter/grpc/server.go so existing client
+// retry interceptors handle it transparently.
+var ErrCacheHorizonExceeded = errors.New("admission cache horizon exceeded: 2+ cache rotations predicted between propose and apply")

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -122,6 +122,22 @@ func resolveAttributePreload[K interface {
 		id, tag := attributes.MakeKey(canonicalKey)
 
 		switch attrCache.CheckCache(nextIndex, id) {
+		case cache.CacheUnreachable:
+			// Admission predicts ≥2 rotations between propose and apply: a
+			// preload computed now would be rotated out before the FSM read.
+			// Reject the whole proposal — the client retries against a fresh
+			// admission snapshot once the FSM has caught up. See plan.errors.
+			if logger.Enabled(logging.TraceLevel) {
+				logger.WithFields(map[string]any{
+					"type":      typeName,
+					"key":       hex.EncodeToString(canonicalKey),
+					"nextIndex": nextIndex,
+					"boundary":  boundary,
+				}).Tracef("Cache horizon exceeded: admission rejection")
+			}
+
+			return &resolveResult{tracker: tracker}, ErrCacheHorizonExceeded
+
 		case cache.CacheGuaranteed:
 			// Record the declaration so the FSM-side preload.View admits
 			// reads on this key. The apply path triggers no cache mutation

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -125,8 +125,11 @@ func resolveAttributePreload[K interface {
 		case cache.CacheUnreachable:
 			// Admission predicts ≥2 rotations between propose and apply: a
 			// preload computed now would be rotated out before the FSM read.
-			// Reject the whole proposal — the client retries against a fresh
-			// admission snapshot once the FSM has caught up. See plan.errors.
+			// Record the rejection but continue processing so the wg.Wait()
+			// below drains any CacheMiss loader goroutine earlier iterations
+			// already launched — an immediate return would race with those
+			// goroutines' appends to plans/tracker and leak their
+			// AttributeLoader entries past the caller's cleanup token.
 			if logger.Enabled(logging.TraceLevel) {
 				logger.WithFields(map[string]any{
 					"type":      typeName,
@@ -136,7 +139,13 @@ func resolveAttributePreload[K interface {
 				}).Tracef("Cache horizon exceeded: admission rejection")
 			}
 
-			return &resolveResult{tracker: tracker}, ErrCacheHorizonExceeded
+			mu.Lock()
+			if firstErr == nil {
+				firstErr = ErrCacheHorizonExceeded
+			}
+			mu.Unlock()
+
+			continue
 
 		case cache.CacheGuaranteed:
 			// Record the declaration so the FSM-side preload.View admits

--- a/internal/infra/state/machine_cache_epoch_test.go
+++ b/internal/infra/state/machine_cache_epoch_test.go
@@ -40,7 +40,7 @@ func TestCheckStaleProposal_CacheEpochMismatchAfterFirstReset(t *testing.T) {
 		"proposal carrying the live cache epoch must pass")
 
 	// A cluster config change wipes the cache and bumps the epoch.
-	fsm.Registry.Cache.ResetWithThreshold(2000)
+	fsm.Registry.Cache.ResetWithThreshold(2000, 0)
 	require.Equal(t, uint64(2), fsm.Registry.Cache.Epoch())
 
 	// The in-flight proposal (still carrying epoch=1) must now be rejected
@@ -61,7 +61,7 @@ func TestCheckStaleProposal_PreloadWithoutEpochIsAccepted(t *testing.T) {
 	t.Parallel()
 
 	fsm, _, _ := newTestMachine(t)
-	fsm.Registry.Cache.ResetWithThreshold(2000) // live epoch = 2
+	fsm.Registry.Cache.ResetWithThreshold(2000, 0) // live epoch = 2
 
 	proposal := &raftcmdpb.Proposal{
 		Id: 1,

--- a/internal/infra/state/machine_technical_updates.go
+++ b/internal/infra/state/machine_technical_updates.go
@@ -7,7 +7,6 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
-	"github.com/formancehq/ledger/v3/internal/infra/cache"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -112,14 +111,19 @@ func (fsm *Machine) applyClusterConfig(batch *dal.WriteSession, raftIndex uint64
 		}).Infof("Applying cluster config change: resetting cache and purging 0xFF")
 
 		fsm.Registry.Cache.ResetWithThreshold(newThreshold)
-		// ResetWithThreshold leaves currentGeneration=0, but the Raft log is
-		// long past index 0 — admission's CheckCache would compute
-		// Gen(nextIndex, newThreshold) - 0, a large value that erroneously
-		// trips the CacheUnreachable horizon and rejects every incoming
-		// proposal until the next FSM apply moves currentGeneration forward.
-		// Set it to the post-reset truth immediately so admission queries
-		// see a consistent (currentGeneration, threshold) pair.
-		fsm.Registry.Cache.SetCurrentGeneration(cache.Gen(raftIndex, newThreshold))
+		// ResetWithThreshold leaves currentGeneration=0 and BaseIndex={0,0},
+		// but the Raft log is long past index 0. Admission's CheckCache would
+		// then compute Gen(nextIndex, newThreshold) - 0, a large value that
+		// erroneously trips the CacheUnreachable horizon. And any proposal
+		// admitted after the reset with the new epoch would carry a
+		// LastPersistedIndex that doesn't match BaseIndex.{Gen0,Gen1}=0 —
+		// triggering the FSM-side preload boundary mismatch panic on apply.
+		//
+		// CheckRotationNeeded jumps currentGeneration AND BaseIndex to
+		// Gen(raftIndex, newThreshold) atomically (rotateLocked under the
+		// same cache.mu as the reset), so admission's next snapshot sees a
+		// consistent (currentGeneration, threshold, BaseIndex) tuple.
+		fsm.Registry.Cache.CheckRotationNeeded(raftIndex)
 
 		// Purge both generation byte positions (0 and 1) in the 0xFF cache zone.
 		// We can't use a single DeleteRange from [0xFF] to [0xFF+1] because

--- a/internal/infra/state/machine_technical_updates.go
+++ b/internal/infra/state/machine_technical_updates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
+	"github.com/formancehq/ledger/v3/internal/infra/cache"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -111,6 +112,14 @@ func (fsm *Machine) applyClusterConfig(batch *dal.WriteSession, raftIndex uint64
 		}).Infof("Applying cluster config change: resetting cache and purging 0xFF")
 
 		fsm.Registry.Cache.ResetWithThreshold(newThreshold)
+		// ResetWithThreshold leaves currentGeneration=0, but the Raft log is
+		// long past index 0 — admission's CheckCache would compute
+		// Gen(nextIndex, newThreshold) - 0, a large value that erroneously
+		// trips the CacheUnreachable horizon and rejects every incoming
+		// proposal until the next FSM apply moves currentGeneration forward.
+		// Set it to the post-reset truth immediately so admission queries
+		// see a consistent (currentGeneration, threshold) pair.
+		fsm.Registry.Cache.SetCurrentGeneration(cache.Gen(raftIndex, newThreshold))
 
 		// Purge both generation byte positions (0 and 1) in the 0xFF cache zone.
 		// We can't use a single DeleteRange from [0xFF] to [0xFF+1] because

--- a/internal/infra/state/machine_technical_updates.go
+++ b/internal/infra/state/machine_technical_updates.go
@@ -110,20 +110,13 @@ func (fsm *Machine) applyClusterConfig(batch *dal.WriteSession, raftIndex uint64
 			"raftIndex":    raftIndex,
 		}).Infof("Applying cluster config change: resetting cache and purging 0xFF")
 
-		fsm.Registry.Cache.ResetWithThreshold(newThreshold)
-		// ResetWithThreshold leaves currentGeneration=0 and BaseIndex={0,0},
-		// but the Raft log is long past index 0. Admission's CheckCache would
-		// then compute Gen(nextIndex, newThreshold) - 0, a large value that
-		// erroneously trips the CacheUnreachable horizon. And any proposal
-		// admitted after the reset with the new epoch would carry a
-		// LastPersistedIndex that doesn't match BaseIndex.{Gen0,Gen1}=0 —
-		// triggering the FSM-side preload boundary mismatch panic on apply.
-		//
-		// CheckRotationNeeded jumps currentGeneration AND BaseIndex to
-		// Gen(raftIndex, newThreshold) atomically (rotateLocked under the
-		// same cache.mu as the reset), so admission's next snapshot sees a
-		// consistent (currentGeneration, threshold, BaseIndex) tuple.
-		fsm.Registry.Cache.CheckRotationNeeded(raftIndex)
+		// ResetWithThreshold atomically resets caches, bumps the epoch, sets
+		// the new threshold, AND realigns currentGeneration + BaseIndex to
+		// Gen(raftIndex, newThreshold) — all under the same cache.mu so
+		// admission's next snapshot never observes a transient
+		// (currentGeneration=0, threshold=new) window that would falsely
+		// trip the CacheUnreachable horizon (2+ predicted rotations).
+		fsm.Registry.Cache.ResetWithThreshold(newThreshold, raftIndex)
 
 		// Purge both generation byte positions (0 and 1) in the 0xFF cache zone.
 		// We can't use a single DeleteRange from [0xFF] to [0xFF+1] because

--- a/internal/infra/state/machine_technical_updates.go
+++ b/internal/infra/state/machine_technical_updates.go
@@ -138,14 +138,38 @@ func (fsm *Machine) applyClusterConfig(batch *dal.WriteSession, raftIndex uint64
 			}
 		}
 
-		// Reset the cache metadata sentinel to currentGeneration=0 (post-reset state).
-		// We must NOT delete it — RestoreFromStore tolerates a missing sentinel
-		// but other code paths may depend on it being present.
+		// Persist the post-reset in-memory state — CurrentGeneration AND both
+		// per-gen BaseIndex sentinels — so a node restart before the next
+		// organic rotation reconstructs the same (currentGeneration,
+		// BaseIndex.Gen0, BaseIndex.Gen1) tuple CheckRotationNeeded set here.
+		// Without this the disk still says currentGeneration=0, RestoreFromStore
+		// loads that, and admission's CheckCache re-observes a stale
+		// currentGeneration far behind Gen(nextIndex) — falsely tripping the
+		// CacheUnreachable horizon until another apply event catches the
+		// generation forward.
+		postResetGen := fsm.Registry.Cache.CurrentGeneration()
+		gen0Byte := byte(postResetGen % 2)
+		gen1Byte := byte((postResetGen + 1) % 2)
+
 		if err := batch.SetProto(
 			[]byte{dal.ZoneCache, dal.SubCacheMeta},
-			&raftcmdpb.CacheSnapshotMeta{CurrentGeneration: 0},
+			&raftcmdpb.CacheSnapshotMeta{CurrentGeneration: postResetGen},
 		); err != nil {
-			return fmt.Errorf("resetting cache snapshot meta: %w", err)
+			return fmt.Errorf("persisting cache snapshot meta: %w", err)
+		}
+
+		if err := batch.SetProto(
+			[]byte{dal.ZoneCache, gen0Byte, dal.SubCacheGenMeta},
+			&raftcmdpb.CacheGenerationMeta{BaseIndex: fsm.Registry.Cache.BaseIndex.Gen0},
+		); err != nil {
+			return fmt.Errorf("persisting gen0 meta: %w", err)
+		}
+
+		if err := batch.SetProto(
+			[]byte{dal.ZoneCache, gen1Byte, dal.SubCacheGenMeta},
+			&raftcmdpb.CacheGenerationMeta{BaseIndex: fsm.Registry.Cache.BaseIndex.Gen1},
+		); err != nil {
+			return fmt.Errorf("persisting gen1 meta: %w", err)
 		}
 	}
 

--- a/internal/infra/state/machine_threshold_change_persistence_test.go
+++ b/internal/infra/state/machine_threshold_change_persistence_test.go
@@ -1,0 +1,113 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/cache"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// TestApplyClusterConfig_ThresholdChangePersistsGeneration is the regression
+// for NumaryBot's blocker on the admission-cache-horizon PR: after a
+// rotation-threshold change fires CheckRotationNeeded to realign
+// currentGeneration and BaseIndex in memory, the FSM must persist that
+// realigned state to Pebble. Without persistence a node restart before the
+// next organic rotation would rehydrate currentGeneration=0 from disk and
+// admission's CheckCache would re-observe a stale horizon, falsely tripping
+// CacheUnreachable for valid preloaded proposals.
+//
+// The test drives applyClusterConfig at a Raft index whose new-threshold gen
+// is non-zero, then simulates the restart via Reset + RestoreFromStore and
+// asserts the reconstructed (currentGeneration, BaseIndex) tuple matches the
+// pre-restart in-memory state.
+func TestApplyClusterConfig_ThresholdChangePersistsGeneration(t *testing.T) {
+	t.Parallel()
+
+	// Threshold 1000 initially — the default in newTestMachine.
+	fsm, dataStore, _ := newTestMachine(t)
+
+	// The threshold change we want to apply. With threshold=10 and
+	// raftIndex=25, Gen(25, 10) = 2 → CheckRotationNeeded must jump
+	// currentGeneration to 2 and BaseIndex.Gen0 to genEndIndex(1, 10) = 20.
+	const (
+		newThreshold uint64 = 10
+		raftIndex    uint64 = 25
+		expectedGen  uint64 = 2 // Gen(25, 10)
+		expectedGen0 uint64 = 20
+	)
+
+	batch := dataStore.OpenWriteSession()
+	require.NoError(t, fsm.applyClusterConfig(batch, raftIndex, &commonpb.ClusterConfig{
+		RotationThreshold: newThreshold,
+	}))
+	require.NoError(t, batch.Commit())
+
+	// Verify the in-memory state was realigned.
+	require.Equal(t, expectedGen, fsm.Registry.Cache.CurrentGeneration())
+	require.Equal(t, expectedGen0, fsm.Registry.Cache.BaseIndex.Gen0)
+	require.Equal(t, uint64(0), fsm.Registry.Cache.BaseIndex.Gen1)
+
+	// Verify the on-disk state matches — this is what a fresh RestoreFromStore
+	// will see.
+	meta := readCacheSnapshotMeta(t, dataStore)
+	require.Equal(t, expectedGen, meta.GetCurrentGeneration(),
+		"disk CacheMeta must carry the post-CheckRotationNeeded currentGeneration")
+
+	gen0Byte := byte(expectedGen % 2)
+	gen1Byte := byte((expectedGen + 1) % 2)
+
+	require.Equal(t, expectedGen0, readCacheGenMeta(t, dataStore, gen0Byte).GetBaseIndex(),
+		"disk gen0 CacheGenMeta must carry the post-rotation BaseIndex.Gen0")
+	require.Equal(t, uint64(0), readCacheGenMeta(t, dataStore, gen1Byte).GetBaseIndex(),
+		"disk gen1 CacheGenMeta must carry the post-rotation BaseIndex.Gen1")
+
+	// Simulate a restart: reset the in-memory cache and restore from disk.
+	fsm.Registry.Cache.Reset()
+	require.NoError(t, fsm.cacheSnapshotter.RestoreFromStore(dataStore))
+
+	require.Equal(t, expectedGen, fsm.Registry.Cache.CurrentGeneration(),
+		"restart must reconstruct the post-threshold-change currentGeneration")
+	require.Equal(t, expectedGen0, fsm.Registry.Cache.BaseIndex.Gen0,
+		"restart must reconstruct the post-threshold-change BaseIndex.Gen0")
+	require.Equal(t, uint64(0), fsm.Registry.Cache.BaseIndex.Gen1,
+		"restart must reconstruct the post-threshold-change BaseIndex.Gen1")
+
+	// A CheckCache query at any index within the current generation must NOT
+	// return CacheUnreachable — the horizon must reflect the persisted-then-
+	// restored generation, not currentGeneration=0.
+	inGenIndex := raftIndex + 1
+	require.NotEqual(t, cache.CacheUnreachable,
+		fsm.Registry.Cache.LedgerMetadata.CheckCache(inGenIndex, attributes.NewU128(0, 0)),
+		"CheckCache at a future index in the same generation must not fire the horizon guard")
+}
+
+func readCacheSnapshotMeta(t *testing.T, store *dal.Store) *raftcmdpb.CacheSnapshotMeta {
+	t.Helper()
+
+	val, closer, err := store.Get([]byte{dal.ZoneCache, dal.SubCacheMeta})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	meta := &raftcmdpb.CacheSnapshotMeta{}
+	require.NoError(t, meta.UnmarshalVT(val))
+
+	return meta
+}
+
+func readCacheGenMeta(t *testing.T, store *dal.Store, genByte byte) *raftcmdpb.CacheGenerationMeta {
+	t.Helper()
+
+	val, closer, err := store.Get([]byte{dal.ZoneCache, genByte, dal.SubCacheGenMeta})
+	require.NoError(t, err)
+	defer func() { _ = closer.Close() }()
+
+	meta := &raftcmdpb.CacheGenerationMeta{}
+	require.NoError(t, meta.UnmarshalVT(val))
+
+	return meta
+}


### PR DESCRIPTION
## Problem

When admission's predicted apply-time generation `Gen(nextIndex)` is 2+
generations ahead of the FSM's current applied generation, any value loaded
as a `MirrorPreload` is doomed: the first rotation between propose and apply
moves it Gen0 → Gen1, the second discards it entirely. By apply time the
cache has no record of the preloaded value — the FSM read misses and the
order fails with `ErrNotFound` for a key admission promised would be
available. This violates invariant #1 (cache is the source of authority).

Today the code returns `CacheMiss` in this regime and emits a stale
`MirrorPreload` anyway. This is the path the EN-1242 churn investigation
surfaced.

## Fix — reject at admission

| `Gen(at) − currentGen` | `CheckCache` result | Plan emitted |
|---|---|---|
| 0 | `CacheGuaranteed` / `CacheNeedsTouch` / `CacheMiss` | `Declare` / `Touch` / `Preload` |
| 1 | `CacheGuaranteed` / `CacheMiss` | `Declare` / `Preload` |
| **≥ 2** | **`CacheUnreachable`** | **proposal rejected** |

When admission encounters `CacheUnreachable` it returns
`plan.ErrCacheHorizonExceeded`. The gRPC adapter maps that to
`codes.Unavailable` so the existing client retry interceptors handle it
transparently. The proposal never enters Raft, no audit entry is owed, and
the client retries against a fresh admission snapshot once the FSM has
caught up.

## Why this is not a domain error

The rejection is **not** a business outcome — the user-submitted operation
might be perfectly valid. It is an *operational* signal that admission's
view is too far behind FSM apply for the system to safely admit any new
proposal whose preload would target keys this stale. So `ErrCacheHorizonExceeded`
lives in `internal/infra/plan/`, not in `internal/domain/`, and the gRPC
adapter classifies it as a transient infrastructure error.

## When can it fire?

Under a correctly tuned `--cache-rotation-threshold` (default 1000) and
an FSM apply rate that keeps up with proposals, the ≥ 2-generation horizon
should never be reached: admission's `nextIndex` would have to sit at least
`2 × threshold` indices past the FSM's last-applied index (≥ 2000 in-flight
proposals at default tuning).

Recurring rejections are an operational signal — see [the new doc](docs/technical/architecture/core/admission-cache-horizon.md)
for runbook guidance.

## Changes

| File | Change |
|---|---|
| `internal/infra/cache/cache.go` | New `CacheUnreachable` constant; `CheckCache` default branch returns it instead of `CacheMiss`. |
| `internal/infra/plan/errors.go` | New `ErrCacheHorizonExceeded` sentinel + rationale comment. |
| `internal/infra/plan/resolve.go` | Switch case on `CacheUnreachable` short-circuits with the sentinel. |
| `internal/adapter/grpc/server.go` | `convertToGRPCError` maps `ErrCacheHorizonExceeded` → `codes.Unavailable`. |
| `docs/technical/architecture/core/admission-cache-horizon.md` | New doc explaining the contract, the operational signal, and recovery. |
| `docs/technical/architecture/core/fsm-cache-layers.md` | Reference the new doc from the Related section. |

## Tests

- `TestAttributeCache_IsGuaranteedInCache_TwoGenerationsAhead` — strengthened
  to assert `CacheUnreachable` specifically (not the prior `CacheMiss`), for
  both stored and absent keys.
- `TestBuildPreloads_RejectsCacheHorizonExceeded` — end-to-end resolver run
  with a tracker pinned past two generation boundaries; asserts
  `ErrCacheHorizonExceeded` propagates out of `Builder.Build` so the gRPC
  layer maps to `codes.Unavailable`.

## Verification

- `go build ./...` passes.
- `golangci-lint run ./internal/infra/cache/... ./internal/infra/plan/... ./internal/adapter/grpc/...` → 0 issues.
- Targeted test suites green.
- Standalone from EN-1242 (#1455).