### PR TITLE
fix(EN-1441): propagate initIndexConfig boot errors with self-healing retry

### DIFF
--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -31,11 +31,14 @@ The ticker is intentional: an indexer that wakes only on signal would stall on s
 
 ### Boot
 
-On `Start()`, the builder:
+On `Start()`, the builder runs a boot prologue (`bootInit`) that rebuilds the in-memory index-config cache and seeds the progress cursors as a single **retryable unit**:
 
-1. Reads the persisted progress cursors (main + AppliedProposal) — see [Progress Cursors](#progress-cursors).
-2. Reads all `IndexVersionState` rows under `SubInternalIndexVersion` into an in-memory map.
-3. Performs an **initial catch-up pass** with a larger batch size, stripping `BUILDING` indexes from the dispatch set so partially-built keyspaces do not get half-populated rows before backfill resumes.
+1. Rebuilds the index-config cache (`initIndexConfig`): reads all `IndexVersionState` rows under `SubInternalIndexVersion`, seeds a per-ledger config from the active ledgers, and loads the `SubAttrIndex` registry, scheduling backfills/rewrites for `BUILDING` entries. `initIndexConfig` resets its own builder-local state at entry, so re-running it on retry is idempotent (no double-scheduled backfill/rewrite tasks).
+2. Reads the persisted progress cursors (main + AppliedProposal) and the last-known Pebble sequence — see [Progress Cursors](#progress-cursors).
+
+`bootInit` is wrapped in `worker.RetryWithBackoff` (100 ms → 10 s). A transient Pebble / read-store failure at boot must **not** advance the persisted cursor against an incomplete config, so boot retries until it succeeds or shutdown is requested. The config rebuild, `LastIndexedSequence`, and the Pebble read-handle open are fatal (retried); the AppliedProposal-progress and last-sequence reads stay best-effort. After the retry returns, a `ctx.Err()` check distinguishes "init succeeded" from "shutdown requested" so the loop never processes logs against a failed init. A boot *read* failure is thus treated as transient and retried, rather than the non-recoverable panic path noted above — which remains reserved for invariant violations during processing.
+
+Only once boot init succeeds does the builder perform an **initial catch-up pass** with a larger batch size, stripping `BUILDING` indexes from the dispatch set so partially-built keyspaces do not get half-populated rows before backfill resumes.
 
 ## `processLogs` — Two-Pass Commit
 

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -2,6 +2,7 @@ package indexbuilder
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -440,43 +441,32 @@ func (b *Builder) loop(ctx context.Context) {
 	// (same signal, same semantics).
 	stop := ctx.Done()
 
-	// Initialize index config cache from Pebble before processing any logs.
-	b.initIndexConfig(ctx)
+	// Boot init: rebuild the index-config cache and seed cursors. Any
+	// transient Pebble/read-store failure here must NOT advance the
+	// persisted cursor against an incomplete config, so retry with
+	// backoff until it succeeds or shutdown is requested. initIndexConfig
+	// resets its own state, so re-running it on retry is idempotent.
+	var (
+		cursor     uint64
+		pebbleLast uint64
+		err        error
+	)
+	worker.RetryWithBackoff(stop, b.logger, func() error {
+		cursor, pebbleLast, err = b.bootInit(ctx)
 
-	cursor, err := b.readStore.LastIndexedSequence()
-	if err != nil {
-		b.logger.Errorf("Failed to read progress: %v", err)
+		return err
+	})
 
+	// RetryWithBackoff returns only on success or when stop is closed. If
+	// the context was cancelled we never got a good init — return without
+	// processing any log.
+	if ctx.Err() != nil {
 		return
 	}
 
 	b.lastIndexedSeq.Store(cursor)
+	b.pebbleLastSeq.Store(pebbleLast)
 
-	// Recover AppliedProposal sync progress. A corrupt cursor surfaces loudly
-	// and falls back to a full re-sync from 0 (the projection is rebuildable),
-	// rather than aborting the whole builder.
-	if seq, err := b.readStore.ReadAppliedProposalProgress(); err != nil {
-		b.logger.Errorf("read applied-proposal cursor (re-syncing from 0): %v", err)
-	} else {
-		b.lastAppliedProposalSeq = seq
-	}
-
-	// Seed pebble last sequence. The handle is closed immediately after use
-	// to release the RLock — keeping it open would deadlock with
-	// RestoreCheckpoint (write lock) when processLogs tries to take a new RLock.
-	var pebbleLast uint64
-	if handle, err := b.pebbleStore.NewDirectReadHandle(); err != nil {
-		b.logger.Errorf("Failed to create read handle: %v", err)
-
-		return
-	} else {
-		if v, err := query.ReadLastSequence(handle); err == nil {
-			pebbleLast = v
-			b.pebbleLastSeq.Store(v)
-		}
-
-		_ = handle.Close()
-	}
 	b.logger.WithFields(map[string]any{
 		"cursor":     cursor,
 		"pebbleLast": pebbleLast,
@@ -587,4 +577,48 @@ func (b *Builder) loop(ctx context.Context) {
 		// the broadcast and block until new logs arrive.
 		b.readStore.NotifyProgress()
 	}
+}
+
+// bootInit runs the index builder's boot prologue as a single retryable unit:
+// rebuild the index-config cache from Pebble/the read store, then read the
+// persisted indexed cursor and seed the last-known Pebble sequence. It returns
+// the recovered cursor and pebbleLast, or an error if any required read failed
+// — the caller (loop) retries with backoff so a transient failure never
+// advances the cursor against an incomplete config. ReadAppliedProposalProgress
+// and query.ReadLastSequence stay best-effort (they tolerate failure today);
+// only initIndexConfig, LastIndexedSequence, and NewDirectReadHandle are fatal.
+func (b *Builder) bootInit(ctx context.Context) (cursor uint64, pebbleLast uint64, err error) {
+	if err := b.initIndexConfig(ctx); err != nil {
+		return 0, 0, fmt.Errorf("initializing index config: %w", err)
+	}
+
+	cursor, err = b.readStore.LastIndexedSequence()
+	if err != nil {
+		return 0, 0, fmt.Errorf("reading last indexed sequence: %w", err)
+	}
+
+	// Recover AppliedProposal sync progress (best-effort: a corrupt cursor
+	// surfaces loudly and falls back to a full re-sync from 0, since the
+	// projection is rebuildable, rather than aborting the whole builder).
+	if seq, err := b.readStore.ReadAppliedProposalProgress(); err != nil {
+		b.logger.Errorf("read applied-proposal cursor (re-syncing from 0): %v", err)
+	} else {
+		b.lastAppliedProposalSeq = seq
+	}
+
+	// Seed pebble last sequence. The handle is closed immediately after use
+	// to release the RLock — keeping it open would deadlock with
+	// RestoreCheckpoint (write lock) when processLogs tries to take a new RLock.
+	handle, err := b.pebbleStore.NewDirectReadHandle()
+	if err != nil {
+		return 0, 0, fmt.Errorf("creating read handle: %w", err)
+	}
+
+	if v, err := query.ReadLastSequence(handle); err == nil {
+		pebbleLast = v
+	}
+
+	_ = handle.Close()
+
+	return cursor, pebbleLast, nil
 }

--- a/internal/application/indexbuilder/builder_boot_test.go
+++ b/internal/application/indexbuilder/builder_boot_test.go
@@ -1,0 +1,34 @@
+package indexbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBootInit_PropagatesError pins that the extracted boot prologue surfaces a
+// read failure (via initIndexConfig / LastIndexedSequence / NewDirectReadHandle)
+// so loop's RetryWithBackoff wrapper can retry instead of silently proceeding.
+func TestBootInit_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	require.NoError(t, b.pebbleStore.Close())
+
+	_, _, err := b.bootInit(context.Background())
+	require.Error(t, err)
+}
+
+// TestBootInit_Success returns the persisted cursor and pebbleLast on a healthy
+// store (empty store: cursor 0, pebbleLast 0).
+func TestBootInit_Success(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	cursor, pebbleLast, err := b.bootInit(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), cursor)
+	require.Equal(t, uint64(0), pebbleLast)
+}

--- a/internal/application/indexbuilder/gc_test.go
+++ b/internal/application/indexbuilder/gc_test.go
@@ -245,7 +245,7 @@ func TestInitIndexConfig_PurgesOrphanVersionsOnBoot(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fsmBatch.Commit())
 
-	b.initIndexConfig(context.Background())
+	require.NoError(t, b.initIndexConfig(context.Background()))
 
 	assertReadStoreMissing(t, b, fwdV1)
 	assertReadStoreMissing(t, b, rmapV1)

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -47,12 +47,23 @@ func newLedgerIndexConfig() *ledgerIndexConfig {
 // Bucket-scoped entries (Index.Ledger == "") land in b.bucketIndexConfig
 // and are reserved for audit-style indexes (see #436); they aren't tied
 // to any ledger and don't trigger per-ledger backfill paths.
-func (b *Builder) initIndexConfig(ctx context.Context) {
+func (b *Builder) initIndexConfig(ctx context.Context) error {
+	// Reset builder-local init state so every attempt (including a retry
+	// after a partial failure) starts from a clean slate. backfillTasks
+	// and schemaRewriteTasks are slices appended to by
+	// scheduleBackfillForIndex / scheduleResumedRewrites; without this
+	// reset a retry would double-schedule them. The maps are keyed and
+	// would only be overwritten, but are reset too for a self-contained
+	// attempt.
+	b.indexConfig = make(map[string]*ledgerIndexConfig)
+	b.bucketIndexConfig = nil
+	b.backfillTasks = nil
+	b.schemaRewriteTasks = nil
+	b.indexVersions = nil
+
 	handle, err := b.pebbleStore.NewDirectReadHandle()
 	if err != nil {
-		b.logger.Errorf("Failed to create read handle for index config: %v", err)
-
-		return
+		return fmt.Errorf("creating read handle for index config: %w", err)
 	}
 
 	defer func() { _ = handle.Close() }()
@@ -62,9 +73,7 @@ func (b *Builder) initIndexConfig(ctx context.Context) {
 	// consult the cache when deciding whether to schedule a backfill.
 	versionEntries, err := b.readStore.ReadAllIndexVersionStates()
 	if err != nil {
-		b.logger.Errorf("Failed to read index version state: %v", err)
-
-		return
+		return fmt.Errorf("reading index version state: %w", err)
 	}
 
 	for _, e := range versionEntries {
@@ -72,15 +81,11 @@ func (b *Builder) initIndexConfig(ctx context.Context) {
 	}
 
 	if err := b.seedLedgerIndexConfig(ctx, handle); err != nil {
-		b.logger.Errorf("Failed to seed ledger index config: %v", err)
-
-		return
+		return fmt.Errorf("seeding ledger index config: %w", err)
 	}
 
 	if err := b.loadIndexRegistry(handle); err != nil {
-		b.logger.Errorf("Failed to load index registry: %v", err)
-
-		return
+		return fmt.Errorf("loading index registry: %w", err)
 	}
 
 	// Load persisted backfill progress from Pebble.
@@ -124,6 +129,8 @@ func (b *Builder) initIndexConfig(ctx context.Context) {
 	if err := b.purgeOrphanVersions(); err != nil {
 		b.logger.Errorf("Failed to purge orphan index versions: %v", err)
 	}
+
+	return nil
 }
 
 // seedLedgerIndexConfig enumerates every (non-deleted) ledger and seeds an

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -959,7 +959,7 @@ func TestInitIndexConfig_ResumesRewriteFromPendingVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fsmBatch.Commit())
 
-	b.initIndexConfig(context.Background())
+	require.NoError(t, b.initIndexConfig(context.Background()))
 
 	// The rewrite task is scheduled, mid-cursor, NOT a backfill task.
 	require.Len(t, b.schemaRewriteTasks, 1, "pending_version != 0 must schedule a rewrite task")

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -999,3 +999,68 @@ func (n noopLogger) WithField(string, any) logging.Logger       { return n }
 func (n noopLogger) WithContext(context.Context) logging.Logger { return n }
 func (noopLogger) Writer() io.Writer                            { return io.Discard }
 func (noopLogger) Enabled(logging.Level) bool                   { return false }
+
+// TestInitIndexConfig_PropagatesReadError pins EN-1441: a boot read failure
+// must surface as an error, not a swallowed log-and-return. Closing the FSM
+// store makes NewDirectReadHandle fail deterministically.
+func TestInitIndexConfig_PropagatesReadError(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	// Close the FSM store so the first boot read (NewDirectReadHandle)
+	// fails. This is the error-injection seam — no mock store exists.
+	require.NoError(t, b.pebbleStore.Close())
+
+	err := b.initIndexConfig(context.Background())
+	require.Error(t, err, "a boot read failure must propagate, not be swallowed")
+}
+
+// TestInitIndexConfig_IdempotentAcrossRetries pins EN-1441: initIndexConfig
+// may run more than once (the loop retries it on a transient boot error), so
+// a second call must not double-schedule the backfillTasks / schemaRewriteTasks
+// slices. A BUILDING index with no persisted version state (current == 0)
+// schedules exactly one backfill task per call.
+func TestInitIndexConfig_IdempotentAcrossRetries(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const (
+		ledger = "customer"
+		key    = "role"
+	)
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
+
+	// Persist a LedgerInfo (so seedLedgerIndexConfig -> ReadLedgers returns
+	// it and the index is not dropped as an orphan) and a BUILDING Index
+	// registry entry with no version state, so loadIndexRegistry schedules
+	// a backfill (versionFor defaults current == 0).
+	fsmBatch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(fsmBatch, &commonpb.LedgerInfo{
+		Name: ledger,
+		MetadataSchema: &commonpb.MetadataSchema{
+			AccountFields: map[string]*commonpb.MetadataFieldSchema{
+				key: {Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+			},
+		},
+	}))
+	indexKey := domain.IndexKey{LedgerName: ledger, Canonical: indexes.Canonical(id)}.Bytes()
+	_, err := b.attrs.Index.Set(fsmBatch, indexKey, &commonpb.Index{
+		Ledger:                 ledger,
+		Id:                     id,
+		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
+		ForwardEncodingVersion: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fsmBatch.Commit())
+
+	require.NoError(t, b.initIndexConfig(context.Background()))
+	firstBackfills := len(b.backfillTasks)
+	firstRewrites := len(b.schemaRewriteTasks)
+	require.Equal(t, 1, firstBackfills, "one BUILDING index must schedule one backfill")
+
+	require.NoError(t, b.initIndexConfig(context.Background()))
+	assert.Equal(t, firstBackfills, len(b.backfillTasks), "retry must not double-schedule backfills")
+	assert.Equal(t, firstRewrites, len(b.schemaRewriteTasks), "retry must not double-schedule rewrites")
+}


### PR DESCRIPTION
## Summary

`Builder.initIndexConfig` returned `void` and logged-and-returned on every boot error branch, so `Builder.loop` could not observe the failure and unconditionally advanced to `processLogs`. A transient Pebble/read-store failure at boot left the in-memory index config empty or partially populated — the write path then silently skipped index writes (byCanonical miss ⇒ `isMetadataIndexed`/`isBuiltinIndexed` return `false`) **while the persisted cursor kept advancing**, leaving the read-side index permanently incomplete with no error, no retry, and no crash.

## Fix

- `initIndexConfig(ctx) error` (was `void`): the four boot read branches now return a wrapped error instead of a swallowed log. A top-of-function reset of `indexConfig`/`bucketIndexConfig`/`backfillTasks`/`schemaRewriteTasks`/`indexVersions` makes it idempotent across retries (the two slices would otherwise double-schedule).
- Extracted the boot prologue into `bootInit(ctx) (cursor, pebbleLast, err)` and wrapped it in the existing `worker.RetryWithBackoff` (100 ms → 10 s, honors the stop channel). A `ctx.Err()` check after the retry distinguishes "init succeeded" from "shutdown requested" so `loop` never processes logs against a failed init.
- This also closes the identical silent-return defects at the sibling `LastIndexedSequence` and `NewDirectReadHandle` boot reads. `ReadAppliedProposalProgress` / `ReadLastSequence` keep their existing best-effort semantics.

A transient boot read failure now retries with backoff instead of silently advancing the cursor against an incomplete config.

## Tests

- `TestInitIndexConfig_PropagatesReadError` — a closed store makes the boot read fail; the error propagates instead of being swallowed.
- `TestInitIndexConfig_IdempotentAcrossRetries` — calling `initIndexConfig` twice does not double-schedule backfill/rewrite tasks.
- `TestBootInit_PropagatesError` / `TestBootInit_Success` — cover the extracted prologue.
- `worker.RetryWithBackoff` mechanics are already covered by `internal/pkg/worker/worker_test.go`.

`go build ./...`, `just pre-commit` (0 lint issues), and `go test ./internal/application/indexbuilder/...` all pass.

## Ticket

https://formance-team.atlassian.net/browse/EN-1441

Same silent-swallow class as EN-1440.
