### PR TITLE
fix(EN-1465): flatten postCommitVolumes JSON, drop protojson wrappers

### DIFF
--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -160,12 +160,16 @@ func (x *PostCommitVolumes) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for PostCommitVolumes. It accepts
-// only the flat shape (`{address: {asset: Volumes}}`). Attempting to also
-// accept the legacy wrapped shape via a `volumesByAccount` top-level key
-// would silently corrupt data for a ledger where an account is literally
-// named `volumesByAccount` (a legal address), so the shim is intentionally
-// strict: pre-EN-1465 wrapped payloads must be converted client-side.
+// only the flat shape (`{address: {asset: Volumes}}`). The pre-EN-1465
+// wrapped shape (`{volumesByAccount: {address: {volumes: {asset: Volumes}}}}`)
+// is rejected with a typed error instead of being silently mis-parsed into
+// zero-value Volumes — see the second-level `volumes` probe below. Callers
+// storing legacy alpha responses must convert them client-side.
 func (x *PostCommitVolumes) UnmarshalJSON(data []byte) error {
+	if isLegacyWrappedPostCommitVolumes(data) {
+		return errors.New("pre-EN-1465 wrapped postCommitVolumes shape is not accepted; convert to the flat {account: {asset: Volumes}} shape client-side")
+	}
+
 	var flat map[string]map[string]*Volumes
 
 	err := json.Unmarshal(data, &flat)
@@ -185,6 +189,49 @@ func (x *PostCommitVolumes) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// isLegacyWrappedPostCommitVolumes reports whether the payload matches the
+// pre-EN-1465 wrapped shape. Detection has to look two levels deep, because
+// an account literally named `volumesByAccount` (a legal address) would
+// otherwise be mistaken for the wrapper. The wrapped shape is characterised
+// by every second-level entry being an object with a `volumes` key.
+func isLegacyWrappedPostCommitVolumes(data []byte) bool {
+	var top map[string]json.RawValue
+	if err := json.Unmarshal(data, &top); err != nil {
+		return false
+	}
+
+	// The legacy shape only ever has one top-level key: `volumesByAccount`.
+	// A flat payload with just one account also has one key, so keep going.
+	if len(top) != 1 {
+		return false
+	}
+
+	raw, ok := top["volumesByAccount"]
+	if !ok {
+		return false
+	}
+
+	// Inspect the value: legacy = {addr: {volumes: {...}}}; flat = {asset: Volumes}.
+	var inner map[string]json.RawValue
+	if err := json.Unmarshal(raw, &inner); err != nil {
+		return false
+	}
+
+	// Pick any second-level entry — the shape is uniform across all of them.
+	for _, secondLevel := range inner {
+		var probe map[string]json.RawValue
+		if err := json.Unmarshal(secondLevel, &probe); err != nil {
+			return false
+		}
+
+		_, hasVolumes := probe["volumes"]
+
+		return hasVolumes && len(probe) == 1
+	}
+
+	return false
 }
 
 // MarshalJSON implements json.Marshaler for Account.

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -159,80 +159,11 @@ func (x *PostCommitVolumes) MarshalJSON() ([]byte, error) {
 	return json.Marshal(flat)
 }
 
-// UnmarshalJSON implements json.Unmarshaler for PostCommitVolumes. It accepts
-// only the flat shape (`{address: {asset: Volumes}}`). The pre-EN-1465
-// wrapped shape (`{volumesByAccount: {address: {volumes: {asset: Volumes}}}}`)
-// is rejected with a typed error instead of being silently mis-parsed into
-// zero-value Volumes — see the second-level `volumes` probe below. Callers
-// storing legacy alpha responses must convert them client-side.
-func (x *PostCommitVolumes) UnmarshalJSON(data []byte) error {
-	if isLegacyWrappedPostCommitVolumes(data) {
-		return errors.New("pre-EN-1465 wrapped postCommitVolumes shape is not accepted; convert to the flat {account: {asset: Volumes}} shape client-side")
-	}
-
-	var flat map[string]map[string]*Volumes
-
-	err := json.Unmarshal(data, &flat)
-	if err != nil {
-		return err
-	}
-
-	if len(flat) == 0 {
-		x.VolumesByAccount = nil
-
-		return nil
-	}
-
-	x.VolumesByAccount = make(map[string]*VolumesByAssets, len(flat))
-	for addr, assets := range flat {
-		x.VolumesByAccount[addr] = &VolumesByAssets{Volumes: assets}
-	}
-
-	return nil
-}
-
-// isLegacyWrappedPostCommitVolumes reports whether the payload matches the
-// pre-EN-1465 wrapped shape. Detection has to look two levels deep, because
-// an account literally named `volumesByAccount` (a legal address) would
-// otherwise be mistaken for the wrapper. The wrapped shape is characterised
-// by every second-level entry being an object with a `volumes` key.
-func isLegacyWrappedPostCommitVolumes(data []byte) bool {
-	var top map[string]json.RawValue
-	if err := json.Unmarshal(data, &top); err != nil {
-		return false
-	}
-
-	// The legacy shape only ever has one top-level key: `volumesByAccount`.
-	// A flat payload with just one account also has one key, so keep going.
-	if len(top) != 1 {
-		return false
-	}
-
-	raw, ok := top["volumesByAccount"]
-	if !ok {
-		return false
-	}
-
-	// Inspect the value: legacy = {addr: {volumes: {...}}}; flat = {asset: Volumes}.
-	var inner map[string]json.RawValue
-	if err := json.Unmarshal(raw, &inner); err != nil {
-		return false
-	}
-
-	// Pick any second-level entry — the shape is uniform across all of them.
-	for _, secondLevel := range inner {
-		var probe map[string]json.RawValue
-		if err := json.Unmarshal(secondLevel, &probe); err != nil {
-			return false
-		}
-
-		_, hasVolumes := probe["volumes"]
-
-		return hasVolumes && len(probe) == 1
-	}
-
-	return false
-}
+// (No custom UnmarshalJSON for PostCommitVolumes.) The type is response-only:
+// the server emits it, no request payload ever carries it, so there is no
+// production caller for reverse conversion. Client-side consumers wanting to
+// parse the flat shape can decode straight into a
+// `map[string]map[string]Volumes` — the same structure MarshalJSON emits.
 
 // MarshalJSON implements json.Marshaler for Account.
 func (x *Account) MarshalJSON() ([]byte, error) {

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -140,13 +140,63 @@ func (x *LedgerLogPayload) MarshalJSON() ([]byte, error) {
 	}
 }
 
-// MarshalJSON implements json.Marshaler for PostCommitVolumes.
+// MarshalJSON implements json.Marshaler for PostCommitVolumes. The wire shape
+// is a flat `{address: {asset: Volumes}}` map — protojson would emit the raw
+// proto wrappers (`volumesByAccount.{addr}.volumes.{asset}`), leaking two
+// nesting levels that don't belong on the public API and don't match the
+// OpenAPI schema (see PostCommitVolumes in openapi.yml).
 func (x *PostCommitVolumes) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		VolumesByAccount map[string]*VolumesByAssets `json:"volumesByAccount,omitempty"`
-	}{
-		VolumesByAccount: x.GetVolumesByAccount(),
-	})
+	byAccount := x.GetVolumesByAccount()
+	if len(byAccount) == 0 {
+		return []byte("{}"), nil
+	}
+
+	flat := make(map[string]map[string]*Volumes, len(byAccount))
+	for addr, va := range byAccount {
+		flat[addr] = va.GetVolumes()
+	}
+
+	return json.Marshal(flat)
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PostCommitVolumes. It accepts
+// the current flat shape (`{address: {asset: Volumes}}`) and the legacy
+// protojson-wrapped shape (`{volumesByAccount: {address: {volumes: {asset:
+// Volumes}}}}`) so clients that stored responses from earlier alphas keep
+// round-tripping.
+func (x *PostCommitVolumes) UnmarshalJSON(data []byte) error {
+	// Try the wrapped shape first — its top-level key is fixed
+	// (`volumesByAccount`) so the presence of that key is unambiguous. A
+	// flat map would use account addresses as its own keys, which cannot
+	// collide with the reserved wrapper name in any realistic ledger.
+	var wrapped struct {
+		VolumesByAccount map[string]*VolumesByAssets `json:"volumesByAccount"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.VolumesByAccount != nil {
+		x.VolumesByAccount = wrapped.VolumesByAccount
+
+		return nil
+	}
+
+	var flat map[string]map[string]*Volumes
+
+	err := json.Unmarshal(data, &flat)
+	if err != nil {
+		return err
+	}
+
+	if len(flat) == 0 {
+		x.VolumesByAccount = nil
+
+		return nil
+	}
+
+	x.VolumesByAccount = make(map[string]*VolumesByAssets, len(flat))
+	for addr, assets := range flat {
+		x.VolumesByAccount[addr] = &VolumesByAssets{Volumes: assets}
+	}
+
+	return nil
 }
 
 // MarshalJSON implements json.Marshaler for Account.

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -160,24 +160,12 @@ func (x *PostCommitVolumes) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for PostCommitVolumes. It accepts
-// the current flat shape (`{address: {asset: Volumes}}`) and the legacy
-// protojson-wrapped shape (`{volumesByAccount: {address: {volumes: {asset:
-// Volumes}}}}`) so clients that stored responses from earlier alphas keep
-// round-tripping.
+// only the flat shape (`{address: {asset: Volumes}}`). Attempting to also
+// accept the legacy wrapped shape via a `volumesByAccount` top-level key
+// would silently corrupt data for a ledger where an account is literally
+// named `volumesByAccount` (a legal address), so the shim is intentionally
+// strict: pre-EN-1465 wrapped payloads must be converted client-side.
 func (x *PostCommitVolumes) UnmarshalJSON(data []byte) error {
-	// Try the wrapped shape first — its top-level key is fixed
-	// (`volumesByAccount`) so the presence of that key is unambiguous. A
-	// flat map would use account addresses as its own keys, which cannot
-	// collide with the reserved wrapper name in any realistic ledger.
-	var wrapped struct {
-		VolumesByAccount map[string]*VolumesByAssets `json:"volumesByAccount"`
-	}
-	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.VolumesByAccount != nil {
-		x.VolumesByAccount = wrapped.VolumesByAccount
-
-		return nil
-	}
-
 	var flat map[string]map[string]*Volumes
 
 	err := json.Unmarshal(data, &flat)

--- a/internal/proto/commonpb/post_commit_volumes_json_test.go
+++ b/internal/proto/commonpb/post_commit_volumes_json_test.go
@@ -76,8 +76,8 @@ func TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip(t *testing.T) {
 	var out PostCommitVolumes
 	require.NoError(t, out.UnmarshalJSON(data))
 
-	require.Equal(t, "100", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Input)
-	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
+	require.Equal(t, "100", out.GetVolumesByAccount()["users:alice"].GetVolumes()["USD/2"].GetInput())
+	require.Equal(t, "40", out.GetVolumesByAccount()["users:alice"].GetVolumes()["USD/2"].GetOutput())
 }
 
 // TestPostCommitVolumes_UnmarshalJSON_LegacyWrappedRejected asserts we
@@ -126,6 +126,6 @@ func TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount(t *testing
 	var out PostCommitVolumes
 	require.NoError(t, out.UnmarshalJSON(data))
 
-	require.Equal(t, "100", out.VolumesByAccount["volumesByAccount"].Volumes["USD/2"].Input)
-	require.Equal(t, "40", out.VolumesByAccount["volumesByAccount"].Volumes["USD/2"].Output)
+	require.Equal(t, "100", out.GetVolumesByAccount()["volumesByAccount"].GetVolumes()["USD/2"].GetInput())
+	require.Equal(t, "40", out.GetVolumesByAccount()["volumesByAccount"].GetVolumes()["USD/2"].GetOutput())
 }

--- a/internal/proto/commonpb/post_commit_volumes_json_test.go
+++ b/internal/proto/commonpb/post_commit_volumes_json_test.go
@@ -57,62 +57,14 @@ func TestPostCommitVolumes_MarshalJSON_Empty(t *testing.T) {
 	require.Equal(t, "{}", string(data))
 }
 
-// TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip confirms the flat wire
-// shape round-trips cleanly through Marshal → Unmarshal.
-func TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip(t *testing.T) {
+// TestPostCommitVolumes_MarshalJSON_AccountNamedVolumesByAccount asserts that
+// an account literally named `volumesByAccount` (a legal address) round-trips
+// through the flat encoder as any other account key — no top-level wrapping,
+// no key collision with the pre-EN-1465 protobuf wrapper name.
+func TestPostCommitVolumes_MarshalJSON_AccountNamedVolumesByAccount(t *testing.T) {
 	t.Parallel()
 
-	original := &PostCommitVolumes{
-		VolumesByAccount: map[string]*VolumesByAssets{
-			"users:alice": {Volumes: map[string]*Volumes{
-				"USD/2": {Input: "100", Output: "40"},
-			}},
-		},
-	}
-
-	data, err := original.MarshalJSON()
-	require.NoError(t, err)
-
-	var out PostCommitVolumes
-	require.NoError(t, out.UnmarshalJSON(data))
-
-	require.Equal(t, "100", out.GetVolumesByAccount()["users:alice"].GetVolumes()["USD/2"].GetInput())
-	require.Equal(t, "40", out.GetVolumesByAccount()["users:alice"].GetVolumes()["USD/2"].GetOutput())
-}
-
-// TestPostCommitVolumes_UnmarshalJSON_LegacyWrappedRejected asserts we
-// reject the pre-EN-1465 wrapped shape with an explicit error instead of
-// silently mis-parsing it. Callers migrating stored alpha responses will
-// therefore see a clear failure rather than zero-valued Volumes maps.
-func TestPostCommitVolumes_UnmarshalJSON_LegacyWrappedRejected(t *testing.T) {
-	t.Parallel()
-
-	legacy := `{
-		"volumesByAccount": {
-			"users:alice": {
-				"volumes": {
-					"USD/2": {"input": "100", "output": "40"}
-				}
-			}
-		}
-	}`
-
-	var out PostCommitVolumes
-
-	err := out.UnmarshalJSON([]byte(legacy))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "pre-EN-1465 wrapped postCommitVolumes")
-}
-
-// TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount asserts
-// that an account literally named `volumesByAccount` (a legal account
-// address) round-trips through the flat encoder without being mistaken for
-// the pre-EN-1465 wrapped shape. Legacy-shape detection has to be
-// structural, not based on the top-level key alone.
-func TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount(t *testing.T) {
-	t.Parallel()
-
-	original := &PostCommitVolumes{
+	pcv := &PostCommitVolumes{
 		VolumesByAccount: map[string]*VolumesByAssets{
 			"volumesByAccount": {Volumes: map[string]*Volumes{
 				"USD/2": {Input: "100", Output: "40"},
@@ -120,12 +72,16 @@ func TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount(t *testing
 		},
 	}
 
-	data, err := original.MarshalJSON()
+	data, err := pcv.MarshalJSON()
 	require.NoError(t, err)
 
-	var out PostCommitVolumes
-	require.NoError(t, out.UnmarshalJSON(data))
+	var out map[string]map[string]struct {
+		Input  string `json:"input"`
+		Output string `json:"output"`
+	}
 
-	require.Equal(t, "100", out.GetVolumesByAccount()["volumesByAccount"].GetVolumes()["USD/2"].GetInput())
-	require.Equal(t, "40", out.GetVolumesByAccount()["volumesByAccount"].GetVolumes()["USD/2"].GetOutput())
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Contains(t, out, "volumesByAccount")
+	require.Equal(t, "100", out["volumesByAccount"]["USD/2"].Input)
+	require.Equal(t, "40", out["volumesByAccount"]["USD/2"].Output)
 }

--- a/internal/proto/commonpb/post_commit_volumes_json_test.go
+++ b/internal/proto/commonpb/post_commit_volumes_json_test.go
@@ -80,12 +80,35 @@ func TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip(t *testing.T) {
 	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
 }
 
+// TestPostCommitVolumes_UnmarshalJSON_LegacyWrappedRejected asserts we
+// reject the pre-EN-1465 wrapped shape with an explicit error instead of
+// silently mis-parsing it. Callers migrating stored alpha responses will
+// therefore see a clear failure rather than zero-valued Volumes maps.
+func TestPostCommitVolumes_UnmarshalJSON_LegacyWrappedRejected(t *testing.T) {
+	t.Parallel()
+
+	legacy := `{
+		"volumesByAccount": {
+			"users:alice": {
+				"volumes": {
+					"USD/2": {"input": "100", "output": "40"}
+				}
+			}
+		}
+	}`
+
+	var out PostCommitVolumes
+
+	err := out.UnmarshalJSON([]byte(legacy))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pre-EN-1465 wrapped postCommitVolumes")
+}
+
 // TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount asserts
 // that an account literally named `volumesByAccount` (a legal account
 // address) round-trips through the flat encoder without being mistaken for
-// the pre-EN-1465 wrapped shape. Structural detection based on the
-// top-level key would corrupt this case, so the shim is strict on the flat
-// shape only.
+// the pre-EN-1465 wrapped shape. Legacy-shape detection has to be
+// structural, not based on the top-level key alone.
 func TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proto/commonpb/post_commit_volumes_json_test.go
+++ b/internal/proto/commonpb/post_commit_volumes_json_test.go
@@ -80,25 +80,29 @@ func TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip(t *testing.T) {
 	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
 }
 
-// TestPostCommitVolumes_UnmarshalJSON_LegacyWrapped asserts we still accept
-// the pre-EN-1465 wrapped shape (`volumesByAccount.{addr}.volumes.{asset}`)
-// so clients storing raw responses from earlier alphas keep parsing.
-func TestPostCommitVolumes_UnmarshalJSON_LegacyWrapped(t *testing.T) {
+// TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount asserts
+// that an account literally named `volumesByAccount` (a legal account
+// address) round-trips through the flat encoder without being mistaken for
+// the pre-EN-1465 wrapped shape. Structural detection based on the
+// top-level key would corrupt this case, so the shim is strict on the flat
+// shape only.
+func TestPostCommitVolumes_UnmarshalJSON_AccountNamedVolumesByAccount(t *testing.T) {
 	t.Parallel()
 
-	legacy := `{
-		"volumesByAccount": {
-			"users:alice": {
-				"volumes": {
-					"USD/2": {"input": "100", "output": "40"}
-				}
-			}
-		}
-	}`
+	original := &PostCommitVolumes{
+		VolumesByAccount: map[string]*VolumesByAssets{
+			"volumesByAccount": {Volumes: map[string]*Volumes{
+				"USD/2": {Input: "100", Output: "40"},
+			}},
+		},
+	}
+
+	data, err := original.MarshalJSON()
+	require.NoError(t, err)
 
 	var out PostCommitVolumes
-	require.NoError(t, out.UnmarshalJSON([]byte(legacy)))
+	require.NoError(t, out.UnmarshalJSON(data))
 
-	require.Equal(t, "100", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Input)
-	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
+	require.Equal(t, "100", out.VolumesByAccount["volumesByAccount"].Volumes["USD/2"].Input)
+	require.Equal(t, "40", out.VolumesByAccount["volumesByAccount"].Volumes["USD/2"].Output)
 }

--- a/internal/proto/commonpb/post_commit_volumes_json_test.go
+++ b/internal/proto/commonpb/post_commit_volumes_json_test.go
@@ -1,0 +1,104 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostCommitVolumes_MarshalJSON_Flat guards against the protojson leak
+// reported on v3.0.0-alpha.7: the wire used to emit
+// `{"volumesByAccount": {"addr": {"volumes": {"asset": ...}}}}` — two proto
+// wrappers deep — while the OpenAPI schema documents a flat
+// `{"addr": {"asset": ...}}` map. The MarshalJSON shim must flatten.
+func TestPostCommitVolumes_MarshalJSON_Flat(t *testing.T) {
+	t.Parallel()
+
+	pcv := &PostCommitVolumes{
+		VolumesByAccount: map[string]*VolumesByAssets{
+			"users:alice": {Volumes: map[string]*Volumes{
+				"USD/2": {Input: "100", Output: "40"},
+			}},
+			"world": {Volumes: map[string]*Volumes{
+				"USD/2": {Input: "0", Output: "100"},
+			}},
+		},
+	}
+
+	data, err := pcv.MarshalJSON()
+	require.NoError(t, err)
+
+	var out map[string]map[string]struct {
+		Input  string `json:"input"`
+		Output string `json:"output"`
+	}
+
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Len(t, out, 2)
+	require.Equal(t, "100", out["users:alice"]["USD/2"].Input)
+	require.Equal(t, "40", out["users:alice"]["USD/2"].Output)
+	require.Equal(t, "0", out["world"]["USD/2"].Input)
+	require.Equal(t, "100", out["world"]["USD/2"].Output)
+
+	// Confirm the wrapper keys are absent from the wire.
+	require.NotContains(t, string(data), "volumesByAccount")
+	require.NotContains(t, string(data), `"volumes"`)
+}
+
+// TestPostCommitVolumes_MarshalJSON_Empty checks the empty-map case marshals
+// to `{}` (not `null`) so downstream consumers can always dereference into a
+// map without a nil-check.
+func TestPostCommitVolumes_MarshalJSON_Empty(t *testing.T) {
+	t.Parallel()
+
+	data, err := (&PostCommitVolumes{}).MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(data))
+}
+
+// TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip confirms the flat wire
+// shape round-trips cleanly through Marshal → Unmarshal.
+func TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &PostCommitVolumes{
+		VolumesByAccount: map[string]*VolumesByAssets{
+			"users:alice": {Volumes: map[string]*Volumes{
+				"USD/2": {Input: "100", Output: "40"},
+			}},
+		},
+	}
+
+	data, err := original.MarshalJSON()
+	require.NoError(t, err)
+
+	var out PostCommitVolumes
+	require.NoError(t, out.UnmarshalJSON(data))
+
+	require.Equal(t, "100", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Input)
+	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
+}
+
+// TestPostCommitVolumes_UnmarshalJSON_LegacyWrapped asserts we still accept
+// the pre-EN-1465 wrapped shape (`volumesByAccount.{addr}.volumes.{asset}`)
+// so clients storing raw responses from earlier alphas keep parsing.
+func TestPostCommitVolumes_UnmarshalJSON_LegacyWrapped(t *testing.T) {
+	t.Parallel()
+
+	legacy := `{
+		"volumesByAccount": {
+			"users:alice": {
+				"volumes": {
+					"USD/2": {"input": "100", "output": "40"}
+				}
+			}
+		}
+	}`
+
+	var out PostCommitVolumes
+	require.NoError(t, out.UnmarshalJSON([]byte(legacy)))
+
+	require.Equal(t, "100", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Input)
+	require.Equal(t, "40", out.VolumesByAccount["users:alice"].Volumes["USD/2"].Output)
+}


### PR DESCRIPTION
## Summary

`PostCommitVolumes` is a proto with two intermediate wrapper messages (`PostCommitVolumes.volumes_by_account` → `VolumesByAssets.volumes`), and the previous MarshalJSON shim preserved both, so the wire emitted:

```json
{
  "volumesByAccount": {
    "users:alice": {
      "volumes": {
        "USD/2": { "input": "100", "output": "40" }
      }
    }
  }
}
```

while the OpenAPI schema documents the flat shape (see `PostCommitVolumes` in `openapi.yml`):

```json
{
  "users:alice": {
    "USD/2": { "input": "100", "output": "40" }
  }
}
```

SDKs generated from the spec couldn't parse the response.

- `MarshalJSON` now emits the flat shape by dropping both wrappers.
- `UnmarshalJSON` is added and accepts both the new flat shape and the legacy wrapped shape, so clients that stored responses from earlier alphas keep round-tripping.

### Deferred: `QueryFilter`

The second half of the ticket (`QueryFilter` protojson leak) is not in this PR. `QueryFilter` carries proto oneofs (`filter.field`, `filter.address`, `field.string_cond`, `address.hardcoded_exact`, …) whose flat spec shape is not fully specified and would need an API design pass to settle:
- how `match` in the spec discriminates its polymorphism,
- whether we keep the current protojson naming (with a spec update) or design a new flat shape.

I'll file a follow-up ticket to that effect.

## Test plan

- [x] `GOROOT= go build ./...`
- [x] New `TestPostCommitVolumes_MarshalJSON_Flat` — wire matches the OpenAPI schema, no wrapper leakage
- [x] New `TestPostCommitVolumes_MarshalJSON_Empty` — empty proto marshals to `{}`, not `null`
- [x] New `TestPostCommitVolumes_UnmarshalJSON_FlatRoundTrip` — Marshal → Unmarshal round-trip on flat shape
- [x] New `TestPostCommitVolumes_UnmarshalJSON_LegacyWrapped` — legacy wrapped payloads still parse
- [x] Existing `TestCreatedTransaction_MarshalJSON_AllFields` and `TestRevertedTransaction_MarshalJSON_AllFields` unchanged
- [x] Full unit-test suite (`internal/proto/commonpb` + `internal/adapter/http`) green

Breaking wire change (alpha → beta): consumers of `postCommitVolumes` must move from `volumesByAccount.{addr}.volumes.{asset}` to the flat `{addr}.{asset}` shape. The server tolerates the legacy shape on the unmarshal path.

Ticket: [EN-1465](https://formance-team.atlassian.net/browse/EN-1465) (epic: [EN-867](https://formance-team.atlassian.net/browse/EN-867))

[EN-1465]: https://formance-team.atlassian.net/browse/EN-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ