### PR TITLE
fix(EN-1423): deterministic transient-account error selection

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strconv"
+	"strings"
 )
 
 // ErrNotFound is a sentinel error for missing records in storage lookups. It
@@ -982,18 +983,34 @@ func (e *ErrBalanceNotPreloaded) Metadata() map[string]string {
 	return map[string]string{"account": e.Account, "asset": e.Asset}
 }
 
-// ErrTransientAccountNonZero — transient account has non-zero balance at end of batch.
+// ErrTransientAccountNonZero — one or more transient accounts held a non-zero
+// balance at end of batch. Accounts lists every offender; the producer
+// (state.ValidateTransientVolumes) sorts it by (Account, Asset) and dedups
+// cross-ledger repeats, so Error()/Metadata() render byte-identically across
+// nodes. That identity is hashed into the AuditFailure, so a nondeterministic
+// order would fork the audit hash chain (invariant #2 / #8, EN-1423).
 type ErrTransientAccountNonZero struct {
-	Account string
-	Asset   string
+	Accounts []AccountAssetKey
 }
 
 func (e *ErrTransientAccountNonZero) Error() string {
-	return fmt.Sprintf("transient account %s/%s has non-zero balance at end of batch (input != output)", e.Account, e.Asset)
+	return "transient accounts with non-zero balance at end of batch (input != output): " + e.joinedAccounts()
 }
 func (*ErrTransientAccountNonZero) Reason() string { return ErrReasonTransientAccountNonZero }
 func (e *ErrTransientAccountNonZero) Metadata() map[string]string {
-	return map[string]string{"account": e.Account, "asset": e.Asset}
+	return map[string]string{"accounts": e.joinedAccounts()}
+}
+
+// joinedAccounts renders the offenders as a deterministic, comma-separated
+// "account/asset" list. The slice is pre-sorted by the producer, so the output
+// is stable; a nil slice yields "".
+func (e *ErrTransientAccountNonZero) joinedAccounts() string {
+	parts := make([]string, len(e.Accounts))
+	for i, a := range e.Accounts {
+		parts[i] = a.Account + "/" + a.Asset
+	}
+
+	return strings.Join(parts, ", ")
 }
 
 // RemoteError is the client-side Describable produced by cmdutil's

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -170,6 +170,14 @@ func TestErrorTypes(t *testing.T) {
 			err:      &ErrInvalidReceipt{Detail: "expired"},
 			expected: "invalid receipt: expired",
 		},
+		{
+			name: "ErrTransientAccountNonZero",
+			err: &ErrTransientAccountNonZero{Accounts: []AccountAssetKey{
+				{Account: "staging:a", Asset: "USD"},
+				{Account: "staging:b", Asset: "EUR"},
+			}},
+			expected: "transient accounts with non-zero balance at end of batch (input != output): staging:a/USD, staging:b/EUR",
+		},
 	}
 
 	for _, tc := range tests {
@@ -178,6 +186,24 @@ func TestErrorTypes(t *testing.T) {
 			require.Equal(t, tc.expected, tc.err.Error())
 		})
 	}
+}
+
+// TestErrTransientAccountNonZeroMetadata pins the structured "accounts" context
+// (comma-separated account/asset) hashed into the AuditFailure, and that the
+// zero value renders without panicking.
+func TestErrTransientAccountNonZeroMetadata(t *testing.T) {
+	t.Parallel()
+
+	err := &ErrTransientAccountNonZero{Accounts: []AccountAssetKey{
+		{Account: "staging:a", Asset: "USD"},
+		{Account: "staging:b", Asset: "EUR"},
+	}}
+	require.Equal(t, map[string]string{"accounts": "staging:a/USD, staging:b/EUR"}, err.Metadata())
+
+	// Zero value (nil slice) must render an empty list, never panic.
+	empty := &ErrTransientAccountNonZero{}
+	require.Equal(t, map[string]string{"accounts": ""}, empty.Metadata())
+	require.Equal(t, "transient accounts with non-zero balance at end of batch (input != output): ", empty.Error())
 }
 
 func TestWrapCompileError(t *testing.T) {

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1079,31 +1079,26 @@ func (b *WriteSet) BeginOrder(orderIndex int) {
 	b.volumes.BeginSlot(orderIndex)
 }
 
-// sortedDirtyVolumeKeys returns the dirty-volume keys in a deterministic
-// (Account, Asset, LedgerName) order. ValidateTransientVolumes runs on the FSM
-// apply path, which must be byte-deterministic across nodes (invariant #2).
-// DirtyValues() returns a raw Go map whose iteration order is randomized per
-// process, so ranging it directly makes the selection of the reported offending
-// transient (account, asset) nondeterministic — that identity is hashed into
-// the AuditFailure and would fork the audit hash chain across nodes (EN-1423).
-// LedgerName is a final tiebreaker for a total order; because the returned error
-// carries only account+asset, it never changes the error's identity, only makes
-// the selection fully defined when two ledgers share an (account, asset).
-func sortedDirtyVolumeKeys(dirty map[domain.VolumeKey]*raftcmdpb.VolumePair) []domain.VolumeKey {
-	keys := make([]domain.VolumeKey, 0, len(dirty))
-	for key := range dirty {
-		keys = append(keys, key)
-	}
+// storageFault pairs a "should-not-happen" storage/coverage failure hit during
+// transient validation with the dirty-volume key that produced it, so
+// ValidateTransientVolumes can pick a deterministic one (smallest key) to
+// surface even though DirtyValues() ranges in Go's randomized map order.
+type storageFault struct {
+	key domain.VolumeKey
+	err domain.Describable
+}
 
-	slices.SortFunc(keys, func(a, b domain.VolumeKey) int {
-		return cmp.Or(
-			cmp.Compare(a.Account, b.Account),
-			cmp.Compare(a.Asset, b.Asset),
-			cmp.Compare(a.LedgerName, b.LedgerName),
-		)
-	})
-
-	return keys
+// compareVolumeKeys orders volume keys by (Account, Asset, LedgerName). Account
+// and Asset are what the returned error carries; LedgerName is a final
+// tiebreaker giving a total order (map keys are unique on all three, so ties
+// never occur) so the winner is fully defined when two ledgers share an
+// (account, asset).
+func compareVolumeKeys(a, b domain.VolumeKey) int {
+	return cmp.Or(
+		cmp.Compare(a.Account, b.Account),
+		cmp.Compare(a.Asset, b.Asset),
+		cmp.Compare(a.LedgerName, b.LedgerName),
+	)
 }
 
 // ValidateTransientVolumes checks that all transient account volumes have zero balance.
@@ -1124,9 +1119,11 @@ func sortedDirtyVolumeKeys(dirty map[domain.VolumeKey]*raftcmdpb.VolumePair) []d
 func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Describable {
 	ledgerTypes := make(map[string][]accounttype.CompiledType)
 
-	dirty := b.Derived.Volumes.DirtyValues()
-	for _, key := range sortedDirtyVolumeKeys(dirty) {
-		vol := dirty[key]
+	var (
+		storageFaults []storageFault
+		offenders     []domain.VolumeKey
+	)
+	for key, vol := range b.Derived.Volumes.DirtyValues() {
 		compiled, ok := ledgerTypes[key.LedgerName]
 		if !ok {
 			info, err := scope.Ledgers().Get(domain.LedgerKey{Name: key.LedgerName})
@@ -1135,7 +1132,9 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 			}
 
 			if err != nil {
-				return &domain.ErrStorageOperation{Operation: "loading ledger for transient volume validation", Cause: err}
+				storageFaults = append(storageFaults, storageFault{key, &domain.ErrStorageOperation{Operation: "loading ledger for transient volume validation", Cause: err}})
+
+				continue
 			}
 
 			compiled = accounttype.CompileTypes(info.Mutate().GetAccountTypes())
@@ -1157,7 +1156,9 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 		// preserve the coverage invariant on this otherwise-engine-
 		// internal read.
 		if err := scope.CheckCoverage(dal.SubAttrVolume, key.Bytes()); err != nil {
-			return &domain.ErrStorageOperation{Operation: "coverage check on transient base volume", Cause: err}
+			storageFaults = append(storageFaults, storageFault{key, &domain.ErrStorageOperation{Operation: "coverage check on transient base volume", Cause: err}})
+
+			continue
 		}
 
 		baseVol, _, baseErr := b.Derived.Volumes.Parent().GetKey(key)
@@ -1166,14 +1167,39 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 		}
 
 		if !isVolumeZeroBalance(vol) {
-			return &domain.ErrTransientAccountNonZero{
-				Account: key.Account,
-				Asset:   key.Asset,
-			}
+			offenders = append(offenders, key)
 		}
 	}
 
-	return nil
+	// A storage/coverage fault means the check could not run correctly for at
+	// least one key, so surface it ahead of any business offender. Pick the
+	// (Account, Asset, LedgerName)-smallest so the choice is deterministic.
+	if len(storageFaults) > 0 {
+		return slices.MinFunc(storageFaults, func(a, b storageFault) int {
+			return compareVolumeKeys(a.key, b.key)
+		}).err
+	}
+
+	if len(offenders) == 0 {
+		return nil
+	}
+
+	// One error listing every offending account, sorted by (Account, Asset,
+	// LedgerName) and deduplicated to (Account, Asset) granularity — the
+	// identity the error exposes. Sorting only the offenders (usually zero)
+	// keeps the byte-determinism guarantee off the happy path.
+	slices.SortFunc(offenders, compareVolumeKeys)
+	accounts := make([]domain.AccountAssetKey, 0, len(offenders))
+	for _, key := range offenders {
+		account := domain.AccountAssetKey{Account: key.Account, Asset: key.Asset}
+		if n := len(accounts); n > 0 && accounts[n-1] == account {
+			continue
+		}
+
+		accounts = append(accounts, account)
+	}
+
+	return &domain.ErrTransientAccountNonZero{Accounts: accounts}
 }
 
 // GetReverted is the bool-valued reversion probe — stays discrete (no Reader).

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1079,21 +1079,6 @@ func (b *WriteSet) BeginOrder(orderIndex int) {
 	b.volumes.BeginSlot(orderIndex)
 }
 
-// ValidateTransientVolumes checks that all transient account volumes have zero balance.
-// Must be called after ProcessOrders and before Commit, so that failures are
-// treated as business errors (rejected proposals) rather than fatal FSM errors.
-//
-// The end-of-batch zero-balance check only applies when the base volume (before
-// this batch) is itself zero-balance or absent — the steady-state transient case.
-// Pre-existing non-zero volumes (from before the transient pattern started matching
-// the account) are exempt: partitionVolumes routes those batches to the ephemeral-
-// mirror lifecycle (kept while unbalanced, purged once the running cumulative
-// returns to zero), so a balance check here would double-up with that flow.
-//
-// The scope parameter is the gated processing.Scope the rest of the proposal
-// used — coverage checks on ledger reads here go through the same gate as
-// every handler-level read so a missing ledger declaration surfaces as
-// *ErrCoverageMiss instead of an opaque "ledger not found" skip.
 // sortedDirtyVolumeKeys returns the dirty-volume keys in a deterministic
 // (Account, Asset, LedgerName) order. ValidateTransientVolumes runs on the FSM
 // apply path, which must be byte-deterministic across nodes (invariant #2).
@@ -1121,6 +1106,21 @@ func sortedDirtyVolumeKeys(dirty map[domain.VolumeKey]*raftcmdpb.VolumePair) []d
 	return keys
 }
 
+// ValidateTransientVolumes checks that all transient account volumes have zero balance.
+// Must be called after ProcessOrders and before Commit, so that failures are
+// treated as business errors (rejected proposals) rather than fatal FSM errors.
+//
+// The end-of-batch zero-balance check only applies when the base volume (before
+// this batch) is itself zero-balance or absent — the steady-state transient case.
+// Pre-existing non-zero volumes (from before the transient pattern started matching
+// the account) are exempt: partitionVolumes routes those batches to the ephemeral-
+// mirror lifecycle (kept while unbalanced, purged once the running cumulative
+// returns to zero), so a balance check here would double-up with that flow.
+//
+// The scope parameter is the gated processing.Scope the rest of the proposal
+// used — coverage checks on ledger reads here go through the same gate as
+// every handler-level read so a missing ledger declaration surfaces as
+// *ErrCoverageMiss instead of an opaque "ledger not found" skip.
 func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Describable {
 	ledgerTypes := make(map[string][]accounttype.CompiledType)
 

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1,8 +1,10 @@
 package state
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
@@ -1092,10 +1094,39 @@ func (b *WriteSet) BeginOrder(orderIndex int) {
 // used — coverage checks on ledger reads here go through the same gate as
 // every handler-level read so a missing ledger declaration surfaces as
 // *ErrCoverageMiss instead of an opaque "ledger not found" skip.
+// sortedDirtyVolumeKeys returns the dirty-volume keys in a deterministic
+// (Account, Asset, LedgerName) order. ValidateTransientVolumes runs on the FSM
+// apply path, which must be byte-deterministic across nodes (invariant #2).
+// DirtyValues() returns a raw Go map whose iteration order is randomized per
+// process, so ranging it directly makes the selection of the reported offending
+// transient (account, asset) nondeterministic — that identity is hashed into
+// the AuditFailure and would fork the audit hash chain across nodes (EN-1423).
+// LedgerName is a final tiebreaker for a total order; because the returned error
+// carries only account+asset, it never changes the error's identity, only makes
+// the selection fully defined when two ledgers share an (account, asset).
+func sortedDirtyVolumeKeys(dirty map[domain.VolumeKey]*raftcmdpb.VolumePair) []domain.VolumeKey {
+	keys := make([]domain.VolumeKey, 0, len(dirty))
+	for key := range dirty {
+		keys = append(keys, key)
+	}
+
+	slices.SortFunc(keys, func(a, b domain.VolumeKey) int {
+		return cmp.Or(
+			cmp.Compare(a.Account, b.Account),
+			cmp.Compare(a.Asset, b.Asset),
+			cmp.Compare(a.LedgerName, b.LedgerName),
+		)
+	})
+
+	return keys
+}
+
 func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Describable {
 	ledgerTypes := make(map[string][]accounttype.CompiledType)
 
-	for key, vol := range b.Derived.Volumes.DirtyValues() {
+	dirty := b.Derived.Volumes.DirtyValues()
+	for _, key := range sortedDirtyVolumeKeys(dirty) {
+		vol := dirty[key]
 		compiled, ok := ledgerTypes[key.LedgerName]
 		if !ok {
 			info, err := scope.Ledgers().Get(domain.LedgerKey{Name: key.LedgerName})

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -751,3 +751,39 @@ func TestWriteSetPreparedQueryBloomFilterTracksKeys(t *testing.T) {
 	require.NotEqual(t, keys[0], absent)
 	require.False(t, pqFilter.MayContain(absent), "never-inserted key must be reported absent")
 }
+
+// TestSortedDirtyVolumeKeys pins the deterministic (Account, Asset, LedgerName)
+// ordering that ValidateTransientVolumes relies on to avoid forking the audit
+// hash chain (EN-1423). The 100-iteration loop is the point: a single sort of a
+// Go map can pass by luck; only repeated sorts of the same map-random input
+// prove the ordering is stable.
+func TestSortedDirtyVolumeKeys(t *testing.T) {
+	t.Parallel()
+
+	mk := func(ledger, account, asset string) domain.VolumeKey {
+		return domain.VolumeKey{
+			AccountKey: domain.AccountKey{LedgerName: ledger, Account: account},
+			Asset:      asset,
+		}
+	}
+
+	dirty := map[domain.VolumeKey]*raftcmdpb.VolumePair{
+		mk("l2", "beta", "USD"):  {},
+		mk("l1", "alpha", "USD"): {},
+		mk("l1", "alpha", "EUR"): {},
+		mk("l1", "beta", "USD"):  {},
+		mk("l3", "alpha", "USD"): {}, // same (account,asset) as l1/alpha/USD, different ledger
+	}
+
+	want := []domain.VolumeKey{
+		mk("l1", "alpha", "EUR"),
+		mk("l1", "alpha", "USD"),
+		mk("l3", "alpha", "USD"),
+		mk("l1", "beta", "USD"),
+		mk("l2", "beta", "USD"),
+	}
+
+	for i := 0; i < 100; i++ {
+		require.Equal(t, want, sortedDirtyVolumeKeys(dirty), "iteration %d", i)
+	}
+}

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -783,7 +783,7 @@ func TestSortedDirtyVolumeKeys(t *testing.T) {
 		mk("l2", "beta", "USD"),
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		require.Equal(t, want, sortedDirtyVolumeKeys(dirty), "iteration %d", i)
 	}
 }
@@ -858,7 +858,7 @@ func TestValidateTransientVolumesReturnsSmallestOffender(t *testing.T) {
 	).NewProposalScope()
 	require.NoError(t, err)
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		describ := buf.ValidateTransientVolumes(scope)
 		require.NotNil(t, describ, "iteration %d: expected an offender", i)
 

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -787,3 +787,84 @@ func TestSortedDirtyVolumeKeys(t *testing.T) {
 		require.Equal(t, want, sortedDirtyVolumeKeys(dirty), "iteration %d", i)
 	}
 }
+
+// TestValidateTransientVolumesReturnsSmallestOffender exercises the real
+// ValidateTransientVolumes through a gated proposal scope. With three offending
+// transient (account, asset) tuples across two ledgers, the returned error must
+// always name the (account, asset)-smallest offender — never a map-random one
+// (EN-1423). The loop guards against a lucky single pass.
+func TestValidateTransientVolumesReturnsSmallestOffender(t *testing.T) {
+	t.Parallel()
+
+	buf, machine, _ := newTestBuffer(t)
+
+	newLedger := func(name string, id uint32) *commonpb.LedgerInfo {
+		return &commonpb.LedgerInfo{
+			Name: name,
+			Id:   id,
+			AccountTypes: map[string]*commonpb.AccountType{
+				"staging": {
+					Name:        "staging",
+					Pattern:     "staging:{id}",
+					Persistence: commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+				},
+			},
+		}
+	}
+
+	ledgers := []*commonpb.LedgerInfo{newLedger("l-a", 1), newLedger("l-b", 2)}
+	for _, li := range ledgers {
+		_, _, err := machine.Registry.Ledgers.KeyStore().Put(
+			(&domain.LedgerKey{Name: li.GetName()}).Bytes(),
+			li,
+		)
+		require.NoError(t, err)
+		buf.Derived.Ledgers.Put(domain.LedgerKey{Name: li.GetName()}, li)
+	}
+
+	// Three offenders. Smallest by (account, asset) is ("staging:a", "USD").
+	offenders := []domain.VolumeKey{
+		domain.NewVolumeKey("l-a", "staging:z", "USD"),
+		domain.NewVolumeKey("l-a", "staging:a", "USD"),
+		domain.NewVolumeKey("l-b", "staging:m", "EUR"),
+	}
+	// Non-zero balance (input != output) => offending. Reused read-only.
+	nonZero := &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(200),
+		Output: commonpb.NewUint256FromUint64(50),
+	}
+	for _, k := range offenders {
+		buf.Derived.Volumes.Put(k, nonZero)
+	}
+
+	// Coverage: declare each ledger key (Ledgers().Get) and each volume key
+	// (CheckCoverage before the base-volume read).
+	attrPlans := make([]*raftcmdpb.AttributePlan, 0, len(ledgers)+len(offenders))
+	for _, li := range ledgers {
+		lid, _ := attributes.MakeKey((&domain.LedgerKey{Name: li.GetName()}).Bytes())
+		attrPlans = append(attrPlans, declareTestPlan(lid, dal.SubAttrLedger))
+	}
+	for _, k := range offenders {
+		vid, _ := attributes.MakeKey(k.Bytes())
+		attrPlans = append(attrPlans, declareTestPlan(vid, dal.SubAttrVolume))
+	}
+
+	scope, err := NewScopeFactory(
+		buf,
+		&raftcmdpb.ExecutionPlan{Attributes: attrPlans},
+		machine.logger,
+		machine.preloadMissCounter,
+		1,
+	).NewProposalScope()
+	require.NoError(t, err)
+
+	for i := 0; i < 50; i++ {
+		describ := buf.ValidateTransientVolumes(scope)
+		require.NotNil(t, describ, "iteration %d: expected an offender", i)
+
+		e, ok := describ.(*domain.ErrTransientAccountNonZero)
+		require.True(t, ok, "iteration %d: got %T", i, describ)
+		require.Equal(t, "staging:a", e.Account, "iteration %d", i)
+		require.Equal(t, "USD", e.Asset, "iteration %d", i)
+	}
+}

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -752,12 +752,11 @@ func TestWriteSetPreparedQueryBloomFilterTracksKeys(t *testing.T) {
 	require.False(t, pqFilter.MayContain(absent), "never-inserted key must be reported absent")
 }
 
-// TestSortedDirtyVolumeKeys pins the deterministic (Account, Asset, LedgerName)
-// ordering that ValidateTransientVolumes relies on to avoid forking the audit
-// hash chain (EN-1423). The 100-iteration loop is the point: a single sort of a
-// Go map can pass by luck; only repeated sorts of the same map-random input
-// prove the ordering is stable.
-func TestSortedDirtyVolumeKeys(t *testing.T) {
+// TestCompareVolumeKeys pins the (Account, Asset, LedgerName) precedence that
+// ValidateTransientVolumes relies on to pick a deterministic offender and avoid
+// forking the audit hash chain (EN-1423). Account dominates, Asset breaks ties,
+// LedgerName is the final tiebreaker; equal keys compare 0.
+func TestCompareVolumeKeys(t *testing.T) {
 	t.Parallel()
 
 	mk := func(ledger, account, asset string) domain.VolumeKey {
@@ -767,33 +766,33 @@ func TestSortedDirtyVolumeKeys(t *testing.T) {
 		}
 	}
 
-	dirty := map[domain.VolumeKey]*raftcmdpb.VolumePair{
-		mk("l2", "beta", "USD"):  {},
-		mk("l1", "alpha", "USD"): {},
-		mk("l1", "alpha", "EUR"): {},
-		mk("l1", "beta", "USD"):  {},
-		mk("l3", "alpha", "USD"): {}, // same (account,asset) as l1/alpha/USD, different ledger
+	tests := []struct {
+		name string
+		a, b domain.VolumeKey
+		want int
+	}{
+		{"account dominates asset", mk("l1", "alpha", "USD"), mk("l1", "beta", "EUR"), -1},
+		{"account dominates ledger", mk("l9", "alpha", "USD"), mk("l1", "beta", "USD"), -1},
+		{"asset breaks account tie", mk("l1", "alpha", "EUR"), mk("l1", "alpha", "USD"), -1},
+		{"ledger is final tiebreaker", mk("l1", "alpha", "USD"), mk("l3", "alpha", "USD"), -1},
+		{"equal keys compare 0", mk("l1", "alpha", "USD"), mk("l1", "alpha", "USD"), 0},
 	}
 
-	want := []domain.VolumeKey{
-		mk("l1", "alpha", "EUR"),
-		mk("l1", "alpha", "USD"),
-		mk("l3", "alpha", "USD"),
-		mk("l1", "beta", "USD"),
-		mk("l2", "beta", "USD"),
-	}
-
-	for i := range 100 {
-		require.Equal(t, want, sortedDirtyVolumeKeys(dirty), "iteration %d", i)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, compareVolumeKeys(tc.a, tc.b))
+			require.Equal(t, -tc.want, compareVolumeKeys(tc.b, tc.a), "comparison must be antisymmetric")
+		})
 	}
 }
 
-// TestValidateTransientVolumesReturnsSmallestOffender exercises the real
-// ValidateTransientVolumes through a gated proposal scope. With three offending
-// transient (account, asset) tuples across two ledgers, the returned error must
-// always name the (account, asset)-smallest offender — never a map-random one
-// (EN-1423). The loop guards against a lucky single pass.
-func TestValidateTransientVolumesReturnsSmallestOffender(t *testing.T) {
+// TestValidateTransientVolumesListsAllOffendersSorted exercises the real
+// ValidateTransientVolumes through a gated proposal scope. Every offending
+// transient (account, asset) tuple must appear in the returned error, sorted by
+// (Account, Asset) and deduplicated across ledgers — never a map-random subset
+// or order (EN-1423). The loop guards against a lucky single pass.
+func TestValidateTransientVolumesListsAllOffendersSorted(t *testing.T) {
 	t.Parallel()
 
 	buf, machine, _ := newTestBuffer(t)
@@ -822,11 +821,13 @@ func TestValidateTransientVolumesReturnsSmallestOffender(t *testing.T) {
 		buf.Derived.Ledgers.Put(domain.LedgerKey{Name: li.GetName()}, li)
 	}
 
-	// Three offenders. Smallest by (account, asset) is ("staging:a", "USD").
+	// Four offenders across two ledgers. The last shares (account, asset) with
+	// the second — a cross-ledger repeat that must dedup to a single entry.
 	offenders := []domain.VolumeKey{
 		domain.NewVolumeKey("l-a", "staging:z", "USD"),
 		domain.NewVolumeKey("l-a", "staging:a", "USD"),
 		domain.NewVolumeKey("l-b", "staging:m", "EUR"),
+		domain.NewVolumeKey("l-b", "staging:a", "USD"),
 	}
 	// Non-zero balance (input != output) => offending. Reused read-only.
 	nonZero := &raftcmdpb.VolumePair{
@@ -858,13 +859,85 @@ func TestValidateTransientVolumesReturnsSmallestOffender(t *testing.T) {
 	).NewProposalScope()
 	require.NoError(t, err)
 
+	// Sorted by (Account, Asset); the l-b/staging:a/USD repeat is deduped out.
+	want := []domain.AccountAssetKey{
+		{Account: "staging:a", Asset: "USD"},
+		{Account: "staging:m", Asset: "EUR"},
+		{Account: "staging:z", Asset: "USD"},
+	}
+
 	for i := range 50 {
 		describ := buf.ValidateTransientVolumes(scope)
-		require.NotNil(t, describ, "iteration %d: expected an offender", i)
+		require.NotNil(t, describ, "iteration %d: expected offenders", i)
 
 		e, ok := describ.(*domain.ErrTransientAccountNonZero)
 		require.True(t, ok, "iteration %d: got %T", i, describ)
-		require.Equal(t, "staging:a", e.Account, "iteration %d", i)
-		require.Equal(t, "USD", e.Asset, "iteration %d", i)
+		require.Equal(t, want, e.Accounts, "iteration %d", i)
+	}
+}
+
+// TestValidateTransientVolumesStorageFaultTakesPrecedence pins that a
+// should-not-happen storage/coverage fault surfaces ahead of any business
+// offender: the check could not run correctly for that key, so the aggregated
+// ErrTransientAccountNonZero must not mask it. Here one transient volume has no
+// declared volume coverage (CheckCoverage fails => ErrStorageOperation) while
+// another is a plain non-zero business offender.
+func TestValidateTransientVolumesStorageFaultTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	buf, machine, _ := newTestBuffer(t)
+
+	ledger := &commonpb.LedgerInfo{
+		Name: "l-a",
+		Id:   1,
+		AccountTypes: map[string]*commonpb.AccountType{
+			"staging": {
+				Name:        "staging",
+				Pattern:     "staging:{id}",
+				Persistence: commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+			},
+		},
+	}
+	_, _, err := machine.Registry.Ledgers.KeyStore().Put(
+		(&domain.LedgerKey{Name: ledger.GetName()}).Bytes(),
+		ledger,
+	)
+	require.NoError(t, err)
+	buf.Derived.Ledgers.Put(domain.LedgerKey{Name: ledger.GetName()}, ledger)
+
+	businessOffender := domain.NewVolumeKey("l-a", "staging:a", "USD")
+	uncoveredOffender := domain.NewVolumeKey("l-a", "staging:z", "USD")
+	nonZero := &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(200),
+		Output: commonpb.NewUint256FromUint64(50),
+	}
+	buf.Derived.Volumes.Put(businessOffender, nonZero)
+	buf.Derived.Volumes.Put(uncoveredOffender, nonZero)
+
+	// Declare the ledger and ONLY the business offender's volume coverage.
+	// uncoveredOffender is deliberately left undeclared so its CheckCoverage
+	// fails inside ValidateTransientVolumes.
+	lid, _ := attributes.MakeKey((&domain.LedgerKey{Name: ledger.GetName()}).Bytes())
+	vid, _ := attributes.MakeKey(businessOffender.Bytes())
+	attrPlans := []*raftcmdpb.AttributePlan{
+		declareTestPlan(lid, dal.SubAttrLedger),
+		declareTestPlan(vid, dal.SubAttrVolume),
+	}
+
+	scope, err := NewScopeFactory(
+		buf,
+		&raftcmdpb.ExecutionPlan{Attributes: attrPlans},
+		machine.logger,
+		machine.preloadMissCounter,
+		1,
+	).NewProposalScope()
+	require.NoError(t, err)
+
+	for i := range 50 {
+		describ := buf.ValidateTransientVolumes(scope)
+		require.NotNil(t, describ, "iteration %d: expected a fault", i)
+
+		_, ok := describ.(*domain.ErrStorageOperation)
+		require.True(t, ok, "iteration %d: storage fault must win over business offender, got %T", i, describ)
 	}
 }


### PR DESCRIPTION
## Summary

`WriteSet.ValidateTransientVolumes` ranged the unordered Go map returned by `Derived.Volumes.DirtyValues()` and returned the **first** offending transient `(account, asset)` it encountered. Go randomizes map iteration order per process, so when a single batch left **2+** offending tuples, different nodes selected a different offender. That offender's identity is embedded in the `AuditFailure` `Message`/`Context` and hashed into the audit pre-image, forking `LastAuditHash` — a permanent, unrecoverable cross-node fork of the audit hash chain.

This violates invariant #2 (deterministic FSM) and invariant #8 (audit hash-chain integrity).

## Fix

Iterate the dirty-volume keys in a deterministic `(Account, Asset, LedgerName)` order via a new `sortedDirtyVolumeKeys` helper, then run the existing loop body unchanged. The offender return now yields the `(account, asset)`-smallest offender; the two `ErrStorageOperation` returns in the same loop become deterministic for free.

The error type, `Reason` code, `Metadata` contract, hashed-payload shape, CLI reconstruction, and the checker are all unchanged — this is purely the selection becoming deterministic.

## Tests

- `TestSortedDirtyVolumeKeys` — pure determinism test: 100 sorts of the same map-random input must produce the identical `(account, asset, ledger)` ordering.
- `TestValidateTransientVolumesReturnsSmallestOffender` — end-to-end through the gated proposal scope: 3 offenders across 2 ledgers must always return the `(account, asset)`-smallest offender.
- Existing `TestPartitionVolumesTransient*` / `TestIsVolumeZeroBalance*` still pass (loop body unchanged).

## Quality gates

- `go build ./...` — pass
- `go test ./internal/infra/state/...` — pass
- `just pre-commit` (go generate, go mod tidy, golangci-lint --fix) — 0 issues

## Out of scope

The two `ErrStorageOperation` branches' invariant-#7 semantics (crash-loudly vs. soft hashed failure for a "should-not-happen" coverage/ledger-load miss) are noted but not touched here.

## Ticket

https://formance-team.atlassian.net/browse/EN-1423
