### PR TITLE
fix(ledgerctl): reject --target/--key for non-metadata index types

### DIFF
--- a/cmd/ledgerctl/indexes/create.go
+++ b/cmd/ledgerctl/indexes/create.go
@@ -82,6 +82,10 @@ func runCreateIndex(cmd *cobra.Command, _ []string) error {
 		indexType = result
 	}
 
+	if err := rejectMetadataOnlyFlags(cmd, indexType); err != nil {
+		return err
+	}
+
 	req := &servicepb.CreateIndexRequest{
 		Ledger: ledgerName,
 	}

--- a/cmd/ledgerctl/indexes/drop.go
+++ b/cmd/ledgerctl/indexes/drop.go
@@ -73,6 +73,10 @@ func runDropIndex(cmd *cobra.Command, _ []string) error {
 		indexType = result
 	}
 
+	if err := rejectMetadataOnlyFlags(cmd, indexType); err != nil {
+		return err
+	}
+
 	req := &servicepb.DropIndexRequest{
 		Ledger: ledgerName,
 	}

--- a/cmd/ledgerctl/indexes/flag_validation.go
+++ b/cmd/ledgerctl/indexes/flag_validation.go
@@ -1,0 +1,29 @@
+package indexes
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// rejectMetadataOnlyFlags surfaces an error when --target or --key was passed
+// alongside a non-metadata index type. The switch statements in create.go /
+// drop.go used to consume those flags only in the `metadata` case, silently
+// dropping them for every other type — letting a caller believe that
+// `--type address --target account` produced an account-scoped address index
+// even though no such builtin exists (AccountBuiltinIndex only carries
+// ACCT_BUILTIN_INDEX_ASSET). Failing fast prevents the misleading "success"
+// message that actually re-issued the transaction-scoped address index.
+func rejectMetadataOnlyFlags(cmd *cobra.Command, indexType string) error {
+	if indexType == "metadata" {
+		return nil
+	}
+
+	for _, name := range []string{"target", "key"} {
+		if cmd.Flags().Changed(name) {
+			return fmt.Errorf("--%s is only valid with --type metadata (got --type %s)", name, indexType)
+		}
+	}
+
+	return nil
+}

--- a/cmd/ledgerctl/indexes/flag_validation_test.go
+++ b/cmd/ledgerctl/indexes/flag_validation_test.go
@@ -1,0 +1,54 @@
+package indexes
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRejectMetadataOnlyFlags(t *testing.T) {
+	t.Parallel()
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("target", "", "")
+		cmd.Flags().String("key", "", "")
+
+		return cmd
+	}
+
+	t.Run("metadata accepts target and key", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("target", "account"))
+		require.NoError(t, cmd.Flags().Set("key", "address"))
+		require.NoError(t, rejectMetadataOnlyFlags(cmd, "metadata"))
+	})
+
+	t.Run("non-metadata without extras is ok", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, rejectMetadataOnlyFlags(newCmd(), "address"))
+	})
+
+	// The confusing case: user tries to scope a builtin address index to
+	// accounts. There is no ACCT_BUILTIN_INDEX_ADDRESS in the proto, so the
+	// old CLI silently issued the transaction-scoped one and reported success.
+	t.Run("target rejected for non-metadata", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("target", "account"))
+		require.ErrorContains(t, rejectMetadataOnlyFlags(cmd, "address"), "--target is only valid with --type metadata")
+	})
+
+	t.Run("key rejected for non-metadata", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("key", "address"))
+		require.ErrorContains(t, rejectMetadataOnlyFlags(cmd, "reference"), "--key is only valid with --type metadata")
+	})
+}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -587,6 +587,7 @@ ledgerctl indexes create [flags]
 - The index starts building in the background immediately
 - Queries using the index will be rejected until the index reaches READY status
 - Creating an index that already exists and is READY is idempotent (no error)
+- `--target` and `--key` are only valid with `--type metadata`; passing them with any other type is rejected. In particular, there is no builtin address index scoped to accounts — `address`, `source-address`, and `dest-address` all index transactions.
 
 **Example:**
 
@@ -639,6 +640,7 @@ ledgerctl indexes drop [flags]
 **Behavior:**
 - Queries using the dropped index will be rejected after the drop
 - Dropping a non-existent index returns an error
+- `--target` and `--key` are only valid with `--type metadata`; passing them with any other type is rejected.
 
 **Example:**
 


### PR DESCRIPTION
## Summary

`ledgerctl indexes create --type address --target account` looked like it created an account-scoped address index but silently dropped `--target` and re-issued the transaction-scoped one. The proto has no `ACCT_BUILTIN_INDEX_ADDRESS` (`AccountBuiltinIndex` only carries `ACCT_BUILTIN_INDEX_ASSET`), and the FSM apply short-circuits on an already-READY index, so the misleading "success" message hid the mistake — users then wondered why only one index appeared in `indexes list`.

- Shared helper `rejectMetadataOnlyFlags` rejects `--target`/`--key` when `--type != metadata` in both `create` and `drop`.
- `docs/ops/cli.md` calls out the constraint and clarifies that all `address` builtins are transaction-scoped.

## Test plan

- [x] `go test ./cmd/ledgerctl/indexes/...` — 4 new sub-tests around the helper
- [x] `golangci-lint run ./cmd/ledgerctl/indexes/...` clean
- [ ] Manual: `ledgerctl indexes create --type address --target account` now errors with `--target is only valid with --type metadata`
- [ ] Manual: `ledgerctl indexes create --type metadata --target account --key address` still works