### PR TITLE
feat(ledgerctl): show account balances and add global --rescale flag

### DIFF
--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -154,7 +154,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 			balance := new(big.Int).Sub(input, output)
 
 			tableData = append(tableData, []string{
-				cmdutil.AssetLabel(base, *rescale),
+				invariants.FormatAsset(base, *rescale),
 				cmdutil.RescaleAmount(input, precision, *rescale),
 				cmdutil.RescaleAmount(output, precision, *rescale),
 				withSign(cmdutil.RescaleAmount(balance, precision, *rescale), balance.Sign()),

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -82,11 +84,16 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 
 	var trailer metadata.MD
 
+	// With --rescale, ask the server to merge same-base assets under the highest
+	// precision observed (use_max_precision), so the group-by-base aggregation is
+	// done once, server-side, on the native uint256 volumes. The CLI then only
+	// re-expresses each merged row at the requested scale for display.
 	result, err := client.AggregateVolumes(ctx, &servicepb.AggregateVolumesRequest{
-		Ledger:         ledgerName,
-		Filter:         filter,
-		MinLogSequence: minLogSeq,
-		CheckpointId:   checkpointID,
+		Ledger:          ledgerName,
+		Filter:          filter,
+		MinLogSequence:  minLogSeq,
+		CheckpointId:    checkpointID,
+		UseMaxPrecision: rescale != nil,
 	}, grpc.Trailer(&trailer))
 	_ = spinner.Stop()
 
@@ -135,23 +142,22 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 		{"ASSET", "INPUT", "OUTPUT", "BALANCE"},
 	}
 
-	// With --rescale, currencies that differ only in precision are summed into
-	// a single base-currency row, re-expressed at the requested scale.
+	// With --rescale, the server has already merged currencies that differ only
+	// in precision into a single base-currency row expressed at the group's
+	// highest precision (use_max_precision above). The CLI only re-expresses each
+	// row at the requested scale.
 	if rescale != nil {
-		raw := make(map[string]cmdutil.RawVolume, len(result.GetVolumes()))
 		for _, vol := range result.GetVolumes() {
-			raw[vol.GetAsset()] = cmdutil.RawVolume{
-				Input:  vol.GetInput().ToBigInt().String(),
-				Output: vol.GetOutput().ToBigInt().String(),
-			}
-		}
+			base, precision := invariants.ParseAssetPrecision(vol.GetAsset())
+			input := vol.GetInput().ToBigInt()
+			output := vol.GetOutput().ToBigInt()
+			balance := new(big.Int).Sub(input, output)
 
-		for _, av := range cmdutil.AggregateVolumes(raw) {
 			tableData = append(tableData, []string{
-				cmdutil.AssetLabel(av.Asset, *rescale),
-				cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
-				cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
-				withSign(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale), av.Balance.Sign()),
+				cmdutil.AssetLabel(base, *rescale),
+				cmdutil.RescaleAmount(input, precision, *rescale),
+				cmdutil.RescaleAmount(output, precision, *rescale),
+				withSign(cmdutil.RescaleAmount(balance, precision, *rescale), balance.Sign()),
 			})
 		}
 	} else {

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -84,16 +84,21 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 
 	var trailer metadata.MD
 
-	// With --rescale, ask the server to merge same-base assets under the highest
-	// precision observed (use_max_precision), so the group-by-base aggregation is
-	// done once, server-side, on the native uint256 volumes. The CLI then only
-	// re-expresses each merged row at the requested scale for display.
+	// With --rescale on the human-readable path, ask the server to merge
+	// same-base assets under the highest precision observed (use_max_precision),
+	// so the group-by-base aggregation is done once, server-side, on the native
+	// uint256 volumes; the CLI then only re-expresses each merged row at the
+	// requested scale for display. Structured output (--json/--yaml) must keep the
+	// raw integer amounts and full "CUR/precision" strings (see the --rescale flag
+	// contract in main.go), so the merge is gated off there.
+	useMaxPrecision := rescale != nil && !cmdutil.IsStructuredOutput(cmd)
+
 	result, err := client.AggregateVolumes(ctx, &servicepb.AggregateVolumesRequest{
 		Ledger:          ledgerName,
 		Filter:          filter,
 		MinLogSequence:  minLogSeq,
 		CheckpointId:    checkpointID,
-		UseMaxPrecision: rescale != nil,
+		UseMaxPrecision: useMaxPrecision,
 	}, grpc.Trailer(&trailer))
 	_ = spinner.Stop()
 

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -62,6 +62,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 	prefix, _ := cmd.Flags().GetString("prefix")
 	filterExpr, _ := cmd.Flags().GetString("filter")
 	showProfile, _ := cmd.Flags().GetBool("analyze")
+	rescale := cmdutil.RescaleTarget(cmd)
 	minLogSeq, _ := cmd.Flags().GetUint64("min-log-sequence")
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 
@@ -134,16 +135,38 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 		{"ASSET", "INPUT", "OUTPUT", "BALANCE"},
 	}
 
-	for _, vol := range result.GetVolumes() {
-		input := vol.GetInput().ToBigInt()
-		output := vol.GetOutput().ToBigInt()
-		balance := new(big.Int).Sub(input, output)
-		tableData = append(tableData, []string{
-			vol.GetAsset(),
-			input.String(),
-			output.String(),
-			formatBalance(balance),
-		})
+	// With --rescale, currencies that differ only in precision are summed into
+	// a single base-currency row, re-expressed at the requested scale.
+	if rescale != nil {
+		raw := make(map[string]cmdutil.RawVolume, len(result.GetVolumes()))
+		for _, vol := range result.GetVolumes() {
+			raw[vol.GetAsset()] = cmdutil.RawVolume{
+				Input:  vol.GetInput().ToBigInt().String(),
+				Output: vol.GetOutput().ToBigInt().String(),
+			}
+		}
+
+		for _, av := range cmdutil.AggregateVolumes(raw) {
+			tableData = append(tableData, []string{
+				cmdutil.AssetLabel(av.Asset, *rescale),
+				cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+				cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				withSign(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale), av.Balance.Sign()),
+			})
+		}
+	} else {
+		for _, vol := range result.GetVolumes() {
+			input := vol.GetInput().ToBigInt()
+			output := vol.GetOutput().ToBigInt()
+			balance := new(big.Int).Sub(input, output)
+
+			tableData = append(tableData, []string{
+				vol.GetAsset(),
+				input.String(),
+				output.String(),
+				withSign(balance.String(), balance.Sign()),
+			})
+		}
 	}
 
 	_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
@@ -151,11 +174,13 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// formatBalance formats a balance with a sign indicator.
-func formatBalance(b *big.Int) string {
-	if b.Sign() > 0 {
-		return "+" + b.String()
+// withSign prefixes a positive amount with '+' so credit/debit direction reads
+// at a glance; zero and negative values are returned unchanged (negatives
+// already carry '-').
+func withSign(s string, sign int) string {
+	if sign > 0 {
+		return "+" + s
 	}
 
-	return b.String()
+	return s
 }

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -62,6 +62,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 	prefix, _ := cmd.Flags().GetString("prefix")
 	filterExpr, _ := cmd.Flags().GetString("filter")
 	showProfile, _ := cmd.Flags().GetBool("analyze")
+	rescale := cmdutil.RescaleTarget(cmd)
 	minLogSeq, _ := cmd.Flags().GetUint64("min-log-sequence")
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 
@@ -136,17 +137,43 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 		{"ASSET", "COLOR", "INPUT", "OUTPUT", "BALANCE"},
 	}
 
-	for _, vol := range result.GetVolumes() {
-		input := vol.GetInput().ToBigInt()
-		output := vol.GetOutput().ToBigInt()
-		balance := new(big.Int).Sub(input, output)
-		tableData = append(tableData, []string{
-			vol.GetAsset(),
-			vol.GetColor(),
-			input.String(),
-			output.String(),
-			formatBalance(balance),
-		})
+	// With --rescale, currencies that differ only in precision are summed into
+	// a single base-currency row per color, re-expressed at the requested scale.
+	// Colors stay segregated: they are distinct balance buckets.
+	if rescale != nil {
+		raw := make([]cmdutil.RawVolume, 0, len(result.GetVolumes()))
+		for _, vol := range result.GetVolumes() {
+			raw = append(raw, cmdutil.RawVolume{
+				Asset:  vol.GetAsset(),
+				Color:  vol.GetColor(),
+				Input:  vol.GetInput().ToBigInt().String(),
+				Output: vol.GetOutput().ToBigInt().String(),
+			})
+		}
+
+		for _, av := range cmdutil.AggregateVolumes(raw) {
+			tableData = append(tableData, []string{
+				cmdutil.AssetLabel(av.Asset, *rescale),
+				av.Color,
+				cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+				cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				withSign(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale), av.Balance.Sign()),
+			})
+		}
+	} else {
+		for _, vol := range result.GetVolumes() {
+			input := vol.GetInput().ToBigInt()
+			output := vol.GetOutput().ToBigInt()
+			balance := new(big.Int).Sub(input, output)
+
+			tableData = append(tableData, []string{
+				vol.GetAsset(),
+				vol.GetColor(),
+				input.String(),
+				output.String(),
+				withSign(balance.String(), balance.Sign()),
+			})
+		}
 	}
 
 	_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
@@ -154,11 +181,13 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// formatBalance formats a balance with a sign indicator.
-func formatBalance(b *big.Int) string {
-	if b.Sign() > 0 {
-		return "+" + b.String()
+// withSign prefixes a positive amount with '+' so credit/debit direction reads
+// at a glance; zero and negative values are returned unchanged (negatives
+// already carry '-').
+func withSign(s string, sign int) string {
+	if sign > 0 {
+		return "+" + s
 	}
 
-	return b.String()
+	return s
 }

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -82,11 +84,16 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 
 	var trailer metadata.MD
 
+	// With --rescale, ask the server to merge same-base assets under the highest
+	// precision observed (use_max_precision), so the group-by-base aggregation is
+	// done once, server-side, on the native uint256 volumes. The CLI then only
+	// re-expresses each merged row at the requested scale for display.
 	result, err := client.AggregateVolumes(ctx, &servicepb.AggregateVolumesRequest{
-		Ledger:         ledgerName,
-		Filter:         filter,
-		MinLogSequence: minLogSeq,
-		CheckpointId:   checkpointID,
+		Ledger:          ledgerName,
+		Filter:          filter,
+		MinLogSequence:  minLogSeq,
+		CheckpointId:    checkpointID,
+		UseMaxPrecision: rescale != nil,
 	}, grpc.Trailer(&trailer))
 	_ = spinner.Stop()
 
@@ -137,27 +144,24 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 		{"ASSET", "COLOR", "INPUT", "OUTPUT", "BALANCE"},
 	}
 
-	// With --rescale, currencies that differ only in precision are summed into
-	// a single base-currency row per color, re-expressed at the requested scale.
-	// Colors stay segregated: they are distinct balance buckets.
+	// With --rescale, the server has already merged currencies that differ only
+	// in precision into a single base-currency row expressed at the group's
+	// highest precision (use_max_precision above). Colors stay segregated: they
+	// are part of the server's merge key. The CLI only re-expresses each row at
+	// the requested scale.
 	if rescale != nil {
-		raw := make([]cmdutil.RawVolume, 0, len(result.GetVolumes()))
 		for _, vol := range result.GetVolumes() {
-			raw = append(raw, cmdutil.RawVolume{
-				Asset:  vol.GetAsset(),
-				Color:  vol.GetColor(),
-				Input:  vol.GetInput().ToBigInt().String(),
-				Output: vol.GetOutput().ToBigInt().String(),
-			})
-		}
+			base, precision := invariants.ParseAssetPrecision(vol.GetAsset())
+			input := vol.GetInput().ToBigInt()
+			output := vol.GetOutput().ToBigInt()
+			balance := new(big.Int).Sub(input, output)
 
-		for _, av := range cmdutil.AggregateVolumes(raw) {
 			tableData = append(tableData, []string{
-				cmdutil.AssetLabel(av.Asset, *rescale),
-				av.Color,
-				cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
-				cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
-				withSign(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale), av.Balance.Sign()),
+				cmdutil.AssetLabel(base, *rescale),
+				vol.GetColor(),
+				cmdutil.RescaleAmount(input, precision, *rescale),
+				cmdutil.RescaleAmount(output, precision, *rescale),
+				withSign(cmdutil.RescaleAmount(balance, precision, *rescale), balance.Sign()),
 			})
 		}
 	} else {

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -157,7 +157,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 			balance := new(big.Int).Sub(input, output)
 
 			tableData = append(tableData, []string{
-				cmdutil.AssetLabel(base, *rescale),
+				invariants.FormatAsset(base, *rescale),
 				vol.GetColor(),
 				cmdutil.RescaleAmount(input, precision, *rescale),
 				cmdutil.RescaleAmount(output, precision, *rescale),

--- a/cmd/ledgerctl/accounts/get.go
+++ b/cmd/ledgerctl/accounts/get.go
@@ -132,6 +132,31 @@ func runGet(cmd *cobra.Command, args []string) error {
 			{"ASSET", "INPUT", "OUTPUT", "BALANCE"},
 		}
 
+		// With --rescale, currencies that differ only in precision are summed
+		// into a single base-currency row, re-expressed at the requested scale.
+		if rescale := cmdutil.RescaleTarget(cmd); rescale != nil {
+			raw := make(map[string]cmdutil.RawVolume, len(account.GetVolumes()))
+			for asset, vol := range account.GetVolumes() {
+				raw[asset] = cmdutil.RawVolume{Input: vol.GetInput(), Output: vol.GetOutput()}
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				balanceColor := pterm.Green
+				if av.Balance.Sign() < 0 {
+					balanceColor = pterm.Red
+				}
+
+				volumesTable = append(volumesTable, []string{
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+					balanceColor(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)),
+				})
+			}
+
+			return pterm.DefaultTable.WithHasHeader().WithData(volumesTable).Render()
+		}
+
 		assets := make([]string, 0, len(account.GetVolumes()))
 		for asset := range account.GetVolumes() {
 			assets = append(assets, asset)

--- a/cmd/ledgerctl/accounts/get.go
+++ b/cmd/ledgerctl/accounts/get.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -147,7 +149,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 				}
 
 				volumesTable = append(volumesTable, []string{
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
 					balanceColor(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)),

--- a/cmd/ledgerctl/accounts/get.go
+++ b/cmd/ledgerctl/accounts/get.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -159,7 +161,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 				}
 
 				volumesTable = append(volumesTable, []string{
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					displayColor,
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),

--- a/cmd/ledgerctl/accounts/get.go
+++ b/cmd/ledgerctl/accounts/get.go
@@ -131,6 +131,45 @@ func runGet(cmd *cobra.Command, args []string) error {
 			{"ASSET", "COLOR", "INPUT", "OUTPUT", "BALANCE"},
 		}
 
+		// With --rescale, currencies that differ only in precision are summed
+		// into a single base-currency row per color, re-expressed at the
+		// requested scale. Colors stay segregated: they are distinct balance
+		// buckets.
+		if rescale := cmdutil.RescaleTarget(cmd); rescale != nil {
+			raw := make([]cmdutil.RawVolume, 0, len(account.GetVolumes()))
+			for _, entry := range account.GetVolumes() {
+				vol := entry.GetVolumes()
+				raw = append(raw, cmdutil.RawVolume{
+					Asset:  entry.GetAsset(),
+					Color:  entry.GetColor(),
+					Input:  vol.GetInput(),
+					Output: vol.GetOutput(),
+				})
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				balanceColor := pterm.Green
+				if av.Balance.Sign() < 0 {
+					balanceColor = pterm.Red
+				}
+
+				displayColor := av.Color
+				if displayColor == "" {
+					displayColor = "-"
+				}
+
+				volumesTable = append(volumesTable, []string{
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					displayColor,
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+					balanceColor(cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)),
+				})
+			}
+
+			return pterm.DefaultTable.WithHasHeader().WithData(volumesTable).Render()
+		}
+
 		// account.GetVolumes() is already sorted by (asset, color) ascending
 		// server-side, so we just render in-order.
 		for _, entry := range account.GetVolumes() {

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 
 	"github.com/pterm/pterm"
@@ -268,26 +269,80 @@ func renderAccountsTable(accounts []*commonpb.Account) {
 
 	const (
 		metadataColWidth   = 8
+		balanceColWidth    = 28
 		separatorWidth     = 3
 		continuationIndent = "  "
 	)
 
-	maxAddressWidth := max(termWidth-metadataColWidth-separatorWidth-len(continuationIndent), 20)
+	// Two extra separators now (ADDRESS | BALANCES | METADATA).
+	maxAddressWidth := max(termWidth-balanceColWidth-metadataColWidth-2*separatorWidth-len(continuationIndent), 20)
 
 	tableData := pterm.TableData{
-		{"ADDRESS", "METADATA"},
+		{"ADDRESS", "BALANCES", "METADATA"},
 	}
 
 	for _, account := range accounts {
 		metadataCount := strconv.Itoa(len(account.GetMetadata()))
 
-		lines := cmdutil.WrapText(account.GetAddress(), maxAddressWidth, ":")
+		addressLines := cmdutil.WrapText(account.GetAddress(), maxAddressWidth, ":")
+		balanceLines := formatAccountBalances(account.GetVolumes())
 
-		tableData = append(tableData, []string{lines[0], metadataCount})
-		for _, line := range lines[1:] {
-			tableData = append(tableData, []string{continuationIndent + line, ""})
+		// An account row spans as many lines as its longest column so wrapped
+		// addresses and multi-asset balances stay vertically aligned.
+		rowCount := max(len(addressLines), len(balanceLines))
+		for i := range rowCount {
+			var address, balance, metadata string
+
+			if i < len(addressLines) {
+				if i == 0 {
+					address = addressLines[0]
+				} else {
+					address = continuationIndent + addressLines[i]
+				}
+			}
+
+			if i < len(balanceLines) {
+				balance = balanceLines[i]
+			}
+
+			if i == 0 {
+				metadata = metadataCount
+			}
+
+			tableData = append(tableData, []string{address, balance, metadata})
 		}
 	}
 
 	_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+}
+
+// formatAccountBalances renders one "ASSET balance" line per asset, sorted by
+// asset, coloring negative balances red and the rest green (matching the
+// accounts get view). Returns a single muted placeholder when there are no
+// volumes.
+func formatAccountBalances(volumes map[string]*commonpb.VolumesWithBalance) []string {
+	if len(volumes) == 0 {
+		return []string{pterm.Gray("—")}
+	}
+
+	assets := make([]string, 0, len(volumes))
+	for asset := range volumes {
+		assets = append(assets, asset)
+	}
+
+	sort.Strings(assets)
+
+	lines := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		balance := volumes[asset].GetBalance()
+
+		balanceColor := pterm.Green
+		if balance != "" && balance[0] == '-' {
+			balanceColor = pterm.Red
+		}
+
+		lines = append(lines, fmt.Sprintf("%s %s", asset, balanceColor(balance)))
+	}
+
+	return lines
 }

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -77,6 +77,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	flt := cmdutil.GetFilterFlags(cmd)
 	cns := cmdutil.GetConsistencyFlags(cmd)
 	showProfile, _ := cmd.Flags().GetBool("analyze")
+	rescale := cmdutil.RescaleTarget(cmd)
 
 	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	if err != nil {
@@ -84,13 +85,13 @@ func runList(cmd *cobra.Command, _ []string) error {
 	}
 
 	if pgn.All {
-		return fetchAllAccounts(cmd, client, ledgerName, filter, pgn.Cursor, pgn.Reverse, cns, showProfile)
+		return fetchAllAccounts(cmd, client, ledgerName, filter, pgn.Cursor, pgn.Reverse, cns, showProfile, rescale)
 	}
 
-	return fetchAccountsWithPager(cmd, client, ledgerName, pgn, filter, cns, showProfile)
+	return fetchAccountsWithPager(cmd, client, ledgerName, pgn, filter, cns, showProfile, rescale)
 }
 
-func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, filter *commonpb.QueryFilter, initialCursor string, reverse bool, cns cmdutil.ConsistencyFlags, showProfile bool) error {
+func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, filter *commonpb.QueryFilter, initialCursor string, reverse bool, cns cmdutil.ConsistencyFlags, showProfile bool, rescale *uint8) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
@@ -139,7 +140,7 @@ func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, 
 		pterm.Info.Println("No accounts found.")
 		pterm.Println(pterm.Gray("Create transactions to populate accounts."))
 	default:
-		renderAccountsTable(accounts)
+		renderAccountsTable(accounts, rescale)
 	}
 
 	if showProfile && lastTrailer != nil {
@@ -149,7 +150,7 @@ func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, 
 	return nil
 }
 
-func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, pgn cmdutil.PaginationFlags, filter *commonpb.QueryFilter, cns cmdutil.ConsistencyFlags, showProfile bool) error {
+func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, pgn cmdutil.PaginationFlags, filter *commonpb.QueryFilter, cns cmdutil.ConsistencyFlags, showProfile bool, rescale *uint8) error {
 	page := pgn
 	pageNum := 1
 
@@ -221,7 +222,7 @@ func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceCl
 			pterm.Println()
 			pterm.Printf("Accounts (Page %d)\n", pageNum)
 			pterm.Println(pterm.Gray("─────────────────────────────────"))
-			renderAccountsTable(accounts)
+			renderAccountsTable(accounts, rescale)
 		}
 
 		if showProfile {
@@ -264,7 +265,7 @@ func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceCl
 	}
 }
 
-func renderAccountsTable(accounts []*commonpb.Account) {
+func renderAccountsTable(accounts []*commonpb.Account, rescale *uint8) {
 	termWidth := pterm.GetTerminalWidth()
 
 	const (
@@ -285,7 +286,7 @@ func renderAccountsTable(accounts []*commonpb.Account) {
 		metadataCount := strconv.Itoa(len(account.GetMetadata()))
 
 		addressLines := cmdutil.WrapText(account.GetAddress(), maxAddressWidth, ":")
-		balanceLines := formatAccountBalances(account.GetVolumes())
+		balanceLines := formatAccountBalances(account.GetVolumes(), rescale)
 
 		// An account row spans as many lines as its longest column so wrapped
 		// addresses and multi-asset balances stay vertically aligned.
@@ -320,9 +321,34 @@ func renderAccountsTable(accounts []*commonpb.Account) {
 // asset, coloring negative balances red and the rest green (matching the
 // accounts get view). Returns a single muted placeholder when there are no
 // volumes.
-func formatAccountBalances(volumes map[string]*commonpb.VolumesWithBalance) []string {
+func formatAccountBalances(volumes map[string]*commonpb.VolumesWithBalance, rescale *uint8) []string {
 	if len(volumes) == 0 {
 		return []string{pterm.Gray("—")}
+	}
+
+	// With --rescale, currencies that differ only in precision (USD/4, USD/8)
+	// collapse to a single base currency, their balances are summed, and the
+	// sum is re-expressed at the requested scale.
+	if rescale != nil {
+		raw := make(map[string]cmdutil.RawVolume, len(volumes))
+		for asset, vol := range volumes {
+			raw[asset] = cmdutil.RawVolume{Input: vol.GetInput(), Output: vol.GetOutput()}
+		}
+
+		aggregated := cmdutil.AggregateVolumes(raw)
+
+		lines := make([]string, 0, len(aggregated))
+		for _, av := range aggregated {
+			balanceColor := pterm.Green
+			if av.Balance.Sign() < 0 {
+				balanceColor = pterm.Red
+			}
+
+			balance := cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)
+			lines = append(lines, fmt.Sprintf("%s %s", cmdutil.AssetLabel(av.Asset, *rescale), balanceColor(balance)))
+		}
+
+		return lines
 	}
 
 	assets := make([]string, 0, len(volumes))

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -345,7 +347,7 @@ func formatAccountBalances(volumes map[string]*commonpb.VolumesWithBalance, resc
 			}
 
 			balance := cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)
-			lines = append(lines, fmt.Sprintf("%s %s", cmdutil.AssetLabel(av.Asset, *rescale), balanceColor(balance)))
+			lines = append(lines, fmt.Sprintf("%s %s", invariants.FormatAsset(av.Asset, *rescale), balanceColor(balance)))
 		}
 
 		return lines

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -351,7 +353,7 @@ func formatAccountBalances(volumes []*commonpb.AccountVolume, rescale *uint8) []
 			}
 
 			balance := cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)
-			label := balanceLabel(cmdutil.AssetLabel(av.Asset, *rescale), av.Color)
+			label := balanceLabel(invariants.FormatAsset(av.Asset, *rescale), av.Color)
 			lines = append(lines, fmt.Sprintf("%s %s", label, balanceColor(balance)))
 		}
 

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
 
 	"github.com/pterm/pterm"
@@ -77,6 +76,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	flt := cmdutil.GetFilterFlags(cmd)
 	cns := cmdutil.GetConsistencyFlags(cmd)
 	showProfile, _ := cmd.Flags().GetBool("analyze")
+	rescale := cmdutil.RescaleTarget(cmd)
 
 	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	if err != nil {
@@ -84,13 +84,13 @@ func runList(cmd *cobra.Command, _ []string) error {
 	}
 
 	if pgn.All {
-		return fetchAllAccounts(cmd, client, ledgerName, filter, pgn.Cursor, pgn.Reverse, cns, showProfile)
+		return fetchAllAccounts(cmd, client, ledgerName, filter, pgn.Cursor, pgn.Reverse, cns, showProfile, rescale)
 	}
 
-	return fetchAccountsWithPager(cmd, client, ledgerName, pgn, filter, cns, showProfile)
+	return fetchAccountsWithPager(cmd, client, ledgerName, pgn, filter, cns, showProfile, rescale)
 }
 
-func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, filter *commonpb.QueryFilter, initialCursor string, reverse bool, cns cmdutil.ConsistencyFlags, showProfile bool) error {
+func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, filter *commonpb.QueryFilter, initialCursor string, reverse bool, cns cmdutil.ConsistencyFlags, showProfile bool, rescale *uint8) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
@@ -139,7 +139,7 @@ func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, 
 		pterm.Info.Println("No accounts found.")
 		pterm.Println(pterm.Gray("Create transactions to populate accounts."))
 	default:
-		renderAccountsTable(accounts)
+		renderAccountsTable(accounts, rescale)
 	}
 
 	if showProfile && lastTrailer != nil {
@@ -149,7 +149,7 @@ func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, 
 	return nil
 }
 
-func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, pgn cmdutil.PaginationFlags, filter *commonpb.QueryFilter, cns cmdutil.ConsistencyFlags, showProfile bool) error {
+func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceClient, ledgerName string, pgn cmdutil.PaginationFlags, filter *commonpb.QueryFilter, cns cmdutil.ConsistencyFlags, showProfile bool, rescale *uint8) error {
 	page := pgn
 	pageNum := 1
 
@@ -221,7 +221,7 @@ func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceCl
 			pterm.Println()
 			pterm.Printf("Accounts (Page %d)\n", pageNum)
 			pterm.Println(pterm.Gray("─────────────────────────────────"))
-			renderAccountsTable(accounts)
+			renderAccountsTable(accounts, rescale)
 		}
 
 		if showProfile {
@@ -264,7 +264,7 @@ func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceCl
 	}
 }
 
-func renderAccountsTable(accounts []*commonpb.Account) {
+func renderAccountsTable(accounts []*commonpb.Account, rescale *uint8) {
 	termWidth := pterm.GetTerminalWidth()
 
 	const (
@@ -285,7 +285,7 @@ func renderAccountsTable(accounts []*commonpb.Account) {
 		metadataCount := strconv.Itoa(len(account.GetMetadata()))
 
 		addressLines := cmdutil.WrapText(account.GetAddress(), maxAddressWidth, ":")
-		balanceLines := formatAccountBalances(account.GetVolumes())
+		balanceLines := formatAccountBalances(account.GetVolumes(), rescale)
 
 		// An account row spans as many lines as its longest column so wrapped
 		// addresses and multi-asset balances stay vertically aligned.
@@ -316,33 +316,74 @@ func renderAccountsTable(accounts []*commonpb.Account) {
 	_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
 }
 
-// formatAccountBalances renders one "ASSET balance" line per asset, sorted by
-// asset, coloring negative balances red and the rest green (matching the
-// accounts get view). Returns a single muted placeholder when there are no
-// volumes.
-func formatAccountBalances(volumes map[string]*commonpb.VolumesWithBalance) []string {
+// formatAccountBalances renders one "ASSET balance" line per (asset, color)
+// bucket, coloring negative balances red and the rest green (matching the
+// accounts get view). Colored buckets carry a "[COLOR]" marker; the uncolored
+// bucket is labelled by its asset alone. Returns a single muted placeholder when
+// there are no volumes.
+func formatAccountBalances(volumes []*commonpb.AccountVolume, rescale *uint8) []string {
 	if len(volumes) == 0 {
 		return []string{pterm.Gray("—")}
 	}
 
-	assets := make([]string, 0, len(volumes))
-	for asset := range volumes {
-		assets = append(assets, asset)
+	// With --rescale, currencies that differ only in precision (USD/4, USD/8)
+	// collapse to a single base currency per color, their balances are summed,
+	// and the sum is re-expressed at the requested scale.
+	if rescale != nil {
+		raw := make([]cmdutil.RawVolume, 0, len(volumes))
+		for _, entry := range volumes {
+			vol := entry.GetVolumes()
+			raw = append(raw, cmdutil.RawVolume{
+				Asset:  entry.GetAsset(),
+				Color:  entry.GetColor(),
+				Input:  vol.GetInput(),
+				Output: vol.GetOutput(),
+			})
+		}
+
+		aggregated := cmdutil.AggregateVolumes(raw)
+
+		lines := make([]string, 0, len(aggregated))
+		for _, av := range aggregated {
+			balanceColor := pterm.Green
+			if av.Balance.Sign() < 0 {
+				balanceColor = pterm.Red
+			}
+
+			balance := cmdutil.RescaleAmount(av.Balance, av.Precision, *rescale)
+			label := balanceLabel(cmdutil.AssetLabel(av.Asset, *rescale), av.Color)
+			lines = append(lines, fmt.Sprintf("%s %s", label, balanceColor(balance)))
+		}
+
+		return lines
 	}
 
-	sort.Strings(assets)
+	// volumes is already sorted by (asset, color) ascending server-side, so we
+	// just render in-order.
+	lines := make([]string, 0, len(volumes))
 
-	lines := make([]string, 0, len(assets))
-	for _, asset := range assets {
-		balance := volumes[asset].GetBalance()
+	for _, entry := range volumes {
+		balance := entry.GetVolumes().GetBalance()
 
 		balanceColor := pterm.Green
 		if balance != "" && balance[0] == '-' {
 			balanceColor = pterm.Red
 		}
 
-		lines = append(lines, fmt.Sprintf("%s %s", asset, balanceColor(balance)))
+		label := balanceLabel(entry.GetAsset(), entry.GetColor())
+		lines = append(lines, fmt.Sprintf("%s %s", label, balanceColor(balance)))
 	}
 
 	return lines
+}
+
+// balanceLabel names a balance bucket: the asset alone for the uncolored bucket,
+// or the asset followed by a "[COLOR]" marker for a colored one. The BALANCES
+// column is a single column, so the color cannot get a header of its own.
+func balanceLabel(asset, color string) string {
+	if color == "" {
+		return asset
+	}
+
+	return fmt.Sprintf("%s[%s]", asset, color)
 }

--- a/cmd/ledgerctl/accounts/list_test.go
+++ b/cmd/ledgerctl/accounts/list_test.go
@@ -1,0 +1,54 @@
+package accounts
+
+import (
+	"testing"
+
+	"github.com/pterm/pterm"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func TestFormatAccountBalances(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no volumes returns a single placeholder", func(t *testing.T) {
+		t.Parallel()
+
+		lines := formatAccountBalances(nil)
+		if len(lines) != 1 {
+			t.Fatalf("expected 1 placeholder line, got %d: %v", len(lines), lines)
+		}
+
+		if want := pterm.Gray("—"); lines[0] != want {
+			t.Fatalf("expected placeholder %q, got %q", want, lines[0])
+		}
+	})
+
+	t.Run("assets are sorted and colored by sign", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := map[string]*commonpb.VolumesWithBalance{
+			"USD/2": {Balance: "1000"},
+			"EUR/2": {Balance: "-50"},
+			"GBP/2": {Balance: "0"},
+		}
+
+		lines := formatAccountBalances(volumes)
+
+		want := []string{
+			"EUR/2 " + pterm.Red("-50"),
+			"GBP/2 " + pterm.Green("0"),
+			"USD/2 " + pterm.Green("1000"),
+		}
+
+		if len(lines) != len(want) {
+			t.Fatalf("expected %d lines, got %d: %v", len(want), len(lines), lines)
+		}
+
+		for i := range want {
+			if lines[i] != want[i] {
+				t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
+			}
+		}
+	})
+}

--- a/cmd/ledgerctl/accounts/list_test.go
+++ b/cmd/ledgerctl/accounts/list_test.go
@@ -11,10 +11,26 @@ import (
 func TestFormatAccountBalances(t *testing.T) {
 	t.Parallel()
 
+	scale := func(u uint8) *uint8 { return &u }
+
+	assertLines := func(t *testing.T, got, want []string) {
+		t.Helper()
+
+		if len(got) != len(want) {
+			t.Fatalf("expected %d lines, got %d: %v", len(want), len(got), got)
+		}
+
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("line %d: expected %q, got %q", i, want[i], got[i])
+			}
+		}
+	}
+
 	t.Run("no volumes returns a single placeholder", func(t *testing.T) {
 		t.Parallel()
 
-		lines := formatAccountBalances(nil)
+		lines := formatAccountBalances(nil, nil)
 		if len(lines) != 1 {
 			t.Fatalf("expected 1 placeholder line, got %d: %v", len(lines), lines)
 		}
@@ -24,7 +40,7 @@ func TestFormatAccountBalances(t *testing.T) {
 		}
 	})
 
-	t.Run("assets are sorted and colored by sign", func(t *testing.T) {
+	t.Run("without --rescale, assets are sorted and colored by sign", func(t *testing.T) {
 		t.Parallel()
 
 		volumes := map[string]*commonpb.VolumesWithBalance{
@@ -33,22 +49,55 @@ func TestFormatAccountBalances(t *testing.T) {
 			"GBP/2": {Balance: "0"},
 		}
 
-		lines := formatAccountBalances(volumes)
-
-		want := []string{
+		assertLines(t, formatAccountBalances(volumes, nil), []string{
 			"EUR/2 " + pterm.Red("-50"),
 			"GBP/2 " + pterm.Green("0"),
 			"USD/2 " + pterm.Green("1000"),
+		})
+	})
+
+	t.Run("rescale to scale 0 sums currencies that differ only in precision", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := map[string]*commonpb.VolumesWithBalance{
+			"USD/4": {Input: "10000", Output: "0", Balance: "10000"},         // 1.0000
+			"USD/8": {Input: "100000000", Output: "0", Balance: "100000000"}, // 1.00000000
+			"EUR/2": {Input: "250", Output: "0", Balance: "250"},             // 2.50
 		}
 
-		if len(lines) != len(want) {
-			t.Fatalf("expected %d lines, got %d: %v", len(want), len(lines), lines)
+		assertLines(t, formatAccountBalances(volumes, scale(0)), []string{
+			"EUR " + pterm.Green("2.50"),
+			"USD " + pterm.Green("2.00000000"), // summed at the highest precision (8)
+		})
+	})
+
+	t.Run("rescale to scale 0 divides by precision and drops the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := map[string]*commonpb.VolumesWithBalance{
+			"USD/3": {Input: "1123456780", Output: "0", Balance: "1123456780"},
+			"EUR/2": {Input: "0", Output: "50", Balance: "-50"},
+			"JPY":   {Input: "1000", Output: "0", Balance: "1000"},
 		}
 
-		for i := range want {
-			if lines[i] != want[i] {
-				t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
-			}
+		assertLines(t, formatAccountBalances(volumes, scale(0)), []string{
+			"EUR " + pterm.Red("-0.50"),
+			"JPY " + pterm.Green("1000"),
+			"USD " + pterm.Green("1123456.780"),
+		})
+	})
+
+	t.Run("rescale to a non-zero scale keeps the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		// 12.34 (USD/2) + 56.789 (USD/3) = 69.129 USD; at scale 2 → 6912.9 USD/2.
+		volumes := map[string]*commonpb.VolumesWithBalance{
+			"USD/2": {Input: "1234", Output: "0", Balance: "1234"},
+			"USD/3": {Input: "56789", Output: "0", Balance: "56789"},
 		}
+
+		assertLines(t, formatAccountBalances(volumes, scale(2)), []string{
+			"USD/2 " + pterm.Green("6912.9"),
+		})
 	})
 }

--- a/cmd/ledgerctl/accounts/list_test.go
+++ b/cmd/ledgerctl/accounts/list_test.go
@@ -11,10 +11,40 @@ import (
 func TestFormatAccountBalances(t *testing.T) {
 	t.Parallel()
 
+	scale := func(u uint8) *uint8 { return &u }
+
+	// The server returns Account.volumes already sorted by (asset, color)
+	// ascending, so fixtures are written in that order.
+	entry := func(asset, color, input, output, balance string) *commonpb.AccountVolume {
+		return &commonpb.AccountVolume{
+			Asset: asset,
+			Color: color,
+			Volumes: &commonpb.VolumesWithBalance{
+				Input:   input,
+				Output:  output,
+				Balance: balance,
+			},
+		}
+	}
+
+	assertLines := func(t *testing.T, got, want []string) {
+		t.Helper()
+
+		if len(got) != len(want) {
+			t.Fatalf("expected %d lines, got %d: %v", len(want), len(got), got)
+		}
+
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("line %d: expected %q, got %q", i, want[i], got[i])
+			}
+		}
+	}
+
 	t.Run("no volumes returns a single placeholder", func(t *testing.T) {
 		t.Parallel()
 
-		lines := formatAccountBalances(nil)
+		lines := formatAccountBalances(nil, nil)
 		if len(lines) != 1 {
 			t.Fatalf("expected 1 placeholder line, got %d: %v", len(lines), lines)
 		}
@@ -24,31 +54,83 @@ func TestFormatAccountBalances(t *testing.T) {
 		}
 	})
 
-	t.Run("assets are sorted and colored by sign", func(t *testing.T) {
+	t.Run("without --rescale, assets keep server order and are colored by sign", func(t *testing.T) {
 		t.Parallel()
 
-		volumes := map[string]*commonpb.VolumesWithBalance{
-			"USD/2": {Balance: "1000"},
-			"EUR/2": {Balance: "-50"},
-			"GBP/2": {Balance: "0"},
+		volumes := []*commonpb.AccountVolume{
+			entry("EUR/2", "", "", "", "-50"),
+			entry("GBP/2", "", "", "", "0"),
+			entry("USD/2", "", "", "", "1000"),
 		}
 
-		lines := formatAccountBalances(volumes)
-
-		want := []string{
+		assertLines(t, formatAccountBalances(volumes, nil), []string{
 			"EUR/2 " + pterm.Red("-50"),
 			"GBP/2 " + pterm.Green("0"),
 			"USD/2 " + pterm.Green("1000"),
+		})
+	})
+
+	t.Run("colored buckets are labelled and stay segregated", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := []*commonpb.AccountVolume{
+			entry("USD/2", "", "1000", "0", "1000"),
+			entry("USD/2", "GREEN", "0", "250", "-250"),
 		}
 
-		if len(lines) != len(want) {
-			t.Fatalf("expected %d lines, got %d: %v", len(want), len(lines), lines)
+		assertLines(t, formatAccountBalances(volumes, nil), []string{
+			"USD/2 " + pterm.Green("1000"),
+			"USD/2[GREEN] " + pterm.Red("-250"),
+		})
+
+		assertLines(t, formatAccountBalances(volumes, scale(0)), []string{
+			"USD " + pterm.Green("10.00"),
+			"USD[GREEN] " + pterm.Red("-2.50"),
+		})
+	})
+
+	t.Run("rescale to scale 0 sums currencies that differ only in precision", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := []*commonpb.AccountVolume{
+			entry("EUR/2", "", "250", "0", "250"),             // 2.50
+			entry("USD/4", "", "10000", "0", "10000"),         // 1.0000
+			entry("USD/8", "", "100000000", "0", "100000000"), // 1.00000000
 		}
 
-		for i := range want {
-			if lines[i] != want[i] {
-				t.Errorf("line %d: expected %q, got %q", i, want[i], lines[i])
-			}
+		assertLines(t, formatAccountBalances(volumes, scale(0)), []string{
+			"EUR " + pterm.Green("2.50"),
+			"USD " + pterm.Green("2.00000000"), // summed at the highest precision (8)
+		})
+	})
+
+	t.Run("rescale to scale 0 divides by precision and drops the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		volumes := []*commonpb.AccountVolume{
+			entry("EUR/2", "", "0", "50", "-50"),
+			entry("JPY", "", "1000", "0", "1000"),
+			entry("USD/3", "", "1123456780", "0", "1123456780"),
 		}
+
+		assertLines(t, formatAccountBalances(volumes, scale(0)), []string{
+			"EUR " + pterm.Red("-0.50"),
+			"JPY " + pterm.Green("1000"),
+			"USD " + pterm.Green("1123456.780"),
+		})
+	})
+
+	t.Run("rescale to a non-zero scale keeps the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		// 12.34 (USD/2) + 56.789 (USD/3) = 69.129 USD; at scale 2 → 6912.9 USD/2.
+		volumes := []*commonpb.AccountVolume{
+			entry("USD/2", "", "1234", "0", "1234"),
+			entry("USD/3", "", "56789", "0", "56789"),
+		}
+
+		assertLines(t, formatAccountBalances(volumes, scale(2)), []string{
+			"USD/2 " + pterm.Green("6912.9"),
+		})
 	})
 }

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -6,8 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/formancehq/invariants"
 	"github.com/spf13/cobra"
+
+	"github.com/formancehq/invariants"
 )
 
 // RescaleFlagName is the name of the global flag that re-expresses amounts at a

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -1,0 +1,213 @@
+package cmdutil
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/formancehq/invariants"
+	"github.com/spf13/cobra"
+)
+
+// RescaleFlagName is the name of the global flag that re-expresses amounts at a
+// chosen scale.
+const RescaleFlagName = "rescale"
+
+// RescaleTarget returns the target scale requested via --rescale, or nil when
+// the flag was not given. --rescale passed without a value yields a non-nil
+// pointer to 0 (rescale to whole units, dropping the precision suffix), which is
+// deliberately distinct from the flag being absent (no rescaling at all). The
+// scale is a uint8: an asset's precision is a single byte, so pflag rejects any
+// value above 255 at parse time.
+func RescaleTarget(cmd *cobra.Command) *uint8 {
+	if !cmd.Flags().Changed(RescaleFlagName) {
+		return nil
+	}
+
+	v, _ := cmd.Flags().GetUint8(RescaleFlagName)
+
+	return &v
+}
+
+// Rescale re-expresses a raw integer amount, recorded at its asset's precision,
+// as an amount at toScale, returning the rendered amount and the asset label
+// re-suffixed to toScale (bare currency when toScale is 0).
+//
+//	1234 "USD/2" @ scale 0 -> "12.34",  "USD"
+//	1234 "USD/2" @ scale 2 -> "1234",   "USD/2"
+//	1234 "USD/2" @ scale 4 -> "123400", "USD/4"
+//
+// Amounts that do not parse as an integer are returned unchanged.
+func Rescale(amount, asset string, toScale uint8) (string, string) {
+	base, precision := invariants.ParseAssetPrecision(asset)
+
+	n, ok := new(big.Int).SetString(amount, 10)
+	if !ok {
+		return amount, asset
+	}
+
+	return RescaleAmount(n, precision, toScale), AssetLabel(base, toScale)
+}
+
+// RescaleAmount renders amount — an integer recorded at fromPrecision — expressed
+// at toScale. When toScale is coarser than fromPrecision the surplus digits
+// become a fractional part (1234 at precision 2, scale 0 → "12.34"); when finer,
+// the value is padded with zeros (1234 at precision 2, scale 4 → "123400").
+func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
+	switch {
+	case fromPrecision > toScale:
+		return scaleDown(amount, fromPrecision-toScale)
+	case fromPrecision < toScale:
+		factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(toScale-fromPrecision)), nil)
+
+		return new(big.Int).Mul(amount, factor).String()
+	default:
+		return amount.String()
+	}
+}
+
+// AssetLabel reconstructs an asset string for a bare currency at the given scale:
+// scale 0 yields the currency alone, otherwise "CUR/scale".
+func AssetLabel(base string, scale uint8) string {
+	if scale == 0 {
+		return base
+	}
+
+	return fmt.Sprintf("%s/%d", base, scale)
+}
+
+// RawVolume holds an asset's raw integer input/output amounts as decimal
+// strings, as carried on the wire.
+type RawVolume struct {
+	Input  string
+	Output string
+}
+
+// AssetVolumes is the result of aggregating one base currency across precisions.
+// Input, Output and Balance (= Input - Output) are summed and expressed at
+// Precision, the highest precision seen in the group; render them at a target
+// scale with RescaleAmount(amount, Precision, toScale). Asset is the bare
+// currency (no "/precision" suffix).
+type AssetVolumes struct {
+	Asset     string
+	Precision uint8
+	Input     *big.Int
+	Output    *big.Int
+	Balance   *big.Int
+}
+
+// AggregateVolumes groups per-asset input/output volumes by base currency and
+// sums entries that share a base but differ in precision: "USD/4" and "USD/8"
+// both collapse to "USD". Summing is done on the real (scaled) amounts, not the
+// raw integers — each value is lifted to the group's highest precision first —
+// so no fractional digits are lost (1.0000 + 1.00000000 → 2.00000000). Balance
+// is derived as Input - Output. Results are sorted by currency. An asset whose
+// input or output does not parse as an integer is skipped — server-issued
+// amounts are always canonical integer strings.
+func AggregateVolumes(volumes map[string]RawVolume) []AssetVolumes {
+	maxPrecision := make(map[string]uint8, len(volumes))
+
+	type entry struct {
+		base      string
+		precision uint8
+		input     *big.Int
+		output    *big.Int
+	}
+
+	entries := make([]entry, 0, len(volumes))
+
+	for asset, vol := range volumes {
+		base, precision := invariants.ParseAssetPrecision(asset)
+
+		input, okIn := new(big.Int).SetString(vol.Input, 10)
+		output, okOut := new(big.Int).SetString(vol.Output, 10)
+		if !okIn || !okOut {
+			continue
+		}
+
+		entries = append(entries, entry{base: base, precision: precision, input: input, output: output})
+
+		if precision > maxPrecision[base] {
+			maxPrecision[base] = precision
+		}
+	}
+
+	type sums struct {
+		input  *big.Int
+		output *big.Int
+	}
+
+	agg := make(map[string]*sums, len(maxPrecision))
+	order := make([]string, 0, len(maxPrecision))
+
+	for _, e := range entries {
+		s, seen := agg[e.base]
+		if !seen {
+			s = &sums{input: new(big.Int), output: new(big.Int)}
+			agg[e.base] = s
+
+			order = append(order, e.base)
+		}
+
+		shift := maxPrecision[e.base] - e.precision
+		s.input.Add(s.input, lift(e.input, shift))
+		s.output.Add(s.output, lift(e.output, shift))
+	}
+
+	sort.Strings(order)
+
+	result := make([]AssetVolumes, 0, len(order))
+
+	for _, base := range order {
+		s := agg[base]
+		result = append(result, AssetVolumes{
+			Asset:     base,
+			Precision: maxPrecision[base],
+			Input:     s.input,
+			Output:    s.output,
+			Balance:   new(big.Int).Sub(s.input, s.output),
+		})
+	}
+
+	return result
+}
+
+// lift multiplies amount by 10^shift, used to express a value at a higher
+// precision before summing. shift 0 returns amount unchanged.
+func lift(amount *big.Int, shift uint8) *big.Int {
+	if shift == 0 {
+		return amount
+	}
+
+	factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(shift)), nil)
+
+	return new(big.Int).Mul(amount, factor)
+}
+
+// scaleDown renders amount / 10^precision as a fixed-point decimal string with
+// exactly precision fractional digits, preserving the sign and any trailing
+// zeros (so "780" stays ".780", never ".78").
+func scaleDown(amount *big.Int, precision uint8) string {
+	if precision == 0 {
+		return amount.String()
+	}
+
+	sign := ""
+
+	abs := amount
+	if amount.Sign() < 0 {
+		sign = "-"
+		abs = new(big.Int).Neg(amount)
+	}
+
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+	quo, rem := new(big.Int).QuoRem(abs, divisor, new(big.Int))
+
+	frac := rem.String()
+	if pad := int(precision) - len(frac); pad > 0 {
+		frac = strings.Repeat("0", pad) + frac
+	}
+
+	return sign + quo.String() + "." + frac
+}

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -1,7 +1,6 @@
 package cmdutil
 
 import (
-	"fmt"
 	"math/big"
 	"sort"
 	"strings"
@@ -69,13 +68,11 @@ func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
 }
 
 // AssetLabel reconstructs an asset string for a bare currency at the given scale:
-// scale 0 yields the currency alone, otherwise "CUR/scale".
+// scale 0 yields the currency alone, otherwise "CUR/scale". It delegates to
+// invariants.FormatAsset so the "CUR/N" grammar has a single implementation
+// shared with the server side.
 func AssetLabel(base string, scale uint8) string {
-	if scale == 0 {
-		return base
-	}
-
-	return fmt.Sprintf("%s/%d", base, scale)
+	return invariants.FormatAsset(base, scale)
 }
 
 // RawVolume holds an asset's raw integer input/output amounts as decimal

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -47,7 +47,7 @@ func Rescale(amount, asset string, toScale uint8) (string, string) {
 		return amount, asset
 	}
 
-	return RescaleAmount(n, precision, toScale), AssetLabel(base, toScale)
+	return RescaleAmount(n, precision, toScale), invariants.FormatAsset(base, toScale)
 }
 
 // RescaleAmount renders amount — an integer recorded at fromPrecision — expressed
@@ -65,14 +65,6 @@ func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
 	default:
 		return amount.String()
 	}
-}
-
-// AssetLabel reconstructs an asset string for a bare currency at the given scale:
-// scale 0 yields the currency alone, otherwise "CUR/scale". It delegates to
-// invariants.FormatAsset so the "CUR/N" grammar has a single implementation
-// shared with the server side.
-func AssetLabel(base string, scale uint8) string {
-	return invariants.FormatAsset(base, scale)
 }
 
 // RawVolume holds an asset's raw integer input/output amounts as decimal

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -47,7 +47,7 @@ func Rescale(amount, asset string, toScale uint8) (string, string) {
 		return amount, asset
 	}
 
-	return RescaleAmount(n, precision, toScale), AssetLabel(base, toScale)
+	return RescaleAmount(n, precision, toScale), invariants.FormatAsset(base, toScale)
 }
 
 // RescaleAmount renders amount — an integer recorded at fromPrecision — expressed
@@ -65,14 +65,6 @@ func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
 	default:
 		return amount.String()
 	}
-}
-
-// AssetLabel reconstructs an asset string for a bare currency at the given scale:
-// scale 0 yields the currency alone, otherwise "CUR/scale". It delegates to
-// invariants.FormatAsset so the "CUR/N" grammar has a single implementation
-// shared with the server side.
-func AssetLabel(base string, scale uint8) string {
-	return invariants.FormatAsset(base, scale)
 }
 
 // RawVolume holds one (asset, color) bucket's raw integer input/output amounts

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -1,7 +1,6 @@
 package cmdutil
 
 import (
-	"fmt"
 	"math/big"
 	"sort"
 	"strings"
@@ -69,13 +68,11 @@ func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
 }
 
 // AssetLabel reconstructs an asset string for a bare currency at the given scale:
-// scale 0 yields the currency alone, otherwise "CUR/scale".
+// scale 0 yields the currency alone, otherwise "CUR/scale". It delegates to
+// invariants.FormatAsset so the "CUR/N" grammar has a single implementation
+// shared with the server side.
 func AssetLabel(base string, scale uint8) string {
-	if scale == 0 {
-		return base
-	}
-
-	return fmt.Sprintf("%s/%d", base, scale)
+	return invariants.FormatAsset(base, scale)
 }
 
 // RawVolume holds one (asset, color) bucket's raw integer input/output amounts

--- a/cmd/ledgerctl/cmdutil/amount.go
+++ b/cmd/ledgerctl/cmdutil/amount.go
@@ -1,0 +1,232 @@
+package cmdutil
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/formancehq/invariants"
+	"github.com/spf13/cobra"
+)
+
+// RescaleFlagName is the name of the global flag that re-expresses amounts at a
+// chosen scale.
+const RescaleFlagName = "rescale"
+
+// RescaleTarget returns the target scale requested via --rescale, or nil when
+// the flag was not given. --rescale passed without a value yields a non-nil
+// pointer to 0 (rescale to whole units, dropping the precision suffix), which is
+// deliberately distinct from the flag being absent (no rescaling at all). The
+// scale is a uint8: an asset's precision is a single byte, so pflag rejects any
+// value above 255 at parse time.
+func RescaleTarget(cmd *cobra.Command) *uint8 {
+	if !cmd.Flags().Changed(RescaleFlagName) {
+		return nil
+	}
+
+	v, _ := cmd.Flags().GetUint8(RescaleFlagName)
+
+	return &v
+}
+
+// Rescale re-expresses a raw integer amount, recorded at its asset's precision,
+// as an amount at toScale, returning the rendered amount and the asset label
+// re-suffixed to toScale (bare currency when toScale is 0).
+//
+//	1234 "USD/2" @ scale 0 -> "12.34",  "USD"
+//	1234 "USD/2" @ scale 2 -> "1234",   "USD/2"
+//	1234 "USD/2" @ scale 4 -> "123400", "USD/4"
+//
+// Amounts that do not parse as an integer are returned unchanged.
+func Rescale(amount, asset string, toScale uint8) (string, string) {
+	base, precision := invariants.ParseAssetPrecision(asset)
+
+	n, ok := new(big.Int).SetString(amount, 10)
+	if !ok {
+		return amount, asset
+	}
+
+	return RescaleAmount(n, precision, toScale), AssetLabel(base, toScale)
+}
+
+// RescaleAmount renders amount — an integer recorded at fromPrecision — expressed
+// at toScale. When toScale is coarser than fromPrecision the surplus digits
+// become a fractional part (1234 at precision 2, scale 0 → "12.34"); when finer,
+// the value is padded with zeros (1234 at precision 2, scale 4 → "123400").
+func RescaleAmount(amount *big.Int, fromPrecision, toScale uint8) string {
+	switch {
+	case fromPrecision > toScale:
+		return scaleDown(amount, fromPrecision-toScale)
+	case fromPrecision < toScale:
+		factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(toScale-fromPrecision)), nil)
+
+		return new(big.Int).Mul(amount, factor).String()
+	default:
+		return amount.String()
+	}
+}
+
+// AssetLabel reconstructs an asset string for a bare currency at the given scale:
+// scale 0 yields the currency alone, otherwise "CUR/scale".
+func AssetLabel(base string, scale uint8) string {
+	if scale == 0 {
+		return base
+	}
+
+	return fmt.Sprintf("%s/%d", base, scale)
+}
+
+// RawVolume holds one (asset, color) bucket's raw integer input/output amounts
+// as decimal strings, as carried on the wire. The empty color is the uncolored
+// bucket.
+type RawVolume struct {
+	Asset  string
+	Color  string
+	Input  string
+	Output string
+}
+
+// AssetVolumes is the result of aggregating one (base currency, color) bucket
+// across precisions. Input, Output and Balance (= Input - Output) are summed and
+// expressed at Precision, the highest precision seen in the group; render them at
+// a target scale with RescaleAmount(amount, Precision, toScale). Asset is the
+// bare currency (no "/precision" suffix).
+type AssetVolumes struct {
+	Asset     string
+	Color     string
+	Precision uint8
+	Input     *big.Int
+	Output    *big.Int
+	Balance   *big.Int
+}
+
+// AggregateVolumes groups input/output volumes by (base currency, color) and
+// sums entries that share a bucket but differ in precision: "USD/4" and "USD/8"
+// both collapse to "USD". Colors stay segregated — they are distinct balance
+// buckets and are never summed together. Summing is done on the real (scaled)
+// amounts, not the raw integers — each value is lifted to the group's highest
+// precision first — so no fractional digits are lost (1.0000 + 1.00000000 →
+// 2.00000000). Balance is derived as Input - Output. Results are sorted by
+// (currency, color). An asset whose input or output does not parse as an integer
+// is skipped — server-issued amounts are always canonical integer strings.
+func AggregateVolumes(volumes []RawVolume) []AssetVolumes {
+	type bucket struct {
+		base  string
+		color string
+	}
+
+	maxPrecision := make(map[bucket]uint8, len(volumes))
+
+	type entry struct {
+		bucket    bucket
+		precision uint8
+		input     *big.Int
+		output    *big.Int
+	}
+
+	entries := make([]entry, 0, len(volumes))
+
+	for _, vol := range volumes {
+		base, precision := invariants.ParseAssetPrecision(vol.Asset)
+
+		input, okIn := new(big.Int).SetString(vol.Input, 10)
+		output, okOut := new(big.Int).SetString(vol.Output, 10)
+		if !okIn || !okOut {
+			continue
+		}
+
+		b := bucket{base: base, color: vol.Color}
+
+		entries = append(entries, entry{bucket: b, precision: precision, input: input, output: output})
+
+		if precision > maxPrecision[b] {
+			maxPrecision[b] = precision
+		}
+	}
+
+	type sums struct {
+		input  *big.Int
+		output *big.Int
+	}
+
+	agg := make(map[bucket]*sums, len(maxPrecision))
+	order := make([]bucket, 0, len(maxPrecision))
+
+	for _, e := range entries {
+		s, seen := agg[e.bucket]
+		if !seen {
+			s = &sums{input: new(big.Int), output: new(big.Int)}
+			agg[e.bucket] = s
+
+			order = append(order, e.bucket)
+		}
+
+		shift := maxPrecision[e.bucket] - e.precision
+		s.input.Add(s.input, lift(e.input, shift))
+		s.output.Add(s.output, lift(e.output, shift))
+	}
+
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].base != order[j].base {
+			return order[i].base < order[j].base
+		}
+
+		return order[i].color < order[j].color
+	})
+
+	result := make([]AssetVolumes, 0, len(order))
+
+	for _, b := range order {
+		s := agg[b]
+		result = append(result, AssetVolumes{
+			Asset:     b.base,
+			Color:     b.color,
+			Precision: maxPrecision[b],
+			Input:     s.input,
+			Output:    s.output,
+			Balance:   new(big.Int).Sub(s.input, s.output),
+		})
+	}
+
+	return result
+}
+
+// lift multiplies amount by 10^shift, used to express a value at a higher
+// precision before summing. shift 0 returns amount unchanged.
+func lift(amount *big.Int, shift uint8) *big.Int {
+	if shift == 0 {
+		return amount
+	}
+
+	factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(shift)), nil)
+
+	return new(big.Int).Mul(amount, factor)
+}
+
+// scaleDown renders amount / 10^precision as a fixed-point decimal string with
+// exactly precision fractional digits, preserving the sign and any trailing
+// zeros (so "780" stays ".780", never ".78").
+func scaleDown(amount *big.Int, precision uint8) string {
+	if precision == 0 {
+		return amount.String()
+	}
+
+	sign := ""
+
+	abs := amount
+	if amount.Sign() < 0 {
+		sign = "-"
+		abs = new(big.Int).Neg(amount)
+	}
+
+	divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(precision)), nil)
+	quo, rem := new(big.Int).QuoRem(abs, divisor, new(big.Int))
+
+	frac := rem.String()
+	if pad := int(precision) - len(frac); pad > 0 {
+		frac = strings.Repeat("0", pad) + frac
+	}
+
+	return sign + quo.String() + "." + frac
+}

--- a/cmd/ledgerctl/cmdutil/amount_test.go
+++ b/cmd/ledgerctl/cmdutil/amount_test.go
@@ -1,0 +1,210 @@
+package cmdutil
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestRescale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     string
+		asset      string
+		toScale    uint8
+		wantAmount string
+		wantAsset  string
+	}{
+		{
+			name:       "coarser scale exposes a fractional part",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    0,
+			wantAmount: "12.34",
+			wantAsset:  "USD",
+		},
+		{
+			name:       "same scale is a no-op that keeps the suffix",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    2,
+			wantAmount: "1234",
+			wantAsset:  "USD/2",
+		},
+		{
+			name:       "finer scale pads with zeros",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    4,
+			wantAmount: "123400",
+			wantAsset:  "USD/4",
+		},
+		{
+			name:       "bare currency, scale 0",
+			amount:     "1000",
+			asset:      "JPY",
+			toScale:    0,
+			wantAmount: "1000",
+			wantAsset:  "JPY",
+		},
+		{
+			name:       "negative amount keeps its sign",
+			amount:     "-50",
+			asset:      "EUR/2",
+			toScale:    0,
+			wantAmount: "-0.50",
+			wantAsset:  "EUR",
+		},
+		{
+			name:       "unparseable amount is left as-is",
+			amount:     "not-a-number",
+			asset:      "USD/2",
+			toScale:    0,
+			wantAmount: "not-a-number",
+			wantAsset:  "USD/2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotAmount, gotAsset := Rescale(tc.amount, tc.asset, tc.toScale)
+			if gotAmount != tc.wantAmount || gotAsset != tc.wantAsset {
+				t.Errorf("Rescale(%q, %q, %d) = (%q, %q), want (%q, %q)",
+					tc.amount, tc.asset, tc.toScale, gotAmount, gotAsset, tc.wantAmount, tc.wantAsset)
+			}
+		})
+	}
+}
+
+func TestRescaleAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		amount        int64
+		fromPrecision uint8
+		toScale       uint8
+		want          string
+	}{
+		{"coarser", 69129, 3, 0, "69.129"},
+		{"coarser by one", 69129, 3, 2, "6912.9"},
+		{"same", 69129, 3, 3, "69129"},
+		{"finer", 69129, 3, 5, "6912900"},
+		{"precision zero", 1000, 0, 0, "1000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := RescaleAmount(big.NewInt(tc.amount), tc.fromPrecision, tc.toScale); got != tc.want {
+				t.Errorf("RescaleAmount(%d, %d, %d) = %q, want %q",
+					tc.amount, tc.fromPrecision, tc.toScale, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregateVolumesRescaleSpec(t *testing.T) {
+	t.Parallel()
+
+	// The spec example: 1234 USD/2 + 56789 USD/3, summed on real values.
+	got := AggregateVolumes(map[string]RawVolume{
+		"USD/2": {Input: "1234", Output: "0"},
+		"USD/3": {Input: "56789", Output: "0"},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated currency, got %d: %+v", len(got), got)
+	}
+
+	av := got[0]
+
+	// --rescale (scale 0) → 69.129 USD
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 0), AssetLabel(av.Asset, 0); bal != "69.129" || asset != "USD" {
+		t.Errorf("scale 0: got %s %s, want 69.129 USD", bal, asset)
+	}
+
+	// --rescale=2 → 6912.9 USD/2
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 2), AssetLabel(av.Asset, 2); bal != "6912.9" || asset != "USD/2" {
+		t.Errorf("scale 2: got %s %s, want 6912.9 USD/2", bal, asset)
+	}
+}
+
+func TestAggregateVolumes(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		asset                  string
+		precision              uint8
+		input, output, balance string
+	}
+
+	// Render aggregated sums at their natural precision (scale 0 keeps every
+	// fractional digit) for comparison.
+	assert := func(t *testing.T, got []AssetVolumes, wants []want) {
+		t.Helper()
+
+		if len(got) != len(wants) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(wants), len(got), got)
+		}
+
+		for i, w := range wants {
+			g := got[i]
+
+			gotInput := RescaleAmount(g.Input, g.Precision, 0)
+			gotOutput := RescaleAmount(g.Output, g.Precision, 0)
+			gotBalance := RescaleAmount(g.Balance, g.Precision, 0)
+
+			if g.Asset != w.asset || g.Precision != w.precision ||
+				gotInput != w.input || gotOutput != w.output || gotBalance != w.balance {
+				t.Errorf("entry %d: got {asset=%s prec=%d in=%s out=%s bal=%s}, want %+v",
+					i, g.Asset, g.Precision, gotInput, gotOutput, gotBalance, w)
+			}
+		}
+	}
+
+	t.Run("sums input/output/balance across precisions at the highest precision", func(t *testing.T) {
+		t.Parallel()
+
+		got := AggregateVolumes(map[string]RawVolume{
+			"USD/4": {Input: "10000", Output: "0"},     // in 1.0000
+			"USD/8": {Input: "100000000", Output: "0"}, // in 1.00000000
+			"EUR/2": {Input: "250", Output: "100"},     // in 2.50, out 1.00 → bal 1.50
+		})
+
+		assert(t, got, []want{
+			{"EUR", 2, "2.50", "1.00", "1.50"},
+			{"USD", 8, "2.00000000", "0.00000000", "2.00000000"},
+		})
+	})
+
+	t.Run("balance is derived as input minus output and can be negative", func(t *testing.T) {
+		t.Parallel()
+
+		// 1.50 - 2.0000 = -0.5000 at precision 4.
+		got := AggregateVolumes(map[string]RawVolume{
+			"USD/2": {Input: "150", Output: "0"},
+			"USD/4": {Input: "0", Output: "20000"},
+		})
+
+		assert(t, got, []want{
+			{"USD", 4, "1.5000", "2.0000", "-0.5000"},
+		})
+	})
+
+	t.Run("bare currency without precision", func(t *testing.T) {
+		t.Parallel()
+
+		got := AggregateVolumes(map[string]RawVolume{
+			"JPY": {Input: "1000", Output: "400"},
+		})
+
+		assert(t, got, []want{
+			{"JPY", 0, "1000", "400", "600"},
+		})
+	})
+}

--- a/cmd/ledgerctl/cmdutil/amount_test.go
+++ b/cmd/ledgerctl/cmdutil/amount_test.go
@@ -3,6 +3,8 @@ package cmdutil
 import (
 	"math/big"
 	"testing"
+
+	"github.com/formancehq/invariants"
 )
 
 func TestRescale(t *testing.T) {
@@ -124,12 +126,12 @@ func TestAggregateVolumesRescaleSpec(t *testing.T) {
 	av := got[0]
 
 	// --rescale (scale 0) → 69.129 USD
-	if bal, asset := RescaleAmount(av.Balance, av.Precision, 0), AssetLabel(av.Asset, 0); bal != "69.129" || asset != "USD" {
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 0), invariants.FormatAsset(av.Asset, 0); bal != "69.129" || asset != "USD" {
 		t.Errorf("scale 0: got %s %s, want 69.129 USD", bal, asset)
 	}
 
 	// --rescale=2 → 6912.9 USD/2
-	if bal, asset := RescaleAmount(av.Balance, av.Precision, 2), AssetLabel(av.Asset, 2); bal != "6912.9" || asset != "USD/2" {
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 2), invariants.FormatAsset(av.Asset, 2); bal != "6912.9" || asset != "USD/2" {
 		t.Errorf("scale 2: got %s %s, want 6912.9 USD/2", bal, asset)
 	}
 }

--- a/cmd/ledgerctl/cmdutil/amount_test.go
+++ b/cmd/ledgerctl/cmdutil/amount_test.go
@@ -1,0 +1,226 @@
+package cmdutil
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestRescale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		amount     string
+		asset      string
+		toScale    uint8
+		wantAmount string
+		wantAsset  string
+	}{
+		{
+			name:       "coarser scale exposes a fractional part",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    0,
+			wantAmount: "12.34",
+			wantAsset:  "USD",
+		},
+		{
+			name:       "same scale is a no-op that keeps the suffix",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    2,
+			wantAmount: "1234",
+			wantAsset:  "USD/2",
+		},
+		{
+			name:       "finer scale pads with zeros",
+			amount:     "1234",
+			asset:      "USD/2",
+			toScale:    4,
+			wantAmount: "123400",
+			wantAsset:  "USD/4",
+		},
+		{
+			name:       "bare currency, scale 0",
+			amount:     "1000",
+			asset:      "JPY",
+			toScale:    0,
+			wantAmount: "1000",
+			wantAsset:  "JPY",
+		},
+		{
+			name:       "negative amount keeps its sign",
+			amount:     "-50",
+			asset:      "EUR/2",
+			toScale:    0,
+			wantAmount: "-0.50",
+			wantAsset:  "EUR",
+		},
+		{
+			name:       "unparseable amount is left as-is",
+			amount:     "not-a-number",
+			asset:      "USD/2",
+			toScale:    0,
+			wantAmount: "not-a-number",
+			wantAsset:  "USD/2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotAmount, gotAsset := Rescale(tc.amount, tc.asset, tc.toScale)
+			if gotAmount != tc.wantAmount || gotAsset != tc.wantAsset {
+				t.Errorf("Rescale(%q, %q, %d) = (%q, %q), want (%q, %q)",
+					tc.amount, tc.asset, tc.toScale, gotAmount, gotAsset, tc.wantAmount, tc.wantAsset)
+			}
+		})
+	}
+}
+
+func TestRescaleAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		amount        int64
+		fromPrecision uint8
+		toScale       uint8
+		want          string
+	}{
+		{"coarser", 69129, 3, 0, "69.129"},
+		{"coarser by one", 69129, 3, 2, "6912.9"},
+		{"same", 69129, 3, 3, "69129"},
+		{"finer", 69129, 3, 5, "6912900"},
+		{"precision zero", 1000, 0, 0, "1000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := RescaleAmount(big.NewInt(tc.amount), tc.fromPrecision, tc.toScale); got != tc.want {
+				t.Errorf("RescaleAmount(%d, %d, %d) = %q, want %q",
+					tc.amount, tc.fromPrecision, tc.toScale, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregateVolumesRescaleSpec(t *testing.T) {
+	t.Parallel()
+
+	// The spec example: 1234 USD/2 + 56789 USD/3, summed on real values.
+	got := AggregateVolumes([]RawVolume{
+		{Asset: "USD/2", Input: "1234", Output: "0"},
+		{Asset: "USD/3", Input: "56789", Output: "0"},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 aggregated currency, got %d: %+v", len(got), got)
+	}
+
+	av := got[0]
+
+	// --rescale (scale 0) → 69.129 USD
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 0), AssetLabel(av.Asset, 0); bal != "69.129" || asset != "USD" {
+		t.Errorf("scale 0: got %s %s, want 69.129 USD", bal, asset)
+	}
+
+	// --rescale=2 → 6912.9 USD/2
+	if bal, asset := RescaleAmount(av.Balance, av.Precision, 2), AssetLabel(av.Asset, 2); bal != "6912.9" || asset != "USD/2" {
+		t.Errorf("scale 2: got %s %s, want 6912.9 USD/2", bal, asset)
+	}
+}
+
+func TestAggregateVolumes(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		asset                  string
+		color                  string
+		precision              uint8
+		input, output, balance string
+	}
+
+	// Render aggregated sums at their natural precision (scale 0 keeps every
+	// fractional digit) for comparison.
+	assert := func(t *testing.T, got []AssetVolumes, wants []want) {
+		t.Helper()
+
+		if len(got) != len(wants) {
+			t.Fatalf("expected %d entries, got %d: %+v", len(wants), len(got), got)
+		}
+
+		for i, w := range wants {
+			g := got[i]
+
+			gotInput := RescaleAmount(g.Input, g.Precision, 0)
+			gotOutput := RescaleAmount(g.Output, g.Precision, 0)
+			gotBalance := RescaleAmount(g.Balance, g.Precision, 0)
+
+			if g.Asset != w.asset || g.Color != w.color || g.Precision != w.precision ||
+				gotInput != w.input || gotOutput != w.output || gotBalance != w.balance {
+				t.Errorf("entry %d: got {asset=%s color=%s prec=%d in=%s out=%s bal=%s}, want %+v",
+					i, g.Asset, g.Color, g.Precision, gotInput, gotOutput, gotBalance, w)
+			}
+		}
+	}
+
+	t.Run("sums input/output/balance across precisions at the highest precision", func(t *testing.T) {
+		t.Parallel()
+
+		got := AggregateVolumes([]RawVolume{
+			{Asset: "USD/4", Input: "10000", Output: "0"},     // in 1.0000
+			{Asset: "USD/8", Input: "100000000", Output: "0"}, // in 1.00000000
+			{Asset: "EUR/2", Input: "250", Output: "100"},     // in 2.50, out 1.00 → bal 1.50
+		})
+
+		assert(t, got, []want{
+			{"EUR", "", 2, "2.50", "1.00", "1.50"},
+			{"USD", "", 8, "2.00000000", "0.00000000", "2.00000000"},
+		})
+	})
+
+	t.Run("colors stay segregated and sort after the uncolored bucket", func(t *testing.T) {
+		t.Parallel()
+
+		got := AggregateVolumes([]RawVolume{
+			{Asset: "USD/2", Color: "GREEN", Input: "150", Output: "0"},
+			{Asset: "USD/4", Color: "GREEN", Input: "0", Output: "20000"},
+			{Asset: "USD/2", Input: "1000", Output: "0"},
+		})
+
+		assert(t, got, []want{
+			{"USD", "", 2, "10.00", "0.00", "10.00"},
+			{"USD", "GREEN", 4, "1.5000", "2.0000", "-0.5000"},
+		})
+	})
+
+	t.Run("balance is derived as input minus output and can be negative", func(t *testing.T) {
+		t.Parallel()
+
+		// 1.50 - 2.0000 = -0.5000 at precision 4.
+		got := AggregateVolumes([]RawVolume{
+			{Asset: "USD/2", Input: "150", Output: "0"},
+			{Asset: "USD/4", Input: "0", Output: "20000"},
+		})
+
+		assert(t, got, []want{
+			{"USD", "", 4, "1.5000", "2.0000", "-0.5000"},
+		})
+	})
+
+	t.Run("bare currency without precision", func(t *testing.T) {
+		t.Parallel()
+
+		got := AggregateVolumes([]RawVolume{
+			{Asset: "JPY", Input: "1000", Output: "400"},
+		})
+
+		assert(t, got, []want{
+			{"JPY", "", 0, "1000", "400", "600"},
+		})
+	})
+}

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -130,6 +130,15 @@ func newRootCommand() *cobra.Command {
 	// kubelet captures the result on pod.status) can all opt in.
 	rootCmd.PersistentFlags().String("result-file", "", "Also write the --json result to this file path (env: LEDGERCTL_RESULT_FILE)")
 
+	// Add persistent flag for human-friendly amount display. Affects only the
+	// rendered tables/text — structured (--json/--yaml) output keeps the raw
+	// integer amounts and full "CUR/precision" asset strings so scripts stay
+	// stable. Absent = no rescaling; --rescale alone = scale 0. The scale is a
+	// uint8 (an asset's precision is a single byte), so pflag rejects values
+	// above 255 at parse time.
+	rootCmd.PersistentFlags().Uint8(cmdutil.RescaleFlagName, 0, "Re-express amounts at the given scale, summing same-currency balances across precisions (e.g. 1234 USD/2 + 56789 USD/3 → 69.129 USD; --rescale=2 → 6912.9 USD/2)")
+	rootCmd.PersistentFlags().Lookup(cmdutil.RescaleFlagName).NoOptDefVal = "0"
+
 	// Add subcommands.
 	rootCmd.AddCommand(ledgers.NewCommand())
 	rootCmd.AddCommand(indexes.NewCommand())

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -131,6 +131,15 @@ func newRootCommand() *cobra.Command {
 	// kubelet captures the result on pod.status) can all opt in.
 	rootCmd.PersistentFlags().String("result-file", "", "Also write the --json result to this file path (env: LEDGERCTL_RESULT_FILE)")
 
+	// Add persistent flag for human-friendly amount display. Affects only the
+	// rendered tables/text — structured (--json/--yaml) output keeps the raw
+	// integer amounts and full "CUR/precision" asset strings so scripts stay
+	// stable. Absent = no rescaling; --rescale alone = scale 0. The scale is a
+	// uint8 (an asset's precision is a single byte), so pflag rejects values
+	// above 255 at parse time.
+	rootCmd.PersistentFlags().Uint8(cmdutil.RescaleFlagName, 0, "Re-express amounts at the given scale, summing same-currency balances across precisions (e.g. 1234 USD/2 + 56789 USD/3 → 69.129 USD; --rescale=2 → 6912.9 USD/2)")
+	rootCmd.PersistentFlags().Lookup(cmdutil.RescaleFlagName).NoOptDefVal = "0"
+
 	// Add subcommands.
 	rootCmd.AddCommand(ledgers.NewCommand())
 	rootCmd.AddCommand(indexes.NewCommand())

--- a/cmd/ledgerctl/main_test.go
+++ b/cmd/ledgerctl/main_test.go
@@ -396,3 +396,44 @@ func TestBindEnvSkipsOwnedProfile(t *testing.T) {
 	require.Equal(t, "bound-value", probe)
 	require.True(t, set.Changed("probe-only"))
 }
+
+// TestRescaleFlagValidation guards the --rescale scale bound: it is a uint8, so
+// pflag rejects values above an asset's max precision (255) at parse time, while
+// bare --rescale and explicit values in range parse cleanly. "version" is a
+// hermetic leaf that runs without opening a connection.
+func TestRescaleFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"absent is fine", []string{"version"}, false},
+		{"bare --rescale means scale 0", []string{"version", "--rescale"}, false},
+		{"explicit zero", []string{"version", "--rescale=0"}, false},
+		{"max in range", []string{"version", "--rescale=255"}, false},
+		{"out of range", []string{"version", "--rescale=256"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Hermetic config: empty temp dir so LoadConfig() returns a zero
+			// Config on every platform (see TestServerFlagEnvResolution).
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+			t.Setenv("XDG_CONFIG_HOME", tmp)
+			t.Setenv("APPDATA", tmp)
+			t.Setenv("LOCALAPPDATA", tmp)
+
+			root := newRootCommand()
+			root.SilenceErrors = true
+			root.SetArgs(tc.args)
+
+			err := root.Execute()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/ledgerctl/main_test.go
+++ b/cmd/ledgerctl/main_test.go
@@ -405,3 +405,44 @@ func TestBindEnvSkipsOwnedProfile(t *testing.T) {
 	require.Equal(t, "bound-value", probe)
 	require.True(t, set.Changed("probe-only"))
 }
+
+// TestRescaleFlagValidation guards the --rescale scale bound: it is a uint8, so
+// pflag rejects values above an asset's max precision (255) at parse time, while
+// bare --rescale and explicit values in range parse cleanly. "version" is a
+// hermetic leaf that runs without opening a connection.
+func TestRescaleFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"absent is fine", []string{"version"}, false},
+		{"bare --rescale means scale 0", []string{"version", "--rescale"}, false},
+		{"explicit zero", []string{"version", "--rescale=0"}, false},
+		{"max in range", []string{"version", "--rescale=255"}, false},
+		{"out of range", []string{"version", "--rescale=256"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Hermetic config: empty temp dir so LoadConfig() returns a zero
+			// Config on every platform (see TestServerFlagEnvResolution).
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+			t.Setenv("XDG_CONFIG_HOME", tmp)
+			t.Setenv("APPDATA", tmp)
+			t.Setenv("LOCALAPPDATA", tmp)
+
+			root := newRootCommand()
+			root.SilenceErrors = true
+			root.SetArgs(tc.args)
+
+			err := root.Execute()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/ledgerctl/queries/execute.go
+++ b/cmd/ledgerctl/queries/execute.go
@@ -232,9 +232,36 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 		return err
 	}
 
-	if len(result.GetVolumes()) > 0 {
+	rescale := cmdutil.RescaleTarget(cmd)
+
+	// volumesTable builds the ASSET/INPUT/OUTPUT table for one set of aggregated
+	// volumes. With --rescale, same-currency rows that differ only in precision
+	// are summed and re-expressed at the requested scale (matching accounts
+	// aggregate-volumes); otherwise each row is rendered raw.
+	volumesTable := func(vols []*commonpb.AggregatedVolume) pterm.TableData {
 		tableData := pterm.TableData{{"ASSET", "INPUT", "OUTPUT"}}
-		for _, v := range result.GetVolumes() {
+
+		if rescale != nil {
+			raw := make(map[string]cmdutil.RawVolume, len(vols))
+			for _, v := range vols {
+				raw[v.GetAsset()] = cmdutil.RawVolume{
+					Input:  v.GetInput().ToBigInt().String(),
+					Output: v.GetOutput().ToBigInt().String(),
+				}
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				tableData = append(tableData, []string{
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				})
+			}
+
+			return tableData
+		}
+
+		for _, v := range vols {
 			tableData = append(tableData, []string{
 				v.GetAsset(),
 				v.GetInput().ToBigInt().String(),
@@ -242,23 +269,18 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 			})
 		}
 
-		_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+		return tableData
+	}
+
+	if len(result.GetVolumes()) > 0 {
+		_ = pterm.DefaultTable.WithHasHeader().WithData(volumesTable(result.GetVolumes())).Render()
 	}
 
 	for _, g := range result.GetGroups() {
 		pterm.Println()
 		pterm.Printfln("Group: %s", g.GetPrefix())
 
-		tableData := pterm.TableData{{"ASSET", "INPUT", "OUTPUT"}}
-		for _, v := range g.GetVolumes() {
-			tableData = append(tableData, []string{
-				v.GetAsset(),
-				v.GetInput().ToBigInt().String(),
-				v.GetOutput().ToBigInt().String(),
-			})
-		}
-
-		_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+		_ = pterm.DefaultTable.WithHasHeader().WithData(volumesTable(g.GetVolumes())).Render()
 	}
 
 	return nil

--- a/cmd/ledgerctl/queries/execute.go
+++ b/cmd/ledgerctl/queries/execute.go
@@ -10,6 +10,8 @@ import (
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -252,7 +254,7 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 
 			for _, av := range cmdutil.AggregateVolumes(raw) {
 				tableData = append(tableData, []string{
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
 				})

--- a/cmd/ledgerctl/queries/execute.go
+++ b/cmd/ledgerctl/queries/execute.go
@@ -232,9 +232,40 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 		return err
 	}
 
-	if len(result.GetVolumes()) > 0 {
+	rescale := cmdutil.RescaleTarget(cmd)
+
+	// volumesTable builds the ASSET/COLOR/INPUT/OUTPUT table for one set of
+	// aggregated volumes. With --rescale, rows that share a (currency, color)
+	// bucket but differ only in precision are summed and re-expressed at the
+	// requested scale (matching accounts aggregate-volumes); otherwise each row is
+	// rendered raw.
+	volumesTable := func(vols []*commonpb.AggregatedVolume) pterm.TableData {
 		tableData := pterm.TableData{{"ASSET", "COLOR", "INPUT", "OUTPUT"}}
-		for _, v := range result.GetVolumes() {
+
+		if rescale != nil {
+			raw := make([]cmdutil.RawVolume, 0, len(vols))
+			for _, v := range vols {
+				raw = append(raw, cmdutil.RawVolume{
+					Asset:  v.GetAsset(),
+					Color:  v.GetColor(),
+					Input:  v.GetInput().ToBigInt().String(),
+					Output: v.GetOutput().ToBigInt().String(),
+				})
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				tableData = append(tableData, []string{
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					av.Color,
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				})
+			}
+
+			return tableData
+		}
+
+		for _, v := range vols {
 			tableData = append(tableData, []string{
 				v.GetAsset(),
 				v.GetColor(),
@@ -243,24 +274,18 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 			})
 		}
 
-		_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+		return tableData
+	}
+
+	if len(result.GetVolumes()) > 0 {
+		_ = pterm.DefaultTable.WithHasHeader().WithData(volumesTable(result.GetVolumes())).Render()
 	}
 
 	for _, g := range result.GetGroups() {
 		pterm.Println()
 		pterm.Printfln("Group: %s", g.GetPrefix())
 
-		tableData := pterm.TableData{{"ASSET", "COLOR", "INPUT", "OUTPUT"}}
-		for _, v := range g.GetVolumes() {
-			tableData = append(tableData, []string{
-				v.GetAsset(),
-				v.GetColor(),
-				v.GetInput().ToBigInt().String(),
-				v.GetOutput().ToBigInt().String(),
-			})
-		}
-
-		_ = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
+		_ = pterm.DefaultTable.WithHasHeader().WithData(volumesTable(g.GetVolumes())).Render()
 	}
 
 	return nil

--- a/cmd/ledgerctl/queries/execute.go
+++ b/cmd/ledgerctl/queries/execute.go
@@ -10,6 +10,8 @@ import (
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -255,7 +257,7 @@ func renderAggregate(cmd *cobra.Command, result *commonpb.AggregateResult) error
 
 			for _, av := range cmdutil.AggregateVolumes(raw) {
 				tableData = append(tableData, []string{
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					av.Color,
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -454,6 +454,8 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		pterm.Printf("Timestamp:   %s\n", pterm.Gray(tx.GetTimestamp().AsTime().Format("2006-01-02T15:04:05Z07:00")))
 	}
 
+	rescale := cmdutil.RescaleTarget(cmd)
+
 	// Display postings
 	if len(tx.GetPostings()) > 0 {
 		pterm.Println()
@@ -464,13 +466,18 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		}
 
 		for i, posting := range tx.GetPostings() {
+			amount, asset := posting.GetAmount().Dec(), posting.GetAsset()
+			if rescale != nil {
+				amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+			}
+
 			postingsTable = append(postingsTable, []string{
 				strconv.Itoa(i + 1),
 				posting.GetSource(),
 				"→",
 				posting.GetDestination(),
-				posting.GetAmount().Dec(),
-				posting.GetAsset(),
+				amount,
+				asset,
 			})
 		}
 
@@ -503,7 +510,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	// Display post-commit volumes
 	if createdTx.GetPostCommitVolumes() != nil {
-		err := renderPostCommitVolumes(createdTx.GetPostCommitVolumes())
+		err := renderPostCommitVolumes(createdTx.GetPostCommitVolumes(), rescale)
 		if err != nil {
 			return err
 		}

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -451,6 +451,8 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		pterm.Printf("Timestamp:   %s\n", pterm.Gray(tx.GetTimestamp().AsTime().Format("2006-01-02T15:04:05Z07:00")))
 	}
 
+	rescale := cmdutil.RescaleTarget(cmd)
+
 	// Display postings
 	if len(tx.GetPostings()) > 0 {
 		pterm.Println()
@@ -461,17 +463,23 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		}
 
 		for i, posting := range tx.GetPostings() {
+			amount, asset := posting.GetAmount().Dec(), posting.GetAsset()
+			if rescale != nil {
+				amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+			}
+
 			color := posting.GetColor()
 			if color == "" {
 				color = "-"
 			}
+
 			postingsTable = append(postingsTable, []string{
 				strconv.Itoa(i + 1),
 				posting.GetSource(),
 				"→",
 				posting.GetDestination(),
-				posting.GetAmount().Dec(),
-				posting.GetAsset(),
+				amount,
+				asset,
 				color,
 			})
 		}
@@ -505,7 +513,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	// Display post-commit volumes (carried on the created transaction)
 	if pcv := createdTx.GetTransaction().GetPostCommitVolumes(); pcv != nil {
-		err := renderPostCommitVolumes(pcv)
+		err := renderPostCommitVolumes(pcv, rescale)
 		if err != nil {
 			return err
 		}

--- a/cmd/ledgerctl/transactions/display_volumes.go
+++ b/cmd/ledgerctl/transactions/display_volumes.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/pterm/pterm"
 
+	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // renderPostCommitVolumes displays a PostCommitVolumes table in the CLI output.
-func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
+func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes, rescale *uint8) error {
 	if len(pcv.GetVolumesByAccount()) == 0 {
 		return nil
 	}
@@ -32,6 +33,28 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
 	for _, account := range accounts {
 		vba := pcv.GetVolumesByAccount()[account]
 
+		// With --rescale, an account's per-asset volumes are aggregated by base
+		// currency (USD/2 + USD/3 → one USD row) and re-expressed at the
+		// requested scale, matching accounts get/aggregate-volumes. Otherwise
+		// each asset is rendered raw, sorted for stable output.
+		if rescale != nil {
+			raw := make(map[string]cmdutil.RawVolume, len(vba.GetVolumes()))
+			for asset, v := range vba.GetVolumes() {
+				raw[asset] = cmdutil.RawVolume{Input: v.GetInput(), Output: v.GetOutput()}
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				table = append(table, []string{
+					account,
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				})
+			}
+
+			continue
+		}
+
 		// Sort assets for stable output
 		assets := make([]string, 0, len(vba.GetVolumes()))
 		for asset := range vba.GetVolumes() {
@@ -42,6 +65,7 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
 
 		for _, asset := range assets {
 			v := vba.GetVolumes()[asset]
+
 			table = append(table, []string{
 				account,
 				asset,

--- a/cmd/ledgerctl/transactions/display_volumes.go
+++ b/cmd/ledgerctl/transactions/display_volumes.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pterm/pterm"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -46,7 +48,7 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes, rescale *uint8) er
 			for _, av := range cmdutil.AggregateVolumes(raw) {
 				table = append(table, []string{
 					account,
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
 				})

--- a/cmd/ledgerctl/transactions/display_volumes.go
+++ b/cmd/ledgerctl/transactions/display_volumes.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/pterm/pterm"
 
+	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // renderPostCommitVolumes displays a PostCommitVolumes table in the CLI output.
 // Volumes are listed per (account, asset, color). The "" color is rendered as
 // "-" so the uncolored bucket stands out in the table.
-func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
+func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes, rescale *uint8) error {
 	if len(pcv.GetVolumesByAccount()) == 0 {
 		return nil
 	}
@@ -31,6 +32,41 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
 
 	for _, account := range accounts {
 		vba := pcv.GetVolumesByAccount()[account]
+
+		// With --rescale, an account's volumes are aggregated by (base currency,
+		// color) — USD/2 + USD/3 → one USD row per color — and re-expressed at
+		// the requested scale, matching accounts get/aggregate-volumes. Otherwise
+		// each entry is rendered raw.
+		if rescale != nil {
+			raw := make([]cmdutil.RawVolume, 0, len(vba.GetVolumes()))
+			for _, entry := range vba.GetVolumes() {
+				v := entry.GetVolumes()
+				raw = append(raw, cmdutil.RawVolume{
+					Asset:  entry.GetAsset(),
+					Color:  entry.GetColor(),
+					Input:  v.GetInput(),
+					Output: v.GetOutput(),
+				})
+			}
+
+			for _, av := range cmdutil.AggregateVolumes(raw) {
+				displayColor := av.Color
+				if displayColor == "" {
+					displayColor = "-"
+				}
+
+				table = append(table, []string{
+					account,
+					cmdutil.AssetLabel(av.Asset, *rescale),
+					displayColor,
+					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
+					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),
+				})
+			}
+
+			continue
+		}
+
 		// VolumesByAssets.Volumes is sorted by (asset, color) server-side.
 		for _, entry := range vba.GetVolumes() {
 			v := entry.GetVolumes()
@@ -38,6 +74,7 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes) error {
 			if displayColor == "" {
 				displayColor = "-"
 			}
+
 			table = append(table, []string{
 				account,
 				entry.GetAsset(),

--- a/cmd/ledgerctl/transactions/display_volumes.go
+++ b/cmd/ledgerctl/transactions/display_volumes.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pterm/pterm"
 
+	"github.com/formancehq/invariants"
+
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -57,7 +59,7 @@ func renderPostCommitVolumes(pcv *commonpb.PostCommitVolumes, rescale *uint8) er
 
 				table = append(table, []string{
 					account,
-					cmdutil.AssetLabel(av.Asset, *rescale),
+					invariants.FormatAsset(av.Asset, *rescale),
 					displayColor,
 					cmdutil.RescaleAmount(av.Input, av.Precision, *rescale),
 					cmdutil.RescaleAmount(av.Output, av.Precision, *rescale),

--- a/cmd/ledgerctl/transactions/get.go
+++ b/cmd/ledgerctl/transactions/get.go
@@ -159,6 +159,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 
 		const continuationIndent = "  "
 
+		rescale := cmdutil.RescaleTarget(cmd)
+
 		for i, posting := range tx.GetPostings() {
 			srcLines := cmdutil.WrapText(posting.GetSource(), maxAddrWidth, ":")
 			dstLines := cmdutil.WrapText(posting.GetDestination(), maxAddrWidth, ":")
@@ -186,8 +188,11 @@ func runGet(cmd *cobra.Command, args []string) error {
 				if line == 0 {
 					num = strconv.Itoa(i + 1)
 					arrow = "→"
-					amount = posting.GetAmount().Dec()
-					asset = posting.GetAsset()
+					amount, asset = posting.GetAmount().Dec(), posting.GetAsset()
+
+					if rescale != nil {
+						amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+					}
 				}
 
 				postingsTable = append(postingsTable, []string{

--- a/cmd/ledgerctl/transactions/get.go
+++ b/cmd/ledgerctl/transactions/get.go
@@ -159,6 +159,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 
 		const continuationIndent = "  "
 
+		rescale := cmdutil.RescaleTarget(cmd)
+
 		for i, posting := range tx.GetPostings() {
 			srcLines := cmdutil.WrapText(posting.GetSource(), maxAddrWidth, ":")
 			dstLines := cmdutil.WrapText(posting.GetDestination(), maxAddrWidth, ":")
@@ -186,8 +188,12 @@ func runGet(cmd *cobra.Command, args []string) error {
 				if line == 0 {
 					num = strconv.Itoa(i + 1)
 					arrow = "→"
-					amount = posting.GetAmount().Dec()
-					asset = posting.GetAsset()
+					amount, asset = posting.GetAmount().Dec(), posting.GetAsset()
+
+					if rescale != nil {
+						amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+					}
+
 					color = posting.GetColor()
 					if color == "" {
 						color = "-"

--- a/cmd/ledgerctl/transactions/revert.go
+++ b/cmd/ledgerctl/transactions/revert.go
@@ -227,6 +227,8 @@ func runRevert(cmd *cobra.Command, args []string) error {
 		pterm.Printf("Timestamp:            %s\n", pterm.Gray(revertedTx.GetRevertTransaction().GetTimestamp().AsTime().Format("2006-01-02T15:04:05Z07:00")))
 	}
 
+	rescale := cmdutil.RescaleTarget(cmd)
+
 	// Display postings of the revert transaction
 	if len(revertedTx.GetRevertTransaction().GetPostings()) > 0 {
 		pterm.Println()
@@ -237,13 +239,18 @@ func runRevert(cmd *cobra.Command, args []string) error {
 		}
 
 		for i, posting := range revertedTx.GetRevertTransaction().GetPostings() {
+			amount, asset := posting.GetAmount().Dec(), posting.GetAsset()
+			if rescale != nil {
+				amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+			}
+
 			postingsTable = append(postingsTable, []string{
 				strconv.Itoa(i + 1),
 				posting.GetSource(),
 				"→",
 				posting.GetDestination(),
-				posting.GetAmount().Dec(),
-				posting.GetAsset(),
+				amount,
+				asset,
 			})
 		}
 
@@ -255,7 +262,7 @@ func runRevert(cmd *cobra.Command, args []string) error {
 
 	// Display post-commit volumes
 	if revertedTx.GetPostCommitVolumes() != nil {
-		err := renderPostCommitVolumes(revertedTx.GetPostCommitVolumes())
+		err := renderPostCommitVolumes(revertedTx.GetPostCommitVolumes(), rescale)
 		if err != nil {
 			return err
 		}

--- a/cmd/ledgerctl/transactions/revert.go
+++ b/cmd/ledgerctl/transactions/revert.go
@@ -224,6 +224,8 @@ func runRevert(cmd *cobra.Command, args []string) error {
 		pterm.Printf("Timestamp:            %s\n", pterm.Gray(revertedTx.GetRevertTransaction().GetTimestamp().AsTime().Format("2006-01-02T15:04:05Z07:00")))
 	}
 
+	rescale := cmdutil.RescaleTarget(cmd)
+
 	// Display postings of the revert transaction
 	if len(revertedTx.GetRevertTransaction().GetPostings()) > 0 {
 		pterm.Println()
@@ -234,17 +236,23 @@ func runRevert(cmd *cobra.Command, args []string) error {
 		}
 
 		for i, posting := range revertedTx.GetRevertTransaction().GetPostings() {
+			amount, asset := posting.GetAmount().Dec(), posting.GetAsset()
+			if rescale != nil {
+				amount, asset = cmdutil.Rescale(amount, asset, *rescale)
+			}
+
 			color := posting.GetColor()
 			if color == "" {
 				color = "-"
 			}
+
 			postingsTable = append(postingsTable, []string{
 				strconv.Itoa(i + 1),
 				posting.GetSource(),
 				"→",
 				posting.GetDestination(),
-				posting.GetAmount().Dec(),
-				posting.GetAsset(),
+				amount,
+				asset,
 				color,
 			})
 		}
@@ -257,7 +265,7 @@ func runRevert(cmd *cobra.Command, args []string) error {
 
 	// Display post-commit volumes (carried on the revert transaction)
 	if pcv := revertedTx.GetRevertTransaction().GetPostCommitVolumes(); pcv != nil {
-		err := renderPostCommitVolumes(pcv)
+		err := renderPostCommitVolumes(pcv, rescale)
 		if err != nil {
 			return err
 		}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -31,6 +31,7 @@ These flags are available for all commands:
 | `--response-verify-key` | | Path to Ed25519 public key file for verifying server response signatures |
 | `--consistency` | | Read consistency level: `stale`, `leader`, or `linearizable` (default) |
 | `--auth-token` | | Bearer token for authentication (JWT string or `@path-to-file`) |
+| `--rescale` | | Re-express amounts at a given scale in human-readable output, summing same-currency balances across precisions. Absent = no rescaling; `--rescale` alone = scale 0; `--rescale=N` = scale N. Does not affect `--json`/`--yaml` output. See [Amount Rescaling](#amount-rescaling). |
 
 ### Read Consistency
 
@@ -84,6 +85,31 @@ ledgerctl ledgers list
 ```
 
 Buffered spans are flushed (with a 5s timeout) before the process exits — on both success and error paths — so short-lived invocations still deliver their traces.
+
+### Amount Rescaling
+
+`--rescale` is a global, display-only flag that re-expresses ledger amounts at a
+chosen scale in the human-readable tables/text, summing same-currency balances
+that were recorded at different precisions (e.g. `USD/2` and `USD/3`) into a
+single base-currency figure.
+
+| Form | Meaning |
+|---|---|
+| flag absent | No rescaling. Amounts render exactly as stored, one row per `CUR/precision`. |
+| `--rescale` (no value) | Rescale to scale `0` — whole units, dropping the precision suffix (e.g. `1234 USD/2` → `12.34 USD`). |
+| `--rescale=N` | Rescale to scale `N` (e.g. `--rescale=2` → `6912.9 USD/2`). `N` is a `uint8`; values above `255` are rejected at parse time. |
+
+Same-currency rows are first summed at the group's highest precision, then
+re-expressed at the requested scale; scaling to a coarser scale yields a decimal
+fraction, a finer scale pads with zeros.
+
+**Structured output is never rescaled.** `--json` / `--yaml` always emit the raw
+integer amounts and full `CUR/precision` asset strings so scripts stay stable,
+regardless of `--rescale`. Rescaling applies only to the rendered tables/text.
+
+Applies to the volume/balance columns of `accounts list`, `accounts get`,
+`accounts aggregate-volumes`, `transactions` post-commit volumes, and
+`queries execute` aggregate results.
 
 ### Shared Flag Contract
 
@@ -937,6 +963,8 @@ ledgerctl accounts list [flags]
 
 **Behavior:**
 - Accounts are listed in alphabetical order by default; use `--reverse` for reverse-alphabetical (Z→A)
+- Each account row includes a **balances** column showing the per-asset balance (`input − output`) for every asset the account holds
+- The global `--rescale` flag re-expresses those balances at a chosen scale in the table (see [Amount Rescaling](#amount-rescaling)); it does not affect `--json`/`--yaml` output
 - If `--ledger` is not provided and only one ledger exists, it will be used automatically
 - If multiple ledgers exist, you will be prompted to select one
 - Use `--prefix` to filter by address prefix (e.g. `users:` lists only accounts starting with `users:`)
@@ -1735,9 +1763,16 @@ ledgerctl accounts aggregate-volumes --ledger my-ledger --prefix users:
 # Aggregate with filter
 ledgerctl accounts aggregate-volumes --ledger my-ledger --filter "metadata[category] == premium"
 
-# Output as JSON
+# Sum same-currency rows across precisions and show whole units (display only)
+ledgerctl accounts aggregate-volumes --ledger my-ledger --rescale
+
+# Output as JSON (raw integer amounts and full CUR/precision assets; --rescale ignored)
 ledgerctl accounts aggregate-volumes --ledger my-ledger --json
 ```
+
+**Behavior:**
+- With the global `--rescale` flag, same-currency rows that differ only in precision are merged server-side (`use_max_precision`) and re-expressed at the requested scale in the table (see [Amount Rescaling](#amount-rescaling))
+- Structured output (`--json`/`--yaml`) is never rescaled or merged: it returns the raw per-precision volumes with integer amounts
 
 ---
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -43,6 +43,7 @@ These flags are available for all commands:
 | `--response-verify-key` | | Path to Ed25519 public key file for verifying server response signatures |
 | `--consistency` | | Read consistency level: `stale`, `leader`, or `linearizable` (default) |
 | `--auth-token` | | Bearer token for authentication (JWT string or `@path-to-file`) |
+| `--rescale` | | Re-express amounts at a given scale in human-readable output, summing same-currency balances across precisions. Absent = no rescaling; `--rescale` alone = scale 0; `--rescale=N` = scale N. Does not affect `--json`/`--yaml` output. See [Amount Rescaling](#amount-rescaling). |
 
 ### TLS server name (verifying by name while dialing by IP)
 
@@ -130,6 +131,31 @@ ledgerctl ledgers list
 ```
 
 Buffered spans are flushed (with a 5s timeout) before the process exits — on both success and error paths — so short-lived invocations still deliver their traces.
+
+### Amount Rescaling
+
+`--rescale` is a global, display-only flag that re-expresses ledger amounts at a
+chosen scale in the human-readable tables/text, summing same-currency balances
+that were recorded at different precisions (e.g. `USD/2` and `USD/3`) into a
+single base-currency figure.
+
+| Form | Meaning |
+|---|---|
+| flag absent | No rescaling. Amounts render exactly as stored, one row per `CUR/precision`. |
+| `--rescale` (no value) | Rescale to scale `0` — whole units, dropping the precision suffix (e.g. `1234 USD/2` → `12.34 USD`). |
+| `--rescale=N` | Rescale to scale `N` (e.g. `--rescale=2` → `6912.9 USD/2`). `N` is a `uint8`; values above `255` are rejected at parse time. |
+
+Same-currency rows are first summed at the group's highest precision, then
+re-expressed at the requested scale; scaling to a coarser scale yields a decimal
+fraction, a finer scale pads with zeros.
+
+**Structured output is never rescaled.** `--json` / `--yaml` always emit the raw
+integer amounts and full `CUR/precision` asset strings so scripts stay stable,
+regardless of `--rescale`. Rescaling applies only to the rendered tables/text.
+
+Applies to the volume/balance columns of `accounts list`, `accounts get`,
+`accounts aggregate-volumes`, `transactions` post-commit volumes, and
+`queries execute` aggregate results.
 
 ### Shared Flag Contract
 
@@ -987,6 +1013,8 @@ ledgerctl accounts list [flags]
 
 **Behavior:**
 - Accounts are listed in alphabetical order by default; use `--reverse` for reverse-alphabetical (Z→A)
+- Each account row includes a **balances** column showing one balance (`input − output`) per `(asset, color)` bucket the account holds. Colored buckets are labelled `ASSET[COLOR]`; the uncolored bucket is labelled by its asset alone
+- The global `--rescale` flag re-expresses those balances at a chosen scale in the table (see [Amount Rescaling](#amount-rescaling)); it does not affect `--json`/`--yaml` output. Colors stay segregated: only precisions of the same color are summed
 - If `--ledger` is not provided and only one ledger exists, it will be used automatically
 - If multiple ledgers exist, you will be prompted to select one
 - Use `--prefix` to filter by address prefix (e.g. `users:` lists only accounts starting with `users:`)
@@ -1801,9 +1829,16 @@ ledgerctl accounts aggregate-volumes --ledger my-ledger --prefix users:
 # Aggregate with filter
 ledgerctl accounts aggregate-volumes --ledger my-ledger --filter "metadata[category] == premium"
 
-# Output as JSON
+# Sum same-currency rows across precisions and show whole units (display only)
+ledgerctl accounts aggregate-volumes --ledger my-ledger --rescale
+
+# Output as JSON (raw integer amounts and full CUR/precision assets; --rescale ignored)
 ledgerctl accounts aggregate-volumes --ledger my-ledger --json
 ```
+
+**Behavior:**
+- With the global `--rescale` flag, same-currency rows that differ only in precision are merged server-side (`use_max_precision`) and re-expressed at the requested scale in the table (see [Amount Rescaling](#amount-rescaling))
+- Structured output (`--json`/`--yaml`) is never rescaled or merged: it returns the raw per-precision volumes with integer amounts
 
 ---
 


### PR DESCRIPTION
## What

Two related improvements to how `ledgerctl` displays amounts:

### 1. Show balances in `accounts list`
The `ListAccounts` RPC already enriches each account with per-asset volumes, so balances were available client-side but never rendered. Adds a `BALANCES` column (one `ASSET balance` line per asset, colored by sign).

### 2. Global `--rescale[=N]` flag
Re-expresses amounts at a target scale N: the shown value is the real value × 10ᴺ and the asset is relabelled to `CUR/N` (bare `CUR` at N=0).

```
1234 USD/2 + 56789 USD/3
  --rescale      → 69.129 USD
  --rescale=2    → 6912.9 USD/2
  (absent)       → 1234 USD/2, 56789 USD/3   (no rescaling)
```

- **Absence vs presence:** no flag = no rescaling; bare `--rescale` = scale 0 (`NoOptDefVal`). Modelled as `*uint8` (nil = absent), since present-with-0 and absent both read as 0 by value.
- **Scale is a `uint8`:** an asset's precision is a single byte, so `pflag` rejects values > 255 at parse time and the `10^scale` math can't overflow.
- **Currency aggregation:** same-currency assets that differ only in precision (`USD/4`, `USD/8`) are summed into one base currency, added on the real (scaled) values at the group's highest precision so no fractional digits are lost. Balance is derived as `input - output`.

Applies across `accounts get`/`list`/`aggregate-volumes` and `queries execute` (aggregate + rescale), and `transactions get`/`create`/`revert` + post-commit volumes (per-item rescale).

## Notes

- **Structured output is unchanged.** `--json`/`--yaml` keep raw integer amounts and full `CUR/precision` asset strings so scripts stay stable — `--rescale` is a human-display toggle only.

## Tests

- `cmdutil`: `TestRescale`, `TestRescaleAmount`, `TestAggregateVolumes`, `TestAggregateVolumesRescaleSpec` (the exact spec example).
- `accounts`: `TestFormatAccountBalances` (raw + rescale-0 + non-zero-scale).
- `main`: `TestRescaleFlagValidation` (absent / bare / explicit 0 / 255 / rejected 256).
- Full `cmd/ledgerctl/...` suite, `go vet`, and build all pass.

## Not tested

- Interactive pager rendering and very-narrow terminal wrapping.