### PR TITLE
fix(auth): align ledger granular scope names

### DIFF
--- a/cmd/ledgerctl/cmdutil/errors_test.go
+++ b/cmd/ledgerctl/cmdutil/errors_test.go
@@ -236,7 +236,7 @@ func TestFormatGRPCError_Unauthenticated_MissingToken(t *testing.T) {
 func TestFormatGRPCError_PermissionDenied(t *testing.T) {
 	t.Parallel()
 
-	grpcErr := status.Error(codes.PermissionDenied, "missing required scope (required: [ledgers:read])")
+	grpcErr := status.Error(codes.PermissionDenied, "missing required scope (required: [ledger:LedgerRead])")
 	err := FormatGRPCError("list ledgers", grpcErr)
 	require.Contains(t, err.Error(), "missing required scope")
 }

--- a/docs/ops/authentication.md
+++ b/docs/ops/authentication.md
@@ -30,15 +30,27 @@ When `--auth-enabled` is set:
 
 ## Scopes
 
-The ledger uses three authorization scopes. When `--auth-service=ledger`, the scopes are:
+The ledger accepts virtual scopes in JWTs and expands them to granular Ledger scopes. When `--auth-service=ledger`, the default virtual scopes are:
 
 | Scope | Operations |
 |-------|------------|
-| `ledger:read` | All read operations (GET HTTP, List*/Get* gRPC RPCs). Also covers `Barrier`, which is read-after-write tooling but proposes a no-op through Raft, so it is authenticated and requires the `ops:read` granular scope (included in the read bundle). |
+| `ledger:read` | All read operations (GET HTTP, List*/Get* gRPC RPCs). Also covers `Barrier`, which is read-after-write tooling but proposes a no-op through Raft, so it is authenticated and requires the `ledger:OpsRead` granular scope (included in the read bundle). |
 | `ledger:write` | All write operations (Apply: create/revert transactions, save/delete metadata, create/delete ledgers, set maintenance mode, etc.) |
 | `ledger:admin` | Cluster operations (GetClusterState, TransferLeadership, Backup, AddLearner, PromoteLearner, RemoveNode, GetDiskUsage, GetNodeTime) |
 
 If `--auth-service=myapp`, the scopes become `myapp:read`, `myapp:write`, `myapp:admin`.
+
+Granular scopes use the Ledger application namespace with the `ledger:<Resource><Action>` shape:
+
+```
+ledger:LedgerRead       ledger:LedgerWrite
+ledger:TransactionRead  ledger:TransactionWrite
+ledger:AccountRead      ledger:MetadataWrite
+ledger:AuditRead        ledger:AuditWrite
+ledger:OpsRead          ledger:OpsWrite
+ledger:QueryRead        ledger:QueryWrite
+ledger:ClusterRead      ledger:ClusterWrite
+```
 
 ## Configuration Invariants
 
@@ -79,9 +91,9 @@ Semantics:
 |---------|-------|---------|
 | Read endpoint | Absent | **200** — anonymous covers the required `*:read` scope |
 | Read endpoint | Invalid (bad signature, expired, malformed) | **401** — a broken token is a client error, never silently ignored |
-| Read endpoint | Valid with `*:read` | 200 — the token's scopes apply (no anonymous merging) |
+| Read endpoint | Valid with `ledger:read` or a matching granular read scope | 200 — the token's scopes apply (no anonymous merging) |
 | Write endpoint | Absent | **401** — anonymous does not cover writes |
-| Write endpoint | Valid with `*:write` | 200 |
+| Write endpoint | Valid with `ledger:write` or a matching granular write scope | 200 |
 | Write endpoint | Valid without write scope | 403 |
 
 Equivalent scope-mapping JSON (`--auth-scope-mapping-file`):
@@ -94,7 +106,7 @@ Both forms are supported — the CLI flag is shorthand for the JSON entry.
 
 When neither is set, the behavior is identical to before (every request must authenticate, no regression possible).
 
-Note: `/debug/pprof/*` endpoints require the `ops:read` scope when authentication is enabled.
+Note: `/debug/pprof/*` endpoints require the `ledger:OpsRead` scope when authentication is enabled.
 
 ## gRPC Authentication
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4320,7 +4320,7 @@ on/off TLS toggle workflow.
 | `--auth-anonymous-scopes` | string | `""` | Comma-separated granular scopes (or `*:read` / `*:write` wildcards) granted to requests that arrive without a bearer token |
 | `--auth-discovery-timeout` | duration | `10s` | Bound the HTTP calls used for OIDC discovery and JWKS fetches (`0` = unbounded). Applies one operator-controlled timeout to both the discovery call and later JWKS key fetches. |
 
-Allows expanding virtual scopes into fine-grained scopes. For example, mapping `ledger:read` to a set of more specific scopes. The mapping can also be provided via the `AUTH_SCOPE_MAPPING` environment variable (JSON string).
+Allows expanding virtual scopes into granular Ledger scopes. For example, mapping `ledger:read` to scopes such as `ledger:LedgerRead` and `ledger:TransactionRead`. Granular Ledger scopes use the `ledger:<Resource><Action>` shape. The mapping can also be provided via the `AUTH_SCOPE_MAPPING` environment variable (JSON string).
 
 ```bash
 ledger run --auth-scope-mapping-file /etc/ledger/scope-mapping.json [other flags...]
@@ -4337,7 +4337,7 @@ ledger run --auth-enabled --auth-issuer https://auth.example.com \
 
 With this configuration:
 
-- A read request without a token receives all `*:read` scopes and is allowed.
+- A read request without a token receives all granular read scopes matched by `*:read` and is allowed.
 - A read request with a **malformed/expired/invalid** token is rejected with `401` (a broken token is still treated as a client error — it is not silently ignored).
 - A write request without a token is rejected with `401` (anonymous scopes do not cover writes).
 - A write request with a valid token is allowed iff the token carries the required write scope (unchanged behavior).
@@ -4473,7 +4473,7 @@ ledger run \
   [other flags...]
 ```
 
-When enabled, the server performs OIDC discovery, downloads the JWKS, and validates JWT signatures, issuer, and expiration on every request. Three scopes are used: `ledger:read`, `ledger:write`, `ledger:admin`.
+When enabled, the server performs OIDC discovery, downloads the JWKS, and validates JWT signatures, issuer, and expiration on every request. By default, tokens may use the virtual scopes `ledger:read`, `ledger:write`, and `ledger:admin`, which expand to granular `ledger:<Resource><Action>` scopes.
 
 When `--auth-ed25519-keys` is set, both OIDC and Ed25519 authentication can coexist. See [Authentication Guide](authentication.md) for full Ed25519 setup instructions.
 

--- a/docs/technical/architecture/subsystems/api/auth.md
+++ b/docs/technical/architecture/subsystems/api/auth.md
@@ -50,16 +50,16 @@ The lack of cache is deliberate at this stage — JWKS lookups are local to the 
 `internal/adapter/auth/scopes.go:21-36` defines 14 granular scopes:
 
 ```
-ledgers:read       ledgers:write
-transactions:read  transactions:write
-accounts:read      metadata:write
-audit:read         audit:write
-ops:read           ops:write
-queries:read       queries:write
-cluster:read       cluster:write
+ledger:LedgerRead       ledger:LedgerWrite
+ledger:TransactionRead  ledger:TransactionWrite
+ledger:AccountRead      ledger:MetadataWrite
+ledger:AuditRead        ledger:AuditWrite
+ledger:OpsRead          ledger:OpsWrite
+ledger:QueryRead        ledger:QueryWrite
+ledger:ClusterRead      ledger:ClusterWrite
 ```
 
-Tokens may carry either **granular** scopes (used as-is) or **virtual** scopes (e.g. `ledger:read`, `ledger:write`, `ledger:admin`) that expand into a granular set via a configurable mapping (`scopes.go:56-89`). The mapping can be a JSON file, an environment variable, or a built-in default. Once expanded, only the granular form is consulted at authorization time.
+Tokens may carry either **granular** scopes (used as-is) or **virtual** scopes (for example `ledger:read`, `ledger:write`, `ledger:admin`) that expand into a granular set via a configurable mapping (`scopes.go:56-89`). Granular scopes are always in the Ledger application namespace with the `ledger:<Resource><Action>` shape, matching the Membership scope convention. The mapping can be a JSON file, an environment variable, or a built-in default. Once expanded, only the granular form is consulted at authorization time.
 
 ### Authorization enforcement
 
@@ -85,7 +85,7 @@ Failures are structured-logged with reason, key ID, remote address, and an OTel 
 |------------|--------|
 | `""` (default) | Every request must be authenticated. |
 | `"*:read"` | Public reads, authenticated writes. |
-| `"ledgers:read,transactions:read"` | Specific anonymous reads, nothing else. |
+| `"ledger:LedgerRead,ledger:TransactionRead"` | Specific anonymous reads, nothing else. |
 
 This is the right setting to relax for embedded / dev deployments without disabling auth altogether.
 

--- a/docs/technical/architecture/subsystems/chapters/receipts.md
+++ b/docs/technical/architecture/subsystems/chapters/receipts.md
@@ -81,7 +81,7 @@ The resulting `RevertedTransaction` log is hash-bound by the audit chain exactly
 
 ## What a receipt does not authorise
 
-- **It does not authenticate the caller.** Receipt verification proves "this content was signed by the cluster" — it says nothing about who is allowed to invoke it. The standard [auth](../api/auth.md) flow (JWT bearer + scopes) still runs in front. A valid receipt without a valid `transactions:write` scope is rejected at admission.
+- **It does not authenticate the caller.** Receipt verification proves "this content was signed by the cluster" — it says nothing about who is allowed to invoke it. The standard [auth](../api/auth.md) flow (JWT bearer + scopes) still runs in front. A valid receipt without a valid `ledger:TransactionWrite` scope is rejected at admission.
 - **It is not idempotency.** Re-submitting the same receipt twice produces two revert attempts; the second one is rejected by the FSM because the original is already reverted (`checkReversionInvariants` enforces no-double-revert). If the client needs idempotent retries, it uses the standard idempotency key on the request — receipts and idempotency keys are orthogonal.
 - **It is not arbitrary forging power.** The receipt's `Postings` are fixed at issuance time; they cannot be edited and re-signed. A receipt revert produces a revert log that is, byte-for-byte, the revert the cluster would have produced from cold-storage replay.
 

--- a/internal/adapter/auth/caller_snapshot_test.go
+++ b/internal/adapter/auth/caller_snapshot_test.go
@@ -91,7 +91,7 @@ func TestResolveCallerSnapshot_ForwardedShortCircuitsClaims(t *testing.T) {
 			Subject: "original-user",
 			Source:  &commonpb.CallerIdentity_Issuer{Issuer: "https://idp.example.com"},
 		},
-		Scopes: []string{"transactions:write"},
+		Scopes: []string{"ledger:TransactionWrite"},
 	}
 
 	ctx := WithClaims(context.Background(), claims)
@@ -102,7 +102,7 @@ func TestResolveCallerSnapshot_ForwardedShortCircuitsClaims(t *testing.T) {
 	require.Equal(t, "original-user", got.GetIdentity().GetSubject(),
 		"forwarded snapshot must win over local peer claims")
 	require.Equal(t, "https://idp.example.com", got.GetIdentity().GetIssuer())
-	require.Equal(t, []string{"transactions:write"}, got.GetScopes())
+	require.Equal(t, []string{"ledger:TransactionWrite"}, got.GetScopes())
 }
 
 func TestIsClusterInternal_DefaultsFalse(t *testing.T) {

--- a/internal/adapter/auth/grpc_auth_test.go
+++ b/internal/adapter/auth/grpc_auth_test.go
@@ -442,7 +442,7 @@ func TestAuthenticate_GranularScopePassThrough(t *testing.T) {
 	cfg := testAuthConfig(t, keySet)
 
 	// Token has granular scope directly (identity pass-through)
-	token := signToken(t, privKey, newTestClaims("transactions:read"))
+	token := signToken(t, privKey, newTestClaims("ledger:TransactionRead"))
 	ctx := ctxWithBearer(token)
 
 	newCtx, err := Authenticate(ctx, cfg, ScopeTransactionsRead)

--- a/internal/adapter/auth/request_scope.go
+++ b/internal/adapter/auth/request_scope.go
@@ -50,7 +50,7 @@ func RequiredScopeForRequest(req *servicepb.Request) Scope {
 	case *servicepb.Request_DeletePreparedQuery:
 		return ScopeQueriesWrite
 	default:
-		// Unknown request type — default to ops:write (most restrictive write scope)
+		// Unknown request type — default to ledger:OpsWrite (most restrictive write scope)
 		return ScopeOpsWrite
 	}
 }

--- a/internal/adapter/auth/request_scope_test.go
+++ b/internal/adapter/auth/request_scope_test.go
@@ -165,6 +165,6 @@ func TestRequiredScopeForLedgerApply_NilApply(t *testing.T) {
 			Apply: nil,
 		},
 	}
-	// Nil apply defaults to ops:write (most restrictive)
+	// Nil apply defaults to ledger:OpsWrite (most restrictive)
 	assert.Equal(t, ScopeOpsWrite, RequiredScopeForRequest(req))
 }

--- a/internal/adapter/auth/scope_mapping_file.go
+++ b/internal/adapter/auth/scope_mapping_file.go
@@ -17,7 +17,7 @@ func LoadScopeMappingFromFile(path string) (ScopeMapping, error) {
 }
 
 // ParseScopeMappingJSON parses a JSON-encoded scope mapping.
-// Expected format: {"ledger:read": ["ledgers:read", "transactions:read", ...], ...}.
+// Expected format: {"ledger:read": ["ledger:LedgerRead", "ledger:TransactionRead", ...], ...}.
 func ParseScopeMappingJSON(data []byte) (ScopeMapping, error) {
 	var raw map[string][]string
 

--- a/internal/adapter/auth/scope_mapping_file_test.go
+++ b/internal/adapter/auth/scope_mapping_file_test.go
@@ -13,8 +13,8 @@ func TestParseScopeMappingJSON_Valid(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-		"ledger:read": ["ledgers:read", "transactions:read", "accounts:read"],
-		"ledger:write": ["ledgers:write", "transactions:write", "metadata:write"]
+		"ledger:read": ["ledger:LedgerRead", "ledger:TransactionRead", "ledger:AccountRead"],
+		"ledger:write": ["ledger:LedgerWrite", "ledger:TransactionWrite", "ledger:MetadataWrite"]
 	}`)
 
 	mapping, err := ParseScopeMappingJSON(data)
@@ -32,7 +32,7 @@ func TestParseScopeMappingJSON_UnknownScope(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-		"ledger:read": ["ledgers:read", "nonexistent:scope"]
+		"ledger:read": ["ledger:LedgerRead", "nonexistent:scope"]
 	}`)
 
 	_, err := ParseScopeMappingJSON(data)
@@ -61,8 +61,8 @@ func TestLoadScopeMappingFromFile(t *testing.T) {
 	t.Parallel()
 
 	content := `{
-		"custom:read": ["ledgers:read", "transactions:read"],
-		"custom:write": ["ledgers:write"]
+		"custom:read": ["ledger:LedgerRead", "ledger:TransactionRead"],
+		"custom:write": ["ledger:LedgerWrite"]
 	}`
 
 	dir := t.TempDir()
@@ -88,8 +88,8 @@ func TestParseScopeMappingJSON_AllScopes(t *testing.T) {
 
 	// Verify all 14 granular scopes can be used in a mapping
 	data := []byte(`{
-		"all:read": ["ledgers:read", "transactions:read", "accounts:read", "audit:read", "ops:read", "queries:read", "cluster:read"],
-		"all:write": ["ledgers:write", "transactions:write", "metadata:write", "audit:write", "ops:write", "queries:write", "cluster:write"]
+		"all:read": ["ledger:LedgerRead", "ledger:TransactionRead", "ledger:AccountRead", "ledger:AuditRead", "ledger:OpsRead", "ledger:QueryRead", "ledger:ClusterRead"],
+		"all:write": ["ledger:LedgerWrite", "ledger:TransactionWrite", "ledger:MetadataWrite", "ledger:AuditWrite", "ledger:OpsWrite", "ledger:QueryWrite", "ledger:ClusterWrite"]
 	}`)
 
 	mapping, err := ParseScopeMappingJSON(data)
@@ -121,7 +121,7 @@ func TestParseScopeMappingJSON_WildcardMixedWithExplicit(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{
-		"anonymous": ["*:read", "metadata:write"]
+		"anonymous": ["*:read", "ledger:MetadataWrite"]
 	}`)
 
 	mapping, err := ParseScopeMappingJSON(data)

--- a/internal/adapter/auth/scopes.go
+++ b/internal/adapter/auth/scopes.go
@@ -18,21 +18,23 @@ const (
 )
 
 // Granular scopes — 14 total, grouped by resource category.
+// Canonical Ledger scopes use the app namespace followed by ResourceAction,
+// matching the Membership scope style (for example, ledger:ClusterRead).
 var (
-	ScopeLedgersRead       Scope = "ledgers:read"
-	ScopeLedgersWrite      Scope = "ledgers:write"
-	ScopeTransactionsRead  Scope = "transactions:read"
-	ScopeTransactionsWrite Scope = "transactions:write"
-	ScopeAccountsRead      Scope = "accounts:read"
-	ScopeMetadataWrite     Scope = "metadata:write"
-	ScopeAuditRead         Scope = "audit:read"
-	ScopeAuditWrite        Scope = "audit:write"
-	ScopeOpsRead           Scope = "ops:read"
-	ScopeOpsWrite          Scope = "ops:write"
-	ScopeQueriesRead       Scope = "queries:read"
-	ScopeQueriesWrite      Scope = "queries:write"
-	ScopeClusterRead       Scope = "cluster:read"
-	ScopeClusterWrite      Scope = "cluster:write"
+	ScopeLedgersRead       Scope = "ledger:LedgerRead"
+	ScopeLedgersWrite      Scope = "ledger:LedgerWrite"
+	ScopeTransactionsRead  Scope = "ledger:TransactionRead"
+	ScopeTransactionsWrite Scope = "ledger:TransactionWrite"
+	ScopeAccountsRead      Scope = "ledger:AccountRead"
+	ScopeMetadataWrite     Scope = "ledger:MetadataWrite"
+	ScopeAuditRead         Scope = "ledger:AuditRead"
+	ScopeAuditWrite        Scope = "ledger:AuditWrite"
+	ScopeOpsRead           Scope = "ledger:OpsRead"
+	ScopeOpsWrite          Scope = "ledger:OpsWrite"
+	ScopeQueriesRead       Scope = "ledger:QueryRead"
+	ScopeQueriesWrite      Scope = "ledger:QueryWrite"
+	ScopeClusterRead       Scope = "ledger:ClusterRead"
+	ScopeClusterWrite      Scope = "ledger:ClusterWrite"
 )
 
 // AllGranularScopes is the complete set of valid granular scopes for validation.
@@ -122,21 +124,21 @@ func (m ScopeMapping) AnonymousScopes() map[Scope]struct{} {
 }
 
 // ExpandWildcardScope expands a wildcard token (e.g. "*:read", "*:write") into
-// the list of granular scopes that share its suffix. Returns (nil, false) when
-// the input is not a recognized wildcard.
+// the list of granular scopes with a matching action suffix. Returns (nil, false)
+// when the input is not a recognized wildcard.
 func ExpandWildcardScope(s string) ([]Scope, bool) {
 	switch s {
 	case WildcardRead:
-		return scopesWithSuffix(":read"), true
+		return scopesWithSuffix("Read"), true
 	case WildcardWrite:
-		return scopesWithSuffix(":write"), true
+		return scopesWithSuffix("Write"), true
 	default:
 		return nil, false
 	}
 }
 
 // scopesWithSuffix returns every granular scope whose name ends with the given
-// suffix (e.g. ":read", ":write"). Order is not stable.
+// action suffix (e.g. "Read", "Write"). Order is not stable.
 func scopesWithSuffix(suffix string) []Scope {
 	out := make([]Scope, 0, len(AllGranularScopes))
 	for s := range AllGranularScopes {

--- a/internal/adapter/auth/scopes_test.go
+++ b/internal/adapter/auth/scopes_test.go
@@ -65,7 +65,7 @@ func TestExpandScopes_IdentityPassThrough(t *testing.T) {
 
 	m := DefaultMapping("ledger")
 	// Token has a granular scope directly
-	effective := m.ExpandScopes([]string{"transactions:read"})
+	effective := m.ExpandScopes([]string{"ledger:TransactionRead"})
 
 	assert.Contains(t, effective, ScopeTransactionsRead)
 	// Should NOT expand to other scopes
@@ -76,7 +76,7 @@ func TestExpandScopes_MixedVirtualAndGranular(t *testing.T) {
 	t.Parallel()
 
 	m := DefaultMapping("ledger")
-	effective := m.ExpandScopes([]string{"ledger:admin", "transactions:read"})
+	effective := m.ExpandScopes([]string{"ledger:admin", "ledger:TransactionRead"})
 
 	// From virtual scope
 	assert.Contains(t, effective, ScopeClusterRead)
@@ -168,7 +168,7 @@ func TestExpandWildcardScope_Unknown(t *testing.T) {
 	_, ok := ExpandWildcardScope("*:admin")
 	assert.False(t, ok)
 
-	_, ok = ExpandWildcardScope("ledgers:read")
+	_, ok = ExpandWildcardScope("ledger:LedgerRead")
 	assert.False(t, ok)
 }
 

--- a/internal/adapter/grpc/client_bucket_test.go
+++ b/internal/adapter/grpc/client_bucket_test.go
@@ -963,7 +963,7 @@ func TestApply_PropagatesExistingForwardedSnapshot(t *testing.T) {
 			Subject: "original-user",
 			Source:  &commonpb.CallerIdentity_KeyId{KeyId: "ed25519-7"},
 		},
-		Scopes: []string{"transactions:write"},
+		Scopes: []string{"ledger:TransactionWrite"},
 	}
 	ctx := auth.WithForwardedSnapshot(context.Background(), original)
 
@@ -975,5 +975,5 @@ func TestApply_PropagatesExistingForwardedSnapshot(t *testing.T) {
 	require.NotNil(t, fc)
 	require.Equal(t, "original-user", fc.GetIdentity().GetSubject())
 	require.Equal(t, "ed25519-7", fc.GetIdentity().GetKeyId())
-	require.Equal(t, []string{"transactions:write"}, fc.GetScopes())
+	require.Equal(t, []string{"ledger:TransactionWrite"}, fc.GetScopes())
 }

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -910,10 +910,10 @@ func (impl *BucketServiceServerImpl) ListIndexes(req *servicepb.ListIndexesReque
 	ctx := stream.Context()
 
 	// Per-ledger callers previously read indexes through GetLedger under
-	// ledgers:read, so we keep that scope for SCOPE_LEDGER to preserve
-	// granular-auth tokens that don't carry ops:read. SCOPE_BUCKET and
+	// ledger:LedgerRead, so we keep that scope for SCOPE_LEDGER to preserve
+	// granular-auth tokens that don't carry ledger:OpsRead. SCOPE_BUCKET and
 	// SCOPE_ALL surface cross-ledger / operator-grade visibility and stay
-	// under ops:read (PR #453 review).
+	// under ledger:OpsRead (PR #453 review).
 	requiredScope := internalauth.ScopeOpsRead
 	if req.GetScope() == servicepb.ListIndexesRequest_SCOPE_LEDGER {
 		requiredScope = internalauth.ScopeLedgersRead
@@ -1626,7 +1626,7 @@ func (impl *BucketServiceServerImpl) InspectIndex(ctx context.Context, req *serv
 func (impl *BucketServiceServerImpl) Barrier(ctx context.Context, _ *servicepb.BarrierRequest) (*servicepb.BarrierResponse, error) {
 	// Barrier proposes a no-op through Raft and waits for it to apply, so it
 	// consumes consensus capacity like a write. Require an authenticated scope
-	// (ops:read) so it can't be used anonymously as a DoS amplifier or a
+	// (ledger:OpsRead) so it can't be used anonymously as a DoS amplifier or a
 	// commit-index timing side channel. Leader-forwarded calls carry the
 	// cluster secret, which grants all scopes.
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeOpsRead); err != nil {

--- a/internal/adapter/grpc/server_bucket_auth_test.go
+++ b/internal/adapter/grpc/server_bucket_auth_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestBarrier_RequiresOpsReadScope guards the fix for the unauthenticated
-// Barrier RPC: it proposes a no-op through Raft, so it must require ops:read
+// Barrier RPC: it proposes a no-op through Raft, so it must require ledger:OpsRead
 // and must not reach the controller (i.e. must not propose) when the caller
 // lacks it.
 func TestBarrier_RequiresOpsReadScope(t *testing.T) {
@@ -57,17 +57,17 @@ func TestBarrier_RequiresOpsReadScope(t *testing.T) {
 		require.Equal(t, codes.Unauthenticated, status.Code(err))
 	})
 
-	t.Run("rejects caller whose scopes omit ops:read", func(t *testing.T) {
+	t.Run("rejects caller whose scopes omit ledger:OpsRead", func(t *testing.T) {
 		t.Parallel()
 
-		// Effective scopes lack ops:read — the wrong-scope case.
+		// Effective scopes lack ledger:OpsRead — the wrong-scope case.
 		impl := newImpl(anonCfg(internalauth.ScopeAccountsRead, internalauth.ScopeTransactionsRead), false)
 
 		_, err := impl.Barrier(context.Background(), &servicepb.BarrierRequest{})
 		require.Error(t, err)
 	})
 
-	t.Run("allows caller with ops:read", func(t *testing.T) {
+	t.Run("allows caller with ledger:OpsRead", func(t *testing.T) {
 		t.Parallel()
 
 		impl := newImpl(anonCfg(internalauth.ScopeOpsRead), true)

--- a/internal/adapter/grpc/server_bucket_test.go
+++ b/internal/adapter/grpc/server_bucket_test.go
@@ -24,7 +24,7 @@ func TestAdoptForwardedSnapshotIfTrusted_TrustsClusterInternal(t *testing.T) {
 			Subject: "alice",
 			Source:  &commonpb.CallerIdentity_Issuer{Issuer: "https://idp.example.com"},
 		},
-		Scopes: []string{"transactions:write"},
+		Scopes: []string{"ledger:TransactionWrite"},
 	}
 	req := &servicepb.ApplyRequest{ForwardedCallerSnapshot: snapshot}
 

--- a/internal/adapter/http/handlers_bulk_test.go
+++ b/internal/adapter/http/handlers_bulk_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // bulkWriteBody is a single-element bulk payload whose action (CREATE_TRANSACTION)
-// requires the transactions:write granular scope.
+// requires the ledger:TransactionWrite granular scope.
 const bulkWriteBody = `[{"action":"CREATE_TRANSACTION","data":{"postings":[{"source":"world","destination":"bank","amount":100,"asset":"USD/2"}]}}]`
 
 func TestHandleBulk_InvalidBody(t *testing.T) {

--- a/internal/application/membership/membership.go
+++ b/internal/application/membership/membership.go
@@ -5,7 +5,7 @@
 // Two gRPC surfaces depend on these operations:
 //
 //   - ClusterService on the external ServiceServer, gated by user JWT
-//     scopes (cluster:write, cluster:read), used by ledgerctl and
+//     scopes (ledger:ClusterWrite, ledger:ClusterRead), used by ledgerctl and
 //     observability tooling.
 //   - ClusterBootstrapService on the inter-node RaftServer, gated by
 //     cluster-id metadata (+ cluster-secret bearer when configured),

--- a/internal/bootstrap/module_test.go
+++ b/internal/bootstrap/module_test.go
@@ -22,7 +22,7 @@ func TestLoadScopeMapping_FromFile(t *testing.T) {
 	mappingFile := filepath.Join(dir, "scope-mapping.json")
 
 	mapping := map[string][]string{
-		"custom:read": {"ledgers:read", "transactions:read"},
+		"custom:read": {"ledger:LedgerRead", "ledger:TransactionRead"},
 	}
 
 	data, err := json.Marshal(mapping)
@@ -49,7 +49,7 @@ func TestLoadScopeMapping_FromEnvJSON(t *testing.T) {
 
 	logger := logging.Testing()
 
-	rawJSON := `{"my-scope:write": ["ledgers:write", "metadata:write"]}`
+	rawJSON := `{"my-scope:write": ["ledger:LedgerWrite", "ledger:MetadataWrite"]}`
 	cfg := Config{
 		AuthConfig: AuthFlagConfig{
 			ScopeMappingJSON: rawJSON,
@@ -139,7 +139,7 @@ func TestLoadScopeMapping_FilePrecedenceOverJSON(t *testing.T) {
 	mappingFile := filepath.Join(dir, "scope-mapping.json")
 
 	mapping := map[string][]string{
-		"file:read": {"ledgers:read"},
+		"file:read": {"ledger:LedgerRead"},
 	}
 
 	data, err := json.Marshal(mapping)
@@ -150,7 +150,7 @@ func TestLoadScopeMapping_FilePrecedenceOverJSON(t *testing.T) {
 	cfg := Config{
 		AuthConfig: AuthFlagConfig{
 			ScopeMappingFile: mappingFile,
-			ScopeMappingJSON: `{"json:read": ["ledgers:read"]}`,
+			ScopeMappingJSON: `{"json:read": ["ledger:LedgerRead"]}`,
 		},
 	}
 
@@ -179,7 +179,7 @@ func TestApplyAnonymousScopes_ExplicitList(t *testing.T) {
 	t.Parallel()
 
 	mapping := internalauth.DefaultMapping("ledger")
-	require.NoError(t, applyAnonymousScopes(mapping, "ledgers:read, accounts:read", logging.Testing()))
+	require.NoError(t, applyAnonymousScopes(mapping, "ledger:LedgerRead, ledger:AccountRead", logging.Testing()))
 
 	anon := mapping.AnonymousScopes()
 	assert.Contains(t, anon, internalauth.ScopeLedgersRead)
@@ -200,7 +200,7 @@ func TestApplyAnonymousScopes_UnknownScope(t *testing.T) {
 	t.Parallel()
 
 	mapping := internalauth.DefaultMapping("ledger")
-	err := applyAnonymousScopes(mapping, "ledgers:read,bogus:scope", logging.Testing())
+	err := applyAnonymousScopes(mapping, "ledger:LedgerRead,bogus:scope", logging.Testing())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown granular scope")
 }

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -769,8 +769,8 @@ func TestBuildEnvVars_AuthScopeMapping(t *testing.T) {
 		ls := newMinimalLedgerService()
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 			ScopeMapping: map[string][]string{
-				"ledger:read":  {"ledger:transactions:read", "ledger:accounts:read"},
-				"ledger:write": {"ledger:transactions:write"},
+				"ledger:read":  {"ledger:TransactionRead", "ledger:AccountRead"},
+				"ledger:write": {"ledger:TransactionWrite"},
 			},
 		}
 		envs := buildEnvVars(ls, "disabled", nil)
@@ -812,12 +812,12 @@ func TestBuildEnvVars_AuthAnonymousScopes(t *testing.T) {
 		t.Parallel()
 		ls := newMinimalLedgerService()
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
-			AnonymousScopes: []string{"ledgers:read", "accounts:read"},
+			AnonymousScopes: []string{"ledger:LedgerRead", "ledger:AccountRead"},
 		}
 		envs := buildEnvVars(ls, "disabled", nil)
 		e := findEnv(envs, "AUTH_ANONYMOUS_SCOPES")
 		require.NotNil(t, e)
-		assert.Equal(t, "ledgers:read,accounts:read", e.Value)
+		assert.Equal(t, "ledger:LedgerRead,ledger:AccountRead", e.Value)
 	})
 
 	t.Run("empty slice omitted", func(t *testing.T) {

--- a/openapi.yml
+++ b/openapi.yml
@@ -320,7 +320,7 @@ paths:
       description: |
         Lists log entries for a specific ledger, ordered by ledger-local log ID ascending.
         Requires the builtin `LOG` index to be enabled on the ledger via `CreateIndex`.
-        Supports cursor pagination via the `after` query parameter. Requires `ops:read` scope.
+        Supports cursor pagination via the `after` query parameter. Requires `ledger:OpsRead` scope.
       operationId: listLedgerLogs
       tags:
         - Logs
@@ -614,7 +614,7 @@ paths:
       description: |
         Returns aggregated volumes (input/output/balance per asset) across all accounts in the ledger.
         Supports filtering by account address prefix, grouping by account prefixes, and max-precision merging.
-        Requires `accounts:read` scope.
+        Requires `ledger:AccountRead` scope.
       operationId: aggregateVolumes
       tags:
         - Volumes
@@ -1548,7 +1548,7 @@ paths:
       summary: Create a prepared query
       description: |
         Creates a new prepared query for a ledger. A prepared query defines a reusable
-        filter that can be executed later with parameter substitution. Requires `queries:write` scope.
+        filter that can be executed later with parameter substitution. Requires `ledger:QueryWrite` scope.
       operationId: createPreparedQuery
       tags:
         - Prepared Queries
@@ -1585,7 +1585,7 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
     get:
       summary: List prepared queries
-      description: Returns a list of all prepared queries for a ledger. Requires `queries:read` scope.
+      description: Returns a list of all prepared queries for a ledger. Requires `ledger:QueryRead` scope.
       operationId: listPreparedQueries
       tags:
         - Prepared Queries
@@ -1620,7 +1620,7 @@ paths:
     put:
       summary: Update a prepared query
       description: |
-        Updates the filter of an existing prepared query. Requires `queries:write` scope.
+        Updates the filter of an existing prepared query. Requires `ledger:QueryWrite` scope.
       operationId: updatePreparedQuery
       tags:
         - Prepared Queries
@@ -1655,7 +1655,7 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
     delete:
       summary: Delete a prepared query
-      description: Deletes a prepared query from a ledger. Requires `queries:write` scope.
+      description: Deletes a prepared query from a ledger. Requires `ledger:QueryWrite` scope.
       operationId: deletePreparedQuery
       tags:
         - Prepared Queries
@@ -1689,7 +1689,7 @@ paths:
       description: |
         Executes a prepared query with optional parameter substitution. Supports LIST and
         AGGREGATE_VOLUMES modes with cursor pagination. Also accepts pageSize and cursor
-        as query parameters. Requires `queries:read` scope.
+        as query parameters. Requires `ledger:QueryRead` scope.
       operationId: executePreparedQuery
       tags:
         - Prepared Queries
@@ -1743,7 +1743,7 @@ paths:
       summary: Add an account type
       description: |
         Adds a new account type to a ledger's chart of accounts. Account types define
-        address patterns for account validation. Requires `metadata:write` scope.
+        address patterns for account validation. Requires `ledger:MetadataWrite` scope.
       operationId: addAccountType
       tags:
         - Account Types
@@ -1781,7 +1781,7 @@ paths:
       summary: List account types
       description: |
         Returns all account types defined on a ledger, sorted by name.
-        Requires `accounts:read` scope.
+        Requires `ledger:AccountRead` scope.
       operationId: listAccountTypes
       tags:
         - Account Types
@@ -1817,7 +1817,7 @@ paths:
       summary: Set default enforcement mode
       description: |
         Sets the default enforcement mode for accounts that do not match any defined
-        account type. Must be STRICT or AUDIT. Requires `metadata:write` scope.
+        account type. Must be STRICT or AUDIT. Requires `ledger:MetadataWrite` scope.
       operationId: setDefaultEnforcementMode
       tags:
         - Account Types
@@ -1853,7 +1853,7 @@ paths:
   /v3/{ledgerName}/account-types/{typeName}:
     get:
       summary: Get an account type
-      description: Retrieves a specific account type by name from a ledger. Requires `accounts:read` scope.
+      description: Retrieves a specific account type by name from a ledger. Requires `ledger:AccountRead` scope.
       operationId: getAccountType
       tags:
         - Account Types
@@ -1886,7 +1886,7 @@ paths:
           $ref: '#/components/responses/MethodNotAllowed'
     delete:
       summary: Remove an account type
-      description: Removes an account type from a ledger's chart of accounts. Requires `metadata:write` scope.
+      description: Removes an account type from a ledger's chart of accounts. Requires `ledger:MetadataWrite` scope.
       operationId: removeAccountType
       tags:
         - Account Types

--- a/tests/e2e/cluster/auth_test.go
+++ b/tests/e2e/cluster/auth_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Auth", Ordered, func() {
 			Expect(st.Code()).To(Equal(codes.Unauthenticated))
 		})
 
-		It("should allow GetNumscript with ledger:read scope (queries:read mapped)", func() {
+		It("should allow GetNumscript with ledger:read scope (ledger:QueryRead mapped)", func() {
 			token, err := signJWT(privKey, makeAuthClaims(oidcServer.URL, "ledger:read"))
 			Expect(err).To(Succeed())
 			authCtx := withAuthToken(ctx, token)
@@ -343,7 +343,7 @@ var _ = Describe("Auth", Ordered, func() {
 			}
 		})
 
-		It("should allow ListNumscripts with ledger:read scope (queries:read mapped)", func() {
+		It("should allow ListNumscripts with ledger:read scope (ledger:QueryRead mapped)", func() {
 			token, err := signJWT(privKey, makeAuthClaims(oidcServer.URL, "ledger:read"))
 			Expect(err).To(Succeed())
 			authCtx := withAuthToken(ctx, token)


### PR DESCRIPTION
## Summary
- rename Ledger granular scope strings to the canonical `ledger:<Resource><Action>` pattern
- keep virtual scopes `ledger:read`, `ledger:write`, and `ledger:admin` as the default mapping inputs
- update wildcard expansion, docs, OpenAPI descriptions, operator examples, and tests to use the canonical names

## Checks
- `nix develop --command bash -c 'GOROOT= go test ./internal/bootstrap ./cmd/ledgerctl/cmdutil ./internal/adapter/grpc ./internal/adapter/http ./internal/application/membership'`
- `GOROOT= go test ./internal/controller` from `misc/operator`
- `nix develop --command bash -c 'just pre-commit'`
- `nix develop --command bash -c 'GOROOT= go build ./...'` from repo root
- `nix develop --command bash -c 'GOROOT= go build ./...'` from `misc/operator`
- GitNexus `detect_changes`: medium risk, scoped to auth/docs/tests