### PR TITLE
ci(release): wrap release archives in a named root directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,7 @@ archives:
   formats:
   - tar.gz
   name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}"
+  wrap_in_directory: true
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## What

Set `wrap_in_directory: true` on the GoReleaser archive so each release tarball extracts into a top-level folder matching the archive name.

## Why

Today `ledger-v3_{os}-{arch}.tar.gz` drops `ledger-server` and `ledgerctl` directly into the extraction directory. Wrapping them under `ledger-v3_{os}-{arch}/` keeps extractions tidy and follows the common release-archive convention.

## Notes

- `goreleaser check` passes (only the pre-existing `dockers` deprecation notices remain, unrelated to this change).