### PR TITLE
refactor: homogenize source/destination naming to full words

### DIFF
--- a/cmd/ledgerctl/indexes/create.go
+++ b/cmd/ledgerctl/indexes/create.go
@@ -23,7 +23,7 @@ func NewCreateCommand() *cobra.Command {
 Index types:
   address              Account→transaction mapping (any role)
   source-address       Source account→transaction mapping
-  dest-address         Destination account→transaction mapping
+  destination-address  Destination account→transaction mapping
   metadata             Metadata field index (requires --target and --key)
   reference            Transaction reference index (exact-match filter)
   timestamp            Transaction timestamp index (range filter)
@@ -46,7 +46,7 @@ Examples:
 	}
 
 	cmd.Flags().String("ledger", "", "Name of the ledger")
-	cmd.Flags().String("type", "", "Index type: address, source-address, dest-address, metadata")
+	cmd.Flags().String("type", "", "Index type: address, source-address, destination-address, metadata")
 	cmdutil.RegisterEnumCompletion(cmd, "type", indexTypeOptions...)
 	cmd.Flags().String("target", "", "Target type for metadata index: account, transaction, or ledger")
 	cmdutil.RegisterEnumCompletion(cmd, "target", cmdutil.TargetTypeOptions()...)
@@ -101,9 +101,9 @@ func runCreateIndex(cmd *cobra.Command, _ []string) error {
 	case "source-address":
 		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
 		indexDesc = "source-address"
-	case "dest-address":
-		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)
-		indexDesc = "dest-address"
+	case "destination-address":
+		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)
+		indexDesc = "destination-address"
 	case "metadata":
 		target, key, err := resolveMetadataIndexFlags(cmd)
 		if err != nil {
@@ -125,7 +125,7 @@ func runCreateIndex(cmd *cobra.Command, _ []string) error {
 		req.Id = accountBuiltinIndexID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
 		indexDesc = "account has-asset"
 	default:
-		return fmt.Errorf("invalid index type %q: must be address, source-address, dest-address, metadata, reference, timestamp, inserted-at, log-ledger, or account-asset", indexType)
+		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, log-ledger, or account-asset", indexType)
 	}
 
 	ctx, cancel := cmdutil.GetContext(cmd)

--- a/cmd/ledgerctl/indexes/drop.go
+++ b/cmd/ledgerctl/indexes/drop.go
@@ -23,7 +23,7 @@ and frees the associated storage.
 Index types:
   address              Account→transaction mapping (any role)
   source-address       Source account→transaction mapping
-  dest-address         Destination account→transaction mapping
+  destination-address  Destination account→transaction mapping
   metadata             Metadata field index (requires --target and --key)
   account-asset        Account asset-presence index (the 'has asset' account filter)
 
@@ -37,7 +37,7 @@ Examples:
 	}
 
 	cmd.Flags().String("ledger", "", "Name of the ledger")
-	cmd.Flags().String("type", "", "Index type: address, source-address, dest-address, metadata")
+	cmd.Flags().String("type", "", "Index type: address, source-address, destination-address, metadata")
 	cmdutil.RegisterEnumCompletion(cmd, "type", indexTypeOptions...)
 	cmd.Flags().String("target", "", "Target type for metadata index: account, transaction, or ledger")
 	cmdutil.RegisterEnumCompletion(cmd, "target", cmdutil.TargetTypeOptions()...)
@@ -92,9 +92,9 @@ func runDropIndex(cmd *cobra.Command, _ []string) error {
 	case "source-address":
 		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
 		indexDesc = "source-address"
-	case "dest-address":
-		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)
-		indexDesc = "dest-address"
+	case "destination-address":
+		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)
+		indexDesc = "destination-address"
 	case "metadata":
 		target, key, err := resolveMetadataIndexFlags(cmd)
 		if err != nil {
@@ -116,7 +116,7 @@ func runDropIndex(cmd *cobra.Command, _ []string) error {
 		req.Id = accountBuiltinIndexID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
 		indexDesc = "account has-asset"
 	default:
-		return fmt.Errorf("invalid index type %q: must be address, source-address, dest-address, metadata, reference, timestamp, inserted-at, or account-asset", indexType)
+		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, or account-asset", indexType)
 	}
 
 	ctx, cancel := cmdutil.GetContext(cmd)

--- a/cmd/ledgerctl/indexes/id_helpers.go
+++ b/cmd/ledgerctl/indexes/id_helpers.go
@@ -11,7 +11,7 @@ import "github.com/formancehq/ledger/v3/internal/proto/commonpb"
 var indexTypeOptions = []string{
 	"address",
 	"source-address",
-	"dest-address",
+	"destination-address",
 	"metadata",
 	"reference",
 	"timestamp",

--- a/cmd/ledgerctl/indexes/list.go
+++ b/cmd/ledgerctl/indexes/list.go
@@ -184,8 +184,8 @@ func describeIndex(id *commonpb.IndexID) (typeName, target, key string) {
 			return "address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS:
 			return "source-address", "-", "-"
-		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS:
-			return "dest-address", "-", "-"
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS:
+			return "destination-address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			return "inserted-at", "-", "-"
 		}

--- a/cmd/ledgerctl/ledgers/config_model.go
+++ b/cmd/ledgerctl/ledgers/config_model.go
@@ -44,12 +44,12 @@ type EditableMetaField struct {
 
 // EditableIndexes represents the set of enabled builtin indexes.
 type EditableIndexes struct {
-	Reference     bool `json:"reference"     yaml:"reference"`
-	Timestamp     bool `json:"timestamp"     yaml:"timestamp"`
-	Address       bool `json:"address"       yaml:"address"`
-	SourceAddress bool `json:"sourceAddress" yaml:"sourceAddress"`
-	DestAddress   bool `json:"destAddress"   yaml:"destAddress"`
-	InsertedAt    bool `json:"insertedAt"    yaml:"insertedAt"`
+	Reference          bool `json:"reference"          yaml:"reference"`
+	Timestamp          bool `json:"timestamp"          yaml:"timestamp"`
+	Address            bool `json:"address"            yaml:"address"`
+	SourceAddress      bool `json:"sourceAddress"      yaml:"sourceAddress"`
+	DestinationAddress bool `json:"destinationAddress" yaml:"destinationAddress"`
+	InsertedAt         bool `json:"insertedAt"         yaml:"insertedAt"`
 }
 
 // EditablePreparedQuery is the editable subset of a prepared query.
@@ -158,8 +158,8 @@ func ConfigFromProto(
 			cfg.Indexes.Address = true
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS:
 			cfg.Indexes.SourceAddress = true
-		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS:
-			cfg.Indexes.DestAddress = true
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS:
+			cfg.Indexes.DestinationAddress = true
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			cfg.Indexes.InsertedAt = true
 		}
@@ -564,7 +564,7 @@ func diffIndexes(ledgerName string, current, desired *EditableConfig) []DiffActi
 		{"timestamp", current.Indexes.Timestamp, desired.Indexes.Timestamp, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP},
 		{"address", current.Indexes.Address, desired.Indexes.Address, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS},
 		{"source-address", current.Indexes.SourceAddress, desired.Indexes.SourceAddress, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS},
-		{"dest-address", current.Indexes.DestAddress, desired.Indexes.DestAddress, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS},
+		{"destination-address", current.Indexes.DestinationAddress, desired.Indexes.DestinationAddress, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS},
 		{"inserted-at", current.Indexes.InsertedAt, desired.Indexes.InsertedAt, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT},
 	}
 

--- a/cmd/ledgerctl/ledgers/configuration.go
+++ b/cmd/ledgerctl/ledgers/configuration.go
@@ -258,8 +258,8 @@ func describeIndex(id *commonpb.IndexID) (typeName, target, key string) {
 			return "address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS:
 			return "source-address", "-", "-"
-		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS:
-			return "dest-address", "-", "-"
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS:
+			return "destination-address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			return "inserted-at", "-", "-"
 		}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -563,7 +563,7 @@ ledgerctl indexes create [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--ledger` | | Name of the ledger |
-| `--type` | | Index type: `address`, `source-address`, `dest-address`, `metadata`, `reference`, `timestamp`, `inserted-at`, `account-asset` |
+| `--type` | | Index type: `address`, `source-address`, `destination-address`, `metadata`, `reference`, `timestamp`, `inserted-at`, `account-asset` |
 | `--target` | | Target type for metadata index: `account` or `transaction` |
 | `--key` | | Metadata key name (for metadata index) |
 | `--timeout` | `10s` | Request timeout |
@@ -574,7 +574,7 @@ ledgerctl indexes create [flags]
 |------|-------------|
 | `address` | Account-to-transaction mapping for any posting role |
 | `source-address` | Source account-to-transaction mapping |
-| `dest-address` | Destination account-to-transaction mapping |
+| `destination-address` | Destination account-to-transaction mapping |
 | `metadata` | Metadata field index (requires `--target` and `--key`) |
 | `reference` | Transaction reference exact-match index |
 | `timestamp` | Transaction timestamp (effective date) range-scan index |
@@ -587,7 +587,7 @@ ledgerctl indexes create [flags]
 - The index starts building in the background immediately
 - Queries using the index will be rejected until the index reaches READY status
 - Creating an index that already exists and is READY is idempotent (no error)
-- `--target` and `--key` are only valid with `--type metadata`; passing them with any other type is rejected. In particular, there is no builtin address index scoped to accounts — `address`, `source-address`, and `dest-address` all index transactions.
+- `--target` and `--key` are only valid with `--type metadata`; passing them with any other type is rejected. In particular, there is no builtin address index scoped to accounts — `address`, `source-address`, and `destination-address` all index transactions.
 
 **Example:**
 
@@ -632,7 +632,7 @@ ledgerctl indexes drop [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--ledger` | | Name of the ledger |
-| `--type` | | Index type: `address`, `source-address`, `dest-address`, `metadata`, `reference`, `timestamp`, `inserted-at`, `account-asset` |
+| `--type` | | Index type: `address`, `source-address`, `destination-address`, `metadata`, `reference`, `timestamp`, `inserted-at`, `account-asset` |
 | `--target` | | Target type for metadata index: `account` or `transaction` |
 | `--key` | | Metadata key name (for metadata index) |
 | `--timeout` | `10s` | Request timeout |

--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -78,7 +78,7 @@ flowchart TB
 
 | Log type | Handler | What it writes |
 |----------|---------|---------------|
-| `CreatedTransaction` | `indexCreatedTransaction` | Postings-address mappings (any / source / destination via `WriteAccountTxMapping` + `WriteSourceAccountTxMapping` + `WriteDestAccountTxMapping`), reference / timestamp / inserted-at builtin indexes, account-metadata via `dualWriteMetadataIndex`, transaction-metadata via `dualWriteMetadataIndex`. Existence rows are written by `dualWriteMetadataIndex` *only* for entities that carry an indexed metadata key — there is no standalone transaction-existence or account-existence write. |
+| `CreatedTransaction` | `indexCreatedTransaction` | Postings-address mappings (any / source / destination via `WriteAccountTxMapping` + `WriteSourceAccountTxMapping` + `WriteDestinationAccountTxMapping`), reference / timestamp / inserted-at builtin indexes, account-metadata via `dualWriteMetadataIndex`, transaction-metadata via `dualWriteMetadataIndex`. Existence rows are written by `dualWriteMetadataIndex` *only* for entities that carry an indexed metadata key — there is no standalone transaction-existence or account-existence write. |
 | `RevertedTransaction` | `indexRevertedTransaction` | Inverse adjustments to the postings mappings; the revert link is kept (not deleted) so revert lookups stay queryable. |
 | `SavedMetadata` | `indexSavedMetadata` → `dualWriteMetadataIndex` | New `(value, entity)` row in the metadata index, plus a reverse-map row for later schema rewrites. |
 | `DeletedMetadata` | `indexDeletedMetadata` → `dualDeleteMetadataEntry` | Removes the metadata index row and the reverse-map row. |

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -377,7 +377,7 @@ Prepared queries are reusable, named filter queries stored per-ledger. They can 
 |------------|----------|---------|
 | `address` | `--type address` | `AddressMatch` on transaction queries |
 | `source-address` | `--type source-address` | source-only address matching |
-| `dest-address` | `--type dest-address` | destination-only address matching |
+| `destination-address` | `--type destination-address` | destination-only address matching |
 | `metadata` | `--type metadata --target … --key …` | `FieldCondition` on the specified field |
 | `reference` | `--type reference` | `ReferenceCondition` |
 | `timestamp` | `--type timestamp` | `BuiltinUintCondition(TIMESTAMP)` |

--- a/internal/application/indexbuilder/backfill_postings.go
+++ b/internal/application/indexbuilder/backfill_postings.go
@@ -12,7 +12,7 @@ import (
 )
 
 // processBackfillPostings is the fast path for backfilling posting-related
-// indexes (ADDRESS, SOURCE_ADDRESS, DEST_ADDRESS). It reads raw Pebble values
+// indexes (ADDRESS, SOURCE_ADDRESS, DESTINATION_ADDRESS). It reads raw Pebble values
 // and uses a protowire parser that only extracts the fields needed for posting
 // indexation (~30% of the payload), skipping metadata, balances, volumes,
 // timestamps, signatures and hash.
@@ -46,9 +46,9 @@ func (b *Builder) processBackfillPostings(ctx context.Context, stop <-chan struc
 	// cfg (account-by-asset hook), so exactly one of the two backfill modes
 	// is active per task.
 	var (
-		indexAny bool
-		indexSrc bool
-		indexDst bool
+		indexAny         bool
+		indexSource      bool
+		indexDestination bool
 		// cfg controls the account-by-asset hook in indexPostingAddressMappings.
 		// An empty config leaves ACCT_BUILTIN_INDEX_ASSET unregistered so the
 		// hook is a no-op; only the account-asset task registers it.
@@ -60,8 +60,8 @@ func (b *Builder) processBackfillPostings(ctx context.Context, stop <-chan struc
 		// A tx-address builtin task: turn on the matching address-mapping
 		// flag and leave the account-by-asset hook off (cfg stays empty).
 		indexAny = k.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS
-		indexSrc = k.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS
-		indexDst = k.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS
+		indexSource = k.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS
+		indexDestination = k.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS
 	case *commonpb.IndexID_AccountBuiltin:
 		if k.AccountBuiltin != commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET {
 			// Unreachable by design: isPostingIndex only routes the account
@@ -172,7 +172,7 @@ func (b *Builder) processBackfillPostings(ctx context.Context, stop <-chan struc
 				p := &parsed.Postings[i]
 				if err := b.indexPostingAddressMappings(
 					kb, cfg, parsed.Ledger, parsed.TxID, p.Source, p.Destination, p.Asset,
-					indexAny, indexSrc, indexDst, excludedVolumes,
+					indexAny, indexSource, indexDestination, excludedVolumes,
 				); err != nil {
 					_ = batch.Cancel()
 
@@ -230,14 +230,14 @@ func (b *Builder) processBackfillPostings(ctx context.Context, stop <-chan struc
 
 // isPostingIndex returns true if the index is replayed through the shared
 // posting walk during backfill: the transaction builtin address indexes
-// (ADDRESS, SOURCE_ADDRESS, DEST_ADDRESS) and the account has-asset index.
+// (ADDRESS, SOURCE_ADDRESS, DESTINATION_ADDRESS) and the account has-asset index.
 func isPostingIndex(id *commonpb.IndexID) bool {
 	switch k := id.GetKind().(type) {
 	case *commonpb.IndexID_TxBuiltin:
 		switch k.TxBuiltin {
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS,
 			commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS,
-			commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS:
+			commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS:
 			return true
 		}
 	case *commonpb.IndexID_AccountBuiltin:

--- a/internal/application/indexbuilder/backfill_test.go
+++ b/internal/application/indexbuilder/backfill_test.go
@@ -320,7 +320,7 @@ func TestIndexPostingAddressMappingsSkipsExcludedAccounts(t *testing.T) {
 		dal.NewKeyBuilder(), readstore.PrefixAccountTx, "test", "kept:dest", 42,
 	)))
 	assert.True(t, readStoreKeyExists(t, store, readstore.AccountTxKey(
-		dal.NewKeyBuilder(), readstore.PrefixDestAccountTx, "test", "kept:dest", 42,
+		dal.NewKeyBuilder(), readstore.PrefixDestinationAccountTx, "test", "kept:dest", 42,
 	)))
 	assert.True(t, readStoreKeyExists(t, store, readstore.AccountTxKey(
 		dal.NewKeyBuilder(), readstore.PrefixAccountTx, "test", "kept:source", 43,
@@ -332,7 +332,7 @@ func TestIndexPostingAddressMappingsSkipsExcludedAccounts(t *testing.T) {
 		dal.NewKeyBuilder(), readstore.PrefixAccountTx, "test", "purged:dest", 43,
 	)))
 	assert.False(t, readStoreKeyExists(t, store, readstore.AccountTxKey(
-		dal.NewKeyBuilder(), readstore.PrefixDestAccountTx, "test", "purged:dest", 43,
+		dal.NewKeyBuilder(), readstore.PrefixDestinationAccountTx, "test", "purged:dest", 43,
 	)))
 
 	// Multi-asset: shared:account USD (tx 44) is excluded, EUR (tx 45) is not.
@@ -406,7 +406,7 @@ func TestIndexPostingAddressMappingsWritesAccountByAsset(t *testing.T) {
 
 	cfg := acctAssetConfig()
 
-	// source=accounts:alice dest=accounts:bob asset="USD/2".
+	// source=accounts:alice destination=accounts:bob asset="USD/2".
 	require.NoError(t, b.indexPostingAddressMappings(
 		b.kb, cfg, "test", 1, "accounts:alice", "accounts:bob", "USD/2",
 		false, false, false, nil,
@@ -1520,8 +1520,8 @@ func TestIsPostingIndex(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "dest address index",
-			id:       indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS),
+			name:     "destination address index",
+			id:       indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS),
 			expected: true,
 		},
 		{

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -344,7 +344,7 @@ func (c *ledgerIndexConfig) isBuiltinIndexed(index commonpb.TransactionBuiltinIn
 func (c *ledgerIndexConfig) indexesPostingAddressMappings() bool {
 	return c.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS) ||
 		c.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS) ||
-		c.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)
+		c.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)
 }
 
 // indexesPostingDerived reports whether any enabled index is derived from

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -479,8 +479,8 @@ func (b *Builder) indexCreatedTransaction(
 
 	// Collect unique accounts from postings (reuse builder's map)
 	indexAny := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS)
-	indexSrc := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
-	indexDst := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)
+	indexSource := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
+	indexDestination := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)
 
 	clear(b.accounts)
 
@@ -490,7 +490,7 @@ func (b *Builder) indexCreatedTransaction(
 
 		if err := b.indexPostingAddressMappings(
 			kb, cfg, ledger, txn.GetId(), posting.GetSource(), posting.GetDestination(), posting.GetAsset(),
-			indexAny, indexSrc, indexDst, excludedVolumes,
+			indexAny, indexSource, indexDestination, excludedVolumes,
 		); err != nil {
 			return err
 		}
@@ -605,8 +605,8 @@ func (b *Builder) indexRevertedTransaction(
 
 	// Account→tx mapping for revert postings (reuse builder's map)
 	indexAny := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS)
-	indexSrc := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
-	indexDst := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)
+	indexSource := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)
+	indexDestination := cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)
 
 	clear(b.accounts)
 
@@ -616,7 +616,7 @@ func (b *Builder) indexRevertedTransaction(
 
 		if err := b.indexPostingAddressMappings(
 			kb, cfg, ledger, revertTxn.GetId(), posting.GetSource(), posting.GetDestination(), posting.GetAsset(),
-			indexAny, indexSrc, indexDst, excludedVolumes,
+			indexAny, indexSource, indexDestination, excludedVolumes,
 		); err != nil {
 			return err
 		}
@@ -682,13 +682,13 @@ func (b *Builder) indexPostingAddressMappings(
 	destination string,
 	asset string,
 	indexAny bool,
-	indexSrc bool,
-	indexDst bool,
+	indexSource bool,
+	indexDestination bool,
 	excludedVolumes map[domain.AccountAssetKey]struct{},
 ) error {
 	wb := b.wb
-	srcExcluded := isExcluded(excludedVolumes, source, asset)
-	dstExcluded := isExcluded(excludedVolumes, destination, asset)
+	sourceExcluded := isExcluded(excludedVolumes, source, asset)
+	destinationExcluded := isExcluded(excludedVolumes, destination, asset)
 
 	// Account has-asset index: record every (account, assetBase, precision) a
 	// posting touches, for both source and destination, skipping excluded
@@ -697,13 +697,13 @@ func (b *Builder) indexPostingAddressMappings(
 	if cfg.isAccountBuiltinIndexed(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET) {
 		assetBase, precision := domain.ParseAssetPrecision(asset)
 
-		if !srcExcluded {
+		if !sourceExcluded {
 			if err := b.writeAccountByAssetDedup(kb, ledger, source, assetBase, precision); err != nil {
 				return err
 			}
 		}
 
-		if !dstExcluded {
+		if !destinationExcluded {
 			if err := b.writeAccountByAssetDedup(kb, ledger, destination, assetBase, precision); err != nil {
 				return err
 			}
@@ -711,13 +711,13 @@ func (b *Builder) indexPostingAddressMappings(
 	}
 
 	if indexAny {
-		if !srcExcluded {
+		if !sourceExcluded {
 			if err := wb.WriteAccountTxMapping(kb, ledger, source, txID); err != nil {
 				return err
 			}
 		}
 
-		if !dstExcluded {
+		if !destinationExcluded {
 			if err := wb.WriteAccountTxMapping(kb, ledger, destination, txID); err != nil {
 				return err
 			}
@@ -727,14 +727,14 @@ func (b *Builder) indexPostingAddressMappings(
 	// Role-specific mappings skip transient and purged ephemeral volumes —
 	// matched per (account, asset) tuple so a multi-asset account keeps its
 	// mappings for the assets that survived this proposal.
-	if indexSrc && !srcExcluded {
+	if indexSource && !sourceExcluded {
 		if err := wb.WriteSourceAccountTxMapping(kb, ledger, source, txID); err != nil {
 			return err
 		}
 	}
 
-	if indexDst && !dstExcluded {
-		if err := wb.WriteDestAccountTxMapping(kb, ledger, destination, txID); err != nil {
+	if indexDestination && !destinationExcluded {
+		if err := wb.WriteDestinationAccountTxMapping(kb, ledger, destination, txID); err != nil {
 			return err
 		}
 	}

--- a/internal/domain/analysis/flow_discovery.go
+++ b/internal/domain/analysis/flow_discovery.go
@@ -431,12 +431,12 @@ func classifyPostingStructure(postings []*servicepb.NormalizedPosting) servicepb
 	}
 
 	singleSource := len(sources) == 1
-	singleDest := len(destinations) == 1
+	singleDestination := len(destinations) == 1
 
 	switch {
-	case singleSource && !singleDest:
+	case singleSource && !singleDestination:
 		return servicepb.PostingStructure_POSTING_STRUCTURE_MULTI_DESTINATION
-	case !singleSource && singleDest:
+	case !singleSource && singleDestination:
 		return servicepb.PostingStructure_POSTING_STRUCTURE_MULTI_SOURCE
 	default:
 		return servicepb.PostingStructure_POSTING_STRUCTURE_COMPLEX

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -197,13 +197,13 @@ func (IndexBuildStatus) EnumDescriptor() ([]byte, []int) {
 type TransactionBuiltinIndex int32
 
 const (
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE      TransactionBuiltinIndex = 0 // requires Pebble "txref" index
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP      TransactionBuiltinIndex = 1 // requires Pebble "tstmp" index
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID             TransactionBuiltinIndex = 2 // range scan on existence bucket (no index)
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS        TransactionBuiltinIndex = 3 // account→transaction mapping (any role)
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS TransactionBuiltinIndex = 4 // source account→transaction mapping
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS   TransactionBuiltinIndex = 5 // destination account→transaction mapping
-	TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT    TransactionBuiltinIndex = 6 // requires Pebble "txiat" index (inserted_at date)
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE           TransactionBuiltinIndex = 0 // requires Pebble "txref" index
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP           TransactionBuiltinIndex = 1 // requires Pebble "tstmp" index
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID                  TransactionBuiltinIndex = 2 // range scan on existence bucket (no index)
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS             TransactionBuiltinIndex = 3 // account→transaction mapping (any role)
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS      TransactionBuiltinIndex = 4 // source account→transaction mapping
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS TransactionBuiltinIndex = 5 // destination account→transaction mapping
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT         TransactionBuiltinIndex = 6 // requires Pebble "txiat" index (inserted_at date)
 )
 
 // Enum value maps for TransactionBuiltinIndex.
@@ -214,17 +214,17 @@ var (
 		2: "TX_BUILTIN_INDEX_ID",
 		3: "TX_BUILTIN_INDEX_ADDRESS",
 		4: "TX_BUILTIN_INDEX_SOURCE_ADDRESS",
-		5: "TX_BUILTIN_INDEX_DEST_ADDRESS",
+		5: "TX_BUILTIN_INDEX_DESTINATION_ADDRESS",
 		6: "TX_BUILTIN_INDEX_INSERTED_AT",
 	}
 	TransactionBuiltinIndex_value = map[string]int32{
-		"TX_BUILTIN_INDEX_REFERENCE":      0,
-		"TX_BUILTIN_INDEX_TIMESTAMP":      1,
-		"TX_BUILTIN_INDEX_ID":             2,
-		"TX_BUILTIN_INDEX_ADDRESS":        3,
-		"TX_BUILTIN_INDEX_SOURCE_ADDRESS": 4,
-		"TX_BUILTIN_INDEX_DEST_ADDRESS":   5,
-		"TX_BUILTIN_INDEX_INSERTED_AT":    6,
+		"TX_BUILTIN_INDEX_REFERENCE":           0,
+		"TX_BUILTIN_INDEX_TIMESTAMP":           1,
+		"TX_BUILTIN_INDEX_ID":                  2,
+		"TX_BUILTIN_INDEX_ADDRESS":             3,
+		"TX_BUILTIN_INDEX_SOURCE_ADDRESS":      4,
+		"TX_BUILTIN_INDEX_DESTINATION_ADDRESS": 5,
+		"TX_BUILTIN_INDEX_INSERTED_AT":         6,
 	}
 )
 
@@ -11418,14 +11418,14 @@ const file_common_proto_rawDesc = "" +
 	"\x10IndexBuildStatus\x12\"\n" +
 	"\x1eINDEX_BUILD_STATUS_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bINDEX_BUILD_STATUS_BUILDING\x10\x01\x12\x1c\n" +
-	"\x18INDEX_BUILD_STATUS_READY\x10\x02*\xfa\x01\n" +
+	"\x18INDEX_BUILD_STATUS_READY\x10\x02*\x81\x02\n" +
 	"\x17TransactionBuiltinIndex\x12\x1e\n" +
 	"\x1aTX_BUILTIN_INDEX_REFERENCE\x10\x00\x12\x1e\n" +
 	"\x1aTX_BUILTIN_INDEX_TIMESTAMP\x10\x01\x12\x17\n" +
 	"\x13TX_BUILTIN_INDEX_ID\x10\x02\x12\x1c\n" +
 	"\x18TX_BUILTIN_INDEX_ADDRESS\x10\x03\x12#\n" +
-	"\x1fTX_BUILTIN_INDEX_SOURCE_ADDRESS\x10\x04\x12!\n" +
-	"\x1dTX_BUILTIN_INDEX_DEST_ADDRESS\x10\x05\x12 \n" +
+	"\x1fTX_BUILTIN_INDEX_SOURCE_ADDRESS\x10\x04\x12(\n" +
+	"$TX_BUILTIN_INDEX_DESTINATION_ADDRESS\x10\x05\x12 \n" +
 	"\x1cTX_BUILTIN_INDEX_INSERTED_AT\x10\x06*W\n" +
 	"\x13AccountBuiltinIndex\x12\"\n" +
 	"\x1eACCT_BUILTIN_INDEX_UNSPECIFIED\x10\x00\x12\x1c\n" +

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -853,7 +853,7 @@ func addressRolePrefix(role commonpb.AddressRole) byte {
 	case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
 		return readstore.PrefixSourceAccountTx
 	case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
-		return readstore.PrefixDestAccountTx
+		return readstore.PrefixDestinationAccountTx
 	default:
 		return readstore.PrefixAccountTx
 	}
@@ -1735,7 +1735,7 @@ func txAddressIndexID(role commonpb.AddressRole) (*commonpb.IndexID, string) {
 	case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
 		return indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS), "source"
 	case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
-		return indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS), "destination"
+		return indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS), "destination"
 	default:
 		return indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS), "address"
 	}

--- a/internal/storage/readstore/delete_ledger.go
+++ b/internal/storage/readstore/delete_ledger.go
@@ -23,7 +23,7 @@ var ledgerScopedPrefixes = [][]byte{
 	{PrefixReverseMap},
 	{PrefixAccountTx},
 	{PrefixSourceAccountTx},
-	{PrefixDestAccountTx},
+	{PrefixDestinationAccountTx},
 	{PrefixTransactionReference},
 	{PrefixTransactionTimestamp},
 	{PrefixLedgerLogs},

--- a/internal/storage/readstore/keys.go
+++ b/internal/storage/readstore/keys.go
@@ -14,7 +14,7 @@ const (
 	PrefixReverseMap            byte = 0x03 // rmap — reverse metadata map
 	PrefixAccountTx             byte = 0x04 // atxm — account→tx (any role)
 	PrefixSourceAccountTx       byte = 0x05 // satx — source account→tx
-	PrefixDestAccountTx         byte = 0x06 // datx — dest account→tx
+	PrefixDestinationAccountTx  byte = 0x06 // datx — destination account→tx
 	PrefixTransactionReference  byte = 0x07 // txref — transaction reference
 	PrefixTransactionTimestamp  byte = 0x08 // tstmp — transaction timestamp
 	PrefixLedgerLogs            byte = 0x09 // llog — ledger log mapping

--- a/internal/storage/readstore/write_batch.go
+++ b/internal/storage/readstore/write_batch.go
@@ -113,9 +113,9 @@ func (wb *WriteBatch) WriteSourceAccountTxMapping(kb *dal.KeyBuilder, ledgerName
 	return wb.put(key, nil)
 }
 
-// WriteDestAccountTxMapping records that an account is a destination in a transaction.
-func (wb *WriteBatch) WriteDestAccountTxMapping(kb *dal.KeyBuilder, ledgerName string, account string, txID uint64) error {
-	key := AccountTxKey(kb, PrefixDestAccountTx, ledgerName, account, txID)
+// WriteDestinationAccountTxMapping records that an account is a destination in a transaction.
+func (wb *WriteBatch) WriteDestinationAccountTxMapping(kb *dal.KeyBuilder, ledgerName string, account string, txID uint64) error {
+	key := AccountTxKey(kb, PrefixDestinationAccountTx, ledgerName, account, txID)
 
 	return wb.put(key, nil)
 }

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -200,7 +200,7 @@ enum TransactionBuiltinIndex {
   TX_BUILTIN_INDEX_ID = 2;               // range scan on existence bucket (no index)
   TX_BUILTIN_INDEX_ADDRESS = 3;          // account→transaction mapping (any role)
   TX_BUILTIN_INDEX_SOURCE_ADDRESS = 4;   // source account→transaction mapping
-  TX_BUILTIN_INDEX_DEST_ADDRESS = 5;     // destination account→transaction mapping
+  TX_BUILTIN_INDEX_DESTINATION_ADDRESS = 5;     // destination account→transaction mapping
   TX_BUILTIN_INDEX_INSERTED_AT = 6;     // requires Pebble "txiat" index (inserted_at date)
 }
 

--- a/pkg/actions/indexes.go
+++ b/pkg/actions/indexes.go
@@ -15,7 +15,7 @@ func AddressRoleToBuiltinIndex(role commonpb.AddressRole) commonpb.TransactionBu
 	case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
 		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS
 	case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
-		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS
+		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS
 	default:
 		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS
 	}

--- a/tests/e2e/business/indexes_test.go
+++ b/tests/e2e/business/indexes_test.go
@@ -168,7 +168,7 @@ var _ = Describe("UserConfigurableIndexes", Ordered, func() {
 				indexes, err := listLedgerIndexes(sharedCtx, sharedClient, ledgerName)
 				g.Expect(err).To(Succeed())
 				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)).To(BeTrue())
-				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)).To(BeTrue())
+				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)).To(BeTrue())
 			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 		})
 
@@ -182,7 +182,7 @@ var _ = Describe("UserConfigurableIndexes", Ordered, func() {
 				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS)).To(BeFalse())
 				// Source and destination should still be enabled
 				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS)).To(BeTrue())
-				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DEST_ADDRESS)).To(BeTrue())
+				g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)).To(BeTrue())
 			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
## Context

Throughout the transaction builtin address-index code, the **source** concept was spelled in full (`source`/`Source`/`SOURCE`) while its **destination** counterpart was abbreviated to `dest`/`Dest`/`DEST`. This normalizes every abbreviated `dest` paired with a full `source` to the full word `destination`.

## Changes (22 files, symmetric 96/96)

**Proto enum (root cause)**
- `TX_BUILTIN_INDEX_DEST_ADDRESS` → `TX_BUILTIN_INDEX_DESTINATION_ADDRESS` in `misc/proto/common.proto` (**value stays `5`** → binary/wire compat preserved), `common.pb.go` regenerated via `just generate-proto`.

**Internal Go identifiers**
- `PrefixDestAccountTx` → `PrefixDestinationAccountTx` (Pebble byte `0x06` unchanged)
- `WriteDestAccountTxMapping` → `WriteDestinationAccountTxMapping`
- Locals: `singleDest`→`singleDestination`, `indexDst`/`indexSrc`→`indexDestination`/`indexSource`, `dstExcluded`/`srcExcluded`→`destinationExcluded`/`sourceExcluded`
- Propagated the new enum symbol to all Go call sites

**User-facing (clean break)**
- CLI `--type dest-address` → `destination-address`
- Config field + tags `DestAddress`/`destAddress` → `DestinationAddress`/`destinationAddress`
- Docs: `docs/ops/cli.md`, `api-comparison.md`, `indexer.md`

**Left intentionally**: matched-pair `satx`/`datx` Pebble mnemonics, generic `src`/`dst` copy helpers, operator backup `Destination`, `MirrorSource`.

## ⚠️ Compatibility note

The enum name is embedded in persisted index canonical keys via `indexes.Canonical()`, so the on-disk key for a **destination-address** index changes. Wire/binary proto compat is preserved (value `5`), but any existing deployment with a destination-address index will need to **rebuild** that index. Accepted per dev-mode scope.

## Verification

- `go build ./...` ✅
- `just lint` → 0 issues ✅
- Targeted tests (indexes, readstore, query, indexbuilder, ledgerctl, commonpb) ✅
- Regenerated proto diff is only the enum rename + gofmt realignment; `go.mod`/`go.sum` untouched.