### PR TITLE
fix(EN-1425): pendingTx overlay in RebuildDelta + reader wrapper hotfix

### DIFF
--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -45,6 +45,7 @@ func RebuildDelta(
 		metadata:       attrs.Metadata,
 		tx:             attrs.Transaction,
 		pendingVolumes: make(map[string]*raftcmdpb.VolumePair),
+		pendingTx:      make(map[string]*commonpb.TransactionState),
 	}
 
 	sinkConfig := attrs.SinkConfig
@@ -313,6 +314,7 @@ func RebuildDelta(
 			batch = store.OpenWriteSession()
 			writer.batch = batch
 			clear(writer.pendingVolumes)
+			clear(writer.pendingTx)
 
 			logger.WithFields(map[string]any{
 				"logsProcessed": count,
@@ -438,6 +440,11 @@ func seedLedgerContext(
 
 // attributeReplayWriter implements replay.Writer by writing directly to
 // Pebble attributes via Attribute[V].Set/Get/Delete.
+//
+// Pebble batches are not indexed (see OpenWriteSession), so writes committed
+// through w.batch are invisible to w.store.Get until Commit. The pending*
+// overlays make in-batch state visible to same-batch reads; both maps are
+// cleared on every batch commit alongside the batch itself.
 type attributeReplayWriter struct {
 	store          *dal.Store
 	batch          *dal.WriteSession
@@ -445,6 +452,7 @@ type attributeReplayWriter struct {
 	metadata       *attributes.Attribute[*commonpb.MetadataValue]
 	tx             *attributes.Attribute[*commonpb.TransactionState]
 	pendingVolumes map[string]*raftcmdpb.VolumePair
+	pendingTx      map[string]*commonpb.TransactionState
 }
 
 func (w *attributeReplayWriter) AddVolumeDelta(canonicalKey []byte, inputDelta, outputDelta *big.Int) error {
@@ -552,6 +560,18 @@ func (w *attributeReplayWriter) MoveMetadata(oldKey, newKey []byte) error {
 	return w.metadata.Delete(w.batch, oldKey)
 }
 
+// getTx returns the in-batch state if present, otherwise the committed state.
+// Symmetric to GetVolume — required because w.batch is non-indexed and would
+// otherwise hide same-batch writes from subsequent reads within the 5000-log
+// commit window.
+func (w *attributeReplayWriter) getTx(canonicalKey []byte) (*commonpb.TransactionState, error) {
+	if state, ok := w.pendingTx[string(canonicalKey)]; ok {
+		return state, nil
+	}
+
+	return w.tx.Get(w.store, canonicalKey)
+}
+
 func (w *attributeReplayWriter) CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting, revertsTransaction uint64) error {
 	txState := &commonpb.TransactionState{
 		CreatedByLog:       seq,
@@ -561,13 +581,17 @@ func (w *attributeReplayWriter) CreateTransaction(canonicalKey []byte, seq uint6
 		RevertsTransaction: revertsTransaction,
 	}
 
-	_, err := w.tx.Set(w.batch, canonicalKey, txState)
+	if _, err := w.tx.Set(w.batch, canonicalKey, txState); err != nil {
+		return err
+	}
 
-	return err
+	w.pendingTx[string(canonicalKey)] = txState
+
+	return nil
 }
 
 func (w *attributeReplayWriter) SetRevertedBy(canonicalKey []byte, revertTxID uint64, revertedAt *commonpb.Timestamp) error {
-	existing, err := w.tx.Get(w.store, canonicalKey)
+	existing, err := w.getTx(canonicalKey)
 	if err != nil {
 		return err
 	}
@@ -579,13 +603,17 @@ func (w *attributeReplayWriter) SetRevertedBy(canonicalKey []byte, revertTxID ui
 	existing.RevertedByTransaction = revertTxID
 	existing.RevertedAt = revertedAt
 
-	_, err = w.tx.Set(w.batch, canonicalKey, existing)
+	if _, err := w.tx.Set(w.batch, canonicalKey, existing); err != nil {
+		return err
+	}
 
-	return err
+	w.pendingTx[string(canonicalKey)] = existing
+
+	return nil
 }
 
 func (w *attributeReplayWriter) SaveTxMetadata(canonicalKey []byte, metadata map[string]*commonpb.MetadataValue) error {
-	existing, err := w.tx.Get(w.store, canonicalKey)
+	existing, err := w.getTx(canonicalKey)
 	if err != nil {
 		return err
 	}
@@ -600,13 +628,17 @@ func (w *attributeReplayWriter) SaveTxMetadata(canonicalKey []byte, metadata map
 
 	maps.Copy(existing.GetMetadata(), metadata)
 
-	_, err = w.tx.Set(w.batch, canonicalKey, existing)
+	if _, err := w.tx.Set(w.batch, canonicalKey, existing); err != nil {
+		return err
+	}
 
-	return err
+	w.pendingTx[string(canonicalKey)] = existing
+
+	return nil
 }
 
 func (w *attributeReplayWriter) DeleteTxMetadata(canonicalKey []byte, key string) error {
-	existing, err := w.tx.Get(w.store, canonicalKey)
+	existing, err := w.getTx(canonicalKey)
 	if err != nil {
 		return err
 	}
@@ -617,7 +649,11 @@ func (w *attributeReplayWriter) DeleteTxMetadata(canonicalKey []byte, key string
 
 	delete(existing.GetMetadata(), key)
 
-	_, err = w.tx.Set(w.batch, canonicalKey, existing)
+	if _, err := w.tx.Set(w.batch, canonicalKey, existing); err != nil {
+		return err
+	}
 
-	return err
+	w.pendingTx[string(canonicalKey)] = existing
+
+	return nil
 }

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
@@ -219,4 +220,155 @@ func TestRebuildDelta_ReplaysEphemeralPurgeAtProposalBoundary(t *testing.T) {
 	require.NotNil(t, pair)
 	require.Equal(t, "8", pair.GetInput().ToBigInt().String())
 	require.Equal(t, "5", pair.GetOutput().ToBigInt().String())
+}
+
+// newAttributeReplayWriter builds an isolated writer for regression tests of
+// EN-1425: an in-batch create followed by a mutate must produce the merged
+// state, not overwrite it with a fresh zero-value TransactionState.
+func newAttributeReplayWriter(t *testing.T) (*attributeReplayWriter, *attributes.Attributes, *dal.Store) {
+	t.Helper()
+
+	store := newRebuildTestStore(t)
+	attrs := attributes.New()
+	writer := &attributeReplayWriter{
+		store:          store,
+		batch:          store.OpenWriteSession(),
+		volume:         attrs.Volume,
+		metadata:       attrs.Metadata,
+		tx:             attrs.Transaction,
+		pendingVolumes: make(map[string]*raftcmdpb.VolumePair),
+		pendingTx:      make(map[string]*commonpb.TransactionState),
+	}
+	t.Cleanup(func() { _ = writer.batch.Cancel() })
+
+	return writer, attrs, store
+}
+
+func rebuildTestMetaMap(entries ...string) map[string]*commonpb.MetadataValue {
+	m := make(map[string]*commonpb.MetadataValue, len(entries)/2)
+	for i := 0; i < len(entries); i += 2 {
+		m[entries[i]] = &commonpb.MetadataValue{Type: &commonpb.MetadataValue_StringValue{StringValue: entries[i+1]}}
+	}
+
+	return m
+}
+
+// TestAttributeReplayWriter_SetRevertedByPreservesCreatedByLog is the EN-1425
+// revert scenario: CreateTransaction then SetRevertedBy in the same batch must
+// not drop CreatedByLog/Timestamp/Metadata by re-reading committed state.
+func TestAttributeReplayWriter_SetRevertedByPreservesCreatedByLog(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	key := []byte("ledger\x00tx\x0042")
+
+	require.NoError(t, writer.CreateTransaction(key, 42,
+		&commonpb.Timestamp{Data: 100},
+		rebuildTestMetaMap("env", "prod"),
+		[]*commonpb.Posting{rebuildTestPosting("world", "orders:1", "USD", 5)},
+		0,
+	))
+	require.NoError(t, writer.SetRevertedBy(key, 99, &commonpb.Timestamp{Data: 150}))
+	require.NoError(t, writer.batch.Commit())
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	got, err := attrs.Transaction.Get(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(42), got.GetCreatedByLog(), "CreatedByLog must survive same-batch revert")
+	require.Equal(t, uint64(99), got.GetRevertedByTransaction())
+	require.Equal(t, uint64(150), got.GetRevertedAt().GetData(), "RevertedAt must survive same-batch revert")
+	require.Equal(t, uint64(100), got.GetTimestamp().GetData(), "Timestamp must survive same-batch revert")
+	require.Equal(t, "prod", got.GetMetadata()["env"].GetStringValue(), "Metadata must survive same-batch revert")
+	require.Len(t, got.GetPostings(), 1, "Postings must survive same-batch revert")
+}
+
+// TestAttributeReplayWriter_SaveTxMetadataPreservesCreatedByLog is the EN-1425
+// metadata-upsert scenario: CreateTransaction then SaveTxMetadata in the same
+// batch must merge into the existing state, not clobber it.
+func TestAttributeReplayWriter_SaveTxMetadataPreservesCreatedByLog(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	key := []byte("ledger\x00tx\x00043")
+
+	require.NoError(t, writer.CreateTransaction(key, 43,
+		&commonpb.Timestamp{Data: 200},
+		rebuildTestMetaMap("env", "prod"),
+		nil,
+		0,
+	))
+	require.NoError(t, writer.SaveTxMetadata(key, rebuildTestMetaMap("region", "eu-west")))
+	require.NoError(t, writer.batch.Commit())
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	got, err := attrs.Transaction.Get(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, uint64(43), got.GetCreatedByLog())
+	require.Equal(t, uint64(200), got.GetTimestamp().GetData())
+	require.Equal(t, "prod", got.GetMetadata()["env"].GetStringValue(), "pre-existing metadata must survive upsert")
+	require.Equal(t, "eu-west", got.GetMetadata()["region"].GetStringValue(), "new metadata must be merged in")
+}
+
+// TestAttributeReplayWriter_TwoMetadataUpsertsInSameBatchMerge exercises the
+// second EN-1425 sub-scenario: two SaveTxMetadata calls within the same batch
+// window must both persist, not clobber each other.
+func TestAttributeReplayWriter_TwoMetadataUpsertsInSameBatchMerge(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	key := []byte("ledger\x00tx\x00044")
+
+	require.NoError(t, writer.CreateTransaction(key, 44,
+		&commonpb.Timestamp{Data: 300}, nil, nil, 0,
+	))
+	require.NoError(t, writer.SaveTxMetadata(key, rebuildTestMetaMap("status", "pending")))
+	require.NoError(t, writer.SaveTxMetadata(key, rebuildTestMetaMap("owner", "alice")))
+	require.NoError(t, writer.batch.Commit())
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	got, err := attrs.Transaction.Get(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "pending", got.GetMetadata()["status"].GetStringValue())
+	require.Equal(t, "alice", got.GetMetadata()["owner"].GetStringValue())
+}
+
+// TestAttributeReplayWriter_DeleteTxMetadataSeesPendingCreate is the EN-1425
+// delete scenario: without the overlay the read returns nil and the delete is
+// a silent no-op, leaving stale metadata after commit.
+func TestAttributeReplayWriter_DeleteTxMetadataSeesPendingCreate(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	key := []byte("ledger\x00tx\x00045")
+
+	require.NoError(t, writer.CreateTransaction(key, 45,
+		&commonpb.Timestamp{Data: 400},
+		rebuildTestMetaMap("env", "prod", "region", "eu-west"),
+		nil,
+		0,
+	))
+	require.NoError(t, writer.DeleteTxMetadata(key, "env"))
+	require.NoError(t, writer.batch.Commit())
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	got, err := attrs.Transaction.Get(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotContains(t, got.GetMetadata(), "env", "same-batch delete must actually remove the key")
+	require.Equal(t, "eu-west", got.GetMetadata()["region"].GetStringValue())
 }

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -618,11 +618,11 @@ func (r *transactionReadonly) GetRevertedAt() TimestampReader {
 }
 
 func (r *transactionReadonly) GetRevertedByTransaction() uint64 {
-	return r.v.GetRevertedByTransaction()
+	return (*Transaction)(r).GetRevertedByTransaction()
 }
 
 func (r *transactionReadonly) GetRevertsTransaction() uint64 {
-	return r.v.GetRevertsTransaction()
+	return (*Transaction)(r).GetRevertsTransaction()
 }
 
 func (r *transactionReadonly) Mutate() *Transaction {
@@ -7696,7 +7696,7 @@ func (r *transactionStateReadonly) GetPostings() PostingListReader {
 }
 
 func (r *transactionStateReadonly) GetRevertedAt() TimestampReader {
-	v := r.v.GetRevertedAt()
+	v := (*TransactionState)(r).GetRevertedAt()
 	if v == nil {
 		return nil
 	}
@@ -7704,7 +7704,7 @@ func (r *transactionStateReadonly) GetRevertedAt() TimestampReader {
 }
 
 func (r *transactionStateReadonly) GetRevertsTransaction() uint64 {
-	return r.v.GetRevertsTransaction()
+	return (*TransactionState)(r).GetRevertsTransaction()
 }
 
 func (r *transactionStateReadonly) Mutate() *TransactionState {
@@ -8839,14 +8839,14 @@ type RevertedConditionReader interface {
 	Mutate() *RevertedCondition
 }
 
-type revertedConditionReadonly struct{ v *RevertedCondition }
+type revertedConditionReadonly RevertedCondition
 
 func (r *revertedConditionReadonly) GetValue() bool {
-	return r.v.GetValue()
+	return (*RevertedCondition)(r).GetValue()
 }
 
 func (r *revertedConditionReadonly) Mutate() *RevertedCondition {
-	return r.v.CloneVT()
+	return (*RevertedCondition)(r).CloneVT()
 }
 
 // AsReader returns a read-only view of this RevertedCondition.
@@ -8854,7 +8854,7 @@ func (m *RevertedCondition) AsReader() RevertedConditionReader {
 	if m == nil {
 		return nil
 	}
-	return &revertedConditionReadonly{v: m}
+	return (*revertedConditionReadonly)(m)
 }
 
 // Mutate returns a mutable deep clone of this RevertedCondition.


### PR DESCRIPTION
## Summary

- **fix(EN-1425)**: `RebuildDelta` reconstructs transaction state via read-modify-write on a non-indexed Pebble batch. A `CreateTransaction` followed by `SetRevertedBy` / `SaveTxMetadata` / `DeleteTxMetadata` within the same 5000-log commit window used to re-read committed state (nil), rebuild a fresh zero-value `TransactionState`, and clobber `CreatedByLog` / `Timestamp` / `Metadata` on commit — corrupting the restored image. `DeleteTxMetadata` silently no-op'd for the same reason. Fix mirrors the existing `pendingVolumes` overlay: a `pendingTx` map routes reads through in-batch writes and is cleared alongside `pendingVolumes` on each commit. Four regression tests exercise the exact scenarios from the ticket (verified failing without the fix).
- **chore(proto): reader wrapper hotfix**. `release/v3.0` at 0713a7669 doesn't build: the four accessors #1508 added on `transactionReadonly` / `transactionStateReadonly` use the old `r.v.GetX()` form even though #1511 had already switched those readonly types to the named-type-conversion pattern. This PR patches the four accessors to `(*Transaction)(r).GetX()` / `(*TransactionState)(r).GetX()` so the rebase (and CI) can proceed. Happy to split into a standalone PR if preferred — kept it in the same PR to keep the rebase self-contained.

Refs: https://formance-team.atlassian.net/browse/EN-1425

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/infra/backup/...` — 3 pre-existing + 4 new tests pass
- [x] `go test ./internal/application/check/...` — checker `replayStore` unaffected (different implementation of `replay.Writer` via merge operators)
- [x] Regression tests fail with `pendingTx` overlay disabled from `CreateTransaction` (proves they catch the exact bug)
- [x] `golangci-lint run --fix ./internal/infra/backup/...` — 0 issues
- [x] Verify the reader hotfix actually unblocks compilation of the whole tree