### PR TITLE
fix(EN-1431): exclude self from voters when re-joining as learner (follow-up #2 to #1463)

### DIFF
--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -285,11 +285,7 @@ func NewNode(
 			case len(cfg.Peers) > 0:
 				// Join mode: existing peers are voters, self joins as learner.
 				// The leader will add us via ConfChange after we start.
-				voters = make([]uint64, 0, len(cfg.Peers))
-				for _, peerEntry := range cfg.Peers {
-					voters = append(voters, peerEntry.ID)
-				}
-
+				voters = initialJoinVoters(cfg.Peers, cfg.NodeID)
 				learners = []uint64{cfg.NodeID}
 				logger.WithFields(map[string]any{
 					"voters":   voters,
@@ -2370,6 +2366,35 @@ func confStateContainsNode(cs raftpb.ConfState, nodeID uint64) bool {
 	}
 
 	return slices.Contains(cs.Learners, nodeID)
+}
+
+// initialJoinVoters returns the voter list for the join-mode initial WAL
+// snapshot. It maps every peer discovered from the existing cluster to its
+// ID and excludes self.
+//
+// The exclusion matters when this node was previously a cluster member and
+// is now rejoining with fresh WAL — e.g. after a scale-down/scale-up cycle
+// that removed its Pod but left the leader's status.Progress carrying the
+// node ID from an earlier auto-promote. discoverPeersFromCluster echoes
+// whatever the leader's Progress contains, so self can appear in cfg.Peers.
+// Passing that ID both here (as voter) AND to cfg.NodeID's Learners entry
+// produces the raft-invalid ConfState `Voters=[..., self], Learners=[self]`:
+// on the next boot, raft.newRaft's assertConfStatesEquivalent detects the
+// mismatch between the snapshot's ConfState and the tracker-restored
+// equivalent (which normalises self into voters only) and panics with
+// "ConfStates not equivalent after sorting", producing a permanent
+// CrashLoopBackOff that no amount of retries recovers from.
+func initialJoinVoters(peers []Peer, selfID uint64) []uint64 {
+	voters := make([]uint64, 0, len(peers))
+	for _, p := range peers {
+		if p.ID == selfID {
+			continue
+		}
+
+		voters = append(voters, p.ID)
+	}
+
+	return voters
 }
 
 // ExtractPeerAddressesFromEntries scans committed entries for ConfChange entries

--- a/internal/infra/node/node_confstate_test.go
+++ b/internal/infra/node/node_confstate_test.go
@@ -48,6 +48,52 @@ func TestConfStateContainsNode(t *testing.T) {
 	})
 }
 
+// TestInitialJoinVoters_ExcludesSelf verifies the EN-1431 follow-up bug fix:
+// when discoverPeersFromCluster echoes back the joining node's own ID (which
+// happens when the leader's status.Progress still carries this node from a
+// previous life — e.g. auto-promoted voter before a scale-down/scale-up),
+// initialJoinVoters must drop self so the initial WAL snapshot does not end
+// up with `Voters=[..., self], Learners=[self]`. That raft-invalid state
+// triggers assertConfStatesEquivalent's panic on the next boot, producing a
+// permanent CrashLoopBackOff that only wiping cluster-side state recovers
+// from.
+func TestInitialJoinVoters_ExcludesSelf(t *testing.T) {
+	t.Parallel()
+
+	t.Run("self absent from peers", func(t *testing.T) {
+		t.Parallel()
+
+		peers := []Peer{{ID: 1}, {ID: 3}}
+		voters := initialJoinVoters(peers, 2)
+		require.Equal(t, []uint64{1, 3}, voters)
+	})
+
+	t.Run("self present in peers is dropped", func(t *testing.T) {
+		t.Parallel()
+
+		peers := []Peer{{ID: 1}, {ID: 2}, {ID: 3}}
+		voters := initialJoinVoters(peers, 2)
+		require.Equal(t, []uint64{1, 3}, voters,
+			"self must be excluded from the voter list to avoid the "+
+				"Voters=[...,self]/Learners=[self] raft-invalid ConfState")
+	})
+
+	t.Run("self is the only peer", func(t *testing.T) {
+		t.Parallel()
+
+		peers := []Peer{{ID: 2}}
+		voters := initialJoinVoters(peers, 2)
+		require.Empty(t, voters)
+	})
+
+	t.Run("empty peers", func(t *testing.T) {
+		t.Parallel()
+
+		voters := initialJoinVoters(nil, 2)
+		require.Empty(t, voters)
+	})
+}
+
 func TestFinishReady_SnapshotInstall_PreservesWALConfState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Third fix in the EN-1431 series. Discovered on `eks-acme-dev-euw1-01/blockchains-1` while chaos-testing the previous two fixes (#1463 merged, #1467 open).

`NewNode`'s fresh-start join branch takes `cfg.Peers` verbatim as the initial voter list, then adds `cfg.NodeID` to Learners. On a **rejoining** node that was previously a voter (auto-promoted, then reprovisioned via scale-down/scale-up), the leader's `status.Progress` still carries this node's ID, and `discoverPeersFromCluster` echoes it back into `cfg.Peers`. Self ends up in **both** Voters and Learners of the initial WAL snapshot — a raft-invalid state.

On boot, `raft.newRaft` calls `confchange.Restore` to reconstruct the tracker; the tracker normalises self to voters only. `assertConfStatesEquivalent` then compares the snapshot's ConfState to the reconstructed one, they don't match, and etcd-raft panics with:

```
panic: ConfStates not equivalent after sorting:
  raftpb.ConfState{Voters:[1,2,3], Learners:[2], ...}
  raftpb.ConfState{Voters:[1,3], Learners:[2], ...}
```

Permanent CrashLoopBackOff. No PVC wipe recovers, because the leader still lists node 2 as voter and every rejoin lands in the same broken shape.

## Reproduction

1. Cluster of 3 nodes, all healthy.
2. Kill node 2 hard (chaos, OOM, whatever) so it lands in a state that requires PVC wipe to recover.
3. Delete all 3 of node 2's PVCs.
4. StatefulSet reprovisions pod-1. Node 2 boots fresh in `--join` mode, calls `discoverPeersFromCluster` which returns `[node 1, node 2, node 3]` (leader still has node 2 as voter). The `for _, peerEntry := range cfg.Peers` loop appends all three IDs to voters. `learners = []uint64{cfg.NodeID}` = `[2]`. Panic on `assertConfStatesEquivalent`.

Observed live on `eks-acme-dev-euw1-01` on 2026-07-02.

## Fix

Extract the voter-list construction into `initialJoinVoters(peers, selfID)` and drop `selfID` from the result. The Bootstrap branch is not affected — its `cfg.Peers` comes from operator config, not from peer discovery, and the surrounding code already prepends `cfg.NodeID` separately.

## Related PRs

- #1463 (**merged**) — bypasses the durability-gap panic when applier is out-of-sync.
- #1467 (open) — triggers `SyncSnapshot` from every Ready when out-of-sync (unblocks the sync that #1463 makes recoverable).
- **This PR** — makes the rejoin path produce a valid initial ConfState so the follower reaches the recovery path at all.

The three PRs together cover the full lifecycle: rejoin cleanly (this) → hit durability-gap and don't panic (#1463) → recover from the leader (#1467).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/infra/node/...` (full node package suite)
- [x] New `TestInitialJoinVoters_ExcludesSelf` covers self-absent, self-present, self-only, empty
- [ ] Deploy `pr-<num>-<sha>` on `eks-acme-dev-euw1-01/blockchains` and verify node 2 rejoins after the scale-down/scale-up chaos without hitting the ConfState mismatch panic

## Out of scope

- **Leader-side** rejection of `AddLearner` for a node already in Progress: `AddLearner` at `node.go:2161` already returns `ErrNodeAlreadyInCluster` in that case, so the leader path is fine. The bug is entirely on the joining node's initial-snapshot construction.
- Filtering self out of the Bootstrap branch's voters too (defensive): the Bootstrap path uses operator-supplied peers and is not the observed failure mode. Left for a follow-up if we ever see it happen.