### PR TITLE
docs(EN-1467): reconcile openapi.yml with actual v3 wire

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2588,11 +2588,11 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/VolumesWithBalance'
           description: |
-            Per-asset input/output/balance for this account. Populated only
-            when the caller opts in via `expandVolumes=true` on
-            `GET /v3/{ledgerName}/accounts/{address}`; omitted otherwise.
-            For per-account balances at scale, use `GET /v3/{ledgerName}/volumes`
-            or a prepared query with type `AGGREGATE_VOLUMES`.
+            Per-asset input/output/balance for this account. Populated
+            inline on `GET /v3/{ledgerName}/accounts/{address}` (EN-1470).
+            List responses currently omit this field; for per-account
+            balances at scale, use `GET /v3/{ledgerName}/volumes` or a
+            prepared query with type `AGGREGATE_VOLUMES`.
 
     VolumesWithBalance:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
-  title: Ledger V3 POC API
-  description: API for the Ledger V3 Proof of Concept with Raft consensus
+  title: Ledger v3 API
+  description: API for the Ledger v3, a distributed accounting ledger with Raft consensus
   version: 1.0.0
   contact:
     name: Formance
@@ -543,7 +543,11 @@ paths:
             type: string
         - name: prefix
           in: query
-          description: Filter accounts by address prefix (e.g. "users:")
+          description: |
+            Filter accounts whose address starts with this raw byte-level
+            prefix (e.g. `users:` matches `users:alice`, `users:bob`, ...).
+            Matching is not path-segment aware: `acc:1` also matches
+            `acc:10`, `acc:11`, etc. Do not use for exact-address lookups.
           schema:
             type: string
       responses:
@@ -625,7 +629,10 @@ paths:
         - $ref: '#/components/parameters/LedgerName'
         - name: prefix
           in: query
-          description: Filter accounts by address prefix
+          description: |
+            Filter accounts whose address starts with this raw byte-level
+            prefix. Matching is not path-segment aware (see the note on the
+            `prefix` query parameter of `GET /v3/{ledgerName}/accounts`).
           schema:
             type: string
         - name: useMaxPrecision
@@ -1924,6 +1931,16 @@ components:
         JWT token issued by a trusted OIDC provider. Required when the server
         is started with `--auth-enabled`. Scopes: `ledger:read` (read operations),
         `ledger:write` (write operations), `ledger:admin` (cluster operations).
+    Ed25519Signature:
+      type: apiKey
+      in: header
+      name: X-Signature
+      description: >
+        Optional Ed25519 request signature for authenticity and integrity.
+        When request signing is enabled on the server, callers sign the request
+        payload with a registered key and pass the base64-encoded signature in
+        `X-Signature` together with the key id in `X-Signing-Key-Id`. See
+        `docs/ops/signing.md` for the exact signing algorithm and header set.
 
   parameters:
     LedgerName:
@@ -2482,9 +2499,12 @@ components:
           type: string
           description: Error description (present only on error)
         data:
-          description: Operation result data (transaction object for CREATE_TRANSACTION, null for others)
+          description: |
+            Operation result data. For `CREATE_TRANSACTION` this is the full
+            created transaction object. Omitted for other actions and on error.
           nullable: true
-          description: Log ID of the operation
+          allOf:
+            - $ref: '#/components/schemas/TransactionResponse'
 
     CreateTransactionResponse:
       type: object
@@ -2577,7 +2597,11 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/VolumesWithBalance'
-          description: Account volumes per asset (input, output, balance)
+          description: |
+            Deprecated: never populated on account read responses. To retrieve
+            per-account volumes/balances, use a prepared query with type
+            `AGGREGATE_VOLUMES` scoped to the account address.
+          deprecated: true
 
     VolumesWithBalance:
       type: object
@@ -2626,20 +2650,19 @@ components:
         - asset
         - input
         - output
-        - balance
       properties:
         asset:
           type: string
           description: Asset identifier (e.g. "USD/2")
         input:
-          type: string
-          description: Total amount received (as big integer string)
+          description: |
+            Total amount received. Emitted as a JSON number decimal
+            (Uint256), which may exceed 2^53. JavaScript clients must parse
+            this as a BigInt/BigNumber to avoid precision loss.
         output:
-          type: string
-          description: Total amount sent (as big integer string)
-        balance:
-          type: string
-          description: Net balance (input - output, as big integer string)
+          description: |
+            Total amount sent. Emitted as a JSON number decimal (Uint256);
+            see the note on `input` for JS precision handling.
 
     GroupedAggregateResult:
       type: object
@@ -2682,15 +2705,15 @@ components:
         reverted:
           type: boolean
           description: Whether this transaction has been reverted
-        inserted_at:
+        insertedAt:
           type: string
           format: date-time
           description: When the transaction was inserted into the ledger
-        updated_at:
+        updatedAt:
           type: string
           format: date-time
           description: Last update timestamp
-        reverted_at:
+        revertedAt:
           type: string
           format: date-time
           description: When the transaction was reverted (null if not reverted)
@@ -3578,36 +3601,49 @@ components:
 
     ExecutePreparedQueryResponse:
       type: object
+      description: |
+        Wraps either a cursor (for list-style targets like `LIST_ACCOUNTS`,
+        `LIST_TRANSACTIONS`) or an aggregate result (for `AGGREGATE_VOLUMES`).
+        Exactly one of `cursor` or `aggregateResult` is populated per response.
       properties:
         cursor:
           type: object
           properties:
+            pageSize:
+              type: integer
+              format: uint32
+              description: Number of entities in this page
             hasMore:
               type: boolean
+            previous:
+              type: string
+              description: Cursor to pass for the previous page
             next:
               type: string
               description: Cursor to pass for the next page
-            data:
+            accountData:
               type: array
               items:
-                type: string
-              description: Entity IDs (account addresses or transaction IDs)
+                $ref: '#/components/schemas/Account'
+              description: Full account entities (populated for account-target queries)
+            transactionData:
+              type: array
+              items:
+                $ref: '#/components/schemas/TransactionResponse'
+              description: Full transaction entities (populated for transaction-target queries)
         aggregateResult:
           type: object
           properties:
             volumes:
               type: array
               items:
-                type: object
-                properties:
-                  asset:
-                    type: string
-                  input:
-                    type: string
-                    description: Total input as big integer string
-                  output:
-                    type: string
-                    description: Total output as big integer string
+                $ref: '#/components/schemas/AggregatedVolume'
+              description: Per-asset aggregated volumes
+            groups:
+              type: array
+              items:
+                $ref: '#/components/schemas/GroupedAggregateResult'
+              description: Per-prefix aggregated volumes (present when `groupByPrefixes` is set)
 
     HealthResponse:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -1931,16 +1931,6 @@ components:
         JWT token issued by a trusted OIDC provider. Required when the server
         is started with `--auth-enabled`. Scopes: `ledger:read` (read operations),
         `ledger:write` (write operations), `ledger:admin` (cluster operations).
-    Ed25519Signature:
-      type: apiKey
-      in: header
-      name: X-Signature
-      description: >
-        Optional Ed25519 request signature for authenticity and integrity.
-        When request signing is enabled on the server, callers sign the request
-        payload with a registered key and pass the base64-encoded signature in
-        `X-Signature` together with the key id in `X-Signing-Key-Id`. See
-        `docs/ops/signing.md` for the exact signing algorithm and header set.
 
   parameters:
     LedgerName:
@@ -2646,23 +2636,29 @@ components:
 
     AggregatedVolume:
       type: object
+      description: |
+        Per-asset aggregated volume as emitted by `GET /v3/{ledgerName}/volumes`.
+        Prepared-query `AGGREGATE_VOLUMES` responses use the same shape
+        conceptually but currently leak the raw protojson encoding (numeric
+        Uint256, no `balance`) — reconciliation tracked in EN-1465 / EN-1469.
       required:
         - asset
         - input
         - output
+        - balance
       properties:
         asset:
           type: string
           description: Asset identifier (e.g. "USD/2")
         input:
-          description: |
-            Total amount received. Emitted as a JSON number decimal
-            (Uint256), which may exceed 2^53. JavaScript clients must parse
-            this as a BigInt/BigNumber to avoid precision loss.
+          type: string
+          description: Total amount received (as big integer string)
         output:
-          description: |
-            Total amount sent. Emitted as a JSON number decimal (Uint256);
-            see the note on `input` for JS precision handling.
+          type: string
+          description: Total amount sent (as big integer string)
+        balance:
+          type: string
+          description: Net balance (input - output, as big integer string)
 
     GroupedAggregateResult:
       type: object
@@ -3602,48 +3598,14 @@ components:
     ExecutePreparedQueryResponse:
       type: object
       description: |
-        Wraps either a cursor (for list-style targets like `LIST_ACCOUNTS`,
-        `LIST_TRANSACTIONS`) or an aggregate result (for `AGGREGATE_VOLUMES`).
-        Exactly one of `cursor` or `aggregateResult` is populated per response.
-      properties:
-        cursor:
-          type: object
-          properties:
-            pageSize:
-              type: integer
-              format: uint32
-              description: Number of entities in this page
-            hasMore:
-              type: boolean
-            previous:
-              type: string
-              description: Cursor to pass for the previous page
-            next:
-              type: string
-              description: Cursor to pass for the next page
-            accountData:
-              type: array
-              items:
-                $ref: '#/components/schemas/Account'
-              description: Full account entities (populated for account-target queries)
-            transactionData:
-              type: array
-              items:
-                $ref: '#/components/schemas/TransactionResponse'
-              description: Full transaction entities (populated for transaction-target queries)
-        aggregateResult:
-          type: object
-          properties:
-            volumes:
-              type: array
-              items:
-                $ref: '#/components/schemas/AggregatedVolume'
-              description: Per-asset aggregated volumes
-            groups:
-              type: array
-              items:
-                $ref: '#/components/schemas/GroupedAggregateResult'
-              description: Per-prefix aggregated volumes (present when `groupByPrefixes` is set)
+        Response wraps either a paged cursor (list-style targets like
+        `LIST_ACCOUNTS`, `LIST_TRANSACTIONS`) or an aggregate result
+        (`AGGREGATE_VOLUMES`). The current wire encoding leaks the raw
+        protobuf oneof shape (Go-cased `Result.Cursor` / `Result.Aggregate`
+        with nested proto field names). Reconciling the wire with a clean
+        top-level `cursor` / `aggregateResult` envelope is tracked in
+        EN-1465; this schema will be finalised together with that fix.
+      additionalProperties: true
 
     HealthResponse:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -2588,11 +2588,12 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/VolumesWithBalance'
           description: |
-            Per-asset input/output/balance for this account. Populated
-            inline on `GET /v3/{ledgerName}/accounts/{address}` (EN-1470).
-            List responses currently omit this field; for per-account
-            balances at scale, use `GET /v3/{ledgerName}/volumes` or a
-            prepared query with type `AGGREGATE_VOLUMES`.
+            Per-asset input/output/balance. On the current v3.0.0 wire this
+            field is not populated on `GET /v3/{ledgerName}/accounts/{address}`
+            responses — use `GET /v3/{ledgerName}/volumes` or a prepared
+            query with type `AGGREGATE_VOLUMES` for per-account balances.
+            Restoring v2's inline population is tracked separately in
+            EN-1470; this description will be updated once that fix lands.
 
     VolumesWithBalance:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -2588,12 +2588,12 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/VolumesWithBalance'
           description: |
-            Per-asset input/output/balance. On the current v3.0.0 wire this
-            field is not populated on `GET /v3/{ledgerName}/accounts/{address}`
-            responses — use `GET /v3/{ledgerName}/volumes` or a prepared
-            query with type `AGGREGATE_VOLUMES` for per-account balances.
-            Restoring v2's inline population is tracked separately in
-            EN-1470; this description will be updated once that fix lands.
+            Per-asset input/output/balance. The field is defined here so
+            the schema stays stable across future wire changes, but it is
+            not populated on the current v3 wire — `Account.MarshalJSON`
+            drops it. For per-account balances, use
+            `GET /v3/{ledgerName}/volumes` or a prepared query with type
+            `AGGREGATE_VOLUMES`.
 
     VolumesWithBalance:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -2588,10 +2588,11 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/VolumesWithBalance'
           description: |
-            Deprecated: never populated on account read responses. To retrieve
-            per-account volumes/balances, use a prepared query with type
-            `AGGREGATE_VOLUMES` scoped to the account address.
-          deprecated: true
+            Per-asset input/output/balance for this account. Populated only
+            when the caller opts in via `expandVolumes=true` on
+            `GET /v3/{ledgerName}/accounts/{address}`; omitted otherwise.
+            For per-account balances at scale, use `GET /v3/{ledgerName}/volumes`
+            or a prepared query with type `AGGREGATE_VOLUMES`.
 
     VolumesWithBalance:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -2591,9 +2591,12 @@ components:
             Per-asset input/output/balance. The field is defined here so
             the schema stays stable across future wire changes, but it is
             not populated on the current v3 wire — `Account.MarshalJSON`
-            drops it. For per-account balances, use
-            `GET /v3/{ledgerName}/volumes` or a prepared query with type
-            `AGGREGATE_VOLUMES`.
+            drops it. For per-account balances, use a prepared query with
+            type `AGGREGATE_VOLUMES` and an exact-address filter
+            (`address.hardcodedExact`); the aggregated volumes returned by
+            `GET /v3/{ledgerName}/volumes?prefix=…` match by raw byte
+            prefix (`acc:1` matches `acc:10`) and will produce incorrect
+            balances for a single-account lookup.
 
     VolumesWithBalance:
       type: object


### PR DESCRIPTION
## Summary

Several schemas in `openapi.yml` documented shapes that never appear on the wire, so SDK codegen and integrators hitting `v3.0.0-alpha.7` saw mismatches. This aligns the spec with reality — the wire is correct on all these points; only the spec moves here. Code-side fixes ship separately in [EN-1465](https://formance-team.atlassian.net/browse/EN-1465) (protojson leaks), [EN-1466](https://formance-team.atlassian.net/browse/EN-1466) (bulk cleanup), and [EN-1469](https://formance-team.atlassian.net/browse/EN-1469) (Uint256 encoding).

Fixes in this PR:

- **Info**: drop "V3 POC" from the title/description.
- **Transaction**: rename `inserted_at`/`updated_at`/`reverted_at` → `insertedAt`/`updatedAt`/`revertedAt` (camelCase per the invariant).
- **BulkResult.data**: describe as a nullable `TransactionResponse` (returned on `CREATE_TRANSACTION`); remove the duplicate `description` key that made the schema state both "operation result data" and "log ID".
- **Account.volumes**: mark deprecated with a note pointing to `AGGREGATE_VOLUMES` prepared queries for per-account balances.
- **AggregatedVolume**: drop `balance` from `required` (never emitted); note that `input`/`output` are unquoted JSON numbers today (Uint256) — JS clients must parse as BigInt. Will move to string in EN-1469.
- **ExecutePreparedQueryResponse**: describe the real shape — cursor carries `accountData`/`transactionData` with full entities plus `pageSize`/`previous`; `aggregateResult` references `AggregatedVolume` and adds `groups` for prefix grouping.
- **Ed25519Signature**: new `securityScheme` entry pointing to `docs/ops/signing.md`.
- **`prefix=`** on `/accounts` and `/volumes`: documented as byte-level (so `acc:1` matches `acc:10`) — never a path-segment match.

Note on `MirrorSyncProgress`: the spec already uses camelCase (`sourceLogCount`, `remainingLogs`) which is what CLAUDE.md mandates. If the wire actually emits snake_case, that's a code bug to fix separately (not here).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('openapi.yml'))"` succeeds
- [ ] `just generate` (or the downstream SDK build) picks up the schema changes without warnings
- [ ] Rendered in Redoc/Swagger — schemas match a real `alpha.7` response

Ticket: [EN-1467](https://formance-team.atlassian.net/browse/EN-1467) (epic: [EN-867](https://formance-team.atlassian.net/browse/EN-867))

[EN-1465]: https://formance-team.atlassian.net/browse/EN-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1466]: https://formance-team.atlassian.net/browse/EN-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1469]: https://formance-team.atlassian.net/browse/EN-1469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1467]: https://formance-team.atlassian.net/browse/EN-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ