### PR TITLE
fix(EN-1436): fail-fast when leader has stale Progress for a rejoining node

### DIFF
--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -530,6 +530,15 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 		return status.Error(codes.AlreadyExists, err.Error())
 	}
 
+	// EN-1436: stale raft Progress (non-zero Match for a node whose caller
+	// cannot own that state) is a precondition failure, not an idempotent
+	// success. The bootstrap JoinAsLearner path builds its own richer status
+	// (with the STALE_RAFT_PROGRESS detail and remediation); this generic
+	// mapping covers the admin cluster.AddLearner path.
+	if errors.Is(err, node.ErrNodeStaleProgress) {
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+
 	// Convert ErrNodeRemoved to FailedPrecondition (EN-1045 blacklist).
 	if errors.Is(err, node.ErrNodeRemoved) {
 		return status.Error(codes.FailedPrecondition, err.Error())

--- a/internal/adapter/grpc/server_bootstrap.go
+++ b/internal/adapter/grpc/server_bootstrap.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -223,15 +225,39 @@ func (impl *ClusterBootstrapServiceServerImpl) JoinAsLearner(ctx context.Context
 		// behalf — which would mask real operational events (why did the
 		// WAL disappear? did GitOps drift the PVC?) — surface it as a
 		// FailedPrecondition with the exact remediation command in the
-		// message. Client-side, tryAddLearner treats FailedPrecondition as
+		// message. Client-side, tryAddLearner treats this specific reason as
 		// fatal-with-clear-message so the pod fails fast with an operator-
 		// actionable log line instead of crash-looping on tocommit.
-		if errors.Is(err, node.ErrNodeAlreadyInCluster) {
-			return nil, status.Errorf(codes.FailedPrecondition,
+		//
+		// EN-1436: the guard keys on ErrNodeStaleProgress, which AddLearner
+		// returns whenever the leader's Progress.Match for this node is
+		// non-zero — covering BOTH the identical-identity rejoin and the
+		// fresh-identity (WAL-wiped) rejoin, where a new instance_id would
+		// otherwise route through a benign ConfChangeUpdateNode refresh and
+		// bypass the fail-fast entirely. A distinguishing ErrorInfo detail
+		// (reason STALE_RAFT_PROGRESS) is attached so the client can tell
+		// this apart from the removed-member blacklist rejection above,
+		// which is also FailedPrecondition but needs `forget-removed`, not
+		// `remove-node --force`.
+		if errors.Is(err, node.ErrNodeStaleProgress) {
+			st := status.New(codes.FailedPrecondition, fmt.Sprintf(
 				"node %d is already in the leader's raft Progress but the caller has no CLUSTER_JOINED marker — "+
 					"its local WAL cannot satisfy the leader's known match index. "+
 					"Reset membership first: `ledgerctl cluster remove-node %d --force` on the leader, then restart this pod.",
-				req.GetNodeId(), req.GetNodeId())
+				req.GetNodeId(), req.GetNodeId()))
+
+			detailed, detailErr := st.WithDetails(&errdetails.ErrorInfo{
+				Reason: node.StaleRaftProgressReason,
+				Domain: "ledger",
+			})
+			if detailErr != nil {
+				// Attaching the detail failed (marshal error): fall back to
+				// the bare status so the caller still fails fast, just
+				// without the machine-readable reason.
+				return nil, st.Err()
+			}
+
+			return nil, detailed.Err()
 		}
 
 		// Notably:

--- a/internal/adapter/grpc/server_bootstrap.go
+++ b/internal/adapter/grpc/server_bootstrap.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -196,9 +197,44 @@ func (impl *ClusterBootstrapServiceServerImpl) JoinAsLearner(ctx context.Context
 	}
 
 	if err := impl.membership.AddLearner(ctx, req.GetNodeId(), req.GetRaftAddress(), req.GetServiceAddress(), req.GetInstanceId()); err != nil {
+		// EN-1436: a JoinAsLearner call reaches the leader only when the caller
+		// has no CLUSTER_JOINED marker on its WAL (see bootstrap/module.go
+		// tryAddLearner). If the leader's Progress already carries this
+		// nodeID, one of two things happened:
+		//
+		//   1. Legitimate previous member whose WAL was reprovisioned (chaos,
+		//      operator, GitOps drift). Local raftLog.lastIndex is 0.
+		//   2. Half-populated WAL from a crash between "initial snapshot
+		//      write" and "CLUSTER_JOINED marker write". Local raftLog may
+		//      have some entries but the marker did not persist.
+		//
+		// The old code returned AlreadyExists (mapped from
+		// ErrNodeAlreadyInCluster) and the client treated it as idempotent
+		// success. That works for shape 2 with a lucky lastIndex, and
+		// silently breaks shape 1: as soon as raft starts on the caller,
+		// the leader's next MsgApp/heartbeat carries Commit=Progress.Match,
+		// etcd-raft's commitTo guard fires ("tocommit out of range"), and
+		// the pod CrashLoopBackOffs indefinitely with no clue for the
+		// operator. We cannot distinguish the two shapes from server-side
+		// data (Progress.Match alone doesn't say whether the caller's log
+		// covers it).
+		//
+		// Rather than silently patch this by force-removing on the caller's
+		// behalf — which would mask real operational events (why did the
+		// WAL disappear? did GitOps drift the PVC?) — surface it as a
+		// FailedPrecondition with the exact remediation command in the
+		// message. Client-side, tryAddLearner treats FailedPrecondition as
+		// fatal-with-clear-message so the pod fails fast with an operator-
+		// actionable log line instead of crash-looping on tocommit.
+		if errors.Is(err, node.ErrNodeAlreadyInCluster) {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"node %d is already in the leader's raft Progress but the caller has no CLUSTER_JOINED marker — "+
+					"its local WAL cannot satisfy the leader's known match index. "+
+					"Reset membership first: `ledgerctl cluster remove-node %d --force` on the leader, then restart this pod.",
+				req.GetNodeId(), req.GetNodeId())
+		}
+
 		// Notably:
-		//   - ErrNodeAlreadyInCluster → AlreadyExists (idempotent join,
-		//     handled as success in tryAddLearner)
 		//   - ErrNotLeader / ErrProposalDropped / ErrNoLeader → Unavailable
 		//     (retried by the client)
 		return nil, convertToGRPCError(err, impl.logger)

--- a/internal/bootstrap/join_preflight_test.go
+++ b/internal/bootstrap/join_preflight_test.go
@@ -1,0 +1,185 @@
+package bootstrap
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/storage/wal"
+)
+
+// TestShouldRunJoinPreflight covers the skip logic that decides whether the
+// EN-1436 join preflight runs for a given boot.
+func TestShouldRunJoinPreflight(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.Testing()
+
+	t.Run("bootstrap node never joins", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{RaftConfig: node.NodeConfig{
+			Bootstrap: true,
+			Peers:     []node.Peer{{ID: 1, Address: "leader:7777"}},
+			WalDir:    t.TempDir(),
+		}}
+		assert.False(t, shouldRunJoinPreflight(cfg, logger))
+	})
+
+	t.Run("no peers means no join", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{RaftConfig: node.NodeConfig{WalDir: t.TempDir()}}
+		assert.False(t, shouldRunJoinPreflight(cfg, logger))
+	})
+
+	t.Run("already joined skips", func(t *testing.T) {
+		t.Parallel()
+
+		walDir := t.TempDir()
+		require.NoError(t, wal.MarkClusterJoined(walDir))
+
+		cfg := Config{RaftConfig: node.NodeConfig{
+			Peers:  []node.Peer{{ID: 1, Address: "leader:7777"}},
+			WalDir: walDir,
+		}}
+		assert.False(t, shouldRunJoinPreflight(cfg, logger))
+	})
+
+	t.Run("fresh joining node runs preflight", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{RaftConfig: node.NodeConfig{
+			Peers:  []node.Peer{{ID: 1, Address: "leader:7777"}},
+			WalDir: t.TempDir(),
+		}}
+		assert.True(t, shouldRunJoinPreflight(cfg, logger))
+	})
+}
+
+// TestJoinPreflightRunsBeforeRaftTraffic proves the EN-1436 ordering invariant
+// (flemzord review on #1478): the join preflight OnStart hook must run — and,
+// when it fails, abort startup — BEFORE any hook that lets inbound Raft traffic
+// reach rawNode.Step.
+//
+// It mirrors the module's registration order: the join preflight hook is
+// appended first, followed by a sentinel "inbound Raft traffic" hook standing
+// in for the Raft gRPC server start / membership.Start() / node.Run() hooks.
+// fx runs OnStart hooks in Append order and halts the sequence on the first
+// error, so if the preflight fails, the sentinel hook must never start. We make
+// the preflight fail deterministically (unreachable peer + a start context that
+// is cancelled almost immediately, driving tryAddLearner's backoff loop to
+// return ctx.Err()) and assert the sentinel never ran.
+func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.Testing()
+
+	cfg := Config{RaftConfig: node.NodeConfig{
+		NodeID: 2,
+		// Unreachable peer: the outbound dial fails, tryAddLearner enters its
+		// backoff select, and the cancelled context makes it return ctx.Err().
+		Peers:         []node.Peer{{ID: 1, Address: "127.0.0.1:1"}},
+		AdvertiseAddr: "127.0.0.1:7777",
+		WalDir:        filepath.Join(t.TempDir(), "wal"),
+	}}
+
+	require.True(t, shouldRunJoinPreflight(cfg, logger),
+		"test setup: this cfg must exercise the preflight path")
+
+	var (
+		preflightStarted    atomic.Bool
+		raftTrafficStarted  atomic.Bool
+		preflightBeforeRaft atomic.Bool
+	)
+
+	// startCtx is cancelled shortly after Start begins so the preflight's
+	// backoff loop returns promptly instead of retrying the unreachable peer
+	// forever. This models "the preflight did not pass" without any network.
+	startCtx, cancel := context.WithCancel(context.Background())
+
+	app := fx.New(
+		fx.NopLogger,
+		fx.Supply(cfg),
+		fx.Provide(func() logging.Logger { return logger }),
+		// Registration order MUST match module.go: preflight first, inbound
+		// Raft traffic second.
+		fx.Invoke(func(lc fx.Lifecycle, cfg Config, logger logging.Logger) {
+			if !shouldRunJoinPreflight(cfg, logger) {
+				return
+			}
+
+			hook := joinPreflightHook(cfg, logger)
+			inner := hook.OnStart
+			hook.OnStart = func(ctx context.Context) error {
+				preflightStarted.Store(true)
+				// Record that the raft-traffic hook had not started yet at the
+				// moment the preflight began.
+				preflightBeforeRaft.Store(!raftTrafficStarted.Load())
+
+				return inner(ctx)
+			}
+			lc.Append(hook)
+		}),
+		fx.Invoke(func(lc fx.Lifecycle) {
+			lc.Append(fx.Hook{
+				OnStart: func(_ context.Context) error {
+					// Stand-in for the Raft gRPC server start / membership.Start()
+					// / node.Run() hooks that feed rawNode.Step.
+					raftTrafficStarted.Store(true)
+
+					return nil
+				},
+			})
+		}),
+	)
+
+	require.NoError(t, app.Err())
+
+	// Cancel the start context once the preflight is under way so the backoff
+	// loop unwinds and Start returns the failure. Poll from a plain goroutine
+	// (no testing assertions off the test goroutine); a hard deadline cancel
+	// guards against the preflight never starting so the test can't hang.
+	go func() {
+		deadline := time.After(5 * time.Second)
+		tick := time.NewTicker(time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-deadline:
+				cancel()
+
+				return
+			case <-tick.C:
+				if preflightStarted.Load() {
+					cancel()
+
+					return
+				}
+			}
+		}
+	}()
+
+	startErr := app.Start(startCtx)
+	t.Cleanup(func() { cancel() })
+
+	// The failing preflight must abort Start.
+	require.Error(t, startErr, "a failed preflight must abort fx startup")
+	assert.True(t, preflightStarted.Load(), "preflight OnStart must have run")
+	assert.True(t, preflightBeforeRaft.Load(),
+		"preflight must start before the inbound-Raft-traffic hook")
+	assert.False(t, raftTrafficStarted.Load(),
+		"inbound Raft traffic must NOT start when the preflight fails")
+
+	// App never fully started; Stop should be a no-op error path we can ignore.
+	_ = app.Stop(context.Background())
+}

--- a/internal/bootstrap/join_preflight_test.go
+++ b/internal/bootstrap/join_preflight_test.go
@@ -77,13 +77,21 @@ func TestShouldRunJoinPreflight(t *testing.T) {
 // fx runs OnStart hooks in Append order and halts the sequence on the first
 // error, so if the preflight fails, the sentinel hook must never start. We make
 // the preflight fail deterministically (unreachable peer + a start context that
-// is cancelled almost immediately, driving tryAddLearner's backoff loop to
-// return ctx.Err()) and assert the sentinel never ran.
+// is cancelled once the preflight is under way, driving tryAddLearner's backoff
+// loop to return ctx.Err()) and assert the sentinel never ran.
 func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
 	t.Parallel()
 
 	logger := logging.Testing()
 
+	// tryAddLearner calls wal.EnsureInstanceID, which writes an INSTANCE_ID file
+	// into WalDir from the preflight goroutine. fx's app.Start returns as soon
+	// as startCtx is cancelled — potentially while that goroutine is still
+	// writing — so we MUST join the goroutine before WalDir is removed,
+	// otherwise a late write races the cleanup's RemoveAll and yields
+	// "directory not empty". t.TempDir registers its RemoveAll cleanup here; the
+	// goroutine-join cleanup registered below runs before it (t.Cleanup is
+	// LIFO), guaranteeing no concurrent WAL writer remains at removal time.
 	cfg := Config{RaftConfig: node.NodeConfig{
 		NodeID: 2,
 		// Unreachable peer: the outbound dial fails, tryAddLearner enters its
@@ -98,14 +106,16 @@ func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
 
 	var (
 		preflightStarted    atomic.Bool
+		preflightReturned   = make(chan struct{})
 		raftTrafficStarted  atomic.Bool
 		preflightBeforeRaft atomic.Bool
 	)
 
-	// startCtx is cancelled shortly after Start begins so the preflight's
-	// backoff loop returns promptly instead of retrying the unreachable peer
-	// forever. This models "the preflight did not pass" without any network.
+	// startCtx is cancelled once the preflight is under way so the backoff loop
+	// returns promptly instead of retrying the unreachable peer forever. This
+	// models "the preflight did not pass" without any network.
 	startCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	app := fx.New(
 		fx.NopLogger,
@@ -121,6 +131,10 @@ func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
 			hook := joinPreflightHook(cfg, logger)
 			inner := hook.OnStart
 			hook.OnStart = func(ctx context.Context) error {
+				// Signal completion on EVERY return path so the test can join
+				// this goroutine before removing WalDir.
+				defer close(preflightReturned)
+
 				preflightStarted.Store(true)
 				// Record that the raft-traffic hook had not started yet at the
 				// moment the preflight began.
@@ -144,6 +158,17 @@ func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
 	)
 
 	require.NoError(t, app.Err())
+
+	// Join the preflight goroutine before WalDir is removed. Registered AFTER
+	// t.TempDir's RemoveAll cleanup, so it runs BEFORE it (LIFO): the WAL
+	// writer is guaranteed to have returned when the dir is deleted.
+	t.Cleanup(func() {
+		select {
+		case <-preflightReturned:
+		case <-time.After(10 * time.Second):
+			t.Error("preflight goroutine did not return before cleanup")
+		}
+	})
 
 	// Cancel the start context once the preflight is under way so the backoff
 	// loop unwinds and Start returns the failure. Poll from a plain goroutine
@@ -170,7 +195,6 @@ func TestJoinPreflightRunsBeforeRaftTraffic(t *testing.T) {
 	}()
 
 	startErr := app.Start(startCtx)
-	t.Cleanup(func() { cancel() })
 
 	// The failing preflight must abort Start.
 	require.Error(t, startErr, "a failed preflight must abort fx startup")

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/fx"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
@@ -1493,15 +1494,23 @@ func tryAddLearner(ctx context.Context, cfg Config, tlsCfg TLSConfig, logger log
 			}
 
 			st, ok := status.FromError(err)
-			// EN-1436: the leader detected this nodeID in its raft Progress but
-			// we (the caller) have no CLUSTER_JOINED marker on our WAL. This
-			// means the leader's Match for us points at state we don't have,
-			// and the next MsgApp/heartbeat would trigger etcd-raft's
-			// "tocommit out of range" panic. Fail fast with the operator-
-			// actionable server message rather than retry, mark, or silently
-			// crash-loop. The server message already contains the exact
-			// remediation command; surface it verbatim as the fatal reason.
-			if ok && st.Code() == codes.FailedPrecondition {
+			// EN-1436: the leader detected this nodeID in its raft Progress
+			// with a non-zero Match but we (the caller) have no CLUSTER_JOINED
+			// marker on our WAL. The leader's Match for us points at state we
+			// don't have, and the next MsgApp/heartbeat would trigger
+			// etcd-raft's "tocommit out of range" panic. Fail fast with the
+			// operator-actionable server message rather than retry, mark, or
+			// silently crash-loop. The server message already contains the
+			// exact remediation command; surface it verbatim as the fatal
+			// reason.
+			//
+			// Match on the STALE_RAFT_PROGRESS ErrorInfo reason, not on the
+			// bare FailedPrecondition code: the removed-member blacklist
+			// rejection (EN-1045) is also FailedPrecondition but needs
+			// `forget-removed`, not `remove-node --force`. Conflating the two
+			// would print misleading remediation. A blacklist rejection falls
+			// through to the generic fatal handler below with its own message.
+			if ok && st.Code() == codes.FailedPrecondition && isStaleRaftProgress(st) {
 				logger.WithFields(map[string]any{
 					"peer":   peer.ID,
 					"nodeID": cfg.RaftConfig.NodeID,
@@ -1571,6 +1580,22 @@ func tryAddLearner(ctx context.Context, cfg Config, tlsCfg TLSConfig, logger log
 
 		backoff = min(backoff*2, maxBackoff)
 	}
+}
+
+// isStaleRaftProgress reports whether a FailedPrecondition status carries the
+// EN-1436 STALE_RAFT_PROGRESS ErrorInfo reason, distinguishing a stale-raft-
+// progress join rejection (remediation: `remove-node --force`) from the
+// removed-member blacklist rejection (remediation: `forget-removed`), which is
+// also FailedPrecondition. Falls back to false when no matching detail is
+// present so unrelated FailedPrecondition responses keep their generic handling.
+func isStaleRaftProgress(st *status.Status) bool {
+	for _, d := range st.Details() {
+		if info, ok := d.(*errdetails.ErrorInfo); ok && info.GetReason() == node.StaleRaftProgressReason {
+			return true
+		}
+	}
+
+	return false
 }
 
 // proposeClusterConfigIfNeeded reads the persisted cluster state from Pebble

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -1493,10 +1493,33 @@ func tryAddLearner(ctx context.Context, cfg Config, tlsCfg TLSConfig, logger log
 			}
 
 			st, ok := status.FromError(err)
+			// EN-1436: the leader detected this nodeID in its raft Progress but
+			// we (the caller) have no CLUSTER_JOINED marker on our WAL. This
+			// means the leader's Match for us points at state we don't have,
+			// and the next MsgApp/heartbeat would trigger etcd-raft's
+			// "tocommit out of range" panic. Fail fast with the operator-
+			// actionable server message rather than retry, mark, or silently
+			// crash-loop. The server message already contains the exact
+			// remediation command; surface it verbatim as the fatal reason.
+			if ok && st.Code() == codes.FailedPrecondition {
+				logger.WithFields(map[string]any{
+					"peer":   peer.ID,
+					"nodeID": cfg.RaftConfig.NodeID,
+					"reason": st.Message(),
+				}).Errorf("STALE MEMBERSHIP on leader — operator action required to unblock rejoin")
+
+				return fmt.Errorf("stale raft membership on the leader: %s", st.Message())
+			}
+
+			// AlreadyExists path kept for rolling-upgrade compatibility with
+			// leaders that predate EN-1436's server-side fail-fast. Once every
+			// live cluster is past that version, this branch can be dropped —
+			// the invariant it silently patches (idempotent join treating
+			// stale Progress as success) is exactly the bug EN-1436 fixes.
 			if ok && st.Code() == codes.AlreadyExists {
 				logger.WithFields(map[string]any{
 					"nodeID": cfg.RaftConfig.NodeID,
-				}).Infof("Already a cluster member, skipping learner registration")
+				}).Infof("Already a cluster member, skipping learner registration (deprecated pre-EN-1436 semantics)")
 
 				if markErr := wal.MarkClusterJoined(cfg.RaftConfig.WalDir); markErr != nil {
 					return fmt.Errorf("marking cluster joined after AlreadyExists: %w", markErr)

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -879,6 +879,26 @@ func Module() fx.Option {
 					},
 				})
 			},
+			// Join preflight (EN-1436): register this node as a learner on the
+			// leader and fail fast on stale raft Progress. Registered FIRST
+			// among the Raft startup hooks so its OnStart runs (and, on stale
+			// Progress, aborts boot) BEFORE any hook that lets inbound Raft
+			// traffic reach rawNode.Step — the Raft gRPC server start +
+			// membership.Start() and node.Run() below. fx runs OnStart hooks in
+			// Append order; keeping this closure ahead of those enforces the
+			// ordering the fail-fast depends on. See joinPreflightHook for the
+			// inbound-vs-outbound / no-deadlock rationale.
+			func(
+				lc fx.Lifecycle,
+				cfg Config,
+				logger logging.Logger,
+			) {
+				if !shouldRunJoinPreflight(cfg, logger) {
+					return
+				}
+
+				lc.Append(joinPreflightHook(cfg, logger))
+			},
 			func(
 				lc fx.Lifecycle,
 				t *node.DefaultTransport,
@@ -1198,50 +1218,10 @@ func Module() fx.Option {
 					},
 				})
 			},
-			// Join mode: auto-register as learner on the leader after raft starts.
-			// Any peer will forward the request to the current leader automatically.
-			// The AddLearner call is idempotent: if the node is already a cluster
-			// member (e.g. after a crash-restart where the initial WAL was written
-			// but the AddLearner RPC never reached the leader), the server returns
-			// AlreadyExists which we treat as success.
-			//
-			// Skip entirely on restart: the CLUSTER_JOINED marker is written
-			// after the initial join succeeds (see tryAddLearner). On any
-			// subsequent boot — even one where --join is still in the CLI
-			// (e.g. E2E test framework that reuses Instruments across restarts)
-			// — re-running tryAddLearner would propose a redundant AddLearner
-			// for a node that is already a voter, racing leadership state and
-			// stalling the test's "should become follower" Eventually. The
-			// operator's StatefulSet entrypoint already gates --join on the
-			// same marker; this check makes the safety hold regardless of how
-			// the binary is invoked.
-			func(
-				lc fx.Lifecycle,
-				cfg Config,
-				logger logging.Logger,
-			) {
-				if cfg.RaftConfig.Bootstrap || len(cfg.RaftConfig.Peers) == 0 {
-					return
-				}
-
-				if wal.IsClusterJoined(cfg.RaftConfig.WalDir) {
-					logger.Infof("CLUSTER_JOINED marker present, skipping learner registration")
-
-					return
-				}
-
-				lc.Append(fx.Hook{
-					OnStart: func(ctx context.Context) error {
-						logger.WithFields(map[string]any{
-							"nodeID":         cfg.RaftConfig.NodeID,
-							"raftAddress":    cfg.RaftConfig.AdvertiseAddr,
-							"serviceAddress": cfg.ServiceAdvertiseAddr(),
-						}).Infof("Join mode: requesting peer to add this node as learner")
-
-						return tryAddLearner(ctx, cfg, cfg.TLSConfig, logger)
-					},
-				})
-			},
+			// Join mode preflight is registered EARLIER (before the Raft
+			// transport/server/node startup hooks) so it runs before any inbound
+			// Raft traffic can be stepped — see the joinPreflightHook closure
+			// above and its doc comment for the EN-1436 ordering rationale.
 			func(lc fx.Lifecycle, cfg Config, handler http.Handler) {
 				lc.Append(transportfx.FXHook(httpserver.NewHook(handler,
 					httpserver.WithAddress(fmt.Sprintf(":%d", cfg.HTTPPort)),
@@ -1415,6 +1395,68 @@ func (e *JoinAuthError) Error() string {
 		"cluster join rejected by %s: inter-node authentication failed (%s); %s",
 		target, e.Detail, hint,
 	)
+}
+
+// shouldRunJoinPreflight reports whether the join preflight (tryAddLearner)
+// must run for this boot. It runs only for a node that is joining an existing
+// cluster and has not yet recorded a successful join:
+//
+//   - Bootstrap nodes and nodes with no configured peers never join — they
+//     ARE the seed of the cluster.
+//   - A node whose WAL already carries the CLUSTER_JOINED marker has joined on
+//     a previous boot; re-running tryAddLearner would propose a redundant
+//     AddLearner for a node that is already a voter, racing leadership state.
+//     The operator's StatefulSet entrypoint already gates --join on the same
+//     marker; this check makes the safety hold regardless of how the binary is
+//     invoked (e.g. an E2E framework that reuses instruments across restarts).
+func shouldRunJoinPreflight(cfg Config, logger logging.Logger) bool {
+	if cfg.RaftConfig.Bootstrap || len(cfg.RaftConfig.Peers) == 0 {
+		return false
+	}
+
+	if wal.IsClusterJoined(cfg.RaftConfig.WalDir) {
+		logger.Infof("CLUSTER_JOINED marker present, skipping learner registration")
+
+		return false
+	}
+
+	return true
+}
+
+// joinPreflightHook builds the OnStart hook that registers this node as a
+// learner on the leader (and fails fast on stale raft Progress, EN-1436).
+//
+// EN-1436 ordering (flemzord review on #1478): this hook MUST run BEFORE the
+// node starts accepting/stepping inbound Raft traffic — i.e. before the Raft
+// gRPC transport server begins serving, before membership.Start() wires the
+// leader connection, and before node.Run() drains the recv queues into
+// rawNode.Step. Otherwise, once the leader can reach this pod, it may deliver a
+// stale MsgApp/heartbeat whose Commit points past our (empty) log and trip
+// etcd-raft's "tocommit out of range" panic BEFORE this preflight returns the
+// STALE_RAFT_PROGRESS fail-fast — losing exactly the race the fail-fast exists
+// to prevent. Registering this hook earlier in the fx lifecycle guarantees its
+// OnStart runs (and, on stale Progress, aborts boot) before any inbound Raft
+// message can be stepped.
+//
+// This does NOT deadlock: the preflight reaches the leader over an OUTBOUND,
+// short-lived gRPC client it dials itself (see tryAddLearner) — it depends on
+// neither the local Raft gRPC server (inbound serving) nor the transport
+// connection pool that membership.Start() wires. Only INBOUND stepping is
+// gated behind the preflight; OUTBOUND dialing is always available because it
+// is self-contained. Gating inbound-serving on an outbound-only preflight is
+// therefore safe.
+func joinPreflightHook(cfg Config, logger logging.Logger) fx.Hook {
+	return fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			logger.WithFields(map[string]any{
+				"nodeID":         cfg.RaftConfig.NodeID,
+				"raftAddress":    cfg.RaftConfig.AdvertiseAddr,
+				"serviceAddress": cfg.ServiceAdvertiseAddr(),
+			}).Infof("Join mode: requesting peer to add this node as learner (preflight, before Raft traffic)")
+
+			return tryAddLearner(ctx, cfg, cfg.TLSConfig, logger)
+		},
+	}
 }
 
 // tryAddLearner attempts to register this node as a learner on an existing

--- a/internal/infra/node/add_learner_classify_test.go
+++ b/internal/infra/node/add_learner_classify_test.go
@@ -1,0 +1,83 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifyExistingLearner locks in the EN-1436 fail-fast decision: when the
+// leader already tracks the joining nodeID, a non-zero Progress.Match must fail
+// fast with stale-progress REGARDLESS of whether the stored instance_id matches
+// the incoming one. The fresh-identity (WAL-wiped) rejoin is the case that
+// previously slipped through as a benign ConfChangeUpdateNode refresh and
+// re-introduced the "tocommit out of range" crash loop.
+func TestClassifyExistingLearner(t *testing.T) {
+	t.Parallel()
+
+	old := []byte("0123456789abcdef")   // 16-byte stored identity
+	fresh := []byte("fedcba9876543210") // 16-byte incoming identity (post-wipe)
+
+	t.Run("stale progress, matching identity", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerStaleProgress,
+			classifyExistingLearner(5, old, true, old),
+			"Match>0 must fail fast even when the identity is unchanged")
+	})
+
+	t.Run("stale progress, fresh identity after WAL wipe", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerStaleProgress,
+			classifyExistingLearner(5, old, true, fresh),
+			"Match>0 must fail fast on the fresh-identity rejoin — the bug the finding flagged")
+	})
+
+	t.Run("stale progress, empty stored identity", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerStaleProgress,
+			classifyExistingLearner(5, nil, false, fresh),
+			"Match>0 outranks the missing-row refresh path")
+	})
+
+	t.Run("no replicated state, matching identity is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerAlreadyInCluster,
+			classifyExistingLearner(0, old, true, old))
+	})
+
+	t.Run("no replicated state, differing identity needs refresh", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerNeedsRefresh,
+			classifyExistingLearner(0, old, true, fresh),
+			"Match==0 with a stale stored identity is a benign UpdateNode refresh")
+	})
+
+	t.Run("no replicated state, empty stored identity needs refresh", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerNeedsRefresh,
+			classifyExistingLearner(0, nil, true, fresh),
+			"admin AddLearner + boot: stored is empty, fill it in via UpdateNode")
+	})
+
+	t.Run("no replicated state, no row is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerAlreadyInCluster,
+			classifyExistingLearner(0, nil, false, fresh),
+			"no peer row to refresh and nothing replicated — treat as idempotent")
+	})
+
+	t.Run("no replicated state, non-16-byte incoming id is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, existingLearnerAlreadyInCluster,
+			classifyExistingLearner(0, old, true, []byte("short")),
+			"an admin AddLearner without a booted pod carries no 16-byte id; do not refresh")
+	})
+}

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -64,6 +64,20 @@ var (
 	// ErrNodeAlreadyInCluster is returned when trying to add a node that already exists.
 	ErrNodeAlreadyInCluster = errors.New("node already in cluster")
 
+	// ErrNodeStaleProgress (EN-1436) is returned by AddLearner when the
+	// leader already holds a Progress entry for the joining nodeID with a
+	// non-zero Match — the leader believes it has already replicated log
+	// entries to this node. A JoinAsLearner call only reaches AddLearner
+	// when the caller has no CLUSTER_JOINED marker (empty/reprovisioned
+	// WAL), so a non-zero Match means the leader's known match index points
+	// at state the caller cannot possibly have. Proceeding would trigger
+	// etcd-raft's "tocommit out of range" panic on the next MsgApp. This is
+	// distinct from ErrNodeAlreadyInCluster (Match == 0: a benign idempotent
+	// join or a not-yet-replicated learner refresh) and fires regardless of
+	// whether the stored instance_id matches the incoming one — covering
+	// both the identical-identity and the fresh-identity (WAL-wiped) rejoin.
+	ErrNodeStaleProgress = errors.New("node already has stale raft progress on the leader")
+
 	// ErrLearnerNotEligible is returned when trying to transfer leadership to a learner.
 	ErrLearnerNotEligible = errors.New("learner nodes are not eligible for leadership")
 
@@ -82,6 +96,13 @@ var (
 	// (restoring a snapshot or replaying spool). Callers should forward the read to the leader.
 	ErrNodeSyncing = errors.New("node is syncing")
 )
+
+// StaleRaftProgressReason is the machine-readable ErrorInfo reason attached to
+// the FailedPrecondition status a leader returns when a JoinAsLearner call hits
+// ErrNodeStaleProgress (EN-1436). The joining node matches on it to tell the
+// stale-progress rejection apart from the removed-member blacklist rejection,
+// which is also FailedPrecondition but calls for a different remediation.
+const StaleRaftProgressReason = "STALE_RAFT_PROGRESS"
 
 // clusterCommand represents an operation that must execute in the orchestrate loop
 // because rawNode is not thread-safe. Implementations return an error via errCh.
@@ -2255,6 +2276,45 @@ func (node *Node) retryConfChange(ctx context.Context, nodeID uint64, name strin
 	}
 }
 
+// existingLearnerAction is the decision AddLearner takes when the leader
+// already tracks the joining nodeID in its raft Progress.
+type existingLearnerAction int
+
+const (
+	// existingLearnerStaleProgress: the leader has already replicated log
+	// entries to this node (Match > 0). A JoinAsLearner caller cannot own
+	// that state (it only calls with no CLUSTER_JOINED marker), so proceeding
+	// would trip etcd-raft's "tocommit out of range" panic — fail fast.
+	existingLearnerStaleProgress existingLearnerAction = iota
+	// existingLearnerAlreadyInCluster: Match == 0 and the stored identity
+	// matches (or none to refresh). Idempotent join — nothing to do.
+	existingLearnerAlreadyInCluster
+	// existingLearnerNeedsRefresh: Match == 0 but the stored instance_id
+	// differs from the joining pod's — refresh the peer row via
+	// ConfChangeUpdateNode (admin AddLearner + boot, or a learner
+	// reprovisioned before it received any entries).
+	existingLearnerNeedsRefresh
+)
+
+// classifyExistingLearner decides what AddLearner must do when the leader's
+// Progress already carries the joining nodeID (EN-1436). The Match > 0 check
+// precedes the identity comparison so the stale-progress fail-fast fires on
+// BOTH the identical-identity rejoin and the fresh-identity (WAL-wiped) rejoin
+// — the latter otherwise slips through as a benign ConfChangeUpdateNode refresh
+// and re-introduces the crash loop this guard exists to prevent.
+func classifyExistingLearner(match uint64, existingInstanceID []byte, hasRow bool, incomingInstanceID []byte) existingLearnerAction {
+	if match > 0 {
+		return existingLearnerStaleProgress
+	}
+
+	needsRefresh := hasRow && len(incomingInstanceID) == 16 && !bytes.Equal(existingInstanceID, incomingInstanceID)
+	if needsRefresh {
+		return existingLearnerNeedsRefresh
+	}
+
+	return existingLearnerAlreadyInCluster
+}
+
 // AddLearner proposes adding a non-voting learner node to the Raft cluster.
 // The call blocks until the ConfChange is committed through Raft consensus.
 // instanceID (16 bytes, empty only from the admin cluster.AddLearner RPC
@@ -2270,6 +2330,14 @@ func (node *Node) retryConfChange(ctx context.Context, nodeID uint64, name strin
 // this refreshes the peer row across all nodes and unblocks
 // checkAndPromoteLearners which otherwise defers promotion for rows
 // without an instance_id.
+//
+// EN-1436: if the peer already exists with a non-zero Progress.Match (the
+// leader has already replicated entries to it), this returns
+// ErrNodeStaleProgress instead — a JoinAsLearner caller with no
+// CLUSTER_JOINED marker cannot own that state, so both the AlreadyExists
+// and the UpdateNode-refresh outcomes would let a "tocommit out of range"
+// crash loop through. This check precedes the identity comparison so it
+// fires on the fresh-identity (WAL-wiped) rejoin too.
 //
 // Must be called on the leader.
 func (node *Node) AddLearner(ctx context.Context, nodeID uint64, raftAddr, serviceAddr string, instanceID []byte) error {
@@ -2306,27 +2374,23 @@ func (node *Node) AddLearner(ctx context.Context, nodeID uint64, raftAddr, servi
 			}
 		}
 
-		if _, ok := status.Progress[nodeID]; ok {
-			// Peer already a Raft member. Refresh the peer row via
-			// UpdateNode whenever the stored instance_id differs
-			// from the joining pod's — the admin cluster.AddLearner
-			// + boot flow (stored is empty), and reprovisioning of
-			// a learner before promotion (stored is a stale
-			// previous instance_id). Otherwise return AlreadyExists
-			// (idempotent join with matching identity).
+		if prog, ok := status.Progress[nodeID]; ok {
 			existing, hasRow := node.membership.GetInstanceID(nodeID)
-			needsRefresh := hasRow && len(instanceID) == 16 && !bytes.Equal(existing, instanceID)
-			if !needsRefresh {
-				return ErrNodeAlreadyInCluster
-			}
 
-			return node.rawNode.ProposeConfChange(&raftpb.ConfChangeV2{
-				Changes: []*raftpb.ConfChangeSingle{{
-					Type:   new(raftpb.ConfChangeUpdateNode),
-					NodeId: new(nodeID),
-				}},
-				Context: ccCtx,
-			})
+			switch classifyExistingLearner(prog.Match, existing, hasRow, instanceID) {
+			case existingLearnerStaleProgress:
+				return ErrNodeStaleProgress
+			case existingLearnerAlreadyInCluster:
+				return ErrNodeAlreadyInCluster
+			case existingLearnerNeedsRefresh:
+				return node.rawNode.ProposeConfChange(&raftpb.ConfChangeV2{
+					Changes: []*raftpb.ConfChangeSingle{{
+						Type:   new(raftpb.ConfChangeUpdateNode),
+						NodeId: new(nodeID),
+					}},
+					Context: ccCtx,
+				})
+			}
 		}
 
 		return node.rawNode.ProposeConfChange(&raftpb.ConfChangeV2{


### PR DESCRIPTION
## Summary

Replace the silent `AlreadyExists → idempotent success` semantics on `JoinAsLearner` with a fail-fast that surfaces the exact remediation command. Follows CLAUDE.md invariant #7 (never silently skip a should-not-happen branch) — the previous behavior was papering over a raft-invariant violation and leaving operators with an unrecoverable CrashLoopBackOff.

## Background

`JoinAsLearner` reaches the leader only when the caller has no `CLUSTER_JOINED` marker on its WAL (see `bootstrap/module.go tryAddLearner`). If the leader's Progress already carries this nodeID, one of two shapes hit:

1. Legitimate previous member whose WAL was reprovisioned (chaos, operator, GitOps drift). Local `raftLog.lastIndex` is 0.
2. Half-populated WAL from a crash between "initial snapshot write" and "CLUSTER_JOINED marker write". Local raftLog may have some entries but the marker didn't persist.

The old code returned `AlreadyExists` (mapped from `ErrNodeAlreadyInCluster`) and the client treated it as idempotent success. That works for shape 2 with a lucky `lastIndex`, and silently breaks shape 1: as soon as raft starts on the caller, the leader's next MsgApp/heartbeat carries `Commit=Progress.Match`, etcd-raft's `commitTo` guard fires (`tocommit out of range`), and the pod CrashLoopBackOffs indefinitely with no clue for the operator.

Reproduced live today on `eks-acme-dev-euw1-01/blockchains-1`: ~40 minutes of tocommit crashes, resolved only by manually running `ledgerctl cluster remove-node 2 --force`.

## Why fail-fast instead of auto-recovery

An earlier draft (closed #1476) silently issued a `RemoveNode(force=true)` + retry `AddLearner` inside `JoinAsLearner`. That would have hidden real operational signals (why did the WAL disappear? did GitOps drift the PVC? did the operator's raft_scaledown misfire?) and violated CLAUDE.md invariant #7. Force-removing a raft member is a destructive operation; auto-firing it on any `AlreadyExists` conflates multiple failure modes and prevents an operator from investigating the trigger.

We cannot distinguish shape 1 from shape 2 from server-side data alone — `Progress.Match` doesn't say whether the caller's log covers it. Surfacing the ambiguity to the operator is the correct move.

## Behavior

- **Server** returns `codes.FailedPrecondition` with a message that names the offending nodeID and the exact `ledgerctl` remediation command.
- **Client** (`tryAddLearner`) catches `FailedPrecondition`, logs the server message at ERROR level with the operator-facing key `STALE MEMBERSHIP on leader — operator action required to unblock rejoin`, and returns a fatal error. Pod fails fast at boot with a single clear log line instead of crash-looping on `tocommit`.

## Rolling-upgrade compatibility

The pre-existing `AlreadyExists` branch in `tryAddLearner` is kept so a new client can still talk to a pre-fix leader during rollout. Flagged in a comment for eventual removal — the invariant it patches is exactly what this PR is fixing.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapter/grpc/...` and `./internal/bootstrap/...` — both pass
- [ ] Deploy on a chaos-test cluster, wipe a follower's WAL PVC, verify the pod fails fast with the STALE MEMBERSHIP log rather than crash-looping

## Ticket

[EN-1436](https://formance-team.atlassian.net/browse/EN-1436)

[EN-1436]: https://formance-team.atlassian.net/browse/EN-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ