### PR TITLE
fix(EN-1431): allow out-of-sync recovery past durability gap check

### DIFF
--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -783,16 +783,47 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 
 	// If Pebble's durable applied index is below the WAL's first available
 	// entry, the entries needed to catch the FSM up to walSnap.Metadata.Index
-	// are gone from both Pebble and the Raft WAL. With Store.SyncWAL in the
-	// maintenance path this is unreachable in correct operation; if it
-	// triggers, something is very wrong — refuse to start rather than mask it.
+	// are gone from the Raft WAL — but that only means data loss when the
+	// entries are also missing everywhere else. Two distinct paths reach here:
+	//
+	//  1. Genuine data loss (applier status != statusOutOfSync). The maintenance
+	//     invariant (SyncWAL before Compact) was violated; Pebble's applied truly
+	//     lags the WAL and no external replica has the missing entries. Refuse
+	//     to start.
+	//
+	//  2. Crashed post-InstallSnapshot, pre-SynchronizeWithLeader (applier
+	//     status == statusOutOfSync). The follower processed a MsgSnap from the
+	//     leader: etcd-raft compacted the WAL to snapshotIndex synchronously
+	//     (node.go processReady), but the async SynchronizeWithLeader that
+	//     materialises the leader's checkpoint into Pebble had not completed
+	//     when the process died. RecoverAndReplay detected the gap
+	//     (LastAppliedIndex < SnapshotIndex) and flagged the applier
+	//     out-of-sync. This state is self-healing: processReady will re-trigger
+	//     SyncSnapshot on the next SoftState carrying a leader (node.go
+	//     ready-loop). Cap Applied to walSnap.Metadata.Index so etcd-raft can
+	//     boot — semantically consistent with State.SnapshotIndex, which
+	//     synchronizer.InstallSnapshot already set to the same value.
 	if applied+1 < walFirstIdx {
-		return fmt.Errorf(
-			"durability gap exceeds WAL retention: Pebble applied=%d, WAL firstIndex=%d, "+
-				"WAL snapshot=%d. The compaction margin was overrun before Pebble fsync'd. "+
-				"Restore from a Pebble checkpoint or contact ops",
-			applied, walFirstIdx, walSnap.Metadata.Index,
+		if node.applier.Status() != statusOutOfSync {
+			return fmt.Errorf(
+				"durability gap exceeds WAL retention: Pebble applied=%d, WAL firstIndex=%d, "+
+					"WAL snapshot=%d. The compaction margin was overrun before Pebble fsync'd. "+
+					"Restore from a Pebble checkpoint or contact ops",
+				applied, walFirstIdx, walSnap.Metadata.Index,
+			)
+		}
+
+		node.logger.WithFields(map[string]any{
+			"applied":          applied,
+			"walFirstIndex":    walFirstIdx,
+			"walSnapshotIndex": walSnap.Metadata.Index,
+		}).Errorf(
+			"Pebble applied lags WAL snapshot — previous process crashed between " +
+				"InstallSnapshot and SynchronizeWithLeader completion; applier is " +
+				"out-of-sync, will re-sync from leader",
 		)
+
+		applied = walSnap.Metadata.Index
 	}
 
 	if walSnap.Metadata.Index > applied {

--- a/internal/infra/node/recovery_test.go
+++ b/internal/infra/node/recovery_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,16 +11,11 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
-// TestRun_RefusesStartWhenGapExceedsWALRetention verifies the only hard
-// failure mode introduced by the durability fix: when Pebble's durable
-// applied index is behind the Raft WAL's first available entry, the entries
-// needed to catch the FSM up via Raft replay are gone from both Pebble and
-// the WAL. Recovery would silently lose them; the node refuses to start.
-//
-// Reaching this state requires the durability gap between
-// fsm.lastPersistedIndex and Pebble's durable applied index to exceed the
-// compaction margin between two maintenance ticks — pathological but
-// possible under sustained write bursts with a small margin.
+// TestRun_RefusesStartWhenGapExceedsWALRetention verifies that when the applier
+// is NOT out-of-sync but Pebble's applied lags the WAL's first available entry,
+// node.Run refuses to start. This is the "genuine data-loss" branch of the
+// durability guard: the maintenance invariant (SyncWAL before Compact) has been
+// violated and the missing entries exist nowhere reachable.
 func TestRun_RefusesStartWhenGapExceedsWALRetention(t *testing.T) {
 	t.Parallel()
 
@@ -56,4 +52,72 @@ func TestRun_RefusesStartWhenGapExceedsWALRetention(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "durability gap exceeds WAL retention")
 	require.Contains(t, err.Error(), "Pebble applied=0")
+}
+
+// TestRun_AllowsOutOfSyncRecoveryPastGap verifies EN-1431: when the same
+// applied<walFirstIdx condition holds AND the applier is already flagged
+// out-of-sync (RecoverAndReplay observed LastAppliedIndex < SnapshotIndex),
+// node.Run must NOT refuse to start with the durability-gap error. This is
+// the recoverable "crashed post-InstallSnapshot, pre-SynchronizeWithLeader"
+// state: WAL was compacted to snapshotIndex by etcd-raft synchronously, but
+// the async SynchronizeWithLeader did not populate Pebble before the crash.
+// The applier will re-trigger SyncSnapshot from processReady once a leader is
+// detected.
+//
+// With the minimal test setup (no NodeID, no transport, no full raft config),
+// Run either returns an error or panics further down in raft.newRaft — the
+// assertion is that whichever way it fails, the failure must NOT carry the
+// durability-gap message.
+func TestRun_AllowsOutOfSyncRecoveryPastGap(t *testing.T) {
+	t.Parallel()
+
+	setup := newTestApplierSetup(t)
+
+	entries := make([]raftpb.Entry, 5)
+	for i := range entries {
+		entries[i] = raftpb.Entry{
+			Term:  1,
+			Index: uint64(i + 1),
+			Type:  raftpb.EntryNormal,
+			Data:  []byte{byte(i)},
+		}
+	}
+
+	require.NoError(t, setup.wal.Append(raftpb.HardState{Term: 1, Vote: 1, Commit: 5}, entries))
+	require.NoError(t, setup.wal.CreateSnapshot(5, setup.confState, nil))
+	require.NoError(t, setup.wal.Compact(3))
+
+	// Flag the applier as out-of-sync, matching what RecoverAndReplay would
+	// do in production when it observes LastAppliedIndex < SnapshotIndex.
+	setup.applier.setOutOfSync()
+
+	node := &Node{
+		logger:        logging.Testing(),
+		wal:           setup.wal,
+		fsm:           setup.fsm,
+		applier:       setup.applier,
+		peerAddresses: map[uint64]ConfChangeContext{},
+	}
+	node.confState.Store(setup.confState)
+
+	var runErr error
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// Any panic that reaches here came from further down in Run
+				// (etcd-raft in the minimal test setup). It must NOT be the
+				// durability-gap panic, and it PROVES the check at node.go:789
+				// was bypassed.
+				require.NotContains(t, fmt.Sprint(r), "durability gap exceeds WAL retention")
+			}
+		}()
+
+		ready := make(chan struct{})
+		runErr = node.Run(context.Background(), ready)
+	}()
+
+	if runErr != nil {
+		require.NotContains(t, runErr.Error(), "durability gap exceeds WAL retention")
+	}
 }


### PR DESCRIPTION
## Summary

- Bypass the `node.Run` durability-gap panic when `applier.Status() == statusOutOfSync` and cap `applied` to `walSnap.Metadata.Index` so etcd-raft can boot — the applier's `processReady` loop will re-trigger `SyncSnapshot` once a leader is seen.
- Retain the panic for the genuine-data-loss branch (applier NOT out-of-sync — the original SyncWAL/Compact-invariant violation the check was designed to catch).
- Add `TestRun_AllowsOutOfSyncRecoveryPastGap` covering the recoverable path; the existing `TestRun_RefusesStartWhenGapExceedsWALRetention` continues to guard the genuine-loss branch.

## Context

Jira: [EN-1431](https://formance-team.atlassian.net/browse/EN-1431)

Full root-cause analysis in the ticket. TL;DR:

In `processReady` (`internal/infra/node/node.go:1150-1192`), when a follower receives a `MsgSnap`:
1. `synchronizer.InstallSnapshot` updates in-memory FSM state only (comment at `synchronizer.go:123` is explicit).
2. etcd-raft compacts the Raft WAL to `snapshotIndex` synchronously.
3. `applier.SyncSnapshot` is enqueued — the actual `SynchronizeWithLeader` that materialises the leader's checkpoint into Pebble runs asynchronously.

Any crash between step 2 and completion of step 3 leaves permanent unrecoverable state:
- WAL `firstIndex = snapshotIndex + 1`
- Pebble `SubGlobLastAppliedIndex = 0`

On next boot, `node.Run` (`node.go:789`) panicked with `durability gap exceeds WAL retention`. The panic guard was intended for the maintenance-loop `SyncWAL/Compact` invariant, but doesn't distinguish this recoverable transient from real data loss.

## Reproduction

Reproduced reliably in one shot on `eks-acme-dev-euw1-01` / `blockchains`:
1. Delete a follower's PVCs, let StatefulSet reprovision → fresh boot in join mode.
2. After the `Snapshot from leader applied, starting checkpoint sync` log line: `kubectl delete pod ledger-blockchains-2 --grace-period=0 --force`.
3. Pod goes into permanent `CrashLoopBackOff` with the panic.

OOM is not required — any process interruption in that window (kubelet eviction, node reboot, deploy rollout) triggers it.

## Impact

Production risk: a follower that OOMs / restarts during the `SynchronizeWithLeader` window becomes permanently unbootable, requiring manual PVC-wipe intervention. A rolling deploy while any follower is mid-sync could take down multiple nodes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/infra/node/...` — full node package suite passes
- [x] `TestRun_RefusesStartWhenGapExceedsWALRetention` still passes (genuine-loss branch preserved)
- [x] New `TestRun_AllowsOutOfSyncRecoveryPastGap` verifies the recoverable branch bypasses the panic
- [x] `golangci-lint run ./internal/infra/node/...` clean
- [ ] Re-run the k8s repro on `eks-acme-dev-euw1-01` blockchains against a build of this branch to verify end-to-end recovery

## Follow-ups (out of scope here)

- The error message ("compaction margin was overrun before Pebble fsync'd", "Restore from a Pebble checkpoint or contact ops") is misleading for the genuine-loss case too when the underlying trigger is InstallSnapshot-related. Worth a separate small PR to differentiate.
- Consider whether `WAL.ApplySnapshot` should be deferred until `SynchronizeWithLeader` completes + fsyncs Pebble, closing the window entirely rather than making the state recoverable after the fact. Larger refactor touching etcd-raft interaction.

[EN-1431]: https://formance-team.atlassian.net/browse/EN-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ