### PR TITLE
fix(EN-1431): trigger SyncSnapshot from every Ready when out-of-sync (follow-up to #1463)

### DIFF
--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -780,6 +780,22 @@ func (a *Applier) SyncSnapshot(leader uint64, stop chan struct{}) {
 	}
 }
 
+// TrySyncSnapshot is a non-blocking variant of SyncSnapshot: returns true
+// if the sync request was enqueued, false if the work channel is full
+// (another item is already pending). Callers that fire from a per-Ready
+// polling loop (e.g. the out-of-sync fallback in processReady) MUST use
+// this variant — blocking would stall the raft-ready goroutine and enqueuing
+// duplicate syncLeader items causes startMaintenanceTask to interrupt its
+// own in-flight fetch, restarting checkpoint download from scratch.
+func (a *Applier) TrySyncSnapshot(leader uint64) bool {
+	select {
+	case a.ch <- applyWork{syncLeader: leader}:
+		return true
+	default:
+		return false
+	}
+}
+
 // startSyncSnapshot is called from Run to perform the actual sync.
 func (a *Applier) startSyncSnapshot(ctx context.Context, leader uint64) {
 	syncDetails := map[string]any{

--- a/internal/infra/node/applier_test.go
+++ b/internal/infra/node/applier_test.go
@@ -386,6 +386,37 @@ func TestApplierRunExitsOnStop(t *testing.T) {
 	}
 }
 
+// TestApplierTrySyncSnapshotIsNonBlocking verifies the EN-1431 follow-up
+// invariant: TrySyncSnapshot must never block. When the applier's work
+// channel is full (buffered size 1), a second call returns false rather
+// than blocking. The processReady out-of-sync fallback fires on every
+// Ready; blocking would stall the raft-ready goroutine, and enqueuing
+// duplicate syncLeader items causes startMaintenanceTask to interrupt
+// its own in-flight checkpoint fetch.
+func TestApplierTrySyncSnapshotIsNonBlocking(t *testing.T) {
+	t.Parallel()
+
+	setup := newTestApplierSetup(t)
+
+	// First call succeeds: channel has capacity 1.
+	require.True(t, setup.applier.TrySyncSnapshot(1),
+		"first TrySyncSnapshot must enqueue with an empty channel")
+
+	// Second call must return false immediately (channel is full — the
+	// Run goroutine isn't started in this test, so nothing drains it).
+	done := make(chan bool, 1)
+	go func() {
+		done <- setup.applier.TrySyncSnapshot(1)
+	}()
+
+	select {
+	case result := <-done:
+		require.False(t, result, "second TrySyncSnapshot on a full channel must return false")
+	case <-time.After(1 * time.Second):
+		t.Fatal("TrySyncSnapshot blocked instead of returning false when channel was full")
+	}
+}
+
 func TestApplierFutureResolution(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -1002,15 +1002,6 @@ func (node *Node) processReady(ctx context.Context, stop chan struct{}, rd raft.
 
 	if rd.SoftState != nil {
 		ss := rd.SoftState
-		// Only trigger sync from SoftState if this Ready does NOT also contain
-		// a snapshot. When both are present, the snapshot processing below will
-		// trigger its own syncSnapshot. Doing it here too would start a background
-		// task that is immediately interrupted by the second syncSnapshot call,
-		// which corrupts the spool read cache (entries read but never applied).
-		if ss.Lead != 0 && node.applier.Status() == statusOutOfSync && raft.IsEmptySnap(rd.Snapshot) && !isStopping(stop) {
-			node.applier.SyncSnapshot(ss.Lead, stop)
-		}
-
 		actualNodeLastSoftState := node.lastSoftState.Load()
 		wasLeader := actualNodeLastSoftState != nil && actualNodeLastSoftState.RaftState == raft.StateLeader
 		isLeader := ss.RaftState == raft.StateLeader
@@ -1105,6 +1096,33 @@ func (node *Node) processReady(ctx context.Context, stop chan struct{}, rd raft.
 		node.leadMonitorHistogram.Record(ctx, int64(ss.Lead))
 
 		node.lastSoftState.Store(ss)
+	}
+
+	// Trigger SyncSnapshot when the applier is out-of-sync. Reads lastSoftState
+	// after the SoftState block above so both cases are covered by one
+	// site: this Ready carries a fresh SoftState (Lead learned or changed),
+	// or this Ready has none but a previous Ready already set lastSoftState.
+	//
+	// Without this fallback, a follower that booted through node.Run's
+	// durability-gap recovery branch (Pebble empty, WAL compacted past
+	// snapshot) stays statusOutOfSync forever: the applier spools every
+	// MsgApp without applying to Pebble, so LastPersistedIndex never
+	// advances, node.Run's WaitForApplied never returns, the readiness
+	// probe never succeeds, and the Raft WAL grows unbounded (no
+	// maintenance snapshot until LastPersistedIndex moves) until the WAL
+	// PVC runs out of space. EN-1431 follow-up.
+	//
+	// Guarded on IsEmptySnap so we don't collide with the snapshot-processing
+	// block below, which fires its own syncSnapshot for the leader that just
+	// sent this snapshot. TrySyncSnapshot is non-blocking so back-to-back
+	// Readies can't stack duplicate syncLeader items (which would interrupt
+	// an in-flight checkpoint fetch via taskExecutor.Interrupt()). The
+	// applier's own status transition (statusOutOfSync -> statusGated)
+	// makes subsequent Readies skip this block once the request is picked up.
+	if raft.IsEmptySnap(rd.Snapshot) && node.applier.Status() == statusOutOfSync && !isStopping(stop) {
+		if ss := node.lastSoftState.Load(); ss != nil && ss.Lead != 0 {
+			node.applier.TrySyncSnapshot(ss.Lead)
+		}
 	}
 
 	// Resolve pending ReadIndex requests from rd.ReadStates.


### PR DESCRIPTION
## Summary

Follow-up to #1463. That PR bypassed the durability-gap panic to let a follower boot when Pebble is empty but the Raft WAL is compacted past its snapshot. But bypassing the panic wasn't enough — the follower then needed to reach the existing `SyncSnapshot` trigger in `processReady`, gated on `rd.SoftState.Lead != 0`. Since etcd-raft only emits `SoftState` when the raft state **changes**, a follower that persisted its leader across restart never gets a fresh SoftState signal, so the trigger never fires. Live symptom: the applier stays `statusOutOfSync` forever, spools every MsgApp, `LastPersistedIndex` never advances, `WaitForApplied` blocks, `/readyz` stays down, the Raft WAL grows unbounded (no maintenance snapshot until `LastPersistedIndex` moves), and the WAL PVC eventually runs out of space.

## Observed

`eks-acme-dev-euw1-01` / `blockchains-1` during chaos testing of #1463:
- Applier fired the new EN-1431 warning: ` Pebble applied lags WAL snapshot — previous process crashed between InstallSnapshot and SynchronizeWithLeader completion; applier is out-of-sync, will re-sync from leader {applied:0, walFirstIndex:29775, walSnapshotIndex:29774}`.
- `IndexTracker` advanced continuously (raft was receiving MsgApp from the leader), but no `Fetching fresh checkpoint from leader` log ever appeared.
- After 5+ minutes the WAL PVC (15 GiB) filled up and the pod crashed on `failed to preallocate space when creating a new WAL: no space left on device`.

## Fix

- Move the `SyncSnapshot` trigger out of the `if rd.SoftState != nil` block into a single site right after `SoftState` has been stored. It reads `lastSoftState` (which reflects the freshest known leader — whether stored by this Ready or by an earlier one) and fires whenever `applier.Status() == statusOutOfSync` and the Ready carries no snapshot.
- Add `Applier.TrySyncSnapshot` — non-blocking send on the size-1 work channel. Back-to-back Readies would otherwise stack duplicate `syncLeader` items, and each `startMaintenanceTask` call issues a `taskExecutor.Interrupt()` that aborts the previous in-flight checkpoint fetch and restarts the download from scratch. `TrySyncSnapshot` returns `false` when the channel is full — the next Ready retries.

## Tests

- New `TestApplierTrySyncSnapshotIsNonBlocking` (`applier_test.go`) verifies the non-blocking contract: with a full channel, `TrySyncSnapshot` returns `false` within milliseconds.
- Existing `TestRun_RefusesStartWhenGapExceedsWALRetention` and `TestRun_AllowsOutOfSyncRecoveryPastGap` still pass (this PR doesn't touch `node.Run`'s panic guard).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/infra/node/...` — full package suite passes
- [x] New `TestApplierTrySyncSnapshotIsNonBlocking` passes
- [ ] Deploy PR build to `eks-acme-dev-euw1-01/blockchains` and verify pod-1/pod-2 fully recover after a delete-pod chaos event (no permanent CrashLoop, no WAL growth past healthy baseline)

## Related

- Depends on #1463 (already merged into `release/v3.0`).
- Follow-up work still pending (out of scope here): distinguish the two triggers of the panic message in `node.Run` (genuine SyncWAL invariant violation vs InstallSnapshot pre-Sync crash) so operators don't get sent down the wrong remediation path.