### PR TITLE
fix(EN-1466): drop /_bulk alias and fix continueOnFailure=true status

### DIFF
--- a/docs/ops/performance-tuning.md
+++ b/docs/ops/performance-tuning.md
@@ -158,7 +158,7 @@ Use multi-source/multi-destination patterns when the business logic requires it,
 
 ### Use Bulk Mode for High Throughput
 
-The bulk API (`POST /{ledger}/_bulk` or gRPC `Apply` with multiple actions) amortizes the Raft consensus overhead across many transactions.
+The bulk API (`POST /v3/{ledger}/bulk` or gRPC `Apply` with multiple actions) amortizes the Raft consensus overhead across many transactions.
 
 | Approach | Raft entries | Network roundtrips |
 |----------|--------------|--------------------|

--- a/docs/technical/architecture/data-flows.md
+++ b/docs/technical/architecture/data-flows.md
@@ -651,7 +651,7 @@ sequenceDiagram
     participant RaftNode
     participant FSM
     
-    Client->>BulkHandler: POST /{ledger}/_bulk
+    Client->>BulkHandler: POST /v3/{ledger}/bulk
     BulkHandler->>BulkHandler: Parse Elements
     
     loop for each element
@@ -675,7 +675,7 @@ sequenceDiagram
     participant RaftNode
     participant FSM
     
-    Client->>BulkHandler: POST /{ledger}/_bulk?atomic=true
+    Client->>BulkHandler: POST /v3/{ledger}/bulk?atomic=true
     BulkHandler->>BulkHandler: Parse All Elements
     BulkHandler->>RaftNode: Apply(action1, action2, ..., actionN)
     Note over RaftNode,FSM: Single Raft Command with N actions

--- a/docs/technical/architecture/data-model.md
+++ b/docs/technical/architecture/data-model.md
@@ -415,7 +415,7 @@ All writes must go through the leader:
 ### Batching
 
 Transactions can be batched to improve throughput:
-- `/_bulk` API to send multiple operations
+- `/bulk` API to send multiple operations
 - Parallel processing possible
 - Optional atomicity
 

--- a/docs/technical/architecture/subsystems/admission/idempotency.md
+++ b/docs/technical/architecture/subsystems/admission/idempotency.md
@@ -168,7 +168,7 @@ All write operations support idempotency keys:
 | Delete transaction metadata | `DELETE /{ledger}/transactions/{id}/metadata/{key}` | Yes |
 | Create ledger | `POST /{ledger}` | Yes |
 | Delete ledger | `DELETE /{ledger}` | Yes |
-| Bulk operations | `POST /{ledger}/_bulk` | Yes (per action) |
+| Bulk operations | `POST /{ledger}/bulk` | Yes (per action) |
 
 ## Key Validation
 

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -308,10 +308,8 @@ Content-Type: application/json
 ]
 ```
 
-**Alternative endpoint**: `POST /v3/{ledgerName}/_bulk` (for backward compatibility)
-
 **Query Parameters**:
-- `continueOnFailure=true`: Continue even if an error occurs
+- `continueOnFailure=true`: Continue even if an element fails. The overall status stays 200; per-element failures surface via `errorCode` on each result.
 - `atomic=true`: Execute atomically (all or nothing) - not yet supported
 
 ### Account Metadata

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -309,7 +309,7 @@ Content-Type: application/json
 ```
 
 **Query Parameters**:
-- `continueOnFailure=true`: Continue even if an element fails. The overall status stays 200; per-element failures surface via `errorCode` on each result.
+- `continueOnFailure=true`: When the request is accepted, keep processing subsequent elements after a per-element **business** failure (validation / not-found / conflict / precondition / permission) instead of aborting. Business failures surface as `errorCode` on each element and the overall status stays `200`. Request-level failures (malformed body, missing scope, oversized) and processing-time infra/retryable failures (`ErrNoLeader`, cache-horizon exceeded, `KindInternal`, `KindResourceExhausted`, `KindUnavailable`) still surface as non-2xx (`4xx`, `429`, `503`, `500`) regardless of this flag — see the `POST /v3/{ledgerName}/bulk` operation in `openapi.yml` for the full status matrix.
 - `atomic=true`: Execute atomically (all or nothing) - not yet supported
 
 ### Account Metadata

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -190,7 +190,7 @@ Ledger metadata is stored separately from ledger configuration (LedgerInfo) and 
 
 ### 4. Bulk Operations
 
-**Endpoint:** `POST /v3/{ledgerName}/_bulk`
+**Endpoint:** `POST /v3/{ledgerName}/bulk`
 
 **Supported actions:**
 - ✅ `CREATE_TRANSACTION`

--- a/internal/adapter/http/handler.go
+++ b/internal/adapter/http/handler.go
@@ -157,9 +157,8 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 				r.Put("/{ledgerName}/account-types/default-enforcement-mode", server.handleSetDefaultEnforcementMode)
 			})
 
-			// Bulk endpoints: per-element scope check handled inside the handler
+			// Bulk endpoint: per-element scope check handled inside the handler
 			r.Post("/{ledgerName}/bulk", server.handleBulk)
-			r.Post("/{ledgerName}/_bulk", server.handleBulk)
 
 			// Prepared queries (read)
 			r.With(requireQueriesRead).Group(func(r chi.Router) {

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -191,29 +191,23 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 	return results
 }
 
-// writeBulkResponse writes the bulk response. Per-element errors are bucketed
-// into four classes that decide the top-level status; the ordering mirrors
-// handleError so a given error surfaces the same HTTP status inside a bulk as
-// it would in a single request:
+// writeBulkResponse writes the bulk response. Each per-element error is
+// mapped to the HTTP status it would carry as a single request (via
+// perElementStatus, which mirrors handleError). The top-level status is
+// then the "worst" of those statuses, with two rollup rules:
 //
-//  1. **Retryable infra** — `commonpb.ErrNoLeader`, `plan.ErrCacheHorizonExceeded`,
-//     or any `domain.Describable` whose Kind is Unavailable. Top-level `503`
-//     with `Retry-After: 1`, regardless of `continueOnFailure` (mirrors
-//     handleError's retryable-sentinel branch).
-//  2. **Non-retryable infra** — anything else that is not a domain business
-//     outcome, or a Describable whose Kind is Internal/ResourceExhausted.
-//     Top-level `500`, regardless of `continueOnFailure`.
-//  3. **Aborted** (`context.Canceled` sentinel emitted by runBulkSequential
-//     when `continueOnFailure=false` and a prior element failed): these
-//     elements were never attempted and contribute nothing to the top-level
-//     status — the original failing element drives the rollup.
-//  4. **Per-element business failures** — a Describable whose Kind maps to a
-//     4xx status. Rolled up per `continueOnFailure`: `200` when opt-in, `400`
-//     otherwise.
+//   - **Aborted** (`context.Canceled` sentinel emitted by runBulkSequential
+//     when `continueOnFailure=false` and a prior element failed): perElementStatus
+//     returns 0 and the element contributes nothing to the rollup.
+//   - **Per-element business** (4xx from a domain Describable): rolled up per
+//     `continueOnFailure` — suppressed to 200 when opt-in, surfaced as its
+//     own status (typically 400/404/409) otherwise.
+//
+// Any 5xx/429 status from infra/retryable/rate-limit errors always surfaces,
+// with `Retry-After: 1` on 503 to match handleError.
 func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
-	hasDomainError := false
-	hasRetryableInfraError := false
-	hasFatalInfraError := false
+	worstBusiness := 0 // highest 4xx from a per-element business failure
+	worstInfra := 0    // highest ≥429 from a retryable/infra/rate-limit error
 	apiResults := make([]bulkAPIResult, len(results))
 
 	for i, result := range results {
@@ -222,15 +216,24 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 		var data any
 
 		if result.err != nil {
-			switch classifyBulkError(result.err) {
-			case bulkErrClassAborted:
-				// Skipped element — no top-level status contribution.
-			case bulkErrClassDomain:
-				hasDomainError = true
-			case bulkErrClassRetryableInfra:
-				hasRetryableInfraError = true
-			case bulkErrClassFatalInfra:
-				hasFatalInfraError = true
+			switch st := perElementStatus(result.err); {
+			case st == 0:
+				// Aborted sentinel — no top-level status contribution.
+			case st >= 500:
+				if st > worstInfra {
+					worstInfra = st
+				}
+			case st == http.StatusTooManyRequests:
+				// KindResourceExhausted: retryable resource-limit, still
+				// forced past the continueOnFailure rollup.
+				if st > worstInfra {
+					worstInfra = st
+				}
+			default:
+				// 4xx per-element business error — subject to continueOnFailure.
+				if st > worstBusiness {
+					worstBusiness = st
+				}
 			}
 
 			apiResults[i] = bulkAPIResult{
@@ -261,65 +264,46 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 
 	statusCode := http.StatusOK
 	switch {
-	case hasFatalInfraError:
-		statusCode = http.StatusInternalServerError
-	case hasRetryableInfraError:
-		// Match handleError's leader-loss / cache-horizon branch: the caller
-		// must retry, and Retry-After gives them the same backoff hint they
-		// get on single requests.
-		w.Header().Set("Retry-After", "1")
-		statusCode = http.StatusServiceUnavailable
-	case hasDomainError && !continueOnFailure:
-		statusCode = http.StatusBadRequest
+	case worstInfra > 0:
+		statusCode = worstInfra
+		if worstInfra == http.StatusServiceUnavailable {
+			// Match handleError's leader-loss / cache-horizon branch: give
+			// callers the same backoff hint on single requests.
+			w.Header().Set("Retry-After", "1")
+		}
+	case worstBusiness > 0 && !continueOnFailure:
+		statusCode = worstBusiness
 	}
 
 	response := bulkResponse{Data: apiResults}
 	writeJSONResponse(w, statusCode, response)
 }
 
-// bulkErrClass tags where a per-element error counts in the top-level status
-// roll-up.
-type bulkErrClass int
-
-const (
-	bulkErrClassAborted bulkErrClass = iota
-	bulkErrClassDomain
-	bulkErrClassRetryableInfra
-	bulkErrClassFatalInfra
-)
-
-// classifyBulkError decides which bucket a per-element error falls into. The
-// checks mirror the ones in handleError so bulk stays consistent with single
-// requests: the same error would produce the same HTTP status outside a bulk.
-func classifyBulkError(err error) bulkErrClass {
+// perElementStatus returns the HTTP status a given per-element error would
+// carry as a single request, or 0 for the runBulkSequential context.Canceled
+// sentinel that marks skipped elements. The mapping mirrors handleError so
+// bulk stays consistent with single-request handling.
+func perElementStatus(err error) int {
+	// Aborted sentinel: runBulkSequential sets this on remaining elements
+	// after the first failure when continueOnFailure=false. Not a status
+	// contributor — the originating error drives the rollup.
 	if errors.Is(err, context.Canceled) {
-		return bulkErrClassAborted
+		return 0
 	}
 
-	// Retryable infra sentinels handled before Describable dispatch, mirroring
-	// handleError.
+	// Retryable infra sentinels handled before Describable dispatch,
+	// mirroring handleError.
 	if errors.Is(err, commonpb.ErrNoLeader) || errors.Is(err, plan.ErrCacheHorizonExceeded) {
-		return bulkErrClassRetryableInfra
+		return http.StatusServiceUnavailable
 	}
 
 	var d domain.Describable
 	if errors.As(err, &d) {
-		// A Describable's Kind decides whether the outcome is a business
-		// failure (4xx → per-element), a retryable infra condition
-		// (Unavailable → 503), or a fatal infra condition (Internal /
-		// ResourceExhausted → 500).
-		switch domain.Kind(d) {
-		case domain.KindUnavailable:
-			return bulkErrClassRetryableInfra
-		case domain.KindInternal, domain.KindResourceExhausted:
-			return bulkErrClassFatalInfra
-		default:
-			return bulkErrClassDomain
-		}
+		return kindToHTTPStatus(domain.Kind(d))
 	}
 
-	// Unknown error: assume fatal infra so it can't be masked as a 200.
-	return bulkErrClassFatalInfra
+	// Unknown error: 500. Can't be masked as 200 under continueOnFailure.
+	return http.StatusInternalServerError
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -190,12 +190,20 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 	return results
 }
 
-// writeBulkResponse writes the bulk response. When continueOnFailure is true
-// the caller opted into per-element failures being non-fatal, so the top-level
-// status stays 200 regardless of any element errors (per-element errorCode
-// still reports the failure). When false, any element error surfaces as 400.
+// writeBulkResponse writes the bulk response. Two error dimensions decide the
+// top-level status:
+//
+//  1. Kind: per-element domain business errors (`domain.Describable`) vs
+//     infrastructure/transport errors (leader lost, cache-horizon, timeouts).
+//     Infra errors are never opt-in-able — they always surface as top-level
+//     failures (`500`), because they indicate the whole request could not
+//     complete deterministically. `continueOnFailure` does not apply to them.
+//  2. Rollup: for the remaining pure-domain errors, `continueOnFailure=true`
+//     keeps the top-level status `200` (per-element `errorCode` is enough);
+//     `continueOnFailure=false` surfaces the first business failure as `400`.
 func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
-	hasError := false
+	hasDomainError := false
+	hasInfraError := false
 	apiResults := make([]bulkAPIResult, len(results))
 
 	for i, result := range results {
@@ -204,7 +212,12 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 		var data any
 
 		if result.err != nil {
-			hasError = true
+			if isDomainError(result.err) {
+				hasDomainError = true
+			} else {
+				hasInfraError = true
+			}
+
 			apiResults[i] = bulkAPIResult{
 				ResponseType:     "ERROR",
 				ErrorCode:        bulkErrorCode(result.err),
@@ -232,12 +245,26 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 	}
 
 	statusCode := http.StatusOK
-	if hasError && !continueOnFailure {
+	switch {
+	case hasInfraError:
+		statusCode = http.StatusInternalServerError
+	case hasDomainError && !continueOnFailure:
 		statusCode = http.StatusBadRequest
 	}
 
 	response := bulkResponse{Data: apiResults}
 	writeJSONResponse(w, statusCode, response)
+}
+
+// isDomainError reports whether the given error carries a domain-level
+// Describable outcome (validation, not-found, insufficient-fund, etc.). Any
+// error that does not implement the contract is treated as infrastructural,
+// which turns off the `continueOnFailure` roll-up: the bulk did not fail on
+// business grounds and must not be masked as `200`.
+func isDomainError(err error) bool {
+	var d domain.Describable
+
+	return errors.As(err, &d)
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -8,11 +8,12 @@ import (
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-// handleBulk handles POST /{ledgerName}/_bulk to create multiple transactions/operations.
+// handleBulk handles POST /{ledgerName}/bulk to create multiple transactions/operations.
 func (s *Server) handleBulk(w http.ResponseWriter, r *http.Request) {
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
@@ -78,7 +79,7 @@ func (s *Server) handleBulk(w http.ResponseWriter, r *http.Request) {
 	results := s.runBulk(r.Context(), ledgerName, elements, opts)
 
 	// Write response
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, opts.continueOnFailure)
 }
 
 // bulkOptions contains options for bulk processing.
@@ -189,8 +190,11 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 	return results
 }
 
-// writeBulkResponse writes the bulk response.
-func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult) {
+// writeBulkResponse writes the bulk response. When continueOnFailure is true
+// the caller opted into per-element failures being non-fatal, so the top-level
+// status stays 200 regardless of any element errors (per-element errorCode
+// still reports the failure). When false, any element error surfaces as 400.
+func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
 	hasError := false
 	apiResults := make([]bulkAPIResult, len(results))
 
@@ -203,7 +207,7 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 			hasError = true
 			apiResults[i] = bulkAPIResult{
 				ResponseType:     "ERROR",
-				ErrorCode:        "ERROR",
+				ErrorCode:        bulkErrorCode(result.err),
 				ErrorDescription: result.err.Error(),
 			}
 
@@ -228,12 +232,24 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 	}
 
 	statusCode := http.StatusOK
-	if hasError {
+	if hasError && !continueOnFailure {
 		statusCode = http.StatusBadRequest
 	}
 
 	response := bulkResponse{Data: apiResults}
 	writeJSONResponse(w, statusCode, response)
+}
+
+// bulkErrorCode returns a machine-readable code for a per-element bulk failure.
+// Domain-typed errors expose it through the Describable contract; anything else
+// keeps the generic "ERROR" fallback rather than leaking a raw string.
+func bulkErrorCode(err error) string {
+	var d domain.Describable
+	if errors.As(err, &d) {
+		return d.Reason()
+	}
+
+	return "ERROR"
 }
 
 // writeBulkErrorResponse writes a bulk error response.

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -191,27 +191,29 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 	return results
 }
 
-// writeBulkResponse writes the bulk response. Three error classes decide the
-// top-level status:
+// writeBulkResponse writes the bulk response. Per-element errors are bucketed
+// into four classes that decide the top-level status; the ordering mirrors
+// handleError so a given error surfaces the same HTTP status inside a bulk as
+// it would in a single request:
 //
-//  1. **Aborted** (sentinel `context.Canceled` from runBulkSequential when
-//     `continueOnFailure=false` and a prior element failed). Not a real
-//     failure — these elements were not attempted. They contribute no
-//     top-level status of their own; the top-level status is driven by the
-//     original failing element instead.
-//  2. **Per-element business failures** — a `domain.Describable` whose Kind
-//     maps to a 4xx status (validation, not-found, conflict, precondition,
-//     permission). Rolled up according to `continueOnFailure`: `200` when
-//     opt-in, `400` (default) otherwise.
-//  3. **Infrastructure / retryable failures** — anything else, including
-//     `commonpb.ErrNoLeader`, `plan.ErrCacheHorizonExceeded`, and any
-//     Describable whose Kind maps to 5xx (Unavailable, Internal,
-//     ResourceExhausted). These always surface as top-level `500`
-//     regardless of `continueOnFailure`; the bulk did not complete
-//     deterministically and the caller must retry.
+//  1. **Retryable infra** — `commonpb.ErrNoLeader`, `plan.ErrCacheHorizonExceeded`,
+//     or any `domain.Describable` whose Kind is Unavailable. Top-level `503`
+//     with `Retry-After: 1`, regardless of `continueOnFailure` (mirrors
+//     handleError's retryable-sentinel branch).
+//  2. **Non-retryable infra** — anything else that is not a domain business
+//     outcome, or a Describable whose Kind is Internal/ResourceExhausted.
+//     Top-level `500`, regardless of `continueOnFailure`.
+//  3. **Aborted** (`context.Canceled` sentinel emitted by runBulkSequential
+//     when `continueOnFailure=false` and a prior element failed): these
+//     elements were never attempted and contribute nothing to the top-level
+//     status — the original failing element drives the rollup.
+//  4. **Per-element business failures** — a Describable whose Kind maps to a
+//     4xx status. Rolled up per `continueOnFailure`: `200` when opt-in, `400`
+//     otherwise.
 func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
 	hasDomainError := false
-	hasInfraError := false
+	hasRetryableInfraError := false
+	hasFatalInfraError := false
 	apiResults := make([]bulkAPIResult, len(results))
 
 	for i, result := range results {
@@ -225,8 +227,10 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 				// Skipped element — no top-level status contribution.
 			case bulkErrClassDomain:
 				hasDomainError = true
-			case bulkErrClassInfra:
-				hasInfraError = true
+			case bulkErrClassRetryableInfra:
+				hasRetryableInfraError = true
+			case bulkErrClassFatalInfra:
+				hasFatalInfraError = true
 			}
 
 			apiResults[i] = bulkAPIResult{
@@ -257,8 +261,14 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 
 	statusCode := http.StatusOK
 	switch {
-	case hasInfraError:
+	case hasFatalInfraError:
 		statusCode = http.StatusInternalServerError
+	case hasRetryableInfraError:
+		// Match handleError's leader-loss / cache-horizon branch: the caller
+		// must retry, and Retry-After gives them the same backoff hint they
+		// get on single requests.
+		w.Header().Set("Retry-After", "1")
+		statusCode = http.StatusServiceUnavailable
 	case hasDomainError && !continueOnFailure:
 		statusCode = http.StatusBadRequest
 	}
@@ -267,15 +277,15 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 	writeJSONResponse(w, statusCode, response)
 }
 
-// bulkErrClass tags where a per-element error should count in the top-level
-// status roll-up: aborted (no contribution), per-element business, or
-// infrastructure/retryable.
+// bulkErrClass tags where a per-element error counts in the top-level status
+// roll-up.
 type bulkErrClass int
 
 const (
 	bulkErrClassAborted bulkErrClass = iota
 	bulkErrClassDomain
-	bulkErrClassInfra
+	bulkErrClassRetryableInfra
+	bulkErrClassFatalInfra
 )
 
 // classifyBulkError decides which bucket a per-element error falls into. The
@@ -289,22 +299,27 @@ func classifyBulkError(err error) bulkErrClass {
 	// Retryable infra sentinels handled before Describable dispatch, mirroring
 	// handleError.
 	if errors.Is(err, commonpb.ErrNoLeader) || errors.Is(err, plan.ErrCacheHorizonExceeded) {
-		return bulkErrClassInfra
+		return bulkErrClassRetryableInfra
 	}
 
 	var d domain.Describable
 	if errors.As(err, &d) {
 		// A Describable's Kind decides whether the outcome is a business
-		// failure (4xx → per-element) or an infra condition (5xx → top-level).
-		if kindToHTTPStatus(domain.Kind(d)) >= 500 {
-			return bulkErrClassInfra
+		// failure (4xx → per-element), a retryable infra condition
+		// (Unavailable → 503), or a fatal infra condition (Internal /
+		// ResourceExhausted → 500).
+		switch domain.Kind(d) {
+		case domain.KindUnavailable:
+			return bulkErrClassRetryableInfra
+		case domain.KindInternal, domain.KindResourceExhausted:
+			return bulkErrClassFatalInfra
+		default:
+			return bulkErrClassDomain
 		}
-
-		return bulkErrClassDomain
 	}
 
-	// Unknown error: assume infra so it can't be masked as a 200.
-	return bulkErrClassInfra
+	// Unknown error: assume fatal infra so it can't be masked as a 200.
+	return bulkErrClassFatalInfra
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -9,6 +9,7 @@ import (
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/plan"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -190,17 +191,24 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 	return results
 }
 
-// writeBulkResponse writes the bulk response. Two error dimensions decide the
+// writeBulkResponse writes the bulk response. Three error classes decide the
 // top-level status:
 //
-//  1. Kind: per-element domain business errors (`domain.Describable`) vs
-//     infrastructure/transport errors (leader lost, cache-horizon, timeouts).
-//     Infra errors are never opt-in-able — they always surface as top-level
-//     failures (`500`), because they indicate the whole request could not
-//     complete deterministically. `continueOnFailure` does not apply to them.
-//  2. Rollup: for the remaining pure-domain errors, `continueOnFailure=true`
-//     keeps the top-level status `200` (per-element `errorCode` is enough);
-//     `continueOnFailure=false` surfaces the first business failure as `400`.
+//  1. **Aborted** (sentinel `context.Canceled` from runBulkSequential when
+//     `continueOnFailure=false` and a prior element failed). Not a real
+//     failure — these elements were not attempted. They contribute no
+//     top-level status of their own; the top-level status is driven by the
+//     original failing element instead.
+//  2. **Per-element business failures** — a `domain.Describable` whose Kind
+//     maps to a 4xx status (validation, not-found, conflict, precondition,
+//     permission). Rolled up according to `continueOnFailure`: `200` when
+//     opt-in, `400` (default) otherwise.
+//  3. **Infrastructure / retryable failures** — anything else, including
+//     `commonpb.ErrNoLeader`, `plan.ErrCacheHorizonExceeded`, and any
+//     Describable whose Kind maps to 5xx (Unavailable, Internal,
+//     ResourceExhausted). These always surface as top-level `500`
+//     regardless of `continueOnFailure`; the bulk did not complete
+//     deterministically and the caller must retry.
 func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
 	hasDomainError := false
 	hasInfraError := false
@@ -212,9 +220,12 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 		var data any
 
 		if result.err != nil {
-			if isDomainError(result.err) {
+			switch classifyBulkError(result.err) {
+			case bulkErrClassAborted:
+				// Skipped element — no top-level status contribution.
+			case bulkErrClassDomain:
 				hasDomainError = true
-			} else {
+			case bulkErrClassInfra:
 				hasInfraError = true
 			}
 
@@ -256,15 +267,44 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 	writeJSONResponse(w, statusCode, response)
 }
 
-// isDomainError reports whether the given error carries a domain-level
-// Describable outcome (validation, not-found, insufficient-fund, etc.). Any
-// error that does not implement the contract is treated as infrastructural,
-// which turns off the `continueOnFailure` roll-up: the bulk did not fail on
-// business grounds and must not be masked as `200`.
-func isDomainError(err error) bool {
-	var d domain.Describable
+// bulkErrClass tags where a per-element error should count in the top-level
+// status roll-up: aborted (no contribution), per-element business, or
+// infrastructure/retryable.
+type bulkErrClass int
 
-	return errors.As(err, &d)
+const (
+	bulkErrClassAborted bulkErrClass = iota
+	bulkErrClassDomain
+	bulkErrClassInfra
+)
+
+// classifyBulkError decides which bucket a per-element error falls into. The
+// checks mirror the ones in handleError so bulk stays consistent with single
+// requests: the same error would produce the same HTTP status outside a bulk.
+func classifyBulkError(err error) bulkErrClass {
+	if errors.Is(err, context.Canceled) {
+		return bulkErrClassAborted
+	}
+
+	// Retryable infra sentinels handled before Describable dispatch, mirroring
+	// handleError.
+	if errors.Is(err, commonpb.ErrNoLeader) || errors.Is(err, plan.ErrCacheHorizonExceeded) {
+		return bulkErrClassInfra
+	}
+
+	var d domain.Describable
+	if errors.As(err, &d) {
+		// A Describable's Kind decides whether the outcome is a business
+		// failure (4xx → per-element) or an infra condition (5xx → top-level).
+		if kindToHTTPStatus(domain.Kind(d)) >= 500 {
+			return bulkErrClassInfra
+		}
+
+		return bulkErrClassDomain
+	}
+
+	// Unknown error: assume infra so it can't be masked as a 200.
+	return bulkErrClassInfra
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -955,6 +955,53 @@ func TestWriteBulkResponse_WithErrors(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestWriteBulkResponse_KindDispatch enumerates every domain.ErrorKind and
+// asserts the per-element status maps to the corresponding top-level status
+// under continueOnFailure=true — pinning that infrastructure/retryable
+// Describables (KindInternal, KindUnavailable, KindResourceExhausted) surface
+// their real 5xx/429 status even when the caller opts into rollup.
+func TestWriteBulkResponse_KindDispatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantRetry  bool
+	}{
+		// Business kinds → suppressed to 200 under continueOnFailure=true.
+		{"validation", domain.NewValidationSentinel("bad"), http.StatusOK, false},
+		// Retryable infra → 503 with Retry-After, unmasked by continueOnFailure.
+		{"leader-loss", commonpb.ErrNoLeader, http.StatusServiceUnavailable, true},
+		// Plain infrastructure error (non-Describable) → 500.
+		{"opaque-infra", errors.New("boom"), http.StatusInternalServerError, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			elements := []*servicepb.BulkElement{{Action: &servicepb.LedgerAction{
+				Data: &servicepb.LedgerAction_CreateTransaction{
+					CreateTransaction: &servicepb.CreateTransactionPayload{},
+				},
+			}}}
+
+			w := httptest.NewRecorder()
+			writeBulkResponse(w, elements, []bulkResult{{err: tc.err}}, true)
+
+			require.Equal(t, tc.wantStatus, w.Code, "unexpected top-level status for %q", tc.name)
+
+			retryAfter := w.Header().Get("Retry-After")
+			if tc.wantRetry {
+				require.Equal(t, "1", retryAfter, "Retry-After missing for %q", tc.name)
+			} else {
+				require.Empty(t, retryAfter, "Retry-After should be absent for %q", tc.name)
+			}
+		})
+	}
+}
+
 func TestWriteBulkResponse_ContinueOnFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -1184,9 +1184,9 @@ func TestWriteBulkResponse_AbortedElementsDontEscalate(t *testing.T) {
 
 // TestHandleBulk_InfraErrorNotSwallowed asserts that continueOnFailure=true
 // does NOT swallow an infrastructure-level Apply error (any non-Describable
-// error, e.g. leader loss, cache-horizon exceeded, transport timeout). Those
-// mean the request could not complete deterministically and the caller must
-// see a 5xx regardless of the continueOnFailure opt-in.
+// error, e.g. transport timeout, pebble error). Those mean the request could
+// not complete deterministically and the caller must see a 5xx regardless of
+// the continueOnFailure opt-in.
 func TestHandleBulk_InfraErrorNotSwallowed(t *testing.T) {
 	t.Parallel()
 
@@ -1206,6 +1206,33 @@ func TestHandleBulk_InfraErrorNotSwallowed(t *testing.T) {
 	srv.handleBulk(w, r)
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestHandleBulk_LeaderLossReturns503WithRetryAfter asserts that
+// commonpb.ErrNoLeader — a retryable infra sentinel — surfaces as 503 with a
+// Retry-After header, matching the shape handleError uses on single requests
+// (see internal/adapter/http/error_handler.go). Any other status would leave
+// callers without the backoff hint the sentinel is meant to carry.
+func TestHandleBulk_LeaderLossReturns503WithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			return nil, commonpb.ErrNoLeader
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`[{"action":"CREATE_TRANSACTION","data":{"script":{"plain":"a"}}}]`)
+	r := newRequest(t, http.MethodPost, "/ledger1/bulk?continueOnFailure=true", body, map[string]string{
+		"ledgerName": "ledger1",
+	})
+
+	srv.handleBulk(w, r)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Equal(t, "1", w.Header().Get("Retry-After"))
 }
 
 // --------------------------------------------------------------------------

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -950,9 +950,47 @@ func TestWriteBulkResponse_WithErrors(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, false)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestWriteBulkResponse_ContinueOnFailure(t *testing.T) {
+	t.Parallel()
+
+	elements := []*servicepb.BulkElement{
+		{Action: &servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_CreateTransaction{
+				CreateTransaction: &servicepb.CreateTransactionPayload{},
+			},
+		}},
+		{Action: &servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_CreateTransaction{
+				CreateTransaction: &servicepb.CreateTransactionPayload{},
+			},
+		}},
+	}
+
+	results := []bulkResult{
+		{err: errors.New("something failed")},
+		{
+			log: &commonpb.LedgerLog{
+				Id: 2,
+				Data: &commonpb.LedgerLogPayload{
+					Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+						CreatedTransaction: &commonpb.CreatedTransaction{
+							Transaction: &commonpb.Transaction{Id: 2},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	writeBulkResponse(w, elements, results, true)
+
+	require.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestWriteBulkResponse_AllSuccess(t *testing.T) {
@@ -982,7 +1020,7 @@ func TestWriteBulkResponse_AllSuccess(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1001,7 +1039,7 @@ func TestWriteBulkResponse_NilLog(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1102,8 +1140,10 @@ func TestHandleBulk_WithContinueOnFailure(t *testing.T) {
 
 	srv.handleBulk(w, r)
 
-	// Should have errors, so 400
-	require.Equal(t, http.StatusBadRequest, w.Code)
+	// continueOnFailure=true → per-element failures don't turn the request
+	// itself into a top-level failure. Response stays 200 and the caller reads
+	// per-element errorCode.
+	require.Equal(t, http.StatusOK, w.Code)
 }
 
 // --------------------------------------------------------------------------
@@ -1267,7 +1307,7 @@ func TestWriteBulkResponse_LogWithCreatedTransaction(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Body.String(), "CREATE_TRANSACTION")
@@ -1292,7 +1332,7 @@ func TestWriteBulkResponse_LogWithoutData(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results)
+	writeBulkResponse(w, elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -934,7 +934,7 @@ func TestWriteBulkResponse_WithErrors(t *testing.T) {
 	}
 
 	results := []bulkResult{
-		{err: errors.New("something failed")},
+		{err: domain.ErrEmptyTransaction},
 		{
 			log: &commonpb.LedgerLog{
 				Id: 2,
@@ -972,7 +972,7 @@ func TestWriteBulkResponse_ContinueOnFailure(t *testing.T) {
 	}
 
 	results := []bulkResult{
-		{err: errors.New("something failed")},
+		{err: domain.ErrEmptyTransaction},
 		{
 			log: &commonpb.LedgerLog{
 				Id: 2,
@@ -1106,7 +1106,11 @@ func TestHandleBulk_WithContinueOnFailure(t *testing.T) {
 		func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
 			callCount++
 			if callCount == 1 {
-				return nil, errors.New("first fails")
+				// Domain-level (Describable) business error — the caller
+				// opted into continuing on this kind of per-element
+				// failure. Non-domain (infra) errors are asserted
+				// separately, see TestHandleBulk_InfraErrorNotSwallowed.
+				return nil, domain.ErrEmptyTransaction
 			}
 
 			return []*commonpb.Log{
@@ -1140,10 +1144,36 @@ func TestHandleBulk_WithContinueOnFailure(t *testing.T) {
 
 	srv.handleBulk(w, r)
 
-	// continueOnFailure=true → per-element failures don't turn the request
-	// itself into a top-level failure. Response stays 200 and the caller reads
-	// per-element errorCode.
+	// continueOnFailure=true → per-element domain failures don't turn the
+	// request itself into a top-level failure. Response stays 200 and the
+	// caller reads per-element errorCode.
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestHandleBulk_InfraErrorNotSwallowed asserts that continueOnFailure=true
+// does NOT swallow an infrastructure-level Apply error (any non-Describable
+// error, e.g. leader loss, cache-horizon exceeded, transport timeout). Those
+// mean the request could not complete deterministically and the caller must
+// see a 5xx regardless of the continueOnFailure opt-in.
+func TestHandleBulk_InfraErrorNotSwallowed(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			return nil, errors.New("boom: pebble store unavailable")
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`[{"action":"CREATE_TRANSACTION","data":{"script":{"plain":"a"}}}]`)
+	r := newRequest(t, http.MethodPost, "/ledger1/bulk?continueOnFailure=true", body, map[string]string{
+		"ledgerName": "ledger1",
+	})
+
+	srv.handleBulk(w, r)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 // --------------------------------------------------------------------------

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -1150,6 +1150,38 @@ func TestHandleBulk_WithContinueOnFailure(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
+// TestWriteBulkResponse_AbortedElementsDontEscalate asserts that
+// runBulkSequential's context.Canceled sentinel (marking elements skipped
+// after a prior failed with continueOnFailure=false) never turns the
+// top-level status into 500. The originating domain error alone drives the
+// 400 rollup; the skipped tail contributes nothing.
+func TestWriteBulkResponse_AbortedElementsDontEscalate(t *testing.T) {
+	t.Parallel()
+
+	elements := []*servicepb.BulkElement{
+		{Action: &servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_CreateTransaction{
+				CreateTransaction: &servicepb.CreateTransactionPayload{},
+			},
+		}},
+		{Action: &servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_CreateTransaction{
+				CreateTransaction: &servicepb.CreateTransactionPayload{},
+			},
+		}},
+	}
+
+	results := []bulkResult{
+		{err: domain.ErrEmptyTransaction},
+		{err: context.Canceled}, // skipped by runBulkSequential
+	}
+
+	w := httptest.NewRecorder()
+	writeBulkResponse(w, elements, results, false)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 // TestHandleBulk_InfraErrorNotSwallowed asserts that continueOnFailure=true
 // does NOT swallow an infrastructure-level Apply error (any non-Describable
 // error, e.g. leader loss, cache-horizon exceeded, transport timeout). Those

--- a/openapi.yml
+++ b/openapi.yml
@@ -1427,17 +1427,19 @@ paths:
         revert transactions, delete metadata) in a single request. Requires
         `ledger:write` scope.
 
-        Request-level failures (malformed body, size limit, missing scope)
-        return the usual `400` / `401` / `403` / `413` before any element
-        is processed.
+        The response status distinguishes two failure classes:
 
-        Once the request is accepted, `continueOnFailure` controls how
-        per-element failures roll up to the response status:
-        - `continueOnFailure=true` → status stays `200`, and per-element
-          success or failure is reported via the `errorCode` on each
-          element in `data`.
-        - `continueOnFailure=false` (default) → the bulk aborts on the
-          first per-element failure and the response is `400`.
+        1. **Request-level failures** (before per-element processing):
+           malformed body → `400`, missing/insufficient scope → `401` or
+           `403`, oversized body → `413`, leader unavailable → `503`. These
+           are returned unconditionally, regardless of `continueOnFailure`.
+        2. **Per-element failures** (during processing, after the request
+           was accepted): rolled up according to `continueOnFailure`:
+           - `continueOnFailure=true` → the overall status is `200`; each
+             element in `data` carries its own `errorCode` on failure.
+           - `continueOnFailure=false` (default) → the bulk aborts on the
+             first per-element failure and the overall status is `400`,
+             with the same per-element `errorCode` on the failing element.
       operationId: bulkOperations
       tags:
         - Transactions

--- a/openapi.yml
+++ b/openapi.yml
@@ -1438,9 +1438,17 @@ paths:
            status is `500`, regardless of `continueOnFailure`. Callers
            must retry the bulk — the top-level failure means the request
            did not complete deterministically.
-        3. **Per-element business failures** (validation, insufficient
-           fund, not-found, etc.): rolled up according to
-           `continueOnFailure`:
+        3. **Retryable infrastructure failures** (leader loss,
+           cache-horizon exceeded, or any Describable with a `KindUnavailable`
+           outcome): the overall status is `503` with a `Retry-After` header,
+           regardless of `continueOnFailure`. The caller must retry.
+        4. **Non-retryable infrastructure failures** (transport / storage
+           errors, unclassified errors, Describable with `KindInternal` or
+           `KindResourceExhausted`): the overall status is `500`, regardless
+           of `continueOnFailure`.
+        5. **Per-element business failures** (validation, insufficient
+           fund, not-found, precondition, permission, etc.): rolled up
+           according to `continueOnFailure`:
            - `continueOnFailure=true` → the overall status is `200`; each
              element in `data` carries its own `errorCode` on failure.
            - `continueOnFailure=false` (default) → the bulk aborts on the

--- a/openapi.yml
+++ b/openapi.yml
@@ -1427,14 +1427,20 @@ paths:
         revert transactions, delete metadata) in a single request. Requires
         `ledger:write` scope.
 
-        The response status distinguishes two failure classes:
+        The response status is decided in three tiers:
 
         1. **Request-level failures** (before per-element processing):
            malformed body → `400`, missing/insufficient scope → `401` or
-           `403`, oversized body → `413`, leader unavailable → `503`. These
-           are returned unconditionally, regardless of `continueOnFailure`.
-        2. **Per-element failures** (during processing, after the request
-           was accepted): rolled up according to `continueOnFailure`:
+           `403`, oversized body → `413`, leader unavailable → `503`.
+           Returned unconditionally, `continueOnFailure` does not apply.
+        2. **Infrastructure failures during processing** (transport
+           timeout, cache-horizon exceeded, storage error): the overall
+           status is `500`, regardless of `continueOnFailure`. Callers
+           must retry the bulk — the top-level failure means the request
+           did not complete deterministically.
+        3. **Per-element business failures** (validation, insufficient
+           fund, not-found, etc.): rolled up according to
+           `continueOnFailure`:
            - `continueOnFailure=true` → the overall status is `200`; each
              element in `data` carries its own `errorCode` on failure.
            - `continueOnFailure=false` (default) → the bulk aborts on the

--- a/openapi.yml
+++ b/openapi.yml
@@ -1499,6 +1499,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkResponse'
+        '429':
+          description: |
+            A per-element error mapped to `KindResourceExhausted` (quota
+            or rate-limit hit during processing). Surfaces unconditionally,
+            regardless of `continueOnFailure`. Body carries the per-element
+            details in `data`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/openapi.yml
+++ b/openapi.yml
@@ -1424,12 +1424,20 @@ paths:
       summary: Bulk operations
       description: |
         Execute multiple operations (create transactions, add metadata,
-        revert transactions, delete metadata) in a single request. When
-        `continueOnFailure=true` the response always uses status 200 and
-        callers must inspect the per-element `errorCode` for individual
-        failures; otherwise a per-element failure surfaces as status 400
-        with `errorCode` set on the failing element. Requires
+        revert transactions, delete metadata) in a single request. Requires
         `ledger:write` scope.
+
+        Request-level failures (malformed body, size limit, missing scope)
+        return the usual `400` / `401` / `403` / `413` before any element
+        is processed.
+
+        Once the request is accepted, `continueOnFailure` controls how
+        per-element failures roll up to the response status:
+        - `continueOnFailure=true` → status stays `200`, and per-element
+          success or failure is reported via the `errorCode` on each
+          element in `data`.
+        - `continueOnFailure=false` (default) → the bulk aborts on the
+          first per-element failure and the response is `400`.
       operationId: bulkOperations
       tags:
         - Transactions

--- a/openapi.yml
+++ b/openapi.yml
@@ -1419,78 +1419,18 @@ paths:
         '405':
           $ref: '#/components/responses/MethodNotAllowed'
 
-  /v3/{ledgerName}/_bulk:
-    post:
-      summary: Bulk operations
-      description: Execute multiple operations (create transactions, add metadata, revert transactions, delete metadata) in a single request. Requires `ledger:write` scope.
-      operationId: bulkOperations
-      tags:
-        - Transactions
-      security:
-        - BearerAuth: []
-        - {}
-      parameters:
-        - $ref: '#/components/parameters/LedgerName'
-        - name: continueOnFailure
-          in: query
-          schema:
-            type: boolean
-            default: false
-          description: Continue processing remaining operations even if one fails
-        - name: atomic
-          in: query
-          schema:
-            type: boolean
-            default: false
-          description: Execute all operations atomically (not yet supported)
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/BulkElement'
-      responses:
-        '200':
-          description: Bulk operations completed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BulkResponse'
-        '400':
-          description: Bulk operations completed with errors, or invalid request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BulkResponse'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '413':
-          description: Request entity too large
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-        '405':
-          $ref: '#/components/responses/MethodNotAllowed'
-
   /v3/{ledgerName}/bulk:
     post:
-      summary: Bulk operations (alternate path)
+      summary: Bulk operations
       description: |
-        Alias for `POST /{ledgerName}/_bulk`. Execute multiple operations
-        (create transactions, add metadata, revert transactions, delete metadata)
-        in a single request. Requires `ledger:write` scope.
-      operationId: bulkOperationsAlternate
+        Execute multiple operations (create transactions, add metadata,
+        revert transactions, delete metadata) in a single request. When
+        `continueOnFailure=true` the response always uses status 200 and
+        callers must inspect the per-element `errorCode` for individual
+        failures; otherwise a per-element failure surfaces as status 400
+        with `errorCode` set on the failing element. Requires
+        `ledger:write` scope.
+      operationId: bulkOperations
       tags:
         - Transactions
       security:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1438,22 +1438,26 @@ paths:
            status is `500`, regardless of `continueOnFailure`. Callers
            must retry the bulk — the top-level failure means the request
            did not complete deterministically.
-        3. **Retryable infrastructure failures** (leader loss,
-           cache-horizon exceeded, or any Describable with a `KindUnavailable`
-           outcome): the overall status is `503` with a `Retry-After` header,
-           regardless of `continueOnFailure`. The caller must retry.
-        4. **Non-retryable infrastructure failures** (transport / storage
-           errors, unclassified errors, Describable with `KindInternal` or
-           `KindResourceExhausted`): the overall status is `500`, regardless
-           of `continueOnFailure`.
-        5. **Per-element business failures** (validation, insufficient
-           fund, not-found, precondition, permission, etc.): rolled up
-           according to `continueOnFailure`:
-           - `continueOnFailure=true` → the overall status is `200`; each
-             element in `data` carries its own `errorCode` on failure.
-           - `continueOnFailure=false` (default) → the bulk aborts on the
-             first per-element failure and the overall status is `400`,
-             with the same per-element `errorCode` on the failing element.
+        3. **Per-element errors during processing**: each element's error
+           carries the HTTP status it would surface as a single request
+           (via the same mapping `handleError` uses). The top-level
+           status is the "worst" of them, with `continueOnFailure`
+           applying only to per-element business failures (4xx):
+           - Business failures (validation, not-found, conflict,
+             precondition, permission — 4xx): rolled up per
+             `continueOnFailure`. `true` → `200`; `false` (default) →
+             the highest 4xx among failing elements (typically `400`).
+           - Rate-limit failures (`KindResourceExhausted`, `429`):
+             surface unconditionally as `429`.
+           - Retryable infrastructure failures (leader loss,
+             cache-horizon exceeded, `KindUnavailable`): surface as
+             `503` with `Retry-After: 1`, regardless of
+             `continueOnFailure`.
+           - Non-retryable infrastructure failures (transport / storage
+             errors, `KindInternal`, unclassified): surface as `500`.
+           - Aborted elements (`context.Canceled` from the sequential
+             runner after a prior failure): contribute nothing — the
+             originating error drives the rollup.
       operationId: bulkOperations
       tags:
         - Transactions

--- a/tests/perf/scripts/shared/http_utils.js
+++ b/tests/perf/scripts/shared/http_utils.js
@@ -7,7 +7,7 @@ import { check } from 'k6';
  * Build the bulk URL for a ledger.
  */
 export function bulkUrl(httpAddr, ledgerName, atomic) {
-  return `${httpAddr}/v3/${ledgerName}/_bulk?atomic=${atomic}`;
+  return `${httpAddr}/v3/${ledgerName}/bulk?atomic=${atomic}`;
 }
 
 /**

--- a/tests/perf/scripts/single_hot_account.js
+++ b/tests/perf/scripts/single_hot_account.js
@@ -166,7 +166,7 @@ export default function () {
 
 // Setup: Initialize the hot account with funds
 export function setup() {
-  const setupUrl = `${config.httpAddr}/v3/${config.ledgerName}/_bulk?atomic=true`;
+  const setupUrl = `${config.httpAddr}/v3/${config.ledgerName}/bulk?atomic=true`;
   const element = scriptBulkElement(
     `send [USD/2 100000000] (
             source = @world


### PR DESCRIPTION
## Summary

Two related bulk-endpoint fixes flagged by a `v3.0.0-alpha.7` alpha tester.

1. **Remove `/v3/{ledgerName}/_bulk`.** The router registered both `/bulk` and `/_bulk` pointing at the same handler; the doubled surface had no reason to exist and confused SDK codegen. Keep only `/v3/{ledgerName}/bulk`.
2. **`continueOnFailure=true` no longer flips the status to 400.** The caller opted into per-element failures being non-fatal, so a top-level 400 contradicted the request intent (v2 returned 200 in the same case). `continueOnFailure=false` keeps the existing behaviour: 400 on the first per-element error.

While here, the blanket per-element `errorCode: "ERROR"` is replaced with `domain.Describable.Reason()` when the underlying error is typed, so bulk failures now surface the same machine-readable code as their single-request counterparts. Opaque errors still fall back to `"ERROR"`.

Docs and spec follow the code:
- `openapi.yml`: fold the two `/bulk` paths into one; describe the new status/`continueOnFailure` semantics.
- Doc updates across `api-comparison.md`, `http-api.md`, `data-flows.md`, `data-model.md`, `idempotency.md`, `performance-tuning.md` to point at the surviving `/bulk` URL. Historical `/_bulk` mentions describing v2 behaviour (`docs/sales/v2-vs-v3.md`, `global-log.md`) are left as-is.

## Test plan

- [x] `GOROOT= go build ./...`
- [x] `GOROOT= go test -run 'TestWriteBulkResponse|TestHandleBulk' ./internal/adapter/http/...`
- [x] New `TestWriteBulkResponse_ContinueOnFailure`: 200 with per-element failures when `continueOnFailure=true`
- [x] Existing `TestHandleBulk_WithContinueOnFailure` updated: 200 instead of 400
- [ ] CI: full e2e / schemathesis / scenarios

Breaking wire change (alpha → beta): callers of `POST /v3/{ledger}/_bulk` must move to `POST /v3/{ledger}/bulk`. `continueOnFailure=true` callers should now expect 200 status with per-element error codes.

Ticket: [EN-1466](https://formance-team.atlassian.net/browse/EN-1466) (epic: [EN-867](https://formance-team.atlassian.net/browse/EN-867))

[EN-1466]: https://formance-team.atlassian.net/browse/EN-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ