### PR TITLE
fix(ledgerctl): honor --profile in shell completion

### DIFF
--- a/cmd/ledgerctl/cmdutil/ledger.go
+++ b/cmd/ledgerctl/cmdutil/ledger.go
@@ -82,6 +82,14 @@ func SelectLedger(cmd *cobra.Command, client servicepb.BucketServiceClient, ledg
 // unreachable, auth missing, slow network) returns no suggestions rather than
 // surfacing an error: a broken connection must never disrupt tab completion.
 func CompleteLedgerNames(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	// cobra does not run the root PersistentPreRunE during `__complete`, so the
+	// connection flags still hold their defaults here. Resolve --profile/env
+	// ourselves or we would list ledgers from the default server instead of the
+	// one the active profile points at.
+	if err := ResolveConnectionFlags(cmd); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	client, conn, err := GetClient(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/ledgerctl/cmdutil/resolve.go
+++ b/cmd/ledgerctl/cmdutil/resolve.go
@@ -1,0 +1,124 @@
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ResolveConnectionFlags applies the profile/env/flag precedence to ledgerctl's
+// connection and security flags, in order: explicit CLI flag > LEDGERCTL_ env
+// var > active profile value > cobra default.
+//
+// It runs from the root PersistentPreRunE for normal command execution, and is
+// ALSO invoked explicitly from shell-completion functions (the --ledger flag
+// completion and the prepared-query ValidArgsFunction). cobra does NOT run
+// PersistentPreRunE during `__complete`, so without this call completion would
+// connect to the default --server (localhost:8888) instead of the one selected
+// by --profile, returning ledgers from the wrong cluster. EN-1295.
+func ResolveConnectionFlags(cmd *cobra.Command) error {
+	// During `__complete`, cobra runs the root PersistentPreRunE with cmd set to
+	// the completion helper command, whose args are the line being completed — so
+	// --profile is NOT parsed onto it and resolution would fall back to the
+	// *active* profile. Worse, resolveFlag writes that active profile's values
+	// onto the shared persistent flags and marks them Changed, which then blocks
+	// the real per-completion resolution (driven by the explicit --profile in the
+	// args) from overriding them. The connection-completion functions call
+	// ResolveConnectionFlags themselves with the real target command, so this
+	// pre-run pass during completion must be a no-op. EN-1295.
+	if cmd.Name() == cobra.ShellCompRequestCmd || cmd.Name() == cobra.ShellCompNoDescRequestCmd {
+		return nil
+	}
+
+	// Skip profile/env resolution for profile management commands — they define
+	// local flags with the same names and must not be contaminated by the active
+	// profile or environment variables.
+	if isProfileCommand(cmd) {
+		return nil
+	}
+
+	// Load config and resolve the active profile.
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	// Resolve profile name: --profile flag > LEDGERCTL_PROFILE env > config activeProfile.
+	profileName, _ := cmd.Flags().GetString("profile")
+	profileExplicit := cmd.Flags().Changed("profile")
+
+	if profileName == "" {
+		if v, ok := os.LookupEnv("LEDGERCTL_PROFILE"); ok && v != "" {
+			profileName = strings.TrimSpace(v)
+			profileExplicit = true
+		}
+	}
+
+	name, p := GetActiveProfile(cfg, profileName)
+	if profileExplicit && p == nil && !isProfileBootstrapCommand(cmd) {
+		return fmt.Errorf("profile %q not found", name)
+	}
+
+	// Resolve flags: explicit CLI flag > env var > profile value > cobra default.
+	resolveFlag(cmd, "server", "LEDGERCTL_SERVER", ProfileFlagValue(p, "server"))
+	resolveFlag(cmd, "insecure", "LEDGERCTL_INSECURE", ProfileFlagValue(p, "insecure"))
+	resolveFlag(cmd, "tls-ca-cert", "LEDGERCTL_TLS_CA_CERT", ProfileFlagValue(p, "tls-ca-cert"))
+	resolveFlag(cmd, "consistency", "LEDGERCTL_CONSISTENCY", "")
+	resolveFlag(cmd, "auth-token", "LEDGERCTL_AUTH_TOKEN", "")
+	resolveFlag(cmd, "signing-key", "LEDGERCTL_SIGNING_KEY", ProfileFlagValue(p, "signing-key"))
+	resolveFlag(cmd, "signing-key-id", "LEDGERCTL_SIGNING_KEY_ID", ProfileFlagValue(p, "signing-key-id"))
+	resolveFlag(cmd, "response-verify-key", "LEDGERCTL_RESPONSE_VERIFY_KEY", ProfileFlagValue(p, "response-verify-key"))
+	resolveFlag(cmd, "result-file", "LEDGERCTL_RESULT_FILE", "")
+
+	return nil
+}
+
+// resolveFlag sets a cobra flag's value using the first available source:
+// explicit CLI flag > environment variable > profile value > cobra default.
+// It only writes to the flag when it was not explicitly set on the command line.
+func resolveFlag(cmd *cobra.Command, flagName, envVar, profileValue string) {
+	if cmd.Flags().Changed(flagName) {
+		return
+	}
+
+	if v, ok := os.LookupEnv(envVar); ok && v != "" {
+		_ = cmd.Flags().Set(flagName, strings.TrimSpace(v))
+
+		return
+	}
+
+	if profileValue != "" {
+		_ = cmd.Flags().Set(flagName, profileValue)
+	}
+}
+
+// isProfileCommand returns true when cmd is a subcommand of "profile".
+// Profile management commands define local flags that overlap with the
+// persistent connection flags (--server, --insecure, --tls-ca-cert) and
+// must not inherit values from the active profile or environment.
+func isProfileCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "profile" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isProfileBootstrapCommand returns true for commands that should work even
+// when the referenced --profile does not exist yet (e.g. auth login, profile create).
+func isProfileBootstrapCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "login", "create":
+			if p := c.Parent(); p != nil && (p.Name() == "auth" || p.Name() == "profile") {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/cmd/ledgerctl/cmdutil/resolve_test.go
+++ b/cmd/ledgerctl/cmdutil/resolve_test.go
@@ -1,0 +1,172 @@
+package cmdutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// newConnCmd builds a leaf command carrying the same connection/security flags
+// ledgerctl declares as root persistent flags, so ResolveConnectionFlags can be
+// exercised in isolation without standing up the whole command tree.
+func newConnCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("server", "localhost:8888", "")
+	cmd.Flags().Bool("insecure", false, "")
+	cmd.Flags().String("tls-ca-cert", "", "")
+	cmd.Flags().String("consistency", "", "")
+	cmd.Flags().String("auth-token", "", "")
+	cmd.Flags().String("signing-key", "", "")
+	cmd.Flags().String("signing-key-id", "", "")
+	cmd.Flags().String("response-verify-key", "", "")
+	cmd.Flags().String("result-file", "", "")
+
+	return cmd
+}
+
+// emptyKeyring is a Keyring that never has a token, so GetContext's auth-token
+// fallback resolves to "" without touching the OS keychain.
+type emptyKeyring struct{}
+
+func (emptyKeyring) Get(string) (string, error) { return "", ErrTokenNotFound }
+func (emptyKeyring) Set(string, string) error   { return nil }
+func (emptyKeyring) Delete(string) error        { return nil }
+
+// TestResolveConnectionFlagsAppliesActiveProfile asserts the shared resolver
+// pulls the connection settings from the profile named by --profile. This is
+// the behavior the root PersistentPreRunE and every shell-completion function
+// rely on.
+func TestResolveConnectionFlagsAppliesActiveProfile(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_SERVER", "")
+
+	require.NoError(t, SaveConfig(Config{
+		Profiles: map[string]Profile{
+			"dev": {Server: "dev.example.com:443", Insecure: true},
+		},
+	}))
+
+	cmd := newConnCmd()
+	require.NoError(t, cmd.Flags().Set("profile", "dev"))
+
+	require.NoError(t, ResolveConnectionFlags(cmd))
+
+	server, _ := cmd.Flags().GetString("server")
+	require.Equal(t, "dev.example.com:443", server, "server must come from the active profile")
+
+	insecure, _ := cmd.Flags().GetBool("insecure")
+	require.True(t, insecure, "insecure must come from the active profile")
+}
+
+// TestResolveConnectionFlagsExplicitFlagWins guards the precedence: an explicit
+// --server on the command line is never overwritten by the profile value.
+func TestResolveConnectionFlagsExplicitFlagWins(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_SERVER", "")
+
+	require.NoError(t, SaveConfig(Config{
+		Profiles: map[string]Profile{
+			"dev": {Server: "dev.example.com:443"},
+		},
+	}))
+
+	cmd := newConnCmd()
+	require.NoError(t, cmd.Flags().Set("profile", "dev"))
+	require.NoError(t, cmd.Flags().Set("server", "cli.example.com:443"))
+
+	require.NoError(t, ResolveConnectionFlags(cmd))
+
+	server, _ := cmd.Flags().GetString("server")
+	require.Equal(t, "cli.example.com:443", server, "explicit --server must win over the profile")
+}
+
+// TestResolveConnectionFlagsUnknownProfile asserts an explicitly named profile
+// that does not exist is a hard error (matching command execution).
+func TestResolveConnectionFlagsUnknownProfile(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+
+	require.NoError(t, SaveConfig(Config{
+		Profiles: map[string]Profile{
+			"dev": {Server: "dev.example.com:443"},
+		},
+	}))
+
+	cmd := newConnCmd()
+	require.NoError(t, cmd.Flags().Set("profile", "ghost"))
+
+	err := ResolveConnectionFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ghost")
+}
+
+// TestResolveConnectionFlagsSkipsCompletionCommand asserts the resolver is a
+// no-op when invoked for the cobra completion helper command. cobra runs the
+// root PersistentPreRunE with that command during `__complete`; resolving there
+// would apply the active profile to the shared persistent flags and block the
+// real per-completion resolution from honoring the explicit --profile.
+func TestResolveConnectionFlagsSkipsCompletionCommand(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_SERVER", "")
+
+	require.NoError(t, SaveConfig(Config{
+		ActiveProfile: "acme",
+		Profiles: map[string]Profile{
+			"acme": {Server: "active.example.com:443"},
+		},
+	}))
+
+	cmd := newConnCmd()
+	cmd.Use = cobra.ShellCompRequestCmd // simulate the __complete helper command
+
+	require.NoError(t, ResolveConnectionFlags(cmd))
+
+	server, _ := cmd.Flags().GetString("server")
+	require.Equal(t, "localhost:8888", server, "completion helper command must not resolve the active profile")
+	require.False(t, cmd.Flags().Changed("server"), "server must stay unchanged so per-completion resolution can set it")
+}
+
+// TestCompleteLedgerNamesResolvesProfileServer is the regression guard for the
+// reported bug: `ledgerctl __complete --profile dev ... --ledger=` listed
+// ledgers from the default server because cobra skips PersistentPreRunE during
+// completion. CompleteLedgerNames must run the profile resolution itself.
+//
+// We point the profile at an unreachable address with a tiny timeout so the
+// connection fails fast, and assert the --server flag was resolved from the
+// profile (the resolution happens before the dial, so its effect is observable
+// regardless of the connection outcome). Before the fix, --server stayed at the
+// default localhost:8888.
+func TestCompleteLedgerNamesResolvesProfileServer(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_SERVER", "")
+
+	require.NoError(t, SaveConfig(Config{
+		Profiles: map[string]Profile{
+			"dev": {Server: "127.0.0.1:1", Insecure: true},
+		},
+	}))
+
+	cmd := newConnCmd()
+	cmd.Flags().Duration("timeout", 100*time.Millisecond, "")
+	require.NoError(t, cmd.Flags().Set("profile", "dev"))
+
+	// Inject an empty keyring so the auth-token fallback in GetContext never
+	// touches the OS keychain.
+	cmd.SetContext(context.WithValue(context.Background(), contextKeyKeyring{}, emptyKeyring{}))
+
+	// Connection will fail (nothing listens on 127.0.0.1:1); we only care that
+	// the resolution ran. The directive on failure is NoFileComp.
+	_, directive := CompleteLedgerNames(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	server, _ := cmd.Flags().GetString("server")
+	require.Equal(t, "127.0.0.1:1", server, "completion must resolve --server from the active profile")
+}

--- a/cmd/ledgerctl/e2e_complete_test.go
+++ b/cmd/ledgerctl/e2e_complete_test.go
@@ -17,6 +17,7 @@ import (
 
 type namedBucketServer struct {
 	servicepb.UnimplementedBucketServiceServer
+
 	ledger string
 }
 
@@ -32,6 +33,7 @@ func startServer(t *testing.T, ledgerName string) string {
 	servicepb.RegisterBucketServiceServer(srv, namedBucketServer{ledger: ledgerName})
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
+
 	return lis.Addr().String()
 }
 

--- a/cmd/ledgerctl/e2e_complete_test.go
+++ b/cmd/ledgerctl/e2e_complete_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+type namedBucketServer struct {
+	servicepb.UnimplementedBucketServiceServer
+	ledger string
+}
+
+func (s namedBucketServer) ListLedgers(_ *servicepb.ListLedgersRequest, st grpc.ServerStreamingServer[commonpb.LedgerInfo]) error {
+	return st.Send(&commonpb.LedgerInfo{Name: s.ledger})
+}
+
+func startServer(t *testing.T, ledgerName string) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	servicepb.RegisterBucketServiceServer(srv, namedBucketServer{ledger: ledgerName})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// TestE2ECompletionUsesExplicitProfileNotActive reproduces the reported bug:
+// with an active profile that differs from the one named by --profile, ledger
+// completion must connect to the EXPLICIT profile's server, not the active one.
+func TestE2ECompletionUsesExplicitProfileNotActive(t *testing.T) {
+	activeAddr := startServer(t, "WRONG-active-ledger")
+	devAddr := startServer(t, "aws-costs")
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_SERVER", "")
+	base, err := os.UserConfigDir()
+	require.NoError(t, err)
+	dir := filepath.Join(base, "ledgerctl")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	cfg := `{"activeProfile":"acme","profiles":{` +
+		`"acme":{"server":"` + activeAddr + `","insecure":true},` +
+		`"dev":{"server":"` + devAddr + `","insecure":true}}}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(cfg), 0o600))
+
+	root := newRootCommand()
+	root.SilenceErrors = true
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{cobra.ShellCompRequestCmd, "--profile", "dev", "accounts", "list", "--ledger", ""})
+	require.NoError(t, root.Execute())
+
+	t.Logf("completion output:\n%s", out.String())
+	require.Contains(t, out.String(), "aws-costs", "completion must use the --profile dev server")
+	require.NotContains(t, out.String(), "WRONG-active-ledger", "completion must NOT use the active profile's server")
+}

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -94,47 +93,11 @@ func newRootCommand() *cobra.Command {
 			// EncodeStructured).
 			cmdutil.RoutePtermForStructuredOutput(cmd)
 
-			// Skip profile/env resolution for profile management commands —
-			// they define local flags with the same names and must not be
-			// contaminated by the active profile or environment variables.
-			if isProfileCommand(cmd) {
-				return nil
-			}
-
-			// Load config and resolve the active profile.
-			cfg, err := cmdutil.LoadConfig()
-			if err != nil {
-				return err
-			}
-
-			// Resolve profile name: --profile flag > LEDGERCTL_PROFILE env > config activeProfile.
-			profileName, _ := cmd.Flags().GetString("profile")
-			profileExplicit := cmd.Flags().Changed("profile")
-
-			if profileName == "" {
-				if v, ok := os.LookupEnv("LEDGERCTL_PROFILE"); ok && v != "" {
-					profileName = strings.TrimSpace(v)
-					profileExplicit = true
-				}
-			}
-
-			name, p := cmdutil.GetActiveProfile(cfg, profileName)
-			if profileExplicit && p == nil && !isProfileBootstrapCommand(cmd) {
-				return fmt.Errorf("profile %q not found", name)
-			}
-
-			// Resolve flags: explicit CLI flag > env var > profile value > cobra default.
-			resolveFlag(cmd, "server", "LEDGERCTL_SERVER", cmdutil.ProfileFlagValue(p, "server"))
-			resolveFlag(cmd, "insecure", "LEDGERCTL_INSECURE", cmdutil.ProfileFlagValue(p, "insecure"))
-			resolveFlag(cmd, "tls-ca-cert", "LEDGERCTL_TLS_CA_CERT", cmdutil.ProfileFlagValue(p, "tls-ca-cert"))
-			resolveFlag(cmd, "consistency", "LEDGERCTL_CONSISTENCY", "")
-			resolveFlag(cmd, "auth-token", "LEDGERCTL_AUTH_TOKEN", "")
-			resolveFlag(cmd, "signing-key", "LEDGERCTL_SIGNING_KEY", cmdutil.ProfileFlagValue(p, "signing-key"))
-			resolveFlag(cmd, "signing-key-id", "LEDGERCTL_SIGNING_KEY_ID", cmdutil.ProfileFlagValue(p, "signing-key-id"))
-			resolveFlag(cmd, "response-verify-key", "LEDGERCTL_RESPONSE_VERIFY_KEY", cmdutil.ProfileFlagValue(p, "response-verify-key"))
-			resolveFlag(cmd, "result-file", "LEDGERCTL_RESULT_FILE", "")
-
-			return nil
+			// Resolve connection/security flags from the active profile and
+			// environment. Shared with the shell-completion path, which must run
+			// the same resolution because cobra skips PersistentPreRunE during
+			// `__complete`.
+			return cmdutil.ResolveConnectionFlags(cmd)
 		},
 	}
 
@@ -215,39 +178,6 @@ func registerLedgerFlagCompletion(cmd *cobra.Command) {
 	}
 }
 
-// isProfileCommand returns true when cmd is a subcommand of "profile".
-// Profile management commands define local flags that overlap with the
-// persistent connection flags (--server, --insecure, --tls-ca-cert) and
-// must not inherit values from the active profile or environment.
-func isProfileCommand(cmd *cobra.Command) bool {
-	for c := cmd; c != nil; c = c.Parent() {
-		if c.Name() == "profile" {
-			return true
-		}
-	}
-
-	return false
-}
-
-// resolveFlag sets a cobra flag's value using the first available source:
-// explicit CLI flag > environment variable > profile value > cobra default.
-// It only writes to the flag when it was not explicitly set on the command line.
-func resolveFlag(cmd *cobra.Command, flagName, envVar, profileValue string) {
-	if cmd.Flags().Changed(flagName) {
-		return
-	}
-
-	if v, ok := os.LookupEnv(envVar); ok && v != "" {
-		_ = cmd.Flags().Set(flagName, strings.TrimSpace(v))
-
-		return
-	}
-
-	if profileValue != "" {
-		_ = cmd.Flags().Set(flagName, profileValue)
-	}
-}
-
 // ledgerctlOwnedFlagNames are the profile/connection/security flags ledgerctl
 // resolves exclusively through the LEDGERCTL_ prefix (root PersistentPreRunE for
 // inherited flags, ResolveTokenSource for the token). They must never be bound to
@@ -322,21 +252,6 @@ func bindFlagSetSkippingOwned(set *pflag.FlagSet) {
 		// place, matching resolveFlag's best-effort env handling.
 		_ = set.Set(flag.Name, value)
 	})
-}
-
-// isProfileBootstrapCommand returns true for commands that should work even
-// when the referenced --profile does not exist yet (e.g. auth login, profile create).
-func isProfileBootstrapCommand(cmd *cobra.Command) bool {
-	for c := cmd; c != nil; c = c.Parent() {
-		switch c.Name() {
-		case "login", "create":
-			if p := c.Parent(); p != nil && (p.Name() == "auth" || p.Name() == "profile") {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 func newVersionCommand() *cobra.Command {

--- a/cmd/ledgerctl/queries/completion.go
+++ b/cmd/ledgerctl/queries/completion.go
@@ -15,6 +15,14 @@ func completeQueryNames(cmd *cobra.Command, args []string, _ string) ([]string, 
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	// cobra does not run the root PersistentPreRunE during `__complete`, so the
+	// connection flags still hold their defaults here. Resolve --profile/env
+	// ourselves or we would query the default server instead of the one the
+	// active profile points at.
+	if err := cmdutil.ResolveConnectionFlags(cmd); err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
 	client, conn, err := cmdutil.GetClient(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError


### PR DESCRIPTION
## Problem

`ledgerctl __complete --profile <name> ... --ledger=` returned the wrong ledgers (or none): completion connected to the **default / active-profile** server instead of the one selected by `--profile`.

Two root causes, both stemming from cobra not running the root `PersistentPreRunE` during `__complete`:

1. **The completion path never resolved the profile at all** — profile/connection resolution lived only in `PersistentPreRunE`, which cobra skips for completion. So `CompleteLedgerNames` → `GetClient` read the default `--server` (`localhost:8888`).

2. **Active-profile leakage** — cobra *does* run `PersistentPreRunE` on the `__complete` **helper command** (which has no `--profile` parsed onto it). That resolved the *active* profile onto the shared persistent flags and marked them `Changed`, which then blocked the real per-completion resolution from honoring the explicit `--profile`. This produced the mixed `server`(active) / `insecure`(requested) values observed in the field.

## Fix

- Extract resolution into a shared `cmdutil.ResolveConnectionFlags`, called from both `PersistentPreRunE` and the connection-completion functions (`--ledger` and prepared-query names).
- Make `ResolveConnectionFlags` a **no-op for the `__complete` / `__completeNoDesc` helper command**, so the pre-run pass during completion no longer pollutes the shared flags. The completion functions do their own resolution with the correct `--profile`.

## Tests

- `cmdutil/resolve_test.go` — profile precedence, explicit-flag-wins, unknown-profile error, completion-command no-op, and `CompleteLedgerNames` resolving the profile server.
- `e2e_complete_test.go` — drives the real `__complete` against in-process gRPC servers with an **active profile that differs from the requested one**; asserts completion uses the requested profile's server. Verified to fail without the guard.

All `./cmd/ledgerctl/...` tests, `go vet`, and `gofmt` pass.

## Not covered

- Completion against a TLS profile requiring a keychain auth token (e2e uses insecure servers).
- Completion results are **not cached** — each TAB does a fresh `ListLedgers` RPC. A short-TTL on-disk cache is a possible follow-up.