### PR TITLE
perf(proto): zero-alloc reader wrappers via named-type conversion

### DIFF
--- a/internal/proto/auditpb/audit_reader.pb.go
+++ b/internal/proto/auditpb/audit_reader.pb.go
@@ -28,14 +28,14 @@ type AuditEntryReader interface {
 	Mutate() *AuditEntry
 }
 
-type auditEntryReadonly struct{ v *AuditEntry }
+type auditEntryReadonly AuditEntry
 
 func (r *auditEntryReadonly) GetSequence() uint64 {
-	return r.v.GetSequence()
+	return (*AuditEntry)(r).GetSequence()
 }
 
 func (r *auditEntryReadonly) GetTimestamp() commonpb.TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*AuditEntry)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -43,31 +43,31 @@ func (r *auditEntryReadonly) GetTimestamp() commonpb.TimestampReader {
 }
 
 func (r *auditEntryReadonly) GetProposalId() uint64 {
-	return r.v.GetProposalId()
+	return (*AuditEntry)(r).GetProposalId()
 }
 
 func (r *auditEntryReadonly) GetOrderCount() uint32 {
-	return r.v.GetOrderCount()
+	return (*AuditEntry)(r).GetOrderCount()
 }
 
 func (r *auditEntryReadonly) GetItems() AuditItemListReader {
-	return NewAuditItemListReader(r.v.GetItems())
+	return NewAuditItemListReader((*AuditEntry)(r).GetItems())
 }
 
 func (r *auditEntryReadonly) GetLedgers() []string {
-	return slices.Clone(r.v.GetLedgers())
+	return slices.Clone((*AuditEntry)(r).GetLedgers())
 }
 
 func (r *auditEntryReadonly) GetHash() []byte {
-	return bytes.Clone(r.v.GetHash())
+	return bytes.Clone((*AuditEntry)(r).GetHash())
 }
 
 func (r *auditEntryReadonly) GetHashVersion() uint32 {
-	return r.v.GetHashVersion()
+	return (*AuditEntry)(r).GetHashVersion()
 }
 
 func (r *auditEntryReadonly) GetCallerSnapshot() commonpb.CallerSnapshotReader {
-	v := r.v.GetCallerSnapshot()
+	v := (*AuditEntry)(r).GetCallerSnapshot()
 	if v == nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (r *auditEntryReadonly) GetCallerSnapshot() commonpb.CallerSnapshotReader {
 }
 
 func (r *auditEntryReadonly) GetIdempotency() commonpb.IdempotencyReader {
-	v := r.v.GetIdempotency()
+	v := (*AuditEntry)(r).GetIdempotency()
 	if v == nil {
 		return nil
 	}
@@ -83,7 +83,7 @@ func (r *auditEntryReadonly) GetIdempotency() commonpb.IdempotencyReader {
 }
 
 func (r *auditEntryReadonly) GetSignature() signaturepb.SignedApplyBatchReader {
-	v := r.v.GetSignature()
+	v := (*AuditEntry)(r).GetSignature()
 	if v == nil {
 		return nil
 	}
@@ -91,11 +91,11 @@ func (r *auditEntryReadonly) GetSignature() signaturepb.SignedApplyBatchReader {
 }
 
 func (r *auditEntryReadonly) GetOutcome() isAuditEntry_Outcome {
-	return r.v.GetOutcome()
+	return (*AuditEntry)(r).GetOutcome()
 }
 
 func (r *auditEntryReadonly) Mutate() *AuditEntry {
-	return r.v.CloneVT()
+	return (*AuditEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AuditEntry.
@@ -103,7 +103,7 @@ func (m *AuditEntry) AsReader() AuditEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &auditEntryReadonly{v: m}
+	return (*auditEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AuditEntry.
@@ -155,22 +155,22 @@ type AuditItemReader interface {
 	Mutate() *AuditItem
 }
 
-type auditItemReadonly struct{ v *AuditItem }
+type auditItemReadonly AuditItem
 
 func (r *auditItemReadonly) GetOrderIndex() uint32 {
-	return r.v.GetOrderIndex()
+	return (*AuditItem)(r).GetOrderIndex()
 }
 
 func (r *auditItemReadonly) GetSerializedOrder() []byte {
-	return bytes.Clone(r.v.GetSerializedOrder())
+	return bytes.Clone((*AuditItem)(r).GetSerializedOrder())
 }
 
 func (r *auditItemReadonly) GetLogSequence() uint64 {
-	return r.v.GetLogSequence()
+	return (*AuditItem)(r).GetLogSequence()
 }
 
 func (r *auditItemReadonly) Mutate() *AuditItem {
-	return r.v.CloneVT()
+	return (*AuditItem)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AuditItem.
@@ -178,7 +178,7 @@ func (m *AuditItem) AsReader() AuditItemReader {
 	if m == nil {
 		return nil
 	}
-	return &auditItemReadonly{v: m}
+	return (*auditItemReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AuditItem.
@@ -229,18 +229,18 @@ type AuditSuccessReader interface {
 	Mutate() *AuditSuccess
 }
 
-type auditSuccessReadonly struct{ v *AuditSuccess }
+type auditSuccessReadonly AuditSuccess
 
 func (r *auditSuccessReadonly) GetMinLogSequence() uint64 {
-	return r.v.GetMinLogSequence()
+	return (*AuditSuccess)(r).GetMinLogSequence()
 }
 
 func (r *auditSuccessReadonly) GetMaxLogSequence() uint64 {
-	return r.v.GetMaxLogSequence()
+	return (*AuditSuccess)(r).GetMaxLogSequence()
 }
 
 func (r *auditSuccessReadonly) Mutate() *AuditSuccess {
-	return r.v.CloneVT()
+	return (*AuditSuccess)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AuditSuccess.
@@ -248,7 +248,7 @@ func (m *AuditSuccess) AsReader() AuditSuccessReader {
 	if m == nil {
 		return nil
 	}
-	return &auditSuccessReadonly{v: m}
+	return (*auditSuccessReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AuditSuccess.
@@ -302,22 +302,22 @@ type AuditFailureReader interface {
 	Mutate() *AuditFailure
 }
 
-type auditFailureReadonly struct{ v *AuditFailure }
+type auditFailureReadonly AuditFailure
 
 func (r *auditFailureReadonly) GetReason() commonpb.ErrorReason {
-	return r.v.GetReason()
+	return (*AuditFailure)(r).GetReason()
 }
 
 func (r *auditFailureReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*AuditFailure)(r).GetMessage()
 }
 
 func (r *auditFailureReadonly) GetContext() AuditFailure_ContextMapReader {
-	return auditFailure_contextMapReadonly(r.v.GetContext())
+	return auditFailure_contextMapReadonly((*AuditFailure)(r).GetContext())
 }
 
 func (r *auditFailureReadonly) Mutate() *AuditFailure {
-	return r.v.CloneVT()
+	return (*AuditFailure)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AuditFailure.
@@ -325,7 +325,7 @@ func (m *AuditFailure) AsReader() AuditFailureReader {
 	if m == nil {
 		return nil
 	}
-	return &auditFailureReadonly{v: m}
+	return (*auditFailureReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AuditFailure.

--- a/internal/proto/clusterbootstrappb/cluster_bootstrap_reader.pb.go
+++ b/internal/proto/clusterbootstrappb/cluster_bootstrap_reader.pb.go
@@ -9,10 +9,10 @@ type GetPeersRequestReader interface {
 	Mutate() *GetPeersRequest
 }
 
-type getPeersRequestReadonly struct{ v *GetPeersRequest }
+type getPeersRequestReadonly GetPeersRequest
 
 func (r *getPeersRequestReadonly) Mutate() *GetPeersRequest {
-	return r.v.CloneVT()
+	return (*GetPeersRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetPeersRequest.
@@ -20,7 +20,7 @@ func (m *GetPeersRequest) AsReader() GetPeersRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getPeersRequestReadonly{v: m}
+	return (*getPeersRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetPeersRequest.
@@ -72,14 +72,14 @@ type GetPeersResponseReader interface {
 	Mutate() *GetPeersResponse
 }
 
-type getPeersResponseReadonly struct{ v *GetPeersResponse }
+type getPeersResponseReadonly GetPeersResponse
 
 func (r *getPeersResponseReadonly) GetPeers() PeerInfoListReader {
-	return NewPeerInfoListReader(r.v.GetPeers())
+	return NewPeerInfoListReader((*GetPeersResponse)(r).GetPeers())
 }
 
 func (r *getPeersResponseReadonly) Mutate() *GetPeersResponse {
-	return r.v.CloneVT()
+	return (*GetPeersResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetPeersResponse.
@@ -87,7 +87,7 @@ func (m *GetPeersResponse) AsReader() GetPeersResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getPeersResponseReadonly{v: m}
+	return (*getPeersResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetPeersResponse.
@@ -141,22 +141,22 @@ type PeerInfoReader interface {
 	Mutate() *PeerInfo
 }
 
-type peerInfoReadonly struct{ v *PeerInfo }
+type peerInfoReadonly PeerInfo
 
 func (r *peerInfoReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*PeerInfo)(r).GetId()
 }
 
 func (r *peerInfoReadonly) GetRaftAddress() string {
-	return r.v.GetRaftAddress()
+	return (*PeerInfo)(r).GetRaftAddress()
 }
 
 func (r *peerInfoReadonly) GetServiceAddress() string {
-	return r.v.GetServiceAddress()
+	return (*PeerInfo)(r).GetServiceAddress()
 }
 
 func (r *peerInfoReadonly) Mutate() *PeerInfo {
-	return r.v.CloneVT()
+	return (*PeerInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PeerInfo.
@@ -164,7 +164,7 @@ func (m *PeerInfo) AsReader() PeerInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &peerInfoReadonly{v: m}
+	return (*peerInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PeerInfo.
@@ -216,22 +216,22 @@ type JoinAsLearnerRequestReader interface {
 	Mutate() *JoinAsLearnerRequest
 }
 
-type joinAsLearnerRequestReadonly struct{ v *JoinAsLearnerRequest }
+type joinAsLearnerRequestReadonly JoinAsLearnerRequest
 
 func (r *joinAsLearnerRequestReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*JoinAsLearnerRequest)(r).GetNodeId()
 }
 
 func (r *joinAsLearnerRequestReadonly) GetRaftAddress() string {
-	return r.v.GetRaftAddress()
+	return (*JoinAsLearnerRequest)(r).GetRaftAddress()
 }
 
 func (r *joinAsLearnerRequestReadonly) GetServiceAddress() string {
-	return r.v.GetServiceAddress()
+	return (*JoinAsLearnerRequest)(r).GetServiceAddress()
 }
 
 func (r *joinAsLearnerRequestReadonly) Mutate() *JoinAsLearnerRequest {
-	return r.v.CloneVT()
+	return (*JoinAsLearnerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this JoinAsLearnerRequest.
@@ -239,7 +239,7 @@ func (m *JoinAsLearnerRequest) AsReader() JoinAsLearnerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &joinAsLearnerRequestReadonly{v: m}
+	return (*joinAsLearnerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this JoinAsLearnerRequest.
@@ -290,10 +290,10 @@ type JoinAsLearnerResponseReader interface {
 	Mutate() *JoinAsLearnerResponse
 }
 
-type joinAsLearnerResponseReadonly struct{ v *JoinAsLearnerResponse }
+type joinAsLearnerResponseReadonly JoinAsLearnerResponse
 
 func (r *joinAsLearnerResponseReadonly) Mutate() *JoinAsLearnerResponse {
-	return r.v.CloneVT()
+	return (*JoinAsLearnerResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this JoinAsLearnerResponse.
@@ -301,7 +301,7 @@ func (m *JoinAsLearnerResponse) AsReader() JoinAsLearnerResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &joinAsLearnerResponseReadonly{v: m}
+	return (*joinAsLearnerResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this JoinAsLearnerResponse.

--- a/internal/proto/clusterpb/cluster_reader.pb.go
+++ b/internal/proto/clusterpb/cluster_reader.pb.go
@@ -14,14 +14,14 @@ type GetClusterStateRequestReader interface {
 	Mutate() *GetClusterStateRequest
 }
 
-type getClusterStateRequestReadonly struct{ v *GetClusterStateRequest }
+type getClusterStateRequestReadonly GetClusterStateRequest
 
 func (r *getClusterStateRequestReadonly) GetNodeId() uint32 {
-	return r.v.GetNodeId()
+	return (*GetClusterStateRequest)(r).GetNodeId()
 }
 
 func (r *getClusterStateRequestReadonly) Mutate() *GetClusterStateRequest {
-	return r.v.CloneVT()
+	return (*GetClusterStateRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetClusterStateRequest.
@@ -29,7 +29,7 @@ func (m *GetClusterStateRequest) AsReader() GetClusterStateRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getClusterStateRequestReadonly{v: m}
+	return (*getClusterStateRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetClusterStateRequest.
@@ -88,18 +88,18 @@ type NodeInfoReader interface {
 	Mutate() *NodeInfo
 }
 
-type nodeInfoReadonly struct{ v *NodeInfo }
+type nodeInfoReadonly NodeInfo
 
 func (r *nodeInfoReadonly) GetId() uint32 {
-	return r.v.GetId()
+	return (*NodeInfo)(r).GetId()
 }
 
 func (r *nodeInfoReadonly) GetSuffrage() string {
-	return r.v.GetSuffrage()
+	return (*NodeInfo)(r).GetSuffrage()
 }
 
 func (r *nodeInfoReadonly) GetProgress() ProgressInfoReader {
-	v := r.v.GetProgress()
+	v := (*NodeInfo)(r).GetProgress()
 	if v == nil {
 		return nil
 	}
@@ -107,15 +107,15 @@ func (r *nodeInfoReadonly) GetProgress() ProgressInfoReader {
 }
 
 func (r *nodeInfoReadonly) GetRaftAddress() string {
-	return r.v.GetRaftAddress()
+	return (*NodeInfo)(r).GetRaftAddress()
 }
 
 func (r *nodeInfoReadonly) GetServiceAddress() string {
-	return r.v.GetServiceAddress()
+	return (*NodeInfo)(r).GetServiceAddress()
 }
 
 func (r *nodeInfoReadonly) GetSyncProgress() SyncProgressReader {
-	v := r.v.GetSyncProgress()
+	v := (*NodeInfo)(r).GetSyncProgress()
 	if v == nil {
 		return nil
 	}
@@ -123,7 +123,7 @@ func (r *nodeInfoReadonly) GetSyncProgress() SyncProgressReader {
 }
 
 func (r *nodeInfoReadonly) GetIndexProgress() IndexProgressReader {
-	v := r.v.GetIndexProgress()
+	v := (*NodeInfo)(r).GetIndexProgress()
 	if v == nil {
 		return nil
 	}
@@ -131,11 +131,11 @@ func (r *nodeInfoReadonly) GetIndexProgress() IndexProgressReader {
 }
 
 func (r *nodeInfoReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*NodeInfo)(r).GetVersion()
 }
 
 func (r *nodeInfoReadonly) Mutate() *NodeInfo {
-	return r.v.CloneVT()
+	return (*NodeInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NodeInfo.
@@ -143,7 +143,7 @@ func (m *NodeInfo) AsReader() NodeInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &nodeInfoReadonly{v: m}
+	return (*nodeInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NodeInfo.
@@ -200,42 +200,42 @@ type ProgressInfoReader interface {
 	Mutate() *ProgressInfo
 }
 
-type progressInfoReadonly struct{ v *ProgressInfo }
+type progressInfoReadonly ProgressInfo
 
 func (r *progressInfoReadonly) GetMatch() uint64 {
-	return r.v.GetMatch()
+	return (*ProgressInfo)(r).GetMatch()
 }
 
 func (r *progressInfoReadonly) GetNext() uint64 {
-	return r.v.GetNext()
+	return (*ProgressInfo)(r).GetNext()
 }
 
 func (r *progressInfoReadonly) GetState() string {
-	return r.v.GetState()
+	return (*ProgressInfo)(r).GetState()
 }
 
 func (r *progressInfoReadonly) GetPendingSnapshot() uint64 {
-	return r.v.GetPendingSnapshot()
+	return (*ProgressInfo)(r).GetPendingSnapshot()
 }
 
 func (r *progressInfoReadonly) GetRecentActive() bool {
-	return r.v.GetRecentActive()
+	return (*ProgressInfo)(r).GetRecentActive()
 }
 
 func (r *progressInfoReadonly) GetMsgAppFlowPaused() bool {
-	return r.v.GetMsgAppFlowPaused()
+	return (*ProgressInfo)(r).GetMsgAppFlowPaused()
 }
 
 func (r *progressInfoReadonly) GetIsPaused() bool {
-	return r.v.GetIsPaused()
+	return (*ProgressInfo)(r).GetIsPaused()
 }
 
 func (r *progressInfoReadonly) GetIsLearner() bool {
-	return r.v.GetIsLearner()
+	return (*ProgressInfo)(r).GetIsLearner()
 }
 
 func (r *progressInfoReadonly) Mutate() *ProgressInfo {
-	return r.v.CloneVT()
+	return (*ProgressInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ProgressInfo.
@@ -243,7 +243,7 @@ func (m *ProgressInfo) AsReader() ProgressInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &progressInfoReadonly{v: m}
+	return (*progressInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ProgressInfo.
@@ -303,46 +303,46 @@ type RaftStatusReader interface {
 	Mutate() *RaftStatus
 }
 
-type raftStatusReadonly struct{ v *RaftStatus }
+type raftStatusReadonly RaftStatus
 
 func (r *raftStatusReadonly) GetState() string {
-	return r.v.GetState()
+	return (*RaftStatus)(r).GetState()
 }
 
 func (r *raftStatusReadonly) GetTerm() uint64 {
-	return r.v.GetTerm()
+	return (*RaftStatus)(r).GetTerm()
 }
 
 func (r *raftStatusReadonly) GetLeader() uint64 {
-	return r.v.GetLeader()
+	return (*RaftStatus)(r).GetLeader()
 }
 
 func (r *raftStatusReadonly) GetApplied() uint64 {
-	return r.v.GetApplied()
+	return (*RaftStatus)(r).GetApplied()
 }
 
 func (r *raftStatusReadonly) GetCommit() uint64 {
-	return r.v.GetCommit()
+	return (*RaftStatus)(r).GetCommit()
 }
 
 func (r *raftStatusReadonly) GetLastIndex() uint64 {
-	return r.v.GetLastIndex()
+	return (*RaftStatus)(r).GetLastIndex()
 }
 
 func (r *raftStatusReadonly) GetVote() uint64 {
-	return r.v.GetVote()
+	return (*RaftStatus)(r).GetVote()
 }
 
 func (r *raftStatusReadonly) GetProgress() RaftStatus_ProgressMapReader {
-	return raftStatus_progressMapReadonly(r.v.GetProgress())
+	return raftStatus_progressMapReadonly((*RaftStatus)(r).GetProgress())
 }
 
 func (r *raftStatusReadonly) GetLastPersistedIndex() uint64 {
-	return r.v.GetLastPersistedIndex()
+	return (*RaftStatus)(r).GetLastPersistedIndex()
 }
 
 func (r *raftStatusReadonly) Mutate() *RaftStatus {
-	return r.v.CloneVT()
+	return (*RaftStatus)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RaftStatus.
@@ -350,7 +350,7 @@ func (m *RaftStatus) AsReader() RaftStatusReader {
 	if m == nil {
 		return nil
 	}
-	return &raftStatusReadonly{v: m}
+	return (*raftStatusReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RaftStatus.
@@ -440,26 +440,26 @@ type ClusterStateReader interface {
 	Mutate() *ClusterState
 }
 
-type clusterStateReadonly struct{ v *ClusterState }
+type clusterStateReadonly ClusterState
 
 func (r *clusterStateReadonly) GetState() string {
-	return r.v.GetState()
+	return (*ClusterState)(r).GetState()
 }
 
 func (r *clusterStateReadonly) GetLeader() uint32 {
-	return r.v.GetLeader()
+	return (*ClusterState)(r).GetLeader()
 }
 
 func (r *clusterStateReadonly) GetNodes() NodeInfoListReader {
-	return NewNodeInfoListReader(r.v.GetNodes())
+	return NewNodeInfoListReader((*ClusterState)(r).GetNodes())
 }
 
 func (r *clusterStateReadonly) GetLocalNode() uint32 {
-	return r.v.GetLocalNode()
+	return (*ClusterState)(r).GetLocalNode()
 }
 
 func (r *clusterStateReadonly) GetRaftStatus() RaftStatusReader {
-	v := r.v.GetRaftStatus()
+	v := (*ClusterState)(r).GetRaftStatus()
 	if v == nil {
 		return nil
 	}
@@ -467,11 +467,11 @@ func (r *clusterStateReadonly) GetRaftStatus() RaftStatusReader {
 }
 
 func (r *clusterStateReadonly) GetMaintenanceMode() bool {
-	return r.v.GetMaintenanceMode()
+	return (*ClusterState)(r).GetMaintenanceMode()
 }
 
 func (r *clusterStateReadonly) GetSyncProgress() SyncProgressReader {
-	v := r.v.GetSyncProgress()
+	v := (*ClusterState)(r).GetSyncProgress()
 	if v == nil {
 		return nil
 	}
@@ -479,7 +479,7 @@ func (r *clusterStateReadonly) GetSyncProgress() SyncProgressReader {
 }
 
 func (r *clusterStateReadonly) GetIndexProgress() IndexProgressReader {
-	v := r.v.GetIndexProgress()
+	v := (*ClusterState)(r).GetIndexProgress()
 	if v == nil {
 		return nil
 	}
@@ -487,7 +487,7 @@ func (r *clusterStateReadonly) GetIndexProgress() IndexProgressReader {
 }
 
 func (r *clusterStateReadonly) GetClusterConfig() commonpb.ClusterConfigReader {
-	v := r.v.GetClusterConfig()
+	v := (*ClusterState)(r).GetClusterConfig()
 	if v == nil {
 		return nil
 	}
@@ -495,11 +495,11 @@ func (r *clusterStateReadonly) GetClusterConfig() commonpb.ClusterConfigReader {
 }
 
 func (r *clusterStateReadonly) GetNodeVersion() string {
-	return r.v.GetNodeVersion()
+	return (*ClusterState)(r).GetNodeVersion()
 }
 
 func (r *clusterStateReadonly) Mutate() *ClusterState {
-	return r.v.CloneVT()
+	return (*ClusterState)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ClusterState.
@@ -507,7 +507,7 @@ func (m *ClusterState) AsReader() ClusterStateReader {
 	if m == nil {
 		return nil
 	}
-	return &clusterStateReadonly{v: m}
+	return (*clusterStateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ClusterState.
@@ -560,18 +560,18 @@ type IndexProgressReader interface {
 	Mutate() *IndexProgress
 }
 
-type indexProgressReadonly struct{ v *IndexProgress }
+type indexProgressReadonly IndexProgress
 
 func (r *indexProgressReadonly) GetLastIndexedSequence() uint64 {
-	return r.v.GetLastIndexedSequence()
+	return (*IndexProgress)(r).GetLastIndexedSequence()
 }
 
 func (r *indexProgressReadonly) GetPebbleLastSequence() uint64 {
-	return r.v.GetPebbleLastSequence()
+	return (*IndexProgress)(r).GetPebbleLastSequence()
 }
 
 func (r *indexProgressReadonly) Mutate() *IndexProgress {
-	return r.v.CloneVT()
+	return (*IndexProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IndexProgress.
@@ -579,7 +579,7 @@ func (m *IndexProgress) AsReader() IndexProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &indexProgressReadonly{v: m}
+	return (*indexProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IndexProgress.
@@ -633,22 +633,22 @@ type SyncProgressReader interface {
 	Mutate() *SyncProgress
 }
 
-type syncProgressReadonly struct{ v *SyncProgress }
+type syncProgressReadonly SyncProgress
 
 func (r *syncProgressReadonly) GetStatus() string {
-	return r.v.GetStatus()
+	return (*SyncProgress)(r).GetStatus()
 }
 
 func (r *syncProgressReadonly) GetBytesReceived() uint64 {
-	return r.v.GetBytesReceived()
+	return (*SyncProgress)(r).GetBytesReceived()
 }
 
 func (r *syncProgressReadonly) GetBytesTotal() uint64 {
-	return r.v.GetBytesTotal()
+	return (*SyncProgress)(r).GetBytesTotal()
 }
 
 func (r *syncProgressReadonly) Mutate() *SyncProgress {
-	return r.v.CloneVT()
+	return (*SyncProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SyncProgress.
@@ -656,7 +656,7 @@ func (m *SyncProgress) AsReader() SyncProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &syncProgressReadonly{v: m}
+	return (*syncProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SyncProgress.
@@ -708,14 +708,14 @@ type TransferLeadershipRequestReader interface {
 	Mutate() *TransferLeadershipRequest
 }
 
-type transferLeadershipRequestReadonly struct{ v *TransferLeadershipRequest }
+type transferLeadershipRequestReadonly TransferLeadershipRequest
 
 func (r *transferLeadershipRequestReadonly) GetTransferee() uint32 {
-	return r.v.GetTransferee()
+	return (*TransferLeadershipRequest)(r).GetTransferee()
 }
 
 func (r *transferLeadershipRequestReadonly) Mutate() *TransferLeadershipRequest {
-	return r.v.CloneVT()
+	return (*TransferLeadershipRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransferLeadershipRequest.
@@ -723,7 +723,7 @@ func (m *TransferLeadershipRequest) AsReader() TransferLeadershipRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &transferLeadershipRequestReadonly{v: m}
+	return (*transferLeadershipRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransferLeadershipRequest.
@@ -775,14 +775,14 @@ type TransferLeadershipResponseReader interface {
 	Mutate() *TransferLeadershipResponse
 }
 
-type transferLeadershipResponseReadonly struct{ v *TransferLeadershipResponse }
+type transferLeadershipResponseReadonly TransferLeadershipResponse
 
 func (r *transferLeadershipResponseReadonly) GetNewLeader() uint32 {
-	return r.v.GetNewLeader()
+	return (*TransferLeadershipResponse)(r).GetNewLeader()
 }
 
 func (r *transferLeadershipResponseReadonly) Mutate() *TransferLeadershipResponse {
-	return r.v.CloneVT()
+	return (*TransferLeadershipResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransferLeadershipResponse.
@@ -790,7 +790,7 @@ func (m *TransferLeadershipResponse) AsReader() TransferLeadershipResponseReader
 	if m == nil {
 		return nil
 	}
-	return &transferLeadershipResponseReadonly{v: m}
+	return (*transferLeadershipResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransferLeadershipResponse.
@@ -841,10 +841,10 @@ type GetDiskUsageRequestReader interface {
 	Mutate() *GetDiskUsageRequest
 }
 
-type getDiskUsageRequestReadonly struct{ v *GetDiskUsageRequest }
+type getDiskUsageRequestReadonly GetDiskUsageRequest
 
 func (r *getDiskUsageRequestReadonly) Mutate() *GetDiskUsageRequest {
-	return r.v.CloneVT()
+	return (*GetDiskUsageRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetDiskUsageRequest.
@@ -852,7 +852,7 @@ func (m *GetDiskUsageRequest) AsReader() GetDiskUsageRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getDiskUsageRequestReadonly{v: m}
+	return (*getDiskUsageRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetDiskUsageRequest.
@@ -903,10 +903,10 @@ type GetNodeTimeRequestReader interface {
 	Mutate() *GetNodeTimeRequest
 }
 
-type getNodeTimeRequestReadonly struct{ v *GetNodeTimeRequest }
+type getNodeTimeRequestReadonly GetNodeTimeRequest
 
 func (r *getNodeTimeRequestReadonly) Mutate() *GetNodeTimeRequest {
-	return r.v.CloneVT()
+	return (*GetNodeTimeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetNodeTimeRequest.
@@ -914,7 +914,7 @@ func (m *GetNodeTimeRequest) AsReader() GetNodeTimeRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getNodeTimeRequestReadonly{v: m}
+	return (*getNodeTimeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetNodeTimeRequest.
@@ -966,14 +966,14 @@ type NodeTimeReader interface {
 	Mutate() *NodeTime
 }
 
-type nodeTimeReadonly struct{ v *NodeTime }
+type nodeTimeReadonly NodeTime
 
 func (r *nodeTimeReadonly) GetTimestampUs() uint64 {
-	return r.v.GetTimestampUs()
+	return (*NodeTime)(r).GetTimestampUs()
 }
 
 func (r *nodeTimeReadonly) Mutate() *NodeTime {
-	return r.v.CloneVT()
+	return (*NodeTime)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NodeTime.
@@ -981,7 +981,7 @@ func (m *NodeTime) AsReader() NodeTimeReader {
 	if m == nil {
 		return nil
 	}
-	return &nodeTimeReadonly{v: m}
+	return (*nodeTimeReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NodeTime.
@@ -1032,18 +1032,18 @@ type VolumeUsageReader interface {
 	Mutate() *VolumeUsage
 }
 
-type volumeUsageReadonly struct{ v *VolumeUsage }
+type volumeUsageReadonly VolumeUsage
 
 func (r *volumeUsageReadonly) GetUsedBytes() uint64 {
-	return r.v.GetUsedBytes()
+	return (*VolumeUsage)(r).GetUsedBytes()
 }
 
 func (r *volumeUsageReadonly) GetTotalBytes() uint64 {
-	return r.v.GetTotalBytes()
+	return (*VolumeUsage)(r).GetTotalBytes()
 }
 
 func (r *volumeUsageReadonly) Mutate() *VolumeUsage {
-	return r.v.CloneVT()
+	return (*VolumeUsage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this VolumeUsage.
@@ -1051,7 +1051,7 @@ func (m *VolumeUsage) AsReader() VolumeUsageReader {
 	if m == nil {
 		return nil
 	}
-	return &volumeUsageReadonly{v: m}
+	return (*volumeUsageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this VolumeUsage.
@@ -1104,10 +1104,10 @@ type DiskUsageReader interface {
 	Mutate() *DiskUsage
 }
 
-type diskUsageReadonly struct{ v *DiskUsage }
+type diskUsageReadonly DiskUsage
 
 func (r *diskUsageReadonly) GetWalVolume() VolumeUsageReader {
-	v := r.v.GetWalVolume()
+	v := (*DiskUsage)(r).GetWalVolume()
 	if v == nil {
 		return nil
 	}
@@ -1115,7 +1115,7 @@ func (r *diskUsageReadonly) GetWalVolume() VolumeUsageReader {
 }
 
 func (r *diskUsageReadonly) GetDataVolume() VolumeUsageReader {
-	v := r.v.GetDataVolume()
+	v := (*DiskUsage)(r).GetDataVolume()
 	if v == nil {
 		return nil
 	}
@@ -1123,7 +1123,7 @@ func (r *diskUsageReadonly) GetDataVolume() VolumeUsageReader {
 }
 
 func (r *diskUsageReadonly) Mutate() *DiskUsage {
-	return r.v.CloneVT()
+	return (*DiskUsage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DiskUsage.
@@ -1131,7 +1131,7 @@ func (m *DiskUsage) AsReader() DiskUsageReader {
 	if m == nil {
 		return nil
 	}
-	return &diskUsageReadonly{v: m}
+	return (*diskUsageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DiskUsage.
@@ -1183,22 +1183,22 @@ type AddLearnerRequestReader interface {
 	Mutate() *AddLearnerRequest
 }
 
-type addLearnerRequestReadonly struct{ v *AddLearnerRequest }
+type addLearnerRequestReadonly AddLearnerRequest
 
 func (r *addLearnerRequestReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*AddLearnerRequest)(r).GetNodeId()
 }
 
 func (r *addLearnerRequestReadonly) GetRaftAddress() string {
-	return r.v.GetRaftAddress()
+	return (*AddLearnerRequest)(r).GetRaftAddress()
 }
 
 func (r *addLearnerRequestReadonly) GetServiceAddress() string {
-	return r.v.GetServiceAddress()
+	return (*AddLearnerRequest)(r).GetServiceAddress()
 }
 
 func (r *addLearnerRequestReadonly) Mutate() *AddLearnerRequest {
-	return r.v.CloneVT()
+	return (*AddLearnerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddLearnerRequest.
@@ -1206,7 +1206,7 @@ func (m *AddLearnerRequest) AsReader() AddLearnerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &addLearnerRequestReadonly{v: m}
+	return (*addLearnerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddLearnerRequest.
@@ -1257,10 +1257,10 @@ type AddLearnerResponseReader interface {
 	Mutate() *AddLearnerResponse
 }
 
-type addLearnerResponseReadonly struct{ v *AddLearnerResponse }
+type addLearnerResponseReadonly AddLearnerResponse
 
 func (r *addLearnerResponseReadonly) Mutate() *AddLearnerResponse {
-	return r.v.CloneVT()
+	return (*AddLearnerResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddLearnerResponse.
@@ -1268,7 +1268,7 @@ func (m *AddLearnerResponse) AsReader() AddLearnerResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &addLearnerResponseReadonly{v: m}
+	return (*addLearnerResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddLearnerResponse.
@@ -1320,14 +1320,14 @@ type PromoteLearnerRequestReader interface {
 	Mutate() *PromoteLearnerRequest
 }
 
-type promoteLearnerRequestReadonly struct{ v *PromoteLearnerRequest }
+type promoteLearnerRequestReadonly PromoteLearnerRequest
 
 func (r *promoteLearnerRequestReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*PromoteLearnerRequest)(r).GetNodeId()
 }
 
 func (r *promoteLearnerRequestReadonly) Mutate() *PromoteLearnerRequest {
-	return r.v.CloneVT()
+	return (*PromoteLearnerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PromoteLearnerRequest.
@@ -1335,7 +1335,7 @@ func (m *PromoteLearnerRequest) AsReader() PromoteLearnerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &promoteLearnerRequestReadonly{v: m}
+	return (*promoteLearnerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PromoteLearnerRequest.
@@ -1386,10 +1386,10 @@ type PromoteLearnerResponseReader interface {
 	Mutate() *PromoteLearnerResponse
 }
 
-type promoteLearnerResponseReadonly struct{ v *PromoteLearnerResponse }
+type promoteLearnerResponseReadonly PromoteLearnerResponse
 
 func (r *promoteLearnerResponseReadonly) Mutate() *PromoteLearnerResponse {
-	return r.v.CloneVT()
+	return (*PromoteLearnerResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PromoteLearnerResponse.
@@ -1397,7 +1397,7 @@ func (m *PromoteLearnerResponse) AsReader() PromoteLearnerResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &promoteLearnerResponseReadonly{v: m}
+	return (*promoteLearnerResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PromoteLearnerResponse.
@@ -1450,18 +1450,18 @@ type RemoveNodeRequestReader interface {
 	Mutate() *RemoveNodeRequest
 }
 
-type removeNodeRequestReadonly struct{ v *RemoveNodeRequest }
+type removeNodeRequestReadonly RemoveNodeRequest
 
 func (r *removeNodeRequestReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*RemoveNodeRequest)(r).GetNodeId()
 }
 
 func (r *removeNodeRequestReadonly) GetForce() bool {
-	return r.v.GetForce()
+	return (*RemoveNodeRequest)(r).GetForce()
 }
 
 func (r *removeNodeRequestReadonly) Mutate() *RemoveNodeRequest {
-	return r.v.CloneVT()
+	return (*RemoveNodeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveNodeRequest.
@@ -1469,7 +1469,7 @@ func (m *RemoveNodeRequest) AsReader() RemoveNodeRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &removeNodeRequestReadonly{v: m}
+	return (*removeNodeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveNodeRequest.
@@ -1520,10 +1520,10 @@ type RemoveNodeResponseReader interface {
 	Mutate() *RemoveNodeResponse
 }
 
-type removeNodeResponseReadonly struct{ v *RemoveNodeResponse }
+type removeNodeResponseReadonly RemoveNodeResponse
 
 func (r *removeNodeResponseReadonly) Mutate() *RemoveNodeResponse {
-	return r.v.CloneVT()
+	return (*RemoveNodeResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveNodeResponse.
@@ -1531,7 +1531,7 @@ func (m *RemoveNodeResponse) AsReader() RemoveNodeResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &removeNodeResponseReadonly{v: m}
+	return (*removeNodeResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveNodeResponse.
@@ -1585,18 +1585,18 @@ type BackupRequestReader interface {
 	Mutate() *BackupRequest
 }
 
-type backupRequestReadonly struct{ v *BackupRequest }
+type backupRequestReadonly BackupRequest
 
 func (r *backupRequestReadonly) GetBasePath() string {
-	return r.v.GetBasePath()
+	return (*BackupRequest)(r).GetBasePath()
 }
 
 func (r *backupRequestReadonly) GetBucketId() string {
-	return r.v.GetBucketId()
+	return (*BackupRequest)(r).GetBucketId()
 }
 
 func (r *backupRequestReadonly) GetStorage() commonpb.BackupStorageReader {
-	v := r.v.GetStorage()
+	v := (*BackupRequest)(r).GetStorage()
 	if v == nil {
 		return nil
 	}
@@ -1604,7 +1604,7 @@ func (r *backupRequestReadonly) GetStorage() commonpb.BackupStorageReader {
 }
 
 func (r *backupRequestReadonly) Mutate() *BackupRequest {
-	return r.v.CloneVT()
+	return (*BackupRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupRequest.
@@ -1612,7 +1612,7 @@ func (m *BackupRequest) AsReader() BackupRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &backupRequestReadonly{v: m}
+	return (*backupRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupRequest.
@@ -1671,42 +1671,42 @@ type BackupResponseReader interface {
 	Mutate() *BackupResponse
 }
 
-type backupResponseReadonly struct{ v *BackupResponse }
+type backupResponseReadonly BackupResponse
 
 func (r *backupResponseReadonly) GetFilesUploaded() uint32 {
-	return r.v.GetFilesUploaded()
+	return (*BackupResponse)(r).GetFilesUploaded()
 }
 
 func (r *backupResponseReadonly) GetFilesDeleted() uint32 {
-	return r.v.GetFilesDeleted()
+	return (*BackupResponse)(r).GetFilesDeleted()
 }
 
 func (r *backupResponseReadonly) GetTotalFiles() uint32 {
-	return r.v.GetTotalFiles()
+	return (*BackupResponse)(r).GetTotalFiles()
 }
 
 func (r *backupResponseReadonly) GetDurationMs() int64 {
-	return r.v.GetDurationMs()
+	return (*BackupResponse)(r).GetDurationMs()
 }
 
 func (r *backupResponseReadonly) GetLastLogSequence() uint64 {
-	return r.v.GetLastLogSequence()
+	return (*BackupResponse)(r).GetLastLogSequence()
 }
 
 func (r *backupResponseReadonly) GetLastAuditSequence() uint64 {
-	return r.v.GetLastAuditSequence()
+	return (*BackupResponse)(r).GetLastAuditSequence()
 }
 
 func (r *backupResponseReadonly) GetLastAppliedIndex() uint64 {
-	return r.v.GetLastAppliedIndex()
+	return (*BackupResponse)(r).GetLastAppliedIndex()
 }
 
 func (r *backupResponseReadonly) GetOrphansDeleted() uint32 {
-	return r.v.GetOrphansDeleted()
+	return (*BackupResponse)(r).GetOrphansDeleted()
 }
 
 func (r *backupResponseReadonly) Mutate() *BackupResponse {
-	return r.v.CloneVT()
+	return (*BackupResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupResponse.
@@ -1714,7 +1714,7 @@ func (m *BackupResponse) AsReader() BackupResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &backupResponseReadonly{v: m}
+	return (*backupResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupResponse.
@@ -1768,18 +1768,18 @@ type IncrementalBackupRequestReader interface {
 	Mutate() *IncrementalBackupRequest
 }
 
-type incrementalBackupRequestReadonly struct{ v *IncrementalBackupRequest }
+type incrementalBackupRequestReadonly IncrementalBackupRequest
 
 func (r *incrementalBackupRequestReadonly) GetBasePath() string {
-	return r.v.GetBasePath()
+	return (*IncrementalBackupRequest)(r).GetBasePath()
 }
 
 func (r *incrementalBackupRequestReadonly) GetBucketId() string {
-	return r.v.GetBucketId()
+	return (*IncrementalBackupRequest)(r).GetBucketId()
 }
 
 func (r *incrementalBackupRequestReadonly) GetStorage() commonpb.BackupStorageReader {
-	v := r.v.GetStorage()
+	v := (*IncrementalBackupRequest)(r).GetStorage()
 	if v == nil {
 		return nil
 	}
@@ -1787,7 +1787,7 @@ func (r *incrementalBackupRequestReadonly) GetStorage() commonpb.BackupStorageRe
 }
 
 func (r *incrementalBackupRequestReadonly) Mutate() *IncrementalBackupRequest {
-	return r.v.CloneVT()
+	return (*IncrementalBackupRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IncrementalBackupRequest.
@@ -1795,7 +1795,7 @@ func (m *IncrementalBackupRequest) AsReader() IncrementalBackupRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &incrementalBackupRequestReadonly{v: m}
+	return (*incrementalBackupRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IncrementalBackupRequest.
@@ -1853,38 +1853,38 @@ type IncrementalBackupResponseReader interface {
 	Mutate() *IncrementalBackupResponse
 }
 
-type incrementalBackupResponseReadonly struct{ v *IncrementalBackupResponse }
+type incrementalBackupResponseReadonly IncrementalBackupResponse
 
 func (r *incrementalBackupResponseReadonly) GetLogEntriesExported() uint64 {
-	return r.v.GetLogEntriesExported()
+	return (*IncrementalBackupResponse)(r).GetLogEntriesExported()
 }
 
 func (r *incrementalBackupResponseReadonly) GetAuditEntriesExported() uint64 {
-	return r.v.GetAuditEntriesExported()
+	return (*IncrementalBackupResponse)(r).GetAuditEntriesExported()
 }
 
 func (r *incrementalBackupResponseReadonly) GetSegmentsUploaded() uint32 {
-	return r.v.GetSegmentsUploaded()
+	return (*IncrementalBackupResponse)(r).GetSegmentsUploaded()
 }
 
 func (r *incrementalBackupResponseReadonly) GetDurationMs() int64 {
-	return r.v.GetDurationMs()
+	return (*IncrementalBackupResponse)(r).GetDurationMs()
 }
 
 func (r *incrementalBackupResponseReadonly) GetLastLogSequence() uint64 {
-	return r.v.GetLastLogSequence()
+	return (*IncrementalBackupResponse)(r).GetLastLogSequence()
 }
 
 func (r *incrementalBackupResponseReadonly) GetLastAuditSequence() uint64 {
-	return r.v.GetLastAuditSequence()
+	return (*IncrementalBackupResponse)(r).GetLastAuditSequence()
 }
 
 func (r *incrementalBackupResponseReadonly) GetOrphansDeleted() uint32 {
-	return r.v.GetOrphansDeleted()
+	return (*IncrementalBackupResponse)(r).GetOrphansDeleted()
 }
 
 func (r *incrementalBackupResponseReadonly) Mutate() *IncrementalBackupResponse {
-	return r.v.CloneVT()
+	return (*IncrementalBackupResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IncrementalBackupResponse.
@@ -1892,7 +1892,7 @@ func (m *IncrementalBackupResponse) AsReader() IncrementalBackupResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &incrementalBackupResponseReadonly{v: m}
+	return (*incrementalBackupResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IncrementalBackupResponse.
@@ -1943,10 +1943,10 @@ type CompactPrimaryRequestReader interface {
 	Mutate() *CompactPrimaryRequest
 }
 
-type compactPrimaryRequestReadonly struct{ v *CompactPrimaryRequest }
+type compactPrimaryRequestReadonly CompactPrimaryRequest
 
 func (r *compactPrimaryRequestReadonly) Mutate() *CompactPrimaryRequest {
-	return r.v.CloneVT()
+	return (*CompactPrimaryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CompactPrimaryRequest.
@@ -1954,7 +1954,7 @@ func (m *CompactPrimaryRequest) AsReader() CompactPrimaryRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &compactPrimaryRequestReadonly{v: m}
+	return (*compactPrimaryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CompactPrimaryRequest.
@@ -2006,14 +2006,14 @@ type CompactPrimaryResponseReader interface {
 	Mutate() *CompactPrimaryResponse
 }
 
-type compactPrimaryResponseReadonly struct{ v *CompactPrimaryResponse }
+type compactPrimaryResponseReadonly CompactPrimaryResponse
 
 func (r *compactPrimaryResponseReadonly) GetDurationMs() int64 {
-	return r.v.GetDurationMs()
+	return (*CompactPrimaryResponse)(r).GetDurationMs()
 }
 
 func (r *compactPrimaryResponseReadonly) Mutate() *CompactPrimaryResponse {
-	return r.v.CloneVT()
+	return (*CompactPrimaryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CompactPrimaryResponse.
@@ -2021,7 +2021,7 @@ func (m *CompactPrimaryResponse) AsReader() CompactPrimaryResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &compactPrimaryResponseReadonly{v: m}
+	return (*compactPrimaryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CompactPrimaryResponse.
@@ -2072,10 +2072,10 @@ type CompactSecondaryRequestReader interface {
 	Mutate() *CompactSecondaryRequest
 }
 
-type compactSecondaryRequestReadonly struct{ v *CompactSecondaryRequest }
+type compactSecondaryRequestReadonly CompactSecondaryRequest
 
 func (r *compactSecondaryRequestReadonly) Mutate() *CompactSecondaryRequest {
-	return r.v.CloneVT()
+	return (*CompactSecondaryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CompactSecondaryRequest.
@@ -2083,7 +2083,7 @@ func (m *CompactSecondaryRequest) AsReader() CompactSecondaryRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &compactSecondaryRequestReadonly{v: m}
+	return (*compactSecondaryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CompactSecondaryRequest.
@@ -2137,22 +2137,22 @@ type CompactSecondaryResponseReader interface {
 	Mutate() *CompactSecondaryResponse
 }
 
-type compactSecondaryResponseReadonly struct{ v *CompactSecondaryResponse }
+type compactSecondaryResponseReadonly CompactSecondaryResponse
 
 func (r *compactSecondaryResponseReadonly) GetDurationMs() int64 {
-	return r.v.GetDurationMs()
+	return (*CompactSecondaryResponse)(r).GetDurationMs()
 }
 
 func (r *compactSecondaryResponseReadonly) GetSizeBeforeBytes() uint64 {
-	return r.v.GetSizeBeforeBytes()
+	return (*CompactSecondaryResponse)(r).GetSizeBeforeBytes()
 }
 
 func (r *compactSecondaryResponseReadonly) GetSizeAfterBytes() uint64 {
-	return r.v.GetSizeAfterBytes()
+	return (*CompactSecondaryResponse)(r).GetSizeAfterBytes()
 }
 
 func (r *compactSecondaryResponseReadonly) Mutate() *CompactSecondaryResponse {
-	return r.v.CloneVT()
+	return (*CompactSecondaryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CompactSecondaryResponse.
@@ -2160,7 +2160,7 @@ func (m *CompactSecondaryResponse) AsReader() CompactSecondaryResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &compactSecondaryResponseReadonly{v: m}
+	return (*compactSecondaryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CompactSecondaryResponse.
@@ -2211,10 +2211,10 @@ type CreateCheckpointRequestReader interface {
 	Mutate() *CreateCheckpointRequest
 }
 
-type createCheckpointRequestReadonly struct{ v *CreateCheckpointRequest }
+type createCheckpointRequestReadonly CreateCheckpointRequest
 
 func (r *createCheckpointRequestReadonly) Mutate() *CreateCheckpointRequest {
-	return r.v.CloneVT()
+	return (*CreateCheckpointRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateCheckpointRequest.
@@ -2222,7 +2222,7 @@ func (m *CreateCheckpointRequest) AsReader() CreateCheckpointRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &createCheckpointRequestReadonly{v: m}
+	return (*createCheckpointRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateCheckpointRequest.
@@ -2274,14 +2274,14 @@ type CreateCheckpointResponseReader interface {
 	Mutate() *CreateCheckpointResponse
 }
 
-type createCheckpointResponseReadonly struct{ v *CreateCheckpointResponse }
+type createCheckpointResponseReadonly CreateCheckpointResponse
 
 func (r *createCheckpointResponseReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*CreateCheckpointResponse)(r).GetCheckpointId()
 }
 
 func (r *createCheckpointResponseReadonly) Mutate() *CreateCheckpointResponse {
-	return r.v.CloneVT()
+	return (*CreateCheckpointResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateCheckpointResponse.
@@ -2289,7 +2289,7 @@ func (m *CreateCheckpointResponse) AsReader() CreateCheckpointResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &createCheckpointResponseReadonly{v: m}
+	return (*createCheckpointResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateCheckpointResponse.
@@ -2340,10 +2340,10 @@ type CreateQueryCheckpointRequestReader interface {
 	Mutate() *CreateQueryCheckpointRequest
 }
 
-type createQueryCheckpointRequestReadonly struct{ v *CreateQueryCheckpointRequest }
+type createQueryCheckpointRequestReadonly CreateQueryCheckpointRequest
 
 func (r *createQueryCheckpointRequestReadonly) Mutate() *CreateQueryCheckpointRequest {
-	return r.v.CloneVT()
+	return (*CreateQueryCheckpointRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateQueryCheckpointRequest.
@@ -2351,7 +2351,7 @@ func (m *CreateQueryCheckpointRequest) AsReader() CreateQueryCheckpointRequestRe
 	if m == nil {
 		return nil
 	}
-	return &createQueryCheckpointRequestReadonly{v: m}
+	return (*createQueryCheckpointRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateQueryCheckpointRequest.
@@ -2404,20 +2404,18 @@ type CreateQueryCheckpointResponseReader interface {
 	Mutate() *CreateQueryCheckpointResponse
 }
 
-type createQueryCheckpointResponseReadonly struct {
-	v *CreateQueryCheckpointResponse
-}
+type createQueryCheckpointResponseReadonly CreateQueryCheckpointResponse
 
 func (r *createQueryCheckpointResponseReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*CreateQueryCheckpointResponse)(r).GetCheckpointId()
 }
 
 func (r *createQueryCheckpointResponseReadonly) GetMaxSequence() uint64 {
-	return r.v.GetMaxSequence()
+	return (*CreateQueryCheckpointResponse)(r).GetMaxSequence()
 }
 
 func (r *createQueryCheckpointResponseReadonly) Mutate() *CreateQueryCheckpointResponse {
-	return r.v.CloneVT()
+	return (*CreateQueryCheckpointResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateQueryCheckpointResponse.
@@ -2425,7 +2423,7 @@ func (m *CreateQueryCheckpointResponse) AsReader() CreateQueryCheckpointResponse
 	if m == nil {
 		return nil
 	}
-	return &createQueryCheckpointResponseReadonly{v: m}
+	return (*createQueryCheckpointResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateQueryCheckpointResponse.
@@ -2477,14 +2475,14 @@ type DeleteQueryCheckpointRequestReader interface {
 	Mutate() *DeleteQueryCheckpointRequest
 }
 
-type deleteQueryCheckpointRequestReadonly struct{ v *DeleteQueryCheckpointRequest }
+type deleteQueryCheckpointRequestReadonly DeleteQueryCheckpointRequest
 
 func (r *deleteQueryCheckpointRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*DeleteQueryCheckpointRequest)(r).GetCheckpointId()
 }
 
 func (r *deleteQueryCheckpointRequestReadonly) Mutate() *DeleteQueryCheckpointRequest {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointRequest.
@@ -2492,7 +2490,7 @@ func (m *DeleteQueryCheckpointRequest) AsReader() DeleteQueryCheckpointRequestRe
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointRequestReadonly{v: m}
+	return (*deleteQueryCheckpointRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointRequest.
@@ -2543,12 +2541,10 @@ type DeleteQueryCheckpointResponseReader interface {
 	Mutate() *DeleteQueryCheckpointResponse
 }
 
-type deleteQueryCheckpointResponseReadonly struct {
-	v *DeleteQueryCheckpointResponse
-}
+type deleteQueryCheckpointResponseReadonly DeleteQueryCheckpointResponse
 
 func (r *deleteQueryCheckpointResponseReadonly) Mutate() *DeleteQueryCheckpointResponse {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointResponse.
@@ -2556,7 +2552,7 @@ func (m *DeleteQueryCheckpointResponse) AsReader() DeleteQueryCheckpointResponse
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointResponseReadonly{v: m}
+	return (*deleteQueryCheckpointResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointResponse.
@@ -2607,10 +2603,10 @@ type ListQueryCheckpointsRequestReader interface {
 	Mutate() *ListQueryCheckpointsRequest
 }
 
-type listQueryCheckpointsRequestReadonly struct{ v *ListQueryCheckpointsRequest }
+type listQueryCheckpointsRequestReadonly ListQueryCheckpointsRequest
 
 func (r *listQueryCheckpointsRequestReadonly) Mutate() *ListQueryCheckpointsRequest {
-	return r.v.CloneVT()
+	return (*ListQueryCheckpointsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListQueryCheckpointsRequest.
@@ -2618,7 +2614,7 @@ func (m *ListQueryCheckpointsRequest) AsReader() ListQueryCheckpointsRequestRead
 	if m == nil {
 		return nil
 	}
-	return &listQueryCheckpointsRequestReadonly{v: m}
+	return (*listQueryCheckpointsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListQueryCheckpointsRequest.
@@ -2670,14 +2666,14 @@ type ListQueryCheckpointsResponseReader interface {
 	Mutate() *ListQueryCheckpointsResponse
 }
 
-type listQueryCheckpointsResponseReadonly struct{ v *ListQueryCheckpointsResponse }
+type listQueryCheckpointsResponseReadonly ListQueryCheckpointsResponse
 
 func (r *listQueryCheckpointsResponseReadonly) GetCheckpoints() QueryCheckpointInfoListReader {
-	return NewQueryCheckpointInfoListReader(r.v.GetCheckpoints())
+	return NewQueryCheckpointInfoListReader((*ListQueryCheckpointsResponse)(r).GetCheckpoints())
 }
 
 func (r *listQueryCheckpointsResponseReadonly) Mutate() *ListQueryCheckpointsResponse {
-	return r.v.CloneVT()
+	return (*ListQueryCheckpointsResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListQueryCheckpointsResponse.
@@ -2685,7 +2681,7 @@ func (m *ListQueryCheckpointsResponse) AsReader() ListQueryCheckpointsResponseRe
 	if m == nil {
 		return nil
 	}
-	return &listQueryCheckpointsResponseReadonly{v: m}
+	return (*listQueryCheckpointsResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListQueryCheckpointsResponse.
@@ -2737,16 +2733,14 @@ type GetQueryCheckpointInfoRequestReader interface {
 	Mutate() *GetQueryCheckpointInfoRequest
 }
 
-type getQueryCheckpointInfoRequestReadonly struct {
-	v *GetQueryCheckpointInfoRequest
-}
+type getQueryCheckpointInfoRequestReadonly GetQueryCheckpointInfoRequest
 
 func (r *getQueryCheckpointInfoRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*GetQueryCheckpointInfoRequest)(r).GetCheckpointId()
 }
 
 func (r *getQueryCheckpointInfoRequestReadonly) Mutate() *GetQueryCheckpointInfoRequest {
-	return r.v.CloneVT()
+	return (*GetQueryCheckpointInfoRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetQueryCheckpointInfoRequest.
@@ -2754,7 +2748,7 @@ func (m *GetQueryCheckpointInfoRequest) AsReader() GetQueryCheckpointInfoRequest
 	if m == nil {
 		return nil
 	}
-	return &getQueryCheckpointInfoRequestReadonly{v: m}
+	return (*getQueryCheckpointInfoRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetQueryCheckpointInfoRequest.
@@ -2805,12 +2799,10 @@ type GetQueryCheckpointScheduleRequestReader interface {
 	Mutate() *GetQueryCheckpointScheduleRequest
 }
 
-type getQueryCheckpointScheduleRequestReadonly struct {
-	v *GetQueryCheckpointScheduleRequest
-}
+type getQueryCheckpointScheduleRequestReadonly GetQueryCheckpointScheduleRequest
 
 func (r *getQueryCheckpointScheduleRequestReadonly) Mutate() *GetQueryCheckpointScheduleRequest {
-	return r.v.CloneVT()
+	return (*GetQueryCheckpointScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetQueryCheckpointScheduleRequest.
@@ -2818,7 +2810,7 @@ func (m *GetQueryCheckpointScheduleRequest) AsReader() GetQueryCheckpointSchedul
 	if m == nil {
 		return nil
 	}
-	return &getQueryCheckpointScheduleRequestReadonly{v: m}
+	return (*getQueryCheckpointScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetQueryCheckpointScheduleRequest.
@@ -2870,16 +2862,14 @@ type GetQueryCheckpointScheduleResponseReader interface {
 	Mutate() *GetQueryCheckpointScheduleResponse
 }
 
-type getQueryCheckpointScheduleResponseReadonly struct {
-	v *GetQueryCheckpointScheduleResponse
-}
+type getQueryCheckpointScheduleResponseReadonly GetQueryCheckpointScheduleResponse
 
 func (r *getQueryCheckpointScheduleResponseReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*GetQueryCheckpointScheduleResponse)(r).GetCron()
 }
 
 func (r *getQueryCheckpointScheduleResponseReadonly) Mutate() *GetQueryCheckpointScheduleResponse {
-	return r.v.CloneVT()
+	return (*GetQueryCheckpointScheduleResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetQueryCheckpointScheduleResponse.
@@ -2887,7 +2877,7 @@ func (m *GetQueryCheckpointScheduleResponse) AsReader() GetQueryCheckpointSchedu
 	if m == nil {
 		return nil
 	}
-	return &getQueryCheckpointScheduleResponseReadonly{v: m}
+	return (*getQueryCheckpointScheduleResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetQueryCheckpointScheduleResponse.
@@ -2941,18 +2931,18 @@ type QueryCheckpointInfoReader interface {
 	Mutate() *QueryCheckpointInfo
 }
 
-type queryCheckpointInfoReadonly struct{ v *QueryCheckpointInfo }
+type queryCheckpointInfoReadonly QueryCheckpointInfo
 
 func (r *queryCheckpointInfoReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*QueryCheckpointInfo)(r).GetCheckpointId()
 }
 
 func (r *queryCheckpointInfoReadonly) GetMaxSequence() uint64 {
-	return r.v.GetMaxSequence()
+	return (*QueryCheckpointInfo)(r).GetMaxSequence()
 }
 
 func (r *queryCheckpointInfoReadonly) GetCreatedAt() commonpb.TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*QueryCheckpointInfo)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -2960,7 +2950,7 @@ func (r *queryCheckpointInfoReadonly) GetCreatedAt() commonpb.TimestampReader {
 }
 
 func (r *queryCheckpointInfoReadonly) Mutate() *QueryCheckpointInfo {
-	return r.v.CloneVT()
+	return (*QueryCheckpointInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this QueryCheckpointInfo.
@@ -2968,7 +2958,7 @@ func (m *QueryCheckpointInfo) AsReader() QueryCheckpointInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &queryCheckpointInfoReadonly{v: m}
+	return (*queryCheckpointInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this QueryCheckpointInfo.

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -17,14 +17,14 @@ type TimestampReader interface {
 	Mutate() *Timestamp
 }
 
-type timestampReadonly struct{ v *Timestamp }
+type timestampReadonly Timestamp
 
 func (r *timestampReadonly) GetData() uint64 {
-	return r.v.GetData()
+	return (*Timestamp)(r).GetData()
 }
 
 func (r *timestampReadonly) Mutate() *Timestamp {
-	return r.v.CloneVT()
+	return (*Timestamp)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Timestamp.
@@ -32,7 +32,7 @@ func (m *Timestamp) AsReader() TimestampReader {
 	if m == nil {
 		return nil
 	}
-	return &timestampReadonly{v: m}
+	return (*timestampReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Timestamp.
@@ -82,14 +82,14 @@ type NullValueReader interface {
 	Mutate() *NullValue
 }
 
-type nullValueReadonly struct{ v *NullValue }
+type nullValueReadonly NullValue
 
 func (r *nullValueReadonly) GetOriginal() string {
-	return r.v.GetOriginal()
+	return (*NullValue)(r).GetOriginal()
 }
 
 func (r *nullValueReadonly) Mutate() *NullValue {
-	return r.v.CloneVT()
+	return (*NullValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NullValue.
@@ -97,7 +97,7 @@ func (m *NullValue) AsReader() NullValueReader {
 	if m == nil {
 		return nil
 	}
-	return &nullValueReadonly{v: m}
+	return (*nullValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NullValue.
@@ -147,14 +147,14 @@ type MetadataValueReader interface {
 	Mutate() *MetadataValue
 }
 
-type metadataValueReadonly struct{ v *MetadataValue }
+type metadataValueReadonly MetadataValue
 
 func (r *metadataValueReadonly) GetType() isMetadataValue_Type {
-	return r.v.GetType()
+	return (*MetadataValue)(r).GetType()
 }
 
 func (r *metadataValueReadonly) Mutate() *MetadataValue {
-	return r.v.CloneVT()
+	return (*MetadataValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataValue.
@@ -162,7 +162,7 @@ func (m *MetadataValue) AsReader() MetadataValueReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataValueReadonly{v: m}
+	return (*metadataValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataValue.
@@ -214,14 +214,14 @@ type MetadataMapReader interface {
 	Mutate() *MetadataMap
 }
 
-type metadataMapReadonly struct{ v *MetadataMap }
+type metadataMapReadonly MetadataMap
 
 func (r *metadataMapReadonly) GetValues() MetadataMap_ValuesMapReader {
-	return metadataMap_valuesMapReadonly(r.v.GetValues())
+	return metadataMap_valuesMapReadonly((*MetadataMap)(r).GetValues())
 }
 
 func (r *metadataMapReadonly) Mutate() *MetadataMap {
-	return r.v.CloneVT()
+	return (*MetadataMap)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataMap.
@@ -229,7 +229,7 @@ func (m *MetadataMap) AsReader() MetadataMapReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataMapReadonly{v: m}
+	return (*metadataMapReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataMap.
@@ -312,14 +312,14 @@ type ParameterValueReader interface {
 	Mutate() *ParameterValue
 }
 
-type parameterValueReadonly struct{ v *ParameterValue }
+type parameterValueReadonly ParameterValue
 
 func (r *parameterValueReadonly) GetValue() isParameterValue_Value {
-	return r.v.GetValue()
+	return (*ParameterValue)(r).GetValue()
 }
 
 func (r *parameterValueReadonly) Mutate() *ParameterValue {
-	return r.v.CloneVT()
+	return (*ParameterValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ParameterValue.
@@ -327,7 +327,7 @@ func (m *ParameterValue) AsReader() ParameterValueReader {
 	if m == nil {
 		return nil
 	}
-	return &parameterValueReadonly{v: m}
+	return (*parameterValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ParameterValue.
@@ -384,34 +384,34 @@ type Uint256Reader interface {
 	Mutate() *Uint256
 }
 
-type uint256Readonly struct{ v *Uint256 }
+type uint256Readonly Uint256
 
 func (r *uint256Readonly) GetV0() uint64 {
-	return r.v.GetV0()
+	return (*Uint256)(r).GetV0()
 }
 
 func (r *uint256Readonly) GetV1() uint64 {
-	return r.v.GetV1()
+	return (*Uint256)(r).GetV1()
 }
 
 func (r *uint256Readonly) GetV2() uint64 {
-	return r.v.GetV2()
+	return (*Uint256)(r).GetV2()
 }
 
 func (r *uint256Readonly) GetV3() uint64 {
-	return r.v.GetV3()
+	return (*Uint256)(r).GetV3()
 }
 
 func (r *uint256Readonly) IntoUint256(dst *uint256.Int) {
-	r.v.IntoUint256(dst)
+	(*Uint256)(r).IntoUint256(dst)
 }
 
 func (r *uint256Readonly) IsZero() bool {
-	return r.v.IsZero()
+	return (*Uint256)(r).IsZero()
 }
 
 func (r *uint256Readonly) Mutate() *Uint256 {
-	return r.v.CloneVT()
+	return (*Uint256)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Uint256.
@@ -419,7 +419,7 @@ func (m *Uint256) AsReader() Uint256Reader {
 	if m == nil {
 		return nil
 	}
-	return &uint256Readonly{v: m}
+	return (*uint256Readonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Uint256.
@@ -472,18 +472,18 @@ type PostingReader interface {
 	Mutate() *Posting
 }
 
-type postingReadonly struct{ v *Posting }
+type postingReadonly Posting
 
 func (r *postingReadonly) GetSource() string {
-	return r.v.GetSource()
+	return (*Posting)(r).GetSource()
 }
 
 func (r *postingReadonly) GetDestination() string {
-	return r.v.GetDestination()
+	return (*Posting)(r).GetDestination()
 }
 
 func (r *postingReadonly) GetAmount() Uint256Reader {
-	v := r.v.GetAmount()
+	v := (*Posting)(r).GetAmount()
 	if v == nil {
 		return nil
 	}
@@ -491,11 +491,11 @@ func (r *postingReadonly) GetAmount() Uint256Reader {
 }
 
 func (r *postingReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*Posting)(r).GetAsset()
 }
 
 func (r *postingReadonly) Mutate() *Posting {
-	return r.v.CloneVT()
+	return (*Posting)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Posting.
@@ -503,7 +503,7 @@ func (m *Posting) AsReader() PostingReader {
 	if m == nil {
 		return nil
 	}
-	return &postingReadonly{v: m}
+	return (*postingReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Posting.
@@ -561,18 +561,18 @@ type TransactionReader interface {
 	Mutate() *Transaction
 }
 
-type transactionReadonly struct{ v *Transaction }
+type transactionReadonly Transaction
 
 func (r *transactionReadonly) GetPostings() PostingListReader {
-	return NewPostingListReader(r.v.GetPostings())
+	return NewPostingListReader((*Transaction)(r).GetPostings())
 }
 
 func (r *transactionReadonly) GetMetadata() Transaction_MetadataMapReader {
-	return transaction_metadataMapReadonly(r.v.GetMetadata())
+	return transaction_metadataMapReadonly((*Transaction)(r).GetMetadata())
 }
 
 func (r *transactionReadonly) GetTimestamp() TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*Transaction)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -580,19 +580,19 @@ func (r *transactionReadonly) GetTimestamp() TimestampReader {
 }
 
 func (r *transactionReadonly) GetReference() string {
-	return r.v.GetReference()
+	return (*Transaction)(r).GetReference()
 }
 
 func (r *transactionReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*Transaction)(r).GetId()
 }
 
 func (r *transactionReadonly) GetReverted() bool {
-	return r.v.GetReverted()
+	return (*Transaction)(r).GetReverted()
 }
 
 func (r *transactionReadonly) GetInsertedAt() TimestampReader {
-	v := r.v.GetInsertedAt()
+	v := (*Transaction)(r).GetInsertedAt()
 	if v == nil {
 		return nil
 	}
@@ -600,7 +600,7 @@ func (r *transactionReadonly) GetInsertedAt() TimestampReader {
 }
 
 func (r *transactionReadonly) GetUpdatedAt() TimestampReader {
-	v := r.v.GetUpdatedAt()
+	v := (*Transaction)(r).GetUpdatedAt()
 	if v == nil {
 		return nil
 	}
@@ -608,7 +608,7 @@ func (r *transactionReadonly) GetUpdatedAt() TimestampReader {
 }
 
 func (r *transactionReadonly) GetRevertedAt() TimestampReader {
-	v := r.v.GetRevertedAt()
+	v := (*Transaction)(r).GetRevertedAt()
 	if v == nil {
 		return nil
 	}
@@ -616,7 +616,7 @@ func (r *transactionReadonly) GetRevertedAt() TimestampReader {
 }
 
 func (r *transactionReadonly) Mutate() *Transaction {
-	return r.v.CloneVT()
+	return (*Transaction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Transaction.
@@ -624,7 +624,7 @@ func (m *Transaction) AsReader() TransactionReader {
 	if m == nil {
 		return nil
 	}
-	return &transactionReadonly{v: m}
+	return (*transactionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Transaction.
@@ -709,22 +709,22 @@ type ScriptReader interface {
 	Mutate() *Script
 }
 
-type scriptReadonly struct{ v *Script }
+type scriptReadonly Script
 
 func (r *scriptReadonly) GetPlain() string {
-	return r.v.GetPlain()
+	return (*Script)(r).GetPlain()
 }
 
 func (r *scriptReadonly) GetVars() Script_VarsMapReader {
-	return script_varsMapReadonly(r.v.GetVars())
+	return script_varsMapReadonly((*Script)(r).GetVars())
 }
 
 func (r *scriptReadonly) GetContentHash() []byte {
-	return bytes.Clone(r.v.GetContentHash())
+	return bytes.Clone((*Script)(r).GetContentHash())
 }
 
 func (r *scriptReadonly) Mutate() *Script {
-	return r.v.CloneVT()
+	return (*Script)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Script.
@@ -732,7 +732,7 @@ func (m *Script) AsReader() ScriptReader {
 	if m == nil {
 		return nil
 	}
-	return &scriptReadonly{v: m}
+	return (*scriptReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Script.
@@ -807,18 +807,18 @@ type VolumesReader interface {
 	Mutate() *Volumes
 }
 
-type volumesReadonly struct{ v *Volumes }
+type volumesReadonly Volumes
 
 func (r *volumesReadonly) GetInput() string {
-	return r.v.GetInput()
+	return (*Volumes)(r).GetInput()
 }
 
 func (r *volumesReadonly) GetOutput() string {
-	return r.v.GetOutput()
+	return (*Volumes)(r).GetOutput()
 }
 
 func (r *volumesReadonly) Mutate() *Volumes {
-	return r.v.CloneVT()
+	return (*Volumes)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Volumes.
@@ -826,7 +826,7 @@ func (m *Volumes) AsReader() VolumesReader {
 	if m == nil {
 		return nil
 	}
-	return &volumesReadonly{v: m}
+	return (*volumesReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Volumes.
@@ -878,22 +878,22 @@ type VolumesWithBalanceReader interface {
 	Mutate() *VolumesWithBalance
 }
 
-type volumesWithBalanceReadonly struct{ v *VolumesWithBalance }
+type volumesWithBalanceReadonly VolumesWithBalance
 
 func (r *volumesWithBalanceReadonly) GetInput() string {
-	return r.v.GetInput()
+	return (*VolumesWithBalance)(r).GetInput()
 }
 
 func (r *volumesWithBalanceReadonly) GetOutput() string {
-	return r.v.GetOutput()
+	return (*VolumesWithBalance)(r).GetOutput()
 }
 
 func (r *volumesWithBalanceReadonly) GetBalance() string {
-	return r.v.GetBalance()
+	return (*VolumesWithBalance)(r).GetBalance()
 }
 
 func (r *volumesWithBalanceReadonly) Mutate() *VolumesWithBalance {
-	return r.v.CloneVT()
+	return (*VolumesWithBalance)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this VolumesWithBalance.
@@ -901,7 +901,7 @@ func (m *VolumesWithBalance) AsReader() VolumesWithBalanceReader {
 	if m == nil {
 		return nil
 	}
-	return &volumesWithBalanceReadonly{v: m}
+	return (*volumesWithBalanceReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this VolumesWithBalance.
@@ -953,14 +953,14 @@ type VolumesByAssetsReader interface {
 	Mutate() *VolumesByAssets
 }
 
-type volumesByAssetsReadonly struct{ v *VolumesByAssets }
+type volumesByAssetsReadonly VolumesByAssets
 
 func (r *volumesByAssetsReadonly) GetVolumes() VolumesByAssets_VolumesMapReader {
-	return volumesByAssets_volumesMapReadonly(r.v.GetVolumes())
+	return volumesByAssets_volumesMapReadonly((*VolumesByAssets)(r).GetVolumes())
 }
 
 func (r *volumesByAssetsReadonly) Mutate() *VolumesByAssets {
-	return r.v.CloneVT()
+	return (*VolumesByAssets)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this VolumesByAssets.
@@ -968,7 +968,7 @@ func (m *VolumesByAssets) AsReader() VolumesByAssetsReader {
 	if m == nil {
 		return nil
 	}
-	return &volumesByAssetsReadonly{v: m}
+	return (*volumesByAssetsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this VolumesByAssets.
@@ -1051,14 +1051,14 @@ type PostCommitVolumesReader interface {
 	Mutate() *PostCommitVolumes
 }
 
-type postCommitVolumesReadonly struct{ v *PostCommitVolumes }
+type postCommitVolumesReadonly PostCommitVolumes
 
 func (r *postCommitVolumesReadonly) GetVolumesByAccount() PostCommitVolumes_VolumesByAccountMapReader {
-	return postCommitVolumes_volumesByAccountMapReadonly(r.v.GetVolumesByAccount())
+	return postCommitVolumes_volumesByAccountMapReadonly((*PostCommitVolumes)(r).GetVolumesByAccount())
 }
 
 func (r *postCommitVolumesReadonly) Mutate() *PostCommitVolumes {
-	return r.v.CloneVT()
+	return (*PostCommitVolumes)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PostCommitVolumes.
@@ -1066,7 +1066,7 @@ func (m *PostCommitVolumes) AsReader() PostCommitVolumesReader {
 	if m == nil {
 		return nil
 	}
-	return &postCommitVolumesReadonly{v: m}
+	return (*postCommitVolumesReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PostCommitVolumes.
@@ -1154,18 +1154,18 @@ type AccountReader interface {
 	Mutate() *Account
 }
 
-type accountReadonly struct{ v *Account }
+type accountReadonly Account
 
 func (r *accountReadonly) GetAddress() string {
-	return r.v.GetAddress()
+	return (*Account)(r).GetAddress()
 }
 
 func (r *accountReadonly) GetMetadata() Account_MetadataMapReader {
-	return account_metadataMapReadonly(r.v.GetMetadata())
+	return account_metadataMapReadonly((*Account)(r).GetMetadata())
 }
 
 func (r *accountReadonly) GetFirstUsage() TimestampReader {
-	v := r.v.GetFirstUsage()
+	v := (*Account)(r).GetFirstUsage()
 	if v == nil {
 		return nil
 	}
@@ -1173,7 +1173,7 @@ func (r *accountReadonly) GetFirstUsage() TimestampReader {
 }
 
 func (r *accountReadonly) GetInsertionDate() TimestampReader {
-	v := r.v.GetInsertionDate()
+	v := (*Account)(r).GetInsertionDate()
 	if v == nil {
 		return nil
 	}
@@ -1181,7 +1181,7 @@ func (r *accountReadonly) GetInsertionDate() TimestampReader {
 }
 
 func (r *accountReadonly) GetUpdatedAt() TimestampReader {
-	v := r.v.GetUpdatedAt()
+	v := (*Account)(r).GetUpdatedAt()
 	if v == nil {
 		return nil
 	}
@@ -1189,11 +1189,11 @@ func (r *accountReadonly) GetUpdatedAt() TimestampReader {
 }
 
 func (r *accountReadonly) GetVolumes() Account_VolumesMapReader {
-	return account_volumesMapReadonly(r.v.GetVolumes())
+	return account_volumesMapReadonly((*Account)(r).GetVolumes())
 }
 
 func (r *accountReadonly) Mutate() *Account {
-	return r.v.CloneVT()
+	return (*Account)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Account.
@@ -1201,7 +1201,7 @@ func (m *Account) AsReader() AccountReader {
 	if m == nil {
 		return nil
 	}
-	return &accountReadonly{v: m}
+	return (*accountReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Account.
@@ -1313,14 +1313,14 @@ type TargetAccountReader interface {
 	Mutate() *TargetAccount
 }
 
-type targetAccountReadonly struct{ v *TargetAccount }
+type targetAccountReadonly TargetAccount
 
 func (r *targetAccountReadonly) GetAddr() string {
-	return r.v.GetAddr()
+	return (*TargetAccount)(r).GetAddr()
 }
 
 func (r *targetAccountReadonly) Mutate() *TargetAccount {
-	return r.v.CloneVT()
+	return (*TargetAccount)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TargetAccount.
@@ -1328,7 +1328,7 @@ func (m *TargetAccount) AsReader() TargetAccountReader {
 	if m == nil {
 		return nil
 	}
-	return &targetAccountReadonly{v: m}
+	return (*targetAccountReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TargetAccount.
@@ -1380,14 +1380,14 @@ type TargetReader interface {
 	Mutate() *Target
 }
 
-type targetReadonly struct{ v *Target }
+type targetReadonly Target
 
 func (r *targetReadonly) GetTarget() isTarget_Target {
-	return r.v.GetTarget()
+	return (*Target)(r).GetTarget()
 }
 
 func (r *targetReadonly) Mutate() *Target {
-	return r.v.CloneVT()
+	return (*Target)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Target.
@@ -1395,7 +1395,7 @@ func (m *Target) AsReader() TargetReader {
 	if m == nil {
 		return nil
 	}
-	return &targetReadonly{v: m}
+	return (*targetReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Target.
@@ -1445,14 +1445,14 @@ type MetadataFieldSchemaReader interface {
 	Mutate() *MetadataFieldSchema
 }
 
-type metadataFieldSchemaReadonly struct{ v *MetadataFieldSchema }
+type metadataFieldSchemaReadonly MetadataFieldSchema
 
 func (r *metadataFieldSchemaReadonly) GetType() MetadataType {
-	return r.v.GetType()
+	return (*MetadataFieldSchema)(r).GetType()
 }
 
 func (r *metadataFieldSchemaReadonly) Mutate() *MetadataFieldSchema {
-	return r.v.CloneVT()
+	return (*MetadataFieldSchema)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataFieldSchema.
@@ -1460,7 +1460,7 @@ func (m *MetadataFieldSchema) AsReader() MetadataFieldSchemaReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataFieldSchemaReadonly{v: m}
+	return (*metadataFieldSchemaReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataFieldSchema.
@@ -1514,22 +1514,22 @@ type MetadataSchemaReader interface {
 	Mutate() *MetadataSchema
 }
 
-type metadataSchemaReadonly struct{ v *MetadataSchema }
+type metadataSchemaReadonly MetadataSchema
 
 func (r *metadataSchemaReadonly) GetAccountFields() MetadataSchema_AccountFieldsMapReader {
-	return metadataSchema_accountFieldsMapReadonly(r.v.GetAccountFields())
+	return metadataSchema_accountFieldsMapReadonly((*MetadataSchema)(r).GetAccountFields())
 }
 
 func (r *metadataSchemaReadonly) GetTransactionFields() MetadataSchema_TransactionFieldsMapReader {
-	return metadataSchema_transactionFieldsMapReadonly(r.v.GetTransactionFields())
+	return metadataSchema_transactionFieldsMapReadonly((*MetadataSchema)(r).GetTransactionFields())
 }
 
 func (r *metadataSchemaReadonly) GetLedgerFields() MetadataSchema_LedgerFieldsMapReader {
-	return metadataSchema_ledgerFieldsMapReadonly(r.v.GetLedgerFields())
+	return metadataSchema_ledgerFieldsMapReadonly((*MetadataSchema)(r).GetLedgerFields())
 }
 
 func (r *metadataSchemaReadonly) Mutate() *MetadataSchema {
-	return r.v.CloneVT()
+	return (*MetadataSchema)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataSchema.
@@ -1537,7 +1537,7 @@ func (m *MetadataSchema) AsReader() MetadataSchemaReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataSchemaReadonly{v: m}
+	return (*metadataSchemaReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataSchema.
@@ -1684,22 +1684,22 @@ type SetMetadataFieldTypeCommandReader interface {
 	Mutate() *SetMetadataFieldTypeCommand
 }
 
-type setMetadataFieldTypeCommandReadonly struct{ v *SetMetadataFieldTypeCommand }
+type setMetadataFieldTypeCommandReadonly SetMetadataFieldTypeCommand
 
 func (r *setMetadataFieldTypeCommandReadonly) GetTargetType() TargetType {
-	return r.v.GetTargetType()
+	return (*SetMetadataFieldTypeCommand)(r).GetTargetType()
 }
 
 func (r *setMetadataFieldTypeCommandReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*SetMetadataFieldTypeCommand)(r).GetKey()
 }
 
 func (r *setMetadataFieldTypeCommandReadonly) GetType() MetadataType {
-	return r.v.GetType()
+	return (*SetMetadataFieldTypeCommand)(r).GetType()
 }
 
 func (r *setMetadataFieldTypeCommandReadonly) Mutate() *SetMetadataFieldTypeCommand {
-	return r.v.CloneVT()
+	return (*SetMetadataFieldTypeCommand)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMetadataFieldTypeCommand.
@@ -1707,7 +1707,7 @@ func (m *SetMetadataFieldTypeCommand) AsReader() SetMetadataFieldTypeCommandRead
 	if m == nil {
 		return nil
 	}
-	return &setMetadataFieldTypeCommandReadonly{v: m}
+	return (*setMetadataFieldTypeCommandReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMetadataFieldTypeCommand.
@@ -1760,18 +1760,18 @@ type MetadataIndexIDReader interface {
 	Mutate() *MetadataIndexID
 }
 
-type metadataIndexIDReadonly struct{ v *MetadataIndexID }
+type metadataIndexIDReadonly MetadataIndexID
 
 func (r *metadataIndexIDReadonly) GetTarget() TargetType {
-	return r.v.GetTarget()
+	return (*MetadataIndexID)(r).GetTarget()
 }
 
 func (r *metadataIndexIDReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*MetadataIndexID)(r).GetKey()
 }
 
 func (r *metadataIndexIDReadonly) Mutate() *MetadataIndexID {
-	return r.v.CloneVT()
+	return (*MetadataIndexID)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataIndexID.
@@ -1779,7 +1779,7 @@ func (m *MetadataIndexID) AsReader() MetadataIndexIDReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataIndexIDReadonly{v: m}
+	return (*metadataIndexIDReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataIndexID.
@@ -1831,14 +1831,14 @@ type IndexIDReader interface {
 	Mutate() *IndexID
 }
 
-type indexIDReadonly struct{ v *IndexID }
+type indexIDReadonly IndexID
 
 func (r *indexIDReadonly) GetKind() isIndexID_Kind {
-	return r.v.GetKind()
+	return (*IndexID)(r).GetKind()
 }
 
 func (r *indexIDReadonly) Mutate() *IndexID {
-	return r.v.CloneVT()
+	return (*IndexID)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IndexID.
@@ -1846,7 +1846,7 @@ func (m *IndexID) AsReader() IndexIDReader {
 	if m == nil {
 		return nil
 	}
-	return &indexIDReadonly{v: m}
+	return (*indexIDReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IndexID.
@@ -1902,10 +1902,10 @@ type IndexReader interface {
 	Mutate() *Index
 }
 
-type indexReadonly struct{ v *Index }
+type indexReadonly Index
 
 func (r *indexReadonly) GetId() IndexIDReader {
-	v := r.v.GetId()
+	v := (*Index)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -1913,11 +1913,11 @@ func (r *indexReadonly) GetId() IndexIDReader {
 }
 
 func (r *indexReadonly) GetBuildStatus() IndexBuildStatus {
-	return r.v.GetBuildStatus()
+	return (*Index)(r).GetBuildStatus()
 }
 
 func (r *indexReadonly) GetCreatedAt() TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*Index)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -1925,7 +1925,7 @@ func (r *indexReadonly) GetCreatedAt() TimestampReader {
 }
 
 func (r *indexReadonly) GetLastBuiltAt() TimestampReader {
-	v := r.v.GetLastBuiltAt()
+	v := (*Index)(r).GetLastBuiltAt()
 	if v == nil {
 		return nil
 	}
@@ -1933,19 +1933,19 @@ func (r *indexReadonly) GetLastBuiltAt() TimestampReader {
 }
 
 func (r *indexReadonly) GetLastError() string {
-	return r.v.GetLastError()
+	return (*Index)(r).GetLastError()
 }
 
 func (r *indexReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*Index)(r).GetLedger()
 }
 
 func (r *indexReadonly) GetForwardEncodingVersion() uint32 {
-	return r.v.GetForwardEncodingVersion()
+	return (*Index)(r).GetForwardEncodingVersion()
 }
 
 func (r *indexReadonly) Mutate() *Index {
-	return r.v.CloneVT()
+	return (*Index)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Index.
@@ -1953,7 +1953,7 @@ func (m *Index) AsReader() IndexReader {
 	if m == nil {
 		return nil
 	}
-	return &indexReadonly{v: m}
+	return (*indexReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Index.
@@ -2003,14 +2003,14 @@ type IdempotencyReader interface {
 	Mutate() *Idempotency
 }
 
-type idempotencyReadonly struct{ v *Idempotency }
+type idempotencyReadonly Idempotency
 
 func (r *idempotencyReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*Idempotency)(r).GetKey()
 }
 
 func (r *idempotencyReadonly) Mutate() *Idempotency {
-	return r.v.CloneVT()
+	return (*Idempotency)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Idempotency.
@@ -2018,7 +2018,7 @@ func (m *Idempotency) AsReader() IdempotencyReader {
 	if m == nil {
 		return nil
 	}
-	return &idempotencyReadonly{v: m}
+	return (*idempotencyReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Idempotency.
@@ -2071,18 +2071,18 @@ type IdempotencyEntryReader interface {
 	Mutate() *IdempotencyEntry
 }
 
-type idempotencyEntryReadonly struct{ v *IdempotencyEntry }
+type idempotencyEntryReadonly IdempotencyEntry
 
 func (r *idempotencyEntryReadonly) GetHash() []byte {
-	return bytes.Clone(r.v.GetHash())
+	return bytes.Clone((*IdempotencyEntry)(r).GetHash())
 }
 
 func (r *idempotencyEntryReadonly) GetLogId() uint64 {
-	return r.v.GetLogId()
+	return (*IdempotencyEntry)(r).GetLogId()
 }
 
 func (r *idempotencyEntryReadonly) Mutate() *IdempotencyEntry {
-	return r.v.CloneVT()
+	return (*IdempotencyEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IdempotencyEntry.
@@ -2090,7 +2090,7 @@ func (m *IdempotencyEntry) AsReader() IdempotencyEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &idempotencyEntryReadonly{v: m}
+	return (*idempotencyEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IdempotencyEntry.
@@ -2145,14 +2145,14 @@ type LogReader interface {
 	Mutate() *Log
 }
 
-type logReadonly struct{ v *Log }
+type logReadonly Log
 
 func (r *logReadonly) GetSequence() uint64 {
-	return r.v.GetSequence()
+	return (*Log)(r).GetSequence()
 }
 
 func (r *logReadonly) GetPayload() LogPayloadReader {
-	v := r.v.GetPayload()
+	v := (*Log)(r).GetPayload()
 	if v == nil {
 		return nil
 	}
@@ -2160,11 +2160,11 @@ func (r *logReadonly) GetPayload() LogPayloadReader {
 }
 
 func (r *logReadonly) GetReceipt() string {
-	return r.v.GetReceipt()
+	return (*Log)(r).GetReceipt()
 }
 
 func (r *logReadonly) GetResponseSignature() signaturepb.SignedLogReader {
-	v := r.v.GetResponseSignature()
+	v := (*Log)(r).GetResponseSignature()
 	if v == nil {
 		return nil
 	}
@@ -2172,7 +2172,7 @@ func (r *logReadonly) GetResponseSignature() signaturepb.SignedLogReader {
 }
 
 func (r *logReadonly) Mutate() *Log {
-	return r.v.CloneVT()
+	return (*Log)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Log.
@@ -2180,7 +2180,7 @@ func (m *Log) AsReader() LogReader {
 	if m == nil {
 		return nil
 	}
-	return &logReadonly{v: m}
+	return (*logReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Log.
@@ -2230,14 +2230,14 @@ type LogPayloadReader interface {
 	Mutate() *LogPayload
 }
 
-type logPayloadReadonly struct{ v *LogPayload }
+type logPayloadReadonly LogPayload
 
 func (r *logPayloadReadonly) GetType() isLogPayload_Type {
-	return r.v.GetType()
+	return (*LogPayload)(r).GetType()
 }
 
 func (r *logPayloadReadonly) Mutate() *LogPayload {
-	return r.v.CloneVT()
+	return (*LogPayload)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LogPayload.
@@ -2245,7 +2245,7 @@ func (m *LogPayload) AsReader() LogPayloadReader {
 	if m == nil {
 		return nil
 	}
-	return &logPayloadReadonly{v: m}
+	return (*logPayloadReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LogPayload.
@@ -2295,14 +2295,14 @@ type PromotedLedgerLogReader interface {
 	Mutate() *PromotedLedgerLog
 }
 
-type promotedLedgerLogReadonly struct{ v *PromotedLedgerLog }
+type promotedLedgerLogReadonly PromotedLedgerLog
 
 func (r *promotedLedgerLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*PromotedLedgerLog)(r).GetName()
 }
 
 func (r *promotedLedgerLogReadonly) Mutate() *PromotedLedgerLog {
-	return r.v.CloneVT()
+	return (*PromotedLedgerLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PromotedLedgerLog.
@@ -2310,7 +2310,7 @@ func (m *PromotedLedgerLog) AsReader() PromotedLedgerLogReader {
 	if m == nil {
 		return nil
 	}
-	return &promotedLedgerLogReadonly{v: m}
+	return (*promotedLedgerLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PromotedLedgerLog.
@@ -2364,22 +2364,22 @@ type RegisteredSigningKeyLogReader interface {
 	Mutate() *RegisteredSigningKeyLog
 }
 
-type registeredSigningKeyLogReadonly struct{ v *RegisteredSigningKeyLog }
+type registeredSigningKeyLogReadonly RegisteredSigningKeyLog
 
 func (r *registeredSigningKeyLogReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RegisteredSigningKeyLog)(r).GetKeyId()
 }
 
 func (r *registeredSigningKeyLogReadonly) GetPublicKey() []byte {
-	return bytes.Clone(r.v.GetPublicKey())
+	return bytes.Clone((*RegisteredSigningKeyLog)(r).GetPublicKey())
 }
 
 func (r *registeredSigningKeyLogReadonly) GetParentKeyId() string {
-	return r.v.GetParentKeyId()
+	return (*RegisteredSigningKeyLog)(r).GetParentKeyId()
 }
 
 func (r *registeredSigningKeyLogReadonly) Mutate() *RegisteredSigningKeyLog {
-	return r.v.CloneVT()
+	return (*RegisteredSigningKeyLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RegisteredSigningKeyLog.
@@ -2387,7 +2387,7 @@ func (m *RegisteredSigningKeyLog) AsReader() RegisteredSigningKeyLogReader {
 	if m == nil {
 		return nil
 	}
-	return &registeredSigningKeyLogReadonly{v: m}
+	return (*registeredSigningKeyLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RegisteredSigningKeyLog.
@@ -2440,18 +2440,18 @@ type RevokedSigningKeyLogReader interface {
 	Mutate() *RevokedSigningKeyLog
 }
 
-type revokedSigningKeyLogReadonly struct{ v *RevokedSigningKeyLog }
+type revokedSigningKeyLogReadonly RevokedSigningKeyLog
 
 func (r *revokedSigningKeyLogReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RevokedSigningKeyLog)(r).GetKeyId()
 }
 
 func (r *revokedSigningKeyLogReadonly) GetCascadedKeyIds() []string {
-	return slices.Clone(r.v.GetCascadedKeyIds())
+	return slices.Clone((*RevokedSigningKeyLog)(r).GetCascadedKeyIds())
 }
 
 func (r *revokedSigningKeyLogReadonly) Mutate() *RevokedSigningKeyLog {
-	return r.v.CloneVT()
+	return (*RevokedSigningKeyLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevokedSigningKeyLog.
@@ -2459,7 +2459,7 @@ func (m *RevokedSigningKeyLog) AsReader() RevokedSigningKeyLogReader {
 	if m == nil {
 		return nil
 	}
-	return &revokedSigningKeyLogReadonly{v: m}
+	return (*revokedSigningKeyLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevokedSigningKeyLog.
@@ -2513,22 +2513,22 @@ type SigningKeyReader interface {
 	Mutate() *SigningKey
 }
 
-type signingKeyReadonly struct{ v *SigningKey }
+type signingKeyReadonly SigningKey
 
 func (r *signingKeyReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*SigningKey)(r).GetKeyId()
 }
 
 func (r *signingKeyReadonly) GetPublicKey() []byte {
-	return bytes.Clone(r.v.GetPublicKey())
+	return bytes.Clone((*SigningKey)(r).GetPublicKey())
 }
 
 func (r *signingKeyReadonly) GetParentKeyId() string {
-	return r.v.GetParentKeyId()
+	return (*SigningKey)(r).GetParentKeyId()
 }
 
 func (r *signingKeyReadonly) Mutate() *SigningKey {
-	return r.v.CloneVT()
+	return (*SigningKey)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SigningKey.
@@ -2536,7 +2536,7 @@ func (m *SigningKey) AsReader() SigningKeyReader {
 	if m == nil {
 		return nil
 	}
-	return &signingKeyReadonly{v: m}
+	return (*signingKeyReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SigningKey.
@@ -2586,14 +2586,14 @@ type SetSigningConfigLogReader interface {
 	Mutate() *SetSigningConfigLog
 }
 
-type setSigningConfigLogReadonly struct{ v *SetSigningConfigLog }
+type setSigningConfigLogReadonly SetSigningConfigLog
 
 func (r *setSigningConfigLogReadonly) GetRequireSignatures() bool {
-	return r.v.GetRequireSignatures()
+	return (*SetSigningConfigLog)(r).GetRequireSignatures()
 }
 
 func (r *setSigningConfigLogReadonly) Mutate() *SetSigningConfigLog {
-	return r.v.CloneVT()
+	return (*SetSigningConfigLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetSigningConfigLog.
@@ -2601,7 +2601,7 @@ func (m *SetSigningConfigLog) AsReader() SetSigningConfigLogReader {
 	if m == nil {
 		return nil
 	}
-	return &setSigningConfigLogReadonly{v: m}
+	return (*setSigningConfigLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetSigningConfigLog.
@@ -2653,10 +2653,10 @@ type AddedEventsSinkLogReader interface {
 	Mutate() *AddedEventsSinkLog
 }
 
-type addedEventsSinkLogReadonly struct{ v *AddedEventsSinkLog }
+type addedEventsSinkLogReadonly AddedEventsSinkLog
 
 func (r *addedEventsSinkLogReadonly) GetConfig() SinkConfigReader {
-	v := r.v.GetConfig()
+	v := (*AddedEventsSinkLog)(r).GetConfig()
 	if v == nil {
 		return nil
 	}
@@ -2664,7 +2664,7 @@ func (r *addedEventsSinkLogReadonly) GetConfig() SinkConfigReader {
 }
 
 func (r *addedEventsSinkLogReadonly) Mutate() *AddedEventsSinkLog {
-	return r.v.CloneVT()
+	return (*AddedEventsSinkLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddedEventsSinkLog.
@@ -2672,7 +2672,7 @@ func (m *AddedEventsSinkLog) AsReader() AddedEventsSinkLogReader {
 	if m == nil {
 		return nil
 	}
-	return &addedEventsSinkLogReadonly{v: m}
+	return (*addedEventsSinkLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddedEventsSinkLog.
@@ -2724,14 +2724,14 @@ type RemovedEventsSinkLogReader interface {
 	Mutate() *RemovedEventsSinkLog
 }
 
-type removedEventsSinkLogReadonly struct{ v *RemovedEventsSinkLog }
+type removedEventsSinkLogReadonly RemovedEventsSinkLog
 
 func (r *removedEventsSinkLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemovedEventsSinkLog)(r).GetName()
 }
 
 func (r *removedEventsSinkLogReadonly) Mutate() *RemovedEventsSinkLog {
-	return r.v.CloneVT()
+	return (*RemovedEventsSinkLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemovedEventsSinkLog.
@@ -2739,7 +2739,7 @@ func (m *RemovedEventsSinkLog) AsReader() RemovedEventsSinkLogReader {
 	if m == nil {
 		return nil
 	}
-	return &removedEventsSinkLogReadonly{v: m}
+	return (*removedEventsSinkLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemovedEventsSinkLog.
@@ -2791,14 +2791,14 @@ type SetMaintenanceModeLogReader interface {
 	Mutate() *SetMaintenanceModeLog
 }
 
-type setMaintenanceModeLogReadonly struct{ v *SetMaintenanceModeLog }
+type setMaintenanceModeLogReadonly SetMaintenanceModeLog
 
 func (r *setMaintenanceModeLogReadonly) GetEnabled() bool {
-	return r.v.GetEnabled()
+	return (*SetMaintenanceModeLog)(r).GetEnabled()
 }
 
 func (r *setMaintenanceModeLogReadonly) Mutate() *SetMaintenanceModeLog {
-	return r.v.CloneVT()
+	return (*SetMaintenanceModeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMaintenanceModeLog.
@@ -2806,7 +2806,7 @@ func (m *SetMaintenanceModeLog) AsReader() SetMaintenanceModeLogReader {
 	if m == nil {
 		return nil
 	}
-	return &setMaintenanceModeLogReadonly{v: m}
+	return (*setMaintenanceModeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMaintenanceModeLog.
@@ -2859,18 +2859,18 @@ type BloomTypeConfigReader interface {
 	Mutate() *BloomTypeConfig
 }
 
-type bloomTypeConfigReadonly struct{ v *BloomTypeConfig }
+type bloomTypeConfigReadonly BloomTypeConfig
 
 func (r *bloomTypeConfigReadonly) GetExpectedKeys() uint64 {
-	return r.v.GetExpectedKeys()
+	return (*BloomTypeConfig)(r).GetExpectedKeys()
 }
 
 func (r *bloomTypeConfigReadonly) GetFpRate() float64 {
-	return r.v.GetFpRate()
+	return (*BloomTypeConfig)(r).GetFpRate()
 }
 
 func (r *bloomTypeConfigReadonly) Mutate() *BloomTypeConfig {
-	return r.v.CloneVT()
+	return (*BloomTypeConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BloomTypeConfig.
@@ -2878,7 +2878,7 @@ func (m *BloomTypeConfig) AsReader() BloomTypeConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &bloomTypeConfigReadonly{v: m}
+	return (*bloomTypeConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BloomTypeConfig.
@@ -2943,14 +2943,14 @@ type ClusterConfigReader interface {
 	Mutate() *ClusterConfig
 }
 
-type clusterConfigReadonly struct{ v *ClusterConfig }
+type clusterConfigReadonly ClusterConfig
 
 func (r *clusterConfigReadonly) GetRotationThreshold() uint64 {
-	return r.v.GetRotationThreshold()
+	return (*ClusterConfig)(r).GetRotationThreshold()
 }
 
 func (r *clusterConfigReadonly) GetBloomVolumes() BloomTypeConfigReader {
-	v := r.v.GetBloomVolumes()
+	v := (*ClusterConfig)(r).GetBloomVolumes()
 	if v == nil {
 		return nil
 	}
@@ -2958,7 +2958,7 @@ func (r *clusterConfigReadonly) GetBloomVolumes() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomMetadata() BloomTypeConfigReader {
-	v := r.v.GetBloomMetadata()
+	v := (*ClusterConfig)(r).GetBloomMetadata()
 	if v == nil {
 		return nil
 	}
@@ -2966,7 +2966,7 @@ func (r *clusterConfigReadonly) GetBloomMetadata() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomReferences() BloomTypeConfigReader {
-	v := r.v.GetBloomReferences()
+	v := (*ClusterConfig)(r).GetBloomReferences()
 	if v == nil {
 		return nil
 	}
@@ -2974,7 +2974,7 @@ func (r *clusterConfigReadonly) GetBloomReferences() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomLedgers() BloomTypeConfigReader {
-	v := r.v.GetBloomLedgers()
+	v := (*ClusterConfig)(r).GetBloomLedgers()
 	if v == nil {
 		return nil
 	}
@@ -2982,7 +2982,7 @@ func (r *clusterConfigReadonly) GetBloomLedgers() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomBoundaries() BloomTypeConfigReader {
-	v := r.v.GetBloomBoundaries()
+	v := (*ClusterConfig)(r).GetBloomBoundaries()
 	if v == nil {
 		return nil
 	}
@@ -2990,7 +2990,7 @@ func (r *clusterConfigReadonly) GetBloomBoundaries() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomTransactions() BloomTypeConfigReader {
-	v := r.v.GetBloomTransactions()
+	v := (*ClusterConfig)(r).GetBloomTransactions()
 	if v == nil {
 		return nil
 	}
@@ -2998,7 +2998,7 @@ func (r *clusterConfigReadonly) GetBloomTransactions() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomSinkConfigs() BloomTypeConfigReader {
-	v := r.v.GetBloomSinkConfigs()
+	v := (*ClusterConfig)(r).GetBloomSinkConfigs()
 	if v == nil {
 		return nil
 	}
@@ -3006,7 +3006,7 @@ func (r *clusterConfigReadonly) GetBloomSinkConfigs() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomNumscriptVersions() BloomTypeConfigReader {
-	v := r.v.GetBloomNumscriptVersions()
+	v := (*ClusterConfig)(r).GetBloomNumscriptVersions()
 	if v == nil {
 		return nil
 	}
@@ -3014,7 +3014,7 @@ func (r *clusterConfigReadonly) GetBloomNumscriptVersions() BloomTypeConfigReade
 }
 
 func (r *clusterConfigReadonly) GetBloomNumscriptContents() BloomTypeConfigReader {
-	v := r.v.GetBloomNumscriptContents()
+	v := (*ClusterConfig)(r).GetBloomNumscriptContents()
 	if v == nil {
 		return nil
 	}
@@ -3022,11 +3022,11 @@ func (r *clusterConfigReadonly) GetBloomNumscriptContents() BloomTypeConfigReade
 }
 
 func (r *clusterConfigReadonly) GetHashAlgorithm() HashAlgorithm {
-	return r.v.GetHashAlgorithm()
+	return (*ClusterConfig)(r).GetHashAlgorithm()
 }
 
 func (r *clusterConfigReadonly) GetBloomLedgerMetadata() BloomTypeConfigReader {
-	v := r.v.GetBloomLedgerMetadata()
+	v := (*ClusterConfig)(r).GetBloomLedgerMetadata()
 	if v == nil {
 		return nil
 	}
@@ -3034,7 +3034,7 @@ func (r *clusterConfigReadonly) GetBloomLedgerMetadata() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) GetBloomPreparedQueries() BloomTypeConfigReader {
-	v := r.v.GetBloomPreparedQueries()
+	v := (*ClusterConfig)(r).GetBloomPreparedQueries()
 	if v == nil {
 		return nil
 	}
@@ -3042,7 +3042,7 @@ func (r *clusterConfigReadonly) GetBloomPreparedQueries() BloomTypeConfigReader 
 }
 
 func (r *clusterConfigReadonly) GetBloomIndexes() BloomTypeConfigReader {
-	v := r.v.GetBloomIndexes()
+	v := (*ClusterConfig)(r).GetBloomIndexes()
 	if v == nil {
 		return nil
 	}
@@ -3050,7 +3050,7 @@ func (r *clusterConfigReadonly) GetBloomIndexes() BloomTypeConfigReader {
 }
 
 func (r *clusterConfigReadonly) Mutate() *ClusterConfig {
-	return r.v.CloneVT()
+	return (*ClusterConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ClusterConfig.
@@ -3058,7 +3058,7 @@ func (m *ClusterConfig) AsReader() ClusterConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &clusterConfigReadonly{v: m}
+	return (*clusterConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ClusterConfig.
@@ -3111,10 +3111,10 @@ type PersistedClusterStateReader interface {
 	Mutate() *PersistedClusterState
 }
 
-type persistedClusterStateReadonly struct{ v *PersistedClusterState }
+type persistedClusterStateReadonly PersistedClusterState
 
 func (r *persistedClusterStateReadonly) GetConfig() ClusterConfigReader {
-	v := r.v.GetConfig()
+	v := (*PersistedClusterState)(r).GetConfig()
 	if v == nil {
 		return nil
 	}
@@ -3122,11 +3122,11 @@ func (r *persistedClusterStateReadonly) GetConfig() ClusterConfigReader {
 }
 
 func (r *persistedClusterStateReadonly) GetCacheEpoch() uint64 {
-	return r.v.GetCacheEpoch()
+	return (*PersistedClusterState)(r).GetCacheEpoch()
 }
 
 func (r *persistedClusterStateReadonly) Mutate() *PersistedClusterState {
-	return r.v.CloneVT()
+	return (*PersistedClusterState)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PersistedClusterState.
@@ -3134,7 +3134,7 @@ func (m *PersistedClusterState) AsReader() PersistedClusterStateReader {
 	if m == nil {
 		return nil
 	}
-	return &persistedClusterStateReadonly{v: m}
+	return (*persistedClusterStateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PersistedClusterState.
@@ -3186,14 +3186,14 @@ type SetChapterScheduleLogReader interface {
 	Mutate() *SetChapterScheduleLog
 }
 
-type setChapterScheduleLogReadonly struct{ v *SetChapterScheduleLog }
+type setChapterScheduleLogReadonly SetChapterScheduleLog
 
 func (r *setChapterScheduleLogReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetChapterScheduleLog)(r).GetCron()
 }
 
 func (r *setChapterScheduleLogReadonly) Mutate() *SetChapterScheduleLog {
-	return r.v.CloneVT()
+	return (*SetChapterScheduleLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetChapterScheduleLog.
@@ -3201,7 +3201,7 @@ func (m *SetChapterScheduleLog) AsReader() SetChapterScheduleLogReader {
 	if m == nil {
 		return nil
 	}
-	return &setChapterScheduleLogReadonly{v: m}
+	return (*setChapterScheduleLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetChapterScheduleLog.
@@ -3252,10 +3252,10 @@ type DeletedChapterScheduleLogReader interface {
 	Mutate() *DeletedChapterScheduleLog
 }
 
-type deletedChapterScheduleLogReadonly struct{ v *DeletedChapterScheduleLog }
+type deletedChapterScheduleLogReadonly DeletedChapterScheduleLog
 
 func (r *deletedChapterScheduleLogReadonly) Mutate() *DeletedChapterScheduleLog {
-	return r.v.CloneVT()
+	return (*DeletedChapterScheduleLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedChapterScheduleLog.
@@ -3263,7 +3263,7 @@ func (m *DeletedChapterScheduleLog) AsReader() DeletedChapterScheduleLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedChapterScheduleLogReadonly{v: m}
+	return (*deletedChapterScheduleLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedChapterScheduleLog.
@@ -3316,14 +3316,14 @@ type CreatedPreparedQueryLogReader interface {
 	Mutate() *CreatedPreparedQueryLog
 }
 
-type createdPreparedQueryLogReadonly struct{ v *CreatedPreparedQueryLog }
+type createdPreparedQueryLogReadonly CreatedPreparedQueryLog
 
 func (r *createdPreparedQueryLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*CreatedPreparedQueryLog)(r).GetLedger()
 }
 
 func (r *createdPreparedQueryLogReadonly) GetQuery() PreparedQueryReader {
-	v := r.v.GetQuery()
+	v := (*CreatedPreparedQueryLog)(r).GetQuery()
 	if v == nil {
 		return nil
 	}
@@ -3331,7 +3331,7 @@ func (r *createdPreparedQueryLogReadonly) GetQuery() PreparedQueryReader {
 }
 
 func (r *createdPreparedQueryLogReadonly) Mutate() *CreatedPreparedQueryLog {
-	return r.v.CloneVT()
+	return (*CreatedPreparedQueryLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedPreparedQueryLog.
@@ -3339,7 +3339,7 @@ func (m *CreatedPreparedQueryLog) AsReader() CreatedPreparedQueryLogReader {
 	if m == nil {
 		return nil
 	}
-	return &createdPreparedQueryLogReadonly{v: m}
+	return (*createdPreparedQueryLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedPreparedQueryLog.
@@ -3394,18 +3394,18 @@ type UpdatedPreparedQueryLogReader interface {
 	Mutate() *UpdatedPreparedQueryLog
 }
 
-type updatedPreparedQueryLogReadonly struct{ v *UpdatedPreparedQueryLog }
+type updatedPreparedQueryLogReadonly UpdatedPreparedQueryLog
 
 func (r *updatedPreparedQueryLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*UpdatedPreparedQueryLog)(r).GetLedger()
 }
 
 func (r *updatedPreparedQueryLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*UpdatedPreparedQueryLog)(r).GetName()
 }
 
 func (r *updatedPreparedQueryLogReadonly) GetPreviousFilter() QueryFilterReader {
-	v := r.v.GetPreviousFilter()
+	v := (*UpdatedPreparedQueryLog)(r).GetPreviousFilter()
 	if v == nil {
 		return nil
 	}
@@ -3413,7 +3413,7 @@ func (r *updatedPreparedQueryLogReadonly) GetPreviousFilter() QueryFilterReader 
 }
 
 func (r *updatedPreparedQueryLogReadonly) GetNewFilter() QueryFilterReader {
-	v := r.v.GetNewFilter()
+	v := (*UpdatedPreparedQueryLog)(r).GetNewFilter()
 	if v == nil {
 		return nil
 	}
@@ -3421,7 +3421,7 @@ func (r *updatedPreparedQueryLogReadonly) GetNewFilter() QueryFilterReader {
 }
 
 func (r *updatedPreparedQueryLogReadonly) Mutate() *UpdatedPreparedQueryLog {
-	return r.v.CloneVT()
+	return (*UpdatedPreparedQueryLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdatedPreparedQueryLog.
@@ -3429,7 +3429,7 @@ func (m *UpdatedPreparedQueryLog) AsReader() UpdatedPreparedQueryLogReader {
 	if m == nil {
 		return nil
 	}
-	return &updatedPreparedQueryLogReadonly{v: m}
+	return (*updatedPreparedQueryLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdatedPreparedQueryLog.
@@ -3482,18 +3482,18 @@ type DeletedPreparedQueryLogReader interface {
 	Mutate() *DeletedPreparedQueryLog
 }
 
-type deletedPreparedQueryLogReadonly struct{ v *DeletedPreparedQueryLog }
+type deletedPreparedQueryLogReadonly DeletedPreparedQueryLog
 
 func (r *deletedPreparedQueryLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeletedPreparedQueryLog)(r).GetLedger()
 }
 
 func (r *deletedPreparedQueryLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeletedPreparedQueryLog)(r).GetName()
 }
 
 func (r *deletedPreparedQueryLogReadonly) Mutate() *DeletedPreparedQueryLog {
-	return r.v.CloneVT()
+	return (*DeletedPreparedQueryLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedPreparedQueryLog.
@@ -3501,7 +3501,7 @@ func (m *DeletedPreparedQueryLog) AsReader() DeletedPreparedQueryLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedPreparedQueryLogReadonly{v: m}
+	return (*deletedPreparedQueryLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedPreparedQueryLog.
@@ -3554,18 +3554,18 @@ type SavedLedgerMetadataLogReader interface {
 	Mutate() *SavedLedgerMetadataLog
 }
 
-type savedLedgerMetadataLogReadonly struct{ v *SavedLedgerMetadataLog }
+type savedLedgerMetadataLogReadonly SavedLedgerMetadataLog
 
 func (r *savedLedgerMetadataLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*SavedLedgerMetadataLog)(r).GetLedger()
 }
 
 func (r *savedLedgerMetadataLogReadonly) GetMetadata() SavedLedgerMetadataLog_MetadataMapReader {
-	return savedLedgerMetadataLog_metadataMapReadonly(r.v.GetMetadata())
+	return savedLedgerMetadataLog_metadataMapReadonly((*SavedLedgerMetadataLog)(r).GetMetadata())
 }
 
 func (r *savedLedgerMetadataLogReadonly) Mutate() *SavedLedgerMetadataLog {
-	return r.v.CloneVT()
+	return (*SavedLedgerMetadataLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SavedLedgerMetadataLog.
@@ -3573,7 +3573,7 @@ func (m *SavedLedgerMetadataLog) AsReader() SavedLedgerMetadataLogReader {
 	if m == nil {
 		return nil
 	}
-	return &savedLedgerMetadataLogReadonly{v: m}
+	return (*savedLedgerMetadataLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SavedLedgerMetadataLog.
@@ -3657,18 +3657,18 @@ type DeletedLedgerMetadataLogReader interface {
 	Mutate() *DeletedLedgerMetadataLog
 }
 
-type deletedLedgerMetadataLogReadonly struct{ v *DeletedLedgerMetadataLog }
+type deletedLedgerMetadataLogReadonly DeletedLedgerMetadataLog
 
 func (r *deletedLedgerMetadataLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeletedLedgerMetadataLog)(r).GetLedger()
 }
 
 func (r *deletedLedgerMetadataLogReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeletedLedgerMetadataLog)(r).GetKey()
 }
 
 func (r *deletedLedgerMetadataLogReadonly) Mutate() *DeletedLedgerMetadataLog {
-	return r.v.CloneVT()
+	return (*DeletedLedgerMetadataLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedLedgerMetadataLog.
@@ -3676,7 +3676,7 @@ func (m *DeletedLedgerMetadataLog) AsReader() DeletedLedgerMetadataLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedLedgerMetadataLogReadonly{v: m}
+	return (*deletedLedgerMetadataLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedLedgerMetadataLog.
@@ -3732,22 +3732,22 @@ type NumscriptInfoReader interface {
 	Mutate() *NumscriptInfo
 }
 
-type numscriptInfoReadonly struct{ v *NumscriptInfo }
+type numscriptInfoReadonly NumscriptInfo
 
 func (r *numscriptInfoReadonly) GetName() string {
-	return r.v.GetName()
+	return (*NumscriptInfo)(r).GetName()
 }
 
 func (r *numscriptInfoReadonly) GetContent() string {
-	return r.v.GetContent()
+	return (*NumscriptInfo)(r).GetContent()
 }
 
 func (r *numscriptInfoReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*NumscriptInfo)(r).GetVersion()
 }
 
 func (r *numscriptInfoReadonly) GetCreatedAt() TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*NumscriptInfo)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -3755,11 +3755,11 @@ func (r *numscriptInfoReadonly) GetCreatedAt() TimestampReader {
 }
 
 func (r *numscriptInfoReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*NumscriptInfo)(r).GetLedger()
 }
 
 func (r *numscriptInfoReadonly) Mutate() *NumscriptInfo {
-	return r.v.CloneVT()
+	return (*NumscriptInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NumscriptInfo.
@@ -3767,7 +3767,7 @@ func (m *NumscriptInfo) AsReader() NumscriptInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &numscriptInfoReadonly{v: m}
+	return (*numscriptInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NumscriptInfo.
@@ -3819,10 +3819,10 @@ type SavedNumscriptLogReader interface {
 	Mutate() *SavedNumscriptLog
 }
 
-type savedNumscriptLogReadonly struct{ v *SavedNumscriptLog }
+type savedNumscriptLogReadonly SavedNumscriptLog
 
 func (r *savedNumscriptLogReadonly) GetInfo() NumscriptInfoReader {
-	v := r.v.GetInfo()
+	v := (*SavedNumscriptLog)(r).GetInfo()
 	if v == nil {
 		return nil
 	}
@@ -3830,7 +3830,7 @@ func (r *savedNumscriptLogReadonly) GetInfo() NumscriptInfoReader {
 }
 
 func (r *savedNumscriptLogReadonly) Mutate() *SavedNumscriptLog {
-	return r.v.CloneVT()
+	return (*SavedNumscriptLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SavedNumscriptLog.
@@ -3838,7 +3838,7 @@ func (m *SavedNumscriptLog) AsReader() SavedNumscriptLogReader {
 	if m == nil {
 		return nil
 	}
-	return &savedNumscriptLogReadonly{v: m}
+	return (*savedNumscriptLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SavedNumscriptLog.
@@ -3891,18 +3891,18 @@ type DeletedNumscriptLogReader interface {
 	Mutate() *DeletedNumscriptLog
 }
 
-type deletedNumscriptLogReadonly struct{ v *DeletedNumscriptLog }
+type deletedNumscriptLogReadonly DeletedNumscriptLog
 
 func (r *deletedNumscriptLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeletedNumscriptLog)(r).GetName()
 }
 
 func (r *deletedNumscriptLogReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeletedNumscriptLog)(r).GetLedger()
 }
 
 func (r *deletedNumscriptLogReadonly) Mutate() *DeletedNumscriptLog {
-	return r.v.CloneVT()
+	return (*DeletedNumscriptLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedNumscriptLog.
@@ -3910,7 +3910,7 @@ func (m *DeletedNumscriptLog) AsReader() DeletedNumscriptLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedNumscriptLogReadonly{v: m}
+	return (*deletedNumscriptLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedNumscriptLog.
@@ -3962,16 +3962,14 @@ type SetQueryCheckpointScheduleLogReader interface {
 	Mutate() *SetQueryCheckpointScheduleLog
 }
 
-type setQueryCheckpointScheduleLogReadonly struct {
-	v *SetQueryCheckpointScheduleLog
-}
+type setQueryCheckpointScheduleLogReadonly SetQueryCheckpointScheduleLog
 
 func (r *setQueryCheckpointScheduleLogReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetQueryCheckpointScheduleLog)(r).GetCron()
 }
 
 func (r *setQueryCheckpointScheduleLogReadonly) Mutate() *SetQueryCheckpointScheduleLog {
-	return r.v.CloneVT()
+	return (*SetQueryCheckpointScheduleLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetQueryCheckpointScheduleLog.
@@ -3979,7 +3977,7 @@ func (m *SetQueryCheckpointScheduleLog) AsReader() SetQueryCheckpointScheduleLog
 	if m == nil {
 		return nil
 	}
-	return &setQueryCheckpointScheduleLogReadonly{v: m}
+	return (*setQueryCheckpointScheduleLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetQueryCheckpointScheduleLog.
@@ -4030,12 +4028,10 @@ type DeletedQueryCheckpointScheduleLogReader interface {
 	Mutate() *DeletedQueryCheckpointScheduleLog
 }
 
-type deletedQueryCheckpointScheduleLogReadonly struct {
-	v *DeletedQueryCheckpointScheduleLog
-}
+type deletedQueryCheckpointScheduleLogReadonly DeletedQueryCheckpointScheduleLog
 
 func (r *deletedQueryCheckpointScheduleLogReadonly) Mutate() *DeletedQueryCheckpointScheduleLog {
-	return r.v.CloneVT()
+	return (*DeletedQueryCheckpointScheduleLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedQueryCheckpointScheduleLog.
@@ -4043,7 +4039,7 @@ func (m *DeletedQueryCheckpointScheduleLog) AsReader() DeletedQueryCheckpointSch
 	if m == nil {
 		return nil
 	}
-	return &deletedQueryCheckpointScheduleLogReadonly{v: m}
+	return (*deletedQueryCheckpointScheduleLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedQueryCheckpointScheduleLog.
@@ -4096,18 +4092,18 @@ type CreatedQueryCheckpointLogReader interface {
 	Mutate() *CreatedQueryCheckpointLog
 }
 
-type createdQueryCheckpointLogReadonly struct{ v *CreatedQueryCheckpointLog }
+type createdQueryCheckpointLogReadonly CreatedQueryCheckpointLog
 
 func (r *createdQueryCheckpointLogReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*CreatedQueryCheckpointLog)(r).GetCheckpointId()
 }
 
 func (r *createdQueryCheckpointLogReadonly) GetMaxSequence() uint64 {
-	return r.v.GetMaxSequence()
+	return (*CreatedQueryCheckpointLog)(r).GetMaxSequence()
 }
 
 func (r *createdQueryCheckpointLogReadonly) Mutate() *CreatedQueryCheckpointLog {
-	return r.v.CloneVT()
+	return (*CreatedQueryCheckpointLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedQueryCheckpointLog.
@@ -4115,7 +4111,7 @@ func (m *CreatedQueryCheckpointLog) AsReader() CreatedQueryCheckpointLogReader {
 	if m == nil {
 		return nil
 	}
-	return &createdQueryCheckpointLogReadonly{v: m}
+	return (*createdQueryCheckpointLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedQueryCheckpointLog.
@@ -4167,14 +4163,14 @@ type DeletedQueryCheckpointLogReader interface {
 	Mutate() *DeletedQueryCheckpointLog
 }
 
-type deletedQueryCheckpointLogReadonly struct{ v *DeletedQueryCheckpointLog }
+type deletedQueryCheckpointLogReadonly DeletedQueryCheckpointLog
 
 func (r *deletedQueryCheckpointLogReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*DeletedQueryCheckpointLog)(r).GetCheckpointId()
 }
 
 func (r *deletedQueryCheckpointLogReadonly) Mutate() *DeletedQueryCheckpointLog {
-	return r.v.CloneVT()
+	return (*DeletedQueryCheckpointLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedQueryCheckpointLog.
@@ -4182,7 +4178,7 @@ func (m *DeletedQueryCheckpointLog) AsReader() DeletedQueryCheckpointLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedQueryCheckpointLogReadonly{v: m}
+	return (*deletedQueryCheckpointLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedQueryCheckpointLog.
@@ -4239,34 +4235,34 @@ type SinkConfigReader interface {
 	Mutate() *SinkConfig
 }
 
-type sinkConfigReadonly struct{ v *SinkConfig }
+type sinkConfigReadonly SinkConfig
 
 func (r *sinkConfigReadonly) GetName() string {
-	return r.v.GetName()
+	return (*SinkConfig)(r).GetName()
 }
 
 func (r *sinkConfigReadonly) GetFormat() string {
-	return r.v.GetFormat()
+	return (*SinkConfig)(r).GetFormat()
 }
 
 func (r *sinkConfigReadonly) GetBatchSize() int32 {
-	return r.v.GetBatchSize()
+	return (*SinkConfig)(r).GetBatchSize()
 }
 
 func (r *sinkConfigReadonly) GetBatchDelayMs() int64 {
-	return r.v.GetBatchDelayMs()
+	return (*SinkConfig)(r).GetBatchDelayMs()
 }
 
 func (r *sinkConfigReadonly) GetEventTypes() []EventType {
-	return slices.Clone(r.v.GetEventTypes())
+	return slices.Clone((*SinkConfig)(r).GetEventTypes())
 }
 
 func (r *sinkConfigReadonly) GetType() isSinkConfig_Type {
-	return r.v.GetType()
+	return (*SinkConfig)(r).GetType()
 }
 
 func (r *sinkConfigReadonly) Mutate() *SinkConfig {
-	return r.v.CloneVT()
+	return (*SinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SinkConfig.
@@ -4274,7 +4270,7 @@ func (m *SinkConfig) AsReader() SinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &sinkConfigReadonly{v: m}
+	return (*sinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SinkConfig.
@@ -4326,18 +4322,18 @@ type SinkStatusReader interface {
 	Mutate() *SinkStatus
 }
 
-type sinkStatusReadonly struct{ v *SinkStatus }
+type sinkStatusReadonly SinkStatus
 
 func (r *sinkStatusReadonly) GetSinkName() string {
-	return r.v.GetSinkName()
+	return (*SinkStatus)(r).GetSinkName()
 }
 
 func (r *sinkStatusReadonly) GetCursor() uint64 {
-	return r.v.GetCursor()
+	return (*SinkStatus)(r).GetCursor()
 }
 
 func (r *sinkStatusReadonly) GetError() SinkErrorReader {
-	v := r.v.GetError()
+	v := (*SinkStatus)(r).GetError()
 	if v == nil {
 		return nil
 	}
@@ -4345,7 +4341,7 @@ func (r *sinkStatusReadonly) GetError() SinkErrorReader {
 }
 
 func (r *sinkStatusReadonly) Mutate() *SinkStatus {
-	return r.v.CloneVT()
+	return (*SinkStatus)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SinkStatus.
@@ -4353,7 +4349,7 @@ func (m *SinkStatus) AsReader() SinkStatusReader {
 	if m == nil {
 		return nil
 	}
-	return &sinkStatusReadonly{v: m}
+	return (*sinkStatusReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SinkStatus.
@@ -4404,14 +4400,14 @@ type SinkErrorReader interface {
 	Mutate() *SinkError
 }
 
-type sinkErrorReadonly struct{ v *SinkError }
+type sinkErrorReadonly SinkError
 
 func (r *sinkErrorReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*SinkError)(r).GetMessage()
 }
 
 func (r *sinkErrorReadonly) GetOccurredAt() TimestampReader {
-	v := r.v.GetOccurredAt()
+	v := (*SinkError)(r).GetOccurredAt()
 	if v == nil {
 		return nil
 	}
@@ -4419,7 +4415,7 @@ func (r *sinkErrorReadonly) GetOccurredAt() TimestampReader {
 }
 
 func (r *sinkErrorReadonly) Mutate() *SinkError {
-	return r.v.CloneVT()
+	return (*SinkError)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SinkError.
@@ -4427,7 +4423,7 @@ func (m *SinkError) AsReader() SinkErrorReader {
 	if m == nil {
 		return nil
 	}
-	return &sinkErrorReadonly{v: m}
+	return (*sinkErrorReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SinkError.
@@ -4478,18 +4474,18 @@ type NatsSinkConfigReader interface {
 	Mutate() *NatsSinkConfig
 }
 
-type natsSinkConfigReadonly struct{ v *NatsSinkConfig }
+type natsSinkConfigReadonly NatsSinkConfig
 
 func (r *natsSinkConfigReadonly) GetUrl() string {
-	return r.v.GetUrl()
+	return (*NatsSinkConfig)(r).GetUrl()
 }
 
 func (r *natsSinkConfigReadonly) GetTopic() string {
-	return r.v.GetTopic()
+	return (*NatsSinkConfig)(r).GetTopic()
 }
 
 func (r *natsSinkConfigReadonly) Mutate() *NatsSinkConfig {
-	return r.v.CloneVT()
+	return (*NatsSinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NatsSinkConfig.
@@ -4497,7 +4493,7 @@ func (m *NatsSinkConfig) AsReader() NatsSinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &natsSinkConfigReadonly{v: m}
+	return (*natsSinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NatsSinkConfig.
@@ -4550,18 +4546,18 @@ type ClickHouseSinkConfigReader interface {
 	Mutate() *ClickHouseSinkConfig
 }
 
-type clickHouseSinkConfigReadonly struct{ v *ClickHouseSinkConfig }
+type clickHouseSinkConfigReadonly ClickHouseSinkConfig
 
 func (r *clickHouseSinkConfigReadonly) GetDsn() string {
-	return r.v.GetDsn()
+	return (*ClickHouseSinkConfig)(r).GetDsn()
 }
 
 func (r *clickHouseSinkConfigReadonly) GetTable() string {
-	return r.v.GetTable()
+	return (*ClickHouseSinkConfig)(r).GetTable()
 }
 
 func (r *clickHouseSinkConfigReadonly) Mutate() *ClickHouseSinkConfig {
-	return r.v.CloneVT()
+	return (*ClickHouseSinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ClickHouseSinkConfig.
@@ -4569,7 +4565,7 @@ func (m *ClickHouseSinkConfig) AsReader() ClickHouseSinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &clickHouseSinkConfigReadonly{v: m}
+	return (*clickHouseSinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ClickHouseSinkConfig.
@@ -4626,34 +4622,34 @@ type KafkaSinkConfigReader interface {
 	Mutate() *KafkaSinkConfig
 }
 
-type kafkaSinkConfigReadonly struct{ v *KafkaSinkConfig }
+type kafkaSinkConfigReadonly KafkaSinkConfig
 
 func (r *kafkaSinkConfigReadonly) GetBrokers() []string {
-	return slices.Clone(r.v.GetBrokers())
+	return slices.Clone((*KafkaSinkConfig)(r).GetBrokers())
 }
 
 func (r *kafkaSinkConfigReadonly) GetTopic() string {
-	return r.v.GetTopic()
+	return (*KafkaSinkConfig)(r).GetTopic()
 }
 
 func (r *kafkaSinkConfigReadonly) GetTls() bool {
-	return r.v.GetTls()
+	return (*KafkaSinkConfig)(r).GetTls()
 }
 
 func (r *kafkaSinkConfigReadonly) GetSaslMechanism() string {
-	return r.v.GetSaslMechanism()
+	return (*KafkaSinkConfig)(r).GetSaslMechanism()
 }
 
 func (r *kafkaSinkConfigReadonly) GetSaslUsername() string {
-	return r.v.GetSaslUsername()
+	return (*KafkaSinkConfig)(r).GetSaslUsername()
 }
 
 func (r *kafkaSinkConfigReadonly) GetSaslPassword() string {
-	return r.v.GetSaslPassword()
+	return (*KafkaSinkConfig)(r).GetSaslPassword()
 }
 
 func (r *kafkaSinkConfigReadonly) Mutate() *KafkaSinkConfig {
-	return r.v.CloneVT()
+	return (*KafkaSinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this KafkaSinkConfig.
@@ -4661,7 +4657,7 @@ func (m *KafkaSinkConfig) AsReader() KafkaSinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &kafkaSinkConfigReadonly{v: m}
+	return (*kafkaSinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this KafkaSinkConfig.
@@ -4714,18 +4710,18 @@ type HttpSinkConfigReader interface {
 	Mutate() *HttpSinkConfig
 }
 
-type httpSinkConfigReadonly struct{ v *HttpSinkConfig }
+type httpSinkConfigReadonly HttpSinkConfig
 
 func (r *httpSinkConfigReadonly) GetEndpoint() string {
-	return r.v.GetEndpoint()
+	return (*HttpSinkConfig)(r).GetEndpoint()
 }
 
 func (r *httpSinkConfigReadonly) GetSecret() string {
-	return r.v.GetSecret()
+	return (*HttpSinkConfig)(r).GetSecret()
 }
 
 func (r *httpSinkConfigReadonly) Mutate() *HttpSinkConfig {
-	return r.v.CloneVT()
+	return (*HttpSinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this HttpSinkConfig.
@@ -4733,7 +4729,7 @@ func (m *HttpSinkConfig) AsReader() HttpSinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &httpSinkConfigReadonly{v: m}
+	return (*httpSinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this HttpSinkConfig.
@@ -4791,38 +4787,38 @@ type DatabricksSinkConfigReader interface {
 	Mutate() *DatabricksSinkConfig
 }
 
-type databricksSinkConfigReadonly struct{ v *DatabricksSinkConfig }
+type databricksSinkConfigReadonly DatabricksSinkConfig
 
 func (r *databricksSinkConfigReadonly) GetServerHostname() string {
-	return r.v.GetServerHostname()
+	return (*DatabricksSinkConfig)(r).GetServerHostname()
 }
 
 func (r *databricksSinkConfigReadonly) GetHttpPath() string {
-	return r.v.GetHttpPath()
+	return (*DatabricksSinkConfig)(r).GetHttpPath()
 }
 
 func (r *databricksSinkConfigReadonly) GetCatalog() string {
-	return r.v.GetCatalog()
+	return (*DatabricksSinkConfig)(r).GetCatalog()
 }
 
 func (r *databricksSinkConfigReadonly) GetSchema() string {
-	return r.v.GetSchema()
+	return (*DatabricksSinkConfig)(r).GetSchema()
 }
 
 func (r *databricksSinkConfigReadonly) GetTable() string {
-	return r.v.GetTable()
+	return (*DatabricksSinkConfig)(r).GetTable()
 }
 
 func (r *databricksSinkConfigReadonly) GetPort() int32 {
-	return r.v.GetPort()
+	return (*DatabricksSinkConfig)(r).GetPort()
 }
 
 func (r *databricksSinkConfigReadonly) GetAuth() isDatabricksSinkConfig_Auth {
-	return r.v.GetAuth()
+	return (*DatabricksSinkConfig)(r).GetAuth()
 }
 
 func (r *databricksSinkConfigReadonly) Mutate() *DatabricksSinkConfig {
-	return r.v.CloneVT()
+	return (*DatabricksSinkConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DatabricksSinkConfig.
@@ -4830,7 +4826,7 @@ func (m *DatabricksSinkConfig) AsReader() DatabricksSinkConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &databricksSinkConfigReadonly{v: m}
+	return (*databricksSinkConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DatabricksSinkConfig.
@@ -4883,18 +4879,18 @@ type DatabricksOAuthM2MReader interface {
 	Mutate() *DatabricksOAuthM2M
 }
 
-type databricksOAuthM2MReadonly struct{ v *DatabricksOAuthM2M }
+type databricksOAuthM2MReadonly DatabricksOAuthM2M
 
 func (r *databricksOAuthM2MReadonly) GetClientId() string {
-	return r.v.GetClientId()
+	return (*DatabricksOAuthM2M)(r).GetClientId()
 }
 
 func (r *databricksOAuthM2MReadonly) GetClientSecret() string {
-	return r.v.GetClientSecret()
+	return (*DatabricksOAuthM2M)(r).GetClientSecret()
 }
 
 func (r *databricksOAuthM2MReadonly) Mutate() *DatabricksOAuthM2M {
-	return r.v.CloneVT()
+	return (*DatabricksOAuthM2M)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DatabricksOAuthM2M.
@@ -4902,7 +4898,7 @@ func (m *DatabricksOAuthM2M) AsReader() DatabricksOAuthM2MReader {
 	if m == nil {
 		return nil
 	}
-	return &databricksOAuthM2MReadonly{v: m}
+	return (*databricksOAuthM2MReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DatabricksOAuthM2M.
@@ -4961,14 +4957,14 @@ type CreatedLedgerLogReader interface {
 	Mutate() *CreatedLedgerLog
 }
 
-type createdLedgerLogReadonly struct{ v *CreatedLedgerLog }
+type createdLedgerLogReadonly CreatedLedgerLog
 
 func (r *createdLedgerLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*CreatedLedgerLog)(r).GetName()
 }
 
 func (r *createdLedgerLogReadonly) GetCreatedAt() TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*CreatedLedgerLog)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -4976,7 +4972,7 @@ func (r *createdLedgerLogReadonly) GetCreatedAt() TimestampReader {
 }
 
 func (r *createdLedgerLogReadonly) GetMetadataSchema() MetadataSchemaReader {
-	v := r.v.GetMetadataSchema()
+	v := (*CreatedLedgerLog)(r).GetMetadataSchema()
 	if v == nil {
 		return nil
 	}
@@ -4984,11 +4980,11 @@ func (r *createdLedgerLogReadonly) GetMetadataSchema() MetadataSchemaReader {
 }
 
 func (r *createdLedgerLogReadonly) GetMode() LedgerMode {
-	return r.v.GetMode()
+	return (*CreatedLedgerLog)(r).GetMode()
 }
 
 func (r *createdLedgerLogReadonly) GetMirrorSource() MirrorSourceConfigReader {
-	v := r.v.GetMirrorSource()
+	v := (*CreatedLedgerLog)(r).GetMirrorSource()
 	if v == nil {
 		return nil
 	}
@@ -4996,19 +4992,19 @@ func (r *createdLedgerLogReadonly) GetMirrorSource() MirrorSourceConfigReader {
 }
 
 func (r *createdLedgerLogReadonly) GetAccountTypes() CreatedLedgerLog_AccountTypesMapReader {
-	return createdLedgerLog_accountTypesMapReadonly(r.v.GetAccountTypes())
+	return createdLedgerLog_accountTypesMapReadonly((*CreatedLedgerLog)(r).GetAccountTypes())
 }
 
 func (r *createdLedgerLogReadonly) GetDefaultEnforcementMode() ChartEnforcementMode {
-	return r.v.GetDefaultEnforcementMode()
+	return (*CreatedLedgerLog)(r).GetDefaultEnforcementMode()
 }
 
 func (r *createdLedgerLogReadonly) GetId() uint32 {
-	return r.v.GetId()
+	return (*CreatedLedgerLog)(r).GetId()
 }
 
 func (r *createdLedgerLogReadonly) Mutate() *CreatedLedgerLog {
-	return r.v.CloneVT()
+	return (*CreatedLedgerLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedLedgerLog.
@@ -5016,7 +5012,7 @@ func (m *CreatedLedgerLog) AsReader() CreatedLedgerLogReader {
 	if m == nil {
 		return nil
 	}
-	return &createdLedgerLogReadonly{v: m}
+	return (*createdLedgerLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedLedgerLog.
@@ -5100,14 +5096,14 @@ type DeletedLedgerLogReader interface {
 	Mutate() *DeletedLedgerLog
 }
 
-type deletedLedgerLogReadonly struct{ v *DeletedLedgerLog }
+type deletedLedgerLogReadonly DeletedLedgerLog
 
 func (r *deletedLedgerLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeletedLedgerLog)(r).GetName()
 }
 
 func (r *deletedLedgerLogReadonly) GetDeletedAt() TimestampReader {
-	v := r.v.GetDeletedAt()
+	v := (*DeletedLedgerLog)(r).GetDeletedAt()
 	if v == nil {
 		return nil
 	}
@@ -5115,7 +5111,7 @@ func (r *deletedLedgerLogReadonly) GetDeletedAt() TimestampReader {
 }
 
 func (r *deletedLedgerLogReadonly) Mutate() *DeletedLedgerLog {
-	return r.v.CloneVT()
+	return (*DeletedLedgerLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedLedgerLog.
@@ -5123,7 +5119,7 @@ func (m *DeletedLedgerLog) AsReader() DeletedLedgerLogReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedLedgerLogReadonly{v: m}
+	return (*deletedLedgerLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedLedgerLog.
@@ -5176,14 +5172,14 @@ type ApplyLedgerLogReader interface {
 	Mutate() *ApplyLedgerLog
 }
 
-type applyLedgerLogReadonly struct{ v *ApplyLedgerLog }
+type applyLedgerLogReadonly ApplyLedgerLog
 
 func (r *applyLedgerLogReadonly) GetLedgerName() string {
-	return r.v.GetLedgerName()
+	return (*ApplyLedgerLog)(r).GetLedgerName()
 }
 
 func (r *applyLedgerLogReadonly) GetLog() LedgerLogReader {
-	v := r.v.GetLog()
+	v := (*ApplyLedgerLog)(r).GetLog()
 	if v == nil {
 		return nil
 	}
@@ -5191,7 +5187,7 @@ func (r *applyLedgerLogReadonly) GetLog() LedgerLogReader {
 }
 
 func (r *applyLedgerLogReadonly) Mutate() *ApplyLedgerLog {
-	return r.v.CloneVT()
+	return (*ApplyLedgerLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ApplyLedgerLog.
@@ -5199,7 +5195,7 @@ func (m *ApplyLedgerLog) AsReader() ApplyLedgerLogReader {
 	if m == nil {
 		return nil
 	}
-	return &applyLedgerLogReadonly{v: m}
+	return (*applyLedgerLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ApplyLedgerLog.
@@ -5254,10 +5250,10 @@ type LedgerLogReader interface {
 	Mutate() *LedgerLog
 }
 
-type ledgerLogReadonly struct{ v *LedgerLog }
+type ledgerLogReadonly LedgerLog
 
 func (r *ledgerLogReadonly) GetData() LedgerLogPayloadReader {
-	v := r.v.GetData()
+	v := (*LedgerLog)(r).GetData()
 	if v == nil {
 		return nil
 	}
@@ -5265,7 +5261,7 @@ func (r *ledgerLogReadonly) GetData() LedgerLogPayloadReader {
 }
 
 func (r *ledgerLogReadonly) GetDate() TimestampReader {
-	v := r.v.GetDate()
+	v := (*LedgerLog)(r).GetDate()
 	if v == nil {
 		return nil
 	}
@@ -5273,15 +5269,15 @@ func (r *ledgerLogReadonly) GetDate() TimestampReader {
 }
 
 func (r *ledgerLogReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*LedgerLog)(r).GetId()
 }
 
 func (r *ledgerLogReadonly) GetPurgedVolumes() TouchedVolumeListReader {
-	return NewTouchedVolumeListReader(r.v.GetPurgedVolumes())
+	return NewTouchedVolumeListReader((*LedgerLog)(r).GetPurgedVolumes())
 }
 
 func (r *ledgerLogReadonly) Mutate() *LedgerLog {
-	return r.v.CloneVT()
+	return (*LedgerLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerLog.
@@ -5289,7 +5285,7 @@ func (m *LedgerLog) AsReader() LedgerLogReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerLogReadonly{v: m}
+	return (*ledgerLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerLog.
@@ -5340,18 +5336,18 @@ type TouchedVolumeReader interface {
 	Mutate() *TouchedVolume
 }
 
-type touchedVolumeReadonly struct{ v *TouchedVolume }
+type touchedVolumeReadonly TouchedVolume
 
 func (r *touchedVolumeReadonly) GetAccount() string {
-	return r.v.GetAccount()
+	return (*TouchedVolume)(r).GetAccount()
 }
 
 func (r *touchedVolumeReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*TouchedVolume)(r).GetAsset()
 }
 
 func (r *touchedVolumeReadonly) Mutate() *TouchedVolume {
-	return r.v.CloneVT()
+	return (*TouchedVolume)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TouchedVolume.
@@ -5359,7 +5355,7 @@ func (m *TouchedVolume) AsReader() TouchedVolumeReader {
 	if m == nil {
 		return nil
 	}
-	return &touchedVolumeReadonly{v: m}
+	return (*touchedVolumeReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TouchedVolume.
@@ -5411,14 +5407,14 @@ type LedgerLogPayloadReader interface {
 	Mutate() *LedgerLogPayload
 }
 
-type ledgerLogPayloadReadonly struct{ v *LedgerLogPayload }
+type ledgerLogPayloadReadonly LedgerLogPayload
 
 func (r *ledgerLogPayloadReadonly) GetPayload() isLedgerLogPayload_Payload {
-	return r.v.GetPayload()
+	return (*LedgerLogPayload)(r).GetPayload()
 }
 
 func (r *ledgerLogPayloadReadonly) Mutate() *LedgerLogPayload {
-	return r.v.CloneVT()
+	return (*LedgerLogPayload)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerLogPayload.
@@ -5426,7 +5422,7 @@ func (m *LedgerLogPayload) AsReader() LedgerLogPayloadReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerLogPayloadReadonly{v: m}
+	return (*ledgerLogPayloadReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerLogPayload.
@@ -5478,10 +5474,10 @@ type CreatedIndexLogReader interface {
 	Mutate() *CreatedIndexLog
 }
 
-type createdIndexLogReadonly struct{ v *CreatedIndexLog }
+type createdIndexLogReadonly CreatedIndexLog
 
 func (r *createdIndexLogReadonly) GetId() IndexIDReader {
-	v := r.v.GetId()
+	v := (*CreatedIndexLog)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -5489,7 +5485,7 @@ func (r *createdIndexLogReadonly) GetId() IndexIDReader {
 }
 
 func (r *createdIndexLogReadonly) Mutate() *CreatedIndexLog {
-	return r.v.CloneVT()
+	return (*CreatedIndexLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedIndexLog.
@@ -5497,7 +5493,7 @@ func (m *CreatedIndexLog) AsReader() CreatedIndexLogReader {
 	if m == nil {
 		return nil
 	}
-	return &createdIndexLogReadonly{v: m}
+	return (*createdIndexLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedIndexLog.
@@ -5549,10 +5545,10 @@ type DroppedIndexLogReader interface {
 	Mutate() *DroppedIndexLog
 }
 
-type droppedIndexLogReadonly struct{ v *DroppedIndexLog }
+type droppedIndexLogReadonly DroppedIndexLog
 
 func (r *droppedIndexLogReadonly) GetId() IndexIDReader {
-	v := r.v.GetId()
+	v := (*DroppedIndexLog)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -5560,7 +5556,7 @@ func (r *droppedIndexLogReadonly) GetId() IndexIDReader {
 }
 
 func (r *droppedIndexLogReadonly) Mutate() *DroppedIndexLog {
-	return r.v.CloneVT()
+	return (*DroppedIndexLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DroppedIndexLog.
@@ -5568,7 +5564,7 @@ func (m *DroppedIndexLog) AsReader() DroppedIndexLogReader {
 	if m == nil {
 		return nil
 	}
-	return &droppedIndexLogReadonly{v: m}
+	return (*droppedIndexLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DroppedIndexLog.
@@ -5620,14 +5616,14 @@ type FilledGapLogReader interface {
 	Mutate() *FilledGapLog
 }
 
-type filledGapLogReadonly struct{ v *FilledGapLog }
+type filledGapLogReadonly FilledGapLog
 
 func (r *filledGapLogReadonly) GetOriginalId() uint64 {
-	return r.v.GetOriginalId()
+	return (*FilledGapLog)(r).GetOriginalId()
 }
 
 func (r *filledGapLogReadonly) Mutate() *FilledGapLog {
-	return r.v.CloneVT()
+	return (*FilledGapLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FilledGapLog.
@@ -5635,7 +5631,7 @@ func (m *FilledGapLog) AsReader() FilledGapLogReader {
 	if m == nil {
 		return nil
 	}
-	return &filledGapLogReadonly{v: m}
+	return (*filledGapLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FilledGapLog.
@@ -5690,10 +5686,10 @@ type CreatedTransactionReader interface {
 	Mutate() *CreatedTransaction
 }
 
-type createdTransactionReadonly struct{ v *CreatedTransaction }
+type createdTransactionReadonly CreatedTransaction
 
 func (r *createdTransactionReadonly) GetTransaction() TransactionReader {
-	v := r.v.GetTransaction()
+	v := (*CreatedTransaction)(r).GetTransaction()
 	if v == nil {
 		return nil
 	}
@@ -5701,15 +5697,15 @@ func (r *createdTransactionReadonly) GetTransaction() TransactionReader {
 }
 
 func (r *createdTransactionReadonly) GetAccountMetadata() CreatedTransaction_AccountMetadataMapReader {
-	return createdTransaction_accountMetadataMapReadonly(r.v.GetAccountMetadata())
+	return createdTransaction_accountMetadataMapReadonly((*CreatedTransaction)(r).GetAccountMetadata())
 }
 
 func (r *createdTransactionReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*CreatedTransaction)(r).GetChapterId()
 }
 
 func (r *createdTransactionReadonly) GetPostCommitVolumes() PostCommitVolumesReader {
-	v := r.v.GetPostCommitVolumes()
+	v := (*CreatedTransaction)(r).GetPostCommitVolumes()
 	if v == nil {
 		return nil
 	}
@@ -5717,7 +5713,7 @@ func (r *createdTransactionReadonly) GetPostCommitVolumes() PostCommitVolumesRea
 }
 
 func (r *createdTransactionReadonly) Mutate() *CreatedTransaction {
-	return r.v.CloneVT()
+	return (*CreatedTransaction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedTransaction.
@@ -5725,7 +5721,7 @@ func (m *CreatedTransaction) AsReader() CreatedTransactionReader {
 	if m == nil {
 		return nil
 	}
-	return &createdTransactionReadonly{v: m}
+	return (*createdTransactionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedTransaction.
@@ -5810,14 +5806,14 @@ type RevertedTransactionReader interface {
 	Mutate() *RevertedTransaction
 }
 
-type revertedTransactionReadonly struct{ v *RevertedTransaction }
+type revertedTransactionReadonly RevertedTransaction
 
 func (r *revertedTransactionReadonly) GetRevertedTransactionId() uint64 {
-	return r.v.GetRevertedTransactionId()
+	return (*RevertedTransaction)(r).GetRevertedTransactionId()
 }
 
 func (r *revertedTransactionReadonly) GetRevertTransaction() TransactionReader {
-	v := r.v.GetRevertTransaction()
+	v := (*RevertedTransaction)(r).GetRevertTransaction()
 	if v == nil {
 		return nil
 	}
@@ -5825,7 +5821,7 @@ func (r *revertedTransactionReadonly) GetRevertTransaction() TransactionReader {
 }
 
 func (r *revertedTransactionReadonly) GetPostCommitVolumes() PostCommitVolumesReader {
-	v := r.v.GetPostCommitVolumes()
+	v := (*RevertedTransaction)(r).GetPostCommitVolumes()
 	if v == nil {
 		return nil
 	}
@@ -5833,7 +5829,7 @@ func (r *revertedTransactionReadonly) GetPostCommitVolumes() PostCommitVolumesRe
 }
 
 func (r *revertedTransactionReadonly) Mutate() *RevertedTransaction {
-	return r.v.CloneVT()
+	return (*RevertedTransaction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevertedTransaction.
@@ -5841,7 +5837,7 @@ func (m *RevertedTransaction) AsReader() RevertedTransactionReader {
 	if m == nil {
 		return nil
 	}
-	return &revertedTransactionReadonly{v: m}
+	return (*revertedTransactionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevertedTransaction.
@@ -5894,10 +5890,10 @@ type SavedMetadataReader interface {
 	Mutate() *SavedMetadata
 }
 
-type savedMetadataReadonly struct{ v *SavedMetadata }
+type savedMetadataReadonly SavedMetadata
 
 func (r *savedMetadataReadonly) GetTarget() TargetReader {
-	v := r.v.GetTarget()
+	v := (*SavedMetadata)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -5905,11 +5901,11 @@ func (r *savedMetadataReadonly) GetTarget() TargetReader {
 }
 
 func (r *savedMetadataReadonly) GetMetadata() SavedMetadata_MetadataMapReader {
-	return savedMetadata_metadataMapReadonly(r.v.GetMetadata())
+	return savedMetadata_metadataMapReadonly((*SavedMetadata)(r).GetMetadata())
 }
 
 func (r *savedMetadataReadonly) Mutate() *SavedMetadata {
-	return r.v.CloneVT()
+	return (*SavedMetadata)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SavedMetadata.
@@ -5917,7 +5913,7 @@ func (m *SavedMetadata) AsReader() SavedMetadataReader {
 	if m == nil {
 		return nil
 	}
-	return &savedMetadataReadonly{v: m}
+	return (*savedMetadataReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SavedMetadata.
@@ -6001,10 +5997,10 @@ type DeletedMetadataReader interface {
 	Mutate() *DeletedMetadata
 }
 
-type deletedMetadataReadonly struct{ v *DeletedMetadata }
+type deletedMetadataReadonly DeletedMetadata
 
 func (r *deletedMetadataReadonly) GetTarget() TargetReader {
-	v := r.v.GetTarget()
+	v := (*DeletedMetadata)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -6012,11 +6008,11 @@ func (r *deletedMetadataReadonly) GetTarget() TargetReader {
 }
 
 func (r *deletedMetadataReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeletedMetadata)(r).GetKey()
 }
 
 func (r *deletedMetadataReadonly) Mutate() *DeletedMetadata {
-	return r.v.CloneVT()
+	return (*DeletedMetadata)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletedMetadata.
@@ -6024,7 +6020,7 @@ func (m *DeletedMetadata) AsReader() DeletedMetadataReader {
 	if m == nil {
 		return nil
 	}
-	return &deletedMetadataReadonly{v: m}
+	return (*deletedMetadataReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletedMetadata.
@@ -6078,22 +6074,22 @@ type SetMetadataFieldTypeLogReader interface {
 	Mutate() *SetMetadataFieldTypeLog
 }
 
-type setMetadataFieldTypeLogReadonly struct{ v *SetMetadataFieldTypeLog }
+type setMetadataFieldTypeLogReadonly SetMetadataFieldTypeLog
 
 func (r *setMetadataFieldTypeLogReadonly) GetTargetType() TargetType {
-	return r.v.GetTargetType()
+	return (*SetMetadataFieldTypeLog)(r).GetTargetType()
 }
 
 func (r *setMetadataFieldTypeLogReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*SetMetadataFieldTypeLog)(r).GetKey()
 }
 
 func (r *setMetadataFieldTypeLogReadonly) GetType() MetadataType {
-	return r.v.GetType()
+	return (*SetMetadataFieldTypeLog)(r).GetType()
 }
 
 func (r *setMetadataFieldTypeLogReadonly) Mutate() *SetMetadataFieldTypeLog {
-	return r.v.CloneVT()
+	return (*SetMetadataFieldTypeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMetadataFieldTypeLog.
@@ -6101,7 +6097,7 @@ func (m *SetMetadataFieldTypeLog) AsReader() SetMetadataFieldTypeLogReader {
 	if m == nil {
 		return nil
 	}
-	return &setMetadataFieldTypeLogReadonly{v: m}
+	return (*setMetadataFieldTypeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMetadataFieldTypeLog.
@@ -6155,18 +6151,18 @@ type RemovedMetadataFieldTypeLogReader interface {
 	Mutate() *RemovedMetadataFieldTypeLog
 }
 
-type removedMetadataFieldTypeLogReadonly struct{ v *RemovedMetadataFieldTypeLog }
+type removedMetadataFieldTypeLogReadonly RemovedMetadataFieldTypeLog
 
 func (r *removedMetadataFieldTypeLogReadonly) GetTargetType() TargetType {
-	return r.v.GetTargetType()
+	return (*RemovedMetadataFieldTypeLog)(r).GetTargetType()
 }
 
 func (r *removedMetadataFieldTypeLogReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*RemovedMetadataFieldTypeLog)(r).GetKey()
 }
 
 func (r *removedMetadataFieldTypeLogReadonly) GetDroppedIndex() IndexIDReader {
-	v := r.v.GetDroppedIndex()
+	v := (*RemovedMetadataFieldTypeLog)(r).GetDroppedIndex()
 	if v == nil {
 		return nil
 	}
@@ -6174,7 +6170,7 @@ func (r *removedMetadataFieldTypeLogReadonly) GetDroppedIndex() IndexIDReader {
 }
 
 func (r *removedMetadataFieldTypeLogReadonly) Mutate() *RemovedMetadataFieldTypeLog {
-	return r.v.CloneVT()
+	return (*RemovedMetadataFieldTypeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemovedMetadataFieldTypeLog.
@@ -6182,7 +6178,7 @@ func (m *RemovedMetadataFieldTypeLog) AsReader() RemovedMetadataFieldTypeLogRead
 	if m == nil {
 		return nil
 	}
-	return &removedMetadataFieldTypeLogReadonly{v: m}
+	return (*removedMetadataFieldTypeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemovedMetadataFieldTypeLog.
@@ -6244,14 +6240,14 @@ type ChapterReader interface {
 	Mutate() *Chapter
 }
 
-type chapterReadonly struct{ v *Chapter }
+type chapterReadonly Chapter
 
 func (r *chapterReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*Chapter)(r).GetId()
 }
 
 func (r *chapterReadonly) GetStart() TimestampReader {
-	v := r.v.GetStart()
+	v := (*Chapter)(r).GetStart()
 	if v == nil {
 		return nil
 	}
@@ -6259,7 +6255,7 @@ func (r *chapterReadonly) GetStart() TimestampReader {
 }
 
 func (r *chapterReadonly) GetEnd() TimestampReader {
-	v := r.v.GetEnd()
+	v := (*Chapter)(r).GetEnd()
 	if v == nil {
 		return nil
 	}
@@ -6267,39 +6263,39 @@ func (r *chapterReadonly) GetEnd() TimestampReader {
 }
 
 func (r *chapterReadonly) GetStatus() ChapterStatus {
-	return r.v.GetStatus()
+	return (*Chapter)(r).GetStatus()
 }
 
 func (r *chapterReadonly) GetCloseSequence() uint64 {
-	return r.v.GetCloseSequence()
+	return (*Chapter)(r).GetCloseSequence()
 }
 
 func (r *chapterReadonly) GetSealingHash() []byte {
-	return bytes.Clone(r.v.GetSealingHash())
+	return bytes.Clone((*Chapter)(r).GetSealingHash())
 }
 
 func (r *chapterReadonly) GetLastAuditHash() []byte {
-	return bytes.Clone(r.v.GetLastAuditHash())
+	return bytes.Clone((*Chapter)(r).GetLastAuditHash())
 }
 
 func (r *chapterReadonly) GetStartSequence() uint64 {
-	return r.v.GetStartSequence()
+	return (*Chapter)(r).GetStartSequence()
 }
 
 func (r *chapterReadonly) GetStateHash() []byte {
-	return bytes.Clone(r.v.GetStateHash())
+	return bytes.Clone((*Chapter)(r).GetStateHash())
 }
 
 func (r *chapterReadonly) GetStartAuditSequence() uint64 {
-	return r.v.GetStartAuditSequence()
+	return (*Chapter)(r).GetStartAuditSequence()
 }
 
 func (r *chapterReadonly) GetCloseAuditSequence() uint64 {
-	return r.v.GetCloseAuditSequence()
+	return (*Chapter)(r).GetCloseAuditSequence()
 }
 
 func (r *chapterReadonly) Mutate() *Chapter {
-	return r.v.CloneVT()
+	return (*Chapter)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Chapter.
@@ -6307,7 +6303,7 @@ func (m *Chapter) AsReader() ChapterReader {
 	if m == nil {
 		return nil
 	}
-	return &chapterReadonly{v: m}
+	return (*chapterReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Chapter.
@@ -6358,10 +6354,10 @@ type ClosedChapterLogReader interface {
 	Mutate() *ClosedChapterLog
 }
 
-type closedChapterLogReadonly struct{ v *ClosedChapterLog }
+type closedChapterLogReadonly ClosedChapterLog
 
 func (r *closedChapterLogReadonly) GetClosedChapter() ChapterReader {
-	v := r.v.GetClosedChapter()
+	v := (*ClosedChapterLog)(r).GetClosedChapter()
 	if v == nil {
 		return nil
 	}
@@ -6369,7 +6365,7 @@ func (r *closedChapterLogReadonly) GetClosedChapter() ChapterReader {
 }
 
 func (r *closedChapterLogReadonly) GetNewChapter() ChapterReader {
-	v := r.v.GetNewChapter()
+	v := (*ClosedChapterLog)(r).GetNewChapter()
 	if v == nil {
 		return nil
 	}
@@ -6377,7 +6373,7 @@ func (r *closedChapterLogReadonly) GetNewChapter() ChapterReader {
 }
 
 func (r *closedChapterLogReadonly) Mutate() *ClosedChapterLog {
-	return r.v.CloneVT()
+	return (*ClosedChapterLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ClosedChapterLog.
@@ -6385,7 +6381,7 @@ func (m *ClosedChapterLog) AsReader() ClosedChapterLogReader {
 	if m == nil {
 		return nil
 	}
-	return &closedChapterLogReadonly{v: m}
+	return (*closedChapterLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ClosedChapterLog.
@@ -6437,10 +6433,10 @@ type SealedChapterLogReader interface {
 	Mutate() *SealedChapterLog
 }
 
-type sealedChapterLogReadonly struct{ v *SealedChapterLog }
+type sealedChapterLogReadonly SealedChapterLog
 
 func (r *sealedChapterLogReadonly) GetChapter() ChapterReader {
-	v := r.v.GetChapter()
+	v := (*SealedChapterLog)(r).GetChapter()
 	if v == nil {
 		return nil
 	}
@@ -6448,7 +6444,7 @@ func (r *sealedChapterLogReadonly) GetChapter() ChapterReader {
 }
 
 func (r *sealedChapterLogReadonly) Mutate() *SealedChapterLog {
-	return r.v.CloneVT()
+	return (*SealedChapterLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SealedChapterLog.
@@ -6456,7 +6452,7 @@ func (m *SealedChapterLog) AsReader() SealedChapterLogReader {
 	if m == nil {
 		return nil
 	}
-	return &sealedChapterLogReadonly{v: m}
+	return (*sealedChapterLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SealedChapterLog.
@@ -6508,10 +6504,10 @@ type ArchivedChapterLogReader interface {
 	Mutate() *ArchivedChapterLog
 }
 
-type archivedChapterLogReadonly struct{ v *ArchivedChapterLog }
+type archivedChapterLogReadonly ArchivedChapterLog
 
 func (r *archivedChapterLogReadonly) GetChapter() ChapterReader {
-	v := r.v.GetChapter()
+	v := (*ArchivedChapterLog)(r).GetChapter()
 	if v == nil {
 		return nil
 	}
@@ -6519,7 +6515,7 @@ func (r *archivedChapterLogReadonly) GetChapter() ChapterReader {
 }
 
 func (r *archivedChapterLogReadonly) Mutate() *ArchivedChapterLog {
-	return r.v.CloneVT()
+	return (*ArchivedChapterLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ArchivedChapterLog.
@@ -6527,7 +6523,7 @@ func (m *ArchivedChapterLog) AsReader() ArchivedChapterLogReader {
 	if m == nil {
 		return nil
 	}
-	return &archivedChapterLogReadonly{v: m}
+	return (*archivedChapterLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ArchivedChapterLog.
@@ -6579,10 +6575,10 @@ type ConfirmedArchiveChapterLogReader interface {
 	Mutate() *ConfirmedArchiveChapterLog
 }
 
-type confirmedArchiveChapterLogReadonly struct{ v *ConfirmedArchiveChapterLog }
+type confirmedArchiveChapterLogReadonly ConfirmedArchiveChapterLog
 
 func (r *confirmedArchiveChapterLogReadonly) GetChapter() ChapterReader {
-	v := r.v.GetChapter()
+	v := (*ConfirmedArchiveChapterLog)(r).GetChapter()
 	if v == nil {
 		return nil
 	}
@@ -6590,7 +6586,7 @@ func (r *confirmedArchiveChapterLogReadonly) GetChapter() ChapterReader {
 }
 
 func (r *confirmedArchiveChapterLogReadonly) Mutate() *ConfirmedArchiveChapterLog {
-	return r.v.CloneVT()
+	return (*ConfirmedArchiveChapterLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ConfirmedArchiveChapterLog.
@@ -6598,7 +6594,7 @@ func (m *ConfirmedArchiveChapterLog) AsReader() ConfirmedArchiveChapterLogReader
 	if m == nil {
 		return nil
 	}
-	return &confirmedArchiveChapterLogReadonly{v: m}
+	return (*confirmedArchiveChapterLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ConfirmedArchiveChapterLog.
@@ -6653,26 +6649,26 @@ type MirrorSourceConfigReader interface {
 	Mutate() *MirrorSourceConfig
 }
 
-type mirrorSourceConfigReadonly struct{ v *MirrorSourceConfig }
+type mirrorSourceConfigReadonly MirrorSourceConfig
 
 func (r *mirrorSourceConfigReadonly) GetLedgerName() string {
-	return r.v.GetLedgerName()
+	return (*MirrorSourceConfig)(r).GetLedgerName()
 }
 
 func (r *mirrorSourceConfigReadonly) GetBatchSize() uint32 {
-	return r.v.GetBatchSize()
+	return (*MirrorSourceConfig)(r).GetBatchSize()
 }
 
 func (r *mirrorSourceConfigReadonly) GetAddressRewriteRules() AddressRewriteRuleListReader {
-	return NewAddressRewriteRuleListReader(r.v.GetAddressRewriteRules())
+	return NewAddressRewriteRuleListReader((*MirrorSourceConfig)(r).GetAddressRewriteRules())
 }
 
 func (r *mirrorSourceConfigReadonly) GetType() isMirrorSourceConfig_Type {
-	return r.v.GetType()
+	return (*MirrorSourceConfig)(r).GetType()
 }
 
 func (r *mirrorSourceConfigReadonly) Mutate() *MirrorSourceConfig {
-	return r.v.CloneVT()
+	return (*MirrorSourceConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorSourceConfig.
@@ -6680,7 +6676,7 @@ func (m *MirrorSourceConfig) AsReader() MirrorSourceConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorSourceConfigReadonly{v: m}
+	return (*mirrorSourceConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorSourceConfig.
@@ -6733,18 +6729,18 @@ type AddressRewriteRuleReader interface {
 	Mutate() *AddressRewriteRule
 }
 
-type addressRewriteRuleReadonly struct{ v *AddressRewriteRule }
+type addressRewriteRuleReadonly AddressRewriteRule
 
 func (r *addressRewriteRuleReadonly) GetPattern() string {
-	return r.v.GetPattern()
+	return (*AddressRewriteRule)(r).GetPattern()
 }
 
 func (r *addressRewriteRuleReadonly) GetReplacement() string {
-	return r.v.GetReplacement()
+	return (*AddressRewriteRule)(r).GetReplacement()
 }
 
 func (r *addressRewriteRuleReadonly) Mutate() *AddressRewriteRule {
-	return r.v.CloneVT()
+	return (*AddressRewriteRule)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddressRewriteRule.
@@ -6752,7 +6748,7 @@ func (m *AddressRewriteRule) AsReader() AddressRewriteRuleReader {
 	if m == nil {
 		return nil
 	}
-	return &addressRewriteRuleReadonly{v: m}
+	return (*addressRewriteRuleReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddressRewriteRule.
@@ -6805,14 +6801,14 @@ type HttpMirrorSourceConfigReader interface {
 	Mutate() *HttpMirrorSourceConfig
 }
 
-type httpMirrorSourceConfigReadonly struct{ v *HttpMirrorSourceConfig }
+type httpMirrorSourceConfigReadonly HttpMirrorSourceConfig
 
 func (r *httpMirrorSourceConfigReadonly) GetBaseUrl() string {
-	return r.v.GetBaseUrl()
+	return (*HttpMirrorSourceConfig)(r).GetBaseUrl()
 }
 
 func (r *httpMirrorSourceConfigReadonly) GetOauth2ClientCredentials() OAuth2ClientCredentialsReader {
-	v := r.v.GetOauth2ClientCredentials()
+	v := (*HttpMirrorSourceConfig)(r).GetOauth2ClientCredentials()
 	if v == nil {
 		return nil
 	}
@@ -6820,7 +6816,7 @@ func (r *httpMirrorSourceConfigReadonly) GetOauth2ClientCredentials() OAuth2Clie
 }
 
 func (r *httpMirrorSourceConfigReadonly) Mutate() *HttpMirrorSourceConfig {
-	return r.v.CloneVT()
+	return (*HttpMirrorSourceConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this HttpMirrorSourceConfig.
@@ -6828,7 +6824,7 @@ func (m *HttpMirrorSourceConfig) AsReader() HttpMirrorSourceConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &httpMirrorSourceConfigReadonly{v: m}
+	return (*httpMirrorSourceConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this HttpMirrorSourceConfig.
@@ -6883,26 +6879,26 @@ type OAuth2ClientCredentialsReader interface {
 	Mutate() *OAuth2ClientCredentials
 }
 
-type oAuth2ClientCredentialsReadonly struct{ v *OAuth2ClientCredentials }
+type oAuth2ClientCredentialsReadonly OAuth2ClientCredentials
 
 func (r *oAuth2ClientCredentialsReadonly) GetClientId() string {
-	return r.v.GetClientId()
+	return (*OAuth2ClientCredentials)(r).GetClientId()
 }
 
 func (r *oAuth2ClientCredentialsReadonly) GetClientSecret() string {
-	return r.v.GetClientSecret()
+	return (*OAuth2ClientCredentials)(r).GetClientSecret()
 }
 
 func (r *oAuth2ClientCredentialsReadonly) GetTokenEndpoint() string {
-	return r.v.GetTokenEndpoint()
+	return (*OAuth2ClientCredentials)(r).GetTokenEndpoint()
 }
 
 func (r *oAuth2ClientCredentialsReadonly) GetScopes() []string {
-	return slices.Clone(r.v.GetScopes())
+	return slices.Clone((*OAuth2ClientCredentials)(r).GetScopes())
 }
 
 func (r *oAuth2ClientCredentialsReadonly) Mutate() *OAuth2ClientCredentials {
-	return r.v.CloneVT()
+	return (*OAuth2ClientCredentials)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this OAuth2ClientCredentials.
@@ -6910,7 +6906,7 @@ func (m *OAuth2ClientCredentials) AsReader() OAuth2ClientCredentialsReader {
 	if m == nil {
 		return nil
 	}
-	return &oAuth2ClientCredentialsReadonly{v: m}
+	return (*oAuth2ClientCredentialsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this OAuth2ClientCredentials.
@@ -6963,14 +6959,14 @@ type PostgresMirrorSourceConfigReader interface {
 	Mutate() *PostgresMirrorSourceConfig
 }
 
-type postgresMirrorSourceConfigReadonly struct{ v *PostgresMirrorSourceConfig }
+type postgresMirrorSourceConfigReadonly PostgresMirrorSourceConfig
 
 func (r *postgresMirrorSourceConfigReadonly) GetDsn() string {
-	return r.v.GetDsn()
+	return (*PostgresMirrorSourceConfig)(r).GetDsn()
 }
 
 func (r *postgresMirrorSourceConfigReadonly) GetAwsIamAuth() PostgresAwsIamAuthReader {
-	v := r.v.GetAwsIamAuth()
+	v := (*PostgresMirrorSourceConfig)(r).GetAwsIamAuth()
 	if v == nil {
 		return nil
 	}
@@ -6978,7 +6974,7 @@ func (r *postgresMirrorSourceConfigReadonly) GetAwsIamAuth() PostgresAwsIamAuthR
 }
 
 func (r *postgresMirrorSourceConfigReadonly) Mutate() *PostgresMirrorSourceConfig {
-	return r.v.CloneVT()
+	return (*PostgresMirrorSourceConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PostgresMirrorSourceConfig.
@@ -6986,7 +6982,7 @@ func (m *PostgresMirrorSourceConfig) AsReader() PostgresMirrorSourceConfigReader
 	if m == nil {
 		return nil
 	}
-	return &postgresMirrorSourceConfigReadonly{v: m}
+	return (*postgresMirrorSourceConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PostgresMirrorSourceConfig.
@@ -7039,18 +7035,18 @@ type PostgresAwsIamAuthReader interface {
 	Mutate() *PostgresAwsIamAuth
 }
 
-type postgresAwsIamAuthReadonly struct{ v *PostgresAwsIamAuth }
+type postgresAwsIamAuthReadonly PostgresAwsIamAuth
 
 func (r *postgresAwsIamAuthReadonly) GetRegion() string {
-	return r.v.GetRegion()
+	return (*PostgresAwsIamAuth)(r).GetRegion()
 }
 
 func (r *postgresAwsIamAuthReadonly) GetAssumeRoleArn() string {
-	return r.v.GetAssumeRoleArn()
+	return (*PostgresAwsIamAuth)(r).GetAssumeRoleArn()
 }
 
 func (r *postgresAwsIamAuthReadonly) Mutate() *PostgresAwsIamAuth {
-	return r.v.CloneVT()
+	return (*PostgresAwsIamAuth)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PostgresAwsIamAuth.
@@ -7058,7 +7054,7 @@ func (m *PostgresAwsIamAuth) AsReader() PostgresAwsIamAuthReader {
 	if m == nil {
 		return nil
 	}
-	return &postgresAwsIamAuthReadonly{v: m}
+	return (*postgresAwsIamAuthReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PostgresAwsIamAuth.
@@ -7111,14 +7107,14 @@ type MirrorSyncErrorReader interface {
 	Mutate() *MirrorSyncError
 }
 
-type mirrorSyncErrorReadonly struct{ v *MirrorSyncError }
+type mirrorSyncErrorReadonly MirrorSyncError
 
 func (r *mirrorSyncErrorReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*MirrorSyncError)(r).GetMessage()
 }
 
 func (r *mirrorSyncErrorReadonly) GetOccurredAt() TimestampReader {
-	v := r.v.GetOccurredAt()
+	v := (*MirrorSyncError)(r).GetOccurredAt()
 	if v == nil {
 		return nil
 	}
@@ -7126,7 +7122,7 @@ func (r *mirrorSyncErrorReadonly) GetOccurredAt() TimestampReader {
 }
 
 func (r *mirrorSyncErrorReadonly) Mutate() *MirrorSyncError {
-	return r.v.CloneVT()
+	return (*MirrorSyncError)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorSyncError.
@@ -7134,7 +7130,7 @@ func (m *MirrorSyncError) AsReader() MirrorSyncErrorReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorSyncErrorReadonly{v: m}
+	return (*mirrorSyncErrorReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorSyncError.
@@ -7190,26 +7186,26 @@ type MirrorSyncProgressReader interface {
 	Mutate() *MirrorSyncProgress
 }
 
-type mirrorSyncProgressReadonly struct{ v *MirrorSyncProgress }
+type mirrorSyncProgressReadonly MirrorSyncProgress
 
 func (r *mirrorSyncProgressReadonly) GetState() MirrorSyncState {
-	return r.v.GetState()
+	return (*MirrorSyncProgress)(r).GetState()
 }
 
 func (r *mirrorSyncProgressReadonly) GetCursor() uint64 {
-	return r.v.GetCursor()
+	return (*MirrorSyncProgress)(r).GetCursor()
 }
 
 func (r *mirrorSyncProgressReadonly) GetSourceLogCount() uint64 {
-	return r.v.GetSourceLogCount()
+	return (*MirrorSyncProgress)(r).GetSourceLogCount()
 }
 
 func (r *mirrorSyncProgressReadonly) GetRemainingLogs() uint64 {
-	return r.v.GetRemainingLogs()
+	return (*MirrorSyncProgress)(r).GetRemainingLogs()
 }
 
 func (r *mirrorSyncProgressReadonly) GetError() MirrorSyncErrorReader {
-	v := r.v.GetError()
+	v := (*MirrorSyncProgress)(r).GetError()
 	if v == nil {
 		return nil
 	}
@@ -7217,7 +7213,7 @@ func (r *mirrorSyncProgressReadonly) GetError() MirrorSyncErrorReader {
 }
 
 func (r *mirrorSyncProgressReadonly) Mutate() *MirrorSyncProgress {
-	return r.v.CloneVT()
+	return (*MirrorSyncProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorSyncProgress.
@@ -7225,7 +7221,7 @@ func (m *MirrorSyncProgress) AsReader() MirrorSyncProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorSyncProgressReadonly{v: m}
+	return (*mirrorSyncProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorSyncProgress.
@@ -7287,14 +7283,14 @@ type LedgerInfoReader interface {
 	Mutate() *LedgerInfo
 }
 
-type ledgerInfoReadonly struct{ v *LedgerInfo }
+type ledgerInfoReadonly LedgerInfo
 
 func (r *ledgerInfoReadonly) GetName() string {
-	return r.v.GetName()
+	return (*LedgerInfo)(r).GetName()
 }
 
 func (r *ledgerInfoReadonly) GetCreatedAt() TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*LedgerInfo)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -7302,7 +7298,7 @@ func (r *ledgerInfoReadonly) GetCreatedAt() TimestampReader {
 }
 
 func (r *ledgerInfoReadonly) GetDeletedAt() TimestampReader {
-	v := r.v.GetDeletedAt()
+	v := (*LedgerInfo)(r).GetDeletedAt()
 	if v == nil {
 		return nil
 	}
@@ -7310,7 +7306,7 @@ func (r *ledgerInfoReadonly) GetDeletedAt() TimestampReader {
 }
 
 func (r *ledgerInfoReadonly) GetMetadataSchema() MetadataSchemaReader {
-	v := r.v.GetMetadataSchema()
+	v := (*LedgerInfo)(r).GetMetadataSchema()
 	if v == nil {
 		return nil
 	}
@@ -7318,11 +7314,11 @@ func (r *ledgerInfoReadonly) GetMetadataSchema() MetadataSchemaReader {
 }
 
 func (r *ledgerInfoReadonly) GetMode() LedgerMode {
-	return r.v.GetMode()
+	return (*LedgerInfo)(r).GetMode()
 }
 
 func (r *ledgerInfoReadonly) GetMirrorSource() MirrorSourceConfigReader {
-	v := r.v.GetMirrorSource()
+	v := (*LedgerInfo)(r).GetMirrorSource()
 	if v == nil {
 		return nil
 	}
@@ -7330,7 +7326,7 @@ func (r *ledgerInfoReadonly) GetMirrorSource() MirrorSourceConfigReader {
 }
 
 func (r *ledgerInfoReadonly) GetMirrorSyncProgress() MirrorSyncProgressReader {
-	v := r.v.GetMirrorSyncProgress()
+	v := (*LedgerInfo)(r).GetMirrorSyncProgress()
 	if v == nil {
 		return nil
 	}
@@ -7338,23 +7334,23 @@ func (r *ledgerInfoReadonly) GetMirrorSyncProgress() MirrorSyncProgressReader {
 }
 
 func (r *ledgerInfoReadonly) GetAccountTypes() LedgerInfo_AccountTypesMapReader {
-	return ledgerInfo_accountTypesMapReadonly(r.v.GetAccountTypes())
+	return ledgerInfo_accountTypesMapReadonly((*LedgerInfo)(r).GetAccountTypes())
 }
 
 func (r *ledgerInfoReadonly) GetDefaultEnforcementMode() ChartEnforcementMode {
-	return r.v.GetDefaultEnforcementMode()
+	return (*LedgerInfo)(r).GetDefaultEnforcementMode()
 }
 
 func (r *ledgerInfoReadonly) GetMetadata() LedgerInfo_MetadataMapReader {
-	return ledgerInfo_metadataMapReadonly(r.v.GetMetadata())
+	return ledgerInfo_metadataMapReadonly((*LedgerInfo)(r).GetMetadata())
 }
 
 func (r *ledgerInfoReadonly) GetId() uint32 {
-	return r.v.GetId()
+	return (*LedgerInfo)(r).GetId()
 }
 
 func (r *ledgerInfoReadonly) Mutate() *LedgerInfo {
-	return r.v.CloneVT()
+	return (*LedgerInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerInfo.
@@ -7362,7 +7358,7 @@ func (m *LedgerInfo) AsReader() LedgerInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerInfoReadonly{v: m}
+	return (*ledgerInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerInfo.
@@ -7475,10 +7471,10 @@ type SaveMetadataCommandReader interface {
 	Mutate() *SaveMetadataCommand
 }
 
-type saveMetadataCommandReadonly struct{ v *SaveMetadataCommand }
+type saveMetadataCommandReadonly SaveMetadataCommand
 
 func (r *saveMetadataCommandReadonly) GetTarget() TargetReader {
-	v := r.v.GetTarget()
+	v := (*SaveMetadataCommand)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -7486,11 +7482,11 @@ func (r *saveMetadataCommandReadonly) GetTarget() TargetReader {
 }
 
 func (r *saveMetadataCommandReadonly) GetMetadata() SaveMetadataCommand_MetadataMapReader {
-	return saveMetadataCommand_metadataMapReadonly(r.v.GetMetadata())
+	return saveMetadataCommand_metadataMapReadonly((*SaveMetadataCommand)(r).GetMetadata())
 }
 
 func (r *saveMetadataCommandReadonly) Mutate() *SaveMetadataCommand {
-	return r.v.CloneVT()
+	return (*SaveMetadataCommand)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveMetadataCommand.
@@ -7498,7 +7494,7 @@ func (m *SaveMetadataCommand) AsReader() SaveMetadataCommandReader {
 	if m == nil {
 		return nil
 	}
-	return &saveMetadataCommandReadonly{v: m}
+	return (*saveMetadataCommandReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveMetadataCommand.
@@ -7582,10 +7578,10 @@ type DeleteMetadataCommandReader interface {
 	Mutate() *DeleteMetadataCommand
 }
 
-type deleteMetadataCommandReadonly struct{ v *DeleteMetadataCommand }
+type deleteMetadataCommandReadonly DeleteMetadataCommand
 
 func (r *deleteMetadataCommandReadonly) GetTarget() TargetReader {
-	v := r.v.GetTarget()
+	v := (*DeleteMetadataCommand)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -7593,11 +7589,11 @@ func (r *deleteMetadataCommandReadonly) GetTarget() TargetReader {
 }
 
 func (r *deleteMetadataCommandReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeleteMetadataCommand)(r).GetKey()
 }
 
 func (r *deleteMetadataCommandReadonly) Mutate() *DeleteMetadataCommand {
-	return r.v.CloneVT()
+	return (*DeleteMetadataCommand)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteMetadataCommand.
@@ -7605,7 +7601,7 @@ func (m *DeleteMetadataCommand) AsReader() DeleteMetadataCommandReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteMetadataCommandReadonly{v: m}
+	return (*deleteMetadataCommandReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteMetadataCommand.
@@ -7661,22 +7657,22 @@ type TransactionStateReader interface {
 	Mutate() *TransactionState
 }
 
-type transactionStateReadonly struct{ v *TransactionState }
+type transactionStateReadonly TransactionState
 
 func (r *transactionStateReadonly) GetCreatedByLog() uint64 {
-	return r.v.GetCreatedByLog()
+	return (*TransactionState)(r).GetCreatedByLog()
 }
 
 func (r *transactionStateReadonly) GetRevertedByTransaction() uint64 {
-	return r.v.GetRevertedByTransaction()
+	return (*TransactionState)(r).GetRevertedByTransaction()
 }
 
 func (r *transactionStateReadonly) GetMetadata() TransactionState_MetadataMapReader {
-	return transactionState_metadataMapReadonly(r.v.GetMetadata())
+	return transactionState_metadataMapReadonly((*TransactionState)(r).GetMetadata())
 }
 
 func (r *transactionStateReadonly) GetTimestamp() TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*TransactionState)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -7684,11 +7680,11 @@ func (r *transactionStateReadonly) GetTimestamp() TimestampReader {
 }
 
 func (r *transactionStateReadonly) GetPostings() PostingListReader {
-	return NewPostingListReader(r.v.GetPostings())
+	return NewPostingListReader((*TransactionState)(r).GetPostings())
 }
 
 func (r *transactionStateReadonly) Mutate() *TransactionState {
-	return r.v.CloneVT()
+	return (*TransactionState)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransactionState.
@@ -7696,7 +7692,7 @@ func (m *TransactionState) AsReader() TransactionStateReader {
 	if m == nil {
 		return nil
 	}
-	return &transactionStateReadonly{v: m}
+	return (*transactionStateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransactionState.
@@ -7784,26 +7780,26 @@ type IdempotencyKeyValueReader interface {
 	Mutate() *IdempotencyKeyValue
 }
 
-type idempotencyKeyValueReadonly struct{ v *IdempotencyKeyValue }
+type idempotencyKeyValueReadonly IdempotencyKeyValue
 
 func (r *idempotencyKeyValueReadonly) GetFirstLogSequence() uint64 {
-	return r.v.GetFirstLogSequence()
+	return (*IdempotencyKeyValue)(r).GetFirstLogSequence()
 }
 
 func (r *idempotencyKeyValueReadonly) GetHash() []byte {
-	return bytes.Clone(r.v.GetHash())
+	return bytes.Clone((*IdempotencyKeyValue)(r).GetHash())
 }
 
 func (r *idempotencyKeyValueReadonly) GetHashVersion() uint32 {
-	return r.v.GetHashVersion()
+	return (*IdempotencyKeyValue)(r).GetHashVersion()
 }
 
 func (r *idempotencyKeyValueReadonly) GetCreatedAt() uint64 {
-	return r.v.GetCreatedAt()
+	return (*IdempotencyKeyValue)(r).GetCreatedAt()
 }
 
 func (r *idempotencyKeyValueReadonly) GetFailure() IdempotencyFailureReader {
-	v := r.v.GetFailure()
+	v := (*IdempotencyKeyValue)(r).GetFailure()
 	if v == nil {
 		return nil
 	}
@@ -7811,11 +7807,11 @@ func (r *idempotencyKeyValueReadonly) GetFailure() IdempotencyFailureReader {
 }
 
 func (r *idempotencyKeyValueReadonly) GetLogCount() uint32 {
-	return r.v.GetLogCount()
+	return (*IdempotencyKeyValue)(r).GetLogCount()
 }
 
 func (r *idempotencyKeyValueReadonly) Mutate() *IdempotencyKeyValue {
-	return r.v.CloneVT()
+	return (*IdempotencyKeyValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IdempotencyKeyValue.
@@ -7823,7 +7819,7 @@ func (m *IdempotencyKeyValue) AsReader() IdempotencyKeyValueReader {
 	if m == nil {
 		return nil
 	}
-	return &idempotencyKeyValueReadonly{v: m}
+	return (*idempotencyKeyValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IdempotencyKeyValue.
@@ -7877,22 +7873,22 @@ type IdempotencyFailureReader interface {
 	Mutate() *IdempotencyFailure
 }
 
-type idempotencyFailureReadonly struct{ v *IdempotencyFailure }
+type idempotencyFailureReadonly IdempotencyFailure
 
 func (r *idempotencyFailureReadonly) GetReason() ErrorReason {
-	return r.v.GetReason()
+	return (*IdempotencyFailure)(r).GetReason()
 }
 
 func (r *idempotencyFailureReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*IdempotencyFailure)(r).GetMessage()
 }
 
 func (r *idempotencyFailureReadonly) GetMetadata() IdempotencyFailure_MetadataMapReader {
-	return idempotencyFailure_metadataMapReadonly(r.v.GetMetadata())
+	return idempotencyFailure_metadataMapReadonly((*IdempotencyFailure)(r).GetMetadata())
 }
 
 func (r *idempotencyFailureReadonly) Mutate() *IdempotencyFailure {
-	return r.v.CloneVT()
+	return (*IdempotencyFailure)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IdempotencyFailure.
@@ -7900,7 +7896,7 @@ func (m *IdempotencyFailure) AsReader() IdempotencyFailureReader {
 	if m == nil {
 		return nil
 	}
-	return &idempotencyFailureReadonly{v: m}
+	return (*idempotencyFailureReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IdempotencyFailure.
@@ -7976,14 +7972,14 @@ type TransactionReferenceValueReader interface {
 	Mutate() *TransactionReferenceValue
 }
 
-type transactionReferenceValueReadonly struct{ v *TransactionReferenceValue }
+type transactionReferenceValueReadonly TransactionReferenceValue
 
 func (r *transactionReferenceValueReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*TransactionReferenceValue)(r).GetTransactionId()
 }
 
 func (r *transactionReferenceValueReadonly) Mutate() *TransactionReferenceValue {
-	return r.v.CloneVT()
+	return (*TransactionReferenceValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransactionReferenceValue.
@@ -7991,7 +7987,7 @@ func (m *TransactionReferenceValue) AsReader() TransactionReferenceValueReader {
 	if m == nil {
 		return nil
 	}
-	return &transactionReferenceValueReadonly{v: m}
+	return (*transactionReferenceValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransactionReferenceValue.
@@ -8043,14 +8039,14 @@ type NumscriptVersionValueReader interface {
 	Mutate() *NumscriptVersionValue
 }
 
-type numscriptVersionValueReadonly struct{ v *NumscriptVersionValue }
+type numscriptVersionValueReadonly NumscriptVersionValue
 
 func (r *numscriptVersionValueReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*NumscriptVersionValue)(r).GetVersion()
 }
 
 func (r *numscriptVersionValueReadonly) Mutate() *NumscriptVersionValue {
-	return r.v.CloneVT()
+	return (*NumscriptVersionValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NumscriptVersionValue.
@@ -8058,7 +8054,7 @@ func (m *NumscriptVersionValue) AsReader() NumscriptVersionValueReader {
 	if m == nil {
 		return nil
 	}
-	return &numscriptVersionValueReadonly{v: m}
+	return (*numscriptVersionValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NumscriptVersionValue.
@@ -8110,14 +8106,14 @@ type SegmentTypeReader interface {
 	Mutate() *SegmentType
 }
 
-type segmentTypeReadonly struct{ v *SegmentType }
+type segmentTypeReadonly SegmentType
 
 func (r *segmentTypeReadonly) GetConstraint() isSegmentType_Constraint {
-	return r.v.GetConstraint()
+	return (*SegmentType)(r).GetConstraint()
 }
 
 func (r *segmentTypeReadonly) Mutate() *SegmentType {
-	return r.v.CloneVT()
+	return (*SegmentType)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SegmentType.
@@ -8125,7 +8121,7 @@ func (m *SegmentType) AsReader() SegmentTypeReader {
 	if m == nil {
 		return nil
 	}
-	return &segmentTypeReadonly{v: m}
+	return (*segmentTypeReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SegmentType.
@@ -8176,10 +8172,10 @@ type UUIDConstraintReader interface {
 	Mutate() *UUIDConstraint
 }
 
-type uUIDConstraintReadonly struct{ v *UUIDConstraint }
+type uUIDConstraintReadonly UUIDConstraint
 
 func (r *uUIDConstraintReadonly) Mutate() *UUIDConstraint {
-	return r.v.CloneVT()
+	return (*UUIDConstraint)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UUIDConstraint.
@@ -8187,7 +8183,7 @@ func (m *UUIDConstraint) AsReader() UUIDConstraintReader {
 	if m == nil {
 		return nil
 	}
-	return &uUIDConstraintReadonly{v: m}
+	return (*uUIDConstraintReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UUIDConstraint.
@@ -8238,10 +8234,10 @@ type Uint64ConstraintReader interface {
 	Mutate() *Uint64Constraint
 }
 
-type uint64ConstraintReadonly struct{ v *Uint64Constraint }
+type uint64ConstraintReadonly Uint64Constraint
 
 func (r *uint64ConstraintReadonly) Mutate() *Uint64Constraint {
-	return r.v.CloneVT()
+	return (*Uint64Constraint)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Uint64Constraint.
@@ -8249,7 +8245,7 @@ func (m *Uint64Constraint) AsReader() Uint64ConstraintReader {
 	if m == nil {
 		return nil
 	}
-	return &uint64ConstraintReadonly{v: m}
+	return (*uint64ConstraintReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Uint64Constraint.
@@ -8300,10 +8296,10 @@ type BytesConstraintReader interface {
 	Mutate() *BytesConstraint
 }
 
-type bytesConstraintReadonly struct{ v *BytesConstraint }
+type bytesConstraintReadonly BytesConstraint
 
 func (r *bytesConstraintReadonly) Mutate() *BytesConstraint {
-	return r.v.CloneVT()
+	return (*BytesConstraint)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BytesConstraint.
@@ -8311,7 +8307,7 @@ func (m *BytesConstraint) AsReader() BytesConstraintReader {
 	if m == nil {
 		return nil
 	}
-	return &bytesConstraintReadonly{v: m}
+	return (*bytesConstraintReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BytesConstraint.
@@ -8366,26 +8362,26 @@ type AccountTypeReader interface {
 	Mutate() *AccountType
 }
 
-type accountTypeReadonly struct{ v *AccountType }
+type accountTypeReadonly AccountType
 
 func (r *accountTypeReadonly) GetName() string {
-	return r.v.GetName()
+	return (*AccountType)(r).GetName()
 }
 
 func (r *accountTypeReadonly) GetPattern() string {
-	return r.v.GetPattern()
+	return (*AccountType)(r).GetPattern()
 }
 
 func (r *accountTypeReadonly) GetPersistence() AccountTypePersistence {
-	return r.v.GetPersistence()
+	return (*AccountType)(r).GetPersistence()
 }
 
 func (r *accountTypeReadonly) GetSegmentTypes() AccountType_SegmentTypesMapReader {
-	return accountType_segmentTypesMapReadonly(r.v.GetSegmentTypes())
+	return accountType_segmentTypesMapReadonly((*AccountType)(r).GetSegmentTypes())
 }
 
 func (r *accountTypeReadonly) Mutate() *AccountType {
-	return r.v.CloneVT()
+	return (*AccountType)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AccountType.
@@ -8393,7 +8389,7 @@ func (m *AccountType) AsReader() AccountTypeReader {
 	if m == nil {
 		return nil
 	}
-	return &accountTypeReadonly{v: m}
+	return (*accountTypeReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AccountType.
@@ -8476,10 +8472,10 @@ type AddedAccountTypeLogReader interface {
 	Mutate() *AddedAccountTypeLog
 }
 
-type addedAccountTypeLogReadonly struct{ v *AddedAccountTypeLog }
+type addedAccountTypeLogReadonly AddedAccountTypeLog
 
 func (r *addedAccountTypeLogReadonly) GetAccountType() AccountTypeReader {
-	v := r.v.GetAccountType()
+	v := (*AddedAccountTypeLog)(r).GetAccountType()
 	if v == nil {
 		return nil
 	}
@@ -8487,7 +8483,7 @@ func (r *addedAccountTypeLogReadonly) GetAccountType() AccountTypeReader {
 }
 
 func (r *addedAccountTypeLogReadonly) Mutate() *AddedAccountTypeLog {
-	return r.v.CloneVT()
+	return (*AddedAccountTypeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddedAccountTypeLog.
@@ -8495,7 +8491,7 @@ func (m *AddedAccountTypeLog) AsReader() AddedAccountTypeLogReader {
 	if m == nil {
 		return nil
 	}
-	return &addedAccountTypeLogReadonly{v: m}
+	return (*addedAccountTypeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddedAccountTypeLog.
@@ -8547,14 +8543,14 @@ type RemovedAccountTypeLogReader interface {
 	Mutate() *RemovedAccountTypeLog
 }
 
-type removedAccountTypeLogReadonly struct{ v *RemovedAccountTypeLog }
+type removedAccountTypeLogReadonly RemovedAccountTypeLog
 
 func (r *removedAccountTypeLogReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemovedAccountTypeLog)(r).GetName()
 }
 
 func (r *removedAccountTypeLogReadonly) Mutate() *RemovedAccountTypeLog {
-	return r.v.CloneVT()
+	return (*RemovedAccountTypeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemovedAccountTypeLog.
@@ -8562,7 +8558,7 @@ func (m *RemovedAccountTypeLog) AsReader() RemovedAccountTypeLogReader {
 	if m == nil {
 		return nil
 	}
-	return &removedAccountTypeLogReadonly{v: m}
+	return (*removedAccountTypeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemovedAccountTypeLog.
@@ -8614,16 +8610,14 @@ type UpdatedDefaultEnforcementModeLogReader interface {
 	Mutate() *UpdatedDefaultEnforcementModeLog
 }
 
-type updatedDefaultEnforcementModeLogReadonly struct {
-	v *UpdatedDefaultEnforcementModeLog
-}
+type updatedDefaultEnforcementModeLogReadonly UpdatedDefaultEnforcementModeLog
 
 func (r *updatedDefaultEnforcementModeLogReadonly) GetEnforcementMode() ChartEnforcementMode {
-	return r.v.GetEnforcementMode()
+	return (*UpdatedDefaultEnforcementModeLog)(r).GetEnforcementMode()
 }
 
 func (r *updatedDefaultEnforcementModeLogReadonly) Mutate() *UpdatedDefaultEnforcementModeLog {
-	return r.v.CloneVT()
+	return (*UpdatedDefaultEnforcementModeLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdatedDefaultEnforcementModeLog.
@@ -8631,7 +8625,7 @@ func (m *UpdatedDefaultEnforcementModeLog) AsReader() UpdatedDefaultEnforcementM
 	if m == nil {
 		return nil
 	}
-	return &updatedDefaultEnforcementModeLogReadonly{v: m}
+	return (*updatedDefaultEnforcementModeLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdatedDefaultEnforcementModeLog.
@@ -8683,14 +8677,14 @@ type QueryFilterReader interface {
 	Mutate() *QueryFilter
 }
 
-type queryFilterReadonly struct{ v *QueryFilter }
+type queryFilterReadonly QueryFilter
 
 func (r *queryFilterReadonly) GetFilter() isQueryFilter_Filter {
-	return r.v.GetFilter()
+	return (*QueryFilter)(r).GetFilter()
 }
 
 func (r *queryFilterReadonly) Mutate() *QueryFilter {
-	return r.v.CloneVT()
+	return (*QueryFilter)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this QueryFilter.
@@ -8698,7 +8692,7 @@ func (m *QueryFilter) AsReader() QueryFilterReader {
 	if m == nil {
 		return nil
 	}
-	return &queryFilterReadonly{v: m}
+	return (*queryFilterReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this QueryFilter.
@@ -8750,10 +8744,10 @@ type ReferenceConditionReader interface {
 	Mutate() *ReferenceCondition
 }
 
-type referenceConditionReadonly struct{ v *ReferenceCondition }
+type referenceConditionReadonly ReferenceCondition
 
 func (r *referenceConditionReadonly) GetCond() StringConditionReader {
-	v := r.v.GetCond()
+	v := (*ReferenceCondition)(r).GetCond()
 	if v == nil {
 		return nil
 	}
@@ -8761,7 +8755,7 @@ func (r *referenceConditionReadonly) GetCond() StringConditionReader {
 }
 
 func (r *referenceConditionReadonly) Mutate() *ReferenceCondition {
-	return r.v.CloneVT()
+	return (*ReferenceCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ReferenceCondition.
@@ -8769,7 +8763,7 @@ func (m *ReferenceCondition) AsReader() ReferenceConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &referenceConditionReadonly{v: m}
+	return (*referenceConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ReferenceCondition.
@@ -8821,10 +8815,10 @@ type LedgerConditionReader interface {
 	Mutate() *LedgerCondition
 }
 
-type ledgerConditionReadonly struct{ v *LedgerCondition }
+type ledgerConditionReadonly LedgerCondition
 
 func (r *ledgerConditionReadonly) GetCond() StringConditionReader {
-	v := r.v.GetCond()
+	v := (*LedgerCondition)(r).GetCond()
 	if v == nil {
 		return nil
 	}
@@ -8832,7 +8826,7 @@ func (r *ledgerConditionReadonly) GetCond() StringConditionReader {
 }
 
 func (r *ledgerConditionReadonly) Mutate() *LedgerCondition {
-	return r.v.CloneVT()
+	return (*LedgerCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerCondition.
@@ -8840,7 +8834,7 @@ func (m *LedgerCondition) AsReader() LedgerConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerConditionReadonly{v: m}
+	return (*ledgerConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerCondition.
@@ -8892,10 +8886,10 @@ type LogIdConditionReader interface {
 	Mutate() *LogIdCondition
 }
 
-type logIdConditionReadonly struct{ v *LogIdCondition }
+type logIdConditionReadonly LogIdCondition
 
 func (r *logIdConditionReadonly) GetCond() UintConditionReader {
-	v := r.v.GetCond()
+	v := (*LogIdCondition)(r).GetCond()
 	if v == nil {
 		return nil
 	}
@@ -8903,7 +8897,7 @@ func (r *logIdConditionReadonly) GetCond() UintConditionReader {
 }
 
 func (r *logIdConditionReadonly) Mutate() *LogIdCondition {
-	return r.v.CloneVT()
+	return (*LogIdCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LogIdCondition.
@@ -8911,7 +8905,7 @@ func (m *LogIdCondition) AsReader() LogIdConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &logIdConditionReadonly{v: m}
+	return (*logIdConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LogIdCondition.
@@ -8964,14 +8958,14 @@ type BuiltinUintConditionReader interface {
 	Mutate() *BuiltinUintCondition
 }
 
-type builtinUintConditionReadonly struct{ v *BuiltinUintCondition }
+type builtinUintConditionReadonly BuiltinUintCondition
 
 func (r *builtinUintConditionReadonly) GetField() TransactionBuiltinIndex {
-	return r.v.GetField()
+	return (*BuiltinUintCondition)(r).GetField()
 }
 
 func (r *builtinUintConditionReadonly) GetCond() UintConditionReader {
-	v := r.v.GetCond()
+	v := (*BuiltinUintCondition)(r).GetCond()
 	if v == nil {
 		return nil
 	}
@@ -8979,7 +8973,7 @@ func (r *builtinUintConditionReadonly) GetCond() UintConditionReader {
 }
 
 func (r *builtinUintConditionReadonly) Mutate() *BuiltinUintCondition {
-	return r.v.CloneVT()
+	return (*BuiltinUintCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BuiltinUintCondition.
@@ -8987,7 +8981,7 @@ func (m *BuiltinUintCondition) AsReader() BuiltinUintConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &builtinUintConditionReadonly{v: m}
+	return (*builtinUintConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BuiltinUintCondition.
@@ -9040,14 +9034,14 @@ type LogBuiltinUintConditionReader interface {
 	Mutate() *LogBuiltinUintCondition
 }
 
-type logBuiltinUintConditionReadonly struct{ v *LogBuiltinUintCondition }
+type logBuiltinUintConditionReadonly LogBuiltinUintCondition
 
 func (r *logBuiltinUintConditionReadonly) GetField() LogBuiltinIndex {
-	return r.v.GetField()
+	return (*LogBuiltinUintCondition)(r).GetField()
 }
 
 func (r *logBuiltinUintConditionReadonly) GetCond() UintConditionReader {
-	v := r.v.GetCond()
+	v := (*LogBuiltinUintCondition)(r).GetCond()
 	if v == nil {
 		return nil
 	}
@@ -9055,7 +9049,7 @@ func (r *logBuiltinUintConditionReadonly) GetCond() UintConditionReader {
 }
 
 func (r *logBuiltinUintConditionReadonly) Mutate() *LogBuiltinUintCondition {
-	return r.v.CloneVT()
+	return (*LogBuiltinUintCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LogBuiltinUintCondition.
@@ -9063,7 +9057,7 @@ func (m *LogBuiltinUintCondition) AsReader() LogBuiltinUintConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &logBuiltinUintConditionReadonly{v: m}
+	return (*logBuiltinUintConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LogBuiltinUintCondition.
@@ -9116,18 +9110,18 @@ type AccountHasAssetConditionReader interface {
 	Mutate() *AccountHasAssetCondition
 }
 
-type accountHasAssetConditionReadonly struct{ v *AccountHasAssetCondition }
+type accountHasAssetConditionReadonly AccountHasAssetCondition
 
 func (r *accountHasAssetConditionReadonly) GetAssetBase() string {
-	return r.v.GetAssetBase()
+	return (*AccountHasAssetCondition)(r).GetAssetBase()
 }
 
 func (r *accountHasAssetConditionReadonly) GetPrecision() uint32 {
-	return r.v.GetPrecision()
+	return (*AccountHasAssetCondition)(r).GetPrecision()
 }
 
 func (r *accountHasAssetConditionReadonly) Mutate() *AccountHasAssetCondition {
-	return r.v.CloneVT()
+	return (*AccountHasAssetCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AccountHasAssetCondition.
@@ -9135,7 +9129,7 @@ func (m *AccountHasAssetCondition) AsReader() AccountHasAssetConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &accountHasAssetConditionReadonly{v: m}
+	return (*accountHasAssetConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AccountHasAssetCondition.
@@ -9187,14 +9181,14 @@ type AndFilterReader interface {
 	Mutate() *AndFilter
 }
 
-type andFilterReadonly struct{ v *AndFilter }
+type andFilterReadonly AndFilter
 
 func (r *andFilterReadonly) GetFilters() QueryFilterListReader {
-	return NewQueryFilterListReader(r.v.GetFilters())
+	return NewQueryFilterListReader((*AndFilter)(r).GetFilters())
 }
 
 func (r *andFilterReadonly) Mutate() *AndFilter {
-	return r.v.CloneVT()
+	return (*AndFilter)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AndFilter.
@@ -9202,7 +9196,7 @@ func (m *AndFilter) AsReader() AndFilterReader {
 	if m == nil {
 		return nil
 	}
-	return &andFilterReadonly{v: m}
+	return (*andFilterReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AndFilter.
@@ -9252,14 +9246,14 @@ type OrFilterReader interface {
 	Mutate() *OrFilter
 }
 
-type orFilterReadonly struct{ v *OrFilter }
+type orFilterReadonly OrFilter
 
 func (r *orFilterReadonly) GetFilters() QueryFilterListReader {
-	return NewQueryFilterListReader(r.v.GetFilters())
+	return NewQueryFilterListReader((*OrFilter)(r).GetFilters())
 }
 
 func (r *orFilterReadonly) Mutate() *OrFilter {
-	return r.v.CloneVT()
+	return (*OrFilter)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this OrFilter.
@@ -9267,7 +9261,7 @@ func (m *OrFilter) AsReader() OrFilterReader {
 	if m == nil {
 		return nil
 	}
-	return &orFilterReadonly{v: m}
+	return (*orFilterReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this OrFilter.
@@ -9317,10 +9311,10 @@ type NotFilterReader interface {
 	Mutate() *NotFilter
 }
 
-type notFilterReadonly struct{ v *NotFilter }
+type notFilterReadonly NotFilter
 
 func (r *notFilterReadonly) GetFilter() QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*NotFilter)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -9328,7 +9322,7 @@ func (r *notFilterReadonly) GetFilter() QueryFilterReader {
 }
 
 func (r *notFilterReadonly) Mutate() *NotFilter {
-	return r.v.CloneVT()
+	return (*NotFilter)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NotFilter.
@@ -9336,7 +9330,7 @@ func (m *NotFilter) AsReader() NotFilterReader {
 	if m == nil {
 		return nil
 	}
-	return &notFilterReadonly{v: m}
+	return (*notFilterReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NotFilter.
@@ -9386,14 +9380,14 @@ type FieldRefReader interface {
 	Mutate() *FieldRef
 }
 
-type fieldRefReadonly struct{ v *FieldRef }
+type fieldRefReadonly FieldRef
 
 func (r *fieldRefReadonly) GetMetadata() string {
-	return r.v.GetMetadata()
+	return (*FieldRef)(r).GetMetadata()
 }
 
 func (r *fieldRefReadonly) Mutate() *FieldRef {
-	return r.v.CloneVT()
+	return (*FieldRef)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FieldRef.
@@ -9401,7 +9395,7 @@ func (m *FieldRef) AsReader() FieldRefReader {
 	if m == nil {
 		return nil
 	}
-	return &fieldRefReadonly{v: m}
+	return (*fieldRefReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FieldRef.
@@ -9452,10 +9446,10 @@ type FieldConditionReader interface {
 	Mutate() *FieldCondition
 }
 
-type fieldConditionReadonly struct{ v *FieldCondition }
+type fieldConditionReadonly FieldCondition
 
 func (r *fieldConditionReadonly) GetField() FieldRefReader {
-	v := r.v.GetField()
+	v := (*FieldCondition)(r).GetField()
 	if v == nil {
 		return nil
 	}
@@ -9463,11 +9457,11 @@ func (r *fieldConditionReadonly) GetField() FieldRefReader {
 }
 
 func (r *fieldConditionReadonly) GetCondition() isFieldCondition_Condition {
-	return r.v.GetCondition()
+	return (*FieldCondition)(r).GetCondition()
 }
 
 func (r *fieldConditionReadonly) Mutate() *FieldCondition {
-	return r.v.CloneVT()
+	return (*FieldCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FieldCondition.
@@ -9475,7 +9469,7 @@ func (m *FieldCondition) AsReader() FieldConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &fieldConditionReadonly{v: m}
+	return (*fieldConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FieldCondition.
@@ -9527,14 +9521,14 @@ type StringConditionReader interface {
 	Mutate() *StringCondition
 }
 
-type stringConditionReadonly struct{ v *StringCondition }
+type stringConditionReadonly StringCondition
 
 func (r *stringConditionReadonly) GetValue() isStringCondition_Value {
-	return r.v.GetValue()
+	return (*StringCondition)(r).GetValue()
 }
 
 func (r *stringConditionReadonly) Mutate() *StringCondition {
-	return r.v.CloneVT()
+	return (*StringCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this StringCondition.
@@ -9542,7 +9536,7 @@ func (m *StringCondition) AsReader() StringConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &stringConditionReadonly{v: m}
+	return (*stringConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this StringCondition.
@@ -9599,34 +9593,34 @@ type IntConditionReader interface {
 	Mutate() *IntCondition
 }
 
-type intConditionReadonly struct{ v *IntCondition }
+type intConditionReadonly IntCondition
 
 func (r *intConditionReadonly) GetMin() int64 {
-	return r.v.GetMin()
+	return (*IntCondition)(r).GetMin()
 }
 
 func (r *intConditionReadonly) GetMax() int64 {
-	return r.v.GetMax()
+	return (*IntCondition)(r).GetMax()
 }
 
 func (r *intConditionReadonly) GetMinExclusive() bool {
-	return r.v.GetMinExclusive()
+	return (*IntCondition)(r).GetMinExclusive()
 }
 
 func (r *intConditionReadonly) GetMaxExclusive() bool {
-	return r.v.GetMaxExclusive()
+	return (*IntCondition)(r).GetMaxExclusive()
 }
 
 func (r *intConditionReadonly) GetParamMin() string {
-	return r.v.GetParamMin()
+	return (*IntCondition)(r).GetParamMin()
 }
 
 func (r *intConditionReadonly) GetParamMax() string {
-	return r.v.GetParamMax()
+	return (*IntCondition)(r).GetParamMax()
 }
 
 func (r *intConditionReadonly) Mutate() *IntCondition {
-	return r.v.CloneVT()
+	return (*IntCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IntCondition.
@@ -9634,7 +9628,7 @@ func (m *IntCondition) AsReader() IntConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &intConditionReadonly{v: m}
+	return (*intConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IntCondition.
@@ -9691,34 +9685,34 @@ type UintConditionReader interface {
 	Mutate() *UintCondition
 }
 
-type uintConditionReadonly struct{ v *UintCondition }
+type uintConditionReadonly UintCondition
 
 func (r *uintConditionReadonly) GetMin() uint64 {
-	return r.v.GetMin()
+	return (*UintCondition)(r).GetMin()
 }
 
 func (r *uintConditionReadonly) GetMax() uint64 {
-	return r.v.GetMax()
+	return (*UintCondition)(r).GetMax()
 }
 
 func (r *uintConditionReadonly) GetMinExclusive() bool {
-	return r.v.GetMinExclusive()
+	return (*UintCondition)(r).GetMinExclusive()
 }
 
 func (r *uintConditionReadonly) GetMaxExclusive() bool {
-	return r.v.GetMaxExclusive()
+	return (*UintCondition)(r).GetMaxExclusive()
 }
 
 func (r *uintConditionReadonly) GetParamMin() string {
-	return r.v.GetParamMin()
+	return (*UintCondition)(r).GetParamMin()
 }
 
 func (r *uintConditionReadonly) GetParamMax() string {
-	return r.v.GetParamMax()
+	return (*UintCondition)(r).GetParamMax()
 }
 
 func (r *uintConditionReadonly) Mutate() *UintCondition {
-	return r.v.CloneVT()
+	return (*UintCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UintCondition.
@@ -9726,7 +9720,7 @@ func (m *UintCondition) AsReader() UintConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &uintConditionReadonly{v: m}
+	return (*uintConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UintCondition.
@@ -9778,14 +9772,14 @@ type BoolConditionReader interface {
 	Mutate() *BoolCondition
 }
 
-type boolConditionReadonly struct{ v *BoolCondition }
+type boolConditionReadonly BoolCondition
 
 func (r *boolConditionReadonly) GetValue() isBoolCondition_Value {
-	return r.v.GetValue()
+	return (*BoolCondition)(r).GetValue()
 }
 
 func (r *boolConditionReadonly) Mutate() *BoolCondition {
-	return r.v.CloneVT()
+	return (*BoolCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BoolCondition.
@@ -9793,7 +9787,7 @@ func (m *BoolCondition) AsReader() BoolConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &boolConditionReadonly{v: m}
+	return (*boolConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BoolCondition.
@@ -9845,14 +9839,14 @@ type ExistsConditionReader interface {
 	Mutate() *ExistsCondition
 }
 
-type existsConditionReadonly struct{ v *ExistsCondition }
+type existsConditionReadonly ExistsCondition
 
 func (r *existsConditionReadonly) GetIncludeNull() bool {
-	return r.v.GetIncludeNull()
+	return (*ExistsCondition)(r).GetIncludeNull()
 }
 
 func (r *existsConditionReadonly) Mutate() *ExistsCondition {
-	return r.v.CloneVT()
+	return (*ExistsCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ExistsCondition.
@@ -9860,7 +9854,7 @@ func (m *ExistsCondition) AsReader() ExistsConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &existsConditionReadonly{v: m}
+	return (*existsConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ExistsCondition.
@@ -9913,18 +9907,18 @@ type AddressMatchReader interface {
 	Mutate() *AddressMatch
 }
 
-type addressMatchReadonly struct{ v *AddressMatch }
+type addressMatchReadonly AddressMatch
 
 func (r *addressMatchReadonly) GetRole() AddressRole {
-	return r.v.GetRole()
+	return (*AddressMatch)(r).GetRole()
 }
 
 func (r *addressMatchReadonly) GetMatch() isAddressMatch_Match {
-	return r.v.GetMatch()
+	return (*AddressMatch)(r).GetMatch()
 }
 
 func (r *addressMatchReadonly) Mutate() *AddressMatch {
-	return r.v.CloneVT()
+	return (*AddressMatch)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddressMatch.
@@ -9932,7 +9926,7 @@ func (m *AddressMatch) AsReader() AddressMatchReader {
 	if m == nil {
 		return nil
 	}
-	return &addressMatchReadonly{v: m}
+	return (*addressMatchReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddressMatch.
@@ -9986,14 +9980,14 @@ type PreparedQueryReader interface {
 	Mutate() *PreparedQuery
 }
 
-type preparedQueryReadonly struct{ v *PreparedQuery }
+type preparedQueryReadonly PreparedQuery
 
 func (r *preparedQueryReadonly) GetName() string {
-	return r.v.GetName()
+	return (*PreparedQuery)(r).GetName()
 }
 
 func (r *preparedQueryReadonly) GetFilter() QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*PreparedQuery)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -10001,11 +9995,11 @@ func (r *preparedQueryReadonly) GetFilter() QueryFilterReader {
 }
 
 func (r *preparedQueryReadonly) GetTarget() QueryTarget {
-	return r.v.GetTarget()
+	return (*PreparedQuery)(r).GetTarget()
 }
 
 func (r *preparedQueryReadonly) Mutate() *PreparedQuery {
-	return r.v.CloneVT()
+	return (*PreparedQuery)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PreparedQuery.
@@ -10013,7 +10007,7 @@ func (m *PreparedQuery) AsReader() PreparedQueryReader {
 	if m == nil {
 		return nil
 	}
-	return &preparedQueryReadonly{v: m}
+	return (*preparedQueryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PreparedQuery.
@@ -10067,14 +10061,14 @@ type AggregatedVolumeReader interface {
 	Mutate() *AggregatedVolume
 }
 
-type aggregatedVolumeReadonly struct{ v *AggregatedVolume }
+type aggregatedVolumeReadonly AggregatedVolume
 
 func (r *aggregatedVolumeReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*AggregatedVolume)(r).GetAsset()
 }
 
 func (r *aggregatedVolumeReadonly) GetInput() Uint256Reader {
-	v := r.v.GetInput()
+	v := (*AggregatedVolume)(r).GetInput()
 	if v == nil {
 		return nil
 	}
@@ -10082,7 +10076,7 @@ func (r *aggregatedVolumeReadonly) GetInput() Uint256Reader {
 }
 
 func (r *aggregatedVolumeReadonly) GetOutput() Uint256Reader {
-	v := r.v.GetOutput()
+	v := (*AggregatedVolume)(r).GetOutput()
 	if v == nil {
 		return nil
 	}
@@ -10090,7 +10084,7 @@ func (r *aggregatedVolumeReadonly) GetOutput() Uint256Reader {
 }
 
 func (r *aggregatedVolumeReadonly) Mutate() *AggregatedVolume {
-	return r.v.CloneVT()
+	return (*AggregatedVolume)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AggregatedVolume.
@@ -10098,7 +10092,7 @@ func (m *AggregatedVolume) AsReader() AggregatedVolumeReader {
 	if m == nil {
 		return nil
 	}
-	return &aggregatedVolumeReadonly{v: m}
+	return (*aggregatedVolumeReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AggregatedVolume.
@@ -10151,18 +10145,18 @@ type AggregateResultReader interface {
 	Mutate() *AggregateResult
 }
 
-type aggregateResultReadonly struct{ v *AggregateResult }
+type aggregateResultReadonly AggregateResult
 
 func (r *aggregateResultReadonly) GetVolumes() AggregatedVolumeListReader {
-	return NewAggregatedVolumeListReader(r.v.GetVolumes())
+	return NewAggregatedVolumeListReader((*AggregateResult)(r).GetVolumes())
 }
 
 func (r *aggregateResultReadonly) GetGroups() GroupedAggregateResultListReader {
-	return NewGroupedAggregateResultListReader(r.v.GetGroups())
+	return NewGroupedAggregateResultListReader((*AggregateResult)(r).GetGroups())
 }
 
 func (r *aggregateResultReadonly) Mutate() *AggregateResult {
-	return r.v.CloneVT()
+	return (*AggregateResult)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AggregateResult.
@@ -10170,7 +10164,7 @@ func (m *AggregateResult) AsReader() AggregateResultReader {
 	if m == nil {
 		return nil
 	}
-	return &aggregateResultReadonly{v: m}
+	return (*aggregateResultReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AggregateResult.
@@ -10223,18 +10217,18 @@ type GroupedAggregateResultReader interface {
 	Mutate() *GroupedAggregateResult
 }
 
-type groupedAggregateResultReadonly struct{ v *GroupedAggregateResult }
+type groupedAggregateResultReadonly GroupedAggregateResult
 
 func (r *groupedAggregateResultReadonly) GetPrefix() string {
-	return r.v.GetPrefix()
+	return (*GroupedAggregateResult)(r).GetPrefix()
 }
 
 func (r *groupedAggregateResultReadonly) GetVolumes() AggregatedVolumeListReader {
-	return NewAggregatedVolumeListReader(r.v.GetVolumes())
+	return NewAggregatedVolumeListReader((*GroupedAggregateResult)(r).GetVolumes())
 }
 
 func (r *groupedAggregateResultReadonly) Mutate() *GroupedAggregateResult {
-	return r.v.CloneVT()
+	return (*GroupedAggregateResult)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GroupedAggregateResult.
@@ -10242,7 +10236,7 @@ func (m *GroupedAggregateResult) AsReader() GroupedAggregateResultReader {
 	if m == nil {
 		return nil
 	}
-	return &groupedAggregateResultReadonly{v: m}
+	return (*groupedAggregateResultReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GroupedAggregateResult.
@@ -10299,34 +10293,34 @@ type PreparedQueryCursorReader interface {
 	Mutate() *PreparedQueryCursor
 }
 
-type preparedQueryCursorReadonly struct{ v *PreparedQueryCursor }
+type preparedQueryCursorReadonly PreparedQueryCursor
 
 func (r *preparedQueryCursorReadonly) GetPageSize() uint32 {
-	return r.v.GetPageSize()
+	return (*PreparedQueryCursor)(r).GetPageSize()
 }
 
 func (r *preparedQueryCursorReadonly) GetHasMore() bool {
-	return r.v.GetHasMore()
+	return (*PreparedQueryCursor)(r).GetHasMore()
 }
 
 func (r *preparedQueryCursorReadonly) GetPrevious() string {
-	return r.v.GetPrevious()
+	return (*PreparedQueryCursor)(r).GetPrevious()
 }
 
 func (r *preparedQueryCursorReadonly) GetNext() string {
-	return r.v.GetNext()
+	return (*PreparedQueryCursor)(r).GetNext()
 }
 
 func (r *preparedQueryCursorReadonly) GetAccountData() AccountListReader {
-	return NewAccountListReader(r.v.GetAccountData())
+	return NewAccountListReader((*PreparedQueryCursor)(r).GetAccountData())
 }
 
 func (r *preparedQueryCursorReadonly) GetTransactionData() TransactionListReader {
-	return NewTransactionListReader(r.v.GetTransactionData())
+	return NewTransactionListReader((*PreparedQueryCursor)(r).GetTransactionData())
 }
 
 func (r *preparedQueryCursorReadonly) Mutate() *PreparedQueryCursor {
-	return r.v.CloneVT()
+	return (*PreparedQueryCursor)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PreparedQueryCursor.
@@ -10334,7 +10328,7 @@ func (m *PreparedQueryCursor) AsReader() PreparedQueryCursorReader {
 	if m == nil {
 		return nil
 	}
-	return &preparedQueryCursorReadonly{v: m}
+	return (*preparedQueryCursorReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PreparedQueryCursor.
@@ -10395,50 +10389,50 @@ type LedgerStatsReader interface {
 	Mutate() *LedgerStats
 }
 
-type ledgerStatsReadonly struct{ v *LedgerStats }
+type ledgerStatsReadonly LedgerStats
 
 func (r *ledgerStatsReadonly) GetTransactionCount() uint64 {
-	return r.v.GetTransactionCount()
+	return (*LedgerStats)(r).GetTransactionCount()
 }
 
 func (r *ledgerStatsReadonly) GetVolumeCount() uint64 {
-	return r.v.GetVolumeCount()
+	return (*LedgerStats)(r).GetVolumeCount()
 }
 
 func (r *ledgerStatsReadonly) GetMetadataCount() uint64 {
-	return r.v.GetMetadataCount()
+	return (*LedgerStats)(r).GetMetadataCount()
 }
 
 func (r *ledgerStatsReadonly) GetReferenceCount() uint64 {
-	return r.v.GetReferenceCount()
+	return (*LedgerStats)(r).GetReferenceCount()
 }
 
 func (r *ledgerStatsReadonly) GetPostingCount() uint64 {
-	return r.v.GetPostingCount()
+	return (*LedgerStats)(r).GetPostingCount()
 }
 
 func (r *ledgerStatsReadonly) GetEphemeralEvictedCount() uint64 {
-	return r.v.GetEphemeralEvictedCount()
+	return (*LedgerStats)(r).GetEphemeralEvictedCount()
 }
 
 func (r *ledgerStatsReadonly) GetTransientUsedCount() uint64 {
-	return r.v.GetTransientUsedCount()
+	return (*LedgerStats)(r).GetTransientUsedCount()
 }
 
 func (r *ledgerStatsReadonly) GetRevertCount() uint64 {
-	return r.v.GetRevertCount()
+	return (*LedgerStats)(r).GetRevertCount()
 }
 
 func (r *ledgerStatsReadonly) GetNumscriptExecutionCount() uint64 {
-	return r.v.GetNumscriptExecutionCount()
+	return (*LedgerStats)(r).GetNumscriptExecutionCount()
 }
 
 func (r *ledgerStatsReadonly) GetLogCount() uint64 {
-	return r.v.GetLogCount()
+	return (*LedgerStats)(r).GetLogCount()
 }
 
 func (r *ledgerStatsReadonly) Mutate() *LedgerStats {
-	return r.v.CloneVT()
+	return (*LedgerStats)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerStats.
@@ -10446,7 +10440,7 @@ func (m *LedgerStats) AsReader() LedgerStatsReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerStatsReadonly{v: m}
+	return (*ledgerStatsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerStats.
@@ -10501,26 +10495,26 @@ type PersistedConfigReader interface {
 	Mutate() *PersistedConfig
 }
 
-type persistedConfigReadonly struct{ v *PersistedConfig }
+type persistedConfigReadonly PersistedConfig
 
 func (r *persistedConfigReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*PersistedConfig)(r).GetNodeId()
 }
 
 func (r *persistedConfigReadonly) GetClusterId() string {
-	return r.v.GetClusterId()
+	return (*PersistedConfig)(r).GetClusterId()
 }
 
 func (r *persistedConfigReadonly) GetIdempotencyTtlSeconds() uint64 {
-	return r.v.GetIdempotencyTtlSeconds()
+	return (*PersistedConfig)(r).GetIdempotencyTtlSeconds()
 }
 
 func (r *persistedConfigReadonly) GetStorageSchemaVersion() uint32 {
-	return r.v.GetStorageSchemaVersion()
+	return (*PersistedConfig)(r).GetStorageSchemaVersion()
 }
 
 func (r *persistedConfigReadonly) Mutate() *PersistedConfig {
-	return r.v.CloneVT()
+	return (*PersistedConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PersistedConfig.
@@ -10528,7 +10522,7 @@ func (m *PersistedConfig) AsReader() PersistedConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &persistedConfigReadonly{v: m}
+	return (*persistedConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PersistedConfig.
@@ -10581,18 +10575,18 @@ type CallerIdentityReader interface {
 	Mutate() *CallerIdentity
 }
 
-type callerIdentityReadonly struct{ v *CallerIdentity }
+type callerIdentityReadonly CallerIdentity
 
 func (r *callerIdentityReadonly) GetSubject() string {
-	return r.v.GetSubject()
+	return (*CallerIdentity)(r).GetSubject()
 }
 
 func (r *callerIdentityReadonly) GetSource() isCallerIdentity_Source {
-	return r.v.GetSource()
+	return (*CallerIdentity)(r).GetSource()
 }
 
 func (r *callerIdentityReadonly) Mutate() *CallerIdentity {
-	return r.v.CloneVT()
+	return (*CallerIdentity)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CallerIdentity.
@@ -10600,7 +10594,7 @@ func (m *CallerIdentity) AsReader() CallerIdentityReader {
 	if m == nil {
 		return nil
 	}
-	return &callerIdentityReadonly{v: m}
+	return (*callerIdentityReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CallerIdentity.
@@ -10654,10 +10648,10 @@ type CallerSnapshotReader interface {
 	Mutate() *CallerSnapshot
 }
 
-type callerSnapshotReadonly struct{ v *CallerSnapshot }
+type callerSnapshotReadonly CallerSnapshot
 
 func (r *callerSnapshotReadonly) GetIdentity() CallerIdentityReader {
-	v := r.v.GetIdentity()
+	v := (*CallerSnapshot)(r).GetIdentity()
 	if v == nil {
 		return nil
 	}
@@ -10665,15 +10659,15 @@ func (r *callerSnapshotReadonly) GetIdentity() CallerIdentityReader {
 }
 
 func (r *callerSnapshotReadonly) GetScopes() []string {
-	return slices.Clone(r.v.GetScopes())
+	return slices.Clone((*CallerSnapshot)(r).GetScopes())
 }
 
 func (r *callerSnapshotReadonly) GetGod() bool {
-	return r.v.GetGod()
+	return (*CallerSnapshot)(r).GetGod()
 }
 
 func (r *callerSnapshotReadonly) Mutate() *CallerSnapshot {
-	return r.v.CloneVT()
+	return (*CallerSnapshot)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CallerSnapshot.
@@ -10681,7 +10675,7 @@ func (m *CallerSnapshot) AsReader() CallerSnapshotReader {
 	if m == nil {
 		return nil
 	}
-	return &callerSnapshotReadonly{v: m}
+	return (*callerSnapshotReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CallerSnapshot.
@@ -10737,30 +10731,30 @@ type S3StorageConfigReader interface {
 	Mutate() *S3StorageConfig
 }
 
-type s3StorageConfigReadonly struct{ v *S3StorageConfig }
+type s3StorageConfigReadonly S3StorageConfig
 
 func (r *s3StorageConfigReadonly) GetBucket() string {
-	return r.v.GetBucket()
+	return (*S3StorageConfig)(r).GetBucket()
 }
 
 func (r *s3StorageConfigReadonly) GetRegion() string {
-	return r.v.GetRegion()
+	return (*S3StorageConfig)(r).GetRegion()
 }
 
 func (r *s3StorageConfigReadonly) GetEndpoint() string {
-	return r.v.GetEndpoint()
+	return (*S3StorageConfig)(r).GetEndpoint()
 }
 
 func (r *s3StorageConfigReadonly) GetAccessKeyId() string {
-	return r.v.GetAccessKeyId()
+	return (*S3StorageConfig)(r).GetAccessKeyId()
 }
 
 func (r *s3StorageConfigReadonly) GetSecretAccessKey() string {
-	return r.v.GetSecretAccessKey()
+	return (*S3StorageConfig)(r).GetSecretAccessKey()
 }
 
 func (r *s3StorageConfigReadonly) Mutate() *S3StorageConfig {
-	return r.v.CloneVT()
+	return (*S3StorageConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this S3StorageConfig.
@@ -10768,7 +10762,7 @@ func (m *S3StorageConfig) AsReader() S3StorageConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &s3StorageConfigReadonly{v: m}
+	return (*s3StorageConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this S3StorageConfig.
@@ -10823,26 +10817,26 @@ type AzureStorageConfigReader interface {
 	Mutate() *AzureStorageConfig
 }
 
-type azureStorageConfigReadonly struct{ v *AzureStorageConfig }
+type azureStorageConfigReadonly AzureStorageConfig
 
 func (r *azureStorageConfigReadonly) GetAccountName() string {
-	return r.v.GetAccountName()
+	return (*AzureStorageConfig)(r).GetAccountName()
 }
 
 func (r *azureStorageConfigReadonly) GetAccountKey() string {
-	return r.v.GetAccountKey()
+	return (*AzureStorageConfig)(r).GetAccountKey()
 }
 
 func (r *azureStorageConfigReadonly) GetContainer() string {
-	return r.v.GetContainer()
+	return (*AzureStorageConfig)(r).GetContainer()
 }
 
 func (r *azureStorageConfigReadonly) GetEndpoint() string {
-	return r.v.GetEndpoint()
+	return (*AzureStorageConfig)(r).GetEndpoint()
 }
 
 func (r *azureStorageConfigReadonly) Mutate() *AzureStorageConfig {
-	return r.v.CloneVT()
+	return (*AzureStorageConfig)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AzureStorageConfig.
@@ -10850,7 +10844,7 @@ func (m *AzureStorageConfig) AsReader() AzureStorageConfigReader {
 	if m == nil {
 		return nil
 	}
-	return &azureStorageConfigReadonly{v: m}
+	return (*azureStorageConfigReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AzureStorageConfig.
@@ -10902,14 +10896,14 @@ type BackupStorageReader interface {
 	Mutate() *BackupStorage
 }
 
-type backupStorageReadonly struct{ v *BackupStorage }
+type backupStorageReadonly BackupStorage
 
 func (r *backupStorageReadonly) GetProvider() isBackupStorage_Provider {
-	return r.v.GetProvider()
+	return (*BackupStorage)(r).GetProvider()
 }
 
 func (r *backupStorageReadonly) Mutate() *BackupStorage {
-	return r.v.CloneVT()
+	return (*BackupStorage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupStorage.
@@ -10917,7 +10911,7 @@ func (m *BackupStorage) AsReader() BackupStorageReader {
 	if m == nil {
 		return nil
 	}
-	return &backupStorageReadonly{v: m}
+	return (*backupStorageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupStorage.
@@ -10970,18 +10964,18 @@ type ReadOptionsReader interface {
 	Mutate() *ReadOptions
 }
 
-type readOptionsReadonly struct{ v *ReadOptions }
+type readOptionsReadonly ReadOptions
 
 func (r *readOptionsReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*ReadOptions)(r).GetCheckpointId()
 }
 
 func (r *readOptionsReadonly) GetMinLogSequence() uint64 {
-	return r.v.GetMinLogSequence()
+	return (*ReadOptions)(r).GetMinLogSequence()
 }
 
 func (r *readOptionsReadonly) Mutate() *ReadOptions {
-	return r.v.CloneVT()
+	return (*ReadOptions)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ReadOptions.
@@ -10989,7 +10983,7 @@ func (m *ReadOptions) AsReader() ReadOptionsReader {
 	if m == nil {
 		return nil
 	}
-	return &readOptionsReadonly{v: m}
+	return (*readOptionsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ReadOptions.
@@ -11045,10 +11039,10 @@ type ListOptionsReader interface {
 	Mutate() *ListOptions
 }
 
-type listOptionsReadonly struct{ v *ListOptions }
+type listOptionsReadonly ListOptions
 
 func (r *listOptionsReadonly) GetRead() ReadOptionsReader {
-	v := r.v.GetRead()
+	v := (*ListOptions)(r).GetRead()
 	if v == nil {
 		return nil
 	}
@@ -11056,19 +11050,19 @@ func (r *listOptionsReadonly) GetRead() ReadOptionsReader {
 }
 
 func (r *listOptionsReadonly) GetPageSize() uint32 {
-	return r.v.GetPageSize()
+	return (*ListOptions)(r).GetPageSize()
 }
 
 func (r *listOptionsReadonly) GetCursor() string {
-	return r.v.GetCursor()
+	return (*ListOptions)(r).GetCursor()
 }
 
 func (r *listOptionsReadonly) GetReverse() bool {
-	return r.v.GetReverse()
+	return (*ListOptions)(r).GetReverse()
 }
 
 func (r *listOptionsReadonly) GetFilter() QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*ListOptions)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -11076,7 +11070,7 @@ func (r *listOptionsReadonly) GetFilter() QueryFilterReader {
 }
 
 func (r *listOptionsReadonly) Mutate() *ListOptions {
-	return r.v.CloneVT()
+	return (*ListOptions)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListOptions.
@@ -11084,7 +11078,7 @@ func (m *ListOptions) AsReader() ListOptionsReader {
 	if m == nil {
 		return nil
 	}
-	return &listOptionsReadonly{v: m}
+	return (*listOptionsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListOptions.

--- a/internal/proto/commonpb/reader_alloc_test.go
+++ b/internal/proto/commonpb/reader_alloc_test.go
@@ -1,0 +1,62 @@
+package commonpb_test
+
+import (
+	"testing"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// BenchmarkReader_AsReader confirms that obtaining a Reader view is zero-alloc.
+// The wrapper is a named-type over the concrete message (`type X Msg`) so
+// AsReader() does a pointer type-conversion — the resulting *xReadonly fits in
+// the interface data word and never escapes to the heap.
+func BenchmarkReader_AsReader(b *testing.B) {
+	tx := &commonpb.Transaction{
+		Postings: []*commonpb.Posting{{Source: "world", Destination: "user:1", Asset: "USD"}},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = tx.AsReader()
+	}
+}
+
+// BenchmarkReader_GetChain confirms that a chained descent through sub-message
+// getters allocates nothing: each transitive AsReader() is likewise a pointer
+// type-conversion.
+func BenchmarkReader_GetChain(b *testing.B) {
+	tx := &commonpb.Transaction{
+		Postings: []*commonpb.Posting{{Source: "world", Destination: "user:1", Asset: "USD"}},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		r := tx.AsReader()
+		list := r.GetPostings()
+		p := list.Get(0)
+		_ = p.GetSource()
+		_ = p.GetDestination()
+		_ = p.GetAsset()
+	}
+}
+
+// BenchmarkReader_ListRange confirms that ListReader.Range yields Reader views
+// without per-element allocation.
+func BenchmarkReader_ListRange(b *testing.B) {
+	postings := make([]*commonpb.Posting, 32)
+	for i := range postings {
+		postings[i] = &commonpb.Posting{Source: "world", Destination: "user:1", Asset: "USD"}
+	}
+	tx := &commonpb.Transaction{Postings: postings}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var acc int
+		tx.AsReader().GetPostings().Range(func(_ int, p commonpb.PostingReader) bool {
+			acc += len(p.GetSource())
+
+			return true
+		})
+		_ = acc
+	}
+}

--- a/internal/proto/eventspb/events_reader.pb.go
+++ b/internal/proto/eventspb/events_reader.pb.go
@@ -18,18 +18,18 @@ type EventReader interface {
 	Mutate() *Event
 }
 
-type eventReadonly struct{ v *Event }
+type eventReadonly Event
 
 func (r *eventReadonly) GetType() commonpb.EventType {
-	return r.v.GetType()
+	return (*Event)(r).GetType()
 }
 
 func (r *eventReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*Event)(r).GetLedger()
 }
 
 func (r *eventReadonly) GetDate() commonpb.TimestampReader {
-	v := r.v.GetDate()
+	v := (*Event)(r).GetDate()
 	if v == nil {
 		return nil
 	}
@@ -37,11 +37,11 @@ func (r *eventReadonly) GetDate() commonpb.TimestampReader {
 }
 
 func (r *eventReadonly) GetLogSequence() uint64 {
-	return r.v.GetLogSequence()
+	return (*Event)(r).GetLogSequence()
 }
 
 func (r *eventReadonly) GetLog() commonpb.LogReader {
-	v := r.v.GetLog()
+	v := (*Event)(r).GetLog()
 	if v == nil {
 		return nil
 	}
@@ -49,7 +49,7 @@ func (r *eventReadonly) GetLog() commonpb.LogReader {
 }
 
 func (r *eventReadonly) Mutate() *Event {
-	return r.v.CloneVT()
+	return (*Event)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Event.
@@ -57,7 +57,7 @@ func (m *Event) AsReader() EventReader {
 	if m == nil {
 		return nil
 	}
-	return &eventReadonly{v: m}
+	return (*eventReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Event.

--- a/internal/proto/proposalpb/proposal_reader.pb.go
+++ b/internal/proto/proposalpb/proposal_reader.pb.go
@@ -17,26 +17,26 @@ type AppliedProposalReader interface {
 	Mutate() *AppliedProposal
 }
 
-type appliedProposalReadonly struct{ v *AppliedProposal }
+type appliedProposalReadonly AppliedProposal
 
 func (r *appliedProposalReadonly) GetSequence() uint64 {
-	return r.v.GetSequence()
+	return (*AppliedProposal)(r).GetSequence()
 }
 
 func (r *appliedProposalReadonly) GetMinLogSequence() uint64 {
-	return r.v.GetMinLogSequence()
+	return (*AppliedProposal)(r).GetMinLogSequence()
 }
 
 func (r *appliedProposalReadonly) GetMaxLogSequence() uint64 {
-	return r.v.GetMaxLogSequence()
+	return (*AppliedProposal)(r).GetMaxLogSequence()
 }
 
 func (r *appliedProposalReadonly) GetTransientVolumes() AppliedProposal_TransientVolumesMapReader {
-	return appliedProposal_transientVolumesMapReadonly(r.v.GetTransientVolumes())
+	return appliedProposal_transientVolumesMapReadonly((*AppliedProposal)(r).GetTransientVolumes())
 }
 
 func (r *appliedProposalReadonly) Mutate() *AppliedProposal {
-	return r.v.CloneVT()
+	return (*AppliedProposal)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AppliedProposal.
@@ -44,7 +44,7 @@ func (m *AppliedProposal) AsReader() AppliedProposalReader {
 	if m == nil {
 		return nil
 	}
-	return &appliedProposalReadonly{v: m}
+	return (*appliedProposalReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AppliedProposal.
@@ -127,14 +127,14 @@ type TouchedVolumeListReader interface {
 	Mutate() *TouchedVolumeList
 }
 
-type touchedVolumeListReadonly struct{ v *TouchedVolumeList }
+type touchedVolumeListReadonly TouchedVolumeList
 
 func (r *touchedVolumeListReadonly) GetVolumes() commonpb.TouchedVolumeListReader {
-	return commonpb.NewTouchedVolumeListReader(r.v.GetVolumes())
+	return commonpb.NewTouchedVolumeListReader((*TouchedVolumeList)(r).GetVolumes())
 }
 
 func (r *touchedVolumeListReadonly) Mutate() *TouchedVolumeList {
-	return r.v.CloneVT()
+	return (*TouchedVolumeList)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TouchedVolumeList.
@@ -142,7 +142,7 @@ func (m *TouchedVolumeList) AsReader() TouchedVolumeListReader {
 	if m == nil {
 		return nil
 	}
-	return &touchedVolumeListReadonly{v: m}
+	return (*touchedVolumeListReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TouchedVolumeList.

--- a/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
@@ -18,18 +18,18 @@ type OrderReader interface {
 	Mutate() *Order
 }
 
-type orderReadonly struct{ v *Order }
+type orderReadonly Order
 
 func (r *orderReadonly) GetCoverageBits() []byte {
-	return bytes.Clone(r.v.GetCoverageBits())
+	return bytes.Clone((*Order)(r).GetCoverageBits())
 }
 
 func (r *orderReadonly) GetType() isOrder_Type {
-	return r.v.GetType()
+	return (*Order)(r).GetType()
 }
 
 func (r *orderReadonly) Mutate() *Order {
-	return r.v.CloneVT()
+	return (*Order)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Order.
@@ -37,7 +37,7 @@ func (m *Order) AsReader() OrderReader {
 	if m == nil {
 		return nil
 	}
-	return &orderReadonly{v: m}
+	return (*orderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Order.
@@ -88,18 +88,18 @@ type LedgerScopedOrderReader interface {
 	Mutate() *LedgerScopedOrder
 }
 
-type ledgerScopedOrderReadonly struct{ v *LedgerScopedOrder }
+type ledgerScopedOrderReadonly LedgerScopedOrder
 
 func (r *ledgerScopedOrderReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*LedgerScopedOrder)(r).GetLedger()
 }
 
 func (r *ledgerScopedOrderReadonly) GetPayload() isLedgerScopedOrder_Payload {
-	return r.v.GetPayload()
+	return (*LedgerScopedOrder)(r).GetPayload()
 }
 
 func (r *ledgerScopedOrderReadonly) Mutate() *LedgerScopedOrder {
-	return r.v.CloneVT()
+	return (*LedgerScopedOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerScopedOrder.
@@ -107,7 +107,7 @@ func (m *LedgerScopedOrder) AsReader() LedgerScopedOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerScopedOrderReadonly{v: m}
+	return (*ledgerScopedOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerScopedOrder.
@@ -159,14 +159,14 @@ type SystemScopedOrderReader interface {
 	Mutate() *SystemScopedOrder
 }
 
-type systemScopedOrderReadonly struct{ v *SystemScopedOrder }
+type systemScopedOrderReadonly SystemScopedOrder
 
 func (r *systemScopedOrderReadonly) GetPayload() isSystemScopedOrder_Payload {
-	return r.v.GetPayload()
+	return (*SystemScopedOrder)(r).GetPayload()
 }
 
 func (r *systemScopedOrderReadonly) Mutate() *SystemScopedOrder {
-	return r.v.CloneVT()
+	return (*SystemScopedOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SystemScopedOrder.
@@ -174,7 +174,7 @@ func (m *SystemScopedOrder) AsReader() SystemScopedOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &systemScopedOrderReadonly{v: m}
+	return (*systemScopedOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SystemScopedOrder.
@@ -226,10 +226,10 @@ type CreatePreparedQueryOrderReader interface {
 	Mutate() *CreatePreparedQueryOrder
 }
 
-type createPreparedQueryOrderReadonly struct{ v *CreatePreparedQueryOrder }
+type createPreparedQueryOrderReadonly CreatePreparedQueryOrder
 
 func (r *createPreparedQueryOrderReadonly) GetQuery() commonpb.PreparedQueryReader {
-	v := r.v.GetQuery()
+	v := (*CreatePreparedQueryOrder)(r).GetQuery()
 	if v == nil {
 		return nil
 	}
@@ -237,7 +237,7 @@ func (r *createPreparedQueryOrderReadonly) GetQuery() commonpb.PreparedQueryRead
 }
 
 func (r *createPreparedQueryOrderReadonly) Mutate() *CreatePreparedQueryOrder {
-	return r.v.CloneVT()
+	return (*CreatePreparedQueryOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatePreparedQueryOrder.
@@ -245,7 +245,7 @@ func (m *CreatePreparedQueryOrder) AsReader() CreatePreparedQueryOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &createPreparedQueryOrderReadonly{v: m}
+	return (*createPreparedQueryOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatePreparedQueryOrder.
@@ -298,14 +298,14 @@ type UpdatePreparedQueryOrderReader interface {
 	Mutate() *UpdatePreparedQueryOrder
 }
 
-type updatePreparedQueryOrderReadonly struct{ v *UpdatePreparedQueryOrder }
+type updatePreparedQueryOrderReadonly UpdatePreparedQueryOrder
 
 func (r *updatePreparedQueryOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*UpdatePreparedQueryOrder)(r).GetName()
 }
 
 func (r *updatePreparedQueryOrderReadonly) GetFilter() commonpb.QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*UpdatePreparedQueryOrder)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -313,7 +313,7 @@ func (r *updatePreparedQueryOrderReadonly) GetFilter() commonpb.QueryFilterReade
 }
 
 func (r *updatePreparedQueryOrderReadonly) Mutate() *UpdatePreparedQueryOrder {
-	return r.v.CloneVT()
+	return (*UpdatePreparedQueryOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdatePreparedQueryOrder.
@@ -321,7 +321,7 @@ func (m *UpdatePreparedQueryOrder) AsReader() UpdatePreparedQueryOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &updatePreparedQueryOrderReadonly{v: m}
+	return (*updatePreparedQueryOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdatePreparedQueryOrder.
@@ -373,14 +373,14 @@ type DeletePreparedQueryOrderReader interface {
 	Mutate() *DeletePreparedQueryOrder
 }
 
-type deletePreparedQueryOrderReadonly struct{ v *DeletePreparedQueryOrder }
+type deletePreparedQueryOrderReadonly DeletePreparedQueryOrder
 
 func (r *deletePreparedQueryOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeletePreparedQueryOrder)(r).GetName()
 }
 
 func (r *deletePreparedQueryOrderReadonly) Mutate() *DeletePreparedQueryOrder {
-	return r.v.CloneVT()
+	return (*DeletePreparedQueryOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletePreparedQueryOrder.
@@ -388,7 +388,7 @@ func (m *DeletePreparedQueryOrder) AsReader() DeletePreparedQueryOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &deletePreparedQueryOrderReadonly{v: m}
+	return (*deletePreparedQueryOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletePreparedQueryOrder.
@@ -440,10 +440,10 @@ type AddEventsSinkOrderReader interface {
 	Mutate() *AddEventsSinkOrder
 }
 
-type addEventsSinkOrderReadonly struct{ v *AddEventsSinkOrder }
+type addEventsSinkOrderReadonly AddEventsSinkOrder
 
 func (r *addEventsSinkOrderReadonly) GetConfig() commonpb.SinkConfigReader {
-	v := r.v.GetConfig()
+	v := (*AddEventsSinkOrder)(r).GetConfig()
 	if v == nil {
 		return nil
 	}
@@ -451,7 +451,7 @@ func (r *addEventsSinkOrderReadonly) GetConfig() commonpb.SinkConfigReader {
 }
 
 func (r *addEventsSinkOrderReadonly) Mutate() *AddEventsSinkOrder {
-	return r.v.CloneVT()
+	return (*AddEventsSinkOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddEventsSinkOrder.
@@ -459,7 +459,7 @@ func (m *AddEventsSinkOrder) AsReader() AddEventsSinkOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &addEventsSinkOrderReadonly{v: m}
+	return (*addEventsSinkOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddEventsSinkOrder.
@@ -511,14 +511,14 @@ type RemoveEventsSinkOrderReader interface {
 	Mutate() *RemoveEventsSinkOrder
 }
 
-type removeEventsSinkOrderReadonly struct{ v *RemoveEventsSinkOrder }
+type removeEventsSinkOrderReadonly RemoveEventsSinkOrder
 
 func (r *removeEventsSinkOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemoveEventsSinkOrder)(r).GetName()
 }
 
 func (r *removeEventsSinkOrderReadonly) Mutate() *RemoveEventsSinkOrder {
-	return r.v.CloneVT()
+	return (*RemoveEventsSinkOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveEventsSinkOrder.
@@ -526,7 +526,7 @@ func (m *RemoveEventsSinkOrder) AsReader() RemoveEventsSinkOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &removeEventsSinkOrderReadonly{v: m}
+	return (*removeEventsSinkOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveEventsSinkOrder.
@@ -580,22 +580,22 @@ type RegisterSigningKeyOrderReader interface {
 	Mutate() *RegisterSigningKeyOrder
 }
 
-type registerSigningKeyOrderReadonly struct{ v *RegisterSigningKeyOrder }
+type registerSigningKeyOrderReadonly RegisterSigningKeyOrder
 
 func (r *registerSigningKeyOrderReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RegisterSigningKeyOrder)(r).GetKeyId()
 }
 
 func (r *registerSigningKeyOrderReadonly) GetPublicKey() []byte {
-	return bytes.Clone(r.v.GetPublicKey())
+	return bytes.Clone((*RegisterSigningKeyOrder)(r).GetPublicKey())
 }
 
 func (r *registerSigningKeyOrderReadonly) GetParentKeyId() string {
-	return r.v.GetParentKeyId()
+	return (*RegisterSigningKeyOrder)(r).GetParentKeyId()
 }
 
 func (r *registerSigningKeyOrderReadonly) Mutate() *RegisterSigningKeyOrder {
-	return r.v.CloneVT()
+	return (*RegisterSigningKeyOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RegisterSigningKeyOrder.
@@ -603,7 +603,7 @@ func (m *RegisterSigningKeyOrder) AsReader() RegisterSigningKeyOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &registerSigningKeyOrderReadonly{v: m}
+	return (*registerSigningKeyOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RegisterSigningKeyOrder.
@@ -656,18 +656,18 @@ type RevokeSigningKeyOrderReader interface {
 	Mutate() *RevokeSigningKeyOrder
 }
 
-type revokeSigningKeyOrderReadonly struct{ v *RevokeSigningKeyOrder }
+type revokeSigningKeyOrderReadonly RevokeSigningKeyOrder
 
 func (r *revokeSigningKeyOrderReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RevokeSigningKeyOrder)(r).GetKeyId()
 }
 
 func (r *revokeSigningKeyOrderReadonly) GetCascade() bool {
-	return r.v.GetCascade()
+	return (*RevokeSigningKeyOrder)(r).GetCascade()
 }
 
 func (r *revokeSigningKeyOrderReadonly) Mutate() *RevokeSigningKeyOrder {
-	return r.v.CloneVT()
+	return (*RevokeSigningKeyOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevokeSigningKeyOrder.
@@ -675,7 +675,7 @@ func (m *RevokeSigningKeyOrder) AsReader() RevokeSigningKeyOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &revokeSigningKeyOrderReadonly{v: m}
+	return (*revokeSigningKeyOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevokeSigningKeyOrder.
@@ -727,14 +727,14 @@ type SetSigningConfigOrderReader interface {
 	Mutate() *SetSigningConfigOrder
 }
 
-type setSigningConfigOrderReadonly struct{ v *SetSigningConfigOrder }
+type setSigningConfigOrderReadonly SetSigningConfigOrder
 
 func (r *setSigningConfigOrderReadonly) GetRequireSignatures() bool {
-	return r.v.GetRequireSignatures()
+	return (*SetSigningConfigOrder)(r).GetRequireSignatures()
 }
 
 func (r *setSigningConfigOrderReadonly) Mutate() *SetSigningConfigOrder {
-	return r.v.CloneVT()
+	return (*SetSigningConfigOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetSigningConfigOrder.
@@ -742,7 +742,7 @@ func (m *SetSigningConfigOrder) AsReader() SetSigningConfigOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &setSigningConfigOrderReadonly{v: m}
+	return (*setSigningConfigOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetSigningConfigOrder.
@@ -793,10 +793,10 @@ type CloseChapterOrderReader interface {
 	Mutate() *CloseChapterOrder
 }
 
-type closeChapterOrderReadonly struct{ v *CloseChapterOrder }
+type closeChapterOrderReadonly CloseChapterOrder
 
 func (r *closeChapterOrderReadonly) Mutate() *CloseChapterOrder {
-	return r.v.CloneVT()
+	return (*CloseChapterOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CloseChapterOrder.
@@ -804,7 +804,7 @@ func (m *CloseChapterOrder) AsReader() CloseChapterOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &closeChapterOrderReadonly{v: m}
+	return (*closeChapterOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CloseChapterOrder.
@@ -858,22 +858,22 @@ type SealChapterOrderReader interface {
 	Mutate() *SealChapterOrder
 }
 
-type sealChapterOrderReadonly struct{ v *SealChapterOrder }
+type sealChapterOrderReadonly SealChapterOrder
 
 func (r *sealChapterOrderReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*SealChapterOrder)(r).GetChapterId()
 }
 
 func (r *sealChapterOrderReadonly) GetSealingHash() []byte {
-	return bytes.Clone(r.v.GetSealingHash())
+	return bytes.Clone((*SealChapterOrder)(r).GetSealingHash())
 }
 
 func (r *sealChapterOrderReadonly) GetStateHash() []byte {
-	return bytes.Clone(r.v.GetStateHash())
+	return bytes.Clone((*SealChapterOrder)(r).GetStateHash())
 }
 
 func (r *sealChapterOrderReadonly) Mutate() *SealChapterOrder {
-	return r.v.CloneVT()
+	return (*SealChapterOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SealChapterOrder.
@@ -881,7 +881,7 @@ func (m *SealChapterOrder) AsReader() SealChapterOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &sealChapterOrderReadonly{v: m}
+	return (*sealChapterOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SealChapterOrder.
@@ -933,14 +933,14 @@ type ArchiveChapterOrderReader interface {
 	Mutate() *ArchiveChapterOrder
 }
 
-type archiveChapterOrderReadonly struct{ v *ArchiveChapterOrder }
+type archiveChapterOrderReadonly ArchiveChapterOrder
 
 func (r *archiveChapterOrderReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*ArchiveChapterOrder)(r).GetChapterId()
 }
 
 func (r *archiveChapterOrderReadonly) Mutate() *ArchiveChapterOrder {
-	return r.v.CloneVT()
+	return (*ArchiveChapterOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ArchiveChapterOrder.
@@ -948,7 +948,7 @@ func (m *ArchiveChapterOrder) AsReader() ArchiveChapterOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &archiveChapterOrderReadonly{v: m}
+	return (*archiveChapterOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ArchiveChapterOrder.
@@ -1000,14 +1000,14 @@ type ConfirmArchiveChapterOrderReader interface {
 	Mutate() *ConfirmArchiveChapterOrder
 }
 
-type confirmArchiveChapterOrderReadonly struct{ v *ConfirmArchiveChapterOrder }
+type confirmArchiveChapterOrderReadonly ConfirmArchiveChapterOrder
 
 func (r *confirmArchiveChapterOrderReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*ConfirmArchiveChapterOrder)(r).GetChapterId()
 }
 
 func (r *confirmArchiveChapterOrderReadonly) Mutate() *ConfirmArchiveChapterOrder {
-	return r.v.CloneVT()
+	return (*ConfirmArchiveChapterOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ConfirmArchiveChapterOrder.
@@ -1015,7 +1015,7 @@ func (m *ConfirmArchiveChapterOrder) AsReader() ConfirmArchiveChapterOrderReader
 	if m == nil {
 		return nil
 	}
-	return &confirmArchiveChapterOrderReadonly{v: m}
+	return (*confirmArchiveChapterOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ConfirmArchiveChapterOrder.
@@ -1067,14 +1067,14 @@ type SetMaintenanceModeOrderReader interface {
 	Mutate() *SetMaintenanceModeOrder
 }
 
-type setMaintenanceModeOrderReadonly struct{ v *SetMaintenanceModeOrder }
+type setMaintenanceModeOrderReadonly SetMaintenanceModeOrder
 
 func (r *setMaintenanceModeOrderReadonly) GetEnabled() bool {
-	return r.v.GetEnabled()
+	return (*SetMaintenanceModeOrder)(r).GetEnabled()
 }
 
 func (r *setMaintenanceModeOrderReadonly) Mutate() *SetMaintenanceModeOrder {
-	return r.v.CloneVT()
+	return (*SetMaintenanceModeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMaintenanceModeOrder.
@@ -1082,7 +1082,7 @@ func (m *SetMaintenanceModeOrder) AsReader() SetMaintenanceModeOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &setMaintenanceModeOrderReadonly{v: m}
+	return (*setMaintenanceModeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMaintenanceModeOrder.
@@ -1134,14 +1134,14 @@ type SetChapterScheduleOrderReader interface {
 	Mutate() *SetChapterScheduleOrder
 }
 
-type setChapterScheduleOrderReadonly struct{ v *SetChapterScheduleOrder }
+type setChapterScheduleOrderReadonly SetChapterScheduleOrder
 
 func (r *setChapterScheduleOrderReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetChapterScheduleOrder)(r).GetCron()
 }
 
 func (r *setChapterScheduleOrderReadonly) Mutate() *SetChapterScheduleOrder {
-	return r.v.CloneVT()
+	return (*SetChapterScheduleOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetChapterScheduleOrder.
@@ -1149,7 +1149,7 @@ func (m *SetChapterScheduleOrder) AsReader() SetChapterScheduleOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &setChapterScheduleOrderReadonly{v: m}
+	return (*setChapterScheduleOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetChapterScheduleOrder.
@@ -1200,10 +1200,10 @@ type DeleteChapterScheduleOrderReader interface {
 	Mutate() *DeleteChapterScheduleOrder
 }
 
-type deleteChapterScheduleOrderReadonly struct{ v *DeleteChapterScheduleOrder }
+type deleteChapterScheduleOrderReadonly DeleteChapterScheduleOrder
 
 func (r *deleteChapterScheduleOrderReadonly) Mutate() *DeleteChapterScheduleOrder {
-	return r.v.CloneVT()
+	return (*DeleteChapterScheduleOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteChapterScheduleOrder.
@@ -1211,7 +1211,7 @@ func (m *DeleteChapterScheduleOrder) AsReader() DeleteChapterScheduleOrderReader
 	if m == nil {
 		return nil
 	}
-	return &deleteChapterScheduleOrderReadonly{v: m}
+	return (*deleteChapterScheduleOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteChapterScheduleOrder.
@@ -1265,22 +1265,22 @@ type SaveNumscriptOrderReader interface {
 	Mutate() *SaveNumscriptOrder
 }
 
-type saveNumscriptOrderReadonly struct{ v *SaveNumscriptOrder }
+type saveNumscriptOrderReadonly SaveNumscriptOrder
 
 func (r *saveNumscriptOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*SaveNumscriptOrder)(r).GetName()
 }
 
 func (r *saveNumscriptOrderReadonly) GetContent() string {
-	return r.v.GetContent()
+	return (*SaveNumscriptOrder)(r).GetContent()
 }
 
 func (r *saveNumscriptOrderReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*SaveNumscriptOrder)(r).GetVersion()
 }
 
 func (r *saveNumscriptOrderReadonly) Mutate() *SaveNumscriptOrder {
-	return r.v.CloneVT()
+	return (*SaveNumscriptOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveNumscriptOrder.
@@ -1288,7 +1288,7 @@ func (m *SaveNumscriptOrder) AsReader() SaveNumscriptOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &saveNumscriptOrderReadonly{v: m}
+	return (*saveNumscriptOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveNumscriptOrder.
@@ -1340,14 +1340,14 @@ type DeleteNumscriptOrderReader interface {
 	Mutate() *DeleteNumscriptOrder
 }
 
-type deleteNumscriptOrderReadonly struct{ v *DeleteNumscriptOrder }
+type deleteNumscriptOrderReadonly DeleteNumscriptOrder
 
 func (r *deleteNumscriptOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeleteNumscriptOrder)(r).GetName()
 }
 
 func (r *deleteNumscriptOrderReadonly) Mutate() *DeleteNumscriptOrder {
-	return r.v.CloneVT()
+	return (*DeleteNumscriptOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteNumscriptOrder.
@@ -1355,7 +1355,7 @@ func (m *DeleteNumscriptOrder) AsReader() DeleteNumscriptOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteNumscriptOrderReadonly{v: m}
+	return (*deleteNumscriptOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteNumscriptOrder.
@@ -1406,10 +1406,10 @@ type CreateQueryCheckpointOrderReader interface {
 	Mutate() *CreateQueryCheckpointOrder
 }
 
-type createQueryCheckpointOrderReadonly struct{ v *CreateQueryCheckpointOrder }
+type createQueryCheckpointOrderReadonly CreateQueryCheckpointOrder
 
 func (r *createQueryCheckpointOrderReadonly) Mutate() *CreateQueryCheckpointOrder {
-	return r.v.CloneVT()
+	return (*CreateQueryCheckpointOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateQueryCheckpointOrder.
@@ -1417,7 +1417,7 @@ func (m *CreateQueryCheckpointOrder) AsReader() CreateQueryCheckpointOrderReader
 	if m == nil {
 		return nil
 	}
-	return &createQueryCheckpointOrderReadonly{v: m}
+	return (*createQueryCheckpointOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateQueryCheckpointOrder.
@@ -1469,14 +1469,14 @@ type DeleteQueryCheckpointOrderReader interface {
 	Mutate() *DeleteQueryCheckpointOrder
 }
 
-type deleteQueryCheckpointOrderReadonly struct{ v *DeleteQueryCheckpointOrder }
+type deleteQueryCheckpointOrderReadonly DeleteQueryCheckpointOrder
 
 func (r *deleteQueryCheckpointOrderReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*DeleteQueryCheckpointOrder)(r).GetCheckpointId()
 }
 
 func (r *deleteQueryCheckpointOrderReadonly) Mutate() *DeleteQueryCheckpointOrder {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointOrder.
@@ -1484,7 +1484,7 @@ func (m *DeleteQueryCheckpointOrder) AsReader() DeleteQueryCheckpointOrderReader
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointOrderReadonly{v: m}
+	return (*deleteQueryCheckpointOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointOrder.
@@ -1538,18 +1538,18 @@ type QueryCheckpointStateReader interface {
 	Mutate() *QueryCheckpointState
 }
 
-type queryCheckpointStateReadonly struct{ v *QueryCheckpointState }
+type queryCheckpointStateReadonly QueryCheckpointState
 
 func (r *queryCheckpointStateReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*QueryCheckpointState)(r).GetCheckpointId()
 }
 
 func (r *queryCheckpointStateReadonly) GetMaxSequence() uint64 {
-	return r.v.GetMaxSequence()
+	return (*QueryCheckpointState)(r).GetMaxSequence()
 }
 
 func (r *queryCheckpointStateReadonly) GetCreatedAt() commonpb.TimestampReader {
-	v := r.v.GetCreatedAt()
+	v := (*QueryCheckpointState)(r).GetCreatedAt()
 	if v == nil {
 		return nil
 	}
@@ -1557,7 +1557,7 @@ func (r *queryCheckpointStateReadonly) GetCreatedAt() commonpb.TimestampReader {
 }
 
 func (r *queryCheckpointStateReadonly) Mutate() *QueryCheckpointState {
-	return r.v.CloneVT()
+	return (*QueryCheckpointState)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this QueryCheckpointState.
@@ -1565,7 +1565,7 @@ func (m *QueryCheckpointState) AsReader() QueryCheckpointStateReader {
 	if m == nil {
 		return nil
 	}
-	return &queryCheckpointStateReadonly{v: m}
+	return (*queryCheckpointStateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this QueryCheckpointState.
@@ -1617,16 +1617,14 @@ type SetQueryCheckpointScheduleOrderReader interface {
 	Mutate() *SetQueryCheckpointScheduleOrder
 }
 
-type setQueryCheckpointScheduleOrderReadonly struct {
-	v *SetQueryCheckpointScheduleOrder
-}
+type setQueryCheckpointScheduleOrderReadonly SetQueryCheckpointScheduleOrder
 
 func (r *setQueryCheckpointScheduleOrderReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetQueryCheckpointScheduleOrder)(r).GetCron()
 }
 
 func (r *setQueryCheckpointScheduleOrderReadonly) Mutate() *SetQueryCheckpointScheduleOrder {
-	return r.v.CloneVT()
+	return (*SetQueryCheckpointScheduleOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetQueryCheckpointScheduleOrder.
@@ -1634,7 +1632,7 @@ func (m *SetQueryCheckpointScheduleOrder) AsReader() SetQueryCheckpointScheduleO
 	if m == nil {
 		return nil
 	}
-	return &setQueryCheckpointScheduleOrderReadonly{v: m}
+	return (*setQueryCheckpointScheduleOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetQueryCheckpointScheduleOrder.
@@ -1685,12 +1683,10 @@ type DeleteQueryCheckpointScheduleOrderReader interface {
 	Mutate() *DeleteQueryCheckpointScheduleOrder
 }
 
-type deleteQueryCheckpointScheduleOrderReadonly struct {
-	v *DeleteQueryCheckpointScheduleOrder
-}
+type deleteQueryCheckpointScheduleOrderReadonly DeleteQueryCheckpointScheduleOrder
 
 func (r *deleteQueryCheckpointScheduleOrderReadonly) Mutate() *DeleteQueryCheckpointScheduleOrder {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointScheduleOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointScheduleOrder.
@@ -1698,7 +1694,7 @@ func (m *DeleteQueryCheckpointScheduleOrder) AsReader() DeleteQueryCheckpointSch
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointScheduleOrderReadonly{v: m}
+	return (*deleteQueryCheckpointScheduleOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointScheduleOrder.
@@ -1754,18 +1750,18 @@ type CreateLedgerOrderReader interface {
 	Mutate() *CreateLedgerOrder
 }
 
-type createLedgerOrderReadonly struct{ v *CreateLedgerOrder }
+type createLedgerOrderReadonly CreateLedgerOrder
 
 func (r *createLedgerOrderReadonly) GetInitialSchema() commonpb.SetMetadataFieldTypeCommandListReader {
-	return commonpb.NewSetMetadataFieldTypeCommandListReader(r.v.GetInitialSchema())
+	return commonpb.NewSetMetadataFieldTypeCommandListReader((*CreateLedgerOrder)(r).GetInitialSchema())
 }
 
 func (r *createLedgerOrderReadonly) GetMode() commonpb.LedgerMode {
-	return r.v.GetMode()
+	return (*CreateLedgerOrder)(r).GetMode()
 }
 
 func (r *createLedgerOrderReadonly) GetMirrorSource() commonpb.MirrorSourceConfigReader {
-	v := r.v.GetMirrorSource()
+	v := (*CreateLedgerOrder)(r).GetMirrorSource()
 	if v == nil {
 		return nil
 	}
@@ -1773,15 +1769,15 @@ func (r *createLedgerOrderReadonly) GetMirrorSource() commonpb.MirrorSourceConfi
 }
 
 func (r *createLedgerOrderReadonly) GetAccountTypes() CreateLedgerOrder_AccountTypesMapReader {
-	return createLedgerOrder_accountTypesMapReadonly(r.v.GetAccountTypes())
+	return createLedgerOrder_accountTypesMapReadonly((*CreateLedgerOrder)(r).GetAccountTypes())
 }
 
 func (r *createLedgerOrderReadonly) GetDefaultEnforcementMode() commonpb.ChartEnforcementMode {
-	return r.v.GetDefaultEnforcementMode()
+	return (*CreateLedgerOrder)(r).GetDefaultEnforcementMode()
 }
 
 func (r *createLedgerOrderReadonly) Mutate() *CreateLedgerOrder {
-	return r.v.CloneVT()
+	return (*CreateLedgerOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateLedgerOrder.
@@ -1789,7 +1785,7 @@ func (m *CreateLedgerOrder) AsReader() CreateLedgerOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &createLedgerOrderReadonly{v: m}
+	return (*createLedgerOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateLedgerOrder.
@@ -1872,10 +1868,10 @@ type MirrorIngestOrderReader interface {
 	Mutate() *MirrorIngestOrder
 }
 
-type mirrorIngestOrderReadonly struct{ v *MirrorIngestOrder }
+type mirrorIngestOrderReadonly MirrorIngestOrder
 
 func (r *mirrorIngestOrderReadonly) GetEntry() MirrorLogEntryReader {
-	v := r.v.GetEntry()
+	v := (*MirrorIngestOrder)(r).GetEntry()
 	if v == nil {
 		return nil
 	}
@@ -1883,7 +1879,7 @@ func (r *mirrorIngestOrderReadonly) GetEntry() MirrorLogEntryReader {
 }
 
 func (r *mirrorIngestOrderReadonly) Mutate() *MirrorIngestOrder {
-	return r.v.CloneVT()
+	return (*MirrorIngestOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorIngestOrder.
@@ -1891,7 +1887,7 @@ func (m *MirrorIngestOrder) AsReader() MirrorIngestOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorIngestOrderReadonly{v: m}
+	return (*mirrorIngestOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorIngestOrder.
@@ -1944,18 +1940,18 @@ type MirrorLogEntryReader interface {
 	Mutate() *MirrorLogEntry
 }
 
-type mirrorLogEntryReadonly struct{ v *MirrorLogEntry }
+type mirrorLogEntryReadonly MirrorLogEntry
 
 func (r *mirrorLogEntryReadonly) GetV2LogId() uint64 {
-	return r.v.GetV2LogId()
+	return (*MirrorLogEntry)(r).GetV2LogId()
 }
 
 func (r *mirrorLogEntryReadonly) GetData() isMirrorLogEntry_Data {
-	return r.v.GetData()
+	return (*MirrorLogEntry)(r).GetData()
 }
 
 func (r *mirrorLogEntryReadonly) Mutate() *MirrorLogEntry {
-	return r.v.CloneVT()
+	return (*MirrorLogEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorLogEntry.
@@ -1963,7 +1959,7 @@ func (m *MirrorLogEntry) AsReader() MirrorLogEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorLogEntryReadonly{v: m}
+	return (*mirrorLogEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorLogEntry.
@@ -2015,14 +2011,14 @@ type MirrorFillGapReader interface {
 	Mutate() *MirrorFillGap
 }
 
-type mirrorFillGapReadonly struct{ v *MirrorFillGap }
+type mirrorFillGapReadonly MirrorFillGap
 
 func (r *mirrorFillGapReadonly) GetSkippedTransactionIds() []uint64 {
-	return slices.Clone(r.v.GetSkippedTransactionIds())
+	return slices.Clone((*MirrorFillGap)(r).GetSkippedTransactionIds())
 }
 
 func (r *mirrorFillGapReadonly) Mutate() *MirrorFillGap {
-	return r.v.CloneVT()
+	return (*MirrorFillGap)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorFillGap.
@@ -2030,7 +2026,7 @@ func (m *MirrorFillGap) AsReader() MirrorFillGapReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorFillGapReadonly{v: m}
+	return (*mirrorFillGapReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorFillGap.
@@ -2087,22 +2083,22 @@ type MirrorCreatedTransactionReader interface {
 	Mutate() *MirrorCreatedTransaction
 }
 
-type mirrorCreatedTransactionReadonly struct{ v *MirrorCreatedTransaction }
+type mirrorCreatedTransactionReadonly MirrorCreatedTransaction
 
 func (r *mirrorCreatedTransactionReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*MirrorCreatedTransaction)(r).GetTransactionId()
 }
 
 func (r *mirrorCreatedTransactionReadonly) GetPostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader(r.v.GetPostings())
+	return commonpb.NewPostingListReader((*MirrorCreatedTransaction)(r).GetPostings())
 }
 
 func (r *mirrorCreatedTransactionReadonly) GetMetadata() MirrorCreatedTransaction_MetadataMapReader {
-	return mirrorCreatedTransaction_metadataMapReadonly(r.v.GetMetadata())
+	return mirrorCreatedTransaction_metadataMapReadonly((*MirrorCreatedTransaction)(r).GetMetadata())
 }
 
 func (r *mirrorCreatedTransactionReadonly) GetTimestamp() commonpb.TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*MirrorCreatedTransaction)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -2110,15 +2106,15 @@ func (r *mirrorCreatedTransactionReadonly) GetTimestamp() commonpb.TimestampRead
 }
 
 func (r *mirrorCreatedTransactionReadonly) GetReference() string {
-	return r.v.GetReference()
+	return (*MirrorCreatedTransaction)(r).GetReference()
 }
 
 func (r *mirrorCreatedTransactionReadonly) GetAccountMetadata() MirrorCreatedTransaction_AccountMetadataMapReader {
-	return mirrorCreatedTransaction_accountMetadataMapReadonly(r.v.GetAccountMetadata())
+	return mirrorCreatedTransaction_accountMetadataMapReadonly((*MirrorCreatedTransaction)(r).GetAccountMetadata())
 }
 
 func (r *mirrorCreatedTransactionReadonly) Mutate() *MirrorCreatedTransaction {
-	return r.v.CloneVT()
+	return (*MirrorCreatedTransaction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorCreatedTransaction.
@@ -2126,7 +2122,7 @@ func (m *MirrorCreatedTransaction) AsReader() MirrorCreatedTransactionReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorCreatedTransactionReadonly{v: m}
+	return (*mirrorCreatedTransactionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorCreatedTransaction.
@@ -2241,10 +2237,10 @@ type MirrorSavedMetadataReader interface {
 	Mutate() *MirrorSavedMetadata
 }
 
-type mirrorSavedMetadataReadonly struct{ v *MirrorSavedMetadata }
+type mirrorSavedMetadataReadonly MirrorSavedMetadata
 
 func (r *mirrorSavedMetadataReadonly) GetTarget() commonpb.TargetReader {
-	v := r.v.GetTarget()
+	v := (*MirrorSavedMetadata)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -2252,11 +2248,11 @@ func (r *mirrorSavedMetadataReadonly) GetTarget() commonpb.TargetReader {
 }
 
 func (r *mirrorSavedMetadataReadonly) GetMetadata() MirrorSavedMetadata_MetadataMapReader {
-	return mirrorSavedMetadata_metadataMapReadonly(r.v.GetMetadata())
+	return mirrorSavedMetadata_metadataMapReadonly((*MirrorSavedMetadata)(r).GetMetadata())
 }
 
 func (r *mirrorSavedMetadataReadonly) Mutate() *MirrorSavedMetadata {
-	return r.v.CloneVT()
+	return (*MirrorSavedMetadata)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorSavedMetadata.
@@ -2264,7 +2260,7 @@ func (m *MirrorSavedMetadata) AsReader() MirrorSavedMetadataReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorSavedMetadataReadonly{v: m}
+	return (*mirrorSavedMetadataReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorSavedMetadata.
@@ -2351,26 +2347,26 @@ type MirrorRevertedTransactionReader interface {
 	Mutate() *MirrorRevertedTransaction
 }
 
-type mirrorRevertedTransactionReadonly struct{ v *MirrorRevertedTransaction }
+type mirrorRevertedTransactionReadonly MirrorRevertedTransaction
 
 func (r *mirrorRevertedTransactionReadonly) GetRevertedTransactionId() uint64 {
-	return r.v.GetRevertedTransactionId()
+	return (*MirrorRevertedTransaction)(r).GetRevertedTransactionId()
 }
 
 func (r *mirrorRevertedTransactionReadonly) GetNewTransactionId() uint64 {
-	return r.v.GetNewTransactionId()
+	return (*MirrorRevertedTransaction)(r).GetNewTransactionId()
 }
 
 func (r *mirrorRevertedTransactionReadonly) GetReversePostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader(r.v.GetReversePostings())
+	return commonpb.NewPostingListReader((*MirrorRevertedTransaction)(r).GetReversePostings())
 }
 
 func (r *mirrorRevertedTransactionReadonly) GetMetadata() MirrorRevertedTransaction_MetadataMapReader {
-	return mirrorRevertedTransaction_metadataMapReadonly(r.v.GetMetadata())
+	return mirrorRevertedTransaction_metadataMapReadonly((*MirrorRevertedTransaction)(r).GetMetadata())
 }
 
 func (r *mirrorRevertedTransactionReadonly) GetTimestamp() commonpb.TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*MirrorRevertedTransaction)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -2378,7 +2374,7 @@ func (r *mirrorRevertedTransactionReadonly) GetTimestamp() commonpb.TimestampRea
 }
 
 func (r *mirrorRevertedTransactionReadonly) Mutate() *MirrorRevertedTransaction {
-	return r.v.CloneVT()
+	return (*MirrorRevertedTransaction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorRevertedTransaction.
@@ -2386,7 +2382,7 @@ func (m *MirrorRevertedTransaction) AsReader() MirrorRevertedTransactionReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorRevertedTransactionReadonly{v: m}
+	return (*mirrorRevertedTransactionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorRevertedTransaction.
@@ -2470,10 +2466,10 @@ type MirrorDeletedMetadataReader interface {
 	Mutate() *MirrorDeletedMetadata
 }
 
-type mirrorDeletedMetadataReadonly struct{ v *MirrorDeletedMetadata }
+type mirrorDeletedMetadataReadonly MirrorDeletedMetadata
 
 func (r *mirrorDeletedMetadataReadonly) GetTarget() commonpb.TargetReader {
-	v := r.v.GetTarget()
+	v := (*MirrorDeletedMetadata)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -2481,11 +2477,11 @@ func (r *mirrorDeletedMetadataReadonly) GetTarget() commonpb.TargetReader {
 }
 
 func (r *mirrorDeletedMetadataReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*MirrorDeletedMetadata)(r).GetKey()
 }
 
 func (r *mirrorDeletedMetadataReadonly) Mutate() *MirrorDeletedMetadata {
-	return r.v.CloneVT()
+	return (*MirrorDeletedMetadata)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorDeletedMetadata.
@@ -2493,7 +2489,7 @@ func (m *MirrorDeletedMetadata) AsReader() MirrorDeletedMetadataReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorDeletedMetadataReadonly{v: m}
+	return (*mirrorDeletedMetadataReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorDeletedMetadata.
@@ -2544,10 +2540,10 @@ type PromoteLedgerOrderReader interface {
 	Mutate() *PromoteLedgerOrder
 }
 
-type promoteLedgerOrderReadonly struct{ v *PromoteLedgerOrder }
+type promoteLedgerOrderReadonly PromoteLedgerOrder
 
 func (r *promoteLedgerOrderReadonly) Mutate() *PromoteLedgerOrder {
-	return r.v.CloneVT()
+	return (*PromoteLedgerOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PromoteLedgerOrder.
@@ -2555,7 +2551,7 @@ func (m *PromoteLedgerOrder) AsReader() PromoteLedgerOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &promoteLedgerOrderReadonly{v: m}
+	return (*promoteLedgerOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PromoteLedgerOrder.
@@ -2606,10 +2602,10 @@ type DeleteLedgerOrderReader interface {
 	Mutate() *DeleteLedgerOrder
 }
 
-type deleteLedgerOrderReadonly struct{ v *DeleteLedgerOrder }
+type deleteLedgerOrderReadonly DeleteLedgerOrder
 
 func (r *deleteLedgerOrderReadonly) Mutate() *DeleteLedgerOrder {
-	return r.v.CloneVT()
+	return (*DeleteLedgerOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteLedgerOrder.
@@ -2617,7 +2613,7 @@ func (m *DeleteLedgerOrder) AsReader() DeleteLedgerOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteLedgerOrderReadonly{v: m}
+	return (*deleteLedgerOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteLedgerOrder.
@@ -2669,14 +2665,14 @@ type LedgerApplyOrderReader interface {
 	Mutate() *LedgerApplyOrder
 }
 
-type ledgerApplyOrderReadonly struct{ v *LedgerApplyOrder }
+type ledgerApplyOrderReadonly LedgerApplyOrder
 
 func (r *ledgerApplyOrderReadonly) GetData() isLedgerApplyOrder_Data {
-	return r.v.GetData()
+	return (*LedgerApplyOrder)(r).GetData()
 }
 
 func (r *ledgerApplyOrderReadonly) Mutate() *LedgerApplyOrder {
-	return r.v.CloneVT()
+	return (*LedgerApplyOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerApplyOrder.
@@ -2684,7 +2680,7 @@ func (m *LedgerApplyOrder) AsReader() LedgerApplyOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerApplyOrderReadonly{v: m}
+	return (*ledgerApplyOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerApplyOrder.
@@ -2736,10 +2732,10 @@ type CreateIndexOrderReader interface {
 	Mutate() *CreateIndexOrder
 }
 
-type createIndexOrderReadonly struct{ v *CreateIndexOrder }
+type createIndexOrderReadonly CreateIndexOrder
 
 func (r *createIndexOrderReadonly) GetId() commonpb.IndexIDReader {
-	v := r.v.GetId()
+	v := (*CreateIndexOrder)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -2747,7 +2743,7 @@ func (r *createIndexOrderReadonly) GetId() commonpb.IndexIDReader {
 }
 
 func (r *createIndexOrderReadonly) Mutate() *CreateIndexOrder {
-	return r.v.CloneVT()
+	return (*CreateIndexOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateIndexOrder.
@@ -2755,7 +2751,7 @@ func (m *CreateIndexOrder) AsReader() CreateIndexOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &createIndexOrderReadonly{v: m}
+	return (*createIndexOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateIndexOrder.
@@ -2807,10 +2803,10 @@ type DropIndexOrderReader interface {
 	Mutate() *DropIndexOrder
 }
 
-type dropIndexOrderReadonly struct{ v *DropIndexOrder }
+type dropIndexOrderReadonly DropIndexOrder
 
 func (r *dropIndexOrderReadonly) GetId() commonpb.IndexIDReader {
-	v := r.v.GetId()
+	v := (*DropIndexOrder)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -2818,7 +2814,7 @@ func (r *dropIndexOrderReadonly) GetId() commonpb.IndexIDReader {
 }
 
 func (r *dropIndexOrderReadonly) Mutate() *DropIndexOrder {
-	return r.v.CloneVT()
+	return (*DropIndexOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DropIndexOrder.
@@ -2826,7 +2822,7 @@ func (m *DropIndexOrder) AsReader() DropIndexOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &dropIndexOrderReadonly{v: m}
+	return (*dropIndexOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DropIndexOrder.
@@ -2878,10 +2874,10 @@ type AddAccountTypeOrderReader interface {
 	Mutate() *AddAccountTypeOrder
 }
 
-type addAccountTypeOrderReadonly struct{ v *AddAccountTypeOrder }
+type addAccountTypeOrderReadonly AddAccountTypeOrder
 
 func (r *addAccountTypeOrderReadonly) GetAccountType() commonpb.AccountTypeReader {
-	v := r.v.GetAccountType()
+	v := (*AddAccountTypeOrder)(r).GetAccountType()
 	if v == nil {
 		return nil
 	}
@@ -2889,7 +2885,7 @@ func (r *addAccountTypeOrderReadonly) GetAccountType() commonpb.AccountTypeReade
 }
 
 func (r *addAccountTypeOrderReadonly) Mutate() *AddAccountTypeOrder {
-	return r.v.CloneVT()
+	return (*AddAccountTypeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddAccountTypeOrder.
@@ -2897,7 +2893,7 @@ func (m *AddAccountTypeOrder) AsReader() AddAccountTypeOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &addAccountTypeOrderReadonly{v: m}
+	return (*addAccountTypeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddAccountTypeOrder.
@@ -2949,14 +2945,14 @@ type RemoveAccountTypeOrderReader interface {
 	Mutate() *RemoveAccountTypeOrder
 }
 
-type removeAccountTypeOrderReadonly struct{ v *RemoveAccountTypeOrder }
+type removeAccountTypeOrderReadonly RemoveAccountTypeOrder
 
 func (r *removeAccountTypeOrderReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemoveAccountTypeOrder)(r).GetName()
 }
 
 func (r *removeAccountTypeOrderReadonly) Mutate() *RemoveAccountTypeOrder {
-	return r.v.CloneVT()
+	return (*RemoveAccountTypeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveAccountTypeOrder.
@@ -2964,7 +2960,7 @@ func (m *RemoveAccountTypeOrder) AsReader() RemoveAccountTypeOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &removeAccountTypeOrderReadonly{v: m}
+	return (*removeAccountTypeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveAccountTypeOrder.
@@ -3016,16 +3012,14 @@ type UpdateDefaultEnforcementModeOrderReader interface {
 	Mutate() *UpdateDefaultEnforcementModeOrder
 }
 
-type updateDefaultEnforcementModeOrderReadonly struct {
-	v *UpdateDefaultEnforcementModeOrder
-}
+type updateDefaultEnforcementModeOrderReadonly UpdateDefaultEnforcementModeOrder
 
 func (r *updateDefaultEnforcementModeOrderReadonly) GetEnforcementMode() commonpb.ChartEnforcementMode {
-	return r.v.GetEnforcementMode()
+	return (*UpdateDefaultEnforcementModeOrder)(r).GetEnforcementMode()
 }
 
 func (r *updateDefaultEnforcementModeOrderReadonly) Mutate() *UpdateDefaultEnforcementModeOrder {
-	return r.v.CloneVT()
+	return (*UpdateDefaultEnforcementModeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdateDefaultEnforcementModeOrder.
@@ -3033,7 +3027,7 @@ func (m *UpdateDefaultEnforcementModeOrder) AsReader() UpdateDefaultEnforcementM
 	if m == nil {
 		return nil
 	}
-	return &updateDefaultEnforcementModeOrderReadonly{v: m}
+	return (*updateDefaultEnforcementModeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdateDefaultEnforcementModeOrder.
@@ -3087,22 +3081,22 @@ type SetMetadataFieldTypeOrderReader interface {
 	Mutate() *SetMetadataFieldTypeOrder
 }
 
-type setMetadataFieldTypeOrderReadonly struct{ v *SetMetadataFieldTypeOrder }
+type setMetadataFieldTypeOrderReadonly SetMetadataFieldTypeOrder
 
 func (r *setMetadataFieldTypeOrderReadonly) GetTargetType() commonpb.TargetType {
-	return r.v.GetTargetType()
+	return (*SetMetadataFieldTypeOrder)(r).GetTargetType()
 }
 
 func (r *setMetadataFieldTypeOrderReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*SetMetadataFieldTypeOrder)(r).GetKey()
 }
 
 func (r *setMetadataFieldTypeOrderReadonly) GetType() commonpb.MetadataType {
-	return r.v.GetType()
+	return (*SetMetadataFieldTypeOrder)(r).GetType()
 }
 
 func (r *setMetadataFieldTypeOrderReadonly) Mutate() *SetMetadataFieldTypeOrder {
-	return r.v.CloneVT()
+	return (*SetMetadataFieldTypeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMetadataFieldTypeOrder.
@@ -3110,7 +3104,7 @@ func (m *SetMetadataFieldTypeOrder) AsReader() SetMetadataFieldTypeOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &setMetadataFieldTypeOrderReadonly{v: m}
+	return (*setMetadataFieldTypeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMetadataFieldTypeOrder.
@@ -3163,18 +3157,18 @@ type RemoveMetadataFieldTypeOrderReader interface {
 	Mutate() *RemoveMetadataFieldTypeOrder
 }
 
-type removeMetadataFieldTypeOrderReadonly struct{ v *RemoveMetadataFieldTypeOrder }
+type removeMetadataFieldTypeOrderReadonly RemoveMetadataFieldTypeOrder
 
 func (r *removeMetadataFieldTypeOrderReadonly) GetTargetType() commonpb.TargetType {
-	return r.v.GetTargetType()
+	return (*RemoveMetadataFieldTypeOrder)(r).GetTargetType()
 }
 
 func (r *removeMetadataFieldTypeOrderReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*RemoveMetadataFieldTypeOrder)(r).GetKey()
 }
 
 func (r *removeMetadataFieldTypeOrderReadonly) Mutate() *RemoveMetadataFieldTypeOrder {
-	return r.v.CloneVT()
+	return (*RemoveMetadataFieldTypeOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveMetadataFieldTypeOrder.
@@ -3182,7 +3176,7 @@ func (m *RemoveMetadataFieldTypeOrder) AsReader() RemoveMetadataFieldTypeOrderRe
 	if m == nil {
 		return nil
 	}
-	return &removeMetadataFieldTypeOrderReadonly{v: m}
+	return (*removeMetadataFieldTypeOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveMetadataFieldTypeOrder.
@@ -3242,14 +3236,14 @@ type CreateTransactionOrderReader interface {
 	Mutate() *CreateTransactionOrder
 }
 
-type createTransactionOrderReadonly struct{ v *CreateTransactionOrder }
+type createTransactionOrderReadonly CreateTransactionOrder
 
 func (r *createTransactionOrderReadonly) GetPostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader(r.v.GetPostings())
+	return commonpb.NewPostingListReader((*CreateTransactionOrder)(r).GetPostings())
 }
 
 func (r *createTransactionOrderReadonly) GetScript() commonpb.ScriptReader {
-	v := r.v.GetScript()
+	v := (*CreateTransactionOrder)(r).GetScript()
 	if v == nil {
 		return nil
 	}
@@ -3257,7 +3251,7 @@ func (r *createTransactionOrderReadonly) GetScript() commonpb.ScriptReader {
 }
 
 func (r *createTransactionOrderReadonly) GetTimestamp() commonpb.TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*CreateTransactionOrder)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -3265,27 +3259,27 @@ func (r *createTransactionOrderReadonly) GetTimestamp() commonpb.TimestampReader
 }
 
 func (r *createTransactionOrderReadonly) GetReference() string {
-	return r.v.GetReference()
+	return (*CreateTransactionOrder)(r).GetReference()
 }
 
 func (r *createTransactionOrderReadonly) GetMetadata() CreateTransactionOrder_MetadataMapReader {
-	return createTransactionOrder_metadataMapReadonly(r.v.GetMetadata())
+	return createTransactionOrder_metadataMapReadonly((*CreateTransactionOrder)(r).GetMetadata())
 }
 
 func (r *createTransactionOrderReadonly) GetAccountMetadata() CreateTransactionOrder_AccountMetadataMapReader {
-	return createTransactionOrder_accountMetadataMapReadonly(r.v.GetAccountMetadata())
+	return createTransactionOrder_accountMetadataMapReadonly((*CreateTransactionOrder)(r).GetAccountMetadata())
 }
 
 func (r *createTransactionOrderReadonly) GetForce() bool {
-	return r.v.GetForce()
+	return (*CreateTransactionOrder)(r).GetForce()
 }
 
 func (r *createTransactionOrderReadonly) GetExpandVolumes() bool {
-	return r.v.GetExpandVolumes()
+	return (*CreateTransactionOrder)(r).GetExpandVolumes()
 }
 
 func (r *createTransactionOrderReadonly) GetNumscriptReference() NumscriptReferenceReader {
-	v := r.v.GetNumscriptReference()
+	v := (*CreateTransactionOrder)(r).GetNumscriptReference()
 	if v == nil {
 		return nil
 	}
@@ -3293,7 +3287,7 @@ func (r *createTransactionOrderReadonly) GetNumscriptReference() NumscriptRefere
 }
 
 func (r *createTransactionOrderReadonly) Mutate() *CreateTransactionOrder {
-	return r.v.CloneVT()
+	return (*CreateTransactionOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateTransactionOrder.
@@ -3301,7 +3295,7 @@ func (m *CreateTransactionOrder) AsReader() CreateTransactionOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &createTransactionOrderReadonly{v: m}
+	return (*createTransactionOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateTransactionOrder.
@@ -3417,22 +3411,22 @@ type NumscriptReferenceReader interface {
 	Mutate() *NumscriptReference
 }
 
-type numscriptReferenceReadonly struct{ v *NumscriptReference }
+type numscriptReferenceReadonly NumscriptReference
 
 func (r *numscriptReferenceReadonly) GetName() string {
-	return r.v.GetName()
+	return (*NumscriptReference)(r).GetName()
 }
 
 func (r *numscriptReferenceReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*NumscriptReference)(r).GetVersion()
 }
 
 func (r *numscriptReferenceReadonly) GetVars() NumscriptReference_VarsMapReader {
-	return numscriptReference_varsMapReadonly(r.v.GetVars())
+	return numscriptReference_varsMapReadonly((*NumscriptReference)(r).GetVars())
 }
 
 func (r *numscriptReferenceReadonly) Mutate() *NumscriptReference {
-	return r.v.CloneVT()
+	return (*NumscriptReference)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NumscriptReference.
@@ -3440,7 +3434,7 @@ func (m *NumscriptReference) AsReader() NumscriptReferenceReader {
 	if m == nil {
 		return nil
 	}
-	return &numscriptReferenceReadonly{v: m}
+	return (*numscriptReferenceReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NumscriptReference.
@@ -3517,10 +3511,10 @@ type SaveMetadataOrderReader interface {
 	Mutate() *SaveMetadataOrder
 }
 
-type saveMetadataOrderReadonly struct{ v *SaveMetadataOrder }
+type saveMetadataOrderReadonly SaveMetadataOrder
 
 func (r *saveMetadataOrderReadonly) GetTarget() commonpb.TargetReader {
-	v := r.v.GetTarget()
+	v := (*SaveMetadataOrder)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -3528,11 +3522,11 @@ func (r *saveMetadataOrderReadonly) GetTarget() commonpb.TargetReader {
 }
 
 func (r *saveMetadataOrderReadonly) GetMetadata() SaveMetadataOrder_MetadataMapReader {
-	return saveMetadataOrder_metadataMapReadonly(r.v.GetMetadata())
+	return saveMetadataOrder_metadataMapReadonly((*SaveMetadataOrder)(r).GetMetadata())
 }
 
 func (r *saveMetadataOrderReadonly) Mutate() *SaveMetadataOrder {
-	return r.v.CloneVT()
+	return (*SaveMetadataOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveMetadataOrder.
@@ -3540,7 +3534,7 @@ func (m *SaveMetadataOrder) AsReader() SaveMetadataOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &saveMetadataOrderReadonly{v: m}
+	return (*saveMetadataOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveMetadataOrder.
@@ -3628,34 +3622,34 @@ type RevertTransactionOrderReader interface {
 	Mutate() *RevertTransactionOrder
 }
 
-type revertTransactionOrderReadonly struct{ v *RevertTransactionOrder }
+type revertTransactionOrderReadonly RevertTransactionOrder
 
 func (r *revertTransactionOrderReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*RevertTransactionOrder)(r).GetTransactionId()
 }
 
 func (r *revertTransactionOrderReadonly) GetForce() bool {
-	return r.v.GetForce()
+	return (*RevertTransactionOrder)(r).GetForce()
 }
 
 func (r *revertTransactionOrderReadonly) GetAtEffectiveDate() bool {
-	return r.v.GetAtEffectiveDate()
+	return (*RevertTransactionOrder)(r).GetAtEffectiveDate()
 }
 
 func (r *revertTransactionOrderReadonly) GetMetadata() RevertTransactionOrder_MetadataMapReader {
-	return revertTransactionOrder_metadataMapReadonly(r.v.GetMetadata())
+	return revertTransactionOrder_metadataMapReadonly((*RevertTransactionOrder)(r).GetMetadata())
 }
 
 func (r *revertTransactionOrderReadonly) GetOriginalPostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader(r.v.GetOriginalPostings())
+	return commonpb.NewPostingListReader((*RevertTransactionOrder)(r).GetOriginalPostings())
 }
 
 func (r *revertTransactionOrderReadonly) GetExpandVolumes() bool {
-	return r.v.GetExpandVolumes()
+	return (*RevertTransactionOrder)(r).GetExpandVolumes()
 }
 
 func (r *revertTransactionOrderReadonly) Mutate() *RevertTransactionOrder {
-	return r.v.CloneVT()
+	return (*RevertTransactionOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevertTransactionOrder.
@@ -3663,7 +3657,7 @@ func (m *RevertTransactionOrder) AsReader() RevertTransactionOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &revertTransactionOrderReadonly{v: m}
+	return (*revertTransactionOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevertTransactionOrder.
@@ -3747,10 +3741,10 @@ type DeleteMetadataOrderReader interface {
 	Mutate() *DeleteMetadataOrder
 }
 
-type deleteMetadataOrderReadonly struct{ v *DeleteMetadataOrder }
+type deleteMetadataOrderReadonly DeleteMetadataOrder
 
 func (r *deleteMetadataOrderReadonly) GetTarget() commonpb.TargetReader {
-	v := r.v.GetTarget()
+	v := (*DeleteMetadataOrder)(r).GetTarget()
 	if v == nil {
 		return nil
 	}
@@ -3758,11 +3752,11 @@ func (r *deleteMetadataOrderReadonly) GetTarget() commonpb.TargetReader {
 }
 
 func (r *deleteMetadataOrderReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeleteMetadataOrder)(r).GetKey()
 }
 
 func (r *deleteMetadataOrderReadonly) Mutate() *DeleteMetadataOrder {
-	return r.v.CloneVT()
+	return (*DeleteMetadataOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteMetadataOrder.
@@ -3770,7 +3764,7 @@ func (m *DeleteMetadataOrder) AsReader() DeleteMetadataOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteMetadataOrderReadonly{v: m}
+	return (*deleteMetadataOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteMetadataOrder.
@@ -3822,14 +3816,14 @@ type SaveLedgerMetadataOrderReader interface {
 	Mutate() *SaveLedgerMetadataOrder
 }
 
-type saveLedgerMetadataOrderReadonly struct{ v *SaveLedgerMetadataOrder }
+type saveLedgerMetadataOrderReadonly SaveLedgerMetadataOrder
 
 func (r *saveLedgerMetadataOrderReadonly) GetMetadata() SaveLedgerMetadataOrder_MetadataMapReader {
-	return saveLedgerMetadataOrder_metadataMapReadonly(r.v.GetMetadata())
+	return saveLedgerMetadataOrder_metadataMapReadonly((*SaveLedgerMetadataOrder)(r).GetMetadata())
 }
 
 func (r *saveLedgerMetadataOrderReadonly) Mutate() *SaveLedgerMetadataOrder {
-	return r.v.CloneVT()
+	return (*SaveLedgerMetadataOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveLedgerMetadataOrder.
@@ -3837,7 +3831,7 @@ func (m *SaveLedgerMetadataOrder) AsReader() SaveLedgerMetadataOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &saveLedgerMetadataOrderReadonly{v: m}
+	return (*saveLedgerMetadataOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveLedgerMetadataOrder.
@@ -3920,14 +3914,14 @@ type DeleteLedgerMetadataOrderReader interface {
 	Mutate() *DeleteLedgerMetadataOrder
 }
 
-type deleteLedgerMetadataOrderReadonly struct{ v *DeleteLedgerMetadataOrder }
+type deleteLedgerMetadataOrderReadonly DeleteLedgerMetadataOrder
 
 func (r *deleteLedgerMetadataOrderReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeleteLedgerMetadataOrder)(r).GetKey()
 }
 
 func (r *deleteLedgerMetadataOrderReadonly) Mutate() *DeleteLedgerMetadataOrder {
-	return r.v.CloneVT()
+	return (*DeleteLedgerMetadataOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteLedgerMetadataOrder.
@@ -3935,7 +3929,7 @@ func (m *DeleteLedgerMetadataOrder) AsReader() DeleteLedgerMetadataOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteLedgerMetadataOrderReadonly{v: m}
+	return (*deleteLedgerMetadataOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteLedgerMetadataOrder.
@@ -3995,18 +3989,18 @@ type ProposalReader interface {
 	Mutate() *Proposal
 }
 
-type proposalReadonly struct{ v *Proposal }
+type proposalReadonly Proposal
 
 func (r *proposalReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*Proposal)(r).GetId()
 }
 
 func (r *proposalReadonly) GetOrders() OrderListReader {
-	return NewOrderListReader(r.v.GetOrders())
+	return NewOrderListReader((*Proposal)(r).GetOrders())
 }
 
 func (r *proposalReadonly) GetDate() commonpb.TimestampReader {
-	v := r.v.GetDate()
+	v := (*Proposal)(r).GetDate()
 	if v == nil {
 		return nil
 	}
@@ -4014,7 +4008,7 @@ func (r *proposalReadonly) GetDate() commonpb.TimestampReader {
 }
 
 func (r *proposalReadonly) GetExecutionPlan() ExecutionPlanReader {
-	v := r.v.GetExecutionPlan()
+	v := (*Proposal)(r).GetExecutionPlan()
 	if v == nil {
 		return nil
 	}
@@ -4022,11 +4016,11 @@ func (r *proposalReadonly) GetExecutionPlan() ExecutionPlanReader {
 }
 
 func (r *proposalReadonly) GetPredictedIndex() uint64 {
-	return r.v.GetPredictedIndex()
+	return (*Proposal)(r).GetPredictedIndex()
 }
 
 func (r *proposalReadonly) GetCallerSnapshot() commonpb.CallerSnapshotReader {
-	v := r.v.GetCallerSnapshot()
+	v := (*Proposal)(r).GetCallerSnapshot()
 	if v == nil {
 		return nil
 	}
@@ -4034,7 +4028,7 @@ func (r *proposalReadonly) GetCallerSnapshot() commonpb.CallerSnapshotReader {
 }
 
 func (r *proposalReadonly) GetIdempotency() commonpb.IdempotencyReader {
-	v := r.v.GetIdempotency()
+	v := (*Proposal)(r).GetIdempotency()
 	if v == nil {
 		return nil
 	}
@@ -4042,7 +4036,7 @@ func (r *proposalReadonly) GetIdempotency() commonpb.IdempotencyReader {
 }
 
 func (r *proposalReadonly) GetSignature() signaturepb.SignedApplyBatchReader {
-	v := r.v.GetSignature()
+	v := (*Proposal)(r).GetSignature()
 	if v == nil {
 		return nil
 	}
@@ -4050,11 +4044,11 @@ func (r *proposalReadonly) GetSignature() signaturepb.SignedApplyBatchReader {
 }
 
 func (r *proposalReadonly) GetTechnicalUpdates() TechnicalUpdateListReader {
-	return NewTechnicalUpdateListReader(r.v.GetTechnicalUpdates())
+	return NewTechnicalUpdateListReader((*Proposal)(r).GetTechnicalUpdates())
 }
 
 func (r *proposalReadonly) Mutate() *Proposal {
-	return r.v.CloneVT()
+	return (*Proposal)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Proposal.
@@ -4062,7 +4056,7 @@ func (m *Proposal) AsReader() ProposalReader {
 	if m == nil {
 		return nil
 	}
-	return &proposalReadonly{v: m}
+	return (*proposalReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Proposal.
@@ -4113,18 +4107,18 @@ type TechnicalUpdateReader interface {
 	Mutate() *TechnicalUpdate
 }
 
-type technicalUpdateReadonly struct{ v *TechnicalUpdate }
+type technicalUpdateReadonly TechnicalUpdate
 
 func (r *technicalUpdateReadonly) GetCoverageBits() []byte {
-	return bytes.Clone(r.v.GetCoverageBits())
+	return bytes.Clone((*TechnicalUpdate)(r).GetCoverageBits())
 }
 
 func (r *technicalUpdateReadonly) GetKind() isTechnicalUpdate_Kind {
-	return r.v.GetKind()
+	return (*TechnicalUpdate)(r).GetKind()
 }
 
 func (r *technicalUpdateReadonly) Mutate() *TechnicalUpdate {
-	return r.v.CloneVT()
+	return (*TechnicalUpdate)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TechnicalUpdate.
@@ -4132,7 +4126,7 @@ func (m *TechnicalUpdate) AsReader() TechnicalUpdateReader {
 	if m == nil {
 		return nil
 	}
-	return &technicalUpdateReadonly{v: m}
+	return (*technicalUpdateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TechnicalUpdate.
@@ -4186,22 +4180,22 @@ type BackupDestinationReader interface {
 	Mutate() *BackupDestination
 }
 
-type backupDestinationReadonly struct{ v *BackupDestination }
+type backupDestinationReadonly BackupDestination
 
 func (r *backupDestinationReadonly) GetBasePath() string {
-	return r.v.GetBasePath()
+	return (*BackupDestination)(r).GetBasePath()
 }
 
 func (r *backupDestinationReadonly) GetBucketId() string {
-	return r.v.GetBucketId()
+	return (*BackupDestination)(r).GetBucketId()
 }
 
 func (r *backupDestinationReadonly) GetTarget() isBackupDestination_Target {
-	return r.v.GetTarget()
+	return (*BackupDestination)(r).GetTarget()
 }
 
 func (r *backupDestinationReadonly) Mutate() *BackupDestination {
-	return r.v.CloneVT()
+	return (*BackupDestination)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupDestination.
@@ -4209,7 +4203,7 @@ func (m *BackupDestination) AsReader() BackupDestinationReader {
 	if m == nil {
 		return nil
 	}
-	return &backupDestinationReadonly{v: m}
+	return (*backupDestinationReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupDestination.
@@ -4263,22 +4257,22 @@ type S3BackupTargetReader interface {
 	Mutate() *S3BackupTarget
 }
 
-type s3BackupTargetReadonly struct{ v *S3BackupTarget }
+type s3BackupTargetReadonly S3BackupTarget
 
 func (r *s3BackupTargetReadonly) GetBucket() string {
-	return r.v.GetBucket()
+	return (*S3BackupTarget)(r).GetBucket()
 }
 
 func (r *s3BackupTargetReadonly) GetRegion() string {
-	return r.v.GetRegion()
+	return (*S3BackupTarget)(r).GetRegion()
 }
 
 func (r *s3BackupTargetReadonly) GetEndpoint() string {
-	return r.v.GetEndpoint()
+	return (*S3BackupTarget)(r).GetEndpoint()
 }
 
 func (r *s3BackupTargetReadonly) Mutate() *S3BackupTarget {
-	return r.v.CloneVT()
+	return (*S3BackupTarget)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this S3BackupTarget.
@@ -4286,7 +4280,7 @@ func (m *S3BackupTarget) AsReader() S3BackupTargetReader {
 	if m == nil {
 		return nil
 	}
-	return &s3BackupTargetReadonly{v: m}
+	return (*s3BackupTargetReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this S3BackupTarget.
@@ -4340,22 +4334,22 @@ type AzureBackupTargetReader interface {
 	Mutate() *AzureBackupTarget
 }
 
-type azureBackupTargetReadonly struct{ v *AzureBackupTarget }
+type azureBackupTargetReadonly AzureBackupTarget
 
 func (r *azureBackupTargetReadonly) GetAccountName() string {
-	return r.v.GetAccountName()
+	return (*AzureBackupTarget)(r).GetAccountName()
 }
 
 func (r *azureBackupTargetReadonly) GetContainer() string {
-	return r.v.GetContainer()
+	return (*AzureBackupTarget)(r).GetContainer()
 }
 
 func (r *azureBackupTargetReadonly) GetEndpoint() string {
-	return r.v.GetEndpoint()
+	return (*AzureBackupTarget)(r).GetEndpoint()
 }
 
 func (r *azureBackupTargetReadonly) Mutate() *AzureBackupTarget {
-	return r.v.CloneVT()
+	return (*AzureBackupTarget)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AzureBackupTarget.
@@ -4363,7 +4357,7 @@ func (m *AzureBackupTarget) AsReader() AzureBackupTargetReader {
 	if m == nil {
 		return nil
 	}
-	return &azureBackupTargetReadonly{v: m}
+	return (*azureBackupTargetReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AzureBackupTarget.
@@ -4428,22 +4422,22 @@ type BackupJobReader interface {
 	Mutate() *BackupJob
 }
 
-type backupJobReadonly struct{ v *BackupJob }
+type backupJobReadonly BackupJob
 
 func (r *backupJobReadonly) GetJobId() uint64 {
-	return r.v.GetJobId()
+	return (*BackupJob)(r).GetJobId()
 }
 
 func (r *backupJobReadonly) GetKind() BackupKind {
-	return r.v.GetKind()
+	return (*BackupJob)(r).GetKind()
 }
 
 func (r *backupJobReadonly) GetStatus() BackupJobStatus {
-	return r.v.GetStatus()
+	return (*BackupJob)(r).GetStatus()
 }
 
 func (r *backupJobReadonly) GetDestination() BackupDestinationReader {
-	v := r.v.GetDestination()
+	v := (*BackupJob)(r).GetDestination()
 	if v == nil {
 		return nil
 	}
@@ -4451,47 +4445,47 @@ func (r *backupJobReadonly) GetDestination() BackupDestinationReader {
 }
 
 func (r *backupJobReadonly) GetDestinationKey() []byte {
-	return bytes.Clone(r.v.GetDestinationKey())
+	return bytes.Clone((*BackupJob)(r).GetDestinationKey())
 }
 
 func (r *backupJobReadonly) GetExecutorNodeId() uint64 {
-	return r.v.GetExecutorNodeId()
+	return (*BackupJob)(r).GetExecutorNodeId()
 }
 
 func (r *backupJobReadonly) GetStartedAtAppliedIndex() uint64 {
-	return r.v.GetStartedAtAppliedIndex()
+	return (*BackupJob)(r).GetStartedAtAppliedIndex()
 }
 
 func (r *backupJobReadonly) GetFilesUploaded() uint64 {
-	return r.v.GetFilesUploaded()
+	return (*BackupJob)(r).GetFilesUploaded()
 }
 
 func (r *backupJobReadonly) GetSegmentsUploaded() uint64 {
-	return r.v.GetSegmentsUploaded()
+	return (*BackupJob)(r).GetSegmentsUploaded()
 }
 
 func (r *backupJobReadonly) GetCompletedAtAppliedIndex() uint64 {
-	return r.v.GetCompletedAtAppliedIndex()
+	return (*BackupJob)(r).GetCompletedAtAppliedIndex()
 }
 
 func (r *backupJobReadonly) GetFailureMessage() string {
-	return r.v.GetFailureMessage()
+	return (*BackupJob)(r).GetFailureMessage()
 }
 
 func (r *backupJobReadonly) GetLastLogSequence() uint64 {
-	return r.v.GetLastLogSequence()
+	return (*BackupJob)(r).GetLastLogSequence()
 }
 
 func (r *backupJobReadonly) GetLastAuditSequence() uint64 {
-	return r.v.GetLastAuditSequence()
+	return (*BackupJob)(r).GetLastAuditSequence()
 }
 
 func (r *backupJobReadonly) GetLastAppliedIndex() uint64 {
-	return r.v.GetLastAppliedIndex()
+	return (*BackupJob)(r).GetLastAppliedIndex()
 }
 
 func (r *backupJobReadonly) Mutate() *BackupJob {
-	return r.v.CloneVT()
+	return (*BackupJob)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupJob.
@@ -4499,7 +4493,7 @@ func (m *BackupJob) AsReader() BackupJobReader {
 	if m == nil {
 		return nil
 	}
-	return &backupJobReadonly{v: m}
+	return (*backupJobReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupJob.
@@ -4549,14 +4543,14 @@ type BackupOrderReader interface {
 	Mutate() *BackupOrder
 }
 
-type backupOrderReadonly struct{ v *BackupOrder }
+type backupOrderReadonly BackupOrder
 
 func (r *backupOrderReadonly) GetOp() isBackupOrder_Op {
-	return r.v.GetOp()
+	return (*BackupOrder)(r).GetOp()
 }
 
 func (r *backupOrderReadonly) Mutate() *BackupOrder {
-	return r.v.CloneVT()
+	return (*BackupOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupOrder.
@@ -4564,7 +4558,7 @@ func (m *BackupOrder) AsReader() BackupOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &backupOrderReadonly{v: m}
+	return (*backupOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupOrder.
@@ -4616,14 +4610,14 @@ type IncrementalBackupOrderReader interface {
 	Mutate() *IncrementalBackupOrder
 }
 
-type incrementalBackupOrderReadonly struct{ v *IncrementalBackupOrder }
+type incrementalBackupOrderReadonly IncrementalBackupOrder
 
 func (r *incrementalBackupOrderReadonly) GetOp() isIncrementalBackupOrder_Op {
-	return r.v.GetOp()
+	return (*IncrementalBackupOrder)(r).GetOp()
 }
 
 func (r *incrementalBackupOrderReadonly) Mutate() *IncrementalBackupOrder {
-	return r.v.CloneVT()
+	return (*IncrementalBackupOrder)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IncrementalBackupOrder.
@@ -4631,7 +4625,7 @@ func (m *IncrementalBackupOrder) AsReader() IncrementalBackupOrderReader {
 	if m == nil {
 		return nil
 	}
-	return &incrementalBackupOrderReadonly{v: m}
+	return (*incrementalBackupOrderReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IncrementalBackupOrder.
@@ -4685,14 +4679,14 @@ type BackupOrderStartReader interface {
 	Mutate() *BackupOrderStart
 }
 
-type backupOrderStartReadonly struct{ v *BackupOrderStart }
+type backupOrderStartReadonly BackupOrderStart
 
 func (r *backupOrderStartReadonly) GetJobId() uint64 {
-	return r.v.GetJobId()
+	return (*BackupOrderStart)(r).GetJobId()
 }
 
 func (r *backupOrderStartReadonly) GetDestination() BackupDestinationReader {
-	v := r.v.GetDestination()
+	v := (*BackupOrderStart)(r).GetDestination()
 	if v == nil {
 		return nil
 	}
@@ -4700,11 +4694,11 @@ func (r *backupOrderStartReadonly) GetDestination() BackupDestinationReader {
 }
 
 func (r *backupOrderStartReadonly) GetExecutorNodeId() uint64 {
-	return r.v.GetExecutorNodeId()
+	return (*BackupOrderStart)(r).GetExecutorNodeId()
 }
 
 func (r *backupOrderStartReadonly) Mutate() *BackupOrderStart {
-	return r.v.CloneVT()
+	return (*BackupOrderStart)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupOrderStart.
@@ -4712,7 +4706,7 @@ func (m *BackupOrderStart) AsReader() BackupOrderStartReader {
 	if m == nil {
 		return nil
 	}
-	return &backupOrderStartReadonly{v: m}
+	return (*backupOrderStartReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupOrderStart.
@@ -4769,34 +4763,34 @@ type BackupOrderCompleteReader interface {
 	Mutate() *BackupOrderComplete
 }
 
-type backupOrderCompleteReadonly struct{ v *BackupOrderComplete }
+type backupOrderCompleteReadonly BackupOrderComplete
 
 func (r *backupOrderCompleteReadonly) GetJobId() uint64 {
-	return r.v.GetJobId()
+	return (*BackupOrderComplete)(r).GetJobId()
 }
 
 func (r *backupOrderCompleteReadonly) GetLastLogSequence() uint64 {
-	return r.v.GetLastLogSequence()
+	return (*BackupOrderComplete)(r).GetLastLogSequence()
 }
 
 func (r *backupOrderCompleteReadonly) GetLastAuditSequence() uint64 {
-	return r.v.GetLastAuditSequence()
+	return (*BackupOrderComplete)(r).GetLastAuditSequence()
 }
 
 func (r *backupOrderCompleteReadonly) GetLastAppliedIndex() uint64 {
-	return r.v.GetLastAppliedIndex()
+	return (*BackupOrderComplete)(r).GetLastAppliedIndex()
 }
 
 func (r *backupOrderCompleteReadonly) GetFilesUploaded() uint64 {
-	return r.v.GetFilesUploaded()
+	return (*BackupOrderComplete)(r).GetFilesUploaded()
 }
 
 func (r *backupOrderCompleteReadonly) GetSegmentsUploaded() uint64 {
-	return r.v.GetSegmentsUploaded()
+	return (*BackupOrderComplete)(r).GetSegmentsUploaded()
 }
 
 func (r *backupOrderCompleteReadonly) Mutate() *BackupOrderComplete {
-	return r.v.CloneVT()
+	return (*BackupOrderComplete)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupOrderComplete.
@@ -4804,7 +4798,7 @@ func (m *BackupOrderComplete) AsReader() BackupOrderCompleteReader {
 	if m == nil {
 		return nil
 	}
-	return &backupOrderCompleteReadonly{v: m}
+	return (*backupOrderCompleteReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupOrderComplete.
@@ -4857,18 +4851,18 @@ type BackupOrderFailReader interface {
 	Mutate() *BackupOrderFail
 }
 
-type backupOrderFailReadonly struct{ v *BackupOrderFail }
+type backupOrderFailReadonly BackupOrderFail
 
 func (r *backupOrderFailReadonly) GetJobId() uint64 {
-	return r.v.GetJobId()
+	return (*BackupOrderFail)(r).GetJobId()
 }
 
 func (r *backupOrderFailReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*BackupOrderFail)(r).GetMessage()
 }
 
 func (r *backupOrderFailReadonly) Mutate() *BackupOrderFail {
-	return r.v.CloneVT()
+	return (*BackupOrderFail)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BackupOrderFail.
@@ -4876,7 +4870,7 @@ func (m *BackupOrderFail) AsReader() BackupOrderFailReader {
 	if m == nil {
 		return nil
 	}
-	return &backupOrderFailReadonly{v: m}
+	return (*backupOrderFailReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BackupOrderFail.
@@ -4930,14 +4924,14 @@ type IdempotencyEvictionReader interface {
 	Mutate() *IdempotencyEviction
 }
 
-type idempotencyEvictionReadonly struct{ v *IdempotencyEviction }
+type idempotencyEvictionReadonly IdempotencyEviction
 
 func (r *idempotencyEvictionReadonly) GetCutoffMicros() uint64 {
-	return r.v.GetCutoffMicros()
+	return (*IdempotencyEviction)(r).GetCutoffMicros()
 }
 
 func (r *idempotencyEvictionReadonly) GetPebbleKeyHashes() [][]byte {
-	src := r.v.GetPebbleKeyHashes()
+	src := (*IdempotencyEviction)(r).GetPebbleKeyHashes()
 	if src == nil {
 		return nil
 	}
@@ -4949,11 +4943,11 @@ func (r *idempotencyEvictionReadonly) GetPebbleKeyHashes() [][]byte {
 }
 
 func (r *idempotencyEvictionReadonly) GetLastScannedTimeIndexKey() []byte {
-	return bytes.Clone(r.v.GetLastScannedTimeIndexKey())
+	return bytes.Clone((*IdempotencyEviction)(r).GetLastScannedTimeIndexKey())
 }
 
 func (r *idempotencyEvictionReadonly) Mutate() *IdempotencyEviction {
-	return r.v.CloneVT()
+	return (*IdempotencyEviction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IdempotencyEviction.
@@ -4961,7 +4955,7 @@ func (m *IdempotencyEviction) AsReader() IdempotencyEvictionReader {
 	if m == nil {
 		return nil
 	}
-	return &idempotencyEvictionReadonly{v: m}
+	return (*idempotencyEvictionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IdempotencyEviction.
@@ -5017,18 +5011,18 @@ type MirrorSyncUpdateReader interface {
 	Mutate() *MirrorSyncUpdate
 }
 
-type mirrorSyncUpdateReadonly struct{ v *MirrorSyncUpdate }
+type mirrorSyncUpdateReadonly MirrorSyncUpdate
 
 func (r *mirrorSyncUpdateReadonly) GetLedgerName() string {
-	return r.v.GetLedgerName()
+	return (*MirrorSyncUpdate)(r).GetLedgerName()
 }
 
 func (r *mirrorSyncUpdateReadonly) GetCursor() uint64 {
-	return r.v.GetCursor()
+	return (*MirrorSyncUpdate)(r).GetCursor()
 }
 
 func (r *mirrorSyncUpdateReadonly) GetError() commonpb.MirrorSyncErrorReader {
-	v := r.v.GetError()
+	v := (*MirrorSyncUpdate)(r).GetError()
 	if v == nil {
 		return nil
 	}
@@ -5036,15 +5030,15 @@ func (r *mirrorSyncUpdateReadonly) GetError() commonpb.MirrorSyncErrorReader {
 }
 
 func (r *mirrorSyncUpdateReadonly) GetClearError() bool {
-	return r.v.GetClearError()
+	return (*MirrorSyncUpdate)(r).GetClearError()
 }
 
 func (r *mirrorSyncUpdateReadonly) GetSourceLogCount() uint64 {
-	return r.v.GetSourceLogCount()
+	return (*MirrorSyncUpdate)(r).GetSourceLogCount()
 }
 
 func (r *mirrorSyncUpdateReadonly) Mutate() *MirrorSyncUpdate {
-	return r.v.CloneVT()
+	return (*MirrorSyncUpdate)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MirrorSyncUpdate.
@@ -5052,7 +5046,7 @@ func (m *MirrorSyncUpdate) AsReader() MirrorSyncUpdateReader {
 	if m == nil {
 		return nil
 	}
-	return &mirrorSyncUpdateReadonly{v: m}
+	return (*mirrorSyncUpdateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MirrorSyncUpdate.
@@ -5107,18 +5101,18 @@ type EventsSinkUpdateReader interface {
 	Mutate() *EventsSinkUpdate
 }
 
-type eventsSinkUpdateReadonly struct{ v *EventsSinkUpdate }
+type eventsSinkUpdateReadonly EventsSinkUpdate
 
 func (r *eventsSinkUpdateReadonly) GetSinkName() string {
-	return r.v.GetSinkName()
+	return (*EventsSinkUpdate)(r).GetSinkName()
 }
 
 func (r *eventsSinkUpdateReadonly) GetCursor() uint64 {
-	return r.v.GetCursor()
+	return (*EventsSinkUpdate)(r).GetCursor()
 }
 
 func (r *eventsSinkUpdateReadonly) GetError() commonpb.SinkErrorReader {
-	v := r.v.GetError()
+	v := (*EventsSinkUpdate)(r).GetError()
 	if v == nil {
 		return nil
 	}
@@ -5126,11 +5120,11 @@ func (r *eventsSinkUpdateReadonly) GetError() commonpb.SinkErrorReader {
 }
 
 func (r *eventsSinkUpdateReadonly) GetClearError() bool {
-	return r.v.GetClearError()
+	return (*EventsSinkUpdate)(r).GetClearError()
 }
 
 func (r *eventsSinkUpdateReadonly) Mutate() *EventsSinkUpdate {
-	return r.v.CloneVT()
+	return (*EventsSinkUpdate)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this EventsSinkUpdate.
@@ -5138,7 +5132,7 @@ func (m *EventsSinkUpdate) AsReader() EventsSinkUpdateReader {
 	if m == nil {
 		return nil
 	}
-	return &eventsSinkUpdateReadonly{v: m}
+	return (*eventsSinkUpdateReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this EventsSinkUpdate.
@@ -5190,14 +5184,14 @@ type CreatedLogOrReferenceReader interface {
 	Mutate() *CreatedLogOrReference
 }
 
-type createdLogOrReferenceReadonly struct{ v *CreatedLogOrReference }
+type createdLogOrReferenceReadonly CreatedLogOrReference
 
 func (r *createdLogOrReferenceReadonly) GetType() isCreatedLogOrReference_Type {
-	return r.v.GetType()
+	return (*CreatedLogOrReference)(r).GetType()
 }
 
 func (r *createdLogOrReferenceReadonly) Mutate() *CreatedLogOrReference {
-	return r.v.CloneVT()
+	return (*CreatedLogOrReference)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatedLogOrReference.
@@ -5205,7 +5199,7 @@ func (m *CreatedLogOrReference) AsReader() CreatedLogOrReferenceReader {
 	if m == nil {
 		return nil
 	}
-	return &createdLogOrReferenceReadonly{v: m}
+	return (*createdLogOrReferenceReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatedLogOrReference.
@@ -5266,50 +5260,50 @@ type LedgerBoundariesReader interface {
 	Mutate() *LedgerBoundaries
 }
 
-type ledgerBoundariesReadonly struct{ v *LedgerBoundaries }
+type ledgerBoundariesReadonly LedgerBoundaries
 
 func (r *ledgerBoundariesReadonly) GetNextTransactionId() uint64 {
-	return r.v.GetNextTransactionId()
+	return (*LedgerBoundaries)(r).GetNextTransactionId()
 }
 
 func (r *ledgerBoundariesReadonly) GetNextLogId() uint64 {
-	return r.v.GetNextLogId()
+	return (*LedgerBoundaries)(r).GetNextLogId()
 }
 
 func (r *ledgerBoundariesReadonly) GetVolumeCount() uint64 {
-	return r.v.GetVolumeCount()
+	return (*LedgerBoundaries)(r).GetVolumeCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetMetadataCount() uint64 {
-	return r.v.GetMetadataCount()
+	return (*LedgerBoundaries)(r).GetMetadataCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetReferenceCount() uint64 {
-	return r.v.GetReferenceCount()
+	return (*LedgerBoundaries)(r).GetReferenceCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetPostingCount() uint64 {
-	return r.v.GetPostingCount()
+	return (*LedgerBoundaries)(r).GetPostingCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetEphemeralEvictedCount() uint64 {
-	return r.v.GetEphemeralEvictedCount()
+	return (*LedgerBoundaries)(r).GetEphemeralEvictedCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetTransientUsedCount() uint64 {
-	return r.v.GetTransientUsedCount()
+	return (*LedgerBoundaries)(r).GetTransientUsedCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetRevertCount() uint64 {
-	return r.v.GetRevertCount()
+	return (*LedgerBoundaries)(r).GetRevertCount()
 }
 
 func (r *ledgerBoundariesReadonly) GetNumscriptExecutionCount() uint64 {
-	return r.v.GetNumscriptExecutionCount()
+	return (*LedgerBoundaries)(r).GetNumscriptExecutionCount()
 }
 
 func (r *ledgerBoundariesReadonly) Mutate() *LedgerBoundaries {
-	return r.v.CloneVT()
+	return (*LedgerBoundaries)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerBoundaries.
@@ -5317,7 +5311,7 @@ func (m *LedgerBoundaries) AsReader() LedgerBoundariesReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerBoundariesReadonly{v: m}
+	return (*ledgerBoundariesReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerBoundaries.
@@ -5370,10 +5364,10 @@ type VolumePairReader interface {
 	Mutate() *VolumePair
 }
 
-type volumePairReadonly struct{ v *VolumePair }
+type volumePairReadonly VolumePair
 
 func (r *volumePairReadonly) GetInput() commonpb.Uint256Reader {
-	v := r.v.GetInput()
+	v := (*VolumePair)(r).GetInput()
 	if v == nil {
 		return nil
 	}
@@ -5381,7 +5375,7 @@ func (r *volumePairReadonly) GetInput() commonpb.Uint256Reader {
 }
 
 func (r *volumePairReadonly) GetOutput() commonpb.Uint256Reader {
-	v := r.v.GetOutput()
+	v := (*VolumePair)(r).GetOutput()
 	if v == nil {
 		return nil
 	}
@@ -5389,7 +5383,7 @@ func (r *volumePairReadonly) GetOutput() commonpb.Uint256Reader {
 }
 
 func (r *volumePairReadonly) Mutate() *VolumePair {
-	return r.v.CloneVT()
+	return (*VolumePair)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this VolumePair.
@@ -5397,7 +5391,7 @@ func (m *VolumePair) AsReader() VolumePairReader {
 	if m == nil {
 		return nil
 	}
-	return &volumePairReadonly{v: m}
+	return (*volumePairReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this VolumePair.
@@ -5450,26 +5444,26 @@ type ExecutionPlanReader interface {
 	Mutate() *ExecutionPlan
 }
 
-type executionPlanReadonly struct{ v *ExecutionPlan }
+type executionPlanReadonly ExecutionPlan
 
 func (r *executionPlanReadonly) GetLastPersistedIndex() uint64 {
-	return r.v.GetLastPersistedIndex()
+	return (*ExecutionPlan)(r).GetLastPersistedIndex()
 }
 
 func (r *executionPlanReadonly) GetCacheEpoch() uint64 {
-	return r.v.GetCacheEpoch()
+	return (*ExecutionPlan)(r).GetCacheEpoch()
 }
 
 func (r *executionPlanReadonly) GetAttributes() AttributeCoverageListReader {
-	return NewAttributeCoverageListReader(r.v.GetAttributes())
+	return NewAttributeCoverageListReader((*ExecutionPlan)(r).GetAttributes())
 }
 
 func (r *executionPlanReadonly) GetIdempotencyKeys() ReloadIdempotencyKeyListReader {
-	return NewReloadIdempotencyKeyListReader(r.v.GetIdempotencyKeys())
+	return NewReloadIdempotencyKeyListReader((*ExecutionPlan)(r).GetIdempotencyKeys())
 }
 
 func (r *executionPlanReadonly) Mutate() *ExecutionPlan {
-	return r.v.CloneVT()
+	return (*ExecutionPlan)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ExecutionPlan.
@@ -5477,7 +5471,7 @@ func (m *ExecutionPlan) AsReader() ExecutionPlanReader {
 	if m == nil {
 		return nil
 	}
-	return &executionPlanReadonly{v: m}
+	return (*executionPlanReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ExecutionPlan.
@@ -5531,10 +5525,10 @@ type AttributeCoverageReader interface {
 	Mutate() *AttributeCoverage
 }
 
-type attributeCoverageReadonly struct{ v *AttributeCoverage }
+type attributeCoverageReadonly AttributeCoverage
 
 func (r *attributeCoverageReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*AttributeCoverage)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -5542,11 +5536,11 @@ func (r *attributeCoverageReadonly) GetId() AttributeIDReader {
 }
 
 func (r *attributeCoverageReadonly) GetAttrCode() uint32 {
-	return r.v.GetAttrCode()
+	return (*AttributeCoverage)(r).GetAttrCode()
 }
 
 func (r *attributeCoverageReadonly) GetValue() AttributeValueReader {
-	v := r.v.GetValue()
+	v := (*AttributeCoverage)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -5554,7 +5548,7 @@ func (r *attributeCoverageReadonly) GetValue() AttributeValueReader {
 }
 
 func (r *attributeCoverageReadonly) Mutate() *AttributeCoverage {
-	return r.v.CloneVT()
+	return (*AttributeCoverage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AttributeCoverage.
@@ -5562,7 +5556,7 @@ func (m *AttributeCoverage) AsReader() AttributeCoverageReader {
 	if m == nil {
 		return nil
 	}
-	return &attributeCoverageReadonly{v: m}
+	return (*attributeCoverageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AttributeCoverage.
@@ -5614,14 +5608,14 @@ type AttributeValueReader interface {
 	Mutate() *AttributeValue
 }
 
-type attributeValueReadonly struct{ v *AttributeValue }
+type attributeValueReadonly AttributeValue
 
 func (r *attributeValueReadonly) GetRawValue() []byte {
-	return bytes.Clone(r.v.GetRawValue())
+	return bytes.Clone((*AttributeValue)(r).GetRawValue())
 }
 
 func (r *attributeValueReadonly) Mutate() *AttributeValue {
-	return r.v.CloneVT()
+	return (*AttributeValue)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AttributeValue.
@@ -5629,7 +5623,7 @@ func (m *AttributeValue) AsReader() AttributeValueReader {
 	if m == nil {
 		return nil
 	}
-	return &attributeValueReadonly{v: m}
+	return (*attributeValueReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AttributeValue.
@@ -5682,14 +5676,14 @@ type ReloadIdempotencyKeyReader interface {
 	Mutate() *ReloadIdempotencyKey
 }
 
-type reloadIdempotencyKeyReadonly struct{ v *ReloadIdempotencyKey }
+type reloadIdempotencyKeyReadonly ReloadIdempotencyKey
 
 func (r *reloadIdempotencyKeyReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*ReloadIdempotencyKey)(r).GetKey()
 }
 
 func (r *reloadIdempotencyKeyReadonly) GetValue() commonpb.IdempotencyKeyValueReader {
-	v := r.v.GetValue()
+	v := (*ReloadIdempotencyKey)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -5697,7 +5691,7 @@ func (r *reloadIdempotencyKeyReadonly) GetValue() commonpb.IdempotencyKeyValueRe
 }
 
 func (r *reloadIdempotencyKeyReadonly) Mutate() *ReloadIdempotencyKey {
-	return r.v.CloneVT()
+	return (*ReloadIdempotencyKey)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ReloadIdempotencyKey.
@@ -5705,7 +5699,7 @@ func (m *ReloadIdempotencyKey) AsReader() ReloadIdempotencyKeyReader {
 	if m == nil {
 		return nil
 	}
-	return &reloadIdempotencyKeyReadonly{v: m}
+	return (*reloadIdempotencyKeyReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ReloadIdempotencyKey.
@@ -5757,14 +5751,14 @@ type CacheGenerationMetaReader interface {
 	Mutate() *CacheGenerationMeta
 }
 
-type cacheGenerationMetaReadonly struct{ v *CacheGenerationMeta }
+type cacheGenerationMetaReadonly CacheGenerationMeta
 
 func (r *cacheGenerationMetaReadonly) GetBaseIndex() uint64 {
-	return r.v.GetBaseIndex()
+	return (*CacheGenerationMeta)(r).GetBaseIndex()
 }
 
 func (r *cacheGenerationMetaReadonly) Mutate() *CacheGenerationMeta {
-	return r.v.CloneVT()
+	return (*CacheGenerationMeta)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CacheGenerationMeta.
@@ -5772,7 +5766,7 @@ func (m *CacheGenerationMeta) AsReader() CacheGenerationMetaReader {
 	if m == nil {
 		return nil
 	}
-	return &cacheGenerationMetaReadonly{v: m}
+	return (*cacheGenerationMetaReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CacheGenerationMeta.
@@ -5824,14 +5818,14 @@ type CacheSnapshotMetaReader interface {
 	Mutate() *CacheSnapshotMeta
 }
 
-type cacheSnapshotMetaReadonly struct{ v *CacheSnapshotMeta }
+type cacheSnapshotMetaReadonly CacheSnapshotMeta
 
 func (r *cacheSnapshotMetaReadonly) GetCurrentGeneration() uint64 {
-	return r.v.GetCurrentGeneration()
+	return (*CacheSnapshotMeta)(r).GetCurrentGeneration()
 }
 
 func (r *cacheSnapshotMetaReadonly) Mutate() *CacheSnapshotMeta {
-	return r.v.CloneVT()
+	return (*CacheSnapshotMeta)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CacheSnapshotMeta.
@@ -5839,7 +5833,7 @@ func (m *CacheSnapshotMeta) AsReader() CacheSnapshotMetaReader {
 	if m == nil {
 		return nil
 	}
-	return &cacheSnapshotMetaReadonly{v: m}
+	return (*cacheSnapshotMetaReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CacheSnapshotMeta.
@@ -5893,22 +5887,22 @@ type PeerAddressReader interface {
 	Mutate() *PeerAddress
 }
 
-type peerAddressReadonly struct{ v *PeerAddress }
+type peerAddressReadonly PeerAddress
 
 func (r *peerAddressReadonly) GetNodeId() uint64 {
-	return r.v.GetNodeId()
+	return (*PeerAddress)(r).GetNodeId()
 }
 
 func (r *peerAddressReadonly) GetRaftAddress() string {
-	return r.v.GetRaftAddress()
+	return (*PeerAddress)(r).GetRaftAddress()
 }
 
 func (r *peerAddressReadonly) GetServiceAddress() string {
-	return r.v.GetServiceAddress()
+	return (*PeerAddress)(r).GetServiceAddress()
 }
 
 func (r *peerAddressReadonly) Mutate() *PeerAddress {
-	return r.v.CloneVT()
+	return (*PeerAddress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PeerAddress.
@@ -5916,7 +5910,7 @@ func (m *PeerAddress) AsReader() PeerAddressReader {
 	if m == nil {
 		return nil
 	}
-	return &peerAddressReadonly{v: m}
+	return (*peerAddressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PeerAddress.
@@ -5975,42 +5969,42 @@ type GenerationSnapshotReader interface {
 	Mutate() *GenerationSnapshot
 }
 
-type generationSnapshotReadonly struct{ v *GenerationSnapshot }
+type generationSnapshotReadonly GenerationSnapshot
 
 func (r *generationSnapshotReadonly) GetBaseIndex() uint64 {
-	return r.v.GetBaseIndex()
+	return (*GenerationSnapshot)(r).GetBaseIndex()
 }
 
 func (r *generationSnapshotReadonly) GetVolumes() VolumeAttributeSnapshotEntryListReader {
-	return NewVolumeAttributeSnapshotEntryListReader(r.v.GetVolumes())
+	return NewVolumeAttributeSnapshotEntryListReader((*GenerationSnapshot)(r).GetVolumes())
 }
 
 func (r *generationSnapshotReadonly) GetMetadata() MetadataAttributeEntryListReader {
-	return NewMetadataAttributeEntryListReader(r.v.GetMetadata())
+	return NewMetadataAttributeEntryListReader((*GenerationSnapshot)(r).GetMetadata())
 }
 
 func (r *generationSnapshotReadonly) GetLedgerMetadata() MetadataAttributeEntryListReader {
-	return NewMetadataAttributeEntryListReader(r.v.GetLedgerMetadata())
+	return NewMetadataAttributeEntryListReader((*GenerationSnapshot)(r).GetLedgerMetadata())
 }
 
 func (r *generationSnapshotReadonly) GetLedgers() LedgerAttributeEntryListReader {
-	return NewLedgerAttributeEntryListReader(r.v.GetLedgers())
+	return NewLedgerAttributeEntryListReader((*GenerationSnapshot)(r).GetLedgers())
 }
 
 func (r *generationSnapshotReadonly) GetBoundaries() BoundaryAttributeEntryListReader {
-	return NewBoundaryAttributeEntryListReader(r.v.GetBoundaries())
+	return NewBoundaryAttributeEntryListReader((*GenerationSnapshot)(r).GetBoundaries())
 }
 
 func (r *generationSnapshotReadonly) GetReferences() TransactionReferenceAttributeEntryListReader {
-	return NewTransactionReferenceAttributeEntryListReader(r.v.GetReferences())
+	return NewTransactionReferenceAttributeEntryListReader((*GenerationSnapshot)(r).GetReferences())
 }
 
 func (r *generationSnapshotReadonly) GetTransactions() TransactionStateAttributeEntryListReader {
-	return NewTransactionStateAttributeEntryListReader(r.v.GetTransactions())
+	return NewTransactionStateAttributeEntryListReader((*GenerationSnapshot)(r).GetTransactions())
 }
 
 func (r *generationSnapshotReadonly) Mutate() *GenerationSnapshot {
-	return r.v.CloneVT()
+	return (*GenerationSnapshot)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GenerationSnapshot.
@@ -6018,7 +6012,7 @@ func (m *GenerationSnapshot) AsReader() GenerationSnapshotReader {
 	if m == nil {
 		return nil
 	}
-	return &generationSnapshotReadonly{v: m}
+	return (*generationSnapshotReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GenerationSnapshot.
@@ -6072,10 +6066,10 @@ type VolumeAttributeSnapshotEntryReader interface {
 	Mutate() *VolumeAttributeSnapshotEntry
 }
 
-type volumeAttributeSnapshotEntryReadonly struct{ v *VolumeAttributeSnapshotEntry }
+type volumeAttributeSnapshotEntryReadonly VolumeAttributeSnapshotEntry
 
 func (r *volumeAttributeSnapshotEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*VolumeAttributeSnapshotEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6083,7 +6077,7 @@ func (r *volumeAttributeSnapshotEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *volumeAttributeSnapshotEntryReadonly) GetInput() commonpb.Uint256Reader {
-	v := r.v.GetInput()
+	v := (*VolumeAttributeSnapshotEntry)(r).GetInput()
 	if v == nil {
 		return nil
 	}
@@ -6091,7 +6085,7 @@ func (r *volumeAttributeSnapshotEntryReadonly) GetInput() commonpb.Uint256Reader
 }
 
 func (r *volumeAttributeSnapshotEntryReadonly) GetOutput() commonpb.Uint256Reader {
-	v := r.v.GetOutput()
+	v := (*VolumeAttributeSnapshotEntry)(r).GetOutput()
 	if v == nil {
 		return nil
 	}
@@ -6099,7 +6093,7 @@ func (r *volumeAttributeSnapshotEntryReadonly) GetOutput() commonpb.Uint256Reade
 }
 
 func (r *volumeAttributeSnapshotEntryReadonly) Mutate() *VolumeAttributeSnapshotEntry {
-	return r.v.CloneVT()
+	return (*VolumeAttributeSnapshotEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this VolumeAttributeSnapshotEntry.
@@ -6107,7 +6101,7 @@ func (m *VolumeAttributeSnapshotEntry) AsReader() VolumeAttributeSnapshotEntryRe
 	if m == nil {
 		return nil
 	}
-	return &volumeAttributeSnapshotEntryReadonly{v: m}
+	return (*volumeAttributeSnapshotEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this VolumeAttributeSnapshotEntry.
@@ -6160,10 +6154,10 @@ type MetadataAttributeEntryReader interface {
 	Mutate() *MetadataAttributeEntry
 }
 
-type metadataAttributeEntryReadonly struct{ v *MetadataAttributeEntry }
+type metadataAttributeEntryReadonly MetadataAttributeEntry
 
 func (r *metadataAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*MetadataAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6171,7 +6165,7 @@ func (r *metadataAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *metadataAttributeEntryReadonly) GetValue() commonpb.MetadataValueReader {
-	v := r.v.GetValue()
+	v := (*MetadataAttributeEntry)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -6179,7 +6173,7 @@ func (r *metadataAttributeEntryReadonly) GetValue() commonpb.MetadataValueReader
 }
 
 func (r *metadataAttributeEntryReadonly) Mutate() *MetadataAttributeEntry {
-	return r.v.CloneVT()
+	return (*MetadataAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataAttributeEntry.
@@ -6187,7 +6181,7 @@ func (m *MetadataAttributeEntry) AsReader() MetadataAttributeEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataAttributeEntryReadonly{v: m}
+	return (*metadataAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataAttributeEntry.
@@ -6240,10 +6234,10 @@ type LedgerAttributeEntryReader interface {
 	Mutate() *LedgerAttributeEntry
 }
 
-type ledgerAttributeEntryReadonly struct{ v *LedgerAttributeEntry }
+type ledgerAttributeEntryReadonly LedgerAttributeEntry
 
 func (r *ledgerAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*LedgerAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6251,7 +6245,7 @@ func (r *ledgerAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *ledgerAttributeEntryReadonly) GetInfo() commonpb.LedgerInfoReader {
-	v := r.v.GetInfo()
+	v := (*LedgerAttributeEntry)(r).GetInfo()
 	if v == nil {
 		return nil
 	}
@@ -6259,7 +6253,7 @@ func (r *ledgerAttributeEntryReadonly) GetInfo() commonpb.LedgerInfoReader {
 }
 
 func (r *ledgerAttributeEntryReadonly) Mutate() *LedgerAttributeEntry {
-	return r.v.CloneVT()
+	return (*LedgerAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerAttributeEntry.
@@ -6267,7 +6261,7 @@ func (m *LedgerAttributeEntry) AsReader() LedgerAttributeEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerAttributeEntryReadonly{v: m}
+	return (*ledgerAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerAttributeEntry.
@@ -6320,10 +6314,10 @@ type BoundaryAttributeEntryReader interface {
 	Mutate() *BoundaryAttributeEntry
 }
 
-type boundaryAttributeEntryReadonly struct{ v *BoundaryAttributeEntry }
+type boundaryAttributeEntryReadonly BoundaryAttributeEntry
 
 func (r *boundaryAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*BoundaryAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6331,7 +6325,7 @@ func (r *boundaryAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *boundaryAttributeEntryReadonly) GetBoundaries() LedgerBoundariesReader {
-	v := r.v.GetBoundaries()
+	v := (*BoundaryAttributeEntry)(r).GetBoundaries()
 	if v == nil {
 		return nil
 	}
@@ -6339,7 +6333,7 @@ func (r *boundaryAttributeEntryReadonly) GetBoundaries() LedgerBoundariesReader 
 }
 
 func (r *boundaryAttributeEntryReadonly) Mutate() *BoundaryAttributeEntry {
-	return r.v.CloneVT()
+	return (*BoundaryAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BoundaryAttributeEntry.
@@ -6347,7 +6341,7 @@ func (m *BoundaryAttributeEntry) AsReader() BoundaryAttributeEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &boundaryAttributeEntryReadonly{v: m}
+	return (*boundaryAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BoundaryAttributeEntry.
@@ -6400,12 +6394,10 @@ type TransactionReferenceAttributeEntryReader interface {
 	Mutate() *TransactionReferenceAttributeEntry
 }
 
-type transactionReferenceAttributeEntryReadonly struct {
-	v *TransactionReferenceAttributeEntry
-}
+type transactionReferenceAttributeEntryReadonly TransactionReferenceAttributeEntry
 
 func (r *transactionReferenceAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*TransactionReferenceAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6413,7 +6405,7 @@ func (r *transactionReferenceAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *transactionReferenceAttributeEntryReadonly) GetValue() commonpb.TransactionReferenceValueReader {
-	v := r.v.GetValue()
+	v := (*TransactionReferenceAttributeEntry)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -6421,7 +6413,7 @@ func (r *transactionReferenceAttributeEntryReadonly) GetValue() commonpb.Transac
 }
 
 func (r *transactionReferenceAttributeEntryReadonly) Mutate() *TransactionReferenceAttributeEntry {
-	return r.v.CloneVT()
+	return (*TransactionReferenceAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransactionReferenceAttributeEntry.
@@ -6429,7 +6421,7 @@ func (m *TransactionReferenceAttributeEntry) AsReader() TransactionReferenceAttr
 	if m == nil {
 		return nil
 	}
-	return &transactionReferenceAttributeEntryReadonly{v: m}
+	return (*transactionReferenceAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransactionReferenceAttributeEntry.
@@ -6482,12 +6474,10 @@ type TransactionStateAttributeEntryReader interface {
 	Mutate() *TransactionStateAttributeEntry
 }
 
-type transactionStateAttributeEntryReadonly struct {
-	v *TransactionStateAttributeEntry
-}
+type transactionStateAttributeEntryReadonly TransactionStateAttributeEntry
 
 func (r *transactionStateAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*TransactionStateAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6495,7 +6485,7 @@ func (r *transactionStateAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *transactionStateAttributeEntryReadonly) GetState() commonpb.TransactionStateReader {
-	v := r.v.GetState()
+	v := (*TransactionStateAttributeEntry)(r).GetState()
 	if v == nil {
 		return nil
 	}
@@ -6503,7 +6493,7 @@ func (r *transactionStateAttributeEntryReadonly) GetState() commonpb.Transaction
 }
 
 func (r *transactionStateAttributeEntryReadonly) Mutate() *TransactionStateAttributeEntry {
-	return r.v.CloneVT()
+	return (*TransactionStateAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TransactionStateAttributeEntry.
@@ -6511,7 +6501,7 @@ func (m *TransactionStateAttributeEntry) AsReader() TransactionStateAttributeEnt
 	if m == nil {
 		return nil
 	}
-	return &transactionStateAttributeEntryReadonly{v: m}
+	return (*transactionStateAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TransactionStateAttributeEntry.
@@ -6564,10 +6554,10 @@ type IdempotencyKeyAttributeEntryReader interface {
 	Mutate() *IdempotencyKeyAttributeEntry
 }
 
-type idempotencyKeyAttributeEntryReadonly struct{ v *IdempotencyKeyAttributeEntry }
+type idempotencyKeyAttributeEntryReadonly IdempotencyKeyAttributeEntry
 
 func (r *idempotencyKeyAttributeEntryReadonly) GetId() AttributeIDReader {
-	v := r.v.GetId()
+	v := (*IdempotencyKeyAttributeEntry)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -6575,7 +6565,7 @@ func (r *idempotencyKeyAttributeEntryReadonly) GetId() AttributeIDReader {
 }
 
 func (r *idempotencyKeyAttributeEntryReadonly) GetValue() commonpb.IdempotencyKeyValueReader {
-	v := r.v.GetValue()
+	v := (*IdempotencyKeyAttributeEntry)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -6583,7 +6573,7 @@ func (r *idempotencyKeyAttributeEntryReadonly) GetValue() commonpb.IdempotencyKe
 }
 
 func (r *idempotencyKeyAttributeEntryReadonly) Mutate() *IdempotencyKeyAttributeEntry {
-	return r.v.CloneVT()
+	return (*IdempotencyKeyAttributeEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IdempotencyKeyAttributeEntry.
@@ -6591,7 +6581,7 @@ func (m *IdempotencyKeyAttributeEntry) AsReader() IdempotencyKeyAttributeEntryRe
 	if m == nil {
 		return nil
 	}
-	return &idempotencyKeyAttributeEntryReadonly{v: m}
+	return (*idempotencyKeyAttributeEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IdempotencyKeyAttributeEntry.
@@ -6644,18 +6634,18 @@ type AttributeIDReader interface {
 	Mutate() *AttributeID
 }
 
-type attributeIDReadonly struct{ v *AttributeID }
+type attributeIDReadonly AttributeID
 
 func (r *attributeIDReadonly) GetId() []byte {
-	return bytes.Clone(r.v.GetId())
+	return bytes.Clone((*AttributeID)(r).GetId())
 }
 
 func (r *attributeIDReadonly) GetTag() uint64 {
-	return r.v.GetTag()
+	return (*AttributeID)(r).GetTag()
 }
 
 func (r *attributeIDReadonly) Mutate() *AttributeID {
-	return r.v.CloneVT()
+	return (*AttributeID)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AttributeID.
@@ -6663,7 +6653,7 @@ func (m *AttributeID) AsReader() AttributeIDReader {
 	if m == nil {
 		return nil
 	}
-	return &attributeIDReadonly{v: m}
+	return (*attributeIDReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AttributeID.

--- a/internal/proto/rafttransportpb/raft_transport_reader.pb.go
+++ b/internal/proto/rafttransportpb/raft_transport_reader.pb.go
@@ -15,18 +15,18 @@ type RaftRequestMessageReader interface {
 	Mutate() *RaftRequestMessage
 }
 
-type raftRequestMessageReadonly struct{ v *RaftRequestMessage }
+type raftRequestMessageReadonly RaftRequestMessage
 
 func (r *raftRequestMessageReadonly) GetId() uint64 {
-	return r.v.GetId()
+	return (*RaftRequestMessage)(r).GetId()
 }
 
 func (r *raftRequestMessageReadonly) GetMessage() []byte {
-	return bytes.Clone(r.v.GetMessage())
+	return bytes.Clone((*RaftRequestMessage)(r).GetMessage())
 }
 
 func (r *raftRequestMessageReadonly) Mutate() *RaftRequestMessage {
-	return r.v.CloneVT()
+	return (*RaftRequestMessage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RaftRequestMessage.
@@ -34,7 +34,7 @@ func (m *RaftRequestMessage) AsReader() RaftRequestMessageReader {
 	if m == nil {
 		return nil
 	}
-	return &raftRequestMessageReadonly{v: m}
+	return (*raftRequestMessageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RaftRequestMessage.
@@ -86,14 +86,14 @@ type RaftRequestBatchReader interface {
 	Mutate() *RaftRequestBatch
 }
 
-type raftRequestBatchReadonly struct{ v *RaftRequestBatch }
+type raftRequestBatchReadonly RaftRequestBatch
 
 func (r *raftRequestBatchReadonly) GetMessages() RaftRequestMessageListReader {
-	return NewRaftRequestMessageListReader(r.v.GetMessages())
+	return NewRaftRequestMessageListReader((*RaftRequestBatch)(r).GetMessages())
 }
 
 func (r *raftRequestBatchReadonly) Mutate() *RaftRequestBatch {
-	return r.v.CloneVT()
+	return (*RaftRequestBatch)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RaftRequestBatch.
@@ -101,7 +101,7 @@ func (m *RaftRequestBatch) AsReader() RaftRequestBatchReader {
 	if m == nil {
 		return nil
 	}
-	return &raftRequestBatchReadonly{v: m}
+	return (*raftRequestBatchReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RaftRequestBatch.
@@ -155,22 +155,22 @@ type RaftResponseMessageReader interface {
 	Mutate() *RaftResponseMessage
 }
 
-type raftResponseMessageReadonly struct{ v *RaftResponseMessage }
+type raftResponseMessageReadonly RaftResponseMessage
 
 func (r *raftResponseMessageReadonly) GetRequestId() uint64 {
-	return r.v.GetRequestId()
+	return (*RaftResponseMessage)(r).GetRequestId()
 }
 
 func (r *raftResponseMessageReadonly) GetSuccess() bool {
-	return r.v.GetSuccess()
+	return (*RaftResponseMessage)(r).GetSuccess()
 }
 
 func (r *raftResponseMessageReadonly) GetError() string {
-	return r.v.GetError()
+	return (*RaftResponseMessage)(r).GetError()
 }
 
 func (r *raftResponseMessageReadonly) Mutate() *RaftResponseMessage {
-	return r.v.CloneVT()
+	return (*RaftResponseMessage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RaftResponseMessage.
@@ -178,7 +178,7 @@ func (m *RaftResponseMessage) AsReader() RaftResponseMessageReader {
 	if m == nil {
 		return nil
 	}
-	return &raftResponseMessageReadonly{v: m}
+	return (*raftResponseMessageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RaftResponseMessage.
@@ -230,14 +230,14 @@ type RaftResponseBatchReader interface {
 	Mutate() *RaftResponseBatch
 }
 
-type raftResponseBatchReadonly struct{ v *RaftResponseBatch }
+type raftResponseBatchReadonly RaftResponseBatch
 
 func (r *raftResponseBatchReadonly) GetMessages() RaftResponseMessageListReader {
-	return NewRaftResponseMessageListReader(r.v.GetMessages())
+	return NewRaftResponseMessageListReader((*RaftResponseBatch)(r).GetMessages())
 }
 
 func (r *raftResponseBatchReadonly) Mutate() *RaftResponseBatch {
-	return r.v.CloneVT()
+	return (*RaftResponseBatch)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RaftResponseBatch.
@@ -245,7 +245,7 @@ func (m *RaftResponseBatch) AsReader() RaftResponseBatchReader {
 	if m == nil {
 		return nil
 	}
-	return &raftResponseBatchReadonly{v: m}
+	return (*raftResponseBatchReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RaftResponseBatch.
@@ -297,14 +297,14 @@ type PingMessageReader interface {
 	Mutate() *PingMessage
 }
 
-type pingMessageReadonly struct{ v *PingMessage }
+type pingMessageReadonly PingMessage
 
 func (r *pingMessageReadonly) GetSeqId() uint64 {
-	return r.v.GetSeqId()
+	return (*PingMessage)(r).GetSeqId()
 }
 
 func (r *pingMessageReadonly) Mutate() *PingMessage {
-	return r.v.CloneVT()
+	return (*PingMessage)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PingMessage.
@@ -312,7 +312,7 @@ func (m *PingMessage) AsReader() PingMessageReader {
 	if m == nil {
 		return nil
 	}
-	return &pingMessageReadonly{v: m}
+	return (*pingMessageReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PingMessage.
@@ -364,14 +364,14 @@ type PongResponseReader interface {
 	Mutate() *PongResponse
 }
 
-type pongResponseReadonly struct{ v *PongResponse }
+type pongResponseReadonly PongResponse
 
 func (r *pongResponseReadonly) GetSeqId() uint64 {
-	return r.v.GetSeqId()
+	return (*PongResponse)(r).GetSeqId()
 }
 
 func (r *pongResponseReadonly) Mutate() *PongResponse {
-	return r.v.CloneVT()
+	return (*PongResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PongResponse.
@@ -379,7 +379,7 @@ func (m *PongResponse) AsReader() PongResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &pongResponseReadonly{v: m}
+	return (*pongResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PongResponse.
@@ -431,14 +431,14 @@ type SendMessageRequestReader interface {
 	Mutate() *SendMessageRequest
 }
 
-type sendMessageRequestReadonly struct{ v *SendMessageRequest }
+type sendMessageRequestReadonly SendMessageRequest
 
 func (r *sendMessageRequestReadonly) GetMessage() isSendMessageRequest_Message {
-	return r.v.GetMessage()
+	return (*SendMessageRequest)(r).GetMessage()
 }
 
 func (r *sendMessageRequestReadonly) Mutate() *SendMessageRequest {
-	return r.v.CloneVT()
+	return (*SendMessageRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SendMessageRequest.
@@ -446,7 +446,7 @@ func (m *SendMessageRequest) AsReader() SendMessageRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &sendMessageRequestReadonly{v: m}
+	return (*sendMessageRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SendMessageRequest.
@@ -498,14 +498,14 @@ type SendMessageResponseReader interface {
 	Mutate() *SendMessageResponse
 }
 
-type sendMessageResponseReadonly struct{ v *SendMessageResponse }
+type sendMessageResponseReadonly SendMessageResponse
 
 func (r *sendMessageResponseReadonly) GetMessage() isSendMessageResponse_Message {
-	return r.v.GetMessage()
+	return (*SendMessageResponse)(r).GetMessage()
 }
 
 func (r *sendMessageResponseReadonly) Mutate() *SendMessageResponse {
-	return r.v.CloneVT()
+	return (*SendMessageResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SendMessageResponse.
@@ -513,7 +513,7 @@ func (m *SendMessageResponse) AsReader() SendMessageResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &sendMessageResponseReadonly{v: m}
+	return (*sendMessageResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SendMessageResponse.

--- a/internal/proto/restorepb/restore_reader.pb.go
+++ b/internal/proto/restorepb/restore_reader.pb.go
@@ -16,14 +16,14 @@ type StartDownloadBackupRequestReader interface {
 	Mutate() *StartDownloadBackupRequest
 }
 
-type startDownloadBackupRequestReadonly struct{ v *StartDownloadBackupRequest }
+type startDownloadBackupRequestReadonly StartDownloadBackupRequest
 
 func (r *startDownloadBackupRequestReadonly) GetBucketId() string {
-	return r.v.GetBucketId()
+	return (*StartDownloadBackupRequest)(r).GetBucketId()
 }
 
 func (r *startDownloadBackupRequestReadonly) GetStorage() commonpb.BackupStorageReader {
-	v := r.v.GetStorage()
+	v := (*StartDownloadBackupRequest)(r).GetStorage()
 	if v == nil {
 		return nil
 	}
@@ -31,7 +31,7 @@ func (r *startDownloadBackupRequestReadonly) GetStorage() commonpb.BackupStorage
 }
 
 func (r *startDownloadBackupRequestReadonly) Mutate() *StartDownloadBackupRequest {
-	return r.v.CloneVT()
+	return (*StartDownloadBackupRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this StartDownloadBackupRequest.
@@ -39,7 +39,7 @@ func (m *StartDownloadBackupRequest) AsReader() StartDownloadBackupRequestReader
 	if m == nil {
 		return nil
 	}
-	return &startDownloadBackupRequestReadonly{v: m}
+	return (*startDownloadBackupRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this StartDownloadBackupRequest.
@@ -91,14 +91,14 @@ type StartDownloadBackupResponseReader interface {
 	Mutate() *StartDownloadBackupResponse
 }
 
-type startDownloadBackupResponseReadonly struct{ v *StartDownloadBackupResponse }
+type startDownloadBackupResponseReadonly StartDownloadBackupResponse
 
 func (r *startDownloadBackupResponseReadonly) GetJobId() string {
-	return r.v.GetJobId()
+	return (*StartDownloadBackupResponse)(r).GetJobId()
 }
 
 func (r *startDownloadBackupResponseReadonly) Mutate() *StartDownloadBackupResponse {
-	return r.v.CloneVT()
+	return (*StartDownloadBackupResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this StartDownloadBackupResponse.
@@ -106,7 +106,7 @@ func (m *StartDownloadBackupResponse) AsReader() StartDownloadBackupResponseRead
 	if m == nil {
 		return nil
 	}
-	return &startDownloadBackupResponseReadonly{v: m}
+	return (*startDownloadBackupResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this StartDownloadBackupResponse.
@@ -158,14 +158,14 @@ type GetDownloadStatusRequestReader interface {
 	Mutate() *GetDownloadStatusRequest
 }
 
-type getDownloadStatusRequestReadonly struct{ v *GetDownloadStatusRequest }
+type getDownloadStatusRequestReadonly GetDownloadStatusRequest
 
 func (r *getDownloadStatusRequestReadonly) GetJobId() string {
-	return r.v.GetJobId()
+	return (*GetDownloadStatusRequest)(r).GetJobId()
 }
 
 func (r *getDownloadStatusRequestReadonly) Mutate() *GetDownloadStatusRequest {
-	return r.v.CloneVT()
+	return (*GetDownloadStatusRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetDownloadStatusRequest.
@@ -173,7 +173,7 @@ func (m *GetDownloadStatusRequest) AsReader() GetDownloadStatusRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getDownloadStatusRequestReadonly{v: m}
+	return (*getDownloadStatusRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetDownloadStatusRequest.
@@ -233,46 +233,46 @@ type GetDownloadStatusResponseReader interface {
 	Mutate() *GetDownloadStatusResponse
 }
 
-type getDownloadStatusResponseReadonly struct{ v *GetDownloadStatusResponse }
+type getDownloadStatusResponseReadonly GetDownloadStatusResponse
 
 func (r *getDownloadStatusResponseReadonly) GetState() DownloadState {
-	return r.v.GetState()
+	return (*GetDownloadStatusResponse)(r).GetState()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetFilesDownloaded() uint64 {
-	return r.v.GetFilesDownloaded()
+	return (*GetDownloadStatusResponse)(r).GetFilesDownloaded()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetTotalFiles() uint64 {
-	return r.v.GetTotalFiles()
+	return (*GetDownloadStatusResponse)(r).GetTotalFiles()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetBytesDownloaded() uint64 {
-	return r.v.GetBytesDownloaded()
+	return (*GetDownloadStatusResponse)(r).GetBytesDownloaded()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetTotalBytes() uint64 {
-	return r.v.GetTotalBytes()
+	return (*GetDownloadStatusResponse)(r).GetTotalBytes()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetCurrentFile() string {
-	return r.v.GetCurrentFile()
+	return (*GetDownloadStatusResponse)(r).GetCurrentFile()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetErrorMessage() string {
-	return r.v.GetErrorMessage()
+	return (*GetDownloadStatusResponse)(r).GetErrorMessage()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetStartedAtUnix() uint64 {
-	return r.v.GetStartedAtUnix()
+	return (*GetDownloadStatusResponse)(r).GetStartedAtUnix()
 }
 
 func (r *getDownloadStatusResponseReadonly) GetFinishedAtUnix() uint64 {
-	return r.v.GetFinishedAtUnix()
+	return (*GetDownloadStatusResponse)(r).GetFinishedAtUnix()
 }
 
 func (r *getDownloadStatusResponseReadonly) Mutate() *GetDownloadStatusResponse {
-	return r.v.CloneVT()
+	return (*GetDownloadStatusResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetDownloadStatusResponse.
@@ -280,7 +280,7 @@ func (m *GetDownloadStatusResponse) AsReader() GetDownloadStatusResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getDownloadStatusResponseReadonly{v: m}
+	return (*getDownloadStatusResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetDownloadStatusResponse.
@@ -332,14 +332,14 @@ type CancelDownloadRequestReader interface {
 	Mutate() *CancelDownloadRequest
 }
 
-type cancelDownloadRequestReadonly struct{ v *CancelDownloadRequest }
+type cancelDownloadRequestReadonly CancelDownloadRequest
 
 func (r *cancelDownloadRequestReadonly) GetJobId() string {
-	return r.v.GetJobId()
+	return (*CancelDownloadRequest)(r).GetJobId()
 }
 
 func (r *cancelDownloadRequestReadonly) Mutate() *CancelDownloadRequest {
-	return r.v.CloneVT()
+	return (*CancelDownloadRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CancelDownloadRequest.
@@ -347,7 +347,7 @@ func (m *CancelDownloadRequest) AsReader() CancelDownloadRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &cancelDownloadRequestReadonly{v: m}
+	return (*cancelDownloadRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CancelDownloadRequest.
@@ -398,10 +398,10 @@ type CancelDownloadResponseReader interface {
 	Mutate() *CancelDownloadResponse
 }
 
-type cancelDownloadResponseReadonly struct{ v *CancelDownloadResponse }
+type cancelDownloadResponseReadonly CancelDownloadResponse
 
 func (r *cancelDownloadResponseReadonly) Mutate() *CancelDownloadResponse {
-	return r.v.CloneVT()
+	return (*CancelDownloadResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CancelDownloadResponse.
@@ -409,7 +409,7 @@ func (m *CancelDownloadResponse) AsReader() CancelDownloadResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &cancelDownloadResponseReadonly{v: m}
+	return (*cancelDownloadResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CancelDownloadResponse.
@@ -460,10 +460,10 @@ type ValidateRestoreRequestReader interface {
 	Mutate() *ValidateRestoreRequest
 }
 
-type validateRestoreRequestReadonly struct{ v *ValidateRestoreRequest }
+type validateRestoreRequestReadonly ValidateRestoreRequest
 
 func (r *validateRestoreRequestReadonly) Mutate() *ValidateRestoreRequest {
-	return r.v.CloneVT()
+	return (*ValidateRestoreRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ValidateRestoreRequest.
@@ -471,7 +471,7 @@ func (m *ValidateRestoreRequest) AsReader() ValidateRestoreRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &validateRestoreRequestReadonly{v: m}
+	return (*validateRestoreRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ValidateRestoreRequest.
@@ -523,14 +523,14 @@ type ValidateRestoreEventReader interface {
 	Mutate() *ValidateRestoreEvent
 }
 
-type validateRestoreEventReadonly struct{ v *ValidateRestoreEvent }
+type validateRestoreEventReadonly ValidateRestoreEvent
 
 func (r *validateRestoreEventReadonly) GetType() isValidateRestoreEvent_Type {
-	return r.v.GetType()
+	return (*ValidateRestoreEvent)(r).GetType()
 }
 
 func (r *validateRestoreEventReadonly) Mutate() *ValidateRestoreEvent {
-	return r.v.CloneVT()
+	return (*ValidateRestoreEvent)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ValidateRestoreEvent.
@@ -538,7 +538,7 @@ func (m *ValidateRestoreEvent) AsReader() ValidateRestoreEventReader {
 	if m == nil {
 		return nil
 	}
-	return &validateRestoreEventReadonly{v: m}
+	return (*validateRestoreEventReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ValidateRestoreEvent.
@@ -590,14 +590,14 @@ type ValidateRestoreErrorReader interface {
 	Mutate() *ValidateRestoreError
 }
 
-type validateRestoreErrorReadonly struct{ v *ValidateRestoreError }
+type validateRestoreErrorReadonly ValidateRestoreError
 
 func (r *validateRestoreErrorReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*ValidateRestoreError)(r).GetMessage()
 }
 
 func (r *validateRestoreErrorReadonly) Mutate() *ValidateRestoreError {
-	return r.v.CloneVT()
+	return (*ValidateRestoreError)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ValidateRestoreError.
@@ -605,7 +605,7 @@ func (m *ValidateRestoreError) AsReader() ValidateRestoreErrorReader {
 	if m == nil {
 		return nil
 	}
-	return &validateRestoreErrorReadonly{v: m}
+	return (*validateRestoreErrorReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ValidateRestoreError.
@@ -658,18 +658,18 @@ type ValidateRestoreProgressReader interface {
 	Mutate() *ValidateRestoreProgress
 }
 
-type validateRestoreProgressReadonly struct{ v *ValidateRestoreProgress }
+type validateRestoreProgressReadonly ValidateRestoreProgress
 
 func (r *validateRestoreProgressReadonly) GetLogsChecked() uint64 {
-	return r.v.GetLogsChecked()
+	return (*ValidateRestoreProgress)(r).GetLogsChecked()
 }
 
 func (r *validateRestoreProgressReadonly) GetTotalLogs() uint64 {
-	return r.v.GetTotalLogs()
+	return (*ValidateRestoreProgress)(r).GetTotalLogs()
 }
 
 func (r *validateRestoreProgressReadonly) Mutate() *ValidateRestoreProgress {
-	return r.v.CloneVT()
+	return (*ValidateRestoreProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ValidateRestoreProgress.
@@ -677,7 +677,7 @@ func (m *ValidateRestoreProgress) AsReader() ValidateRestoreProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &validateRestoreProgressReadonly{v: m}
+	return (*validateRestoreProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ValidateRestoreProgress.
@@ -728,10 +728,10 @@ type PreviewRestoreRequestReader interface {
 	Mutate() *PreviewRestoreRequest
 }
 
-type previewRestoreRequestReadonly struct{ v *PreviewRestoreRequest }
+type previewRestoreRequestReadonly PreviewRestoreRequest
 
 func (r *previewRestoreRequestReadonly) Mutate() *PreviewRestoreRequest {
-	return r.v.CloneVT()
+	return (*PreviewRestoreRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PreviewRestoreRequest.
@@ -739,7 +739,7 @@ func (m *PreviewRestoreRequest) AsReader() PreviewRestoreRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &previewRestoreRequestReadonly{v: m}
+	return (*previewRestoreRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PreviewRestoreRequest.
@@ -799,46 +799,46 @@ type PreviewRestoreResponseReader interface {
 	Mutate() *PreviewRestoreResponse
 }
 
-type previewRestoreResponseReadonly struct{ v *PreviewRestoreResponse }
+type previewRestoreResponseReadonly PreviewRestoreResponse
 
 func (r *previewRestoreResponseReadonly) GetLastAppliedIndex() uint64 {
-	return r.v.GetLastAppliedIndex()
+	return (*PreviewRestoreResponse)(r).GetLastAppliedIndex()
 }
 
 func (r *previewRestoreResponseReadonly) GetLastAppliedTimestamp() uint64 {
-	return r.v.GetLastAppliedTimestamp()
+	return (*PreviewRestoreResponse)(r).GetLastAppliedTimestamp()
 }
 
 func (r *previewRestoreResponseReadonly) GetLastSequence() uint64 {
-	return r.v.GetLastSequence()
+	return (*PreviewRestoreResponse)(r).GetLastSequence()
 }
 
 func (r *previewRestoreResponseReadonly) GetLedgerCount() uint32 {
-	return r.v.GetLedgerCount()
+	return (*PreviewRestoreResponse)(r).GetLedgerCount()
 }
 
 func (r *previewRestoreResponseReadonly) GetLedgerNames() []string {
-	return slices.Clone(r.v.GetLedgerNames())
+	return slices.Clone((*PreviewRestoreResponse)(r).GetLedgerNames())
 }
 
 func (r *previewRestoreResponseReadonly) GetFirstLogSequence() uint64 {
-	return r.v.GetFirstLogSequence()
+	return (*PreviewRestoreResponse)(r).GetFirstLogSequence()
 }
 
 func (r *previewRestoreResponseReadonly) GetFirstAuditSequence() uint64 {
-	return r.v.GetFirstAuditSequence()
+	return (*PreviewRestoreResponse)(r).GetFirstAuditSequence()
 }
 
 func (r *previewRestoreResponseReadonly) GetHasExports() bool {
-	return r.v.GetHasExports()
+	return (*PreviewRestoreResponse)(r).GetHasExports()
 }
 
 func (r *previewRestoreResponseReadonly) GetExportCount() uint32 {
-	return r.v.GetExportCount()
+	return (*PreviewRestoreResponse)(r).GetExportCount()
 }
 
 func (r *previewRestoreResponseReadonly) Mutate() *PreviewRestoreResponse {
-	return r.v.CloneVT()
+	return (*PreviewRestoreResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PreviewRestoreResponse.
@@ -846,7 +846,7 @@ func (m *PreviewRestoreResponse) AsReader() PreviewRestoreResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &previewRestoreResponseReadonly{v: m}
+	return (*previewRestoreResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PreviewRestoreResponse.
@@ -897,10 +897,10 @@ type FinalizeRestoreRequestReader interface {
 	Mutate() *FinalizeRestoreRequest
 }
 
-type finalizeRestoreRequestReadonly struct{ v *FinalizeRestoreRequest }
+type finalizeRestoreRequestReadonly FinalizeRestoreRequest
 
 func (r *finalizeRestoreRequestReadonly) Mutate() *FinalizeRestoreRequest {
-	return r.v.CloneVT()
+	return (*FinalizeRestoreRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FinalizeRestoreRequest.
@@ -908,7 +908,7 @@ func (m *FinalizeRestoreRequest) AsReader() FinalizeRestoreRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &finalizeRestoreRequestReadonly{v: m}
+	return (*finalizeRestoreRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FinalizeRestoreRequest.
@@ -960,14 +960,14 @@ type FinalizeRestoreResponseReader interface {
 	Mutate() *FinalizeRestoreResponse
 }
 
-type finalizeRestoreResponseReadonly struct{ v *FinalizeRestoreResponse }
+type finalizeRestoreResponseReadonly FinalizeRestoreResponse
 
 func (r *finalizeRestoreResponseReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*FinalizeRestoreResponse)(r).GetMessage()
 }
 
 func (r *finalizeRestoreResponseReadonly) Mutate() *FinalizeRestoreResponse {
-	return r.v.CloneVT()
+	return (*FinalizeRestoreResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FinalizeRestoreResponse.
@@ -975,7 +975,7 @@ func (m *FinalizeRestoreResponse) AsReader() FinalizeRestoreResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &finalizeRestoreResponseReadonly{v: m}
+	return (*finalizeRestoreResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FinalizeRestoreResponse.

--- a/internal/proto/servicepb/bucket_reader.pb.go
+++ b/internal/proto/servicepb/bucket_reader.pb.go
@@ -18,22 +18,22 @@ type GetAccountRequestReader interface {
 	Mutate() *GetAccountRequest
 }
 
-type getAccountRequestReadonly struct{ v *GetAccountRequest }
+type getAccountRequestReadonly GetAccountRequest
 
 func (r *getAccountRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetAccountRequest)(r).GetLedger()
 }
 
 func (r *getAccountRequestReadonly) GetAddress() string {
-	return r.v.GetAddress()
+	return (*GetAccountRequest)(r).GetAddress()
 }
 
 func (r *getAccountRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*GetAccountRequest)(r).GetCheckpointId()
 }
 
 func (r *getAccountRequestReadonly) Mutate() *GetAccountRequest {
-	return r.v.CloneVT()
+	return (*GetAccountRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetAccountRequest.
@@ -41,7 +41,7 @@ func (m *GetAccountRequest) AsReader() GetAccountRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getAccountRequestReadonly{v: m}
+	return (*getAccountRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetAccountRequest.
@@ -95,22 +95,22 @@ type GetTransactionRequestReader interface {
 	Mutate() *GetTransactionRequest
 }
 
-type getTransactionRequestReadonly struct{ v *GetTransactionRequest }
+type getTransactionRequestReadonly GetTransactionRequest
 
 func (r *getTransactionRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetTransactionRequest)(r).GetLedger()
 }
 
 func (r *getTransactionRequestReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*GetTransactionRequest)(r).GetTransactionId()
 }
 
 func (r *getTransactionRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*GetTransactionRequest)(r).GetCheckpointId()
 }
 
 func (r *getTransactionRequestReadonly) Mutate() *GetTransactionRequest {
-	return r.v.CloneVT()
+	return (*GetTransactionRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetTransactionRequest.
@@ -118,7 +118,7 @@ func (m *GetTransactionRequest) AsReader() GetTransactionRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getTransactionRequestReadonly{v: m}
+	return (*getTransactionRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetTransactionRequest.
@@ -171,10 +171,10 @@ type GetTransactionResponseReader interface {
 	Mutate() *GetTransactionResponse
 }
 
-type getTransactionResponseReadonly struct{ v *GetTransactionResponse }
+type getTransactionResponseReadonly GetTransactionResponse
 
 func (r *getTransactionResponseReadonly) GetTransaction() commonpb.TransactionReader {
-	v := r.v.GetTransaction()
+	v := (*GetTransactionResponse)(r).GetTransaction()
 	if v == nil {
 		return nil
 	}
@@ -182,11 +182,11 @@ func (r *getTransactionResponseReadonly) GetTransaction() commonpb.TransactionRe
 }
 
 func (r *getTransactionResponseReadonly) GetReceipt() string {
-	return r.v.GetReceipt()
+	return (*GetTransactionResponse)(r).GetReceipt()
 }
 
 func (r *getTransactionResponseReadonly) Mutate() *GetTransactionResponse {
-	return r.v.CloneVT()
+	return (*GetTransactionResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetTransactionResponse.
@@ -194,7 +194,7 @@ func (m *GetTransactionResponse) AsReader() GetTransactionResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getTransactionResponseReadonly{v: m}
+	return (*getTransactionResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetTransactionResponse.
@@ -247,14 +247,14 @@ type ListTransactionsRequestReader interface {
 	Mutate() *ListTransactionsRequest
 }
 
-type listTransactionsRequestReadonly struct{ v *ListTransactionsRequest }
+type listTransactionsRequestReadonly ListTransactionsRequest
 
 func (r *listTransactionsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListTransactionsRequest)(r).GetLedger()
 }
 
 func (r *listTransactionsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListTransactionsRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -262,7 +262,7 @@ func (r *listTransactionsRequestReadonly) GetOptions() commonpb.ListOptionsReade
 }
 
 func (r *listTransactionsRequestReadonly) Mutate() *ListTransactionsRequest {
-	return r.v.CloneVT()
+	return (*ListTransactionsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListTransactionsRequest.
@@ -270,7 +270,7 @@ func (m *ListTransactionsRequest) AsReader() ListTransactionsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listTransactionsRequestReadonly{v: m}
+	return (*listTransactionsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListTransactionsRequest.
@@ -323,14 +323,14 @@ type ListAccountsRequestReader interface {
 	Mutate() *ListAccountsRequest
 }
 
-type listAccountsRequestReadonly struct{ v *ListAccountsRequest }
+type listAccountsRequestReadonly ListAccountsRequest
 
 func (r *listAccountsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListAccountsRequest)(r).GetLedger()
 }
 
 func (r *listAccountsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListAccountsRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -338,7 +338,7 @@ func (r *listAccountsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
 }
 
 func (r *listAccountsRequestReadonly) Mutate() *ListAccountsRequest {
-	return r.v.CloneVT()
+	return (*ListAccountsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListAccountsRequest.
@@ -346,7 +346,7 @@ func (m *ListAccountsRequest) AsReader() ListAccountsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listAccountsRequestReadonly{v: m}
+	return (*listAccountsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListAccountsRequest.
@@ -403,22 +403,22 @@ type CreateLedgerRequestReader interface {
 	Mutate() *CreateLedgerRequest
 }
 
-type createLedgerRequestReadonly struct{ v *CreateLedgerRequest }
+type createLedgerRequestReadonly CreateLedgerRequest
 
 func (r *createLedgerRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*CreateLedgerRequest)(r).GetName()
 }
 
 func (r *createLedgerRequestReadonly) GetInitialSchema() commonpb.SetMetadataFieldTypeCommandListReader {
-	return commonpb.NewSetMetadataFieldTypeCommandListReader(r.v.GetInitialSchema())
+	return commonpb.NewSetMetadataFieldTypeCommandListReader((*CreateLedgerRequest)(r).GetInitialSchema())
 }
 
 func (r *createLedgerRequestReadonly) GetMode() commonpb.LedgerMode {
-	return r.v.GetMode()
+	return (*CreateLedgerRequest)(r).GetMode()
 }
 
 func (r *createLedgerRequestReadonly) GetMirrorSource() commonpb.MirrorSourceConfigReader {
-	v := r.v.GetMirrorSource()
+	v := (*CreateLedgerRequest)(r).GetMirrorSource()
 	if v == nil {
 		return nil
 	}
@@ -426,15 +426,15 @@ func (r *createLedgerRequestReadonly) GetMirrorSource() commonpb.MirrorSourceCon
 }
 
 func (r *createLedgerRequestReadonly) GetAccountTypes() CreateLedgerRequest_AccountTypesMapReader {
-	return createLedgerRequest_accountTypesMapReadonly(r.v.GetAccountTypes())
+	return createLedgerRequest_accountTypesMapReadonly((*CreateLedgerRequest)(r).GetAccountTypes())
 }
 
 func (r *createLedgerRequestReadonly) GetDefaultEnforcementMode() commonpb.ChartEnforcementMode {
-	return r.v.GetDefaultEnforcementMode()
+	return (*CreateLedgerRequest)(r).GetDefaultEnforcementMode()
 }
 
 func (r *createLedgerRequestReadonly) Mutate() *CreateLedgerRequest {
-	return r.v.CloneVT()
+	return (*CreateLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateLedgerRequest.
@@ -442,7 +442,7 @@ func (m *CreateLedgerRequest) AsReader() CreateLedgerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &createLedgerRequestReadonly{v: m}
+	return (*createLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateLedgerRequest.
@@ -525,14 +525,14 @@ type DeleteLedgerRequestReader interface {
 	Mutate() *DeleteLedgerRequest
 }
 
-type deleteLedgerRequestReadonly struct{ v *DeleteLedgerRequest }
+type deleteLedgerRequestReadonly DeleteLedgerRequest
 
 func (r *deleteLedgerRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeleteLedgerRequest)(r).GetName()
 }
 
 func (r *deleteLedgerRequestReadonly) Mutate() *DeleteLedgerRequest {
-	return r.v.CloneVT()
+	return (*DeleteLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteLedgerRequest.
@@ -540,7 +540,7 @@ func (m *DeleteLedgerRequest) AsReader() DeleteLedgerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteLedgerRequestReadonly{v: m}
+	return (*deleteLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteLedgerRequest.
@@ -591,10 +591,10 @@ type DeleteLedgerResponseReader interface {
 	Mutate() *DeleteLedgerResponse
 }
 
-type deleteLedgerResponseReadonly struct{ v *DeleteLedgerResponse }
+type deleteLedgerResponseReadonly DeleteLedgerResponse
 
 func (r *deleteLedgerResponseReadonly) Mutate() *DeleteLedgerResponse {
-	return r.v.CloneVT()
+	return (*DeleteLedgerResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteLedgerResponse.
@@ -602,7 +602,7 @@ func (m *DeleteLedgerResponse) AsReader() DeleteLedgerResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteLedgerResponseReadonly{v: m}
+	return (*deleteLedgerResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteLedgerResponse.
@@ -654,10 +654,10 @@ type ListLedgersRequestReader interface {
 	Mutate() *ListLedgersRequest
 }
 
-type listLedgersRequestReadonly struct{ v *ListLedgersRequest }
+type listLedgersRequestReadonly ListLedgersRequest
 
 func (r *listLedgersRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListLedgersRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -665,7 +665,7 @@ func (r *listLedgersRequestReadonly) GetOptions() commonpb.ListOptionsReader {
 }
 
 func (r *listLedgersRequestReadonly) Mutate() *ListLedgersRequest {
-	return r.v.CloneVT()
+	return (*ListLedgersRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListLedgersRequest.
@@ -673,7 +673,7 @@ func (m *ListLedgersRequest) AsReader() ListLedgersRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listLedgersRequestReadonly{v: m}
+	return (*listLedgersRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListLedgersRequest.
@@ -726,14 +726,14 @@ type GetLedgerRequestReader interface {
 	Mutate() *GetLedgerRequest
 }
 
-type getLedgerRequestReadonly struct{ v *GetLedgerRequest }
+type getLedgerRequestReadonly GetLedgerRequest
 
 func (r *getLedgerRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetLedgerRequest)(r).GetLedger()
 }
 
 func (r *getLedgerRequestReadonly) GetRead() commonpb.ReadOptionsReader {
-	v := r.v.GetRead()
+	v := (*GetLedgerRequest)(r).GetRead()
 	if v == nil {
 		return nil
 	}
@@ -741,7 +741,7 @@ func (r *getLedgerRequestReadonly) GetRead() commonpb.ReadOptionsReader {
 }
 
 func (r *getLedgerRequestReadonly) Mutate() *GetLedgerRequest {
-	return r.v.CloneVT()
+	return (*GetLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetLedgerRequest.
@@ -749,7 +749,7 @@ func (m *GetLedgerRequest) AsReader() GetLedgerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getLedgerRequestReadonly{v: m}
+	return (*getLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetLedgerRequest.
@@ -803,10 +803,10 @@ type ApplyRequestReader interface {
 	Mutate() *ApplyRequest
 }
 
-type applyRequestReadonly struct{ v *ApplyRequest }
+type applyRequestReadonly ApplyRequest
 
 func (r *applyRequestReadonly) GetForwardedCallerSnapshot() commonpb.CallerSnapshotReader {
-	v := r.v.GetForwardedCallerSnapshot()
+	v := (*ApplyRequest)(r).GetForwardedCallerSnapshot()
 	if v == nil {
 		return nil
 	}
@@ -814,15 +814,15 @@ func (r *applyRequestReadonly) GetForwardedCallerSnapshot() commonpb.CallerSnaps
 }
 
 func (r *applyRequestReadonly) GetSkipResponse() bool {
-	return r.v.GetSkipResponse()
+	return (*ApplyRequest)(r).GetSkipResponse()
 }
 
 func (r *applyRequestReadonly) GetVariant() isApplyRequest_Variant {
-	return r.v.GetVariant()
+	return (*ApplyRequest)(r).GetVariant()
 }
 
 func (r *applyRequestReadonly) Mutate() *ApplyRequest {
-	return r.v.CloneVT()
+	return (*ApplyRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ApplyRequest.
@@ -830,7 +830,7 @@ func (m *ApplyRequest) AsReader() ApplyRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &applyRequestReadonly{v: m}
+	return (*applyRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ApplyRequest.
@@ -883,18 +883,18 @@ type ApplyBatchReader interface {
 	Mutate() *ApplyBatch
 }
 
-type applyBatchReadonly struct{ v *ApplyBatch }
+type applyBatchReadonly ApplyBatch
 
 func (r *applyBatchReadonly) GetRequests() RequestListReader {
-	return NewRequestListReader(r.v.GetRequests())
+	return NewRequestListReader((*ApplyBatch)(r).GetRequests())
 }
 
 func (r *applyBatchReadonly) GetIdempotencyKey() string {
-	return r.v.GetIdempotencyKey()
+	return (*ApplyBatch)(r).GetIdempotencyKey()
 }
 
 func (r *applyBatchReadonly) Mutate() *ApplyBatch {
-	return r.v.CloneVT()
+	return (*ApplyBatch)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ApplyBatch.
@@ -902,7 +902,7 @@ func (m *ApplyBatch) AsReader() ApplyBatchReader {
 	if m == nil {
 		return nil
 	}
-	return &applyBatchReadonly{v: m}
+	return (*applyBatchReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ApplyBatch.
@@ -952,14 +952,14 @@ type ApplyResponseReader interface {
 	Mutate() *ApplyResponse
 }
 
-type applyResponseReadonly struct{ v *ApplyResponse }
+type applyResponseReadonly ApplyResponse
 
 func (r *applyResponseReadonly) GetLogs() commonpb.LogListReader {
-	return commonpb.NewLogListReader(r.v.GetLogs())
+	return commonpb.NewLogListReader((*ApplyResponse)(r).GetLogs())
 }
 
 func (r *applyResponseReadonly) Mutate() *ApplyResponse {
-	return r.v.CloneVT()
+	return (*ApplyResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ApplyResponse.
@@ -967,7 +967,7 @@ func (m *ApplyResponse) AsReader() ApplyResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &applyResponseReadonly{v: m}
+	return (*applyResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ApplyResponse.
@@ -1019,14 +1019,14 @@ type RequestReader interface {
 	Mutate() *Request
 }
 
-type requestReadonly struct{ v *Request }
+type requestReadonly Request
 
 func (r *requestReadonly) GetType() isRequest_Type {
-	return r.v.GetType()
+	return (*Request)(r).GetType()
 }
 
 func (r *requestReadonly) Mutate() *Request {
-	return r.v.CloneVT()
+	return (*Request)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this Request.
@@ -1034,7 +1034,7 @@ func (m *Request) AsReader() RequestReader {
 	if m == nil {
 		return nil
 	}
-	return &requestReadonly{v: m}
+	return (*requestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this Request.
@@ -1083,10 +1083,10 @@ type CreateQueryCheckpointRequestReader interface {
 	Mutate() *CreateQueryCheckpointRequest
 }
 
-type createQueryCheckpointRequestReadonly struct{ v *CreateQueryCheckpointRequest }
+type createQueryCheckpointRequestReadonly CreateQueryCheckpointRequest
 
 func (r *createQueryCheckpointRequestReadonly) Mutate() *CreateQueryCheckpointRequest {
-	return r.v.CloneVT()
+	return (*CreateQueryCheckpointRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateQueryCheckpointRequest.
@@ -1094,7 +1094,7 @@ func (m *CreateQueryCheckpointRequest) AsReader() CreateQueryCheckpointRequestRe
 	if m == nil {
 		return nil
 	}
-	return &createQueryCheckpointRequestReadonly{v: m}
+	return (*createQueryCheckpointRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateQueryCheckpointRequest.
@@ -1146,14 +1146,14 @@ type DeleteQueryCheckpointRequestReader interface {
 	Mutate() *DeleteQueryCheckpointRequest
 }
 
-type deleteQueryCheckpointRequestReadonly struct{ v *DeleteQueryCheckpointRequest }
+type deleteQueryCheckpointRequestReadonly DeleteQueryCheckpointRequest
 
 func (r *deleteQueryCheckpointRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*DeleteQueryCheckpointRequest)(r).GetCheckpointId()
 }
 
 func (r *deleteQueryCheckpointRequestReadonly) Mutate() *DeleteQueryCheckpointRequest {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointRequest.
@@ -1161,7 +1161,7 @@ func (m *DeleteQueryCheckpointRequest) AsReader() DeleteQueryCheckpointRequestRe
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointRequestReadonly{v: m}
+	return (*deleteQueryCheckpointRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointRequest.
@@ -1213,14 +1213,14 @@ type PromoteLedgerRequestReader interface {
 	Mutate() *PromoteLedgerRequest
 }
 
-type promoteLedgerRequestReadonly struct{ v *PromoteLedgerRequest }
+type promoteLedgerRequestReadonly PromoteLedgerRequest
 
 func (r *promoteLedgerRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*PromoteLedgerRequest)(r).GetLedger()
 }
 
 func (r *promoteLedgerRequestReadonly) Mutate() *PromoteLedgerRequest {
-	return r.v.CloneVT()
+	return (*PromoteLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PromoteLedgerRequest.
@@ -1228,7 +1228,7 @@ func (m *PromoteLedgerRequest) AsReader() PromoteLedgerRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &promoteLedgerRequestReadonly{v: m}
+	return (*promoteLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PromoteLedgerRequest.
@@ -1281,18 +1281,18 @@ type SaveLedgerMetadataRequestReader interface {
 	Mutate() *SaveLedgerMetadataRequest
 }
 
-type saveLedgerMetadataRequestReadonly struct{ v *SaveLedgerMetadataRequest }
+type saveLedgerMetadataRequestReadonly SaveLedgerMetadataRequest
 
 func (r *saveLedgerMetadataRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*SaveLedgerMetadataRequest)(r).GetLedger()
 }
 
 func (r *saveLedgerMetadataRequestReadonly) GetMetadata() SaveLedgerMetadataRequest_MetadataMapReader {
-	return saveLedgerMetadataRequest_metadataMapReadonly(r.v.GetMetadata())
+	return saveLedgerMetadataRequest_metadataMapReadonly((*SaveLedgerMetadataRequest)(r).GetMetadata())
 }
 
 func (r *saveLedgerMetadataRequestReadonly) Mutate() *SaveLedgerMetadataRequest {
-	return r.v.CloneVT()
+	return (*SaveLedgerMetadataRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveLedgerMetadataRequest.
@@ -1300,7 +1300,7 @@ func (m *SaveLedgerMetadataRequest) AsReader() SaveLedgerMetadataRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &saveLedgerMetadataRequestReadonly{v: m}
+	return (*saveLedgerMetadataRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveLedgerMetadataRequest.
@@ -1384,18 +1384,18 @@ type DeleteLedgerMetadataRequestReader interface {
 	Mutate() *DeleteLedgerMetadataRequest
 }
 
-type deleteLedgerMetadataRequestReadonly struct{ v *DeleteLedgerMetadataRequest }
+type deleteLedgerMetadataRequestReadonly DeleteLedgerMetadataRequest
 
 func (r *deleteLedgerMetadataRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeleteLedgerMetadataRequest)(r).GetLedger()
 }
 
 func (r *deleteLedgerMetadataRequestReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*DeleteLedgerMetadataRequest)(r).GetKey()
 }
 
 func (r *deleteLedgerMetadataRequestReadonly) Mutate() *DeleteLedgerMetadataRequest {
-	return r.v.CloneVT()
+	return (*DeleteLedgerMetadataRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteLedgerMetadataRequest.
@@ -1403,7 +1403,7 @@ func (m *DeleteLedgerMetadataRequest) AsReader() DeleteLedgerMetadataRequestRead
 	if m == nil {
 		return nil
 	}
-	return &deleteLedgerMetadataRequestReadonly{v: m}
+	return (*deleteLedgerMetadataRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteLedgerMetadataRequest.
@@ -1455,10 +1455,10 @@ type AddEventsSinkRequestReader interface {
 	Mutate() *AddEventsSinkRequest
 }
 
-type addEventsSinkRequestReadonly struct{ v *AddEventsSinkRequest }
+type addEventsSinkRequestReadonly AddEventsSinkRequest
 
 func (r *addEventsSinkRequestReadonly) GetConfig() commonpb.SinkConfigReader {
-	v := r.v.GetConfig()
+	v := (*AddEventsSinkRequest)(r).GetConfig()
 	if v == nil {
 		return nil
 	}
@@ -1466,7 +1466,7 @@ func (r *addEventsSinkRequestReadonly) GetConfig() commonpb.SinkConfigReader {
 }
 
 func (r *addEventsSinkRequestReadonly) Mutate() *AddEventsSinkRequest {
-	return r.v.CloneVT()
+	return (*AddEventsSinkRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddEventsSinkRequest.
@@ -1474,7 +1474,7 @@ func (m *AddEventsSinkRequest) AsReader() AddEventsSinkRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &addEventsSinkRequestReadonly{v: m}
+	return (*addEventsSinkRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddEventsSinkRequest.
@@ -1526,14 +1526,14 @@ type RemoveEventsSinkRequestReader interface {
 	Mutate() *RemoveEventsSinkRequest
 }
 
-type removeEventsSinkRequestReadonly struct{ v *RemoveEventsSinkRequest }
+type removeEventsSinkRequestReadonly RemoveEventsSinkRequest
 
 func (r *removeEventsSinkRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemoveEventsSinkRequest)(r).GetName()
 }
 
 func (r *removeEventsSinkRequestReadonly) Mutate() *RemoveEventsSinkRequest {
-	return r.v.CloneVT()
+	return (*RemoveEventsSinkRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveEventsSinkRequest.
@@ -1541,7 +1541,7 @@ func (m *RemoveEventsSinkRequest) AsReader() RemoveEventsSinkRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &removeEventsSinkRequestReadonly{v: m}
+	return (*removeEventsSinkRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveEventsSinkRequest.
@@ -1594,18 +1594,18 @@ type RegisterSigningKeyRequestReader interface {
 	Mutate() *RegisterSigningKeyRequest
 }
 
-type registerSigningKeyRequestReadonly struct{ v *RegisterSigningKeyRequest }
+type registerSigningKeyRequestReadonly RegisterSigningKeyRequest
 
 func (r *registerSigningKeyRequestReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RegisterSigningKeyRequest)(r).GetKeyId()
 }
 
 func (r *registerSigningKeyRequestReadonly) GetPublicKey() []byte {
-	return bytes.Clone(r.v.GetPublicKey())
+	return bytes.Clone((*RegisterSigningKeyRequest)(r).GetPublicKey())
 }
 
 func (r *registerSigningKeyRequestReadonly) Mutate() *RegisterSigningKeyRequest {
-	return r.v.CloneVT()
+	return (*RegisterSigningKeyRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RegisterSigningKeyRequest.
@@ -1613,7 +1613,7 @@ func (m *RegisterSigningKeyRequest) AsReader() RegisterSigningKeyRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &registerSigningKeyRequestReadonly{v: m}
+	return (*registerSigningKeyRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RegisterSigningKeyRequest.
@@ -1666,18 +1666,18 @@ type RevokeSigningKeyRequestReader interface {
 	Mutate() *RevokeSigningKeyRequest
 }
 
-type revokeSigningKeyRequestReadonly struct{ v *RevokeSigningKeyRequest }
+type revokeSigningKeyRequestReadonly RevokeSigningKeyRequest
 
 func (r *revokeSigningKeyRequestReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*RevokeSigningKeyRequest)(r).GetKeyId()
 }
 
 func (r *revokeSigningKeyRequestReadonly) GetCascade() bool {
-	return r.v.GetCascade()
+	return (*RevokeSigningKeyRequest)(r).GetCascade()
 }
 
 func (r *revokeSigningKeyRequestReadonly) Mutate() *RevokeSigningKeyRequest {
-	return r.v.CloneVT()
+	return (*RevokeSigningKeyRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevokeSigningKeyRequest.
@@ -1685,7 +1685,7 @@ func (m *RevokeSigningKeyRequest) AsReader() RevokeSigningKeyRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &revokeSigningKeyRequestReadonly{v: m}
+	return (*revokeSigningKeyRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevokeSigningKeyRequest.
@@ -1737,14 +1737,14 @@ type SetSigningConfigRequestReader interface {
 	Mutate() *SetSigningConfigRequest
 }
 
-type setSigningConfigRequestReadonly struct{ v *SetSigningConfigRequest }
+type setSigningConfigRequestReadonly SetSigningConfigRequest
 
 func (r *setSigningConfigRequestReadonly) GetRequireSignatures() bool {
-	return r.v.GetRequireSignatures()
+	return (*SetSigningConfigRequest)(r).GetRequireSignatures()
 }
 
 func (r *setSigningConfigRequestReadonly) Mutate() *SetSigningConfigRequest {
-	return r.v.CloneVT()
+	return (*SetSigningConfigRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetSigningConfigRequest.
@@ -1752,7 +1752,7 @@ func (m *SetSigningConfigRequest) AsReader() SetSigningConfigRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &setSigningConfigRequestReadonly{v: m}
+	return (*setSigningConfigRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetSigningConfigRequest.
@@ -1804,10 +1804,10 @@ type ListSigningKeysRequestReader interface {
 	Mutate() *ListSigningKeysRequest
 }
 
-type listSigningKeysRequestReadonly struct{ v *ListSigningKeysRequest }
+type listSigningKeysRequestReadonly ListSigningKeysRequest
 
 func (r *listSigningKeysRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListSigningKeysRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -1815,7 +1815,7 @@ func (r *listSigningKeysRequestReadonly) GetOptions() commonpb.ListOptionsReader
 }
 
 func (r *listSigningKeysRequestReadonly) Mutate() *ListSigningKeysRequest {
-	return r.v.CloneVT()
+	return (*ListSigningKeysRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListSigningKeysRequest.
@@ -1823,7 +1823,7 @@ func (m *ListSigningKeysRequest) AsReader() ListSigningKeysRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listSigningKeysRequestReadonly{v: m}
+	return (*listSigningKeysRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListSigningKeysRequest.
@@ -1874,10 +1874,10 @@ type CloseChapterRequestReader interface {
 	Mutate() *CloseChapterRequest
 }
 
-type closeChapterRequestReadonly struct{ v *CloseChapterRequest }
+type closeChapterRequestReadonly CloseChapterRequest
 
 func (r *closeChapterRequestReadonly) Mutate() *CloseChapterRequest {
-	return r.v.CloneVT()
+	return (*CloseChapterRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CloseChapterRequest.
@@ -1885,7 +1885,7 @@ func (m *CloseChapterRequest) AsReader() CloseChapterRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &closeChapterRequestReadonly{v: m}
+	return (*closeChapterRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CloseChapterRequest.
@@ -1939,22 +1939,22 @@ type SealChapterRequestReader interface {
 	Mutate() *SealChapterRequest
 }
 
-type sealChapterRequestReadonly struct{ v *SealChapterRequest }
+type sealChapterRequestReadonly SealChapterRequest
 
 func (r *sealChapterRequestReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*SealChapterRequest)(r).GetChapterId()
 }
 
 func (r *sealChapterRequestReadonly) GetSealingHash() []byte {
-	return bytes.Clone(r.v.GetSealingHash())
+	return bytes.Clone((*SealChapterRequest)(r).GetSealingHash())
 }
 
 func (r *sealChapterRequestReadonly) GetStateHash() []byte {
-	return bytes.Clone(r.v.GetStateHash())
+	return bytes.Clone((*SealChapterRequest)(r).GetStateHash())
 }
 
 func (r *sealChapterRequestReadonly) Mutate() *SealChapterRequest {
-	return r.v.CloneVT()
+	return (*SealChapterRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SealChapterRequest.
@@ -1962,7 +1962,7 @@ func (m *SealChapterRequest) AsReader() SealChapterRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &sealChapterRequestReadonly{v: m}
+	return (*sealChapterRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SealChapterRequest.
@@ -2014,14 +2014,14 @@ type ArchiveChapterRequestReader interface {
 	Mutate() *ArchiveChapterRequest
 }
 
-type archiveChapterRequestReadonly struct{ v *ArchiveChapterRequest }
+type archiveChapterRequestReadonly ArchiveChapterRequest
 
 func (r *archiveChapterRequestReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*ArchiveChapterRequest)(r).GetChapterId()
 }
 
 func (r *archiveChapterRequestReadonly) Mutate() *ArchiveChapterRequest {
-	return r.v.CloneVT()
+	return (*ArchiveChapterRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ArchiveChapterRequest.
@@ -2029,7 +2029,7 @@ func (m *ArchiveChapterRequest) AsReader() ArchiveChapterRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &archiveChapterRequestReadonly{v: m}
+	return (*archiveChapterRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ArchiveChapterRequest.
@@ -2081,14 +2081,14 @@ type ConfirmArchiveChapterRequestReader interface {
 	Mutate() *ConfirmArchiveChapterRequest
 }
 
-type confirmArchiveChapterRequestReadonly struct{ v *ConfirmArchiveChapterRequest }
+type confirmArchiveChapterRequestReadonly ConfirmArchiveChapterRequest
 
 func (r *confirmArchiveChapterRequestReadonly) GetChapterId() uint64 {
-	return r.v.GetChapterId()
+	return (*ConfirmArchiveChapterRequest)(r).GetChapterId()
 }
 
 func (r *confirmArchiveChapterRequestReadonly) Mutate() *ConfirmArchiveChapterRequest {
-	return r.v.CloneVT()
+	return (*ConfirmArchiveChapterRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ConfirmArchiveChapterRequest.
@@ -2096,7 +2096,7 @@ func (m *ConfirmArchiveChapterRequest) AsReader() ConfirmArchiveChapterRequestRe
 	if m == nil {
 		return nil
 	}
-	return &confirmArchiveChapterRequestReadonly{v: m}
+	return (*confirmArchiveChapterRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ConfirmArchiveChapterRequest.
@@ -2148,10 +2148,10 @@ type ListChaptersRequestReader interface {
 	Mutate() *ListChaptersRequest
 }
 
-type listChaptersRequestReadonly struct{ v *ListChaptersRequest }
+type listChaptersRequestReadonly ListChaptersRequest
 
 func (r *listChaptersRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListChaptersRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -2159,7 +2159,7 @@ func (r *listChaptersRequestReadonly) GetOptions() commonpb.ListOptionsReader {
 }
 
 func (r *listChaptersRequestReadonly) Mutate() *ListChaptersRequest {
-	return r.v.CloneVT()
+	return (*ListChaptersRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListChaptersRequest.
@@ -2167,7 +2167,7 @@ func (m *ListChaptersRequest) AsReader() ListChaptersRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listChaptersRequestReadonly{v: m}
+	return (*listChaptersRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListChaptersRequest.
@@ -2219,14 +2219,14 @@ type SetMaintenanceModeRequestReader interface {
 	Mutate() *SetMaintenanceModeRequest
 }
 
-type setMaintenanceModeRequestReadonly struct{ v *SetMaintenanceModeRequest }
+type setMaintenanceModeRequestReadonly SetMaintenanceModeRequest
 
 func (r *setMaintenanceModeRequestReadonly) GetEnabled() bool {
-	return r.v.GetEnabled()
+	return (*SetMaintenanceModeRequest)(r).GetEnabled()
 }
 
 func (r *setMaintenanceModeRequestReadonly) Mutate() *SetMaintenanceModeRequest {
-	return r.v.CloneVT()
+	return (*SetMaintenanceModeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMaintenanceModeRequest.
@@ -2234,7 +2234,7 @@ func (m *SetMaintenanceModeRequest) AsReader() SetMaintenanceModeRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &setMaintenanceModeRequestReadonly{v: m}
+	return (*setMaintenanceModeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMaintenanceModeRequest.
@@ -2286,14 +2286,14 @@ type SetChapterScheduleRequestReader interface {
 	Mutate() *SetChapterScheduleRequest
 }
 
-type setChapterScheduleRequestReadonly struct{ v *SetChapterScheduleRequest }
+type setChapterScheduleRequestReadonly SetChapterScheduleRequest
 
 func (r *setChapterScheduleRequestReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetChapterScheduleRequest)(r).GetCron()
 }
 
 func (r *setChapterScheduleRequestReadonly) Mutate() *SetChapterScheduleRequest {
-	return r.v.CloneVT()
+	return (*SetChapterScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetChapterScheduleRequest.
@@ -2301,7 +2301,7 @@ func (m *SetChapterScheduleRequest) AsReader() SetChapterScheduleRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &setChapterScheduleRequestReadonly{v: m}
+	return (*setChapterScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetChapterScheduleRequest.
@@ -2352,10 +2352,10 @@ type DeleteChapterScheduleRequestReader interface {
 	Mutate() *DeleteChapterScheduleRequest
 }
 
-type deleteChapterScheduleRequestReadonly struct{ v *DeleteChapterScheduleRequest }
+type deleteChapterScheduleRequestReadonly DeleteChapterScheduleRequest
 
 func (r *deleteChapterScheduleRequestReadonly) Mutate() *DeleteChapterScheduleRequest {
-	return r.v.CloneVT()
+	return (*DeleteChapterScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteChapterScheduleRequest.
@@ -2363,7 +2363,7 @@ func (m *DeleteChapterScheduleRequest) AsReader() DeleteChapterScheduleRequestRe
 	if m == nil {
 		return nil
 	}
-	return &deleteChapterScheduleRequestReadonly{v: m}
+	return (*deleteChapterScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteChapterScheduleRequest.
@@ -2418,26 +2418,26 @@ type SetMetadataFieldTypeRequestReader interface {
 	Mutate() *SetMetadataFieldTypeRequest
 }
 
-type setMetadataFieldTypeRequestReadonly struct{ v *SetMetadataFieldTypeRequest }
+type setMetadataFieldTypeRequestReadonly SetMetadataFieldTypeRequest
 
 func (r *setMetadataFieldTypeRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*SetMetadataFieldTypeRequest)(r).GetLedger()
 }
 
 func (r *setMetadataFieldTypeRequestReadonly) GetTargetType() commonpb.TargetType {
-	return r.v.GetTargetType()
+	return (*SetMetadataFieldTypeRequest)(r).GetTargetType()
 }
 
 func (r *setMetadataFieldTypeRequestReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*SetMetadataFieldTypeRequest)(r).GetKey()
 }
 
 func (r *setMetadataFieldTypeRequestReadonly) GetType() commonpb.MetadataType {
-	return r.v.GetType()
+	return (*SetMetadataFieldTypeRequest)(r).GetType()
 }
 
 func (r *setMetadataFieldTypeRequestReadonly) Mutate() *SetMetadataFieldTypeRequest {
-	return r.v.CloneVT()
+	return (*SetMetadataFieldTypeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetMetadataFieldTypeRequest.
@@ -2445,7 +2445,7 @@ func (m *SetMetadataFieldTypeRequest) AsReader() SetMetadataFieldTypeRequestRead
 	if m == nil {
 		return nil
 	}
-	return &setMetadataFieldTypeRequestReadonly{v: m}
+	return (*setMetadataFieldTypeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetMetadataFieldTypeRequest.
@@ -2499,24 +2499,22 @@ type RemoveMetadataFieldTypeRequestReader interface {
 	Mutate() *RemoveMetadataFieldTypeRequest
 }
 
-type removeMetadataFieldTypeRequestReadonly struct {
-	v *RemoveMetadataFieldTypeRequest
-}
+type removeMetadataFieldTypeRequestReadonly RemoveMetadataFieldTypeRequest
 
 func (r *removeMetadataFieldTypeRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*RemoveMetadataFieldTypeRequest)(r).GetLedger()
 }
 
 func (r *removeMetadataFieldTypeRequestReadonly) GetTargetType() commonpb.TargetType {
-	return r.v.GetTargetType()
+	return (*RemoveMetadataFieldTypeRequest)(r).GetTargetType()
 }
 
 func (r *removeMetadataFieldTypeRequestReadonly) GetKey() string {
-	return r.v.GetKey()
+	return (*RemoveMetadataFieldTypeRequest)(r).GetKey()
 }
 
 func (r *removeMetadataFieldTypeRequestReadonly) Mutate() *RemoveMetadataFieldTypeRequest {
-	return r.v.CloneVT()
+	return (*RemoveMetadataFieldTypeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveMetadataFieldTypeRequest.
@@ -2524,7 +2522,7 @@ func (m *RemoveMetadataFieldTypeRequest) AsReader() RemoveMetadataFieldTypeReque
 	if m == nil {
 		return nil
 	}
-	return &removeMetadataFieldTypeRequestReadonly{v: m}
+	return (*removeMetadataFieldTypeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveMetadataFieldTypeRequest.
@@ -2577,14 +2575,14 @@ type CreateIndexRequestReader interface {
 	Mutate() *CreateIndexRequest
 }
 
-type createIndexRequestReadonly struct{ v *CreateIndexRequest }
+type createIndexRequestReadonly CreateIndexRequest
 
 func (r *createIndexRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*CreateIndexRequest)(r).GetLedger()
 }
 
 func (r *createIndexRequestReadonly) GetId() commonpb.IndexIDReader {
-	v := r.v.GetId()
+	v := (*CreateIndexRequest)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -2592,7 +2590,7 @@ func (r *createIndexRequestReadonly) GetId() commonpb.IndexIDReader {
 }
 
 func (r *createIndexRequestReadonly) Mutate() *CreateIndexRequest {
-	return r.v.CloneVT()
+	return (*CreateIndexRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateIndexRequest.
@@ -2600,7 +2598,7 @@ func (m *CreateIndexRequest) AsReader() CreateIndexRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &createIndexRequestReadonly{v: m}
+	return (*createIndexRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateIndexRequest.
@@ -2653,14 +2651,14 @@ type DropIndexRequestReader interface {
 	Mutate() *DropIndexRequest
 }
 
-type dropIndexRequestReadonly struct{ v *DropIndexRequest }
+type dropIndexRequestReadonly DropIndexRequest
 
 func (r *dropIndexRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DropIndexRequest)(r).GetLedger()
 }
 
 func (r *dropIndexRequestReadonly) GetId() commonpb.IndexIDReader {
-	v := r.v.GetId()
+	v := (*DropIndexRequest)(r).GetId()
 	if v == nil {
 		return nil
 	}
@@ -2668,7 +2666,7 @@ func (r *dropIndexRequestReadonly) GetId() commonpb.IndexIDReader {
 }
 
 func (r *dropIndexRequestReadonly) Mutate() *DropIndexRequest {
-	return r.v.CloneVT()
+	return (*DropIndexRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DropIndexRequest.
@@ -2676,7 +2674,7 @@ func (m *DropIndexRequest) AsReader() DropIndexRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &dropIndexRequestReadonly{v: m}
+	return (*dropIndexRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DropIndexRequest.
@@ -2731,26 +2729,26 @@ type SaveNumscriptRequestReader interface {
 	Mutate() *SaveNumscriptRequest
 }
 
-type saveNumscriptRequestReadonly struct{ v *SaveNumscriptRequest }
+type saveNumscriptRequestReadonly SaveNumscriptRequest
 
 func (r *saveNumscriptRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*SaveNumscriptRequest)(r).GetName()
 }
 
 func (r *saveNumscriptRequestReadonly) GetContent() string {
-	return r.v.GetContent()
+	return (*SaveNumscriptRequest)(r).GetContent()
 }
 
 func (r *saveNumscriptRequestReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*SaveNumscriptRequest)(r).GetVersion()
 }
 
 func (r *saveNumscriptRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*SaveNumscriptRequest)(r).GetLedger()
 }
 
 func (r *saveNumscriptRequestReadonly) Mutate() *SaveNumscriptRequest {
-	return r.v.CloneVT()
+	return (*SaveNumscriptRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SaveNumscriptRequest.
@@ -2758,7 +2756,7 @@ func (m *SaveNumscriptRequest) AsReader() SaveNumscriptRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &saveNumscriptRequestReadonly{v: m}
+	return (*saveNumscriptRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SaveNumscriptRequest.
@@ -2811,18 +2809,18 @@ type DeleteNumscriptRequestReader interface {
 	Mutate() *DeleteNumscriptRequest
 }
 
-type deleteNumscriptRequestReadonly struct{ v *DeleteNumscriptRequest }
+type deleteNumscriptRequestReadonly DeleteNumscriptRequest
 
 func (r *deleteNumscriptRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeleteNumscriptRequest)(r).GetName()
 }
 
 func (r *deleteNumscriptRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeleteNumscriptRequest)(r).GetLedger()
 }
 
 func (r *deleteNumscriptRequestReadonly) Mutate() *DeleteNumscriptRequest {
-	return r.v.CloneVT()
+	return (*DeleteNumscriptRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteNumscriptRequest.
@@ -2830,7 +2828,7 @@ func (m *DeleteNumscriptRequest) AsReader() DeleteNumscriptRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &deleteNumscriptRequestReadonly{v: m}
+	return (*deleteNumscriptRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteNumscriptRequest.
@@ -2885,22 +2883,22 @@ type GetNumscriptRequestReader interface {
 	Mutate() *GetNumscriptRequest
 }
 
-type getNumscriptRequestReadonly struct{ v *GetNumscriptRequest }
+type getNumscriptRequestReadonly GetNumscriptRequest
 
 func (r *getNumscriptRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*GetNumscriptRequest)(r).GetName()
 }
 
 func (r *getNumscriptRequestReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*GetNumscriptRequest)(r).GetVersion()
 }
 
 func (r *getNumscriptRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetNumscriptRequest)(r).GetLedger()
 }
 
 func (r *getNumscriptRequestReadonly) GetRead() commonpb.ReadOptionsReader {
-	v := r.v.GetRead()
+	v := (*GetNumscriptRequest)(r).GetRead()
 	if v == nil {
 		return nil
 	}
@@ -2908,7 +2906,7 @@ func (r *getNumscriptRequestReadonly) GetRead() commonpb.ReadOptionsReader {
 }
 
 func (r *getNumscriptRequestReadonly) Mutate() *GetNumscriptRequest {
-	return r.v.CloneVT()
+	return (*GetNumscriptRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetNumscriptRequest.
@@ -2916,7 +2914,7 @@ func (m *GetNumscriptRequest) AsReader() GetNumscriptRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getNumscriptRequestReadonly{v: m}
+	return (*getNumscriptRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetNumscriptRequest.
@@ -2969,14 +2967,14 @@ type ListNumscriptsRequestReader interface {
 	Mutate() *ListNumscriptsRequest
 }
 
-type listNumscriptsRequestReadonly struct{ v *ListNumscriptsRequest }
+type listNumscriptsRequestReadonly ListNumscriptsRequest
 
 func (r *listNumscriptsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListNumscriptsRequest)(r).GetLedger()
 }
 
 func (r *listNumscriptsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListNumscriptsRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -2984,7 +2982,7 @@ func (r *listNumscriptsRequestReadonly) GetOptions() commonpb.ListOptionsReader 
 }
 
 func (r *listNumscriptsRequestReadonly) Mutate() *ListNumscriptsRequest {
-	return r.v.CloneVT()
+	return (*ListNumscriptsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListNumscriptsRequest.
@@ -2992,7 +2990,7 @@ func (m *ListNumscriptsRequest) AsReader() ListNumscriptsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listNumscriptsRequestReadonly{v: m}
+	return (*listNumscriptsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListNumscriptsRequest.
@@ -3046,22 +3044,22 @@ type ScriptReferenceReader interface {
 	Mutate() *ScriptReference
 }
 
-type scriptReferenceReadonly struct{ v *ScriptReference }
+type scriptReferenceReadonly ScriptReference
 
 func (r *scriptReferenceReadonly) GetName() string {
-	return r.v.GetName()
+	return (*ScriptReference)(r).GetName()
 }
 
 func (r *scriptReferenceReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*ScriptReference)(r).GetVersion()
 }
 
 func (r *scriptReferenceReadonly) GetVars() ScriptReference_VarsMapReader {
-	return scriptReference_varsMapReadonly(r.v.GetVars())
+	return scriptReference_varsMapReadonly((*ScriptReference)(r).GetVars())
 }
 
 func (r *scriptReferenceReadonly) Mutate() *ScriptReference {
-	return r.v.CloneVT()
+	return (*ScriptReference)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ScriptReference.
@@ -3069,7 +3067,7 @@ func (m *ScriptReference) AsReader() ScriptReferenceReader {
 	if m == nil {
 		return nil
 	}
-	return &scriptReferenceReadonly{v: m}
+	return (*scriptReferenceReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ScriptReference.
@@ -3145,16 +3143,14 @@ type SetQueryCheckpointScheduleRequestReader interface {
 	Mutate() *SetQueryCheckpointScheduleRequest
 }
 
-type setQueryCheckpointScheduleRequestReadonly struct {
-	v *SetQueryCheckpointScheduleRequest
-}
+type setQueryCheckpointScheduleRequestReadonly SetQueryCheckpointScheduleRequest
 
 func (r *setQueryCheckpointScheduleRequestReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*SetQueryCheckpointScheduleRequest)(r).GetCron()
 }
 
 func (r *setQueryCheckpointScheduleRequestReadonly) Mutate() *SetQueryCheckpointScheduleRequest {
-	return r.v.CloneVT()
+	return (*SetQueryCheckpointScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetQueryCheckpointScheduleRequest.
@@ -3162,7 +3158,7 @@ func (m *SetQueryCheckpointScheduleRequest) AsReader() SetQueryCheckpointSchedul
 	if m == nil {
 		return nil
 	}
-	return &setQueryCheckpointScheduleRequestReadonly{v: m}
+	return (*setQueryCheckpointScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetQueryCheckpointScheduleRequest.
@@ -3213,12 +3209,10 @@ type DeleteQueryCheckpointScheduleRequestReader interface {
 	Mutate() *DeleteQueryCheckpointScheduleRequest
 }
 
-type deleteQueryCheckpointScheduleRequestReadonly struct {
-	v *DeleteQueryCheckpointScheduleRequest
-}
+type deleteQueryCheckpointScheduleRequestReadonly DeleteQueryCheckpointScheduleRequest
 
 func (r *deleteQueryCheckpointScheduleRequestReadonly) Mutate() *DeleteQueryCheckpointScheduleRequest {
-	return r.v.CloneVT()
+	return (*DeleteQueryCheckpointScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeleteQueryCheckpointScheduleRequest.
@@ -3226,7 +3220,7 @@ func (m *DeleteQueryCheckpointScheduleRequest) AsReader() DeleteQueryCheckpointS
 	if m == nil {
 		return nil
 	}
-	return &deleteQueryCheckpointScheduleRequestReadonly{v: m}
+	return (*deleteQueryCheckpointScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeleteQueryCheckpointScheduleRequest.
@@ -3277,10 +3271,10 @@ type GetChapterScheduleRequestReader interface {
 	Mutate() *GetChapterScheduleRequest
 }
 
-type getChapterScheduleRequestReadonly struct{ v *GetChapterScheduleRequest }
+type getChapterScheduleRequestReadonly GetChapterScheduleRequest
 
 func (r *getChapterScheduleRequestReadonly) Mutate() *GetChapterScheduleRequest {
-	return r.v.CloneVT()
+	return (*GetChapterScheduleRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetChapterScheduleRequest.
@@ -3288,7 +3282,7 @@ func (m *GetChapterScheduleRequest) AsReader() GetChapterScheduleRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getChapterScheduleRequestReadonly{v: m}
+	return (*getChapterScheduleRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetChapterScheduleRequest.
@@ -3340,14 +3334,14 @@ type GetChapterScheduleResponseReader interface {
 	Mutate() *GetChapterScheduleResponse
 }
 
-type getChapterScheduleResponseReadonly struct{ v *GetChapterScheduleResponse }
+type getChapterScheduleResponseReadonly GetChapterScheduleResponse
 
 func (r *getChapterScheduleResponseReadonly) GetCron() string {
-	return r.v.GetCron()
+	return (*GetChapterScheduleResponse)(r).GetCron()
 }
 
 func (r *getChapterScheduleResponseReadonly) Mutate() *GetChapterScheduleResponse {
-	return r.v.CloneVT()
+	return (*GetChapterScheduleResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetChapterScheduleResponse.
@@ -3355,7 +3349,7 @@ func (m *GetChapterScheduleResponse) AsReader() GetChapterScheduleResponseReader
 	if m == nil {
 		return nil
 	}
-	return &getChapterScheduleResponseReadonly{v: m}
+	return (*getChapterScheduleResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetChapterScheduleResponse.
@@ -3406,10 +3400,10 @@ type DiscoveryRequestReader interface {
 	Mutate() *DiscoveryRequest
 }
 
-type discoveryRequestReadonly struct{ v *DiscoveryRequest }
+type discoveryRequestReadonly DiscoveryRequest
 
 func (r *discoveryRequestReadonly) Mutate() *DiscoveryRequest {
-	return r.v.CloneVT()
+	return (*DiscoveryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DiscoveryRequest.
@@ -3417,7 +3411,7 @@ func (m *DiscoveryRequest) AsReader() DiscoveryRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &discoveryRequestReadonly{v: m}
+	return (*discoveryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DiscoveryRequest.
@@ -3472,26 +3466,26 @@ type ServerInfoReader interface {
 	Mutate() *ServerInfo
 }
 
-type serverInfoReadonly struct{ v *ServerInfo }
+type serverInfoReadonly ServerInfo
 
 func (r *serverInfoReadonly) GetVersion() string {
-	return r.v.GetVersion()
+	return (*ServerInfo)(r).GetVersion()
 }
 
 func (r *serverInfoReadonly) GetCommit() string {
-	return r.v.GetCommit()
+	return (*ServerInfo)(r).GetCommit()
 }
 
 func (r *serverInfoReadonly) GetBuildDate() string {
-	return r.v.GetBuildDate()
+	return (*ServerInfo)(r).GetBuildDate()
 }
 
 func (r *serverInfoReadonly) GetGoVersion() string {
-	return r.v.GetGoVersion()
+	return (*ServerInfo)(r).GetGoVersion()
 }
 
 func (r *serverInfoReadonly) Mutate() *ServerInfo {
-	return r.v.CloneVT()
+	return (*ServerInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ServerInfo.
@@ -3499,7 +3493,7 @@ func (m *ServerInfo) AsReader() ServerInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &serverInfoReadonly{v: m}
+	return (*serverInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ServerInfo.
@@ -3550,10 +3544,10 @@ type DiscoveryResponseReader interface {
 	Mutate() *DiscoveryResponse
 }
 
-type discoveryResponseReadonly struct{ v *DiscoveryResponse }
+type discoveryResponseReadonly DiscoveryResponse
 
 func (r *discoveryResponseReadonly) GetResponseSigning() ResponseSigningInfoReader {
-	v := r.v.GetResponseSigning()
+	v := (*DiscoveryResponse)(r).GetResponseSigning()
 	if v == nil {
 		return nil
 	}
@@ -3561,7 +3555,7 @@ func (r *discoveryResponseReadonly) GetResponseSigning() ResponseSigningInfoRead
 }
 
 func (r *discoveryResponseReadonly) GetServerInfo() ServerInfoReader {
-	v := r.v.GetServerInfo()
+	v := (*DiscoveryResponse)(r).GetServerInfo()
 	if v == nil {
 		return nil
 	}
@@ -3569,7 +3563,7 @@ func (r *discoveryResponseReadonly) GetServerInfo() ServerInfoReader {
 }
 
 func (r *discoveryResponseReadonly) Mutate() *DiscoveryResponse {
-	return r.v.CloneVT()
+	return (*DiscoveryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DiscoveryResponse.
@@ -3577,7 +3571,7 @@ func (m *DiscoveryResponse) AsReader() DiscoveryResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &discoveryResponseReadonly{v: m}
+	return (*discoveryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DiscoveryResponse.
@@ -3630,18 +3624,18 @@ type ResponseSigningInfoReader interface {
 	Mutate() *ResponseSigningInfo
 }
 
-type responseSigningInfoReadonly struct{ v *ResponseSigningInfo }
+type responseSigningInfoReadonly ResponseSigningInfo
 
 func (r *responseSigningInfoReadonly) GetPublicKey() []byte {
-	return bytes.Clone(r.v.GetPublicKey())
+	return bytes.Clone((*ResponseSigningInfo)(r).GetPublicKey())
 }
 
 func (r *responseSigningInfoReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*ResponseSigningInfo)(r).GetKeyId()
 }
 
 func (r *responseSigningInfoReadonly) Mutate() *ResponseSigningInfo {
-	return r.v.CloneVT()
+	return (*ResponseSigningInfo)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ResponseSigningInfo.
@@ -3649,7 +3643,7 @@ func (m *ResponseSigningInfo) AsReader() ResponseSigningInfoReader {
 	if m == nil {
 		return nil
 	}
-	return &responseSigningInfoReadonly{v: m}
+	return (*responseSigningInfoReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ResponseSigningInfo.
@@ -3709,14 +3703,14 @@ type CreateTransactionPayloadReader interface {
 	Mutate() *CreateTransactionPayload
 }
 
-type createTransactionPayloadReadonly struct{ v *CreateTransactionPayload }
+type createTransactionPayloadReadonly CreateTransactionPayload
 
 func (r *createTransactionPayloadReadonly) GetPostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader(r.v.GetPostings())
+	return commonpb.NewPostingListReader((*CreateTransactionPayload)(r).GetPostings())
 }
 
 func (r *createTransactionPayloadReadonly) GetScript() commonpb.ScriptReader {
-	v := r.v.GetScript()
+	v := (*CreateTransactionPayload)(r).GetScript()
 	if v == nil {
 		return nil
 	}
@@ -3724,7 +3718,7 @@ func (r *createTransactionPayloadReadonly) GetScript() commonpb.ScriptReader {
 }
 
 func (r *createTransactionPayloadReadonly) GetTimestamp() commonpb.TimestampReader {
-	v := r.v.GetTimestamp()
+	v := (*CreateTransactionPayload)(r).GetTimestamp()
 	if v == nil {
 		return nil
 	}
@@ -3732,27 +3726,27 @@ func (r *createTransactionPayloadReadonly) GetTimestamp() commonpb.TimestampRead
 }
 
 func (r *createTransactionPayloadReadonly) GetReference() string {
-	return r.v.GetReference()
+	return (*CreateTransactionPayload)(r).GetReference()
 }
 
 func (r *createTransactionPayloadReadonly) GetMetadata() CreateTransactionPayload_MetadataMapReader {
-	return createTransactionPayload_metadataMapReadonly(r.v.GetMetadata())
+	return createTransactionPayload_metadataMapReadonly((*CreateTransactionPayload)(r).GetMetadata())
 }
 
 func (r *createTransactionPayloadReadonly) GetAccountMetadata() CreateTransactionPayload_AccountMetadataMapReader {
-	return createTransactionPayload_accountMetadataMapReadonly(r.v.GetAccountMetadata())
+	return createTransactionPayload_accountMetadataMapReadonly((*CreateTransactionPayload)(r).GetAccountMetadata())
 }
 
 func (r *createTransactionPayloadReadonly) GetForce() bool {
-	return r.v.GetForce()
+	return (*CreateTransactionPayload)(r).GetForce()
 }
 
 func (r *createTransactionPayloadReadonly) GetExpandVolumes() bool {
-	return r.v.GetExpandVolumes()
+	return (*CreateTransactionPayload)(r).GetExpandVolumes()
 }
 
 func (r *createTransactionPayloadReadonly) GetScriptReference() ScriptReferenceReader {
-	v := r.v.GetScriptReference()
+	v := (*CreateTransactionPayload)(r).GetScriptReference()
 	if v == nil {
 		return nil
 	}
@@ -3760,7 +3754,7 @@ func (r *createTransactionPayloadReadonly) GetScriptReference() ScriptReferenceR
 }
 
 func (r *createTransactionPayloadReadonly) Mutate() *CreateTransactionPayload {
-	return r.v.CloneVT()
+	return (*CreateTransactionPayload)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreateTransactionPayload.
@@ -3768,7 +3762,7 @@ func (m *CreateTransactionPayload) AsReader() CreateTransactionPayloadReader {
 	if m == nil {
 		return nil
 	}
-	return &createTransactionPayloadReadonly{v: m}
+	return (*createTransactionPayloadReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreateTransactionPayload.
@@ -3887,34 +3881,34 @@ type RevertTransactionPayloadReader interface {
 	Mutate() *RevertTransactionPayload
 }
 
-type revertTransactionPayloadReadonly struct{ v *RevertTransactionPayload }
+type revertTransactionPayloadReadonly RevertTransactionPayload
 
 func (r *revertTransactionPayloadReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*RevertTransactionPayload)(r).GetTransactionId()
 }
 
 func (r *revertTransactionPayloadReadonly) GetForce() bool {
-	return r.v.GetForce()
+	return (*RevertTransactionPayload)(r).GetForce()
 }
 
 func (r *revertTransactionPayloadReadonly) GetAtEffectiveDate() bool {
-	return r.v.GetAtEffectiveDate()
+	return (*RevertTransactionPayload)(r).GetAtEffectiveDate()
 }
 
 func (r *revertTransactionPayloadReadonly) GetMetadata() RevertTransactionPayload_MetadataMapReader {
-	return revertTransactionPayload_metadataMapReadonly(r.v.GetMetadata())
+	return revertTransactionPayload_metadataMapReadonly((*RevertTransactionPayload)(r).GetMetadata())
 }
 
 func (r *revertTransactionPayloadReadonly) GetReceipt() string {
-	return r.v.GetReceipt()
+	return (*RevertTransactionPayload)(r).GetReceipt()
 }
 
 func (r *revertTransactionPayloadReadonly) GetExpandVolumes() bool {
-	return r.v.GetExpandVolumes()
+	return (*RevertTransactionPayload)(r).GetExpandVolumes()
 }
 
 func (r *revertTransactionPayloadReadonly) Mutate() *RevertTransactionPayload {
-	return r.v.CloneVT()
+	return (*RevertTransactionPayload)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevertTransactionPayload.
@@ -3922,7 +3916,7 @@ func (m *RevertTransactionPayload) AsReader() RevertTransactionPayloadReader {
 	if m == nil {
 		return nil
 	}
-	return &revertTransactionPayloadReadonly{v: m}
+	return (*revertTransactionPayloadReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevertTransactionPayload.
@@ -4005,14 +3999,14 @@ type LedgerActionReader interface {
 	Mutate() *LedgerAction
 }
 
-type ledgerActionReadonly struct{ v *LedgerAction }
+type ledgerActionReadonly LedgerAction
 
 func (r *ledgerActionReadonly) GetData() isLedgerAction_Data {
-	return r.v.GetData()
+	return (*LedgerAction)(r).GetData()
 }
 
 func (r *ledgerActionReadonly) Mutate() *LedgerAction {
-	return r.v.CloneVT()
+	return (*LedgerAction)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerAction.
@@ -4020,7 +4014,7 @@ func (m *LedgerAction) AsReader() LedgerActionReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerActionReadonly{v: m}
+	return (*ledgerActionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerAction.
@@ -4073,14 +4067,14 @@ type LedgerApplyRequestReader interface {
 	Mutate() *LedgerApplyRequest
 }
 
-type ledgerApplyRequestReadonly struct{ v *LedgerApplyRequest }
+type ledgerApplyRequestReadonly LedgerApplyRequest
 
 func (r *ledgerApplyRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*LedgerApplyRequest)(r).GetLedger()
 }
 
 func (r *ledgerApplyRequestReadonly) GetAction() LedgerActionReader {
-	v := r.v.GetAction()
+	v := (*LedgerApplyRequest)(r).GetAction()
 	if v == nil {
 		return nil
 	}
@@ -4088,7 +4082,7 @@ func (r *ledgerApplyRequestReadonly) GetAction() LedgerActionReader {
 }
 
 func (r *ledgerApplyRequestReadonly) Mutate() *LedgerApplyRequest {
-	return r.v.CloneVT()
+	return (*LedgerApplyRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LedgerApplyRequest.
@@ -4096,7 +4090,7 @@ func (m *LedgerApplyRequest) AsReader() LedgerApplyRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &ledgerApplyRequestReadonly{v: m}
+	return (*ledgerApplyRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LedgerApplyRequest.
@@ -4148,10 +4142,10 @@ type AddAccountTypeRequestReader interface {
 	Mutate() *AddAccountTypeRequest
 }
 
-type addAccountTypeRequestReadonly struct{ v *AddAccountTypeRequest }
+type addAccountTypeRequestReadonly AddAccountTypeRequest
 
 func (r *addAccountTypeRequestReadonly) GetAccountType() commonpb.AccountTypeReader {
-	v := r.v.GetAccountType()
+	v := (*AddAccountTypeRequest)(r).GetAccountType()
 	if v == nil {
 		return nil
 	}
@@ -4159,7 +4153,7 @@ func (r *addAccountTypeRequestReadonly) GetAccountType() commonpb.AccountTypeRea
 }
 
 func (r *addAccountTypeRequestReadonly) Mutate() *AddAccountTypeRequest {
-	return r.v.CloneVT()
+	return (*AddAccountTypeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddAccountTypeRequest.
@@ -4167,7 +4161,7 @@ func (m *AddAccountTypeRequest) AsReader() AddAccountTypeRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &addAccountTypeRequestReadonly{v: m}
+	return (*addAccountTypeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddAccountTypeRequest.
@@ -4219,14 +4213,14 @@ type RemoveAccountTypeRequestReader interface {
 	Mutate() *RemoveAccountTypeRequest
 }
 
-type removeAccountTypeRequestReadonly struct{ v *RemoveAccountTypeRequest }
+type removeAccountTypeRequestReadonly RemoveAccountTypeRequest
 
 func (r *removeAccountTypeRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemoveAccountTypeRequest)(r).GetName()
 }
 
 func (r *removeAccountTypeRequestReadonly) Mutate() *RemoveAccountTypeRequest {
-	return r.v.CloneVT()
+	return (*RemoveAccountTypeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveAccountTypeRequest.
@@ -4234,7 +4228,7 @@ func (m *RemoveAccountTypeRequest) AsReader() RemoveAccountTypeRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &removeAccountTypeRequestReadonly{v: m}
+	return (*removeAccountTypeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveAccountTypeRequest.
@@ -4286,16 +4280,14 @@ type SetDefaultEnforcementModeRequestReader interface {
 	Mutate() *SetDefaultEnforcementModeRequest
 }
 
-type setDefaultEnforcementModeRequestReadonly struct {
-	v *SetDefaultEnforcementModeRequest
-}
+type setDefaultEnforcementModeRequestReadonly SetDefaultEnforcementModeRequest
 
 func (r *setDefaultEnforcementModeRequestReadonly) GetEnforcementMode() commonpb.ChartEnforcementMode {
-	return r.v.GetEnforcementMode()
+	return (*SetDefaultEnforcementModeRequest)(r).GetEnforcementMode()
 }
 
 func (r *setDefaultEnforcementModeRequestReadonly) Mutate() *SetDefaultEnforcementModeRequest {
-	return r.v.CloneVT()
+	return (*SetDefaultEnforcementModeRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetDefaultEnforcementModeRequest.
@@ -4303,7 +4295,7 @@ func (m *SetDefaultEnforcementModeRequest) AsReader() SetDefaultEnforcementModeR
 	if m == nil {
 		return nil
 	}
-	return &setDefaultEnforcementModeRequestReadonly{v: m}
+	return (*setDefaultEnforcementModeRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetDefaultEnforcementModeRequest.
@@ -4356,20 +4348,18 @@ type SetDefaultEnforcementModeLedgerRequestReader interface {
 	Mutate() *SetDefaultEnforcementModeLedgerRequest
 }
 
-type setDefaultEnforcementModeLedgerRequestReadonly struct {
-	v *SetDefaultEnforcementModeLedgerRequest
-}
+type setDefaultEnforcementModeLedgerRequestReadonly SetDefaultEnforcementModeLedgerRequest
 
 func (r *setDefaultEnforcementModeLedgerRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*SetDefaultEnforcementModeLedgerRequest)(r).GetLedger()
 }
 
 func (r *setDefaultEnforcementModeLedgerRequestReadonly) GetEnforcementMode() commonpb.ChartEnforcementMode {
-	return r.v.GetEnforcementMode()
+	return (*SetDefaultEnforcementModeLedgerRequest)(r).GetEnforcementMode()
 }
 
 func (r *setDefaultEnforcementModeLedgerRequestReadonly) Mutate() *SetDefaultEnforcementModeLedgerRequest {
-	return r.v.CloneVT()
+	return (*SetDefaultEnforcementModeLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SetDefaultEnforcementModeLedgerRequest.
@@ -4377,7 +4367,7 @@ func (m *SetDefaultEnforcementModeLedgerRequest) AsReader() SetDefaultEnforcemen
 	if m == nil {
 		return nil
 	}
-	return &setDefaultEnforcementModeLedgerRequestReadonly{v: m}
+	return (*setDefaultEnforcementModeLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SetDefaultEnforcementModeLedgerRequest.
@@ -4430,14 +4420,14 @@ type AddAccountTypeLedgerRequestReader interface {
 	Mutate() *AddAccountTypeLedgerRequest
 }
 
-type addAccountTypeLedgerRequestReadonly struct{ v *AddAccountTypeLedgerRequest }
+type addAccountTypeLedgerRequestReadonly AddAccountTypeLedgerRequest
 
 func (r *addAccountTypeLedgerRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*AddAccountTypeLedgerRequest)(r).GetLedger()
 }
 
 func (r *addAccountTypeLedgerRequestReadonly) GetAccountType() commonpb.AccountTypeReader {
-	v := r.v.GetAccountType()
+	v := (*AddAccountTypeLedgerRequest)(r).GetAccountType()
 	if v == nil {
 		return nil
 	}
@@ -4445,7 +4435,7 @@ func (r *addAccountTypeLedgerRequestReadonly) GetAccountType() commonpb.AccountT
 }
 
 func (r *addAccountTypeLedgerRequestReadonly) Mutate() *AddAccountTypeLedgerRequest {
-	return r.v.CloneVT()
+	return (*AddAccountTypeLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AddAccountTypeLedgerRequest.
@@ -4453,7 +4443,7 @@ func (m *AddAccountTypeLedgerRequest) AsReader() AddAccountTypeLedgerRequestRead
 	if m == nil {
 		return nil
 	}
-	return &addAccountTypeLedgerRequestReadonly{v: m}
+	return (*addAccountTypeLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AddAccountTypeLedgerRequest.
@@ -4506,20 +4496,18 @@ type RemoveAccountTypeLedgerRequestReader interface {
 	Mutate() *RemoveAccountTypeLedgerRequest
 }
 
-type removeAccountTypeLedgerRequestReadonly struct {
-	v *RemoveAccountTypeLedgerRequest
-}
+type removeAccountTypeLedgerRequestReadonly RemoveAccountTypeLedgerRequest
 
 func (r *removeAccountTypeLedgerRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*RemoveAccountTypeLedgerRequest)(r).GetLedger()
 }
 
 func (r *removeAccountTypeLedgerRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*RemoveAccountTypeLedgerRequest)(r).GetName()
 }
 
 func (r *removeAccountTypeLedgerRequestReadonly) Mutate() *RemoveAccountTypeLedgerRequest {
-	return r.v.CloneVT()
+	return (*RemoveAccountTypeLedgerRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RemoveAccountTypeLedgerRequest.
@@ -4527,7 +4515,7 @@ func (m *RemoveAccountTypeLedgerRequest) AsReader() RemoveAccountTypeLedgerReque
 	if m == nil {
 		return nil
 	}
-	return &removeAccountTypeLedgerRequestReadonly{v: m}
+	return (*removeAccountTypeLedgerRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RemoveAccountTypeLedgerRequest.
@@ -4579,14 +4567,14 @@ type GetPrimaryMetricsRequestReader interface {
 	Mutate() *GetPrimaryMetricsRequest
 }
 
-type getPrimaryMetricsRequestReadonly struct{ v *GetPrimaryMetricsRequest }
+type getPrimaryMetricsRequestReadonly GetPrimaryMetricsRequest
 
 func (r *getPrimaryMetricsRequestReadonly) GetNodeId() uint32 {
-	return r.v.GetNodeId()
+	return (*GetPrimaryMetricsRequest)(r).GetNodeId()
 }
 
 func (r *getPrimaryMetricsRequestReadonly) Mutate() *GetPrimaryMetricsRequest {
-	return r.v.CloneVT()
+	return (*GetPrimaryMetricsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetPrimaryMetricsRequest.
@@ -4594,7 +4582,7 @@ func (m *GetPrimaryMetricsRequest) AsReader() GetPrimaryMetricsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getPrimaryMetricsRequestReadonly{v: m}
+	return (*getPrimaryMetricsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetPrimaryMetricsRequest.
@@ -4647,14 +4635,14 @@ type GetPrimaryMetricsResponseReader interface {
 	Mutate() *GetPrimaryMetricsResponse
 }
 
-type getPrimaryMetricsResponseReadonly struct{ v *GetPrimaryMetricsResponse }
+type getPrimaryMetricsResponseReadonly GetPrimaryMetricsResponse
 
 func (r *getPrimaryMetricsResponseReadonly) GetAvailable() bool {
-	return r.v.GetAvailable()
+	return (*GetPrimaryMetricsResponse)(r).GetAvailable()
 }
 
 func (r *getPrimaryMetricsResponseReadonly) GetMetrics() PebbleMetricsReader {
-	v := r.v.GetMetrics()
+	v := (*GetPrimaryMetricsResponse)(r).GetMetrics()
 	if v == nil {
 		return nil
 	}
@@ -4662,7 +4650,7 @@ func (r *getPrimaryMetricsResponseReadonly) GetMetrics() PebbleMetricsReader {
 }
 
 func (r *getPrimaryMetricsResponseReadonly) Mutate() *GetPrimaryMetricsResponse {
-	return r.v.CloneVT()
+	return (*GetPrimaryMetricsResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetPrimaryMetricsResponse.
@@ -4670,7 +4658,7 @@ func (m *GetPrimaryMetricsResponse) AsReader() GetPrimaryMetricsResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getPrimaryMetricsResponseReadonly{v: m}
+	return (*getPrimaryMetricsResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetPrimaryMetricsResponse.
@@ -4722,14 +4710,14 @@ type GetSecondaryMetricsRequestReader interface {
 	Mutate() *GetSecondaryMetricsRequest
 }
 
-type getSecondaryMetricsRequestReadonly struct{ v *GetSecondaryMetricsRequest }
+type getSecondaryMetricsRequestReadonly GetSecondaryMetricsRequest
 
 func (r *getSecondaryMetricsRequestReadonly) GetNodeId() uint32 {
-	return r.v.GetNodeId()
+	return (*GetSecondaryMetricsRequest)(r).GetNodeId()
 }
 
 func (r *getSecondaryMetricsRequestReadonly) Mutate() *GetSecondaryMetricsRequest {
-	return r.v.CloneVT()
+	return (*GetSecondaryMetricsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetSecondaryMetricsRequest.
@@ -4737,7 +4725,7 @@ func (m *GetSecondaryMetricsRequest) AsReader() GetSecondaryMetricsRequestReader
 	if m == nil {
 		return nil
 	}
-	return &getSecondaryMetricsRequestReadonly{v: m}
+	return (*getSecondaryMetricsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetSecondaryMetricsRequest.
@@ -4790,14 +4778,14 @@ type GetSecondaryMetricsResponseReader interface {
 	Mutate() *GetSecondaryMetricsResponse
 }
 
-type getSecondaryMetricsResponseReadonly struct{ v *GetSecondaryMetricsResponse }
+type getSecondaryMetricsResponseReadonly GetSecondaryMetricsResponse
 
 func (r *getSecondaryMetricsResponseReadonly) GetAvailable() bool {
-	return r.v.GetAvailable()
+	return (*GetSecondaryMetricsResponse)(r).GetAvailable()
 }
 
 func (r *getSecondaryMetricsResponseReadonly) GetMetrics() PebbleMetricsReader {
-	v := r.v.GetMetrics()
+	v := (*GetSecondaryMetricsResponse)(r).GetMetrics()
 	if v == nil {
 		return nil
 	}
@@ -4805,7 +4793,7 @@ func (r *getSecondaryMetricsResponseReadonly) GetMetrics() PebbleMetricsReader {
 }
 
 func (r *getSecondaryMetricsResponseReadonly) Mutate() *GetSecondaryMetricsResponse {
-	return r.v.CloneVT()
+	return (*GetSecondaryMetricsResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetSecondaryMetricsResponse.
@@ -4813,7 +4801,7 @@ func (m *GetSecondaryMetricsResponse) AsReader() GetSecondaryMetricsResponseRead
 	if m == nil {
 		return nil
 	}
-	return &getSecondaryMetricsResponseReadonly{v: m}
+	return (*getSecondaryMetricsResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetSecondaryMetricsResponse.
@@ -4875,10 +4863,10 @@ type PebbleMetricsReader interface {
 	Mutate() *PebbleMetrics
 }
 
-type pebbleMetricsReadonly struct{ v *PebbleMetrics }
+type pebbleMetricsReadonly PebbleMetrics
 
 func (r *pebbleMetricsReadonly) GetBlockCache() BlockCacheMetricsReader {
-	v := r.v.GetBlockCache()
+	v := (*PebbleMetrics)(r).GetBlockCache()
 	if v == nil {
 		return nil
 	}
@@ -4886,7 +4874,7 @@ func (r *pebbleMetricsReadonly) GetBlockCache() BlockCacheMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetCompact() CompactMetricsReader {
-	v := r.v.GetCompact()
+	v := (*PebbleMetrics)(r).GetCompact()
 	if v == nil {
 		return nil
 	}
@@ -4894,7 +4882,7 @@ func (r *pebbleMetricsReadonly) GetCompact() CompactMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetFlush() FlushMetricsReader {
-	v := r.v.GetFlush()
+	v := (*PebbleMetrics)(r).GetFlush()
 	if v == nil {
 		return nil
 	}
@@ -4902,7 +4890,7 @@ func (r *pebbleMetricsReadonly) GetFlush() FlushMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetMemTable() MemTableMetricsReader {
-	v := r.v.GetMemTable()
+	v := (*PebbleMetrics)(r).GetMemTable()
 	if v == nil {
 		return nil
 	}
@@ -4910,7 +4898,7 @@ func (r *pebbleMetricsReadonly) GetMemTable() MemTableMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetSnapshots() SnapshotsMetricsReader {
-	v := r.v.GetSnapshots()
+	v := (*PebbleMetrics)(r).GetSnapshots()
 	if v == nil {
 		return nil
 	}
@@ -4918,7 +4906,7 @@ func (r *pebbleMetricsReadonly) GetSnapshots() SnapshotsMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetTable() TableMetricsReader {
-	v := r.v.GetTable()
+	v := (*PebbleMetrics)(r).GetTable()
 	if v == nil {
 		return nil
 	}
@@ -4926,7 +4914,7 @@ func (r *pebbleMetricsReadonly) GetTable() TableMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetTableCache() TableCacheMetricsReader {
-	v := r.v.GetTableCache()
+	v := (*PebbleMetrics)(r).GetTableCache()
 	if v == nil {
 		return nil
 	}
@@ -4934,7 +4922,7 @@ func (r *pebbleMetricsReadonly) GetTableCache() TableCacheMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetWal() WALMetricsReader {
-	v := r.v.GetWal()
+	v := (*PebbleMetrics)(r).GetWal()
 	if v == nil {
 		return nil
 	}
@@ -4942,7 +4930,7 @@ func (r *pebbleMetricsReadonly) GetWal() WALMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetKeys() KeysMetricsReader {
-	v := r.v.GetKeys()
+	v := (*PebbleMetrics)(r).GetKeys()
 	if v == nil {
 		return nil
 	}
@@ -4950,15 +4938,15 @@ func (r *pebbleMetricsReadonly) GetKeys() KeysMetricsReader {
 }
 
 func (r *pebbleMetricsReadonly) GetLevels() LevelMetricsListReader {
-	return NewLevelMetricsListReader(r.v.GetLevels())
+	return NewLevelMetricsListReader((*PebbleMetrics)(r).GetLevels())
 }
 
 func (r *pebbleMetricsReadonly) GetDiskSpaceUsage() uint64 {
-	return r.v.GetDiskSpaceUsage()
+	return (*PebbleMetrics)(r).GetDiskSpaceUsage()
 }
 
 func (r *pebbleMetricsReadonly) Mutate() *PebbleMetrics {
-	return r.v.CloneVT()
+	return (*PebbleMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PebbleMetrics.
@@ -4966,7 +4954,7 @@ func (m *PebbleMetrics) AsReader() PebbleMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &pebbleMetricsReadonly{v: m}
+	return (*pebbleMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PebbleMetrics.
@@ -5021,26 +5009,26 @@ type BlockCacheMetricsReader interface {
 	Mutate() *BlockCacheMetrics
 }
 
-type blockCacheMetricsReadonly struct{ v *BlockCacheMetrics }
+type blockCacheMetricsReadonly BlockCacheMetrics
 
 func (r *blockCacheMetricsReadonly) GetSize() int64 {
-	return r.v.GetSize()
+	return (*BlockCacheMetrics)(r).GetSize()
 }
 
 func (r *blockCacheMetricsReadonly) GetCount() int64 {
-	return r.v.GetCount()
+	return (*BlockCacheMetrics)(r).GetCount()
 }
 
 func (r *blockCacheMetricsReadonly) GetHits() int64 {
-	return r.v.GetHits()
+	return (*BlockCacheMetrics)(r).GetHits()
 }
 
 func (r *blockCacheMetricsReadonly) GetMisses() int64 {
-	return r.v.GetMisses()
+	return (*BlockCacheMetrics)(r).GetMisses()
 }
 
 func (r *blockCacheMetricsReadonly) Mutate() *BlockCacheMetrics {
-	return r.v.CloneVT()
+	return (*BlockCacheMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BlockCacheMetrics.
@@ -5048,7 +5036,7 @@ func (m *BlockCacheMetrics) AsReader() BlockCacheMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &blockCacheMetricsReadonly{v: m}
+	return (*blockCacheMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BlockCacheMetrics.
@@ -5111,58 +5099,58 @@ type CompactMetricsReader interface {
 	Mutate() *CompactMetrics
 }
 
-type compactMetricsReadonly struct{ v *CompactMetrics }
+type compactMetricsReadonly CompactMetrics
 
 func (r *compactMetricsReadonly) GetCount() int64 {
-	return r.v.GetCount()
+	return (*CompactMetrics)(r).GetCount()
 }
 
 func (r *compactMetricsReadonly) GetDefaultCount() int64 {
-	return r.v.GetDefaultCount()
+	return (*CompactMetrics)(r).GetDefaultCount()
 }
 
 func (r *compactMetricsReadonly) GetDeleteOnlyCount() int64 {
-	return r.v.GetDeleteOnlyCount()
+	return (*CompactMetrics)(r).GetDeleteOnlyCount()
 }
 
 func (r *compactMetricsReadonly) GetElisionOnlyCount() int64 {
-	return r.v.GetElisionOnlyCount()
+	return (*CompactMetrics)(r).GetElisionOnlyCount()
 }
 
 func (r *compactMetricsReadonly) GetMoveCount() int64 {
-	return r.v.GetMoveCount()
+	return (*CompactMetrics)(r).GetMoveCount()
 }
 
 func (r *compactMetricsReadonly) GetReadCount() int64 {
-	return r.v.GetReadCount()
+	return (*CompactMetrics)(r).GetReadCount()
 }
 
 func (r *compactMetricsReadonly) GetRewriteCount() int64 {
-	return r.v.GetRewriteCount()
+	return (*CompactMetrics)(r).GetRewriteCount()
 }
 
 func (r *compactMetricsReadonly) GetMultiLevelCount() int64 {
-	return r.v.GetMultiLevelCount()
+	return (*CompactMetrics)(r).GetMultiLevelCount()
 }
 
 func (r *compactMetricsReadonly) GetEstimatedDebt() uint64 {
-	return r.v.GetEstimatedDebt()
+	return (*CompactMetrics)(r).GetEstimatedDebt()
 }
 
 func (r *compactMetricsReadonly) GetInProgressBytes() int64 {
-	return r.v.GetInProgressBytes()
+	return (*CompactMetrics)(r).GetInProgressBytes()
 }
 
 func (r *compactMetricsReadonly) GetNumInProgress() int64 {
-	return r.v.GetNumInProgress()
+	return (*CompactMetrics)(r).GetNumInProgress()
 }
 
 func (r *compactMetricsReadonly) GetMarkedFiles() int32 {
-	return r.v.GetMarkedFiles()
+	return (*CompactMetrics)(r).GetMarkedFiles()
 }
 
 func (r *compactMetricsReadonly) Mutate() *CompactMetrics {
-	return r.v.CloneVT()
+	return (*CompactMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CompactMetrics.
@@ -5170,7 +5158,7 @@ func (m *CompactMetrics) AsReader() CompactMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &compactMetricsReadonly{v: m}
+	return (*compactMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CompactMetrics.
@@ -5226,30 +5214,30 @@ type FlushMetricsReader interface {
 	Mutate() *FlushMetrics
 }
 
-type flushMetricsReadonly struct{ v *FlushMetrics }
+type flushMetricsReadonly FlushMetrics
 
 func (r *flushMetricsReadonly) GetCount() int64 {
-	return r.v.GetCount()
+	return (*FlushMetrics)(r).GetCount()
 }
 
 func (r *flushMetricsReadonly) GetNumInProgress() int64 {
-	return r.v.GetNumInProgress()
+	return (*FlushMetrics)(r).GetNumInProgress()
 }
 
 func (r *flushMetricsReadonly) GetAsIngestCount() uint64 {
-	return r.v.GetAsIngestCount()
+	return (*FlushMetrics)(r).GetAsIngestCount()
 }
 
 func (r *flushMetricsReadonly) GetAsIngestTableCount() uint64 {
-	return r.v.GetAsIngestTableCount()
+	return (*FlushMetrics)(r).GetAsIngestTableCount()
 }
 
 func (r *flushMetricsReadonly) GetAsIngestBytes() uint64 {
-	return r.v.GetAsIngestBytes()
+	return (*FlushMetrics)(r).GetAsIngestBytes()
 }
 
 func (r *flushMetricsReadonly) Mutate() *FlushMetrics {
-	return r.v.CloneVT()
+	return (*FlushMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FlushMetrics.
@@ -5257,7 +5245,7 @@ func (m *FlushMetrics) AsReader() FlushMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &flushMetricsReadonly{v: m}
+	return (*flushMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FlushMetrics.
@@ -5312,26 +5300,26 @@ type MemTableMetricsReader interface {
 	Mutate() *MemTableMetrics
 }
 
-type memTableMetricsReadonly struct{ v *MemTableMetrics }
+type memTableMetricsReadonly MemTableMetrics
 
 func (r *memTableMetricsReadonly) GetSize() uint64 {
-	return r.v.GetSize()
+	return (*MemTableMetrics)(r).GetSize()
 }
 
 func (r *memTableMetricsReadonly) GetCount() int64 {
-	return r.v.GetCount()
+	return (*MemTableMetrics)(r).GetCount()
 }
 
 func (r *memTableMetricsReadonly) GetZombieSize() uint64 {
-	return r.v.GetZombieSize()
+	return (*MemTableMetrics)(r).GetZombieSize()
 }
 
 func (r *memTableMetricsReadonly) GetZombieCount() int64 {
-	return r.v.GetZombieCount()
+	return (*MemTableMetrics)(r).GetZombieCount()
 }
 
 func (r *memTableMetricsReadonly) Mutate() *MemTableMetrics {
-	return r.v.CloneVT()
+	return (*MemTableMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MemTableMetrics.
@@ -5339,7 +5327,7 @@ func (m *MemTableMetrics) AsReader() MemTableMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &memTableMetricsReadonly{v: m}
+	return (*memTableMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MemTableMetrics.
@@ -5394,26 +5382,26 @@ type SnapshotsMetricsReader interface {
 	Mutate() *SnapshotsMetrics
 }
 
-type snapshotsMetricsReadonly struct{ v *SnapshotsMetrics }
+type snapshotsMetricsReadonly SnapshotsMetrics
 
 func (r *snapshotsMetricsReadonly) GetCount() int32 {
-	return r.v.GetCount()
+	return (*SnapshotsMetrics)(r).GetCount()
 }
 
 func (r *snapshotsMetricsReadonly) GetEarliestSeqNum() uint64 {
-	return r.v.GetEarliestSeqNum()
+	return (*SnapshotsMetrics)(r).GetEarliestSeqNum()
 }
 
 func (r *snapshotsMetricsReadonly) GetPinnedKeys() uint64 {
-	return r.v.GetPinnedKeys()
+	return (*SnapshotsMetrics)(r).GetPinnedKeys()
 }
 
 func (r *snapshotsMetricsReadonly) GetPinnedSize() uint64 {
-	return r.v.GetPinnedSize()
+	return (*SnapshotsMetrics)(r).GetPinnedSize()
 }
 
 func (r *snapshotsMetricsReadonly) Mutate() *SnapshotsMetrics {
-	return r.v.CloneVT()
+	return (*SnapshotsMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SnapshotsMetrics.
@@ -5421,7 +5409,7 @@ func (m *SnapshotsMetrics) AsReader() SnapshotsMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &snapshotsMetricsReadonly{v: m}
+	return (*snapshotsMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SnapshotsMetrics.
@@ -5476,26 +5464,26 @@ type TableMetricsReader interface {
 	Mutate() *TableMetrics
 }
 
-type tableMetricsReadonly struct{ v *TableMetrics }
+type tableMetricsReadonly TableMetrics
 
 func (r *tableMetricsReadonly) GetZombieSize() uint64 {
-	return r.v.GetZombieSize()
+	return (*TableMetrics)(r).GetZombieSize()
 }
 
 func (r *tableMetricsReadonly) GetZombieCount() int64 {
-	return r.v.GetZombieCount()
+	return (*TableMetrics)(r).GetZombieCount()
 }
 
 func (r *tableMetricsReadonly) GetBackingTableCount() uint64 {
-	return r.v.GetBackingTableCount()
+	return (*TableMetrics)(r).GetBackingTableCount()
 }
 
 func (r *tableMetricsReadonly) GetBackingTableSize() uint64 {
-	return r.v.GetBackingTableSize()
+	return (*TableMetrics)(r).GetBackingTableSize()
 }
 
 func (r *tableMetricsReadonly) Mutate() *TableMetrics {
-	return r.v.CloneVT()
+	return (*TableMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TableMetrics.
@@ -5503,7 +5491,7 @@ func (m *TableMetrics) AsReader() TableMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &tableMetricsReadonly{v: m}
+	return (*tableMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TableMetrics.
@@ -5558,26 +5546,26 @@ type TableCacheMetricsReader interface {
 	Mutate() *TableCacheMetrics
 }
 
-type tableCacheMetricsReadonly struct{ v *TableCacheMetrics }
+type tableCacheMetricsReadonly TableCacheMetrics
 
 func (r *tableCacheMetricsReadonly) GetSize() int64 {
-	return r.v.GetSize()
+	return (*TableCacheMetrics)(r).GetSize()
 }
 
 func (r *tableCacheMetricsReadonly) GetCount() int64 {
-	return r.v.GetCount()
+	return (*TableCacheMetrics)(r).GetCount()
 }
 
 func (r *tableCacheMetricsReadonly) GetHits() int64 {
-	return r.v.GetHits()
+	return (*TableCacheMetrics)(r).GetHits()
 }
 
 func (r *tableCacheMetricsReadonly) GetMisses() int64 {
-	return r.v.GetMisses()
+	return (*TableCacheMetrics)(r).GetMisses()
 }
 
 func (r *tableCacheMetricsReadonly) Mutate() *TableCacheMetrics {
-	return r.v.CloneVT()
+	return (*TableCacheMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TableCacheMetrics.
@@ -5585,7 +5573,7 @@ func (m *TableCacheMetrics) AsReader() TableCacheMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &tableCacheMetricsReadonly{v: m}
+	return (*tableCacheMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TableCacheMetrics.
@@ -5641,30 +5629,30 @@ type WALMetricsReader interface {
 	Mutate() *WALMetrics
 }
 
-type wALMetricsReadonly struct{ v *WALMetrics }
+type wALMetricsReadonly WALMetrics
 
 func (r *wALMetricsReadonly) GetFiles() int64 {
-	return r.v.GetFiles()
+	return (*WALMetrics)(r).GetFiles()
 }
 
 func (r *wALMetricsReadonly) GetObsoleteFiles() int64 {
-	return r.v.GetObsoleteFiles()
+	return (*WALMetrics)(r).GetObsoleteFiles()
 }
 
 func (r *wALMetricsReadonly) GetSize() uint64 {
-	return r.v.GetSize()
+	return (*WALMetrics)(r).GetSize()
 }
 
 func (r *wALMetricsReadonly) GetBytesIn() uint64 {
-	return r.v.GetBytesIn()
+	return (*WALMetrics)(r).GetBytesIn()
 }
 
 func (r *wALMetricsReadonly) GetBytesWritten() uint64 {
-	return r.v.GetBytesWritten()
+	return (*WALMetrics)(r).GetBytesWritten()
 }
 
 func (r *wALMetricsReadonly) Mutate() *WALMetrics {
-	return r.v.CloneVT()
+	return (*WALMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this WALMetrics.
@@ -5672,7 +5660,7 @@ func (m *WALMetrics) AsReader() WALMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &wALMetricsReadonly{v: m}
+	return (*wALMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this WALMetrics.
@@ -5723,18 +5711,18 @@ type KeysMetricsReader interface {
 	Mutate() *KeysMetrics
 }
 
-type keysMetricsReadonly struct{ v *KeysMetrics }
+type keysMetricsReadonly KeysMetrics
 
 func (r *keysMetricsReadonly) GetRangeKeySetsCount() uint64 {
-	return r.v.GetRangeKeySetsCount()
+	return (*KeysMetrics)(r).GetRangeKeySetsCount()
 }
 
 func (r *keysMetricsReadonly) GetTombstoneCount() uint64 {
-	return r.v.GetTombstoneCount()
+	return (*KeysMetrics)(r).GetTombstoneCount()
 }
 
 func (r *keysMetricsReadonly) Mutate() *KeysMetrics {
-	return r.v.CloneVT()
+	return (*KeysMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this KeysMetrics.
@@ -5742,7 +5730,7 @@ func (m *KeysMetrics) AsReader() KeysMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &keysMetricsReadonly{v: m}
+	return (*keysMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this KeysMetrics.
@@ -5807,66 +5795,66 @@ type LevelMetricsReader interface {
 	Mutate() *LevelMetrics
 }
 
-type levelMetricsReadonly struct{ v *LevelMetrics }
+type levelMetricsReadonly LevelMetrics
 
 func (r *levelMetricsReadonly) GetLevel() int32 {
-	return r.v.GetLevel()
+	return (*LevelMetrics)(r).GetLevel()
 }
 
 func (r *levelMetricsReadonly) GetNumFiles() int64 {
-	return r.v.GetNumFiles()
+	return (*LevelMetrics)(r).GetNumFiles()
 }
 
 func (r *levelMetricsReadonly) GetSize() int64 {
-	return r.v.GetSize()
+	return (*LevelMetrics)(r).GetSize()
 }
 
 func (r *levelMetricsReadonly) GetScore() float64 {
-	return r.v.GetScore()
+	return (*LevelMetrics)(r).GetScore()
 }
 
 func (r *levelMetricsReadonly) GetBytesIn() uint64 {
-	return r.v.GetBytesIn()
+	return (*LevelMetrics)(r).GetBytesIn()
 }
 
 func (r *levelMetricsReadonly) GetBytesIngested() uint64 {
-	return r.v.GetBytesIngested()
+	return (*LevelMetrics)(r).GetBytesIngested()
 }
 
 func (r *levelMetricsReadonly) GetBytesMoved() uint64 {
-	return r.v.GetBytesMoved()
+	return (*LevelMetrics)(r).GetBytesMoved()
 }
 
 func (r *levelMetricsReadonly) GetBytesRead() uint64 {
-	return r.v.GetBytesRead()
+	return (*LevelMetrics)(r).GetBytesRead()
 }
 
 func (r *levelMetricsReadonly) GetBytesCompacted() uint64 {
-	return r.v.GetBytesCompacted()
+	return (*LevelMetrics)(r).GetBytesCompacted()
 }
 
 func (r *levelMetricsReadonly) GetBytesFlushed() uint64 {
-	return r.v.GetBytesFlushed()
+	return (*LevelMetrics)(r).GetBytesFlushed()
 }
 
 func (r *levelMetricsReadonly) GetTablesCompacted() uint64 {
-	return r.v.GetTablesCompacted()
+	return (*LevelMetrics)(r).GetTablesCompacted()
 }
 
 func (r *levelMetricsReadonly) GetTablesFlushed() uint64 {
-	return r.v.GetTablesFlushed()
+	return (*LevelMetrics)(r).GetTablesFlushed()
 }
 
 func (r *levelMetricsReadonly) GetTablesIngested() uint64 {
-	return r.v.GetTablesIngested()
+	return (*LevelMetrics)(r).GetTablesIngested()
 }
 
 func (r *levelMetricsReadonly) GetTablesMoved() uint64 {
-	return r.v.GetTablesMoved()
+	return (*LevelMetrics)(r).GetTablesMoved()
 }
 
 func (r *levelMetricsReadonly) Mutate() *LevelMetrics {
-	return r.v.CloneVT()
+	return (*LevelMetrics)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this LevelMetrics.
@@ -5874,7 +5862,7 @@ func (m *LevelMetrics) AsReader() LevelMetricsReader {
 	if m == nil {
 		return nil
 	}
-	return &levelMetricsReadonly{v: m}
+	return (*levelMetricsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this LevelMetrics.
@@ -5925,10 +5913,10 @@ type CheckStoreRequestReader interface {
 	Mutate() *CheckStoreRequest
 }
 
-type checkStoreRequestReadonly struct{ v *CheckStoreRequest }
+type checkStoreRequestReadonly CheckStoreRequest
 
 func (r *checkStoreRequestReadonly) Mutate() *CheckStoreRequest {
-	return r.v.CloneVT()
+	return (*CheckStoreRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CheckStoreRequest.
@@ -5936,7 +5924,7 @@ func (m *CheckStoreRequest) AsReader() CheckStoreRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &checkStoreRequestReadonly{v: m}
+	return (*checkStoreRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CheckStoreRequest.
@@ -5988,14 +5976,14 @@ type CheckStoreEventReader interface {
 	Mutate() *CheckStoreEvent
 }
 
-type checkStoreEventReadonly struct{ v *CheckStoreEvent }
+type checkStoreEventReadonly CheckStoreEvent
 
 func (r *checkStoreEventReadonly) GetType() isCheckStoreEvent_Type {
-	return r.v.GetType()
+	return (*CheckStoreEvent)(r).GetType()
 }
 
 func (r *checkStoreEventReadonly) Mutate() *CheckStoreEvent {
-	return r.v.CloneVT()
+	return (*CheckStoreEvent)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CheckStoreEvent.
@@ -6003,7 +5991,7 @@ func (m *CheckStoreEvent) AsReader() CheckStoreEventReader {
 	if m == nil {
 		return nil
 	}
-	return &checkStoreEventReadonly{v: m}
+	return (*checkStoreEventReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CheckStoreEvent.
@@ -6061,38 +6049,38 @@ type CheckStoreErrorReader interface {
 	Mutate() *CheckStoreError
 }
 
-type checkStoreErrorReadonly struct{ v *CheckStoreError }
+type checkStoreErrorReadonly CheckStoreError
 
 func (r *checkStoreErrorReadonly) GetErrorType() CheckStoreErrorType {
-	return r.v.GetErrorType()
+	return (*CheckStoreError)(r).GetErrorType()
 }
 
 func (r *checkStoreErrorReadonly) GetMessage() string {
-	return r.v.GetMessage()
+	return (*CheckStoreError)(r).GetMessage()
 }
 
 func (r *checkStoreErrorReadonly) GetLogSequence() uint64 {
-	return r.v.GetLogSequence()
+	return (*CheckStoreError)(r).GetLogSequence()
 }
 
 func (r *checkStoreErrorReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*CheckStoreError)(r).GetLedger()
 }
 
 func (r *checkStoreErrorReadonly) GetAccount() string {
-	return r.v.GetAccount()
+	return (*CheckStoreError)(r).GetAccount()
 }
 
 func (r *checkStoreErrorReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*CheckStoreError)(r).GetAsset()
 }
 
 func (r *checkStoreErrorReadonly) GetTransactionId() uint64 {
-	return r.v.GetTransactionId()
+	return (*CheckStoreError)(r).GetTransactionId()
 }
 
 func (r *checkStoreErrorReadonly) Mutate() *CheckStoreError {
-	return r.v.CloneVT()
+	return (*CheckStoreError)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CheckStoreError.
@@ -6100,7 +6088,7 @@ func (m *CheckStoreError) AsReader() CheckStoreErrorReader {
 	if m == nil {
 		return nil
 	}
-	return &checkStoreErrorReadonly{v: m}
+	return (*checkStoreErrorReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CheckStoreError.
@@ -6153,18 +6141,18 @@ type CheckStoreProgressReader interface {
 	Mutate() *CheckStoreProgress
 }
 
-type checkStoreProgressReadonly struct{ v *CheckStoreProgress }
+type checkStoreProgressReadonly CheckStoreProgress
 
 func (r *checkStoreProgressReadonly) GetLogsChecked() uint64 {
-	return r.v.GetLogsChecked()
+	return (*CheckStoreProgress)(r).GetLogsChecked()
 }
 
 func (r *checkStoreProgressReadonly) GetTotalLogs() uint64 {
-	return r.v.GetTotalLogs()
+	return (*CheckStoreProgress)(r).GetTotalLogs()
 }
 
 func (r *checkStoreProgressReadonly) Mutate() *CheckStoreProgress {
-	return r.v.CloneVT()
+	return (*CheckStoreProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CheckStoreProgress.
@@ -6172,7 +6160,7 @@ func (m *CheckStoreProgress) AsReader() CheckStoreProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &checkStoreProgressReadonly{v: m}
+	return (*checkStoreProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CheckStoreProgress.
@@ -6226,10 +6214,10 @@ type ListAuditEntriesRequestReader interface {
 	Mutate() *ListAuditEntriesRequest
 }
 
-type listAuditEntriesRequestReadonly struct{ v *ListAuditEntriesRequest }
+type listAuditEntriesRequestReadonly ListAuditEntriesRequest
 
 func (r *listAuditEntriesRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListAuditEntriesRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -6237,15 +6225,15 @@ func (r *listAuditEntriesRequestReadonly) GetOptions() commonpb.ListOptionsReade
 }
 
 func (r *listAuditEntriesRequestReadonly) GetFailuresOnly() bool {
-	return r.v.GetFailuresOnly()
+	return (*ListAuditEntriesRequest)(r).GetFailuresOnly()
 }
 
 func (r *listAuditEntriesRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListAuditEntriesRequest)(r).GetLedger()
 }
 
 func (r *listAuditEntriesRequestReadonly) Mutate() *ListAuditEntriesRequest {
-	return r.v.CloneVT()
+	return (*ListAuditEntriesRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListAuditEntriesRequest.
@@ -6253,7 +6241,7 @@ func (m *ListAuditEntriesRequest) AsReader() ListAuditEntriesRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listAuditEntriesRequestReadonly{v: m}
+	return (*listAuditEntriesRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListAuditEntriesRequest.
@@ -6305,14 +6293,14 @@ type GetAuditEntryRequestReader interface {
 	Mutate() *GetAuditEntryRequest
 }
 
-type getAuditEntryRequestReadonly struct{ v *GetAuditEntryRequest }
+type getAuditEntryRequestReadonly GetAuditEntryRequest
 
 func (r *getAuditEntryRequestReadonly) GetSequence() uint64 {
-	return r.v.GetSequence()
+	return (*GetAuditEntryRequest)(r).GetSequence()
 }
 
 func (r *getAuditEntryRequestReadonly) Mutate() *GetAuditEntryRequest {
-	return r.v.CloneVT()
+	return (*GetAuditEntryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetAuditEntryRequest.
@@ -6320,7 +6308,7 @@ func (m *GetAuditEntryRequest) AsReader() GetAuditEntryRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getAuditEntryRequestReadonly{v: m}
+	return (*getAuditEntryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetAuditEntryRequest.
@@ -6373,14 +6361,14 @@ type ListLogsRequestReader interface {
 	Mutate() *ListLogsRequest
 }
 
-type listLogsRequestReadonly struct{ v *ListLogsRequest }
+type listLogsRequestReadonly ListLogsRequest
 
 func (r *listLogsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListLogsRequest)(r).GetLedger()
 }
 
 func (r *listLogsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
-	v := r.v.GetOptions()
+	v := (*ListLogsRequest)(r).GetOptions()
 	if v == nil {
 		return nil
 	}
@@ -6388,7 +6376,7 @@ func (r *listLogsRequestReadonly) GetOptions() commonpb.ListOptionsReader {
 }
 
 func (r *listLogsRequestReadonly) Mutate() *ListLogsRequest {
-	return r.v.CloneVT()
+	return (*ListLogsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListLogsRequest.
@@ -6396,7 +6384,7 @@ func (m *ListLogsRequest) AsReader() ListLogsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listLogsRequestReadonly{v: m}
+	return (*listLogsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListLogsRequest.
@@ -6449,18 +6437,18 @@ type GetLogRequestReader interface {
 	Mutate() *GetLogRequest
 }
 
-type getLogRequestReadonly struct{ v *GetLogRequest }
+type getLogRequestReadonly GetLogRequest
 
 func (r *getLogRequestReadonly) GetSequence() uint64 {
-	return r.v.GetSequence()
+	return (*GetLogRequest)(r).GetSequence()
 }
 
 func (r *getLogRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*GetLogRequest)(r).GetCheckpointId()
 }
 
 func (r *getLogRequestReadonly) Mutate() *GetLogRequest {
-	return r.v.CloneVT()
+	return (*GetLogRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetLogRequest.
@@ -6468,7 +6456,7 @@ func (m *GetLogRequest) AsReader() GetLogRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getLogRequestReadonly{v: m}
+	return (*getLogRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetLogRequest.
@@ -6519,10 +6507,10 @@ type GetEventsSinksRequestReader interface {
 	Mutate() *GetEventsSinksRequest
 }
 
-type getEventsSinksRequestReadonly struct{ v *GetEventsSinksRequest }
+type getEventsSinksRequestReadonly GetEventsSinksRequest
 
 func (r *getEventsSinksRequestReadonly) Mutate() *GetEventsSinksRequest {
-	return r.v.CloneVT()
+	return (*GetEventsSinksRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetEventsSinksRequest.
@@ -6530,7 +6518,7 @@ func (m *GetEventsSinksRequest) AsReader() GetEventsSinksRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getEventsSinksRequestReadonly{v: m}
+	return (*getEventsSinksRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetEventsSinksRequest.
@@ -6583,18 +6571,18 @@ type GetEventsSinksResponseReader interface {
 	Mutate() *GetEventsSinksResponse
 }
 
-type getEventsSinksResponseReadonly struct{ v *GetEventsSinksResponse }
+type getEventsSinksResponseReadonly GetEventsSinksResponse
 
 func (r *getEventsSinksResponseReadonly) GetSinks() commonpb.SinkConfigListReader {
-	return commonpb.NewSinkConfigListReader(r.v.GetSinks())
+	return commonpb.NewSinkConfigListReader((*GetEventsSinksResponse)(r).GetSinks())
 }
 
 func (r *getEventsSinksResponseReadonly) GetSinkStatuses() commonpb.SinkStatusListReader {
-	return commonpb.NewSinkStatusListReader(r.v.GetSinkStatuses())
+	return commonpb.NewSinkStatusListReader((*GetEventsSinksResponse)(r).GetSinkStatuses())
 }
 
 func (r *getEventsSinksResponseReadonly) Mutate() *GetEventsSinksResponse {
-	return r.v.CloneVT()
+	return (*GetEventsSinksResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetEventsSinksResponse.
@@ -6602,7 +6590,7 @@ func (m *GetEventsSinksResponse) AsReader() GetEventsSinksResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getEventsSinksResponseReadonly{v: m}
+	return (*getEventsSinksResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetEventsSinksResponse.
@@ -6654,16 +6642,14 @@ type GetMetadataSchemaStatusRequestReader interface {
 	Mutate() *GetMetadataSchemaStatusRequest
 }
 
-type getMetadataSchemaStatusRequestReadonly struct {
-	v *GetMetadataSchemaStatusRequest
-}
+type getMetadataSchemaStatusRequestReadonly GetMetadataSchemaStatusRequest
 
 func (r *getMetadataSchemaStatusRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetMetadataSchemaStatusRequest)(r).GetLedger()
 }
 
 func (r *getMetadataSchemaStatusRequestReadonly) Mutate() *GetMetadataSchemaStatusRequest {
-	return r.v.CloneVT()
+	return (*GetMetadataSchemaStatusRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetMetadataSchemaStatusRequest.
@@ -6671,7 +6657,7 @@ func (m *GetMetadataSchemaStatusRequest) AsReader() GetMetadataSchemaStatusReque
 	if m == nil {
 		return nil
 	}
-	return &getMetadataSchemaStatusRequestReadonly{v: m}
+	return (*getMetadataSchemaStatusRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetMetadataSchemaStatusRequest.
@@ -6725,24 +6711,22 @@ type GetMetadataSchemaStatusResponseReader interface {
 	Mutate() *GetMetadataSchemaStatusResponse
 }
 
-type getMetadataSchemaStatusResponseReadonly struct {
-	v *GetMetadataSchemaStatusResponse
-}
+type getMetadataSchemaStatusResponseReadonly GetMetadataSchemaStatusResponse
 
 func (r *getMetadataSchemaStatusResponseReadonly) GetAccountFields() GetMetadataSchemaStatusResponse_AccountFieldsMapReader {
-	return getMetadataSchemaStatusResponse_accountFieldsMapReadonly(r.v.GetAccountFields())
+	return getMetadataSchemaStatusResponse_accountFieldsMapReadonly((*GetMetadataSchemaStatusResponse)(r).GetAccountFields())
 }
 
 func (r *getMetadataSchemaStatusResponseReadonly) GetTransactionFields() GetMetadataSchemaStatusResponse_TransactionFieldsMapReader {
-	return getMetadataSchemaStatusResponse_transactionFieldsMapReadonly(r.v.GetTransactionFields())
+	return getMetadataSchemaStatusResponse_transactionFieldsMapReadonly((*GetMetadataSchemaStatusResponse)(r).GetTransactionFields())
 }
 
 func (r *getMetadataSchemaStatusResponseReadonly) GetLedgerFields() GetMetadataSchemaStatusResponse_LedgerFieldsMapReader {
-	return getMetadataSchemaStatusResponse_ledgerFieldsMapReadonly(r.v.GetLedgerFields())
+	return getMetadataSchemaStatusResponse_ledgerFieldsMapReadonly((*GetMetadataSchemaStatusResponse)(r).GetLedgerFields())
 }
 
 func (r *getMetadataSchemaStatusResponseReadonly) Mutate() *GetMetadataSchemaStatusResponse {
-	return r.v.CloneVT()
+	return (*GetMetadataSchemaStatusResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetMetadataSchemaStatusResponse.
@@ -6750,7 +6734,7 @@ func (m *GetMetadataSchemaStatusResponse) AsReader() GetMetadataSchemaStatusResp
 	if m == nil {
 		return nil
 	}
-	return &getMetadataSchemaStatusResponseReadonly{v: m}
+	return (*getMetadataSchemaStatusResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetMetadataSchemaStatusResponse.
@@ -6895,14 +6879,14 @@ type MetadataFieldStatusReader interface {
 	Mutate() *MetadataFieldStatus
 }
 
-type metadataFieldStatusReadonly struct{ v *MetadataFieldStatus }
+type metadataFieldStatusReadonly MetadataFieldStatus
 
 func (r *metadataFieldStatusReadonly) GetDeclaredType() commonpb.MetadataType {
-	return r.v.GetDeclaredType()
+	return (*MetadataFieldStatus)(r).GetDeclaredType()
 }
 
 func (r *metadataFieldStatusReadonly) Mutate() *MetadataFieldStatus {
-	return r.v.CloneVT()
+	return (*MetadataFieldStatus)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this MetadataFieldStatus.
@@ -6910,7 +6894,7 @@ func (m *MetadataFieldStatus) AsReader() MetadataFieldStatusReader {
 	if m == nil {
 		return nil
 	}
-	return &metadataFieldStatusReadonly{v: m}
+	return (*metadataFieldStatusReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this MetadataFieldStatus.
@@ -6963,18 +6947,18 @@ type AnalyzeAccountsRequestReader interface {
 	Mutate() *AnalyzeAccountsRequest
 }
 
-type analyzeAccountsRequestReadonly struct{ v *AnalyzeAccountsRequest }
+type analyzeAccountsRequestReadonly AnalyzeAccountsRequest
 
 func (r *analyzeAccountsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*AnalyzeAccountsRequest)(r).GetLedger()
 }
 
 func (r *analyzeAccountsRequestReadonly) GetVariableThreshold() uint32 {
-	return r.v.GetVariableThreshold()
+	return (*AnalyzeAccountsRequest)(r).GetVariableThreshold()
 }
 
 func (r *analyzeAccountsRequestReadonly) Mutate() *AnalyzeAccountsRequest {
-	return r.v.CloneVT()
+	return (*AnalyzeAccountsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeAccountsRequest.
@@ -6982,7 +6966,7 @@ func (m *AnalyzeAccountsRequest) AsReader() AnalyzeAccountsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &analyzeAccountsRequestReadonly{v: m}
+	return (*analyzeAccountsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeAccountsRequest.
@@ -7035,18 +7019,18 @@ type AnalyzeAccountsResponseReader interface {
 	Mutate() *AnalyzeAccountsResponse
 }
 
-type analyzeAccountsResponseReadonly struct{ v *AnalyzeAccountsResponse }
+type analyzeAccountsResponseReadonly AnalyzeAccountsResponse
 
 func (r *analyzeAccountsResponseReadonly) GetPatterns() AccountPatternListReader {
-	return NewAccountPatternListReader(r.v.GetPatterns())
+	return NewAccountPatternListReader((*AnalyzeAccountsResponse)(r).GetPatterns())
 }
 
 func (r *analyzeAccountsResponseReadonly) GetTotalAccounts() uint64 {
-	return r.v.GetTotalAccounts()
+	return (*AnalyzeAccountsResponse)(r).GetTotalAccounts()
 }
 
 func (r *analyzeAccountsResponseReadonly) Mutate() *AnalyzeAccountsResponse {
-	return r.v.CloneVT()
+	return (*AnalyzeAccountsResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeAccountsResponse.
@@ -7054,7 +7038,7 @@ func (m *AnalyzeAccountsResponse) AsReader() AnalyzeAccountsResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &analyzeAccountsResponseReadonly{v: m}
+	return (*analyzeAccountsResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeAccountsResponse.
@@ -7108,22 +7092,22 @@ type AnalyzeProgressReader interface {
 	Mutate() *AnalyzeProgress
 }
 
-type analyzeProgressReadonly struct{ v *AnalyzeProgress }
+type analyzeProgressReadonly AnalyzeProgress
 
 func (r *analyzeProgressReadonly) GetProcessed() uint64 {
-	return r.v.GetProcessed()
+	return (*AnalyzeProgress)(r).GetProcessed()
 }
 
 func (r *analyzeProgressReadonly) GetTotal() uint64 {
-	return r.v.GetTotal()
+	return (*AnalyzeProgress)(r).GetTotal()
 }
 
 func (r *analyzeProgressReadonly) GetPhase() string {
-	return r.v.GetPhase()
+	return (*AnalyzeProgress)(r).GetPhase()
 }
 
 func (r *analyzeProgressReadonly) Mutate() *AnalyzeProgress {
-	return r.v.CloneVT()
+	return (*AnalyzeProgress)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeProgress.
@@ -7131,7 +7115,7 @@ func (m *AnalyzeProgress) AsReader() AnalyzeProgressReader {
 	if m == nil {
 		return nil
 	}
-	return &analyzeProgressReadonly{v: m}
+	return (*analyzeProgressReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeProgress.
@@ -7183,14 +7167,14 @@ type AnalyzeAccountsEventReader interface {
 	Mutate() *AnalyzeAccountsEvent
 }
 
-type analyzeAccountsEventReadonly struct{ v *AnalyzeAccountsEvent }
+type analyzeAccountsEventReadonly AnalyzeAccountsEvent
 
 func (r *analyzeAccountsEventReadonly) GetType() isAnalyzeAccountsEvent_Type {
-	return r.v.GetType()
+	return (*AnalyzeAccountsEvent)(r).GetType()
 }
 
 func (r *analyzeAccountsEventReadonly) Mutate() *AnalyzeAccountsEvent {
-	return r.v.CloneVT()
+	return (*AnalyzeAccountsEvent)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeAccountsEvent.
@@ -7198,7 +7182,7 @@ func (m *AnalyzeAccountsEvent) AsReader() AnalyzeAccountsEventReader {
 	if m == nil {
 		return nil
 	}
-	return &analyzeAccountsEventReadonly{v: m}
+	return (*analyzeAccountsEventReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeAccountsEvent.
@@ -7250,14 +7234,14 @@ type AnalyzeTransactionsEventReader interface {
 	Mutate() *AnalyzeTransactionsEvent
 }
 
-type analyzeTransactionsEventReadonly struct{ v *AnalyzeTransactionsEvent }
+type analyzeTransactionsEventReadonly AnalyzeTransactionsEvent
 
 func (r *analyzeTransactionsEventReadonly) GetType() isAnalyzeTransactionsEvent_Type {
-	return r.v.GetType()
+	return (*AnalyzeTransactionsEvent)(r).GetType()
 }
 
 func (r *analyzeTransactionsEventReadonly) Mutate() *AnalyzeTransactionsEvent {
-	return r.v.CloneVT()
+	return (*AnalyzeTransactionsEvent)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeTransactionsEvent.
@@ -7265,7 +7249,7 @@ func (m *AnalyzeTransactionsEvent) AsReader() AnalyzeTransactionsEventReader {
 	if m == nil {
 		return nil
 	}
-	return &analyzeTransactionsEventReadonly{v: m}
+	return (*analyzeTransactionsEventReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeTransactionsEvent.
@@ -7321,30 +7305,30 @@ type AccountPatternReader interface {
 	Mutate() *AccountPattern
 }
 
-type accountPatternReadonly struct{ v *AccountPattern }
+type accountPatternReadonly AccountPattern
 
 func (r *accountPatternReadonly) GetPattern() string {
-	return r.v.GetPattern()
+	return (*AccountPattern)(r).GetPattern()
 }
 
 func (r *accountPatternReadonly) GetAccountCount() uint64 {
-	return r.v.GetAccountCount()
+	return (*AccountPattern)(r).GetAccountCount()
 }
 
 func (r *accountPatternReadonly) GetAssets() []string {
-	return slices.Clone(r.v.GetAssets())
+	return slices.Clone((*AccountPattern)(r).GetAssets())
 }
 
 func (r *accountPatternReadonly) GetMetadataKeys() []string {
-	return slices.Clone(r.v.GetMetadataKeys())
+	return slices.Clone((*AccountPattern)(r).GetMetadataKeys())
 }
 
 func (r *accountPatternReadonly) GetSegments() PatternSegmentListReader {
-	return NewPatternSegmentListReader(r.v.GetSegments())
+	return NewPatternSegmentListReader((*AccountPattern)(r).GetSegments())
 }
 
 func (r *accountPatternReadonly) Mutate() *AccountPattern {
-	return r.v.CloneVT()
+	return (*AccountPattern)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AccountPattern.
@@ -7352,7 +7336,7 @@ func (m *AccountPattern) AsReader() AccountPatternReader {
 	if m == nil {
 		return nil
 	}
-	return &accountPatternReadonly{v: m}
+	return (*accountPatternReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AccountPattern.
@@ -7410,38 +7394,38 @@ type PatternSegmentReader interface {
 	Mutate() *PatternSegment
 }
 
-type patternSegmentReadonly struct{ v *PatternSegment }
+type patternSegmentReadonly PatternSegment
 
 func (r *patternSegmentReadonly) GetPosition() uint32 {
-	return r.v.GetPosition()
+	return (*PatternSegment)(r).GetPosition()
 }
 
 func (r *patternSegmentReadonly) GetType() PatternSegmentType {
-	return r.v.GetType()
+	return (*PatternSegment)(r).GetType()
 }
 
 func (r *patternSegmentReadonly) GetFixedValue() string {
-	return r.v.GetFixedValue()
+	return (*PatternSegment)(r).GetFixedValue()
 }
 
 func (r *patternSegmentReadonly) GetVariableName() string {
-	return r.v.GetVariableName()
+	return (*PatternSegment)(r).GetVariableName()
 }
 
 func (r *patternSegmentReadonly) GetInferredPattern() string {
-	return r.v.GetInferredPattern()
+	return (*PatternSegment)(r).GetInferredPattern()
 }
 
 func (r *patternSegmentReadonly) GetUniqueValues() uint64 {
-	return r.v.GetUniqueValues()
+	return (*PatternSegment)(r).GetUniqueValues()
 }
 
 func (r *patternSegmentReadonly) GetExamples() []string {
-	return slices.Clone(r.v.GetExamples())
+	return slices.Clone((*PatternSegment)(r).GetExamples())
 }
 
 func (r *patternSegmentReadonly) Mutate() *PatternSegment {
-	return r.v.CloneVT()
+	return (*PatternSegment)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PatternSegment.
@@ -7449,7 +7433,7 @@ func (m *PatternSegment) AsReader() PatternSegmentReader {
 	if m == nil {
 		return nil
 	}
-	return &patternSegmentReadonly{v: m}
+	return (*patternSegmentReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PatternSegment.
@@ -7502,18 +7486,18 @@ type AnalyzeTransactionsRequestReader interface {
 	Mutate() *AnalyzeTransactionsRequest
 }
 
-type analyzeTransactionsRequestReadonly struct{ v *AnalyzeTransactionsRequest }
+type analyzeTransactionsRequestReadonly AnalyzeTransactionsRequest
 
 func (r *analyzeTransactionsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*AnalyzeTransactionsRequest)(r).GetLedger()
 }
 
 func (r *analyzeTransactionsRequestReadonly) GetVariableThreshold() uint32 {
-	return r.v.GetVariableThreshold()
+	return (*AnalyzeTransactionsRequest)(r).GetVariableThreshold()
 }
 
 func (r *analyzeTransactionsRequestReadonly) Mutate() *AnalyzeTransactionsRequest {
-	return r.v.CloneVT()
+	return (*AnalyzeTransactionsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeTransactionsRequest.
@@ -7521,7 +7505,7 @@ func (m *AnalyzeTransactionsRequest) AsReader() AnalyzeTransactionsRequestReader
 	if m == nil {
 		return nil
 	}
-	return &analyzeTransactionsRequestReadonly{v: m}
+	return (*analyzeTransactionsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeTransactionsRequest.
@@ -7575,22 +7559,22 @@ type AnalyzeTransactionsResponseReader interface {
 	Mutate() *AnalyzeTransactionsResponse
 }
 
-type analyzeTransactionsResponseReadonly struct{ v *AnalyzeTransactionsResponse }
+type analyzeTransactionsResponseReadonly AnalyzeTransactionsResponse
 
 func (r *analyzeTransactionsResponseReadonly) GetFlowPatterns() FlowPatternListReader {
-	return NewFlowPatternListReader(r.v.GetFlowPatterns())
+	return NewFlowPatternListReader((*AnalyzeTransactionsResponse)(r).GetFlowPatterns())
 }
 
 func (r *analyzeTransactionsResponseReadonly) GetTotalTransactions() uint64 {
-	return r.v.GetTotalTransactions()
+	return (*AnalyzeTransactionsResponse)(r).GetTotalTransactions()
 }
 
 func (r *analyzeTransactionsResponseReadonly) GetTotalReverted() uint64 {
-	return r.v.GetTotalReverted()
+	return (*AnalyzeTransactionsResponse)(r).GetTotalReverted()
 }
 
 func (r *analyzeTransactionsResponseReadonly) Mutate() *AnalyzeTransactionsResponse {
-	return r.v.CloneVT()
+	return (*AnalyzeTransactionsResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AnalyzeTransactionsResponse.
@@ -7598,7 +7582,7 @@ func (m *AnalyzeTransactionsResponse) AsReader() AnalyzeTransactionsResponseRead
 	if m == nil {
 		return nil
 	}
-	return &analyzeTransactionsResponseReadonly{v: m}
+	return (*analyzeTransactionsResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AnalyzeTransactionsResponse.
@@ -7656,26 +7640,26 @@ type FlowPatternReader interface {
 	Mutate() *FlowPattern
 }
 
-type flowPatternReadonly struct{ v *FlowPattern }
+type flowPatternReadonly FlowPattern
 
 func (r *flowPatternReadonly) GetSignature() string {
-	return r.v.GetSignature()
+	return (*FlowPattern)(r).GetSignature()
 }
 
 func (r *flowPatternReadonly) GetStructure() PostingStructure {
-	return r.v.GetStructure()
+	return (*FlowPattern)(r).GetStructure()
 }
 
 func (r *flowPatternReadonly) GetTransactionCount() uint64 {
-	return r.v.GetTransactionCount()
+	return (*FlowPattern)(r).GetTransactionCount()
 }
 
 func (r *flowPatternReadonly) GetPostings() NormalizedPostingListReader {
-	return NewNormalizedPostingListReader(r.v.GetPostings())
+	return NewNormalizedPostingListReader((*FlowPattern)(r).GetPostings())
 }
 
 func (r *flowPatternReadonly) GetTemporal() TemporalStatsReader {
-	v := r.v.GetTemporal()
+	v := (*FlowPattern)(r).GetTemporal()
 	if v == nil {
 		return nil
 	}
@@ -7683,15 +7667,15 @@ func (r *flowPatternReadonly) GetTemporal() TemporalStatsReader {
 }
 
 func (r *flowPatternReadonly) GetVolumeStats() AssetVolumeStatsListReader {
-	return NewAssetVolumeStatsListReader(r.v.GetVolumeStats())
+	return NewAssetVolumeStatsListReader((*FlowPattern)(r).GetVolumeStats())
 }
 
 func (r *flowPatternReadonly) GetMetadataKeys() []string {
-	return slices.Clone(r.v.GetMetadataKeys())
+	return slices.Clone((*FlowPattern)(r).GetMetadataKeys())
 }
 
 func (r *flowPatternReadonly) Mutate() *FlowPattern {
-	return r.v.CloneVT()
+	return (*FlowPattern)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FlowPattern.
@@ -7699,7 +7683,7 @@ func (m *FlowPattern) AsReader() FlowPatternReader {
 	if m == nil {
 		return nil
 	}
-	return &flowPatternReadonly{v: m}
+	return (*flowPatternReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FlowPattern.
@@ -7753,22 +7737,22 @@ type NormalizedPostingReader interface {
 	Mutate() *NormalizedPosting
 }
 
-type normalizedPostingReadonly struct{ v *NormalizedPosting }
+type normalizedPostingReadonly NormalizedPosting
 
 func (r *normalizedPostingReadonly) GetSourcePattern() string {
-	return r.v.GetSourcePattern()
+	return (*NormalizedPosting)(r).GetSourcePattern()
 }
 
 func (r *normalizedPostingReadonly) GetDestinationPattern() string {
-	return r.v.GetDestinationPattern()
+	return (*NormalizedPosting)(r).GetDestinationPattern()
 }
 
 func (r *normalizedPostingReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*NormalizedPosting)(r).GetAsset()
 }
 
 func (r *normalizedPostingReadonly) Mutate() *NormalizedPosting {
-	return r.v.CloneVT()
+	return (*NormalizedPosting)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this NormalizedPosting.
@@ -7776,7 +7760,7 @@ func (m *NormalizedPosting) AsReader() NormalizedPostingReader {
 	if m == nil {
 		return nil
 	}
-	return &normalizedPostingReadonly{v: m}
+	return (*normalizedPostingReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this NormalizedPosting.
@@ -7831,10 +7815,10 @@ type TemporalStatsReader interface {
 	Mutate() *TemporalStats
 }
 
-type temporalStatsReadonly struct{ v *TemporalStats }
+type temporalStatsReadonly TemporalStats
 
 func (r *temporalStatsReadonly) GetFirstSeen() commonpb.TimestampReader {
-	v := r.v.GetFirstSeen()
+	v := (*TemporalStats)(r).GetFirstSeen()
 	if v == nil {
 		return nil
 	}
@@ -7842,7 +7826,7 @@ func (r *temporalStatsReadonly) GetFirstSeen() commonpb.TimestampReader {
 }
 
 func (r *temporalStatsReadonly) GetLastSeen() commonpb.TimestampReader {
-	v := r.v.GetLastSeen()
+	v := (*TemporalStats)(r).GetLastSeen()
 	if v == nil {
 		return nil
 	}
@@ -7850,15 +7834,15 @@ func (r *temporalStatsReadonly) GetLastSeen() commonpb.TimestampReader {
 }
 
 func (r *temporalStatsReadonly) GetTransactionsPerDay() float64 {
-	return r.v.GetTransactionsPerDay()
+	return (*TemporalStats)(r).GetTransactionsPerDay()
 }
 
 func (r *temporalStatsReadonly) GetPeakHours() HourBucketListReader {
-	return NewHourBucketListReader(r.v.GetPeakHours())
+	return NewHourBucketListReader((*TemporalStats)(r).GetPeakHours())
 }
 
 func (r *temporalStatsReadonly) Mutate() *TemporalStats {
-	return r.v.CloneVT()
+	return (*TemporalStats)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this TemporalStats.
@@ -7866,7 +7850,7 @@ func (m *TemporalStats) AsReader() TemporalStatsReader {
 	if m == nil {
 		return nil
 	}
-	return &temporalStatsReadonly{v: m}
+	return (*temporalStatsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this TemporalStats.
@@ -7919,18 +7903,18 @@ type HourBucketReader interface {
 	Mutate() *HourBucket
 }
 
-type hourBucketReadonly struct{ v *HourBucket }
+type hourBucketReadonly HourBucket
 
 func (r *hourBucketReadonly) GetHour() uint32 {
-	return r.v.GetHour()
+	return (*HourBucket)(r).GetHour()
 }
 
 func (r *hourBucketReadonly) GetCount() uint64 {
-	return r.v.GetCount()
+	return (*HourBucket)(r).GetCount()
 }
 
 func (r *hourBucketReadonly) Mutate() *HourBucket {
-	return r.v.CloneVT()
+	return (*HourBucket)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this HourBucket.
@@ -7938,7 +7922,7 @@ func (m *HourBucket) AsReader() HourBucketReader {
 	if m == nil {
 		return nil
 	}
-	return &hourBucketReadonly{v: m}
+	return (*hourBucketReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this HourBucket.
@@ -7993,34 +7977,34 @@ type AssetVolumeStatsReader interface {
 	Mutate() *AssetVolumeStats
 }
 
-type assetVolumeStatsReadonly struct{ v *AssetVolumeStats }
+type assetVolumeStatsReadonly AssetVolumeStats
 
 func (r *assetVolumeStatsReadonly) GetAsset() string {
-	return r.v.GetAsset()
+	return (*AssetVolumeStats)(r).GetAsset()
 }
 
 func (r *assetVolumeStatsReadonly) GetTotalVolume() string {
-	return r.v.GetTotalVolume()
+	return (*AssetVolumeStats)(r).GetTotalVolume()
 }
 
 func (r *assetVolumeStatsReadonly) GetAverageVolume() string {
-	return r.v.GetAverageVolume()
+	return (*AssetVolumeStats)(r).GetAverageVolume()
 }
 
 func (r *assetVolumeStatsReadonly) GetMinVolume() string {
-	return r.v.GetMinVolume()
+	return (*AssetVolumeStats)(r).GetMinVolume()
 }
 
 func (r *assetVolumeStatsReadonly) GetMaxVolume() string {
-	return r.v.GetMaxVolume()
+	return (*AssetVolumeStats)(r).GetMaxVolume()
 }
 
 func (r *assetVolumeStatsReadonly) GetTransactionCount() uint64 {
-	return r.v.GetTransactionCount()
+	return (*AssetVolumeStats)(r).GetTransactionCount()
 }
 
 func (r *assetVolumeStatsReadonly) Mutate() *AssetVolumeStats {
-	return r.v.CloneVT()
+	return (*AssetVolumeStats)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AssetVolumeStats.
@@ -8028,7 +8012,7 @@ func (m *AssetVolumeStats) AsReader() AssetVolumeStatsReader {
 	if m == nil {
 		return nil
 	}
-	return &assetVolumeStatsReadonly{v: m}
+	return (*assetVolumeStatsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AssetVolumeStats.
@@ -8081,14 +8065,14 @@ type CreatePreparedQueryRequestReader interface {
 	Mutate() *CreatePreparedQueryRequest
 }
 
-type createPreparedQueryRequestReadonly struct{ v *CreatePreparedQueryRequest }
+type createPreparedQueryRequestReadonly CreatePreparedQueryRequest
 
 func (r *createPreparedQueryRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*CreatePreparedQueryRequest)(r).GetLedger()
 }
 
 func (r *createPreparedQueryRequestReadonly) GetQuery() commonpb.PreparedQueryReader {
-	v := r.v.GetQuery()
+	v := (*CreatePreparedQueryRequest)(r).GetQuery()
 	if v == nil {
 		return nil
 	}
@@ -8096,7 +8080,7 @@ func (r *createPreparedQueryRequestReadonly) GetQuery() commonpb.PreparedQueryRe
 }
 
 func (r *createPreparedQueryRequestReadonly) Mutate() *CreatePreparedQueryRequest {
-	return r.v.CloneVT()
+	return (*CreatePreparedQueryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatePreparedQueryRequest.
@@ -8104,7 +8088,7 @@ func (m *CreatePreparedQueryRequest) AsReader() CreatePreparedQueryRequestReader
 	if m == nil {
 		return nil
 	}
-	return &createPreparedQueryRequestReadonly{v: m}
+	return (*createPreparedQueryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatePreparedQueryRequest.
@@ -8155,10 +8139,10 @@ type CreatePreparedQueryResponseReader interface {
 	Mutate() *CreatePreparedQueryResponse
 }
 
-type createPreparedQueryResponseReadonly struct{ v *CreatePreparedQueryResponse }
+type createPreparedQueryResponseReadonly CreatePreparedQueryResponse
 
 func (r *createPreparedQueryResponseReadonly) Mutate() *CreatePreparedQueryResponse {
-	return r.v.CloneVT()
+	return (*CreatePreparedQueryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CreatePreparedQueryResponse.
@@ -8166,7 +8150,7 @@ func (m *CreatePreparedQueryResponse) AsReader() CreatePreparedQueryResponseRead
 	if m == nil {
 		return nil
 	}
-	return &createPreparedQueryResponseReadonly{v: m}
+	return (*createPreparedQueryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CreatePreparedQueryResponse.
@@ -8220,18 +8204,18 @@ type UpdatePreparedQueryRequestReader interface {
 	Mutate() *UpdatePreparedQueryRequest
 }
 
-type updatePreparedQueryRequestReadonly struct{ v *UpdatePreparedQueryRequest }
+type updatePreparedQueryRequestReadonly UpdatePreparedQueryRequest
 
 func (r *updatePreparedQueryRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*UpdatePreparedQueryRequest)(r).GetLedger()
 }
 
 func (r *updatePreparedQueryRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*UpdatePreparedQueryRequest)(r).GetName()
 }
 
 func (r *updatePreparedQueryRequestReadonly) GetFilter() commonpb.QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*UpdatePreparedQueryRequest)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -8239,7 +8223,7 @@ func (r *updatePreparedQueryRequestReadonly) GetFilter() commonpb.QueryFilterRea
 }
 
 func (r *updatePreparedQueryRequestReadonly) Mutate() *UpdatePreparedQueryRequest {
-	return r.v.CloneVT()
+	return (*UpdatePreparedQueryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdatePreparedQueryRequest.
@@ -8247,7 +8231,7 @@ func (m *UpdatePreparedQueryRequest) AsReader() UpdatePreparedQueryRequestReader
 	if m == nil {
 		return nil
 	}
-	return &updatePreparedQueryRequestReadonly{v: m}
+	return (*updatePreparedQueryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdatePreparedQueryRequest.
@@ -8298,10 +8282,10 @@ type UpdatePreparedQueryResponseReader interface {
 	Mutate() *UpdatePreparedQueryResponse
 }
 
-type updatePreparedQueryResponseReadonly struct{ v *UpdatePreparedQueryResponse }
+type updatePreparedQueryResponseReadonly UpdatePreparedQueryResponse
 
 func (r *updatePreparedQueryResponseReadonly) Mutate() *UpdatePreparedQueryResponse {
-	return r.v.CloneVT()
+	return (*UpdatePreparedQueryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this UpdatePreparedQueryResponse.
@@ -8309,7 +8293,7 @@ func (m *UpdatePreparedQueryResponse) AsReader() UpdatePreparedQueryResponseRead
 	if m == nil {
 		return nil
 	}
-	return &updatePreparedQueryResponseReadonly{v: m}
+	return (*updatePreparedQueryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this UpdatePreparedQueryResponse.
@@ -8362,18 +8346,18 @@ type DeletePreparedQueryRequestReader interface {
 	Mutate() *DeletePreparedQueryRequest
 }
 
-type deletePreparedQueryRequestReadonly struct{ v *DeletePreparedQueryRequest }
+type deletePreparedQueryRequestReadonly DeletePreparedQueryRequest
 
 func (r *deletePreparedQueryRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*DeletePreparedQueryRequest)(r).GetLedger()
 }
 
 func (r *deletePreparedQueryRequestReadonly) GetName() string {
-	return r.v.GetName()
+	return (*DeletePreparedQueryRequest)(r).GetName()
 }
 
 func (r *deletePreparedQueryRequestReadonly) Mutate() *DeletePreparedQueryRequest {
-	return r.v.CloneVT()
+	return (*DeletePreparedQueryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletePreparedQueryRequest.
@@ -8381,7 +8365,7 @@ func (m *DeletePreparedQueryRequest) AsReader() DeletePreparedQueryRequestReader
 	if m == nil {
 		return nil
 	}
-	return &deletePreparedQueryRequestReadonly{v: m}
+	return (*deletePreparedQueryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletePreparedQueryRequest.
@@ -8432,10 +8416,10 @@ type DeletePreparedQueryResponseReader interface {
 	Mutate() *DeletePreparedQueryResponse
 }
 
-type deletePreparedQueryResponseReadonly struct{ v *DeletePreparedQueryResponse }
+type deletePreparedQueryResponseReadonly DeletePreparedQueryResponse
 
 func (r *deletePreparedQueryResponseReadonly) Mutate() *DeletePreparedQueryResponse {
-	return r.v.CloneVT()
+	return (*DeletePreparedQueryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this DeletePreparedQueryResponse.
@@ -8443,7 +8427,7 @@ func (m *DeletePreparedQueryResponse) AsReader() DeletePreparedQueryResponseRead
 	if m == nil {
 		return nil
 	}
-	return &deletePreparedQueryResponseReadonly{v: m}
+	return (*deletePreparedQueryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this DeletePreparedQueryResponse.
@@ -8495,14 +8479,14 @@ type ListPreparedQueriesRequestReader interface {
 	Mutate() *ListPreparedQueriesRequest
 }
 
-type listPreparedQueriesRequestReadonly struct{ v *ListPreparedQueriesRequest }
+type listPreparedQueriesRequestReadonly ListPreparedQueriesRequest
 
 func (r *listPreparedQueriesRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListPreparedQueriesRequest)(r).GetLedger()
 }
 
 func (r *listPreparedQueriesRequestReadonly) Mutate() *ListPreparedQueriesRequest {
-	return r.v.CloneVT()
+	return (*ListPreparedQueriesRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListPreparedQueriesRequest.
@@ -8510,7 +8494,7 @@ func (m *ListPreparedQueriesRequest) AsReader() ListPreparedQueriesRequestReader
 	if m == nil {
 		return nil
 	}
-	return &listPreparedQueriesRequestReadonly{v: m}
+	return (*listPreparedQueriesRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListPreparedQueriesRequest.
@@ -8562,14 +8546,14 @@ type ListPreparedQueriesResponseReader interface {
 	Mutate() *ListPreparedQueriesResponse
 }
 
-type listPreparedQueriesResponseReadonly struct{ v *ListPreparedQueriesResponse }
+type listPreparedQueriesResponseReadonly ListPreparedQueriesResponse
 
 func (r *listPreparedQueriesResponseReadonly) GetQueries() commonpb.PreparedQueryListReader {
-	return commonpb.NewPreparedQueryListReader(r.v.GetQueries())
+	return commonpb.NewPreparedQueryListReader((*ListPreparedQueriesResponse)(r).GetQueries())
 }
 
 func (r *listPreparedQueriesResponseReadonly) Mutate() *ListPreparedQueriesResponse {
-	return r.v.CloneVT()
+	return (*ListPreparedQueriesResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListPreparedQueriesResponse.
@@ -8577,7 +8561,7 @@ func (m *ListPreparedQueriesResponse) AsReader() ListPreparedQueriesResponseRead
 	if m == nil {
 		return nil
 	}
-	return &listPreparedQueriesResponseReadonly{v: m}
+	return (*listPreparedQueriesResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListPreparedQueriesResponse.
@@ -8635,38 +8619,38 @@ type ExecutePreparedQueryRequestReader interface {
 	Mutate() *ExecutePreparedQueryRequest
 }
 
-type executePreparedQueryRequestReadonly struct{ v *ExecutePreparedQueryRequest }
+type executePreparedQueryRequestReadonly ExecutePreparedQueryRequest
 
 func (r *executePreparedQueryRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ExecutePreparedQueryRequest)(r).GetLedger()
 }
 
 func (r *executePreparedQueryRequestReadonly) GetQueryName() string {
-	return r.v.GetQueryName()
+	return (*ExecutePreparedQueryRequest)(r).GetQueryName()
 }
 
 func (r *executePreparedQueryRequestReadonly) GetParameters() ExecutePreparedQueryRequest_ParametersMapReader {
-	return executePreparedQueryRequest_parametersMapReadonly(r.v.GetParameters())
+	return executePreparedQueryRequest_parametersMapReadonly((*ExecutePreparedQueryRequest)(r).GetParameters())
 }
 
 func (r *executePreparedQueryRequestReadonly) GetPageSize() uint32 {
-	return r.v.GetPageSize()
+	return (*ExecutePreparedQueryRequest)(r).GetPageSize()
 }
 
 func (r *executePreparedQueryRequestReadonly) GetCursor() string {
-	return r.v.GetCursor()
+	return (*ExecutePreparedQueryRequest)(r).GetCursor()
 }
 
 func (r *executePreparedQueryRequestReadonly) GetMinLogSequence() uint64 {
-	return r.v.GetMinLogSequence()
+	return (*ExecutePreparedQueryRequest)(r).GetMinLogSequence()
 }
 
 func (r *executePreparedQueryRequestReadonly) GetMode() commonpb.QueryMode {
-	return r.v.GetMode()
+	return (*ExecutePreparedQueryRequest)(r).GetMode()
 }
 
 func (r *executePreparedQueryRequestReadonly) Mutate() *ExecutePreparedQueryRequest {
-	return r.v.CloneVT()
+	return (*ExecutePreparedQueryRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ExecutePreparedQueryRequest.
@@ -8674,7 +8658,7 @@ func (m *ExecutePreparedQueryRequest) AsReader() ExecutePreparedQueryRequestRead
 	if m == nil {
 		return nil
 	}
-	return &executePreparedQueryRequestReadonly{v: m}
+	return (*executePreparedQueryRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ExecutePreparedQueryRequest.
@@ -8757,14 +8741,14 @@ type ExecutePreparedQueryResponseReader interface {
 	Mutate() *ExecutePreparedQueryResponse
 }
 
-type executePreparedQueryResponseReadonly struct{ v *ExecutePreparedQueryResponse }
+type executePreparedQueryResponseReadonly ExecutePreparedQueryResponse
 
 func (r *executePreparedQueryResponseReadonly) GetResult() isExecutePreparedQueryResponse_Result {
-	return r.v.GetResult()
+	return (*ExecutePreparedQueryResponse)(r).GetResult()
 }
 
 func (r *executePreparedQueryResponseReadonly) Mutate() *ExecutePreparedQueryResponse {
-	return r.v.CloneVT()
+	return (*ExecutePreparedQueryResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ExecutePreparedQueryResponse.
@@ -8772,7 +8756,7 @@ func (m *ExecutePreparedQueryResponse) AsReader() ExecutePreparedQueryResponseRe
 	if m == nil {
 		return nil
 	}
-	return &executePreparedQueryResponseReadonly{v: m}
+	return (*executePreparedQueryResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ExecutePreparedQueryResponse.
@@ -8824,14 +8808,14 @@ type GetIndexStatusRequestReader interface {
 	Mutate() *GetIndexStatusRequest
 }
 
-type getIndexStatusRequestReadonly struct{ v *GetIndexStatusRequest }
+type getIndexStatusRequestReadonly GetIndexStatusRequest
 
 func (r *getIndexStatusRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetIndexStatusRequest)(r).GetLedger()
 }
 
 func (r *getIndexStatusRequestReadonly) Mutate() *GetIndexStatusRequest {
-	return r.v.CloneVT()
+	return (*GetIndexStatusRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetIndexStatusRequest.
@@ -8839,7 +8823,7 @@ func (m *GetIndexStatusRequest) AsReader() GetIndexStatusRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getIndexStatusRequestReadonly{v: m}
+	return (*getIndexStatusRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetIndexStatusRequest.
@@ -8895,30 +8879,30 @@ type GetIndexStatusResponseReader interface {
 	Mutate() *GetIndexStatusResponse
 }
 
-type getIndexStatusResponseReadonly struct{ v *GetIndexStatusResponse }
+type getIndexStatusResponseReadonly GetIndexStatusResponse
 
 func (r *getIndexStatusResponseReadonly) GetLastIndexedSequence() uint64 {
-	return r.v.GetLastIndexedSequence()
+	return (*GetIndexStatusResponse)(r).GetLastIndexedSequence()
 }
 
 func (r *getIndexStatusResponseReadonly) GetLastLogSequence() uint64 {
-	return r.v.GetLastLogSequence()
+	return (*GetIndexStatusResponse)(r).GetLastLogSequence()
 }
 
 func (r *getIndexStatusResponseReadonly) GetLag() uint64 {
-	return r.v.GetLag()
+	return (*GetIndexStatusResponse)(r).GetLag()
 }
 
 func (r *getIndexStatusResponseReadonly) GetIndexFileSize() uint64 {
-	return r.v.GetIndexFileSize()
+	return (*GetIndexStatusResponse)(r).GetIndexFileSize()
 }
 
 func (r *getIndexStatusResponseReadonly) GetIndexes() IndexEntryListReader {
-	return NewIndexEntryListReader(r.v.GetIndexes())
+	return NewIndexEntryListReader((*GetIndexStatusResponse)(r).GetIndexes())
 }
 
 func (r *getIndexStatusResponseReadonly) Mutate() *GetIndexStatusResponse {
-	return r.v.CloneVT()
+	return (*GetIndexStatusResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetIndexStatusResponse.
@@ -8926,7 +8910,7 @@ func (m *GetIndexStatusResponse) AsReader() GetIndexStatusResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &getIndexStatusResponseReadonly{v: m}
+	return (*getIndexStatusResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetIndexStatusResponse.
@@ -8982,14 +8966,14 @@ type IndexEntryReader interface {
 	Mutate() *IndexEntry
 }
 
-type indexEntryReadonly struct{ v *IndexEntry }
+type indexEntryReadonly IndexEntry
 
 func (r *indexEntryReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*IndexEntry)(r).GetLedger()
 }
 
 func (r *indexEntryReadonly) GetIndex() commonpb.IndexReader {
-	v := r.v.GetIndex()
+	v := (*IndexEntry)(r).GetIndex()
 	if v == nil {
 		return nil
 	}
@@ -8997,19 +8981,19 @@ func (r *indexEntryReadonly) GetIndex() commonpb.IndexReader {
 }
 
 func (r *indexEntryReadonly) GetCursor() uint64 {
-	return r.v.GetCursor()
+	return (*IndexEntry)(r).GetCursor()
 }
 
 func (r *indexEntryReadonly) GetCurrentVersion() uint32 {
-	return r.v.GetCurrentVersion()
+	return (*IndexEntry)(r).GetCurrentVersion()
 }
 
 func (r *indexEntryReadonly) GetPendingVersion() uint32 {
-	return r.v.GetPendingVersion()
+	return (*IndexEntry)(r).GetPendingVersion()
 }
 
 func (r *indexEntryReadonly) Mutate() *IndexEntry {
-	return r.v.CloneVT()
+	return (*IndexEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IndexEntry.
@@ -9017,7 +9001,7 @@ func (m *IndexEntry) AsReader() IndexEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &indexEntryReadonly{v: m}
+	return (*indexEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IndexEntry.
@@ -9068,18 +9052,18 @@ type ListIndexesRequestReader interface {
 	Mutate() *ListIndexesRequest
 }
 
-type listIndexesRequestReadonly struct{ v *ListIndexesRequest }
+type listIndexesRequestReadonly ListIndexesRequest
 
 func (r *listIndexesRequestReadonly) GetScope() ListIndexesRequest_Scope {
-	return r.v.GetScope()
+	return (*ListIndexesRequest)(r).GetScope()
 }
 
 func (r *listIndexesRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*ListIndexesRequest)(r).GetLedger()
 }
 
 func (r *listIndexesRequestReadonly) Mutate() *ListIndexesRequest {
-	return r.v.CloneVT()
+	return (*ListIndexesRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this ListIndexesRequest.
@@ -9087,7 +9071,7 @@ func (m *ListIndexesRequest) AsReader() ListIndexesRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &listIndexesRequestReadonly{v: m}
+	return (*listIndexesRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this ListIndexesRequest.
@@ -9140,18 +9124,18 @@ type GetLedgerStatsRequestReader interface {
 	Mutate() *GetLedgerStatsRequest
 }
 
-type getLedgerStatsRequestReadonly struct{ v *GetLedgerStatsRequest }
+type getLedgerStatsRequestReadonly GetLedgerStatsRequest
 
 func (r *getLedgerStatsRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*GetLedgerStatsRequest)(r).GetLedger()
 }
 
 func (r *getLedgerStatsRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*GetLedgerStatsRequest)(r).GetCheckpointId()
 }
 
 func (r *getLedgerStatsRequestReadonly) Mutate() *GetLedgerStatsRequest {
-	return r.v.CloneVT()
+	return (*GetLedgerStatsRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this GetLedgerStatsRequest.
@@ -9159,7 +9143,7 @@ func (m *GetLedgerStatsRequest) AsReader() GetLedgerStatsRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &getLedgerStatsRequestReadonly{v: m}
+	return (*getLedgerStatsRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this GetLedgerStatsRequest.
@@ -9216,14 +9200,14 @@ type AggregateVolumesRequestReader interface {
 	Mutate() *AggregateVolumesRequest
 }
 
-type aggregateVolumesRequestReadonly struct{ v *AggregateVolumesRequest }
+type aggregateVolumesRequestReadonly AggregateVolumesRequest
 
 func (r *aggregateVolumesRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*AggregateVolumesRequest)(r).GetLedger()
 }
 
 func (r *aggregateVolumesRequestReadonly) GetFilter() commonpb.QueryFilterReader {
-	v := r.v.GetFilter()
+	v := (*AggregateVolumesRequest)(r).GetFilter()
 	if v == nil {
 		return nil
 	}
@@ -9231,23 +9215,23 @@ func (r *aggregateVolumesRequestReadonly) GetFilter() commonpb.QueryFilterReader
 }
 
 func (r *aggregateVolumesRequestReadonly) GetMinLogSequence() uint64 {
-	return r.v.GetMinLogSequence()
+	return (*AggregateVolumesRequest)(r).GetMinLogSequence()
 }
 
 func (r *aggregateVolumesRequestReadonly) GetUseMaxPrecision() bool {
-	return r.v.GetUseMaxPrecision()
+	return (*AggregateVolumesRequest)(r).GetUseMaxPrecision()
 }
 
 func (r *aggregateVolumesRequestReadonly) GetGroupByPrefixes() []string {
-	return slices.Clone(r.v.GetGroupByPrefixes())
+	return slices.Clone((*AggregateVolumesRequest)(r).GetGroupByPrefixes())
 }
 
 func (r *aggregateVolumesRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*AggregateVolumesRequest)(r).GetCheckpointId()
 }
 
 func (r *aggregateVolumesRequestReadonly) Mutate() *AggregateVolumesRequest {
-	return r.v.CloneVT()
+	return (*AggregateVolumesRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this AggregateVolumesRequest.
@@ -9255,7 +9239,7 @@ func (m *AggregateVolumesRequest) AsReader() AggregateVolumesRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &aggregateVolumesRequestReadonly{v: m}
+	return (*aggregateVolumesRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this AggregateVolumesRequest.
@@ -9313,34 +9297,34 @@ type QueryProfileReader interface {
 	Mutate() *QueryProfile
 }
 
-type queryProfileReadonly struct{ v *QueryProfile }
+type queryProfileReadonly QueryProfile
 
 func (r *queryProfileReadonly) GetIndexDurationUs() int64 {
-	return r.v.GetIndexDurationUs()
+	return (*QueryProfile)(r).GetIndexDurationUs()
 }
 
 func (r *queryProfileReadonly) GetEnrichmentDurationUs() int64 {
-	return r.v.GetEnrichmentDurationUs()
+	return (*QueryProfile)(r).GetEnrichmentDurationUs()
 }
 
 func (r *queryProfileReadonly) GetItemsCollected() int32 {
-	return r.v.GetItemsCollected()
+	return (*QueryProfile)(r).GetItemsCollected()
 }
 
 func (r *queryProfileReadonly) GetEnrichedCount() int32 {
-	return r.v.GetEnrichedCount()
+	return (*QueryProfile)(r).GetEnrichedCount()
 }
 
 func (r *queryProfileReadonly) GetMaterializedRanges() int32 {
-	return r.v.GetMaterializedRanges()
+	return (*QueryProfile)(r).GetMaterializedRanges()
 }
 
 func (r *queryProfileReadonly) GetMaterializedItems() int32 {
-	return r.v.GetMaterializedItems()
+	return (*QueryProfile)(r).GetMaterializedItems()
 }
 
 func (r *queryProfileReadonly) GetRootIterator() IteratorProfileReader {
-	v := r.v.GetRootIterator()
+	v := (*QueryProfile)(r).GetRootIterator()
 	if v == nil {
 		return nil
 	}
@@ -9348,7 +9332,7 @@ func (r *queryProfileReadonly) GetRootIterator() IteratorProfileReader {
 }
 
 func (r *queryProfileReadonly) Mutate() *QueryProfile {
-	return r.v.CloneVT()
+	return (*QueryProfile)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this QueryProfile.
@@ -9356,7 +9340,7 @@ func (m *QueryProfile) AsReader() QueryProfileReader {
 	if m == nil {
 		return nil
 	}
-	return &queryProfileReadonly{v: m}
+	return (*queryProfileReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this QueryProfile.
@@ -9418,54 +9402,54 @@ type IteratorProfileReader interface {
 	Mutate() *IteratorProfile
 }
 
-type iteratorProfileReadonly struct{ v *IteratorProfile }
+type iteratorProfileReadonly IteratorProfile
 
 func (r *iteratorProfileReadonly) GetLabel() string {
-	return r.v.GetLabel()
+	return (*IteratorProfile)(r).GetLabel()
 }
 
 func (r *iteratorProfileReadonly) GetKind() string {
-	return r.v.GetKind()
+	return (*IteratorProfile)(r).GetKind()
 }
 
 func (r *iteratorProfileReadonly) GetBucket() string {
-	return r.v.GetBucket()
+	return (*IteratorProfile)(r).GetBucket()
 }
 
 func (r *iteratorProfileReadonly) GetNextCalls() int64 {
-	return r.v.GetNextCalls()
+	return (*IteratorProfile)(r).GetNextCalls()
 }
 
 func (r *iteratorProfileReadonly) GetSeekCalls() int64 {
-	return r.v.GetSeekCalls()
+	return (*IteratorProfile)(r).GetSeekCalls()
 }
 
 func (r *iteratorProfileReadonly) GetChildren() IteratorProfileListReader {
-	return NewIteratorProfileListReader(r.v.GetChildren())
+	return NewIteratorProfileListReader((*IteratorProfile)(r).GetChildren())
 }
 
 func (r *iteratorProfileReadonly) GetDurationUs() int64 {
-	return r.v.GetDurationUs()
+	return (*IteratorProfile)(r).GetDurationUs()
 }
 
 func (r *iteratorProfileReadonly) GetItemsEmitted() int64 {
-	return r.v.GetItemsEmitted()
+	return (*IteratorProfile)(r).GetItemsEmitted()
 }
 
 func (r *iteratorProfileReadonly) GetMaterializedRanges() int32 {
-	return r.v.GetMaterializedRanges()
+	return (*IteratorProfile)(r).GetMaterializedRanges()
 }
 
 func (r *iteratorProfileReadonly) GetMaterializedItems() int64 {
-	return r.v.GetMaterializedItems()
+	return (*IteratorProfile)(r).GetMaterializedItems()
 }
 
 func (r *iteratorProfileReadonly) GetItemsSkipped() int64 {
-	return r.v.GetItemsSkipped()
+	return (*IteratorProfile)(r).GetItemsSkipped()
 }
 
 func (r *iteratorProfileReadonly) Mutate() *IteratorProfile {
-	return r.v.CloneVT()
+	return (*IteratorProfile)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this IteratorProfile.
@@ -9473,7 +9457,7 @@ func (m *IteratorProfile) AsReader() IteratorProfileReader {
 	if m == nil {
 		return nil
 	}
-	return &iteratorProfileReadonly{v: m}
+	return (*iteratorProfileReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this IteratorProfile.
@@ -9531,38 +9515,38 @@ type InspectIndexRequestReader interface {
 	Mutate() *InspectIndexRequest
 }
 
-type inspectIndexRequestReadonly struct{ v *InspectIndexRequest }
+type inspectIndexRequestReadonly InspectIndexRequest
 
 func (r *inspectIndexRequestReadonly) GetLedger() string {
-	return r.v.GetLedger()
+	return (*InspectIndexRequest)(r).GetLedger()
 }
 
 func (r *inspectIndexRequestReadonly) GetTargetType() commonpb.TargetType {
-	return r.v.GetTargetType()
+	return (*InspectIndexRequest)(r).GetTargetType()
 }
 
 func (r *inspectIndexRequestReadonly) GetMetadataKey() string {
-	return r.v.GetMetadataKey()
+	return (*InspectIndexRequest)(r).GetMetadataKey()
 }
 
 func (r *inspectIndexRequestReadonly) GetMode() InspectIndexMode {
-	return r.v.GetMode()
+	return (*InspectIndexRequest)(r).GetMode()
 }
 
 func (r *inspectIndexRequestReadonly) GetPageSize() uint32 {
-	return r.v.GetPageSize()
+	return (*InspectIndexRequest)(r).GetPageSize()
 }
 
 func (r *inspectIndexRequestReadonly) GetCursor() string {
-	return r.v.GetCursor()
+	return (*InspectIndexRequest)(r).GetCursor()
 }
 
 func (r *inspectIndexRequestReadonly) GetCheckpointId() uint64 {
-	return r.v.GetCheckpointId()
+	return (*InspectIndexRequest)(r).GetCheckpointId()
 }
 
 func (r *inspectIndexRequestReadonly) Mutate() *InspectIndexRequest {
-	return r.v.CloneVT()
+	return (*InspectIndexRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectIndexRequest.
@@ -9570,7 +9554,7 @@ func (m *InspectIndexRequest) AsReader() InspectIndexRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectIndexRequestReadonly{v: m}
+	return (*inspectIndexRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectIndexRequest.
@@ -9622,14 +9606,14 @@ type InspectIndexResponseReader interface {
 	Mutate() *InspectIndexResponse
 }
 
-type inspectIndexResponseReadonly struct{ v *InspectIndexResponse }
+type inspectIndexResponseReadonly InspectIndexResponse
 
 func (r *inspectIndexResponseReadonly) GetResult() isInspectIndexResponse_Result {
-	return r.v.GetResult()
+	return (*InspectIndexResponse)(r).GetResult()
 }
 
 func (r *inspectIndexResponseReadonly) Mutate() *InspectIndexResponse {
-	return r.v.CloneVT()
+	return (*InspectIndexResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectIndexResponse.
@@ -9637,7 +9621,7 @@ func (m *InspectIndexResponse) AsReader() InspectIndexResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectIndexResponseReadonly{v: m}
+	return (*inspectIndexResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectIndexResponse.
@@ -9691,22 +9675,22 @@ type InspectDistinctValuesReader interface {
 	Mutate() *InspectDistinctValues
 }
 
-type inspectDistinctValuesReadonly struct{ v *InspectDistinctValues }
+type inspectDistinctValuesReadonly InspectDistinctValues
 
 func (r *inspectDistinctValuesReadonly) GetValues() commonpb.MetadataValueListReader {
-	return commonpb.NewMetadataValueListReader(r.v.GetValues())
+	return commonpb.NewMetadataValueListReader((*InspectDistinctValues)(r).GetValues())
 }
 
 func (r *inspectDistinctValuesReadonly) GetHasMore() bool {
-	return r.v.GetHasMore()
+	return (*InspectDistinctValues)(r).GetHasMore()
 }
 
 func (r *inspectDistinctValuesReadonly) GetNextCursor() string {
-	return r.v.GetNextCursor()
+	return (*InspectDistinctValues)(r).GetNextCursor()
 }
 
 func (r *inspectDistinctValuesReadonly) Mutate() *InspectDistinctValues {
-	return r.v.CloneVT()
+	return (*InspectDistinctValues)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectDistinctValues.
@@ -9714,7 +9698,7 @@ func (m *InspectDistinctValues) AsReader() InspectDistinctValuesReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectDistinctValuesReadonly{v: m}
+	return (*inspectDistinctValuesReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectDistinctValues.
@@ -9767,10 +9751,10 @@ type InspectFacetReader interface {
 	Mutate() *InspectFacet
 }
 
-type inspectFacetReadonly struct{ v *InspectFacet }
+type inspectFacetReadonly InspectFacet
 
 func (r *inspectFacetReadonly) GetValue() commonpb.MetadataValueReader {
-	v := r.v.GetValue()
+	v := (*InspectFacet)(r).GetValue()
 	if v == nil {
 		return nil
 	}
@@ -9778,11 +9762,11 @@ func (r *inspectFacetReadonly) GetValue() commonpb.MetadataValueReader {
 }
 
 func (r *inspectFacetReadonly) GetCount() uint64 {
-	return r.v.GetCount()
+	return (*InspectFacet)(r).GetCount()
 }
 
 func (r *inspectFacetReadonly) Mutate() *InspectFacet {
-	return r.v.CloneVT()
+	return (*InspectFacet)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectFacet.
@@ -9790,7 +9774,7 @@ func (m *InspectFacet) AsReader() InspectFacetReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectFacetReadonly{v: m}
+	return (*inspectFacetReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectFacet.
@@ -9844,22 +9828,22 @@ type InspectFacetsReader interface {
 	Mutate() *InspectFacets
 }
 
-type inspectFacetsReadonly struct{ v *InspectFacets }
+type inspectFacetsReadonly InspectFacets
 
 func (r *inspectFacetsReadonly) GetFacets() InspectFacetListReader {
-	return NewInspectFacetListReader(r.v.GetFacets())
+	return NewInspectFacetListReader((*InspectFacets)(r).GetFacets())
 }
 
 func (r *inspectFacetsReadonly) GetHasMore() bool {
-	return r.v.GetHasMore()
+	return (*InspectFacets)(r).GetHasMore()
 }
 
 func (r *inspectFacetsReadonly) GetNextCursor() string {
-	return r.v.GetNextCursor()
+	return (*InspectFacets)(r).GetNextCursor()
 }
 
 func (r *inspectFacetsReadonly) Mutate() *InspectFacets {
-	return r.v.CloneVT()
+	return (*InspectFacets)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectFacets.
@@ -9867,7 +9851,7 @@ func (m *InspectFacets) AsReader() InspectFacetsReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectFacetsReadonly{v: m}
+	return (*inspectFacetsReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectFacets.
@@ -9923,14 +9907,14 @@ type InspectSummaryReader interface {
 	Mutate() *InspectSummary
 }
 
-type inspectSummaryReadonly struct{ v *InspectSummary }
+type inspectSummaryReadonly InspectSummary
 
 func (r *inspectSummaryReadonly) GetCardinality() uint64 {
-	return r.v.GetCardinality()
+	return (*InspectSummary)(r).GetCardinality()
 }
 
 func (r *inspectSummaryReadonly) GetMin() commonpb.MetadataValueReader {
-	v := r.v.GetMin()
+	v := (*InspectSummary)(r).GetMin()
 	if v == nil {
 		return nil
 	}
@@ -9938,7 +9922,7 @@ func (r *inspectSummaryReadonly) GetMin() commonpb.MetadataValueReader {
 }
 
 func (r *inspectSummaryReadonly) GetMax() commonpb.MetadataValueReader {
-	v := r.v.GetMax()
+	v := (*InspectSummary)(r).GetMax()
 	if v == nil {
 		return nil
 	}
@@ -9946,15 +9930,15 @@ func (r *inspectSummaryReadonly) GetMax() commonpb.MetadataValueReader {
 }
 
 func (r *inspectSummaryReadonly) GetEntitiesWithKey() uint64 {
-	return r.v.GetEntitiesWithKey()
+	return (*InspectSummary)(r).GetEntitiesWithKey()
 }
 
 func (r *inspectSummaryReadonly) GetEntitiesWithNull() uint64 {
-	return r.v.GetEntitiesWithNull()
+	return (*InspectSummary)(r).GetEntitiesWithNull()
 }
 
 func (r *inspectSummaryReadonly) Mutate() *InspectSummary {
-	return r.v.CloneVT()
+	return (*InspectSummary)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this InspectSummary.
@@ -9962,7 +9946,7 @@ func (m *InspectSummary) AsReader() InspectSummaryReader {
 	if m == nil {
 		return nil
 	}
-	return &inspectSummaryReadonly{v: m}
+	return (*inspectSummaryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this InspectSummary.
@@ -10013,10 +9997,10 @@ type BarrierRequestReader interface {
 	Mutate() *BarrierRequest
 }
 
-type barrierRequestReadonly struct{ v *BarrierRequest }
+type barrierRequestReadonly BarrierRequest
 
 func (r *barrierRequestReadonly) Mutate() *BarrierRequest {
-	return r.v.CloneVT()
+	return (*BarrierRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BarrierRequest.
@@ -10024,7 +10008,7 @@ func (m *BarrierRequest) AsReader() BarrierRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &barrierRequestReadonly{v: m}
+	return (*barrierRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BarrierRequest.
@@ -10076,14 +10060,14 @@ type BarrierResponseReader interface {
 	Mutate() *BarrierResponse
 }
 
-type barrierResponseReadonly struct{ v *BarrierResponse }
+type barrierResponseReadonly BarrierResponse
 
 func (r *barrierResponseReadonly) GetCommitIndex() uint64 {
-	return r.v.GetCommitIndex()
+	return (*BarrierResponse)(r).GetCommitIndex()
 }
 
 func (r *barrierResponseReadonly) Mutate() *BarrierResponse {
-	return r.v.CloneVT()
+	return (*BarrierResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this BarrierResponse.
@@ -10091,7 +10075,7 @@ func (m *BarrierResponse) AsReader() BarrierResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &barrierResponseReadonly{v: m}
+	return (*barrierResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this BarrierResponse.

--- a/internal/proto/signaturepb/signature_reader.pb.go
+++ b/internal/proto/signaturepb/signature_reader.pb.go
@@ -16,22 +16,22 @@ type SignedApplyBatchReader interface {
 	Mutate() *SignedApplyBatch
 }
 
-type signedApplyBatchReadonly struct{ v *SignedApplyBatch }
+type signedApplyBatchReadonly SignedApplyBatch
 
 func (r *signedApplyBatchReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*SignedApplyBatch)(r).GetKeyId()
 }
 
 func (r *signedApplyBatchReadonly) GetSignature() []byte {
-	return bytes.Clone(r.v.GetSignature())
+	return bytes.Clone((*SignedApplyBatch)(r).GetSignature())
 }
 
 func (r *signedApplyBatchReadonly) GetPayload() []byte {
-	return bytes.Clone(r.v.GetPayload())
+	return bytes.Clone((*SignedApplyBatch)(r).GetPayload())
 }
 
 func (r *signedApplyBatchReadonly) Mutate() *SignedApplyBatch {
-	return r.v.CloneVT()
+	return (*SignedApplyBatch)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SignedApplyBatch.
@@ -39,7 +39,7 @@ func (m *SignedApplyBatch) AsReader() SignedApplyBatchReader {
 	if m == nil {
 		return nil
 	}
-	return &signedApplyBatchReadonly{v: m}
+	return (*signedApplyBatchReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SignedApplyBatch.
@@ -93,22 +93,22 @@ type SignedLogReader interface {
 	Mutate() *SignedLog
 }
 
-type signedLogReadonly struct{ v *SignedLog }
+type signedLogReadonly SignedLog
 
 func (r *signedLogReadonly) GetKeyId() string {
-	return r.v.GetKeyId()
+	return (*SignedLog)(r).GetKeyId()
 }
 
 func (r *signedLogReadonly) GetSignature() []byte {
-	return bytes.Clone(r.v.GetSignature())
+	return bytes.Clone((*SignedLog)(r).GetSignature())
 }
 
 func (r *signedLogReadonly) GetPayload() []byte {
-	return bytes.Clone(r.v.GetPayload())
+	return bytes.Clone((*SignedLog)(r).GetPayload())
 }
 
 func (r *signedLogReadonly) Mutate() *SignedLog {
-	return r.v.CloneVT()
+	return (*SignedLog)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SignedLog.
@@ -116,7 +116,7 @@ func (m *SignedLog) AsReader() SignedLogReader {
 	if m == nil {
 		return nil
 	}
-	return &signedLogReadonly{v: m}
+	return (*signedLogReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SignedLog.

--- a/internal/proto/snapshotpb/snapshot_reader.pb.go
+++ b/internal/proto/snapshotpb/snapshot_reader.pb.go
@@ -15,18 +15,18 @@ type PrepareSnapshotRequestReader interface {
 	Mutate() *PrepareSnapshotRequest
 }
 
-type prepareSnapshotRequestReadonly struct{ v *PrepareSnapshotRequest }
+type prepareSnapshotRequestReadonly PrepareSnapshotRequest
 
 func (r *prepareSnapshotRequestReadonly) GetNodeId() string {
-	return r.v.GetNodeId()
+	return (*PrepareSnapshotRequest)(r).GetNodeId()
 }
 
 func (r *prepareSnapshotRequestReadonly) GetMinAppliedIndex() uint64 {
-	return r.v.GetMinAppliedIndex()
+	return (*PrepareSnapshotRequest)(r).GetMinAppliedIndex()
 }
 
 func (r *prepareSnapshotRequestReadonly) Mutate() *PrepareSnapshotRequest {
-	return r.v.CloneVT()
+	return (*PrepareSnapshotRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PrepareSnapshotRequest.
@@ -34,7 +34,7 @@ func (m *PrepareSnapshotRequest) AsReader() PrepareSnapshotRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &prepareSnapshotRequestReadonly{v: m}
+	return (*prepareSnapshotRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PrepareSnapshotRequest.
@@ -87,14 +87,14 @@ type PrepareSnapshotResponseReader interface {
 	Mutate() *PrepareSnapshotResponse
 }
 
-type prepareSnapshotResponseReadonly struct{ v *PrepareSnapshotResponse }
+type prepareSnapshotResponseReadonly PrepareSnapshotResponse
 
 func (r *prepareSnapshotResponseReadonly) GetSessionId() string {
-	return r.v.GetSessionId()
+	return (*PrepareSnapshotResponse)(r).GetSessionId()
 }
 
 func (r *prepareSnapshotResponseReadonly) GetManifest() SnapshotManifestReader {
-	v := r.v.GetManifest()
+	v := (*PrepareSnapshotResponse)(r).GetManifest()
 	if v == nil {
 		return nil
 	}
@@ -102,7 +102,7 @@ func (r *prepareSnapshotResponseReadonly) GetManifest() SnapshotManifestReader {
 }
 
 func (r *prepareSnapshotResponseReadonly) Mutate() *PrepareSnapshotResponse {
-	return r.v.CloneVT()
+	return (*PrepareSnapshotResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this PrepareSnapshotResponse.
@@ -110,7 +110,7 @@ func (m *PrepareSnapshotResponse) AsReader() PrepareSnapshotResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &prepareSnapshotResponseReadonly{v: m}
+	return (*prepareSnapshotResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this PrepareSnapshotResponse.
@@ -163,18 +163,18 @@ type FetchFileRequestReader interface {
 	Mutate() *FetchFileRequest
 }
 
-type fetchFileRequestReadonly struct{ v *FetchFileRequest }
+type fetchFileRequestReadonly FetchFileRequest
 
 func (r *fetchFileRequestReadonly) GetSessionId() string {
-	return r.v.GetSessionId()
+	return (*FetchFileRequest)(r).GetSessionId()
 }
 
 func (r *fetchFileRequestReadonly) GetPath() string {
-	return r.v.GetPath()
+	return (*FetchFileRequest)(r).GetPath()
 }
 
 func (r *fetchFileRequestReadonly) Mutate() *FetchFileRequest {
-	return r.v.CloneVT()
+	return (*FetchFileRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FetchFileRequest.
@@ -182,7 +182,7 @@ func (m *FetchFileRequest) AsReader() FetchFileRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &fetchFileRequestReadonly{v: m}
+	return (*fetchFileRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FetchFileRequest.
@@ -235,18 +235,18 @@ type FetchFileResponseReader interface {
 	Mutate() *FetchFileResponse
 }
 
-type fetchFileResponseReadonly struct{ v *FetchFileResponse }
+type fetchFileResponseReadonly FetchFileResponse
 
 func (r *fetchFileResponseReadonly) GetData() []byte {
-	return bytes.Clone(r.v.GetData())
+	return bytes.Clone((*FetchFileResponse)(r).GetData())
 }
 
 func (r *fetchFileResponseReadonly) GetEof() bool {
-	return r.v.GetEof()
+	return (*FetchFileResponse)(r).GetEof()
 }
 
 func (r *fetchFileResponseReadonly) Mutate() *FetchFileResponse {
-	return r.v.CloneVT()
+	return (*FetchFileResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FetchFileResponse.
@@ -254,7 +254,7 @@ func (m *FetchFileResponse) AsReader() FetchFileResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &fetchFileResponseReadonly{v: m}
+	return (*fetchFileResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FetchFileResponse.
@@ -306,14 +306,14 @@ type CloseSessionRequestReader interface {
 	Mutate() *CloseSessionRequest
 }
 
-type closeSessionRequestReadonly struct{ v *CloseSessionRequest }
+type closeSessionRequestReadonly CloseSessionRequest
 
 func (r *closeSessionRequestReadonly) GetSessionId() string {
-	return r.v.GetSessionId()
+	return (*CloseSessionRequest)(r).GetSessionId()
 }
 
 func (r *closeSessionRequestReadonly) Mutate() *CloseSessionRequest {
-	return r.v.CloneVT()
+	return (*CloseSessionRequest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CloseSessionRequest.
@@ -321,7 +321,7 @@ func (m *CloseSessionRequest) AsReader() CloseSessionRequestReader {
 	if m == nil {
 		return nil
 	}
-	return &closeSessionRequestReadonly{v: m}
+	return (*closeSessionRequestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CloseSessionRequest.
@@ -372,10 +372,10 @@ type CloseSessionResponseReader interface {
 	Mutate() *CloseSessionResponse
 }
 
-type closeSessionResponseReadonly struct{ v *CloseSessionResponse }
+type closeSessionResponseReadonly CloseSessionResponse
 
 func (r *closeSessionResponseReadonly) Mutate() *CloseSessionResponse {
-	return r.v.CloneVT()
+	return (*CloseSessionResponse)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this CloseSessionResponse.
@@ -383,7 +383,7 @@ func (m *CloseSessionResponse) AsReader() CloseSessionResponseReader {
 	if m == nil {
 		return nil
 	}
-	return &closeSessionResponseReadonly{v: m}
+	return (*closeSessionResponseReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this CloseSessionResponse.
@@ -435,14 +435,14 @@ type SnapshotManifestReader interface {
 	Mutate() *SnapshotManifest
 }
 
-type snapshotManifestReadonly struct{ v *SnapshotManifest }
+type snapshotManifestReadonly SnapshotManifest
 
 func (r *snapshotManifestReadonly) GetFiles() FileEntryListReader {
-	return NewFileEntryListReader(r.v.GetFiles())
+	return NewFileEntryListReader((*SnapshotManifest)(r).GetFiles())
 }
 
 func (r *snapshotManifestReadonly) Mutate() *SnapshotManifest {
-	return r.v.CloneVT()
+	return (*SnapshotManifest)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this SnapshotManifest.
@@ -450,7 +450,7 @@ func (m *SnapshotManifest) AsReader() SnapshotManifestReader {
 	if m == nil {
 		return nil
 	}
-	return &snapshotManifestReadonly{v: m}
+	return (*snapshotManifestReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this SnapshotManifest.
@@ -504,22 +504,22 @@ type FileEntryReader interface {
 	Mutate() *FileEntry
 }
 
-type fileEntryReadonly struct{ v *FileEntry }
+type fileEntryReadonly FileEntry
 
 func (r *fileEntryReadonly) GetPath() string {
-	return r.v.GetPath()
+	return (*FileEntry)(r).GetPath()
 }
 
 func (r *fileEntryReadonly) GetSize() uint64 {
-	return r.v.GetSize()
+	return (*FileEntry)(r).GetSize()
 }
 
 func (r *fileEntryReadonly) GetSha256() string {
-	return r.v.GetSha256()
+	return (*FileEntry)(r).GetSha256()
 }
 
 func (r *fileEntryReadonly) Mutate() *FileEntry {
-	return r.v.CloneVT()
+	return (*FileEntry)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this FileEntry.
@@ -527,7 +527,7 @@ func (m *FileEntry) AsReader() FileEntryReader {
 	if m == nil {
 		return nil
 	}
-	return &fileEntryReadonly{v: m}
+	return (*fileEntryReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this FileEntry.

--- a/tools/protoc-gen-reader/main.go
+++ b/tools/protoc-gen-reader/main.go
@@ -1,7 +1,10 @@
-// protoc-gen-reader generates read-only interfaces and wrapper structs for
+// protoc-gen-reader generates read-only interfaces and wrapper types for
 // protobuf messages. Each message gets:
 //   - A <Message>Reader interface with all Get* methods + Mutate() *<Message>
-//   - An unexported <message>Readonly wrapper struct implementing the interface
+//   - An unexported <message>Readonly named type defined as `type X Msg` so
+//     that AsReader() can convert *Msg -> *<message>Readonly without heap
+//     allocation. The resulting *<message>Readonly fits in the interface data
+//     word, and every transitive GetFoo() reader view is likewise zero-alloc.
 //   - An AsReader() method on the concrete type returning the reader interface
 //   - A Mutate() method on the concrete type returning CloneVT()
 //
@@ -43,10 +46,12 @@ type extraMethod struct {
 // extraMethods registers custom read-only methods for specific proto messages.
 // Key: proto full name (e.g., "common.Uint256").
 // These methods are added to the Reader interface and delegated on the wrapper.
+// In `call`, the token %BASE% is substituted with a cast of the wrapper receiver
+// back to the concrete message pointer (e.g., "(*Uint256)(r)").
 var extraMethods = map[string][]extraMethod{
 	"common.Uint256": {
-		{name: "IntoUint256", signature: "(dst *uint256.Int)", call: "r.v.IntoUint256(dst)"},
-		{name: "IsZero", signature: "() bool", call: "return r.v.IsZero()"},
+		{name: "IntoUint256", signature: "(dst *uint256.Int)", call: "%BASE%.IntoUint256(dst)"},
+		{name: "IsZero", signature: "() bool", call: "return %BASE%.IsZero()"},
 	},
 }
 
@@ -153,16 +158,23 @@ func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message) {
 	g.P("\tMutate() *", typeName)
 	g.P("}")
 
-	// --- Wrapper struct ---
+	// --- Wrapper type ---
+	// Defined as a named type over the concrete message so that AsReader() can
+	// convert *typeName -> *wrapperName without allocating a heap wrapper. The
+	// resulting *wrapperName fits in the interface data-word, keeping the whole
+	// reader-view chain zero-alloc.
 	g.P()
-	g.P("type ", wrapperName, " struct{ v *", typeName, " }")
+	g.P("type ", wrapperName, " ", typeName)
+
+	// base is the receiver→concrete cast used inside every wrapper method.
+	base := "(*" + typeName + ")(r)"
 
 	for _, field := range msg.Fields {
 		if field.Oneof != nil && !field.Desc.HasOptionalKeyword() {
 			continue
 		}
 
-		writeWrapperGetter(g, msg, field, wrapperName)
+		writeWrapperGetter(g, msg, field, wrapperName, base)
 	}
 
 	// Oneof getters on wrapper
@@ -175,7 +187,7 @@ func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message) {
 		oneofInterfaceName := fmt.Sprintf("is%s_%s", typeName, oneof.GoName)
 		g.P()
 		g.P("func (r *", wrapperName, ") ", getterName, "() ", oneofInterfaceName, " {")
-		g.P("\treturn r.v.", getterName, "()")
+		g.P("\treturn ", base, ".", getterName, "()")
 		g.P("}")
 	}
 
@@ -187,14 +199,14 @@ func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message) {
 
 		g.P()
 		g.P("func (r *", wrapperName, ") ", em.name, em.signature, " {")
-		g.P("\t", em.call)
+		g.P("\t", strings.ReplaceAll(em.call, "%BASE%", base))
 		g.P("}")
 	}
 
 	// Mutate on wrapper
 	g.P()
 	g.P("func (r *", wrapperName, ") Mutate() *", typeName, " {")
-	g.P("\treturn r.v.CloneVT()")
+	g.P("\treturn ", base, ".CloneVT()")
 	g.P("}")
 
 	// --- Methods on concrete type ---
@@ -202,7 +214,7 @@ func generateMessage(g *protogen.GeneratedFile, msg *protogen.Message) {
 	g.P("// AsReader returns a read-only view of this ", typeName, ".")
 	g.P("func (m *", typeName, ") AsReader() ", readerName, " {")
 	g.P("\tif m == nil { return nil }")
-	g.P("\treturn &", wrapperName, "{v: m}")
+	g.P("\treturn (*", wrapperName, ")(m)")
 	g.P("}")
 
 	g.P()
@@ -243,8 +255,9 @@ func readerFieldType(g *protogen.GeneratedFile, owner *protogen.Message, field *
 }
 
 // writeWrapperGetter emits the wrapper method for one field, applying the
-// immutability rules described at the top of the file.
-func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, field *protogen.Field, wrapperName string) {
+// immutability rules described at the top of the file. `base` is the expression
+// used inside method bodies to reach the concrete message (e.g., "(*Foo)(r)").
+func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, field *protogen.Field, wrapperName string, base string) {
 	getterName := "Get" + field.GoName
 
 	switch {
@@ -254,7 +267,7 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 
 		g.P()
 		g.P("func (r *", wrapperName, ") ", getterName, "() ", retType, " {")
-		g.P("\treturn ", mapImpl, "(r.v.", getterName, "())")
+		g.P("\treturn ", mapImpl, "(", base, ".", getterName, "())")
 		g.P("}")
 
 	case field.Desc.IsList():
@@ -270,14 +283,14 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 
 			g.P()
 			g.P("func (r *", wrapperName, ") ", getterName, "() ", retType, " {")
-			g.P("\treturn ", ctor, "(r.v.", getterName, "())")
+			g.P("\treturn ", ctor, "(", base, ".", getterName, "())")
 			g.P("}")
 
 		case protoreflect.BytesKind:
 			// [][]byte — deep clone.
 			g.P()
 			g.P("func (r *", wrapperName, ") ", getterName, "() [][]byte {")
-			g.P("\tsrc := r.v.", getterName, "()")
+			g.P("\tsrc := ", base, ".", getterName, "()")
 			g.P("\tif src == nil { return nil }")
 			g.P("\tout := make([][]byte, len(src))")
 			g.P("\tfor i, b := range src {")
@@ -292,7 +305,7 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 
 			g.P()
 			g.P("func (r *", wrapperName, ") ", getterName, "() ", retType, " {")
-			g.P("\treturn ", g.QualifiedGoIdent(protogen.GoIdent{GoName: "Clone", GoImportPath: slicesPkg}), "(r.v.", getterName, "())")
+			g.P("\treturn ", g.QualifiedGoIdent(protogen.GoIdent{GoName: "Clone", GoImportPath: slicesPkg}), "(", base, ".", getterName, "())")
 			g.P("}")
 		}
 
@@ -301,7 +314,7 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 
 		g.P()
 		g.P("func (r *", wrapperName, ") ", getterName, "() ", retType, " {")
-		g.P("\tv := r.v.", getterName, "()")
+		g.P("\tv := ", base, ".", getterName, "()")
 		g.P("\tif v == nil { return nil }")
 		g.P("\treturn v.AsReader()")
 		g.P("}")
@@ -310,7 +323,7 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 		// Singular []byte — defensive clone.
 		g.P()
 		g.P("func (r *", wrapperName, ") ", getterName, "() []byte {")
-		g.P("\treturn ", g.QualifiedGoIdent(protogen.GoIdent{GoName: "Clone", GoImportPath: bytesPkg}), "(r.v.", getterName, "())")
+		g.P("\treturn ", g.QualifiedGoIdent(protogen.GoIdent{GoName: "Clone", GoImportPath: bytesPkg}), "(", base, ".", getterName, "())")
 		g.P("}")
 
 	default:
@@ -319,7 +332,7 @@ func writeWrapperGetter(g *protogen.GeneratedFile, owner *protogen.Message, fiel
 
 		g.P()
 		g.P("func (r *", wrapperName, ") ", getterName, "() ", retType, " {")
-		g.P("\treturn r.v.", getterName, "()")
+		g.P("\treturn ", base, ".", getterName, "()")
 		g.P("}")
 	}
 }


### PR DESCRIPTION
## Summary

- `protoc-gen-reader` now emits the read-only wrapper as `type xReadonly Msg` (named-type over the concrete message) instead of `struct{ v *Msg }`. `AsReader()` becomes a pointer type-conversion `(*xReadonly)(m)` — the resulting `*xReadonly` fits in the interface data word, so no heap wrapper is allocated. Every transitive `GetFoo()` / `ListReader.Get(i)` / `MapReader.Range` reader view is likewise zero-alloc.
- All 12 `*_reader.pb.go` regenerated. Public surface unchanged: same `Reader` interfaces, same method signatures, same immutability contract.
- Added `internal/proto/commonpb/reader_alloc_test.go` with micro-benchmarks pinning the zero-alloc property.

### Bench (Apple M5 Pro)
```
BenchmarkReader_AsReader-15    717M ops   1.7 ns/op    0 B/op   0 allocs/op
BenchmarkReader_GetChain-15     87M ops  17.5 ns/op   24 B/op   1 allocs/op  ← residual slice-header boxing on ListReader
BenchmarkReader_ListRange-15    17M ops  62.8 ns/op    0 B/op   0 allocs/op
```

Before the patch, each `AsReader()` (and every transitive `GetFoo()` returning a sub-reader) allocated a ~16 B wrapper struct on the heap. On hot paths this compounded — e.g. iterating a `TransactionListReader` and reading a few postings per element caused N allocations per transaction.

### Why not `sync.Pool`
Pooling was considered and rejected:
- Reader lifecycle is intraçable: sub-readers are created implicitly via `GetFoo()` cascades; the caller can't know when to `Release()`.
- Would require adding `Release()` to the Reader interface and threading it through every call site (`Range` bodies would need a release per iteration).
- The wrapper is 8 bytes (one pointer); `sync.Pool` bookkeeping (atomic ops, per-P shard, GC eviction) often costs more than the alloc it saves for objects this small.
- Use-after-release corruption is silent — the reader's underlying pointer would be reassigned.

The named-pointer-type approach gives the same result with zero API changes and zero lifecycle risk.

### Immutability
Unchanged. `xReadonly` remains unexported. External callers cannot type-assert to `*Msg` (dynamic type mismatch) nor to `*xReadonly` (unexported name). `unsafe.Pointer` shenanigans can defeat both the old and the new design equally — no new surface.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/proto/...` — all 6 `reader_immutability_test.go` suites still pass, pinning the read-only contract
- [x] `just pre-commit` — 0 lint issues
- [x] Added benchmarks confirm 0 allocs/op for `AsReader` and `ListReader.Range`