### PR TITLE
fix(EN-1440): propagate coverage-miss errors from buildPostCommitVolumes

### DIFF
--- a/internal/domain/processing/processor_revert_transaction.go
+++ b/internal/domain/processing/processor_revert_transaction.go
@@ -108,7 +108,11 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	// Compute post-commit volumes if requested
 	var postCommitVolumes *commonpb.PostCommitVolumes
 	if order.GetExpandVolumes() {
-		postCommitVolumes = buildPostCommitVolumes(s, ledger, revertPostings)
+		var err domain.Describable
+		postCommitVolumes, err = buildPostCommitVolumes(s, ledger, revertPostings)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &commonpb.LedgerLogPayload{

--- a/internal/domain/processing/processor_transaction.go
+++ b/internal/domain/processing/processor_transaction.go
@@ -190,7 +190,11 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 	// Compute post-commit volumes if requested
 	var postCommitVolumes *commonpb.PostCommitVolumes
 	if order.GetExpandVolumes() {
-		postCommitVolumes = buildPostCommitVolumes(s, ledger, result.Postings)
+		var err domain.Describable
+		postCommitVolumes, err = buildPostCommitVolumes(s, ledger, result.Postings)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get the current open chapter ID for the receipt

--- a/internal/domain/processing/processor_volumes.go
+++ b/internal/domain/processing/processor_volumes.go
@@ -1,8 +1,6 @@
 package processing
 
 import (
-	"errors"
-
 	"github.com/holiman/uint256"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
@@ -13,7 +11,15 @@ import (
 // pairs involved in the given postings. It reads the current volume state from the
 // in-memory store (after postings have been applied) and converts Known values
 // into concrete Input/Output values as big integer strings.
-func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Posting) *commonpb.PostCommitVolumes {
+//
+// Reads go through readVolumeOrZero: a declared-but-absent key (domain.ErrNotFound)
+// is reported as a zero balance, while any other error — notably
+// *state.ErrCoverageMiss, an admission-contract violation (invariants #6/#9) that
+// is impossible by design under a correct preload — is propagated as an
+// ErrStorageOperation so the order is rejected loudly (invariant #7) rather than
+// returned to the client as a silently truncated volume map (EN-1440). This
+// mirrors applyPosting, which reads the same source+destination keys.
+func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Posting) (*commonpb.PostCommitVolumes, domain.Describable) {
 	// Collect unique (account, asset) pairs
 	type accountAsset struct {
 		account string
@@ -43,22 +49,15 @@ func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Pos
 	var scratch uint256.Int
 
 	for _, pair := range pairs {
-		vol, err := s.Volumes().Get(domain.NewVolumeKey(ledgerName, pair.account, pair.asset))
-		if err != nil && !errors.Is(err, domain.ErrNotFound) {
-			continue
+		vol, err := readVolumeOrZero(s, domain.NewVolumeKey(ledgerName, pair.account, pair.asset))
+		if err != nil {
+			return nil, &domain.ErrStorageOperation{Operation: "loading post-commit volume", Cause: err}
 		}
 
-		var inputStr, outputStr string
-
-		if vol != nil {
-			vol.GetInput().IntoUint256(&scratch)
-			inputStr = scratch.Dec()
-			vol.GetOutput().IntoUint256(&scratch)
-			outputStr = scratch.Dec()
-		} else {
-			inputStr = "0"
-			outputStr = "0"
-		}
+		vol.GetInput().IntoUint256(&scratch)
+		inputStr := scratch.Dec()
+		vol.GetOutput().IntoUint256(&scratch)
+		outputStr := scratch.Dec()
 
 		byAssets, ok := volumesByAccount[pair.account]
 		if !ok {
@@ -76,5 +75,5 @@ func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Pos
 
 	return &commonpb.PostCommitVolumes{
 		VolumesByAccount: volumesByAccount,
-	}
+	}, nil
 }

--- a/internal/domain/processing/processor_volumes_test.go
+++ b/internal/domain/processing/processor_volumes_test.go
@@ -1,0 +1,90 @@
+package processing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// TestBuildPostCommitVolumes_PropagatesReadError pins EN-1440: a
+// non-ErrNotFound volume-read error (on the gated FSM scope, that is
+// *state.ErrCoverageMiss — an admission-contract violation (invariants #6/#9)
+// that is impossible by design) must reject the order, not be swallowed into a
+// truncated volume map. The processing package cannot import
+// state.ErrCoverageMiss (import cycle: state imports processing), so a generic
+// sentinel stands in for any non-ErrNotFound error; the fix propagates all of
+// them identically.
+func TestBuildPostCommitVolumes_PropagatesReadError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	volumes := setupVolumesStub(mockStore)
+
+	sentinel := errors.New("simulated coverage miss")
+	// First pair read is the posting source ("world"); program it to fail.
+	volumes.expectGet(domain.NewVolumeKey("test", "world", "USD"), nil, sentinel)
+
+	postings := []*commonpb.Posting{{
+		Source:      "world",
+		Destination: "users:001",
+		Amount:      commonpb.NewUint256FromUint64(500),
+		Asset:       "USD",
+	}}
+
+	result, err := buildPostCommitVolumes(mockStore, "test", postings)
+	require.Nil(t, result, "no volume map must be returned when a read fails")
+	require.Error(t, err)
+
+	var storageErr *domain.ErrStorageOperation
+	require.ErrorAs(t, err, &storageErr, "read error must surface as ErrStorageOperation")
+	require.ErrorIs(t, err, sentinel, "the underlying cause must be preserved for errors.As/Is")
+}
+
+// TestBuildPostCommitVolumes_FoundAndAbsent covers the happy path: a present
+// volume is reported with its real Input/Output, and a declared-but-absent key
+// (ErrNotFound) is reported as "0"/"0" — byte-identical to the pre-fix output.
+func TestBuildPostCommitVolumes_FoundAndAbsent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	volumes := setupVolumesStub(mockStore)
+
+	// Source present with real volumes; destination left unregistered so the
+	// stub returns ErrNotFound -> synthesised zero balance.
+	sourceVol := &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(100),
+		Output: commonpb.NewUint256FromUint64(40),
+	}
+	volumes.expectGet(domain.NewVolumeKey("test", "bank", "USD"), sourceVol.AsReader(), nil)
+
+	postings := []*commonpb.Posting{{
+		Source:      "bank",
+		Destination: "users:001",
+		Amount:      commonpb.NewUint256FromUint64(60),
+		Asset:       "USD",
+	}}
+
+	result, err := buildPostCommitVolumes(mockStore, "test", postings)
+	require.Nil(t, err)
+	require.NotNil(t, result)
+
+	bank := result.GetVolumesByAccount()["bank"].GetVolumes()["USD"]
+	require.Equal(t, "100", bank.GetInput())
+	require.Equal(t, "40", bank.GetOutput())
+
+	users := result.GetVolumesByAccount()["users:001"].GetVolumes()["USD"]
+	require.Equal(t, "0", users.GetInput())
+	require.Equal(t, "0", users.GetOutput())
+}


### PR DESCRIPTION
## Summary

`buildPostCommitVolumes` silently swallowed any non-`ErrNotFound` volume-read error (on the gated FSM scope, that is `*state.ErrCoverageMiss` — an admission-contract violation, invariants #6/#9, impossible by design under a correct preload). A bare `continue` dropped the `(account, asset)` pair **and** the error, returning a silently truncated post-commit volume map to the client whenever `ExpandVolumes` is set.

This violates **invariant #7** (never silently skip a "should-not-happen" branch) and hides an underlying coverage-gate/preload bug behind a wrong-but-deterministic response.

## Fix

- `buildPostCommitVolumes` now returns `(*commonpb.PostCommitVolumes, domain.Describable)`.
- Reads go through the canonical `readVolumeOrZero` helper (`ErrNotFound` → zero balance, any other error propagates) instead of a hand-rolled `Get` + `errors.Is` check — removing the DRY divergence from `applyPosting`.
- Propagated errors are wrapped in `ErrStorageOperation` (mirroring `applyPosting`), preserving the cause for `errors.As`/`errors.Is`.
- Both callers (`processor_transaction.go`, `processor_revert_transaction.go`) propagate the error, rejecting the order instead of committing a truncated map. The rejection is deterministic across nodes, so it does not desync the cluster.

## Behavior

- Happy path and declared-absent (`ErrNotFound`) keys are unchanged — byte-identical output ("0"/"0" for absent).
- A coverage miss now rejects the order loudly.

## Tests

New `internal/domain/processing/processor_volumes_test.go`:
- `TestBuildPostCommitVolumes_PropagatesReadError` — a non-`ErrNotFound` read error surfaces as `ErrStorageOperation` wrapping the cause (a generic sentinel stands in for `*state.ErrCoverageMiss`, which the processing package cannot import due to the `state → processing` import cycle).
- `TestBuildPostCommitVolumes_FoundAndAbsent` — present volume reported with real Input/Output; absent key reported as "0"/"0".

Full processing suite + whole-tree build + `just pre-commit` (golangci-lint 0 issues) all pass.

## Ticket

https://formance-team.atlassian.net/browse/EN-1440