### PR TITLE
feat(mirror): rewrite account addresses during v2→v3 mirror translation

### DIFF
--- a/cmd/ledgerctl/ledgers/create.go
+++ b/cmd/ledgerctl/ledgers/create.go
@@ -48,6 +48,7 @@ func NewCreateCommand() *cobra.Command {
 	cmd.Flags().String("mirror-aws-iam-region", "", "Enable AWS RDS IAM authentication using the given region (for postgres source); credentials are taken from the ambient AWS chain (IRSA, instance profile, env)")
 	cmd.Flags().String("mirror-aws-iam-assume-role-arn", "", "Optional STS role ARN to assume before minting the RDS IAM token (cross-account / multi-tenant mirrors); requires --mirror-aws-iam-region")
 	cmd.Flags().Uint32("mirror-batch-size", 0, "Max logs per batch (0 = default 100)")
+	cmd.Flags().StringArray("mirror-address-rewrite", nil, "Account address rewrite rule as 'pattern=replacement' (RE2 regex applied during translation; empty replacement drops the match, e.g. '(:worker:\\d+)='; repeatable)")
 
 	return cmd
 }

--- a/cmd/ledgerctl/ledgers/display.go
+++ b/cmd/ledgerctl/ledgers/display.go
@@ -3,6 +3,7 @@ package ledgers
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -63,6 +64,14 @@ func renderMirrorSource(src *commonpb.MirrorSourceConfig) {
 	if src.GetBatchSize() > 0 {
 		pterm.Printf("  Batch:   %d\n", src.GetBatchSize())
 	}
+
+	if rules := src.GetAddressRewriteRules(); len(rules) > 0 {
+		pterm.Printf("  Rewrites:\n")
+
+		for _, rule := range rules {
+			pterm.Printf("    %s → %q\n", rule.GetPattern(), rule.GetReplacement())
+		}
+	}
 }
 
 // renderMirrorSyncProgress displays mirror sync progress information.
@@ -113,7 +122,8 @@ func parseMirrorFlags(cmd *cobra.Command, ledgerName string) (commonpb.LedgerMod
 		cmd.Flags().Changed("mirror-dsn") ||
 		cmd.Flags().Changed("mirror-aws-iam-region") ||
 		cmd.Flags().Changed("mirror-aws-iam-assume-role-arn") ||
-		cmd.Flags().Changed("mirror-batch-size")
+		cmd.Flags().Changed("mirror-batch-size") ||
+		cmd.Flags().Changed("mirror-address-rewrite")
 
 	if hasMirrorFlags && !cmd.Flags().Changed("mode") {
 		modeStr = "mirror"
@@ -141,9 +151,15 @@ func parseMirrorFlags(cmd *cobra.Command, ledgerName string) (commonpb.LedgerMod
 
 	batchSize, _ := cmd.Flags().GetUint32("mirror-batch-size")
 
+	rewriteRules, err := parseAddressRewriteRules(cmd)
+	if err != nil {
+		return 0, nil, err
+	}
+
 	cfg := &commonpb.MirrorSourceConfig{
-		LedgerName: sourceLedgerName,
-		BatchSize:  batchSize,
+		LedgerName:          sourceLedgerName,
+		BatchSize:           batchSize,
+		AddressRewriteRules: rewriteRules,
 	}
 
 	switch sourceType {
@@ -212,4 +228,31 @@ func parseMirrorFlags(cmd *cobra.Command, ledgerName string) (commonpb.LedgerMod
 	}
 
 	return commonpb.LedgerMode_LEDGER_MODE_MIRROR, cfg, nil
+}
+
+// parseAddressRewriteRules parses --mirror-address-rewrite flags, each of the
+// form "pattern=replacement" (split on the first '='). An empty replacement
+// drops the matched part.
+func parseAddressRewriteRules(cmd *cobra.Command) ([]*commonpb.AddressRewriteRule, error) {
+	raw, _ := cmd.Flags().GetStringArray("mirror-address-rewrite")
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	rules := make([]*commonpb.AddressRewriteRule, 0, len(raw))
+
+	for _, entry := range raw {
+		pattern, replacement, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --mirror-address-rewrite %q: expected 'pattern=replacement'", entry)
+		}
+
+		if pattern == "" {
+			return nil, fmt.Errorf("invalid --mirror-address-rewrite %q: pattern must not be empty", entry)
+		}
+
+		rules = append(rules, &commonpb.AddressRewriteRule{Pattern: pattern, Replacement: replacement})
+	}
+
+	return rules, nil
 }

--- a/cmd/ledgerctl/ledgers/parse_mirror_flags_test.go
+++ b/cmd/ledgerctl/ledgers/parse_mirror_flags_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 func TestParseMirrorFlags_PostgresEmptyIAMRegionRejected(t *testing.T) {
@@ -20,6 +22,56 @@ func TestParseMirrorFlags_PostgresEmptyIAMRegionRejected(t *testing.T) {
 	_, _, err := parseMirrorFlags(cmd, "ledger-x")
 	require.Error(t, err, "explicit but empty --mirror-aws-iam-region must NOT silently fall back to password auth")
 	require.Contains(t, err.Error(), "non-empty region")
+}
+
+func TestParseMirrorFlags_AddressRewriteRules(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCreateCommand()
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--mode=mirror",
+		"--mirror-base-url=http://v2:3068",
+		`--mirror-address-rewrite=(:worker:\d+)=`,
+		"--mirror-address-rewrite=^payments:=psp:",
+	}))
+
+	_, cfg, err := parseMirrorFlags(cmd, "ledger-x")
+	require.NoError(t, err)
+	require.Len(t, cfg.GetAddressRewriteRules(), 2)
+	require.Equal(t, `(:worker:\d+)`, cfg.GetAddressRewriteRules()[0].GetPattern())
+	require.Equal(t, "", cfg.GetAddressRewriteRules()[0].GetReplacement())
+	require.Equal(t, "^payments:", cfg.GetAddressRewriteRules()[1].GetPattern())
+	require.Equal(t, "psp:", cfg.GetAddressRewriteRules()[1].GetReplacement())
+}
+
+func TestParseMirrorFlags_AddressRewriteInfersMirrorMode(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCreateCommand()
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--mirror-base-url=http://v2:3068",
+		`--mirror-address-rewrite=(:worker:\d+)=`,
+	}))
+
+	mode, cfg, err := parseMirrorFlags(cmd, "ledger-x")
+	require.NoError(t, err)
+	require.Equal(t, commonpb.LedgerMode_LEDGER_MODE_MIRROR, mode)
+	require.Len(t, cfg.GetAddressRewriteRules(), 1)
+}
+
+func TestParseMirrorFlags_AddressRewriteMissingSeparatorRejected(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewCreateCommand()
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--mode=mirror",
+		"--mirror-base-url=http://v2:3068",
+		"--mirror-address-rewrite=no-separator",
+	}))
+
+	_, _, err := parseMirrorFlags(cmd, "ledger-x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pattern=replacement")
 }
 
 func TestParseMirrorFlags_PostgresIAMRegionWiresAwsIamAuth(t *testing.T) {

--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -62,6 +62,16 @@ oneof payload {
 
 `FillGap` is the explicit "we know there's a v2 log here but we have no payload for it" marker — it lets the v3 ledger advance its own logical sequence even when the source skipped one.
 
+### Account-address rewriting
+
+Optional `address_rewrite_rules` on `MirrorSourceConfig` are applied, in order, to every account address as v2 logs are translated (`internal/adapter/v2/rewrite.go`, `AddressRewriter`). Each rule is a `{pattern, replacement}` pair where `pattern` is an RE2 regex matched against the full address and matches are replaced with `replacement`; an empty replacement drops the match. This exists to strip or rename segments that v2 only carried as lock-avoidance shards — e.g. `(:worker:\d+)` turns `payments:acme:worker:001:main` into `payments:acme:main`.
+
+Rewriting happens at the three address-bearing choke points in the translator — posting source/destination (`translatePostings`), metadata account targets (`translateTarget`), and account-metadata map keys (`translateAccountMetadata`). Because coverage/preload and the FSM read the already-translated payload, no change is needed downstream, and volumes are derived from the rewritten postings on apply. When two source addresses collapse onto one, their account-metadata maps are merged (value from the lexicographically-smallest source address wins on conflict).
+
+Properties:
+- **Pure projection** — the source v2 ledger is untouched; rewriting only shapes the v3 orders the leader proposes, so followers apply identical addresses (no cross-node determinism concern).
+- **Validated** — rule regexes are compile-checked at admission (`ErrMirrorAddressRewritePatternInvalid`) before the config is persisted; at translation time a rewrite that produces an invalid address fails the batch, so the cursor does not advance and the worker retries (the standard translation-error path).
+
 ## The Raft command
 
 `misc/proto/raft_cmd.proto:200-212` — `MirrorIngestOrder{MirrorLogEntry entry}`. Each order ingests **one** v2 log entry. A batch of 100 fetched logs becomes 100 orders inside one proposal.
@@ -109,6 +119,7 @@ message MirrorSourceConfig {
     PostgresMirrorSourceConfig postgres = 3;
   }
   uint32 batch_size = 4;
+  repeated AddressRewriteRule address_rewrite_rules = 5;  // see "Account-address rewriting"
 }
 ```
 

--- a/internal/adapter/http/handlers_create_ledger.go
+++ b/internal/adapter/http/handlers_create_ledger.go
@@ -28,6 +28,16 @@ type mirrorSourceBody struct {
 	OAuth2Scopes        []string `json:"oauth2Scopes,omitempty"`        // HTTP source OAuth2
 	DSN                 string   `json:"dsn,omitempty"`                 // Postgres source
 	BatchSize           uint32   `json:"batchSize,omitempty"`           // Max logs per batch (0 = default 100)
+	// AddressRewriteRules rewrite account addresses during translation (drop /
+	// rename v2 lock-avoidance segments). Applied in order to every address.
+	AddressRewriteRules []addressRewriteRuleBody `json:"addressRewriteRules,omitempty"`
+}
+
+// addressRewriteRuleBody is one account-address rewrite rule. Pattern is an RE2
+// regex; an empty replacement drops the matched part.
+type addressRewriteRuleBody struct {
+	Pattern     string `json:"pattern"`
+	Replacement string `json:"replacement"`
 }
 
 // handleCreateLedger handles POST /{ledgerName} to create a new ledger.
@@ -111,6 +121,14 @@ func mirrorSourceToProto(body *mirrorSourceBody) (*commonpb.MirrorSourceConfig, 
 		LedgerName: body.LedgerName,
 		BatchSize:  body.BatchSize,
 	}
+
+	for _, rule := range body.AddressRewriteRules {
+		cfg.AddressRewriteRules = append(cfg.AddressRewriteRules, &commonpb.AddressRewriteRule{
+			Pattern:     rule.Pattern,
+			Replacement: rule.Replacement,
+		})
+	}
+
 	switch body.Type {
 	case "http", "":
 		httpCfg := &commonpb.HttpMirrorSourceConfig{

--- a/internal/adapter/http/handlers_create_ledger_mirror_test.go
+++ b/internal/adapter/http/handlers_create_ledger_mirror_test.go
@@ -222,6 +222,67 @@ func TestMirrorSourceToProto_EmptyType(t *testing.T) {
 	require.Nil(t, httpCfg.GetOauth2ClientCredentials())
 }
 
+func TestMirrorSourceToProto_AddressRewriteRules(t *testing.T) {
+	t.Parallel()
+
+	body := &mirrorSourceBody{
+		LedgerName: "src-ledger",
+		Type:       "http",
+		BaseURL:    "http://localhost:3068",
+		AddressRewriteRules: []addressRewriteRuleBody{
+			{Pattern: `(:worker:\d+)`, Replacement: ""},
+			{Pattern: `^payments:`, Replacement: "psp:"},
+		},
+	}
+
+	cfg, err := mirrorSourceToProto(body)
+	require.NoError(t, err)
+	require.Len(t, cfg.GetAddressRewriteRules(), 2)
+	require.Equal(t, `(:worker:\d+)`, cfg.GetAddressRewriteRules()[0].GetPattern())
+	require.Equal(t, "", cfg.GetAddressRewriteRules()[0].GetReplacement())
+	require.Equal(t, "^payments:", cfg.GetAddressRewriteRules()[1].GetPattern())
+	require.Equal(t, "psp:", cfg.GetAddressRewriteRules()[1].GetReplacement())
+}
+
+func TestHandleCreateLedger_MirrorAddressRewriteRules(t *testing.T) {
+	t.Parallel()
+
+	var capturedReq *servicepb.Request
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			capturedReq = req.GetUnsigned().GetRequests()[0]
+
+			return []*commonpb.Log{{
+				Payload: &commonpb.LogPayload{
+					Type: &commonpb.LogPayload_CreateLedger{
+						CreateLedger: &commonpb.CreatedLedgerLog{
+							Name: "mirror-rw",
+							Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR,
+						},
+					},
+				},
+			}}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	body := `{"mode":"MIRROR","mirrorSource":{"ledgerName":"default","type":"http","baseUrl":"http://v2:3068","addressRewriteRules":[{"pattern":"(:worker:\\d+)","replacement":""}]}}`
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/mirror-rw", strings.NewReader(body), map[string]string{
+		"ledgerName": "mirror-rw",
+	})
+	r.Header.Set("Content-Type", "application/json")
+
+	srv.handleCreateLedger(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	rules := capturedReq.GetCreateLedger().GetMirrorSource().GetAddressRewriteRules()
+	require.Len(t, rules, 1)
+	require.Equal(t, `(:worker:\d+)`, rules[0].GetPattern())
+	require.Equal(t, "", rules[0].GetReplacement())
+}
+
 func TestMirrorSourceToProto_Unsupported(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/v2/rewrite.go
+++ b/internal/adapter/v2/rewrite.go
@@ -1,0 +1,76 @@
+package v2
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/formancehq/invariants"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// AddressRewriter applies a mirror's configured address rewrite rules to every
+// account address while v2 logs are translated into v3 orders. It exists so
+// segments that v2 only carried as lock-avoidance shards (e.g. ":worker:001")
+// can be dropped or renamed as history is replayed into a v3 mirror ledger.
+//
+// Rewriting is a pure translation-time projection: the source v2 ledger is
+// untouched, and the rewritten addresses are baked into the Raft order proposed
+// by the (single) leader, so followers apply identical addresses — no
+// cross-node determinism concern. Because coverage/preload and the FSM read the
+// already-translated payload, rewriting here needs no changes anywhere else.
+type AddressRewriter struct {
+	rules []compiledRule
+}
+
+type compiledRule struct {
+	re          *regexp.Regexp
+	replacement string
+}
+
+// NewAddressRewriter compiles the given rules. It returns a nil rewriter when
+// there are no rules; a nil *AddressRewriter is a valid pass-through (Rewrite is
+// nil-safe).
+func NewAddressRewriter(rules []*commonpb.AddressRewriteRule) (*AddressRewriter, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	compiled := make([]compiledRule, 0, len(rules))
+	for _, rule := range rules {
+		re, err := regexp.Compile(rule.GetPattern())
+		if err != nil {
+			return nil, fmt.Errorf("compiling address rewrite pattern %q: %w", rule.GetPattern(), err)
+		}
+
+		compiled = append(compiled, compiledRule{re: re, replacement: rule.GetReplacement()})
+	}
+
+	return &AddressRewriter{rules: compiled}, nil
+}
+
+// Rewrite applies every rule, in order, to the address. A nil receiver (no
+// rules) returns the address unchanged. When a rule actually changes the
+// address, the result is validated as a ledger account address so an invalid
+// rewrite fails the batch loudly rather than corrupting the mirrored ledger.
+func (r *AddressRewriter) Rewrite(address string) (string, error) {
+	if r == nil {
+		return address, nil
+	}
+
+	rewritten := address
+	for _, rule := range r.rules {
+		rewritten = rule.re.ReplaceAllString(rewritten, rule.replacement)
+	}
+
+	if rewritten == address {
+		// Unchanged: the address came from the source ledger and is already valid.
+		return address, nil
+	}
+
+	if err := invariants.ValidateLedgerAccountAddress(rewritten); err != nil {
+		return "", fmt.Errorf("address rewrite of %q produced invalid address %q: %w", address, rewritten, err)
+	}
+
+	return rewritten, nil
+}

--- a/internal/adapter/v2/rewrite.go
+++ b/internal/adapter/v2/rewrite.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -38,6 +39,13 @@ func NewAddressRewriter(rules []*commonpb.AddressRewriteRule) (*AddressRewriter,
 
 	compiled := make([]compiledRule, 0, len(rules))
 	for _, rule := range rules {
+		// An empty pattern matches at every boundary and would rewrite every
+		// address; admission rejects it, but guard here too since this is the
+		// single point every rule is compiled.
+		if rule.GetPattern() == "" {
+			return nil, errors.New("address rewrite pattern must not be empty")
+		}
+
 		re, err := regexp.Compile(rule.GetPattern())
 		if err != nil {
 			return nil, fmt.Errorf("compiling address rewrite pattern %q: %w", rule.GetPattern(), err)

--- a/internal/adapter/v2/rewrite_test.go
+++ b/internal/adapter/v2/rewrite_test.go
@@ -1,0 +1,109 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func rule(pattern, replacement string) *commonpb.AddressRewriteRule {
+	return &commonpb.AddressRewriteRule{Pattern: pattern, Replacement: replacement}
+}
+
+func TestNewAddressRewriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no rules yields a nil pass-through", func(t *testing.T) {
+		t.Parallel()
+
+		r, err := NewAddressRewriter(nil)
+		require.NoError(t, err)
+		require.Nil(t, r)
+	})
+
+	t.Run("invalid pattern errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewAddressRewriter([]*commonpb.AddressRewriteRule{rule("(", "")})
+		require.Error(t, err)
+	})
+}
+
+func TestAddressRewriter_Rewrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rules   []*commonpb.AddressRewriteRule
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "nil receiver passes through",
+			rules: nil,
+			in:    "payments:acme:worker:001:main",
+			want:  "payments:acme:worker:001:main",
+		},
+		{
+			name:  "drop worker shard segment",
+			rules: []*commonpb.AddressRewriteRule{rule(`(:worker:\d+)`, "")},
+			in:    "payments:acme:worker:001:main",
+			want:  "payments:acme:main",
+		},
+		{
+			name:  "rename prefix",
+			rules: []*commonpb.AddressRewriteRule{rule(`^payments:`, "psp:")},
+			in:    "payments:acme:main",
+			want:  "psp:acme:main",
+		},
+		{
+			name:  "no match leaves address unchanged",
+			rules: []*commonpb.AddressRewriteRule{rule(`(:worker:\d+)`, "")},
+			in:    "world",
+			want:  "world",
+		},
+		{
+			name: "rules apply in order",
+			rules: []*commonpb.AddressRewriteRule{
+				rule(`(:worker:\d+)`, ""),
+				rule(`^payments:`, "psp:"),
+			},
+			in:   "payments:acme:worker:001:main",
+			want: "psp:acme:main",
+		},
+		{
+			name:    "rewrite producing an invalid address errors",
+			rules:   []*commonpb.AddressRewriteRule{rule(`.+`, "")},
+			in:      "payments:acme:main",
+			wantErr: true,
+		},
+		{
+			name:    "rewrite producing an empty segment errors",
+			rules:   []*commonpb.AddressRewriteRule{rule(`acme`, "")},
+			in:      "payments:acme:main",
+			wantErr: true, // -> "payments::main" (empty segment)
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := NewAddressRewriter(tc.rules)
+			require.NoError(t, err)
+
+			got, err := r.Rewrite(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/adapter/v2/rewrite_test.go
+++ b/internal/adapter/v2/rewrite_test.go
@@ -29,6 +29,13 @@ func TestNewAddressRewriter(t *testing.T) {
 		_, err := NewAddressRewriter([]*commonpb.AddressRewriteRule{rule("(", "")})
 		require.Error(t, err)
 	})
+
+	t.Run("empty pattern errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewAddressRewriter([]*commonpb.AddressRewriteRule{rule("", "x")})
+		require.Error(t, err)
+	})
 }
 
 func TestAddressRewriter_Rewrite(t *testing.T) {

--- a/internal/adapter/v2/translator.go
+++ b/internal/adapter/v2/translator.go
@@ -3,6 +3,7 @@ package v2
 import (
 	stdjson "encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -36,7 +37,7 @@ var (
 // TranslateBatch translates a batch of v2 logs into v3 Raft orders.
 // It generates FillGap orders for any gaps in log IDs or transaction IDs.
 // expectedNextLogID and expectedNextTxID are used to detect gaps.
-func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNextTxID uint64) ([]*raftcmdpb.Order, uint64, uint64, error) {
+func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNextTxID uint64, rewriter *AddressRewriter) ([]*raftcmdpb.Order, uint64, uint64, error) {
 	orders := make([]*raftcmdpb.Order, 0, len(v2Logs))
 
 	for _, v2Log := range v2Logs {
@@ -51,7 +52,7 @@ func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNe
 			expectedNextLogID++
 		}
 
-		entry, newNextTxID, err := translateV2Log(v2Log, expectedNextTxID)
+		entry, newNextTxID, err := translateV2Log(v2Log, expectedNextTxID, rewriter)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("translating v2 log %d (type=%s): %w", v2Log.ID, v2Log.Type, err)
 		}
@@ -83,18 +84,18 @@ func makeMirrorOrder(ledger string, entry *raftcmdpb.MirrorLogEntry) *raftcmdpb.
 	}
 }
 
-func translateV2Log(v2Log V2Log, expectedNextTxID uint64) (*raftcmdpb.MirrorLogEntry, uint64, error) {
+func translateV2Log(v2Log V2Log, expectedNextTxID uint64, rewriter *AddressRewriter) (*raftcmdpb.MirrorLogEntry, uint64, error) {
 	switch v2Log.Type {
 	case "NEW_TRANSACTION":
-		return translateNewTransaction(v2Log, expectedNextTxID)
+		return translateNewTransaction(v2Log, expectedNextTxID, rewriter)
 	case "SET_METADATA":
-		entry, err := translateSetMetadata(v2Log)
+		entry, err := translateSetMetadata(v2Log, rewriter)
 
 		return entry, expectedNextTxID, err
 	case "REVERTED_TRANSACTION":
-		return translateRevertedTransaction(v2Log, expectedNextTxID)
+		return translateRevertedTransaction(v2Log, expectedNextTxID, rewriter)
 	case "DELETE_METADATA":
-		entry, err := translateDeleteMetadata(v2Log)
+		entry, err := translateDeleteMetadata(v2Log, rewriter)
 
 		return entry, expectedNextTxID, err
 	default:
@@ -108,7 +109,7 @@ func translateV2Log(v2Log V2Log, expectedNextTxID uint64) (*raftcmdpb.MirrorLogE
 	}
 }
 
-func translateNewTransaction(v2Log V2Log, _ uint64) (*raftcmdpb.MirrorLogEntry, uint64, error) {
+func translateNewTransaction(v2Log V2Log, _ uint64, rewriter *AddressRewriter) (*raftcmdpb.MirrorLogEntry, uint64, error) {
 	data, ok := v2NewTxPool.Get().(*V2NewTransactionData)
 	if !ok {
 		panic("unexpected type from v2NewTxPool")
@@ -123,7 +124,7 @@ func translateNewTransaction(v2Log V2Log, _ uint64) (*raftcmdpb.MirrorLogEntry, 
 
 	txID := data.Transaction.ID
 
-	postings, err := translatePostings(data.Transaction.Postings)
+	postings, err := translatePostings(data.Transaction.Postings, rewriter)
 	if err != nil {
 		resetV2NewTxData(data)
 		v2NewTxPool.Put(data)
@@ -142,12 +143,12 @@ func translateNewTransaction(v2Log V2Log, _ uint64) (*raftcmdpb.MirrorLogEntry, 
 		}
 	}
 
-	var accountMetadata map[string]*commonpb.MetadataMap
-	if len(data.AccountMetadata) > 0 {
-		accountMetadata = make(map[string]*commonpb.MetadataMap, len(data.AccountMetadata))
-		for account, meta := range data.AccountMetadata {
-			accountMetadata[account] = &commonpb.MetadataMap{Values: translateMetadataMap(meta)}
-		}
+	accountMetadata, err := translateAccountMetadata(data.AccountMetadata, rewriter)
+	if err != nil {
+		resetV2NewTxData(data)
+		v2NewTxPool.Put(data)
+
+		return nil, 0, err
 	}
 
 	entry := &raftcmdpb.MirrorLogEntry{
@@ -177,13 +178,13 @@ func resetV2NewTxData(d *V2NewTransactionData) {
 	d.Transaction.Postings = postings
 }
 
-func translateSetMetadata(v2Log V2Log) (*raftcmdpb.MirrorLogEntry, error) {
+func translateSetMetadata(v2Log V2Log, rewriter *AddressRewriter) (*raftcmdpb.MirrorLogEntry, error) {
 	var data V2SetMetadataData
 	if err := sonic.Unmarshal(v2Log.Data, &data); err != nil {
 		return nil, fmt.Errorf("unmarshaling SET_METADATA data: %w", err)
 	}
 
-	target, err := translateTarget(data.TargetType, data.TargetID)
+	target, err := translateTarget(data.TargetType, data.TargetID, rewriter)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +200,7 @@ func translateSetMetadata(v2Log V2Log) (*raftcmdpb.MirrorLogEntry, error) {
 	}, nil
 }
 
-func translateRevertedTransaction(v2Log V2Log, expectedNextTxID uint64) (*raftcmdpb.MirrorLogEntry, uint64, error) {
+func translateRevertedTransaction(v2Log V2Log, expectedNextTxID uint64, rewriter *AddressRewriter) (*raftcmdpb.MirrorLogEntry, uint64, error) {
 	data := v2RevertPool.Get().(*V2RevertedTransactionData)
 
 	if err := sonic.Unmarshal(v2Log.Data, data); err != nil {
@@ -211,7 +212,7 @@ func translateRevertedTransaction(v2Log V2Log, expectedNextTxID uint64) (*raftcm
 
 	revertTxID := data.RevertTransaction.ID
 
-	postings, err := translatePostings(data.RevertTransaction.Postings)
+	postings, err := translatePostings(data.RevertTransaction.Postings, rewriter)
 	if err != nil {
 		resetV2RevertData(data)
 		v2RevertPool.Put(data)
@@ -259,13 +260,13 @@ func resetV2RevertData(d *V2RevertedTransactionData) {
 	d.RevertTransaction.Postings = postings
 }
 
-func translateDeleteMetadata(v2Log V2Log) (*raftcmdpb.MirrorLogEntry, error) {
+func translateDeleteMetadata(v2Log V2Log, rewriter *AddressRewriter) (*raftcmdpb.MirrorLogEntry, error) {
 	var data V2DeleteMetadataData
 	if err := sonic.Unmarshal(v2Log.Data, &data); err != nil {
 		return nil, fmt.Errorf("unmarshaling DELETE_METADATA data: %w", err)
 	}
 
-	target, err := translateTarget(data.TargetType, data.TargetID)
+	target, err := translateTarget(data.TargetType, data.TargetID, rewriter)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +285,7 @@ func translateDeleteMetadata(v2Log V2Log) (*raftcmdpb.MirrorLogEntry, error) {
 // translatePostings converts v2 postings to v3 proto postings.
 // Uses batch-allocated backing arrays to reduce per-posting heap allocations
 // from 3N+1 to 3 (one []Posting, one []Uint256, one []*Posting).
-func translatePostings(v2Postings []V2Posting) ([]*commonpb.Posting, error) {
+func translatePostings(v2Postings []V2Posting, rewriter *AddressRewriter) ([]*commonpb.Posting, error) {
 	n := len(v2Postings)
 	postingBuf := make([]commonpb.Posting, n)
 	uint256Buf := make([]commonpb.Uint256, n)
@@ -296,9 +297,19 @@ func translatePostings(v2Postings []V2Posting) ([]*commonpb.Posting, error) {
 			return nil, fmt.Errorf("parsing posting amount %q: %w", p.Amount.String(), err)
 		}
 
+		source, err := rewriter.Rewrite(p.Source)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting posting source: %w", err)
+		}
+
+		destination, err := rewriter.Rewrite(p.Destination)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting posting destination: %w", err)
+		}
+
 		postingBuf[i] = commonpb.Posting{
-			Source:      p.Source,
-			Destination: p.Destination,
+			Source:      source,
+			Destination: destination,
 			Amount:      &uint256Buf[i],
 			Asset:       p.Asset,
 		}
@@ -330,7 +341,7 @@ func parseUint256Into(s string, dst *commonpb.Uint256) error {
 }
 
 // translateTarget converts v2 target type and ID to a v3 Target.
-func translateTarget(targetType string, rawID stdjson.RawMessage) (*commonpb.Target, error) {
+func translateTarget(targetType string, rawID stdjson.RawMessage, rewriter *AddressRewriter) (*commonpb.Target, error) {
 	switch targetType {
 	case "TRANSACTION":
 		var txID uint64
@@ -364,6 +375,11 @@ func translateTarget(targetType string, rawID stdjson.RawMessage) (*commonpb.Tar
 			return nil, fmt.Errorf("parsing account target ID: %w", err)
 		}
 
+		addr, err = rewriter.Rewrite(addr)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting account target: %w", err)
+		}
+
 		return &commonpb.Target{
 			Target: &commonpb.Target_Account{
 				Account: &commonpb.TargetAccount{Addr: addr},
@@ -372,6 +388,58 @@ func translateTarget(targetType string, rawID stdjson.RawMessage) (*commonpb.Tar
 	default:
 		return nil, fmt.Errorf("unknown target type: %s", targetType)
 	}
+}
+
+// translateAccountMetadata rebuilds the account-address-keyed metadata map with
+// rewritten addresses. When two source addresses collapse onto the same
+// rewritten address, their metadata maps are merged; on a conflicting key the
+// value from the lexicographically-smallest source address wins, so the result
+// is deterministic regardless of Go map iteration order.
+func translateAccountMetadata(accountMetadata map[string]map[string]string, rewriter *AddressRewriter) (map[string]*commonpb.MetadataMap, error) {
+	if len(accountMetadata) == 0 {
+		return nil, nil
+	}
+
+	accounts := make([]string, 0, len(accountMetadata))
+	for account := range accountMetadata {
+		accounts = append(accounts, account)
+	}
+
+	sort.Strings(accounts)
+
+	result := make(map[string]*commonpb.MetadataMap, len(accountMetadata))
+
+	for _, account := range accounts {
+		rewritten, err := rewriter.Rewrite(account)
+		if err != nil {
+			return nil, fmt.Errorf("rewriting account metadata target %q: %w", account, err)
+		}
+
+		existing, ok := result[rewritten]
+		if !ok {
+			result[rewritten] = &commonpb.MetadataMap{Values: translateMetadataMap(accountMetadata[account])}
+
+			continue
+		}
+
+		// Collision: merge, keeping the value already present (from the
+		// lexicographically-smaller source address) on key conflicts.
+		for key, value := range accountMetadata[account] {
+			if _, conflict := existing.GetValues()[key]; conflict {
+				continue
+			}
+
+			if existing.Values == nil {
+				existing.Values = make(map[string]*commonpb.MetadataValue)
+			}
+
+			existing.Values[key] = &commonpb.MetadataValue{
+				Type: &commonpb.MetadataValue_StringValue{StringValue: value},
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // translateMetadataMap converts v2 string metadata to proto metadata values.

--- a/internal/adapter/v2/translator_rewrite_test.go
+++ b/internal/adapter/v2/translator_rewrite_test.go
@@ -1,0 +1,187 @@
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// dropWorker drops the ":worker:<n>" lock-avoidance segment.
+func dropWorkerRewriter(t *testing.T) *AddressRewriter {
+	t.Helper()
+
+	r, err := NewAddressRewriter([]*commonpb.AddressRewriteRule{rule(`(:worker:\d+)`, "")})
+	require.NoError(t, err)
+
+	return r
+}
+
+func TestTranslateBatch_Rewrite_CreatedTransaction(t *testing.T) {
+	t.Parallel()
+
+	v2Logs := []V2Log{{
+		ID:   1,
+		Type: "NEW_TRANSACTION",
+		Data: mustMarshal(t, V2NewTransactionData{
+			Transaction: V2Transaction{
+				ID: 0,
+				Postings: []V2Posting{{
+					Source:      "world",
+					Destination: "payments:acme:worker:001:main",
+					Amount:      "100",
+					Asset:       "USD/2",
+				}},
+			},
+			AccountMetadata: map[string]map[string]string{
+				"payments:acme:worker:001:main": {"kind": "main"},
+			},
+		}),
+	}}
+
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0, dropWorkerRewriter(t))
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+
+	ct := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetCreatedTransaction()
+	require.NotNil(t, ct)
+	require.Equal(t, "world", ct.GetPostings()[0].GetSource())
+	require.Equal(t, "payments:acme:main", ct.GetPostings()[0].GetDestination())
+
+	require.Contains(t, ct.GetAccountMetadata(), "payments:acme:main")
+	require.NotContains(t, ct.GetAccountMetadata(), "payments:acme:worker:001:main")
+	require.Equal(t, "main",
+		ct.GetAccountMetadata()["payments:acme:main"].GetValues()["kind"].GetStringValue())
+}
+
+func TestTranslateBatch_Rewrite_RevertedTransaction(t *testing.T) {
+	t.Parallel()
+
+	v2Logs := []V2Log{{
+		ID:   1,
+		Type: "REVERTED_TRANSACTION",
+		Data: mustMarshal(t, V2RevertedTransactionData{
+			RevertedTransactionID: 0,
+			RevertTransaction: V2Transaction{
+				ID: 1,
+				Postings: []V2Posting{{
+					Source:      "payments:acme:worker:001:main",
+					Destination: "world",
+					Amount:      "100",
+					Asset:       "USD/2",
+				}},
+			},
+		}),
+	}}
+
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, dropWorkerRewriter(t))
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+
+	rt := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetRevertedTransaction()
+	require.NotNil(t, rt)
+	require.Equal(t, "payments:acme:main", rt.GetReversePostings()[0].GetSource())
+	require.Equal(t, "world", rt.GetReversePostings()[0].GetDestination())
+}
+
+func TestTranslateBatch_Rewrite_MetadataTargets(t *testing.T) {
+	t.Parallel()
+
+	v2Logs := []V2Log{
+		{
+			ID:   1,
+			Type: "SET_METADATA",
+			Data: mustMarshal(t, V2SetMetadataData{
+				TargetType: "ACCOUNT",
+				TargetID:   json.RawMessage(`"payments:acme:worker:001:main"`),
+				Metadata:   map[string]string{"k": "v"},
+			}),
+		},
+		{
+			ID:   2,
+			Type: "DELETE_METADATA",
+			Data: mustMarshal(t, V2DeleteMetadataData{
+				TargetType: "ACCOUNT",
+				TargetID:   json.RawMessage(`"payments:acme:worker:002:main"`),
+				Key:        "k",
+			}),
+		},
+		{
+			ID:   3,
+			Type: "SET_METADATA",
+			Data: mustMarshal(t, V2SetMetadataData{
+				TargetType: "TRANSACTION",
+				TargetID:   json.RawMessage(`42`),
+				Metadata:   map[string]string{"k": "v"},
+			}),
+		},
+	}
+
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, dropWorkerRewriter(t))
+	require.NoError(t, err)
+	require.Len(t, orders, 3)
+
+	saved := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetSavedMetadata()
+	require.Equal(t, "payments:acme:main", saved.GetTarget().GetAccount().GetAddr())
+
+	deleted := orders[1].GetLedgerScoped().GetMirrorIngest().GetEntry().GetDeletedMetadata()
+	require.Equal(t, "payments:acme:main", deleted.GetTarget().GetAccount().GetAddr())
+
+	// Transaction targets are untouched.
+	tx := orders[2].GetLedgerScoped().GetMirrorIngest().GetEntry().GetSavedMetadata()
+	require.Equal(t, uint64(42), tx.GetTarget().GetTransactionId())
+}
+
+func TestTranslateBatch_Rewrite_AccountMetadataCollisionMerges(t *testing.T) {
+	t.Parallel()
+
+	// worker:001 and worker:002 collapse onto the same account.
+	v2Logs := []V2Log{{
+		ID:   1,
+		Type: "NEW_TRANSACTION",
+		Data: mustMarshal(t, V2NewTransactionData{
+			Transaction: V2Transaction{ID: 0},
+			AccountMetadata: map[string]map[string]string{
+				"payments:acme:worker:001:main": {"kind": "main", "shard": "001"},
+				"payments:acme:worker:002:main": {"shard": "002"},
+			},
+		}),
+	}}
+
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0, dropWorkerRewriter(t))
+	require.NoError(t, err)
+
+	ct := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetCreatedTransaction()
+	merged := ct.GetAccountMetadata()["payments:acme:main"].GetValues()
+	require.Equal(t, "main", merged["kind"].GetStringValue())
+	// On conflict, the lexicographically-smallest source (worker:001) wins.
+	require.Equal(t, "001", merged["shard"].GetStringValue())
+}
+
+func TestTranslateBatch_Rewrite_InvalidResultErrors(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewAddressRewriter([]*commonpb.AddressRewriteRule{rule(`.+`, "")})
+	require.NoError(t, err)
+
+	v2Logs := []V2Log{{
+		ID:   1,
+		Type: "NEW_TRANSACTION",
+		Data: mustMarshal(t, V2NewTransactionData{
+			Transaction: V2Transaction{
+				ID: 0,
+				Postings: []V2Posting{{
+					Source:      "world",
+					Destination: "payments:acme:main",
+					Amount:      "100",
+					Asset:       "USD/2",
+				}},
+			},
+		}),
+	}}
+
+	_, _, _, err = TranslateBatch("default", v2Logs, 1, 0, r)
+	require.Error(t, err)
+}

--- a/internal/adapter/v2/translator_test.go
+++ b/internal/adapter/v2/translator_test.go
@@ -30,7 +30,7 @@ func TestTranslateBatch_NewTransaction(t *testing.T) {
 		}),
 	}}
 
-	orders, nextLogID, nextTxID, err := TranslateBatch("default", v2Logs, 1, 0)
+	orders, nextLogID, nextTxID, err := TranslateBatch("default", v2Logs, 1, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 	require.Equal(t, uint64(2), nextLogID)
@@ -66,7 +66,7 @@ func TestTranslateBatch_SetMetadata_Account(t *testing.T) {
 		}),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -94,7 +94,7 @@ func TestTranslateBatch_SetMetadata_Transaction(t *testing.T) {
 		}),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -119,7 +119,7 @@ func TestTranslateBatch_SetMetadata_StringMetadataPreserved(t *testing.T) {
 		}`),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -143,7 +143,7 @@ func TestTranslateBatch_SetMetadata_RejectsNonStringMetadata(t *testing.T) {
 			}`),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.Error(t, err)
 	require.Nil(t, orders)
 	require.Contains(t, err.Error(), "unmarshaling SET_METADATA data")
@@ -170,7 +170,7 @@ func TestTranslateBatch_RevertedTransaction(t *testing.T) {
 		}),
 	}}
 
-	orders, _, nextTxID, err := TranslateBatch("default", v2Logs, 3, 1)
+	orders, _, nextTxID, err := TranslateBatch("default", v2Logs, 3, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 	require.Equal(t, uint64(6), nextTxID)
@@ -195,7 +195,7 @@ func TestTranslateBatch_DeleteMetadata(t *testing.T) {
 		}),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -214,7 +214,7 @@ func TestTranslateBatch_UnknownLogType_FillGap(t *testing.T) {
 		Data: json.RawMessage(`{}`),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -236,7 +236,7 @@ func TestTranslateBatch_LogIDGapDetection(t *testing.T) {
 		}),
 	}}
 
-	orders, nextLogID, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	orders, nextLogID, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.NoError(t, err)
 	// 2 fill-gap orders (for IDs 1, 2) + 1 real order (for ID 3)
 	require.Len(t, orders, 3)
@@ -255,7 +255,7 @@ func TestTranslateBatch_LogIDGapDetection(t *testing.T) {
 func TestTranslateBatch_EmptyInput(t *testing.T) {
 	t.Parallel()
 
-	orders, nextLogID, nextTxID, err := TranslateBatch("default", nil, 1, 1)
+	orders, nextLogID, nextTxID, err := TranslateBatch("default", nil, 1, 1, nil)
 	require.NoError(t, err)
 	require.Empty(t, orders)
 	require.Equal(t, uint64(1), nextLogID)
@@ -287,7 +287,7 @@ func TestTranslateBatch_MultipleLogs(t *testing.T) {
 		},
 	}
 
-	orders, nextLogID, nextTxID, err := TranslateBatch("ledger1", v2Logs, 1, 0)
+	orders, nextLogID, nextTxID, err := TranslateBatch("ledger1", v2Logs, 1, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 2)
 	require.Equal(t, uint64(3), nextLogID)
@@ -314,7 +314,7 @@ func TestTranslateBatch_AccountMetadata(t *testing.T) {
 		}),
 	}}
 
-	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0)
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
@@ -333,7 +333,7 @@ func TestTranslatePostings_LargeAmount(t *testing.T) {
 		Asset:       "BTC/8",
 	}}
 
-	result, err := translatePostings(postings)
+	result, err := translatePostings(postings, nil)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	require.NotNil(t, result[0].GetAmount())
@@ -349,7 +349,7 @@ func TestTranslatePostings_NegativeAmount(t *testing.T) {
 		Asset:       "USD",
 	}}
 
-	_, err := translatePostings(postings)
+	_, err := translatePostings(postings, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "negative amount")
 }
@@ -364,7 +364,7 @@ func TestTranslatePostings_InvalidAmount(t *testing.T) {
 		Asset:       "USD",
 	}}
 
-	_, err := translatePostings(postings)
+	_, err := translatePostings(postings, nil)
 	require.Error(t, err)
 }
 
@@ -372,7 +372,7 @@ func TestTranslateTarget_TransactionString(t *testing.T) {
 	t.Parallel()
 
 	// v2 sometimes encodes transaction IDs as strings
-	target, err := translateTarget("TRANSACTION", json.RawMessage(`"42"`))
+	target, err := translateTarget("TRANSACTION", json.RawMessage(`"42"`), nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), target.GetTransactionId())
 }
@@ -380,7 +380,7 @@ func TestTranslateTarget_TransactionString(t *testing.T) {
 func TestTranslateTarget_TransactionUint(t *testing.T) {
 	t.Parallel()
 
-	target, err := translateTarget("TRANSACTION", json.RawMessage(`42`))
+	target, err := translateTarget("TRANSACTION", json.RawMessage(`42`), nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(42), target.GetTransactionId())
 }
@@ -388,7 +388,7 @@ func TestTranslateTarget_TransactionUint(t *testing.T) {
 func TestTranslateTarget_Account(t *testing.T) {
 	t.Parallel()
 
-	target, err := translateTarget("ACCOUNT", json.RawMessage(`"users:001"`))
+	target, err := translateTarget("ACCOUNT", json.RawMessage(`"users:001"`), nil)
 	require.NoError(t, err)
 	require.Equal(t, "users:001", target.GetAccount().GetAddr())
 }
@@ -396,7 +396,7 @@ func TestTranslateTarget_Account(t *testing.T) {
 func TestTranslateTarget_UnknownType(t *testing.T) {
 	t.Parallel()
 
-	_, err := translateTarget("UNKNOWN", json.RawMessage(`"whatever"`))
+	_, err := translateTarget("UNKNOWN", json.RawMessage(`"whatever"`), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown target type")
 }
@@ -443,7 +443,7 @@ func TestTranslateBatch_TxIDSkippedWhenGap(t *testing.T) {
 		}),
 	}}
 
-	orders, _, nextTxID, err := TranslateBatch("default", v2Logs, 1, 2)
+	orders, _, nextTxID, err := TranslateBatch("default", v2Logs, 1, 2, nil)
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 	require.Equal(t, uint64(6), nextTxID)
@@ -458,7 +458,7 @@ func TestTranslateBatch_InvalidJSON(t *testing.T) {
 		Data: json.RawMessage(`{invalid json`),
 	}}
 
-	_, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	_, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "translating v2 log 1")
 }
@@ -476,7 +476,7 @@ func TestTranslateBatch_TrailingJSONRejected(t *testing.T) {
 		}{}`),
 	}}
 
-	_, _, _, err := TranslateBatch("default", v2Logs, 1, 1)
+	_, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "translating v2 log 1")
 }
@@ -536,7 +536,7 @@ func BenchmarkTranslateBatch(b *testing.B) {
 	b.ReportAllocs()
 
 	for range b.N {
-		orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0)
+		orders, _, _, err := TranslateBatch("default", v2Logs, 1, 0, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/application/admission/errors.go
+++ b/internal/application/admission/errors.go
@@ -22,8 +22,10 @@ var (
 	ErrMirrorIAMRequiresTLS = domain.NewValidationSentinel("mirrorSource.postgres: awsIamAuth requires sslmode in {require, verify-ca, verify-full}")
 
 	// ErrMirrorAddressRewritePatternInvalid rejects a mirror config whose
-	// addressRewriteRules contain a pattern that is not a valid Go (RE2) regular
-	// expression. Validating at admission fails fast before the config is
-	// persisted, instead of stalling the mirror worker on every batch.
-	ErrMirrorAddressRewritePatternInvalid = domain.NewValidationSentinel("mirrorSource.addressRewriteRules: pattern is not a valid regular expression")
+	// addressRewriteRules contain a pattern that is empty or not a valid Go (RE2)
+	// regular expression. An empty pattern matches at every boundary and would
+	// silently rewrite every address (including "world"); both are rejected at
+	// admission so a malformed rule fails fast before the config is persisted,
+	// instead of stalling — or corrupting — the mirror on every batch.
+	ErrMirrorAddressRewritePatternInvalid = domain.NewValidationSentinel("mirrorSource.addressRewriteRules: pattern must be a non-empty valid regular expression")
 )

--- a/internal/application/admission/errors.go
+++ b/internal/application/admission/errors.go
@@ -20,4 +20,10 @@ var (
 	// The SigV4 token in cc.Password is a short-lived bearer credential and
 	// must not transit cleartext.
 	ErrMirrorIAMRequiresTLS = domain.NewValidationSentinel("mirrorSource.postgres: awsIamAuth requires sslmode in {require, verify-ca, verify-full}")
+
+	// ErrMirrorAddressRewritePatternInvalid rejects a mirror config whose
+	// addressRewriteRules contain a pattern that is not a valid Go (RE2) regular
+	// expression. Validating at admission fails fast before the config is
+	// persisted, instead of stalling the mirror worker on every batch.
+	ErrMirrorAddressRewritePatternInvalid = domain.NewValidationSentinel("mirrorSource.addressRewriteRules: pattern is not a valid regular expression")
 )

--- a/internal/application/admission/validate_order.go
+++ b/internal/application/admission/validate_order.go
@@ -265,6 +265,12 @@ func validateOrderMirrorSource(order *raftcmdpb.Order) domain.Describable {
 	// audit chain, so a malformed rule fails fast instead of stalling the mirror
 	// worker on every batch.
 	for _, rule := range src.GetAddressRewriteRules() {
+		// An empty pattern compiles fine but matches at every boundary, so it
+		// would rewrite every address; reject it explicitly.
+		if rule.GetPattern() == "" {
+			return ErrMirrorAddressRewritePatternInvalid
+		}
+
 		if _, err := regexp.Compile(rule.GetPattern()); err != nil {
 			return ErrMirrorAddressRewritePatternInvalid
 		}

--- a/internal/application/admission/validate_order.go
+++ b/internal/application/admission/validate_order.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -258,6 +259,15 @@ func validateOrderMirrorSource(order *raftcmdpb.Order) domain.Describable {
 	src := create.CreateLedger.GetMirrorSource()
 	if src == nil {
 		return nil
+	}
+
+	// Reject uncompilable address-rewrite patterns before the order reaches the
+	// audit chain, so a malformed rule fails fast instead of stalling the mirror
+	// worker on every batch.
+	for _, rule := range src.GetAddressRewriteRules() {
+		if _, err := regexp.Compile(rule.GetPattern()); err != nil {
+			return ErrMirrorAddressRewritePatternInvalid
+		}
 	}
 
 	pg := src.GetPostgres()

--- a/internal/application/admission/validate_order_test.go
+++ b/internal/application/admission/validate_order_test.go
@@ -876,6 +876,29 @@ func TestValidateOrder_MirrorIAMRegion(t *testing.T) {
 				Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "http://v2:3068"},
 			}},
 		},
+		{
+			name: "valid address rewrite rules accepted",
+			src: &commonpb.MirrorSourceConfig{
+				Type: &commonpb.MirrorSourceConfig_Http{
+					Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "http://v2:3068"},
+				},
+				AddressRewriteRules: []*commonpb.AddressRewriteRule{
+					{Pattern: `(:worker:\d+)`, Replacement: ""},
+				},
+			},
+		},
+		{
+			name: "invalid address rewrite pattern rejected at admission",
+			src: &commonpb.MirrorSourceConfig{
+				Type: &commonpb.MirrorSourceConfig_Http{
+					Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "http://v2:3068"},
+				},
+				AddressRewriteRules: []*commonpb.AddressRewriteRule{
+					{Pattern: `(unbalanced`, Replacement: ""},
+				},
+			},
+			wantErr: ErrMirrorAddressRewritePatternInvalid,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/application/admission/validate_order_test.go
+++ b/internal/application/admission/validate_order_test.go
@@ -899,6 +899,18 @@ func TestValidateOrder_MirrorIAMRegion(t *testing.T) {
 			},
 			wantErr: ErrMirrorAddressRewritePatternInvalid,
 		},
+		{
+			name: "empty address rewrite pattern rejected at admission",
+			src: &commonpb.MirrorSourceConfig{
+				Type: &commonpb.MirrorSourceConfig_Http{
+					Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "http://v2:3068"},
+				},
+				AddressRewriteRules: []*commonpb.AddressRewriteRule{
+					{Pattern: "", Replacement: "x"},
+				},
+			},
+			wantErr: ErrMirrorAddressRewritePatternInvalid,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/application/mirror/manager.go
+++ b/internal/application/mirror/manager.go
@@ -165,12 +165,21 @@ func (m *Manager) reconcile() {
 			continue
 		}
 
+		rewriter, err := v2.NewAddressRewriter(info.GetMirrorSource().GetAddressRewriteRules())
+		if err != nil {
+			// Rules are validated at admission time, so a compile failure here
+			// indicates corrupted config; skip the worker rather than crash.
+			m.logger.WithFields(map[string]any{"ledger": name}).Errorf("Failed to build mirror address rewriter: %v", err)
+
+			continue
+		}
+
 		batchSize := int(info.GetMirrorSource().GetBatchSize())
 		if m.maxBatchSize > 0 && (batchSize <= 0 || batchSize > m.maxBatchSize) {
 			batchSize = m.maxBatchSize
 		}
 
-		w := NewWorker(name, batchSize, source, m.store, m.proposer, m.builder, m.logger, m.meterProvider)
+		w := NewWorker(name, batchSize, source, rewriter, m.store, m.proposer, m.builder, m.logger, m.meterProvider)
 		w.Start()
 		m.workers[name] = w
 	}

--- a/internal/application/mirror/worker.go
+++ b/internal/application/mirror/worker.go
@@ -49,6 +49,7 @@ type Worker struct {
 	ledgerName     string
 	batchSize      int
 	source         v2.Source
+	rewriter       *v2.AddressRewriter
 	store          *dal.Store
 	proposer       Proposer
 	builder        *plan.Builder
@@ -82,6 +83,7 @@ func NewWorker(
 	ledgerName string,
 	batchSize int,
 	source v2.Source,
+	rewriter *v2.AddressRewriter,
 	store *dal.Store,
 	proposer Proposer,
 	builder *plan.Builder,
@@ -124,6 +126,7 @@ func NewWorker(
 		ledgerName: ledgerName,
 		batchSize:  batchSize,
 		source:     source,
+		rewriter:   rewriter,
 		store:      store,
 		proposer:   proposer,
 		builder:    builder,
@@ -329,7 +332,7 @@ func (w *Worker) processBatch(ctx context.Context) (bool, error) {
 	// Translate v2 logs to v3 orders
 	translateStart := time.Now()
 
-	orders, _, newNextTxID, err := v2.TranslateBatch(w.ledgerName, v2Logs, expectedNextLogID, expectedNextTxID)
+	orders, _, newNextTxID, err := v2.TranslateBatch(w.ledgerName, v2Logs, expectedNextLogID, expectedNextTxID, w.rewriter)
 	if err != nil {
 		return false, err
 	}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -6772,10 +6772,15 @@ type MirrorSourceConfig struct {
 	//
 	//	*MirrorSourceConfig_Http
 	//	*MirrorSourceConfig_Postgres
-	Type          isMirrorSourceConfig_Type `protobuf_oneof:"type"`
-	BatchSize     uint32                    `protobuf:"varint,4,opt,name=batch_size,json=batchSize,proto3" json:"batch_size,omitempty"` // Max logs per batch (0 = default 100). Client's responsibility to avoid saturating the instance.
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Type      isMirrorSourceConfig_Type `protobuf_oneof:"type"`
+	BatchSize uint32                    `protobuf:"varint,4,opt,name=batch_size,json=batchSize,proto3" json:"batch_size,omitempty"` // Max logs per batch (0 = default 100). Client's responsibility to avoid saturating the instance.
+	// Rewrite rules applied, in order, to every account address as v2 logs are
+	// translated into v3 orders. Used to drop or rename address segments that v2
+	// only carried as lock-avoidance shards (e.g. ":worker:001"). See
+	// AddressRewriteRule.
+	AddressRewriteRules []*AddressRewriteRule `protobuf:"bytes,5,rep,name=address_rewrite_rules,json=addressRewriteRules,proto3" json:"address_rewrite_rules,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *MirrorSourceConfig) Reset() {
@@ -6847,6 +6852,13 @@ func (x *MirrorSourceConfig) GetBatchSize() uint32 {
 	return 0
 }
 
+func (x *MirrorSourceConfig) GetAddressRewriteRules() []*AddressRewriteRule {
+	if x != nil {
+		return x.AddressRewriteRules
+	}
+	return nil
+}
+
 type isMirrorSourceConfig_Type interface {
 	isMirrorSourceConfig_Type()
 }
@@ -6863,6 +6875,66 @@ func (*MirrorSourceConfig_Http) isMirrorSourceConfig_Type() {}
 
 func (*MirrorSourceConfig_Postgres) isMirrorSourceConfig_Type() {}
 
+// AddressRewriteRule rewrites account addresses during mirror translation.
+// pattern is a Go (RE2) regular expression matched against the full account
+// address; every match is replaced with replacement (which may reference
+// capture groups). An empty replacement drops the matched part, e.g. pattern
+// "(:worker:\\d+)" turns "payments:acme:worker:001:main" into
+// "payments:acme:main". Rewriting is a pure translation-time projection: the
+// source v2 ledger is never modified, and the rewritten address must still be
+// a valid ledger account address.
+type AddressRewriteRule struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Pattern       string                 `protobuf:"bytes,1,opt,name=pattern,proto3" json:"pattern,omitempty"`
+	Replacement   string                 `protobuf:"bytes,2,opt,name=replacement,proto3" json:"replacement,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddressRewriteRule) Reset() {
+	*x = AddressRewriteRule{}
+	mi := &file_common_proto_msgTypes[81]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddressRewriteRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddressRewriteRule) ProtoMessage() {}
+
+func (x *AddressRewriteRule) ProtoReflect() protoreflect.Message {
+	mi := &file_common_proto_msgTypes[81]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddressRewriteRule.ProtoReflect.Descriptor instead.
+func (*AddressRewriteRule) Descriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{81}
+}
+
+func (x *AddressRewriteRule) GetPattern() string {
+	if x != nil {
+		return x.Pattern
+	}
+	return ""
+}
+
+func (x *AddressRewriteRule) GetReplacement() string {
+	if x != nil {
+		return x.Replacement
+	}
+	return ""
+}
+
 type HttpMirrorSourceConfig struct {
 	state                   protoimpl.MessageState   `protogen:"open.v1"`
 	BaseUrl                 string                   `protobuf:"bytes,1,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
@@ -6873,7 +6945,7 @@ type HttpMirrorSourceConfig struct {
 
 func (x *HttpMirrorSourceConfig) Reset() {
 	*x = HttpMirrorSourceConfig{}
-	mi := &file_common_proto_msgTypes[81]
+	mi := &file_common_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6885,7 +6957,7 @@ func (x *HttpMirrorSourceConfig) String() string {
 func (*HttpMirrorSourceConfig) ProtoMessage() {}
 
 func (x *HttpMirrorSourceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[81]
+	mi := &file_common_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6898,7 +6970,7 @@ func (x *HttpMirrorSourceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HttpMirrorSourceConfig.ProtoReflect.Descriptor instead.
 func (*HttpMirrorSourceConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{81}
+	return file_common_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *HttpMirrorSourceConfig) GetBaseUrl() string {
@@ -6927,7 +6999,7 @@ type OAuth2ClientCredentials struct {
 
 func (x *OAuth2ClientCredentials) Reset() {
 	*x = OAuth2ClientCredentials{}
-	mi := &file_common_proto_msgTypes[82]
+	mi := &file_common_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6939,7 +7011,7 @@ func (x *OAuth2ClientCredentials) String() string {
 func (*OAuth2ClientCredentials) ProtoMessage() {}
 
 func (x *OAuth2ClientCredentials) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[82]
+	mi := &file_common_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6952,7 +7024,7 @@ func (x *OAuth2ClientCredentials) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuth2ClientCredentials.ProtoReflect.Descriptor instead.
 func (*OAuth2ClientCredentials) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{82}
+	return file_common_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *OAuth2ClientCredentials) GetClientId() string {
@@ -6998,7 +7070,7 @@ type PostgresMirrorSourceConfig struct {
 
 func (x *PostgresMirrorSourceConfig) Reset() {
 	*x = PostgresMirrorSourceConfig{}
-	mi := &file_common_proto_msgTypes[83]
+	mi := &file_common_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7010,7 +7082,7 @@ func (x *PostgresMirrorSourceConfig) String() string {
 func (*PostgresMirrorSourceConfig) ProtoMessage() {}
 
 func (x *PostgresMirrorSourceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[83]
+	mi := &file_common_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7023,7 +7095,7 @@ func (x *PostgresMirrorSourceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PostgresMirrorSourceConfig.ProtoReflect.Descriptor instead.
 func (*PostgresMirrorSourceConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{83}
+	return file_common_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *PostgresMirrorSourceConfig) GetDsn() string {
@@ -7056,7 +7128,7 @@ type PostgresAwsIamAuth struct {
 
 func (x *PostgresAwsIamAuth) Reset() {
 	*x = PostgresAwsIamAuth{}
-	mi := &file_common_proto_msgTypes[84]
+	mi := &file_common_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7068,7 +7140,7 @@ func (x *PostgresAwsIamAuth) String() string {
 func (*PostgresAwsIamAuth) ProtoMessage() {}
 
 func (x *PostgresAwsIamAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[84]
+	mi := &file_common_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7081,7 +7153,7 @@ func (x *PostgresAwsIamAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PostgresAwsIamAuth.ProtoReflect.Descriptor instead.
 func (*PostgresAwsIamAuth) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{84}
+	return file_common_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *PostgresAwsIamAuth) GetRegion() string {
@@ -7108,7 +7180,7 @@ type MirrorSyncError struct {
 
 func (x *MirrorSyncError) Reset() {
 	*x = MirrorSyncError{}
-	mi := &file_common_proto_msgTypes[85]
+	mi := &file_common_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7120,7 +7192,7 @@ func (x *MirrorSyncError) String() string {
 func (*MirrorSyncError) ProtoMessage() {}
 
 func (x *MirrorSyncError) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[85]
+	mi := &file_common_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7133,7 +7205,7 @@ func (x *MirrorSyncError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MirrorSyncError.ProtoReflect.Descriptor instead.
 func (*MirrorSyncError) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{85}
+	return file_common_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *MirrorSyncError) GetMessage() string {
@@ -7163,7 +7235,7 @@ type MirrorSyncProgress struct {
 
 func (x *MirrorSyncProgress) Reset() {
 	*x = MirrorSyncProgress{}
-	mi := &file_common_proto_msgTypes[86]
+	mi := &file_common_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7175,7 +7247,7 @@ func (x *MirrorSyncProgress) String() string {
 func (*MirrorSyncProgress) ProtoMessage() {}
 
 func (x *MirrorSyncProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[86]
+	mi := &file_common_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7188,7 +7260,7 @@ func (x *MirrorSyncProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MirrorSyncProgress.ProtoReflect.Descriptor instead.
 func (*MirrorSyncProgress) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{86}
+	return file_common_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *MirrorSyncProgress) GetState() MirrorSyncState {
@@ -7249,7 +7321,7 @@ type LedgerInfo struct {
 
 func (x *LedgerInfo) Reset() {
 	*x = LedgerInfo{}
-	mi := &file_common_proto_msgTypes[87]
+	mi := &file_common_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7261,7 +7333,7 @@ func (x *LedgerInfo) String() string {
 func (*LedgerInfo) ProtoMessage() {}
 
 func (x *LedgerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[87]
+	mi := &file_common_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7274,7 +7346,7 @@ func (x *LedgerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerInfo.ProtoReflect.Descriptor instead.
 func (*LedgerInfo) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{87}
+	return file_common_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *LedgerInfo) GetName() string {
@@ -7365,7 +7437,7 @@ type SaveMetadataCommand struct {
 
 func (x *SaveMetadataCommand) Reset() {
 	*x = SaveMetadataCommand{}
-	mi := &file_common_proto_msgTypes[88]
+	mi := &file_common_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7377,7 +7449,7 @@ func (x *SaveMetadataCommand) String() string {
 func (*SaveMetadataCommand) ProtoMessage() {}
 
 func (x *SaveMetadataCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[88]
+	mi := &file_common_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7390,7 +7462,7 @@ func (x *SaveMetadataCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SaveMetadataCommand.ProtoReflect.Descriptor instead.
 func (*SaveMetadataCommand) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{88}
+	return file_common_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *SaveMetadataCommand) GetTarget() *Target {
@@ -7418,7 +7490,7 @@ type DeleteMetadataCommand struct {
 
 func (x *DeleteMetadataCommand) Reset() {
 	*x = DeleteMetadataCommand{}
-	mi := &file_common_proto_msgTypes[89]
+	mi := &file_common_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7430,7 +7502,7 @@ func (x *DeleteMetadataCommand) String() string {
 func (*DeleteMetadataCommand) ProtoMessage() {}
 
 func (x *DeleteMetadataCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[89]
+	mi := &file_common_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7443,7 +7515,7 @@ func (x *DeleteMetadataCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteMetadataCommand.ProtoReflect.Descriptor instead.
 func (*DeleteMetadataCommand) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{89}
+	return file_common_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *DeleteMetadataCommand) GetTarget() *Target {
@@ -7476,7 +7548,7 @@ type TransactionState struct {
 
 func (x *TransactionState) Reset() {
 	*x = TransactionState{}
-	mi := &file_common_proto_msgTypes[90]
+	mi := &file_common_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7488,7 +7560,7 @@ func (x *TransactionState) String() string {
 func (*TransactionState) ProtoMessage() {}
 
 func (x *TransactionState) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[90]
+	mi := &file_common_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7501,7 +7573,7 @@ func (x *TransactionState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionState.ProtoReflect.Descriptor instead.
 func (*TransactionState) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{90}
+	return file_common_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *TransactionState) GetCreatedByLog() uint64 {
@@ -7551,7 +7623,7 @@ type IdempotencyKeyValue struct {
 
 func (x *IdempotencyKeyValue) Reset() {
 	*x = IdempotencyKeyValue{}
-	mi := &file_common_proto_msgTypes[91]
+	mi := &file_common_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7563,7 +7635,7 @@ func (x *IdempotencyKeyValue) String() string {
 func (*IdempotencyKeyValue) ProtoMessage() {}
 
 func (x *IdempotencyKeyValue) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[91]
+	mi := &file_common_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7576,7 +7648,7 @@ func (x *IdempotencyKeyValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdempotencyKeyValue.ProtoReflect.Descriptor instead.
 func (*IdempotencyKeyValue) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{91}
+	return file_common_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *IdempotencyKeyValue) GetFirstLogSequence() uint64 {
@@ -7637,7 +7709,7 @@ type IdempotencyFailure struct {
 
 func (x *IdempotencyFailure) Reset() {
 	*x = IdempotencyFailure{}
-	mi := &file_common_proto_msgTypes[92]
+	mi := &file_common_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7649,7 +7721,7 @@ func (x *IdempotencyFailure) String() string {
 func (*IdempotencyFailure) ProtoMessage() {}
 
 func (x *IdempotencyFailure) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[92]
+	mi := &file_common_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7662,7 +7734,7 @@ func (x *IdempotencyFailure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdempotencyFailure.ProtoReflect.Descriptor instead.
 func (*IdempotencyFailure) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{92}
+	return file_common_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *IdempotencyFailure) GetReason() ErrorReason {
@@ -7696,7 +7768,7 @@ type TransactionReferenceValue struct {
 
 func (x *TransactionReferenceValue) Reset() {
 	*x = TransactionReferenceValue{}
-	mi := &file_common_proto_msgTypes[93]
+	mi := &file_common_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7708,7 +7780,7 @@ func (x *TransactionReferenceValue) String() string {
 func (*TransactionReferenceValue) ProtoMessage() {}
 
 func (x *TransactionReferenceValue) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[93]
+	mi := &file_common_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7721,7 +7793,7 @@ func (x *TransactionReferenceValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionReferenceValue.ProtoReflect.Descriptor instead.
 func (*TransactionReferenceValue) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{93}
+	return file_common_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *TransactionReferenceValue) GetTransactionId() uint64 {
@@ -7741,7 +7813,7 @@ type NumscriptVersionValue struct {
 
 func (x *NumscriptVersionValue) Reset() {
 	*x = NumscriptVersionValue{}
-	mi := &file_common_proto_msgTypes[94]
+	mi := &file_common_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7753,7 +7825,7 @@ func (x *NumscriptVersionValue) String() string {
 func (*NumscriptVersionValue) ProtoMessage() {}
 
 func (x *NumscriptVersionValue) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[94]
+	mi := &file_common_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7766,7 +7838,7 @@ func (x *NumscriptVersionValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NumscriptVersionValue.ProtoReflect.Descriptor instead.
 func (*NumscriptVersionValue) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{94}
+	return file_common_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *NumscriptVersionValue) GetVersion() string {
@@ -7793,7 +7865,7 @@ type SegmentType struct {
 
 func (x *SegmentType) Reset() {
 	*x = SegmentType{}
-	mi := &file_common_proto_msgTypes[95]
+	mi := &file_common_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7805,7 +7877,7 @@ func (x *SegmentType) String() string {
 func (*SegmentType) ProtoMessage() {}
 
 func (x *SegmentType) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[95]
+	mi := &file_common_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7818,7 +7890,7 @@ func (x *SegmentType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SegmentType.ProtoReflect.Descriptor instead.
 func (*SegmentType) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{95}
+	return file_common_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *SegmentType) GetConstraint() isSegmentType_Constraint {
@@ -7900,7 +7972,7 @@ type UUIDConstraint struct {
 
 func (x *UUIDConstraint) Reset() {
 	*x = UUIDConstraint{}
-	mi := &file_common_proto_msgTypes[96]
+	mi := &file_common_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7912,7 +7984,7 @@ func (x *UUIDConstraint) String() string {
 func (*UUIDConstraint) ProtoMessage() {}
 
 func (x *UUIDConstraint) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[96]
+	mi := &file_common_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7925,7 +7997,7 @@ func (x *UUIDConstraint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UUIDConstraint.ProtoReflect.Descriptor instead.
 func (*UUIDConstraint) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{96}
+	return file_common_proto_rawDescGZIP(), []int{97}
 }
 
 type Uint64Constraint struct {
@@ -7936,7 +8008,7 @@ type Uint64Constraint struct {
 
 func (x *Uint64Constraint) Reset() {
 	*x = Uint64Constraint{}
-	mi := &file_common_proto_msgTypes[97]
+	mi := &file_common_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7948,7 +8020,7 @@ func (x *Uint64Constraint) String() string {
 func (*Uint64Constraint) ProtoMessage() {}
 
 func (x *Uint64Constraint) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[97]
+	mi := &file_common_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7961,7 +8033,7 @@ func (x *Uint64Constraint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Uint64Constraint.ProtoReflect.Descriptor instead.
 func (*Uint64Constraint) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{97}
+	return file_common_proto_rawDescGZIP(), []int{98}
 }
 
 type BytesConstraint struct {
@@ -7972,7 +8044,7 @@ type BytesConstraint struct {
 
 func (x *BytesConstraint) Reset() {
 	*x = BytesConstraint{}
-	mi := &file_common_proto_msgTypes[98]
+	mi := &file_common_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7984,7 +8056,7 @@ func (x *BytesConstraint) String() string {
 func (*BytesConstraint) ProtoMessage() {}
 
 func (x *BytesConstraint) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[98]
+	mi := &file_common_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7997,7 +8069,7 @@ func (x *BytesConstraint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BytesConstraint.ProtoReflect.Descriptor instead.
 func (*BytesConstraint) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{98}
+	return file_common_proto_rawDescGZIP(), []int{99}
 }
 
 // AccountType defines a single account address pattern for a ledger.
@@ -8013,7 +8085,7 @@ type AccountType struct {
 
 func (x *AccountType) Reset() {
 	*x = AccountType{}
-	mi := &file_common_proto_msgTypes[99]
+	mi := &file_common_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8025,7 +8097,7 @@ func (x *AccountType) String() string {
 func (*AccountType) ProtoMessage() {}
 
 func (x *AccountType) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[99]
+	mi := &file_common_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8038,7 +8110,7 @@ func (x *AccountType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccountType.ProtoReflect.Descriptor instead.
 func (*AccountType) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{99}
+	return file_common_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *AccountType) GetName() string {
@@ -8079,7 +8151,7 @@ type AddedAccountTypeLog struct {
 
 func (x *AddedAccountTypeLog) Reset() {
 	*x = AddedAccountTypeLog{}
-	mi := &file_common_proto_msgTypes[100]
+	mi := &file_common_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8091,7 +8163,7 @@ func (x *AddedAccountTypeLog) String() string {
 func (*AddedAccountTypeLog) ProtoMessage() {}
 
 func (x *AddedAccountTypeLog) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[100]
+	mi := &file_common_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8104,7 +8176,7 @@ func (x *AddedAccountTypeLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddedAccountTypeLog.ProtoReflect.Descriptor instead.
 func (*AddedAccountTypeLog) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{100}
+	return file_common_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *AddedAccountTypeLog) GetAccountType() *AccountType {
@@ -8124,7 +8196,7 @@ type RemovedAccountTypeLog struct {
 
 func (x *RemovedAccountTypeLog) Reset() {
 	*x = RemovedAccountTypeLog{}
-	mi := &file_common_proto_msgTypes[101]
+	mi := &file_common_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8136,7 +8208,7 @@ func (x *RemovedAccountTypeLog) String() string {
 func (*RemovedAccountTypeLog) ProtoMessage() {}
 
 func (x *RemovedAccountTypeLog) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[101]
+	mi := &file_common_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8149,7 +8221,7 @@ func (x *RemovedAccountTypeLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemovedAccountTypeLog.ProtoReflect.Descriptor instead.
 func (*RemovedAccountTypeLog) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{101}
+	return file_common_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *RemovedAccountTypeLog) GetName() string {
@@ -8169,7 +8241,7 @@ type UpdatedDefaultEnforcementModeLog struct {
 
 func (x *UpdatedDefaultEnforcementModeLog) Reset() {
 	*x = UpdatedDefaultEnforcementModeLog{}
-	mi := &file_common_proto_msgTypes[102]
+	mi := &file_common_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8181,7 +8253,7 @@ func (x *UpdatedDefaultEnforcementModeLog) String() string {
 func (*UpdatedDefaultEnforcementModeLog) ProtoMessage() {}
 
 func (x *UpdatedDefaultEnforcementModeLog) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[102]
+	mi := &file_common_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8194,7 +8266,7 @@ func (x *UpdatedDefaultEnforcementModeLog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdatedDefaultEnforcementModeLog.ProtoReflect.Descriptor instead.
 func (*UpdatedDefaultEnforcementModeLog) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{102}
+	return file_common_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *UpdatedDefaultEnforcementModeLog) GetEnforcementMode() ChartEnforcementMode {
@@ -8226,7 +8298,7 @@ type QueryFilter struct {
 
 func (x *QueryFilter) Reset() {
 	*x = QueryFilter{}
-	mi := &file_common_proto_msgTypes[103]
+	mi := &file_common_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8238,7 +8310,7 @@ func (x *QueryFilter) String() string {
 func (*QueryFilter) ProtoMessage() {}
 
 func (x *QueryFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[103]
+	mi := &file_common_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8251,7 +8323,7 @@ func (x *QueryFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryFilter.ProtoReflect.Descriptor instead.
 func (*QueryFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{103}
+	return file_common_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *QueryFilter) GetFilter() isQueryFilter_Filter {
@@ -8440,7 +8512,7 @@ type ReferenceCondition struct {
 
 func (x *ReferenceCondition) Reset() {
 	*x = ReferenceCondition{}
-	mi := &file_common_proto_msgTypes[104]
+	mi := &file_common_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8452,7 +8524,7 @@ func (x *ReferenceCondition) String() string {
 func (*ReferenceCondition) ProtoMessage() {}
 
 func (x *ReferenceCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[104]
+	mi := &file_common_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8465,7 +8537,7 @@ func (x *ReferenceCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReferenceCondition.ProtoReflect.Descriptor instead.
 func (*ReferenceCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{104}
+	return file_common_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *ReferenceCondition) GetCond() *StringCondition {
@@ -8485,7 +8557,7 @@ type LedgerCondition struct {
 
 func (x *LedgerCondition) Reset() {
 	*x = LedgerCondition{}
-	mi := &file_common_proto_msgTypes[105]
+	mi := &file_common_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8497,7 +8569,7 @@ func (x *LedgerCondition) String() string {
 func (*LedgerCondition) ProtoMessage() {}
 
 func (x *LedgerCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[105]
+	mi := &file_common_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8510,7 +8582,7 @@ func (x *LedgerCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerCondition.ProtoReflect.Descriptor instead.
 func (*LedgerCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{105}
+	return file_common_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *LedgerCondition) GetCond() *StringCondition {
@@ -8530,7 +8602,7 @@ type LogIdCondition struct {
 
 func (x *LogIdCondition) Reset() {
 	*x = LogIdCondition{}
-	mi := &file_common_proto_msgTypes[106]
+	mi := &file_common_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8542,7 +8614,7 @@ func (x *LogIdCondition) String() string {
 func (*LogIdCondition) ProtoMessage() {}
 
 func (x *LogIdCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[106]
+	mi := &file_common_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8555,7 +8627,7 @@ func (x *LogIdCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogIdCondition.ProtoReflect.Descriptor instead.
 func (*LogIdCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{106}
+	return file_common_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *LogIdCondition) GetCond() *UintCondition {
@@ -8576,7 +8648,7 @@ type BuiltinUintCondition struct {
 
 func (x *BuiltinUintCondition) Reset() {
 	*x = BuiltinUintCondition{}
-	mi := &file_common_proto_msgTypes[107]
+	mi := &file_common_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8588,7 +8660,7 @@ func (x *BuiltinUintCondition) String() string {
 func (*BuiltinUintCondition) ProtoMessage() {}
 
 func (x *BuiltinUintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[107]
+	mi := &file_common_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8601,7 +8673,7 @@ func (x *BuiltinUintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuiltinUintCondition.ProtoReflect.Descriptor instead.
 func (*BuiltinUintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{107}
+	return file_common_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *BuiltinUintCondition) GetField() TransactionBuiltinIndex {
@@ -8629,7 +8701,7 @@ type LogBuiltinUintCondition struct {
 
 func (x *LogBuiltinUintCondition) Reset() {
 	*x = LogBuiltinUintCondition{}
-	mi := &file_common_proto_msgTypes[108]
+	mi := &file_common_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8641,7 +8713,7 @@ func (x *LogBuiltinUintCondition) String() string {
 func (*LogBuiltinUintCondition) ProtoMessage() {}
 
 func (x *LogBuiltinUintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[108]
+	mi := &file_common_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8654,7 +8726,7 @@ func (x *LogBuiltinUintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogBuiltinUintCondition.ProtoReflect.Descriptor instead.
 func (*LogBuiltinUintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{108}
+	return file_common_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *LogBuiltinUintCondition) GetField() LogBuiltinIndex {
@@ -8685,7 +8757,7 @@ type AccountHasAssetCondition struct {
 
 func (x *AccountHasAssetCondition) Reset() {
 	*x = AccountHasAssetCondition{}
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8697,7 +8769,7 @@ func (x *AccountHasAssetCondition) String() string {
 func (*AccountHasAssetCondition) ProtoMessage() {}
 
 func (x *AccountHasAssetCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8710,7 +8782,7 @@ func (x *AccountHasAssetCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccountHasAssetCondition.ProtoReflect.Descriptor instead.
 func (*AccountHasAssetCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{109}
+	return file_common_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *AccountHasAssetCondition) GetAssetBase() string {
@@ -8736,7 +8808,7 @@ type AndFilter struct {
 
 func (x *AndFilter) Reset() {
 	*x = AndFilter{}
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8748,7 +8820,7 @@ func (x *AndFilter) String() string {
 func (*AndFilter) ProtoMessage() {}
 
 func (x *AndFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8761,7 +8833,7 @@ func (x *AndFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AndFilter.ProtoReflect.Descriptor instead.
 func (*AndFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{110}
+	return file_common_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *AndFilter) GetFilters() []*QueryFilter {
@@ -8780,7 +8852,7 @@ type OrFilter struct {
 
 func (x *OrFilter) Reset() {
 	*x = OrFilter{}
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8792,7 +8864,7 @@ func (x *OrFilter) String() string {
 func (*OrFilter) ProtoMessage() {}
 
 func (x *OrFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8805,7 +8877,7 @@ func (x *OrFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OrFilter.ProtoReflect.Descriptor instead.
 func (*OrFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{111}
+	return file_common_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *OrFilter) GetFilters() []*QueryFilter {
@@ -8824,7 +8896,7 @@ type NotFilter struct {
 
 func (x *NotFilter) Reset() {
 	*x = NotFilter{}
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8836,7 +8908,7 @@ func (x *NotFilter) String() string {
 func (*NotFilter) ProtoMessage() {}
 
 func (x *NotFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8849,7 +8921,7 @@ func (x *NotFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotFilter.ProtoReflect.Descriptor instead.
 func (*NotFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{112}
+	return file_common_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *NotFilter) GetFilter() *QueryFilter {
@@ -8871,7 +8943,7 @@ type FieldRef struct {
 
 func (x *FieldRef) Reset() {
 	*x = FieldRef{}
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8883,7 +8955,7 @@ func (x *FieldRef) String() string {
 func (*FieldRef) ProtoMessage() {}
 
 func (x *FieldRef) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8896,7 +8968,7 @@ func (x *FieldRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldRef.ProtoReflect.Descriptor instead.
 func (*FieldRef) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{113}
+	return file_common_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *FieldRef) GetMetadata() string {
@@ -8924,7 +8996,7 @@ type FieldCondition struct {
 
 func (x *FieldCondition) Reset() {
 	*x = FieldCondition{}
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8936,7 +9008,7 @@ func (x *FieldCondition) String() string {
 func (*FieldCondition) ProtoMessage() {}
 
 func (x *FieldCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8949,7 +9021,7 @@ func (x *FieldCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldCondition.ProtoReflect.Descriptor instead.
 func (*FieldCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{114}
+	return file_common_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *FieldCondition) GetField() *FieldRef {
@@ -9058,7 +9130,7 @@ type StringCondition struct {
 
 func (x *StringCondition) Reset() {
 	*x = StringCondition{}
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9070,7 +9142,7 @@ func (x *StringCondition) String() string {
 func (*StringCondition) ProtoMessage() {}
 
 func (x *StringCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9083,7 +9155,7 @@ func (x *StringCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringCondition.ProtoReflect.Descriptor instead.
 func (*StringCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{115}
+	return file_common_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *StringCondition) GetValue() isStringCondition_Value {
@@ -9141,7 +9213,7 @@ type IntCondition struct {
 
 func (x *IntCondition) Reset() {
 	*x = IntCondition{}
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9153,7 +9225,7 @@ func (x *IntCondition) String() string {
 func (*IntCondition) ProtoMessage() {}
 
 func (x *IntCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9166,7 +9238,7 @@ func (x *IntCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntCondition.ProtoReflect.Descriptor instead.
 func (*IntCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{116}
+	return file_common_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *IntCondition) GetMin() int64 {
@@ -9225,7 +9297,7 @@ type UintCondition struct {
 
 func (x *UintCondition) Reset() {
 	*x = UintCondition{}
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9237,7 +9309,7 @@ func (x *UintCondition) String() string {
 func (*UintCondition) ProtoMessage() {}
 
 func (x *UintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9250,7 +9322,7 @@ func (x *UintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UintCondition.ProtoReflect.Descriptor instead.
 func (*UintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{117}
+	return file_common_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *UintCondition) GetMin() uint64 {
@@ -9308,7 +9380,7 @@ type BoolCondition struct {
 
 func (x *BoolCondition) Reset() {
 	*x = BoolCondition{}
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9320,7 +9392,7 @@ func (x *BoolCondition) String() string {
 func (*BoolCondition) ProtoMessage() {}
 
 func (x *BoolCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9333,7 +9405,7 @@ func (x *BoolCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoolCondition.ProtoReflect.Descriptor instead.
 func (*BoolCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{118}
+	return file_common_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *BoolCondition) GetValue() isBoolCondition_Value {
@@ -9386,7 +9458,7 @@ type ExistsCondition struct {
 
 func (x *ExistsCondition) Reset() {
 	*x = ExistsCondition{}
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9398,7 +9470,7 @@ func (x *ExistsCondition) String() string {
 func (*ExistsCondition) ProtoMessage() {}
 
 func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9411,7 +9483,7 @@ func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExistsCondition.ProtoReflect.Descriptor instead.
 func (*ExistsCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{119}
+	return file_common_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *ExistsCondition) GetIncludeNull() bool {
@@ -9437,7 +9509,7 @@ type AddressMatch struct {
 
 func (x *AddressMatch) Reset() {
 	*x = AddressMatch{}
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9449,7 +9521,7 @@ func (x *AddressMatch) String() string {
 func (*AddressMatch) ProtoMessage() {}
 
 func (x *AddressMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9462,7 +9534,7 @@ func (x *AddressMatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddressMatch.ProtoReflect.Descriptor instead.
 func (*AddressMatch) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{120}
+	return file_common_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *AddressMatch) GetMatch() isAddressMatch_Match {
@@ -9558,7 +9630,7 @@ type PreparedQuery struct {
 
 func (x *PreparedQuery) Reset() {
 	*x = PreparedQuery{}
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9570,7 +9642,7 @@ func (x *PreparedQuery) String() string {
 func (*PreparedQuery) ProtoMessage() {}
 
 func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9583,7 +9655,7 @@ func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQuery.ProtoReflect.Descriptor instead.
 func (*PreparedQuery) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{121}
+	return file_common_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *PreparedQuery) GetName() string {
@@ -9619,7 +9691,7 @@ type AggregatedVolume struct {
 
 func (x *AggregatedVolume) Reset() {
 	*x = AggregatedVolume{}
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9631,7 +9703,7 @@ func (x *AggregatedVolume) String() string {
 func (*AggregatedVolume) ProtoMessage() {}
 
 func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9644,7 +9716,7 @@ func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregatedVolume.ProtoReflect.Descriptor instead.
 func (*AggregatedVolume) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{122}
+	return file_common_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AggregatedVolume) GetAsset() string {
@@ -9679,7 +9751,7 @@ type AggregateResult struct {
 
 func (x *AggregateResult) Reset() {
 	*x = AggregateResult{}
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9691,7 +9763,7 @@ func (x *AggregateResult) String() string {
 func (*AggregateResult) ProtoMessage() {}
 
 func (x *AggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9704,7 +9776,7 @@ func (x *AggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregateResult.ProtoReflect.Descriptor instead.
 func (*AggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{123}
+	return file_common_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AggregateResult) GetVolumes() []*AggregatedVolume {
@@ -9732,7 +9804,7 @@ type GroupedAggregateResult struct {
 
 func (x *GroupedAggregateResult) Reset() {
 	*x = GroupedAggregateResult{}
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9744,7 +9816,7 @@ func (x *GroupedAggregateResult) String() string {
 func (*GroupedAggregateResult) ProtoMessage() {}
 
 func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9757,7 +9829,7 @@ func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupedAggregateResult.ProtoReflect.Descriptor instead.
 func (*GroupedAggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{124}
+	return file_common_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GroupedAggregateResult) GetPrefix() string {
@@ -9789,7 +9861,7 @@ type PreparedQueryCursor struct {
 
 func (x *PreparedQueryCursor) Reset() {
 	*x = PreparedQueryCursor{}
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9801,7 +9873,7 @@ func (x *PreparedQueryCursor) String() string {
 func (*PreparedQueryCursor) ProtoMessage() {}
 
 func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9814,7 +9886,7 @@ func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQueryCursor.ProtoReflect.Descriptor instead.
 func (*PreparedQueryCursor) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{125}
+	return file_common_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *PreparedQueryCursor) GetPageSize() uint32 {
@@ -9878,7 +9950,7 @@ type LedgerStats struct {
 
 func (x *LedgerStats) Reset() {
 	*x = LedgerStats{}
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9890,7 +9962,7 @@ func (x *LedgerStats) String() string {
 func (*LedgerStats) ProtoMessage() {}
 
 func (x *LedgerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9903,7 +9975,7 @@ func (x *LedgerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerStats.ProtoReflect.Descriptor instead.
 func (*LedgerStats) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{126}
+	return file_common_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *LedgerStats) GetTransactionCount() uint64 {
@@ -9991,7 +10063,7 @@ type PersistedConfig struct {
 
 func (x *PersistedConfig) Reset() {
 	*x = PersistedConfig{}
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10003,7 +10075,7 @@ func (x *PersistedConfig) String() string {
 func (*PersistedConfig) ProtoMessage() {}
 
 func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10016,7 +10088,7 @@ func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistedConfig.ProtoReflect.Descriptor instead.
 func (*PersistedConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{127}
+	return file_common_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *PersistedConfig) GetNodeId() uint64 {
@@ -10069,7 +10141,7 @@ type CallerIdentity struct {
 
 func (x *CallerIdentity) Reset() {
 	*x = CallerIdentity{}
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10081,7 +10153,7 @@ func (x *CallerIdentity) String() string {
 func (*CallerIdentity) ProtoMessage() {}
 
 func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10094,7 +10166,7 @@ func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerIdentity.ProtoReflect.Descriptor instead.
 func (*CallerIdentity) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{128}
+	return file_common_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *CallerIdentity) GetSubject() string {
@@ -10165,7 +10237,7 @@ type CallerSnapshot struct {
 
 func (x *CallerSnapshot) Reset() {
 	*x = CallerSnapshot{}
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10177,7 +10249,7 @@ func (x *CallerSnapshot) String() string {
 func (*CallerSnapshot) ProtoMessage() {}
 
 func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10190,7 +10262,7 @@ func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerSnapshot.ProtoReflect.Descriptor instead.
 func (*CallerSnapshot) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{129}
+	return file_common_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *CallerSnapshot) GetIdentity() *CallerIdentity {
@@ -10228,7 +10300,7 @@ type S3StorageConfig struct {
 
 func (x *S3StorageConfig) Reset() {
 	*x = S3StorageConfig{}
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10240,7 +10312,7 @@ func (x *S3StorageConfig) String() string {
 func (*S3StorageConfig) ProtoMessage() {}
 
 func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10253,7 +10325,7 @@ func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3StorageConfig.ProtoReflect.Descriptor instead.
 func (*S3StorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{130}
+	return file_common_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *S3StorageConfig) GetBucket() string {
@@ -10304,7 +10376,7 @@ type AzureStorageConfig struct {
 
 func (x *AzureStorageConfig) Reset() {
 	*x = AzureStorageConfig{}
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10316,7 +10388,7 @@ func (x *AzureStorageConfig) String() string {
 func (*AzureStorageConfig) ProtoMessage() {}
 
 func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10329,7 +10401,7 @@ func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureStorageConfig.ProtoReflect.Descriptor instead.
 func (*AzureStorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{131}
+	return file_common_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *AzureStorageConfig) GetAccountName() string {
@@ -10376,7 +10448,7 @@ type BackupStorage struct {
 
 func (x *BackupStorage) Reset() {
 	*x = BackupStorage{}
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10388,7 +10460,7 @@ func (x *BackupStorage) String() string {
 func (*BackupStorage) ProtoMessage() {}
 
 func (x *BackupStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10401,7 +10473,7 @@ func (x *BackupStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupStorage.ProtoReflect.Descriptor instead.
 func (*BackupStorage) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{132}
+	return file_common_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *BackupStorage) GetProvider() isBackupStorage_Provider {
@@ -10464,7 +10536,7 @@ type ReadOptions struct {
 
 func (x *ReadOptions) Reset() {
 	*x = ReadOptions{}
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10476,7 +10548,7 @@ func (x *ReadOptions) String() string {
 func (*ReadOptions) ProtoMessage() {}
 
 func (x *ReadOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10489,7 +10561,7 @@ func (x *ReadOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadOptions.ProtoReflect.Descriptor instead.
 func (*ReadOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{133}
+	return file_common_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *ReadOptions) GetCheckpointId() uint64 {
@@ -10541,7 +10613,7 @@ type ListOptions struct {
 
 func (x *ListOptions) Reset() {
 	*x = ListOptions{}
-	mi := &file_common_proto_msgTypes[134]
+	mi := &file_common_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10553,7 +10625,7 @@ func (x *ListOptions) String() string {
 func (*ListOptions) ProtoMessage() {}
 
 func (x *ListOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[134]
+	mi := &file_common_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10566,7 +10638,7 @@ func (x *ListOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOptions.ProtoReflect.Descriptor instead.
 func (*ListOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{134}
+	return file_common_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *ListOptions) GetRead() *ReadOptions {
@@ -11047,15 +11119,19 @@ const file_common_proto_rawDesc = "" +
 	"\x12ArchivedChapterLog\x12)\n" +
 	"\achapter\x18\x01 \x01(\v2\x0f.common.ChapterR\achapter\"G\n" +
 	"\x1aConfirmedArchiveChapterLog\x12)\n" +
-	"\achapter\x18\x01 \x01(\v2\x0f.common.ChapterR\achapter\"\xd4\x01\n" +
+	"\achapter\x18\x01 \x01(\v2\x0f.common.ChapterR\achapter\"\xa4\x02\n" +
 	"\x12MirrorSourceConfig\x12\x1f\n" +
 	"\vledger_name\x18\x01 \x01(\tR\n" +
 	"ledgerName\x124\n" +
 	"\x04http\x18\x02 \x01(\v2\x1e.common.HttpMirrorSourceConfigH\x00R\x04http\x12@\n" +
 	"\bpostgres\x18\x03 \x01(\v2\".common.PostgresMirrorSourceConfigH\x00R\bpostgres\x12\x1d\n" +
 	"\n" +
-	"batch_size\x18\x04 \x01(\rR\tbatchSizeB\x06\n" +
-	"\x04type\"\x90\x01\n" +
+	"batch_size\x18\x04 \x01(\rR\tbatchSize\x12N\n" +
+	"\x15address_rewrite_rules\x18\x05 \x03(\v2\x1a.common.AddressRewriteRuleR\x13addressRewriteRulesB\x06\n" +
+	"\x04type\"P\n" +
+	"\x12AddressRewriteRule\x12\x18\n" +
+	"\apattern\x18\x01 \x01(\tR\apattern\x12 \n" +
+	"\vreplacement\x18\x02 \x01(\tR\vreplacement\"\x90\x01\n" +
 	"\x16HttpMirrorSourceConfig\x12\x19\n" +
 	"\bbase_url\x18\x01 \x01(\tR\abaseUrl\x12[\n" +
 	"\x19oauth2_client_credentials\x18\x02 \x01(\v2\x1f.common.OAuth2ClientCredentialsR\x17oauth2ClientCredentials\"\x9a\x01\n" +
@@ -11478,7 +11554,7 @@ func file_common_proto_rawDescGZIP() []byte {
 }
 
 var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
-var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 155)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
 var file_common_proto_goTypes = []any{
 	(TargetType)(0),                           // 0: common.TargetType
 	(MetadataType)(0),                         // 1: common.MetadataType
@@ -11578,105 +11654,106 @@ var file_common_proto_goTypes = []any{
 	(*ArchivedChapterLog)(nil),                // 95: common.ArchivedChapterLog
 	(*ConfirmedArchiveChapterLog)(nil),        // 96: common.ConfirmedArchiveChapterLog
 	(*MirrorSourceConfig)(nil),                // 97: common.MirrorSourceConfig
-	(*HttpMirrorSourceConfig)(nil),            // 98: common.HttpMirrorSourceConfig
-	(*OAuth2ClientCredentials)(nil),           // 99: common.OAuth2ClientCredentials
-	(*PostgresMirrorSourceConfig)(nil),        // 100: common.PostgresMirrorSourceConfig
-	(*PostgresAwsIamAuth)(nil),                // 101: common.PostgresAwsIamAuth
-	(*MirrorSyncError)(nil),                   // 102: common.MirrorSyncError
-	(*MirrorSyncProgress)(nil),                // 103: common.MirrorSyncProgress
-	(*LedgerInfo)(nil),                        // 104: common.LedgerInfo
-	(*SaveMetadataCommand)(nil),               // 105: common.SaveMetadataCommand
-	(*DeleteMetadataCommand)(nil),             // 106: common.DeleteMetadataCommand
-	(*TransactionState)(nil),                  // 107: common.TransactionState
-	(*IdempotencyKeyValue)(nil),               // 108: common.IdempotencyKeyValue
-	(*IdempotencyFailure)(nil),                // 109: common.IdempotencyFailure
-	(*TransactionReferenceValue)(nil),         // 110: common.TransactionReferenceValue
-	(*NumscriptVersionValue)(nil),             // 111: common.NumscriptVersionValue
-	(*SegmentType)(nil),                       // 112: common.SegmentType
-	(*UUIDConstraint)(nil),                    // 113: common.UUIDConstraint
-	(*Uint64Constraint)(nil),                  // 114: common.Uint64Constraint
-	(*BytesConstraint)(nil),                   // 115: common.BytesConstraint
-	(*AccountType)(nil),                       // 116: common.AccountType
-	(*AddedAccountTypeLog)(nil),               // 117: common.AddedAccountTypeLog
-	(*RemovedAccountTypeLog)(nil),             // 118: common.RemovedAccountTypeLog
-	(*UpdatedDefaultEnforcementModeLog)(nil),  // 119: common.UpdatedDefaultEnforcementModeLog
-	(*QueryFilter)(nil),                       // 120: common.QueryFilter
-	(*ReferenceCondition)(nil),                // 121: common.ReferenceCondition
-	(*LedgerCondition)(nil),                   // 122: common.LedgerCondition
-	(*LogIdCondition)(nil),                    // 123: common.LogIdCondition
-	(*BuiltinUintCondition)(nil),              // 124: common.BuiltinUintCondition
-	(*LogBuiltinUintCondition)(nil),           // 125: common.LogBuiltinUintCondition
-	(*AccountHasAssetCondition)(nil),          // 126: common.AccountHasAssetCondition
-	(*AndFilter)(nil),                         // 127: common.AndFilter
-	(*OrFilter)(nil),                          // 128: common.OrFilter
-	(*NotFilter)(nil),                         // 129: common.NotFilter
-	(*FieldRef)(nil),                          // 130: common.FieldRef
-	(*FieldCondition)(nil),                    // 131: common.FieldCondition
-	(*StringCondition)(nil),                   // 132: common.StringCondition
-	(*IntCondition)(nil),                      // 133: common.IntCondition
-	(*UintCondition)(nil),                     // 134: common.UintCondition
-	(*BoolCondition)(nil),                     // 135: common.BoolCondition
-	(*ExistsCondition)(nil),                   // 136: common.ExistsCondition
-	(*AddressMatch)(nil),                      // 137: common.AddressMatch
-	(*PreparedQuery)(nil),                     // 138: common.PreparedQuery
-	(*AggregatedVolume)(nil),                  // 139: common.AggregatedVolume
-	(*AggregateResult)(nil),                   // 140: common.AggregateResult
-	(*GroupedAggregateResult)(nil),            // 141: common.GroupedAggregateResult
-	(*PreparedQueryCursor)(nil),               // 142: common.PreparedQueryCursor
-	(*LedgerStats)(nil),                       // 143: common.LedgerStats
-	(*PersistedConfig)(nil),                   // 144: common.PersistedConfig
-	(*CallerIdentity)(nil),                    // 145: common.CallerIdentity
-	(*CallerSnapshot)(nil),                    // 146: common.CallerSnapshot
-	(*S3StorageConfig)(nil),                   // 147: common.S3StorageConfig
-	(*AzureStorageConfig)(nil),                // 148: common.AzureStorageConfig
-	(*BackupStorage)(nil),                     // 149: common.BackupStorage
-	(*ReadOptions)(nil),                       // 150: common.ReadOptions
-	(*ListOptions)(nil),                       // 151: common.ListOptions
-	nil,                                       // 152: common.MetadataMap.ValuesEntry
-	nil,                                       // 153: common.Transaction.MetadataEntry
-	nil,                                       // 154: common.Script.VarsEntry
-	nil,                                       // 155: common.VolumesByAssets.VolumesEntry
-	nil,                                       // 156: common.PostCommitVolumes.VolumesByAccountEntry
-	nil,                                       // 157: common.Account.MetadataEntry
-	nil,                                       // 158: common.Account.VolumesEntry
-	nil,                                       // 159: common.MetadataSchema.AccountFieldsEntry
-	nil,                                       // 160: common.MetadataSchema.TransactionFieldsEntry
-	nil,                                       // 161: common.MetadataSchema.LedgerFieldsEntry
-	nil,                                       // 162: common.SavedLedgerMetadataLog.MetadataEntry
-	nil,                                       // 163: common.CreatedLedgerLog.AccountTypesEntry
-	nil,                                       // 164: common.CreatedTransaction.AccountMetadataEntry
-	nil,                                       // 165: common.SavedMetadata.MetadataEntry
-	nil,                                       // 166: common.LedgerInfo.AccountTypesEntry
-	nil,                                       // 167: common.LedgerInfo.MetadataEntry
-	nil,                                       // 168: common.SaveMetadataCommand.MetadataEntry
-	nil,                                       // 169: common.TransactionState.MetadataEntry
-	nil,                                       // 170: common.IdempotencyFailure.MetadataEntry
-	nil,                                       // 171: common.AccountType.SegmentTypesEntry
-	(*signaturepb.SignedLog)(nil),             // 172: signature.SignedLog
+	(*AddressRewriteRule)(nil),                // 98: common.AddressRewriteRule
+	(*HttpMirrorSourceConfig)(nil),            // 99: common.HttpMirrorSourceConfig
+	(*OAuth2ClientCredentials)(nil),           // 100: common.OAuth2ClientCredentials
+	(*PostgresMirrorSourceConfig)(nil),        // 101: common.PostgresMirrorSourceConfig
+	(*PostgresAwsIamAuth)(nil),                // 102: common.PostgresAwsIamAuth
+	(*MirrorSyncError)(nil),                   // 103: common.MirrorSyncError
+	(*MirrorSyncProgress)(nil),                // 104: common.MirrorSyncProgress
+	(*LedgerInfo)(nil),                        // 105: common.LedgerInfo
+	(*SaveMetadataCommand)(nil),               // 106: common.SaveMetadataCommand
+	(*DeleteMetadataCommand)(nil),             // 107: common.DeleteMetadataCommand
+	(*TransactionState)(nil),                  // 108: common.TransactionState
+	(*IdempotencyKeyValue)(nil),               // 109: common.IdempotencyKeyValue
+	(*IdempotencyFailure)(nil),                // 110: common.IdempotencyFailure
+	(*TransactionReferenceValue)(nil),         // 111: common.TransactionReferenceValue
+	(*NumscriptVersionValue)(nil),             // 112: common.NumscriptVersionValue
+	(*SegmentType)(nil),                       // 113: common.SegmentType
+	(*UUIDConstraint)(nil),                    // 114: common.UUIDConstraint
+	(*Uint64Constraint)(nil),                  // 115: common.Uint64Constraint
+	(*BytesConstraint)(nil),                   // 116: common.BytesConstraint
+	(*AccountType)(nil),                       // 117: common.AccountType
+	(*AddedAccountTypeLog)(nil),               // 118: common.AddedAccountTypeLog
+	(*RemovedAccountTypeLog)(nil),             // 119: common.RemovedAccountTypeLog
+	(*UpdatedDefaultEnforcementModeLog)(nil),  // 120: common.UpdatedDefaultEnforcementModeLog
+	(*QueryFilter)(nil),                       // 121: common.QueryFilter
+	(*ReferenceCondition)(nil),                // 122: common.ReferenceCondition
+	(*LedgerCondition)(nil),                   // 123: common.LedgerCondition
+	(*LogIdCondition)(nil),                    // 124: common.LogIdCondition
+	(*BuiltinUintCondition)(nil),              // 125: common.BuiltinUintCondition
+	(*LogBuiltinUintCondition)(nil),           // 126: common.LogBuiltinUintCondition
+	(*AccountHasAssetCondition)(nil),          // 127: common.AccountHasAssetCondition
+	(*AndFilter)(nil),                         // 128: common.AndFilter
+	(*OrFilter)(nil),                          // 129: common.OrFilter
+	(*NotFilter)(nil),                         // 130: common.NotFilter
+	(*FieldRef)(nil),                          // 131: common.FieldRef
+	(*FieldCondition)(nil),                    // 132: common.FieldCondition
+	(*StringCondition)(nil),                   // 133: common.StringCondition
+	(*IntCondition)(nil),                      // 134: common.IntCondition
+	(*UintCondition)(nil),                     // 135: common.UintCondition
+	(*BoolCondition)(nil),                     // 136: common.BoolCondition
+	(*ExistsCondition)(nil),                   // 137: common.ExistsCondition
+	(*AddressMatch)(nil),                      // 138: common.AddressMatch
+	(*PreparedQuery)(nil),                     // 139: common.PreparedQuery
+	(*AggregatedVolume)(nil),                  // 140: common.AggregatedVolume
+	(*AggregateResult)(nil),                   // 141: common.AggregateResult
+	(*GroupedAggregateResult)(nil),            // 142: common.GroupedAggregateResult
+	(*PreparedQueryCursor)(nil),               // 143: common.PreparedQueryCursor
+	(*LedgerStats)(nil),                       // 144: common.LedgerStats
+	(*PersistedConfig)(nil),                   // 145: common.PersistedConfig
+	(*CallerIdentity)(nil),                    // 146: common.CallerIdentity
+	(*CallerSnapshot)(nil),                    // 147: common.CallerSnapshot
+	(*S3StorageConfig)(nil),                   // 148: common.S3StorageConfig
+	(*AzureStorageConfig)(nil),                // 149: common.AzureStorageConfig
+	(*BackupStorage)(nil),                     // 150: common.BackupStorage
+	(*ReadOptions)(nil),                       // 151: common.ReadOptions
+	(*ListOptions)(nil),                       // 152: common.ListOptions
+	nil,                                       // 153: common.MetadataMap.ValuesEntry
+	nil,                                       // 154: common.Transaction.MetadataEntry
+	nil,                                       // 155: common.Script.VarsEntry
+	nil,                                       // 156: common.VolumesByAssets.VolumesEntry
+	nil,                                       // 157: common.PostCommitVolumes.VolumesByAccountEntry
+	nil,                                       // 158: common.Account.MetadataEntry
+	nil,                                       // 159: common.Account.VolumesEntry
+	nil,                                       // 160: common.MetadataSchema.AccountFieldsEntry
+	nil,                                       // 161: common.MetadataSchema.TransactionFieldsEntry
+	nil,                                       // 162: common.MetadataSchema.LedgerFieldsEntry
+	nil,                                       // 163: common.SavedLedgerMetadataLog.MetadataEntry
+	nil,                                       // 164: common.CreatedLedgerLog.AccountTypesEntry
+	nil,                                       // 165: common.CreatedTransaction.AccountMetadataEntry
+	nil,                                       // 166: common.SavedMetadata.MetadataEntry
+	nil,                                       // 167: common.LedgerInfo.AccountTypesEntry
+	nil,                                       // 168: common.LedgerInfo.MetadataEntry
+	nil,                                       // 169: common.SaveMetadataCommand.MetadataEntry
+	nil,                                       // 170: common.TransactionState.MetadataEntry
+	nil,                                       // 171: common.IdempotencyFailure.MetadataEntry
+	nil,                                       // 172: common.AccountType.SegmentTypesEntry
+	(*signaturepb.SignedLog)(nil),             // 173: signature.SignedLog
 }
 var file_common_proto_depIdxs = []int32{
 	18,  // 0: common.MetadataValue.null_value:type_name -> common.NullValue
-	152, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
+	153, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
 	22,  // 2: common.Posting.amount:type_name -> common.Uint256
 	23,  // 3: common.Transaction.postings:type_name -> common.Posting
-	153, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
+	154, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
 	17,  // 5: common.Transaction.timestamp:type_name -> common.Timestamp
 	17,  // 6: common.Transaction.inserted_at:type_name -> common.Timestamp
 	17,  // 7: common.Transaction.updated_at:type_name -> common.Timestamp
 	17,  // 8: common.Transaction.reverted_at:type_name -> common.Timestamp
-	154, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
-	155, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
-	156, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
-	157, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
+	155, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
+	156, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
+	157, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
+	158, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
 	17,  // 13: common.Account.first_usage:type_name -> common.Timestamp
 	17,  // 14: common.Account.insertion_date:type_name -> common.Timestamp
 	17,  // 15: common.Account.updated_at:type_name -> common.Timestamp
-	158, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
+	159, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
 	31,  // 17: common.Target.account:type_name -> common.TargetAccount
 	1,   // 18: common.MetadataFieldSchema.type:type_name -> common.MetadataType
-	159, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
-	160, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
-	161, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
+	160, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
+	161, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
+	162, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
 	0,   // 22: common.SetMetadataFieldTypeCommand.target_type:type_name -> common.TargetType
 	1,   // 23: common.SetMetadataFieldTypeCommand.type:type_name -> common.MetadataType
 	0,   // 24: common.MetadataIndexID.target:type_name -> common.TargetType
@@ -11689,7 +11766,7 @@ var file_common_proto_depIdxs = []int32{
 	17,  // 31: common.Index.created_at:type_name -> common.Timestamp
 	17,  // 32: common.Index.last_built_at:type_name -> common.Timestamp
 	42,  // 33: common.Log.payload:type_name -> common.LogPayload
-	172, // 34: common.Log.response_signature:type_name -> signature.SignedLog
+	173, // 34: common.Log.response_signature:type_name -> signature.SignedLog
 	77,  // 35: common.LogPayload.create_ledger:type_name -> common.CreatedLedgerLog
 	78,  // 36: common.LogPayload.delete_ledger:type_name -> common.DeletedLedgerLog
 	79,  // 37: common.LogPayload.apply:type_name -> common.ApplyLedgerLog
@@ -11732,10 +11809,10 @@ var file_common_proto_depIdxs = []int32{
 	51,  // 74: common.ClusterConfig.bloom_prepared_queries:type_name -> common.BloomTypeConfig
 	51,  // 75: common.ClusterConfig.bloom_indexes:type_name -> common.BloomTypeConfig
 	52,  // 76: common.PersistedClusterState.config:type_name -> common.ClusterConfig
-	138, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
-	120, // 78: common.UpdatedPreparedQueryLog.previous_filter:type_name -> common.QueryFilter
-	120, // 79: common.UpdatedPreparedQueryLog.new_filter:type_name -> common.QueryFilter
-	162, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
+	139, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
+	121, // 78: common.UpdatedPreparedQueryLog.previous_filter:type_name -> common.QueryFilter
+	121, // 79: common.UpdatedPreparedQueryLog.new_filter:type_name -> common.QueryFilter
+	163, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
 	17,  // 81: common.NumscriptInfo.created_at:type_name -> common.Timestamp
 	61,  // 82: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
 	71,  // 83: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
@@ -11751,7 +11828,7 @@ var file_common_proto_depIdxs = []int32{
 	34,  // 93: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
 	9,   // 94: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
 	97,  // 95: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
-	163, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
+	164, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
 	12,  // 97: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
 	17,  // 98: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
 	80,  // 99: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
@@ -11767,18 +11844,18 @@ var file_common_proto_depIdxs = []int32{
 	85,  // 109: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
 	83,  // 110: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
 	84,  // 111: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
-	117, // 112: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
-	118, // 113: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
-	119, // 114: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
+	118, // 112: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
+	119, // 113: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
+	120, // 114: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
 	37,  // 115: common.CreatedIndexLog.id:type_name -> common.IndexID
 	37,  // 116: common.DroppedIndexLog.id:type_name -> common.IndexID
 	24,  // 117: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	164, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	165, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
 	29,  // 119: common.CreatedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
 	24,  // 120: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
 	29,  // 121: common.RevertedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
 	32,  // 122: common.SavedMetadata.target:type_name -> common.Target
-	165, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	166, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
 	32,  // 124: common.DeletedMetadata.target:type_name -> common.Target
 	0,   // 125: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
 	1,   // 126: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
@@ -11792,102 +11869,103 @@ var file_common_proto_depIdxs = []int32{
 	92,  // 134: common.SealedChapterLog.chapter:type_name -> common.Chapter
 	92,  // 135: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
 	92,  // 136: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
-	98,  // 137: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
-	100, // 138: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
-	99,  // 139: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
-	101, // 140: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
-	17,  // 141: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
-	10,  // 142: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
-	102, // 143: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
-	17,  // 144: common.LedgerInfo.created_at:type_name -> common.Timestamp
-	17,  // 145: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
-	34,  // 146: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
-	9,   // 147: common.LedgerInfo.mode:type_name -> common.LedgerMode
-	97,  // 148: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
-	103, // 149: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	166, // 150: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
-	12,  // 151: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	167, // 152: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
-	32,  // 153: common.SaveMetadataCommand.target:type_name -> common.Target
-	168, // 154: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
-	32,  // 155: common.DeleteMetadataCommand.target:type_name -> common.Target
-	169, // 156: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
-	17,  // 157: common.TransactionState.timestamp:type_name -> common.Timestamp
-	109, // 158: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
-	11,  // 159: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	170, // 160: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	113, // 161: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	114, // 162: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	115, // 163: common.SegmentType.bytes:type_name -> common.BytesConstraint
-	13,  // 164: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	171, // 165: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	116, // 166: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
-	12,  // 167: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	131, // 168: common.QueryFilter.field:type_name -> common.FieldCondition
-	137, // 169: common.QueryFilter.address:type_name -> common.AddressMatch
-	127, // 170: common.QueryFilter.and:type_name -> common.AndFilter
-	128, // 171: common.QueryFilter.or:type_name -> common.OrFilter
-	129, // 172: common.QueryFilter.not:type_name -> common.NotFilter
-	121, // 173: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	124, // 174: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	122, // 175: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	123, // 176: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	125, // 177: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	126, // 178: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	132, // 179: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	132, // 180: common.LedgerCondition.cond:type_name -> common.StringCondition
-	134, // 181: common.LogIdCondition.cond:type_name -> common.UintCondition
-	3,   // 182: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	134, // 183: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	5,   // 184: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	134, // 185: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	120, // 186: common.AndFilter.filters:type_name -> common.QueryFilter
-	120, // 187: common.OrFilter.filters:type_name -> common.QueryFilter
-	120, // 188: common.NotFilter.filter:type_name -> common.QueryFilter
-	130, // 189: common.FieldCondition.field:type_name -> common.FieldRef
-	132, // 190: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	133, // 191: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	134, // 192: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	135, // 193: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	136, // 194: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 195: common.AddressMatch.role:type_name -> common.AddressRole
-	120, // 196: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 197: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 198: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 199: common.AggregatedVolume.output:type_name -> common.Uint256
-	139, // 200: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	141, // 201: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	139, // 202: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	30,  // 203: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 204: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	145, // 205: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	147, // 206: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	148, // 207: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	150, // 208: common.ListOptions.read:type_name -> common.ReadOptions
-	120, // 209: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 210: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 211: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	26,  // 212: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
-	28,  // 213: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 214: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	27,  // 215: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
-	33,  // 216: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 217: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 218: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 219: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	116, // 220: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 221: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 222: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	116, // 223: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 224: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 225: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 226: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	112, // 227: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	228, // [228:228] is the sub-list for method output_type
-	228, // [228:228] is the sub-list for method input_type
-	228, // [228:228] is the sub-list for extension type_name
-	228, // [228:228] is the sub-list for extension extendee
-	0,   // [0:228] is the sub-list for field type_name
+	99,  // 137: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
+	101, // 138: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
+	98,  // 139: common.MirrorSourceConfig.address_rewrite_rules:type_name -> common.AddressRewriteRule
+	100, // 140: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
+	102, // 141: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
+	17,  // 142: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
+	10,  // 143: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
+	103, // 144: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
+	17,  // 145: common.LedgerInfo.created_at:type_name -> common.Timestamp
+	17,  // 146: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
+	34,  // 147: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
+	9,   // 148: common.LedgerInfo.mode:type_name -> common.LedgerMode
+	97,  // 149: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
+	104, // 150: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
+	167, // 151: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	12,  // 152: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	168, // 153: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	32,  // 154: common.SaveMetadataCommand.target:type_name -> common.Target
+	169, // 155: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	32,  // 156: common.DeleteMetadataCommand.target:type_name -> common.Target
+	170, // 157: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	17,  // 158: common.TransactionState.timestamp:type_name -> common.Timestamp
+	110, // 159: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	11,  // 160: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
+	171, // 161: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	114, // 162: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	115, // 163: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	116, // 164: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	13,  // 165: common.AccountType.persistence:type_name -> common.AccountTypePersistence
+	172, // 166: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	117, // 167: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	12,  // 168: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
+	132, // 169: common.QueryFilter.field:type_name -> common.FieldCondition
+	138, // 170: common.QueryFilter.address:type_name -> common.AddressMatch
+	128, // 171: common.QueryFilter.and:type_name -> common.AndFilter
+	129, // 172: common.QueryFilter.or:type_name -> common.OrFilter
+	130, // 173: common.QueryFilter.not:type_name -> common.NotFilter
+	122, // 174: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	125, // 175: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	123, // 176: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	124, // 177: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	126, // 178: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	127, // 179: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	133, // 180: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	133, // 181: common.LedgerCondition.cond:type_name -> common.StringCondition
+	135, // 182: common.LogIdCondition.cond:type_name -> common.UintCondition
+	3,   // 183: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	135, // 184: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	5,   // 185: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	135, // 186: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	121, // 187: common.AndFilter.filters:type_name -> common.QueryFilter
+	121, // 188: common.OrFilter.filters:type_name -> common.QueryFilter
+	121, // 189: common.NotFilter.filter:type_name -> common.QueryFilter
+	131, // 190: common.FieldCondition.field:type_name -> common.FieldRef
+	133, // 191: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	134, // 192: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	135, // 193: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	136, // 194: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	137, // 195: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	14,  // 196: common.AddressMatch.role:type_name -> common.AddressRole
+	121, // 197: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	15,  // 198: common.PreparedQuery.target:type_name -> common.QueryTarget
+	22,  // 199: common.AggregatedVolume.input:type_name -> common.Uint256
+	22,  // 200: common.AggregatedVolume.output:type_name -> common.Uint256
+	140, // 201: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	142, // 202: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	140, // 203: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	30,  // 204: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	24,  // 205: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	146, // 206: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	148, // 207: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	149, // 208: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	151, // 209: common.ListOptions.read:type_name -> common.ReadOptions
+	121, // 210: common.ListOptions.filter:type_name -> common.QueryFilter
+	19,  // 211: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	19,  // 212: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	26,  // 213: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
+	28,  // 214: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	19,  // 215: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	27,  // 216: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
+	33,  // 217: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 218: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 219: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	19,  // 220: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 221: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 222: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	19,  // 223: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 224: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	19,  // 225: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 226: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 227: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	113, // 228: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	229, // [229:229] is the sub-list for method output_type
+	229, // [229:229] is the sub-list for method input_type
+	229, // [229:229] is the sub-list for extension type_name
+	229, // [229:229] is the sub-list for extension extendee
+	0,   // [0:229] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }
@@ -11977,13 +12055,13 @@ func file_common_proto_init() {
 		(*MirrorSourceConfig_Http)(nil),
 		(*MirrorSourceConfig_Postgres)(nil),
 	}
-	file_common_proto_msgTypes[95].OneofWrappers = []any{
+	file_common_proto_msgTypes[96].OneofWrappers = []any{
 		(*SegmentType_Regex)(nil),
 		(*SegmentType_Uuid)(nil),
 		(*SegmentType_Uint64)(nil),
 		(*SegmentType_Bytes)(nil),
 	}
-	file_common_proto_msgTypes[103].OneofWrappers = []any{
+	file_common_proto_msgTypes[104].OneofWrappers = []any{
 		(*QueryFilter_Field)(nil),
 		(*QueryFilter_Address)(nil),
 		(*QueryFilter_And)(nil),
@@ -11996,34 +12074,34 @@ func file_common_proto_init() {
 		(*QueryFilter_LogBuiltinUint)(nil),
 		(*QueryFilter_AccountHasAsset)(nil),
 	}
-	file_common_proto_msgTypes[114].OneofWrappers = []any{
+	file_common_proto_msgTypes[115].OneofWrappers = []any{
 		(*FieldCondition_StringCond)(nil),
 		(*FieldCondition_IntCond)(nil),
 		(*FieldCondition_UintCond)(nil),
 		(*FieldCondition_BoolCond)(nil),
 		(*FieldCondition_ExistsCond)(nil),
 	}
-	file_common_proto_msgTypes[115].OneofWrappers = []any{
+	file_common_proto_msgTypes[116].OneofWrappers = []any{
 		(*StringCondition_Hardcoded)(nil),
 		(*StringCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[116].OneofWrappers = []any{}
 	file_common_proto_msgTypes[117].OneofWrappers = []any{}
-	file_common_proto_msgTypes[118].OneofWrappers = []any{
+	file_common_proto_msgTypes[118].OneofWrappers = []any{}
+	file_common_proto_msgTypes[119].OneofWrappers = []any{
 		(*BoolCondition_Hardcoded)(nil),
 		(*BoolCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[120].OneofWrappers = []any{
+	file_common_proto_msgTypes[121].OneofWrappers = []any{
 		(*AddressMatch_HardcodedPrefix)(nil),
 		(*AddressMatch_HardcodedExact)(nil),
 		(*AddressMatch_ParamPrefix)(nil),
 		(*AddressMatch_ParamExact)(nil),
 	}
-	file_common_proto_msgTypes[128].OneofWrappers = []any{
+	file_common_proto_msgTypes[129].OneofWrappers = []any{
 		(*CallerIdentity_Issuer)(nil),
 		(*CallerIdentity_KeyId)(nil),
 	}
-	file_common_proto_msgTypes[132].OneofWrappers = []any{
+	file_common_proto_msgTypes[133].OneofWrappers = []any{
 		(*BackupStorage_S3)(nil),
 		(*BackupStorage_Azure)(nil),
 	}
@@ -12033,7 +12111,7 @@ func file_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_common_proto_rawDesc), len(file_common_proto_rawDesc)),
 			NumEnums:      17,
-			NumMessages:   155,
+			NumMessages:   156,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -2101,6 +2101,17 @@ func (m *MirrorSourceConfig) MarshalDeterministicVT(dAtA []byte) []byte {
 	return append(dAtA, b...)
 }
 
+func (m *AddressRewriteRule) MarshalDeterministicVT(dAtA []byte) []byte {
+	if m == nil {
+		return dAtA
+	}
+	b, err := m.MarshalVT()
+	if err != nil {
+		panic("MarshalDeterministicVT: " + err.Error())
+	}
+	return append(dAtA, b...)
+}
+
 func (m *HttpMirrorSourceConfig) MarshalDeterministicVT(dAtA []byte) []byte {
 	if m == nil {
 		return dAtA

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -6648,6 +6648,7 @@ func NewConfirmedArchiveChapterLogListReader(s []*ConfirmedArchiveChapterLog) Co
 type MirrorSourceConfigReader interface {
 	GetLedgerName() string
 	GetBatchSize() uint32
+	GetAddressRewriteRules() AddressRewriteRuleListReader
 	GetType() isMirrorSourceConfig_Type
 	Mutate() *MirrorSourceConfig
 }
@@ -6660,6 +6661,10 @@ func (r *mirrorSourceConfigReadonly) GetLedgerName() string {
 
 func (r *mirrorSourceConfigReadonly) GetBatchSize() uint32 {
 	return r.v.GetBatchSize()
+}
+
+func (r *mirrorSourceConfigReadonly) GetAddressRewriteRules() AddressRewriteRuleListReader {
+	return NewAddressRewriteRuleListReader(r.v.GetAddressRewriteRules())
 }
 
 func (r *mirrorSourceConfigReadonly) GetType() isMirrorSourceConfig_Type {
@@ -6718,6 +6723,78 @@ func (l mirrorSourceConfigListReadonly) Range(yield func(int, MirrorSourceConfig
 // view aliases the underlying slice; do not mutate s afterwards.
 func NewMirrorSourceConfigListReader(s []*MirrorSourceConfig) MirrorSourceConfigListReader {
 	return mirrorSourceConfigListReadonly(s)
+}
+
+// AddressRewriteRuleReader provides read-only access to AddressRewriteRule.
+// Call Mutate() to obtain a mutable clone.
+type AddressRewriteRuleReader interface {
+	GetPattern() string
+	GetReplacement() string
+	Mutate() *AddressRewriteRule
+}
+
+type addressRewriteRuleReadonly struct{ v *AddressRewriteRule }
+
+func (r *addressRewriteRuleReadonly) GetPattern() string {
+	return r.v.GetPattern()
+}
+
+func (r *addressRewriteRuleReadonly) GetReplacement() string {
+	return r.v.GetReplacement()
+}
+
+func (r *addressRewriteRuleReadonly) Mutate() *AddressRewriteRule {
+	return r.v.CloneVT()
+}
+
+// AsReader returns a read-only view of this AddressRewriteRule.
+func (m *AddressRewriteRule) AsReader() AddressRewriteRuleReader {
+	if m == nil {
+		return nil
+	}
+	return &addressRewriteRuleReadonly{v: m}
+}
+
+// Mutate returns a mutable deep clone of this AddressRewriteRule.
+func (m *AddressRewriteRule) Mutate() *AddressRewriteRule {
+	return m.CloneVT()
+}
+
+// AddressRewriteRuleListReader provides read-only iteration over []*AddressRewriteRule.
+type AddressRewriteRuleListReader interface {
+	Len() int
+	Get(i int) AddressRewriteRuleReader
+	Range(yield func(int, AddressRewriteRuleReader) bool)
+}
+
+type addressRewriteRuleListReadonly []*AddressRewriteRule
+
+func (l addressRewriteRuleListReadonly) Len() int { return len(l) }
+
+func (l addressRewriteRuleListReadonly) Get(i int) AddressRewriteRuleReader {
+	v := l[i]
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
+}
+
+func (l addressRewriteRuleListReadonly) Range(yield func(int, AddressRewriteRuleReader) bool) {
+	for i, v := range l {
+		var r AddressRewriteRuleReader
+		if v != nil {
+			r = v.AsReader()
+		}
+		if !yield(i, r) {
+			return
+		}
+	}
+}
+
+// NewAddressRewriteRuleListReader wraps s for read-only iteration. The returned
+// view aliases the underlying slice; do not mutate s afterwards.
+func NewAddressRewriteRuleListReader(s []*AddressRewriteRule) AddressRewriteRuleListReader {
+	return addressRewriteRuleListReadonly(s)
 }
 
 // HttpMirrorSourceConfigReader provides read-only access to HttpMirrorSourceConfig.

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -2236,6 +2236,13 @@ func (m *MirrorSourceConfig) CloneVT() *MirrorSourceConfig {
 			CloneVT() isMirrorSourceConfig_Type
 		}).CloneVT()
 	}
+	if rhs := m.AddressRewriteRules; rhs != nil {
+		tmpContainer := make([]*AddressRewriteRule, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.AddressRewriteRules = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2263,6 +2270,24 @@ func (m *MirrorSourceConfig_Postgres) CloneVT() isMirrorSourceConfig_Type {
 	r := new(MirrorSourceConfig_Postgres)
 	r.Postgres = m.Postgres.CloneVT()
 	return r
+}
+
+func (m *AddressRewriteRule) CloneVT() *AddressRewriteRule {
+	if m == nil {
+		return (*AddressRewriteRule)(nil)
+	}
+	r := new(AddressRewriteRule)
+	r.Pattern = m.Pattern
+	r.Replacement = m.Replacement
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *AddressRewriteRule) CloneMessageVT() proto.Message {
+	return m.CloneVT()
 }
 
 func (m *HttpMirrorSourceConfig) CloneVT() *HttpMirrorSourceConfig {
@@ -7391,6 +7416,23 @@ func (this *MirrorSourceConfig) EqualVT(that *MirrorSourceConfig) bool {
 	if this.BatchSize != that.BatchSize {
 		return false
 	}
+	if len(this.AddressRewriteRules) != len(that.AddressRewriteRules) {
+		return false
+	}
+	for i, vx := range this.AddressRewriteRules {
+		vy := that.AddressRewriteRules[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &AddressRewriteRule{}
+			}
+			if q == nil {
+				q = &AddressRewriteRule{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -7451,6 +7493,28 @@ func (this *MirrorSourceConfig_Postgres) EqualVT(thatIface isMirrorSourceConfig_
 	return true
 }
 
+func (this *AddressRewriteRule) EqualVT(that *AddressRewriteRule) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Pattern != that.Pattern {
+		return false
+	}
+	if this.Replacement != that.Replacement {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *AddressRewriteRule) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*AddressRewriteRule)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *HttpMirrorSourceConfig) EqualVT(that *HttpMirrorSourceConfig) bool {
 	if this == that {
 		return true
@@ -15352,6 +15416,18 @@ func (m *MirrorSourceConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if len(m.AddressRewriteRules) > 0 {
+		for iNdEx := len(m.AddressRewriteRules) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.AddressRewriteRules[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
 	if m.BatchSize != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.BatchSize))
 		i--
@@ -15405,6 +15481,53 @@ func (m *MirrorSourceConfig_Postgres) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	}
 	return len(dAtA) - i, nil
 }
+func (m *AddressRewriteRule) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AddressRewriteRule) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AddressRewriteRule) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Replacement) > 0 {
+		i -= len(m.Replacement)
+		copy(dAtA[i:], m.Replacement)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Replacement)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Pattern) > 0 {
+		i -= len(m.Pattern)
+		copy(dAtA[i:], m.Pattern)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Pattern)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *HttpMirrorSourceConfig) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -21337,6 +21460,12 @@ func (m *MirrorSourceConfig) SizeVT() (n int) {
 	if m.BatchSize != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.BatchSize))
 	}
+	if len(m.AddressRewriteRules) > 0 {
+		for _, e := range m.AddressRewriteRules {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -21365,6 +21494,24 @@ func (m *MirrorSourceConfig_Postgres) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *AddressRewriteRule) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Pattern)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Replacement)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *HttpMirrorSourceConfig) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -36592,6 +36739,155 @@ func (m *MirrorSourceConfig) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AddressRewriteRules", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AddressRewriteRules = append(m.AddressRewriteRules, &AddressRewriteRule{})
+			if err := m.AddressRewriteRules[len(m.AddressRewriteRules)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AddressRewriteRule) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AddressRewriteRule: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AddressRewriteRule: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pattern", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Pattern = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replacement", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Replacement = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -777,6 +777,24 @@ message MirrorSourceConfig {
     PostgresMirrorSourceConfig postgres = 3;
   }
   uint32 batch_size = 4;  // Max logs per batch (0 = default 100). Client's responsibility to avoid saturating the instance.
+  // Rewrite rules applied, in order, to every account address as v2 logs are
+  // translated into v3 orders. Used to drop or rename address segments that v2
+  // only carried as lock-avoidance shards (e.g. ":worker:001"). See
+  // AddressRewriteRule.
+  repeated AddressRewriteRule address_rewrite_rules = 5;
+}
+
+// AddressRewriteRule rewrites account addresses during mirror translation.
+// pattern is a Go (RE2) regular expression matched against the full account
+// address; every match is replaced with replacement (which may reference
+// capture groups). An empty replacement drops the matched part, e.g. pattern
+// "(:worker:\\d+)" turns "payments:acme:worker:001:main" into
+// "payments:acme:main". Rewriting is a pure translation-time projection: the
+// source v2 ledger is never modified, and the rewritten address must still be
+// a valid ledger account address.
+message AddressRewriteRule {
+  string pattern = 1;
+  string replacement = 2;
 }
 
 message HttpMirrorSourceConfig {

--- a/openapi.yml
+++ b/openapi.yml
@@ -3161,6 +3161,32 @@ components:
           minimum: 0
           default: 0
           description: Max logs per batch (0 = server default 100, capped by server's --mirror-max-batch-size)
+        addressRewriteRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/AddressRewriteRule'
+          description: >
+            Rewrite rules applied, in order, to every account address as v2 logs
+            are translated into v3 orders. Used to drop or rename address
+            segments v2 only carried as lock-avoidance shards.
+
+    AddressRewriteRule:
+      type: object
+      description: >
+        Rewrites account addresses during mirror translation. `pattern` is an
+        RE2 regular expression matched against the full account address; matches
+        are replaced with `replacement` (which may reference capture groups). An
+        empty `replacement` drops the matched part, e.g. pattern `(:worker:\d+)`
+        turns `payments:acme:worker:001:main` into `payments:acme:main`. The
+        rewritten address must still be a valid account address.
+      required:
+        - pattern
+        - replacement
+      properties:
+        pattern:
+          type: string
+        replacement:
+          type: string
 
     SaveNumscriptRequest:
       type: object


### PR DESCRIPTION
## What

Adds optional **account-address rewrite rules** to a mirror ledger's `MirrorSourceConfig`. As the mirror worker ingests a v2 source and translates its logs into v3 orders, each rule (`{pattern, replacement}`, applied in order) rewrites every account address — letting segments v2 only carried as lock-avoidance shards be dropped or renamed during migration.

Example: rule `{"pattern": "(:worker:\\d+)", "replacement": ""}` turns `payments:acme:worker:001:main` into `payments:acme:main`.

```bash
# ledgerctl
ledgerctl ledgers create --name main --mode=mirror \
  --mirror-base-url=http://v2:8080 \
  --mirror-address-rewrite='(:worker:\d+)='
```
```jsonc
// HTTP: POST /{ledger}
{ "mode": "MIRROR", "mirrorSource": {
    "ledgerName": "main", "type": "http", "baseUrl": "http://v2:8080",
    "addressRewriteRules": [ { "pattern": "(:worker:\\d+)", "replacement": "" } ] } }
```

## How

- **Rewrite in the translator** (`internal/adapter/v2`, new `AddressRewriter`) at the three address-bearing choke points: posting source/destination, metadata account targets, and account-metadata map keys.
- **Nothing downstream changes** — coverage/preload and the FSM read the already-translated payload, and volumes are derived from the rewritten postings on apply.
- **Pure projection** — the source v2 ledger is never modified; only the leader translates/proposes, so followers apply identical addresses (no cross-node determinism concern beyond RE2 being deterministic).
- **Collisions** — when two source addresses collapse onto one, their account-metadata maps merge (value from the lexicographically-smallest source address wins).
- **Fail loud** — rule regexes are compile-checked at admission (`ErrMirrorAddressRewritePatternInvalid`); a rewrite that yields an invalid address fails the batch, so the cursor never advances and the worker retries (standard translation-error path).

## Touched surface

- Proto: `MirrorSourceConfig.address_rewrite_rules` + `AddressRewriteRule` (`misc/proto/common.proto`, regenerated).
- Translator threading + `AddressRewriter`; `Manager.reconcile → Worker → TranslateBatch`.
- Admission validation; `ledgerctl` create flag/parse/render; HTTP create-ledger handler; `openapi.yml`; architecture docs (`events-mirror/mirror.md`).

## Tests

- `AddressRewriter` (drop/rename/order/invalid-output/nil pass-through).
- Translator with rules: created + reverted postings, metadata targets (account rewritten, transaction untouched), account-metadata **collision merge**, invalid-result error.
- Admission (valid rules accepted, invalid regex rejected), `ledgerctl` flag parsing, HTTP handler + `mirrorSourceToProto`.

Build, `go vet`, and `golangci-lint` are clean on all changed packages.

## Notes for reviewers

- **Collision semantics** (merge, smallest-source-wins) is a deliberate default for the lock-shard use case — flag if you'd prefer rejecting collisions.
- Not added: an end-to-end cluster test (`tests/e2e/cluster`) exercising rewrite rules through a live mirror — it needs a running cluster and wasn't validated locally.