### PR TITLE
perf(applier): prefetch DecodeEntries in a dedicated goroutine

### DIFF
--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -42,6 +42,22 @@ type applyWork struct {
 	responses []raftpb.Message
 }
 
+// decodedApplyWork is the post-prefetch shape consumed by Run's main loop.
+// The decoder goroutine (see Run) reads applyWork from a.ch, invokes
+// state.DecodeEntries for work items carrying entries, and forwards the
+// result here so the Prepare stage never blocks on the UnmarshalVT
+// pass. Non-entries work items (barrier, syncLeader, installSnapshot) are
+// forwarded with `decoded` nil and `err` nil — the decoder is a strict
+// pass-through for them, preserving ordering vs entries.
+//
+// If DecodeEntries fails, `err` carries the wrapped error and `decoded` is
+// nil. The main loop propagates the error immediately without applying.
+type decodedApplyWork struct {
+	work    applyWork
+	decoded []state.DecodedEntry
+	err     error
+}
+
 // gatingResult carries the outcome of a maintenance task back to the Run
 // goroutine so it can decide whether to unspool or mark the node out-of-sync.
 type gatingResult struct {
@@ -70,8 +86,9 @@ type Applier struct {
 	gatingReason     atomic.Int32 // gatingReason* constants — for observability
 	syncProgress     atomic.Pointer[state.SyncProgress]
 	gatingTerminated chan gatingResult
-	ch               chan applyWork  // buffered(1)
-	commitCh         chan commitWork // buffered(1), read by the committer goroutine
+	ch               chan applyWork        // buffered(1); producer-facing input
+	decodedCh        chan decodedApplyWork // buffered(1); read by Run, populated by the decoder goroutine
+	commitCh         chan commitWork       // buffered(1), read by the committer goroutine
 
 	// pending holds the in-flight commit result channel, if any.
 	// At most one at a time. Drained before barriers, checkpoints, and shutdown.
@@ -189,6 +206,7 @@ func NewApplier(
 		responseSink:            responseSink,
 		status:                  &initialStatus,
 		ch:                      make(chan applyWork, 1),
+		decodedCh:               make(chan decodedApplyWork, 1),
 		commitCh:                make(chan commitWork, 1),
 	}
 
@@ -690,6 +708,35 @@ func (a *Applier) Status() int32 {
 
 // Run is the Applier goroutine. It processes submitted work items and
 // handles gating termination (unspool after maintenance tasks).
+//
+// Concurrency layout inside Run:
+//
+//	Submit / Barrier / SyncFromLeader / ... ─▶ a.ch
+//	                                             │
+//	                                             ▼
+//	                                      [decoder goroutine]
+//	                                       - reads a.ch
+//	                                       - state.DecodeEntries for entries
+//	                                       - forwards everything else as-is
+//	                                             │
+//	                                             ▼
+//	                                          a.decodedCh
+//	                                             │
+//	                                             ▼
+//	                                    [main loop below]
+//	                                     - Prepare / async commit
+//	                                     - Barrier / status transitions
+//	                                             │
+//	                                             ▼
+//	                                          a.commitCh
+//	                                             │
+//	                                             ▼
+//	                                      [committer goroutine]
+//	                                       - CommitPreparedBatch
+//
+// The decoder stage is what lets Prepare(N) overlap with Decode(N+1):
+// UnmarshalVT of the next batch runs on a spare core while the applier
+// holds fsm.mu for the current batch.
 func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 	// Start the dedicated committer goroutine. It exits when commitCh is closed.
 	committerDone := make(chan struct{})
@@ -697,6 +744,19 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 	go func() {
 		a.runCommitter(ctx, stop)
 		close(committerDone)
+	}()
+
+	// Start the decoder goroutine. It exits when its context is cancelled
+	// (below on Run's exit) OR when a.ch is closed. We use a local cancel
+	// tied to Run's lifetime so the decoder unwinds even on normal exit
+	// where the outer ctx is still live (e.g. tests that stop the applier
+	// via a stop channel without cancelling ctx).
+	decoderCtx, cancelDecoder := context.WithCancel(ctx)
+	decoderDone := make(chan struct{})
+
+	go func() {
+		defer close(decoderDone)
+		a.runDecoder(decoderCtx)
 	}()
 
 	defer func() {
@@ -707,6 +767,15 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 
 		close(a.commitCh)
 		<-committerDone
+
+		// Signal the decoder to stop, then drain any batches it managed to
+		// hand off before cancellation. Every release returns pooled
+		// proposals to vtproto's pool.
+		cancelDecoder()
+		<-decoderDone
+		for dw := range a.decodedCh {
+			state.ReleaseDecodedEntries(dw.decoded)
+		}
 	}()
 
 	var (
@@ -717,7 +786,8 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 
 	for {
 		select {
-		case work := <-a.ch:
+		case dw := <-a.decodedCh:
+			work := dw.work
 			a.batchWaitDurationHistogram.Record(ctx, time.Since(waitStart).Microseconds())
 
 			if work.barrier != nil {
@@ -777,18 +847,39 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 
 			switch a.status.Load() {
 			case statusNormal:
-				// applyEntriesToFSM threads work.responses down to the last
-				// applyEntriesPipelined call, which attaches them to the
+				// Fail fast on a decode error surfaced by the prefetcher —
+				// the raft entry payload is corrupt (or the wire schema
+				// version is wrong), no point going further.
+				if dw.err != nil {
+					return dw.err
+				}
+				// applyDecodedEntriesToFSM threads work.responses down to the
+				// last applyEntriesPipelined call, which attaches them to the
 				// commitWork sent to runCommitter. runCommitter fires the
 				// responses AFTER CommitPreparedBatch succeeds, so
 				// raft.Applied advances in lockstep with FSM-applied without
 				// serializing prepare-N+1 against commit-N (the
 				// applier→committer pipeline is preserved).
-				err := a.applyEntriesToFSM(ctx, stop, work.confState, work.responses, work.entries...)
+				//
+				// The dw.decoded slice is pre-decoded by the runDecoder
+				// goroutine; applyDecodedEntriesToFSM takes ownership and
+				// releases it back to the pool via its defer.
+				err := a.applyDecodedEntriesToFSM(ctx, stop, work.confState, work.responses, dw.decoded)
 				if err != nil {
 					return err
 				}
 			default:
+				// Non-normal status: the pre-decoded proposals will not be
+				// applied by the FSM (entries go to the spool instead). Return
+				// them to the pool immediately so we don't leak on a
+				// long-running gating period.
+				//
+				// A decode error is non-fatal on this path — the raw entry
+				// bytes are still valid and get spooled as-is; a subsequent
+				// replay will re-attempt the decode with a matching wire
+				// schema.
+				state.ReleaseDecodedEntries(dw.decoded)
+
 				// Drain pending commit before switching to spool mode.
 				if err := a.waitPendingCommit(ctx); err != nil {
 					return err
@@ -1084,6 +1175,67 @@ func (a *Applier) submitAsyncCommit(pb *state.PreparedBatch, pfs []pendingFuture
 // races into the sink send AFTER orchestrate stopped draining would sit
 // forever on ctx.Done alone (finding 70740916). Selecting on stop too
 // unblocks the send synchronously with orchestrate's exit.
+// runDecoder is the prefetching decoder goroutine started by Run. It reads
+// applyWork items from a.ch, invokes state.DecodeEntries when the item
+// carries raft entries, and forwards the decoded batch (or a decode error)
+// on a.decodedCh. Non-entries work items (barrier / syncLeader /
+// installSnapshot) are forwarded verbatim with a nil decoded slice — the
+// decoder is a strict pass-through for them so ordering vs. entries is
+// preserved via a single goroutine.
+//
+// Exit conditions:
+//   - ctx.Done(): drop the currently-in-flight decode result (release its
+//     pooled Proposals) and return. Closing a.decodedCh here signals the
+//     main loop of an unclean shutdown; the Run defer drains anything still
+//     buffered.
+//   - a.ch closed (Stop): drain any remaining items, forward them, then
+//     close a.decodedCh cleanly so the main loop's <-a.decodedCh returns
+//     zero-value on the next iteration and the loop unwinds.
+//
+// The buffer=1 on a.decodedCh lets this goroutine race one batch ahead of
+// the applier: while Prepare(N) runs under fsm.mu, UnmarshalVT(N+1) runs on
+// a separate core. If Prepare(N) finishes before Decode(N+1) — unlikely on
+// the observed workload — the main loop simply waits on <-a.decodedCh.
+func (a *Applier) runDecoder(ctx context.Context) {
+	defer close(a.decodedCh)
+
+	for {
+		var (
+			work applyWork
+			ok   bool
+		)
+
+		select {
+		case <-ctx.Done():
+			return
+		case work, ok = <-a.ch:
+			if !ok {
+				return
+			}
+		}
+
+		dw := decodedApplyWork{work: work}
+		if len(work.entries) > 0 {
+			decoded, err := state.DecodeEntries(work.entries)
+			if err != nil {
+				dw.err = fmt.Errorf("decoding entries: %w", err)
+			} else {
+				dw.decoded = decoded
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			// Handoff aborted: release any pooled proposals we just
+			// decoded so vtproto's pool doesn't leak.
+			state.ReleaseDecodedEntries(dw.decoded)
+
+			return
+		case a.decodedCh <- dw:
+		}
+	}
+}
+
 func (a *Applier) runCommitter(ctx context.Context, stop chan struct{}) {
 	for work := range a.commitCh {
 		err := a.fsm.CommitPreparedBatch(ctx, work.prepared)
@@ -1240,10 +1392,16 @@ func (a *Applier) resolveFutures(result *state.ApplyEntriesResult) {
 	}
 }
 
-// applyEntriesToFSM applies entries to the Machine using pipelined commits.
-// The prepare phase (CPU-bound) runs immediately while the previous batch's
-// commit may still be in-flight. The commit is deferred until the next batch
-// arrives or a drain is required.
+// applyDecodedEntriesToFSM applies pre-decoded entries to the Machine using
+// pipelined commits. The prepare phase (CPU-bound) runs immediately while
+// the previous batch's commit may still be in-flight; the commit is
+// deferred until the next batch arrives or a drain is required.
+//
+// The hot path in Run reads batches from the prefetching decoder goroutine
+// (Run → runDecoder → decodedCh) and calls this method directly, so the
+// UnmarshalVT cost is masked behind the previous batch's
+// PrepareDecodedEntries. The caller passes ownership of `decoded` — this
+// method releases it before returning.
 //
 // To preserve the "one PrepareEntries call = one commit through runCommitter"
 // invariant, callers must never mix a checkpoint-trigger entry with later
@@ -1259,15 +1417,7 @@ func (a *Applier) resolveFutures(result *state.ApplyEntriesResult) {
 // When that happens we MUST continue processing the tail in subsequent FSM
 // batches; dropping it produces an "entry index gap detected" panic in the
 // next PrepareEntries call. Hence the loop.
-func (a *Applier) applyEntriesToFSM(ctx context.Context, stop chan struct{}, confState *raftpb.ConfState, responses []raftpb.Message, entries ...raftpb.Entry) error {
-	// Decode once at the applier boundary so every downstream stage
-	// (checkpoint boundary scan, FSM apply, position validation) reads the
-	// already-decoded proposal instead of re-unmarshalling the raw payload.
-	decoded, err := state.DecodeEntries(entries)
-	if err != nil {
-		return fmt.Errorf("decoding entries: %w", err)
-	}
-
+func (a *Applier) applyDecodedEntriesToFSM(ctx context.Context, stop chan struct{}, confState *raftpb.ConfState, responses []raftpb.Message, decoded []state.DecodedEntry) error {
 	defer state.ReleaseDecodedEntries(decoded)
 
 	for offset := 0; offset < len(decoded); {

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -738,10 +739,19 @@ func (a *Applier) Status() int32 {
 // UnmarshalVT of the next batch runs on a spare core while the applier
 // holds fsm.mu for the current batch.
 func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
+	// Tag this goroutine (the applier main loop / Prepare stage) so pprof /
+	// pyroscope profiles can be filtered by `component` label — necessary to
+	// tell "prepare saturates one core" apart from "aggregate CPU is spread"
+	// in the process-wide profile.
+	mainCtx := pprof.WithLabels(ctx, pprof.Labels("component", "applier.main"))
+	pprof.SetGoroutineLabels(mainCtx)
+
 	// Start the dedicated committer goroutine. It exits when commitCh is closed.
 	committerDone := make(chan struct{})
 
 	go func() {
+		commitCtx := pprof.WithLabels(ctx, pprof.Labels("component", "applier.committer"))
+		pprof.SetGoroutineLabels(commitCtx)
 		a.runCommitter(ctx, stop)
 		close(committerDone)
 	}()
@@ -755,6 +765,8 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 	decoderDone := make(chan struct{})
 
 	go func() {
+		labeledCtx := pprof.WithLabels(decoderCtx, pprof.Labels("component", "applier.decoder"))
+		pprof.SetGoroutineLabels(labeledCtx)
 		defer close(decoderDone)
 		a.runDecoder(decoderCtx)
 	}()

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -157,7 +157,7 @@ type commitWork struct {
 	// responses are MsgStorageApplyResp messages tied to this commit. On
 	// commit success, runCommitter sends them on Applier.responseSink so
 	// raft.Applied advances only after CommitPreparedBatch has landed.
-	// Empty on all but the last sub-batch of an applyEntriesToFSM call,
+	// Empty on all but the last sub-batch of an applyDecodedEntriesToFSM call,
 	// and always empty for the replay path (applyEntriesAndResolveCommands).
 	responses []raftpb.Message
 	done      chan error
@@ -796,9 +796,27 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 		waitStart           = time.Now()
 	)
 
+	// Local handle on the decoded channel so we can stop selecting on it once
+	// the decoder has closed it. The decoder only ever closes decodedCh from
+	// its ctx.Done() path (a.ch is never closed), i.e. runCtx was cancelled —
+	// the OnStart/OnStop-timeout fallback in bootstrap, NOT a graceful stop.
+	// A closed channel always wins the select with a zero value, so without
+	// disabling this branch the loop would busy-spin on the empty batch. We
+	// do NOT return here: the applier task must exit via `stop` (see the fx
+	// hook rationale in bootstrap/module.go — a spontaneous task return is
+	// treated as a fatal task-pool error), and we must NOT nil a.decodedCh
+	// itself or the deferred `range a.decodedCh` drain would block forever.
+	decodedCh := a.decodedCh
+
 	for {
 		select {
-		case dw := <-a.decodedCh:
+		case dw, ok := <-decodedCh:
+			if !ok {
+				decodedCh = nil
+
+				continue
+			}
+
 			work := dw.work
 			a.batchWaitDurationHistogram.Record(ctx, time.Since(waitStart).Microseconds())
 
@@ -1176,17 +1194,6 @@ func (a *Applier) submitAsyncCommit(pb *state.PreparedBatch, pfs []pendingFuture
 	a.commitCh <- commitWork{prepared: pb, futures: pfs, maxTerm: maxTerm, responses: responses, done: done}
 }
 
-// runCommitter is the dedicated goroutine that processes commits sequentially.
-// It reads from commitCh and commits each batch, resolving futures on success
-// or failure. Exits when commitCh is closed.
-//
-// stop is the Applier task's shutdown channel — closed by taskSet.stop() at
-// the same instant as orchestrate's stop. It's a second escape hatch on the
-// response-sink send: node.Stop closes the task stop channels but does NOT
-// cancel ctx (only fx OnStop's outer timeout might), so a runCommitter that
-// races into the sink send AFTER orchestrate stopped draining would sit
-// forever on ctx.Done alone (finding 70740916). Selecting on stop too
-// unblocks the send synchronously with orchestrate's exit.
 // runDecoder is the prefetching decoder goroutine started by Run. It reads
 // applyWork items from a.ch, invokes state.DecodeEntries when the item
 // carries raft entries, and forwards the decoded batch (or a decode error)
@@ -1195,14 +1202,15 @@ func (a *Applier) submitAsyncCommit(pb *state.PreparedBatch, pfs []pendingFuture
 // decoder is a strict pass-through for them so ordering vs. entries is
 // preserved via a single goroutine.
 //
-// Exit conditions:
-//   - ctx.Done(): drop the currently-in-flight decode result (release its
-//     pooled Proposals) and return. Closing a.decodedCh here signals the
-//     main loop of an unclean shutdown; the Run defer drains anything still
-//     buffered.
-//   - a.ch closed (Stop): drain any remaining items, forward them, then
-//     close a.decodedCh cleanly so the main loop's <-a.decodedCh returns
-//     zero-value on the next iteration and the loop unwinds.
+// The only exit is ctx.Done(): a.ch is never closed (closing it would panic
+// the producers — Submit/SyncSnapshot/Barrier/…), so the decoder runs until
+// runCtx is cancelled. That cancel is the bootstrap OnStart/OnStop-timeout
+// fallback, never a graceful stop — graceful stop goes through the task
+// `stop` channel, which the decoder does not watch. On ctx.Done() the decoder
+// drops any in-flight decode result (releasing its pooled Proposals) and
+// returns; the deferred close(a.decodedCh) then unblocks the main loop, which
+// disables its decodedCh select branch (see Run), and the Run defer drains
+// anything still buffered.
 //
 // The buffer=1 on a.decodedCh lets this goroutine race one batch ahead of
 // the applier: while Prepare(N) runs under fsm.mu, UnmarshalVT(N+1) runs on
@@ -1212,18 +1220,12 @@ func (a *Applier) runDecoder(ctx context.Context) {
 	defer close(a.decodedCh)
 
 	for {
-		var (
-			work applyWork
-			ok   bool
-		)
+		var work applyWork
 
 		select {
 		case <-ctx.Done():
 			return
-		case work, ok = <-a.ch:
-			if !ok {
-				return
-			}
+		case work = <-a.ch:
 		}
 
 		dw := decodedApplyWork{work: work}
@@ -1248,6 +1250,17 @@ func (a *Applier) runDecoder(ctx context.Context) {
 	}
 }
 
+// runCommitter is the dedicated goroutine that processes commits sequentially.
+// It reads from commitCh and commits each batch, resolving futures on success
+// or failure. Exits when commitCh is closed.
+//
+// stop is the Applier task's shutdown channel — closed by taskSet.stop() at
+// the same instant as orchestrate's stop. It's a second escape hatch on the
+// response-sink send: node.Stop closes the task stop channels but does NOT
+// cancel ctx (only fx OnStop's outer timeout might), so a runCommitter that
+// races into the sink send AFTER orchestrate stopped draining would sit
+// forever on ctx.Done alone (finding 70740916). Selecting on stop too
+// unblocks the send synchronously with orchestrate's exit.
 func (a *Applier) runCommitter(ctx context.Context, stop chan struct{}) {
 	for work := range a.commitCh {
 		err := a.fsm.CommitPreparedBatch(ctx, work.prepared)
@@ -1338,7 +1351,7 @@ func (a *Applier) runCommitter(ctx context.Context, stop chan struct{}) {
 // asynchronously. The previous batch's commit runs concurrently with this
 // batch's prepare. Used by the hot path in Run (statusNormal).
 //
-// The caller (applyEntriesToFSM) owns the lifetime of decoded[].Proposal
+// The caller (applyDecodedEntriesToFSM) owns the lifetime of decoded[].Proposal
 // pointers — this method does not release them.
 func (a *Applier) applyEntriesPipelined(ctx context.Context, responses []raftpb.Message, decoded ...state.DecodedEntry) (*state.ApplyEntriesResult, error) {
 	prepareStart := time.Now()
@@ -1375,7 +1388,7 @@ func (a *Applier) applyEntriesPipelined(ctx context.Context, responses []raftpb.
 
 	// Send to the committer goroutine. Futures are resolved when the
 	// commit completes. No need to wait for the next batch. responses (may be
-	// nil for non-last sub-batches of the current applyEntriesToFSM call, or
+	// nil for non-last sub-batches of the current applyDecodedEntriesToFSM call, or
 	// when AsyncStorageWrites is off) rides with the commit and is fired by
 	// runCommitter on success.
 	a.submitAsyncCommit(pb, pfs, maxTerm, responses)
@@ -1577,7 +1590,7 @@ type maintenanceTask func(
 // gateAndLaunchMaintenance is the shared setup for every "checkpoint
 // required during apply" flow:
 //  1. Compute frozenAtIndex (the last applied index — the trigger entry is
-//     the last in the slice by construction; see applyEntriesToFSM).
+//     the last in the slice by construction; see applyDecodedEntriesToFSM).
 //  2. Mark the applier as gated with the given gatingReason.
 //  3. Extract the deferred future (the proposal that triggered gating).
 //  4. Sweep stale-term futures so they don't survive the gating window
@@ -1589,7 +1602,7 @@ type maintenanceTask func(
 // resolve the future with the checkpoint path on success or with the
 // error on failure.
 //
-// There are no remaining entries to spool here: applyEntriesToFSM pre-splits
+// There are no remaining entries to spool here: applyDecodedEntriesToFSM pre-splits
 // the slice so the checkpoint trigger is always the last entry it applies.
 // Any entries received from raft AFTER gating starts go to the spool via the
 // normal hot-path routing.

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -794,6 +794,11 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 		readiesDuringGating int64
 		gatingStart         time.Time
 		waitStart           = time.Now()
+		// syncingLeader is the leader of the sync currently in flight (0 when
+		// not syncing). Run-goroutine-local: read and written only here, so it
+		// needs no synchronization. Used to coalesce duplicate syncLeader
+		// requests for the same leader (see the syncLeader branch below).
+		syncingLeader uint64
 	)
 
 	// Local handle on the decoded channel so we can stop selecting on it once
@@ -833,6 +838,24 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 			}
 
 			if work.syncLeader != 0 {
+				// Coalesce a duplicate sync request for the leader we are
+				// already syncing from. The decoder stage adds a second
+				// buffered slot (a.ch → decodedCh) between processReady's
+				// TrySyncSnapshot and this status transition, so a back-to-back
+				// Ready can enqueue a second syncLeader before processReady's
+				// statusOutOfSync gate closes. Re-running startSyncSnapshot
+				// would Interrupt() the in-flight checkpoint fetch and restart
+				// it from scratch. Drop the duplicate here; a genuinely new
+				// leader (leadership changed mid-sync) still falls through and
+				// preempts.
+				if work.syncLeader == syncingLeader &&
+					a.status.Load() == statusGated &&
+					a.gatingReason.Load() == gatingReasonSyncing {
+					waitStart = time.Now()
+
+					continue
+				}
+
 				// Drain pending commit before starting sync.
 				if err := a.waitPendingCommit(ctx); err != nil {
 					return err
@@ -840,6 +863,7 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 
 				a.status.Store(statusGated)
 				a.gatingReason.Store(gatingReasonSyncing)
+				syncingLeader = work.syncLeader
 				a.startSyncSnapshot(ctx, work.syncLeader)
 				waitStart = time.Now()
 
@@ -939,6 +963,11 @@ func (a *Applier) Run(ctx context.Context, stop chan struct{}) error {
 			readiesDuringGating = 0
 			gatingStart = time.Time{}
 			a.gatingTerminated = nil
+			// The in-flight sync (if any) has ended — succeeded, failed, or was
+			// an install-snapshot gating. Clear the coalescing guard so the next
+			// syncLeader request starts fresh, even for the same leader (e.g. a
+			// failed sync that processReady legitimately retries).
+			syncingLeader = 0
 
 			if a.status.Load() == statusInstallingSnapshot {
 				// Run set this status via the installSnapshot command.

--- a/internal/infra/node/applier_async_storage_test.go
+++ b/internal/infra/node/applier_async_storage_test.go
@@ -242,7 +242,7 @@ func TestApplierNoFireWhenResponsesEmpty(t *testing.T) {
 }
 
 // TestApplierMultipleBatchesOnlyLastResponsesFire — with multiple sub-batches
-// resulting from applyEntriesToFSM's checkpoint-boundary splitting (or from
+// resulting from applyDecodedEntriesToFSM's checkpoint-boundary splitting (or from
 // multiple Submits), each Submit's responses must fire independently: no
 // aggregation, no loss, exactly once per Submit that carries responses.
 func TestApplierMultipleBatchesOnlyLastResponsesFire(t *testing.T) {

--- a/internal/infra/node/applier_test.go
+++ b/internal/infra/node/applier_test.go
@@ -841,7 +841,7 @@ func makeCreateQueryCheckpointEntry(t *testing.T, index uint64) (raftpb.Entry, u
 // makeStaleCreateQueryCheckpointEntry builds a CreateQueryCheckpoint entry
 // whose PredictedIndex deliberately differs from the raft index, so
 // checkStaleProposal rejects it before any order runs. Used to exercise the
-// "structural trigger that does not actually fire" branch of applyEntriesToFSM.
+// "structural trigger that does not actually fire" branch of applyDecodedEntriesToFSM.
 func makeStaleCreateQueryCheckpointEntry(t *testing.T, index, predictedIndex uint64) (raftpb.Entry, uint64) {
 	t.Helper()
 
@@ -920,7 +920,7 @@ func TestApplierCascadingQueryCheckpointsDuringReplay(t *testing.T) {
 // panic with "task pool error: preparing entries: invalid index, got 231,
 // expected 230 [recovered, repanicked]".
 //
-// Root cause: applyEntriesToFSM pre-splits the committed entries slice at any
+// Root cause: applyDecodedEntriesToFSM pre-splits the committed entries slice at any
 // CreateQueryCheckpoint / CloseChapter trigger so each FSM batch contains at
 // most one trigger as its last entry. The pre-split is purely structural — it
 // does not know whether the trigger will actually fire at apply time. When

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -132,7 +132,7 @@ type readyResult struct {
 	// applyResponses are MsgStorageApplyResp messages collected from
 	// LocalApplyThread messages in rd.Messages. They are handed to
 	// applier.Submit in finishReady and Step()-ed back into rawNode by the
-	// applier AFTER applyEntriesToFSM (or spool append) completes — bumping
+	// applier AFTER applyDecodedEntriesToFSM (or spool append) completes — bumping
 	// raft.Applied in lockstep with FSM-applied. Used only when
 	// AsyncStorageWrites is enabled.
 	applyResponses []raftpb.Message
@@ -1370,14 +1370,14 @@ func (node *Node) finishReady(result readyResult, stop chan struct{}) error {
 
 	// Submit committed entries to the Applier for async FSM application.
 	// applyResponses (MsgStorageApplyResp) are deferred to the applier: they
-	// are Step()-ed back into rawNode only after applyEntriesToFSM (or the
+	// are Step()-ed back into rawNode only after applyDecodedEntriesToFSM (or the
 	// spool append) completes, so raft.Applied tracks FSM-applied.
 	//
 	// The guard is CommittedEntries-only by design. etcd/raft only emits
 	// MsgStorageApply (source of applyResponses) when CommittedEntries > 0
 	// (rawnode.go's needStorageApplyMsg). So `len(applyResponses) > 0 &&
 	// len(CommittedEntries) == 0` is unreachable — a defensive OR would only
-	// hide a future contract violation, since applyEntriesToFSM's decode+loop
+	// hide a future contract violation, since applyDecodedEntriesToFSM's decode+loop
 	// would silently drop responses when entries is empty (CLAUDE.md #7).
 	if len(rd.CommittedEntries) > 0 {
 		node.applier.Submit(rd.CommittedEntries, node.confState.Load(), result.applyResponses, stop)

--- a/internal/infra/state/machine_test.go
+++ b/internal/infra/state/machine_test.go
@@ -797,7 +797,7 @@ func TestNextLedgerIDRecovery(t *testing.T) {
 // PrepareEntries used to read entries[0].Index unconditionally inside a
 // trace-level log when lastPersistedIndex lagged lastAppliedIndex. Calling
 // it with an empty entries slice (e.g. the empty `head` slice produced by
-// applyEntriesToFSM when a batch boundary lands on the first entry) and
+// applyDecodedEntriesToFSM when a batch boundary lands on the first entry) and
 // trace logging enabled would panic with index out of range. The non-empty
 // sub-test exercises the trace-log code path itself to keep coverage on the
 // guarded block.


### PR DESCRIPTION
## Summary

Moves `state.DecodeEntries` out of the applier's main-loop critical path
into a dedicated prefetching goroutine, so `UnmarshalVT` for batch N+1
runs on a spare core while the applier holds `fsm.mu` running Prepare(N).

## Structure

```
Submit / Barrier / SyncFromLeader / ... ─▶ a.ch
                                             │
                                             ▼
                                      [decoder goroutine]
                                       - reads a.ch
                                       - state.DecodeEntries for entries
                                       - forwards everything else as-is
                                             │
                                             ▼
                                          a.decodedCh
                                             │
                                             ▼
                                        [main loop]
                                     - Prepare / async commit
                                     - Barrier / status transitions
```

Non-entries work items (barrier, syncLeader, installSnapshot) pass through
the decoder verbatim with a nil decoded slice — ordering vs. entries is
preserved by the single-goroutine decoder. Non-normal-status paths (spool,
snapshot install) release the pre-decoded proposals immediately since raw
entries are what the spool consumes.

Shutdown drains `a.decodedCh` so vtproto's pool doesn't leak. The
decoder's context is derived locally from `Run`'s ctx via
`context.WithCancel`, so the decoder unwinds cleanly even on normal exit
via `<-stop` (where the outer ctx stays live).

`applyEntriesToFSM` (the raw-entries wrapper) is dropped as dead code:
the hot path calls `applyDecodedEntriesToFSM` directly.

## Bench results (perf-world-to-bank, 5min saturated window)

| Metric | Baseline | This PR | Delta |
|---|---|---|---|
| `raft_fsm_prepare_duration_microseconds` p95 | ~18-20K μs | ~14-16K μs | **-20-25%** |
| `raft_apply_entries_batch_size` p50 | ~15-16 | ~12 | -20% (smaller batches) |
| batches/sec (derived) | ~107 | ~133 | **+24%** |
| `raft_apply_entries_batch_size_total` rate (throughput) | ~1.6K entries/s | ~1.6K entries/s | ≈0% |

The pipeline does what it says on the tin: Prepare wall-time drops
because DecodeEntries is no longer serialized ahead of it. The applier
processes batches faster (+24% batches/sec) but each batch is smaller
because the queue drains before it accumulates as much.

Throughput is flat because the **actual bottleneck is downstream**:
`raft_applier_commit_wait_duration_microseconds` p95 climbs from
~3-6K μs (dispersed) to ~5-6K μs (sustained). Multiplied by the new
batch rate: ~730 ms/sec of applier time waiting on Pebble commit.
Pebble is the next lever, not decode.

## Why merge anyway

- Pure structural gain, no correctness risk (single-goroutine decoder
  preserves ordering; ownership handoff is explicit).
- Frees the applier core from CPU cycles previously spent on decode
  (~2.4s out of every 27.6s on the profile) — usable by other
  goroutines on the process.
- Unlocks the ability to see the real bottleneck (Pebble commit),
  which was previously masked by decode-inside-apply.
- Prerequisite for future prepare-side optimisations to actually
  translate into throughput.

## Test plan

- [x] `just pre-commit` (build, tests, lint)
- [x] `internal/infra/node/` full test suite passes
- [x] Manual bench on `perf-world-to-bank` shows expected shift
      (Prepare duration down, batches/sec up, throughput bounded by
       Pebble commit as expected)
- [ ] Antithesis run to validate determinism under scheduling shuffle