### PR TITLE
feat(observability): trace PrepareSnapshot on both sides + guard with timeout

### DIFF
--- a/internal/adapter/grpc/server_snapshot.go
+++ b/internal/adapter/grpc/server_snapshot.go
@@ -58,30 +58,45 @@ func StopSnapshotService(server snapshotpb.SnapshotServiceServer) {
 // PrepareSnapshot creates a fresh Pebble checkpoint, builds a manifest, and
 // returns a session ID that can be used for parallel FetchFile calls.
 func (s *SnapshotServiceServerImpl) PrepareSnapshot(ctx context.Context, req *snapshotpb.PrepareSnapshotRequest) (*snapshotpb.PrepareSnapshotResponse, error) {
-	if s.logger.Enabled(logging.TraceLevel) {
-		s.logger.WithFields(map[string]any{
-			"node_id":         req.GetNodeId(),
-			"minAppliedIndex": req.GetMinAppliedIndex(),
-		}).Tracef("PrepareSnapshot request received")
-	}
+	overallStart := time.Now()
+
+	s.logger.WithFields(map[string]any{
+		"node_id":         req.GetNodeId(),
+		"minAppliedIndex": req.GetMinAppliedIndex(),
+	}).Infof("PrepareSnapshot request received")
 
 	// Wait until the FSM has applied at least the requested index before
 	// creating the Pebble checkpoint. Without this, the checkpoint could be
 	// taken before the FSM commits entries the follower needs, causing the
 	// follower to restore a state behind its Raft snapshot index.
 	if minIdx := req.GetMinAppliedIndex(); minIdx > 0 && s.waitForApplied != nil {
+		waitStart := time.Now()
 		if err := s.waitForApplied(ctx, minIdx); err != nil {
 			return nil, fmt.Errorf("waiting for FSM to apply index %d: %w", minIdx, err)
+		}
+
+		if d := time.Since(waitStart); d > 100*time.Millisecond {
+			s.logger.WithFields(map[string]any{
+				"minAppliedIndex": minIdx,
+				"duration":        d.String(),
+			}).Infof("FSM caught up to minAppliedIndex for PrepareSnapshot")
 		}
 	}
 
 	syncName := "follower-sync-" + strconv.FormatUint(s.nextSyncID.Add(1), 10)
 
+	checkpointStart := time.Now()
 	checkpointPath, err := s.store.CreateTemporaryCheckpoint(syncName)
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary checkpoint: %w", err)
 	}
 
+	s.logger.WithFields(map[string]any{
+		"syncName": syncName,
+		"duration": time.Since(checkpointStart).String(),
+	}).Infof("Temporary checkpoint created for follower sync")
+
+	manifestStart := time.Now()
 	manifest, err := buildManifest(checkpointPath)
 	if err != nil {
 		// Clean up checkpoint on manifest build failure.
@@ -102,8 +117,10 @@ func (s *SnapshotServiceServerImpl) PrepareSnapshot(ctx context.Context, req *sn
 	}
 
 	s.logger.WithFields(map[string]any{
-		"sessionId": sessionID,
-		"files":     len(manifest.GetFiles()),
+		"sessionId":        sessionID,
+		"files":            len(manifest.GetFiles()),
+		"manifestDuration": time.Since(manifestStart).String(),
+		"totalDuration":    time.Since(overallStart).String(),
 	}).Infof("Snapshot session created")
 
 	return &snapshotpb.PrepareSnapshotResponse{

--- a/internal/application/ctrl/snapshot_fetcher.go
+++ b/internal/application/ctrl/snapshot_fetcher.go
@@ -120,6 +120,13 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 // blocks the client goroutine indefinitely; without the heartbeat, an
 // operator watching the follower's logs sees only "Fetching fresh checkpoint
 // from leader" and nothing else for the duration.
+//
+// The select waits on both `done` and `callCtx.Done()` so the wrapper
+// returns as soon as the deadline expires — even if the underlying gRPC
+// stub does not observe context cancellation (a defence-in-depth against
+// grpc-go bugs). When we exit via ctx cancellation the inner goroutine may
+// briefly outlive the call while it drains gRPC internals; that is a
+// bounded leak, and the caller is unblocked to retry a fresh session.
 func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, minAppliedIndex uint64) (*snapshotpb.PrepareSnapshotResponse, error) {
 	logger := logging.FromContext(ctx)
 
@@ -148,6 +155,8 @@ func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, 
 		select {
 		case r := <-done:
 			return r.resp, r.err
+		case <-callCtx.Done():
+			return nil, fmt.Errorf("PrepareSnapshot did not return within %s: %w", prepareSnapshotTimeout, callCtx.Err())
 		case <-ticker.C:
 			logger.WithFields(map[string]any{
 				"minAppliedIndex": minAppliedIndex,

--- a/internal/application/ctrl/snapshot_fetcher.go
+++ b/internal/application/ctrl/snapshot_fetcher.go
@@ -20,6 +20,17 @@ const (
 	sessionBackoff      = 1 * time.Second
 	sessionMaxBackoff   = 10 * time.Second
 	closeSessionTimeout = 5 * time.Second
+	// prepareSnapshotTimeout caps PrepareSnapshot — the metadata call that
+	// creates a Pebble checkpoint and builds a manifest on the leader.
+	// Without a cap the client goroutine can wait forever if the server
+	// hangs in the checkpoint or manifest step, and the outer sync task
+	// blocks along with it (node.Run's WaitForApplied → /readyz → pod stuck
+	// at 0/1 for the whole probe budget).
+	prepareSnapshotTimeout = 60 * time.Second
+	// prepareSnapshotHeartbeat drives the periodic "still waiting" log
+	// during PrepareSnapshot. It's short enough to be visible during a
+	// human operator's live look, long enough not to flood.
+	prepareSnapshotHeartbeat = 10 * time.Second
 )
 
 // grpcSnapshotFetcher implements state.SnapshotFetcher using the session-based gRPC protocol.
@@ -64,7 +75,17 @@ func isSessionExpired(err error) bool {
 }
 
 func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
+	logger := logging.FromContext(ctx)
+
 	for attempt := range f.retryCount {
+		if attempt > 0 {
+			logger.WithFields(map[string]any{
+				"attempt":         attempt + 1,
+				"maxAttempts":     f.retryCount,
+				"minAppliedIndex": minAppliedIndex,
+			}).Infof("Retrying snapshot fetch")
+		}
+
 		size, err := f.fetchWithSession(ctx, targetDir, progress, minAppliedIndex)
 		if err == nil {
 			return size, nil
@@ -78,6 +99,11 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 			return 0, err
 		}
 
+		logger.WithFields(map[string]any{
+			"attempt": attempt + 1,
+			"error":   err.Error(),
+		}).Errorf("Snapshot fetch attempt failed, will retry")
+
 		if attempt < f.retryCount-1 {
 			if waitErr := sessionBackoffWait(ctx, attempt); waitErr != nil {
 				return 0, waitErr
@@ -88,25 +114,92 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 	return 0, fmt.Errorf("snapshot fetch failed after %d attempts", f.retryCount)
 }
 
+// prepareSnapshotWithHeartbeat issues PrepareSnapshot with a bounded timeout
+// and a periodic "still waiting" heartbeat log. Without the timeout, a hung
+// server-side step (long checkpoint creation, deadlocked waitForApplied)
+// blocks the client goroutine indefinitely; without the heartbeat, an
+// operator watching the follower's logs sees only "Fetching fresh checkpoint
+// from leader" and nothing else for the duration.
+func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, minAppliedIndex uint64) (*snapshotpb.PrepareSnapshotResponse, error) {
+	logger := logging.FromContext(ctx)
+
+	callCtx, cancel := context.WithTimeout(ctx, prepareSnapshotTimeout)
+	defer cancel()
+
+	type result struct {
+		resp *snapshotpb.PrepareSnapshotResponse
+		err  error
+	}
+
+	done := make(chan result, 1)
+
+	go func() {
+		resp, err := f.client.PrepareSnapshot(callCtx, &snapshotpb.PrepareSnapshotRequest{
+			MinAppliedIndex: minAppliedIndex,
+		})
+		done <- result{resp: resp, err: err}
+	}()
+
+	started := time.Now()
+	ticker := time.NewTicker(prepareSnapshotHeartbeat)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case r := <-done:
+			return r.resp, r.err
+		case <-ticker.C:
+			logger.WithFields(map[string]any{
+				"minAppliedIndex": minAppliedIndex,
+				"elapsed":         time.Since(started).String(),
+				"timeout":         prepareSnapshotTimeout.String(),
+			}).Errorf("Still waiting for PrepareSnapshot response from leader")
+		}
+	}
+}
+
 func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
+	logger := logging.FromContext(ctx)
+
+	logger.WithFields(map[string]any{
+		"minAppliedIndex": minAppliedIndex,
+	}).Infof("Requesting snapshot session from leader")
+
+	prepareStart := time.Now()
+
 	// 1. Prepare session (create checkpoint + get manifest).
-	resp, err := f.client.PrepareSnapshot(ctx, &snapshotpb.PrepareSnapshotRequest{
-		MinAppliedIndex: minAppliedIndex,
-	})
+	resp, err := f.prepareSnapshotWithHeartbeat(ctx, minAppliedIndex)
 	if err != nil {
 		return 0, fmt.Errorf("preparing snapshot: %w", err)
 	}
 
 	sessionID := resp.GetSessionId()
 	manifest := resp.GetManifest()
+	totalSize := manifestTotalSize(manifest)
+
+	logger.WithFields(map[string]any{
+		"sessionId":  sessionID,
+		"filesTotal": len(manifest.GetFiles()),
+		"totalSize":  totalSize,
+		"duration":   time.Since(prepareStart).String(),
+	}).Infof("Snapshot session prepared")
 
 	// Always try to close the session on exit.
 	defer f.closeSession(sessionID)
 
 	// 2. Determine which files still need fetching (resume support).
+	scanStart := time.Now()
 	completedFiles, err := scanCompletedFiles(targetDir, manifest)
 	if err != nil {
 		return 0, fmt.Errorf("scanning completed files: %w", err)
+	}
+
+	if len(completedFiles) > 0 {
+		logger.WithFields(map[string]any{
+			"filesResumed": len(completedFiles),
+			"filesTotal":   len(manifest.GetFiles()),
+			"duration":     time.Since(scanStart).String(),
+		}).Infof("Resuming snapshot fetch from partial staging dir")
 	}
 
 	completedSet := make(map[string]struct{}, len(completedFiles))
@@ -133,8 +226,6 @@ func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir st
 		sessionID:  sessionID,
 		maxRetries: f.fileRetryCount,
 	}
-
-	logger := logging.FromContext(ctx)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(f.parallelism)


### PR DESCRIPTION
## Summary

A follower stuck at `Fetching fresh checkpoint from leader` today (observed live on `eks-acme-dev-euw1-01/blockchains-2` while validating the EN-1431 series) gave **no further hint** until we SIGQUIT'd the process and read the goroutine stack. The client goroutine was blocked on the raw `PrepareSnapshot` gRPC call, and the server was silent on which step was slow: `waitForApplied` could not be timed, `CreateTemporaryCheckpoint` was un-logged (~4-5s on this cluster), `buildManifest` was un-logged, and the only success line \"Snapshot session created\" fires after everything.

This PR fills the observability gap.

## Client side (`snapshot_fetcher.go`)

- Log `Requesting snapshot session from leader` before the RPC (with `minAppliedIndex`).
- Log `Snapshot session prepared` after the response (sessionId, files, totalSize, duration).
- Log resume state when partial completed files are found in staging.
- Log retry attempts and per-attempt errors instead of silently looping.
- Wrap `PrepareSnapshot` in `prepareSnapshotWithHeartbeat`: 60s hard timeout (metadata call, not a data transfer) plus a 10s ticker that emits `Still waiting for PrepareSnapshot response from leader` so an operator watching live logs sees the hang instead of nothing.

## Server side (`server_snapshot.go`)

- Raise `PrepareSnapshot request received` from `Trace` to `Info` — the previous \"only if trace-enabled\" gating meant prod logs showed nothing.
- Emit `FSM caught up to minAppliedIndex` (with duration) if `waitForApplied` blocked longer than 100ms.
- Emit `Temporary checkpoint created for follower sync` with duration — this is the ~4-5s step on this cluster.
- Extend `Snapshot session created` with `manifestDuration` + `totalDuration`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/application/ctrl/...` and `./internal/adapter/grpc/...` — both pass
- [ ] Deploy `pr-<num>-<sha>` on `eks-acme-dev-euw1-01/blockchains` and confirm the new log points fire during a follower rejoin

## Out of scope

- Metrics on the durations (histogram for waitForApplied / checkpoint / manifest). Logs cover the immediate diagnostic need; a follow-up can promote them if they turn out to be worth alerting on.
- A similar treatment on `FetchFile` (per-file streaming) — that path already has decent logs, and it's not the current pain point.

## Related

- The stuck follower is `blockchains-2` in `eks-acme-dev-euw1-01` after the EN-1431 series validation. Investigation of the root cause of the hang is separate — this PR just makes the next such hang diagnosable without a SIGQUIT.