### PR TITLE
feat(ledger): navigable revert relationship + queryable reverted/revertedAt

### DIFF
--- a/cmd/ledgerctl/indexes/create.go
+++ b/cmd/ledgerctl/indexes/create.go
@@ -28,6 +28,7 @@ Index types:
   reference            Transaction reference index (exact-match filter)
   timestamp            Transaction timestamp index (range filter)
   inserted-at          Transaction inserted_at (creation date) index (range filter)
+  reverted-at          Transaction reverted_at (revert date) index (range filter)
   log-ledger           Per-ledger log index (enables filtered log listing)
   account-asset        Account asset-presence index (enables the 'has asset' account filter)
 
@@ -38,6 +39,7 @@ Examples:
   ledgerctl indexes create --ledger my-ledger --type reference
   ledgerctl indexes create --ledger my-ledger --type timestamp
   ledgerctl indexes create --ledger my-ledger --type inserted-at
+  ledgerctl indexes create --ledger my-ledger --type reverted-at
   ledgerctl indexes create --ledger my-ledger --type log-ledger
   ledgerctl indexes create --ledger my-ledger --type account-asset`,
 		Args:              cobra.NoArgs,
@@ -121,11 +123,14 @@ func runCreateIndex(cmd *cobra.Command, _ []string) error {
 	case "inserted-at":
 		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)
 		indexDesc = "inserted-at"
+	case "reverted-at":
+		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT)
+		indexDesc = "reverted-at"
 	case "account-asset":
 		req.Id = accountBuiltinIndexID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
 		indexDesc = "account has-asset"
 	default:
-		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, log-ledger, or account-asset", indexType)
+		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, reverted-at, log-ledger, or account-asset", indexType)
 	}
 
 	ctx, cancel := cmdutil.GetContext(cmd)

--- a/cmd/ledgerctl/indexes/drop.go
+++ b/cmd/ledgerctl/indexes/drop.go
@@ -112,11 +112,14 @@ func runDropIndex(cmd *cobra.Command, _ []string) error {
 	case "inserted-at":
 		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)
 		indexDesc = "inserted-at"
+	case "reverted-at":
+		req.Id = txBuiltinIndexID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT)
+		indexDesc = "reverted-at"
 	case "account-asset":
 		req.Id = accountBuiltinIndexID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
 		indexDesc = "account has-asset"
 	default:
-		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, or account-asset", indexType)
+		return fmt.Errorf("invalid index type %q: must be address, source-address, destination-address, metadata, reference, timestamp, inserted-at, reverted-at, or account-asset", indexType)
 	}
 
 	ctx, cancel := cmdutil.GetContext(cmd)

--- a/cmd/ledgerctl/indexes/id_helpers.go
+++ b/cmd/ledgerctl/indexes/id_helpers.go
@@ -16,6 +16,7 @@ var indexTypeOptions = []string{
 	"reference",
 	"timestamp",
 	"inserted-at",
+	"reverted-at",
 	"account-asset",
 }
 

--- a/cmd/ledgerctl/indexes/list.go
+++ b/cmd/ledgerctl/indexes/list.go
@@ -188,6 +188,8 @@ func describeIndex(id *commonpb.IndexID) (typeName, target, key string) {
 			return "destination-address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			return "inserted-at", "-", "-"
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:
+			return "reverted-at", "-", "-"
 		}
 
 		return "tx-builtin", "-", k.TxBuiltin.String()

--- a/cmd/ledgerctl/ledgers/config_model.go
+++ b/cmd/ledgerctl/ledgers/config_model.go
@@ -50,6 +50,7 @@ type EditableIndexes struct {
 	SourceAddress      bool `json:"sourceAddress"      yaml:"sourceAddress"`
 	DestinationAddress bool `json:"destinationAddress" yaml:"destinationAddress"`
 	InsertedAt         bool `json:"insertedAt"         yaml:"insertedAt"`
+	RevertedAt         bool `json:"revertedAt"         yaml:"revertedAt"`
 }
 
 // EditablePreparedQuery is the editable subset of a prepared query.
@@ -162,6 +163,8 @@ func ConfigFromProto(
 			cfg.Indexes.DestinationAddress = true
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			cfg.Indexes.InsertedAt = true
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:
+			cfg.Indexes.RevertedAt = true
 		}
 	}
 
@@ -566,6 +569,7 @@ func diffIndexes(ledgerName string, current, desired *EditableConfig) []DiffActi
 		{"source-address", current.Indexes.SourceAddress, desired.Indexes.SourceAddress, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS},
 		{"destination-address", current.Indexes.DestinationAddress, desired.Indexes.DestinationAddress, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS},
 		{"inserted-at", current.Indexes.InsertedAt, desired.Indexes.InsertedAt, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT},
+		{"reverted-at", current.Indexes.RevertedAt, desired.Indexes.RevertedAt, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT},
 	}
 
 	for _, b := range builtins {

--- a/cmd/ledgerctl/ledgers/configuration.go
+++ b/cmd/ledgerctl/ledgers/configuration.go
@@ -262,6 +262,8 @@ func describeIndex(id *commonpb.IndexID) (typeName, target, key string) {
 			return "destination-address", "-", "-"
 		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 			return "inserted-at", "-", "-"
+		case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:
+			return "reverted-at", "-", "-"
 		}
 
 		return "tx-builtin", "-", k.TxBuiltin.String()

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -166,8 +166,12 @@ transaction representation (`GET`/list), not metadata — the platform never wri
 `revertedAt` is the compensating transaction's effective timestamp (so under
 `atEffectiveDate` it equals the original's timestamp). All three are derived from
 the structural `TransactionState`, so they hold identically after replay/backfill
-and on the mirror revert path. `revertedByTransactionId`/`revertsTransactionId` are
-not yet queryable (see filtering note below).
+and on the mirror revert path.
+
+Both `reverted` and `revertedAt` are queryable (upstream v2 parity). `reverted` is
+always available (served from the reversion bitset, no index); `revertedAt` requires
+the `reverted-at` builtin index. `revertedByTransactionId`/`revertsTransactionId` are
+navigable in the representation but not queryable (v3-only, no parity baseline).
 
 ### 3. Metadata Management
 
@@ -381,7 +385,9 @@ Prepared queries are reusable, named filter queries stored per-ledger. They can 
 | `ReferenceCondition` — transaction reference exact match | transactions | yes (`reference` builtin index) |
 | `BuiltinUintCondition` with `TIMESTAMP` — effective date range | transactions | yes (`timestamp` builtin index) |
 | `BuiltinUintCondition` with `INSERTED_AT` — creation date range | transactions | yes (`inserted_at` builtin index) |
+| `BuiltinUintCondition` with `REVERTED_AT` — revert date range | transactions | yes (`reverted_at` builtin index) |
 | `BuiltinUintCondition` with `ID` — transaction ID range or equality | transactions | no (direct range scan) |
+| `RevertedCondition` — transaction revert status (true/false) | transactions | no (reversion bitset) |
 | `AccountHasAssetCondition` — accounts that have ever touched an asset | accounts | yes (`account-asset` index) |
 
 **User-configurable indexes** control which filters are available. Each index has a lifecycle: BUILDING (backfill in progress) → READY (queries enabled).
@@ -395,16 +401,19 @@ Prepared queries are reusable, named filter queries stored per-ledger. They can 
 | `reference` | `--type reference` | `ReferenceCondition` |
 | `timestamp` | `--type timestamp` | `BuiltinUintCondition(TIMESTAMP)` |
 | `inserted-at` | `--type inserted-at` | `BuiltinUintCondition(INSERTED_AT)` |
+| `reverted-at` | `--type reverted-at` | `BuiltinUintCondition(REVERTED_AT)` |
 | `account-asset` | `--type account-asset` | `AccountHasAssetCondition` — `has asset <BASE>[/<PRECISION>]` filter on account queries |
 
-> Filtering by transaction ID (`BuiltinUintCondition(ID)`) is always available with no index required.
+> Filtering by transaction ID (`BuiltinUintCondition(ID)`) and by revert status
+> (`RevertedCondition`) are always available with no index required — the latter is
+> served from the per-ledger reversion bitset.
 
-> **Not yet queryable: `reverted` / `revertedAt`.** Upstream `formancehq/ledger`
-> lets clients filter transactions by revert status. v3 exposes the revert
-> relationship on the transaction representation (`reverted`, `revertedAt`,
-> `revertedByTransactionId`, `revertsTransactionId`) but does not yet index it, so
-> there is no `QueryFilter` for it — parity holds only for the queryable subset
-> above. Adding it would require a new builtin index + `QueryFilter` variant.
+> **Revert querying (upstream v2 parity).** v2 queries transactions by both
+> `reverted` and `reverted_at`; v3 matches this: `RevertedCondition` for the boolean
+> and `BuiltinUintCondition(REVERTED_AT)` (behind the `reverted-at` index) for the
+> date range. The v3-only navigable ids `revertedByTransactionId` /
+> `revertsTransactionId` are exposed in the representation but are not queryable
+> (no v2 baseline); adding them would follow the same builtin-index recipe.
 
 **CLI commands:**
 ```bash

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -156,6 +156,19 @@ See [Numscript Guide](./numscript.md) for complete documentation.
 - ✅ Revert metadata
 - ✅ Verification that transaction is not already reverted
 
+**Navigable revert relationship.** The revert link is a first-class part of the
+transaction representation (`GET`/list), not metadata — the platform never writes
+`com.formance.spec/*` keys. A transaction exposes:
+- `reverted` (bool) and `revertedAt` (timestamp) — set on the reverted original.
+- `revertedByTransactionId` — on the reverted original, the id of the compensating transaction.
+- `revertsTransactionId` — on the compensating transaction, the id of the original it reverts.
+
+`revertedAt` is the compensating transaction's effective timestamp (so under
+`atEffectiveDate` it equals the original's timestamp). All three are derived from
+the structural `TransactionState`, so they hold identically after replay/backfill
+and on the mirror revert path. `revertedByTransactionId`/`revertsTransactionId` are
+not yet queryable (see filtering note below).
+
 ### 3. Metadata Management
 
 **Endpoints:**
@@ -385,6 +398,13 @@ Prepared queries are reusable, named filter queries stored per-ledger. They can 
 | `account-asset` | `--type account-asset` | `AccountHasAssetCondition` — `has asset <BASE>[/<PRECISION>]` filter on account queries |
 
 > Filtering by transaction ID (`BuiltinUintCondition(ID)`) is always available with no index required.
+
+> **Not yet queryable: `reverted` / `revertedAt`.** Upstream `formancehq/ledger`
+> lets clients filter transactions by revert status. v3 exposes the revert
+> relationship on the transaction representation (`reverted`, `revertedAt`,
+> `revertedByTransactionId`, `revertsTransactionId`) but does not yet index it, so
+> there is no `QueryFilter` for it — parity holds only for the queryable subset
+> above. Adding it would require a new builtin index + `QueryFilter` variant.
 
 **CLI commands:**
 ```bash

--- a/internal/adapter/http/handlers_get_transaction_test.go
+++ b/internal/adapter/http/handlers_get_transaction_test.go
@@ -38,6 +38,51 @@ func TestHandleGetTransaction_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestHandleGetTransaction_RevertRelationshipFields(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetLedgerByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string) (*commonpb.LedgerInfo, error) {
+			return &commonpb.LedgerInfo{Name: "ledger1"}, nil
+		}).AnyTimes()
+	// Transaction 1 was reverted by transaction 2, which in turn reverts 1.
+	backend.EXPECT().GetTransaction(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, txID uint64) (*commonpb.Transaction, *string, error) {
+			if txID == 1 {
+				return &commonpb.Transaction{
+					Id:                    1,
+					Reverted:              true,
+					RevertedByTransaction: 2,
+					RevertedAt:            &commonpb.Timestamp{Data: 1_700_000_000_000_000},
+				}, nil, nil
+			}
+
+			return &commonpb.Transaction{Id: 2, RevertsTransaction: 1}, nil, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	// The reverted original exposes the forward link and reverted_at.
+	wOrig := httptest.NewRecorder()
+	srv.handleGetTransaction(wOrig, newRequest(t, http.MethodGet, "/ledger1/transactions/1", nil, map[string]string{
+		"ledgerName":    "ledger1",
+		"transactionId": "1",
+	}))
+	require.Equal(t, http.StatusOK, wOrig.Code)
+	require.Contains(t, wOrig.Body.String(), `"reverted":true`)
+	require.Contains(t, wOrig.Body.String(), `"revertedByTransactionId":2`)
+	require.Contains(t, wOrig.Body.String(), `"revertedAt":`)
+
+	// The compensating transaction exposes the back link.
+	wRevert := httptest.NewRecorder()
+	srv.handleGetTransaction(wRevert, newRequest(t, http.MethodGet, "/ledger1/transactions/2", nil, map[string]string{
+		"ledgerName":    "ledger1",
+		"transactionId": "2",
+	}))
+	require.Equal(t, http.StatusOK, wRevert.Code)
+	require.Contains(t, wRevert.Body.String(), `"revertsTransactionId":1`)
+}
+
 func TestHandleGetTransaction_InvalidTxID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/check/replay_store.go
+++ b/internal/application/check/replay_store.go
@@ -35,8 +35,8 @@ const (
 // Transaction merge op tags — each Merge operand starts with one of these.
 const (
 	txOpFinalized  = 0x00 // [txOpFinalized][marshaledTransactionState] — output of a previous Finish
-	txOpCreate     = 0x01 // [txOpCreate][uint64 seq][marshaledMetadataMap]
-	txOpRevertedBy = 0x02 // [txOpRevertedBy][uint64 revertTxId]
+	txOpCreate     = 0x01 // [txOpCreate][uint64 seq][uint64 revertsTransaction][uint8 hasTimestamp][uint64 timestamp][uint32 metaLen][meta][uint32 postingsLen][postings]
+	txOpRevertedBy = 0x02 // [txOpRevertedBy][uint64 revertTxId][uint8 hasRevertedAt][uint64 revertedAt]
 	txOpSetMeta    = 0x03 // [txOpSetMeta][key\x00][marshaledMetadataValue]
 	txOpDeleteMeta = 0x04 // [txOpDeleteMeta][key string]
 )
@@ -209,7 +209,7 @@ func (s *replayStore) DeleteMetadata(canonicalKey []byte) error {
 // A 1-byte presence flag distinguishes a nil timestamp from a real
 // Timestamp{Data: 0} (Unix epoch) — the FSM persists the latter unchanged,
 // so collapsing both to 0 would surface as a CheckStore mismatch.
-func (s *replayStore) CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting) error {
+func (s *replayStore) CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting, revertsTransaction uint64) error {
 	key := replayKey(replayPrefixTransaction, canonicalKey)
 
 	var metaBytes []byte
@@ -240,17 +240,18 @@ func (s *replayStore) CreateTransaction(canonicalKey []byte, seq uint64, timesta
 		}
 	}
 
-	// [txOpCreate][uint64 seq][uint8 hasTimestamp][uint64 timestamp.Data]
-	// [uint32 metaLen][metaBytes][uint32 postingsLen][postingsBytes]
-	buf := make([]byte, 1+8+1+8+4+len(metaBytes)+4+len(postingsBytes))
+	// [txOpCreate][uint64 seq][uint64 revertsTransaction][uint8 hasTimestamp]
+	// [uint64 timestamp.Data][uint32 metaLen][metaBytes][uint32 postingsLen][postingsBytes]
+	buf := make([]byte, 1+8+8+1+8+4+len(metaBytes)+4+len(postingsBytes))
 	buf[0] = txOpCreate
 	binary.BigEndian.PutUint64(buf[1:], seq)
+	binary.BigEndian.PutUint64(buf[9:], revertsTransaction)
 	if timestamp != nil {
-		buf[9] = 1
-		binary.BigEndian.PutUint64(buf[10:], timestamp.GetData())
+		buf[17] = 1
+		binary.BigEndian.PutUint64(buf[18:], timestamp.GetData())
 	}
 
-	off := 18
+	off := 26
 	binary.BigEndian.PutUint32(buf[off:], uint32(len(metaBytes)))
 	off += 4
 	copy(buf[off:], metaBytes)
@@ -263,12 +264,16 @@ func (s *replayStore) CreateTransaction(canonicalKey []byte, seq uint64, timesta
 }
 
 // setRevertedBy records that a transaction was reverted via merge (no read).
-func (s *replayStore) SetRevertedBy(canonicalKey []byte, revertTxID uint64) error {
+func (s *replayStore) SetRevertedBy(canonicalKey []byte, revertTxID uint64, revertedAt *commonpb.Timestamp) error {
 	key := replayKey(replayPrefixTransaction, canonicalKey)
 
-	buf := make([]byte, 1+8)
+	buf := make([]byte, 1+8+1+8)
 	buf[0] = txOpRevertedBy
 	binary.BigEndian.PutUint64(buf[1:], revertTxID)
+	if revertedAt != nil {
+		buf[9] = 1
+		binary.BigEndian.PutUint64(buf[10:], revertedAt.GetData())
+	}
 
 	return s.db.Merge(key, buf, pebble.NoSync)
 }
@@ -427,21 +432,22 @@ func (m *txMerger) Finish(_ bool) ([]byte, io.Closer, error) {
 
 		switch op[0] {
 		case txOpCreate:
-			// [txOpCreate][uint64 seq][uint8 hasTimestamp][uint64 timestamp.Data]
-			// [uint32 metaLen][metaBytes][uint32 postingsLen][postingsBytes]
-			const headerLen = 1 + 8 + 1 + 8 + 4
+			// [txOpCreate][uint64 seq][uint64 revertsTransaction][uint8 hasTimestamp]
+			// [uint64 timestamp.Data][uint32 metaLen][metaBytes][uint32 postingsLen][postingsBytes]
+			const headerLen = 1 + 8 + 8 + 1 + 8 + 4
 			if len(op) < headerLen {
 				return nil, nil, fmt.Errorf("txOpCreate too short: %d bytes", len(op))
 			}
 
 			state.CreatedByLog = binary.BigEndian.Uint64(op[1:9])
+			state.RevertsTransaction = binary.BigEndian.Uint64(op[9:17])
 
-			if op[9] == 1 {
-				state.Timestamp = &commonpb.Timestamp{Data: binary.BigEndian.Uint64(op[10:18])}
+			if op[17] == 1 {
+				state.Timestamp = &commonpb.Timestamp{Data: binary.BigEndian.Uint64(op[18:26])}
 			}
 
-			metaLen := int(binary.BigEndian.Uint32(op[18:22]))
-			off := 22
+			metaLen := int(binary.BigEndian.Uint32(op[26:30]))
+			off := 30
 			if len(op) < off+metaLen+4 {
 				return nil, nil, fmt.Errorf("txOpCreate: metadata length %d overruns buffer of %d bytes", metaLen, len(op))
 			}
@@ -477,6 +483,10 @@ func (m *txMerger) Finish(_ bool) ([]byte, io.Closer, error) {
 			}
 
 			state.RevertedByTransaction = binary.BigEndian.Uint64(op[1:9])
+
+			if len(op) >= 18 && op[9] == 1 {
+				state.RevertedAt = &commonpb.Timestamp{Data: binary.BigEndian.Uint64(op[10:18])}
+			}
 
 		case txOpSetMeta:
 			// Wire format: [key\x00][marshaledMetadataValue]

--- a/internal/application/check/replay_store_test.go
+++ b/internal/application/check/replay_store_test.go
@@ -166,7 +166,7 @@ func TestReplayStoreTransactionCreate(t *testing.T) {
 
 	meta := strMetaMap("env", "prod")
 
-	require.NoError(t, rs.CreateTransaction(key, 42, nil, meta, nil))
+	require.NoError(t, rs.CreateTransaction(key, 42, nil, meta, nil, 0))
 
 	state := readTransaction(t, rs, key)
 	require.Equal(t, uint64(42), state.GetCreatedByLog())
@@ -181,7 +181,7 @@ func TestReplayStoreTransactionCreateWithTimestamp(t *testing.T) {
 	key := []byte("ledger\x00tx:1")
 
 	ts := &commonpb.Timestamp{Data: 1_700_000_000_000_000}
-	require.NoError(t, rs.CreateTransaction(key, 7, ts, nil, nil))
+	require.NoError(t, rs.CreateTransaction(key, 7, ts, nil, nil, 0))
 
 	state := readTransaction(t, rs, key)
 	require.Equal(t, uint64(7), state.GetCreatedByLog())
@@ -198,11 +198,11 @@ func TestReplayStoreTransactionCreatePreservesNilVsZeroTimestamp(t *testing.T) {
 	rs := newTestReplayStore(t)
 
 	keyNil := []byte("ledger\x00tx:1")
-	require.NoError(t, rs.CreateTransaction(keyNil, 1, nil, nil, nil))
+	require.NoError(t, rs.CreateTransaction(keyNil, 1, nil, nil, nil, 0))
 	require.Nil(t, readTransaction(t, rs, keyNil).GetTimestamp())
 
 	keyZero := []byte("ledger\x00tx:2")
-	require.NoError(t, rs.CreateTransaction(keyZero, 2, &commonpb.Timestamp{Data: 0}, nil, nil))
+	require.NoError(t, rs.CreateTransaction(keyZero, 2, &commonpb.Timestamp{Data: 0}, nil, nil, 0))
 	stateZero := readTransaction(t, rs, keyZero)
 	require.NotNil(t, stateZero.GetTimestamp())
 	require.Equal(t, uint64(0), stateZero.GetTimestamp().GetData())
@@ -214,7 +214,7 @@ func TestReplayStoreTransactionCreateWithoutMetadata(t *testing.T) {
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00tx:1")
 
-	require.NoError(t, rs.CreateTransaction(key, 10, nil, nil, nil))
+	require.NoError(t, rs.CreateTransaction(key, 10, nil, nil, nil, 0))
 
 	state := readTransaction(t, rs, key)
 	require.Equal(t, uint64(10), state.GetCreatedByLog())
@@ -226,13 +226,20 @@ func TestReplayStoreTransactionRevertedBy(t *testing.T) {
 
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00tx:1")
+	revertedAt := &commonpb.Timestamp{Data: 1_800_000_000_000_000}
 
-	require.NoError(t, rs.CreateTransaction(key, 5, nil, nil, nil))
-	require.NoError(t, rs.SetRevertedBy(key, 99))
+	require.NoError(t, rs.CreateTransaction(key, 5, nil, nil, nil, 0))
+	require.NoError(t, rs.SetRevertedBy(key, 99, revertedAt))
 
 	state := readTransaction(t, rs, key)
 	require.Equal(t, uint64(5), state.GetCreatedByLog())
 	require.Equal(t, uint64(99), state.GetRevertedByTransaction())
+	require.Equal(t, revertedAt, state.GetRevertedAt())
+
+	// The compensating transaction back-links to the original via reverts_transaction.
+	revertKey := []byte("ledger\x00tx:99")
+	require.NoError(t, rs.CreateTransaction(revertKey, 6, nil, nil, nil, 1))
+	require.Equal(t, uint64(1), readTransaction(t, rs, revertKey).GetRevertsTransaction())
 }
 
 func TestReplayStoreTransactionSaveMeta(t *testing.T) {
@@ -241,7 +248,7 @@ func TestReplayStoreTransactionSaveMeta(t *testing.T) {
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00tx:1")
 
-	require.NoError(t, rs.CreateTransaction(key, 1, nil, nil, nil))
+	require.NoError(t, rs.CreateTransaction(key, 1, nil, nil, nil, 0))
 	require.NoError(t, rs.SaveTxMetadata(key, strMetaMap("env", "staging")))
 
 	state := readTransaction(t, rs, key)
@@ -257,7 +264,7 @@ func TestReplayStoreTransactionSaveMetaOverwrite(t *testing.T) {
 
 	meta := strMetaMap("env", "dev")
 
-	require.NoError(t, rs.CreateTransaction(key, 1, nil, meta, nil))
+	require.NoError(t, rs.CreateTransaction(key, 1, nil, meta, nil, 0))
 	require.NoError(t, rs.SaveTxMetadata(key, strMetaMap("env", "prod")))
 
 	state := readTransaction(t, rs, key)
@@ -273,7 +280,7 @@ func TestReplayStoreTransactionDeleteMeta(t *testing.T) {
 
 	meta := strMetaMap("env", "prod", "region", "eu")
 
-	require.NoError(t, rs.CreateTransaction(key, 1, nil, meta, nil))
+	require.NoError(t, rs.CreateTransaction(key, 1, nil, meta, nil, 0))
 	require.NoError(t, rs.DeleteTxMetadata(key, "env"))
 
 	state := readTransaction(t, rs, key)
@@ -288,7 +295,7 @@ func TestReplayStoreTransactionFullLifecycle(t *testing.T) {
 	key := []byte("ledger\x00tx:1")
 
 	// Create with initial metadata
-	require.NoError(t, rs.CreateTransaction(key, 1, nil, strMetaMap("type", "payment"), nil))
+	require.NoError(t, rs.CreateTransaction(key, 1, nil, strMetaMap("type", "payment"), nil, 0))
 
 	// Add metadata
 	require.NoError(t, rs.SaveTxMetadata(key, strMetaMap("status", "pending")))
@@ -300,11 +307,13 @@ func TestReplayStoreTransactionFullLifecycle(t *testing.T) {
 	require.NoError(t, rs.DeleteTxMetadata(key, "type"))
 
 	// Revert
-	require.NoError(t, rs.SetRevertedBy(key, 42))
+	revertedAt := &commonpb.Timestamp{Data: 1_800_000_000_000_000}
+	require.NoError(t, rs.SetRevertedBy(key, 42, revertedAt))
 
 	state := readTransaction(t, rs, key)
 	require.Equal(t, uint64(1), state.GetCreatedByLog())
 	require.Equal(t, uint64(42), state.GetRevertedByTransaction())
+	require.Equal(t, revertedAt, state.GetRevertedAt())
 	require.Len(t, state.GetMetadata(), 1)
 	require.Equal(t, "completed", state.GetMetadata()["status"].GetStringValue())
 }
@@ -318,7 +327,7 @@ func TestReplayStorePrefixIter(t *testing.T) {
 	require.NoError(t, rs.AddVolumeDelta([]byte("k1"), big.NewInt(10), big.NewInt(0)))
 	require.NoError(t, rs.AddVolumeDelta([]byte("k2"), big.NewInt(20), big.NewInt(0)))
 	require.NoError(t, rs.SetMetadata([]byte("m1"), "v1"))
-	require.NoError(t, rs.CreateTransaction([]byte("t1"), 1, nil, nil, nil))
+	require.NoError(t, rs.CreateTransaction([]byte("t1"), 1, nil, nil, nil, 0))
 
 	// Volume prefix should yield exactly 2 entries.
 	iter, err := rs.newPrefixIter(replayPrefixVolume)

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -269,6 +269,13 @@ func assembleTransactionFromState(ctx context.Context, reader dal.PebbleReader, 
 
 	tx.Reverted = state.GetRevertedByTransaction() > 0
 
+	// The revert relationship is tracked structurally on the state, not in the
+	// create log: reverted_by_transaction + reverted_at on the reverted original,
+	// reverts_transaction on the compensating transaction.
+	tx.RevertedByTransaction = state.GetRevertedByTransaction()
+	tx.RevertedAt = state.GetRevertedAt()
+	tx.RevertsTransaction = state.GetRevertsTransaction()
+
 	// The state carries the current metadata (the create-time snapshot plus
 	// every applied add/delete) and is authoritative even when empty; the
 	// create log only holds the create-time snapshot.

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -670,6 +670,14 @@ func (b *Builder) indexRevertedTransaction(
 		}
 	}
 
+	// reverted_at indexes the original transaction (the one being reverted) by
+	// the time it was reverted — the compensating transaction's timestamp.
+	if cfg.isBuiltinIndexed(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT) && revertTxn.GetTimestamp() != nil {
+		if err := wb.WriteTransactionRevertedAtIndex(kb, ledger, revertTxn.GetTimestamp().GetData(), rt.GetRevertedTransactionId()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/application/indexbuilder/reverted_at_index_test.go
+++ b/internal/application/indexbuilder/reverted_at_index_test.go
@@ -1,0 +1,63 @@
+package indexbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// The reverted_at index keys the ORIGINAL transaction (the one being reverted)
+// by the time it was reverted — the compensating transaction's timestamp — so a
+// reverted_at range query returns the originals. All values come from the
+// RevertedTransaction log, so backfill via log replay covers historical reverts.
+func TestIndexRevertedTransaction_WritesRevertedAtIndex(t *testing.T) {
+	t.Parallel()
+
+	store, err := readstore.New(t.TempDir(), noopLogger{}, readstore.DefaultConfig())
+	require.NoError(t, err)
+
+	defer func() { _ = store.Close() }()
+
+	b := &Builder{
+		readStore: store,
+		kb:        dal.NewKeyBuilder(),
+		wb:        readstore.NewWriteBatch(),
+	}
+
+	batch := store.NewBatch()
+	b.initBatch(batch)
+
+	cfg := newLedgerIndexConfig()
+	id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT)
+	cfg.byCanonical[indexes.Canonical(id)] = &commonpb.Index{Id: id}
+
+	const (
+		originalID uint64 = 7
+		revertID   uint64 = 8
+		revertTs   uint64 = 1_700_000_000_000_000
+	)
+
+	rt := &commonpb.RevertedTransaction{
+		RevertedTransactionId: originalID,
+		RevertTransaction: &commonpb.Transaction{
+			Id:        revertID,
+			Timestamp: &commonpb.Timestamp{Data: revertTs},
+		},
+	}
+
+	require.NoError(t, b.indexRevertedTransaction(b.kb, cfg, "test", rt, nil))
+	require.NoError(t, b.wb.Flush())
+
+	// Entry keyed to the original transaction by the revert timestamp.
+	require.True(t, readStoreKeyExists(t, store,
+		readstore.TransactionRevertedAtKey(dal.NewKeyBuilder(), "test", revertTs, originalID)))
+
+	// Never keyed to the compensating transaction.
+	require.False(t, readStoreKeyExists(t, store,
+		readstore.TransactionRevertedAtKey(dal.NewKeyBuilder(), "test", revertTs, revertID)))
+}

--- a/internal/domain/processing/processor_mirror.go
+++ b/internal/domain/processing/processor_mirror.go
@@ -336,7 +336,13 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 	boundaries.PostingCount += uint64(len(rt.GetReversePostings()))
 	boundaries.RevertCount++
 
-	// Update the original transaction's state to record the reversion
+	timestamp := rt.GetTimestamp()
+	if timestamp == nil {
+		timestamp = s.GetDate().Mutate()
+	}
+
+	// Update the original transaction's state to record the reversion: the id of
+	// the compensating transaction and the effective time it was reverted.
 	origKey := domain.TransactionKey{LedgerName: ledger, ID: rt.GetRevertedTransactionId()}
 
 	origReader, err := s.TransactionStates().Get(origKey)
@@ -347,20 +353,18 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 	if origReader != nil {
 		origState := origReader.Mutate()
 		origState.RevertedByTransaction = revertTxID
+		origState.RevertedAt = timestamp
 		s.TransactionStates().Put(origKey, origState)
 	}
 
-	timestamp := rt.GetTimestamp()
-	if timestamp == nil {
-		timestamp = s.GetDate().Mutate()
-	}
-
-	// Store the revert transaction's state (include metadata from the mirror revert)
+	// Store the revert transaction's state (include metadata from the mirror
+	// revert); RevertsTransaction back-links it to the transaction it compensates.
 	s.TransactionStates().Put(domain.TransactionKey{LedgerName: ledger, ID: revertTxID}, &commonpb.TransactionState{
-		CreatedByLog: s.GetNextSequenceID(),
-		Metadata:     rt.GetMetadata(),
-		Timestamp:    timestamp,
-		Postings:     rt.GetReversePostings(),
+		CreatedByLog:       s.GetNextSequenceID(),
+		Metadata:           rt.GetMetadata(),
+		Timestamp:          timestamp,
+		Postings:           rt.GetReversePostings(),
+		RevertsTransaction: rt.GetRevertedTransactionId(),
 	})
 
 	return &commonpb.LedgerLogPayload{
@@ -368,12 +372,13 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 			RevertedTransaction: &commonpb.RevertedTransaction{
 				RevertedTransactionId: rt.GetRevertedTransactionId(),
 				RevertTransaction: &commonpb.Transaction{
-					Postings:   rt.GetReversePostings(),
-					Metadata:   rt.GetMetadata(),
-					Timestamp:  timestamp,
-					Id:         revertTxID,
-					InsertedAt: s.GetDate().Mutate(),
-					UpdatedAt:  s.GetDate().Mutate(),
+					Postings:           rt.GetReversePostings(),
+					Metadata:           rt.GetMetadata(),
+					Timestamp:          timestamp,
+					Id:                 revertTxID,
+					InsertedAt:         s.GetDate().Mutate(),
+					UpdatedAt:          s.GetDate().Mutate(),
+					RevertsTransaction: rt.GetRevertedTransactionId(),
 				},
 			},
 		},

--- a/internal/domain/processing/processor_mirror_test.go
+++ b/internal/domain/processing/processor_mirror_test.go
@@ -475,7 +475,9 @@ func TestMirrorIngest_RevertedTransaction_AbsentVolumes(t *testing.T) {
 	expectPutVolume(t, mockStore, domain.NewVolumeKey("mirror-ledger", "users:rare-account", "USD/2"), nil)
 	expectPutVolume(t, mockStore, domain.NewVolumeKey("mirror-ledger", "world", "USD/2"), nil)
 	expectPutTransactionState(t, mockStore,
-		domain.TransactionKey{LedgerName: "mirror-ledger", ID: 42}, nil)
+		domain.TransactionKey{LedgerName: "mirror-ledger", ID: 42}, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+			require.Equal(t, uint64(5), st.GetRevertsTransaction())
+		})
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "mirror-ledger"}, nil)
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
 	mockStore.EXPECT().GetDate().Return(now.AsReader()).AnyTimes()
@@ -510,6 +512,85 @@ func TestMirrorIngest_RevertedTransaction_AbsentVolumes(t *testing.T) {
 
 	_, err = processor.ProcessOrder(order, mockStore)
 	require.NoError(t, err)
+}
+
+// When the reverted original is present in the FSM cache, the mirror path records
+// the reversion on it (reverted_by_transaction + reverted_at) just like the
+// non-mirror revert, keeping the read representation identical across nodes.
+func TestMirrorIngest_RevertedTransaction_LinksOriginal(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	ledgerInfo := &commonpb.LedgerInfo{
+		Name: "mirror-ledger",
+		Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR,
+	}
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 10, NextLogId: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil).AnyTimes()
+	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo)
+	expectGetBoundaries(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+
+	revertTimestamp := &commonpb.Timestamp{Data: 1234567890}
+
+	origKey := domain.TransactionKey{LedgerName: "mirror-ledger", ID: 5}
+
+	mockStore.EXPECT().PutReverted(origKey, true)
+	expectGetTransactionState(mockStore, origKey, (&commonpb.TransactionState{CreatedByLog: 7}).AsReader(), nil)
+	expectPutVolume(t, mockStore, domain.NewVolumeKey("mirror-ledger", "users:rare-account", "USD/2"), nil)
+	expectPutVolume(t, mockStore, domain.NewVolumeKey("mirror-ledger", "world", "USD/2"), nil)
+	expectPutTransactionState(t, mockStore, origKey, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+		require.Equal(t, uint64(42), st.GetRevertedByTransaction())
+		require.Equal(t, revertTimestamp, st.GetRevertedAt())
+	})
+	expectPutTransactionState(t, mockStore,
+		domain.TransactionKey{LedgerName: "mirror-ledger", ID: 42}, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+			require.Equal(t, uint64(5), st.GetRevertsTransaction())
+		})
+	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "mirror-ledger"}, nil)
+	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
+	mockStore.EXPECT().GetDate().Return(revertTimestamp.AsReader()).AnyTimes()
+
+	reversePostings := []*commonpb.Posting{{
+		Source:      "users:rare-account",
+		Destination: "world",
+		Amount:      commonpb.NewUint256FromUint64(500),
+		Asset:       "USD/2",
+	}}
+
+	order := &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: "mirror-ledger",
+				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
+					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
+						V2LogId: 2,
+						Data: &raftcmdpb.MirrorLogEntry_RevertedTransaction{
+							RevertedTransaction: &raftcmdpb.MirrorRevertedTransaction{
+								RevertedTransactionId: 5,
+								NewTransactionId:      42,
+								ReversePostings:       reversePostings,
+							},
+						},
+					},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := processor.ProcessOrder(order, mockStore)
+	require.NoError(t, err)
+
+	revertedTx := result.GetApply().GetLog().GetData().GetRevertedTransaction()
+	require.Equal(t, uint64(5), revertedTx.GetRevertedTransactionId())
+	require.Equal(t, uint64(5), revertedTx.GetRevertTransaction().GetRevertsTransaction())
 }
 
 func TestWriteGuard_MirrorModeBlocksApply(t *testing.T) {

--- a/internal/domain/processing/processor_revert_transaction.go
+++ b/internal/domain/processing/processor_revert_transaction.go
@@ -96,10 +96,6 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	boundaries.PostingCount += uint64(len(revertPostings))
 	boundaries.RevertCount++
 
-	// Record the reversion on the original transaction's state.
-	origState.RevertedByTransaction = revertTxID
-	s.TransactionStates().Put(txKey, origState)
-
 	// Resolve the revert timestamp. When at_effective_date is set, the compensating
 	// transaction inherits the original's effective timestamp (parity with
 	// formancehq/ledger). Otherwise it stamps with the current FSM date.
@@ -114,12 +110,20 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 		revertTimestamp = origState.GetTimestamp()
 	}
 
-	// Store the revert transaction's state (include metadata from the revert order)
+	// Record the reversion on the original transaction's state: the id of the
+	// compensating transaction and the effective time it was reverted.
+	origState.RevertedByTransaction = revertTxID
+	origState.RevertedAt = revertTimestamp
+	s.TransactionStates().Put(txKey, origState)
+
+	// Store the revert transaction's state (include metadata from the revert
+	// order); RevertsTransaction back-links it to the transaction it compensates.
 	s.TransactionStates().Put(domain.TransactionKey{LedgerName: ledger, ID: revertTxID}, &commonpb.TransactionState{
-		CreatedByLog: s.GetNextSequenceID(),
-		Metadata:     order.GetMetadata(),
-		Timestamp:    revertTimestamp,
-		Postings:     revertPostings,
+		CreatedByLog:       s.GetNextSequenceID(),
+		Metadata:           order.GetMetadata(),
+		Timestamp:          revertTimestamp,
+		Postings:           revertPostings,
+		RevertsTransaction: order.GetTransactionId(),
 	})
 
 	// Compute post-commit volumes if requested
@@ -137,12 +141,13 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 			RevertedTransaction: &commonpb.RevertedTransaction{
 				RevertedTransactionId: order.GetTransactionId(),
 				RevertTransaction: &commonpb.Transaction{
-					Postings:   revertPostings,
-					Metadata:   order.GetMetadata(),
-					Timestamp:  revertTimestamp,
-					Id:         revertTxID,
-					InsertedAt: s.GetDate().Mutate(),
-					UpdatedAt:  s.GetDate().Mutate(),
+					Postings:           revertPostings,
+					Metadata:           order.GetMetadata(),
+					Timestamp:          revertTimestamp,
+					Id:                 revertTxID,
+					InsertedAt:         s.GetDate().Mutate(),
+					UpdatedAt:          s.GetDate().Mutate(),
+					RevertsTransaction: order.GetTransactionId(),
 				},
 				PostCommitVolumes: postCommitVolumes,
 			},

--- a/internal/domain/processing/processor_revert_transaction_test.go
+++ b/internal/domain/processing/processor_revert_transaction_test.go
@@ -51,15 +51,21 @@ func TestProcessRevertTransaction_Success(t *testing.T) {
 
 	mockStore.EXPECT().PutReverted(txKey, true)
 
-	// Processor reads original transaction state, then updates it with RevertedByTransaction
+	// Processor reads original transaction state, then records the reversion on it:
+	// the compensating transaction id and the effective time it was reverted.
 	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{
 		CreatedByLog: 42,
 	}).AsReader(), nil)
-	expectPutTransactionState(t, mockStore, txKey, nil)
+	expectPutTransactionState(t, mockStore, txKey, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+		require.Equal(t, uint64(5), st.GetRevertedByTransaction())
+		require.Equal(t, now, st.GetRevertedAt())
+	})
 
-	// Processor stores the new revert transaction state
+	// Processor stores the new revert transaction state, back-linked to the original.
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(50))
-	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 5}, nil)
+	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 5}, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+		require.Equal(t, uint64(3), st.GetRevertsTransaction())
+	})
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
 
 	order := &raftcmdpb.Order{
@@ -106,6 +112,9 @@ func TestProcessRevertTransaction_Success(t *testing.T) {
 
 	// Without at_effective_date, the revert is stamped with the current FSM date.
 	require.Equal(t, now, revertedTx.GetRevertTransaction().GetTimestamp())
+
+	// The compensating transaction back-links to the transaction it reverts.
+	require.Equal(t, uint64(3), revertedTx.GetRevertTransaction().GetRevertsTransaction())
 }
 
 func TestProcessRevertTransaction_AtEffectiveDate(t *testing.T) {
@@ -144,10 +153,15 @@ func TestProcessRevertTransaction_AtEffectiveDate(t *testing.T) {
 		CreatedByLog: 42,
 		Timestamp:    originalTimestamp,
 	}).AsReader(), nil)
-	expectPutTransactionState(t, mockStore, txKey, nil)
+	expectPutTransactionState(t, mockStore, txKey, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+		require.Equal(t, uint64(5), st.GetRevertedByTransaction())
+		require.Equal(t, originalTimestamp, st.GetRevertedAt(), "with at_effective_date reverted_at inherits the original timestamp")
+	})
 
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(50))
-	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 5}, nil)
+	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 5}, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
+		require.Equal(t, uint64(3), st.GetRevertsTransaction())
+	})
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
 
 	order := &raftcmdpb.Order{
@@ -219,11 +233,12 @@ func TestProcessRevertTransaction_AtEffectiveDate_MissingOriginalTimestamp(t *te
 
 	// Simulate a TransactionState written before the Timestamp field existed (or
 	// otherwise inconsistent state). With at_effective_date=true this must surface
-	// loudly rather than silently falling back to s.GetDate().
+	// loudly rather than silently falling back to s.GetDate(). The timestamp is
+	// resolved before the reverted markers are written, so no transaction state is
+	// persisted on this path.
 	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{
 		CreatedByLog: 42,
 	}).AsReader(), nil)
-	expectPutTransactionState(t, mockStore, txKey, nil)
 
 	order := &raftcmdpb.Order{
 		Type: &raftcmdpb.Order_LedgerScoped{

--- a/internal/domain/replay/replay.go
+++ b/internal/domain/replay/replay.go
@@ -62,7 +62,7 @@ func ReplayLedgerLog(
 
 		txCanonical := domain.TransactionKey{LedgerName: ledger, ID: tx.GetId()}.Bytes()
 
-		if err := w.CreateTransaction(txCanonical, seq, tx.GetTimestamp(), tx.GetMetadata(), tx.GetPostings()); err != nil {
+		if err := w.CreateTransaction(txCanonical, seq, tx.GetTimestamp(), tx.GetMetadata(), tx.GetPostings(), 0); err != nil {
 			return fmt.Errorf("putting tx state for created tx %d: %w", tx.GetId(), err)
 		}
 
@@ -102,13 +102,15 @@ func ReplayLedgerLog(
 
 		origTxCanonical := domain.TransactionKey{LedgerName: ledger, ID: p.RevertedTransaction.GetRevertedTransactionId()}.Bytes()
 
-		if err := w.SetRevertedBy(origTxCanonical, revertTx.GetId()); err != nil {
+		// The reverted_at stamped on the original is the compensating transaction's
+		// timestamp (see processRevertTransaction); reconstruct it identically here.
+		if err := w.SetRevertedBy(origTxCanonical, revertTx.GetId(), revertTx.GetTimestamp()); err != nil {
 			return fmt.Errorf("putting revert marker for tx %d: %w", p.RevertedTransaction.GetRevertedTransactionId(), err)
 		}
 
 		revertTxCanonical := domain.TransactionKey{LedgerName: ledger, ID: revertTx.GetId()}.Bytes()
 
-		if err := w.CreateTransaction(revertTxCanonical, seq, revertTx.GetTimestamp(), revertTx.GetMetadata(), revertTx.GetPostings()); err != nil {
+		if err := w.CreateTransaction(revertTxCanonical, seq, revertTx.GetTimestamp(), revertTx.GetMetadata(), revertTx.GetPostings(), p.RevertedTransaction.GetRevertedTransactionId()); err != nil {
 			return fmt.Errorf("putting tx state for revert tx %d: %w", revertTx.GetId(), err)
 		}
 

--- a/internal/domain/replay/writer.go
+++ b/internal/domain/replay/writer.go
@@ -18,8 +18,8 @@ type Writer interface {
 	SetMetadata(canonicalKey []byte, value string) error
 	DeleteMetadata(canonicalKey []byte) error
 	MoveMetadata(oldKey, newKey []byte) error
-	CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting) error
-	SetRevertedBy(canonicalKey []byte, revertTxID uint64) error
+	CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting, revertsTransaction uint64) error
+	SetRevertedBy(canonicalKey []byte, revertTxID uint64, revertedAt *commonpb.Timestamp) error
 	SaveTxMetadata(canonicalKey []byte, metadata map[string]*commonpb.MetadataValue) error
 	DeleteTxMetadata(canonicalKey []byte, key string) error
 }

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -552,12 +552,13 @@ func (w *attributeReplayWriter) MoveMetadata(oldKey, newKey []byte) error {
 	return w.metadata.Delete(w.batch, oldKey)
 }
 
-func (w *attributeReplayWriter) CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting) error {
+func (w *attributeReplayWriter) CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting, revertsTransaction uint64) error {
 	txState := &commonpb.TransactionState{
-		CreatedByLog: seq,
-		Metadata:     metadata,
-		Timestamp:    timestamp,
-		Postings:     postings,
+		CreatedByLog:       seq,
+		Metadata:           metadata,
+		Timestamp:          timestamp,
+		Postings:           postings,
+		RevertsTransaction: revertsTransaction,
 	}
 
 	_, err := w.tx.Set(w.batch, canonicalKey, txState)
@@ -565,7 +566,7 @@ func (w *attributeReplayWriter) CreateTransaction(canonicalKey []byte, seq uint6
 	return err
 }
 
-func (w *attributeReplayWriter) SetRevertedBy(canonicalKey []byte, revertTxID uint64) error {
+func (w *attributeReplayWriter) SetRevertedBy(canonicalKey []byte, revertTxID uint64, revertedAt *commonpb.Timestamp) error {
 	existing, err := w.tx.Get(w.store, canonicalKey)
 	if err != nil {
 		return err
@@ -576,6 +577,7 @@ func (w *attributeReplayWriter) SetRevertedBy(canonicalKey []byte, revertTxID ui
 	}
 
 	existing.RevertedByTransaction = revertTxID
+	existing.RevertedAt = revertedAt
 
 	_, err = w.tx.Set(w.batch, canonicalKey, existing)
 

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -1622,18 +1622,22 @@ func (x *Posting) GetAsset() string {
 
 // Transaction represents a transaction
 type Transaction struct {
-	state         protoimpl.MessageState    `protogen:"open.v1"`
-	Postings      []*Posting                `protobuf:"bytes,1,rep,name=postings,proto3" json:"postings,omitempty"`
-	Metadata      map[string]*MetadataValue `protobuf:"bytes,2,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Timestamp     *Timestamp                `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Reference     string                    `protobuf:"bytes,4,opt,name=reference,proto3" json:"reference,omitempty"`
-	Id            uint64                    `protobuf:"fixed64,5,opt,name=id,proto3" json:"id,omitempty"`
-	Reverted      bool                      `protobuf:"varint,6,opt,name=reverted,proto3" json:"reverted,omitempty"`
-	InsertedAt    *Timestamp                `protobuf:"bytes,7,opt,name=inserted_at,json=insertedAt,proto3" json:"inserted_at,omitempty"`
-	UpdatedAt     *Timestamp                `protobuf:"bytes,8,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
-	RevertedAt    *Timestamp                `protobuf:"bytes,9,opt,name=reverted_at,json=revertedAt,proto3" json:"reverted_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state      protoimpl.MessageState    `protogen:"open.v1"`
+	Postings   []*Posting                `protobuf:"bytes,1,rep,name=postings,proto3" json:"postings,omitempty"`
+	Metadata   map[string]*MetadataValue `protobuf:"bytes,2,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Timestamp  *Timestamp                `protobuf:"bytes,3,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Reference  string                    `protobuf:"bytes,4,opt,name=reference,proto3" json:"reference,omitempty"`
+	Id         uint64                    `protobuf:"fixed64,5,opt,name=id,proto3" json:"id,omitempty"`
+	Reverted   bool                      `protobuf:"varint,6,opt,name=reverted,proto3" json:"reverted,omitempty"`
+	InsertedAt *Timestamp                `protobuf:"bytes,7,opt,name=inserted_at,json=insertedAt,proto3" json:"inserted_at,omitempty"`
+	UpdatedAt  *Timestamp                `protobuf:"bytes,8,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	RevertedAt *Timestamp                `protobuf:"bytes,9,opt,name=reverted_at,json=revertedAt,proto3" json:"reverted_at,omitempty"`
+	// Id of the transaction that reverted this one. 0 = not reverted.
+	RevertedByTransaction uint64 `protobuf:"fixed64,10,opt,name=reverted_by_transaction,json=revertedByTransaction,proto3" json:"reverted_by_transaction,omitempty"`
+	// Id of the original transaction this transaction reverts. 0 = not a revert.
+	RevertsTransaction uint64 `protobuf:"fixed64,11,opt,name=reverts_transaction,json=revertsTransaction,proto3" json:"reverts_transaction,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Transaction) Reset() {
@@ -1727,6 +1731,20 @@ func (x *Transaction) GetRevertedAt() *Timestamp {
 		return x.RevertedAt
 	}
 	return nil
+}
+
+func (x *Transaction) GetRevertedByTransaction() uint64 {
+	if x != nil {
+		return x.RevertedByTransaction
+	}
+	return 0
+}
+
+func (x *Transaction) GetRevertsTransaction() uint64 {
+	if x != nil {
+		return x.RevertsTransaction
+	}
+	return 0
 }
 
 type Script struct {
@@ -7548,9 +7566,15 @@ type TransactionState struct {
 	// reads on the hot path) and invariant #8 (business decisions belong in
 	// the audit chain, so a revert of a non-existent tx must reach the FSM
 	// apply loop rather than fail-fast at admission).
-	Postings      []*Posting `protobuf:"bytes,5,rep,name=postings,proto3" json:"postings,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Postings []*Posting `protobuf:"bytes,5,rep,name=postings,proto3" json:"postings,omitempty"`
+	// Effective timestamp at which this transaction was reverted (the
+	// compensating transaction's timestamp). Nil when not reverted.
+	RevertedAt *Timestamp `protobuf:"bytes,6,opt,name=reverted_at,json=revertedAt,proto3" json:"reverted_at,omitempty"`
+	// On a compensating transaction, the id of the transaction it reverts.
+	// 0 = this transaction is not a revert.
+	RevertsTransaction uint64 `protobuf:"fixed64,7,opt,name=reverts_transaction,json=revertsTransaction,proto3" json:"reverts_transaction,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *TransactionState) Reset() {
@@ -7616,6 +7640,20 @@ func (x *TransactionState) GetPostings() []*Posting {
 		return x.Postings
 	}
 	return nil
+}
+
+func (x *TransactionState) GetRevertedAt() *Timestamp {
+	if x != nil {
+		return x.RevertedAt
+	}
+	return nil
+}
+
+func (x *TransactionState) GetRevertsTransaction() uint64 {
+	if x != nil {
+		return x.RevertsTransaction
+	}
+	return 0
 }
 
 // IdempotencyKeyValue stores the outcome associated with a proposal's
@@ -10732,7 +10770,7 @@ const file_common_proto_rawDesc = "" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12 \n" +
 	"\vdestination\x18\x02 \x01(\tR\vdestination\x12'\n" +
 	"\x06amount\x18\x03 \x01(\v2\x0f.common.Uint256R\x06amount\x12\x14\n" +
-	"\x05asset\x18\x04 \x01(\tR\x05asset\"\xe2\x03\n" +
+	"\x05asset\x18\x04 \x01(\tR\x05asset\"\xcb\x04\n" +
 	"\vTransaction\x12+\n" +
 	"\bpostings\x18\x01 \x03(\v2\x0f.common.PostingR\bpostings\x12=\n" +
 	"\bmetadata\x18\x02 \x03(\v2!.common.Transaction.MetadataEntryR\bmetadata\x12/\n" +
@@ -10745,7 +10783,10 @@ const file_common_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\b \x01(\v2\x11.common.TimestampR\tupdatedAt\x122\n" +
 	"\vreverted_at\x18\t \x01(\v2\x11.common.TimestampR\n" +
-	"revertedAt\x1aR\n" +
+	"revertedAt\x126\n" +
+	"\x17reverted_by_transaction\x18\n" +
+	" \x01(\x06R\x15revertedByTransaction\x12/\n" +
+	"\x13reverts_transaction\x18\v \x01(\x06R\x12revertsTransaction\x1aR\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"\xa8\x01\n" +
@@ -11201,13 +11242,16 @@ const file_common_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"Q\n" +
 	"\x15DeleteMetadataCommand\x12&\n" +
 	"\x06target\x18\x01 \x01(\v2\x0e.common.TargetR\x06target\x12\x10\n" +
-	"\x03key\x18\x02 \x01(\tR\x03key\"\xe6\x02\n" +
+	"\x03key\x18\x02 \x01(\tR\x03key\"\xcb\x03\n" +
 	"\x10TransactionState\x12$\n" +
 	"\x0ecreated_by_log\x18\x01 \x01(\x06R\fcreatedByLog\x126\n" +
 	"\x17reverted_by_transaction\x18\x02 \x01(\x06R\x15revertedByTransaction\x12B\n" +
 	"\bmetadata\x18\x03 \x03(\v2&.common.TransactionState.MetadataEntryR\bmetadata\x12/\n" +
 	"\ttimestamp\x18\x04 \x01(\v2\x11.common.TimestampR\ttimestamp\x12+\n" +
-	"\bpostings\x18\x05 \x03(\v2\x0f.common.PostingR\bpostings\x1aR\n" +
+	"\bpostings\x18\x05 \x03(\v2\x0f.common.PostingR\bpostings\x122\n" +
+	"\vreverted_at\x18\x06 \x01(\v2\x11.common.TimestampR\n" +
+	"revertedAt\x12/\n" +
+	"\x13reverts_transaction\x18\a \x01(\x06R\x12revertsTransaction\x1aR\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"\xec\x01\n" +
@@ -11907,81 +11951,82 @@ var file_common_proto_depIdxs = []int32{
 	170, // 157: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
 	17,  // 158: common.TransactionState.timestamp:type_name -> common.Timestamp
 	23,  // 159: common.TransactionState.postings:type_name -> common.Posting
-	110, // 160: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
-	11,  // 161: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	171, // 162: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	114, // 163: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	115, // 164: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	116, // 165: common.SegmentType.bytes:type_name -> common.BytesConstraint
-	13,  // 166: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	172, // 167: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	117, // 168: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
-	12,  // 169: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	132, // 170: common.QueryFilter.field:type_name -> common.FieldCondition
-	138, // 171: common.QueryFilter.address:type_name -> common.AddressMatch
-	128, // 172: common.QueryFilter.and:type_name -> common.AndFilter
-	129, // 173: common.QueryFilter.or:type_name -> common.OrFilter
-	130, // 174: common.QueryFilter.not:type_name -> common.NotFilter
-	122, // 175: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	125, // 176: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	123, // 177: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	124, // 178: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	126, // 179: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	127, // 180: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	133, // 181: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	133, // 182: common.LedgerCondition.cond:type_name -> common.StringCondition
-	135, // 183: common.LogIdCondition.cond:type_name -> common.UintCondition
-	3,   // 184: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	135, // 185: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	5,   // 186: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	135, // 187: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	121, // 188: common.AndFilter.filters:type_name -> common.QueryFilter
-	121, // 189: common.OrFilter.filters:type_name -> common.QueryFilter
-	121, // 190: common.NotFilter.filter:type_name -> common.QueryFilter
-	131, // 191: common.FieldCondition.field:type_name -> common.FieldRef
-	133, // 192: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	134, // 193: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	135, // 194: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	136, // 195: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	137, // 196: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 197: common.AddressMatch.role:type_name -> common.AddressRole
-	121, // 198: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 199: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 200: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 201: common.AggregatedVolume.output:type_name -> common.Uint256
-	140, // 202: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	142, // 203: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	140, // 204: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	30,  // 205: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 206: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	146, // 207: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	148, // 208: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	149, // 209: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	151, // 210: common.ListOptions.read:type_name -> common.ReadOptions
-	121, // 211: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 212: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 213: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	26,  // 214: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
-	28,  // 215: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 216: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	27,  // 217: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
-	33,  // 218: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 219: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 220: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 221: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	117, // 222: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 223: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 224: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	117, // 225: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 226: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 227: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 228: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	113, // 229: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	230, // [230:230] is the sub-list for method output_type
-	230, // [230:230] is the sub-list for method input_type
-	230, // [230:230] is the sub-list for extension type_name
-	230, // [230:230] is the sub-list for extension extendee
-	0,   // [0:230] is the sub-list for field type_name
+	17,  // 160: common.TransactionState.reverted_at:type_name -> common.Timestamp
+	110, // 161: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	11,  // 162: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
+	171, // 163: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	114, // 164: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	115, // 165: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	116, // 166: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	13,  // 167: common.AccountType.persistence:type_name -> common.AccountTypePersistence
+	172, // 168: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	117, // 169: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	12,  // 170: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
+	132, // 171: common.QueryFilter.field:type_name -> common.FieldCondition
+	138, // 172: common.QueryFilter.address:type_name -> common.AddressMatch
+	128, // 173: common.QueryFilter.and:type_name -> common.AndFilter
+	129, // 174: common.QueryFilter.or:type_name -> common.OrFilter
+	130, // 175: common.QueryFilter.not:type_name -> common.NotFilter
+	122, // 176: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	125, // 177: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	123, // 178: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	124, // 179: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	126, // 180: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	127, // 181: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	133, // 182: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	133, // 183: common.LedgerCondition.cond:type_name -> common.StringCondition
+	135, // 184: common.LogIdCondition.cond:type_name -> common.UintCondition
+	3,   // 185: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	135, // 186: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	5,   // 187: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	135, // 188: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	121, // 189: common.AndFilter.filters:type_name -> common.QueryFilter
+	121, // 190: common.OrFilter.filters:type_name -> common.QueryFilter
+	121, // 191: common.NotFilter.filter:type_name -> common.QueryFilter
+	131, // 192: common.FieldCondition.field:type_name -> common.FieldRef
+	133, // 193: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	134, // 194: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	135, // 195: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	136, // 196: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	137, // 197: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	14,  // 198: common.AddressMatch.role:type_name -> common.AddressRole
+	121, // 199: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	15,  // 200: common.PreparedQuery.target:type_name -> common.QueryTarget
+	22,  // 201: common.AggregatedVolume.input:type_name -> common.Uint256
+	22,  // 202: common.AggregatedVolume.output:type_name -> common.Uint256
+	140, // 203: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	142, // 204: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	140, // 205: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	30,  // 206: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	24,  // 207: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	146, // 208: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	148, // 209: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	149, // 210: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	151, // 211: common.ListOptions.read:type_name -> common.ReadOptions
+	121, // 212: common.ListOptions.filter:type_name -> common.QueryFilter
+	19,  // 213: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	19,  // 214: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	26,  // 215: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
+	28,  // 216: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	19,  // 217: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	27,  // 218: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
+	33,  // 219: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 220: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 221: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	19,  // 222: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 223: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 224: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	19,  // 225: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 226: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	19,  // 227: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 228: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 229: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	113, // 230: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	231, // [231:231] is the sub-list for method output_type
+	231, // [231:231] is the sub-list for method input_type
+	231, // [231:231] is the sub-list for extension type_name
+	231, // [231:231] is the sub-list for extension extendee
+	0,   // [0:231] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -204,6 +204,7 @@ const (
 	TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS      TransactionBuiltinIndex = 4 // source account→transaction mapping
 	TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS TransactionBuiltinIndex = 5 // destination account→transaction mapping
 	TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT         TransactionBuiltinIndex = 6 // requires Pebble "txiat" index (inserted_at date)
+	TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT         TransactionBuiltinIndex = 7 // requires Pebble "rvat" index (reverted_at date)
 )
 
 // Enum value maps for TransactionBuiltinIndex.
@@ -216,6 +217,7 @@ var (
 		4: "TX_BUILTIN_INDEX_SOURCE_ADDRESS",
 		5: "TX_BUILTIN_INDEX_DESTINATION_ADDRESS",
 		6: "TX_BUILTIN_INDEX_INSERTED_AT",
+		7: "TX_BUILTIN_INDEX_REVERTED_AT",
 	}
 	TransactionBuiltinIndex_value = map[string]int32{
 		"TX_BUILTIN_INDEX_REFERENCE":           0,
@@ -225,6 +227,7 @@ var (
 		"TX_BUILTIN_INDEX_SOURCE_ADDRESS":      4,
 		"TX_BUILTIN_INDEX_DESTINATION_ADDRESS": 5,
 		"TX_BUILTIN_INDEX_INSERTED_AT":         6,
+		"TX_BUILTIN_INDEX_REVERTED_AT":         7,
 	}
 )
 
@@ -8343,6 +8346,7 @@ type QueryFilter struct {
 	//	*QueryFilter_LogId
 	//	*QueryFilter_LogBuiltinUint
 	//	*QueryFilter_AccountHasAsset
+	//	*QueryFilter_Reverted
 	Filter        isQueryFilter_Filter `protobuf_oneof:"filter"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -8484,6 +8488,15 @@ func (x *QueryFilter) GetAccountHasAsset() *AccountHasAssetCondition {
 	return nil
 }
 
+func (x *QueryFilter) GetReverted() *RevertedCondition {
+	if x != nil {
+		if x, ok := x.Filter.(*QueryFilter_Reverted); ok {
+			return x.Reverted
+		}
+	}
+	return nil
+}
+
 type isQueryFilter_Filter interface {
 	isQueryFilter_Filter()
 }
@@ -8532,6 +8545,10 @@ type QueryFilter_AccountHasAsset struct {
 	AccountHasAsset *AccountHasAssetCondition `protobuf:"bytes,11,opt,name=account_has_asset,json=accountHasAsset,proto3,oneof"`
 }
 
+type QueryFilter_Reverted struct {
+	Reverted *RevertedCondition `protobuf:"bytes,12,opt,name=reverted,proto3,oneof"`
+}
+
 func (*QueryFilter_Field) isQueryFilter_Filter() {}
 
 func (*QueryFilter_Address) isQueryFilter_Filter() {}
@@ -8553,6 +8570,8 @@ func (*QueryFilter_LogId) isQueryFilter_Filter() {}
 func (*QueryFilter_LogBuiltinUint) isQueryFilter_Filter() {}
 
 func (*QueryFilter_AccountHasAsset) isQueryFilter_Filter() {}
+
+func (*QueryFilter_Reverted) isQueryFilter_Filter() {}
 
 // ReferenceCondition filters transactions by reference (exact match).
 type ReferenceCondition struct {
@@ -8599,6 +8618,53 @@ func (x *ReferenceCondition) GetCond() *StringCondition {
 	return nil
 }
 
+// RevertedCondition filters transactions by revert status. Served from the
+// per-ledger reversion bitset (no index required): value=true matches reverted
+// originals, value=false matches everything else.
+type RevertedCondition struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Value         bool                   `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevertedCondition) Reset() {
+	*x = RevertedCondition{}
+	mi := &file_common_proto_msgTypes[106]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevertedCondition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevertedCondition) ProtoMessage() {}
+
+func (x *RevertedCondition) ProtoReflect() protoreflect.Message {
+	mi := &file_common_proto_msgTypes[106]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevertedCondition.ProtoReflect.Descriptor instead.
+func (*RevertedCondition) Descriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{106}
+}
+
+func (x *RevertedCondition) GetValue() bool {
+	if x != nil {
+		return x.Value
+	}
+	return false
+}
+
 // LedgerCondition filters logs by ledger name (exact match).
 type LedgerCondition struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -8609,7 +8675,7 @@ type LedgerCondition struct {
 
 func (x *LedgerCondition) Reset() {
 	*x = LedgerCondition{}
-	mi := &file_common_proto_msgTypes[106]
+	mi := &file_common_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8621,7 +8687,7 @@ func (x *LedgerCondition) String() string {
 func (*LedgerCondition) ProtoMessage() {}
 
 func (x *LedgerCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[106]
+	mi := &file_common_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8634,7 +8700,7 @@ func (x *LedgerCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerCondition.ProtoReflect.Descriptor instead.
 func (*LedgerCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{106}
+	return file_common_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *LedgerCondition) GetCond() *StringCondition {
@@ -8654,7 +8720,7 @@ type LogIdCondition struct {
 
 func (x *LogIdCondition) Reset() {
 	*x = LogIdCondition{}
-	mi := &file_common_proto_msgTypes[107]
+	mi := &file_common_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8666,7 +8732,7 @@ func (x *LogIdCondition) String() string {
 func (*LogIdCondition) ProtoMessage() {}
 
 func (x *LogIdCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[107]
+	mi := &file_common_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8679,7 +8745,7 @@ func (x *LogIdCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogIdCondition.ProtoReflect.Descriptor instead.
 func (*LogIdCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{107}
+	return file_common_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *LogIdCondition) GetCond() *UintCondition {
@@ -8700,7 +8766,7 @@ type BuiltinUintCondition struct {
 
 func (x *BuiltinUintCondition) Reset() {
 	*x = BuiltinUintCondition{}
-	mi := &file_common_proto_msgTypes[108]
+	mi := &file_common_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8712,7 +8778,7 @@ func (x *BuiltinUintCondition) String() string {
 func (*BuiltinUintCondition) ProtoMessage() {}
 
 func (x *BuiltinUintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[108]
+	mi := &file_common_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8725,7 +8791,7 @@ func (x *BuiltinUintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuiltinUintCondition.ProtoReflect.Descriptor instead.
 func (*BuiltinUintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{108}
+	return file_common_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *BuiltinUintCondition) GetField() TransactionBuiltinIndex {
@@ -8753,7 +8819,7 @@ type LogBuiltinUintCondition struct {
 
 func (x *LogBuiltinUintCondition) Reset() {
 	*x = LogBuiltinUintCondition{}
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8765,7 +8831,7 @@ func (x *LogBuiltinUintCondition) String() string {
 func (*LogBuiltinUintCondition) ProtoMessage() {}
 
 func (x *LogBuiltinUintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[109]
+	mi := &file_common_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8778,7 +8844,7 @@ func (x *LogBuiltinUintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogBuiltinUintCondition.ProtoReflect.Descriptor instead.
 func (*LogBuiltinUintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{109}
+	return file_common_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *LogBuiltinUintCondition) GetField() LogBuiltinIndex {
@@ -8809,7 +8875,7 @@ type AccountHasAssetCondition struct {
 
 func (x *AccountHasAssetCondition) Reset() {
 	*x = AccountHasAssetCondition{}
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8821,7 +8887,7 @@ func (x *AccountHasAssetCondition) String() string {
 func (*AccountHasAssetCondition) ProtoMessage() {}
 
 func (x *AccountHasAssetCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[110]
+	mi := &file_common_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8834,7 +8900,7 @@ func (x *AccountHasAssetCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccountHasAssetCondition.ProtoReflect.Descriptor instead.
 func (*AccountHasAssetCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{110}
+	return file_common_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *AccountHasAssetCondition) GetAssetBase() string {
@@ -8860,7 +8926,7 @@ type AndFilter struct {
 
 func (x *AndFilter) Reset() {
 	*x = AndFilter{}
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8872,7 +8938,7 @@ func (x *AndFilter) String() string {
 func (*AndFilter) ProtoMessage() {}
 
 func (x *AndFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[111]
+	mi := &file_common_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8885,7 +8951,7 @@ func (x *AndFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AndFilter.ProtoReflect.Descriptor instead.
 func (*AndFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{111}
+	return file_common_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *AndFilter) GetFilters() []*QueryFilter {
@@ -8904,7 +8970,7 @@ type OrFilter struct {
 
 func (x *OrFilter) Reset() {
 	*x = OrFilter{}
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8916,7 +8982,7 @@ func (x *OrFilter) String() string {
 func (*OrFilter) ProtoMessage() {}
 
 func (x *OrFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[112]
+	mi := &file_common_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8929,7 +8995,7 @@ func (x *OrFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OrFilter.ProtoReflect.Descriptor instead.
 func (*OrFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{112}
+	return file_common_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *OrFilter) GetFilters() []*QueryFilter {
@@ -8948,7 +9014,7 @@ type NotFilter struct {
 
 func (x *NotFilter) Reset() {
 	*x = NotFilter{}
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8960,7 +9026,7 @@ func (x *NotFilter) String() string {
 func (*NotFilter) ProtoMessage() {}
 
 func (x *NotFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[113]
+	mi := &file_common_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8973,7 +9039,7 @@ func (x *NotFilter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotFilter.ProtoReflect.Descriptor instead.
 func (*NotFilter) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{113}
+	return file_common_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *NotFilter) GetFilter() *QueryFilter {
@@ -8995,7 +9061,7 @@ type FieldRef struct {
 
 func (x *FieldRef) Reset() {
 	*x = FieldRef{}
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9007,7 +9073,7 @@ func (x *FieldRef) String() string {
 func (*FieldRef) ProtoMessage() {}
 
 func (x *FieldRef) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[114]
+	mi := &file_common_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9020,7 +9086,7 @@ func (x *FieldRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldRef.ProtoReflect.Descriptor instead.
 func (*FieldRef) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{114}
+	return file_common_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *FieldRef) GetMetadata() string {
@@ -9048,7 +9114,7 @@ type FieldCondition struct {
 
 func (x *FieldCondition) Reset() {
 	*x = FieldCondition{}
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9060,7 +9126,7 @@ func (x *FieldCondition) String() string {
 func (*FieldCondition) ProtoMessage() {}
 
 func (x *FieldCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[115]
+	mi := &file_common_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9073,7 +9139,7 @@ func (x *FieldCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FieldCondition.ProtoReflect.Descriptor instead.
 func (*FieldCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{115}
+	return file_common_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *FieldCondition) GetField() *FieldRef {
@@ -9182,7 +9248,7 @@ type StringCondition struct {
 
 func (x *StringCondition) Reset() {
 	*x = StringCondition{}
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9194,7 +9260,7 @@ func (x *StringCondition) String() string {
 func (*StringCondition) ProtoMessage() {}
 
 func (x *StringCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[116]
+	mi := &file_common_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9207,7 +9273,7 @@ func (x *StringCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringCondition.ProtoReflect.Descriptor instead.
 func (*StringCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{116}
+	return file_common_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *StringCondition) GetValue() isStringCondition_Value {
@@ -9265,7 +9331,7 @@ type IntCondition struct {
 
 func (x *IntCondition) Reset() {
 	*x = IntCondition{}
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9277,7 +9343,7 @@ func (x *IntCondition) String() string {
 func (*IntCondition) ProtoMessage() {}
 
 func (x *IntCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[117]
+	mi := &file_common_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9290,7 +9356,7 @@ func (x *IntCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntCondition.ProtoReflect.Descriptor instead.
 func (*IntCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{117}
+	return file_common_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *IntCondition) GetMin() int64 {
@@ -9349,7 +9415,7 @@ type UintCondition struct {
 
 func (x *UintCondition) Reset() {
 	*x = UintCondition{}
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9361,7 +9427,7 @@ func (x *UintCondition) String() string {
 func (*UintCondition) ProtoMessage() {}
 
 func (x *UintCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[118]
+	mi := &file_common_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9374,7 +9440,7 @@ func (x *UintCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UintCondition.ProtoReflect.Descriptor instead.
 func (*UintCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{118}
+	return file_common_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *UintCondition) GetMin() uint64 {
@@ -9432,7 +9498,7 @@ type BoolCondition struct {
 
 func (x *BoolCondition) Reset() {
 	*x = BoolCondition{}
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9444,7 +9510,7 @@ func (x *BoolCondition) String() string {
 func (*BoolCondition) ProtoMessage() {}
 
 func (x *BoolCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[119]
+	mi := &file_common_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9457,7 +9523,7 @@ func (x *BoolCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BoolCondition.ProtoReflect.Descriptor instead.
 func (*BoolCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{119}
+	return file_common_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *BoolCondition) GetValue() isBoolCondition_Value {
@@ -9510,7 +9576,7 @@ type ExistsCondition struct {
 
 func (x *ExistsCondition) Reset() {
 	*x = ExistsCondition{}
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9522,7 +9588,7 @@ func (x *ExistsCondition) String() string {
 func (*ExistsCondition) ProtoMessage() {}
 
 func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[120]
+	mi := &file_common_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9535,7 +9601,7 @@ func (x *ExistsCondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExistsCondition.ProtoReflect.Descriptor instead.
 func (*ExistsCondition) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{120}
+	return file_common_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *ExistsCondition) GetIncludeNull() bool {
@@ -9561,7 +9627,7 @@ type AddressMatch struct {
 
 func (x *AddressMatch) Reset() {
 	*x = AddressMatch{}
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9573,7 +9639,7 @@ func (x *AddressMatch) String() string {
 func (*AddressMatch) ProtoMessage() {}
 
 func (x *AddressMatch) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[121]
+	mi := &file_common_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9586,7 +9652,7 @@ func (x *AddressMatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddressMatch.ProtoReflect.Descriptor instead.
 func (*AddressMatch) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{121}
+	return file_common_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *AddressMatch) GetMatch() isAddressMatch_Match {
@@ -9682,7 +9748,7 @@ type PreparedQuery struct {
 
 func (x *PreparedQuery) Reset() {
 	*x = PreparedQuery{}
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9694,7 +9760,7 @@ func (x *PreparedQuery) String() string {
 func (*PreparedQuery) ProtoMessage() {}
 
 func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[122]
+	mi := &file_common_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9707,7 +9773,7 @@ func (x *PreparedQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQuery.ProtoReflect.Descriptor instead.
 func (*PreparedQuery) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{122}
+	return file_common_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *PreparedQuery) GetName() string {
@@ -9743,7 +9809,7 @@ type AggregatedVolume struct {
 
 func (x *AggregatedVolume) Reset() {
 	*x = AggregatedVolume{}
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9755,7 +9821,7 @@ func (x *AggregatedVolume) String() string {
 func (*AggregatedVolume) ProtoMessage() {}
 
 func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[123]
+	mi := &file_common_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9768,7 +9834,7 @@ func (x *AggregatedVolume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregatedVolume.ProtoReflect.Descriptor instead.
 func (*AggregatedVolume) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{123}
+	return file_common_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *AggregatedVolume) GetAsset() string {
@@ -9803,7 +9869,7 @@ type AggregateResult struct {
 
 func (x *AggregateResult) Reset() {
 	*x = AggregateResult{}
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9815,7 +9881,7 @@ func (x *AggregateResult) String() string {
 func (*AggregateResult) ProtoMessage() {}
 
 func (x *AggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[124]
+	mi := &file_common_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9828,7 +9894,7 @@ func (x *AggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AggregateResult.ProtoReflect.Descriptor instead.
 func (*AggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{124}
+	return file_common_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *AggregateResult) GetVolumes() []*AggregatedVolume {
@@ -9856,7 +9922,7 @@ type GroupedAggregateResult struct {
 
 func (x *GroupedAggregateResult) Reset() {
 	*x = GroupedAggregateResult{}
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9868,7 +9934,7 @@ func (x *GroupedAggregateResult) String() string {
 func (*GroupedAggregateResult) ProtoMessage() {}
 
 func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[125]
+	mi := &file_common_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9881,7 +9947,7 @@ func (x *GroupedAggregateResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GroupedAggregateResult.ProtoReflect.Descriptor instead.
 func (*GroupedAggregateResult) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{125}
+	return file_common_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *GroupedAggregateResult) GetPrefix() string {
@@ -9913,7 +9979,7 @@ type PreparedQueryCursor struct {
 
 func (x *PreparedQueryCursor) Reset() {
 	*x = PreparedQueryCursor{}
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9925,7 +9991,7 @@ func (x *PreparedQueryCursor) String() string {
 func (*PreparedQueryCursor) ProtoMessage() {}
 
 func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[126]
+	mi := &file_common_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9938,7 +10004,7 @@ func (x *PreparedQueryCursor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreparedQueryCursor.ProtoReflect.Descriptor instead.
 func (*PreparedQueryCursor) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{126}
+	return file_common_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *PreparedQueryCursor) GetPageSize() uint32 {
@@ -10002,7 +10068,7 @@ type LedgerStats struct {
 
 func (x *LedgerStats) Reset() {
 	*x = LedgerStats{}
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10014,7 +10080,7 @@ func (x *LedgerStats) String() string {
 func (*LedgerStats) ProtoMessage() {}
 
 func (x *LedgerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[127]
+	mi := &file_common_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10027,7 +10093,7 @@ func (x *LedgerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LedgerStats.ProtoReflect.Descriptor instead.
 func (*LedgerStats) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{127}
+	return file_common_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *LedgerStats) GetTransactionCount() uint64 {
@@ -10115,7 +10181,7 @@ type PersistedConfig struct {
 
 func (x *PersistedConfig) Reset() {
 	*x = PersistedConfig{}
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10127,7 +10193,7 @@ func (x *PersistedConfig) String() string {
 func (*PersistedConfig) ProtoMessage() {}
 
 func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[128]
+	mi := &file_common_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10140,7 +10206,7 @@ func (x *PersistedConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistedConfig.ProtoReflect.Descriptor instead.
 func (*PersistedConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{128}
+	return file_common_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *PersistedConfig) GetNodeId() uint64 {
@@ -10193,7 +10259,7 @@ type CallerIdentity struct {
 
 func (x *CallerIdentity) Reset() {
 	*x = CallerIdentity{}
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10205,7 +10271,7 @@ func (x *CallerIdentity) String() string {
 func (*CallerIdentity) ProtoMessage() {}
 
 func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[129]
+	mi := &file_common_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10218,7 +10284,7 @@ func (x *CallerIdentity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerIdentity.ProtoReflect.Descriptor instead.
 func (*CallerIdentity) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{129}
+	return file_common_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *CallerIdentity) GetSubject() string {
@@ -10289,7 +10355,7 @@ type CallerSnapshot struct {
 
 func (x *CallerSnapshot) Reset() {
 	*x = CallerSnapshot{}
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10301,7 +10367,7 @@ func (x *CallerSnapshot) String() string {
 func (*CallerSnapshot) ProtoMessage() {}
 
 func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[130]
+	mi := &file_common_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10314,7 +10380,7 @@ func (x *CallerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallerSnapshot.ProtoReflect.Descriptor instead.
 func (*CallerSnapshot) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{130}
+	return file_common_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *CallerSnapshot) GetIdentity() *CallerIdentity {
@@ -10352,7 +10418,7 @@ type S3StorageConfig struct {
 
 func (x *S3StorageConfig) Reset() {
 	*x = S3StorageConfig{}
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10364,7 +10430,7 @@ func (x *S3StorageConfig) String() string {
 func (*S3StorageConfig) ProtoMessage() {}
 
 func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[131]
+	mi := &file_common_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10377,7 +10443,7 @@ func (x *S3StorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use S3StorageConfig.ProtoReflect.Descriptor instead.
 func (*S3StorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{131}
+	return file_common_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *S3StorageConfig) GetBucket() string {
@@ -10428,7 +10494,7 @@ type AzureStorageConfig struct {
 
 func (x *AzureStorageConfig) Reset() {
 	*x = AzureStorageConfig{}
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10440,7 +10506,7 @@ func (x *AzureStorageConfig) String() string {
 func (*AzureStorageConfig) ProtoMessage() {}
 
 func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[132]
+	mi := &file_common_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10453,7 +10519,7 @@ func (x *AzureStorageConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureStorageConfig.ProtoReflect.Descriptor instead.
 func (*AzureStorageConfig) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{132}
+	return file_common_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *AzureStorageConfig) GetAccountName() string {
@@ -10500,7 +10566,7 @@ type BackupStorage struct {
 
 func (x *BackupStorage) Reset() {
 	*x = BackupStorage{}
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10512,7 +10578,7 @@ func (x *BackupStorage) String() string {
 func (*BackupStorage) ProtoMessage() {}
 
 func (x *BackupStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[133]
+	mi := &file_common_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10525,7 +10591,7 @@ func (x *BackupStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackupStorage.ProtoReflect.Descriptor instead.
 func (*BackupStorage) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{133}
+	return file_common_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *BackupStorage) GetProvider() isBackupStorage_Provider {
@@ -10588,7 +10654,7 @@ type ReadOptions struct {
 
 func (x *ReadOptions) Reset() {
 	*x = ReadOptions{}
-	mi := &file_common_proto_msgTypes[134]
+	mi := &file_common_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10600,7 +10666,7 @@ func (x *ReadOptions) String() string {
 func (*ReadOptions) ProtoMessage() {}
 
 func (x *ReadOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[134]
+	mi := &file_common_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10613,7 +10679,7 @@ func (x *ReadOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadOptions.ProtoReflect.Descriptor instead.
 func (*ReadOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{134}
+	return file_common_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *ReadOptions) GetCheckpointId() uint64 {
@@ -10665,7 +10731,7 @@ type ListOptions struct {
 
 func (x *ListOptions) Reset() {
 	*x = ListOptions{}
-	mi := &file_common_proto_msgTypes[135]
+	mi := &file_common_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10677,7 +10743,7 @@ func (x *ListOptions) String() string {
 func (*ListOptions) ProtoMessage() {}
 
 func (x *ListOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[135]
+	mi := &file_common_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10690,7 +10756,7 @@ func (x *ListOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListOptions.ProtoReflect.Descriptor instead.
 func (*ListOptions) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{135}
+	return file_common_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *ListOptions) GetRead() *ReadOptions {
@@ -11297,7 +11363,7 @@ const file_common_proto_rawDesc = "" +
 	"\x15RemovedAccountTypeLog\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"k\n" +
 	" UpdatedDefaultEnforcementModeLog\x12G\n" +
-	"\x10enforcement_mode\x18\x01 \x01(\x0e2\x1c.common.ChartEnforcementModeR\x0fenforcementMode\"\xeb\x04\n" +
+	"\x10enforcement_mode\x18\x01 \x01(\x0e2\x1c.common.ChartEnforcementModeR\x0fenforcementMode\"\xa4\x05\n" +
 	"\vQueryFilter\x12.\n" +
 	"\x05field\x18\x01 \x01(\v2\x16.common.FieldConditionH\x00R\x05field\x120\n" +
 	"\aaddress\x18\x02 \x01(\v2\x14.common.AddressMatchH\x00R\aaddress\x12%\n" +
@@ -11310,10 +11376,13 @@ const file_common_proto_rawDesc = "" +
 	"\x06log_id\x18\t \x01(\v2\x16.common.LogIdConditionH\x00R\x05logId\x12K\n" +
 	"\x10log_builtin_uint\x18\n" +
 	" \x01(\v2\x1f.common.LogBuiltinUintConditionH\x00R\x0elogBuiltinUint\x12N\n" +
-	"\x11account_has_asset\x18\v \x01(\v2 .common.AccountHasAssetConditionH\x00R\x0faccountHasAssetB\b\n" +
+	"\x11account_has_asset\x18\v \x01(\v2 .common.AccountHasAssetConditionH\x00R\x0faccountHasAsset\x127\n" +
+	"\breverted\x18\f \x01(\v2\x19.common.RevertedConditionH\x00R\brevertedB\b\n" +
 	"\x06filter\"A\n" +
 	"\x12ReferenceCondition\x12+\n" +
-	"\x04cond\x18\x01 \x01(\v2\x17.common.StringConditionR\x04cond\">\n" +
+	"\x04cond\x18\x01 \x01(\v2\x17.common.StringConditionR\x04cond\")\n" +
+	"\x11RevertedCondition\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\bR\x05value\">\n" +
 	"\x0fLedgerCondition\x12+\n" +
 	"\x04cond\x18\x01 \x01(\v2\x17.common.StringConditionR\x04cond\";\n" +
 	"\x0eLogIdCondition\x12)\n" +
@@ -11477,7 +11546,7 @@ const file_common_proto_rawDesc = "" +
 	"\x10IndexBuildStatus\x12\"\n" +
 	"\x1eINDEX_BUILD_STATUS_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bINDEX_BUILD_STATUS_BUILDING\x10\x01\x12\x1c\n" +
-	"\x18INDEX_BUILD_STATUS_READY\x10\x02*\x81\x02\n" +
+	"\x18INDEX_BUILD_STATUS_READY\x10\x02*\xa3\x02\n" +
 	"\x17TransactionBuiltinIndex\x12\x1e\n" +
 	"\x1aTX_BUILTIN_INDEX_REFERENCE\x10\x00\x12\x1e\n" +
 	"\x1aTX_BUILTIN_INDEX_TIMESTAMP\x10\x01\x12\x17\n" +
@@ -11485,7 +11554,8 @@ const file_common_proto_rawDesc = "" +
 	"\x18TX_BUILTIN_INDEX_ADDRESS\x10\x03\x12#\n" +
 	"\x1fTX_BUILTIN_INDEX_SOURCE_ADDRESS\x10\x04\x12(\n" +
 	"$TX_BUILTIN_INDEX_DESTINATION_ADDRESS\x10\x05\x12 \n" +
-	"\x1cTX_BUILTIN_INDEX_INSERTED_AT\x10\x06*W\n" +
+	"\x1cTX_BUILTIN_INDEX_INSERTED_AT\x10\x06\x12 \n" +
+	"\x1cTX_BUILTIN_INDEX_REVERTED_AT\x10\a*W\n" +
 	"\x13AccountBuiltinIndex\x12\"\n" +
 	"\x1eACCT_BUILTIN_INDEX_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18ACCT_BUILTIN_INDEX_ASSET\x10\x01*j\n" +
@@ -11613,7 +11683,7 @@ func file_common_proto_rawDescGZIP() []byte {
 }
 
 var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 17)
-var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 157)
 var file_common_proto_goTypes = []any{
 	(TargetType)(0),                           // 0: common.TargetType
 	(MetadataType)(0),                         // 1: common.MetadataType
@@ -11738,81 +11808,82 @@ var file_common_proto_goTypes = []any{
 	(*UpdatedDefaultEnforcementModeLog)(nil),  // 120: common.UpdatedDefaultEnforcementModeLog
 	(*QueryFilter)(nil),                       // 121: common.QueryFilter
 	(*ReferenceCondition)(nil),                // 122: common.ReferenceCondition
-	(*LedgerCondition)(nil),                   // 123: common.LedgerCondition
-	(*LogIdCondition)(nil),                    // 124: common.LogIdCondition
-	(*BuiltinUintCondition)(nil),              // 125: common.BuiltinUintCondition
-	(*LogBuiltinUintCondition)(nil),           // 126: common.LogBuiltinUintCondition
-	(*AccountHasAssetCondition)(nil),          // 127: common.AccountHasAssetCondition
-	(*AndFilter)(nil),                         // 128: common.AndFilter
-	(*OrFilter)(nil),                          // 129: common.OrFilter
-	(*NotFilter)(nil),                         // 130: common.NotFilter
-	(*FieldRef)(nil),                          // 131: common.FieldRef
-	(*FieldCondition)(nil),                    // 132: common.FieldCondition
-	(*StringCondition)(nil),                   // 133: common.StringCondition
-	(*IntCondition)(nil),                      // 134: common.IntCondition
-	(*UintCondition)(nil),                     // 135: common.UintCondition
-	(*BoolCondition)(nil),                     // 136: common.BoolCondition
-	(*ExistsCondition)(nil),                   // 137: common.ExistsCondition
-	(*AddressMatch)(nil),                      // 138: common.AddressMatch
-	(*PreparedQuery)(nil),                     // 139: common.PreparedQuery
-	(*AggregatedVolume)(nil),                  // 140: common.AggregatedVolume
-	(*AggregateResult)(nil),                   // 141: common.AggregateResult
-	(*GroupedAggregateResult)(nil),            // 142: common.GroupedAggregateResult
-	(*PreparedQueryCursor)(nil),               // 143: common.PreparedQueryCursor
-	(*LedgerStats)(nil),                       // 144: common.LedgerStats
-	(*PersistedConfig)(nil),                   // 145: common.PersistedConfig
-	(*CallerIdentity)(nil),                    // 146: common.CallerIdentity
-	(*CallerSnapshot)(nil),                    // 147: common.CallerSnapshot
-	(*S3StorageConfig)(nil),                   // 148: common.S3StorageConfig
-	(*AzureStorageConfig)(nil),                // 149: common.AzureStorageConfig
-	(*BackupStorage)(nil),                     // 150: common.BackupStorage
-	(*ReadOptions)(nil),                       // 151: common.ReadOptions
-	(*ListOptions)(nil),                       // 152: common.ListOptions
-	nil,                                       // 153: common.MetadataMap.ValuesEntry
-	nil,                                       // 154: common.Transaction.MetadataEntry
-	nil,                                       // 155: common.Script.VarsEntry
-	nil,                                       // 156: common.VolumesByAssets.VolumesEntry
-	nil,                                       // 157: common.PostCommitVolumes.VolumesByAccountEntry
-	nil,                                       // 158: common.Account.MetadataEntry
-	nil,                                       // 159: common.Account.VolumesEntry
-	nil,                                       // 160: common.MetadataSchema.AccountFieldsEntry
-	nil,                                       // 161: common.MetadataSchema.TransactionFieldsEntry
-	nil,                                       // 162: common.MetadataSchema.LedgerFieldsEntry
-	nil,                                       // 163: common.SavedLedgerMetadataLog.MetadataEntry
-	nil,                                       // 164: common.CreatedLedgerLog.AccountTypesEntry
-	nil,                                       // 165: common.CreatedTransaction.AccountMetadataEntry
-	nil,                                       // 166: common.SavedMetadata.MetadataEntry
-	nil,                                       // 167: common.LedgerInfo.AccountTypesEntry
-	nil,                                       // 168: common.LedgerInfo.MetadataEntry
-	nil,                                       // 169: common.SaveMetadataCommand.MetadataEntry
-	nil,                                       // 170: common.TransactionState.MetadataEntry
-	nil,                                       // 171: common.IdempotencyFailure.MetadataEntry
-	nil,                                       // 172: common.AccountType.SegmentTypesEntry
-	(*signaturepb.SignedLog)(nil),             // 173: signature.SignedLog
+	(*RevertedCondition)(nil),                 // 123: common.RevertedCondition
+	(*LedgerCondition)(nil),                   // 124: common.LedgerCondition
+	(*LogIdCondition)(nil),                    // 125: common.LogIdCondition
+	(*BuiltinUintCondition)(nil),              // 126: common.BuiltinUintCondition
+	(*LogBuiltinUintCondition)(nil),           // 127: common.LogBuiltinUintCondition
+	(*AccountHasAssetCondition)(nil),          // 128: common.AccountHasAssetCondition
+	(*AndFilter)(nil),                         // 129: common.AndFilter
+	(*OrFilter)(nil),                          // 130: common.OrFilter
+	(*NotFilter)(nil),                         // 131: common.NotFilter
+	(*FieldRef)(nil),                          // 132: common.FieldRef
+	(*FieldCondition)(nil),                    // 133: common.FieldCondition
+	(*StringCondition)(nil),                   // 134: common.StringCondition
+	(*IntCondition)(nil),                      // 135: common.IntCondition
+	(*UintCondition)(nil),                     // 136: common.UintCondition
+	(*BoolCondition)(nil),                     // 137: common.BoolCondition
+	(*ExistsCondition)(nil),                   // 138: common.ExistsCondition
+	(*AddressMatch)(nil),                      // 139: common.AddressMatch
+	(*PreparedQuery)(nil),                     // 140: common.PreparedQuery
+	(*AggregatedVolume)(nil),                  // 141: common.AggregatedVolume
+	(*AggregateResult)(nil),                   // 142: common.AggregateResult
+	(*GroupedAggregateResult)(nil),            // 143: common.GroupedAggregateResult
+	(*PreparedQueryCursor)(nil),               // 144: common.PreparedQueryCursor
+	(*LedgerStats)(nil),                       // 145: common.LedgerStats
+	(*PersistedConfig)(nil),                   // 146: common.PersistedConfig
+	(*CallerIdentity)(nil),                    // 147: common.CallerIdentity
+	(*CallerSnapshot)(nil),                    // 148: common.CallerSnapshot
+	(*S3StorageConfig)(nil),                   // 149: common.S3StorageConfig
+	(*AzureStorageConfig)(nil),                // 150: common.AzureStorageConfig
+	(*BackupStorage)(nil),                     // 151: common.BackupStorage
+	(*ReadOptions)(nil),                       // 152: common.ReadOptions
+	(*ListOptions)(nil),                       // 153: common.ListOptions
+	nil,                                       // 154: common.MetadataMap.ValuesEntry
+	nil,                                       // 155: common.Transaction.MetadataEntry
+	nil,                                       // 156: common.Script.VarsEntry
+	nil,                                       // 157: common.VolumesByAssets.VolumesEntry
+	nil,                                       // 158: common.PostCommitVolumes.VolumesByAccountEntry
+	nil,                                       // 159: common.Account.MetadataEntry
+	nil,                                       // 160: common.Account.VolumesEntry
+	nil,                                       // 161: common.MetadataSchema.AccountFieldsEntry
+	nil,                                       // 162: common.MetadataSchema.TransactionFieldsEntry
+	nil,                                       // 163: common.MetadataSchema.LedgerFieldsEntry
+	nil,                                       // 164: common.SavedLedgerMetadataLog.MetadataEntry
+	nil,                                       // 165: common.CreatedLedgerLog.AccountTypesEntry
+	nil,                                       // 166: common.CreatedTransaction.AccountMetadataEntry
+	nil,                                       // 167: common.SavedMetadata.MetadataEntry
+	nil,                                       // 168: common.LedgerInfo.AccountTypesEntry
+	nil,                                       // 169: common.LedgerInfo.MetadataEntry
+	nil,                                       // 170: common.SaveMetadataCommand.MetadataEntry
+	nil,                                       // 171: common.TransactionState.MetadataEntry
+	nil,                                       // 172: common.IdempotencyFailure.MetadataEntry
+	nil,                                       // 173: common.AccountType.SegmentTypesEntry
+	(*signaturepb.SignedLog)(nil),             // 174: signature.SignedLog
 }
 var file_common_proto_depIdxs = []int32{
 	18,  // 0: common.MetadataValue.null_value:type_name -> common.NullValue
-	153, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
+	154, // 1: common.MetadataMap.values:type_name -> common.MetadataMap.ValuesEntry
 	22,  // 2: common.Posting.amount:type_name -> common.Uint256
 	23,  // 3: common.Transaction.postings:type_name -> common.Posting
-	154, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
+	155, // 4: common.Transaction.metadata:type_name -> common.Transaction.MetadataEntry
 	17,  // 5: common.Transaction.timestamp:type_name -> common.Timestamp
 	17,  // 6: common.Transaction.inserted_at:type_name -> common.Timestamp
 	17,  // 7: common.Transaction.updated_at:type_name -> common.Timestamp
 	17,  // 8: common.Transaction.reverted_at:type_name -> common.Timestamp
-	155, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
-	156, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
-	157, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
-	158, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
+	156, // 9: common.Script.vars:type_name -> common.Script.VarsEntry
+	157, // 10: common.VolumesByAssets.volumes:type_name -> common.VolumesByAssets.VolumesEntry
+	158, // 11: common.PostCommitVolumes.volumes_by_account:type_name -> common.PostCommitVolumes.VolumesByAccountEntry
+	159, // 12: common.Account.metadata:type_name -> common.Account.MetadataEntry
 	17,  // 13: common.Account.first_usage:type_name -> common.Timestamp
 	17,  // 14: common.Account.insertion_date:type_name -> common.Timestamp
 	17,  // 15: common.Account.updated_at:type_name -> common.Timestamp
-	159, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
+	160, // 16: common.Account.volumes:type_name -> common.Account.VolumesEntry
 	31,  // 17: common.Target.account:type_name -> common.TargetAccount
 	1,   // 18: common.MetadataFieldSchema.type:type_name -> common.MetadataType
-	160, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
-	161, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
-	162, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
+	161, // 19: common.MetadataSchema.account_fields:type_name -> common.MetadataSchema.AccountFieldsEntry
+	162, // 20: common.MetadataSchema.transaction_fields:type_name -> common.MetadataSchema.TransactionFieldsEntry
+	163, // 21: common.MetadataSchema.ledger_fields:type_name -> common.MetadataSchema.LedgerFieldsEntry
 	0,   // 22: common.SetMetadataFieldTypeCommand.target_type:type_name -> common.TargetType
 	1,   // 23: common.SetMetadataFieldTypeCommand.type:type_name -> common.MetadataType
 	0,   // 24: common.MetadataIndexID.target:type_name -> common.TargetType
@@ -11825,7 +11896,7 @@ var file_common_proto_depIdxs = []int32{
 	17,  // 31: common.Index.created_at:type_name -> common.Timestamp
 	17,  // 32: common.Index.last_built_at:type_name -> common.Timestamp
 	42,  // 33: common.Log.payload:type_name -> common.LogPayload
-	173, // 34: common.Log.response_signature:type_name -> signature.SignedLog
+	174, // 34: common.Log.response_signature:type_name -> signature.SignedLog
 	77,  // 35: common.LogPayload.create_ledger:type_name -> common.CreatedLedgerLog
 	78,  // 36: common.LogPayload.delete_ledger:type_name -> common.DeletedLedgerLog
 	79,  // 37: common.LogPayload.apply:type_name -> common.ApplyLedgerLog
@@ -11868,10 +11939,10 @@ var file_common_proto_depIdxs = []int32{
 	51,  // 74: common.ClusterConfig.bloom_prepared_queries:type_name -> common.BloomTypeConfig
 	51,  // 75: common.ClusterConfig.bloom_indexes:type_name -> common.BloomTypeConfig
 	52,  // 76: common.PersistedClusterState.config:type_name -> common.ClusterConfig
-	139, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
+	140, // 77: common.CreatedPreparedQueryLog.query:type_name -> common.PreparedQuery
 	121, // 78: common.UpdatedPreparedQueryLog.previous_filter:type_name -> common.QueryFilter
 	121, // 79: common.UpdatedPreparedQueryLog.new_filter:type_name -> common.QueryFilter
-	163, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
+	164, // 80: common.SavedLedgerMetadataLog.metadata:type_name -> common.SavedLedgerMetadataLog.MetadataEntry
 	17,  // 81: common.NumscriptInfo.created_at:type_name -> common.Timestamp
 	61,  // 82: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
 	71,  // 83: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
@@ -11887,7 +11958,7 @@ var file_common_proto_depIdxs = []int32{
 	34,  // 93: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
 	9,   // 94: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
 	97,  // 95: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
-	164, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
+	165, // 96: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
 	12,  // 97: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
 	17,  // 98: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
 	80,  // 99: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
@@ -11909,12 +11980,12 @@ var file_common_proto_depIdxs = []int32{
 	37,  // 115: common.CreatedIndexLog.id:type_name -> common.IndexID
 	37,  // 116: common.DroppedIndexLog.id:type_name -> common.IndexID
 	24,  // 117: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	165, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	166, // 118: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
 	29,  // 119: common.CreatedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
 	24,  // 120: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
 	29,  // 121: common.RevertedTransaction.post_commit_volumes:type_name -> common.PostCommitVolumes
 	32,  // 122: common.SavedMetadata.target:type_name -> common.Target
-	166, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	167, // 123: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
 	32,  // 124: common.DeletedMetadata.target:type_name -> common.Target
 	0,   // 125: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
 	1,   // 126: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
@@ -11942,91 +12013,92 @@ var file_common_proto_depIdxs = []int32{
 	9,   // 148: common.LedgerInfo.mode:type_name -> common.LedgerMode
 	97,  // 149: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
 	104, // 150: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	167, // 151: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	168, // 151: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
 	12,  // 152: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	168, // 153: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	169, // 153: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
 	32,  // 154: common.SaveMetadataCommand.target:type_name -> common.Target
-	169, // 155: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	170, // 155: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
 	32,  // 156: common.DeleteMetadataCommand.target:type_name -> common.Target
-	170, // 157: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	171, // 157: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
 	17,  // 158: common.TransactionState.timestamp:type_name -> common.Timestamp
 	23,  // 159: common.TransactionState.postings:type_name -> common.Posting
 	17,  // 160: common.TransactionState.reverted_at:type_name -> common.Timestamp
 	110, // 161: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
 	11,  // 162: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	171, // 163: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	172, // 163: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
 	114, // 164: common.SegmentType.uuid:type_name -> common.UUIDConstraint
 	115, // 165: common.SegmentType.uint64:type_name -> common.Uint64Constraint
 	116, // 166: common.SegmentType.bytes:type_name -> common.BytesConstraint
 	13,  // 167: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	172, // 168: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	173, // 168: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
 	117, // 169: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
 	12,  // 170: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	132, // 171: common.QueryFilter.field:type_name -> common.FieldCondition
-	138, // 172: common.QueryFilter.address:type_name -> common.AddressMatch
-	128, // 173: common.QueryFilter.and:type_name -> common.AndFilter
-	129, // 174: common.QueryFilter.or:type_name -> common.OrFilter
-	130, // 175: common.QueryFilter.not:type_name -> common.NotFilter
+	133, // 171: common.QueryFilter.field:type_name -> common.FieldCondition
+	139, // 172: common.QueryFilter.address:type_name -> common.AddressMatch
+	129, // 173: common.QueryFilter.and:type_name -> common.AndFilter
+	130, // 174: common.QueryFilter.or:type_name -> common.OrFilter
+	131, // 175: common.QueryFilter.not:type_name -> common.NotFilter
 	122, // 176: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	125, // 177: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	123, // 178: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	124, // 179: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	126, // 180: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	127, // 181: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	133, // 182: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	133, // 183: common.LedgerCondition.cond:type_name -> common.StringCondition
-	135, // 184: common.LogIdCondition.cond:type_name -> common.UintCondition
-	3,   // 185: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	135, // 186: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	5,   // 187: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	135, // 188: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	121, // 189: common.AndFilter.filters:type_name -> common.QueryFilter
-	121, // 190: common.OrFilter.filters:type_name -> common.QueryFilter
-	121, // 191: common.NotFilter.filter:type_name -> common.QueryFilter
-	131, // 192: common.FieldCondition.field:type_name -> common.FieldRef
-	133, // 193: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	134, // 194: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	135, // 195: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	136, // 196: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	137, // 197: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 198: common.AddressMatch.role:type_name -> common.AddressRole
-	121, // 199: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 200: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 201: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 202: common.AggregatedVolume.output:type_name -> common.Uint256
-	140, // 203: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	142, // 204: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	140, // 205: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	30,  // 206: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 207: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	146, // 208: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	148, // 209: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	149, // 210: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	151, // 211: common.ListOptions.read:type_name -> common.ReadOptions
-	121, // 212: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 213: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 214: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	26,  // 215: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
-	28,  // 216: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 217: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	27,  // 218: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
-	33,  // 219: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 220: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	33,  // 221: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 222: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	117, // 223: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 224: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 225: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	117, // 226: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 227: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 228: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 229: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	113, // 230: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	231, // [231:231] is the sub-list for method output_type
-	231, // [231:231] is the sub-list for method input_type
-	231, // [231:231] is the sub-list for extension type_name
-	231, // [231:231] is the sub-list for extension extendee
-	0,   // [0:231] is the sub-list for field type_name
+	126, // 177: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	124, // 178: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	125, // 179: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	127, // 180: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	128, // 181: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	123, // 182: common.QueryFilter.reverted:type_name -> common.RevertedCondition
+	134, // 183: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	134, // 184: common.LedgerCondition.cond:type_name -> common.StringCondition
+	136, // 185: common.LogIdCondition.cond:type_name -> common.UintCondition
+	3,   // 186: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	136, // 187: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	5,   // 188: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	136, // 189: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	121, // 190: common.AndFilter.filters:type_name -> common.QueryFilter
+	121, // 191: common.OrFilter.filters:type_name -> common.QueryFilter
+	121, // 192: common.NotFilter.filter:type_name -> common.QueryFilter
+	132, // 193: common.FieldCondition.field:type_name -> common.FieldRef
+	134, // 194: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	135, // 195: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	136, // 196: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	137, // 197: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	138, // 198: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	14,  // 199: common.AddressMatch.role:type_name -> common.AddressRole
+	121, // 200: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	15,  // 201: common.PreparedQuery.target:type_name -> common.QueryTarget
+	22,  // 202: common.AggregatedVolume.input:type_name -> common.Uint256
+	22,  // 203: common.AggregatedVolume.output:type_name -> common.Uint256
+	141, // 204: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	143, // 205: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	141, // 206: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	30,  // 207: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	24,  // 208: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	147, // 209: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	149, // 210: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	150, // 211: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	152, // 212: common.ListOptions.read:type_name -> common.ReadOptions
+	121, // 213: common.ListOptions.filter:type_name -> common.QueryFilter
+	19,  // 214: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	19,  // 215: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	26,  // 216: common.VolumesByAssets.VolumesEntry.value:type_name -> common.Volumes
+	28,  // 217: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	19,  // 218: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	27,  // 219: common.Account.VolumesEntry.value:type_name -> common.VolumesWithBalance
+	33,  // 220: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 221: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	33,  // 222: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	19,  // 223: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 224: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 225: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	19,  // 226: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	117, // 227: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	19,  // 228: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 229: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 230: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	113, // 231: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	232, // [232:232] is the sub-list for method output_type
+	232, // [232:232] is the sub-list for method input_type
+	232, // [232:232] is the sub-list for extension type_name
+	232, // [232:232] is the sub-list for extension extendee
+	0,   // [0:232] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }
@@ -12134,35 +12206,36 @@ func file_common_proto_init() {
 		(*QueryFilter_LogId)(nil),
 		(*QueryFilter_LogBuiltinUint)(nil),
 		(*QueryFilter_AccountHasAsset)(nil),
+		(*QueryFilter_Reverted)(nil),
 	}
-	file_common_proto_msgTypes[115].OneofWrappers = []any{
+	file_common_proto_msgTypes[116].OneofWrappers = []any{
 		(*FieldCondition_StringCond)(nil),
 		(*FieldCondition_IntCond)(nil),
 		(*FieldCondition_UintCond)(nil),
 		(*FieldCondition_BoolCond)(nil),
 		(*FieldCondition_ExistsCond)(nil),
 	}
-	file_common_proto_msgTypes[116].OneofWrappers = []any{
+	file_common_proto_msgTypes[117].OneofWrappers = []any{
 		(*StringCondition_Hardcoded)(nil),
 		(*StringCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[117].OneofWrappers = []any{}
 	file_common_proto_msgTypes[118].OneofWrappers = []any{}
-	file_common_proto_msgTypes[119].OneofWrappers = []any{
+	file_common_proto_msgTypes[119].OneofWrappers = []any{}
+	file_common_proto_msgTypes[120].OneofWrappers = []any{
 		(*BoolCondition_Hardcoded)(nil),
 		(*BoolCondition_Param)(nil),
 	}
-	file_common_proto_msgTypes[121].OneofWrappers = []any{
+	file_common_proto_msgTypes[122].OneofWrappers = []any{
 		(*AddressMatch_HardcodedPrefix)(nil),
 		(*AddressMatch_HardcodedExact)(nil),
 		(*AddressMatch_ParamPrefix)(nil),
 		(*AddressMatch_ParamExact)(nil),
 	}
-	file_common_proto_msgTypes[129].OneofWrappers = []any{
+	file_common_proto_msgTypes[130].OneofWrappers = []any{
 		(*CallerIdentity_Issuer)(nil),
 		(*CallerIdentity_KeyId)(nil),
 	}
-	file_common_proto_msgTypes[133].OneofWrappers = []any{
+	file_common_proto_msgTypes[134].OneofWrappers = []any{
 		(*BackupStorage_S3)(nil),
 		(*BackupStorage_Azure)(nil),
 	}
@@ -12172,7 +12245,7 @@ func file_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_common_proto_rawDesc), len(file_common_proto_rawDesc)),
 			NumEnums:      17,
-			NumMessages:   156,
+			NumMessages:   157,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -2812,6 +2812,17 @@ func (m *ReferenceCondition) MarshalDeterministicVT(dAtA []byte) []byte {
 	return append(dAtA, b...)
 }
 
+func (m *RevertedCondition) MarshalDeterministicVT(dAtA []byte) []byte {
+	if m == nil {
+		return dAtA
+	}
+	b, err := m.MarshalVT()
+	if err != nil {
+		panic("MarshalDeterministicVT: " + err.Error())
+	}
+	return append(dAtA, b...)
+}
+
 func (m *LedgerCondition) MarshalDeterministicVT(dAtA []byte) []byte {
 	if m == nil {
 		return dAtA

--- a/internal/proto/commonpb/common_dethash.pb.go
+++ b/internal/proto/commonpb/common_dethash.pb.go
@@ -157,6 +157,18 @@ func (m *Transaction) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, err
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.RevertsTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertsTransaction))
+		i--
+		dAtA[i] = 0x59
+	}
+	if m.RevertedByTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertedByTransaction))
+		i--
+		dAtA[i] = 0x51
+	}
 	if m.RevertedAt != nil {
 		size, _ := m.RevertedAt.MarshalToSizedBufferVT(dAtA[:i])
 		i -= size
@@ -2399,6 +2411,19 @@ func (m *TransactionState) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RevertsTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertsTransaction))
+		i--
+		dAtA[i] = 0x39
+	}
+	if m.RevertedAt != nil {
+		size, _ := m.RevertedAt.MarshalToSizedBufferVT(dAtA[:i])
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
 	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -8838,6 +8838,73 @@ func NewReferenceConditionListReader(s []*ReferenceCondition) ReferenceCondition
 	return referenceConditionListReadonly(s)
 }
 
+// RevertedConditionReader provides read-only access to RevertedCondition.
+// Call Mutate() to obtain a mutable clone.
+type RevertedConditionReader interface {
+	GetValue() bool
+	Mutate() *RevertedCondition
+}
+
+type revertedConditionReadonly struct{ v *RevertedCondition }
+
+func (r *revertedConditionReadonly) GetValue() bool {
+	return r.v.GetValue()
+}
+
+func (r *revertedConditionReadonly) Mutate() *RevertedCondition {
+	return r.v.CloneVT()
+}
+
+// AsReader returns a read-only view of this RevertedCondition.
+func (m *RevertedCondition) AsReader() RevertedConditionReader {
+	if m == nil {
+		return nil
+	}
+	return &revertedConditionReadonly{v: m}
+}
+
+// Mutate returns a mutable deep clone of this RevertedCondition.
+func (m *RevertedCondition) Mutate() *RevertedCondition {
+	return m.CloneVT()
+}
+
+// RevertedConditionListReader provides read-only iteration over []*RevertedCondition.
+type RevertedConditionListReader interface {
+	Len() int
+	Get(i int) RevertedConditionReader
+	Range(yield func(int, RevertedConditionReader) bool)
+}
+
+type revertedConditionListReadonly []*RevertedCondition
+
+func (l revertedConditionListReadonly) Len() int { return len(l) }
+
+func (l revertedConditionListReadonly) Get(i int) RevertedConditionReader {
+	v := l[i]
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
+}
+
+func (l revertedConditionListReadonly) Range(yield func(int, RevertedConditionReader) bool) {
+	for i, v := range l {
+		var r RevertedConditionReader
+		if v != nil {
+			r = v.AsReader()
+		}
+		if !yield(i, r) {
+			return
+		}
+	}
+}
+
+// NewRevertedConditionListReader wraps s for read-only iteration. The returned
+// view aliases the underlying slice; do not mutate s afterwards.
+func NewRevertedConditionListReader(s []*RevertedCondition) RevertedConditionListReader {
+	return revertedConditionListReadonly(s)
+}
+
 // LedgerConditionReader provides read-only access to LedgerCondition.
 // Call Mutate() to obtain a mutable clone.
 type LedgerConditionReader interface {

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -558,6 +558,8 @@ type TransactionReader interface {
 	GetInsertedAt() TimestampReader
 	GetUpdatedAt() TimestampReader
 	GetRevertedAt() TimestampReader
+	GetRevertedByTransaction() uint64
+	GetRevertsTransaction() uint64
 	Mutate() *Transaction
 }
 
@@ -613,6 +615,14 @@ func (r *transactionReadonly) GetRevertedAt() TimestampReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *transactionReadonly) GetRevertedByTransaction() uint64 {
+	return r.v.GetRevertedByTransaction()
+}
+
+func (r *transactionReadonly) GetRevertsTransaction() uint64 {
+	return r.v.GetRevertsTransaction()
 }
 
 func (r *transactionReadonly) Mutate() *Transaction {
@@ -7658,6 +7668,8 @@ type TransactionStateReader interface {
 	GetMetadata() TransactionState_MetadataMapReader
 	GetTimestamp() TimestampReader
 	GetPostings() PostingListReader
+	GetRevertedAt() TimestampReader
+	GetRevertsTransaction() uint64
 	Mutate() *TransactionState
 }
 
@@ -7685,6 +7697,18 @@ func (r *transactionStateReadonly) GetTimestamp() TimestampReader {
 
 func (r *transactionStateReadonly) GetPostings() PostingListReader {
 	return NewPostingListReader(r.v.GetPostings())
+}
+
+func (r *transactionStateReadonly) GetRevertedAt() TimestampReader {
+	v := r.v.GetRevertedAt()
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
+}
+
+func (r *transactionStateReadonly) GetRevertsTransaction() uint64 {
+	return r.v.GetRevertsTransaction()
 }
 
 func (r *transactionStateReadonly) Mutate() *TransactionState {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -259,6 +259,8 @@ func (m *Transaction) CloneVT() *Transaction {
 	r.InsertedAt = m.InsertedAt.CloneVT()
 	r.UpdatedAt = m.UpdatedAt.CloneVT()
 	r.RevertedAt = m.RevertedAt.CloneVT()
+	r.RevertedByTransaction = m.RevertedByTransaction
+	r.RevertsTransaction = m.RevertsTransaction
 	if rhs := m.Postings; rhs != nil {
 		tmpContainer := make([]*Posting, len(rhs))
 		for k, v := range rhs {
@@ -2496,6 +2498,8 @@ func (m *TransactionState) CloneVT() *TransactionState {
 	r.CreatedByLog = m.CreatedByLog
 	r.RevertedByTransaction = m.RevertedByTransaction
 	r.Timestamp = m.Timestamp.CloneVT()
+	r.RevertedAt = m.RevertedAt.CloneVT()
+	r.RevertsTransaction = m.RevertsTransaction
 	if rhs := m.Metadata; rhs != nil {
 		tmpContainer := make(map[string]*MetadataValue, len(rhs))
 		for k, v := range rhs {
@@ -4143,6 +4147,12 @@ func (this *Transaction) EqualVT(that *Transaction) bool {
 		return false
 	}
 	if !this.RevertedAt.EqualVT(that.RevertedAt) {
+		return false
+	}
+	if this.RevertedByTransaction != that.RevertedByTransaction {
+		return false
+	}
+	if this.RevertsTransaction != that.RevertsTransaction {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -7871,6 +7881,12 @@ func (this *TransactionState) EqualVT(that *TransactionState) bool {
 			}
 		}
 	}
+	if !this.RevertedAt.EqualVT(that.RevertedAt) {
+		return false
+	}
+	if this.RevertsTransaction != that.RevertsTransaction {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -10320,6 +10336,18 @@ func (m *Transaction) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RevertsTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertsTransaction))
+		i--
+		dAtA[i] = 0x59
+	}
+	if m.RevertedByTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertedByTransaction))
+		i--
+		dAtA[i] = 0x51
 	}
 	if m.RevertedAt != nil {
 		size, err := m.RevertedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -16172,6 +16200,22 @@ func (m *TransactionState) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.RevertsTransaction != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.RevertsTransaction))
+		i--
+		dAtA[i] = 0x39
+	}
+	if m.RevertedAt != nil {
+		size, err := m.RevertedAt.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.Postings) > 0 {
 		for iNdEx := len(m.Postings) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.Postings[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -19335,6 +19379,12 @@ func (m *Transaction) SizeVT() (n int) {
 		l = m.RevertedAt.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.RevertedByTransaction != 0 {
+		n += 9
+	}
+	if m.RevertsTransaction != 0 {
+		n += 9
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -21822,6 +21872,13 @@ func (m *TransactionState) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.RevertedAt != nil {
+		l = m.RevertedAt.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.RevertsTransaction != 0 {
+		n += 9
 	}
 	n += len(m.unknownFields)
 	return n
@@ -24368,6 +24425,26 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 10:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RevertedByTransaction", wireType)
+			}
+			m.RevertedByTransaction = 0
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RevertedByTransaction = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+		case 11:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RevertsTransaction", wireType)
+			}
+			m.RevertsTransaction = 0
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RevertsTransaction = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -38900,6 +38977,52 @@ func (m *TransactionState) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RevertedAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RevertedAt == nil {
+				m.RevertedAt = &Timestamp{}
+			}
+			if err := m.RevertedAt.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RevertsTransaction", wireType)
+			}
+			m.RevertsTransaction = 0
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RevertsTransaction = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -2910,6 +2910,15 @@ func (m *QueryFilter_AccountHasAsset) CloneVT() isQueryFilter_Filter {
 	return r
 }
 
+func (m *QueryFilter_Reverted) CloneVT() isQueryFilter_Filter {
+	if m == nil {
+		return (*QueryFilter_Reverted)(nil)
+	}
+	r := new(QueryFilter_Reverted)
+	r.Reverted = m.Reverted.CloneVT()
+	return r
+}
+
 func (m *ReferenceCondition) CloneVT() *ReferenceCondition {
 	if m == nil {
 		return (*ReferenceCondition)(nil)
@@ -2924,6 +2933,23 @@ func (m *ReferenceCondition) CloneVT() *ReferenceCondition {
 }
 
 func (m *ReferenceCondition) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *RevertedCondition) CloneVT() *RevertedCondition {
+	if m == nil {
+		return (*RevertedCondition)(nil)
+	}
+	r := new(RevertedCondition)
+	r.Value = m.Value
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *RevertedCondition) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -8576,6 +8602,31 @@ func (this *QueryFilter_AccountHasAsset) EqualVT(thatIface isQueryFilter_Filter)
 	return true
 }
 
+func (this *QueryFilter_Reverted) EqualVT(thatIface isQueryFilter_Filter) bool {
+	that, ok := thatIface.(*QueryFilter_Reverted)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.Reverted, that.Reverted; p != q {
+		if p == nil {
+			p = &RevertedCondition{}
+		}
+		if q == nil {
+			q = &RevertedCondition{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
 func (this *ReferenceCondition) EqualVT(that *ReferenceCondition) bool {
 	if this == that {
 		return true
@@ -8590,6 +8641,25 @@ func (this *ReferenceCondition) EqualVT(that *ReferenceCondition) bool {
 
 func (this *ReferenceCondition) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ReferenceCondition)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *RevertedCondition) EqualVT(that *RevertedCondition) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Value != that.Value {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *RevertedCondition) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*RevertedCondition)
 	if !ok {
 		return false
 	}
@@ -17148,6 +17218,25 @@ func (m *QueryFilter_AccountHasAsset) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	}
 	return len(dAtA) - i, nil
 }
+func (m *QueryFilter_Reverted) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *QueryFilter_Reverted) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Reverted != nil {
+		size, err := m.Reverted.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x62
+	}
+	return len(dAtA) - i, nil
+}
 func (m *ReferenceCondition) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -17187,6 +17276,49 @@ func (m *ReferenceCondition) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RevertedCondition) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RevertedCondition) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *RevertedCondition) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Value {
+		i--
+		if m.Value {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -22275,6 +22407,18 @@ func (m *QueryFilter_AccountHasAsset) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *QueryFilter_Reverted) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Reverted != nil {
+		l = m.Reverted.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	return n
+}
 func (m *ReferenceCondition) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -22284,6 +22428,19 @@ func (m *ReferenceCondition) SizeVT() (n int) {
 	if m.Cond != nil {
 		l = m.Cond.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *RevertedCondition) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Value {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -40939,6 +41096,47 @@ func (m *QueryFilter) UnmarshalVT(dAtA []byte) error {
 				m.Filter = &QueryFilter_AccountHasAsset{AccountHasAsset: v}
 			}
 			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reverted", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Filter.(*QueryFilter_Reverted); ok {
+				if err := oneof.Reverted.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &RevertedCondition{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Filter = &QueryFilter_Reverted{Reverted: v}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -41026,6 +41224,77 @@ func (m *ReferenceCondition) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RevertedCondition) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RevertedCondition: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RevertedCondition: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Value = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/commonpb/transaction.go
+++ b/internal/proto/commonpb/transaction.go
@@ -185,22 +185,26 @@ func (tx *Transaction) InvolvedAccounts() []string {
 // MarshalJSON implements json.Marshaler for Transaction.
 func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	type Aux struct {
-		Postings   []*Posting     `json:"postings"`
-		Metadata   map[string]any `json:"metadata"`
-		Timestamp  *time.Time     `json:"timestamp,omitempty"`
-		Reference  string         `json:"reference,omitempty"`
-		ID         *uint64        `json:"id,omitempty"`
-		InsertedAt *time.Time     `json:"insertedAt,omitempty"`
-		UpdatedAt  *time.Time     `json:"updatedAt,omitempty"`
-		RevertedAt *time.Time     `json:"revertedAt,omitempty"`
-		Reverted   bool           `json:"reverted"`
+		Postings                []*Posting     `json:"postings"`
+		Metadata                map[string]any `json:"metadata"`
+		Timestamp               *time.Time     `json:"timestamp,omitempty"`
+		Reference               string         `json:"reference,omitempty"`
+		ID                      *uint64        `json:"id,omitempty"`
+		InsertedAt              *time.Time     `json:"insertedAt,omitempty"`
+		UpdatedAt               *time.Time     `json:"updatedAt,omitempty"`
+		RevertedAt              *time.Time     `json:"revertedAt,omitempty"`
+		RevertedByTransactionID uint64         `json:"revertedByTransactionId,omitempty"`
+		RevertsTransactionID    uint64         `json:"revertsTransactionId,omitempty"`
+		Reverted                bool           `json:"reverted"`
 	}
 
 	aux := Aux{
-		Postings:  tx.GetPostings(),
-		Metadata:  MetadataToAnyMap(tx.GetMetadata()),
-		Reference: tx.GetReference(),
-		Reverted:  tx.IsReverted(),
+		Postings:                tx.GetPostings(),
+		Metadata:                MetadataToAnyMap(tx.GetMetadata()),
+		Reference:               tx.GetReference(),
+		Reverted:                tx.IsReverted(),
+		RevertedByTransactionID: tx.GetRevertedByTransaction(),
+		RevertsTransactionID:    tx.GetRevertsTransaction(),
 	}
 
 	if tx.GetId() != 0 {

--- a/internal/proto/commonpb/transactions_json_test.go
+++ b/internal/proto/commonpb/transactions_json_test.go
@@ -60,3 +60,55 @@ func TestRevertedTransaction_MarshalJSON_AllFields(t *testing.T) {
 	require.False(t, strings.Contains(out, "revertedTransactionID"),
 		"casing must follow the Go convention (Id, not ID)")
 }
+
+// TestTransaction_MarshalJSON_RevertRelationship pins the first-class revert
+// relationship fields: revertedByTransactionId + revertedAt on the reverted
+// original, revertsTransactionId on the compensating transaction. Casing follows
+// the Go convention (Id, not ID) and unset links are omitted.
+func TestTransaction_MarshalJSON_RevertRelationship(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reverted original", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := (&Transaction{
+			Id:                    1,
+			Reverted:              true,
+			RevertedByTransaction: 2,
+			RevertedAt:            &Timestamp{Data: 1_700_000_000_000_000},
+		}).MarshalJSON()
+		require.NoError(t, err)
+
+		out := string(data)
+		require.Contains(t, out, `"reverted":true`)
+		require.Contains(t, out, `"revertedByTransactionId":2`)
+		require.Contains(t, out, `"revertedAt":`)
+		require.NotContains(t, out, "revertsTransactionId")
+		require.NotContains(t, out, "revertedByTransactionID", "casing must follow the Go convention (Id, not ID)")
+	})
+
+	t.Run("compensating transaction", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := (&Transaction{Id: 2, RevertsTransaction: 1}).MarshalJSON()
+		require.NoError(t, err)
+
+		out := string(data)
+		require.Contains(t, out, `"revertsTransactionId":1`)
+		require.Contains(t, out, `"reverted":false`)
+		require.NotContains(t, out, "revertedByTransactionId")
+		require.NotContains(t, out, "revertedAt")
+	})
+
+	t.Run("plain transaction omits revert links", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := (&Transaction{Id: 3}).MarshalJSON()
+		require.NoError(t, err)
+
+		out := string(data)
+		require.NotContains(t, out, "revertedByTransactionId")
+		require.NotContains(t, out, "revertsTransactionId")
+		require.NotContains(t, out, "revertedAt")
+	})
+}

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -152,6 +152,8 @@ func compile(ctx *compileCtx, filter *commonpb.QueryFilter) (readstore.EntityIte
 		return compileNot(ctx, f.Not)
 	case *commonpb.QueryFilter_Reference:
 		return compileReferenceCondition(ctx, f.Reference)
+	case *commonpb.QueryFilter_Reverted:
+		return compileRevertedCondition(ctx, f.Reverted)
 	case *commonpb.QueryFilter_AccountHasAsset:
 		return compileAccountHasAssetCondition(ctx, f.AccountHasAsset)
 	case *commonpb.QueryFilter_BuiltinUint:
@@ -326,6 +328,57 @@ func compileNot(ctx *compileCtx, not *commonpb.NotFilter) (readstore.EntityItera
 	}
 
 	notIter := readstore.NewNotIterator(universe, child)
+
+	return trackIterator(notIter, ctx.profile, &IteratorStats{
+		Label:    "NotIterator",
+		Kind:     "Not",
+		Children: []*IteratorStats{universeStats, childStats},
+	}), nil
+}
+
+// compileRevertedCondition filters transactions by revert status using the
+// per-ledger reversion bitset. No index is required — the bitset is always
+// maintained by the FSM and covers all history. value=true yields reverted
+// originals; value=false yields the universe minus the reverted set.
+func compileRevertedCondition(ctx *compileCtx, cond *commonpb.RevertedCondition) (readstore.EntityIterator, error) {
+	if ctx.target != commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		return nil, domain.NewFilterCompilationError("reverted filter is only valid on transactions")
+	}
+
+	bs, err := ReadReversionBitset(ctx.pebbleReader, ctx.ledgerName)
+	if err != nil {
+		return nil, fmt.Errorf("reading reversion bitset: %w", err)
+	}
+
+	revertedStats := &IteratorStats{
+		Label:  fmt.Sprintf("BitsetIterator(reversions:%s)", ctx.ledgerName),
+		Kind:   "Bitset",
+		Prefix: "pebble:reversions",
+	}
+
+	if cond.GetValue() {
+		return trackIterator(readstore.NewBitsetIterator(bs), ctx.profile, revertedStats), nil
+	}
+
+	// value == false → universe \ reverted, mirroring compileNot.
+	universe, err := compileUniverse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var universeStats *IteratorStats
+	if ctx.profile != nil {
+		universeStats = ctx.profile.Root
+	}
+
+	reverted := trackIterator(readstore.NewBitsetIterator(bs), ctx.profile, revertedStats)
+
+	var childStats *IteratorStats
+	if ctx.profile != nil {
+		childStats = ctx.profile.Root
+	}
+
+	notIter := readstore.NewNotIterator(universe, reverted)
 
 	return trackIterator(notIter, ctx.profile, &IteratorStats{
 		Label:    "NotIterator",
@@ -1065,6 +1118,8 @@ func compileBuiltinUintCondition(ctx *compileCtx, cond *commonpb.BuiltinUintCond
 		return compileTimestampCondition(ctx, cond.GetCond())
 	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
 		return compileInsertedAtCondition(ctx, cond.GetCond())
+	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:
+		return compileRevertedAtCondition(ctx, cond.GetCond())
 	default:
 		return nil, domain.NewFilterCompilationError("unsupported builtin uint field: %v", cond.GetField())
 	}
@@ -1150,6 +1205,19 @@ func compileInsertedAtCondition(ctx *compileCtx, cond *commonpb.UintCondition) (
 
 	return compileTimestampRangeCondition(ctx, cond,
 		readstore.TransactionInsertedAtRangePrefix(ctx.kb, ctx.ledgerName), "txiat")
+}
+
+// compileRevertedAtCondition filters transactions by reverted_at using the transaction reverted_at index.
+// Requires the reverted_at builtin index to be READY.
+func compileRevertedAtCondition(ctx *compileCtx, cond *commonpb.UintCondition) (readstore.EntityIterator, error) {
+	if _, err := requireIndexReady(ctx,
+		indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT),
+		"reverted_at"); err != nil {
+		return nil, err
+	}
+
+	return compileTimestampRangeCondition(ctx, cond,
+		readstore.TransactionRevertedAtRangePrefix(ctx.kb, ctx.ledgerName), "rvat")
 }
 
 // compileTimestampRangeCondition is the shared logic for timestamp-based range scans.

--- a/internal/query/compile_reverted_test.go
+++ b/internal/query/compile_reverted_test.go
@@ -1,0 +1,25 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// The reverted filter is transaction-only; on any other target it must fail to
+// compile rather than silently returning the wrong entities.
+func TestCompileRevertedCondition_RejectsNonTransactionTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := &compileCtx{target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS}
+
+	_, err := compile(ctx, &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Reverted{
+			Reverted: &commonpb.RevertedCondition{Value: true},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only valid on transactions")
+}

--- a/internal/query/reversions.go
+++ b/internal/query/reversions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
 // ReadReversions loads all per-ledger reversion bitsets from Pebble.
@@ -67,4 +68,49 @@ func ReadReversions(reader dal.PebbleReader) (map[string]*bitset.Bitset, error) 
 	}
 
 	return result, nil
+}
+
+// ReadReversionBitset loads a single ledger's reversion bitset from Pebble.
+// It scans only that ledger's words rather than every ledger's (unlike
+// ReadReversions) and returns a never-nil bitset — empty when the ledger has no
+// reversions.
+func ReadReversionBitset(reader dal.PebbleReader, ledgerName string) (*bitset.Bitset, error) {
+	prefix := make([]byte, 2+dal.LedgerNameFixedSize)
+	prefix[0] = dal.ZonePerLedger
+	prefix[1] = dal.SubPLReversions
+	copy(prefix[2:], ledgerName)
+
+	iter, err := reader.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: readstore.IncrementBytes(prefix),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating reversion iterator for ledger %q: %w", ledgerName, err)
+	}
+
+	defer func() { _ = iter.Close() }()
+
+	bs := &bitset.Bitset{}
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := iter.Key()
+		if len(key) < 2+dal.LedgerNameFixedSize+8 {
+			continue
+		}
+
+		wordIndex := binary.BigEndian.Uint64(key[2+dal.LedgerNameFixedSize:])
+
+		val, err := iter.ValueAndErr()
+		if err != nil {
+			return nil, fmt.Errorf("reading reversion word for ledger %q: %w", ledgerName, err)
+		}
+
+		if len(val) < 8 {
+			continue
+		}
+
+		bs.SetWord(wordIndex, binary.LittleEndian.Uint64(val))
+	}
+
+	return bs, nil
 }

--- a/internal/query/reversions_test.go
+++ b/internal/query/reversions_test.go
@@ -1,0 +1,65 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// seedReversions writes reverted transaction IDs into a ledger's reversion
+// bitset using the exact FSM key layout (see state.saveReversionWord).
+func seedReversions(t *testing.T, s *dal.Store, ledger string, ids ...uint64) {
+	t.Helper()
+
+	bs := &bitset.Bitset{}
+	for _, id := range ids {
+		bs.Set(id)
+	}
+
+	sess := s.OpenWriteSession()
+	for wordIndex, word := range bs.Words() {
+		if word == 0 {
+			continue
+		}
+
+		sess.KeyBuilder.PutZonePrefix(dal.ZonePerLedger, dal.SubPLReversions).
+			PutLedgerNameFixed(ledger).
+			PutUint64(uint64(wordIndex))
+
+		require.NoError(t, sess.SetBytes(sess.KeyBuilder.Consume(), bitset.MarshalWord(word)))
+	}
+
+	require.NoError(t, sess.Commit())
+}
+
+func TestReadReversionBitset(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	seedReversions(t, s, "ledgerA", 1, 5, 130)
+	seedReversions(t, s, "ledgerB", 2) // must not leak into ledgerA's read
+
+	handle, err := s.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	bsA, err := query.ReadReversionBitset(handle, "ledgerA")
+	require.NoError(t, err)
+	require.True(t, bsA.Test(1))
+	require.True(t, bsA.Test(5))
+	require.True(t, bsA.Test(130))
+	require.False(t, bsA.Test(2), "ledgerB's reversion must not appear in ledgerA")
+	require.False(t, bsA.Test(3))
+
+	// A ledger with no reversions yields a non-nil empty bitset.
+	bsEmpty, err := query.ReadReversionBitset(handle, "ledgerC")
+	require.NoError(t, err)
+	require.NotNil(t, bsEmpty)
+	require.False(t, bsEmpty.Test(1))
+}

--- a/internal/storage/readstore/delete_ledger.go
+++ b/internal/storage/readstore/delete_ledger.go
@@ -29,6 +29,7 @@ var ledgerScopedPrefixes = [][]byte{
 	{PrefixLedgerLogs},
 	{PrefixLedgerLogDate},
 	{PrefixTransactionInsertedAt},
+	{PrefixTransactionRevertedAt},
 	{PrefixAccountByAsset},
 	{PrefixInternal, SubInternalBackfill},
 	{PrefixInternal, SubInternalIndexVersion},

--- a/internal/storage/readstore/iterator_bitset.go
+++ b/internal/storage/readstore/iterator_bitset.go
@@ -1,0 +1,97 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"math/bits"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+)
+
+// BitsetIterator iterates the set bits of a bitset in ascending order, emitting
+// each bit position as an 8-byte big-endian entity ID. It backs the `reverted`
+// transaction filter, walking the per-ledger reversion bitset (set bit == a
+// reverted transaction ID). Being in-memory, it never errors.
+type BitsetIterator struct {
+	bs        *bitset.Bitset
+	wordIdx   uint64
+	remaining uint64 // current word with already-emitted bits cleared
+	current   []byte
+	started   bool
+	done      bool
+}
+
+// NewBitsetIterator creates an iterator over the set bits of bs. A nil bitset
+// yields no entities.
+func NewBitsetIterator(bs *bitset.Bitset) *BitsetIterator {
+	return &BitsetIterator{bs: bs}
+}
+
+func (it *BitsetIterator) emit() bool {
+	tz := uint64(bits.TrailingZeros64(it.remaining))
+	it.remaining &= it.remaining - 1 // clear lowest set bit
+	it.current = EncodeTxID(nil, it.wordIdx*64+tz)
+
+	return true
+}
+
+func (it *BitsetIterator) advance() bool {
+	for it.remaining == 0 {
+		it.wordIdx++
+		if it.wordIdx >= it.bs.WordCount() {
+			it.done = true
+
+			return false
+		}
+
+		it.remaining = it.bs.Word(it.wordIdx)
+	}
+
+	return it.emit()
+}
+
+func (it *BitsetIterator) Next() bool {
+	if it.done || it.bs == nil {
+		return false
+	}
+
+	if !it.started {
+		it.started = true
+		it.wordIdx = 0
+		it.remaining = it.bs.Word(0)
+	}
+
+	return it.advance()
+}
+
+func (it *BitsetIterator) Current() []byte {
+	return it.current
+}
+
+func (it *BitsetIterator) SeekGE(target []byte) bool {
+	if it.done || it.bs == nil {
+		return false
+	}
+
+	it.started = true
+
+	var from uint64
+	if len(target) >= 8 {
+		from = binary.BigEndian.Uint64(target[:8])
+	}
+
+	it.wordIdx = from / 64
+	if it.wordIdx >= it.bs.WordCount() {
+		it.done = true
+
+		return false
+	}
+
+	// Keep only bits at or above the target's position within the start word.
+	it.remaining = it.bs.Word(it.wordIdx) &^ ((uint64(1) << (from % 64)) - 1)
+
+	return it.advance()
+}
+
+func (it *BitsetIterator) Err() error { return nil }
+
+func (it *BitsetIterator) Close() {}

--- a/internal/storage/readstore/iterator_bitset_test.go
+++ b/internal/storage/readstore/iterator_bitset_test.go
@@ -1,0 +1,71 @@
+package readstore_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func be8(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+
+	return b
+}
+
+func collectBitsetIDs(it *readstore.BitsetIterator) []uint64 {
+	var out []uint64
+	for it.Next() {
+		out = append(out, binary.BigEndian.Uint64(it.Current()))
+	}
+
+	return out
+}
+
+func TestBitsetIterator_EmitsSetBitsAscending(t *testing.T) {
+	t.Parallel()
+
+	bs := &bitset.Bitset{}
+	want := []uint64{0, 3, 63, 64, 65, 200, 4095}
+	for _, id := range want {
+		bs.Set(id)
+	}
+
+	require.Equal(t, want, collectBitsetIDs(readstore.NewBitsetIterator(bs)))
+}
+
+func TestBitsetIterator_Empty(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, collectBitsetIDs(readstore.NewBitsetIterator(&bitset.Bitset{})))
+	require.Empty(t, collectBitsetIDs(readstore.NewBitsetIterator(nil)))
+}
+
+func TestBitsetIterator_SeekGE(t *testing.T) {
+	t.Parallel()
+
+	bs := &bitset.Bitset{}
+	for _, id := range []uint64{1, 5, 64, 130} {
+		bs.Set(id)
+	}
+
+	// Seek onto an exact set bit, then keep iterating.
+	it := readstore.NewBitsetIterator(bs)
+	require.True(t, it.SeekGE(be8(5)))
+	require.Equal(t, uint64(5), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(64), binary.BigEndian.Uint64(it.Current()))
+
+	// Seek into a gap lands on the next set bit (across a word boundary).
+	gap := readstore.NewBitsetIterator(bs)
+	require.True(t, gap.SeekGE(be8(6)))
+	require.Equal(t, uint64(64), binary.BigEndian.Uint64(gap.Current()))
+
+	// Seek beyond the last set bit is exhausted.
+	past := readstore.NewBitsetIterator(bs)
+	require.False(t, past.SeekGE(be8(131)))
+}

--- a/internal/storage/readstore/keys.go
+++ b/internal/storage/readstore/keys.go
@@ -21,6 +21,7 @@ const (
 	PrefixLedgerLogDate         byte = 0x0A // lldt — ledger log date
 	PrefixTransactionInsertedAt byte = 0x0B // txiat — transaction inserted_at
 	PrefixAccountByAsset        byte = 0x0C // abya — account-by-asset inverted index (asset→account)
+	PrefixTransactionRevertedAt byte = 0x0D // rvat — transaction reverted_at
 
 	// PrefixInternal groups all non-ledger-scoped keys under a single prefix
 	// so that Comparer.Split can treat them uniformly (full key = prefix).
@@ -430,6 +431,28 @@ func TransactionInsertedAtKey(kb *dal.KeyBuilder, ledgerName string, timestamp, 
 func TransactionInsertedAtRangePrefix(kb *dal.KeyBuilder, ledgerName string) []byte {
 	return kb.Reset().
 		PutByte(PrefixTransactionInsertedAt).
+		PutLedgerNameFixed(ledgerName).
+		Snapshot()
+}
+
+// TransactionRevertedAtKey builds a full key in the transaction reverted_at index.
+//
+//	[0x0D][ledgerName padded 64B][timestamp_BE(8B)][txID_BE(8B)]
+func TransactionRevertedAtKey(kb *dal.KeyBuilder, ledgerName string, timestamp, txID uint64) []byte {
+	return kb.Reset().
+		PutByte(PrefixTransactionRevertedAt).
+		PutLedgerNameFixed(ledgerName).
+		PutUint64(timestamp).
+		PutUint64(txID).
+		Consume()
+}
+
+// TransactionRevertedAtRangePrefix returns the ledger prefix for range scans in the reverted_at index.
+//
+//	[0x0D][ledgerName padded 64B]
+func TransactionRevertedAtRangePrefix(kb *dal.KeyBuilder, ledgerName string) []byte {
+	return kb.Reset().
+		PutByte(PrefixTransactionRevertedAt).
 		PutLedgerNameFixed(ledgerName).
 		Snapshot()
 }

--- a/internal/storage/readstore/write_batch.go
+++ b/internal/storage/readstore/write_batch.go
@@ -323,6 +323,13 @@ func (wb *WriteBatch) WriteTransactionInsertedAtIndex(kb *dal.KeyBuilder, ledger
 	return wb.put(key, nil)
 }
 
+// WriteTransactionRevertedAtIndex inserts an entry in the transaction reverted_at index.
+func (wb *WriteBatch) WriteTransactionRevertedAtIndex(kb *dal.KeyBuilder, ledgerName string, timestamp, txID uint64) error {
+	key := TransactionRevertedAtKey(kb, ledgerName, timestamp, txID)
+
+	return wb.put(key, nil)
+}
+
 // WriteLedgerLogDateIndex inserts an entry in the per-ledger log date index.
 func (wb *WriteBatch) WriteLedgerLogDateIndex(kb *dal.KeyBuilder, ledgerName string, timestamp, logID uint64) error {
 	key := LedgerLogDateKey(kb, ledgerName, timestamp, logID)

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -74,6 +74,10 @@ message Transaction {
   Timestamp inserted_at = 7;
   Timestamp updated_at = 8;
   Timestamp reverted_at = 9;
+  // Id of the transaction that reverted this one. 0 = not reverted.
+  fixed64 reverted_by_transaction = 10;
+  // Id of the original transaction this transaction reverts. 0 = not a revert.
+  fixed64 reverts_transaction = 11;
 }
 
 message Script {
@@ -902,6 +906,12 @@ message TransactionState {
   // the audit chain, so a revert of a non-existent tx must reach the FSM
   // apply loop rather than fail-fast at admission).
   repeated Posting postings = 5;
+  // Effective timestamp at which this transaction was reverted (the
+  // compensating transaction's timestamp). Nil when not reverted.
+  Timestamp reverted_at = 6;
+  // On a compensating transaction, the id of the transaction it reverts.
+  // 0 = this transaction is not a revert.
+  fixed64 reverts_transaction = 7;
 }
 
 // IdempotencyKeyValue stores the outcome associated with a proposal's

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -206,6 +206,7 @@ enum TransactionBuiltinIndex {
   TX_BUILTIN_INDEX_SOURCE_ADDRESS = 4;   // source account→transaction mapping
   TX_BUILTIN_INDEX_DESTINATION_ADDRESS = 5;     // destination account→transaction mapping
   TX_BUILTIN_INDEX_INSERTED_AT = 6;     // requires Pebble "txiat" index (inserted_at date)
+  TX_BUILTIN_INDEX_REVERTED_AT = 7;     // requires Pebble "rvat" index (reverted_at date)
 }
 
 // AccountBuiltinIndex identifies a built-in account field that can be indexed.
@@ -1096,12 +1097,20 @@ message QueryFilter {
     LogIdCondition log_id = 9;
     LogBuiltinUintCondition log_builtin_uint = 10;
     AccountHasAssetCondition account_has_asset = 11;
+    RevertedCondition reverted = 12;
   }
 }
 
 // ReferenceCondition filters transactions by reference (exact match).
 message ReferenceCondition {
   StringCondition cond = 1;
+}
+
+// RevertedCondition filters transactions by revert status. Served from the
+// per-ledger reversion bitset (no index required): value=true matches reverted
+// originals, value=false matches everything else.
+message RevertedCondition {
+  bool value = 1;
 }
 
 // LedgerCondition filters logs by ledger name (exact match).

--- a/openapi.yml
+++ b/openapi.yml
@@ -2695,6 +2695,14 @@ components:
           format: date-time
           description: When the transaction was reverted (null if not reverted)
           nullable: true
+        revertedByTransactionId:
+          type: integer
+          format: int64
+          description: ID of the transaction that reverted this one (absent when not reverted)
+        revertsTransactionId:
+          type: integer
+          format: int64
+          description: ID of the original transaction this transaction reverts (absent when this is not a revert)
 
     RevertedTransaction:
       type: object

--- a/pkg/actions/filters.go
+++ b/pkg/actions/filters.go
@@ -310,6 +310,20 @@ func InsertedAtRangeFilter(minVal, maxVal uint64) *commonpb.QueryFilter {
 	return BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT, minVal, maxVal)
 }
 
+// RevertedAtRangeFilter creates a filter matching transactions by reverted-at range.
+func RevertedAtRangeFilter(minVal, maxVal uint64) *commonpb.QueryFilter {
+	return BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT, minVal, maxVal)
+}
+
+// RevertedFilter creates a filter matching transactions by revert status.
+func RevertedFilter(reverted bool) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Reverted{
+			Reverted: &commonpb.RevertedCondition{Value: reverted},
+		},
+	}
+}
+
 // TxIDRangeFilter creates a filter matching transactions by ID range.
 func TxIDRangeFilter(minVal, maxVal uint64) *commonpb.QueryFilter {
 	return BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID, minVal, maxVal)


### PR DESCRIPTION
## Summary

Reverts tracked the original↔compensating link only internally (`TransactionState.RevertedByTransaction`), surfaced as a bare `reverted` bool. Clients couldn't navigate between the two sides, `revertedAt` was never populated, and revert status wasn't queryable.

Per the issue's decision, the relationship is modeled as **first-class transaction fields** — not `com.formance.spec/*` metadata. User-supplied metadata stays untouched.

### 1. `feat(ledger): expose revert relationship as first-class transaction fields`
- `TransactionState` gains `reverted_at` + `reverts_transaction`; the API `Transaction` gains `reverted_by_transaction` + `reverts_transaction` and now populates `reverted_at`.
- JSON: `revertedAt` + `revertedByTransactionId` on the reverted original, `revertsTransactionId` on the compensating tx.
- `revertedAt` = the compensating transaction's effective timestamp (so under `atEffectiveDate` it equals the original's).
- Set on both `processor_revert_transaction` and the **mirror** revert path.
- Reconstructed by the shared `replay.Writer` (integrity checker + backup rebuild), so `proto.Equal` holds after **replay/backfill** and across nodes.

### 2. `feat(query): make reverted and revertedAt transaction fields queryable`
Upstream v2 (`internal/queries/resources.go` `TransactionSchema`) queries both `reverted` and `reverted_at`; v3 now matches that subset:
- **`reverted` (bool)** — new `RevertedCondition`, served from the existing per-ledger reversion bitset. No index, always available, complete for all history. `reverted=false` = universe minus the bitset (existing `NotIterator`).
- **`revertedAt` (date range)** — new `reverted-at` builtin index. Entries are derived from the `RevertedTransaction` **log** (original tx keyed by the compensating timestamp), so the standard log-replay backfill covers historical reverts and the mirror path. Wired into `ledgerctl indexes create/drop/list` and the declarative ledger config.

The v3-only `revertedByTransactionId` / `revertsTransactionId` remain navigable-only (no v2 baseline).

## Acceptance criteria (#498)
- [x] GET original → `revertedAt` + `revertedByTransactionId` (absent when not reverted)
- [x] GET reverting → `revertsTransactionId`
- [x] No `com.formance.spec/*` metadata written by the platform
- [x] Filters on `reverted` / `revertedAt` consistent with upstream parity for the queryable subset
- [x] Holds across nodes and after replay/backfill, including the mirror revert path
- [x] Tests for `processor_revert_transaction` + the mirror path; `docs/technical/contributing/api-comparison.md` + `openapi.yml` updated

## Testing
- Unit + integration: revert processor (both paths + `atEffectiveDate`), mirror path, replay-store reconstruction, `Transaction.MarshalJSON`, GET-handler JSON surface, `BitsetIterator`, `ReadReversionBitset`, reverted-at index write, compile dispatch.
- `go build ./...` + touched-package tests green. Protos regenerated with the pinned nix toolchain (byte-identical for unchanged messages); each commit's generated code matches its own `.proto`.
- Unrelated pre-existing failures: 3 `internal/pkg/tarutil` + 1 `cmd/ledgerctl/auth` tests fail only because CI-local ran as root (they assert on `chmod`/keyring denials root bypasses) — confirmed failing on the base branch too.

## Note
`openapi.yml`'s `TransactionResponse` already documented `inserted_at` / `updated_at` / `reverted_at` in snake_case while the server emits camelCase; the new fields are added in camelCase (matching the server) and the pre-existing mismatch is left alone. Happy to align the existing three separately if wanted.
