### PR TITLE
fix(EN-1443): purge same-batch reverse-map orphans on metadata field removal

### DIFF
--- a/internal/application/indexbuilder/process_metadata_field_removal.go
+++ b/internal/application/indexbuilder/process_metadata_field_removal.go
@@ -1,6 +1,8 @@
 package indexbuilder
 
 import (
+	"bytes"
+
 	"github.com/cockroachdb/pebble/v2"
 
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
@@ -22,14 +24,18 @@ import (
 //     covers every v_n (both null and non-null variants).
 //   - 0x03 (reverse map): keys are
 //     [ns:][entityID\x00][version:4B BE][metaKey] — metaKey is the
-//     suffix but it's preceded by a fixed-width version block, so we
-//     scan the per-namespace range and use extractMetadataKeyFromReverseMap
-//     (which already accounts for the version block) to delete every
-//     row matching this metaKey regardless of version.
+//     suffix but it's preceded by a fixed-width version block, so it
+//     can't be range-deleted by (ns, key). purgeReverseMapForKey scans
+//     the per-namespace range and deletes every row matching this
+//     metaKey regardless of version.
 //
-// The reverse-map scan reuses the in-flight indexed batch as snapshot
-// would not see uncommitted writes, but the scan iterates from a fresh
-// Pebble snapshot for consistency. The handler also strips the
+// Unlike the forward/entity-exists range deletes — whose range tombstone
+// gets a higher sequence number than earlier same-batch SETs and so
+// shadows uncommitted rows too — the reverse-map point-delete scan reads
+// a committed-only Pebble snapshot. It therefore also consults the
+// batch's read-your-writes overlay to purge reverse-map PUTs written
+// earlier in this same uncommitted batch (see purgeReverseMapForKey).
+// The handler also strips the
 // corresponding entry from the local ledgerIndexConfig cache so the
 // live path stops considering the index as active immediately, and
 // drops the per-replica IndexVersionState entry so the boot orphan
@@ -111,21 +117,38 @@ func (b *Builder) handleRemovedMetadataFieldType(
 	return nil
 }
 
-// purgeReverseMapForKey scans the reverse map for a (ns, key) pair and
-// deletes every entry whose metadata key field matches, across every
-// per-replica forward-encoding version. The reverse map can't be
-// range-deleted by (ns, key) because the rmap key shape is
-// [entity\x00][version:4B BE][metaKey] — metaKey sits after a
-// fixed-width version block, not directly after the entity null. The
-// scan cost is bounded by the number of (entity, version) tuples that
-// ever held this metadata key.
+// purgeReverseMapForKey deletes every reverse-map entry whose metadata key
+// field matches (ns, key), across every per-replica forward-encoding version.
+// The reverse map can't be range-deleted by (ns, key) because the rmap key
+// shape is [entity\x00][version:4B BE][metaKey] — metaKey sits after a
+// fixed-width version block, not directly after the entity null.
+//
+// Two sources are purged:
+//   - Committed rows: scanned from a fresh Pebble snapshot (committed data
+//     only). Scan cost is bounded by the number of (entity, version) tuples
+//     that ever held this metadata key.
+//   - In-flight rows: reverse-map PUTs written earlier in this same
+//     uncommitted batch are invisible to the snapshot, so we also consult the
+//     batch's read-your-writes overlay. Without this, a SavedMetadata on the
+//     indexed field in the same batch as the removal would commit an orphaned
+//     reverse-map row for a field that no longer exists (EN-1443).
 func (b *Builder) purgeReverseMapForKey(kb *dal.KeyBuilder, ledgerName string, ns, key string) error {
 	rmapPrefix := readstore.ReverseMapPrefix(kb, ledgerName, ns)
 	upper := readstore.IncrementBytes(rmapPrefix)
 
-	// Use a Pebble snapshot so the scan sees committed data only; the
-	// in-flight batch writes from the same processing pass would otherwise
-	// surface as ghost entries.
+	// Deduplicate so a key present in both committed state and the in-flight
+	// overlay is deleted only once.
+	seen := make(map[string]struct{})
+	deleteMatch := func(k []byte) error {
+		if _, done := seen[string(k)]; done {
+			return nil
+		}
+		seen[string(k)] = struct{}{}
+
+		return b.wb.DeleteReverseMapKey(k)
+	}
+
+	// Committed rows.
 	snap := b.readStore.NewSnapshot()
 	defer func() { _ = snap.Close() }()
 
@@ -147,7 +170,33 @@ func (b *Builder) purgeReverseMapForKey(kb *dal.KeyBuilder, ledgerName string, n
 			continue
 		}
 
-		if err := b.wb.Batch().DeleteKey(append([]byte(nil), k...)); err != nil {
+		// iter.Key() is only valid until the next iterator move — clone it
+		// before it outlives this iteration in the batch/dedup set.
+		if err := deleteMatch(append([]byte(nil), k...)); err != nil {
+			return err
+		}
+	}
+
+	// In-flight rows from the same uncommitted batch.
+	var pending [][]byte
+	b.wb.RangeReverseMapOverlay(func(reverseKey []byte, value []byte) {
+		if value == nil {
+			return // already deleted in this batch
+		}
+		if !bytes.HasPrefix(reverseKey, rmapPrefix) {
+			return // different ledger / namespace
+		}
+
+		_, mk, _, parsed := parseReverseMapKey(reverseKey, rmapPrefix, ns)
+		if !parsed || mk != key {
+			return
+		}
+
+		pending = append(pending, reverseKey)
+	})
+
+	for _, k := range pending {
+		if err := deleteMatch(k); err != nil {
 			return err
 		}
 	}

--- a/internal/application/indexbuilder/process_metadata_field_removal_test.go
+++ b/internal/application/indexbuilder/process_metadata_field_removal_test.go
@@ -1,0 +1,163 @@
+package indexbuilder
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// countReverseMapRows scans the reverse map (0x03) for a namespace and returns
+// how many rows carry the given metadata key, across every entity and version.
+func countReverseMapRows(t *testing.T, b *Builder, ledger, ns, metaKey string) int {
+	t.Helper()
+
+	prefix := readstore.ReverseMapPrefix(b.kb, ledger, ns)
+	upper := readstore.IncrementBytes(prefix)
+
+	snap := b.readStore.NewSnapshot()
+	defer func() { _ = snap.Close() }()
+
+	iter, err := snap.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	require.NoError(t, err)
+
+	defer func() { _ = iter.Close() }()
+
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		_, mk, _, ok := parseReverseMapKey(iter.Key(), prefix, ns)
+		if ok && mk == metaKey {
+			count++
+		}
+	}
+
+	return count
+}
+
+func savedAccountMetadata(account, key string, value int64) *commonpb.SavedMetadata {
+	return &commonpb.SavedMetadata{
+		Target: &commonpb.Target{
+			Target: &commonpb.Target_Account{
+				Account: &commonpb.TargetAccount{Addr: account},
+			},
+		},
+		Metadata: map[string]*commonpb.MetadataValue{key: commonpb.NewIntValue(value)},
+	}
+}
+
+// TestHandleRemovedMetadataFieldType_PurgesReverseMap pins EN-1443: when an
+// indexed metadata field is removed, every reverse-map row for that field must
+// be purged — including PUTs written earlier in the *same* uncommitted builder
+// batch, which the committed-only snapshot scan cannot see. The "same batch"
+// and "mixed" cases fail before the read-your-writes overlay consult is added.
+func TestHandleRemovedMetadataFieldType_PurgesReverseMap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ledger     = "test"
+		acct1      = "acct-1"
+		acct2      = "acct-2"
+		removedKey = "role"
+		keepKey    = "team"
+	)
+	ns := readstore.NamespaceAccount
+
+	newActiveCfg := func() *ledgerIndexConfig {
+		cfg := newLedgerIndexConfig()
+		for _, k := range []string{removedKey, keepKey} {
+			id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, k)
+			cfg.byCanonical[indexes.Canonical(id)] = &commonpb.Index{Id: id}
+		}
+
+		return cfg
+	}
+
+	removeRole := func(t *testing.T, b *Builder, cfg *ledgerIndexConfig) {
+		t.Helper()
+
+		removed := &commonpb.RemovedMetadataFieldTypeLog{
+			DroppedIndex: indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, removedKey),
+		}
+		require.NoError(t, b.handleRemovedMetadataFieldType(b.kb, cfg, ledger, removed))
+	}
+
+	t.Run("committed then removed", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// Batch 1: write role on acct-1 and commit.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		require.NoError(t, b.wb.Flush())
+		require.Equal(t, 1, countReverseMapRows(t, b, ledger, ns, removedKey))
+
+		// Batch 2: remove role and commit.
+		b.wb.Init(b.readStore.NewBatch())
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("same batch repro", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// One batch: uncommitted role PUT, then removal, then flush.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("mixed committed and same batch", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// Batch 1: committed role PUT on acct-1.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		require.NoError(t, b.wb.Flush())
+
+		// Batch 2: uncommitted role PUT on acct-2, then removal, then flush.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct2, removedKey, 2)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("unrelated key survives", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// One batch: role and team PUTs (uncommitted), then remove only role.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, keepKey, 2)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+		require.Equal(t, 1, countReverseMapRows(t, b, ledger, ns, keepKey))
+	})
+}

--- a/internal/application/indexbuilder/process_metadata_field_removal_test.go
+++ b/internal/application/indexbuilder/process_metadata_field_removal_test.go
@@ -49,6 +49,26 @@ func savedAccountMetadata(account, key string, value int64) *commonpb.SavedMetad
 	}
 }
 
+func savedTransactionMetadata(txID uint64, key string, value int64) *commonpb.SavedMetadata {
+	return &commonpb.SavedMetadata{
+		Target: &commonpb.Target{
+			Target: &commonpb.Target_TransactionId{TransactionId: txID},
+		},
+		Metadata: map[string]*commonpb.MetadataValue{key: commonpb.NewIntValue(value)},
+	}
+}
+
+func deletedAccountMetadata(account, key string) *commonpb.DeletedMetadata {
+	return &commonpb.DeletedMetadata{
+		Target: &commonpb.Target{
+			Target: &commonpb.Target_Account{
+				Account: &commonpb.TargetAccount{Addr: account},
+			},
+		},
+		Key: key,
+	}
+}
+
 // TestHandleRemovedMetadataFieldType_PurgesReverseMap pins EN-1443: when an
 // indexed metadata field is removed, every reverse-map row for that field must
 // be purged — including PUTs written earlier in the *same* uncommitted builder
@@ -159,5 +179,138 @@ func TestHandleRemovedMetadataFieldType_PurgesReverseMap(t *testing.T) {
 
 		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
 		require.Equal(t, 1, countReverseMapRows(t, b, ledger, ns, keepKey))
+	})
+
+	t.Run("same batch write then delete then remove", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// One batch: write role, then delete it (overlay entry becomes nil),
+		// then remove the field. Exercises the overlay's already-deleted
+		// (value == nil) skip branch in purgeReverseMapForKey.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		require.NoError(t, b.indexDeletedMetadata(b.kb, cfg, ledger, deletedAccountMetadata(acct1, removedKey)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("committed then same batch rewrite same key", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// Batch 1: commit role on acct-1.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 1)))
+		require.NoError(t, b.wb.Flush())
+		require.Equal(t, 1, countReverseMapRows(t, b, ledger, ns, removedKey))
+
+		// Batch 2: rewrite the SAME reverse-map key in-flight (committed row +
+		// non-nil overlay entry for the same key), then remove the field. The
+		// committed scan nils the overlay entry before the overlay pass, so the
+		// row is purged exactly once.
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(acct1, removedKey, 2)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+}
+
+// TestHandleRemovedMetadataFieldType_PurgesReverseMap_Transaction mirrors the
+// account cases for the transaction namespace, whose reverse-map key layout
+// (fixed 8-byte txID + version block) differs from the account null-scan. It
+// exercises the same-batch overlay-purge path for transactions specifically.
+func TestHandleRemovedMetadataFieldType_PurgesReverseMap_Transaction(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ledger     = "test"
+		tx1        = uint64(1)
+		tx2        = uint64(2)
+		removedKey = "role"
+	)
+	ns := readstore.NamespaceTransaction
+
+	newActiveCfg := func() *ledgerIndexConfig {
+		cfg := newLedgerIndexConfig()
+		id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_TRANSACTION, removedKey)
+		cfg.byCanonical[indexes.Canonical(id)] = &commonpb.Index{Id: id}
+
+		return cfg
+	}
+
+	removeRole := func(t *testing.T, b *Builder, cfg *ledgerIndexConfig) {
+		t.Helper()
+
+		removed := &commonpb.RemovedMetadataFieldTypeLog{
+			DroppedIndex: indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_TRANSACTION, removedKey),
+		}
+		require.NoError(t, b.handleRemovedMetadataFieldType(b.kb, cfg, ledger, removed))
+	}
+
+	t.Run("committed then removed", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedTransactionMetadata(tx1, removedKey, 1)))
+		require.NoError(t, b.wb.Flush())
+		require.Equal(t, 1, countReverseMapRows(t, b, ledger, ns, removedKey))
+
+		b.wb.Init(b.readStore.NewBatch())
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("same batch repro", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		// One batch: uncommitted tx metadata PUT, then removal, then flush. The
+		// committed-only snapshot cannot see the in-flight PUT — the overlay
+		// pass is what purges it. Fails before EN-1443 (orphan row survives).
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedTransactionMetadata(tx1, removedKey, 1)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
+	})
+
+	t.Run("mixed committed and same batch", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+		b.seedBatchSchema(t)
+		cfg := newActiveCfg()
+
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedTransactionMetadata(tx1, removedKey, 1)))
+		require.NoError(t, b.wb.Flush())
+
+		b.wb.Init(b.readStore.NewBatch())
+		require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedTransactionMetadata(tx2, removedKey, 2)))
+		removeRole(t, b, cfg)
+		require.NoError(t, b.wb.Flush())
+
+		require.Equal(t, 0, countReverseMapRows(t, b, ledger, ns, removedKey))
 	})
 }

--- a/internal/storage/readstore/write_batch.go
+++ b/internal/storage/readstore/write_batch.go
@@ -84,6 +84,32 @@ func (wb *WriteBatch) del(key []byte) error {
 	return nil
 }
 
+// DeleteReverseMapKey deletes a reverse-map key in the batch and records the
+// deletion in the read-your-writes overlay (rmapOverlay[key] = nil), so a
+// subsequent same-batch ReverseMapOverlay lookup reports the key as deleted
+// rather than surfacing a stale in-flight value. Use this for every reverse-map
+// delete so the overlay never drifts from the batch it tracks.
+func (wb *WriteBatch) DeleteReverseMapKey(reverseKey []byte) error {
+	if err := wb.del(reverseKey); err != nil {
+		return err
+	}
+
+	wb.rmapOverlay[string(reverseKey)] = nil
+
+	return nil
+}
+
+// RangeReverseMapOverlay calls fn for every reverse-map mutation buffered in the
+// current (uncommitted) batch: reverseKey -> encoded value last written (nil =
+// deleted in this batch). It is a read-only view of the read-your-writes
+// overlay — callers that need to delete matching keys must collect them and
+// delete after iteration returns, to avoid mutating the overlay mid-range.
+func (wb *WriteBatch) RangeReverseMapOverlay(fn func(reverseKey []byte, value []byte)) {
+	for k, v := range wb.rmapOverlay {
+		fn([]byte(k), v)
+	}
+}
+
 // Flush commits the batch and resets state.
 func (wb *WriteBatch) Flush() error {
 	if wb.batch == nil {


### PR DESCRIPTION
## Problem

When an indexed metadata field is removed, `handleRemovedMetadataFieldType` purges its read-store projection. The reverse-map (`0x03`) limb (`purgeReverseMapForKey`) scanned a **committed-only** Pebble snapshot. A reverse-map PUT written earlier in the **same** uncommitted builder batch (e.g. a `SavedMetadata` on the indexed field) was invisible to that snapshot, so no delete was emitted and the stale row committed at `Flush()` — an orphaned reverse-map row for a field that no longer exists.

This is a read-index projection that diverges from a from-scratch replay, violating the "every persisted projection must be verifiable against the audit" invariant (CLAUDE.md #8).

The forward-index and entity-exists limbs are unaffected: their range tombstone gets a higher Pebble sequence number than earlier same-batch SETs, so it already shadows uncommitted rows. Only the reverse map — which cannot be range-deleted — relied on the snapshot alone.

## Fix

`purgeReverseMapForKey` now purges from **both** sources:
- committed rows via the snapshot scan (unchanged), and
- same-batch uncommitted PUTs via the batch's read-your-writes `rmapOverlay` — the mechanism the codebase already maintains for exactly this ("callers resolve the current value via `ReverseMapOverlay` before falling back to committed state"). `dal.WriteSession` deliberately exposes no iterator, so the overlay is the sanctioned way to read in-flight reverse-map writes.

This keeps the live path's commit/progress boundaries intact (no mid-batch flush).

New `WriteBatch` helpers:
- `DeleteReverseMapKey` — deletes and clears the overlay entry so it never drifts from the batch.
- `RangeReverseMapOverlay` — read-only iteration over buffered reverse-map mutations.

The two self-contradictory doc comments are corrected.

## Testing

New `process_metadata_field_removal_test.go` (table-driven): `committed then removed`, `same batch repro`, `mixed committed and same batch`, `unrelated key survives`. Verified the three same-batch cases **fail before** this change (orphan row survives) and all pass after. `just pre-commit` (0 lint issues) and the full `just test` unit suite are green.

## Out of scope

- The "empty transient-set persisted" limb — already cancelled on every commit path via `appliedProposalSync.err()`.
- A checker-side pass detecting reverse-map orphans (`compareIndexes` verifies the registry, not reverse-map rows) — noted as a follow-up.

Jira: https://formance-team.atlassian.net/browse/EN-1443