### PR TITLE
feat(node): signal ready as soon as raft loop is up

### DIFF
--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -938,33 +938,6 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 	// on node.Run's ready signal.
 	close(ready)
 
-	// Observational: log FSM catch-up progress asynchronously so it never
-	// blocks node.Run's main goroutine. If the wait errors (only realistic
-	// cause is ctx cancellation at shutdown), we log and return — the
-	// main select loop below handles the real error propagation.
-	initialCommit := status.Commit
-	if initialCommit > 0 {
-		node.logger.WithFields(map[string]any{
-			"from": node.fsm.LastPersistedIndex(),
-			"to":   initialCommit,
-		}).Infof("Replaying WAL...")
-
-		go func() {
-			if err := node.fsm.WaitForApplied(ctx, initialCommit); err != nil {
-				node.logger.WithFields(map[string]any{
-					"targetIndex": initialCommit,
-					"error":       err,
-				}).Errorf("WaitForApplied for initial commit did not complete")
-
-				return
-			}
-
-			node.logger.WithFields(map[string]any{
-				"appliedUpTo": initialCommit,
-			}).Infof("Initial WAL replay complete")
-		}()
-	}
-
 	select {
 	case ch := <-node.stopChannel:
 		err := node.tasks.stop()

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -910,9 +910,38 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 	node.tasks.add(newTask(node.runBackgroundMaintenance))
 	node.tasks.run(ctx)
 
-	// Wait for the FSM to apply all initially committed entries before
-	// signaling ready. This ensures downstream consumers (index builder,
-	// event manager) see the complete Pebble state at startup.
+	// Signal ready as soon as the raft loop is up.
+	//
+	// /readyz is documented as intentionally permissive (see
+	// internal/adapter/http/handlers_health.go): "returns 200 once the local
+	// Raft loop has started, regardless of whether a leader has been elected".
+	// The signal here is what the fx OnStart hook wrapping node.Run is
+	// blocked on (see bootstrap/module.go); fx runs OnStart hooks serially,
+	// so nothing that comes after — most importantly the HTTP server hook
+	// that opens port 9000 — starts until this closes.
+	//
+	// Blocking `ready` on FSM catch-up produced a design bug: a follower
+	// booting with an out-of-sync applier (fresh Pebble, WAL compacted past
+	// its snapshot — see the EN-1431 series) never catches up until
+	// SynchronizeWithLeader completes, which for a 17 GiB checkpoint can
+	// take multiple minutes. During that window the HTTP server never
+	// started, /readyz refused connections, kubelet marked the pod
+	// permanently not-ready, and the StatefulSet's OrderedReady rollout
+	// stalled — even though raft, spool, and apply were all functioning
+	// exactly as designed. The syncing follower IS ready in every sense
+	// that matters at k8s scheduling level; write traffic is forwarded to
+	// the leader and reads that need FSM state have their own gating.
+	//
+	// Downstream consumers that legitimately need the FSM caught up to a
+	// specific index (index builder, event manager, cluster-config
+	// reconciler) call fsm.WaitForApplied on demand rather than piggybacking
+	// on node.Run's ready signal.
+	close(ready)
+
+	// Observational: log FSM catch-up progress asynchronously so it never
+	// blocks node.Run's main goroutine. If the wait errors (only realistic
+	// cause is ctx cancellation at shutdown), we log and return — the
+	// main select loop below handles the real error propagation.
 	initialCommit := status.Commit
 	if initialCommit > 0 {
 		node.logger.WithFields(map[string]any{
@@ -920,17 +949,21 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 			"to":   initialCommit,
 		}).Infof("Replaying WAL...")
 
-		err := node.fsm.WaitForApplied(ctx, initialCommit)
-		if err != nil {
-			return fmt.Errorf("waiting for initial WAL replay: %w", err)
-		}
+		go func() {
+			if err := node.fsm.WaitForApplied(ctx, initialCommit); err != nil {
+				node.logger.WithFields(map[string]any{
+					"targetIndex": initialCommit,
+					"error":       err,
+				}).Errorf("WaitForApplied for initial commit did not complete")
 
-		node.logger.WithFields(map[string]any{
-			"appliedUpTo": initialCommit,
-		}).Infof("Initial WAL replay complete")
+				return
+			}
+
+			node.logger.WithFields(map[string]any{
+				"appliedUpTo": initialCommit,
+			}).Infof("Initial WAL replay complete")
+		}()
 	}
-
-	close(ready)
 
 	select {
 	case ch := <-node.stopChannel:


### PR DESCRIPTION
## Summary

Move `close(ready)` in `node.Run` from after `fsm.WaitForApplied(initialCommit)` to immediately after `node.tasks.run(ctx)`. The former wait becomes observational, running in a background goroutine and never blocking the main goroutine or fx boot.

## Why

`/readyz` is documented as intentionally permissive ([`handlers_health.go`](../blob/release/v3.0/internal/adapter/http/handlers_health.go)):
> "returns 200 once the local Raft loop has started, regardless of whether a leader has been elected"

But its actual behaviour was gated on FSM catch-up — for a follower syncing from a leader (out-of-sync applier + fresh Pebble + WAL compacted past its snapshot: the EN-1431 recovery scenario), catch-up can take multiple minutes to hours on a large checkpoint (~17 GiB observed today). During that window:
- fx OnStart hook wrapping `node.Run` is blocked on `<-ready`
- fx runs OnStart hooks serially, so the HTTP server hook (`bootstrap/module.go:1204`) that opens port 9000 never runs
- `/readyz` refuses connections
- kubelet marks the pod permanently not-ready
- StatefulSet OrderedReady rollout stalls, and every ~20 min the startup probe kills the pod, restarting the sync from scratch — the pod can never complete recovery

Meanwhile raft, spool, and apply are all functioning exactly as designed. The syncing follower IS ready in every sense that matters at the k8s scheduling layer; write traffic is forwarded to the leader and reads that need FSM state have their own gating.

## Observed

`eks-acme-dev-euw1-01/blockchains-2` today (2026-07-02): pod-2 was actively syncing (raft receiving committed entries via MsgApp, applier spooling correctly), but every startup probe cycle timed out at 20 min and kubelet killed the container. The cluster never recovered on its own — required manual intervention.

## Contract preservation

- Downstream consumers that need the FSM caught up to a specific index (index builder, event manager, cluster-config reconciler) already call `fsm.WaitForApplied` on their own goroutines. They don't rely on `ready`.
- `/clusterz` remains the strict "cluster is healthy and can serve" probe.
- The `Replaying WAL...` / `Initial WAL replay complete` log pair is preserved for operator visibility, now emitted asynchronously.
- On `ctx` cancellation (shutdown), the WaitForApplied goroutine logs and exits — no leaked goroutine (context is tied to `node.Run`'s lifetime).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/infra/node/...` — full node package suite passes
- [ ] Deploy `pr-<num>-<sha>` on `eks-acme-dev-euw1-01/blockchains` and observe pod becoming Ready during a multi-minute sync

## Related

- Completes the EN-1431 series (rejoin durability): #1463 (merged), #1467 (merged), #1468 (merged), #1470 (observability, open). This is the last piece — the follower can now actually reach recovery instead of being killed by the probe mid-sync.