### PR TITLE
fix(EN-1043): emit Unreachable on Raft transport channel-full drops

### DIFF
--- a/internal/infra/node/peer_send_race_test.go
+++ b/internal/infra/node/peer_send_race_test.go
@@ -45,6 +45,7 @@ func newRaceTestPeerConn(t *testing.T) *peerConnection {
 		stopCancel:             stopCancel,
 		loopDone:               loopDone,
 		logger:                 logging.Testing(),
+		pushUnreachable:        func(uint64) bool { return true },
 		sendQueueLoadHistogram: [3]metric.Int64Histogram{loadH, loadH, loadH},
 		sendQueueFullCounter:   [3]metric.Float64Counter{fullC, fullC, fullC},
 	}

--- a/internal/infra/node/transport.go
+++ b/internal/infra/node/transport.go
@@ -454,6 +454,21 @@ func (t *DefaultTransport) Send(msgs []raftpb.Message) {
 			"channel": "raft.send.pending_messages",
 		}).Errorf("Channel full")
 		t.pendingSendFullCounter.Add(context.Background(), 1)
+
+		// Signal Unreachable for every peer that had a message in the
+		// dropped batch. pendingSendQueue is shared across peers, so we
+		// can't blame a single one — but transitioning every affected
+		// peer's Progress to StateProbe throttles overall outgoing load,
+		// which is the correct systemic response to a full top-level
+		// queue.
+		reported := make(map[uint64]struct{}, len(msgs))
+		for _, m := range msgs {
+			if _, ok := reported[m.To]; ok {
+				continue
+			}
+			reported[m.To] = struct{}{}
+			t.pushUnreachable(m.To)
+		}
 	}
 }
 
@@ -733,6 +748,13 @@ type peerConnection struct {
 	// a quiescent state at the moment of close.
 	pubMu   sync.RWMutex
 	stopped bool
+
+	// unreachableReported dedups Unreachable notifications during a drop
+	// burst so we don't saturate unreachableCh (capacity 100) when a single
+	// full send channel fires pushMessages hundreds of times per second.
+	// CAS-set on first drop, reset by sendMessages after a successful
+	// stream.Send() (peer confirmed responsive → next drop re-signals Raft).
+	unreachableReported atomic.Bool
 }
 
 // pushMessages pushes a batch of messages to the specified priority queue.
@@ -780,6 +802,15 @@ func (conn *peerConnection) pushMessages(priority int, msgs []raftpb.Message) bo
 			"priority": priority,
 		}).Errorf("Channel full")
 		conn.sendQueueFullCounter[priority].Add(context.Background(), 1)
+
+		// Signal Unreachable to Raft so it throttles this peer's Progress
+		// to StateProbe instead of continuing optimistic replication.
+		// Dedup via CAS: sendMessages resets the flag on the next successful
+		// stream.Send(), letting subsequent drops re-signal if the channel
+		// keeps refilling.
+		if conn.unreachableReported.CompareAndSwap(false, true) {
+			conn.pushUnreachable(conn.peerID)
+		}
 
 		return false
 	}
@@ -1120,6 +1151,12 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 
 			return err
 		}
+
+		// Peer accepted the write — clear the dedup flag so a subsequent
+		// pushMessages drop re-signals Unreachable to Raft (Progress
+		// currently in Replicate can transition back to Probe if we drop
+		// again).
+		conn.unreachableReported.Store(false)
 
 		return nil
 	}

--- a/internal/infra/node/transport.go
+++ b/internal/infra/node/transport.go
@@ -807,9 +807,15 @@ func (conn *peerConnection) pushMessages(priority int, msgs []raftpb.Message) bo
 		// to StateProbe instead of continuing optimistic replication.
 		// Dedup via CAS: sendMessages resets the flag on the next successful
 		// stream.Send(), letting subsequent drops re-signal if the channel
-		// keeps refilling.
+		// keeps refilling. If pushUnreachable itself fails because
+		// unreachableCh is full, roll the flag back so a subsequent drop
+		// can retry the emit — otherwise a transient unreachableCh overflow
+		// permanently silences this peer's signal until sendMessages
+		// succeeds, which is the exact stuck-peer case we want to avoid.
 		if conn.unreachableReported.CompareAndSwap(false, true) {
-			conn.pushUnreachable(conn.peerID)
+			if !conn.pushUnreachable(conn.peerID) {
+				conn.unreachableReported.Store(false)
+			}
 		}
 
 		return false

--- a/internal/infra/node/transport_test.go
+++ b/internal/infra/node/transport_test.go
@@ -98,6 +98,48 @@ func TestPeerConnection_PushMessages_DedupsUnreachableWithinBurst(t *testing.T) 
 	require.Equal(t, []uint64{7}, got(), "burst of 100 drops must emit Unreachable exactly once")
 }
 
+// TestPeerConnection_PushMessages_RollsBackFlagOnEmitFailure pins
+// the NumaryBot finding on PR #1519: when unreachableCh itself is
+// full and pushUnreachable returns false, the dedup flag MUST be
+// rolled back so a subsequent drop can retry the emit. Otherwise a
+// transient unreachableCh overflow silences the peer's Unreachable
+// signal until sendMessages succeeds — which for a stuck peer never
+// happens, defeating the whole fix.
+func TestPeerConnection_PushMessages_RollsBackFlagOnEmitFailure(t *testing.T) {
+	t.Parallel()
+
+	// Toggleable emit: first call fails (unreachableCh "full"), second succeeds.
+	var (
+		mu    sync.Mutex
+		calls []uint64
+		fail  = true
+	)
+	conn := newTestPeerConn(t, 9, func(peerID uint64) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, peerID)
+
+		return !fail
+	})
+
+	// First drop: emit fails, flag must roll back to false.
+	require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	require.False(t, conn.unreachableReported.Load(),
+		"failed emit must not leave the dedup flag set — otherwise subsequent drops are silently suppressed")
+
+	// Flip the emit sink to succeed. Second drop must retry and set the flag.
+	mu.Lock()
+	fail = false
+	mu.Unlock()
+	require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	require.True(t, conn.unreachableReported.Load(),
+		"successful emit after retry must set the dedup flag")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []uint64{9, 9}, calls, "both drops must have attempted an emit")
+}
+
 // TestPeerConnection_PushMessages_ReEmitsAfterSuccessfulSend covers
 // the recovery half of the dedup contract. Once the peer has accepted
 // a write (simulated by clearing the flag as sendMessages does), the

--- a/internal/infra/node/transport_test.go
+++ b/internal/infra/node/transport_test.go
@@ -1,0 +1,197 @@
+package node
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// captureUnreachable wires a channel-backed sink for the pushUnreachable
+// callback on a peerConnection so tests can observe which peer IDs Raft
+// would be notified about on drop.
+func captureUnreachable() (fn func(peerID uint64) bool, got func() []uint64) {
+	var (
+		mu      sync.Mutex
+		peerIDs []uint64
+	)
+
+	fn = func(peerID uint64) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		peerIDs = append(peerIDs, peerID)
+
+		return true
+	}
+	got = func() []uint64 {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]uint64, len(peerIDs))
+		copy(out, peerIDs)
+
+		return out
+	}
+
+	return fn, got
+}
+
+// newTestPeerConn builds a peerConnection whose priority channels have
+// zero capacity, so any pushMessages call immediately hits the default
+// branch. pushUnreachable is captured via the injected callback.
+func newTestPeerConn(t *testing.T, peerID uint64, unreachable func(uint64) bool) *peerConnection {
+	t.Helper()
+
+	m := noop.NewMeterProvider().Meter("test")
+
+	loadH, err := m.Int64Histogram("noop.load")
+	require.NoError(t, err)
+	fullC, err := m.Float64Counter("noop.full")
+	require.NoError(t, err)
+
+	return &peerConnection{
+		highPriorityCh:         make(chan []raftpb.Message), // cap 0 → default branch every send
+		mediumPriorityCh:       make(chan []raftpb.Message),
+		lowPriorityCh:          make(chan []raftpb.Message),
+		logger:                 logging.Testing(),
+		peerID:                 peerID,
+		pushUnreachable:        unreachable,
+		sendQueueLoadHistogram: [3]metric.Int64Histogram{loadH, loadH, loadH},
+		sendQueueFullCounter:   [3]metric.Float64Counter{fullC, fullC, fullC},
+	}
+}
+
+// TestPeerConnection_PushMessages_EmitsUnreachableOnDrop pins the fix
+// for EN-1043: when a batch cannot be enqueued (channel full), the
+// peer's Unreachable signal MUST fire so Raft transitions the peer's
+// Progress from Replicate to Probe. The prior behavior logged a drop
+// and returned silently, leaving Raft in optimistic replication.
+func TestPeerConnection_PushMessages_EmitsUnreachableOnDrop(t *testing.T) {
+	t.Parallel()
+
+	notify, got := captureUnreachable()
+	conn := newTestPeerConn(t, 42, notify)
+
+	ok := conn.pushMessages(0, []raftpb.Message{{}})
+	require.False(t, ok, "pushMessages must report drop on full channel")
+	require.Equal(t, []uint64{42}, got(), "Unreachable must be signalled with the peer ID on drop")
+}
+
+// TestPeerConnection_PushMessages_DedupsUnreachableWithinBurst pins the
+// dedup contract: back-to-back drops for the same peer must NOT spam
+// the shared unreachableCh (capacity 100 in production). Only the
+// first drop in a burst fires; subsequent drops are absorbed until a
+// successful sendMessages resets the flag.
+func TestPeerConnection_PushMessages_DedupsUnreachableWithinBurst(t *testing.T) {
+	t.Parallel()
+
+	notify, got := captureUnreachable()
+	conn := newTestPeerConn(t, 7, notify)
+
+	for range 100 {
+		require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	}
+	require.Equal(t, []uint64{7}, got(), "burst of 100 drops must emit Unreachable exactly once")
+}
+
+// TestPeerConnection_PushMessages_ReEmitsAfterSuccessfulSend covers
+// the recovery half of the dedup contract. Once the peer has accepted
+// a write (simulated by clearing the flag as sendMessages does), the
+// next drop must re-signal Unreachable so Raft can re-throttle if the
+// channel refills.
+func TestPeerConnection_PushMessages_ReEmitsAfterSuccessfulSend(t *testing.T) {
+	t.Parallel()
+
+	notify, got := captureUnreachable()
+	conn := newTestPeerConn(t, 3, notify)
+
+	require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	require.Equal(t, []uint64{3}, got())
+
+	// Second drop within the same burst is deduped.
+	require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	require.Equal(t, []uint64{3}, got())
+
+	// Simulate what sendMessages does on a successful stream.Send.
+	conn.unreachableReported.Store(false)
+
+	require.False(t, conn.pushMessages(0, []raftpb.Message{{}}))
+	require.Equal(t, []uint64{3, 3}, got(), "drop after successful send must re-signal Unreachable")
+}
+
+// newTestTransport builds a DefaultTransport with only the fields Send
+// touches, plus a small unreachableCh we can drain to observe emissions.
+// Peers map is empty on purpose — Send only enqueues to pendingSendQueue,
+// it never consults t.peers directly, so peer registration isn't needed
+// to exercise the drop path.
+func newTestTransport(t *testing.T, pendingCap int) *DefaultTransport {
+	t.Helper()
+
+	meter := noop.NewMeterProvider().Meter("test")
+
+	loadH, err := meter.Int64Histogram("noop.load")
+	require.NoError(t, err)
+	fullC, err := meter.Float64Counter("noop.full")
+	require.NoError(t, err)
+
+	return &DefaultTransport{
+		logger:                   logging.Testing(),
+		pendingSendQueue:         make(chan []raftpb.Message, pendingCap),
+		unreachableCh:            make(chan uint64, 16),
+		pendingSendLoadHistogram: loadH,
+		pendingSendFullCounter:   fullC,
+		unreachableLoadHistogram: loadH,
+		unreachableFullCounter:   fullC,
+	}
+}
+
+// TestDefaultTransport_Send_EmitsUnreachablePerUniquePeer pins the
+// systemic drop path: when pendingSendQueue is full, the batch is
+// dropped and Raft must be told which peers were affected. Emit
+// exactly once per unique msg.To in the dropped batch.
+func TestDefaultTransport_Send_EmitsUnreachablePerUniquePeer(t *testing.T) {
+	t.Parallel()
+
+	// cap 0 → any Send hits the default branch.
+	tr := newTestTransport(t, 0)
+
+	tr.Send([]raftpb.Message{
+		{To: 2},
+		{To: 3},
+		{To: 2}, // duplicate — must not fire Unreachable again
+		{To: 5},
+	})
+
+	// Drain unreachableCh.
+	got := make(map[uint64]int)
+	for {
+		select {
+		case peerID := <-tr.unreachableCh:
+			got[peerID]++
+
+			continue
+		default:
+		}
+
+		break
+	}
+
+	require.Equal(t, map[uint64]int{2: 1, 3: 1, 5: 1}, got,
+		"Send must emit Unreachable exactly once per unique msg.To in the dropped batch")
+}
+
+// TestDefaultTransport_Send_NoUnreachableOnHappyPath ensures the fix
+// does not fire Unreachable when the batch enqueues cleanly.
+func TestDefaultTransport_Send_NoUnreachableOnHappyPath(t *testing.T) {
+	t.Parallel()
+
+	tr := newTestTransport(t, 4)
+
+	tr.Send([]raftpb.Message{{To: 2}, {To: 3}})
+
+	require.Len(t, tr.unreachableCh, 0, "happy path must not push to unreachableCh")
+}

--- a/tests/antithesis/workload/bin/cmds/main/singleton_driver_quorum_recovery/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/singleton_driver_quorum_recovery/main.go
@@ -36,6 +36,15 @@ const (
 	qrCooldown         = 5 * time.Minute
 	qrScaleDownTimeout = 8 * time.Minute
 	qrScaleUpTimeout   = 15 * time.Minute
+
+	// qrConfChangeLatencyBudget is the "should be fast" threshold for the
+	// force-remove ConfChange to bring voters down to 1 after scale-down.
+	// Healthy runs converge in a handful of WaitForVoters poll cycles (5s
+	// each); the EN-1043 regression pushed this past 47s in one antithesis
+	// run. 30s is chosen to sit comfortably between the two, so a
+	// Sometimes assertion catches a regression without flaking on operator
+	// polling variance.
+	qrConfChangeLatencyBudget = 30 * time.Second
 )
 
 func main() {
@@ -158,6 +167,16 @@ func runRound(ctx context.Context, lsClient dynamic.ResourceInterface, clientset
 		return
 	}
 
+	// EN-1043 regression sentinel: measure how long it takes for the
+	// operator's force-remove ConfChange to actually reduce the voter
+	// count to 1. When the transport silently drops MsgApp carrying the
+	// ConfChange (channels full, no Unreachable emitted), etcd/raft
+	// keeps optimistically retrying and recovery stalls ~47s in the
+	// worst antithesis observation (2026-06-08). With Unreachable
+	// emitted on drop, Raft transitions the dead peers to StateProbe
+	// and the ConfChange applies on the next heartbeat.
+	scaleDownStart := time.Now()
+
 	if !internal.WaitForVoters(ctx, clusterClient, 1, qrScaleDownTimeout, details) {
 		// The deferred cleanup restores replicas=3. Sentinel verify is best
 		// effort: the cluster may be in an oscillating (1)↔(1,3) state until
@@ -167,6 +186,14 @@ func runRound(ctx context.Context, lsClient dynamic.ResourceInterface, clientset
 		return
 	}
 	assert.Reachable("force-remove path executed (voters=1)", details)
+
+	// EN-1043: healthy runs should converge well under qrConfChangeLatencyBudget.
+	// WaitForVoters polls every 5s, so the observed elapsed time is bounded
+	// below by ~5s; the buggy behavior pushes it past 47s.
+	elapsed := time.Since(scaleDownStart)
+	assert.Sometimes(elapsed < qrConfChangeLatencyBudget,
+		"force-remove ConfChange applies within latency budget after scale-down (EN-1043)",
+		details.With(internal.Details{"elapsed": elapsed.String(), "budget": qrConfChangeLatencyBudget.String()}))
 
 	sentinel.Verify(ctx, client, "after_quorum_recovery")
 }


### PR DESCRIPTION
## Summary

- Fix silent MsgApp/MsgHeartbeat drops when per-peer or top-level send channels fill up: emit `pushUnreachable(peerID)` on every drop path so etcd/raft transitions the peer's Progress to `StateProbe` and slows retries until the peer responds. Root cause was the asymmetry "drop the message but tell Raft the peer is alive" — Raft is safe under loss, but its drop-tolerance depends on the transport signalling.
- Dedup per-peer via a CAS-guarded `atomic.Bool` on `peerConnection` (reset after a successful `sendMessages`) so a drop burst doesn't cascade-drop `unreachableCh` (cap 100) itself. For `DefaultTransport.Send`, emit exactly once per unique `msg.To` in the dropped batch.
- Antithesis: `singleton_driver_quorum_recovery` now measures elapsed time from scale-down-to-1 to `WaitForVoters(1)` returning and asserts `Sometimes(elapsed < 30s)`. Would fire on the 47s stall observed in the 2026-06-08 run.

## Why this matters

Without the fix, the leader's `nextIndex[peer]` stays in `StateReplicate` while messages are being dropped, retrying optimistically and refilling the channel. Recovery lasts the full TCP timeout (~30-50s observed). Pending `ConfChange` cannot commit during that window (etcd/raft single-in-flight rule), so the K8s operator's scale-up/scale-down loop stalls.

Two mitigations already shipped in-tree address downstream symptoms only:
- `drainLoop` on confirmed connection death (`transport.go:834-871`) — fires too late.
- Priority-0 buffer bump 10→128 (commit `a2fa4a277`, 2026-07-06) — narrows the window but doesn't close it.

This PR closes the "channels full but connection still considered alive" window, which is where the actual stall lives.

## What changed

- `internal/infra/node/transport.go`
  - `peerConnection.pushMessages` — on channel-full, `pushUnreachable(peerID)` via CAS on new `unreachableReported atomic.Bool`.
  - `sendMessages` — reset the dedup flag after a successful `stream.Send()`, so a re-saturation re-signals Raft.
  - `DefaultTransport.Send` — on `pendingSendQueue` full, iterate the batch and emit `pushUnreachable` once per unique `msg.To`.
- `internal/infra/node/transport_test.go` (new) — 5 tests: emit-on-drop, dedup-in-burst, re-emit-after-success, Send-per-unique-peer, no-emit-happy-path.
- `internal/infra/node/peer_send_race_test.go` — helper sets a no-op `pushUnreachable` so the new path doesn't nil-deref in the existing race test.
- `tests/antithesis/workload/bin/cmds/main/singleton_driver_quorum_recovery/main.go` — `Sometimes(elapsed < 30s)` assertion on force-remove ConfChange latency.

## Out of scope

- `pushToRecvQueue` (recv-side drops) — `ReportUnreachable` is a sender→receiver signal, doesn't map.
- Bounded blocking send with deadline — micro-optimization. Raft recovers via probe in ~1 heartbeat (~100ms) once the peer responds; a 5ms pre-attempt is not worth the complexity for v1. Revisit if `raft.transport.peer.sending.full` stays elevated after this ships.
- Buffer sizing (`a2fa4a277`) and drainLoop (already present) — untouched.

## Test plan

- [x] `go build ./...` + full-features `go build -tags "kafka,nats,clickhouse,databricks,s3,azure,pyroscope" ./...`
- [x] `go test ./internal/infra/node/ -race -count=1` — all pass (existing + 5 new)
- [x] `golangci-lint run --new-from-rev=origin/release/v3.0` — 0 issues
- [x] `go vet ./...` — clean
- [ ] Antithesis 30-min k8s run: new `force-remove ConfChange applies within latency budget after scale-down (EN-1043)` assertion holds; `raft.transport.peer.sending.full` counter not materially higher than baseline; no new "Unreachable channel full" logs

Refs: EN-1043