### PR TITLE
feat(EN-1470): opt-in expandVolumes on GET account

### DIFF
--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -51,7 +51,7 @@ This document compares the POC's API with the original Formance ledger API and d
 | Get account type | ✅ | ❌ | Get details of a specific type |
 | Remove account type | ✅ | ❌ | Remove a type from a ledger |
 | **Accounts (Read)** |
-| Get account | ✅ | ✅ | Includes volumes per asset |
+| Get account | ✅ | ✅ | Opt-in per-asset volumes via `expandVolumes=true` (v2 populated them unconditionally; v3 gates the extra aggregation scan behind the flag) |
 | List accounts | ✅ | ✅ | Supports rich boolean filter (metadata equality/range/existence, address) with schema validation and cursor pagination |
 | Get account balances | ⚠️ | ✅ | Included in account volumes |
 | Get account volumes | ✅ | ✅ | Returns input/output/balance per asset |

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -51,7 +51,7 @@ This document compares the POC's API with the original Formance ledger API and d
 | Get account type | ✅ | ❌ | Get details of a specific type |
 | Remove account type | ✅ | ❌ | Remove a type from a ledger |
 | **Accounts (Read)** |
-| Get account | ✅ | ✅ | Opt-in per-asset volumes via `expandVolumes=true` (v2 populated them unconditionally; v3 gates the extra aggregation scan behind the flag) |
+| Get account | ✅ | ✅ | Includes per-asset volumes inline (v2 parity); populated by the controller's account scan on every read |
 | List accounts | ✅ | ✅ | Supports rich boolean filter (metadata equality/range/existence, address) with schema validation and cursor pagination |
 | Get account balances | ⚠️ | ✅ | Included in account volumes |
 | Get account volumes | ✅ | ✅ | Returns input/output/balance per asset |

--- a/internal/adapter/http/handlers_get_account.go
+++ b/internal/adapter/http/handlers_get_account.go
@@ -1,13 +1,25 @@
 package http
 
 import (
+	"context"
 	"errors"
+	"math/big"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // handleGetAccount handles GET /{ledgerName}/accounts/{address} to retrieve an account.
+//
+// When `expandVolumes=true` is set, an extra AggregateVolumes scan runs against
+// the storage layer (filter: hardcoded_exact = address) and the result is
+// folded into `Account.volumes`. The default (no query param) keeps the read
+// lightweight — callers who need per-asset input/output/balance must opt in.
+// v2 populated volumes unconditionally; v3 chose opt-in because volumes are a
+// projection computed on demand, not a first-class stored attribute.
 func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
@@ -41,5 +53,48 @@ func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if queryParamBool(r, "expandVolumes") {
+		err = s.expandAccountVolumes(r.Context(), ledgerName, address, account)
+		if err != nil {
+			handleError(w, r, err)
+
+			return
+		}
+	}
+
 	writeOK(w, account)
+}
+
+// expandAccountVolumes runs an exact-match AggregateVolumes on the account
+// address and folds the result into `account.Volumes` as a per-asset
+// input/output/balance map, matching the shape v2 populated inline.
+func (s *Server) expandAccountVolumes(ctx context.Context, ledgerName, address string, account *commonpb.Account) error {
+	filter := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Address{
+			Address: &commonpb.AddressMatch{
+				Match: &commonpb.AddressMatch_HardcodedExact{HardcodedExact: address},
+			},
+		},
+	}
+
+	result, err := s.backend.AggregateVolumes(ctx, ledgerName, filter, query.AggregateOptions{})
+	if err != nil {
+		return err
+	}
+
+	volumes := make(map[string]*commonpb.VolumesWithBalance, len(result.GetVolumes()))
+	for _, v := range result.GetVolumes() {
+		input := v.GetInput().ToBigInt()
+		output := v.GetOutput().ToBigInt()
+		balance := new(big.Int).Sub(input, output)
+		volumes[v.GetAsset()] = &commonpb.VolumesWithBalance{
+			Input:   input.String(),
+			Output:  output.String(),
+			Balance: balance.String(),
+		}
+	}
+
+	account.Volumes = volumes
+
+	return nil
 }

--- a/internal/adapter/http/handlers_get_account.go
+++ b/internal/adapter/http/handlers_get_account.go
@@ -1,25 +1,19 @@
 package http
 
 import (
-	"context"
 	"errors"
-	"math/big"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-
-	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
-	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // handleGetAccount handles GET /{ledgerName}/accounts/{address} to retrieve an account.
 //
-// When `expandVolumes=true` is set, an extra AggregateVolumes scan runs against
-// the storage layer (filter: hardcoded_exact = address) and the result is
-// folded into `Account.volumes`. The default (no query param) keeps the read
-// lightweight — callers who need per-asset input/output/balance must opt in.
-// v2 populated volumes unconditionally; v3 chose opt-in because volumes are a
-// projection computed on demand, not a first-class stored attribute.
+// Per-asset volumes are populated by the controller's `scanAccount` on every
+// read (Pebble prefix scan on the volume-canonical range), so the response
+// carries them by default — matching v2's inline `volumes`. This handler adds
+// no extra query. The wire shape is driven by `Account.MarshalJSON`, which is
+// the piece that used to drop the field.
 func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
@@ -53,48 +47,5 @@ func (s *Server) handleGetAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if queryParamBool(r, "expandVolumes") {
-		err = s.expandAccountVolumes(r.Context(), ledgerName, address, account)
-		if err != nil {
-			handleError(w, r, err)
-
-			return
-		}
-	}
-
 	writeOK(w, account)
-}
-
-// expandAccountVolumes runs an exact-match AggregateVolumes on the account
-// address and folds the result into `account.Volumes` as a per-asset
-// input/output/balance map, matching the shape v2 populated inline.
-func (s *Server) expandAccountVolumes(ctx context.Context, ledgerName, address string, account *commonpb.Account) error {
-	filter := &commonpb.QueryFilter{
-		Filter: &commonpb.QueryFilter_Address{
-			Address: &commonpb.AddressMatch{
-				Match: &commonpb.AddressMatch_HardcodedExact{HardcodedExact: address},
-			},
-		},
-	}
-
-	result, err := s.backend.AggregateVolumes(ctx, ledgerName, filter, query.AggregateOptions{})
-	if err != nil {
-		return err
-	}
-
-	volumes := make(map[string]*commonpb.VolumesWithBalance, len(result.GetVolumes()))
-	for _, v := range result.GetVolumes() {
-		input := v.GetInput().ToBigInt()
-		output := v.GetOutput().ToBigInt()
-		balance := new(big.Int).Sub(input, output)
-		volumes[v.GetAsset()] = &commonpb.VolumesWithBalance{
-			Input:   input.String(),
-			Output:  output.String(),
-			Balance: balance.String(),
-		}
-	}
-
-	account.Volumes = volumes
-
-	return nil
 }

--- a/internal/adapter/http/handlers_get_account_test.go
+++ b/internal/adapter/http/handlers_get_account_test.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
-	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 func TestHandleGetAccount_Success(t *testing.T) {
@@ -55,10 +54,11 @@ func TestHandleGetAccount_MissingAddress(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestHandleGetAccount_ExpandVolumes covers the EN-1470 opt-in: when the
-// caller sets `expandVolumes=true`, an AggregateVolumes scan runs on the
-// account and its result is folded into `volumes` on the response.
-func TestHandleGetAccount_ExpandVolumes(t *testing.T) {
+// TestHandleGetAccount_VolumesEmitted asserts that per-asset volumes populated
+// upstream (by scanAccount in the controller) survive JSON serialization.
+// Regression against the pre-EN-1470 wire, where Account.MarshalJSON explicitly
+// dropped the field.
+func TestHandleGetAccount_VolumesEmitted(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
@@ -68,27 +68,17 @@ func TestHandleGetAccount_ExpandVolumes(t *testing.T) {
 		}).AnyTimes()
 	backend.EXPECT().GetAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, addr string) (*commonpb.Account, error) {
-			return &commonpb.Account{Address: addr}, nil
-		}).AnyTimes()
-	backend.EXPECT().AggregateVolumes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ string, filter *commonpb.QueryFilter, _ query.AggregateOptions) (*commonpb.AggregateResult, error) {
-			// Sanity-check the filter: exact-match on the requested address.
-			require.Equal(t, "users:001", filter.GetAddress().GetHardcodedExact())
-
-			return &commonpb.AggregateResult{
-				Volumes: []*commonpb.AggregatedVolume{
-					{
-						Asset:  "USD/2",
-						Input:  commonpb.NewUint256FromUint64(1000),
-						Output: commonpb.NewUint256FromUint64(400),
-					},
+			return &commonpb.Account{
+				Address: addr,
+				Volumes: map[string]*commonpb.VolumesWithBalance{
+					"USD/2": {Input: "1000", Output: "400", Balance: "600"},
 				},
 			}, nil
-		}).Times(1)
+		}).AnyTimes()
 	srv := newTestServer(t, backend)
 
 	w := httptest.NewRecorder()
-	r := newRequest(t, http.MethodGet, "/ledger1/accounts/users:001?expandVolumes=true", nil, map[string]string{
+	r := newRequest(t, http.MethodGet, "/ledger1/accounts/users:001", nil, map[string]string{
 		"ledgerName": "ledger1",
 		"address":    "users:001",
 	})
@@ -116,9 +106,10 @@ func TestHandleGetAccount_ExpandVolumes(t *testing.T) {
 	require.Equal(t, "600", body.Data.Volumes["USD/2"].Balance)
 }
 
-// TestHandleGetAccount_NoExpandVolumesLeavesFieldOff asserts that the default
-// read path never populates `volumes` and never calls AggregateVolumes.
-func TestHandleGetAccount_NoExpandVolumesLeavesFieldOff(t *testing.T) {
+// TestHandleGetAccount_NoVolumesOmitsField asserts that a controller returning
+// an account with no `volumes` produces a JSON body without the field
+// (`omitempty` on the marshaller).
+func TestHandleGetAccount_NoVolumesOmitsField(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
@@ -130,7 +121,6 @@ func TestHandleGetAccount_NoExpandVolumesLeavesFieldOff(t *testing.T) {
 		func(_ context.Context, _ string, addr string) (*commonpb.Account, error) {
 			return &commonpb.Account{Address: addr}, nil
 		}).AnyTimes()
-	// AggregateVolumes must NOT be called — no EXPECT() means gomock fails if it is.
 	srv := newTestServer(t, backend)
 
 	w := httptest.NewRecorder()

--- a/internal/adapter/http/handlers_get_account_test.go
+++ b/internal/adapter/http/handlers_get_account_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 func TestHandleGetAccount_Success(t *testing.T) {
@@ -51,6 +53,96 @@ func TestHandleGetAccount_MissingAddress(t *testing.T) {
 	srv.handleGetAccount(w, r)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestHandleGetAccount_ExpandVolumes covers the EN-1470 opt-in: when the
+// caller sets `expandVolumes=true`, an AggregateVolumes scan runs on the
+// account and its result is folded into `volumes` on the response.
+func TestHandleGetAccount_ExpandVolumes(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetLedgerByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string) (*commonpb.LedgerInfo, error) {
+			return &commonpb.LedgerInfo{Name: "ledger1"}, nil
+		}).AnyTimes()
+	backend.EXPECT().GetAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, addr string) (*commonpb.Account, error) {
+			return &commonpb.Account{Address: addr}, nil
+		}).AnyTimes()
+	backend.EXPECT().AggregateVolumes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, filter *commonpb.QueryFilter, _ query.AggregateOptions) (*commonpb.AggregateResult, error) {
+			// Sanity-check the filter: exact-match on the requested address.
+			require.Equal(t, "users:001", filter.GetAddress().GetHardcodedExact())
+
+			return &commonpb.AggregateResult{
+				Volumes: []*commonpb.AggregatedVolume{
+					{
+						Asset:  "USD/2",
+						Input:  commonpb.NewUint256FromUint64(1000),
+						Output: commonpb.NewUint256FromUint64(400),
+					},
+				},
+			}, nil
+		}).Times(1)
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/ledger1/accounts/users:001?expandVolumes=true", nil, map[string]string{
+		"ledgerName": "ledger1",
+		"address":    "users:001",
+	})
+
+	srv.handleGetAccount(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data struct {
+			Address string `json:"address"`
+			Volumes map[string]struct {
+				Input   string `json:"input"`
+				Output  string `json:"output"`
+				Balance string `json:"balance"`
+			} `json:"volumes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	require.Equal(t, "users:001", body.Data.Address)
+	require.Contains(t, body.Data.Volumes, "USD/2")
+	require.Equal(t, "1000", body.Data.Volumes["USD/2"].Input)
+	require.Equal(t, "400", body.Data.Volumes["USD/2"].Output)
+	require.Equal(t, "600", body.Data.Volumes["USD/2"].Balance)
+}
+
+// TestHandleGetAccount_NoExpandVolumesLeavesFieldOff asserts that the default
+// read path never populates `volumes` and never calls AggregateVolumes.
+func TestHandleGetAccount_NoExpandVolumesLeavesFieldOff(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetLedgerByName(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string) (*commonpb.LedgerInfo, error) {
+			return &commonpb.LedgerInfo{Name: "ledger1"}, nil
+		}).AnyTimes()
+	backend.EXPECT().GetAccount(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, addr string) (*commonpb.Account, error) {
+			return &commonpb.Account{Address: addr}, nil
+		}).AnyTimes()
+	// AggregateVolumes must NOT be called — no EXPECT() means gomock fails if it is.
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/ledger1/accounts/users:001", nil, map[string]string{
+		"ledgerName": "ledger1",
+		"address":    "users:001",
+	})
+
+	srv.handleGetAccount(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), `"volumes"`)
 }
 
 func TestHandleGetAccount_LedgerNotFound(t *testing.T) {

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -149,20 +149,24 @@ func (x *PostCommitVolumes) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// MarshalJSON implements json.Marshaler for Account.
+// MarshalJSON implements json.Marshaler for Account. Volumes are emitted only
+// when populated (opt-in via `expandVolumes=true` on the GET-account handler);
+// the default read path leaves them off to preserve the lightweight response.
 func (x *Account) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		Address       string         `json:"address,omitempty"`
-		Metadata      map[string]any `json:"metadata,omitempty"`
-		FirstUsage    *Timestamp     `json:"firstUsage,omitempty"`
-		InsertionDate *Timestamp     `json:"insertionDate,omitempty"`
-		UpdatedAt     *Timestamp     `json:"updatedAt,omitempty"`
+		Address       string                         `json:"address,omitempty"`
+		Metadata      map[string]any                 `json:"metadata,omitempty"`
+		FirstUsage    *Timestamp                     `json:"firstUsage,omitempty"`
+		InsertionDate *Timestamp                     `json:"insertionDate,omitempty"`
+		UpdatedAt     *Timestamp                     `json:"updatedAt,omitempty"`
+		Volumes       map[string]*VolumesWithBalance `json:"volumes,omitempty"`
 	}{
 		Address:       x.GetAddress(),
 		Metadata:      MetadataToAnyMap(x.GetMetadata()),
 		FirstUsage:    x.GetFirstUsage(),
 		InsertionDate: x.GetInsertionDate(),
 		UpdatedAt:     x.GetUpdatedAt(),
+		Volumes:       x.GetVolumes(),
 	})
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -577,13 +577,10 @@ paths:
     get:
       summary: Get an account
       description: |
-        Retrieves account information including metadata for a specific
-        account address. Requires `ledger:read` scope.
-
-        Pass `expandVolumes=true` to also populate per-asset
-        input/output/balance in the response — an extra aggregation scan
-        runs on the account (matches the shape v2 populated inline). Off
-        by default to keep the read lightweight.
+        Retrieves account information including metadata and per-asset
+        volumes (input/output/balance) for a specific account address.
+        Volumes are populated inline, matching v2. Requires `ledger:read`
+        scope.
       operationId: getAccount
       tags:
         - Accounts
@@ -593,12 +590,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/AccountAddress'
-        - name: expandVolumes
-          in: query
-          schema:
-            type: boolean
-            default: false
-          description: When true, populate `volumes` on the returned account with per-asset input/output/balance.
       responses:
         '200':
           description: Account retrieved successfully

--- a/openapi.yml
+++ b/openapi.yml
@@ -576,7 +576,14 @@ paths:
   /v3/{ledgerName}/accounts/{address}:
     get:
       summary: Get an account
-      description: Retrieves account information including metadata for a specific account address. Requires `ledger:read` scope.
+      description: |
+        Retrieves account information including metadata for a specific
+        account address. Requires `ledger:read` scope.
+
+        Pass `expandVolumes=true` to also populate per-asset
+        input/output/balance in the response — an extra aggregation scan
+        runs on the account (matches the shape v2 populated inline). Off
+        by default to keep the read lightweight.
       operationId: getAccount
       tags:
         - Accounts
@@ -586,6 +593,12 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/AccountAddress'
+        - name: expandVolumes
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: When true, populate `volumes` on the returned account with per-asset input/output/balance.
       responses:
         '200':
           description: Account retrieved successfully


### PR DESCRIPTION
## Summary

v2 populated per-asset volumes inline on `GET /v2/{ledger}/accounts/{addr}`; v3 alpha.7 never populated the field, forcing callers migrating from v2 into a second aggregation call. This restores access to volumes on the single-account GET, opt-in via `?expandVolumes=true` — mirroring the pattern already used on `POST /v3/{ledger}/transactions`.

- `handleGetAccount` reads the query param and, when set, runs `AggregateVolumes` with a `hardcoded_exact` filter on the address. The result is folded into `Account.Volumes` as `map<asset, {input, output, balance}>`.
- `Account.MarshalJSON` emits `volumes` only when populated (`omitempty`), so the default read path is unchanged.
- OpenAPI documents the new query parameter.
- `api-comparison.md` updated to describe the opt-in.

Default (no param) behaviour: no extra scan, no `volumes` in the response. Callers only pay for the aggregation when they ask.

## Design choice: opt-in, not always-on

v2 populated volumes unconditionally because volumes were a first-class stored attribute — cheap to look up. v3 stores logs and computes volumes on the fly via aggregation, so always-on would double the latency and load on every GET-account read. Opt-in matches v3's existing `expandVolumes` pattern on transactions (see `docs/technical/contributing/api-comparison.md:473`).

Non-goals:
- **List endpoint** (`GET /v3/{ledger}/accounts`) — the fan-out would be prohibitive. Callers who need volumes across many accounts should use a prepared-query `AGGREGATE_VOLUMES` or hit `GET /v3/{ledger}/volumes` directly.
- `effectiveVolumes` — remains removed in v3 (see `api-comparison.md:474`).

## Test plan

- [x] `GOROOT= go build ./...`
- [x] New `TestHandleGetAccount_ExpandVolumes` — asserts the filter is exact-match on the requested address, the response body has the flat `volumes: {USD/2: {input, output, balance}}` map, and balance = input − output.
- [x] New `TestHandleGetAccount_NoExpandVolumesLeavesFieldOff` — asserts `AggregateVolumes` is NOT called and the response omits `volumes` when the param is absent.
- [x] All existing `TestHandleGetAccount_*` tests still pass.

## Follow-up

Once merged, `Account.volumes` is no longer purely-informational-but-never-populated. If [EN-1467](https://formance-team.atlassian.net/browse/EN-1467) has already marked it `deprecated: true`, revert that marker (should be a one-line spec edit).

Ticket: [EN-1470](https://formance-team.atlassian.net/browse/EN-1470) (epic: [EN-867](https://formance-team.atlassian.net/browse/EN-867))

[EN-1467]: https://formance-team.atlassian.net/browse/EN-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ