### PR TITLE
refactor(EN-1427): factor shared tail-worker skeleton (cursor, loop, gauges)

### DIFF
--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -12,7 +12,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
-	"github.com/formancehq/ledger/v3/internal/pkg/worker"
+	"github.com/formancehq/ledger/v3/internal/pkg/tailworker"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
@@ -62,8 +62,8 @@ type Indexer struct {
 	// Updated on each tick by lastAuditSequence(); used only for metric gauges.
 	auditLast atomic.Uint64
 
-	// w manages the background goroutine lifecycle.
-	w worker.Worker
+	// tw drives the steady-state tail loop (boot + ticker).
+	tw *tailworker.TailWorker
 
 	// reg is the OTEL metric registration; unregistered on Stop.
 	reg metric.Registration
@@ -269,11 +269,17 @@ func (i *Indexer) Start() {
 
 		return
 	}
-	if reg, err := i.registerMetrics(); err == nil {
+	if reg, err := tailworker.RegisterTailGauges(i.meter, "audit_index", "audit", &i.lastIndexed, &i.auditLast); err == nil {
 		i.reg = reg
 	}
-	i.w = worker.New()
-	i.w.RunCtx(i.loop)
+	i.tw = tailworker.New(tailworker.Config{
+		Name:   "audit-indexer",
+		Logger: i.logger,
+		Ticker: TickInterval,
+		Boot:   i.boot,
+		Tick:   i.processTick,
+	})
+	i.tw.Start()
 }
 
 // Stop halts the loop and unregisters metrics.
@@ -281,18 +287,21 @@ func (i *Indexer) Stop() {
 	if i.cfg.Disabled {
 		return
 	}
-	i.w.Stop()
+	i.tw.Stop()
 	if i.reg != nil {
 		_ = i.reg.Unregister()
 	}
 }
 
-func (i *Indexer) loop(ctx context.Context) {
+// boot runs once before the tail loop: it seeds the audit-head gauge and, when
+// the persisted cursor is missing / lagging beyond threshold / ahead of the
+// head, performs a full drop+rebuild. A cursor read error aborts the loop
+// (returned to tailworker, which logs and stops); a rebuild error is logged
+// and swallowed so steady-state indexing still starts.
+func (i *Indexer) boot(ctx context.Context) error {
 	cursor, err := i.readStore.ReadAuditProgress()
 	if err != nil {
-		i.logger.Errorf("read audit cursor: %v", err)
-
-		return
+		return fmt.Errorf("read audit cursor: %w", err)
 	}
 	if last, err := i.lastAuditSequence(); err == nil {
 		i.auditLast.Store(last)
@@ -304,18 +313,7 @@ func (i *Indexer) loop(ctx context.Context) {
 		}
 	}
 
-	ticker := time.NewTicker(TickInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		if err := i.processTick(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			i.logger.Errorf("audit indexing: %v", err)
-		}
-	}
+	return nil
 }
 
 // processTick runs one steady-state iteration: refresh the audit-head gauge,
@@ -345,32 +343,4 @@ func (i *Indexer) processTick(ctx context.Context) error {
 	_, err := i.ProcessOnce(ctx)
 
 	return err
-}
-
-func (i *Indexer) registerMetrics() (metric.Registration, error) {
-	indexed, err := i.meter.Int64ObservableGauge("audit_index.last_indexed_sequence",
-		metric.WithDescription("Last audit sequence indexed"))
-	if err != nil {
-		return nil, err
-	}
-	last, err := i.meter.Int64ObservableGauge("audit_index.audit_last_sequence",
-		metric.WithDescription("Last audit sequence in the store"))
-	if err != nil {
-		return nil, err
-	}
-	lag, err := i.meter.Int64ObservableGauge("audit_index.lag",
-		metric.WithDescription("Audit entries the index is behind"))
-	if err != nil {
-		return nil, err
-	}
-
-	return i.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		idx := int64(i.lastIndexed.Load())
-		al := int64(i.auditLast.Load())
-		o.ObserveInt64(indexed, idx)
-		o.ObserveInt64(last, al)
-		o.ObserveInt64(lag, max(al-idx, 0))
-
-		return nil
-	}, indexed, last, lag)
 }

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -367,7 +367,9 @@ func (b *Builder) SetNotifications(n *signal.Notifications) {
 
 // Start begins the background index-building loop and registers OTEL metrics.
 func (b *Builder) Start() {
-	_ = b.registerMetrics()
+	if err := b.registerMetrics(); err != nil {
+		b.logger.Errorf("register index builder metrics: %v", err)
+	}
 
 	b.w = worker.New()
 	b.w.RunCtx(b.loop)

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/pkg/signal"
+	"github.com/formancehq/ledger/v3/internal/pkg/tailworker"
 	"github.com/formancehq/ledger/v3/internal/pkg/worker"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/query"
@@ -38,10 +39,11 @@ type Builder struct {
 	notifications *signal.Notifications
 	w             worker.Worker
 
-	lastIndexedSeq      atomic.Uint64
-	pebbleLastSeq       atomic.Uint64
-	logsIndexed         atomic.Uint64
-	metricsRegistration metric.Registration
+	lastIndexedSeq          atomic.Uint64
+	pebbleLastSeq           atomic.Uint64
+	logsIndexed             atomic.Uint64
+	metricsRegistration     metric.Registration // tailworker gauge triplet
+	logsIndexedRegistration metric.Registration // builder-specific logs_indexed_total gauge
 
 	// Per-ledger index configuration cache.
 	indexConfig map[string]*ledgerIndexConfig
@@ -365,9 +367,7 @@ func (b *Builder) SetNotifications(n *signal.Notifications) {
 
 // Start begins the background index-building loop and registers OTEL metrics.
 func (b *Builder) Start() {
-	if reg, err := b.registerMetrics(); err == nil {
-		b.metricsRegistration = reg
-	}
+	_ = b.registerMetrics()
 
 	b.w = worker.New()
 	b.w.RunCtx(b.loop)
@@ -379,6 +379,9 @@ func (b *Builder) Stop() {
 
 	if b.metricsRegistration != nil {
 		_ = b.metricsRegistration.Unregister()
+	}
+	if b.logsIndexedRegistration != nil {
+		_ = b.logsIndexedRegistration.Unregister()
 	}
 }
 
@@ -392,59 +395,38 @@ func (b *Builder) PebbleLastSequence() uint64 {
 	return b.pebbleLastSeq.Load()
 }
 
-// registerMetrics registers observable gauges for index builder progress.
-func (b *Builder) registerMetrics() (metric.Registration, error) {
-	lastIndexedGauge, err := b.meter.Int64ObservableGauge(
-		"index.builder.last_indexed_sequence",
-		metric.WithDescription("Last log sequence indexed in Pebble read store"),
-	)
+// registerMetrics registers the shared tail-worker progress gauges plus the
+// builder-specific logs_indexed_total counter-gauge. Two registrations are
+// stored on the receiver so Stop can unregister both.
+func (b *Builder) registerMetrics() error {
+	triplet, err := tailworker.RegisterTailGauges(b.meter, "index.builder", "pebble", &b.lastIndexedSeq, &b.pebbleLastSeq)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	pebbleLastGauge, err := b.meter.Int64ObservableGauge(
-		"index.builder.pebble_last_sequence",
-		metric.WithDescription("Last log sequence in Pebble"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	lagGauge, err := b.meter.Int64ObservableGauge(
-		"index.builder.lag",
-		metric.WithDescription("Number of logs the index builder is behind Pebble"),
-	)
-	if err != nil {
-		return nil, err
-	}
+	b.metricsRegistration = triplet
 
 	logsIndexedGauge, err := b.meter.Int64ObservableGauge(
 		"index.builder.logs_indexed_total",
 		metric.WithDescription("Total number of logs indexed since process start"),
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return b.meter.RegisterCallback(
+	reg, err := b.meter.RegisterCallback(
 		func(_ context.Context, o metric.Observer) error {
-			indexed := int64(b.lastIndexedSeq.Load())
-			pebbleLast := int64(b.pebbleLastSeq.Load())
-
-			lag := max(pebbleLast-indexed, 0)
-
-			o.ObserveInt64(lastIndexedGauge, indexed)
-			o.ObserveInt64(pebbleLastGauge, pebbleLast)
-			o.ObserveInt64(lagGauge, lag)
 			o.ObserveInt64(logsIndexedGauge, int64(b.logsIndexed.Load()))
 
 			return nil
 		},
-		lastIndexedGauge,
-		pebbleLastGauge,
-		lagGauge,
 		logsIndexedGauge,
 	)
+	if err != nil {
+		return err
+	}
+	b.logsIndexedRegistration = reg
+
+	return nil
 }
 
 func (b *Builder) loop(ctx context.Context) {

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -450,8 +450,12 @@ func (b *Builder) loop(ctx context.Context) {
 
 	b.lastIndexedSeq.Store(cursor)
 
-	// Recover AppliedProposal sync progress.
-	if seq, err := b.readStore.ReadAppliedProposalProgress(); err == nil {
+	// Recover AppliedProposal sync progress. A corrupt cursor surfaces loudly
+	// and falls back to a full re-sync from 0 (the projection is rebuildable),
+	// rather than aborting the whole builder.
+	if seq, err := b.readStore.ReadAppliedProposalProgress(); err != nil {
+		b.logger.Errorf("read applied-proposal cursor (re-syncing from 0): %v", err)
+	} else {
 		b.lastAppliedProposalSeq = seq
 	}
 

--- a/internal/infra/monitoring/metrics/registry_test.go
+++ b/internal/infra/monitoring/metrics/registry_test.go
@@ -126,6 +126,12 @@ func collectInstrumentNamesFromCode(t *testing.T, root string) []string {
 	pattern := regexp.MustCompile(
 		`\.` + "(" + strings.Join(instrumentMethods, "|") + ")" + `\(\s*"([^"]+)"`,
 	)
+	// tailworker.RegisterTailGauges(meter, ns, source, ...) creates its three
+	// instruments with names built from the ns/source literals rather than a
+	// single literal at the Int64ObservableGauge call site, so the pattern
+	// above cannot see them. Expand each call site into the triplet it emits:
+	// {ns}.last_indexed_sequence, {ns}.{source}_last_sequence, {ns}.lag.
+	tailGaugePattern := regexp.MustCompile(`RegisterTailGauges\([^,]+,\s*"([^"]+)"\s*,\s*"([^"]+)"`)
 	seen := make(map[string]struct{})
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -150,6 +156,14 @@ func collectInstrumentNamesFromCode(t *testing.T, root string) []string {
 			if name != "" {
 				seen[name] = struct{}{}
 			}
+		}
+
+		for _, m := range tailGaugePattern.FindAllSubmatch(data, -1) {
+			ns := string(m[1])
+			source := string(m[2])
+			seen[ns+".last_indexed_sequence"] = struct{}{}
+			seen[ns+"."+source+"_last_sequence"] = struct{}{}
+			seen[ns+".lag"] = struct{}{}
 		}
 
 		return nil

--- a/internal/pkg/tailworker/gauges.go
+++ b/internal/pkg/tailworker/gauges.go
@@ -1,0 +1,54 @@
+package tailworker
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// computeLag returns how far indexed trails sourceLast, clamped at 0 so a
+// momentarily-ahead indexed cursor never reports a negative lag.
+func computeLag(indexed, sourceLast uint64) int64 {
+	return max(int64(sourceLast)-int64(indexed), 0)
+}
+
+// RegisterTailGauges registers the standard tail-worker progress gauges under
+// the given namespace and returns the registration (Unregister on Stop):
+//
+//	{ns}.last_indexed_sequence   - indexed.Load()
+//	{ns}.{source}_last_sequence  - sourceLast.Load()
+//	{ns}.lag                     - max(sourceLast-indexed, 0)
+//
+// source names the upstream sequence (e.g. "audit", "pebble") so the middle
+// gauge preserves each worker's established metric name.
+func RegisterTailGauges(meter metric.Meter, ns, source string, indexed, sourceLast *atomic.Uint64) (metric.Registration, error) {
+	indexedGauge, err := meter.Int64ObservableGauge(ns+".last_indexed_sequence",
+		metric.WithDescription("Last sequence indexed"))
+	if err != nil {
+		return nil, err
+	}
+
+	sourceGauge, err := meter.Int64ObservableGauge(fmt.Sprintf("%s.%s_last_sequence", ns, source),
+		metric.WithDescription("Last sequence available upstream"))
+	if err != nil {
+		return nil, err
+	}
+
+	lagGauge, err := meter.Int64ObservableGauge(ns+".lag",
+		metric.WithDescription("Sequences the worker is behind upstream"))
+	if err != nil {
+		return nil, err
+	}
+
+	return meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		idx := indexed.Load()
+		src := sourceLast.Load()
+		o.ObserveInt64(indexedGauge, int64(idx))
+		o.ObserveInt64(sourceGauge, int64(src))
+		o.ObserveInt64(lagGauge, computeLag(idx, src))
+
+		return nil
+	}, indexedGauge, sourceGauge, lagGauge)
+}

--- a/internal/pkg/tailworker/gauges_test.go
+++ b/internal/pkg/tailworker/gauges_test.go
@@ -1,0 +1,51 @@
+package tailworker
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestComputeLag(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int64(5), computeLag(3, 8))
+	require.Equal(t, int64(0), computeLag(8, 8))
+	require.Equal(t, int64(0), computeLag(10, 8), "indexed ahead of source clamps to 0")
+}
+
+func TestRegisterTailGaugesObserves(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := provider.Meter("test")
+
+	var indexed, sourceLast atomic.Uint64
+	indexed.Store(3)
+	sourceLast.Store(8)
+
+	reg, err := RegisterTailGauges(meter, "widget", "source", &indexed, &sourceLast)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reg.Unregister() })
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			g, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok, "metric %s must be an int64 gauge", m.Name)
+			got[m.Name] = g.DataPoints[0].Value
+		}
+	}
+
+	require.Equal(t, int64(3), got["widget.last_indexed_sequence"])
+	require.Equal(t, int64(8), got["widget.source_last_sequence"])
+	require.Equal(t, int64(5), got["widget.lag"])
+}

--- a/internal/pkg/tailworker/tailworker.go
+++ b/internal/pkg/tailworker/tailworker.go
@@ -53,7 +53,10 @@ func (t *TailWorker) Start() {
 	t.w.RunCtx(t.loop)
 }
 
-// Stop signals the loop to stop and waits for it to finish.
+// Stop signals the loop to stop and waits for it to finish. It must only be
+// called after Start (mirrors worker.Worker): calling it on a TailWorker that
+// was never started panics on a nil channel close. Consumers that start
+// conditionally must guard Stop with the same condition.
 func (t *TailWorker) Stop() {
 	t.w.Stop()
 }

--- a/internal/pkg/tailworker/tailworker.go
+++ b/internal/pkg/tailworker/tailworker.go
@@ -1,0 +1,87 @@
+// Package tailworker provides the shared skeleton for background workers that
+// tail an append-only sequence: a Start/Stop lifecycle around a ticker loop
+// with an optional wake signal, plus a helper for the standard progress/lag
+// OTEL gauges. It carries no storage dependency (see readstore.Uint64Cursor
+// for the persisted progress cursor).
+package tailworker
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/worker"
+)
+
+// Config parameterises a TailWorker.
+type Config struct {
+	// Name identifies the worker in log messages.
+	Name string
+	// Logger is used for boot and steady-state error logging.
+	Logger logging.Logger
+	// Ticker is the steady-state polling interval.
+	Ticker time.Duration
+	// Wake, when non-nil, triggers an extra Tick as soon as it receives.
+	// A nil channel is never selectable, so leaving it nil yields a
+	// pure-ticker loop with no special-casing.
+	Wake <-chan struct{}
+	// Boot runs once before the ticker starts. A non-nil error aborts the
+	// loop (the worker does no further work). Optional.
+	Boot func(context.Context) error
+	// Tick runs once per ticker fire and per Wake signal. A context.Canceled
+	// error is swallowed (expected on shutdown); any other error is logged
+	// and the loop continues.
+	Tick func(context.Context) error
+}
+
+// TailWorker runs Config.Tick on a ticker (and optional wake) until Stop.
+type TailWorker struct {
+	cfg Config
+	w   worker.Worker
+}
+
+// New constructs a TailWorker. It does not start any goroutine.
+func New(cfg Config) *TailWorker {
+	return &TailWorker{cfg: cfg}
+}
+
+// Start launches the background loop.
+func (t *TailWorker) Start() {
+	t.w = worker.New()
+	t.w.RunCtx(t.loop)
+}
+
+// Stop signals the loop to stop and waits for it to finish.
+func (t *TailWorker) Stop() {
+	t.w.Stop()
+}
+
+func (t *TailWorker) loop(ctx context.Context) {
+	if t.cfg.Boot != nil {
+		if err := t.cfg.Boot(ctx); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				t.cfg.Logger.Errorf("%s boot: %v", t.cfg.Name, err)
+			}
+
+			return
+		}
+	}
+
+	ticker := time.NewTicker(t.cfg.Ticker)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		case <-t.cfg.Wake:
+		}
+
+		if err := t.cfg.Tick(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.cfg.Logger.Errorf("%s tick: %v", t.cfg.Name, err)
+		}
+	}
+}

--- a/internal/pkg/tailworker/tailworker.go
+++ b/internal/pkg/tailworker/tailworker.go
@@ -25,7 +25,9 @@ type Config struct {
 	Ticker time.Duration
 	// Wake, when non-nil, triggers an extra Tick as soon as it receives.
 	// A nil channel is never selectable, so leaving it nil yields a
-	// pure-ticker loop with no special-casing.
+	// pure-ticker loop with no special-casing. Do not close Wake: a closed
+	// channel is always selectable and would spin the loop, calling Tick
+	// continuously.
 	Wake <-chan struct{}
 	// Boot runs once before the ticker starts. A non-nil error aborts the
 	// loop (the worker does no further work). Optional.
@@ -38,8 +40,9 @@ type Config struct {
 
 // TailWorker runs Config.Tick on a ticker (and optional wake) until Stop.
 type TailWorker struct {
-	cfg Config
-	w   worker.Worker
+	cfg     Config
+	w       worker.Worker
+	started bool
 }
 
 // New constructs a TailWorker. It does not start any goroutine.
@@ -50,14 +53,18 @@ func New(cfg Config) *TailWorker {
 // Start launches the background loop.
 func (t *TailWorker) Start() {
 	t.w = worker.New()
+	t.started = true
 	t.w.RunCtx(t.loop)
 }
 
-// Stop signals the loop to stop and waits for it to finish. It must only be
-// called after Start (mirrors worker.Worker): calling it on a TailWorker that
-// was never started panics on a nil channel close. Consumers that start
-// conditionally must guard Stop with the same condition.
+// Stop signals the loop to stop and waits for it to finish. It is a no-op on a
+// TailWorker that was never started, so consumers that start conditionally do
+// not need to mirror the condition around Stop.
 func (t *TailWorker) Stop() {
+	if !t.started {
+		return
+	}
+
 	t.w.Stop()
 }
 

--- a/internal/pkg/tailworker/tailworker_test.go
+++ b/internal/pkg/tailworker/tailworker_test.go
@@ -1,0 +1,128 @@
+package tailworker
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func testLogger() logging.Logger { return logging.NopZap() }
+
+func TestBootRunsOnceThenTicks(t *testing.T) {
+	t.Parallel()
+
+	var boots, ticks atomic.Int32
+
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: 5 * time.Millisecond,
+		Boot:   func(context.Context) error { boots.Add(1); return nil },
+		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+	})
+	tw.Start()
+	t.Cleanup(tw.Stop)
+
+	require.Eventually(t, func() bool { return ticks.Load() >= 3 }, time.Second, 5*time.Millisecond)
+	require.Equal(t, int32(1), boots.Load(), "Boot must run exactly once")
+}
+
+func TestBootErrorAbortsLoop(t *testing.T) {
+	t.Parallel()
+
+	var ticks atomic.Int32
+
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: 5 * time.Millisecond,
+		Boot:   func(context.Context) error { return errors.New("boom") },
+		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+	})
+	tw.Start()
+	t.Cleanup(tw.Stop)
+
+	require.Never(t, func() bool { return ticks.Load() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestTickCanceledErrorSwallowedOthersContinue(t *testing.T) {
+	t.Parallel()
+
+	var ticks atomic.Int32
+
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: 5 * time.Millisecond,
+		Tick: func(context.Context) error {
+			ticks.Add(1)
+			return errors.New("transient")
+		},
+	})
+	tw.Start()
+	t.Cleanup(tw.Stop)
+
+	require.Eventually(t, func() bool { return ticks.Load() >= 3 }, time.Second, 5*time.Millisecond)
+}
+
+func TestWakeTriggersTick(t *testing.T) {
+	t.Parallel()
+
+	wake := make(chan struct{}, 1)
+	var ticks atomic.Int32
+
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: time.Hour,
+		Wake:   wake,
+		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+	})
+	tw.Start()
+	t.Cleanup(tw.Stop)
+
+	wake <- struct{}{}
+	require.Eventually(t, func() bool { return ticks.Load() >= 1 }, time.Second, 5*time.Millisecond)
+}
+
+func TestStopReturnsWhileTickBlocksOnCtx(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{}, 1)
+
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: 5 * time.Millisecond,
+		Tick: func(ctx context.Context) error {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	tw.Start()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("Tick never ran")
+	}
+
+	done := make(chan struct{})
+	go func() { tw.Stop(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return — ctx not propagated to Tick")
+	}
+}

--- a/internal/pkg/tailworker/tailworker_test.go
+++ b/internal/pkg/tailworker/tailworker_test.go
@@ -23,8 +23,14 @@ func TestBootRunsOnceThenTicks(t *testing.T) {
 		Name:   "test",
 		Logger: testLogger(),
 		Ticker: 5 * time.Millisecond,
-		Boot:   func(context.Context) error { boots.Add(1); return nil },
-		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+		Boot: func(context.Context) error {
+			boots.Add(1)
+			return nil
+		},
+		Tick: func(context.Context) error {
+			ticks.Add(1)
+			return nil
+		},
 	})
 	tw.Start()
 	t.Cleanup(tw.Stop)
@@ -43,7 +49,10 @@ func TestBootErrorAbortsLoop(t *testing.T) {
 		Logger: testLogger(),
 		Ticker: 5 * time.Millisecond,
 		Boot:   func(context.Context) error { return errors.New("boom") },
-		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+		Tick: func(context.Context) error {
+			ticks.Add(1)
+			return nil
+		},
 	})
 	tw.Start()
 	t.Cleanup(tw.Stop)
@@ -62,6 +71,7 @@ func TestTickCanceledErrorSwallowedOthersContinue(t *testing.T) {
 		Ticker: 5 * time.Millisecond,
 		Tick: func(context.Context) error {
 			ticks.Add(1)
+
 			return errors.New("transient")
 		},
 	})
@@ -82,7 +92,10 @@ func TestWakeTriggersTick(t *testing.T) {
 		Logger: testLogger(),
 		Ticker: time.Hour,
 		Wake:   wake,
-		Tick:   func(context.Context) error { ticks.Add(1); return nil },
+		Tick: func(context.Context) error {
+			ticks.Add(1)
+			return nil
+		},
 	})
 	tw.Start()
 	t.Cleanup(tw.Stop)
@@ -106,6 +119,7 @@ func TestStopReturnsWhileTickBlocksOnCtx(t *testing.T) {
 			default:
 			}
 			<-ctx.Done()
+
 			return ctx.Err()
 		},
 	})

--- a/internal/pkg/tailworker/tailworker_test.go
+++ b/internal/pkg/tailworker/tailworker_test.go
@@ -25,10 +25,12 @@ func TestBootRunsOnceThenTicks(t *testing.T) {
 		Ticker: 5 * time.Millisecond,
 		Boot: func(context.Context) error {
 			boots.Add(1)
+
 			return nil
 		},
 		Tick: func(context.Context) error {
 			ticks.Add(1)
+
 			return nil
 		},
 	})
@@ -51,6 +53,7 @@ func TestBootErrorAbortsLoop(t *testing.T) {
 		Boot:   func(context.Context) error { return errors.New("boom") },
 		Tick: func(context.Context) error {
 			ticks.Add(1)
+
 			return nil
 		},
 	})
@@ -94,6 +97,7 @@ func TestWakeTriggersTick(t *testing.T) {
 		Wake:   wake,
 		Tick: func(context.Context) error {
 			ticks.Add(1)
+
 			return nil
 		},
 	})

--- a/internal/storage/readstore/audit_index.go
+++ b/internal/storage/readstore/audit_index.go
@@ -2,7 +2,6 @@ package readstore
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -12,29 +11,12 @@ import (
 
 // ReadAuditProgress returns the last indexed audit sequence (0 if unset).
 func (s *Store) ReadAuditProgress() (uint64, error) {
-	v, closer, err := s.db.Get(AuditProgressKey())
-	if err != nil {
-		if errors.Is(err, pebble.ErrNotFound) {
-			return 0, nil
-		}
-
-		return 0, fmt.Errorf("reading audit progress: %w", err)
-	}
-	defer func() { _ = closer.Close() }()
-
-	if len(v) != 8 {
-		return 0, fmt.Errorf("audit progress: unexpected length %d", len(v))
-	}
-
-	return binary.BigEndian.Uint64(v), nil
+	return auditCursor.Read(s.db)
 }
 
 // WriteAuditProgress persists the audit indexing cursor in the batch.
 func (s *Store) WriteAuditProgress(batch *dal.WriteSession, sequence uint64) error {
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], sequence)
-
-	return batch.SetBytes(AuditProgressKey(), buf[:])
+	return auditCursor.Write(batch, sequence)
 }
 
 // DropAuditIndexInBatch stages deletion of every audit-index key (but NOT the

--- a/internal/storage/readstore/cursor.go
+++ b/internal/storage/readstore/cursor.go
@@ -1,0 +1,55 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// Uint64Cursor is a fixed-key big-endian uint64 progress cursor persisted in
+// the read store. It centralises the BE8 encode/decode, the ErrNotFound-as-0
+// mapping, and the length guard shared by every tail-worker progress cursor
+// (log index, applied-proposal, audit). A missing key reads as 0; a stored
+// value whose length is not 8 bytes is a hard error (corruption), never a
+// silent 0 — collapsing it would strand the worker at a bogus position.
+type Uint64Cursor struct{ key []byte }
+
+// Read returns the stored cursor, or 0 if the key is absent.
+func (c Uint64Cursor) Read(r dal.PebbleGetter) (uint64, error) {
+	v, closer, err := r.Get(c.key)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return 0, nil
+		}
+
+		return 0, fmt.Errorf("reading cursor %q: %w", c.key, err)
+	}
+
+	defer func() { _ = closer.Close() }()
+
+	if len(v) != 8 {
+		return 0, fmt.Errorf("cursor %q: unexpected length %d", c.key, len(v))
+	}
+
+	return binary.BigEndian.Uint64(v), nil
+}
+
+// Write stages the cursor value into batch as a big-endian 8-byte value.
+func (c Uint64Cursor) Write(batch *dal.WriteSession, sequence uint64) error {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], sequence)
+
+	return batch.SetBytes(c.key, buf[:])
+}
+
+// Package-level cursors, one per persisted progress key. Keys are unchanged
+// from the pre-refactor methods, so no on-disk migration is required.
+var (
+	progressCursor        = Uint64Cursor{key: ProgressKey()}
+	appliedProposalCursor = Uint64Cursor{key: AppliedProposalProgressKey()}
+	auditCursor           = Uint64Cursor{key: AuditProgressKey()}
+)

--- a/internal/storage/readstore/cursor_test.go
+++ b/internal/storage/readstore/cursor_test.go
@@ -1,0 +1,42 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUint64CursorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	c := Uint64Cursor{key: []byte("test-cursor-key")}
+
+	got, err := c.Read(s.db)
+	require.NoError(t, err)
+	require.Zero(t, got, "missing key reads as 0")
+
+	batch := s.NewBatch()
+	require.NoError(t, c.Write(batch, 42))
+	require.NoError(t, batch.Commit())
+
+	got, err = c.Read(s.db)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), got)
+}
+
+func TestUint64CursorCorruptLength(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	c := Uint64Cursor{key: []byte("corrupt-cursor-key")}
+
+	// The read store opens Pebble with DisableWAL, so writes must use NoSync;
+	// pebble.Sync would return "WAL disabled". NoSync is the same option the
+	// store's own direct-DB writes (DeleteBackfillProgress) use.
+	require.NoError(t, s.db.Set(c.key, []byte{1, 2, 3}, pebble.NoSync))
+
+	_, err := c.Read(s.db)
+	require.Error(t, err, "a non-8-byte value must be a hard error, not silently 0")
+}

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -41,8 +41,6 @@ func DefaultConfig() Config {
 	}
 }
 
-var progressKey = ProgressKey()
-
 // Store wraps a Pebble database for the read-side inverted indexes.
 // It is safe for concurrent use: Pebble supports concurrent readers
 // and writers without a global write lock.
@@ -194,30 +192,12 @@ func (s *Store) Path() string {
 // ReadProgress returns the last indexed log sequence from the progress key.
 // Returns 0 if no progress has been recorded.
 func (s *Store) ReadProgress() (uint64, error) {
-	v, closer, err := s.db.Get(progressKey)
-	if err != nil {
-		if errors.Is(err, pebble.ErrNotFound) {
-			return 0, nil
-		}
-
-		return 0, fmt.Errorf("reading progress: %w", err)
-	}
-
-	defer func() { _ = closer.Close() }()
-
-	if len(v) != 8 {
-		return 0, fmt.Errorf("corrupt progress value: expected 8 bytes, got %d", len(v))
-	}
-
-	return binary.BigEndian.Uint64(v), nil
+	return progressCursor.Read(s.db)
 }
 
 // WriteProgress stores the last indexed log sequence.
 func (s *Store) WriteProgress(batch *dal.WriteSession, sequence uint64) error {
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], sequence)
-
-	return batch.SetBytes(progressKey, buf[:])
+	return progressCursor.Write(batch, sequence)
 }
 
 // LastIndexedSequence returns the last indexed log sequence (read-only).
@@ -234,30 +214,12 @@ func (s *Store) NotifyProgress() {
 // ReadAppliedProposalProgress returns the last consumed AppliedProposal
 // sequence. Returns 0 if no progress has been recorded yet.
 func (s *Store) ReadAppliedProposalProgress() (uint64, error) {
-	v, closer, err := s.db.Get(AppliedProposalProgressKey())
-	if err != nil {
-		if errors.Is(err, pebble.ErrNotFound) {
-			return 0, nil
-		}
-
-		return 0, fmt.Errorf("reading applied proposal progress: %w", err)
-	}
-
-	defer func() { _ = closer.Close() }()
-
-	if len(v) != 8 {
-		return 0, nil
-	}
-
-	return binary.BigEndian.Uint64(v), nil
+	return appliedProposalCursor.Read(s.db)
 }
 
 // WriteAppliedProposalProgress stores the last consumed AppliedProposal sequence.
 func (s *Store) WriteAppliedProposalProgress(batch *dal.WriteSession, sequence uint64) error {
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], sequence)
-
-	return batch.SetBytes(AppliedProposalProgressKey(), buf[:])
+	return appliedProposalCursor.Write(batch, sequence)
 }
 
 // WriteBackfillProgress stores a backfill cursor.


### PR DESCRIPTION
## What

Extracts the three mechanical concerns duplicated between the two tail-workers (`indexbuilder.Builder`, `auditindexer.Indexer`) into reusable bricks, ahead of a third consumer (usage-builder, WIP). Follow-up of [EN-1339](https://formance-team.atlassian.net/browse/EN-1339) / #1446.

Jira: https://formance-team.atlassian.net/browse/EN-1427

## The bricks

1. **`readstore.Uint64Cursor`** (`internal/storage/readstore/cursor.go`) — centralises the BE8 encode/decode + `ErrNotFound→0` + `len!=8` guard shared by the log-index / applied-proposal / audit progress cursors. The existing `Store.Read*Progress`/`Write*Progress` methods become one-line delegators, so **zero call-site churn**.
2. **`tailworker.TailWorker`** (`internal/pkg/tailworker/tailworker.go`) — the `Start`/`Stop` + boot + ticker loop (optional wake channel, `context.Canceled` suppression). Dependency-light: no pebble/dal.
3. **`tailworker.RegisterTailGauges`** (`internal/pkg/tailworker/gauges.go`) — the `{ns}.last_indexed_sequence` / `{ns}.{source}_last_sequence` / `{ns}.lag` triplet.

## Adoption

- **`auditindexer.Indexer`** fully ported onto `TailWorker` + `RegisterTailGauges` (dropped its private `worker.Worker`, `loop`, `registerMetrics`) — ~−30 LOC net, behaviour preserved.
- **`indexbuilder.Builder`** keeps its bespoke two-phase loop (catch-up + backfill/schema-rewrite scheduling); only its gauge triplet is routed through the helper, with the extra `logs_indexed_total` gauge kept via a second registration.
- **usage-builder** is out of scope (not yet in the tree) — the bricks are shaped so it can adopt them in its own PR.

## Metric names & keys — unchanged

All emitted metric names (`audit_index.*`, `index.builder.*` incl. `logs_indexed_total`) and on-disk cursor keys are preserved — no dashboard or storage migration. `TestMetricsRegistry`'s static collector was taught to expand `RegisterTailGauges(meter, ns, source, …)` into its triplet (the names are now built from ns/source rather than literals at the `Int64ObservableGauge` call site).

## Intentional behaviour change

`ReadAppliedProposalProgress` now returns an error on a corrupt (non-8-byte) value instead of silently returning `0`, matching CLAUDE.md invariant #7 (the other two cursors already did this).

## Testing

New unit tests for `tailworker` (loop lifecycle, boot-abort, `context.Canceled` suppression, wake, gauge observation via SDK ManualReader) and `Uint64Cursor` (round-trip, missing→0, corrupt→error). The existing `auditindexer`/`indexbuilder` suites are the behaviour-preservation net. Full `go test ./...` green; `just pre-commit` clean (0 lint issues).

[EN-1339]: https://formance-team.atlassian.net/browse/EN-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ