### PR TITLE
feat(ledgerctl): add --count and --batch-size to transactions create (backport #548)

### DIFF
--- a/cmd/ledgerctl/cmdutil/signing.go
+++ b/cmd/ledgerctl/cmdutil/signing.go
@@ -79,16 +79,27 @@ func VerifyResponseSignatures(cmd *cobra.Command, logs []*commonpb.Log) error {
 // key is configured on the command flags, unsigned otherwise. Signing the batch
 // authenticates its composition and ordering.
 func BuildApplyRequest(cmd *cobra.Command, requests ...*servicepb.Request) (*servicepb.ApplyRequest, error) {
+	return BuildIdempotentApplyRequest(cmd, "", requests...)
+}
+
+// BuildIdempotentApplyRequest is BuildApplyRequest with a batch-level
+// idempotency key. The key is carried on the ApplyBatch (and therefore covered
+// by the signature when signing is enabled), so the server can deduplicate a
+// batch that a transport retry replays byte-for-byte — notably the gRPC
+// UNAVAILABLE retry policy, which would otherwise re-apply a batch that had
+// already committed before the client observed the failure. Pass a value that
+// is stable across retries of the same batch but unique across distinct batches.
+func BuildIdempotentApplyRequest(cmd *cobra.Command, idempotencyKey string, requests ...*servicepb.Request) (*servicepb.ApplyRequest, error) {
 	keyID, privKey, err := LoadSigningKey(cmd)
 	if err != nil {
 		return nil, err
 	}
 
 	if privKey == nil {
-		return servicepb.UnsignedApplyRequest("", requests...), nil
+		return servicepb.UnsignedApplyRequest(idempotencyKey, requests...), nil
 	}
 
-	sb, err := signing.Sign(&servicepb.ApplyBatch{Requests: requests}, keyID, privKey)
+	sb, err := signing.Sign(&servicepb.ApplyBatch{Requests: requests, IdempotencyKey: idempotencyKey}, keyID, privKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign batch: %w", err)
 	}

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -379,6 +379,15 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		return cmdutil.Displayed(errors.New("--batch must be at least 1"))
 	}
 
+	// A transaction reference must be unique, so it cannot be reused across a
+	// bulk create: the first transaction would commit and every subsequent one
+	// would fail with a reference conflict, leaving a partial result.
+	if reference != "" && count > 1 {
+		pterm.Error.Println("--reference cannot be combined with --count > 1 (references must be unique)")
+
+		return cmdutil.Displayed(errors.New("--reference cannot be combined with --count > 1 (references must be unique)"))
+	}
+
 	// newRequest builds a fresh Apply request for one transaction. It is called
 	// once per transaction so each envelope is signed independently.
 	newRequest := func() *servicepb.Request {

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
@@ -443,7 +444,13 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 			requests[i] = newRequest()
 		}
 
-		applyReq, err := cmdutil.BuildApplyRequest(cmd, requests...)
+		// A fresh idempotency key per batch, generated before the (possibly
+		// retried) Apply call: ledgerctl retries UNAVAILABLE up to 50 times, and
+		// gRPC replays the same request bytes on each attempt. The key makes the
+		// server replay an already-committed batch's outcome instead of applying
+		// it a second time — while distinct batches keep distinct keys and each
+		// apply exactly once.
+		applyReq, err := cmdutil.BuildIdempotentApplyRequest(cmd, uuid.NewString(), requests...)
 		if err != nil {
 			spinner.Fail("Failed to sign request")
 

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -81,6 +81,8 @@ Examples:
   ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD"
   ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --posting "bank,user,500,USD"
   ledgerctl transactions create --ledger my-ledger --script transfer.num --var "amount=1000" --var "asset=USD"
+  ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --count 100
+  ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --count 100 --batch 10
   ledgerctl transactions create --ledger my-ledger  # Interactive mode`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
@@ -95,6 +97,8 @@ Examples:
 	cmd.Flags().StringToString("metadata", nil, "Metadata key=value pairs")
 	cmd.Flags().Bool("force", false, "Bypass balance checks (allow accounts to go negative)")
 	cmd.Flags().Bool("expand-volumes", false, "Include post-commit volumes in response")
+	cmd.Flags().Int("count", 1, "Number of times to send the transaction")
+	cmd.Flags().Int("batch", 1, "Bundle the transactions into batches of this size (transactions per Apply request)")
 	cmdutil.AddOutputFlags(cmd)
 	cmd.Flags().Duration("timeout", cmdutil.DefaultTimeout, "Request timeout")
 
@@ -359,14 +363,26 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	force, _ := cmd.Flags().GetBool("force")
 	expandVolumes, _ := cmd.Flags().GetBool("expand-volumes")
 
-	// Create the transaction
-	ctx, cancel := cmdutil.GetContext(cmd)
-	defer cancel()
+	// Get repetition and batching flags
+	count, _ := cmd.Flags().GetInt("count")
+	batchSize, _ := cmd.Flags().GetInt("batch")
 
-	spinner, _ := pterm.DefaultSpinner.Start("Creating transaction...")
+	if count < 1 {
+		pterm.Error.Println("--count must be at least 1")
 
-	requests := []*servicepb.Request{
-		{
+		return cmdutil.Displayed(errors.New("--count must be at least 1"))
+	}
+
+	if batchSize < 1 {
+		pterm.Error.Println("--batch must be at least 1")
+
+		return cmdutil.Displayed(errors.New("--batch must be at least 1"))
+	}
+
+	// newRequest builds a fresh Apply request for one transaction. It is called
+	// once per transaction so each envelope is signed independently.
+	newRequest := func() *servicepb.Request {
+		return &servicepb.Request{
 			Type: &servicepb.Request_Apply{
 				Apply: &servicepb.LedgerApplyRequest{
 					Ledger: ledgerName,
@@ -384,53 +400,106 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 					},
 				},
 			},
-		},
+		}
 	}
 
-	applyReq, err := cmdutil.BuildApplyRequest(cmd, requests...)
-	if err != nil {
-		spinner.Fail("Failed to sign request")
+	// Create the transaction(s)
+	ctx, cancel := cmdutil.GetContext(cmd)
+	defer cancel()
 
-		return cmdutil.Displayed(err)
+	spinnerText := "Creating transaction..."
+	if count > 1 {
+		spinnerText = fmt.Sprintf("Creating %d transactions...", count)
 	}
 
-	resp, err := client.Apply(ctx, applyReq)
-	if err != nil {
-		_ = spinner.Stop()
+	spinner, _ := pterm.DefaultSpinner.Start(spinnerText)
 
-		return cmdutil.FormatGRPCError("failed to create transaction", err)
+	// Send count transactions, bundling up to batchSize of them per Apply
+	// request. Collect every returned log so callers can inspect each result.
+	var createdTxs []*commonpb.CreatedTransaction
+
+	for sent := 0; sent < count; sent += batchSize {
+		n := batchSize
+		if remaining := count - sent; n > remaining {
+			n = remaining
+		}
+
+		requests := make([]*servicepb.Request, n)
+		for i := range requests {
+			requests[i] = newRequest()
+		}
+
+		applyReq, err := cmdutil.BuildApplyRequest(cmd, requests...)
+		if err != nil {
+			spinner.Fail("Failed to sign request")
+
+			return cmdutil.Displayed(err)
+		}
+
+		resp, err := client.Apply(ctx, applyReq)
+		if err != nil {
+			_ = spinner.Stop()
+
+			return cmdutil.FormatGRPCError("failed to create transaction", err)
+		}
+
+		// Verify response signatures if a verification key is configured
+		if err := cmdutil.VerifyResponseSignatures(cmd, resp.GetLogs()); err != nil {
+			spinner.Fail("Response signature verification failed")
+
+			return cmdutil.Displayed(fmt.Errorf("response signature verification failed: %w", err))
+		}
+
+		for _, log := range resp.GetLogs() {
+			applyLog := log.GetPayload().GetApply()
+			if applyLog == nil {
+				spinner.Fail("Unexpected response type")
+
+				return cmdutil.Displayed(errors.New("unexpected response type"))
+			}
+
+			createdTx := applyLog.GetLog().GetData().GetCreatedTransaction()
+			if createdTx == nil {
+				spinner.Fail("Unexpected log payload type")
+
+				return cmdutil.Displayed(errors.New("unexpected log payload type"))
+			}
+
+			createdTxs = append(createdTxs, createdTx)
+		}
+
+		if count > 1 {
+			spinner.UpdateText(fmt.Sprintf("Creating %d transactions... %d/%d", count, len(createdTxs), count))
+		}
 	}
 
-	// Verify response signatures if a verification key is configured
-	if err := cmdutil.VerifyResponseSignatures(cmd, resp.GetLogs()); err != nil {
-		spinner.Fail("Response signature verification failed")
-
-		return cmdutil.Displayed(fmt.Errorf("response signature verification failed: %w", err))
-	}
-
-	// Extract the created transaction from the response
-	if len(resp.GetLogs()) == 0 {
+	// Extract the created transaction(s) from the response
+	if len(createdTxs) == 0 {
 		spinner.Fail("No response received")
 
 		return cmdutil.Displayed(errors.New("no response received"))
 	}
 
-	log := resp.GetLogs()[0]
+	// Bulk mode: report a summary rather than the full detail of every
+	// transaction, which would be unreadable at scale.
+	if count > 1 {
+		spinner.Success(fmt.Sprintf("Created %d transactions", len(createdTxs)))
 
-	applyLog := log.GetPayload().GetApply()
-	if applyLog == nil {
-		spinner.Fail("Unexpected response type")
+		if handled, err := cmdutil.EncodeStructured(cmd, createdTxs); handled || err != nil {
+			return err
+		}
 
-		return cmdutil.Displayed(errors.New("unexpected response type"))
+		pterm.Println()
+		pterm.Printf("Created %s transactions across %s batch(es) of up to %s.\n",
+			pterm.Cyan(strconv.Itoa(len(createdTxs))),
+			pterm.Cyan(strconv.Itoa((count+batchSize-1)/batchSize)),
+			pterm.Cyan(strconv.Itoa(batchSize)),
+		)
+
+		return nil
 	}
 
-	createdTx := applyLog.GetLog().GetData().GetCreatedTransaction()
-	if createdTx == nil {
-		spinner.Fail("Unexpected log payload type")
-
-		return cmdutil.Displayed(errors.New("unexpected log payload type"))
-	}
-
+	createdTx := createdTxs[0]
 	tx := createdTx.GetTransaction()
 
 	spinner.Success("Created")

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -412,9 +412,14 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Create the transaction(s)
-	ctx, cancel := cmdutil.GetContext(cmd)
-	defer cancel()
+	// applyBatch sends one Apply request under its own context so the
+	// --timeout applies per request rather than cumulatively across batches.
+	applyBatch := func(applyReq *servicepb.ApplyRequest) (*servicepb.ApplyResponse, error) {
+		ctx, cancel := cmdutil.GetContext(cmd)
+		defer cancel()
+
+		return client.Apply(ctx, applyReq)
+	}
 
 	spinnerText := "Creating transaction..."
 	if count > 1 {
@@ -445,7 +450,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 			return cmdutil.Displayed(err)
 		}
 
-		resp, err := client.Apply(ctx, applyReq)
+		resp, err := applyBatch(applyReq)
 		if err != nil {
 			_ = spinner.Stop()
 

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -82,7 +82,7 @@ Examples:
   ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --posting "bank,user,500,USD"
   ledgerctl transactions create --ledger my-ledger --script transfer.num --var "amount=1000" --var "asset=USD"
   ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --count 100
-  ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --count 100 --batch 10
+  ledgerctl transactions create --ledger my-ledger --posting "world,bank,1000,USD" --count 100 --batch-size 10
   ledgerctl transactions create --ledger my-ledger  # Interactive mode`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
@@ -98,7 +98,7 @@ Examples:
 	cmd.Flags().Bool("force", false, "Bypass balance checks (allow accounts to go negative)")
 	cmd.Flags().Bool("expand-volumes", false, "Include post-commit volumes in response")
 	cmd.Flags().Int("count", 1, "Number of times to send the transaction")
-	cmd.Flags().Int("batch", 1, "Bundle the transactions into batches of this size (transactions per Apply request)")
+	cmd.Flags().Int("batch-size", 1, "Bundle the transactions into batches of this size (transactions per Apply request)")
 	cmdutil.AddOutputFlags(cmd)
 	cmd.Flags().Duration("timeout", cmdutil.DefaultTimeout, "Request timeout")
 
@@ -365,7 +365,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	// Get repetition and batching flags
 	count, _ := cmd.Flags().GetInt("count")
-	batchSize, _ := cmd.Flags().GetInt("batch")
+	batchSize, _ := cmd.Flags().GetInt("batch-size")
 
 	if count < 1 {
 		pterm.Error.Println("--count must be at least 1")
@@ -374,9 +374,9 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	if batchSize < 1 {
-		pterm.Error.Println("--batch must be at least 1")
+		pterm.Error.Println("--batch-size must be at least 1")
 
-		return cmdutil.Displayed(errors.New("--batch must be at least 1"))
+		return cmdutil.Displayed(errors.New("--batch-size must be at least 1"))
 	}
 
 	// A transaction reference must be unique, so it cannot be reused across a

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1343,7 +1343,8 @@ ledgerctl transactions create --ledger my-ledger \
 
 When `--count` is greater than 1 a summary is printed instead of each
 transaction's full detail. The `--json`/`--yaml` output becomes the array of
-created transactions.
+created transactions. `--reference` cannot be combined with `--count` greater
+than 1, because transaction references must be unique.
 
 **Creating transactions with Numscript:**
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1303,6 +1303,8 @@ ledgerctl transactions create [flags]
 | `--metadata` | | Metadata key=value pairs |
 | `--force` | `false` | Bypass balance checks (allow accounts to go negative) |
 | `--expand-volumes` | `false` | Include post-commit volumes (per account/asset) in response |
+| `--count` | `1` | Number of times to send the transaction |
+| `--batch` | `1` | Bundle the transactions into batches of this size (transactions per Apply request) |
 | `--json` | `false` | Output as JSON |
 | `--timeout` | `10s` | Request timeout |
 
@@ -1327,7 +1329,21 @@ ledgerctl transactions create --ledger my-ledger \
 ledgerctl transactions create --ledger my-ledger \
   --posting "empty-account,destination,1000,USD" \
   --force
+
+# Send the same transaction 100 times (one Apply request each)
+ledgerctl transactions create --ledger my-ledger \
+  --posting "world,bank,1000,USD" \
+  --count 100
+
+# Send 100 transactions, bundled 10 per Apply request (10 batches)
+ledgerctl transactions create --ledger my-ledger \
+  --posting "world,bank,1000,USD" \
+  --count 100 --batch 10
 ```
+
+When `--count` is greater than 1 a summary is printed instead of each
+transaction's full detail. The `--json`/`--yaml` output becomes the array of
+created transactions.
 
 **Creating transactions with Numscript:**
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1304,7 +1304,7 @@ ledgerctl transactions create [flags]
 | `--force` | `false` | Bypass balance checks (allow accounts to go negative) |
 | `--expand-volumes` | `false` | Include post-commit volumes (per account/asset) in response |
 | `--count` | `1` | Number of times to send the transaction |
-| `--batch` | `1` | Bundle the transactions into batches of this size (transactions per Apply request) |
+| `--batch-size` | `1` | Bundle the transactions into batches of this size (transactions per Apply request) |
 | `--json` | `false` | Output as JSON |
 | `--timeout` | `10s` | Request timeout |
 
@@ -1338,7 +1338,7 @@ ledgerctl transactions create --ledger my-ledger \
 # Send 100 transactions, bundled 10 per Apply request (10 batches)
 ledgerctl transactions create --ledger my-ledger \
   --posting "world,bank,1000,USD" \
-  --count 100 --batch 10
+  --count 100 --batch-size 10
 ```
 
 When `--count` is greater than 1 a summary is printed instead of each


### PR DESCRIPTION
Backport of formancehq/ledger-v3-poc#548 onto `release/v3.0`.

Adds two flags to `ledgerctl transactions create`:

- `--count` (default `1`) — send the same transaction N times.
- `--batch-size` (default `1`) — bundle up to N transactions per `Apply` request.

Behaviour:
- Each transaction is built from a freshly constructed request via a `newRequest` closure.
- In bulk mode (`--count > 1`) a summary is printed instead of each transaction's full detail; structured (`--json`/`--yaml`) output becomes the array of created transactions.
- Inputs are validated: `--count` and `--batch-size` must each be `>= 1`.
- `--reference` is rejected with `--count > 1`, since transaction references must be unique.
- `--timeout` is scoped per `Apply` request (via an `applyBatch` closure that builds a fresh context) rather than cumulatively across batches.

### Backport adaptation

The poc branch used the lower-level `cmdutil.BuildEnvelopes` + manual `ApplyRequest{Envelopes: ...}`. `release/v3.0` has since consolidated request construction/signing into `cmdutil.BuildApplyRequest(cmd, requests...)`, which signs the whole `ApplyBatch` as a unit. The batch loop was adapted to call `BuildApplyRequest(cmd, requests...)` and `applyBatch(applyReq)` accordingly — behaviour is otherwise identical.

Commits are cherry-picked 1:1 from the original PR (with the above conflict resolution folded into the relevant commits).

Docs (`docs/ops/cli.md`) updated with the new flags and examples.
