### PR TITLE
fix(ledger): reflect transaction metadata deletes in GetTransaction

### DIFF
--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -269,10 +269,10 @@ func assembleTransactionFromState(ctx context.Context, reader dal.PebbleReader, 
 
 	tx.Reverted = state.GetRevertedByTransaction() > 0
 
-	// Override metadata from the state (which is the current truth)
-	if len(state.GetMetadata()) > 0 {
-		tx.Metadata = state.GetMetadata()
-	}
+	// The state carries the current metadata (the create-time snapshot plus
+	// every applied add/delete) and is authoritative even when empty; the
+	// create log only holds the create-time snapshot.
+	tx.Metadata = state.GetMetadata()
 
 	return tx, nil
 }

--- a/tests/e2e/business/metadata_test.go
+++ b/tests/e2e/business/metadata_test.go
@@ -338,6 +338,27 @@ var _ = Describe("Metadata", Ordered, func() {
 			Expect(exists).To(BeFalse())
 		})
 
+		It("Should read back empty metadata after deleting the last key", func() {
+			// Create a transaction carrying a single metadata key at creation.
+			resp, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "bank", big.NewInt(1000), "USD"),
+			}, map[string]string{"only": "value"}, nil)))
+			Expect(err).To(Succeed())
+			transactionID := resp.Logs[0].Payload.GetApply().Log.Data.GetCreatedTransaction().Transaction.Id
+
+			// Delete that key, emptying the transaction's metadata.
+			_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.DeleteTransactionMetadataAction(ledgerName, transactionID, "only")))
+			Expect(err).To(Succeed())
+
+			// The read reflects the state (now empty), not the create-time metadata.
+			tx, err := sharedClient.GetTransaction(sharedCtx, &servicepb.GetTransactionRequest{
+				Ledger:        ledgerName,
+				TransactionId: transactionID,
+			})
+			Expect(err).To(Succeed())
+			Expect(commonpb.MetadataToGoMap(tx.Transaction.Metadata)).To(BeEmpty())
+		})
+
 		It("Should preserve metadata set at transaction creation", func() {
 			// Create transaction with initial metadata
 			resp, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{


### PR DESCRIPTION
## Summary
`GetTransaction` (and `ListTransactions`, which shares the same assembly) could return a transaction-metadata key that had already been deleted. Once a committed `DeleteMetadata` removed the **last** remaining key from a transaction, the read resurfaced whatever metadata the transaction was *created* with.

## Root cause
`assembleTransactionFromState` builds the returned transaction from the creation log — which carries the create-time metadata — then overrides it with the authoritative `TransactionState`:

```go
// before
if len(state.GetMetadata()) > 0 {
    tx.Metadata = state.GetMetadata()
}
```

The `len(...) > 0` guard conflates *"metadata was deleted down to empty"* with *"no state metadata — fall back to the create log."* Deleting the last key leaves `state.Metadata` empty, so the override is skipped and the read returns the stale create-time map. Partial deletes (map stays non-empty) were unaffected — which is why this went unnoticed.

## Fix
The `TransactionState` metadata is always the current truth (create-time snapshot + every applied add/delete), authoritative even when empty — so take it unconditionally:

```go
tx.Metadata = state.GetMetadata()
```

## Scope
- Fixes both `GetTransaction` and `ListTransactions`; both hydrate through the single `assembleTransactionFromState` funnel.
- The searchable metadata index (readStore, used by metadata-filtered queries) already applies `DeletedMetadata`, so it is not affected.

## How it was found
The `singleton_driver_model` antithesis model checker's transaction read-back flagged the divergence: the server returned metadata the model had deleted. It reproduced deterministically on a single node; replaying the committed batch stream through the oracle showed **0 commit-side divergences**, pinning the bug to the read path.

## Testing
- New e2e regression (`tests/e2e/business/metadata_test.go`): create a transaction with one metadata key, delete it, assert `GetTransaction` returns no metadata. Committed **test-first** — it fails on `release/v3.0` and passes with the fix.
- Full e2e `Metadata` suite green; `golangci-lint` clean.
