### PR TITLE
fix(EN-1436): reset stale leader Progress on rejoin via JoinAsLearner

### DIFF
--- a/internal/adapter/grpc/server_bootstrap.go
+++ b/internal/adapter/grpc/server_bootstrap.go
@@ -2,6 +2,8 @@ package grpc
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -160,11 +162,43 @@ func (impl *ClusterBootstrapServiceServerImpl) JoinAsLearner(ctx context.Context
 	}
 
 	if err := impl.membership.AddLearner(ctx, req.GetNodeId(), req.GetRaftAddress(), req.GetServiceAddress()); err != nil {
-		// Notably:
-		//   - ErrNodeAlreadyInCluster → AlreadyExists (idempotent join,
-		//     handled as success in tryAddLearner)
+		// EN-1436: if the node is already in the leader's Progress, its Match is
+		// stale w.r.t. the caller. JoinAsLearner is only invoked when the caller
+		// has no CLUSTER_JOINED marker on its WAL (see bootstrap/module.go); its
+		// local log is therefore either fresh (never joined) or half-populated
+		// from a previous life. Treating "already exists" as a no-op — as the
+		// old code did — leaves Progress[nodeID].Match pointing at state the
+		// caller doesn't have. As soon as raft starts on the caller it receives
+		// a MsgApp/heartbeat with Commit=Progress.Match, panics with
+		// "tocommit out of range" (raftLog.lastIndex < commit), and
+		// CrashLoopBackOffs indefinitely.
+		//
+		// Reset Progress by force-removing and re-adding. Both ConfChanges are
+		// cheap. The result on the caller is a fresh Progress with Match=0,
+		// State=Probe, which triggers a proper MsgSnap catch-up.
+		//
+		// The other cases fall through untouched:
 		//   - ErrNotLeader / ErrProposalDropped / ErrNoLeader → Unavailable
 		//     (retried by the client)
+		//   - anything else → propagated as-is
+		if errors.Is(err, node.ErrNodeAlreadyInCluster) {
+			impl.logger.WithFields(map[string]any{
+				"nodeID":         req.GetNodeId(),
+				"raftAddress":    req.GetRaftAddress(),
+				"serviceAddress": req.GetServiceAddress(),
+			}).Infof("JoinAsLearner: node already in cluster with stale Progress; force-removing before re-adding")
+
+			if rmErr := impl.membership.RemoveNode(ctx, req.GetNodeId(), true); rmErr != nil {
+				return nil, convertToGRPCError(fmt.Errorf("force-removing stale membership for rejoin: %w", rmErr), impl.logger)
+			}
+
+			if addErr := impl.membership.AddLearner(ctx, req.GetNodeId(), req.GetRaftAddress(), req.GetServiceAddress()); addErr != nil {
+				return nil, convertToGRPCError(fmt.Errorf("re-adding learner after stale-membership cleanup: %w", addErr), impl.logger)
+			}
+
+			return &clusterbootstrappb.JoinAsLearnerResponse{}, nil
+		}
+
 		return nil, convertToGRPCError(err, impl.logger)
 	}
 


### PR DESCRIPTION
## Summary

`JoinAsLearner` is only invoked when the caller has no `CLUSTER_JOINED` marker on its WAL — fresh WAL, or half-populated from a previous life. The old handler treated `ErrNodeAlreadyInCluster` as an idempotent success and returned. But if the leader's Progress for that nodeID still carries `Match > 0` from the previous life (common after a WAL PVC reprovision), the caller's local raftLog `lastIndex` is 0, and the leader's next MsgApp/heartbeat carries `Commit=Progress.Match`. etcd-raft's `commitTo` guard panics with \"tocommit out of range\" and the pod CrashLoopBackOffs indefinitely; no `RemoveNode` is ever issued to reset Progress.

Fix: on the leader-side handler, when `AddLearner` returns `ErrNodeAlreadyInCluster`, issue a `RemoveNode(force=true)` first and then retry `AddLearner`. Both ConfChanges are cheap. The result on the caller is a fresh `Progress{Match: 0, State: Probe}`, which triggers a proper MsgSnap catch-up — exactly the shape the caller's raftLog needs.

## Reproduction

Live on `eks-acme-dev-euw1-01/blockchains-1` today: after a WAL-PVC-only wipe, pod-1 hit `tocommit(31422) is out of range [lastIndex(0)]` on every boot for ~40 min. Resolved only by manually running:
\`\`\`
ledgerctl cluster remove-node 2 --force
\`\`\`
followed by another WAL-PVC delete + pod restart.

With this PR, the operator step would be unnecessary — the leader's `JoinAsLearner` handler auto-resets Progress when it detects the stale-membership shape.

## Backwards compatibility

The client's `tryAddLearner` `AlreadyExists` branch is intentionally left untouched. During a rolling upgrade, the client may still talk to an old leader that returns `AlreadyExists`; the marker-write fallback preserves idempotency semantics for that transitional case.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/grpc/...` — full grpc adapter suite passes
- [ ] Deploy `pr-<num>-<sha>` on a chaos-test cluster and verify a WAL-PVC-wipe rejoin recovers without manual intervention (blocked on next Antithesis run — the current cluster is healthy after today's manual cleanup)

## Ticket

[EN-1436](https://formance-team.atlassian.net/browse/EN-1436) — Operator: rejoining node with wiped WAL PVC panics on 'tocommit out of range' due to stale leader Progress

[EN-1436]: https://formance-team.atlassian.net/browse/EN-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ