### PR TITLE
temp: combined #1470 + #1471 for blockchains deploy

### DIFF
--- a/internal/adapter/grpc/server_snapshot.go
+++ b/internal/adapter/grpc/server_snapshot.go
@@ -58,30 +58,45 @@ func StopSnapshotService(server snapshotpb.SnapshotServiceServer) {
 // PrepareSnapshot creates a fresh Pebble checkpoint, builds a manifest, and
 // returns a session ID that can be used for parallel FetchFile calls.
 func (s *SnapshotServiceServerImpl) PrepareSnapshot(ctx context.Context, req *snapshotpb.PrepareSnapshotRequest) (*snapshotpb.PrepareSnapshotResponse, error) {
-	if s.logger.Enabled(logging.TraceLevel) {
-		s.logger.WithFields(map[string]any{
-			"node_id":         req.GetNodeId(),
-			"minAppliedIndex": req.GetMinAppliedIndex(),
-		}).Tracef("PrepareSnapshot request received")
-	}
+	overallStart := time.Now()
+
+	s.logger.WithFields(map[string]any{
+		"node_id":         req.GetNodeId(),
+		"minAppliedIndex": req.GetMinAppliedIndex(),
+	}).Infof("PrepareSnapshot request received")
 
 	// Wait until the FSM has applied at least the requested index before
 	// creating the Pebble checkpoint. Without this, the checkpoint could be
 	// taken before the FSM commits entries the follower needs, causing the
 	// follower to restore a state behind its Raft snapshot index.
 	if minIdx := req.GetMinAppliedIndex(); minIdx > 0 && s.waitForApplied != nil {
+		waitStart := time.Now()
 		if err := s.waitForApplied(ctx, minIdx); err != nil {
 			return nil, fmt.Errorf("waiting for FSM to apply index %d: %w", minIdx, err)
+		}
+
+		if d := time.Since(waitStart); d > 100*time.Millisecond {
+			s.logger.WithFields(map[string]any{
+				"minAppliedIndex": minIdx,
+				"duration":        d.String(),
+			}).Infof("FSM caught up to minAppliedIndex for PrepareSnapshot")
 		}
 	}
 
 	syncName := "follower-sync-" + strconv.FormatUint(s.nextSyncID.Add(1), 10)
 
+	checkpointStart := time.Now()
 	checkpointPath, err := s.store.CreateTemporaryCheckpoint(syncName)
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary checkpoint: %w", err)
 	}
 
+	s.logger.WithFields(map[string]any{
+		"syncName": syncName,
+		"duration": time.Since(checkpointStart).String(),
+	}).Infof("Temporary checkpoint created for follower sync")
+
+	manifestStart := time.Now()
 	manifest, err := buildManifest(checkpointPath)
 	if err != nil {
 		// Clean up checkpoint on manifest build failure.
@@ -102,8 +117,10 @@ func (s *SnapshotServiceServerImpl) PrepareSnapshot(ctx context.Context, req *sn
 	}
 
 	s.logger.WithFields(map[string]any{
-		"sessionId": sessionID,
-		"files":     len(manifest.GetFiles()),
+		"sessionId":        sessionID,
+		"files":            len(manifest.GetFiles()),
+		"manifestDuration": time.Since(manifestStart).String(),
+		"totalDuration":    time.Since(overallStart).String(),
 	}).Infof("Snapshot session created")
 
 	return &snapshotpb.PrepareSnapshotResponse{

--- a/internal/application/ctrl/snapshot_fetcher.go
+++ b/internal/application/ctrl/snapshot_fetcher.go
@@ -20,6 +20,17 @@ const (
 	sessionBackoff      = 1 * time.Second
 	sessionMaxBackoff   = 10 * time.Second
 	closeSessionTimeout = 5 * time.Second
+	// prepareSnapshotTimeout caps PrepareSnapshot — the metadata call that
+	// creates a Pebble checkpoint and builds a manifest on the leader.
+	// Without a cap the client goroutine can wait forever if the server
+	// hangs in the checkpoint or manifest step, and the outer sync task
+	// blocks along with it (node.Run's WaitForApplied → /readyz → pod stuck
+	// at 0/1 for the whole probe budget).
+	prepareSnapshotTimeout = 60 * time.Second
+	// prepareSnapshotHeartbeat drives the periodic "still waiting" log
+	// during PrepareSnapshot. It's short enough to be visible during a
+	// human operator's live look, long enough not to flood.
+	prepareSnapshotHeartbeat = 10 * time.Second
 )
 
 // grpcSnapshotFetcher implements state.SnapshotFetcher using the session-based gRPC protocol.
@@ -64,7 +75,17 @@ func isSessionExpired(err error) bool {
 }
 
 func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
+	logger := logging.FromContext(ctx)
+
 	for attempt := range f.retryCount {
+		if attempt > 0 {
+			logger.WithFields(map[string]any{
+				"attempt":         attempt + 1,
+				"maxAttempts":     f.retryCount,
+				"minAppliedIndex": minAppliedIndex,
+			}).Infof("Retrying snapshot fetch")
+		}
+
 		size, err := f.fetchWithSession(ctx, targetDir, progress, minAppliedIndex)
 		if err == nil {
 			return size, nil
@@ -78,6 +99,11 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 			return 0, err
 		}
 
+		logger.WithFields(map[string]any{
+			"attempt": attempt + 1,
+			"error":   err.Error(),
+		}).Errorf("Snapshot fetch attempt failed, will retry")
+
 		if attempt < f.retryCount-1 {
 			if waitErr := sessionBackoffWait(ctx, attempt); waitErr != nil {
 				return 0, waitErr
@@ -88,25 +114,92 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 	return 0, fmt.Errorf("snapshot fetch failed after %d attempts", f.retryCount)
 }
 
+// prepareSnapshotWithHeartbeat issues PrepareSnapshot with a bounded timeout
+// and a periodic "still waiting" heartbeat log. Without the timeout, a hung
+// server-side step (long checkpoint creation, deadlocked waitForApplied)
+// blocks the client goroutine indefinitely; without the heartbeat, an
+// operator watching the follower's logs sees only "Fetching fresh checkpoint
+// from leader" and nothing else for the duration.
+func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, minAppliedIndex uint64) (*snapshotpb.PrepareSnapshotResponse, error) {
+	logger := logging.FromContext(ctx)
+
+	callCtx, cancel := context.WithTimeout(ctx, prepareSnapshotTimeout)
+	defer cancel()
+
+	type result struct {
+		resp *snapshotpb.PrepareSnapshotResponse
+		err  error
+	}
+
+	done := make(chan result, 1)
+
+	go func() {
+		resp, err := f.client.PrepareSnapshot(callCtx, &snapshotpb.PrepareSnapshotRequest{
+			MinAppliedIndex: minAppliedIndex,
+		})
+		done <- result{resp: resp, err: err}
+	}()
+
+	started := time.Now()
+	ticker := time.NewTicker(prepareSnapshotHeartbeat)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case r := <-done:
+			return r.resp, r.err
+		case <-ticker.C:
+			logger.WithFields(map[string]any{
+				"minAppliedIndex": minAppliedIndex,
+				"elapsed":         time.Since(started).String(),
+				"timeout":         prepareSnapshotTimeout.String(),
+			}).Errorf("Still waiting for PrepareSnapshot response from leader")
+		}
+	}
+}
+
 func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
+	logger := logging.FromContext(ctx)
+
+	logger.WithFields(map[string]any{
+		"minAppliedIndex": minAppliedIndex,
+	}).Infof("Requesting snapshot session from leader")
+
+	prepareStart := time.Now()
+
 	// 1. Prepare session (create checkpoint + get manifest).
-	resp, err := f.client.PrepareSnapshot(ctx, &snapshotpb.PrepareSnapshotRequest{
-		MinAppliedIndex: minAppliedIndex,
-	})
+	resp, err := f.prepareSnapshotWithHeartbeat(ctx, minAppliedIndex)
 	if err != nil {
 		return 0, fmt.Errorf("preparing snapshot: %w", err)
 	}
 
 	sessionID := resp.GetSessionId()
 	manifest := resp.GetManifest()
+	totalSize := manifestTotalSize(manifest)
+
+	logger.WithFields(map[string]any{
+		"sessionId":  sessionID,
+		"filesTotal": len(manifest.GetFiles()),
+		"totalSize":  totalSize,
+		"duration":   time.Since(prepareStart).String(),
+	}).Infof("Snapshot session prepared")
 
 	// Always try to close the session on exit.
 	defer f.closeSession(sessionID)
 
 	// 2. Determine which files still need fetching (resume support).
+	scanStart := time.Now()
 	completedFiles, err := scanCompletedFiles(targetDir, manifest)
 	if err != nil {
 		return 0, fmt.Errorf("scanning completed files: %w", err)
+	}
+
+	if len(completedFiles) > 0 {
+		logger.WithFields(map[string]any{
+			"filesResumed": len(completedFiles),
+			"filesTotal":   len(manifest.GetFiles()),
+			"duration":     time.Since(scanStart).String(),
+		}).Infof("Resuming snapshot fetch from partial staging dir")
 	}
 
 	completedSet := make(map[string]struct{}, len(completedFiles))
@@ -133,8 +226,6 @@ func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir st
 		sessionID:  sessionID,
 		maxRetries: f.fileRetryCount,
 	}
-
-	logger := logging.FromContext(ctx)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(f.parallelism)

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -938,33 +938,6 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 	// on node.Run's ready signal.
 	close(ready)
 
-	// Observational: log FSM catch-up progress asynchronously so it never
-	// blocks node.Run's main goroutine. If the wait errors (only realistic
-	// cause is ctx cancellation at shutdown), we log and return — the
-	// main select loop below handles the real error propagation.
-	initialCommit := status.Commit
-	if initialCommit > 0 {
-		node.logger.WithFields(map[string]any{
-			"from": node.fsm.LastPersistedIndex(),
-			"to":   initialCommit,
-		}).Infof("Replaying WAL...")
-
-		go func() {
-			if err := node.fsm.WaitForApplied(ctx, initialCommit); err != nil {
-				node.logger.WithFields(map[string]any{
-					"targetIndex": initialCommit,
-					"error":       err,
-				}).Errorf("WaitForApplied for initial commit did not complete")
-
-				return
-			}
-
-			node.logger.WithFields(map[string]any{
-				"appliedUpTo": initialCommit,
-			}).Infof("Initial WAL replay complete")
-		}()
-	}
-
 	select {
 	case ch := <-node.stopChannel:
 		err := node.tasks.stop()

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -910,9 +910,38 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 	node.tasks.add(newTask(node.runBackgroundMaintenance))
 	node.tasks.run(ctx)
 
-	// Wait for the FSM to apply all initially committed entries before
-	// signaling ready. This ensures downstream consumers (index builder,
-	// event manager) see the complete Pebble state at startup.
+	// Signal ready as soon as the raft loop is up.
+	//
+	// /readyz is documented as intentionally permissive (see
+	// internal/adapter/http/handlers_health.go): "returns 200 once the local
+	// Raft loop has started, regardless of whether a leader has been elected".
+	// The signal here is what the fx OnStart hook wrapping node.Run is
+	// blocked on (see bootstrap/module.go); fx runs OnStart hooks serially,
+	// so nothing that comes after — most importantly the HTTP server hook
+	// that opens port 9000 — starts until this closes.
+	//
+	// Blocking `ready` on FSM catch-up produced a design bug: a follower
+	// booting with an out-of-sync applier (fresh Pebble, WAL compacted past
+	// its snapshot — see the EN-1431 series) never catches up until
+	// SynchronizeWithLeader completes, which for a 17 GiB checkpoint can
+	// take multiple minutes. During that window the HTTP server never
+	// started, /readyz refused connections, kubelet marked the pod
+	// permanently not-ready, and the StatefulSet's OrderedReady rollout
+	// stalled — even though raft, spool, and apply were all functioning
+	// exactly as designed. The syncing follower IS ready in every sense
+	// that matters at k8s scheduling level; write traffic is forwarded to
+	// the leader and reads that need FSM state have their own gating.
+	//
+	// Downstream consumers that legitimately need the FSM caught up to a
+	// specific index (index builder, event manager, cluster-config
+	// reconciler) call fsm.WaitForApplied on demand rather than piggybacking
+	// on node.Run's ready signal.
+	close(ready)
+
+	// Observational: log FSM catch-up progress asynchronously so it never
+	// blocks node.Run's main goroutine. If the wait errors (only realistic
+	// cause is ctx cancellation at shutdown), we log and return — the
+	// main select loop below handles the real error propagation.
 	initialCommit := status.Commit
 	if initialCommit > 0 {
 		node.logger.WithFields(map[string]any{
@@ -920,17 +949,21 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 			"to":   initialCommit,
 		}).Infof("Replaying WAL...")
 
-		err := node.fsm.WaitForApplied(ctx, initialCommit)
-		if err != nil {
-			return fmt.Errorf("waiting for initial WAL replay: %w", err)
-		}
+		go func() {
+			if err := node.fsm.WaitForApplied(ctx, initialCommit); err != nil {
+				node.logger.WithFields(map[string]any{
+					"targetIndex": initialCommit,
+					"error":       err,
+				}).Errorf("WaitForApplied for initial commit did not complete")
 
-		node.logger.WithFields(map[string]any{
-			"appliedUpTo": initialCommit,
-		}).Infof("Initial WAL replay complete")
+				return
+			}
+
+			node.logger.WithFields(map[string]any{
+				"appliedUpTo": initialCommit,
+			}).Infof("Initial WAL replay complete")
+		}()
 	}
-
-	close(ready)
 
 	select {
 	case ch := <-node.stopChannel:


### PR DESCRIPTION
Ephemeral PR — just to trigger a build-images run that produces an image containing both #1470 (snapshot-sync observability) and #1471 (early ready signal). Not intended to merge — those two land via their own PRs.

Deployed to eks-acme-dev-euw1-01/blockchains for live diagnosis of the PrepareSnapshot hang.