### PR TITLE
test(antithesis): dev-loop filter — restrict workload image to a driver subset

### DIFF
--- a/tests/antithesis/Justfile
+++ b/tests/antithesis/Justfile
@@ -11,8 +11,12 @@ ledger_image_name := env_var_or_default("LEDGER_IMAGE_NAME", "ledger")
 
 # --- Docker Compose mode (legacy) ---
 
-run duration description='ledger-v3 manual run' *ARGS:
-    just tag={{tag}} push-images {{ARGS}}
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image. Empty ships every driver (the default). Use the
+# filtered mode for dev-loop runs where the Antithesis composer should focus
+# on a specific subset (e.g. "main/parallel_driver_bulk,main/first_default_ledger").
+run duration description='ledger-v3 manual run' include='' *ARGS:
+    just tag={{tag}} push-images {{quote(include)}} {{ARGS}}
     curl --fail \
         --user "formance:$ANTITHESIS_PASSWORD" \
         -X POST https://formance.antithesis.com/api/v1/launch/basic_test -d '{ \
@@ -39,10 +43,10 @@ build-images:
         -t "$ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}" \
         ../../
 
-push-images *ARGS:
+push-images include='' *ARGS:
     just tag={{tag}} build-images
     just --justfile config/Justfile -d config tag={{tag}} push {{ARGS}}
-    just --justfile workload/Justfile -d workload tag={{tag}} push
+    just --justfile workload/Justfile -d workload tag={{tag}} push {{quote(include)}}
     docker push $ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}
     docker push $ANTITHESIS_REPOSITORY/etcd:v3.5.9
 
@@ -62,8 +66,12 @@ deploy-local: build-images
 
 # Launch a test run on Antithesis using the k8s environment.
 # Duration is in hours (converted to minutes for the Antithesis API).
-k8s-run duration_hours description='ledger-v3 k8s run' *ARGS:
-    just tag={{tag}} k8s-push-images {{ARGS}}
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image. Empty ships every driver. Use the filtered mode for
+# dev-loop runs where the composer should focus on a specific subset (e.g.
+# "main/parallel_driver_bulk,main/first_default_ledger").
+k8s-run duration_hours description='ledger-v3 k8s run' include='' *ARGS:
+    just tag={{tag}} k8s-push-images {{quote(include)}} {{ARGS}}
     curl --fail \
         --user "formance:$ANTITHESIS_PASSWORD" \
         -X POST https://formance.antithesis.com/api/v1/launch/basic_k8s_test -d '{ \
@@ -93,9 +101,9 @@ k8s-build-images:
         ../../misc/operator
 
 # Push all images for k8s mode.
-k8s-push-images *ARGS:
+k8s-push-images include='' *ARGS:
     just tag={{tag}} k8s-build-images
     just --justfile k8s/Justfile -d k8s tag={{tag}} push {{ARGS}}
-    just --justfile workload/Justfile -d workload tag={{tag}} push
+    just --justfile workload/Justfile -d workload tag={{tag}} push {{quote(include)}}
     docker push $ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}
     docker push $ANTITHESIS_REPOSITORY/ledger-operator:{{tag}}

--- a/tests/antithesis/workload/Dockerfile
+++ b/tests/antithesis/workload/Dockerfile
@@ -31,12 +31,29 @@ RUN mkdir -p /cmds
 # compile the unique main.go (~117 LOC each).
 RUN go build -race ./internal/...
 
+# Optional dev-loop filter: when INCLUDED_DRIVERS is a non-empty comma-separated
+# list of <template>/<driver> paths (e.g. "main/parallel_driver_bulk,main/first_default_ledger"),
+# only those binaries are built and shipped. The Antithesis composer then has
+# no choice but to schedule them — useful for iterating on a targeted fix
+# without waiting for the global composer to randomly pick the driver under
+# test. Leave empty (default) for full-coverage runs.
+ARG INCLUDED_DRIVERS=""
+
 # Build all workload binaries in parallel, preserving the
 # bin/cmds/<template>/<command> layout so each command lands in its own test
 # template directory. The shared dependency cache is warm from the previous step,
 # so each build only compiles main.go.
-RUN find ./bin/cmds -mindepth 2 -maxdepth 2 -type d \
-        | sed 's|^\./bin/cmds/||' \
+RUN set -e; \
+    find ./bin/cmds -mindepth 2 -maxdepth 2 -type d | sed 's|^\./bin/cmds/||' > /tmp/all-drivers.txt; \
+    if [ -n "$INCLUDED_DRIVERS" ]; then \
+        echo "$INCLUDED_DRIVERS" | tr ',' '\n' > /tmp/include.txt; \
+        grep -Fx -f /tmp/include.txt /tmp/all-drivers.txt > /tmp/targets.txt; \
+        echo "Filtered build ($(wc -l < /tmp/targets.txt) of $(wc -l < /tmp/all-drivers.txt) drivers):"; \
+        cat /tmp/targets.txt; \
+    else \
+        cp /tmp/all-drivers.txt /tmp/targets.txt; \
+    fi; \
+    cat /tmp/targets.txt \
         | xargs -P"$(nproc)" -I{} sh -c 'mkdir -p "/cmds/$(dirname "$1")" && go build -race -o "/cmds/$1" "./bin/cmds/$1"' _ {}
 
 # Runner

--- a/tests/antithesis/workload/Justfile
+++ b/tests/antithesis/workload/Justfile
@@ -1,7 +1,11 @@
 tag := 'antithesis'
 
-build:
-	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
+# include: optional comma-separated list of <template>/<driver> paths to ship
+# in the workload image (e.g. "main/parallel_driver_bulk,main/first_default_ledger").
+# Empty (default) ships every driver. Use the filtered mode for dev-loop runs
+# where the Antithesis composer should focus on a specific subset.
+build include='':
+	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
 
-push: build
+push include='': (build include)
 	docker push "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}"


### PR DESCRIPTION
## Summary

Adds a build-arg on the workload image so a dev-loop run can force the Antithesis Test Composer to schedule specific drivers, instead of gambling on the composer's opaque ranking.

Cherry-pick of `0a723997d` — originally shipped inside PR #1442 (an EN-1410 red detector, closed unmerged when the bug was fixed elsewhere). The bug fix is now in — the tooling piece is orthogonal and worth having on its own.

## Why

Antithesis's Test Composer ranking algorithm is opaque and not user-configurable (per the `test_composer` reference). On a 2h run with ~40 `parallel_driver_*` binaries + ~15 `singleton_driver_*`, low-weight drivers are frequently scheduled zero times. Concrete recent example: PR #1498's async-storage validation (`56f8e87e...` run) fired 9 chaos singletons under `main/` as "not started/finished" — the composer never picked them.

Waiting hours for the composer to randomly pick the driver under test is the dominant dev-loop cost when iterating on a specific bug or subsystem.

## How

New `INCLUDED_DRIVERS` build arg on `tests/antithesis/workload/Dockerfile`. When set to a comma-separated list of `<template>/<driver>` paths (e.g. `main/parallel_driver_bulk,main/first_default_ledger`), the build only compiles and ships those binaries to `/opt/antithesis/test/v1/`. The composer then has nothing else to schedule — it MUST run the listed drivers.

Empty (default) preserves the current full-coverage behaviour for nightly runs — this is opt-in, not a regression risk.

Plumbed through every recipe chain that builds+pushes the workload:
- `workload/Justfile`: `build` / `push` gain an `include` positional arg, forwarded as `--build-arg INCLUDED_DRIVERS=<value>`.
- `tests/antithesis/Justfile`: `run`, `push-images`, `k8s-run`, `k8s-push-images` all gain the same `include=''` param threaded down via `{{quote(include)}}`.

## Usage

```bash
# Force chaos singletons that never fire naturally under composer ranking
just antithesis::k8s-run 2 "PR#1498 chaos coverage" \
    "main/first_default_ledger,main/singleton_driver_rolling_restart,main/singleton_driver_quorum_recovery,main/parallel_driver_bulk"

# Force the model template
just antithesis::k8s-run 2 "model coverage" "model/singleton_driver_model"

# Nightly default — every driver ships, composer decides
just antithesis::k8s-run 2 "nightly"
```

**Gotcha**: always include `main/first_default_ledger` when filtering. Without an initial ledger, every `parallel_driver_*` call to `GetRandomLedger` blocks until the 10 min timeout.

## Merge conflict resolution

Cherry-pick conflicted with `2748187c0` (skill `antithesis-run` + tag propagation, merged after the original branch). Both changes touch the same sub-`just` lines but are orthogonal — resolved by combining: keep `tag={{tag}}` propagation on all sub-just calls, add `include=''` param and `{{quote(include)}}` forwarding on the workload push.

## Test plan
- [x] `just --justfile tests/antithesis/Justfile --list` — all recipes parse, `include` shows up on every builder recipe
- [x] Empty `include` (default) — full-coverage build behaviour preserved (grep confirms `find ./bin/cmds ...` runs on the full set)
- [ ] Filtered `include` — smoke-tested locally with `docker build --build-arg INCLUDED_DRIVERS=...` to confirm the filter targets the right binaries
- [ ] Filtered k8s-run against a live Antithesis tenant — will validate as part of the PR#1498 async-storage coverage runs I'll launch next