### PR TITLE
fix(proto): regenerate common_reader for named-type reader wrappers

### DIFF
--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -618,11 +618,11 @@ func (r *transactionReadonly) GetRevertedAt() TimestampReader {
 }
 
 func (r *transactionReadonly) GetRevertedByTransaction() uint64 {
-	return r.v.GetRevertedByTransaction()
+	return (*Transaction)(r).GetRevertedByTransaction()
 }
 
 func (r *transactionReadonly) GetRevertsTransaction() uint64 {
-	return r.v.GetRevertsTransaction()
+	return (*Transaction)(r).GetRevertsTransaction()
 }
 
 func (r *transactionReadonly) Mutate() *Transaction {
@@ -7696,7 +7696,7 @@ func (r *transactionStateReadonly) GetPostings() PostingListReader {
 }
 
 func (r *transactionStateReadonly) GetRevertedAt() TimestampReader {
-	v := r.v.GetRevertedAt()
+	v := (*TransactionState)(r).GetRevertedAt()
 	if v == nil {
 		return nil
 	}
@@ -7704,7 +7704,7 @@ func (r *transactionStateReadonly) GetRevertedAt() TimestampReader {
 }
 
 func (r *transactionStateReadonly) GetRevertsTransaction() uint64 {
-	return r.v.GetRevertsTransaction()
+	return (*TransactionState)(r).GetRevertsTransaction()
 }
 
 func (r *transactionStateReadonly) Mutate() *TransactionState {
@@ -8839,14 +8839,14 @@ type RevertedConditionReader interface {
 	Mutate() *RevertedCondition
 }
 
-type revertedConditionReadonly struct{ v *RevertedCondition }
+type revertedConditionReadonly RevertedCondition
 
 func (r *revertedConditionReadonly) GetValue() bool {
-	return r.v.GetValue()
+	return (*RevertedCondition)(r).GetValue()
 }
 
 func (r *revertedConditionReadonly) Mutate() *RevertedCondition {
-	return r.v.CloneVT()
+	return (*RevertedCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevertedCondition.
@@ -8854,7 +8854,7 @@ func (m *RevertedCondition) AsReader() RevertedConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &revertedConditionReadonly{v: m}
+	return (*revertedConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevertedCondition.


### PR DESCRIPTION
## Problem

`release/v3.0` currently fails to compile — `go build ./...` errors with:

```
internal/proto/commonpb/common_reader.pb.go:621:11: r.v undefined (type *transactionReadonly has no field or method v)
```

`common_reader.pb.go` is internally inconsistent: the reader types are named-type
aliases (`type transactionReadonly Transaction`, from #1511's zero-alloc conversion),
but several method bodies still dereference the old struct-wrapper field `r.v`.

## Cause

#1508 (`feat(ledger): navigable revert relationship + queryable reverted/revertedAt`)
added the revert getters (`GetRevertedAt`, `GetRevertedByTransaction`,
`GetRevertsTransaction`) and a `RevertedCondition` reader, generated with the **old**
`r.v` reader-wrapper form. It merged on top of #1511's named-type conversion, leaving
the committed generated file in a mixed state that doesn't build. This reddens the
base branch and every PR targeting it.

## Fix

Regenerated `common_reader.pb.go` via `just generate-proto` (the in-repo
`tools/protoc-gen-reader`). Pure `r.v` → `(*T)(r)` conversion — **no `.proto` source
changes**.

## Verification

- `go build ./...` — passes
- `just pre-commit` (generate + generate-proto + operator-generate + dashboards + tidy + lint) — clean; only `common_reader.pb.go` changes, **0 lint issues** (satisfies the `Dirty` gate)