### PR TITLE
chore(antithesis): force linux/amd64 for snouty-built config image

### DIFF
--- a/.claude/skills/antithesis-run/SKILL.md
+++ b/.claude/skills/antithesis-run/SKILL.md
@@ -38,7 +38,8 @@ Run from the repo root (`git rev-parse --show-toplevel`). Verify:
 - `snouty --version` succeeds. If not, install per `https://github.com/antithesishq/snouty` and abort.
 - These environment variables are set in the shell:
   - `ANTITHESIS_TENANT` (the tenant slug — `formance` for this repo; embedded in the launch URL `formance.antithesis.com`)
-  - `ANTITHESIS_API_KEY` **or** (`ANTITHESIS_USERNAME` + `ANTITHESIS_PASSWORD`)
+  - `ANTITHESIS_API_KEY` — **required** for triage / analysis (`snouty runs …`); the launcher accepts basic auth as a fallback, but every downstream skill (`antithesis-triage`, `antithesis-query-logs`, etc.) needs the API key.
+  - `ANTITHESIS_USERNAME` + `ANTITHESIS_PASSWORD` — accepted by `snouty launch`/`snouty debug` only.
   - `ANTITHESIS_REPOSITORY` (registry for SUT images)
   - `ANTITHESIS_REPORT_RECIPIENT` (used as `--recipients`)
   If any are missing, list which and abort. Run `snouty doctor` to surface what's missing in one shot.
@@ -127,6 +128,9 @@ These steps replace the legacy `just k8s-push-images` / `just push-images`. Buil
 **K8s mode**:
 
 ```bash
+# Force amd64 for the config image snouty builds internally (see note below).
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+
 snouty launch \
   --webhook basic_k8s_test \
   --config tests/antithesis/k8s \
@@ -137,6 +141,7 @@ snouty launch \
 ```
 
 Notes:
+- **`export DOCKER_DEFAULT_PLATFORM=linux/amd64` before invoking snouty on Apple Silicon.** When you pass `--config <dir>`, snouty builds the config image locally without forcing `--platform linux/amd64`; on an M-series Mac this yields an arm64 image, which Antithesis rejects at boot with `antithesis_error code=4005 "Unsupported container type"` — the run finishes as `Incomplete` at `input_hash=0 vtime=0` about two minutes in. Setting the env var is the smallest fix. Fallback if it does not stick: pre-build the config image manually (`docker build --platform linux/amd64 -f tests/antithesis/k8s/Dockerfile.config -t <ref>:$TAG tests/antithesis/k8s && docker push <ref>:$TAG`) and pass `--config-image <ref>:$TAG` to snouty instead of `--config`.
 - **Do NOT pass `--param antithesis.images=...`** — snouty 0.5.x rejects it (`do not specify antithesis.images as --param, use api webhook instead`). In k8s mode the platform reads image refs straight out of the manifests, so the param is unnecessary anyway.
 - **Always pass `--source <branch-slug>`** so the run is *not* marked ephemeral; ephemeral runs (`is_ephemeral=true`) do not appear in property history reports. The slug is the same per-branch slug used in the tag.
 

--- a/.claude/skills/antithesis-run/SKILL.md
+++ b/.claude/skills/antithesis-run/SKILL.md
@@ -36,13 +36,12 @@ Run from the repo root (`git rev-parse --show-toplevel`). Verify:
 
 - `tests/antithesis/k8s/` (k8s mode) or `tests/antithesis/config/` (compose mode) exists. If not, abort — wrong repo.
 - `snouty --version` succeeds. If not, install per `https://github.com/antithesishq/snouty` and abort.
-- These environment variables are set in the shell:
-  - `ANTITHESIS_TENANT` (the tenant slug — `formance` for this repo; embedded in the launch URL `formance.antithesis.com`)
-  - `ANTITHESIS_API_KEY` — **required** for triage / analysis (`snouty runs …`); the launcher accepts basic auth as a fallback, but every downstream skill (`antithesis-triage`, `antithesis-query-logs`, etc.) needs the API key.
-  - `ANTITHESIS_USERNAME` + `ANTITHESIS_PASSWORD` — accepted by `snouty launch`/`snouty debug` only.
-  - `ANTITHESIS_REPOSITORY` (registry for SUT images)
-  - `ANTITHESIS_REPORT_RECIPIENT` (used as `--recipients`)
-  If any are missing, list which and abort. Run `snouty doctor` to surface what's missing in one shot.
+- These environment variables are set in the shell (abort if any **required** value is missing; run `snouty doctor` to surface everything in one shot):
+  - `ANTITHESIS_TENANT` — **required**. The tenant slug (`formance` for this repo; embedded in the launch URL `formance.antithesis.com`).
+  - `ANTITHESIS_API_KEY` — **required**. Needed by both the launcher and every downstream triage skill (`snouty runs …`, `antithesis-triage`, `antithesis-query-logs`, …).
+  - `ANTITHESIS_REPOSITORY` — **required**. Registry for SUT images.
+  - `ANTITHESIS_REPORT_RECIPIENT` — **required**. Used as `--recipients` on the run.
+  - `ANTITHESIS_USERNAME` + `ANTITHESIS_PASSWORD` — *optional* fallback. Only relevant when `ANTITHESIS_API_KEY` is absent, and only for `snouty launch`/`snouty debug` (the `runs` subcommand rejects basic auth). Do **not** abort on their absence when `ANTITHESIS_API_KEY` is set.
 - `docker info` succeeds (daemon reachable). If not, abort.
 
 Auth to `$ANTITHESIS_REPOSITORY` is set up once by the user via `docker login`; this skill does not re-do it.


### PR DESCRIPTION
## Summary

Follow-up to #1457 — captures the first real gotcha the smoke run turned up.

On Apple Silicon, `snouty launch --config <dir>` builds the config image locally without forcing `--platform linux/amd64`. On an M-series Mac this yields an arm64 image, and Antithesis rejects it at boot with:

```
WARNING: image platform (linux/arm64) does not match the expected platform (linux/amd64)
Container …/snouty-config has architecture arm64, which is not supported.
[STATUS] {"antithesis_error":{"code":4005,"message":"Unsupported container type"}}
```

The run finishes as `Incomplete` at `input_hash=0 vtime=0`, ~2 min after launch, and none of the SUT images (ledger / operator / workload — which we already build with explicit `--platform linux/amd64`) ever get a chance to boot. First hit on smoke-run `4d0fb68d6103b92dc51a175d89ccdc11-56-17`.

## Changes

- Add `export DOCKER_DEFAULT_PLATFORM=linux/amd64` immediately before `snouty launch` in the k8s workflow.
- Document the fallback (pre-build the config image with `--platform linux/amd64` and pass `--config-image` to snouty) so future-you knows the escape hatch if the env var ever stops sticking.
- Flag `ANTITHESIS_API_KEY` as **required** for the downstream triage skills (`antithesis-triage`, `antithesis-query-logs`, …) — basic auth only works for `snouty launch` / `snouty debug`.

## Test plan

- [x] Evidence pulled from `snouty runs build-logs 4d0fb68d6103b92dc51a175d89ccdc11-56-17` — arm64 architecture is the exit reason
- [ ] Next smoke run after this lands will validate the fix end-to-end (deferred: not worth another 30 min run purely for a doc change; the arm64 → amd64 flip is a well-known Docker/BuildKit behaviour)