### PR TITLE
chore(deps): replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/cmd/ledgerctl/cmdutil/output.go
+++ b/cmd/ledgerctl/cmdutil/output.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/cmd/ledgerctl/cmdutil/output.go
+++ b/cmd/ledgerctl/cmdutil/output.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/cmd/ledgerctl/ledgers/config_model.go
+++ b/cmd/ledgerctl/ledgers/config_model.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/accounttypes"
 	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	auth "github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -15,9 +15,9 @@ import (
 	"go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.uber.org/fx"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"go.yaml.in/yaml/v3"
 
 	auth "github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -314,5 +313,6 @@ require (
 	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/gotestsum v1.8.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -81,6 +81,7 @@ require (
 	go.etcd.io/raft/v3 v3.6.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 )
 
@@ -301,7 +302,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect

--- a/internal/bootstrap/config_redaction_test.go
+++ b/internal/bootstrap/config_redaction_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // marshalers covers every encoder the config might be rendered with. Redaction


### PR DESCRIPTION
## What

Replaces the `gopkg.in/yaml.v3` import path with the canonical `go.yaml.in/yaml/v3` module across the codebase.

## Changes

- Swapped the import path in all 4 Go files that use it:
  - `cmd/server/server.go`
  - `cmd/ledgerctl/ledgers/config_model.go`
  - `cmd/ledgerctl/cmdutil/output.go`
  - `internal/bootstrap/config_redaction_test.go`
- `go.yaml.in/yaml/v3 v3.0.4` is now a direct dependency in `go.mod`.
- `gopkg.in/yaml.v3` remains as an `// indirect` dependency (still pulled in transitively by other modules).

The package name is unchanged (`yaml`), so no call sites needed modification.

## Verification

- `go build ./...` passes
- `go vet` on affected packages passes
- Bootstrap test package compiles cleanly