### PR TITLE
fix(mirror): tolerate NULL hash on v2 sources with hash logs disabled

### DIFF
--- a/internal/adapter/v2/source_postgres.go
+++ b/internal/adapter/v2/source_postgres.go
@@ -74,8 +74,10 @@ func NewPostgresSource(ctx context.Context, cfg *commonpb.PostgresMirrorSourceCo
 // Returns logs (oldest first), whether there are more, and any error.
 func (s *PostgresSource) FetchLogs(ctx context.Context, afterID uint64, pageSize int) ([]V2Log, bool, error) {
 	// Fetch pageSize+1 rows to determine if there are more.
+	// COALESCE on hash: v2 ledgers with LEDGER_FEATURE_HASH_LOGS disabled leave
+	// logs.hash NULL, which would fail the scan into V2Log.Hash (string).
 	query := fmt.Sprintf(
-		`SELECT id, type, date::text, data, encode(hash, 'hex') FROM %q.logs WHERE ledger = $1 AND id > $2 ORDER BY id ASC LIMIT $3`,
+		`SELECT id, type, date::text, data, COALESCE(encode(hash, 'hex'), '') FROM %q.logs WHERE ledger = $1 AND id > $2 ORDER BY id ASC LIMIT $3`,
 		s.bucket,
 	)
 


### PR DESCRIPTION
## Summary
- v2 ledgers with `LEDGER_FEATURE_HASH_LOGS` disabled leave `logs.hash` NULL, breaking the postgres mirror source scan:

  ```
  scanning log row: can't scan into dest[4] (col: encode): cannot scan NULL into *string
  ```

- Coalesce the hex-encoded hash to `''` at the SQL layer. `V2Log.Hash` is not consumed downstream, so the empty-string default preserves current behavior.

## Test plan
- [ ] Point a v2 mirror at a source ledger with `hash-logs` feature disabled and verify the mirror progresses past the first log page instead of erroring on scan.
- [ ] Existing v2 sources with hashes populated continue to sync with the hex hash string flowing through unchanged.