### PR TITLE
feat(audit): attribute every audit entry; tag system actors, fail-fast on dropped forwarded caller

### DIFF
--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -132,8 +132,8 @@ func printAuditEntry(entry *auditpb.AuditEntry, verbose bool) {
 
 	// Caller info (compact or verbose)
 	callerText := ""
-	if id := entry.GetCallerSnapshot().GetIdentity(); id.GetSubject() != "" {
-		callerText = "  caller=" + pterm.Yellow(id.GetSubject())
+	if label := callerLabel(entry.GetCallerSnapshot()); label != "" {
+		callerText = "  caller=" + pterm.Yellow(label)
 	}
 
 	pterm.Printf("  #%-6d %s  proposal=%-4d %s  %s%s\n",
@@ -147,29 +147,26 @@ func printAuditEntry(entry *auditpb.AuditEntry, verbose bool) {
 
 	// Verbose caller details
 	if verbose {
-		if snap := entry.GetCallerSnapshot(); snap != nil && snap.GetIdentity().GetSubject() != "" {
+		if snap := entry.GetCallerSnapshot(); snap != nil {
 			id := snap.GetIdentity()
+			source := callerSourceString(id)
 
-			var source string
-
-			switch s := id.GetSource().(type) {
-			case *commonpb.CallerIdentity_Issuer:
-				source = "issuer=" + s.Issuer
-			case *commonpb.CallerIdentity_KeyId:
-				source = "key_id=" + s.KeyId
+			subject := id.GetSubject()
+			if subject == "" {
+				subject = "(none)"
 			}
 
 			if snap.GetGod() {
 				pterm.Printf("    %s subject=%s %s %s\n",
 					pterm.Gray("caller:"),
-					pterm.Yellow(id.GetSubject()),
+					pterm.Yellow(subject),
 					pterm.Gray(source),
 					pterm.Red("god=true"),
 				)
 			} else {
 				pterm.Printf("    %s subject=%s %s scopes=[%s]\n",
 					pterm.Gray("caller:"),
-					pterm.Yellow(id.GetSubject()),
+					pterm.Yellow(subject),
 					pterm.Gray(source),
 					pterm.Gray(strings.Join(snap.GetScopes(), ",")),
 				)
@@ -203,6 +200,45 @@ func printAuditEntry(entry *auditpb.AuditEntry, verbose bool) {
 		printGroupedOrders(orders, verbose)
 	} else if entry.GetOrderCount() > 0 {
 		pterm.Printf("    └─ %s orders\n", pterm.Cyan(strconv.FormatUint(uint64(entry.GetOrderCount()), 10)))
+	}
+}
+
+// callerSourceString renders the CallerIdentity source for display.
+func callerSourceString(id *commonpb.CallerIdentity) string {
+	switch s := id.GetSource().(type) {
+	case *commonpb.CallerIdentity_Issuer:
+		return "issuer=" + s.Issuer
+	case *commonpb.CallerIdentity_KeyId:
+		return "key_id=" + s.KeyId
+	case *commonpb.CallerIdentity_SystemComponent:
+		return "system=" + s.SystemComponent
+	default:
+		return ""
+	}
+}
+
+// callerLabel renders a compact one-token caller label, falling back to the
+// source (system component, key id, or issuer) when the subject is empty.
+// Empty when there is no caller snapshot at all.
+func callerLabel(snap *commonpb.CallerSnapshot) string {
+	if snap == nil {
+		return ""
+	}
+
+	id := snap.GetIdentity()
+	if id.GetSubject() != "" {
+		return id.GetSubject()
+	}
+
+	switch s := id.GetSource().(type) {
+	case *commonpb.CallerIdentity_SystemComponent:
+		return "system:" + s.SystemComponent
+	case *commonpb.CallerIdentity_KeyId:
+		return "key:" + s.KeyId
+	case *commonpb.CallerIdentity_Issuer:
+		return "issuer:" + s.Issuer
+	default:
+		return ""
 	}
 }
 

--- a/docs/technical/architecture/subsystems/api/auth.md
+++ b/docs/technical/architecture/subsystems/api/auth.md
@@ -101,26 +101,47 @@ Raft transport uses a **shared cluster secret**, not JWT. `internal/adapter/grpc
 - Comparison uses `crypto/subtle.ConstantTimeCompare` to avoid timing attacks.
 - If `--cluster-secret` is empty, the legacy "no auth" mode is used (not recommended).
 
-There is a **fast path** when the cluster secret is presented through the client surface (`grpc_auth.go:91-100`): the request bypasses JWT validation, gets every granular scope, is marked as cluster-internal in the context, and — if the request is a leader forwarding a follower's work — carries the forwarded `CallerSnapshot` so the audit chain still attributes the operation to the original caller.
+There is a **fast path** when the cluster secret is presented through the client surface (`grpc_auth.go:91-100`): the request bypasses JWT validation, gets every granular scope, is marked as cluster-internal in the context, and — if the request is a leader forwarding a follower's work — carries the forwarded `CallerSnapshot` so the audit chain still attributes the operation to the original caller. If a request carries a forwarded snapshot but the connection is **not** cluster-internal (cluster secret unset or mismatched), the leader **rejects** it with `PermissionDenied` rather than silently dropping the identity (`server_bucket.go:adoptForwardedSnapshotIfTrusted`) — a misconfiguration surfaces as a failed write instead of an unattributed audit entry.
 
 ## Caller identity in the audit chain
 
-Every successful proposal carries a `CallerSnapshot` (proto `common.proto:1264-1277`):
+Every proposal carries a `CallerSnapshot` (proto `common.proto`):
 
 ```proto
 message CallerSnapshot {
-  CallerIdentity identity = 1;        // subject + source (issuer or keyId)
+  CallerIdentity identity = 1;        // subject + source
   repeated string scopes = 2;         // granular scopes at admission time
   bool god = 3;                       // god-mode flag
 }
+
+message CallerIdentity {
+  string subject = 1;
+  oneof source {
+    string issuer = 4;                // OIDC token issuer URL
+    string key_id = 5;                // Ed25519 signing key ID
+    string system_component = 6;      // system/internal actor; subject empty
+  }
+}
 ```
 
-It is built by `ResolveCallerSnapshot()` (`internal/adapter/auth/caller_snapshot.go:56-62`):
+It is built by `ResolveCallerSnapshot()` (`internal/adapter/auth/caller_snapshot.go`), in precedence order:
 
-- For a request that arrived locally: `buildCallerSnapshot()` reads the context (subject, source, scopes, god flag).
-- For a request forwarded by a follower: the snapshot the follower captured is used verbatim.
+1. **System actor** — a background action marked with `WithSystemActor(ctx, component)` resolves to a snapshot whose source is `system_component` (e.g. `chapter-archiver`, `mirror`, `events-sink`, `cluster-config`, `idempotency-eviction`, `backup`). This is what keeps system-generated entries attributable instead of blank.
+2. **Forwarded snapshot** — a request forwarded by a follower uses the snapshot the follower captured, verbatim.
+3. **Local claims** — otherwise `buildCallerSnapshot()` reads the context (subject, source, scopes, god). Returns `nil` only for an unauthenticated user request.
+
+So an audit entry attributes a write by, in order: the user subject when present, otherwise the source (Ed25519 key id / OIDC issuer) — an Ed25519 token minted without a `sub` claim is still attributable by its key id — otherwise the system component. `nil` means an unauthenticated user write.
 
 The snapshot enters the audit-chain hash via `BuildHashedHeaderPayload` (see [audit-chain.md](../checker/audit-chain.md)). **It is not re-evaluated downstream** — the FSM, the checker, and any later observer see exactly what admission resolved. A token expiring between admission and FSM apply does not retroactively invalidate the proposal.
+
+### Attribution observability
+
+Admission emits signals when a user write is committed with weak attribution while auth is enabled (`admission.observeCallerSnapshot`):
+
+- `admission.audit.missing_caller` (+ error log) — a user write resolved to a `nil` caller. Since writes without a valid token are already rejected at the scope check, this is anomalous (e.g. anonymous scopes misconfigured to allow writes).
+- `admission.audit.caller_subject_empty` (+ info log) — the caller has a user source (key id / issuer) but an empty subject; the entry is still attributable by source.
+
+System actions carry a `system_component` source and are exempt from both.
 
 ## OIDC discovery
 
@@ -148,5 +169,7 @@ This bound is what prevents a slow IdP from stalling node startup indefinitely.
 | Scope definitions and mapping | `internal/adapter/auth/scopes.go` |
 | Ed25519 static keyset | `internal/adapter/auth/ed25519_keys.go` |
 | Caller-snapshot resolution | `internal/adapter/auth/caller_snapshot.go` |
+| System-actor snapshot + component names | `internal/pkg/commands/system_caller.go` |
+| Attribution observability | `internal/application/admission/admission.go` (`observeCallerSnapshot`) |
 | Raft cluster-secret interceptor | `internal/adapter/grpc/raft_auth.go` |
 | OIDC discovery + composite keyset wiring | `internal/bootstrap/module.go` (around lines 1587-1652) |

--- a/docs/technical/architecture/subsystems/checker/audit-chain.md
+++ b/docs/technical/architecture/subsystems/checker/audit-chain.md
@@ -34,6 +34,19 @@ Built by `state.BuildHashedHeaderPayload(entry)` (`internal/infra/state/audit_en
 
 Every field is hashed — none is "informational and excluded".
 
+### `CallerSnapshot` sub-payload
+
+The `CallerSnapshot` bytes are built by `state.buildCallerSnapshotPayload` (`audit_envelope.go`): the subject (length-prefixed), then a one-byte source tag with its length-prefixed value, then the god flag (one byte), then the sorted scopes. The source tag identifies who acted:
+
+| Tag | Source | Meaning |
+|-----|--------|---------|
+| `0x00` | none | subject with no known origin |
+| `0x01` | issuer | OIDC token issuer URL |
+| `0x02` | key_id | Ed25519 signing key ID |
+| `0x03` | system_component | system/internal action (e.g. `chapter-archiver`, `mirror`); subject is empty |
+
+The tag switches on the oneof *wrapper type*, not the inner string value, so a source set to an empty string is still distinct from an absent source. A system action therefore hashes differently from a caller-less entry (`0x03` + component vs `0x00` + empty), which is what makes system-generated entries unambiguously attributable in the chain.
+
 ### Per-item payloads
 
 Each `AuditItem` (one per order in the proposal) is encoded by `state.BuildPerItemPayload(item)` (`audit_envelope.go:246-254`):

--- a/internal/adapter/auth/caller_snapshot.go
+++ b/internal/adapter/auth/caller_snapshot.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"sort"
 
+	"github.com/formancehq/ledger/v3/internal/pkg/commands"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 type (
 	clusterInternalKey   struct{}
 	forwardedSnapshotKey struct{}
+	systemActorKey       struct{}
 )
 
 // WithClusterInternal marks the context as belonging to a request that
@@ -44,16 +46,40 @@ func ForwardedSnapshotFromContext(ctx context.Context) *commonpb.CallerSnapshot 
 	return c
 }
 
-// ResolveCallerSnapshot returns the authenticated caller snapshot for the
-// current context. It honors an explicitly forwarded snapshot (set by a
-// follower that already validated the user JWT/Ed25519 token) before falling
-// back to building one from the claims attached locally by Authenticate.
-// Returns nil when the request is unauthenticated.
+// WithSystemActor marks the context as a system/internal action attributed to
+// the named component (see commands.Component*). ResolveCallerSnapshot turns
+// it into a system CallerSnapshot, so system proposals routed through
+// admission (chapter archiver, sealer, schedulers) are attributed to that
+// component.
+func WithSystemActor(ctx context.Context, component string) context.Context {
+	return context.WithValue(ctx, systemActorKey{}, component)
+}
+
+// systemActorFromContext returns the system component set by WithSystemActor,
+// and whether one was set.
+func systemActorFromContext(ctx context.Context) (string, bool) {
+	c, ok := ctx.Value(systemActorKey{}).(string)
+
+	return c, ok && c != ""
+}
+
+// ResolveCallerSnapshot returns the caller snapshot for the current context,
+// in precedence order:
+//  1. an explicit system actor (WithSystemActor) — a background action;
+//  2. an explicitly forwarded snapshot (set by a follower that already
+//     validated the user JWT/Ed25519 token);
+//  3. one built from the claims attached locally by Authenticate.
+//
+// Returns nil only when the request is an unauthenticated user request.
 //
 // Use this from both the follower (when forwarding to the leader, to keep the
 // original snapshot intact across hops) and the leader (when building the
 // proposal carried through Raft).
 func ResolveCallerSnapshot(ctx context.Context) *commonpb.CallerSnapshot {
+	if component, ok := systemActorFromContext(ctx); ok {
+		return commands.SystemCallerSnapshot(component)
+	}
+
 	if forwarded := ForwardedSnapshotFromContext(ctx); forwarded != nil {
 		return forwarded
 	}

--- a/internal/adapter/auth/caller_snapshot_test.go
+++ b/internal/adapter/auth/caller_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 
+	"github.com/formancehq/ledger/v3/internal/pkg/commands"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -103,6 +104,63 @@ func TestResolveCallerSnapshot_ForwardedShortCircuitsClaims(t *testing.T) {
 		"forwarded snapshot must win over local peer claims")
 	require.Equal(t, "https://idp.example.com", got.GetIdentity().GetIssuer())
 	require.Equal(t, []string{"ledger:TransactionWrite"}, got.GetScopes())
+}
+
+func TestResolveCallerSnapshot_SystemActor(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithSystemActor(context.Background(), commands.ComponentChapterArchiver)
+
+	got := ResolveCallerSnapshot(ctx)
+	require.NotNil(t, got)
+	require.Equal(t, commands.ComponentChapterArchiver, got.GetIdentity().GetSystemComponent())
+	require.Empty(t, got.GetIdentity().GetSubject())
+	require.Empty(t, got.GetScopes())
+	require.False(t, got.GetGod())
+}
+
+func TestResolveCallerSnapshot_SystemActorWinsOverForwardedAndClaims(t *testing.T) {
+	t.Parallel()
+
+	// A system action must be attributed to the system component even if a
+	// forwarded snapshot or local claims happen to be present.
+	ctx := WithClaims(context.Background(), &oidc.AccessTokenClaims{
+		TokenClaims: oidc.TokenClaims{Subject: "user-1"},
+	})
+	ctx = WithForwardedSnapshot(ctx, &commonpb.CallerSnapshot{
+		Identity: &commonpb.CallerIdentity{Subject: "forwarded-user"},
+	})
+	ctx = WithSystemActor(ctx, commands.ComponentMirror)
+
+	got := ResolveCallerSnapshot(ctx)
+	require.NotNil(t, got)
+	require.Equal(t, commands.ComponentMirror, got.GetIdentity().GetSystemComponent())
+	require.Empty(t, got.GetIdentity().GetSubject())
+}
+
+func TestResolveCallerSnapshot_EmptySystemComponentFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	// An empty component must not synthesize a bogus system snapshot; with no
+	// claims it resolves to nil like any unauthenticated request.
+	ctx := WithSystemActor(context.Background(), "")
+
+	require.Nil(t, ResolveCallerSnapshot(ctx))
+}
+
+func TestResolveCallerSnapshot_Ed25519WithoutSubject(t *testing.T) {
+	t.Parallel()
+
+	// An Ed25519 token minted without a `sub` claim still authenticates and
+	// must remain attributable: the snapshot is non-nil and the key id
+	// identifies the caller even though the subject is empty.
+	ctx := WithClaims(context.Background(), &oidc.AccessTokenClaims{})
+	ctx = WithKeyID(ctx, "ed25519-key-9")
+
+	got := ResolveCallerSnapshot(ctx)
+	require.NotNil(t, got)
+	require.Empty(t, got.GetIdentity().GetSubject())
+	require.Equal(t, "ed25519-key-9", got.GetIdentity().GetKeyId())
 }
 
 func TestIsClusterInternal_DefaultsFalse(t *testing.T) {

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -108,7 +108,10 @@ func (impl *BucketServiceServerImpl) Apply(ctx context.Context, req *servicepb.A
 		return nil, err
 	}
 
-	ctx = adoptForwardedSnapshotIfTrusted(ctx, req)
+	ctx, err = impl.adoptForwardedSnapshotIfTrusted(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	// Peek the batch (non-authoritative) for the empty check and the per-request
 	// scope checks. Admission re-verifies the signature and unmarshals the same
@@ -206,17 +209,26 @@ func (impl *BucketServiceServerImpl) Apply(ctx context.Context, req *servicepb.A
 // boundary that lets a follower forward a user's admission-time snapshot
 // (identity + scopes + god) to the leader for audit purposes without
 // letting regular clients spoof it.
-func adoptForwardedSnapshotIfTrusted(ctx context.Context, req *servicepb.ApplyRequest) context.Context {
-	if !internalauth.IsClusterInternal(ctx) {
-		return ctx
-	}
-
+//
+// A forwarded snapshot arriving on a non-cluster-internal connection means the
+// cluster secret is unset or mismatched between peers. It is rejected: the
+// write would otherwise commit an unattributed audit entry for an
+// authenticated user, so failing loud forces the misconfiguration to surface.
+func (impl *BucketServiceServerImpl) adoptForwardedSnapshotIfTrusted(ctx context.Context, req *servicepb.ApplyRequest) (context.Context, error) {
 	fc := req.GetForwardedCallerSnapshot()
 	if fc == nil {
-		return ctx
+		return ctx, nil
 	}
 
-	return internalauth.WithForwardedSnapshot(ctx, fc)
+	if !internalauth.IsClusterInternal(ctx) {
+		impl.logger.Errorf("rejecting forwarded caller snapshot on a non-cluster-internal connection; " +
+			"cluster secret is likely unset or mismatched between peers")
+
+		return ctx, status.Error(codes.PermissionDenied,
+			"forwarded caller snapshot on a non-cluster-internal connection")
+	}
+
+	return internalauth.WithForwardedSnapshot(ctx, fc), nil
 }
 
 // signReceiptIfNeeded signs a JWT receipt for logs containing created transactions.

--- a/internal/adapter/grpc/server_bucket_test.go
+++ b/internal/adapter/grpc/server_bucket_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -27,17 +29,21 @@ func TestAdoptForwardedSnapshotIfTrusted_TrustsClusterInternal(t *testing.T) {
 		Scopes: []string{"ledger:TransactionWrite"},
 	}
 	req := &servicepb.ApplyRequest{ForwardedCallerSnapshot: snapshot}
+	impl := &BucketServiceServerImpl{logger: testLogger()}
 
 	ctx := internalauth.WithClusterInternal(context.Background(), true)
-	out := adoptForwardedSnapshotIfTrusted(ctx, req)
+	out, err := impl.adoptForwardedSnapshotIfTrusted(ctx, req)
 
+	require.NoError(t, err)
 	require.Same(t, snapshot, internalauth.ForwardedSnapshotFromContext(out))
 }
 
-// TestAdoptForwardedSnapshotIfTrusted_IgnoresFromRegularClient verifies that
-// a regular (non-cluster-internal) client cannot spoof the audit identity by
-// setting forwarded_caller. The field MUST be dropped on direct requests.
-func TestAdoptForwardedSnapshotIfTrusted_IgnoresFromRegularClient(t *testing.T) {
+// TestAdoptForwardedSnapshotIfTrusted_RejectsFromRegularClient verifies that a
+// regular (non-cluster-internal) client cannot spoof the audit identity by
+// setting forwarded_caller. A forwarded snapshot on an untrusted channel is
+// rejected loudly rather than silently dropped, so a cluster-secret
+// misconfiguration surfaces instead of corrupting the audit trail.
+func TestAdoptForwardedSnapshotIfTrusted_RejectsFromRegularClient(t *testing.T) {
 	t.Parallel()
 
 	req := &servicepb.ApplyRequest{
@@ -45,24 +51,33 @@ func TestAdoptForwardedSnapshotIfTrusted_IgnoresFromRegularClient(t *testing.T) 
 			Identity: &commonpb.CallerIdentity{Subject: "attacker"},
 		},
 	}
+	impl := &BucketServiceServerImpl{logger: testLogger()}
 
-	out := adoptForwardedSnapshotIfTrusted(context.Background(), req)
+	out, err := impl.adoptForwardedSnapshotIfTrusted(context.Background(), req)
 
+	require.Equal(t, codes.PermissionDenied, status.Code(err),
+		"a forwarded snapshot on a non-cluster-internal channel must be rejected")
 	require.Nil(t, internalauth.ForwardedSnapshotFromContext(out),
-		"non-cluster-internal requests must not be allowed to set the forwarded snapshot")
+		"the untrusted forwarded snapshot must not be adopted")
 }
 
 // TestAdoptForwardedSnapshotIfTrusted_NilForwardedNoOp verifies that an
-// empty forwarded_caller leaves the context untouched even on a trusted hop,
-// so the leader falls back to building the snapshot from its own claims (or
-// nil).
+// absent forwarded_caller leaves the context untouched (and errors nowhere),
+// so a direct request or an unauthenticated hop falls back to building the
+// snapshot from its own claims (or nil).
 func TestAdoptForwardedSnapshotIfTrusted_NilForwardedNoOp(t *testing.T) {
 	t.Parallel()
 
 	req := &servicepb.ApplyRequest{}
+	impl := &BucketServiceServerImpl{logger: testLogger()}
 
+	// No forwarded snapshot is fine on both a trusted and a plain context.
 	ctx := internalauth.WithClusterInternal(context.Background(), true)
-	out := adoptForwardedSnapshotIfTrusted(ctx, req)
+	out, err := impl.adoptForwardedSnapshotIfTrusted(ctx, req)
+	require.NoError(t, err)
+	require.Nil(t, internalauth.ForwardedSnapshotFromContext(out))
 
+	out, err = impl.adoptForwardedSnapshotIfTrusted(context.Background(), req)
+	require.NoError(t, err)
 	require.Nil(t, internalauth.ForwardedSnapshotFromContext(out))
 }

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -550,16 +550,26 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 
 	fsmWaitStart := time.Now()
 	result, err := fsmFuture.Wait(ctx)
+
+	// Observe caller attribution for committed entries only. A success, or a
+	// business-rule rejection (insufficient funds, scope/transient validation),
+	// writes an audit entry carrying this caller snapshot; a stale proposal and
+	// the pre-commit rejections (queue-full, guard, marshal) write nothing.
+	committed := err == nil
+	if !committed {
+		var businessErr *domain.BusinessError
+		committed = errors.As(err, &businessErr) && !errors.Is(err, domain.ErrStaleProposal)
+	}
+
+	if committed {
+		a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
+	}
+
 	if err != nil {
 		return nil, err
 	}
 
 	a.fsmFutureWaitHistogram.Record(ctx, time.Since(fsmWaitStart).Microseconds())
-
-	// The proposal is committed and applied here — an audit entry carrying this
-	// caller snapshot has been written. Observing attribution gaps at this point
-	// excludes proposals rejected before commit (guard/marshal/stale/queue-full).
-	a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
 
 	// Resolve CreatedLogOrReference entries into concrete logs.
 	// Created logs are returned directly; reference sequences (idempotent responses)

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -62,6 +62,7 @@ type Admission struct {
 	attrs              *attributes.Attributes
 	numscriptCache     *numscript.NumscriptCache
 	coldStorageEnabled bool
+	authEnabled        bool
 	waitLeaderReady    func(context.Context) error
 
 	// Metrics (noop when metricsEnabled is false)
@@ -79,6 +80,8 @@ type Admission struct {
 	preloadCounter                 metric.Int64Counter
 	preloadKeysNeededCounter       metric.Int64Counter
 	preloadCacheHitsCounter        metric.Int64Counter
+	missingCallerCounter           metric.Int64Counter
+	callerSubjectEmptyCounter      metric.Int64Counter
 }
 
 // NewAdmission creates a new Admission handler.
@@ -101,6 +104,15 @@ func WithReceiptSigner(signer *receipt.Signer) func(*Admission) {
 func WithColdStorageEnabled() func(*Admission) {
 	return func(a *Admission) {
 		a.coldStorageEnabled = true
+	}
+}
+
+// WithAuthEnabled marks authentication as enabled, so the admission path can
+// flag user writes committed without an attributable caller (see
+// observeCallerSnapshot).
+func WithAuthEnabled() func(*Admission) {
+	return func(a *Admission) {
+		a.authEnabled = true
 	}
 }
 
@@ -269,6 +281,24 @@ func NewAdmission(
 		panic(err)
 	}
 
+	missingCallerCounter, err := meter.Int64Counter(
+		"admission.audit.missing_caller",
+		metric.WithDescription("Committed user writes with no caller snapshot while auth is enabled"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	callerSubjectEmptyCounter, err := meter.Int64Counter(
+		"admission.audit.caller_subject_empty",
+		metric.WithDescription("Committed user writes whose caller has a source but an empty subject (e.g. Ed25519 token without sub)"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
 	a.commandDurationHistogram = commandDurationHistogram
 	a.commandSizeHistogram = commandSizeHistogram
 	a.proposeQueueLoadHistogram = proposeQueueLoadHistogram
@@ -281,8 +311,38 @@ func NewAdmission(
 	a.preloadCounter = preloadCounter
 	a.preloadKeysNeededCounter = preloadKeysNeededCounter
 	a.preloadCacheHitsCounter = preloadCacheHitsCounter
+	a.missingCallerCounter = missingCallerCounter
+	a.callerSubjectEmptyCounter = callerSubjectEmptyCounter
 
 	return a
+}
+
+// observeCallerSnapshot flags audit-attribution gaps on the write path. With
+// auth enabled, a committed user write should always carry a caller: a nil
+// snapshot means an authenticated identity was lost or an anonymous write
+// slipped through, and a user source (issuer/key_id) with an empty subject is
+// the Ed25519-token-without-`sub` case where only the key id identifies the
+// caller. System actions carry a system_component source and are exempt.
+func (a *Admission) observeCallerSnapshot(ctx context.Context, snap *commonpb.CallerSnapshot) {
+	if !a.authEnabled {
+		return
+	}
+
+	if snap == nil {
+		a.logger.Errorf("committed write has no caller snapshot while auth is enabled: audit entry will be unattributed")
+		a.missingCallerCounter.Add(ctx, 1)
+
+		return
+	}
+
+	id := snap.GetIdentity()
+	switch id.GetSource().(type) {
+	case *commonpb.CallerIdentity_KeyId, *commonpb.CallerIdentity_Issuer:
+		if id.GetSubject() == "" {
+			a.logger.Infof("committed write caller has a source but an empty subject: audit entry identifies the caller only by source")
+			a.callerSubjectEmptyCounter.Add(ctx, 1)
+		}
+	}
 }
 
 // Admit implements the ctrl.Admission interface.
@@ -405,6 +465,7 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 
 	cmd.ExecutionPlan = build.ExecutionPlan
 	cmd.CallerSnapshot = auth.ResolveCallerSnapshot(ctx)
+	a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
 
 	preloadSpan.End()
 

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -551,17 +551,11 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 	fsmWaitStart := time.Now()
 	result, err := fsmFuture.Wait(ctx)
 
-	// Observe caller attribution for committed entries only. A success, or a
-	// business-rule rejection (insufficient funds, scope/transient validation),
-	// writes an audit entry carrying this caller snapshot; a stale proposal and
-	// the pre-commit rejections (queue-full, guard, marshal) write nothing.
-	committed := err == nil
-	if !committed {
-		var businessErr *domain.BusinessError
-		committed = errors.As(err, &businessErr) && !errors.Is(err, domain.ErrStaleProposal)
-	}
-
-	if committed {
+	// Observe caller attribution only when the FSM actually wrote an audit
+	// entry for this proposal — a success or a committed business-rule failure.
+	// Replays, stale proposals, and pre-commit rejections write no entry, so the
+	// caller snapshot they carry was never recorded and must not be counted.
+	if result.AuditEntryWritten {
 		a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
 	}
 

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -465,7 +465,6 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 
 	cmd.ExecutionPlan = build.ExecutionPlan
 	cmd.CallerSnapshot = auth.ResolveCallerSnapshot(ctx)
-	a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
 
 	preloadSpan.End()
 
@@ -556,6 +555,11 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 	}
 
 	a.fsmFutureWaitHistogram.Record(ctx, time.Since(fsmWaitStart).Microseconds())
+
+	// The proposal is committed and applied here — an audit entry carrying this
+	// caller snapshot has been written. Observing attribution gaps at this point
+	// excludes proposals rejected before commit (guard/marshal/stale/queue-full).
+	a.observeCallerSnapshot(ctx, cmd.GetCallerSnapshot())
 
 	// Resolve CreatedLogOrReference entries into concrete logs.
 	// Created logs are returned directly; reference sequences (idempotent responses)

--- a/internal/application/auditindexer/index_entry.go
+++ b/internal/application/auditindexer/index_entry.go
@@ -47,7 +47,9 @@ func appendEntryKeys(kb *dal.KeyBuilder, emit emitFn, entry *auditpb.AuditEntry,
 		}
 	}
 
-	// Caller subject — skipped when absent (unauthenticated or nil snapshot).
+	// Caller subject — skipped when empty (unauthenticated user, nil snapshot,
+	// system action, or a source-only identity such as an Ed25519 key with no
+	// sub claim; those are still attributed on the entry via CallerSnapshot.Source).
 	if subject := entry.GetCallerSnapshot().GetIdentity().GetSubject(); subject != "" {
 		if err := emit(readstore.AuditIndexStringKey(kb, readstore.AuditFieldCallerSubject, subject, seq)); err != nil {
 			return err

--- a/internal/application/backup/cleanup.go
+++ b/internal/application/backup/cleanup.go
@@ -164,6 +164,7 @@ func (c *Cleanup) tick(ctx context.Context) {
 
 func (c *Cleanup) failOrphan(ctx context.Context, jobID uint64, kind raftcmdpb.BackupKind) error {
 	cmd := commands.NewCommand()
+	cmd.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentBackup)
 	failMessage := "orphan: no live executor on this leader"
 
 	switch kind {

--- a/internal/application/backup/orchestrator.go
+++ b/internal/application/backup/orchestrator.go
@@ -380,6 +380,7 @@ func (o *Orchestrator) proposeTerminal(populate func(*raftcmdpb.Proposal), jobID
 // works at every layer.
 func (o *Orchestrator) proposeAndWait(ctx context.Context, populate func(*raftcmdpb.Proposal)) error {
 	cmd := commands.NewCommand()
+	cmd.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentBackup)
 	populate(cmd)
 
 	return o.proposer.Propose(ctx, cmd)

--- a/internal/application/events/emitter.go
+++ b/internal/application/events/emitter.go
@@ -478,6 +478,7 @@ func (e *Emitter) proposeSinkUpdateOnce(ctx context.Context, update *raftcmdpb.E
 	e.proposal.Reset()
 	e.proposal.Id = commands.GenerateRandomID()
 	e.proposal.ExecutionPlan = nil
+	e.proposal.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentEventsSink)
 	e.proposal.TechnicalUpdates = []*raftcmdpb.TechnicalUpdate{{
 		Kind: &raftcmdpb.TechnicalUpdate_EventsSink{EventsSink: update},
 	}}

--- a/internal/application/mirror/worker.go
+++ b/internal/application/mirror/worker.go
@@ -347,6 +347,7 @@ func (w *Worker) processBatch(ctx context.Context) (bool, error) {
 
 	// Build proposal with orders and preloads for cache population
 	cmd := commands.NewCommand(orders...)
+	cmd.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentMirror)
 
 	preloadStart := time.Now()
 
@@ -502,7 +503,8 @@ func (w *Worker) drainPrefetch(ch chan prefetchResult) {
 
 func (w *Worker) reportError(ctx context.Context, message string) {
 	cmd := &raftcmdpb.Proposal{
-		Date: &commonpb.Timestamp{Data: uint64(libtime.Now().UnixMicro())},
+		Date:           &commonpb.Timestamp{Data: uint64(libtime.Now().UnixMicro())},
+		CallerSnapshot: commands.SystemCallerSnapshot(commands.ComponentMirror),
 		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
 			Kind: &raftcmdpb.TechnicalUpdate_MirrorSync{
 				MirrorSync: &raftcmdpb.MirrorSyncUpdate{

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -161,7 +161,7 @@ func ColdStorageModule(coldStorageDriver string) fx.Option {
 					cold,
 					machine.ArchiveRequestCh(),
 					func(chapterID uint64) error {
-						_, err := admissionHandler.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+						_, err := admissionHandler.Admit(internalauth.WithSystemActor(context.Background(), commands.ComponentChapterArchiver), servicepb.UnsignedApplyRequest("", &servicepb.Request{
 							Type: &servicepb.Request_ConfirmArchiveChapter{
 								ConfirmArchiveChapter: &servicepb.ConfirmArchiveChapterRequest{
 									ChapterId: chapterID,
@@ -670,6 +670,7 @@ func Module() fx.Option {
 				ss *state.SharedState,
 				receiptSigner *receipt.Signer,
 				attrs *attributes.Attributes,
+				authCfg internalauth.AuthConfig,
 			) ctrl.Admission {
 				var opts []func(*admission.Admission)
 				if cfg.AdmissionMetrics {
@@ -682,6 +683,10 @@ func Module() fx.Option {
 
 				if cfg.ColdStorageConfig.Driver != "none" {
 					opts = append(opts, admission.WithColdStorageEnabled())
+				}
+
+				if authCfg.Enabled {
+					opts = append(opts, admission.WithAuthEnabled())
 				}
 
 				return admission.NewAdmission(
@@ -708,7 +713,7 @@ func Module() fx.Option {
 				raftNode *node.Node,
 			) *state.Sealer {
 				return state.NewSealer(logger, store, attrs, machine.SealRequestCh(), func(chapterID uint64, sealingHash, stateHash []byte) error {
-					_, err := admissionHandler.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+					_, err := admissionHandler.Admit(internalauth.WithSystemActor(context.Background(), commands.ComponentChapterSealer), servicepb.UnsignedApplyRequest("", &servicepb.Request{
 						Type: &servicepb.Request_SealChapter{
 							SealChapter: &servicepb.SealChapterRequest{
 								ChapterId:   chapterID,
@@ -732,7 +737,7 @@ func Module() fx.Option {
 					raftNode.IsLeader,
 					machine.ChapterSchedule,
 					func() error {
-						_, err := admissionHandler.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+						_, err := admissionHandler.Admit(internalauth.WithSystemActor(context.Background(), commands.ComponentChapterScheduler), servicepb.UnsignedApplyRequest("", &servicepb.Request{
 							Type: &servicepb.Request_CloseChapter{
 								CloseChapter: &servicepb.CloseChapterRequest{},
 							},
@@ -754,7 +759,7 @@ func Module() fx.Option {
 					raftNode.IsLeader,
 					machine.QueryCheckpointSchedule,
 					func() error {
-						_, err := admissionHandler.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+						_, err := admissionHandler.Admit(internalauth.WithSystemActor(context.Background(), commands.ComponentQueryCheckpoint), servicepb.UnsignedApplyRequest("", &servicepb.Request{
 							Type: &servicepb.Request_CreateQueryCheckpoint{
 								CreateQueryCheckpoint: &servicepb.CreateQueryCheckpointRequest{},
 							},
@@ -1261,6 +1266,7 @@ func Module() fx.Option {
 						raftNode.IsLeader,
 						func(ctx context.Context, cutoffMicros uint64, lastScannedTimeIndexKey []byte, pebbleKeyHashes [][]byte) {
 							proposal := commands.NewCommand()
+							proposal.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentIdempotencyEvict)
 							proposal.TechnicalUpdates = []*raftcmdpb.TechnicalUpdate{{
 								Kind: &raftcmdpb.TechnicalUpdate_IdempotencyEviction{
 									IdempotencyEviction: &raftcmdpb.IdempotencyEviction{
@@ -1485,6 +1491,7 @@ func proposeClusterConfigIfNeeded(n *node.Node, builder *plan.Builder, store *da
 	logger.Infof("Proposing cluster config update on leadership acquisition")
 
 	proposal := commands.NewCommand()
+	proposal.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentClusterConfig)
 	proposal.TechnicalUpdates = []*raftcmdpb.TechnicalUpdate{{
 		Kind: &raftcmdpb.TechnicalUpdate_ClusterConfig{ClusterConfig: desiredCfg},
 	}}

--- a/internal/infra/state/audit_envelope.go
+++ b/internal/infra/state/audit_envelope.go
@@ -43,6 +43,7 @@ const (
 	callerSourceNone   byte = 0
 	callerSourceIssuer byte = 1
 	callerSourceKeyID  byte = 2
+	callerSourceSystem byte = 3
 )
 
 // outcome_tag values in HashedHeaderPayload.
@@ -215,6 +216,9 @@ func buildCallerSnapshotPayload(snap *commonpb.CallerSnapshot) []byte {
 	case *commonpb.CallerIdentity_KeyId:
 		buf = appendU8(buf, callerSourceKeyID)
 		buf = appendLenString(buf, src.KeyId)
+	case *commonpb.CallerIdentity_SystemComponent:
+		buf = appendU8(buf, callerSourceSystem)
+		buf = appendLenString(buf, src.SystemComponent)
 	default:
 		buf = appendU8(buf, callerSourceNone)
 		buf = appendLenBytes(buf, nil)

--- a/internal/infra/state/audit_envelope_test.go
+++ b/internal/infra/state/audit_envelope_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zeebo/blake3"
 
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/pkg/commands"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
@@ -121,6 +122,44 @@ func TestHashChain_Envelope_Golden(t *testing.T) {
 	require.Equal(t, expectedHash, gotHash,
 		"audit chain hash drifted from H(blake3-key(clusterID), header || items... || lastHash). "+
 			"If this drift is intentional, bump commonpb.HashAlgorithm and add a new envelope version.")
+}
+
+// TestHashChain_Envelope_SystemCaller pins the system_component source tag in
+// the hash pre-image and proves a system-attributed entry is NOT byte-equal to
+// a caller-less one — the whole point of tagging system actions is that they
+// are distinguishable in the audit trail, hash included.
+func TestHashChain_Envelope_SystemCaller(t *testing.T) {
+	t.Parallel()
+
+	base := func() *auditpb.AuditEntry {
+		return &auditpb.AuditEntry{
+			Sequence:    7,
+			Timestamp:   &commonpb.Timestamp{Data: 1700000000},
+			ProposalId:  9,
+			OrderCount:  1,
+			HashVersion: uint32(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3),
+			Ledgers:     []string{"ledger-a"},
+			Outcome: &auditpb.AuditEntry_Success{
+				Success: &auditpb.AuditSuccess{MinLogSequence: 1, MaxLogSequence: 1},
+			},
+		}
+	}
+
+	systemEntry := base()
+	systemEntry.CallerSnapshot = commands.SystemCallerSnapshot(commands.ComponentChapterArchiver)
+
+	systemHeader, err := BuildHashedHeaderPayload(systemEntry)
+	require.NoError(t, err)
+
+	// Production builder agrees with the hand-rolled spec for the new tag.
+	require.Equal(t, goldenBuildHeader(systemEntry), systemHeader,
+		"buildCallerSnapshotPayload drifted from the golden spec for system_component")
+
+	// System-attributed vs caller-less must produce different pre-images.
+	nilCallerHeader, err := BuildHashedHeaderPayload(base())
+	require.NoError(t, err)
+	require.NotEqual(t, nilCallerHeader, systemHeader,
+		"a system-tagged audit entry must not hash identically to a caller-less one")
 }
 
 // TestHashChain_Envelope_Failure exercises the failure outcome path. The
@@ -348,6 +387,9 @@ func goldenBuildSnapshot(s *commonpb.CallerSnapshot) []byte {
 	case *commonpb.CallerIdentity_KeyId:
 		buf = append(buf, 0x02) // callerSourceKeyID
 		buf = goldenLenString(buf, src.KeyId)
+	case *commonpb.CallerIdentity_SystemComponent:
+		buf = append(buf, 0x03) // callerSourceSystem
+		buf = goldenLenString(buf, src.SystemComponent)
 	default:
 		buf = append(buf, 0x00) // callerSourceNone
 		buf = goldenLenBytes(buf, nil)

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1501,6 +1501,7 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 		}
 
 		result.Error = &domain.BusinessError{Err: err}
+		result.AuditEntryWritten = true
 
 		return result, nil
 	}
@@ -1534,8 +1535,9 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 		}
 
 		return &ApplyResult{
-			ProposalID: proposal.GetId(),
-			Error:      &domain.BusinessError{Err: invariant},
+			ProposalID:        proposal.GetId(),
+			Error:             &domain.BusinessError{Err: invariant},
+			AuditEntryWritten: true,
 		}, nil
 	}
 
@@ -1555,6 +1557,7 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 		}
 
 		result.Error = &domain.BusinessError{Err: err}
+		result.AuditEntryWritten = true
 
 		return result, nil
 	}
@@ -1691,6 +1694,7 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 	return &ApplyResult{
 		ProposalID:             proposal.GetId(),
 		Logs:                   logs,
+		AuditEntryWritten:      true,
 		SinkConfigChanged:      sinkConfigChanged,
 		MirrorConfigChanged:    mirrorConfigChanged,
 		ArchiveRequested:       archiveRequested,
@@ -2030,10 +2034,16 @@ func (pb *PreparedBatch) Close() {
 }
 
 type ApplyResult struct {
-	ProposalID          uint64
-	AppliedIndex        uint64 // Raft index at which this entry was applied
-	Logs                []*raftcmdpb.CreatedLogOrReference
-	Error               error
+	ProposalID   uint64
+	AppliedIndex uint64 // Raft index at which this entry was applied
+	Logs         []*raftcmdpb.CreatedLogOrReference
+	Error        error
+
+	// AuditEntryWritten is true when an audit entry was appended for this
+	// proposal — a success or a committed business-rule failure. It is false
+	// for idempotency replays, stale proposals, and pre-commit rejections,
+	// which write no entry.
+	AuditEntryWritten   bool
 	CheckpointPath      string // Set by Node after checkpoint creation (CloseChapter proposals)
 	SinkConfigChanged   bool   // True when events sink configuration changed
 	MirrorConfigChanged bool   // True when mirror ledger configuration changed

--- a/internal/pkg/commands/system_caller.go
+++ b/internal/pkg/commands/system_caller.go
@@ -1,0 +1,29 @@
+package commands
+
+import "github.com/formancehq/ledger/v3/internal/proto/commonpb"
+
+// System component identifiers recorded as CallerIdentity.system_component on
+// system/internal proposals, so their audit entries name the acting subsystem.
+const (
+	ComponentChapterArchiver  = "chapter-archiver"
+	ComponentChapterSealer    = "chapter-sealer"
+	ComponentChapterScheduler = "chapter-scheduler"
+	ComponentQueryCheckpoint  = "query-checkpoint-scheduler"
+	ComponentMirror           = "mirror"
+	ComponentEventsSink       = "events-sink"
+	ComponentClusterConfig    = "cluster-config"
+	ComponentIdempotencyEvict = "idempotency-eviction"
+	ComponentBackup           = "backup"
+)
+
+// SystemCallerSnapshot builds the CallerSnapshot stamped onto a
+// system-initiated proposal. It carries no subject, scopes, or god — only a
+// system_component source naming the subsystem — so the FSM records an
+// unambiguous system actor in the audit entry.
+func SystemCallerSnapshot(component string) *commonpb.CallerSnapshot {
+	return &commonpb.CallerSnapshot{
+		Identity: &commonpb.CallerIdentity{
+			Source: &commonpb.CallerIdentity_SystemComponent{SystemComponent: component},
+		},
+	}
+}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -10237,7 +10237,7 @@ func (x *PersistedConfig) GetStorageSchemaVersion() uint32 {
 	return 0
 }
 
-// CallerIdentity uniquely identifies an authenticated caller. It is
+// CallerIdentity uniquely identifies who initiated an action. It is
 // strictly an *identification* — subject plus the mechanism that
 // authenticated it — and carries no authorization decision.
 //
@@ -10245,6 +10245,10 @@ func (x *PersistedConfig) GetStorageSchemaVersion() uint32 {
 // a request to the leader) because no downstream code makes an
 // authorization decision based on it: the admission point that issued
 // it already vetted the call.
+//
+// source distinguishes a user (issuer or key_id) from a system action
+// (system_component). An absent source means the identity is a bare
+// subject with no known origin.
 type CallerIdentity struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Subject string                 `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
@@ -10252,6 +10256,7 @@ type CallerIdentity struct {
 	//
 	//	*CallerIdentity_Issuer
 	//	*CallerIdentity_KeyId
+	//	*CallerIdentity_SystemComponent
 	Source        isCallerIdentity_Source `protobuf_oneof:"source"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -10319,6 +10324,15 @@ func (x *CallerIdentity) GetKeyId() string {
 	return ""
 }
 
+func (x *CallerIdentity) GetSystemComponent() string {
+	if x != nil {
+		if x, ok := x.Source.(*CallerIdentity_SystemComponent); ok {
+			return x.SystemComponent
+		}
+	}
+	return ""
+}
+
 type isCallerIdentity_Source interface {
 	isCallerIdentity_Source()
 }
@@ -10331,9 +10345,15 @@ type CallerIdentity_KeyId struct {
 	KeyId string `protobuf:"bytes,5,opt,name=key_id,json=keyId,proto3,oneof"` // Ed25519 signing key ID
 }
 
+type CallerIdentity_SystemComponent struct {
+	SystemComponent string `protobuf:"bytes,6,opt,name=system_component,json=systemComponent,proto3,oneof"` // system/internal actor (no user); names the subsystem
+}
+
 func (*CallerIdentity_Issuer) isCallerIdentity_Source() {}
 
 func (*CallerIdentity_KeyId) isCallerIdentity_Source() {}
+
+func (*CallerIdentity_SystemComponent) isCallerIdentity_Source() {}
 
 // CallerSnapshot is the *admission-time* record of who initiated an
 // action and what authorization was granted to them at that moment.
@@ -10342,8 +10362,9 @@ func (*CallerIdentity_KeyId) isCallerIdentity_Source() {}
 // etc.).
 //
 // Carried on Proposals through Raft, then copied to AuditEntry by the
-// FSM. Nil when authentication is disabled or for system-initiated
-// proposals.
+// FSM. Nil when authentication is disabled. System-initiated proposals
+// carry a non-nil identity whose source is system_component (never nil),
+// so an audit entry is never ambiguously blank.
 type CallerSnapshot struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Identity      *CallerIdentity        `protobuf:"bytes,1,opt,name=identity,proto3" json:"identity,omitempty"`
@@ -11489,11 +11510,12 @@ const file_common_proto_rawDesc = "" +
 	"\n" +
 	"cluster_id\x18\x02 \x01(\tR\tclusterId\x126\n" +
 	"\x17idempotency_ttl_seconds\x18\x03 \x01(\x04R\x15idempotencyTtlSeconds\x124\n" +
-	"\x16storage_schema_version\x18\x04 \x01(\rR\x14storageSchemaVersion\"\x80\x01\n" +
+	"\x16storage_schema_version\x18\x04 \x01(\rR\x14storageSchemaVersion\"\xad\x01\n" +
 	"\x0eCallerIdentity\x12\x18\n" +
 	"\asubject\x18\x01 \x01(\tR\asubject\x12\x18\n" +
 	"\x06issuer\x18\x04 \x01(\tH\x00R\x06issuer\x12\x17\n" +
-	"\x06key_id\x18\x05 \x01(\tH\x00R\x05keyIdB\b\n" +
+	"\x06key_id\x18\x05 \x01(\tH\x00R\x05keyId\x12+\n" +
+	"\x10system_component\x18\x06 \x01(\tH\x00R\x0fsystemComponentB\b\n" +
 	"\x06sourceJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\x06scopesR\x03god\"n\n" +
 	"\x0eCallerSnapshot\x122\n" +
 	"\bidentity\x18\x01 \x01(\v2\x16.common.CallerIdentityR\bidentity\x12\x16\n" +
@@ -12234,6 +12256,7 @@ func file_common_proto_init() {
 	file_common_proto_msgTypes[130].OneofWrappers = []any{
 		(*CallerIdentity_Issuer)(nil),
 		(*CallerIdentity_KeyId)(nil),
+		(*CallerIdentity_SystemComponent)(nil),
 	}
 	file_common_proto_msgTypes[134].OneofWrappers = []any{
 		(*BackupStorage_S3)(nil),

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -3605,6 +3605,15 @@ func (m *CallerIdentity_KeyId) CloneVT() isCallerIdentity_Source {
 	return r
 }
 
+func (m *CallerIdentity_SystemComponent) CloneVT() isCallerIdentity_Source {
+	if m == nil {
+		return (*CallerIdentity_SystemComponent)(nil)
+	}
+	r := new(CallerIdentity_SystemComponent)
+	r.SystemComponent = m.SystemComponent
+	return r
+}
+
 func (m *CallerSnapshot) CloneVT() *CallerSnapshot {
 	if m == nil {
 		return (*CallerSnapshot)(nil)
@@ -9671,6 +9680,23 @@ func (this *CallerIdentity_KeyId) EqualVT(thatIface isCallerIdentity_Source) boo
 		return false
 	}
 	if this.KeyId != that.KeyId {
+		return false
+	}
+	return true
+}
+
+func (this *CallerIdentity_SystemComponent) EqualVT(thatIface isCallerIdentity_Source) bool {
+	that, ok := thatIface.(*CallerIdentity_SystemComponent)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if this.SystemComponent != that.SystemComponent {
 		return false
 	}
 	return true
@@ -18850,6 +18876,20 @@ func (m *CallerIdentity_KeyId) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	dAtA[i] = 0x2a
 	return len(dAtA) - i, nil
 }
+func (m *CallerIdentity_SystemComponent) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CallerIdentity_SystemComponent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	i -= len(m.SystemComponent)
+	copy(dAtA[i:], m.SystemComponent)
+	i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SystemComponent)))
+	i--
+	dAtA[i] = 0x32
+	return len(dAtA) - i, nil
+}
 func (m *CallerSnapshot) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -23074,6 +23114,16 @@ func (m *CallerIdentity_KeyId) SizeVT() (n int) {
 	var l int
 	_ = l
 	l = len(m.KeyId)
+	n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	return n
+}
+func (m *CallerIdentity_SystemComponent) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.SystemComponent)
 	n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	return n
 }
@@ -44463,6 +44513,38 @@ func (m *CallerIdentity) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Source = &CallerIdentity_KeyId{KeyId: string(dAtA[iNdEx:postIndex])}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SystemComponent", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Source = &CallerIdentity_SystemComponent{SystemComponent: string(dAtA[iNdEx:postIndex])}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/metrics.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/metrics.libsonnet
@@ -25,6 +25,8 @@
     preload_total: 'admission.preload.total',
     preload_keys_needed: 'admission.preload.keys_needed',
     preload_cache_hits: 'admission.preload.cache_hits',
+    audit_missing_caller: 'admission.audit.missing_caller',
+    audit_caller_subject_empty: 'admission.audit.caller_subject_empty',
   },
 
   // bloom — internal/infra/bloom/bloom.go

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1301,7 +1301,7 @@ message PersistedConfig {
   uint32 storage_schema_version = 4;
 }
 
-// CallerIdentity uniquely identifies an authenticated caller. It is
+// CallerIdentity uniquely identifies who initiated an action. It is
 // strictly an *identification* — subject plus the mechanism that
 // authenticated it — and carries no authorization decision.
 //
@@ -1309,6 +1309,10 @@ message PersistedConfig {
 // a request to the leader) because no downstream code makes an
 // authorization decision based on it: the admission point that issued
 // it already vetted the call.
+//
+// source distinguishes a user (issuer or key_id) from a system action
+// (system_component). An absent source means the identity is a bare
+// subject with no known origin.
 message CallerIdentity {
   string subject = 1;
   // Fields 2 and 3 historically held `repeated string scopes` and
@@ -1319,8 +1323,9 @@ message CallerIdentity {
   reserved 2, 3;
   reserved "scopes", "god";
   oneof source {
-    string issuer = 4;   // OIDC token issuer URL
-    string key_id = 5;   // Ed25519 signing key ID
+    string issuer = 4;             // OIDC token issuer URL
+    string key_id = 5;             // Ed25519 signing key ID
+    string system_component = 6;   // system/internal actor (no user); names the subsystem
   }
 }
 
@@ -1331,8 +1336,9 @@ message CallerIdentity {
 // etc.).
 //
 // Carried on Proposals through Raft, then copied to AuditEntry by the
-// FSM. Nil when authentication is disabled or for system-initiated
-// proposals.
+// FSM. Nil when authentication is disabled. System-initiated proposals
+// carry a non-nil identity whose source is system_component (never nil),
+// so an audit entry is never ambiguously blank.
 message CallerSnapshot {
   CallerIdentity identity = 1;
   repeated string scopes = 2;


### PR DESCRIPTION
## Problem

A `nil` `CallerSnapshot` on an audit entry meant two different things — a background/system action, or a user write whose identity was lost — so operators couldn't distinguish "system did this" from "we dropped the caller." Three concrete gaps: system proposals were caller-less by design, a follower-forwarded caller could be silently dropped on a cluster-secret misconfig, and Ed25519 tokens without `sub` produced a blank subject.

## Changes

- **Named system actor** — add `system_component` to the `CallerIdentity.source` oneof; stamp all 11 system-proposal sites (`commands.SystemCallerSnapshot` / `auth.WithSystemActor`). `nil` now unambiguously means lost user identity.
- **Hash chain** — bind the new source tag (`0x03`) into the audit envelope. Additive; existing entries re-verify byte-identically, no `HashVersion` bump.
- **Fail-fast on dropped caller** — a forwarded snapshot on a non-cluster-internal connection is rejected with `PermissionDenied` instead of silently dropped; a cluster-secret misconfig now fails the write rather than committing an unattributed entry.
- **Observability** — admission emits `admission.audit.missing_caller` and `admission.audit.caller_subject_empty` (+ logs) when auth is enabled; system actions are exempt.
- **Consumers/docs** — `ledgerctl audit list` falls back to source/keyId/system_component when subject is empty; auth + audit-chain docs updated.

Note: `IndexReady` and metadata-conversion proposals no longer exist, so no stamping was needed there.

## Acceptance criteria

- [x] Every authenticated user write carries the caller (subject, else source/keyId), across direct-to-leader and follower-forwarded paths
- [x] System-generated entries are tagged with their subsystem, not blank
- [x] A committed authenticated write with a missing caller emits a log + metric
- [x] Tests: direct leader write, follower-forwarded, cluster-secret misconfig, Ed25519 without `sub`, system actor

## Verification

`go build ./...`, `go vet`, `gofmt`, and `golangci-lint` clean on all touched packages. New/existing unit tests pass (auth resolution, envelope golden + system-caller hash distinctness, gRPC hard-reject, admission).

⚠️ One behavior change to call out for review: with **auth enabled but the cluster secret unset/mismatched**, follower-forwarded writes now hard-fail (`PermissionDenied`) instead of committing caller-less. This is the intended fail-loud, but flagging it since it changes a (misconfigured) runtime path.
