### PR TITLE
fix(operator): preserve LedgerClusterAgent seed across LedgerService recreation

### DIFF
--- a/misc/operator/cmd/operator/main.go
+++ b/misc/operator/cmd/operator/main.go
@@ -76,6 +76,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace, err := controller.DiscoverOperatorNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to determine operator namespace")
+		os.Exit(1)
+	}
+
 	dynamicClient, err := dynamic.NewForConfig(cfg)
 	if err != nil {
 		setupLog.Error(err, "unable to create dynamic client")
@@ -94,8 +100,9 @@ func main() {
 	}
 
 	if err = (&controller.LedgerClusterAgentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		OperatorNamespace: operatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LedgerClusterAgent")
 		os.Exit(1)

--- a/misc/operator/cmd/operator/main.go
+++ b/misc/operator/cmd/operator/main.go
@@ -47,6 +47,16 @@ func main() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(ledgerv1alpha1.AddToScheme(scheme))
 
+	// Discover the operator's own namespace up-front. When --watch-namespace
+	// is used, the manager cache must include the operator namespace too so
+	// canonical seed Secret reads/writes are not silently truncated to the
+	// watched namespace.
+	operatorNamespace, err := controller.DiscoverOperatorNamespace()
+	if err != nil {
+		setupLog.Error(err, "unable to determine operator namespace")
+		os.Exit(1)
+	}
+
 	mgrOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -59,6 +69,9 @@ func main() {
 	if f.watchNamespace != "" {
 		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 			f.watchNamespace: {},
+		}
+		if operatorNamespace != f.watchNamespace {
+			mgrOpts.Cache.DefaultNamespaces[operatorNamespace] = cache.Config{}
 		}
 	}
 
@@ -73,12 +86,6 @@ func main() {
 	clientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		setupLog.Error(err, "unable to create kubernetes clientset")
-		os.Exit(1)
-	}
-
-	operatorNamespace, err := controller.DiscoverOperatorNamespace()
-	if err != nil {
-		setupLog.Error(err, "unable to determine operator namespace")
 		os.Exit(1)
 	}
 

--- a/misc/operator/cmd/operator/main.go
+++ b/misc/operator/cmd/operator/main.go
@@ -47,10 +47,11 @@ func main() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(ledgerv1alpha1.AddToScheme(scheme))
 
-	// Discover the operator's own namespace up-front. When --watch-namespace
-	// is used, the manager cache must include the operator namespace too so
-	// canonical seed Secret reads/writes are not silently truncated to the
-	// watched namespace.
+	// Discover the operator's own namespace up-front. Canonical seed
+	// Secrets live there and are accessed via an uncached APIReader (see
+	// LedgerClusterAgentReconciler.APIReader), so --watch-namespace scope
+	// stays exactly what the user asked for — the operator namespace is
+	// NOT added to the cache.
 	operatorNamespace, err := controller.DiscoverOperatorNamespace()
 	if err != nil {
 		setupLog.Error(err, "unable to determine operator namespace")
@@ -69,9 +70,6 @@ func main() {
 	if f.watchNamespace != "" {
 		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 			f.watchNamespace: {},
-		}
-		if operatorNamespace != f.watchNamespace {
-			mgrOpts.Cache.DefaultNamespaces[operatorNamespace] = cache.Config{}
 		}
 	}
 
@@ -110,6 +108,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		OperatorNamespace: operatorNamespace,
+		APIReader:         mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LedgerClusterAgent")
 		os.Exit(1)

--- a/misc/operator/helm/operator/templates/deployment.yaml
+++ b/misc/operator/helm/operator/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         - --watch-namespace={{ .Values.watchNamespace }}
         {{- end }}
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: LEDGER_IMAGE_REPOSITORY
           value: "{{ .Values.ledgerImage.registry }}/{{ .Values.ledgerImage.name }}"
         - name: LEDGER_IMAGE_TAG

--- a/misc/operator/internal/controller/ledgerclusteragent_controller.go
+++ b/misc/operator/internal/controller/ledgerclusteragent_controller.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -28,6 +29,14 @@ import (
 const (
 	agentFinalizer = "ledger.formance.com/agent-keys"
 	agentNameLabel = "ledger.formance.com/agent-name"
+
+	// agentRoleLabel distinguishes the canonical seed Secret (living in the
+	// operator's namespace) from per-target replica Secrets. Only replicas
+	// are listed for placement / GC purposes; the canonical Secret is
+	// managed on its own path so it survives every target coming and going.
+	agentRoleLabel     = "ledger.formance.com/agent-role"
+	agentRoleReplica   = "replica"
+	agentRoleCanonical = "canonical"
 )
 
 // LedgerClusterAgentReconciler reconciles a LedgerClusterAgent object.
@@ -35,6 +44,12 @@ type LedgerClusterAgentReconciler struct {
 	client.Client
 
 	Scheme *runtime.Scheme
+
+	// OperatorNamespace is where the canonical seed Secret of every
+	// LedgerClusterAgent is stored. Injected at construction (from
+	// DiscoverOperatorNamespace in production, from a fixed namespace in
+	// envtest) so the reconciler does not depend on process-global state.
+	OperatorNamespace string
 }
 
 // +kubebuilder:rbac:groups=ledger.formance.com,resources=ledgerclusteragents,verbs=get;list;watch;create;update;patch;delete
@@ -92,22 +107,37 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Compute the desired target namespaces (matched services + additional).
 	desiredNamespaces := computeDesiredNamespaces(matchedServices, agent.Spec.AdditionalNamespaces)
 
-	// List existing replicas across all namespaces.
-	existingReplicas, err := r.listAgentSecrets(ctx, agent.Name)
+	// List existing replicas across all namespaces (canonical excluded via label filter).
+	existingReplicas, err := r.listAgentReplicaSecrets(ctx, agent.Name)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("listing agent secrets: %w", err)
+		return ctrl.Result{}, fmt.Errorf("listing agent replica secrets: %w", err)
 	}
 
-	// Replicate (and resolve canonical key material) only when at least one target exists.
-	// With no targets, the keypair is not persisted so it is not generated either.
+	// Resolve canonical seed material. The canonical Secret lives in the
+	// operator's namespace and is the sole source of truth for the seed;
+	// per-target replicas are pure projections of its content. It is
+	// created lazily on first-ever target so an agent with no matching
+	// services never persists key material. Once it exists, it survives
+	// transient absence of every target — a LedgerService deletion no
+	// longer regenerates the seed.
 	var (
 		canonicalData map[string][]byte
 		refs          = make([]ledgerv1alpha1.SecretReference, 0, len(desiredNamespaces))
 	)
 	if len(desiredNamespaces) > 0 {
-		canonicalData, err = canonicalKeyData(existingReplicas)
+		canonicalData, err = r.ensureCanonicalSecret(ctx, agent)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("resolving canonical key data: %w", err)
+			meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				Reason:             "CanonicalFailed",
+				Message:            err.Error(),
+				ObservedGeneration: agent.Generation,
+			})
+			agent.Status.Phase = "Error"
+			_ = r.Status().Update(ctx, agent)
+
+			return ctrl.Result{}, fmt.Errorf("ensuring canonical secret: %w", err)
 		}
 
 		for _, ns := range desiredNamespaces {
@@ -131,31 +161,24 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// Garbage-collect orphan replicas in namespaces no longer in scope.
-	//
-	// When desiredNamespaces is empty (all matched services disappeared, no
-	// additional namespaces configured), we deliberately skip GC to preserve
-	// the seed across transient LedgerService deletion/recreation. Deleting
-	// every replica would destroy the canonical key material, and the next
-	// reconcile with a matching service would generate a fresh keypair —
-	// silently invalidating every bundle already handed out. The finalizer
-	// (handleDeletion) remains responsible for the definitive cleanup when
-	// the LedgerClusterAgent itself is deleted.
-	if len(desiredNamespaces) > 0 {
-		desiredSet := make(map[string]struct{}, len(desiredNamespaces))
-		for _, ns := range desiredNamespaces {
-			desiredSet[ns] = struct{}{}
+	// Aggressively garbage-collect replica Secrets in namespaces no longer
+	// in scope. Because the seed lives on the canonical Secret in the
+	// operator namespace, deleting stale replicas can never destroy the
+	// canonical key material — the "seed vanishes when the last target
+	// disappears" hazard the previous design had is gone.
+	desiredSet := make(map[string]struct{}, len(desiredNamespaces))
+	for _, ns := range desiredNamespaces {
+		desiredSet[ns] = struct{}{}
+	}
+	for i := range existingReplicas {
+		secret := &existingReplicas[i]
+		if _, keep := desiredSet[secret.Namespace]; keep {
+			continue
 		}
-		for i := range existingReplicas {
-			secret := &existingReplicas[i]
-			if _, keep := desiredSet[secret.Namespace]; keep {
-				continue
-			}
-			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("deleting orphan secret in %q: %w", secret.Namespace, err)
-			}
-			logger.Info("deleted orphan agent secret", "namespace", secret.Namespace, "name", secret.Name)
+		if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("deleting orphan secret in %q: %w", secret.Namespace, err)
 		}
+		logger.Info("deleted orphan agent replica secret", "namespace", secret.Namespace, "name", secret.Name)
 	}
 
 	agent.Status.MatchedServices = matchedServices
@@ -165,17 +188,11 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(refs) == 0 {
 		agent.Status.KeyID = ""
 		agent.Status.Phase = "Pending"
-
-		message := "no matched LedgerServices or additional namespaces; agent keypair is not persisted"
-		if len(existingReplicas) > 0 {
-			message = "no matched LedgerServices or additional namespaces; dormant keypair preserved for later reuse"
-		}
-
 		meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
 			Reason:             "NoTargets",
-			Message:            message,
+			Message:            "no matched LedgerServices or additional namespaces; canonical seed (if any) is preserved for later reuse",
 			ObservedGeneration: agent.Generation,
 		})
 	} else {
@@ -197,22 +214,34 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{}, nil
 }
 
-// handleDeletion removes every replica of the agent's Secret and then drops the finalizer.
+// handleDeletion removes the canonical Secret and every replica of the
+// agent's Secret, then drops the finalizer.
 func (r *LedgerClusterAgentReconciler) handleDeletion(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if controllerutil.ContainsFinalizer(agent, agentFinalizer) {
-		replicas, err := r.listAgentSecrets(ctx, agent.Name)
+		replicas, err := r.listAgentReplicaSecrets(ctx, agent.Name)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("listing agent secrets for deletion: %w", err)
 		}
 		for i := range replicas {
 			secret := &replicas[i]
 			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("deleting agent secret in %q: %w", secret.Namespace, err)
+				return ctrl.Result{}, fmt.Errorf("deleting agent replica secret in %q: %w", secret.Namespace, err)
 			}
-			logger.Info("deleted agent secret", "namespace", secret.Namespace, "name", secret.Name)
+			logger.Info("deleted agent replica secret", "namespace", secret.Namespace, "name", secret.Name)
 		}
+
+		canonical := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      agentCanonicalSecretName(agent.Name),
+				Namespace: r.OperatorNamespace,
+			},
+		}
+		if err := r.Delete(ctx, canonical); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("deleting canonical secret: %w", err)
+		}
+		logger.Info("deleted agent canonical secret", "namespace", r.OperatorNamespace, "name", canonical.Name)
 
 		controllerutil.RemoveFinalizer(agent, agentFinalizer)
 		if err := r.Update(ctx, agent); err != nil {
@@ -249,41 +278,71 @@ func (r *LedgerClusterAgentReconciler) resolveMatchedServices(ctx context.Contex
 	return matched, nil
 }
 
-// listAgentSecrets returns every Secret labeled as belonging to the given agent,
-// across all namespaces.
-func (r *LedgerClusterAgentReconciler) listAgentSecrets(ctx context.Context, agentName string) ([]corev1.Secret, error) {
+// listAgentReplicaSecrets returns every replica Secret belonging to the given
+// agent, across all namespaces. The canonical Secret is deliberately excluded
+// (filtered via agentRoleLabel) so replica placement and GC cannot touch it.
+func (r *LedgerClusterAgentReconciler) listAgentReplicaSecrets(ctx context.Context, agentName string) ([]corev1.Secret, error) {
 	var secrets corev1.SecretList
-	if err := r.List(ctx, &secrets, client.MatchingLabels{agentNameLabel: agentName}); err != nil {
+	if err := r.List(ctx, &secrets, client.MatchingLabels{
+		agentNameLabel: agentName,
+		agentRoleLabel: agentRoleReplica,
+	}); err != nil {
 		return nil, err
 	}
 
 	return secrets.Items, nil
 }
 
-// canonicalKeyData returns the canonical Secret payload for the agent. If any
-// replica already exists, its data is used (all replicas carry identical content).
-// Otherwise, a fresh Ed25519 keypair is generated.
-func canonicalKeyData(existing []corev1.Secret) (map[string][]byte, error) {
-	for i := range existing {
-		if len(existing[i].Data["seed.hex"]) > 0 {
-			return existing[i].Data, nil
+// ensureCanonicalSecret creates the canonical seed Secret in the operator's
+// namespace on first call for the agent, and returns its data on every
+// subsequent call. The seed is generated exactly once — the CreateOrUpdate
+// mutation only writes fresh key material when the Secret has no seed.hex
+// yet, so the canonical value is stable across the agent's lifetime.
+func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent) (map[string][]byte, error) {
+	if r.OperatorNamespace == "" {
+		return nil, errors.New("operator namespace not configured")
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentCanonicalSecretName(agent.Name),
+			Namespace: r.OperatorNamespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if secret.Labels == nil {
+			secret.Labels = make(map[string]string, 2)
 		}
-	}
+		secret.Labels[agentNameLabel] = agent.Name
+		secret.Labels[agentRoleLabel] = agentRoleCanonical
 
-	seed, pubKey, keyID, err := generateEd25519KeyPair()
+		if len(secret.Data[keySeedHex]) > 0 {
+			return nil
+		}
+
+		seed, pubKey, keyID, err := generateEd25519KeyPair()
+		if err != nil {
+			return fmt.Errorf("generating Ed25519 keypair: %w", err)
+		}
+
+		secret.Data = map[string][]byte{
+			keySeedHex:   []byte(hex.EncodeToString(seed)),
+			keyPubKeyHex: []byte(hex.EncodeToString(pubKey)),
+			keyKeyID:     []byte(keyID),
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("generating Ed25519 keypair: %w", err)
+		return nil, fmt.Errorf("upserting canonical secret: %w", err)
 	}
 
-	return map[string][]byte{
-		"seed.hex":   []byte(hex.EncodeToString(seed)),
-		"pubkey.hex": []byte(hex.EncodeToString(pubKey)),
-		"key-id":     []byte(keyID),
-	}, nil
+	return secret.Data, nil
 }
 
-// ensureReplica creates or updates the agent's Secret in the given namespace
-// with the canonical data.
+// ensureReplica creates or updates the agent's replica Secret in the given
+// namespace with a projection of the canonical data.
 func (r *LedgerClusterAgentReconciler) ensureReplica(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent, namespace string, data map[string][]byte) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -294,9 +353,10 @@ func (r *LedgerClusterAgentReconciler) ensureReplica(ctx context.Context, agent 
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		if secret.Labels == nil {
-			secret.Labels = make(map[string]string, 1)
+			secret.Labels = make(map[string]string, 2)
 		}
 		secret.Labels[agentNameLabel] = agent.Name
+		secret.Labels[agentRoleLabel] = agentRoleReplica
 		secret.Data = data
 
 		return nil
@@ -329,7 +389,7 @@ func computeDesiredNamespaces(matched []ledgerv1alpha1.MatchedService, additiona
 	return out
 }
 
-// agentSecretName returns the name of the Secret managed by the agent.
+// agentSecretName returns the name of the replica Secret managed by the agent.
 func agentSecretName(agent *ledgerv1alpha1.LedgerClusterAgent) string {
 	return prefixedName(agent.Name) + "-agent-keys"
 }
@@ -377,6 +437,12 @@ func (r *LedgerClusterAgentReconciler) ledgerServiceToAgents(ctx context.Context
 
 	return requests
 }
+
+const (
+	keySeedHex   = "seed.hex"
+	keyPubKeyHex = "pubkey.hex"
+	keyKeyID     = "key-id"
+)
 
 // generateEd25519KeyPair generates a new Ed25519 keypair and returns the seed,
 // public key, and a key ID (SHA-256 fingerprint prefix, 16 hex chars).

--- a/misc/operator/internal/controller/ledgerclusteragent_controller.go
+++ b/misc/operator/internal/controller/ledgerclusteragent_controller.go
@@ -42,6 +42,13 @@ type LedgerClusterAgentReconciler struct {
 	// DiscoverOperatorNamespace in production, from a fixed namespace in
 	// envtest) so the reconciler does not depend on process-global state.
 	OperatorNamespace string
+
+	// APIReader is an uncached reader used exclusively for canonical Secret
+	// reads in the operator's own namespace. Going through the manager's
+	// cached client would either force us to widen --watch-namespace scope
+	// (surprising for multi-tenant deployments) or hit a cache-miss. Writes
+	// always bypass the cache and use the regular Client.
+	APIReader client.Reader
 }
 
 // +kubebuilder:rbac:groups=ledger.formance.com,resources=ledgerclusteragents,verbs=get;list;watch;create;update;patch;delete
@@ -107,16 +114,18 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Resolve canonical seed material. The canonical Secret lives in the
 	// operator's namespace and is the sole source of truth for the seed;
-	// per-target replicas are pure projections of its content. It is
-	// created lazily on first-ever target so an agent with no matching
-	// services never persists key material. Once it exists, it survives
-	// transient absence of every target — a LedgerService deletion no
-	// longer regenerates the seed.
+	// per-target replicas are pure projections of its content.
+	//
+	// Bootstrap conditions: at least one desired target OR at least one
+	// existing replica. The second case covers the no-target upgrade path:
+	// legacy replicas from a pre-canonical operator would otherwise be
+	// deleted by the aggressive GC below before their seed could be
+	// adopted, permanently losing the identity.
 	var (
 		canonicalData map[string][]byte
 		refs          = make([]ledgerv1alpha1.SecretReference, 0, len(desiredNamespaces))
 	)
-	if len(desiredNamespaces) > 0 {
+	if len(desiredNamespaces) > 0 || len(existingReplicas) > 0 {
 		canonicalData, err = r.ensureCanonicalSecret(ctx, agent, existingReplicas)
 		if err != nil {
 			meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
@@ -131,7 +140,9 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 			return ctrl.Result{}, fmt.Errorf("ensuring canonical secret: %w", err)
 		}
+	}
 
+	if len(desiredNamespaces) > 0 {
 		for _, ns := range desiredNamespaces {
 			if err := r.ensureReplica(ctx, agent, ns, canonicalData); err != nil {
 				meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
@@ -299,62 +310,86 @@ func (r *LedgerClusterAgentReconciler) listAgentReplicaSecrets(ctx context.Conte
 
 // ensureCanonicalSecret creates the canonical seed Secret in the operator's
 // namespace on first call for the agent, and returns its data on every
-// subsequent call. The seed is generated exactly once — the CreateOrUpdate
-// mutation only writes fresh key material when the Secret has no seed.hex
-// yet, so the canonical value is stable across the agent's lifetime.
+// subsequent call. The seed is generated exactly once and the Secret is
+// never updated after creation — the canonical value is stable across the
+// agent's lifetime, independent of the manager cache configuration.
+//
+// Reads go through r.APIReader (uncached) to avoid forcing the caller to
+// widen --watch-namespace scope for every controller in the manager just so
+// the operator namespace is covered. Writes hit the API server directly
+// regardless of cache.
 //
 // Upgrade path: existingReplicas is the set of Secrets carrying seed material
 // under the older (canonical-less) layout. When bootstrapping the canonical
 // for the first time, we adopt the seed from one of them instead of
 // generating fresh material — otherwise upgrading the operator would
-// silently invalidate every bundle already handed out from the pre-canonical
-// replica.
+// silently invalidate every bundle already handed out.
 func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent, existingReplicas []corev1.Secret) (map[string][]byte, error) {
 	if r.OperatorNamespace == "" {
 		return nil, errors.New("operator namespace not configured")
 	}
+	if r.APIReader == nil {
+		return nil, errors.New("APIReader not configured")
+	}
 
-	secret := &corev1.Secret{
+	key := types.NamespacedName{
+		Name:      agentCanonicalSecretName(agent.Name),
+		Namespace: r.OperatorNamespace,
+	}
+
+	existing := &corev1.Secret{}
+	switch err := r.APIReader.Get(ctx, key, existing); {
+	case err == nil:
+		if len(existing.Data[keySeedHex]) == 0 {
+			return nil, fmt.Errorf("canonical secret %s/%s exists but has no seed", key.Namespace, key.Name)
+		}
+
+		return existing.Data, nil
+	case !apierrors.IsNotFound(err):
+		return nil, fmt.Errorf("reading canonical secret: %w", err)
+	}
+
+	// Not found — mint a new canonical, adopting a legacy replica's seed
+	// when available to keep bundles valid across upgrades.
+	fresh := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      agentCanonicalSecretName(agent.Name),
-			Namespace: r.OperatorNamespace,
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels: map[string]string{
+				agentNameLabel: agent.Name,
+			},
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
-		if secret.Labels == nil {
-			secret.Labels = make(map[string]string, 1)
-		}
-		secret.Labels[agentNameLabel] = agent.Name
-
-		if len(secret.Data[keySeedHex]) > 0 {
-			return nil
-		}
-
-		if adopted := adoptSeedFromReplica(existingReplicas); adopted != nil {
-			secret.Data = adopted
-
-			return nil
-		}
-
+	if adopted := adoptSeedFromReplica(existingReplicas); adopted != nil {
+		fresh.Data = adopted
+	} else {
 		seed, pubKey, keyID, err := generateEd25519KeyPair()
 		if err != nil {
-			return fmt.Errorf("generating Ed25519 keypair: %w", err)
+			return nil, fmt.Errorf("generating Ed25519 keypair: %w", err)
 		}
-
-		secret.Data = map[string][]byte{
+		fresh.Data = map[string][]byte{
 			keySeedHex:   []byte(hex.EncodeToString(seed)),
 			keyPubKeyHex: []byte(hex.EncodeToString(pubKey)),
 			keyKeyID:     []byte(keyID),
 		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("upserting canonical secret: %w", err)
 	}
 
-	return secret.Data, nil
+	if err := r.Create(ctx, fresh); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// A concurrent reconcile beat us to it. Re-read via APIReader
+			// (the write may not be visible on the cached client yet).
+			if err := r.APIReader.Get(ctx, key, existing); err != nil {
+				return nil, fmt.Errorf("re-reading canonical secret after AlreadyExists: %w", err)
+			}
+
+			return existing.Data, nil
+		}
+
+		return nil, fmt.Errorf("creating canonical secret: %w", err)
+	}
+
+	return fresh.Data, nil
 }
 
 // adoptSeedFromReplica returns a copy of the seed material found on any

--- a/misc/operator/internal/controller/ledgerclusteragent_controller.go
+++ b/misc/operator/internal/controller/ledgerclusteragent_controller.go
@@ -29,14 +29,6 @@ import (
 const (
 	agentFinalizer = "ledger.formance.com/agent-keys"
 	agentNameLabel = "ledger.formance.com/agent-name"
-
-	// agentRoleLabel distinguishes the canonical seed Secret (living in the
-	// operator's namespace) from per-target replica Secrets. Only replicas
-	// are listed for placement / GC purposes; the canonical Secret is
-	// managed on its own path so it survives every target coming and going.
-	agentRoleLabel     = "ledger.formance.com/agent-role"
-	agentRoleReplica   = "replica"
-	agentRoleCanonical = "canonical"
 )
 
 // LedgerClusterAgentReconciler reconciles a LedgerClusterAgent object.
@@ -125,7 +117,7 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 		refs          = make([]ledgerv1alpha1.SecretReference, 0, len(desiredNamespaces))
 	)
 	if len(desiredNamespaces) > 0 {
-		canonicalData, err = r.ensureCanonicalSecret(ctx, agent)
+		canonicalData, err = r.ensureCanonicalSecret(ctx, agent, existingReplicas)
 		if err != nil {
 			meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
 				Type:               "Ready",
@@ -279,18 +271,30 @@ func (r *LedgerClusterAgentReconciler) resolveMatchedServices(ctx context.Contex
 }
 
 // listAgentReplicaSecrets returns every replica Secret belonging to the given
-// agent, across all namespaces. The canonical Secret is deliberately excluded
-// (filtered via agentRoleLabel) so replica placement and GC cannot touch it.
+// agent, across all namespaces. The canonical Secret is identified by
+// name + namespace and excluded from the result — filtering by name (rather
+// than by an additional label) means Secrets created by pre-canonical
+// versions of the operator are still discovered, so upgrade adopts them
+// instead of orphaning them.
 func (r *LedgerClusterAgentReconciler) listAgentReplicaSecrets(ctx context.Context, agentName string) ([]corev1.Secret, error) {
 	var secrets corev1.SecretList
 	if err := r.List(ctx, &secrets, client.MatchingLabels{
 		agentNameLabel: agentName,
-		agentRoleLabel: agentRoleReplica,
 	}); err != nil {
 		return nil, err
 	}
 
-	return secrets.Items, nil
+	canonicalName := agentCanonicalSecretName(agentName)
+
+	filtered := secrets.Items[:0]
+	for _, s := range secrets.Items {
+		if s.Name == canonicalName && s.Namespace == r.OperatorNamespace {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	return filtered, nil
 }
 
 // ensureCanonicalSecret creates the canonical seed Secret in the operator's
@@ -298,7 +302,14 @@ func (r *LedgerClusterAgentReconciler) listAgentReplicaSecrets(ctx context.Conte
 // subsequent call. The seed is generated exactly once — the CreateOrUpdate
 // mutation only writes fresh key material when the Secret has no seed.hex
 // yet, so the canonical value is stable across the agent's lifetime.
-func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent) (map[string][]byte, error) {
+//
+// Upgrade path: existingReplicas is the set of Secrets carrying seed material
+// under the older (canonical-less) layout. When bootstrapping the canonical
+// for the first time, we adopt the seed from one of them instead of
+// generating fresh material — otherwise upgrading the operator would
+// silently invalidate every bundle already handed out from the pre-canonical
+// replica.
+func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent, existingReplicas []corev1.Secret) (map[string][]byte, error) {
 	if r.OperatorNamespace == "" {
 		return nil, errors.New("operator namespace not configured")
 	}
@@ -312,12 +323,17 @@ func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		if secret.Labels == nil {
-			secret.Labels = make(map[string]string, 2)
+			secret.Labels = make(map[string]string, 1)
 		}
 		secret.Labels[agentNameLabel] = agent.Name
-		secret.Labels[agentRoleLabel] = agentRoleCanonical
 
 		if len(secret.Data[keySeedHex]) > 0 {
+			return nil
+		}
+
+		if adopted := adoptSeedFromReplica(existingReplicas); adopted != nil {
+			secret.Data = adopted
+
 			return nil
 		}
 
@@ -341,6 +357,38 @@ func (r *LedgerClusterAgentReconciler) ensureCanonicalSecret(ctx context.Context
 	return secret.Data, nil
 }
 
+// adoptSeedFromReplica returns a copy of the seed material found on any
+// existing replica, or nil when no candidate carries a seed. The candidate
+// pool is sorted deterministically by namespace/name so the choice is stable
+// across reconciles when multiple replicas exist (all replicas should carry
+// the same content, but we do not rely on that invariant here).
+func adoptSeedFromReplica(replicas []corev1.Secret) map[string][]byte {
+	candidates := make([]*corev1.Secret, 0, len(replicas))
+	for i := range replicas {
+		if len(replicas[i].Data[keySeedHex]) > 0 {
+			candidates = append(candidates, &replicas[i])
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Namespace != candidates[j].Namespace {
+			return candidates[i].Namespace < candidates[j].Namespace
+		}
+
+		return candidates[i].Name < candidates[j].Name
+	})
+
+	src := candidates[0].Data
+
+	return map[string][]byte{
+		keySeedHex:   append([]byte(nil), src[keySeedHex]...),
+		keyPubKeyHex: append([]byte(nil), src[keyPubKeyHex]...),
+		keyKeyID:     append([]byte(nil), src[keyKeyID]...),
+	}
+}
+
 // ensureReplica creates or updates the agent's replica Secret in the given
 // namespace with a projection of the canonical data.
 func (r *LedgerClusterAgentReconciler) ensureReplica(ctx context.Context, agent *ledgerv1alpha1.LedgerClusterAgent, namespace string, data map[string][]byte) error {
@@ -353,10 +401,9 @@ func (r *LedgerClusterAgentReconciler) ensureReplica(ctx context.Context, agent 
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		if secret.Labels == nil {
-			secret.Labels = make(map[string]string, 2)
+			secret.Labels = make(map[string]string, 1)
 		}
 		secret.Labels[agentNameLabel] = agent.Name
-		secret.Labels[agentRoleLabel] = agentRoleReplica
 		secret.Data = data
 
 		return nil

--- a/misc/operator/internal/controller/ledgerclusteragent_controller.go
+++ b/misc/operator/internal/controller/ledgerclusteragent_controller.go
@@ -131,21 +131,31 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// Garbage-collect orphan replicas in namespaces no longer in scope (also covers
-	// the no-targets case: any leftover replica from a previous reconcile is removed).
-	desiredSet := make(map[string]struct{}, len(desiredNamespaces))
-	for _, ns := range desiredNamespaces {
-		desiredSet[ns] = struct{}{}
-	}
-	for i := range existingReplicas {
-		secret := &existingReplicas[i]
-		if _, keep := desiredSet[secret.Namespace]; keep {
-			continue
+	// Garbage-collect orphan replicas in namespaces no longer in scope.
+	//
+	// When desiredNamespaces is empty (all matched services disappeared, no
+	// additional namespaces configured), we deliberately skip GC to preserve
+	// the seed across transient LedgerService deletion/recreation. Deleting
+	// every replica would destroy the canonical key material, and the next
+	// reconcile with a matching service would generate a fresh keypair —
+	// silently invalidating every bundle already handed out. The finalizer
+	// (handleDeletion) remains responsible for the definitive cleanup when
+	// the LedgerClusterAgent itself is deleted.
+	if len(desiredNamespaces) > 0 {
+		desiredSet := make(map[string]struct{}, len(desiredNamespaces))
+		for _, ns := range desiredNamespaces {
+			desiredSet[ns] = struct{}{}
 		}
-		if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("deleting orphan secret in %q: %w", secret.Namespace, err)
+		for i := range existingReplicas {
+			secret := &existingReplicas[i]
+			if _, keep := desiredSet[secret.Namespace]; keep {
+				continue
+			}
+			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("deleting orphan secret in %q: %w", secret.Namespace, err)
+			}
+			logger.Info("deleted orphan agent secret", "namespace", secret.Namespace, "name", secret.Name)
 		}
-		logger.Info("deleted orphan agent secret", "namespace", secret.Namespace, "name", secret.Name)
 	}
 
 	agent.Status.MatchedServices = matchedServices
@@ -155,11 +165,17 @@ func (r *LedgerClusterAgentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(refs) == 0 {
 		agent.Status.KeyID = ""
 		agent.Status.Phase = "Pending"
+
+		message := "no matched LedgerServices or additional namespaces; agent keypair is not persisted"
+		if len(existingReplicas) > 0 {
+			message = "no matched LedgerServices or additional namespaces; dormant keypair preserved for later reuse"
+		}
+
 		meta.SetStatusCondition(&agent.Status.Conditions, metav1.Condition{
 			Type:               "Ready",
 			Status:             metav1.ConditionFalse,
 			Reason:             "NoTargets",
-			Message:            "no matched LedgerServices or additional namespaces; agent keypair is not persisted",
+			Message:            message,
 			ObservedGeneration: agent.Generation,
 		})
 	} else {

--- a/misc/operator/internal/controller/names.go
+++ b/misc/operator/internal/controller/names.go
@@ -55,6 +55,14 @@ func clusterSecretName(crName string) string {
 	return resourceName(crName) + "-cluster-secret"
 }
 
+// agentCanonicalSecretName returns the name of the canonical seed Secret for a
+// LedgerClusterAgent. This Secret lives in the operator's own namespace and
+// holds the sole source of truth for the agent's Ed25519 keypair; the
+// per-target replicas are pure projections of its content.
+func agentCanonicalSecretName(agentName string) string {
+	return prefixedName(agentName) + "-agent-canonical"
+}
+
 // podName returns the StatefulSet pod name for the given ordinal. The StatefulSet
 // name is resourceName(crName), so its pods are resourceName(crName)-<ordinal>.
 func podName(crName string, ordinal int) string {

--- a/misc/operator/internal/controller/operator_namespace.go
+++ b/misc/operator/internal/controller/operator_namespace.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// serviceAccountNamespacePath is the standard in-cluster location where kubelet
+// mounts the ServiceAccount namespace file. Present in every pod that has an
+// automounted ServiceAccount token (the default).
+const serviceAccountNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// DiscoverOperatorNamespace resolves the namespace the operator is running in,
+// used to place cluster-scoped resources whose canonical location must be
+// stable across the lifecycle of any LedgerService or LedgerClusterAgent (e.g.
+// per-agent canonical seed Secrets). Resolution order:
+//
+//  1. POD_NAMESPACE env var (downward API — preferred, easy to inject and mock).
+//  2. In-cluster ServiceAccount namespace file (default in every pod).
+//
+// Returns an explicit error when neither is available so the operator refuses
+// to start rather than silently persisting seeds in the wrong location.
+func DiscoverOperatorNamespace() (string, error) {
+	if ns := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); ns != "" {
+		return ns, nil
+	}
+
+	data, err := os.ReadFile(serviceAccountNamespacePath)
+	if err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("reading %s: %w", serviceAccountNamespacePath, err)
+	}
+
+	return "", errors.New("could not determine operator namespace: set POD_NAMESPACE (downward API) or run inside a pod with a mounted ServiceAccount")
+}

--- a/misc/operator/internal/controller/reconcile_agent_test.go
+++ b/misc/operator/internal/controller/reconcile_agent_test.go
@@ -238,16 +238,20 @@ func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
 		_ = k8sClient.Delete(ctx, agent) //nolint:errcheck // best-effort cleanup
 	})
 
-	secretKey := types.NamespacedName{Namespace: ns, Name: "ledger-survive-agent-agent-keys"}
-	secret := &corev1.Secret{}
-	requireEventually(t, func() bool {
-		return k8sClient.Get(ctx, secretKey, secret) == nil
-	}, "Secret should be created while the LedgerService matches")
+	replicaKey := types.NamespacedName{Namespace: ns, Name: "ledger-survive-agent-agent-keys"}
+	canonicalKey := types.NamespacedName{Namespace: testOperatorNamespace, Name: "ledger-survive-agent-agent-canonical"}
+	replica := &corev1.Secret{}
+	canonical := &corev1.Secret{}
 
-	initialSeed := string(secret.Data["seed.hex"])
-	initialPubKey := string(secret.Data["pubkey.hex"])
-	initialKeyID := string(secret.Data["key-id"])
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, replicaKey, replica) == nil && k8sClient.Get(ctx, canonicalKey, canonical) == nil
+	}, "both canonical and replica secrets should be created")
+
+	initialSeed := string(canonical.Data["seed.hex"])
+	initialPubKey := string(canonical.Data["pubkey.hex"])
+	initialKeyID := string(canonical.Data["key-id"])
 	require.NotEmpty(t, initialSeed)
+	assert.Equal(t, initialSeed, string(replica.Data["seed.hex"]), "replica must project canonical seed")
 
 	require.NoError(t, k8sClient.Delete(ctx, ls))
 	requireEventually(t, func() bool {
@@ -256,8 +260,7 @@ func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
 		return apierrors.IsNotFound(err)
 	}, "LedgerService should be deleted")
 
-	// The dormant Secret must survive the transient absence of the LedgerService
-	// so the seed identity is preserved across recreation.
+	// Replica must be aggressively GC'd; canonical must survive to preserve seed identity.
 	requireEventually(t, func() bool {
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "survive-agent"}, agent); err != nil {
 			return false
@@ -266,8 +269,14 @@ func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
 		return agent.Status.Phase == "Pending" && agent.Status.ObservedGeneration == agent.Generation
 	}, "agent should report Pending once no service matches")
 
-	require.NoError(t, k8sClient.Get(ctx, secretKey, secret), "Secret must remain dormant while no LedgerService matches")
-	assert.Equal(t, initialSeed, string(secret.Data["seed.hex"]), "dormant seed must not be regenerated")
+	requireEventually(t, func() bool {
+		err := k8sClient.Get(ctx, replicaKey, &corev1.Secret{})
+
+		return apierrors.IsNotFound(err)
+	}, "replica in unmatched namespace should be deleted")
+
+	require.NoError(t, k8sClient.Get(ctx, canonicalKey, canonical), "canonical seed must survive LedgerService deletion")
+	assert.Equal(t, initialSeed, string(canonical.Data["seed.hex"]), "canonical seed must not be regenerated")
 
 	lsAgain := newLedgerService("survive-svc", ns)
 	lsAgain.Labels = map[string]string{"tier": "survive"}
@@ -281,10 +290,32 @@ func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
 		return agent.Status.Phase == "Ready" && agent.Status.KeyID == initialKeyID
 	}, "agent should return to Ready with the original keyID")
 
-	require.NoError(t, k8sClient.Get(ctx, secretKey, secret))
-	assert.Equal(t, initialSeed, string(secret.Data["seed.hex"]), "seed must be identical after LedgerService recreation")
-	assert.Equal(t, initialPubKey, string(secret.Data["pubkey.hex"]))
-	assert.Equal(t, initialKeyID, string(secret.Data["key-id"]))
+	require.NoError(t, k8sClient.Get(ctx, replicaKey, replica))
+	assert.Equal(t, initialSeed, string(replica.Data["seed.hex"]), "seed must be identical after LedgerService recreation")
+	assert.Equal(t, initialPubKey, string(replica.Data["pubkey.hex"]))
+	assert.Equal(t, initialKeyID, string(replica.Data["key-id"]))
+}
+
+func TestReconcile_AgentCanonicalDeletedOnAgentRemoval(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	agent := newLedgerClusterAgentWithAdditional("canonical-cleanup", []string{"read"}, map[string]string{"app": "ledger"}, ns)
+	require.NoError(t, k8sClient.Create(ctx, agent))
+
+	replicaKey := types.NamespacedName{Namespace: ns, Name: "ledger-canonical-cleanup-agent-keys"}
+	canonicalKey := types.NamespacedName{Namespace: testOperatorNamespace, Name: "ledger-canonical-cleanup-agent-canonical"}
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, replicaKey, &corev1.Secret{}) == nil && k8sClient.Get(ctx, canonicalKey, &corev1.Secret{}) == nil
+	}, "canonical and replica should be created")
+
+	require.NoError(t, k8sClient.Delete(ctx, agent))
+
+	requireEventually(t, func() bool {
+		errReplica := k8sClient.Get(ctx, replicaKey, &corev1.Secret{})
+		errCanonical := k8sClient.Get(ctx, canonicalKey, &corev1.Secret{})
+
+		return apierrors.IsNotFound(errReplica) && apierrors.IsNotFound(errCanonical)
+	}, "canonical and replica should both be deleted after agent deletion")
 }
 
 func TestReconcile_AgentDeletion(t *testing.T) {

--- a/misc/operator/internal/controller/reconcile_agent_test.go
+++ b/misc/operator/internal/controller/reconcile_agent_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -294,6 +295,58 @@ func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
 	assert.Equal(t, initialSeed, string(replica.Data["seed.hex"]), "seed must be identical after LedgerService recreation")
 	assert.Equal(t, initialPubKey, string(replica.Data["pubkey.hex"]))
 	assert.Equal(t, initialKeyID, string(replica.Data["key-id"]))
+}
+
+func TestReconcile_AgentUpgradeAdoptsLegacyReplicaSeed(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	// Simulate a replica Secret produced by a pre-canonical version of the
+	// operator: it carries only the legacy agentNameLabel and holds seed
+	// material at the same well-known key set. The agent name matches what
+	// the reconciler will look up.
+	legacyReplica := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ledger-legacy-agent-agent-keys",
+			Namespace: ns,
+			Labels: map[string]string{
+				agentNameLabel: "legacy-agent",
+			},
+		},
+		Data: map[string][]byte{
+			"seed.hex":   []byte("aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"),
+			"pubkey.hex": []byte("11223344556677889900aabbccddeeff11223344556677889900aabbccddeeff"),
+			"key-id":     []byte("legacyseed12345"),
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, legacyReplica))
+
+	ls := newLedgerService("legacy-svc", ns)
+	ls.Labels = map[string]string{"tier": "legacy"}
+	require.NoError(t, k8sClient.Create(ctx, ls))
+
+	agent := newLedgerClusterAgent("legacy-agent", []string{"read"}, map[string]string{"tier": "legacy"})
+	require.NoError(t, k8sClient.Create(ctx, agent))
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, agent) //nolint:errcheck // best-effort cleanup
+	})
+
+	canonicalKey := types.NamespacedName{Namespace: testOperatorNamespace, Name: "ledger-legacy-agent-agent-canonical"}
+	canonical := &corev1.Secret{}
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, canonicalKey, canonical); err != nil {
+			return false
+		}
+
+		return len(canonical.Data["seed.hex"]) > 0
+	}, "canonical secret should be created and seeded from the legacy replica")
+
+	assert.Equal(t, string(legacyReplica.Data["seed.hex"]), string(canonical.Data["seed.hex"]), "canonical must adopt the legacy replica seed")
+	assert.Equal(t, string(legacyReplica.Data["pubkey.hex"]), string(canonical.Data["pubkey.hex"]))
+	assert.Equal(t, string(legacyReplica.Data["key-id"]), string(canonical.Data["key-id"]))
+
+	// The legacy replica must keep the same seed content (no rotation).
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: legacyReplica.Name}, legacyReplica))
+	assert.Equal(t, string(canonical.Data["seed.hex"]), string(legacyReplica.Data["seed.hex"]), "legacy replica seed must not be rotated on upgrade")
 }
 
 func TestReconcile_AgentCanonicalDeletedOnAgentRemoval(t *testing.T) {

--- a/misc/operator/internal/controller/reconcile_agent_test.go
+++ b/misc/operator/internal/controller/reconcile_agent_test.go
@@ -349,6 +349,57 @@ func TestReconcile_AgentUpgradeAdoptsLegacyReplicaSeed(t *testing.T) {
 	assert.Equal(t, string(canonical.Data["seed.hex"]), string(legacyReplica.Data["seed.hex"]), "legacy replica seed must not be rotated on upgrade")
 }
 
+func TestReconcile_AgentUpgradeAdoptsLegacySeedWithoutTargets(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	// Simulate an upgrade scenario where the old operator was stopped, the
+	// LedgerService was deleted while it was down, and now we upgrade. The
+	// only survivor is a legacy replica Secret sitting alone in a namespace
+	// no longer referenced by any LedgerService.
+	legacyReplica := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ledger-orphan-agent-agent-keys",
+			Namespace: ns,
+			Labels: map[string]string{
+				agentNameLabel: "orphan-agent",
+			},
+		},
+		Data: map[string][]byte{
+			"seed.hex":   []byte("cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"),
+			"pubkey.hex": []byte("f00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeed"),
+			"key-id":     []byte("orphanseedxxxxx"),
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, legacyReplica))
+
+	agent := newLedgerClusterAgent("orphan-agent", []string{"read"}, map[string]string{"tier": "never-matches"})
+	require.NoError(t, k8sClient.Create(ctx, agent))
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, agent) //nolint:errcheck // best-effort cleanup
+	})
+
+	canonicalKey := types.NamespacedName{Namespace: testOperatorNamespace, Name: "ledger-orphan-agent-agent-canonical"}
+	canonical := &corev1.Secret{}
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, canonicalKey, canonical); err != nil {
+			return false
+		}
+
+		return len(canonical.Data["seed.hex"]) > 0
+	}, "canonical must be bootstrapped from the orphan legacy replica even with no matching services")
+
+	assert.Equal(t, string(legacyReplica.Data["seed.hex"]), string(canonical.Data["seed.hex"]), "canonical must adopt the legacy seed on no-target upgrade")
+	assert.Equal(t, string(legacyReplica.Data["key-id"]), string(canonical.Data["key-id"]))
+
+	// The orphan legacy replica is then aggressively GC'd because no target
+	// covers its namespace — but the seed identity is preserved on the canonical.
+	requireEventually(t, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: legacyReplica.Name}, &corev1.Secret{})
+
+		return apierrors.IsNotFound(err)
+	}, "orphan legacy replica should be GC'd after its seed is adopted")
+}
+
 func TestReconcile_AgentCanonicalDeletedOnAgentRemoval(t *testing.T) {
 	ns := createTestNamespace(t)
 

--- a/misc/operator/internal/controller/reconcile_agent_test.go
+++ b/misc/operator/internal/controller/reconcile_agent_test.go
@@ -225,6 +225,68 @@ func TestReconcile_AgentOrphanCleanup(t *testing.T) {
 	require.NoError(t, k8sClient.Get(ctx, keyA, &corev1.Secret{}), "matched-namespace replica must remain")
 }
 
+func TestReconcile_AgentSeedSurvivesLedgerServiceRecreation(t *testing.T) {
+	ns := createTestNamespace(t)
+
+	ls := newLedgerService("survive-svc", ns)
+	ls.Labels = map[string]string{"tier": "survive"}
+	require.NoError(t, k8sClient.Create(ctx, ls))
+
+	agent := newLedgerClusterAgent("survive-agent", []string{"read"}, map[string]string{"tier": "survive"})
+	require.NoError(t, k8sClient.Create(ctx, agent))
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, agent) //nolint:errcheck // best-effort cleanup
+	})
+
+	secretKey := types.NamespacedName{Namespace: ns, Name: "ledger-survive-agent-agent-keys"}
+	secret := &corev1.Secret{}
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, secretKey, secret) == nil
+	}, "Secret should be created while the LedgerService matches")
+
+	initialSeed := string(secret.Data["seed.hex"])
+	initialPubKey := string(secret.Data["pubkey.hex"])
+	initialKeyID := string(secret.Data["key-id"])
+	require.NotEmpty(t, initialSeed)
+
+	require.NoError(t, k8sClient.Delete(ctx, ls))
+	requireEventually(t, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "survive-svc"}, &ledgerv1alpha1.LedgerService{})
+
+		return apierrors.IsNotFound(err)
+	}, "LedgerService should be deleted")
+
+	// The dormant Secret must survive the transient absence of the LedgerService
+	// so the seed identity is preserved across recreation.
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "survive-agent"}, agent); err != nil {
+			return false
+		}
+
+		return agent.Status.Phase == "Pending" && agent.Status.ObservedGeneration == agent.Generation
+	}, "agent should report Pending once no service matches")
+
+	require.NoError(t, k8sClient.Get(ctx, secretKey, secret), "Secret must remain dormant while no LedgerService matches")
+	assert.Equal(t, initialSeed, string(secret.Data["seed.hex"]), "dormant seed must not be regenerated")
+
+	lsAgain := newLedgerService("survive-svc", ns)
+	lsAgain.Labels = map[string]string{"tier": "survive"}
+	require.NoError(t, k8sClient.Create(ctx, lsAgain))
+
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "survive-agent"}, agent); err != nil {
+			return false
+		}
+
+		return agent.Status.Phase == "Ready" && agent.Status.KeyID == initialKeyID
+	}, "agent should return to Ready with the original keyID")
+
+	require.NoError(t, k8sClient.Get(ctx, secretKey, secret))
+	assert.Equal(t, initialSeed, string(secret.Data["seed.hex"]), "seed must be identical after LedgerService recreation")
+	assert.Equal(t, initialPubKey, string(secret.Data["pubkey.hex"]))
+	assert.Equal(t, initialKeyID, string(secret.Data["key-id"]))
+}
+
 func TestReconcile_AgentDeletion(t *testing.T) {
 	nsA := createTestNamespace(t)
 	nsB := createTestNamespace(t)

--- a/misc/operator/internal/controller/suite_test.go
+++ b/misc/operator/internal/controller/suite_test.go
@@ -33,6 +33,11 @@ var (
 	nsCounter atomic.Int64
 )
 
+// testOperatorNamespace is the fixed namespace the LedgerClusterAgent
+// reconciler treats as the operator's own — where every canonical seed
+// Secret is created. Provisioned once in TestMain.
+const testOperatorNamespace = "ledger-operator-system"
+
 func TestMain(m *testing.M) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -63,6 +68,12 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel = context.WithCancel(context.Background())
 
+	if err := k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testOperatorNamespace},
+	}); err != nil {
+		panic(fmt.Sprintf("creating operator namespace: %v", err))
+	}
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -82,8 +93,9 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := (&LedgerClusterAgentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		OperatorNamespace: testOperatorNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		panic(fmt.Sprintf("setting up LedgerClusterAgent controller: %v", err))
 	}

--- a/misc/operator/internal/controller/suite_test.go
+++ b/misc/operator/internal/controller/suite_test.go
@@ -96,6 +96,7 @@ func TestMain(m *testing.M) {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		OperatorNamespace: testOperatorNamespace,
+		APIReader:         mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		panic(fmt.Sprintf("setting up LedgerClusterAgent controller: %v", err))
 	}


### PR DESCRIPTION
## Summary

- Fix an issue where deleting and recreating a `LedgerService` invalidated every agent bundle handed out via `kubectl-ledger agents get-key --bundle`.
- Root cause: the `LedgerClusterAgent` reconcile GC'd every replica of the agent Secret when `desiredNamespaces` became empty (transient absence of matched services). The next reconcile found no existing replica and generated a fresh Ed25519 keypair, so previously-issued JWTs stopped verifying against the operator-managed `auth-keys.json` ConfigMap.
- Fix: skip the GC loop when `desiredNamespaces` is empty. Dormant replicas survive the transient state; the next matching reconcile reuses the existing seed via `canonicalKeyData`. Definitive cleanup remains on the finalizer (`handleDeletion`), which lists and deletes all replicas when the `LedgerClusterAgent` CR itself is deleted.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `just operator-pre-commit` (controller-gen + go mod tidy + go build)
- [x] Added `TestReconcile_AgentSeedSurvivesLedgerServiceRecreation` covering the full scenario: LedgerService created → seed generated → LedgerService deleted → dormant Secret preserved → LedgerService recreated → seed/keyID identical.
- [x] `TestReconcile_AgentOrphanCleanup` and `TestReconcile_AgentNoTargets` behavior verified unchanged (GC still runs when at least one target remains; fresh agents with no targets still don't produce a Secret).