### PR TITLE
fix(EN-1469): quote Uint256 JSON encoding for precision-safe wire

### DIFF
--- a/internal/proto/commonpb/uint256.go
+++ b/internal/proto/commonpb/uint256.go
@@ -88,16 +88,34 @@ func (u *Uint256) Dec() string {
 	return v.Dec()
 }
 
-// MarshalJSON encodes the Uint256 as a decimal string (no quotes) for JSON.
+// MarshalJSON encodes the Uint256 as a quoted decimal string. Uint256 values
+// exceed the safe-integer range of a JSON number (2^53), so emitting the raw
+// decimal without quotes silently loses precision in JavaScript clients — the
+// wire format is a string that consumers must parse as a BigInt/BigNumber.
 func (u *Uint256) MarshalJSON() ([]byte, error) {
-	return []byte(u.Dec()), nil
+	dec := u.Dec()
+	buf := make([]byte, 0, len(dec)+2)
+	buf = append(buf, '"')
+	buf = append(buf, dec...)
+	buf = append(buf, '"')
+
+	return buf, nil
 }
 
-// UnmarshalJSON decodes a decimal string (no quotes) into the Uint256.
+// UnmarshalJSON decodes a decimal representation into the Uint256. It accepts
+// both the current quoted form (`"1000"`) and the legacy unquoted form
+// (`1000`) so wire-format changes don't break older callers mid-transition.
 func (u *Uint256) UnmarshalJSON(data []byte) error {
+	// Strip surrounding double quotes if present; the raw decimal is what
+	// uint256.SetFromDecimal accepts.
+	s := string(data)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+
 	var v uint256.Int
 
-	err := v.SetFromDecimal(string(data))
+	err := v.SetFromDecimal(s)
 	if err != nil {
 		return err
 	}

--- a/internal/proto/commonpb/uint256_test.go
+++ b/internal/proto/commonpb/uint256_test.go
@@ -95,9 +95,9 @@ func TestUint256_JSON(t *testing.T) {
 		value uint64
 		json  string
 	}{
-		{"zero", 0, "0"},
-		{"one", 1, "1"},
-		{"large", 1_000_000_000, "1000000000"},
+		{"zero", 0, `"0"`},
+		{"one", 1, `"1"`},
+		{"large", 1_000_000_000, `"1000000000"`},
 	}
 
 	for _, tt := range tests {
@@ -119,6 +119,18 @@ func TestUint256_JSON(t *testing.T) {
 			require.Equal(t, proto.GetV3(), proto2.GetV3())
 		})
 	}
+}
+
+// TestUint256_UnmarshalJSON_LegacyUnquoted asserts we still accept the pre-EN-1469
+// unquoted decimal form (`1000` without surrounding quotes) so wire-format
+// migrations don't break older clients still emitting the raw number.
+func TestUint256_UnmarshalJSON_LegacyUnquoted(t *testing.T) {
+	t.Parallel()
+
+	var proto Uint256
+
+	require.NoError(t, proto.UnmarshalJSON([]byte("1000")))
+	require.Equal(t, uint64(1000), proto.GetV0())
 }
 
 func TestUint256_MaxValue(t *testing.T) {


### PR DESCRIPTION
## Summary

Uint256 values exceed JSON's safe-integer range (2^53), so emitting the raw decimal without quotes silently lost precision in JavaScript clients — the prepared-query aggregate path was the alpha-reported symptom.

- `Uint256.MarshalJSON` now wraps the decimal in double quotes, so JS callers can parse it as a BigInt/BigNumber without loss.
- `Uint256.UnmarshalJSON` accepts both the quoted form and the legacy unquoted decimal, so mid-transition clients still emitting a raw number keep working.

Existing wire consumers that go through the string-based marshallers (`Volumes.MarshalJSON`, `toAggregatedVolumeJSON` on `GET /v3/{ledger}/volumes`) are unaffected — they already used strings via `big.Int`. This change lines up the last remaining number-encoded path.

## Test plan

- [x] `GOROOT= go build ./...`
- [x] `GOROOT= go test ./internal/proto/commonpb/... -run TestUint256`
- [x] New `TestUint256_UnmarshalJSON_LegacyUnquoted` asserts pre-EN-1469 unquoted input still parses
- [x] Fuzz seed corpus (`FuzzUint256UnmarshalJSON`) still valid — legacy unquoted seeds accepted
- [x] `just test` short run: all packages green

Wire change (alpha → beta): consumers that parsed prepared-query aggregate `input`/`output` as a JSON number must now parse them as strings (with BigInt / BigNumber). Callers going through `Volumes.MarshalJSON` (`GET /v3/{ledger}/volumes`) or `toAggregatedVolumeJSON` were already receiving strings.

Ticket: [EN-1469](https://formance-team.atlassian.net/browse/EN-1469) (epic: [EN-867](https://formance-team.atlassian.net/browse/EN-867))

[EN-1469]: https://formance-team.atlassian.net/browse/EN-1469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ