### PR TITLE
test(antithesis): expand model-driver coverage, extract oracle model library

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -319,7 +319,9 @@ restart. It catches:
 
 It exercises the chart of accounts, transactions and reverts (with post-commit
 volumes), account/transaction/ledger metadata, the typed-metadata schema, and
-the transient/ephemeral persistence classes.
+the transient/ephemeral persistence classes — and reads them back: account,
+whole-ledger, transaction-by-id, and declared-schema reads are all validated
+against the model.
 
 #### How it works
 
@@ -327,14 +329,21 @@ N workers fan out across a fleet of ledgers, dispatching bulks concurrently;
 the model mirrors the single Raft log (one global re-order buffer, one committed
 state across all ledgers). The pieces:
 
+The forward model is a standalone library under `tests/oracle`; the driver
+under `tests/antithesis/workload/bin/cmds/model/singleton_driver_model/` owns
+the harness around it:
+
 | File | Role |
 |------|------|
-| `model.go` | The pure forward model: `GlobalState`/`LedgerState` + `Apply`, which predicts the server's legal outcome for a bulk, atomically across whatever ledgers it touches. |
-| `checker.go` | Harness bookkeeping: the in-flight set, the re-order buffer, and the committed model state. |
-| `processor.go` | One goroutine that re-orders observed responses by log sequence and drains them into the committed state in commit order. |
-| `search.go` | `candidateBases` — enumerates the states the server could legitimately be in. |
-| `validate.go` | The conformance checks for committed bulks, failures, and reads. |
-| `actions.go` / `reads.go` | Random bulk generation; `GetAccount` / `GetLedger` read execution. |
+| `tests/oracle/model.go` | The pure forward model: `GlobalState`/`LedgerState` + `Apply`, which predicts the server's legal outcome for a bulk, atomically across whatever ledgers it touches. |
+| `tests/oracle/bulk.go` / `accessors.go` | The `Bulk` submission shape the model consumes; read-only accessors over model state for validators and tools. |
+| `tests/oracle/oracletest/` | Shared helpers for tests that drive the oracle. |
+| `tests/oracle/cmd/replay` | Offline replayer for `MODEL_DUMP_BATCHES` captures (see below). |
+| `checker.go` (driver) | Harness bookkeeping: the in-flight set, the re-order buffer, and the committed model state. |
+| `processor.go` (driver) | One goroutine that re-orders observed responses by log sequence and drains them into the committed state in commit order. |
+| `search.go` (driver) | `candidateBases` — enumerates the states the server could legitimately be in. |
+| `validate.go` (driver) | The conformance checks for committed bulks, failures, and reads. |
+| `actions.go` / `reads.go` (driver) | Random bulk generation; account, whole-ledger, transaction-by-id, and metadata-schema read execution. |
 
 The key primitive is **`candidateBases`**: a committed bulk drains in
 log-sequence order, so the committed model state is its exact predecessor and
@@ -372,13 +381,14 @@ default. Common tunables (full list in the script header):
 | `MODEL_LEDGERS` / `MODEL_WORKERS` | Fleet size and concurrency. |
 | `MODEL_DEBUG` | Enable driver debug logging. |
 | `MODEL_FAIL_FAST` | Stop on first finding (default); `0` runs the full duration. |
+| `MODEL_DUMP_BATCHES` | Log every submitted bulk (`[batch-dump]` lines) for deterministic offline replay through `tests/oracle/cmd/replay`. |
 | `RESTART_INTERVAL` / `DEAD_TIME` | Cluster restart cadence and how long a killed node stays down. |
 | `COMPACTION_MARGIN` | Raft entries between snapshots; low values force snapshot recovery. |
 
 #### Maintaining the model
 
-The model in `model.go` is a hand-written mirror of the server's *intended*
-behavior; nothing keeps the two in sync automatically. Treat them as one unit —
+The model in `tests/oracle/model.go` is a hand-written mirror of the server's
+*intended* behavior; nothing keeps the two in sync automatically. Treat them as one unit —
 when a change alters behavior the model relies on, update the model in the same
 change, or the next run will either cry wolf (model stricter than the server) or
 go blind (model more lenient than the server).
@@ -387,11 +397,19 @@ Where to make the matching change:
 
 | Server change | Model change |
 |---|---|
-| New request type or ledger action | Add a `case` to `applyOne` in `model.go` **and** a generator in `actions.go`. |
-| Changed business/validation rule (new rejection condition, enforcement change, volume math) | Update the matching `apply*` predictor in `model.go`. |
+| New request type or ledger action | Add a `case` to `applyOne` in `tests/oracle/model.go` **and** a generator in the driver's `actions.go`. |
+| Changed business/validation rule (new rejection condition, enforcement change, volume math) | Update the matching `apply*` predictor in `tests/oracle/model.go`. |
 | New or changed response field the test should check | Update the validator in `validate.go` and the predicted effect it compares against. |
 | New rejection reason | Return the matching `domain.ErrReason*` from the right model branch so `validateFailure` can explain it. |
 | New persisted projection or read surface | Add the read in `reads.go` and a validator in `validate.go`, mirroring the account/ledger reads. |
+
+To diagnose a finding deterministically, capture the run with
+`MODEL_DUMP_BATCHES=1` and feed the dump back through the model offline:
+`go run ./tests/oracle/cmd/replay <dump-file> [target-ledger]` folds the
+committed bulks in log-sequence order (the server's true serialization) and
+prints each touched ledger's final model state; `--submits` additionally
+compares every bulk's model outcome to the server's, valid for single-worker
+runs where dispatch order is the serialization.
 
 The model is built to fail loud on anything it hasn't been taught: `Apply`
 panics on an unmodeled request type or action rather than skipping it — the same

--- a/tests/antithesis/Justfile
+++ b/tests/antithesis/Justfile
@@ -9,6 +9,11 @@ tag := "antithesis"
 # to cohabit with other forks pushed under the same Antithesis registry.
 ledger_image_name := env_var_or_default("LEDGER_IMAGE_NAME", "ledger")
 
+# Set MODEL_DUMP_BATCHES=1 to make the singleton_driver_model dump every
+# committed ApplyRequest (base64) into the workload logs, for exact
+# deterministic replay through the oracle (see tests/oracle/cmd/replay).
+# e.g.  MODEL_DUMP_BATCHES=1 just k8s-run 1
+
 # --- Docker Compose mode (legacy) ---
 
 # include: optional comma-separated list of <template>/<driver> paths to ship

--- a/tests/antithesis/config/docker-compose.yaml
+++ b/tests/antithesis/config/docker-compose.yaml
@@ -18,6 +18,11 @@ x-ledger-common: &ledger-common
     INSECURE: "true"
     DEBUG: "true"
 
+    # Signed transaction receipts, so the model driver exercises the
+    # receipt-carried revert path (admission verifies the receipt and reverses
+    # its claimed postings, bypassing the store fetch).
+    RECEIPT_SIGNING_KEY: "model-test-receipt-hmac-signing-key"
+
     # Chaos-tuned: lower thresholds to exercise more code paths under fault injection
     SNAPSHOT_THRESHOLD: "200"
     CACHE_ROTATION_THRESHOLD: "50"

--- a/tests/antithesis/k8s/cluster.yaml
+++ b/tests/antithesis/k8s/cluster.yaml
@@ -64,6 +64,11 @@ spec:
   extraEnv:
   - name: INSECURE
     value: "true"
+  # Signed transaction receipts, so the model driver exercises the
+  # receipt-carried revert path (admission verifies the receipt and reverses its
+  # claimed postings, bypassing the store fetch).
+  - name: RECEIPT_SIGNING_KEY
+    value: "model-test-receipt-hmac-signing-key"
   # Chaos-tuned: 256 KiB spool segments (default 256 MiB) so rotation seals segments and Prune has work to do.
   - name: SPOOL_SEGMENT_MAX_BYTES
     value: "262144"

--- a/tests/antithesis/k8s/generate-manifests.sh
+++ b/tests/antithesis/k8s/generate-manifests.sh
@@ -51,7 +51,7 @@ helm template ledger-operator "$REPO_ROOT/misc/operator/helm/operator" \
 
 # 3. Static manifests — substitute tag, registry, image name
 for tmpl in kapp-config.yaml minio.yaml nats.yaml cluster.yaml workload.yaml; do
-  sed "s|__TAG__|$TAG|g; s|__REGISTRY__|$ANTITHESIS_REGISTRY|g; s|__IMAGE_NAME__|$LEDGER_IMAGE_NAME|g" \
+  sed "s|__TAG__|$TAG|g; s|__REGISTRY__|$ANTITHESIS_REGISTRY|g; s|__IMAGE_NAME__|$LEDGER_IMAGE_NAME|g; s|__MODEL_DUMP_BATCHES__|${MODEL_DUMP_BATCHES:-}|g" \
     "$SCRIPT_DIR/$tmpl" > "$OUT/$tmpl"
 done
 

--- a/tests/antithesis/k8s/workload.yaml
+++ b/tests/antithesis/k8s/workload.yaml
@@ -87,6 +87,12 @@ spec:
           value: "ledger-ledger-0.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-1.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-2.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-3.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-4.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-5.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-6.ledger-ledger-headless.default.svc.cluster.local:8888"
         - name: EXPECTED_VOTERS
           value: "3"
+        # Dumps every committed ApplyRequest (base64) for exact deterministic
+        # replay through the oracle (see tests/oracle/cmd/replay). Empty
+        # disables; substituted by generate-manifests.sh from the
+        # MODEL_DUMP_BATCHES env at config-image build.
+        - name: MODEL_DUMP_BATCHES
+          value: "__MODEL_DUMP_BATCHES__"
         # Readiness probe ensures Antithesis waits for the ledger cluster
         # to be reachable before starting the Test Composer.
         readinessProbe:

--- a/tests/antithesis/run_model_test.sh
+++ b/tests/antithesis/run_model_test.sh
@@ -76,6 +76,10 @@ DEAD_TIME="${DEAD_TIME:-30}"
 COMPACTION_MARGIN="${COMPACTION_MARGIN:-200}"
 MAINTENANCE_INTERVAL="${MAINTENANCE_INTERVAL:-10s}"
 CLUSTER_ID="model-test-cluster"
+# HMAC key for signed transaction receipts, so the driver can exercise the
+# receipt-carried revert path (admission verifies the receipt and reverses its
+# claimed postings, bypassing the store fetch).
+RECEIPT_SIGNING_KEY="model-test-receipt-hmac-signing-key"
 
 # Fail-fast (on by default): stop the run the moment a finding appears instead
 # of running out the clock. Set to 0/off to run the full duration, or to a
@@ -154,6 +158,7 @@ start_node() {
 		--advertise-addr "127.0.0.1:${RAFT_PORTS[$i]}" \
 		--grpc-port "${GRPC_PORTS[$i]}" \
 		--http-port "${HTTP_PORTS[$i]}" \
+		--receipt-signing-key "$RECEIPT_SIGNING_KEY" \
 		--wal-dir "${NODE_DIRS[$i]}/wal" \
 		--data-dir "${NODE_DIRS[$i]}/data" \
 		--raft-compaction-margin "$COMPACTION_MARGIN" \

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -57,7 +57,7 @@ func sourceAddress() string {
 // occasionally a bulk spreads its requests across a few, exercising the
 // server's atomic-across-ledgers semantics. Reads the committed state but
 // never mutates it.
-func generateBulk(g oracle.GlobalState, ledgers []string) oracle.Bulk {
+func generateBulk(g oracle.GlobalState, ledgers []string, receipts map[string]string) oracle.Bulk {
 	picks := pickLedgers(ledgers)
 
 	// Whole-bulk transient shapes fund and drain the same cell, so they only
@@ -106,7 +106,7 @@ func generateBulk(g oracle.GlobalState, ledgers []string) oracle.Bulk {
 		}
 
 		if rollRevert() {
-			if req := generateRevert(ledger, ls); req != nil {
+			if req := generateRevert(ledger, ls, receipts); req != nil {
 				requests = append(requests, req)
 				continue
 			}
@@ -676,7 +676,7 @@ func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.R
 // committed reference exercises both the success path and the
 // TRANSACTION_ALREADY_REVERTED rejection (a reference picked after a prior
 // revert committed).
-func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
+func generateRevert(ledger string, ls oracle.LedgerState, receipts map[string]string) *servicepb.Request {
 	ref := pickTxRef(ls)
 	if ref == "" {
 		return nil
@@ -689,6 +689,14 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 		// original's timestamp instead of the server's current date.
 		AtEffectiveDate: random.RandomChoice([]uint8{0, 1}) == 0,
 		ExpandVolumes:   true,
+	}
+
+	// ~half the reverts with a captured receipt carry it, exercising admission's
+	// receipt path: it verifies the JWT and reverses the receipt's claimed
+	// postings, bypassing the transaction-state store fetch. Outcome matches the
+	// store path for a valid receipt, so the model needs no change.
+	if receipt := receipts[ref]; receipt != "" && random.RandomChoice([]uint8{0, 1}) == 0 {
+		payload.Receipt = receipt
 	}
 
 	// ~half the reverts carry metadata on the revert transaction, echoed

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -658,9 +658,12 @@ func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.R
 	}
 }
 
-// generateRevert reverts a committed transaction by reference. force skips the
-// balance check (the reversed posting debits the original destination, which may
-// lack the funds), so the model needs no insufficient-funds modeling;
+// generateRevert reverts a committed transaction by reference, ~half of them
+// with force. A non-forced revert applies the balance floor to the reversed
+// postings — the reversed source is the original destination, which may since
+// have spent (or been purged of) the funds — so it also exercises the revert
+// path's INSUFFICIENT_FUNDS rejection. The server validates account types before
+// the floor on reverts, so the oracle does the same (see applyRevert).
 // expand_volumes returns post-commit volumes for validation. Targeting any
 // committed reference exercises both the success path and the
 // TRANSACTION_ALREADY_REVERTED rejection (a reference picked after a prior
@@ -673,7 +676,7 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 
 	payload := &servicepb.RevertTransactionPayload{
 		TransactionId: uint64(ls.TxByRef()[ref]),
-		Force:         true,
+		Force:         random.RandomChoice([]uint8{0, 1}) == 0,
 		ExpandVolumes: true,
 	}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -252,6 +252,15 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		}
 	}
 
+	// ~1/16: a deliberately-malformed transaction exercising a create rejection
+	// branch (empty / duplicate-reference / volume-overflow). The server rejects
+	// it and the oracle reproduces the reason, so validateFailure explains it.
+	if random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}) == 0 {
+		if req := generateRejectedTransaction(ledger, ls); req != nil {
+			return req
+		}
+	}
+
 	// Force (~1/8) skips the balance floor, letting a non-world source overdraft.
 	force := random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7}) == 0
 
@@ -294,6 +303,11 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		}
 	}
 
+	return applyCreate(ledger, payload)
+}
+
+// applyCreate wraps a CreateTransactionPayload as a ledger Apply request.
+func applyCreate(ledger string, payload *servicepb.CreateTransactionPayload) *servicepb.Request {
 	return &servicepb.Request{
 		Type: &servicepb.Request_Apply{
 			Apply: &servicepb.LedgerApplyRequest{
@@ -306,6 +320,59 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 			},
 		},
 	}
+}
+
+// generateRejectedTransaction builds a transaction the server must reject,
+// cycling the create rejection branches that valid traffic never triggers.
+// Returns nil when the chosen branch is not currently applicable (no committed
+// reference to duplicate yet).
+func generateRejectedTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	switch random.RandomChoice([]uint8{0, 1, 2}) {
+	case 0:
+		return emptyTransaction(ledger)
+	case 1:
+		return duplicateReferenceTransaction(ledger, ls)
+	default:
+		return overflowTransaction(ledger)
+	}
+}
+
+// emptyTransaction carries no postings and no script, so admission rejects it as
+// having no content source (VALIDATION).
+func emptyTransaction(ledger string) *servicepb.Request {
+	return applyCreate(ledger, &servicepb.CreateTransactionPayload{ExpandVolumes: true})
+}
+
+// duplicateReferenceTransaction reuses a committed reference; the FSM rejects it
+// with TRANSACTION_REFERENCE_CONFLICT before any floor/chart check. Nil when the
+// ledger holds no committed reference yet.
+func duplicateReferenceTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	ref := pickTxRef(ls)
+	if ref == "" {
+		return nil
+	}
+
+	return applyCreate(ledger, &servicepb.CreateTransactionPayload{
+		Postings:      []*commonpb.Posting{commonpb.NewPosting("world", poolAddress(), assets[0], big.NewInt(1))},
+		Reference:     ref,
+		ExpandVolumes: true,
+	})
+}
+
+// overflowTransaction sends two near-maximal (2^255) amounts from world to the
+// same account, so the running volume exceeds 2^256 and the server rejects with
+// VOLUME_OVERFLOW (the world Output overflows on the second posting).
+func overflowTransaction(ledger string) *servicepb.Request {
+	half := new(big.Int).Lsh(big.NewInt(1), 255)
+	dst := poolAddress()
+
+	return applyCreate(ledger, &servicepb.CreateTransactionPayload{
+		Postings: []*commonpb.Posting{
+			commonpb.NewPosting("world", dst, assets[0], half),
+			commonpb.NewPosting("world", dst, assets[0], half),
+		},
+		ExpandVolumes: true,
+	})
 }
 
 // AddAccountType at a random pool prefix with a freshly-rolled

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -197,6 +197,13 @@ func rollRevert() bool {
 	return random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5}) == 0
 }
 
+// expandVolumes reports whether a transaction requests post-commit volumes on
+// its response (~9/10). When false the server omits them and the checker skips
+// the volume comparison for that order (crossCheckCommit).
+func expandVolumes() bool {
+	return random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}) != 0
+}
+
 // Picks Add vs Remove.
 func generateChartOp(ledger string) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1}) == 0 {
@@ -276,11 +283,10 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 	// Every transaction gets a unique reference so it is targetable by later
 	// transaction-metadata writes. ~half also carry metadata at creation.
 	payload := &servicepb.CreateTransactionPayload{
-		Postings:  postings,
-		Reference: txRef(),
-		Force:     force,
-		// Need PCV for validation.
-		ExpandVolumes: true,
+		Postings:      postings,
+		Reference:     txRef(),
+		Force:         force,
+		ExpandVolumes: expandVolumes(),
 	}
 
 	if random.RandomChoice([]uint8{0, 1}) == 0 {
@@ -755,7 +761,7 @@ func generateRevert(ledger string, ls oracle.LedgerState, receipts map[string]st
 		// ~half at the original's effective date: the revert inherits the
 		// original's timestamp instead of the server's current date.
 		AtEffectiveDate: random.RandomChoice([]uint8{0, 1}) == 0,
-		ExpandVolumes:   true,
+		ExpandVolumes:   expandVolumes(),
 	}
 
 	// ~half the reverts with a captured receipt carry it, exercising admission's

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -122,7 +122,7 @@ func generateBulk(g oracle.GlobalState, ledgers []string) oracle.Bulk {
 // ledger's committed-transaction count (see the txEmit* knobs) so tracked
 // references don't grow without bound.
 func rollTransaction(ls oracle.LedgerState) bool {
-	switch n := len(ls.TxRefs()); {
+	switch n := len(ls.TxByRef()); {
 	case n < txEmitFull:
 		return true
 	case n < txEmitTaper:
@@ -576,7 +576,7 @@ func generateAddTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.Requ
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_AddMetadata{
 						AddMetadata: &commonpb.SaveMetadataCommand{
-							Target:   txTarget(ls.TxRefs()[ref].Id()),
+							Target:   txTarget(uint64(ls.TxByRef()[ref])),
 							Metadata: randomMetaMap(),
 						},
 					},
@@ -590,19 +590,32 @@ func generateAddTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.Requ
 // occasionally a freshly-rolled key on a known reference to exercise
 // METADATA_NOT_FOUND. Returns nil when the model holds no transaction metadata.
 func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.Request {
-	keys := make([]oracle.TxMetaKey, 0, len(ls.TxMeta()))
-	for tk := range ls.TxMeta() {
-		keys = append(keys, tk)
+	type refKey struct {
+		ref string
+		key string
+	}
+
+	var keys []refKey
+	txs := ls.Txs()
+	for ref, id := range ls.TxByRef() {
+		for k := range txs[id-1].Metadata() {
+			keys = append(keys, refKey{ref: ref, key: k})
+		}
 	}
 
 	if len(keys) == 0 {
 		return nil
 	}
 
-	slices.SortFunc(keys, oracle.CompareTxMetaKey)
+	slices.SortFunc(keys, func(a, b refKey) int {
+		if a.ref != b.ref {
+			return strings.Compare(a.ref, b.ref)
+		}
+		return strings.Compare(a.key, b.key)
+	})
 	chosen := random.RandomChoice(keys)
 
-	ref, key := chosen.Reference, chosen.Key
+	ref, key := chosen.ref, chosen.key
 	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
 		key = metaKey()
 	}
@@ -614,7 +627,7 @@ func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.R
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_DeleteMetadata{
 						DeleteMetadata: &commonpb.DeleteMetadataCommand{
-							Target: txTarget(ls.TxRefs()[ref].Id()),
+							Target: txTarget(uint64(ls.TxByRef()[ref])),
 							Key:    key,
 						},
 					},
@@ -638,7 +651,7 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	}
 
 	payload := &servicepb.RevertTransactionPayload{
-		TransactionId: ls.TxRefs()[ref].Id(),
+		TransactionId: uint64(ls.TxByRef()[ref]),
 		Force:         true,
 		ExpandVolumes: true,
 	}
@@ -666,8 +679,8 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 // pickTxRef returns a deterministically-chosen committed transaction reference,
 // or "" when the model holds none.
 func pickTxRef(ls oracle.LedgerState) string {
-	refs := make([]string, 0, len(ls.TxRefs()))
-	for r := range ls.TxRefs() {
+	refs := make([]string, 0, len(ls.TxByRef()))
+	for r := range ls.TxByRef() {
 		refs = append(refs, r)
 	}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -7,23 +7,22 @@ import (
 	"strings"
 
 	"github.com/antithesishq/antithesis-sdk-go/random"
+	"github.com/holiman/uint256"
+
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
-	"github.com/holiman/uint256"
 )
 
-// Bulk is one Apply call's worth of requests.
-type Bulk struct {
-	Requests []*servicepb.Request
-}
-
-func (b Bulk) ApplyRequest() *servicepb.ApplyRequest {
-	// One fresh idempotency key for the whole batch (idempotency is per
-	// ApplyBatch). Generated once per Apply call and reused across the
-	// client's internal retries, so an ambiguous UNAVAILABLE replays the
-	// committed batch instead of re-applying it.
+// applyRequest renders a bulk into a sendable ApplyRequest. One fresh
+// idempotency key for the whole batch (idempotency is per ApplyBatch),
+// generated once per Apply call and reused across the client's internal
+// retries, so an ambiguous UNAVAILABLE replays the committed batch instead of
+// re-applying it.
+func applyRequest(b oracle.Bulk) *servicepb.ApplyRequest {
 	return servicepb.UnsignedApplyRequest(idempotencyKey(), b.Requests...)
 }
 
@@ -46,22 +45,22 @@ func poolAddress() string {
 // occasionally a bulk spreads its requests across a few, exercising the
 // server's atomic-across-ledgers semantics. Reads the committed state but
 // never mutates it.
-func generateBulk(g GlobalState, ledgers []string) Bulk {
+func generateBulk(g oracle.GlobalState, ledgers []string) oracle.Bulk {
 	picks := pickLedgers(ledgers)
 
 	// Whole-bulk transient shapes fund and drain the same cell, so they only
 	// make sense single-ledger.
 	if len(picks) == 1 {
 		ledger := picks[0]
-		ls := g.ledger(ledger)
+		ls := g.Ledger(ledger)
 		switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}) {
 		case 0:
 			if reqs := generateTransientBalancedBulk(ledger, ls); reqs != nil {
-				return Bulk{Requests: reqs}
+				return oracle.Bulk{Requests: reqs}
 			}
 		case 1:
 			if reqs := generateTransientUnbalancedBulk(ledger, ls); reqs != nil {
-				return Bulk{Requests: reqs}
+				return oracle.Bulk{Requests: reqs}
 			}
 		}
 	}
@@ -71,7 +70,7 @@ func generateBulk(g GlobalState, ledgers []string) Bulk {
 
 	for i := 0; i < size; i++ {
 		ledger := random.RandomChoice(picks)
-		ls := g.ledger(ledger)
+		ls := g.Ledger(ledger)
 
 		if rollChartOp() {
 			if req := generateChartOp(ledger); req != nil {
@@ -116,14 +115,14 @@ func generateBulk(g GlobalState, ledgers []string) Bulk {
 		}
 	}
 
-	return Bulk{Requests: requests}
+	return oracle.Bulk{Requests: requests}
 }
 
 // rollTransaction reports whether to create a new transaction, tapering with the
 // ledger's committed-transaction count (see the txEmit* knobs) so tracked
 // references don't grow without bound.
-func rollTransaction(ls LedgerState) bool {
-	switch n := len(ls.txRefs); {
+func rollTransaction(ls oracle.LedgerState) bool {
+	switch n := len(ls.TxRefs()); {
 	case n < txEmitFull:
 		return true
 	case n < txEmitTaper:
@@ -208,9 +207,9 @@ func bulkSize() int {
 }
 
 // randomTransientType returns a random TRANSIENT type from ls's chart, or nil.
-func randomTransientType(ls LedgerState) *TypeState {
-	names := make([]string, 0, len(ls.types))
-	for name, t := range ls.types {
+func randomTransientType(ls oracle.LedgerState) *oracle.TypeState {
+	names := make([]string, 0, len(ls.Types()))
+	for name, t := range ls.Types() {
 		if t.Persistence == commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT {
 			names = append(names, name)
 		}
@@ -222,7 +221,7 @@ func randomTransientType(ls LedgerState) *TypeState {
 
 	slices.Sort(names)
 
-	t := ls.types[random.RandomChoice(names)]
+	t := ls.Types()[random.RandomChoice(names)]
 
 	return &t
 }
@@ -232,7 +231,7 @@ func randomTransientType(ls LedgerState) *TypeState {
 // Either a chaos posting (world → pool address, picked blindly so the
 // server resolves typing) or — ~1/4 of the time — a deliberate drain
 // of an EPHEMERAL cell to exercise the zero-balance purge sweep.
-func generateTransaction(ledger string, ls LedgerState) *servicepb.Request {
+func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
 		if req := generateDrainTransaction(ledger, ls); req != nil {
 			return req
@@ -334,17 +333,17 @@ func txRequest(ledger, src, dest, asset string, amount *big.Int, force bool) *se
 // Drains the exact balance of some EPHEMERAL cell to "world" with
 // Force=true so the cell lands at input==output and gets purged.
 // Returns nil if no eligible cell exists.
-func generateDrainTransaction(ledger string, ls LedgerState) *servicepb.Request {
+func generateDrainTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	// Collect every drainable cell, then pick via the Antithesis RNG over a
 	// sorted slice — replayable / steerable, unlike map-iteration order.
 	type drainCandidate struct {
-		key     VolumeKey
+		key     oracle.VolumeKey
 		balance uint256.Int
 	}
 
 	var candidates []drainCandidate
-	for key, vp := range ls.volumes {
-		t := ls.matchAddress(key.Address)
+	for key, vp := range ls.Volumes() {
+		t := ls.MatchAddress(key.Address)
 		if t == nil {
 			continue
 		}
@@ -368,7 +367,7 @@ func generateDrainTransaction(ledger string, ls LedgerState) *servicepb.Request 
 	}
 
 	slices.SortFunc(candidates, func(a, b drainCandidate) int {
-		return compareVolumeKey(a.key, b.key)
+		return oracle.CompareVolumeKey(a.key, b.key)
 	})
 
 	chosen := random.RandomChoice(candidates)
@@ -419,7 +418,7 @@ func metaKey() string {
 // account when no transaction exists yet), or an account-level op — each Add
 // (~2/3) vs Delete (~1/3). A delete falls back to its add when the model holds no
 // metadata of that kind yet.
-func generateMetadataOp(ledger string, ls LedgerState) *servicepb.Request {
+func generateMetadataOp(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	switch random.RandomChoice([]uint8{0, 1, 2, 3, 4}) {
 	case 0:
 		if random.RandomChoice([]uint8{0, 1, 2}) == 0 {
@@ -483,9 +482,9 @@ func generateAddMetadata(ledger string) *servicepb.Request {
 // DeleteMetadata of an existing (address, key) from the model — occasionally a
 // freshly-rolled key on that address to exercise METADATA_NOT_FOUND. Returns nil
 // when the model holds no metadata.
-func generateDeleteMetadata(ledger string, ls LedgerState) *servicepb.Request {
-	keys := make([]MetaKey, 0, len(ls.metadata))
-	for mk := range ls.metadata {
+func generateDeleteMetadata(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	keys := make([]oracle.MetaKey, 0, len(ls.Metadata()))
+	for mk := range ls.Metadata() {
 		keys = append(keys, mk)
 	}
 
@@ -493,7 +492,7 @@ func generateDeleteMetadata(ledger string, ls LedgerState) *servicepb.Request {
 		return nil
 	}
 
-	slices.SortFunc(keys, compareMetaKey)
+	slices.SortFunc(keys, oracle.CompareMetaKey)
 	chosen := random.RandomChoice(keys)
 
 	addr, key := chosen.Address, chosen.Key
@@ -521,7 +520,7 @@ func generateDeleteMetadata(ledger string, ls LedgerState) *servicepb.Request {
 // generateTxMetadataOp targets a committed transaction by reference: Delete
 // (~1/3) of an existing (reference, key), else Add. Returns nil when the model
 // holds no transactions yet (caller falls back to account metadata).
-func generateTxMetadataOp(ledger string, ls LedgerState) *servicepb.Request {
+func generateTxMetadataOp(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1, 2}) == 0 {
 		if req := generateDeleteTxMetadata(ledger, ls); req != nil {
 			return req
@@ -533,7 +532,7 @@ func generateTxMetadataOp(ledger string, ls LedgerState) *servicepb.Request {
 
 // generateAddTxMetadata sets 1-2 metadata keys on a committed transaction picked
 // by reference. Returns nil when no transaction exists yet.
-func generateAddTxMetadata(ledger string, ls LedgerState) *servicepb.Request {
+func generateAddTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	ref := pickTxRef(ls)
 	if ref == "" {
 		return nil
@@ -546,7 +545,7 @@ func generateAddTxMetadata(ledger string, ls LedgerState) *servicepb.Request {
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_AddMetadata{
 						AddMetadata: &commonpb.SaveMetadataCommand{
-							Target:   txTarget(ls.txRefs[ref].id),
+							Target:   txTarget(ls.TxRefs()[ref].Id()),
 							Metadata: randomMetaMap(),
 						},
 					},
@@ -559,9 +558,9 @@ func generateAddTxMetadata(ledger string, ls LedgerState) *servicepb.Request {
 // generateDeleteTxMetadata deletes a metadata key from a committed transaction —
 // occasionally a freshly-rolled key on a known reference to exercise
 // METADATA_NOT_FOUND. Returns nil when the model holds no transaction metadata.
-func generateDeleteTxMetadata(ledger string, ls LedgerState) *servicepb.Request {
-	keys := make([]TxMetaKey, 0, len(ls.txMeta))
-	for tk := range ls.txMeta {
+func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	keys := make([]oracle.TxMetaKey, 0, len(ls.TxMeta()))
+	for tk := range ls.TxMeta() {
 		keys = append(keys, tk)
 	}
 
@@ -569,7 +568,7 @@ func generateDeleteTxMetadata(ledger string, ls LedgerState) *servicepb.Request 
 		return nil
 	}
 
-	slices.SortFunc(keys, compareTxMetaKey)
+	slices.SortFunc(keys, oracle.CompareTxMetaKey)
 	chosen := random.RandomChoice(keys)
 
 	ref, key := chosen.Reference, chosen.Key
@@ -584,7 +583,7 @@ func generateDeleteTxMetadata(ledger string, ls LedgerState) *servicepb.Request 
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_DeleteMetadata{
 						DeleteMetadata: &commonpb.DeleteMetadataCommand{
-							Target: txTarget(ls.txRefs[ref].id),
+							Target: txTarget(ls.TxRefs()[ref].Id()),
 							Key:    key,
 						},
 					},
@@ -601,7 +600,7 @@ func generateDeleteTxMetadata(ledger string, ls LedgerState) *servicepb.Request 
 // committed reference exercises both the success path and the
 // TRANSACTION_ALREADY_REVERTED rejection (a reference picked after a prior
 // revert committed).
-func generateRevert(ledger string, ls LedgerState) *servicepb.Request {
+func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	ref := pickTxRef(ls)
 	if ref == "" {
 		return nil
@@ -614,7 +613,7 @@ func generateRevert(ledger string, ls LedgerState) *servicepb.Request {
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_RevertTransaction{
 						RevertTransaction: &servicepb.RevertTransactionPayload{
-							TransactionId: ls.txRefs[ref].id,
+							TransactionId: ls.TxRefs()[ref].Id(),
 							Force:         true,
 							ExpandVolumes: true,
 						},
@@ -627,9 +626,9 @@ func generateRevert(ledger string, ls LedgerState) *servicepb.Request {
 
 // pickTxRef returns a deterministically-chosen committed transaction reference,
 // or "" when the model holds none.
-func pickTxRef(ls LedgerState) string {
-	refs := make([]string, 0, len(ls.txRefs))
-	for r := range ls.txRefs {
+func pickTxRef(ls oracle.LedgerState) string {
+	refs := make([]string, 0, len(ls.TxRefs()))
+	for r := range ls.TxRefs() {
 		refs = append(refs, r)
 	}
 
@@ -680,9 +679,9 @@ func generateSaveLedgerMetadata(ledger string) *servicepb.Request {
 // DeleteLedgerMetadata of an existing key from the model — occasionally a
 // freshly-rolled key to exercise METADATA_NOT_FOUND. Returns nil when the ledger
 // holds no metadata.
-func generateDeleteLedgerMetadata(ledger string, ls LedgerState) *servicepb.Request {
-	keys := make([]string, 0, len(ls.ledgerMeta))
-	for k := range ls.ledgerMeta {
+func generateDeleteLedgerMetadata(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	keys := make([]string, 0, len(ls.LedgerMeta()))
+	for k := range ls.LedgerMeta() {
 		keys = append(keys, k)
 	}
 
@@ -708,7 +707,7 @@ func generateDeleteLedgerMetadata(ledger string, ls LedgerState) *servicepb.Requ
 
 // Picks Set (~3/4) vs Remove (~1/4) of a metadata field type. Remove falls back
 // to Set when the model declares no field types yet.
-func generateSchemaOp(ledger string, ls LedgerState) *servicepb.Request {
+func generateSchemaOp(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
 		if req := generateRemoveMetadataFieldType(ledger, ls); req != nil {
 			return req
@@ -737,20 +736,20 @@ func generateSetMetadataFieldType(ledger string) *servicepb.Request {
 // RemoveMetadataFieldType for a declared (target, key) from the model —
 // occasionally a freshly-rolled one (a no-op on the server). Returns nil when the
 // model declares no field types.
-func generateRemoveMetadataFieldType(ledger string, ls LedgerState) *servicepb.Request {
+func generateRemoveMetadataFieldType(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	type fieldRef struct {
 		target commonpb.TargetType
 		key    string
 	}
 
 	var fields []fieldRef
-	for k := range ls.accountFieldTypes {
+	for k := range ls.AccountFieldTypes() {
 		fields = append(fields, fieldRef{commonpb.TargetType_TARGET_TYPE_ACCOUNT, k})
 	}
-	for k := range ls.ledgerFieldTypes {
+	for k := range ls.LedgerFieldTypes() {
 		fields = append(fields, fieldRef{commonpb.TargetType_TARGET_TYPE_LEDGER, k})
 	}
-	for k := range ls.transactionFieldTypes {
+	for k := range ls.TransactionFieldTypes() {
 		fields = append(fields, fieldRef{commonpb.TargetType_TARGET_TYPE_TRANSACTION, k})
 	}
 
@@ -786,7 +785,7 @@ func generateRemoveMetadataFieldType(ledger string, ls LedgerState) *servicepb.R
 // 2-request fund+drain pair against a TRANSIENT-typed cell — exercises
 // the end-of-batch transient zero check. Returns nil if no TRANSIENT
 // type exists (other generators still cover other surfaces).
-func generateTransientBalancedBulk(ledger string, ls LedgerState) []*servicepb.Request {
+func generateTransientBalancedBulk(ledger string, ls oracle.LedgerState) []*servicepb.Request {
 	t := randomTransientType(ls)
 	if t == nil {
 		return nil
@@ -808,7 +807,7 @@ func generateTransientBalancedBulk(ledger string, ls LedgerState) []*servicepb.R
 
 // Single fund of a TRANSIENT cell, no drain — server is expected to
 // reject the bulk with ErrTransientAccountNonZero.
-func generateTransientUnbalancedBulk(ledger string, ls LedgerState) []*servicepb.Request {
+func generateTransientUnbalancedBulk(ledger string, ls oracle.LedgerState) []*servicepb.Request {
 	t := randomTransientType(ls)
 	if t == nil {
 		return nil

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -61,18 +61,22 @@ func generateBulk(g oracle.GlobalState, ledgers []string, receipts map[string]st
 	picks := pickLedgers(ledgers)
 
 	// Whole-bulk transient shapes fund and drain the same cell, so they only
-	// make sense single-ledger.
+	// make sense single-ledger. Gate them by the same back-pressure as
+	// generateTransaction so their unreferenced fund/drain records don't grow the
+	// log past the cap.
 	if len(picks) == 1 {
 		ledger := picks[0]
 		ls := g.Ledger(ledger)
-		switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}) {
-		case 0:
-			if reqs := generateTransientBalancedBulk(ledger, ls); reqs != nil {
-				return oracle.Bulk{Requests: reqs}
-			}
-		case 1:
-			if reqs := generateTransientUnbalancedBulk(ledger, ls); reqs != nil {
-				return oracle.Bulk{Requests: reqs}
+		if rollTransaction(ls) {
+			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}) {
+			case 0:
+				if reqs := generateTransientBalancedBulk(ledger, ls); reqs != nil {
+					return oracle.Bulk{Requests: reqs}
+				}
+			case 1:
+				if reqs := generateTransientUnbalancedBulk(ledger, ls); reqs != nil {
+					return oracle.Bulk{Requests: reqs}
+				}
 			}
 		}
 	}
@@ -131,10 +135,12 @@ func generateBulk(g oracle.GlobalState, ledgers []string, receipts map[string]st
 }
 
 // rollTransaction reports whether to create a new transaction, tapering with the
-// ledger's committed-transaction count (see the txEmit* knobs) so tracked
-// references don't grow without bound.
+// ledger's full transaction-log size (see the txEmit* knobs) so the log — every
+// entry of which candidateBases clones and hashes on each fold — doesn't grow
+// without bound. Counting only referenced transactions would miss the
+// unreferenced records (reverts, drains, transient helpers) that also accumulate.
 func rollTransaction(ls oracle.LedgerState) bool {
-	switch n := len(ls.TxByRef()); {
+	switch n := len(ls.Txs()); {
 	case n < txEmitFull:
 		return true
 	case n < txEmitTaper:

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -664,11 +664,13 @@ func generateDeleteTxMetadata(ledger string, ls oracle.LedgerState) *servicepb.R
 	}
 }
 
-// generateRevert reverts a committed transaction by reference, ~half of them
-// with force. A non-forced revert applies the balance floor to the reversed
-// postings — the reversed source is the original destination, which may since
-// have spent (or been purged of) the funds — so it also exercises the revert
-// path's INSUFFICIENT_FUNDS rejection. The server validates account types before
+// generateRevert reverts a committed transaction by reference, ~half with force
+// and ~half at the original's effective date (the revert then inherits the
+// original's timestamp — verifiable when the original carried a user-supplied
+// one). A non-forced revert applies the balance floor to the reversed postings —
+// the reversed source is the original destination, which may since have spent
+// (or been purged of) the funds — so it also exercises the revert path's
+// INSUFFICIENT_FUNDS rejection. The server validates account types before
 // the floor on reverts, so the oracle does the same (see applyRevert).
 // expand_volumes returns post-commit volumes for validation. Targeting any
 // committed reference exercises both the success path and the
@@ -683,7 +685,10 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	payload := &servicepb.RevertTransactionPayload{
 		TransactionId: uint64(ls.TxByRef()[ref]),
 		Force:         random.RandomChoice([]uint8{0, 1}) == 0,
-		ExpandVolumes: true,
+		// ~half at the original's effective date: the revert inherits the
+		// original's timestamp instead of the server's current date.
+		AtEffectiveDate: random.RandomChoice([]uint8{0, 1}) == 0,
+		ExpandVolumes:   true,
 	}
 
 	// ~half the reverts carry metadata on the revert transaction, echoed

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -346,7 +346,7 @@ func generateRejectedTransaction(ledger string, ls oracle.LedgerState) *servicep
 // emptyTransaction carries no postings and no script, so admission rejects it as
 // having no content source (VALIDATION).
 func emptyTransaction(ledger string) *servicepb.Request {
-	return applyCreate(ledger, &servicepb.CreateTransactionPayload{ExpandVolumes: true})
+	return applyCreate(ledger, &servicepb.CreateTransactionPayload{ExpandVolumes: expandVolumes()})
 }
 
 // duplicateReferenceTransaction reuses a committed reference; the FSM rejects it
@@ -361,7 +361,7 @@ func duplicateReferenceTransaction(ledger string, ls oracle.LedgerState) *servic
 	return applyCreate(ledger, &servicepb.CreateTransactionPayload{
 		Postings:      []*commonpb.Posting{commonpb.NewPosting("world", poolAddress(), assets[0], big.NewInt(1))},
 		Reference:     ref,
-		ExpandVolumes: true,
+		ExpandVolumes: expandVolumes(),
 	})
 }
 
@@ -377,7 +377,7 @@ func overflowTransaction(ledger string) *servicepb.Request {
 			commonpb.NewPosting("world", dst, assets[0], half),
 			commonpb.NewPosting("world", dst, assets[0], half),
 		},
-		ExpandVolumes: true,
+		ExpandVolumes: expandVolumes(),
 	})
 }
 
@@ -431,7 +431,7 @@ func txRequest(ledger, src, dest, asset string, amount *big.Int, force bool) *se
 								commonpb.NewPosting(src, dest, asset, amount),
 							},
 							Force:         force,
-							ExpandVolumes: true,
+							ExpandVolumes: expandVolumes(),
 						},
 					},
 				},
@@ -494,7 +494,7 @@ func generateDrainTransaction(ledger string, ls oracle.LedgerState) *servicepb.R
 								commonpb.NewPosting(srcKey.Address, "world", srcKey.Asset, balance.ToBig()),
 							},
 							Force:         true,
-							ExpandVolumes: true,
+							ExpandVolumes: expandVolumes(),
 						},
 					},
 				},

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -443,14 +443,35 @@ func generateMetadataOp(ledger string, ls oracle.LedgerState) *servicepb.Request
 	return generateAddMetadata(ledger)
 }
 
-// randomMetaMap builds a 1-2 key metadata map from the small value pool. Small
-// pools make concurrent sets of the same key to different values frequent — the
-// ordering chaos. Values are written as strings; a declared field type coerces.
+// randomMetaValue picks a value across every MetadataValue wire kind — string,
+// int64, uint64, bool, null, datetime — from the small pools. The server stores
+// values verbatim, so each kind must round-trip unchanged regardless of any
+// declared field type.
+func randomMetaValue() *commonpb.MetadataValue {
+	switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5}) {
+	case 0:
+		return commonpb.NewIntValue(random.RandomChoice(metaIntPool))
+	case 1:
+		return commonpb.NewUintValue(random.RandomChoice(metaUintPool))
+	case 2:
+		return commonpb.NewBoolValue(random.RandomChoice([]uint8{0, 1}) == 0)
+	case 3:
+		return commonpb.NewNullValue(random.RandomChoice(metaNullOriginalPool))
+	case 4:
+		return commonpb.NewDatetimeValue(random.RandomChoice(metaDatetimePool))
+	default:
+		return commonpb.NewStringValue(random.RandomChoice(metaValuePool))
+	}
+}
+
+// randomMetaMap builds a 1-2 key metadata map from the small key/value pools.
+// Small pools make concurrent sets of the same key to different values frequent
+// — the ordering chaos the model exists to check.
 func randomMetaMap() map[string]*commonpb.MetadataValue {
 	n := 1 + int(random.RandomChoice([]uint8{0, 1}))
 	md := make(map[string]*commonpb.MetadataValue, n)
 	for i := 0; i < n; i++ {
-		md[metaKey()] = commonpb.NewStringValue(random.RandomChoice(metaValuePool))
+		md[metaKey()] = randomMetaValue()
 	}
 
 	return md
@@ -660,11 +681,7 @@ func txTarget(id uint64) *commonpb.Target {
 // across all workers on the ledger, so concurrent sets of the same key to
 // different values are frequent — the ledger-level ordering chaos.
 func generateSaveLedgerMetadata(ledger string) *servicepb.Request {
-	n := 1 + int(random.RandomChoice([]uint8{0, 1}))
-	md := make(map[string]*commonpb.MetadataValue, n)
-	for i := 0; i < n; i++ {
-		md[metaKey()] = commonpb.NewStringValue(random.RandomChoice(metaValuePool))
-	}
+	md := randomMetaMap()
 
 	return &servicepb.Request{
 		Type: &servicepb.Request_SaveLedgerMetadata{

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -257,6 +257,16 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		payload.Metadata = randomMetaMap()
 	}
 
+	// ~1/3 also set account metadata via the transaction payload, applied
+	// atomically with the tx. Target the transaction's own destination: it
+	// already passes the posting chart check when the tx commits, so the
+	// account-metadata write never introduces a chart rejection.
+	if random.RandomChoice([]uint8{0, 1, 2}) == 0 {
+		payload.AccountMetadata = map[string]*commonpb.MetadataMap{
+			dest: {Values: randomMetaMap()},
+		}
+	}
+
 	return &servicepb.Request{
 		Type: &servicepb.Request_Apply{
 			Apply: &servicepb.LedgerApplyRequest{

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -278,6 +278,12 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		payload.Metadata = randomMetaMap()
 	}
 
+	// ~half also carry a user-supplied timestamp — stored verbatim and echoed on
+	// reads (it does not feed the HLC / log order). Backdated to stay non-future.
+	if random.RandomChoice([]uint8{0, 1}) == 0 {
+		payload.Timestamp = &commonpb.Timestamp{Data: 1 + internal.Rand().Uint64()%1_500_000_000_000_000}
+	}
+
 	// ~1/3 also set account metadata via the transaction payload, applied
 	// atomically with the tx. Target a posting's own destination: it already
 	// passes the posting chart check when the tx commits, so the account-metadata

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -627,17 +627,25 @@ func generateRevert(ledger string, ls oracle.LedgerState) *servicepb.Request {
 		return nil
 	}
 
+	payload := &servicepb.RevertTransactionPayload{
+		TransactionId: ls.TxRefs()[ref].Id(),
+		Force:         true,
+		ExpandVolumes: true,
+	}
+
+	// ~half the reverts carry metadata on the revert transaction, echoed
+	// verbatim on its log (see validateBulkSuccess's revert check).
+	if random.RandomChoice([]uint8{0, 1}) == 0 {
+		payload.Metadata = randomMetaMap()
+	}
+
 	return &servicepb.Request{
 		Type: &servicepb.Request_Apply{
 			Apply: &servicepb.LedgerApplyRequest{
 				Ledger: ledger,
 				Action: &servicepb.LedgerAction{
 					Data: &servicepb.LedgerAction_RevertTransaction{
-						RevertTransaction: &servicepb.RevertTransactionPayload{
-							TransactionId: ls.TxRefs()[ref].Id(),
-							Force:         true,
-							ExpandVolumes: true,
-						},
+						RevertTransaction: payload,
 					},
 				},
 			},

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -240,10 +240,11 @@ func randomTransientType(ls oracle.LedgerState) *oracle.TypeState {
 
 // --- Per-action generators ------------------------------------------------
 
-// A chaos posting between two blindly-picked pool addresses (source may be
-// "world"), amount and force rolled at random so the server resolves typing,
-// the balance floor, and — with force — overdrafts uniformly; or, ~1/4 of the
-// time, a deliberate drain of an EPHEMERAL cell to exercise the purge sweep.
+// A chaos transaction of 1–4 postings between blindly-picked pool addresses
+// (source may be "world"), amounts and force rolled at random so the server
+// resolves typing, the balance floor, intra-transaction posting composition,
+// and — with force — overdrafts uniformly; or, ~1/4 of the time, a deliberate
+// drain of an EPHEMERAL cell to exercise the purge sweep.
 func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
 		if req := generateDrainTransaction(ledger, ls); req != nil {
@@ -251,19 +252,22 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		}
 	}
 
-	src := sourceAddress()
-	dest := poolAddress()
-	asset := assets[int(random.RandomChoice([]uint8{0, 1, 2}))]
-	amount := internal.RandomBigInt()
 	// Force (~1/8) skips the balance floor, letting a non-world source overdraft.
 	force := random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7}) == 0
+
+	// 1–4 postings, each between blindly-picked accounts. Multiple postings
+	// commit atomically and compose in order — an earlier posting can fund a
+	// later one's source (the running balance floor is per-posting).
+	n := 1 + int(random.RandomChoice([]uint8{0, 1, 2, 3}))
+	postings := make([]*commonpb.Posting, n)
+	for i := range postings {
+		postings[i] = commonpb.NewPosting(sourceAddress(), poolAddress(), assets[int(random.RandomChoice([]uint8{0, 1, 2}))], internal.RandomBigInt())
+	}
 
 	// Every transaction gets a unique reference so it is targetable by later
 	// transaction-metadata writes. ~half also carry metadata at creation.
 	payload := &servicepb.CreateTransactionPayload{
-		Postings: []*commonpb.Posting{
-			commonpb.NewPosting(src, dest, asset, amount),
-		},
+		Postings:  postings,
 		Reference: txRef(),
 		Force:     force,
 		// Need PCV for validation.
@@ -275,12 +279,12 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 	}
 
 	// ~1/3 also set account metadata via the transaction payload, applied
-	// atomically with the tx. Target the transaction's own destination: it
-	// already passes the posting chart check when the tx commits, so the
-	// account-metadata write never introduces a chart rejection.
+	// atomically with the tx. Target a posting's own destination: it already
+	// passes the posting chart check when the tx commits, so the account-metadata
+	// write never introduces a chart rejection.
 	if random.RandomChoice([]uint8{0, 1, 2}) == 0 {
 		payload.AccountMetadata = map[string]*commonpb.MetadataMap{
-			dest: {Values: randomMetaMap()},
+			postings[n-1].GetDestination(): {Values: randomMetaMap()},
 		}
 	}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -41,6 +41,18 @@ func poolAddress() string {
 	return fmt.Sprintf("%s:%d", poolName(), internal.Rand().Uint64()%numIDsPerPrefix)
 }
 
+// sourceAddress picks a debit source without filtering on balance: "world"
+// (overdraftable) about half the time to keep accounts funded, otherwise any
+// pool address — most of which are underfunded, so a non-forced debit exercises
+// the INSUFFICIENT_FUNDS floor.
+func sourceAddress() string {
+	if random.RandomChoice([]uint8{0, 1}) == 0 {
+		return "world"
+	}
+
+	return poolAddress()
+}
+
 // generateBulk plans the next bulk. Most bulks target a single ledger;
 // occasionally a bulk spreads its requests across a few, exercising the
 // server's atomic-across-ledgers semantics. Reads the committed state but
@@ -228,9 +240,10 @@ func randomTransientType(ls oracle.LedgerState) *oracle.TypeState {
 
 // --- Per-action generators ------------------------------------------------
 
-// Either a chaos posting (world → pool address, picked blindly so the
-// server resolves typing) or — ~1/4 of the time — a deliberate drain
-// of an EPHEMERAL cell to exercise the zero-balance purge sweep.
+// A chaos posting between two blindly-picked pool addresses (source may be
+// "world"), amount and force rolled at random so the server resolves typing,
+// the balance floor, and — with force — overdrafts uniformly; or, ~1/4 of the
+// time, a deliberate drain of an EPHEMERAL cell to exercise the purge sweep.
 func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Request {
 	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
 		if req := generateDrainTransaction(ledger, ls); req != nil {
@@ -238,17 +251,21 @@ func generateTransaction(ledger string, ls oracle.LedgerState) *servicepb.Reques
 		}
 	}
 
+	src := sourceAddress()
 	dest := poolAddress()
 	asset := assets[int(random.RandomChoice([]uint8{0, 1, 2}))]
 	amount := internal.RandomBigInt()
+	// Force (~1/8) skips the balance floor, letting a non-world source overdraft.
+	force := random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7}) == 0
 
 	// Every transaction gets a unique reference so it is targetable by later
 	// transaction-metadata writes. ~half also carry metadata at creation.
 	payload := &servicepb.CreateTransactionPayload{
 		Postings: []*commonpb.Posting{
-			commonpb.NewPosting("world", dest, asset, amount),
+			commonpb.NewPosting(src, dest, asset, amount),
 		},
 		Reference: txRef(),
+		Force:     force,
 		// Need PCV for validation.
 		ExpandVolumes: true,
 	}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
 )
 
 // Checker drives validation against the model: it owns the in-flight/pending
@@ -31,7 +32,7 @@ type Checker struct {
 	// inflight: dispatched bulks whose response hasn't been observed yet, keyed
 	// by ticket (their dispatch order). The value is what the serialization
 	// search (candidateBases) folds.
-	inflight map[uint64]Bulk
+	inflight map[uint64]oracle.Bulk
 
 	// pending: observed successes not yet drained, sorted by minSeq.
 	pending []*pendingObservation
@@ -47,7 +48,7 @@ type Checker struct {
 	// drain in global log-sequence order, so it is always the exact predecessor
 	// of the next bulk to validate, and the base candidateBases folds the
 	// in-flight set onto.
-	modelState GlobalState
+	modelState oracle.GlobalState
 }
 
 // One worker → processor message. observeTicket is the ticket high-water mark
@@ -55,7 +56,7 @@ type Checker struct {
 // outstanding ops were dispatched after this bulk was observed.
 type observation struct {
 	ticket        uint64
-	bulk          Bulk
+	bulk          oracle.Bulk
 	resp          *servicepb.ApplyResponse
 	err           error
 	observeTicket uint64
@@ -72,9 +73,9 @@ type pendingObservation struct {
 func NewChecker(ledgerNames []string) *Checker {
 	return &Checker{
 		ledgerNames: ledgerNames,
-		inflight:    map[uint64]Bulk{},
+		inflight:    map[uint64]oracle.Bulk{},
 		reads:       map[uint64]struct{}{},
 		incoming:    make(chan observation, incomingBuffer),
-		modelState:  NewGlobalState(),
+		modelState:  oracle.NewGlobalState(),
 	}
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
 )
@@ -69,13 +70,41 @@ type pendingObservation struct {
 	obs    observation
 }
 
-// NewChecker returns an empty checker; caller spawns the processor goroutine.
-func NewChecker(ledgerNames []string) *Checker {
+// NewChecker returns a checker seeded with each ledger's initial metadata schema
+// (declared at creation, see setupLedgers); caller spawns the processor
+// goroutine. The schema is replayed as SetMetadataFieldType orders — the server
+// records the identical declared types at creation (populateInitialSchema), so
+// the model's schema state matches the server's from the first bulk.
+func NewChecker(ledgerNames []string, schemas map[string][]*commonpb.SetMetadataFieldTypeCommand) *Checker {
+	modelState := oracle.NewGlobalState()
+	for _, ledger := range ledgerNames {
+		cmds := schemas[ledger]
+		if len(cmds) == 0 {
+			continue
+		}
+
+		reqs := make([]*servicepb.Request, 0, len(cmds))
+		for _, cmd := range cmds {
+			reqs = append(reqs, &servicepb.Request{
+				Type: &servicepb.Request_SetMetadataFieldType{
+					SetMetadataFieldType: &servicepb.SetMetadataFieldTypeRequest{
+						Ledger:     ledger,
+						TargetType: cmd.GetTargetType(),
+						Key:        cmd.GetKey(),
+						Type:       cmd.GetType(),
+					},
+				},
+			})
+		}
+
+		modelState = modelState.Apply(oracle.Bulk{Requests: reqs}).State
+	}
+
 	return &Checker{
 		ledgerNames: ledgerNames,
 		inflight:    map[uint64]oracle.Bulk{},
 		reads:       map[uint64]struct{}{},
 		incoming:    make(chan observation, incomingBuffer),
-		modelState:  oracle.NewGlobalState(),
+		modelState:  modelState,
 	}
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
@@ -50,6 +50,12 @@ type Checker struct {
 	// of the next bulk to validate, and the base candidateBases folds the
 	// in-flight set onto.
 	modelState oracle.GlobalState
+
+	// receiptByRef maps a committed transaction's reference to the signed receipt
+	// the server returned for it, so generateRevert can exercise the
+	// receipt-carried revert path. Populated at commit (captureReceipts) and read
+	// during generation, both under mu.
+	receiptByRef map[string]string
 }
 
 // One worker → processor message. observeTicket is the ticket high-water mark
@@ -101,10 +107,11 @@ func NewChecker(ledgerNames []string, schemas map[string][]*commonpb.SetMetadata
 	}
 
 	return &Checker{
-		ledgerNames: ledgerNames,
-		inflight:    map[uint64]oracle.Bulk{},
-		reads:       map[uint64]struct{}{},
-		incoming:    make(chan observation, incomingBuffer),
-		modelState:  modelState,
+		ledgerNames:  ledgerNames,
+		inflight:     map[uint64]oracle.Bulk{},
+		reads:        map[uint64]struct{}{},
+		incoming:     make(chan observation, incomingBuffer),
+		modelState:   modelState,
+		receiptByRef: map[string]string{},
 	}
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
@@ -65,6 +65,19 @@ var metaValuePool = []string{
 	"200", "-1", "-200", "40000", "5000000000", "030",
 }
 
+// Typed-value pools, used alongside metaValuePool so metadata writes exercise
+// every MetadataValue wire kind, not just strings. The server stores values
+// verbatim (a declared field type is an index hint, not applied on read), so
+// each kind must round-trip unchanged. Small pools keep same-key collisions
+// frequent. Values straddle the sized-int boundaries and include zero, negative,
+// and pre-1970 datetimes.
+var (
+	metaIntPool          = []int64{0, 1, -1, 42, -200, 5000000000}
+	metaUintPool         = []uint64{0, 1, 42, 200, 40000, 5000000000}
+	metaDatetimePool     = []int64{0, 1, -1000000, 1700000000000000} // microseconds since the Unix epoch
+	metaNullOriginalPool = []string{"", "null", "030"}
+)
+
 // Field types declared by SetMetadataFieldType (string, bool, every
 // signed/unsigned int width), exercising the schema declare/retype apply path.
 var metaTypePool = []commonpb.MetadataType{

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
@@ -78,8 +78,9 @@ var (
 	metaNullOriginalPool = []string{"", "null", "030"}
 )
 
-// Field types declared by SetMetadataFieldType (string, bool, every
-// signed/unsigned int width), exercising the schema declare/retype apply path.
+// Field types declared by SetMetadataFieldType (string, bool, datetime, and
+// every signed/unsigned int width), exercising the schema declare/retype apply
+// path across the full MetadataType set.
 var metaTypePool = []commonpb.MetadataType{
 	commonpb.MetadataType_METADATA_TYPE_STRING,
 	commonpb.MetadataType_METADATA_TYPE_INT64,
@@ -91,6 +92,7 @@ var metaTypePool = []commonpb.MetadataType{
 	commonpb.MetadataType_METADATA_TYPE_UINT8,
 	commonpb.MetadataType_METADATA_TYPE_UINT16,
 	commonpb.MetadataType_METADATA_TYPE_UINT32,
+	commonpb.MetadataType_METADATA_TYPE_DATETIME,
 }
 
 // Targets whose metadata schema the model tracks.

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
-	"github.com/formancehq/ledger/v3/tests/oracle"
 	"log"
 	"os"
 	"sort"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
 )
 
 // MODEL_DEBUG=1 enables verbose per-transaction logging.
@@ -19,6 +20,24 @@ func dbg(format string, args ...any) {
 	if modelDebug {
 		log.Printf("[model-debug] "+format, args...)
 	}
+}
+
+// MODEL_DUMP_BATCHES=1 dumps each committed ApplyRequest (base64 vtproto) keyed
+// by its min committed log sequence, so the exact full sequence can be replayed
+// deterministically through the oracle (see tests/oracle/cmd/replay).
+var dumpBatches = os.Getenv("MODEL_DUMP_BATCHES") != ""
+
+func dumpBatch(seq uint64, req *servicepb.ApplyRequest) {
+	if !dumpBatches {
+		return
+	}
+
+	b, err := req.MarshalVT()
+	if err != nil {
+		return
+	}
+
+	log.Printf("[batch-dump] seq=%d b64=%s", seq, base64.StdEncoding.EncodeToString(b))
 }
 
 // Distinct ledgers a bulk touches, sorted — for debug lines.

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -202,6 +202,25 @@ func (c *Checker) modelLedgerMetaDump(ledger string) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
+// modelTxMetaDump renders the committed model's metadata for the transaction at
+// reference ref. Acquires c.mu.
+func (c *Checker) modelTxMetaDump(ledger, ref string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ls := c.modelState.Ledger(ledger)
+
+	var parts []string
+	for tk, v := range ls.TxMeta() {
+		if tk.Reference == ref {
+			parts = append(parts, tk.Key+"="+oracle.MetaValueString(v))
+		}
+	}
+	sort.Strings(parts)
+
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
 // Server log sequences — for verifying drain order vs commit order.
 func logSeqs(logs []*commonpb.Log) string {
 	ids := make([]string, len(logs))

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -8,9 +8,13 @@ import (
 	"sort"
 	"strings"
 
+	"google.golang.org/grpc/status"
+
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
 // MODEL_DEBUG=1 enables verbose per-transaction logging.
@@ -22,22 +26,42 @@ func dbg(format string, args ...any) {
 	}
 }
 
-// MODEL_DUMP_BATCHES=1 dumps each committed ApplyRequest (base64 vtproto) keyed
-// by its min committed log sequence, so the exact full sequence can be replayed
-// deterministically through the oracle (see tests/oracle/cmd/replay).
+// MODEL_DUMP_BATCHES=1 dumps every submitted ApplyRequest (base64 vtproto) with
+// its dispatch ticket, the server's outcome (OK / a rejection reason / TRANSIENT),
+// and — for committed bulks — its min committed log sequence. The replay tool
+// (tests/oracle/cmd/replay) uses this two ways: sorted by log sequence over the
+// committed (OK) bulks it reconstructs a concurrent run's true serialization;
+// sorted by dispatch ticket over all bulks — valid only single-worker, where
+// dispatch order IS the serialization — it compares each bulk's model outcome to
+// the server's, reproducing a divergence deterministically.
 var dumpBatches = os.Getenv("MODEL_DUMP_BATCHES") != ""
 
-func dumpBatch(seq uint64, req *servicepb.ApplyRequest) {
+func dumpBatch(ticket uint64, req *servicepb.ApplyRequest, resp *servicepb.ApplyResponse, err error) {
 	if !dumpBatches {
 		return
 	}
 
-	b, err := req.MarshalVT()
-	if err != nil {
+	outcome := "OK"
+	var seq uint64
+	switch {
+	case err != nil && (internal.IsTransient(err) || isShutdownError(err)):
+		outcome = "TRANSIENT"
+	case err != nil:
+		if r := internal.ErrorReason(err); r != "" {
+			outcome = r
+		} else {
+			outcome = "ERR:" + status.Code(err).String()
+		}
+	default:
+		seq = minLogSequence(resp.GetLogs())
+	}
+
+	b, mErr := req.MarshalVT()
+	if mErr != nil {
 		return
 	}
 
-	log.Printf("[batch-dump] seq=%d b64=%s", seq, base64.StdEncoding.EncodeToString(b))
+	log.Printf("[batch-dump] ticket=%d seq=%d outcome=%s b64=%s", ticket, seq, outcome, base64.StdEncoding.EncodeToString(b))
 }
 
 // Distinct ledgers a bulk touches, sorted — for debug lines.
@@ -135,6 +159,79 @@ func bulkMeta(b oracle.Bulk) string {
 	}
 
 	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// typeOps renders the add/remove-account-type ops a bulk carries ("+name" /
+// "-name"), or "" if it carries none.
+func typeOps(b oracle.Bulk) string {
+	var ops []string
+	for _, r := range b.Requests {
+		switch t := r.GetType().(type) {
+		case *servicepb.Request_AddAccountType:
+			ops = append(ops, "+"+t.AddAccountType.GetAccountType().GetName())
+		case *servicepb.Request_RemoveAccountType:
+			ops = append(ops, "-"+t.RemoveAccountType.GetName())
+		}
+	}
+
+	return strings.Join(ops, "")
+}
+
+// failureDiag renders a failed bulk's transaction postings, the model's declared
+// account types for the ledgers it touches, and the type-ops sitting in the
+// pending/inflight buffer (with their ticket vs the failure's maxTicket) — so an
+// unexplained-failure finding shows which address the model treats as unmatched,
+// whether a type for it exists in the committed model, and whether a folding
+// candidate (an addType) is available in the buffer. Caller holds c.mu.
+func (c *Checker) failureDiag(b oracle.Bulk, maxTicket uint64) (postings, modelTypes, buffered string) {
+	var ps []string
+	ledgers := map[string]bool{}
+	for _, r := range b.Requests {
+		l := oracle.LedgerOf(r)
+		ledgers[l] = true
+		if ct := r.GetApply().GetAction().GetCreateTransaction(); ct != nil {
+			for _, p := range ct.GetPostings() {
+				ps = append(ps, fmt.Sprintf("%s:%s->%s(%s)", l, p.GetSource(), p.GetDestination(), p.GetAsset()))
+			}
+		}
+	}
+
+	var types []string
+	for l := range ledgers {
+		var names []string
+		for n, t := range c.modelState.Ledger(l).Types() {
+			names = append(names, fmt.Sprintf("%s(%s)", n, t.Pattern))
+		}
+		sort.Strings(names)
+		types = append(types, l+"=["+strings.Join(names, ",")+"]")
+	}
+	sort.Strings(types)
+
+	within := func(t uint64) string {
+		if t <= maxTicket {
+			return "≤"
+		}
+
+		return ">"
+	}
+
+	var pend, infl []string
+	for _, pe := range c.pending {
+		if ops := typeOps(pe.obs.bulk); ops != "" {
+			pend = append(pend, fmt.Sprintf("t%d%s%s", pe.obs.ticket, within(pe.obs.ticket), ops))
+		}
+	}
+	for tkt, bulk := range c.inflight {
+		if ops := typeOps(bulk); ops != "" {
+			infl = append(infl, fmt.Sprintf("t%d%s%s", tkt, within(tkt), ops))
+		}
+	}
+	sort.Strings(pend)
+	sort.Strings(infl)
+
+	buffered = fmt.Sprintf("max=%d pendingTypeOps=[%s] inflightTypeOps=[%s]", maxTicket, strings.Join(pend, " "), strings.Join(infl, " "))
+
+	return "[" + strings.Join(ps, " ") + "]", "[" + strings.Join(types, " ") + "]", buffered
 }
 
 // metaTargetLabel renders a metadata target for debug output: the account address

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -221,6 +221,29 @@ func (c *Checker) modelTxMetaDump(ledger, ref string) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
+// modelSchemaDump renders the committed model's declared field types per target
+// (a=account, t=transaction, l=ledger). Acquires c.mu.
+func (c *Checker) modelSchemaDump(ledger string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ls := c.modelState.Ledger(ledger)
+
+	render := func(tag string, m map[string]commonpb.MetadataType) string {
+		parts := make([]string, 0, len(m))
+		for k, t := range m {
+			parts = append(parts, fmt.Sprintf("%s/%s=%d", tag, k, t))
+		}
+		sort.Strings(parts)
+
+		return strings.Join(parts, ",")
+	}
+
+	return "[" + render("a", ls.AccountFieldTypes()) +
+		" " + render("t", ls.TransactionFieldTypes()) +
+		" " + render("l", ls.LedgerFieldTypes()) + "]"
+}
+
 // Server log sequences — for verifying drain order vs commit order.
 func logSeqs(logs []*commonpb.Log) string {
 	ids := make([]string, len(logs))

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/formancehq/ledger/v3/tests/oracle"
 	"log"
 	"os"
 	"sort"
@@ -21,11 +22,11 @@ func dbg(format string, args ...any) {
 }
 
 // Distinct ledgers a bulk touches, sorted — for debug lines.
-func bulkLedgers(b Bulk) string {
+func bulkLedgers(b oracle.Bulk) string {
 	seen := map[string]bool{}
 	var names []string
 	for _, r := range b.Requests {
-		l := ledgerOf(r)
+		l := oracle.LedgerOf(r)
 		if !seen[l] {
 			seen[l] = true
 			names = append(names, l)
@@ -36,7 +37,7 @@ func bulkLedgers(b Bulk) string {
 	return "[" + strings.Join(names, ",") + "]"
 }
 
-func requestKinds(b Bulk) string {
+func requestKinds(b oracle.Bulk) string {
 	parts := make([]string, len(b.Requests))
 
 	for i, r := range b.Requests {
@@ -76,7 +77,7 @@ func requestKinds(b Bulk) string {
 
 // Metadata targets a bulk touches, for debug: account (add addr{k=v,...} /
 // del addr/key) and ledger (saveL ledger{k=v,...} / delL ledger/key).
-func bulkMeta(b Bulk) string {
+func bulkMeta(b oracle.Bulk) string {
 	kvList := func(m map[string]*commonpb.MetadataValue) string {
 		kvs := make([]string, 0, len(m))
 		for k, v := range m {
@@ -134,7 +135,7 @@ func metaTargetLabel(target *commonpb.Target) string {
 func renderMetaMap(m map[string]*commonpb.MetadataValue) string {
 	parts := make([]string, 0, len(m))
 	for k, v := range m {
-		parts = append(parts, k+"="+metaValueString(v))
+		parts = append(parts, k+"="+oracle.MetaValueString(v))
 	}
 	sort.Strings(parts)
 
@@ -147,15 +148,15 @@ func (c *Checker) modelAccountMetaDump(ledger, addr string) string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	ls := c.modelState.ledger(ledger)
+	ls := c.modelState.Ledger(ledger)
 
 	var parts []string
-	for k, v := range ls.accountMetadata(addr) {
+	for k, v := range ls.AccountMetadata(addr) {
 		ft := "none"
-		if t, ok := ls.accountFieldTypes[k]; ok {
+		if t, ok := ls.AccountFieldTypes()[k]; ok {
 			ft = fmt.Sprintf("%d", t)
 		}
-		parts = append(parts, fmt.Sprintf("%s=%s[ft=%s]", k, metaValueString(v), ft))
+		parts = append(parts, fmt.Sprintf("%s=%s[ft=%s]", k, oracle.MetaValueString(v), ft))
 	}
 	sort.Strings(parts)
 
@@ -167,15 +168,15 @@ func (c *Checker) modelLedgerMetaDump(ledger string) string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	ls := c.modelState.ledger(ledger)
+	ls := c.modelState.Ledger(ledger)
 
 	var parts []string
-	for k, v := range ls.ledgerMeta {
+	for k, v := range ls.LedgerMeta() {
 		ft := "none"
-		if t, ok := ls.ledgerFieldTypes[k]; ok {
+		if t, ok := ls.LedgerFieldTypes()[k]; ok {
 			ft = fmt.Sprintf("%d", t)
 		}
-		parts = append(parts, fmt.Sprintf("%s=%s[ft=%s]", k, metaValueString(v), ft))
+		parts = append(parts, fmt.Sprintf("%s=%s[ft=%s]", k, oracle.MetaValueString(v), ft))
 	}
 	sort.Strings(parts)
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -202,23 +202,25 @@ func (c *Checker) modelLedgerMetaDump(ledger string) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
-// modelTxMetaDump renders the committed model's metadata for the transaction at
-// reference ref. Acquires c.mu.
-func (c *Checker) modelTxMetaDump(ledger, ref string) string {
+// modelTxDump renders the committed model's transaction at id (reference,
+// reverted, metadata), or "<absent>" if the log has no such id. Acquires c.mu.
+func (c *Checker) modelTxDump(ledger string, id uint64) string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	ls := c.modelState.Ledger(ledger)
+	txs := c.modelState.Ledger(ledger).Txs()
+	if id == 0 || id > uint64(len(txs)) {
+		return "<absent>"
+	}
 
-	var parts []string
-	for tk, v := range ls.TxMeta() {
-		if tk.Reference == ref {
-			parts = append(parts, tk.Key+"="+oracle.MetaValueString(v))
-		}
+	tx := txs[id-1]
+	parts := make([]string, 0, len(tx.Metadata()))
+	for k, v := range tx.Metadata() {
+		parts = append(parts, k+"="+oracle.MetaValueString(v))
 	}
 	sort.Strings(parts)
 
-	return "{" + strings.Join(parts, ",") + "}"
+	return fmt.Sprintf("{ref=%q reverted=%v meta={%s}}", tx.Reference(), tx.Reverted(), strings.Join(parts, ","))
 }
 
 // modelSchemaDump renders the committed model's declared field types per target

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -317,7 +317,8 @@ func (c *Checker) modelTxDump(ledger string, id uint64) string {
 	}
 	sort.Strings(parts)
 
-	return fmt.Sprintf("{ref=%q reverted=%v meta={%s}}", tx.Reference(), tx.Reverted(), strings.Join(parts, ","))
+	return fmt.Sprintf("{ref=%q reverted=%v revBy=%d reverts=%d meta={%s}}",
+		tx.Reference(), tx.Reverted(), tx.RevertedBy(), tx.RevertsTransaction(), strings.Join(parts, ","))
 }
 
 // modelSchemaDump renders the committed model's declared field types per target

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -100,7 +100,7 @@ func bulkMeta(b oracle.Bulk) string {
 	kvList := func(m map[string]*commonpb.MetadataValue) string {
 		kvs := make([]string, 0, len(m))
 		for k, v := range m {
-			kvs = append(kvs, k+"="+v.GetStringValue())
+			kvs = append(kvs, k+"="+oracle.MetaValueString(v))
 		}
 		sort.Strings(kvs)
 		return strings.Join(kvs, ",")

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -174,7 +174,7 @@ func runWorker(
 		}
 
 		c.mu.Lock()
-		bulk := generateBulk(c.modelState, c.ledgerNames)
+		bulk := generateBulk(c.modelState, c.ledgerNames, c.receiptByRef)
 		if len(bulk.Requests) == 0 {
 			c.mu.Unlock()
 			continue

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/random"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
@@ -96,11 +97,19 @@ func main() {
 	runID := fmt.Sprintf("%016x", internal.Rand().Uint64())
 	names := ledgerNames(runID, numLedgers)
 
-	if !setupLedgers(ctx, client, names) {
+	// Each ledger is created with a small, random initial metadata schema; the
+	// checker seeds the same declarations so the model's schema state matches
+	// the server's from the first bulk.
+	schemas := make(map[string][]*commonpb.SetMetadataFieldTypeCommand, len(names))
+	for _, name := range names {
+		schemas[name] = initialSchema()
+	}
+
+	if !setupLedgers(ctx, client, names, schemas) {
 		return
 	}
 
-	checker := NewChecker(names)
+	checker := NewChecker(names, schemas)
 
 	// No seed type — workers fill the chart organically; early txs at
 	// untyped prefixes fail ACCOUNT_NOT_MATCHING_TYPE and validate fine.
@@ -197,6 +206,26 @@ func runWorker(
 	}
 }
 
+// initialSchema generates a small, random metadata schema declared at ledger
+// creation via CreateLedger's initial_schema: 0-3 field types across targets,
+// keys, and types from the same pools the runtime schema ops use. NewChecker
+// seeds the same declarations so the model's schema state matches the server's
+// from the start. Declaring a type creates no index (populateInitialSchema only
+// records the schema), so a later remove drops nothing.
+func initialSchema() []*commonpb.SetMetadataFieldTypeCommand {
+	n := int(random.RandomChoice([]uint8{0, 1, 2, 3}))
+	cmds := make([]*commonpb.SetMetadataFieldTypeCommand, 0, n)
+	for i := 0; i < n; i++ {
+		cmds = append(cmds, &commonpb.SetMetadataFieldTypeCommand{
+			TargetType: random.RandomChoice(metaTargetPool),
+			Key:        metaKey(),
+			Type:       random.RandomChoice(metaTypePool),
+		})
+	}
+
+	return cmds
+}
+
 // Per-run fleet names: model-<runID>-0, model-<runID>-1, ... PrefixModel
 // is in internal.ownedLedgerPrefixes so generic drivers skip them.
 func ledgerNames(runID string, n int) []string {
@@ -230,9 +259,9 @@ func envInt(key string, def int) int {
 // missing ledger, so it asserts Unreachable. Shutdown (ctx cancelled) is teardown,
 // not a finding. Returns false to stop the run; the chart is left empty for
 // workers to fill.
-func setupLedgers(ctx context.Context, client servicepb.BucketServiceClient, names []string) bool {
+func setupLedgers(ctx context.Context, client servicepb.BucketServiceClient, names []string, schemas map[string][]*commonpb.SetMetadataFieldTypeCommand) bool {
 	for _, name := range names {
-		err := internal.CreateLedger(ctx, client, name)
+		err := internal.CreateLedger(ctx, client, name, schemas[name]...)
 		if err == nil {
 			continue
 		}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -14,9 +14,10 @@
 //
 // Layout:
 //
-//   - model.go: LedgerState (per-ledger sub-state) + GlobalState + the pure
-//     forward Apply that predicts the server's outcome for a bulk — the model. A
-//     bulk may span ledgers; Apply is atomic across them.
+//   - the model itself is the oracle package (tests/oracle): LedgerState
+//     (per-ledger sub-state) + GlobalState + the pure forward Apply that predicts
+//     the server's outcome for a bulk. A bulk may span ledgers; Apply is atomic
+//     across them. This driver imports it as `oracle`.
 //   - checker.go: Checker — the harness bookkeeping (in-flight/pending re-order
 //     buffer, modelState).
 //   - processor.go: one goroutine; re-orders observed responses by log sequence
@@ -44,7 +45,9 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/random"
+
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
@@ -164,7 +167,7 @@ func runWorker(
 		ticket := c.registerInflight(bulk)
 		c.mu.Unlock()
 
-		resp, err := client.Apply(ctx, bulk.ApplyRequest())
+		resp, err := client.Apply(ctx, applyRequest(bulk))
 
 		// Snapshot the ticket high-water at observe (lock-free, atomic counter);
 		// the drain gate compares outstanding tickets against it (see tryDrain).

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -154,16 +154,18 @@ func runWorker(
 		}
 
 		// 1-in-5: a read this iteration, split across the whole-ledger read
-		// (chart + ledger metadata), a single-account read, and a transaction
-		// read (id + postings + reverted + metadata). Reads validate against the
-		// in-flight bulk set, exercising cross-node freshness without needing
-		// quiescence.
+		// (chart + ledger metadata), a single-account read, a transaction read
+		// (id + postings + reverted + metadata), and a metadata-schema read
+		// (declared field types). Reads validate against the in-flight bulk set,
+		// exercising cross-node freshness without needing quiescence.
 		if random.RandomChoice([]uint8{0, 1, 2, 3, 4}) == 0 {
-			switch random.RandomChoice([]uint8{0, 1, 2, 3}) {
+			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4}) {
 			case 0:
 				runLedgerRead(ctx, client, c)
 			case 1:
 				runTransactionRead(ctx, client, c)
+			case 2:
+				runSchemaRead(ctx, client, c)
 			default:
 				runRead(ctx, client, c)
 			}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -153,14 +153,18 @@ func runWorker(
 		default:
 		}
 
-		// 1-in-5: a read this iteration — 1-in-3 of those a whole-ledger read
-		// (chart + ledger metadata), the rest a single-account read. Reads
-		// validate against the in-flight bulk set, exercising cross-node freshness
-		// without needing quiescence.
+		// 1-in-5: a read this iteration, split across the whole-ledger read
+		// (chart + ledger metadata), a single-account read, and a transaction
+		// read (id + postings + reverted + metadata). Reads validate against the
+		// in-flight bulk set, exercising cross-node freshness without needing
+		// quiescence.
 		if random.RandomChoice([]uint8{0, 1, 2, 3, 4}) == 0 {
-			if random.RandomChoice([]uint8{0, 1, 2}) == 0 {
+			switch random.RandomChoice([]uint8{0, 1, 2, 3}) {
+			case 0:
 				runLedgerRead(ctx, client, c)
-			} else {
+			case 1:
+				runTransactionRead(ctx, client, c)
+			default:
 				runRead(ctx, client, c)
 			}
 			time.Sleep(workerLoopPause)

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -182,7 +182,10 @@ func runWorker(
 		ticket := c.registerInflight(bulk)
 		c.mu.Unlock()
 
-		resp, err := client.Apply(ctx, applyRequest(bulk))
+		req := applyRequest(bulk)
+		resp, err := client.Apply(ctx, req)
+
+		dumpBatch(ticket, req, resp, err)
 
 		// Snapshot the ticket high-water at observe (lock-free, atomic counter);
 		// the drain gate compares outstanding tickets against it (see tryDrain).

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
@@ -4,13 +4,15 @@ import (
 	"context"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
 // registerInflight reserves a ticket and records the bulk. Must run BEFORE the
 // Apply: the ticket is the dispatch order tryDrain relies on, and the bulk is
 // what the serialization search (candidateBases) folds. Caller holds c.mu.
-func (c *Checker) registerInflight(bulk Bulk) uint64 {
+func (c *Checker) registerInflight(bulk oracle.Bulk) uint64 {
 	t := c.ticketSeq.Add(1)
 	c.inflight[t] = bulk
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -179,56 +179,30 @@ func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c 
 	c.validateLedgerRead(maxTicket, ledger, info.GetAccountTypes(), info.GetMetadata())
 }
 
-// pickTransaction returns a committed transaction to read back, as
-// (ledger, reference, id), or ok=false when the model tracks none. Only
-// referenced transactions are tracked; drain/transient transactions set no
-// reference and so are unreadable by reference here.
-func pickTransaction(g oracle.GlobalState) (ledger, ref string, id uint64, ok bool) {
-	type txRef struct {
-		ledger string
-		ref    string
-		id     uint64
+// pickTransactionID picks a ledger and a transaction id to read back, probing up
+// to a small slack past the committed frontier so the id may land on a committed
+// transaction, an in-flight one, or an unassigned id (a legal NotFound).
+// ok=false only before any ledger exists.
+func pickTransactionID(g oracle.GlobalState, ledgers []string) (ledger string, id uint64, ok bool) {
+	if len(ledgers) == 0 {
+		return "", 0, false
 	}
 
-	var txs []txRef
-	for name, ls := range g.Ledgers() {
-		for r, rec := range ls.TxRefs() {
-			txs = append(txs, txRef{ledger: name, ref: r, id: rec.Id()})
-		}
-	}
+	ledger = random.RandomChoice(ledgers)
+	const slack = 8
+	frontier := uint64(len(g.Ledger(ledger).Txs()))
+	id = 1 + internal.Rand().Uint64()%(frontier+slack)
 
-	if len(txs) == 0 {
-		return "", "", 0, false
-	}
-
-	slices.SortFunc(txs, func(a, b txRef) int {
-		if a.ledger != b.ledger {
-			if a.ledger < b.ledger {
-				return -1
-			}
-			return 1
-		}
-		if a.ref < b.ref {
-			return -1
-		}
-		if a.ref > b.ref {
-			return 1
-		}
-		return 0
-	})
-
-	c := random.RandomChoice(txs)
-
-	return c.ledger, c.ref, c.id, true
+	return ledger, id, true
 }
 
-// runTransactionRead issues a linearizable GetTransaction on a committed
-// transaction and checks the server's snapshot — id, reverted flag, postings,
-// and whole metadata map — against the model (see validateTransactionRead). This
-// is the only path that reads accumulated transaction metadata back.
+// runTransactionRead issues a linearizable GetTransaction on a probed id and
+// checks the observation — a returned transaction, or NotFound — against the
+// model (see validateTransactionRead). This is the only path that reads
+// accumulated transaction metadata back.
 func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	c.mu.Lock()
-	ledger, ref, id, ok := pickTransaction(c.modelState)
+	ledger, id, ok := pickTransactionID(c.modelState, c.ledgerNames)
 	if !ok {
 		c.mu.Unlock()
 		return
@@ -246,18 +220,21 @@ func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClien
 		if internal.IsTransient(err) || isShutdownError(err) {
 			return
 		}
-		// The transaction is committed (drained into modelState), so a definitive
-		// error on a linearizable read — NotFound, Internal — is a real finding.
+		// NotFound is a legal outcome for an id not committed in the actual
+		// serialization — validate it like a returned transaction, not a finding.
+		if status.Code(err) == codes.NotFound {
+			c.validateTransactionRead(maxTicket, ledger, id, nil, false)
+			return
+		}
 		assert.Unreachable("singleton_driver_model: GetTransaction returned unexpected error", internal.Details{
-			"ledger":    ledger,
-			"reference": ref,
-			"id":        id,
-			"error":     err.Error(),
+			"ledger": ledger,
+			"id":     id,
+			"error":  err.Error(),
 		})
 		return
 	}
 
-	c.validateTransactionRead(maxTicket, ledger, ref, resp.GetTransaction())
+	c.validateTransactionRead(maxTicket, ledger, id, resp.GetTransaction(), true)
 }
 
 // runSchemaRead issues a GetMetadataSchemaStatus and checks the declared metadata

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -178,3 +178,84 @@ func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c 
 
 	c.validateLedgerRead(maxTicket, ledger, info.GetAccountTypes(), info.GetMetadata())
 }
+
+// pickTransaction returns a committed transaction to read back, as
+// (ledger, reference, id), or ok=false when the model tracks none. Only
+// referenced transactions are tracked; drain/transient transactions set no
+// reference and so are unreadable by reference here.
+func pickTransaction(g oracle.GlobalState) (ledger, ref string, id uint64, ok bool) {
+	type txRef struct {
+		ledger string
+		ref    string
+		id     uint64
+	}
+
+	var txs []txRef
+	for name, ls := range g.Ledgers() {
+		for r, rec := range ls.TxRefs() {
+			txs = append(txs, txRef{ledger: name, ref: r, id: rec.Id()})
+		}
+	}
+
+	if len(txs) == 0 {
+		return "", "", 0, false
+	}
+
+	slices.SortFunc(txs, func(a, b txRef) int {
+		if a.ledger != b.ledger {
+			if a.ledger < b.ledger {
+				return -1
+			}
+			return 1
+		}
+		if a.ref < b.ref {
+			return -1
+		}
+		if a.ref > b.ref {
+			return 1
+		}
+		return 0
+	})
+
+	c := random.RandomChoice(txs)
+
+	return c.ledger, c.ref, c.id, true
+}
+
+// runTransactionRead issues a linearizable GetTransaction on a committed
+// transaction and checks the server's snapshot — id, reverted flag, postings,
+// and whole metadata map — against the model (see validateTransactionRead). This
+// is the only path that reads accumulated transaction metadata back.
+func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	c.mu.Lock()
+	ledger, ref, id, ok := pickTransaction(c.modelState)
+	if !ok {
+		c.mu.Unlock()
+		return
+	}
+	readID := c.registerRead()
+	c.mu.Unlock()
+	defer c.finishRead(readID)
+
+	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
+	resp, err := client.GetTransaction(readCtx, &servicepb.GetTransactionRequest{Ledger: ledger, TransactionId: id})
+	// High-water at the read's response: only bulks dispatched by now could be
+	// reflected in what the server returned.
+	maxTicket := c.ticketSeq.Load()
+	if err != nil {
+		if internal.IsTransient(err) || isShutdownError(err) {
+			return
+		}
+		// The transaction is committed (drained into modelState), so a definitive
+		// error on a linearizable read — NotFound, Internal — is a real finding.
+		assert.Unreachable("singleton_driver_model: GetTransaction returned unexpected error", internal.Details{
+			"ledger":    ledger,
+			"reference": ref,
+			"id":        id,
+			"error":     err.Error(),
+		})
+		return
+	}
+
+	c.validateTransactionRead(maxTicket, ledger, ref, resp.GetTransaction())
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -6,13 +6,16 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/random"
-	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
-	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
-	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 	"github.com/holiman/uint256"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
 // runRead picks a known account, issues a linearizable GetAccount, and validates
@@ -81,24 +84,24 @@ func isShutdownError(err error) bool {
 // candidate (carrying its asset); each metadata-bearing address is also a
 // candidate with an empty asset, so a metadata-only account is still reachable —
 // the read validates that account's metadata regardless of the asset.
-func pickCell(g GlobalState) (ledger, addr, asset string, ok bool) {
+func pickCell(g oracle.GlobalState) (ledger, addr, asset string, ok bool) {
 	type cellRef struct {
 		ledger string
-		key    VolumeKey
+		key    oracle.VolumeKey
 	}
 
 	var cells []cellRef
-	for name, ls := range g.ledgers {
-		for k := range ls.volumes {
+	for name, ls := range g.Ledgers() {
+		for k := range ls.Volumes() {
 			cells = append(cells, cellRef{ledger: name, key: k})
 		}
 
 		metaAddrs := map[string]bool{}
-		for mk := range ls.metadata {
+		for mk := range ls.Metadata() {
 			metaAddrs[mk.Address] = true
 		}
 		for a := range metaAddrs {
-			cells = append(cells, cellRef{ledger: name, key: VolumeKey{Address: a}})
+			cells = append(cells, cellRef{ledger: name, key: oracle.VolumeKey{Address: a}})
 		}
 	}
 
@@ -113,7 +116,7 @@ func pickCell(g GlobalState) (ledger, addr, asset string, ok bool) {
 			}
 			return 1
 		}
-		return compareVolumeKey(a.key, b.key)
+		return oracle.CompareVolumeKey(a.key, b.key)
 	})
 
 	c := random.RandomChoice(cells)

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -259,3 +259,36 @@ func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClien
 
 	c.validateTransactionRead(maxTicket, ledger, ref, resp.GetTransaction())
 }
+
+// runSchemaRead issues a GetMetadataSchemaStatus and checks the declared metadata
+// field types (account / transaction / ledger) against the model (see
+// validateSchemaRead) — the read-back that verifies the declared-schema
+// projection, not just the per-op SetMetadataFieldType echo.
+func runSchemaRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	ledger := random.RandomChoice(c.ledgerNames)
+
+	c.mu.Lock()
+	readID := c.registerRead()
+	c.mu.Unlock()
+	defer c.finishRead(readID)
+
+	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
+	resp, err := client.GetMetadataSchemaStatus(readCtx, &servicepb.GetMetadataSchemaStatusRequest{Ledger: ledger})
+	// High-water at the read's response: only bulks dispatched by now could be
+	// reflected in what the server returned.
+	maxTicket := c.ticketSeq.Load()
+	if err != nil {
+		if internal.IsTransient(err) || isShutdownError(err) {
+			return
+		}
+		// The fleet is created at setup and never deleted, so a definitive error
+		// on a linearizable schema read is a real finding.
+		assert.Unreachable("singleton_driver_model: GetMetadataSchemaStatus returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"error":  err.Error(),
+		})
+		return
+	}
+
+	c.validateSchemaRead(maxTicket, ledger, resp.GetAccountFields(), resp.GetTransactionFields(), resp.GetLedgerFields())
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search.go
@@ -3,6 +3,8 @@ package main
 import (
 	"crypto/sha256"
 	"fmt"
+
+	"github.com/formancehq/ledger/v3/tests/oracle"
 )
 
 // candidateBases enumerates the distinct committed states the server could be in
@@ -34,12 +36,12 @@ import (
 // serialized state. pendingIndex and remaining-inflight are folded in because a
 // state reachable with different continuations (e.g. a duplicate-effect in-flight
 // bulk landing on the same state as a pending one) must be explored under each.
-func (c *Checker) candidateBases(maxTicket uint64, visit func(GlobalState) bool) {
+func (c *Checker) candidateBases(maxTicket uint64, visit func(oracle.GlobalState) bool) {
 	// Only operations dispatched no later than maxTicket (the observation's
 	// high-water) can precede it; one dispatched after the observation's response
 	// cannot have committed before it, so folding it would invent a state the
 	// server was never in and could explain away a real divergence.
-	pending := make([]Bulk, 0, len(c.pending))
+	pending := make([]oracle.Bulk, 0, len(c.pending))
 	for _, pe := range c.pending {
 		// pending is minSeq-ordered, so an entry dispatched after the observation
 		// committed after it — and so did every later (higher-minSeq) entry.
@@ -49,7 +51,7 @@ func (c *Checker) candidateBases(maxTicket uint64, visit func(GlobalState) bool)
 		pending = append(pending, pe.obs.bulk)
 	}
 
-	inflight := make([]Bulk, 0, len(c.inflight))
+	inflight := make([]oracle.Bulk, 0, len(c.inflight))
 	for t, b := range c.inflight {
 		if t <= maxTicket {
 			inflight = append(inflight, b)
@@ -63,9 +65,9 @@ func (c *Checker) candidateBases(maxTicket uint64, visit func(GlobalState) bool)
 
 	seen := map[[sha256.Size]byte]bool{}
 	hasher := sha256.New()
-	key := func(base GlobalState, pIdx int, rem []int) [sha256.Size]byte {
+	key := func(base oracle.GlobalState, pIdx int, rem []int) [sha256.Size]byte {
 		hasher.Reset()
-		base.hash(hasher)
+		base.Hash(hasher)
 		fmt.Fprintf(hasher, "#%d#%v", pIdx, rem)
 
 		var k [sha256.Size]byte
@@ -73,9 +75,9 @@ func (c *Checker) candidateBases(maxTicket uint64, visit func(GlobalState) bool)
 		return k
 	}
 
-	var rec func(base GlobalState, pIdx int, rem []int) bool
+	var rec func(base oracle.GlobalState, pIdx int, rem []int) bool
 
-	rec = func(base GlobalState, pIdx int, rem []int) bool {
+	rec = func(base oracle.GlobalState, pIdx int, rem []int) bool {
 		k := key(base, pIdx, rem)
 		if seen[k] {
 			return false

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search_test.go
@@ -7,12 +7,17 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
 )
 
-func collectBases(c *Checker) []GlobalState {
-	var out []GlobalState
+func bulkOf(reqs ...*servicepb.Request) oracle.Bulk { return oracle.Bulk{Requests: reqs} }
+
+func collectBases(c *Checker) []oracle.GlobalState {
+	var out []oracle.GlobalState
 	// ^uint64(0): no high-water bound — fold every in-flight/pending bulk.
-	c.candidateBases(^uint64(0), func(b GlobalState) bool {
+	c.candidateBases(^uint64(0), func(b oracle.GlobalState) bool {
 		out = append(out, b)
 
 		return false
@@ -28,11 +33,11 @@ func TestCandidateBases_BoundsInflightByMaxTicket(t *testing.T) {
 	t.Parallel()
 
 	c := NewChecker([]string{"L"})
-	c.inflight[5] = bulkOf(addTypeReq("T"))
+	c.inflight[5] = bulkOf(oracletest.AddTypeReq("T"))
 
-	collect := func(maxTicket uint64) []GlobalState {
-		var out []GlobalState
-		c.candidateBases(maxTicket, func(b GlobalState) bool {
+	collect := func(maxTicket uint64) []oracle.GlobalState {
+		var out []oracle.GlobalState
+		c.candidateBases(maxTicket, func(b oracle.GlobalState) bool {
 			out = append(out, b)
 
 			return false
@@ -54,14 +59,14 @@ func TestCandidateBases_TruncatesPendingByMaxTicket(t *testing.T) {
 
 	c := NewChecker([]string{"L"})
 	c.pending = []*pendingObservation{
-		{minSeq: 1, obs: observation{bulk: bulkOf(addTypeReq("A")), ticket: 2}},
-		{minSeq: 2, obs: observation{bulk: bulkOf(addTypeReq("B")), ticket: 6}},
+		{minSeq: 1, obs: observation{bulk: bulkOf(oracletest.AddTypeReq("A")), ticket: 2}},
+		{minSeq: 2, obs: observation{bulk: bulkOf(oracletest.AddTypeReq("B")), ticket: 6}},
 	}
 
-	var bases []GlobalState
+	var bases []oracle.GlobalState
 	// maxTicket 4: P1 (ticket 2) folds, P2 (ticket 6) is excluded — states are
 	// modelState and modelState+P1, never +P1+P2.
-	c.candidateBases(4, func(b GlobalState) bool {
+	c.candidateBases(4, func(b oracle.GlobalState) bool {
 		bases = append(bases, b)
 
 		return false
@@ -73,7 +78,7 @@ func TestCandidateBases_FoldsInflight(t *testing.T) {
 	t.Parallel()
 
 	c := NewChecker([]string{"L"})
-	c.inflight[1] = bulkOf(addTypeReq("T"))
+	c.inflight[1] = bulkOf(oracletest.AddTypeReq("T"))
 
 	// modelState (empty) and the state with the in-flight add folded in.
 	require.Len(t, collectBases(c), 2)
@@ -89,15 +94,15 @@ func TestCandidateBases_PinsPendingOrder(t *testing.T) {
 	t.Parallel()
 
 	c := NewChecker([]string{"L"})
-	p1 := bulkOf(addTypeReqP("a", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))
-	p2 := bulkOf(txReq("world", "a:1", "USD", 5), txReq("a:1", "world", "USD", 5))
+	p1 := bulkOf(oracletest.AddTypeReqP("a", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))
+	p2 := bulkOf(oracletest.TxReq("world", "a:1", "USD", 5), oracletest.TxReq("a:1", "world", "USD", 5))
 	c.pending = []*pendingObservation{
 		{minSeq: 1, obs: observation{bulk: p1}},
 		{minSeq: 3, obs: observation{bulk: p2}},
 	}
 
 	for _, b := range collectBases(c) {
-		_, present := b.ledger("L").volumes[VolumeKey{Address: "a:1", Asset: "USD"}]
+		_, present := b.Ledger("L").Volumes()[oracle.VolumeKey{Address: "a:1", Asset: "USD"}]
 		require.False(t, present, "a:1 must be absent in every candidate base (reordered prefix is illegal)")
 	}
 }
@@ -109,9 +114,9 @@ func TestCandidateBases_PinsPendingOrder(t *testing.T) {
 func TestModelFailure_NoSelfExplanation(t *testing.T) {
 	t.Parallel()
 
-	alreadyExistsExplained := func(bases []GlobalState) bool {
+	alreadyExistsExplained := func(bases []oracle.GlobalState) bool {
 		for _, b := range bases {
-			res := b.Apply(bulkOf(addTypeReq("T")))
+			res := b.Apply(bulkOf(oracletest.AddTypeReq("T")))
 			if !res.OK && res.Reason == domain.ErrReasonAccountTypeAlreadyExists {
 				return true
 			}
@@ -125,6 +130,6 @@ func TestModelFailure_NoSelfExplanation(t *testing.T) {
 
 	// Concurrent in-flight add of T -> AlreadyExists is explainable.
 	withAdd := NewChecker([]string{"L"})
-	withAdd.inflight[1] = bulkOf(addTypeReq("T"))
+	withAdd.inflight[1] = bulkOf(oracletest.AddTypeReq("T"))
 	require.True(t, alreadyExistsExplained(collectBases(withAdd)))
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/search_test.go
@@ -32,7 +32,7 @@ func collectBases(c *Checker) []oracle.GlobalState {
 func TestCandidateBases_BoundsInflightByMaxTicket(t *testing.T) {
 	t.Parallel()
 
-	c := NewChecker([]string{"L"})
+	c := NewChecker([]string{"L"}, nil)
 	c.inflight[5] = bulkOf(oracletest.AddTypeReq("T"))
 
 	collect := func(maxTicket uint64) []oracle.GlobalState {
@@ -57,7 +57,7 @@ func TestCandidateBases_BoundsInflightByMaxTicket(t *testing.T) {
 func TestCandidateBases_TruncatesPendingByMaxTicket(t *testing.T) {
 	t.Parallel()
 
-	c := NewChecker([]string{"L"})
+	c := NewChecker([]string{"L"}, nil)
 	c.pending = []*pendingObservation{
 		{minSeq: 1, obs: observation{bulk: bulkOf(oracletest.AddTypeReq("A")), ticket: 2}},
 		{minSeq: 2, obs: observation{bulk: bulkOf(oracletest.AddTypeReq("B")), ticket: 6}},
@@ -77,7 +77,7 @@ func TestCandidateBases_TruncatesPendingByMaxTicket(t *testing.T) {
 func TestCandidateBases_FoldsInflight(t *testing.T) {
 	t.Parallel()
 
-	c := NewChecker([]string{"L"})
+	c := NewChecker([]string{"L"}, nil)
 	c.inflight[1] = bulkOf(oracletest.AddTypeReq("T"))
 
 	// modelState (empty) and the state with the in-flight add folded in.
@@ -93,7 +93,7 @@ func TestCandidateBases_FoldsInflight(t *testing.T) {
 func TestCandidateBases_PinsPendingOrder(t *testing.T) {
 	t.Parallel()
 
-	c := NewChecker([]string{"L"})
+	c := NewChecker([]string{"L"}, nil)
 	p1 := bulkOf(oracletest.AddTypeReqP("a", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))
 	p2 := bulkOf(oracletest.TxReq("world", "a:1", "USD", 5), oracletest.TxReq("a:1", "world", "USD", 5))
 	c.pending = []*pendingObservation{
@@ -126,10 +126,10 @@ func TestModelFailure_NoSelfExplanation(t *testing.T) {
 	}
 
 	// No concurrent add -> AlreadyExists is not explainable (would be a finding).
-	require.False(t, alreadyExistsExplained(collectBases(NewChecker([]string{"L"}))))
+	require.False(t, alreadyExistsExplained(collectBases(NewChecker([]string{"L"}, nil))))
 
 	// Concurrent in-flight add of T -> AlreadyExists is explainable.
-	withAdd := NewChecker([]string{"L"})
+	withAdd := NewChecker([]string{"L"}, nil)
 	withAdd.inflight[1] = bulkOf(oracletest.AddTypeReq("T"))
 	require.True(t, alreadyExistsExplained(collectBases(withAdd)))
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -23,6 +23,7 @@ import (
 // forward model. Caller holds c.mu.
 func (c *Checker) validateBulkSuccess(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
 	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), bulkMeta(bulk))
+	dumpBatch(minLogSequence(resp.GetLogs()), applyRequest(bulk))
 
 	c.crossCheckCommit(bulk, resp)
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -525,6 +525,49 @@ func txMetaMatches(ls oracle.LedgerState, ref string, serverMeta map[string]*com
 	return true
 }
 
+// validateSchemaRead checks one GetMetadataSchemaStatus snapshot against the
+// model: legal iff some candidate base's declared field types — per target,
+// key-for-key — exactly match the server's. Field types are declared only by
+// SetMetadataFieldType and by initial_schema at ledger creation, both tracked by
+// the model, so this is the read-back that verifies the declared-schema
+// projection rather than just the per-op response echo.
+func (c *Checker) validateSchemaRead(maxTicket uint64, ledger string, acct, txn, ldg map[string]*servicepb.MetadataFieldStatus) {
+	if c.matchesModel(maxTicket, "SCHEMA", func(base oracle.GlobalState) bool {
+		ls := base.Ledger(ledger)
+
+		return fieldTypesMatch(ls.AccountFieldTypes(), acct) &&
+			fieldTypesMatch(ls.TransactionFieldTypes(), txn) &&
+			fieldTypesMatch(ls.LedgerFieldTypes(), ldg)
+	}) {
+		return
+	}
+
+	assert.Unreachable("singleton_driver_model: metadata schema read outside model", internal.Details{
+		"ledger":       ledger,
+		"serverAcct":   len(acct),
+		"serverTxn":    len(txn),
+		"serverLedger": len(ldg),
+		"modelSchema":  c.modelSchemaDump(ledger),
+	})
+}
+
+// fieldTypesMatch reports whether the model's declared field types equal the
+// server's for one target — same keys, same declared type.
+func fieldTypesMatch(model map[string]commonpb.MetadataType, server map[string]*servicepb.MetadataFieldStatus) bool {
+	if len(model) != len(server) {
+		return false
+	}
+
+	for k, t := range model {
+		st, ok := server[k]
+		if !ok || st.GetDeclaredType() != t {
+			return false
+		}
+	}
+
+	return true
+}
+
 // responseMetaEffect extracts the server's stored (as-written) values for a
 // committed metadata write from its response log, dispatching on the request
 // type. Returns nil for non-metadata requests and for deletes, whose log carries

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -44,6 +44,22 @@ func coverReceiptReverts(bulk oracle.Bulk) {
 	}
 }
 
+// requestExpandsVolumes reports whether a create/revert asked the server to
+// return post-commit volumes. When false the response log omits them, so
+// crossCheckCommit skips the volume comparison for that order.
+func requestExpandsVolumes(req *servicepb.Request) bool {
+	action := req.GetApply().GetAction()
+	if ct := action.GetCreateTransaction(); ct != nil {
+		return ct.GetExpandVolumes()
+	}
+
+	if rt := action.GetRevertTransaction(); rt != nil {
+		return rt.GetExpandVolumes()
+	}
+
+	return false
+}
+
 // captureReceipts records the signed receipt the server returned for each newly
 // created, referenced transaction, keyed by reference, so generateRevert can
 // exercise the receipt-carried revert path. The response log at index i pairs
@@ -93,6 +109,15 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 	logs := resp.GetLogs()
 	for i, order := range res.Orders {
 		if order.PCV == nil || i >= len(logs) {
+			continue
+		}
+
+		// A tx created/reverted with ExpandVolumes:false carries no PCV on its
+		// response log; skip the volume comparison (the commit is unaffected, and
+		// later reads validate the volumes).
+		if !requestExpandsVolumes(bulk.Requests[i]) {
+			assert.Reachable("singleton_driver_model: non-expanded-volumes transaction committed", internal.Details{})
+
 			continue
 		}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -529,9 +529,15 @@ func (c *Checker) validateTransactionRead(maxTicket uint64, ledger string, id ui
 		}
 
 		rec := txs[id-1]
+		// A user-supplied timestamp is echoed verbatim; when the model has none
+		// (nil) the server stamped its own command date, which is unpredictable,
+		// so the timestamp is not checked for that record.
+		tsOK := rec.Timestamp() == nil || rec.Timestamp().GetData() == serverTx.GetTimestamp().GetData()
+
 		return rec.Id() == serverTx.GetId() &&
 			rec.Reference() == serverTx.GetReference() &&
 			rec.Reverted() == serverTx.GetReverted() &&
+			tsOK &&
 			postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
 			metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
 	}) {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -158,16 +158,8 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 
 				return
 			}
-
-			if !metaMapEqual(order.Revert.Saved(), revTx.GetMetadata()) {
-				assert.Unreachable("singleton_driver_model: revert metadata mismatch", internal.Details{
-					"ledger":      oracle.LedgerOf(req),
-					"modelSaved":  renderMetaMap(order.Revert.Saved()),
-					"serverSaved": renderMetaMap(revTx.GetMetadata()),
-				})
-
-				return
-			}
+			// The revert transaction's metadata is verified by reading its log
+			// entry back (validateTransactionRead), not at commit.
 		} else if order.TxID != 0 {
 			tx := data.GetCreatedTransaction().GetTransaction()
 			ct := req.GetApply().GetAction().GetCreateTransaction()
@@ -466,63 +458,46 @@ func ledgerMetaMatches(ls oracle.LedgerState, serverMeta map[string]*commonpb.Me
 	return true
 }
 
-// validateTransactionRead checks one GetTransaction snapshot against the model:
-// legal iff some candidate base holds a transaction at reference ref whose id,
-// reverted flag, postings, and whole metadata map all match the server's on the
-// SAME base. The read is picked from committed (drained) state, so id and
-// postings are fixed across bases; only metadata and the reverted flag can vary
-// with in-flight writes/reverts, which candidateBases enumerates. This is the
-// only path that reads accumulated transaction metadata back (add/overwrite/
-// delete), so a divergent stored projection with correct per-write echoes — the
-// ledger-metadata cross-routing bug class — is caught here for transactions.
-func (c *Checker) validateTransactionRead(maxTicket uint64, ledger, ref string, serverTx *commonpb.Transaction) {
+// validateTransactionRead checks one GetTransaction observation — a returned
+// transaction, or NotFound when found is false — against the model: legal iff
+// some candidate base's log agrees at that id. Either the base holds a
+// transaction there matching the server's (id, reference, reverted flag,
+// postings, and whole metadata map), or, for NotFound, the base has not assigned
+// that id yet. The id is probed up to the dispatched frontier, so it may land on
+// a committed tx, an in-flight one, or an unassigned id; candidateBases
+// enumerates the serializations. This is the only path that reads accumulated
+// transaction metadata back (create/add/overwrite/delete/revert), so a divergent
+// stored projection with correct per-write echoes — the ledger-metadata
+// cross-routing bug class — is caught here for transactions.
+func (c *Checker) validateTransactionRead(maxTicket uint64, ledger string, id uint64, serverTx *commonpb.Transaction, found bool) {
 	if c.matchesModel(maxTicket, "TXREAD", func(base oracle.GlobalState) bool {
-		rec, ok := base.Ledger(ledger).TxRefs()[ref]
-		if !ok {
-			return false
+		txs := base.Ledger(ledger).Txs()
+		if id == 0 || id > uint64(len(txs)) {
+			return !found // no tx at this id in this base: consistent only with NotFound
+		}
+		if !found {
+			return false // base has a tx at this id, but the server returned NotFound
 		}
 
+		rec := txs[id-1]
 		return rec.Id() == serverTx.GetId() &&
+			rec.Reference() == serverTx.GetReference() &&
 			rec.Reverted() == serverTx.GetReverted() &&
 			postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
-			txMetaMatches(base.Ledger(ledger), ref, serverTx.GetMetadata())
+			metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
 	}) {
 		return
 	}
 
 	assert.Unreachable("singleton_driver_model: transaction read outside model", internal.Details{
 		"ledger":     ledger,
-		"reference":  ref,
-		"serverId":   fmt.Sprintf("%d", serverTx.GetId()),
-		"serverRev":  fmt.Sprintf("%v", serverTx.GetReverted()),
+		"id":         id,
+		"found":      found,
+		"serverRef":  serverTx.GetReference(),
+		"serverRev":  serverTx.GetReverted(),
 		"serverMeta": renderMetaMap(serverTx.GetMetadata()),
-		"modelMeta":  c.modelTxMetaDump(ledger, ref),
+		"modelTx":    c.modelTxDump(ledger, id),
 	})
-}
-
-// txMetaMatches reports whether ls's metadata for the transaction at ref equals
-// serverMeta exactly — same keys, same verbatim values. Reads surface the stored
-// value as-written; the declared type is an index hint, not applied on read.
-func txMetaMatches(ls oracle.LedgerState, ref string, serverMeta map[string]*commonpb.MetadataValue) bool {
-	model := map[string]*commonpb.MetadataValue{}
-	for tk, v := range ls.TxMeta() {
-		if tk.Reference == ref {
-			model[tk.Key] = v
-		}
-	}
-
-	if len(model) != len(serverMeta) {
-		return false
-	}
-
-	for k, v := range model {
-		sv, ok := serverMeta[k]
-		if !ok || oracle.MetaValueString(sv) != oracle.MetaValueString(v) {
-			return false
-		}
-	}
-
-	return true
 }
 
 // validateSchemaRead checks one GetMetadataSchemaStatus snapshot against the

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/holiman/uint256"
+
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
-	"github.com/holiman/uint256"
 )
 
 // The model-conformance checks: every observed server outcome — a committed
@@ -18,7 +21,7 @@ import (
 
 // validateBulkSuccess records a committed bulk and cross-checks it against the
 // forward model. Caller holds c.mu.
-func (c *Checker) validateBulkSuccess(bulk Bulk, resp *servicepb.ApplyResponse) {
+func (c *Checker) validateBulkSuccess(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
 	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), bulkMeta(bulk))
 
 	c.crossCheckCommit(bulk, resp)
@@ -31,7 +34,7 @@ func (c *Checker) validateBulkSuccess(bulk Bulk, resp *servicepb.ApplyResponse) 
 // post-commit volumes. A disagreement is a finding — the server accepted
 // something the model rejects, or the volumes diverged. modelState advances
 // only on agreement. Caller holds c.mu.
-func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
+func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
 	res := c.modelState.Apply(bulk)
 
 	if !res.OK {
@@ -92,13 +95,13 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 
 		gotSaved := responseMetaEffect(bulk.Requests[i], logs[i])
 
-		if !metaMapEqual(order.Meta.saved, gotSaved) {
-			dbg("MODEL META SAVED MISMATCH: model=%s server=%s", renderMetaMap(order.Meta.saved), renderMetaMap(gotSaved))
+		if !metaMapEqual(order.Meta.Saved(), gotSaved) {
+			dbg("MODEL META SAVED MISMATCH: model=%s server=%s", renderMetaMap(order.Meta.Saved()), renderMetaMap(gotSaved))
 			assert.Unreachable("singleton_driver_model: response metadata value mismatch", internal.Details{
-				"ledger":      ledgerOf(bulk.Requests[i]),
+				"ledger":      oracle.LedgerOf(bulk.Requests[i]),
 				"kinds":       requestKinds(bulk),
 				"meta":        bulkMeta(bulk),
-				"modelSaved":  renderMetaMap(order.Meta.saved),
+				"modelSaved":  renderMetaMap(order.Meta.Saved()),
 				"serverSaved": renderMetaMap(gotSaved),
 			})
 
@@ -127,7 +130,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 
 			if revTx.GetId() != order.TxID {
 				assert.Unreachable("singleton_driver_model: revert transaction id mismatch", internal.Details{
-					"ledger":   ledgerOf(req),
+					"ledger":   oracle.LedgerOf(req),
 					"modelId":  fmt.Sprintf("%d", order.TxID),
 					"serverId": fmt.Sprintf("%d", revTx.GetId()),
 				})
@@ -135,20 +138,20 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 				return
 			}
 
-			if rt.GetRevertedTransactionId() != order.Revert.revertedID {
+			if rt.GetRevertedTransactionId() != order.Revert.RevertedID() {
 				assert.Unreachable("singleton_driver_model: reverted transaction id mismatch", internal.Details{
-					"ledger":   ledgerOf(req),
-					"modelId":  fmt.Sprintf("%d", order.Revert.revertedID),
+					"ledger":   oracle.LedgerOf(req),
+					"modelId":  fmt.Sprintf("%d", order.Revert.RevertedID()),
 					"serverId": fmt.Sprintf("%d", rt.GetRevertedTransactionId()),
 				})
 
 				return
 			}
 
-			if !postingsEqual(order.Revert.postings, revTx.GetPostings()) {
+			if !postingsEqual(order.Revert.Postings(), revTx.GetPostings()) {
 				assert.Unreachable("singleton_driver_model: revert postings mismatch", internal.Details{
-					"ledger":   ledgerOf(req),
-					"model":    renderPostings(order.Revert.postings),
+					"ledger":   oracle.LedgerOf(req),
+					"model":    renderPostings(order.Revert.Postings()),
 					"returned": renderPostings(revTx.GetPostings()),
 				})
 
@@ -160,7 +163,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 
 			if tx.GetId() != order.TxID {
 				assert.Unreachable("singleton_driver_model: transaction id mismatch", internal.Details{
-					"ledger":   ledgerOf(req),
+					"ledger":   oracle.LedgerOf(req),
 					"modelId":  fmt.Sprintf("%d", order.TxID),
 					"serverId": fmt.Sprintf("%d", tx.GetId()),
 				})
@@ -170,7 +173,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 
 			if tx.GetReference() != ct.GetReference() {
 				assert.Unreachable("singleton_driver_model: transaction reference mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": ct.GetReference(),
 					"returned":  tx.GetReference(),
 				})
@@ -180,7 +183,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 
 			if !postingsEqual(ct.GetPostings(), tx.GetPostings()) {
 				assert.Unreachable("singleton_driver_model: transaction postings mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": renderPostings(ct.GetPostings()),
 					"returned":  renderPostings(tx.GetPostings()),
 				})
@@ -194,7 +197,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 			lg, rq := data.GetSetMetadataFieldType(), r.SetMetadataFieldType
 			if lg.GetTargetType() != rq.GetTargetType() || lg.GetKey() != rq.GetKey() || lg.GetType() != rq.GetType() {
 				assert.Unreachable("singleton_driver_model: set-field-type response mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": fmt.Sprintf("tgt%d/%s=%v", rq.GetTargetType(), rq.GetKey(), rq.GetType()),
 					"returned":  fmt.Sprintf("tgt%d/%s=%v", lg.GetTargetType(), lg.GetKey(), lg.GetType()),
 				})
@@ -206,7 +209,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 			lg, rq := data.GetRemovedMetadataFieldType(), r.RemoveMetadataFieldType
 			if lg.GetTargetType() != rq.GetTargetType() || lg.GetKey() != rq.GetKey() {
 				assert.Unreachable("singleton_driver_model: remove-field-type response mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": fmt.Sprintf("tgt%d/%s", rq.GetTargetType(), rq.GetKey()),
 					"returned":  fmt.Sprintf("tgt%d/%s", lg.GetTargetType(), lg.GetKey()),
 				})
@@ -218,7 +221,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 			// never report dropping one.
 			if lg.GetDroppedIndex() != nil {
 				assert.Unreachable("singleton_driver_model: remove-field-type unexpectedly dropped an index", internal.Details{
-					"ledger": ledgerOf(req),
+					"ledger": oracle.LedgerOf(req),
 					"key":    rq.GetKey(),
 				})
 
@@ -229,7 +232,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 			lg, rq := data.GetAddedAccountType().GetAccountType(), r.AddAccountType.GetAccountType()
 			if lg.GetName() != rq.GetName() || lg.GetPattern() != rq.GetPattern() || lg.GetPersistence() != rq.GetPersistence() {
 				assert.Unreachable("singleton_driver_model: add-account-type response mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": fmt.Sprintf("%s=%s/p%d", rq.GetName(), rq.GetPattern(), rq.GetPersistence()),
 					"returned":  fmt.Sprintf("%s=%s/p%d", lg.GetName(), lg.GetPattern(), lg.GetPersistence()),
 				})
@@ -241,7 +244,7 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 			lg := data.GetRemovedAccountType()
 			if lg.GetName() != r.RemoveAccountType.GetName() {
 				assert.Unreachable("singleton_driver_model: remove-account-type response mismatch", internal.Details{
-					"ledger":    ledgerOf(req),
+					"ledger":    oracle.LedgerOf(req),
 					"requested": r.RemoveAccountType.GetName(),
 					"returned":  lg.GetName(),
 				})
@@ -260,11 +263,11 @@ func (c *Checker) crossCheckCommit(bulk Bulk, resp *servicepb.ApplyResponse) {
 // server would reject failedBulk exactly this way. Because failedBulk is applied
 // fresh on each base, its own requests can never "explain" its own rejection.
 // Caller holds c.mu.
-func (c *Checker) validateFailure(maxTicket uint64, failedBulk Bulk, reqErr error) {
+func (c *Checker) validateFailure(maxTicket uint64, failedBulk oracle.Bulk, reqErr error) {
 	var reason string
 
 	matched := false
-	c.candidateBases(maxTicket, func(base GlobalState) bool {
+	c.candidateBases(maxTicket, func(base oracle.GlobalState) bool {
 		res := base.Apply(failedBulk)
 		if !res.OK && internal.HasErrorReason(reqErr, res.Reason) {
 			reason = res.Reason
@@ -299,7 +302,7 @@ func (c *Checker) validateFailure(maxTicket uint64, failedBulk Bulk, reqErr erro
 // with no log means the server committed, or reported committing, without
 // returning the log reference the checker needs to linearize the bulk. Caller
 // holds c.mu.
-func (c *Checker) validateEmptyCommit(bulk Bulk) {
+func (c *Checker) validateEmptyCommit(bulk oracle.Bulk) {
 	dbg("BULK OK (empty): ledgers=%s kinds=%s", bulkLedgers(bulk), requestKinds(bulk))
 
 	assert.Unreachable("singleton_driver_model: successful bulk returned no committed log", internal.Details{
@@ -316,12 +319,12 @@ func (c *Checker) validateEmptyCommit(bulk Bulk) {
 // returned — to enumerate what the server could have returned. The caller asserts
 // on a false result — each assert needs its own callsite with a literal message
 // for Antithesis cataloguing, so this helper never asserts. Acquires c.mu.
-func (c *Checker) matchesModel(maxTicket uint64, label string, matcher func(GlobalState) bool) bool {
+func (c *Checker) matchesModel(maxTicket uint64, label string, matcher func(oracle.GlobalState) bool) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	matched := false
-	c.candidateBases(maxTicket, func(base GlobalState) bool {
+	c.candidateBases(maxTicket, func(base oracle.GlobalState) bool {
 		matched = matcher(base)
 		return matched
 	})
@@ -340,10 +343,10 @@ func (c *Checker) matchesModel(maxTicket uint64, label string, matcher func(Glob
 // volume cell and exactly the server's metadata for the address. Both must hold
 // on the SAME base — the read is one atomic snapshot.
 func (c *Checker) validateAccountRead(maxTicket uint64, ledger, addr, asset string, gotIn, gotOut uint256.Int, found bool, serverMeta map[string]*commonpb.MetadataValue) {
-	key := VolumeKey{Address: addr, Asset: asset}
+	key := oracle.VolumeKey{Address: addr, Asset: asset}
 
-	if c.matchesModel(maxTicket, "READ", func(base GlobalState) bool {
-		ls := base.ledger(ledger)
+	if c.matchesModel(maxTicket, "READ", func(base oracle.GlobalState) bool {
+		ls := base.Ledger(ledger)
 		return volumeCellMatches(ls, key, gotIn, gotOut, found) && metadataMatches(ls, addr, serverMeta)
 	}) {
 		return
@@ -366,8 +369,8 @@ func (c *Checker) validateAccountRead(maxTicket uint64, ledger, addr, asset stri
 // returned no row (the base's purge sweep already removed zero-balance
 // EPHEMERAL/TRANSIENT cells). An empty asset — a metadata-only pick — is never a
 // present cell, so it imposes no volume constraint.
-func volumeCellMatches(ls LedgerState, key VolumeKey, gotIn, gotOut uint256.Int, found bool) bool {
-	vp, present := ls.volumes[key]
+func volumeCellMatches(ls oracle.LedgerState, key oracle.VolumeKey, gotIn, gotOut uint256.Int, found bool) bool {
+	vp, present := ls.Volumes()[key]
 	switch {
 	case found && present && vp.Input.Cmp(&gotIn) == 0 && vp.Output.Cmp(&gotOut) == 0:
 		return true
@@ -381,15 +384,15 @@ func volumeCellMatches(ls LedgerState, key VolumeKey, gotIn, gotOut uint256.Int,
 // metadataMatches reports whether ls holds exactly serverMeta for addr — same
 // keys, same verbatim values. Reads surface the stored value as-written; the
 // declared type is an index hint, not applied on read.
-func metadataMatches(ls LedgerState, addr string, serverMeta map[string]*commonpb.MetadataValue) bool {
-	modelMeta := ls.accountMetadata(addr)
+func metadataMatches(ls oracle.LedgerState, addr string, serverMeta map[string]*commonpb.MetadataValue) bool {
+	modelMeta := ls.AccountMetadata(addr)
 	if len(modelMeta) != len(serverMeta) {
 		return false
 	}
 
 	for k, v := range modelMeta {
 		sv, ok := serverMeta[k]
-		if !ok || metaValueString(sv) != metaValueString(v) {
+		if !ok || oracle.MetaValueString(sv) != oracle.MetaValueString(v) {
 			return false
 		}
 	}
@@ -402,8 +405,8 @@ func metadataMatches(ls LedgerState, addr string, serverMeta map[string]*commonp
 // the server's ledger metadata. Both must hold on the SAME base — the read is one
 // atomic snapshot.
 func (c *Checker) validateLedgerRead(maxTicket uint64, ledger string, serverTypes map[string]*commonpb.AccountType, serverMeta map[string]*commonpb.MetadataValue) {
-	if c.matchesModel(maxTicket, "LEDGER", func(base GlobalState) bool {
-		ls := base.ledger(ledger)
+	if c.matchesModel(maxTicket, "LEDGER", func(base oracle.GlobalState) bool {
+		ls := base.Ledger(ledger)
 		return chartMatches(ls, serverTypes) && ledgerMetaMatches(ls, serverMeta)
 	}) {
 		return
@@ -419,12 +422,12 @@ func (c *Checker) validateLedgerRead(maxTicket uint64, ledger string, serverType
 
 // chartMatches reports whether ls's chart equals the server's account types
 // exactly — same names, patterns, and persistence.
-func chartMatches(ls LedgerState, serverTypes map[string]*commonpb.AccountType) bool {
-	if len(ls.types) != len(serverTypes) {
+func chartMatches(ls oracle.LedgerState, serverTypes map[string]*commonpb.AccountType) bool {
+	if len(ls.Types()) != len(serverTypes) {
 		return false
 	}
 
-	for name, t := range ls.types {
+	for name, t := range ls.Types() {
 		st, ok := serverTypes[name]
 		if !ok || st.GetPattern() != t.Pattern || st.GetPersistence() != t.Persistence {
 			return false
@@ -437,14 +440,14 @@ func chartMatches(ls LedgerState, serverTypes map[string]*commonpb.AccountType) 
 // ledgerMetaMatches reports whether ls's ledger metadata equals serverMeta
 // exactly — same keys, same verbatim values. Reads surface the stored value
 // as-written; the declared type is an index hint, not applied on read.
-func ledgerMetaMatches(ls LedgerState, serverMeta map[string]*commonpb.MetadataValue) bool {
-	if len(ls.ledgerMeta) != len(serverMeta) {
+func ledgerMetaMatches(ls oracle.LedgerState, serverMeta map[string]*commonpb.MetadataValue) bool {
+	if len(ls.LedgerMeta()) != len(serverMeta) {
 		return false
 	}
 
-	for k, v := range ls.ledgerMeta {
+	for k, v := range ls.LedgerMeta() {
 		sv, ok := serverMeta[k]
-		if !ok || metaValueString(sv) != metaValueString(v) {
+		if !ok || oracle.MetaValueString(sv) != oracle.MetaValueString(v) {
 			return false
 		}
 	}
@@ -520,7 +523,7 @@ func metaMapEqual(a, b map[string]*commonpb.MetadataValue) bool {
 
 	for k, v := range a {
 		bv, ok := b[k]
-		if !ok || metaValueString(v) != metaValueString(bv) {
+		if !ok || oracle.MetaValueString(v) != oracle.MetaValueString(bv) {
 			return false
 		}
 	}
@@ -531,7 +534,7 @@ func metaMapEqual(a, b map[string]*commonpb.MetadataValue) bool {
 // postCommitVolume extracts (input, output) for one cell from a server response,
 // parsing the decimal-string volumes into uint256 — the ledger's native volume
 // type. ok is false when the cell is absent or the values don't parse.
-func postCommitVolume(pcv *commonpb.PostCommitVolumes, key VolumeKey) (in, out uint256.Int, ok bool) {
+func postCommitVolume(pcv *commonpb.PostCommitVolumes, key oracle.VolumeKey) (in, out uint256.Int, ok bool) {
 	byAsset, found := pcv.GetVolumesByAccount()[key.Address]
 	if !found {
 		return in, out, false

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -26,6 +26,45 @@ func (c *Checker) validateBulkSuccess(bulk oracle.Bulk, resp *servicepb.ApplyRes
 	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s typeOps=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), typeOps(bulk), bulkMeta(bulk))
 
 	c.crossCheckCommit(bulk, resp)
+	c.captureReceipts(bulk, resp)
+	coverReceiptReverts(bulk)
+}
+
+// coverReceiptReverts fires a coverage signal when the server commits a
+// receipt-carried revert, proving admission's receipt path (verify +
+// claims->postings) is actually exercised — not merely that the driver emitted
+// one. If this stops firing, receipts are no longer being captured or sent.
+func coverReceiptReverts(bulk oracle.Bulk) {
+	for _, req := range bulk.Requests {
+		if rt := req.GetApply().GetAction().GetRevertTransaction(); rt != nil && rt.GetReceipt() != "" {
+			assert.Reachable("singleton_driver_model: receipt-carried revert committed", internal.Details{})
+
+			return
+		}
+	}
+}
+
+// captureReceipts records the signed receipt the server returned for each newly
+// created, referenced transaction, keyed by reference, so generateRevert can
+// exercise the receipt-carried revert path. The response log at index i pairs
+// with bulk.Requests[i]; receipts sign CreatedTransaction logs only. Caller
+// holds c.mu.
+func (c *Checker) captureReceipts(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
+	logs := resp.GetLogs()
+	for i, req := range bulk.Requests {
+		if i >= len(logs) {
+			break
+		}
+
+		ct := req.GetApply().GetAction().GetCreateTransaction()
+		if ct == nil || ct.GetReference() == "" {
+			continue
+		}
+
+		if receipt := logs[i].GetReceipt(); receipt != "" {
+			c.receiptByRef[ct.GetReference()] = receipt
+		}
+	}
 }
 
 // crossCheckCommit validates a committed bulk against the forward model

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -466,6 +466,65 @@ func ledgerMetaMatches(ls oracle.LedgerState, serverMeta map[string]*commonpb.Me
 	return true
 }
 
+// validateTransactionRead checks one GetTransaction snapshot against the model:
+// legal iff some candidate base holds a transaction at reference ref whose id,
+// reverted flag, postings, and whole metadata map all match the server's on the
+// SAME base. The read is picked from committed (drained) state, so id and
+// postings are fixed across bases; only metadata and the reverted flag can vary
+// with in-flight writes/reverts, which candidateBases enumerates. This is the
+// only path that reads accumulated transaction metadata back (add/overwrite/
+// delete), so a divergent stored projection with correct per-write echoes — the
+// ledger-metadata cross-routing bug class — is caught here for transactions.
+func (c *Checker) validateTransactionRead(maxTicket uint64, ledger, ref string, serverTx *commonpb.Transaction) {
+	if c.matchesModel(maxTicket, "TXREAD", func(base oracle.GlobalState) bool {
+		rec, ok := base.Ledger(ledger).TxRefs()[ref]
+		if !ok {
+			return false
+		}
+
+		return rec.Id() == serverTx.GetId() &&
+			rec.Reverted() == serverTx.GetReverted() &&
+			postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
+			txMetaMatches(base.Ledger(ledger), ref, serverTx.GetMetadata())
+	}) {
+		return
+	}
+
+	assert.Unreachable("singleton_driver_model: transaction read outside model", internal.Details{
+		"ledger":     ledger,
+		"reference":  ref,
+		"serverId":   fmt.Sprintf("%d", serverTx.GetId()),
+		"serverRev":  fmt.Sprintf("%v", serverTx.GetReverted()),
+		"serverMeta": renderMetaMap(serverTx.GetMetadata()),
+		"modelMeta":  c.modelTxMetaDump(ledger, ref),
+	})
+}
+
+// txMetaMatches reports whether ls's metadata for the transaction at ref equals
+// serverMeta exactly — same keys, same verbatim values. Reads surface the stored
+// value as-written; the declared type is an index hint, not applied on read.
+func txMetaMatches(ls oracle.LedgerState, ref string, serverMeta map[string]*commonpb.MetadataValue) bool {
+	model := map[string]*commonpb.MetadataValue{}
+	for tk, v := range ls.TxMeta() {
+		if tk.Reference == ref {
+			model[tk.Key] = v
+		}
+	}
+
+	if len(model) != len(serverMeta) {
+		return false
+	}
+
+	for k, v := range model {
+		sv, ok := serverMeta[k]
+		if !ok || oracle.MetaValueString(sv) != oracle.MetaValueString(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // responseMetaEffect extracts the server's stored (as-written) values for a
 // committed metadata write from its response log, dispatching on the request
 // type. Returns nil for non-metadata requests and for deletes, whose log carries

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -158,6 +158,16 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 
 				return
 			}
+
+			if !metaMapEqual(order.Revert.Saved(), revTx.GetMetadata()) {
+				assert.Unreachable("singleton_driver_model: revert metadata mismatch", internal.Details{
+					"ledger":      oracle.LedgerOf(req),
+					"modelSaved":  renderMetaMap(order.Revert.Saved()),
+					"serverSaved": renderMetaMap(revTx.GetMetadata()),
+				})
+
+				return
+			}
 		} else if order.TxID != 0 {
 			tx := data.GetCreatedTransaction().GetTransaction()
 			ct := req.GetApply().GetAction().GetCreateTransaction()

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/holiman/uint256"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
@@ -22,8 +23,7 @@ import (
 // validateBulkSuccess records a committed bulk and cross-checks it against the
 // forward model. Caller holds c.mu.
 func (c *Checker) validateBulkSuccess(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
-	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), bulkMeta(bulk))
-	dumpBatch(minLogSequence(resp.GetLogs()), applyRequest(bulk))
+	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s typeOps=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), typeOps(bulk), bulkMeta(bulk))
 
 	c.crossCheckCommit(bulk, resp)
 }
@@ -311,17 +311,38 @@ func (c *Checker) validateFailure(maxTicket uint64, failedBulk oracle.Bulk, reqE
 	})
 
 	if matched {
+		// Coverage: the balance floor's rejection must actually be exercised —
+		// if this stops firing, the generator has stopped emitting underfunded
+		// non-forced debits and insufficient-funds is no longer tested.
+		if reason == domain.ErrReasonInsufficientFunds {
+			assert.Reachable("singleton_driver_model: insufficient-funds rejection exercised", internal.Details{})
+		}
+
 		dbg("MODEL FAIL OK: ledgers=%s kinds=%s explained by %s", bulkLedgers(failedBulk), requestKinds(failedBulk), reason)
 
 		return
 	}
 
-	dbg("MODEL FAIL FINDING: ledgers=%s kinds=%s meta=%s err=%v", bulkLedgers(failedBulk), requestKinds(failedBulk), bulkMeta(failedBulk), reqErr)
+	// What the model makes of the same bulk on the drained (committed-prefix)
+	// state — surfaced so the finding says why the model disagreed (a different
+	// reject reason, or OK meaning the model thought it would commit).
+	mres := c.modelState.Apply(failedBulk)
+	modelReason := mres.Reason
+	if mres.OK {
+		modelReason = "OK"
+	}
+
+	postings, modelTypes, buffered := c.failureDiag(failedBulk, maxTicket)
+
+	dbg("MODEL FAIL FINDING: ledgers=%s kinds=%s postings=%s modelReason=%s modelTypes=%s %s err=%v", bulkLedgers(failedBulk), requestKinds(failedBulk), postings, modelReason, modelTypes, buffered, reqErr)
 	assert.Unreachable("singleton_driver_model: bulk failure not explained by any serialization", internal.Details{
-		"ledgers": bulkLedgers(failedBulk),
-		"error":   reqErr.Error(),
-		"kinds":   requestKinds(failedBulk),
-		"meta":    bulkMeta(failedBulk),
+		"ledgers":     bulkLedgers(failedBulk),
+		"error":       reqErr.Error(),
+		"kinds":       requestKinds(failedBulk),
+		"postings":    postings,
+		"modelReason": modelReason,
+		"modelTypes":  modelTypes,
+		"buffered":    buffered,
 	})
 }
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -350,11 +350,18 @@ func (c *Checker) validateFailure(maxTicket uint64, failedBulk oracle.Bulk, reqE
 	})
 
 	if matched {
-		// Coverage: the balance floor's rejection must actually be exercised —
-		// if this stops firing, the generator has stopped emitting underfunded
-		// non-forced debits and insufficient-funds is no longer tested.
-		if reason == domain.ErrReasonInsufficientFunds {
+		// Coverage: each deliberately-triggered rejection branch must actually be
+		// exercised — if one stops firing, the generator has stopped emitting that
+		// shape and the branch is no longer tested.
+		switch reason {
+		case domain.ErrReasonInsufficientFunds:
 			assert.Reachable("singleton_driver_model: insufficient-funds rejection exercised", internal.Details{})
+		case domain.ErrReasonTransactionReferenceConflict:
+			assert.Reachable("singleton_driver_model: reference-conflict rejection exercised", internal.Details{})
+		case domain.ErrReasonVolumeOverflow:
+			assert.Reachable("singleton_driver_model: volume-overflow rejection exercised", internal.Details{})
+		case domain.ErrReasonValidation:
+			assert.Reachable("singleton_driver_model: validation rejection exercised", internal.Details{})
 		}
 
 		dbg("MODEL FAIL OK: ledgers=%s kinds=%s explained by %s", bulkLedgers(failedBulk), requestKinds(failedBulk), reason)

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -605,10 +605,25 @@ func (c *Checker) validateTransactionRead(maxTicket uint64, ledger string, id ui
 		// so the timestamp is not checked for that record.
 		tsOK := rec.Timestamp() == nil || rec.Timestamp().GetData() == serverTx.GetTimestamp().GetData()
 
+		// reverted_at follows the same convention: nil in the model means the
+		// compensating transaction was server-dated (unpredictable) — but only a
+		// reverted record may carry one at all.
+		var raOK bool
+		switch {
+		case rec.RevertedAt() != nil:
+			raOK = serverTx.GetRevertedAt() != nil && rec.RevertedAt().GetData() == serverTx.GetRevertedAt().GetData()
+		case rec.Reverted():
+			raOK = true
+		default:
+			raOK = serverTx.GetRevertedAt() == nil
+		}
+
 		return rec.Id() == serverTx.GetId() &&
 			rec.Reference() == serverTx.GetReference() &&
 			rec.Reverted() == serverTx.GetReverted() &&
-			tsOK &&
+			rec.RevertedBy() == serverTx.GetRevertedByTransaction() &&
+			rec.RevertsTransaction() == serverTx.GetRevertsTransaction() &&
+			tsOK && raOK &&
 			postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
 			metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
 	}) {
@@ -616,13 +631,15 @@ func (c *Checker) validateTransactionRead(maxTicket uint64, ledger string, id ui
 	}
 
 	assert.Unreachable("singleton_driver_model: transaction read outside model", internal.Details{
-		"ledger":     ledger,
-		"id":         id,
-		"found":      found,
-		"serverRef":  serverTx.GetReference(),
-		"serverRev":  serverTx.GetReverted(),
-		"serverMeta": renderMetaMap(serverTx.GetMetadata()),
-		"modelTx":    c.modelTxDump(ledger, id),
+		"ledger":        ledger,
+		"id":            id,
+		"found":         found,
+		"serverRef":     serverTx.GetReference(),
+		"serverRev":     serverTx.GetReverted(),
+		"serverRevBy":   serverTx.GetRevertedByTransaction(),
+		"serverReverts": serverTx.GetRevertsTransaction(),
+		"serverMeta":    renderMetaMap(serverTx.GetMetadata()),
+		"modelTx":       c.modelTxDump(ledger, id),
 	})
 }
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -193,6 +193,34 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 
 				return
 			}
+
+			// Account metadata set via the transaction payload is echoed verbatim
+			// on the CreatedTransaction log (the workload uses no numscript, so the
+			// server merges nothing else in).
+			if !accountMetaMapEqual(ct.GetAccountMetadata(), data.GetCreatedTransaction().GetAccountMetadata()) {
+				assert.Unreachable("singleton_driver_model: transaction account-metadata mismatch", internal.Details{
+					"ledger":    oracle.LedgerOf(req),
+					"requested": len(ct.GetAccountMetadata()),
+					"returned":  len(data.GetCreatedTransaction().GetAccountMetadata()),
+				})
+
+				return
+			}
+		}
+
+		// DeleteMetadata (account or transaction) echoes the deleted target and key
+		// on its log; the deletion's effect is verified separately by reads.
+		if dm := req.GetApply().GetAction().GetDeleteMetadata(); dm != nil {
+			logDM := data.GetDeletedMetadata()
+			if logDM.GetKey() != dm.GetKey() || metaTargetLabel(logDM.GetTarget()) != metaTargetLabel(dm.GetTarget()) {
+				assert.Unreachable("singleton_driver_model: delete-metadata response mismatch", internal.Details{
+					"ledger":    oracle.LedgerOf(req),
+					"requested": metaTargetLabel(dm.GetTarget()) + "/" + dm.GetKey(),
+					"returned":  metaTargetLabel(logDM.GetTarget()) + "/" + logDM.GetKey(),
+				})
+
+				return
+			}
 		}
 
 		switch r := req.GetType().(type) {
@@ -612,6 +640,23 @@ func metaMapEqual(a, b map[string]*commonpb.MetadataValue) bool {
 	for k, v := range a {
 		bv, ok := b[k]
 		if !ok || oracle.MetaValueString(v) != oracle.MetaValueString(bv) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// accountMetaMapEqual reports whether two account-metadata maps (address -> map)
+// hold the same addresses and, per address, the same metadata.
+func accountMetaMapEqual(a, b map[string]*commonpb.MetadataMap) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for addr, am := range a {
+		bm, ok := b[addr]
+		if !ok || !metaMapEqual(am.GetValues(), bm.GetValues()) {
 			return false
 		}
 	}

--- a/tests/antithesis/workload/internal/client.go
+++ b/tests/antithesis/workload/internal/client.go
@@ -378,6 +378,27 @@ func HasErrorReason(err error, reason string) bool {
 	return false
 }
 
+// ErrorReason returns the ErrorInfo reason carried by a gRPC status error, or
+// "" if the error is nil or carries no ErrorInfo detail.
+func ErrorReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return ""
+	}
+
+	for _, detail := range st.Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok {
+			return info.GetReason()
+		}
+	}
+
+	return ""
+}
+
 // IsLedgerDeleted returns true if the error indicates a soft-deleted ledger.
 func IsLedgerDeleted(err error) bool {
 	return HasErrorReason(err, domain.ErrReasonLedgerDeleted)

--- a/tests/antithesis/workload/internal/ledger.go
+++ b/tests/antithesis/workload/internal/ledger.go
@@ -38,9 +38,9 @@ const (
 	// account-type / balance invariants a foreign write would break.
 	PrefixTransientAccounts OwnedLedgerPrefix = "transient"
 	PrefixInsufficientFunds OwnedLedgerPrefix = "insuf"
-	PrefixDeltest           OwnedLedgerPrefix = "deltest"   // parallel_driver_concurrent_ledger_delete
-	PrefixMaintenance       OwnedLedgerPrefix = "maint"     // parallel_driver_maintenance
-	PrefixAccountTypes      OwnedLedgerPrefix = "accttype"  // parallel_driver_account_types
+	PrefixDeltest           OwnedLedgerPrefix = "deltest"  // parallel_driver_concurrent_ledger_delete
+	PrefixMaintenance       OwnedLedgerPrefix = "maint"    // parallel_driver_maintenance
+	PrefixAccountTypes      OwnedLedgerPrefix = "accttype" // parallel_driver_account_types
 	PrefixTypeViolation     OwnedLedgerPrefix = "typeviolation"
 	PrefixEphemeral         OwnedLedgerPrefix = "ephemeral" // parallel_driver_delete_ledger
 

--- a/tests/antithesis/workload/internal/ledger.go
+++ b/tests/antithesis/workload/internal/ledger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -130,7 +131,7 @@ func (p OwnedLedgerPrefix) WithSuffix(suffix string) string {
 }
 
 // CreateLedger creates a ledger via the Apply RPC and verifies it can be read back.
-func CreateLedger(ctx context.Context, client servicepb.BucketServiceClient, name string) error {
+func CreateLedger(ctx context.Context, client servicepb.BucketServiceClient, name string, initialSchema ...*commonpb.SetMetadataFieldTypeCommand) error {
 	details := Details{"ledger": name}
 
 	// A fresh idempotency key, reused across the client's internal retries: a
@@ -140,7 +141,7 @@ func CreateLedger(ctx context.Context, client servicepb.BucketServiceClient, nam
 	key := fmt.Sprintf("create-ledger-%016x%016x", Rand().Uint64(), Rand().Uint64())
 	_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest(key, &servicepb.Request{
 		Type: &servicepb.Request_CreateLedger{
-			CreateLedger: &servicepb.CreateLedgerRequest{Name: name},
+			CreateLedger: &servicepb.CreateLedgerRequest{Name: name, InitialSchema: initialSchema},
 		},
 	}))
 	assert.Sometimes(IsTolerated(err), "should be able to create ledger", details.With(Details{"error": err}))

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -15,24 +15,25 @@ func (s LedgerState) Metadata() map[MetaKey]*commonpb.MetadataValue       { retu
 func (s LedgerState) LedgerMeta() map[string]*commonpb.MetadataValue      { return s.ledgerMeta }
 func (s LedgerState) AccountFieldTypes() map[string]commonpb.MetadataType { return s.accountFieldTypes }
 func (s LedgerState) LedgerFieldTypes() map[string]commonpb.MetadataType  { return s.ledgerFieldTypes }
-func (s LedgerState) TxRefs() map[string]*txRecord                        { return s.txRefs }
-func (s LedgerState) TxMeta() map[TxMetaKey]*commonpb.MetadataValue       { return s.txMeta }
 func (s LedgerState) TransactionFieldTypes() map[string]commonpb.MetadataType {
 	return s.transactionFieldTypes
 }
 
-// txRecord accessors expose a committed transaction tracked by reference: its
-// server-assigned id (the generator resolves a reference to its id to target
-// it), its original postings, and whether it has been reverted.
-func (t *txRecord) Id() uint64                    { return t.id }
-func (t *txRecord) Postings() []*commonpb.Posting { return t.postings }
-func (t *txRecord) Reverted() bool                { return t.reverted }
+// Txs is the transaction log; index i holds the transaction with id i+1. TxByRef
+// indexes referenced transactions by reference -> id.
+func (s LedgerState) Txs() []*txRecord        { return s.txs }
+func (s LedgerState) TxByRef() map[string]int { return s.txByRef }
+
+// txRecord accessors expose one committed transaction from the log: its
+// server-assigned id, its reference ("" for drains/transients/reverts), its
+// postings, its metadata, and whether it has been reverted.
+func (t *txRecord) Id() uint64                                   { return t.id }
+func (t *txRecord) Reference() string                            { return t.reference }
+func (t *txRecord) Postings() []*commonpb.Posting                { return t.postings }
+func (t *txRecord) Metadata() map[string]*commonpb.MetadataValue { return t.metadata }
+func (t *txRecord) Reverted() bool                               { return t.reverted }
 
 func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
 
 func (r *revertEffect) RevertedID() uint64            { return r.revertedID }
 func (r *revertEffect) Postings() []*commonpb.Posting { return r.postings }
-
-// Saved is the metadata set on the revert transaction (empty when the revert
-// carried none), echoed verbatim on the RevertedTransaction log.
-func (r *revertEffect) Saved() map[string]*commonpb.MetadataValue { return r.saved }

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -26,12 +26,14 @@ func (s LedgerState) TxByRef() map[string]int { return s.txByRef }
 
 // txRecord accessors expose one committed transaction from the log: its
 // server-assigned id, its reference ("" for drains/transients/reverts), its
-// postings, its metadata, and whether it has been reverted.
+// postings, its metadata, whether it has been reverted, and its user-supplied
+// timestamp (nil when the client sent none — see txRecord.timestamp).
 func (t *txRecord) Id() uint64                                   { return t.id }
 func (t *txRecord) Reference() string                            { return t.reference }
 func (t *txRecord) Postings() []*commonpb.Posting                { return t.postings }
 func (t *txRecord) Metadata() map[string]*commonpb.MetadataValue { return t.metadata }
 func (t *txRecord) Reverted() bool                               { return t.reverted }
+func (t *txRecord) Timestamp() *commonpb.Timestamp               { return t.timestamp }
 
 func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
 

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -1,0 +1,31 @@
+package oracle
+
+import "github.com/formancehq/ledger/v3/internal/proto/commonpb"
+
+// Exported read accessors over the model's internal state. The driver and the
+// replay tool inspect a committed state (chart, volumes, metadata, declared
+// field types) to generate operations and compare against the SUT; the maps are
+// never mutated through these — every model mutation goes through Apply.
+
+func (g GlobalState) Ledgers() map[string]LedgerState { return g.ledgers }
+
+func (s LedgerState) Types() map[string]TypeState                         { return s.types }
+func (s LedgerState) Volumes() map[VolumeKey]VolumePair                   { return s.volumes }
+func (s LedgerState) Metadata() map[MetaKey]*commonpb.MetadataValue       { return s.metadata }
+func (s LedgerState) LedgerMeta() map[string]*commonpb.MetadataValue      { return s.ledgerMeta }
+func (s LedgerState) AccountFieldTypes() map[string]commonpb.MetadataType { return s.accountFieldTypes }
+func (s LedgerState) LedgerFieldTypes() map[string]commonpb.MetadataType  { return s.ledgerFieldTypes }
+func (s LedgerState) TxRefs() map[string]*txRecord                        { return s.txRefs }
+func (s LedgerState) TxMeta() map[TxMetaKey]*commonpb.MetadataValue       { return s.txMeta }
+func (s LedgerState) TransactionFieldTypes() map[string]commonpb.MetadataType {
+	return s.transactionFieldTypes
+}
+
+// txRecord.Id is the server-assigned id of a committed transaction tracked by
+// reference — the generator resolves a reference to its id to target it.
+func (t *txRecord) Id() uint64 { return t.id }
+
+func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
+
+func (r *revertEffect) RevertedID() uint64            { return r.revertedID }
+func (r *revertEffect) Postings() []*commonpb.Posting { return r.postings }

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -21,9 +21,12 @@ func (s LedgerState) TransactionFieldTypes() map[string]commonpb.MetadataType {
 	return s.transactionFieldTypes
 }
 
-// txRecord.Id is the server-assigned id of a committed transaction tracked by
-// reference — the generator resolves a reference to its id to target it.
-func (t *txRecord) Id() uint64 { return t.id }
+// txRecord accessors expose a committed transaction tracked by reference: its
+// server-assigned id (the generator resolves a reference to its id to target
+// it), its original postings, and whether it has been reverted.
+func (t *txRecord) Id() uint64                    { return t.id }
+func (t *txRecord) Postings() []*commonpb.Posting { return t.postings }
+func (t *txRecord) Reverted() bool                { return t.reverted }
 
 func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
 

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -26,14 +26,18 @@ func (s LedgerState) TxByRef() map[string]int { return s.txByRef }
 
 // txRecord accessors expose one committed transaction from the log: its
 // server-assigned id, its reference ("" for drains/transients/reverts), its
-// postings, its metadata, whether it has been reverted, and its user-supplied
-// timestamp (nil when the client sent none — see txRecord.timestamp).
+// postings, its metadata, whether it has been reverted, its user-supplied
+// timestamp (nil when the client sent none — see txRecord.timestamp), and its
+// revert relationships (see the txRecord fields for the nil/zero conventions).
 func (t *txRecord) Id() uint64                                   { return t.id }
 func (t *txRecord) Reference() string                            { return t.reference }
 func (t *txRecord) Postings() []*commonpb.Posting                { return t.postings }
 func (t *txRecord) Metadata() map[string]*commonpb.MetadataValue { return t.metadata }
 func (t *txRecord) Reverted() bool                               { return t.reverted }
 func (t *txRecord) Timestamp() *commonpb.Timestamp               { return t.timestamp }
+func (t *txRecord) RevertedBy() uint64                           { return t.revertedBy }
+func (t *txRecord) RevertedAt() *commonpb.Timestamp              { return t.revertedAt }
+func (t *txRecord) RevertsTransaction() uint64                   { return t.revertsTransaction }
 
 func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
 

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -29,3 +29,7 @@ func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved
 
 func (r *revertEffect) RevertedID() uint64            { return r.revertedID }
 func (r *revertEffect) Postings() []*commonpb.Posting { return r.postings }
+
+// Saved is the metadata set on the revert transaction (empty when the revert
+// carried none), echoed verbatim on the RevertedTransaction log.
+func (r *revertEffect) Saved() map[string]*commonpb.MetadataValue { return r.saved }

--- a/tests/oracle/bulk.go
+++ b/tests/oracle/bulk.go
@@ -1,0 +1,9 @@
+package oracle
+
+import "github.com/formancehq/ledger/v3/internal/proto/servicepb"
+
+// Bulk is one Apply call's worth of requests — the unit the model folds in one
+// atomic step, mirroring the server's per-ApplyBatch atomicity.
+type Bulk struct {
+	Requests []*servicepb.Request
+}

--- a/tests/oracle/cmd/replay/main.go
+++ b/tests/oracle/cmd/replay/main.go
@@ -1,15 +1,19 @@
 // Command replay re-applies a captured commit stream through the model oracle.
 //
-// It reads the "[batch-dump] seq=.. b64=.." lines the singleton_driver_model
-// driver emits under MODEL_DUMP_BATCHES=1 (e.g. from an Antithesis run's
-// workload log), decodes each committed ApplyRequest, and folds them into a
-// fresh oracle.GlobalState in commit order — the exact deterministic sequence
-// the server applied. It prints each touched ledger's final model state and,
-// when a target ledger is given, that ledger's (metadata, type count) at every
-// committed prefix that touches it. A committed bulk the model rejects in
-// commit order is a model/server divergence and is surfaced loudly.
+// It reads the "[batch-dump] ticket=.. seq=.. outcome=.. b64=.." lines the
+// singleton_driver_model driver emits under MODEL_DUMP_BATCHES=1 (e.g. from an
+// Antithesis run's workload log): every submitted bulk with its dispatch ticket,
+// server outcome (OK / a rejection reason / TRANSIENT), and — for committed
+// bulks — its min committed log sequence. Two modes:
 //
-// Usage: replay <dump-file> [target-ledger]
+//   - committed (default): fold the committed (OK) bulks in log-sequence order —
+//     the server's true serialization even under concurrency. A bulk the model
+//     rejects is surfaced, and each touched ledger's final state is printed.
+//   - --submits: fold every bulk in dispatch-ticket order and compare each
+//     bulk's model outcome to the server's. Valid only for a single-worker run,
+//     where dispatch order IS the serialization; the first mismatch is the bug.
+//
+// Usage: replay <dump-file> [target-ledger] [--submits]
 package main
 
 import (
@@ -27,26 +31,109 @@ import (
 )
 
 type batch struct {
-	seq uint64
-	req *servicepb.ApplyRequest
+	ticket  uint64 // dispatch order (single-worker serialization)
+	seq     uint64 // min committed log sequence (server serialization); 0 if not committed
+	outcome string // "OK", a rejection reason, or "TRANSIENT" ("" for legacy dumps)
+	req     *servicepb.ApplyRequest
 }
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: replay <dump-file> [target-ledger]")
+		fmt.Fprintln(os.Stderr, "usage: replay <dump-file> [target-ledger] [--submits]")
 		os.Exit(2)
 	}
 
 	target := ""
-	if len(os.Args) >= 3 {
-		target = os.Args[2]
+	submitsMode := false
+	for _, a := range os.Args[2:] {
+		if a == "--submits" {
+			submitsMode = true
+		} else {
+			target = a
+		}
 	}
 
-	batches, err := parseDump(os.Args[1])
+	batches, err := parse(os.Args[1])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	if submitsMode {
+		replaySubmits(batches, target)
+	} else {
+		replayCommitted(batches, target)
+	}
+}
+
+// replaySubmits folds the submitted stream through a fresh oracle in dispatch
+// order and reports every bulk whose model outcome differs from the server's.
+func replaySubmits(submits []batch, target string) {
+	sort.SliceStable(submits, func(i, j int) bool { return submits[i].ticket < submits[j].ticket })
+	fmt.Printf("parsed %d submitted bulks (trace ledger=%q)\n\n", len(submits), target)
+
+	gs := oracle.NewGlobalState()
+	mismatches := 0
+
+	for _, b := range submits {
+		if b.outcome == "TRANSIENT" {
+			continue // the model drops transient/uncertain outcomes (processor.go)
+		}
+
+		ab, err := servicepb.PeekBatch(b.req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "seq=%d PeekBatch: %v\n", b.seq, err)
+			os.Exit(1)
+		}
+		bulk := oracle.Bulk{Requests: ab.GetRequests()}
+
+		touchesTarget := false
+		for _, r := range bulk.Requests {
+			if oracle.LedgerOf(r) == target {
+				touchesTarget = true
+			}
+		}
+
+		res := gs.Apply(bulk)
+		model := "OK"
+		if !res.OK {
+			model = res.Reason
+		}
+
+		if model != b.outcome {
+			mismatches++
+			fmt.Printf("ticket=%-6d MISMATCH server=%s model=%s\n", b.ticket, b.outcome, model)
+			fmt.Printf("            postings=%s\n", renderPostings(bulk))
+			fmt.Printf("            kinds=%s\n", renderKinds(bulk))
+			fmt.Printf("            modelTypes=%s\n\n", renderTypes(gs, bulk))
+		}
+
+		if res.OK {
+			gs = res.State
+		}
+
+		if target != "" && touchesTarget {
+			fmt.Printf("  trace ticket=%-6d srv=%-22s mdl=%-22s kinds=%-26s typesAfter=%-14s postings=%s\n",
+				b.ticket, b.outcome, model, renderKinds(bulk), typeNames(gs, target), renderPostings(bulk))
+		}
+	}
+
+	fmt.Printf("\n%d submitted bulks, %d model/server mismatches\n", len(submits), mismatches)
+}
+
+func typeNames(gs oracle.GlobalState, ledger string) string {
+	var names []string
+	for n := range gs.Ledger(ledger).Types() {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	return "[" + strings.Join(names, ",") + "]"
+}
+
+// replayCommitted folds the committed stream and prints the final per-ledger
+// state, surfacing any committed bulk the model rejects.
+func replayCommitted(batches []batch, target string) {
 	sort.SliceStable(batches, func(i, j int) bool { return batches[i].seq < batches[j].seq })
 	fmt.Printf("parsed %d committed batches\n", len(batches))
 
@@ -55,6 +142,13 @@ func main() {
 	rejected := 0
 
 	for _, b := range batches {
+		// Only committed bulks form the server's log-ordered serialization. Skip
+		// failures/transients; a legacy dump carries no outcome — treat as
+		// committed.
+		if b.outcome != "" && b.outcome != "OK" {
+			continue
+		}
+
 		ab, err := servicepb.PeekBatch(b.req)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "seq=%d PeekBatch: %v\n", b.seq, err)
@@ -98,32 +192,50 @@ func main() {
 	}
 }
 
-func parseDump(path string) ([]batch, error) {
+// parse reads "[batch-dump] key=value ..." lines, extracting the ticket, commit
+// sequence, outcome, and b64-encoded ApplyRequest. Missing keys default to zero
+// values (legacy dumps carry only seq= and b64=), so older captures still load.
+func parse(path string) ([]batch, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
-	var batches []batch
+	var out []batch
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
 	for sc.Scan() {
-		line := sc.Text()
-		_, after, ok := strings.Cut(line, "[batch-dump] seq=")
+		_, after, ok := strings.Cut(sc.Text(), "[batch-dump] ")
 		if !ok {
 			continue
 		}
-		rest := after
-		fields := strings.SplitN(rest, " b64=", 2)
-		if len(fields) != 2 {
+
+		var (
+			ticket, seq      uint64
+			outcome, encoded string
+		)
+		for field := range strings.FieldsSeq(after) {
+			k, v, ok := strings.Cut(field, "=")
+			if !ok {
+				continue
+			}
+			switch k {
+			case "ticket":
+				ticket, _ = strconv.ParseUint(v, 10, 64)
+			case "seq":
+				seq, _ = strconv.ParseUint(v, 10, 64)
+			case "outcome":
+				outcome = v
+			case "b64":
+				encoded = v
+			}
+		}
+
+		if encoded == "" {
 			continue
 		}
-		seq, err := strconv.ParseUint(strings.TrimSpace(fields[0]), 10, 64)
-		if err != nil {
-			continue
-		}
-		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(fields[1]))
+		raw, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			continue
 		}
@@ -131,10 +243,74 @@ func parseDump(path string) ([]batch, error) {
 		if err := req.UnmarshalVT(raw); err != nil {
 			continue
 		}
-		batches = append(batches, batch{seq: seq, req: req})
+
+		out = append(out, batch{ticket: ticket, seq: seq, outcome: outcome, req: req})
 	}
 
-	return batches, sc.Err()
+	return out, sc.Err()
+}
+
+func renderPostings(b oracle.Bulk) string {
+	var ps []string
+	for _, r := range b.Requests {
+		if ct := r.GetApply().GetAction().GetCreateTransaction(); ct != nil {
+			l := oracle.LedgerOf(r)
+			for _, p := range ct.GetPostings() {
+				ps = append(ps, fmt.Sprintf("%s:%s->%s(%s)", l, p.GetSource(), p.GetDestination(), p.GetAsset()))
+			}
+		}
+	}
+
+	return "[" + strings.Join(ps, " ") + "]"
+}
+
+func renderKinds(b oracle.Bulk) string {
+	kinds := make([]string, 0, len(b.Requests))
+	for _, r := range b.Requests {
+		switch t := r.GetType().(type) {
+		case *servicepb.Request_Apply:
+			switch t.Apply.GetAction().GetData().(type) {
+			case *servicepb.LedgerAction_CreateTransaction:
+				kinds = append(kinds, "tx")
+			case *servicepb.LedgerAction_AddMetadata:
+				kinds = append(kinds, "addMeta")
+			case *servicepb.LedgerAction_DeleteMetadata:
+				kinds = append(kinds, "delMeta")
+			case *servicepb.LedgerAction_RevertTransaction:
+				kinds = append(kinds, "revert")
+			default:
+				kinds = append(kinds, "apply?")
+			}
+		case *servicepb.Request_AddAccountType:
+			kinds = append(kinds, "+"+t.AddAccountType.GetAccountType().GetName())
+		case *servicepb.Request_RemoveAccountType:
+			kinds = append(kinds, "-"+t.RemoveAccountType.GetName())
+		default:
+			kinds = append(kinds, "other")
+		}
+	}
+
+	return "[" + strings.Join(kinds, ",") + "]"
+}
+
+func renderTypes(gs oracle.GlobalState, b oracle.Bulk) string {
+	ledgers := map[string]bool{}
+	for _, r := range b.Requests {
+		ledgers[oracle.LedgerOf(r)] = true
+	}
+
+	var out []string
+	for l := range ledgers {
+		var names []string
+		for n := range gs.Ledger(l).Types() {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		out = append(out, l+"=["+strings.Join(names, ",")+"]")
+	}
+	sort.Strings(out)
+
+	return "[" + strings.Join(out, " ") + "]"
 }
 
 func renderMeta(m map[string]*commonpb.MetadataValue) string {

--- a/tests/oracle/cmd/replay/main.go
+++ b/tests/oracle/cmd/replay/main.go
@@ -1,0 +1,153 @@
+// Command replay re-applies a captured commit stream through the model oracle.
+//
+// It reads the "[batch-dump] seq=.. b64=.." lines the singleton_driver_model
+// driver emits under MODEL_DUMP_BATCHES=1 (e.g. from an Antithesis run's
+// workload log), decodes each committed ApplyRequest, and folds them into a
+// fresh oracle.GlobalState in commit order — the exact deterministic sequence
+// the server applied. It prints each touched ledger's final model state and,
+// when a target ledger is given, that ledger's (metadata, type count) at every
+// committed prefix that touches it. A committed bulk the model rejects in
+// commit order is a model/server divergence and is surfaced loudly.
+//
+// Usage: replay <dump-file> [target-ledger]
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+)
+
+type batch struct {
+	seq uint64
+	req *servicepb.ApplyRequest
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: replay <dump-file> [target-ledger]")
+		os.Exit(2)
+	}
+
+	target := ""
+	if len(os.Args) >= 3 {
+		target = os.Args[2]
+	}
+
+	batches, err := parseDump(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	sort.SliceStable(batches, func(i, j int) bool { return batches[i].seq < batches[j].seq })
+	fmt.Printf("parsed %d committed batches\n", len(batches))
+
+	gs := oracle.NewGlobalState()
+	touched := map[string]bool{}
+	rejected := 0
+
+	for _, b := range batches {
+		ab, err := servicepb.PeekBatch(b.req)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "seq=%d PeekBatch: %v\n", b.seq, err)
+			os.Exit(1)
+		}
+		bulk := oracle.Bulk{Requests: ab.GetRequests()}
+
+		hitsTarget := false
+		for _, r := range bulk.Requests {
+			l := oracle.LedgerOf(r)
+			touched[l] = true
+			if l == target {
+				hitsTarget = true
+			}
+		}
+
+		res := gs.Apply(bulk)
+		if !res.OK {
+			rejected++
+			fmt.Printf("seq=%-6d MODEL REJECTED committed bulk: %s\n", b.seq, res.Reason)
+
+			continue
+		}
+		gs = res.State
+
+		if hitsTarget {
+			ls := gs.Ledger(target)
+			fmt.Printf("seq=%-6d %s meta=%s types=%d\n", b.seq, target, renderMeta(ls.LedgerMeta()), len(ls.Types()))
+		}
+	}
+
+	fmt.Printf("\nfinal model state (%d committed bulks rejected):\n", rejected)
+	names := make([]string, 0, len(touched))
+	for l := range touched {
+		names = append(names, l)
+	}
+	sort.Strings(names)
+	for _, l := range names {
+		ls := gs.Ledger(l)
+		fmt.Printf("  %s meta=%s types=%d\n", l, renderMeta(ls.LedgerMeta()), len(ls.Types()))
+	}
+}
+
+func parseDump(path string) ([]batch, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var batches []batch
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		_, after, ok := strings.Cut(line, "[batch-dump] seq=")
+		if !ok {
+			continue
+		}
+		rest := after
+		fields := strings.SplitN(rest, " b64=", 2)
+		if len(fields) != 2 {
+			continue
+		}
+		seq, err := strconv.ParseUint(strings.TrimSpace(fields[0]), 10, 64)
+		if err != nil {
+			continue
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(fields[1]))
+		if err != nil {
+			continue
+		}
+		req := &servicepb.ApplyRequest{}
+		if err := req.UnmarshalVT(raw); err != nil {
+			continue
+		}
+		batches = append(batches, batch{seq: seq, req: req})
+	}
+
+	return batches, sc.Err()
+}
+
+func renderMeta(m map[string]*commonpb.MetadataValue) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k + "=" + oracle.MetaValueString(m[k])
+	}
+
+	return "{" + strings.Join(parts, ",") + "}"
+}

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -420,10 +420,12 @@ type txRecord struct {
 }
 
 // revertEffect is a committed revert's predicted effect: the original
-// transaction id (echoed as reverted_transaction_id) and the reversed postings.
+// transaction id (echoed as reverted_transaction_id), the reversed postings, and
+// the metadata set on the revert transaction (echoed verbatim on its log).
 type revertEffect struct {
 	revertedID uint64
 	postings   []*commonpb.Posting
+	saved      map[string]*commonpb.MetadataValue
 }
 
 // ApplyResult is the predicted outcome of applying a whole bulk.
@@ -669,7 +671,7 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 		OK:     true,
 		PCV:    pcv,
 		TxID:   id,
-		Revert: &revertEffect{revertedID: rec.id, postings: reversed},
+		Revert: &revertEffect{revertedID: rec.id, postings: reversed, saved: rt.GetMetadata()},
 	}
 }
 

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -446,6 +446,19 @@ func LedgerOf(req *servicepb.Request) string {
 // and leaves every ledger unchanged. A bulk may span ledgers; each request is
 // routed to its own ledger's sub-state and the end-of-bulk checks run per ledger.
 func (g GlobalState) Apply(bulk Bulk) ApplyResult {
+	// Admission validates every order's structure and converts the whole batch
+	// before it reaches the FSM, so a single malformed order rejects the entire
+	// bulk ahead of any per-order FSM outcome. The only structural rejection the
+	// workload produces is an empty create (no postings, no script → VALIDATION);
+	// model it here so a bulk mixing an empty create with an FSM-rejecting order
+	// reports VALIDATION, matching validateOrderContent rather than the FSM reason
+	// the sequential pass below would reach first.
+	for _, req := range bulk.Requests {
+		if ct := req.GetApply().GetAction().GetCreateTransaction(); ct != nil && len(ct.GetPostings()) == 0 {
+			return ApplyResult{OK: false, Reason: domain.ErrReasonValidation, State: g}
+		}
+	}
+
 	next := g.clone()
 	orders := make([]OrderResult, 0, len(bulk.Requests))
 	touched := map[string]map[VolumeKey]bool{}
@@ -557,20 +570,34 @@ func (s *LedgerState) applyOne(req *servicepb.Request, touched map[VolumeKey]boo
 	}
 }
 
-// applyTransaction predicts a CreateTransaction. The server produces the
-// postings — applying the per-posting balance floor (a non-forced debit from a
-// non-world account may not exceed its running balance — see applyPostings) —
-// BEFORE it validates account types (processor_transaction.go: produce() then
-// validatePostingsAgainstAccountTypes). So an underfunded transaction reports
-// INSUFFICIENT_FUNDS even when an address also fails the chart; match that order
-// — floor first, then STRICT chart enforcement, then volume accumulation.
+// applyTransaction predicts a CreateTransaction, matching the server's FSM
+// rejection order (empty payloads are rejected earlier, at admission — see
+// Apply): a duplicate reference is rejected first (processor_transaction.go,
+// before produce()); then the server produces the postings — applying the
+// per-posting balance floor (a non-forced debit from a non-world account may not
+// exceed its running balance — see applyPostings) — BEFORE it validates account
+// types (produce() then validatePostingsAgainstAccountTypes). So an underfunded
+// transaction reports INSUFFICIENT_FUNDS even when an address also fails the
+// chart; match that order — floor first, then STRICT chart enforcement.
 func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, touched map[VolumeKey]bool) OrderResult {
-	pcv, reason := s.applyPostings(ct.GetPostings(), ct.GetForce(), touched)
+	postings := ct.GetPostings()
+
+	// A reference must be unique; the FSM checks this first, before producing
+	// postings or enforcing the chart, so a duplicate wins over any floor/chart
+	// issue the same transaction might also have.
+	ref := ct.GetReference()
+	if ref != "" {
+		if _, exists := s.txByRef[ref]; exists {
+			return OrderResult{Reason: domain.ErrReasonTransactionReferenceConflict}
+		}
+	}
+
+	pcv, reason := s.applyPostings(postings, ct.GetForce(), touched)
 	if reason != "" {
 		return OrderResult{Reason: reason}
 	}
 
-	if s.chartRejects(ct.GetPostings()) {
+	if s.chartRejects(postings) {
 		return OrderResult{Reason: domain.ErrReasonAccountNotMatchingType}
 	}
 
@@ -585,15 +612,6 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 		}
 	}
 
-	// A reference must be unique; a duplicate rejects the whole bulk. The workload
-	// uses unique references, so this guard is never exercised.
-	ref := ct.GetReference()
-	if ref != "" {
-		if _, exists := s.txByRef[ref]; exists {
-			return OrderResult{Reason: domain.ErrReasonTransactionReferenceConflict}
-		}
-	}
-
 	// Append to the log; the id is its 1-based position. Metadata is stored
 	// verbatim (the declared type is applied only on read) and echoed on the
 	// CreatedTransaction log.
@@ -601,7 +619,7 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 	s.txs = append(s.txs, &txRecord{
 		id:        id,
 		reference: ref,
-		postings:  ct.GetPostings(),
+		postings:  postings,
 		metadata:  ct.GetMetadata(),
 		timestamp: ct.GetTimestamp(),
 	})
@@ -731,17 +749,28 @@ func (s *LedgerState) applyPostings(postings []*commonpb.Posting, force bool, to
 		p.GetAmount().IntoUint256(&amt)
 		asset := p.GetAsset()
 		srcKey := VolumeKey{Address: p.GetSource(), Asset: asset}
+		src := s.vol(srcKey)
 
+		var sum uint256.Int
 		if !force && p.GetSource() != "world" {
-			cur := s.vol(srcKey)
-			var sum uint256.Int
-			if _, overflow := sum.AddOverflow(&cur.Output, &amt); overflow || cur.Input.Lt(&sum) {
+			if _, overflow := sum.AddOverflow(&src.Output, &amt); overflow || src.Input.Lt(&sum) {
 				return pcv, domain.ErrReasonInsufficientFunds
 			}
+		} else if _, overflow := sum.AddOverflow(&src.Output, &amt); overflow {
+			// world / force skip the floor, but the source Output still cannot
+			// overflow — processor_posting.go rejects the order (#321).
+			return pcv, domain.ErrReasonVolumeOverflow
+		}
+
+		// The destination Input can never overflow either.
+		dstKey := VolumeKey{Address: p.GetDestination(), Asset: asset}
+		dst := s.vol(dstKey)
+		if _, overflow := sum.AddOverflow(&dst.Input, &amt); overflow {
+			return pcv, domain.ErrReasonVolumeOverflow
 		}
 
 		bump(srcKey, &zero, &amt)
-		bump(VolumeKey{Address: p.GetDestination(), Asset: asset}, &amt, &zero)
+		bump(dstKey, &amt, &zero)
 	}
 
 	return pcv, ""

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -217,14 +217,22 @@ func (s LedgerState) Hash(h io.Writer) {
 	hashFieldTypes(h, "TF", s.transactionFieldTypes)
 
 	// The log is already in id order; hash each tx's identity (id, reference,
-	// reverted) and its metadata. Postings are fixed at creation, so they add
-	// nothing to the canonical fingerprint.
+	// reverted), postings, and metadata. Postings belong in the fingerprint
+	// because two commuting unreferenced transactions can reach identical volumes
+	// and metadata under opposite serializations while differing only in which id
+	// holds which postings — a distinction validateTransactionRead checks by id.
+	var amt uint256.Int
 	for _, tx := range s.txs {
 		rev := ""
 		if tx.reverted {
 			rev = "R"
 		}
 		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s\n", tx.id, tx.reference, rev)
+
+		for _, p := range tx.postings {
+			p.GetAmount().IntoUint256(&amt)
+			_, _ = fmt.Fprintf(h, "TP|%d|%s|%s|%s|%s\n", tx.id, p.GetSource(), p.GetDestination(), p.GetAsset(), amt.Dec())
+		}
 
 		mkeys := make([]string, 0, len(tx.metadata))
 		for k := range tx.metadata {
@@ -343,7 +351,7 @@ func (g GlobalState) Hash(h io.Writer) {
 	for _, n := range names {
 		ls := g.ledgers[n]
 		if len(ls.types) == 0 && len(ls.volumes) == 0 && len(ls.metadata) == 0 && len(ls.ledgerMeta) == 0 &&
-			len(ls.accountFieldTypes) == 0 && len(ls.ledgerFieldTypes) == 0 {
+			len(ls.accountFieldTypes) == 0 && len(ls.ledgerFieldTypes) == 0 && len(ls.transactionFieldTypes) == 0 {
 			continue
 		}
 		_, _ = fmt.Fprintf(h, "L|%s\n", n)

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -593,6 +593,17 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 
 	pcv := s.applyPostings(ct.GetPostings(), touched)
 
+	// Account metadata attached to the transaction is applied verbatim, last-
+	// writer-wins. The server applies it without chart enforcement (unlike a
+	// standalone AddMetadata — processor_transaction.go); the generator only
+	// attaches it to the transaction's own accounts, which already passed the
+	// posting chart check above, so no enforcement branch is needed.
+	for account, mm := range ct.GetAccountMetadata() {
+		for key, val := range mm.GetValues() {
+			s.metadata[MetaKey{Address: account, Key: key}] = val
+		}
+	}
+
 	// A reference becomes targetable. A duplicate rejects the whole bulk; the
 	// workload uses unique references, so this guard is never exercised.
 	ref := ct.GetReference()

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -387,6 +387,11 @@ type txRecord struct {
 	postings  []*commonpb.Posting
 	metadata  map[string]*commonpb.MetadataValue
 	reverted  bool
+	// timestamp is the user-supplied CreateTransaction timestamp, stored verbatim
+	// and echoed on reads. nil when the client sent none — the server then stamps
+	// its own command date, which the model cannot predict, so reads skip the
+	// timestamp check for such records.
+	timestamp *commonpb.Timestamp
 }
 
 // revertEffect is a committed revert's predicted effect: the original
@@ -598,6 +603,7 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 		reference: ref,
 		postings:  ct.GetPostings(),
 		metadata:  ct.GetMetadata(),
+		timestamp: ct.GetTimestamp(),
 	})
 	if ref != "" {
 		s.txByRef[ref] = int(id)
@@ -653,8 +659,11 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 	// Mark the original reverted (replace, don't mutate), then append the revert
 	// itself as a new unreferenced transaction carrying the reversed postings and
 	// any metadata the revert set.
-	s.txs[id-1] = &txRecord{id: orig.id, reference: orig.reference, postings: orig.postings, metadata: orig.metadata, reverted: true}
+	s.txs[id-1] = &txRecord{id: orig.id, reference: orig.reference, postings: orig.postings, metadata: orig.metadata, reverted: true, timestamp: orig.timestamp}
 
+	// The revert transaction's timestamp is the server's date (or, with
+	// at_effective_date, the original's) — the model leaves it nil so reads skip
+	// the check, since the server date is unpredictable.
 	revertID := uint64(len(s.txs)) + 1
 	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata()})
 
@@ -777,7 +786,7 @@ func (s *LedgerState) applyAddTxMetadata(id uint64, md map[string]*commonpb.Meta
 	maps.Copy(meta, old.metadata)
 	maps.Copy(meta, md) // last-writer-wins
 	// Replace (don't mutate) so clones sharing the pointer are unaffected.
-	s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted}
+	s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted, timestamp: old.timestamp}
 
 	return OrderResult{OK: true, Meta: &metaEffect{saved: md}}
 }
@@ -811,7 +820,7 @@ func (s *LedgerState) applyDeleteMetadata(cmd *commonpb.DeleteMetadataCommand) O
 		maps.Copy(meta, old.metadata)
 		delete(meta, cmd.GetKey())
 		// Replace (don't mutate) so clones sharing the pointer are unaffected.
-		s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted}
+		s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted, timestamp: old.timestamp}
 
 		return OrderResult{OK: true}
 	default:

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -218,11 +218,15 @@ func (s LedgerState) Hash(h io.Writer) {
 	hashFieldTypes(h, "TF", s.transactionFieldTypes)
 
 	// The log is already in id order; hash each tx's identity (id, reference,
-	// reverted, timestamp), postings, and metadata. Postings and timestamp belong
-	// in the fingerprint because two commuting unreferenced transactions can reach
-	// identical volumes and metadata under opposite serializations while differing
-	// only in which id holds which postings, or (for at-effective-date reverts) in
-	// the inherited timestamp — distinctions validateTransactionRead checks by id.
+	// reverted, timestamp, revert relationships), postings, and metadata.
+	// Postings and timestamp belong in the fingerprint because two commuting
+	// unreferenced transactions can reach identical volumes and metadata under
+	// opposite serializations while differing only in which id holds which
+	// postings, or (for at-effective-date reverts) in the inherited timestamp —
+	// distinctions validateTransactionRead checks by id. The revert
+	// relationships (revertedBy, revertsTransaction, revertedAt) distinguish
+	// serializations where the same id is reverted by, or reverts, a different
+	// transaction.
 	var amt uint256.Int
 	for _, tx := range s.txs {
 		rev := ""
@@ -232,11 +236,17 @@ func (s LedgerState) Hash(h io.Writer) {
 
 		// A nil timestamp (server-dated, unpredictable) must not collide with any
 		// concrete value: validateTransactionRead skips the check only when nil.
+		// Same for revertedAt.
 		ts := "-"
 		if tx.timestamp != nil {
 			ts = strconv.FormatUint(tx.timestamp.GetData(), 10)
 		}
-		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s|%s\n", tx.id, tx.reference, rev, ts)
+
+		ra := "-"
+		if tx.revertedAt != nil {
+			ra = strconv.FormatUint(tx.revertedAt.GetData(), 10)
+		}
+		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s|%s|%d|%d|%s\n", tx.id, tx.reference, rev, ts, tx.revertedBy, tx.revertsTransaction, ra)
 
 		for _, p := range tx.postings {
 			p.GetAmount().IntoUint256(&amt)
@@ -415,6 +425,15 @@ type txRecord struct {
 	// its own command date, which the model cannot predict, so reads skip the
 	// timestamp check for such records.
 	timestamp *commonpb.Timestamp
+	// Revert relationships, mirroring the server's Transaction fields: on a
+	// reverted original, revertedBy carries the compensating transaction's id
+	// and revertedAt its timestamp (nil when the compensating transaction is
+	// server-dated — unpredictable, so reads skip it, like timestamp); on a
+	// revert transaction, revertsTransaction carries the original's id. Zero
+	// values mean not reverted / not a revert.
+	revertedBy         uint64
+	revertedAt         *commonpb.Timestamp
+	revertsTransaction uint64
 }
 
 // revertEffect is a committed revert's predicted effect: the original
@@ -697,11 +716,6 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 		return OrderResult{Reason: reason}
 	}
 
-	// Mark the original reverted (replace, don't mutate), then append the revert
-	// itself as a new unreferenced transaction carrying the reversed postings and
-	// any metadata the revert set.
-	s.txs[id-1] = &txRecord{id: orig.id, reference: orig.reference, postings: orig.postings, metadata: orig.metadata, reverted: true, timestamp: orig.timestamp}
-
 	// A plain revert stamps the server's current date (nil here — unpredictable,
 	// so reads skip it). With at_effective_date the revert inherits the original's
 	// timestamp (processor_revert_transaction.go), which the model knows iff the
@@ -712,7 +726,18 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 	}
 
 	revertID := uint64(len(s.txs)) + 1
-	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata(), timestamp: revertTS})
+
+	// Mark the original reverted (replace, don't mutate), then append the revert
+	// itself as a new unreferenced transaction carrying the reversed postings and
+	// any metadata the revert set. The reverted_at stamped on the original is the
+	// compensating transaction's timestamp (processor_revert_transaction.go).
+	reverted := *orig
+	reverted.reverted = true
+	reverted.revertedBy = revertID
+	reverted.revertedAt = revertTS
+	s.txs[id-1] = &reverted
+
+	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata(), timestamp: revertTS, revertsTransaction: orig.id})
 
 	return OrderResult{
 		OK:     true,
@@ -843,8 +868,11 @@ func (s *LedgerState) applyAddTxMetadata(id uint64, md map[string]*commonpb.Meta
 	meta := make(map[string]*commonpb.MetadataValue, len(old.metadata)+len(md))
 	maps.Copy(meta, old.metadata)
 	maps.Copy(meta, md) // last-writer-wins
-	// Replace (don't mutate) so clones sharing the pointer are unaffected.
-	s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted, timestamp: old.timestamp}
+	// Replace (don't mutate) so clones sharing the pointer are unaffected; a
+	// value copy carries every field, including the revert relationships.
+	updated := *old
+	updated.metadata = meta
+	s.txs[id-1] = &updated
 
 	return OrderResult{OK: true, Meta: &metaEffect{saved: md}}
 }
@@ -877,8 +905,11 @@ func (s *LedgerState) applyDeleteMetadata(cmd *commonpb.DeleteMetadataCommand) O
 		meta := make(map[string]*commonpb.MetadataValue, len(old.metadata))
 		maps.Copy(meta, old.metadata)
 		delete(meta, cmd.GetKey())
-		// Replace (don't mutate) so clones sharing the pointer are unaffected.
-		s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted, timestamp: old.timestamp}
+		// Replace (don't mutate) so clones sharing the pointer are unaffected; a
+		// value copy carries every field, including the revert relationships.
+		updated := *old
+		updated.metadata = meta
+		s.txs[id-1] = &updated
 
 		return OrderResult{OK: true}
 	default:

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -1,8 +1,9 @@
-package main
+package oracle
 
 import (
 	"fmt"
 	"io"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,8 +35,8 @@ type MetaKey struct {
 	Key     string
 }
 
-// compareMetaKey compares MetaKeys by address, then key.
-func compareMetaKey(a, b MetaKey) int {
+// CompareMetaKey compares MetaKeys by address, then key.
+func CompareMetaKey(a, b MetaKey) int {
 	if c := strings.Compare(a.Address, b.Address); c != 0 {
 		return c
 	}
@@ -52,8 +53,8 @@ type TxMetaKey struct {
 	Key       string
 }
 
-// compareTxMetaKey compares TxMetaKeys by reference, then key.
-func compareTxMetaKey(a, b TxMetaKey) int {
+// CompareTxMetaKey compares TxMetaKeys by reference, then key.
+func CompareTxMetaKey(a, b TxMetaKey) int {
 	if c := strings.Compare(a.Reference, b.Reference); c != 0 {
 		return c
 	}
@@ -67,8 +68,8 @@ type VolumePair struct {
 	Output uint256.Int
 }
 
-// compareVolumeKey compares VolumeKeys by address, then asset.
-func compareVolumeKey(a, b VolumeKey) int {
+// CompareVolumeKey compares VolumeKeys by address, then asset.
+func CompareVolumeKey(a, b VolumeKey) int {
 	if c := strings.Compare(a.Address, b.Address); c != 0 {
 		return c
 	}
@@ -131,56 +132,36 @@ func NewLedgerState() LedgerState {
 // never mutated in place (a set replaces the entry, a delete removes it).
 func (s LedgerState) clone() LedgerState {
 	types := make(map[string]TypeState, len(s.types))
-	for k, v := range s.types {
-		types[k] = v
-	}
+	maps.Copy(types, s.types)
 
 	volumes := make(map[VolumeKey]VolumePair, len(s.volumes))
-	for k, v := range s.volumes {
-		volumes[k] = v
-	}
+	maps.Copy(volumes, s.volumes)
 
 	metadata := make(map[MetaKey]*commonpb.MetadataValue, len(s.metadata))
-	for k, v := range s.metadata {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, s.metadata)
 
 	ledgerMeta := make(map[string]*commonpb.MetadataValue, len(s.ledgerMeta))
-	for k, v := range s.ledgerMeta {
-		ledgerMeta[k] = v
-	}
+	maps.Copy(ledgerMeta, s.ledgerMeta)
 
 	accountFieldTypes := make(map[string]commonpb.MetadataType, len(s.accountFieldTypes))
-	for k, v := range s.accountFieldTypes {
-		accountFieldTypes[k] = v
-	}
+	maps.Copy(accountFieldTypes, s.accountFieldTypes)
 
 	ledgerFieldTypes := make(map[string]commonpb.MetadataType, len(s.ledgerFieldTypes))
-	for k, v := range s.ledgerFieldTypes {
-		ledgerFieldTypes[k] = v
-	}
+	maps.Copy(ledgerFieldTypes, s.ledgerFieldTypes)
 
 	// Records are replaced (not mutated in place) on a revert, so clones can
 	// share the pointer.
 	txRefs := make(map[string]*txRecord, len(s.txRefs))
-	for k, v := range s.txRefs {
-		txRefs[k] = v
-	}
+	maps.Copy(txRefs, s.txRefs)
 
 	txMeta := make(map[TxMetaKey]*commonpb.MetadataValue, len(s.txMeta))
-	for k, v := range s.txMeta {
-		txMeta[k] = v
-	}
+	maps.Copy(txMeta, s.txMeta)
 
 	txIDToRef := make(map[uint64]string, len(s.txIDToRef))
-	for k, v := range s.txIDToRef {
-		txIDToRef[k] = v
-	}
+	maps.Copy(txIDToRef, s.txIDToRef)
 
 	transactionFieldTypes := make(map[string]commonpb.MetadataType, len(s.transactionFieldTypes))
-	for k, v := range s.transactionFieldTypes {
-		transactionFieldTypes[k] = v
-	}
+	maps.Copy(transactionFieldTypes, s.transactionFieldTypes)
 
 	return LedgerState{
 		types:                 types,
@@ -223,7 +204,7 @@ func (s *LedgerState) match(addr string, compiled []accounttype.CompiledType) *T
 }
 
 // hash writes a canonical identity of the ledger's state into h.
-func (s LedgerState) hash(h io.Writer) {
+func (s LedgerState) Hash(h io.Writer) {
 	names := make([]string, 0, len(s.types))
 	for n := range s.types {
 		names = append(names, n)
@@ -231,26 +212,26 @@ func (s LedgerState) hash(h io.Writer) {
 	sort.Strings(names)
 	for _, n := range names {
 		t := s.types[n]
-		fmt.Fprintf(h, "T|%s|%s|%d\n", t.Name, t.Pattern, t.Persistence)
+		_, _ = fmt.Fprintf(h, "T|%s|%s|%d\n", t.Name, t.Pattern, t.Persistence)
 	}
 
 	keys := make([]VolumeKey, 0, len(s.volumes))
 	for k := range s.volumes {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return compareVolumeKey(keys[i], keys[j]) < 0 })
+	sort.Slice(keys, func(i, j int) bool { return CompareVolumeKey(keys[i], keys[j]) < 0 })
 	for _, k := range keys {
 		v := s.volumes[k]
-		fmt.Fprintf(h, "V|%s|%s|%s|%s\n", k.Address, k.Asset, v.Input.Dec(), v.Output.Dec())
+		_, _ = fmt.Fprintf(h, "V|%s|%s|%s|%s\n", k.Address, k.Asset, v.Input.Dec(), v.Output.Dec())
 	}
 
 	mkeys := make([]MetaKey, 0, len(s.metadata))
 	for k := range s.metadata {
 		mkeys = append(mkeys, k)
 	}
-	sort.Slice(mkeys, func(i, j int) bool { return compareMetaKey(mkeys[i], mkeys[j]) < 0 })
+	sort.Slice(mkeys, func(i, j int) bool { return CompareMetaKey(mkeys[i], mkeys[j]) < 0 })
 	for _, k := range mkeys {
-		fmt.Fprintf(h, "M|%s|%s|%s\n", k.Address, k.Key, metaValueString(s.metadata[k]))
+		_, _ = fmt.Fprintf(h, "M|%s|%s|%s\n", k.Address, k.Key, MetaValueString(s.metadata[k]))
 	}
 
 	lkeys := make([]string, 0, len(s.ledgerMeta))
@@ -259,7 +240,7 @@ func (s LedgerState) hash(h io.Writer) {
 	}
 	sort.Strings(lkeys)
 	for _, k := range lkeys {
-		fmt.Fprintf(h, "LM|%s|%s\n", k, metaValueString(s.ledgerMeta[k]))
+		_, _ = fmt.Fprintf(h, "LM|%s|%s\n", k, MetaValueString(s.ledgerMeta[k]))
 	}
 
 	hashFieldTypes(h, "AF", s.accountFieldTypes)
@@ -276,16 +257,16 @@ func (s LedgerState) hash(h io.Writer) {
 		if s.txRefs[r].reverted {
 			rev = "R"
 		}
-		fmt.Fprintf(h, "TR|%s|%s\n", r, rev)
+		_, _ = fmt.Fprintf(h, "TR|%s|%s\n", r, rev)
 	}
 
 	tkeys := make([]TxMetaKey, 0, len(s.txMeta))
 	for k := range s.txMeta {
 		tkeys = append(tkeys, k)
 	}
-	sort.Slice(tkeys, func(i, j int) bool { return compareTxMetaKey(tkeys[i], tkeys[j]) < 0 })
+	sort.Slice(tkeys, func(i, j int) bool { return CompareTxMetaKey(tkeys[i], tkeys[j]) < 0 })
 	for _, k := range tkeys {
-		fmt.Fprintf(h, "TM|%s|%s|%s\n", k.Reference, k.Key, metaValueString(s.txMeta[k]))
+		_, _ = fmt.Fprintf(h, "TM|%s|%s|%s\n", k.Reference, k.Key, MetaValueString(s.txMeta[k]))
 	}
 }
 
@@ -297,14 +278,14 @@ func hashFieldTypes(h io.Writer, tag string, types map[string]commonpb.MetadataT
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		fmt.Fprintf(h, "%s|%s|%d\n", tag, k, types[k])
+		_, _ = fmt.Fprintf(h, "%s|%s|%d\n", tag, k, types[k])
 	}
 }
 
-// metaValueString renders a metadata value as a canonical, type-tagged string,
+// MetaValueString renders a metadata value as a canonical, type-tagged string,
 // used for both hashing and equality: two values are equal iff their renderings
 // match. The type tag keeps a string "5" distinct from an int 5.
-func metaValueString(v *commonpb.MetadataValue) string {
+func MetaValueString(v *commonpb.MetadataValue) string {
 	switch t := v.GetType().(type) {
 	case *commonpb.MetadataValue_StringValue:
 		return "s:" + t.StringValue
@@ -323,7 +304,7 @@ func metaValueString(v *commonpb.MetadataValue) string {
 
 // matchAddress resolves addr to its account type in this state (compiling the
 // chart fresh), or nil. Convenience for callers that match a single address.
-func (s *LedgerState) matchAddress(addr string) *TypeState {
+func (s *LedgerState) MatchAddress(addr string) *TypeState {
 	return s.match(addr, s.compiled())
 }
 
@@ -333,7 +314,7 @@ func (s *LedgerState) vol(key VolumeKey) VolumePair {
 }
 
 // accountMetadata returns addr's metadata as a key→value map (empty if none).
-func (s *LedgerState) accountMetadata(addr string) map[string]*commonpb.MetadataValue {
+func (s *LedgerState) AccountMetadata(addr string) map[string]*commonpb.MetadataValue {
 	out := map[string]*commonpb.MetadataValue{}
 	for mk, v := range s.metadata {
 		if mk.Address == addr {
@@ -372,7 +353,7 @@ func (g GlobalState) clone() GlobalState {
 }
 
 // ledger returns the named ledger's state, or an empty one if untouched.
-func (g GlobalState) ledger(name string) LedgerState {
+func (g GlobalState) Ledger(name string) LedgerState {
 	if ls, ok := g.ledgers[name]; ok {
 		return ls
 	}
@@ -383,7 +364,7 @@ func (g GlobalState) ledger(name string) LedgerState {
 // hash writes a canonical identity across all non-empty ledgers into h.
 // candidateBases dedups on the resulting 64-bit hash, collapsing bases reached
 // via different (commutative) serializations.
-func (g GlobalState) hash(h io.Writer) {
+func (g GlobalState) Hash(h io.Writer) {
 	names := make([]string, 0, len(g.ledgers))
 	for n := range g.ledgers {
 		names = append(names, n)
@@ -396,8 +377,8 @@ func (g GlobalState) hash(h io.Writer) {
 			len(ls.accountFieldTypes) == 0 && len(ls.ledgerFieldTypes) == 0 {
 			continue
 		}
-		fmt.Fprintf(h, "L|%s\n", n)
-		ls.hash(h)
+		_, _ = fmt.Fprintf(h, "L|%s\n", n)
+		ls.Hash(h)
 	}
 }
 
@@ -458,8 +439,8 @@ type ApplyResult struct {
 	Orders []OrderResult
 }
 
-// ledgerOf returns the ledger a request targets.
-func ledgerOf(req *servicepb.Request) string {
+// LedgerOf returns the ledger a request targets.
+func LedgerOf(req *servicepb.Request) string {
 	switch r := req.GetType().(type) {
 	case *servicepb.Request_Apply:
 		return r.Apply.GetLedger()
@@ -476,7 +457,7 @@ func ledgerOf(req *servicepb.Request) string {
 	case *servicepb.Request_RemoveMetadataFieldType:
 		return r.RemoveMetadataFieldType.GetLedger()
 	default:
-		panic(fmt.Sprintf("ledgerOf: unmodeled request type %T", req.GetType()))
+		panic(fmt.Sprintf("LedgerOf: unmodeled request type %T", req.GetType()))
 	}
 }
 
@@ -491,7 +472,7 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 	touched := map[string]map[VolumeKey]bool{}
 
 	for _, req := range bulk.Requests {
-		name := ledgerOf(req)
+		name := LedgerOf(req)
 
 		ls, ok := next.ledgers[name]
 		if !ok {
@@ -523,7 +504,7 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 	// cells are purged.
 	for name, cells := range touched {
 		ls := next.ledgers[name]
-		base := g.ledger(name)
+		base := g.Ledger(name)
 
 		if reason, violated := ls.transientViolation(&base, cells); violated {
 			return ApplyResult{OK: false, Reason: reason, State: g, Orders: orders}

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -552,16 +552,22 @@ func (s *LedgerState) applyOne(req *servicepb.Request, touched map[VolumeKey]boo
 	}
 }
 
-// applyTransaction predicts a CreateTransaction: STRICT chart enforcement
-// (every non-world address must match a type once any type exists), then volume
-// accumulation. Insufficient-funds is not modelled because the workload only
-// debits "world" (overdraftable) or uses Force.
+// applyTransaction predicts a CreateTransaction. The server produces the
+// postings — applying the per-posting balance floor (a non-forced debit from a
+// non-world account may not exceed its running balance — see applyPostings) —
+// BEFORE it validates account types (processor_transaction.go: produce() then
+// validatePostingsAgainstAccountTypes). So an underfunded transaction reports
+// INSUFFICIENT_FUNDS even when an address also fails the chart; match that order
+// — floor first, then STRICT chart enforcement, then volume accumulation.
 func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, touched map[VolumeKey]bool) OrderResult {
+	pcv, reason := s.applyPostings(ct.GetPostings(), ct.GetForce(), touched)
+	if reason != "" {
+		return OrderResult{Reason: reason}
+	}
+
 	if s.chartRejects(ct.GetPostings()) {
 		return OrderResult{Reason: domain.ErrReasonAccountNotMatchingType}
 	}
-
-	pcv := s.applyPostings(ct.GetPostings(), touched)
 
 	// Account metadata attached to the transaction is applied verbatim, last-
 	// writer-wins. The server applies it without chart enforcement (unlike a
@@ -606,8 +612,8 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 }
 
 // applyRevert predicts a RevertTransaction: it reverses the original postings
-// (swap source/destination), enforces the chart on them (force skips only the
-// balance check, which the model does not track), moves the volumes, marks the
+// (swap source/destination), enforces the chart on them, applies the balance
+// floor unless force is set (see applyPostings), moves the volumes, marks the
 // original reverted, and consumes a new transaction id for the revert itself.
 func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touched map[VolumeKey]bool) OrderResult {
 	id := rt.GetTransactionId()
@@ -639,7 +645,10 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 		return OrderResult{Reason: domain.ErrReasonAccountNotMatchingType}
 	}
 
-	pcv := s.applyPostings(reversed, touched)
+	pcv, reason := s.applyPostings(reversed, rt.GetForce(), touched)
+	if reason != "" {
+		return OrderResult{Reason: reason}
+	}
 
 	// Mark the original reverted (replace, don't mutate), then append the revert
 	// itself as a new unreferenced transaction carrying the reversed postings and
@@ -684,7 +693,13 @@ func (s *LedgerState) chartRejects(postings []*commonpb.Posting) bool {
 // applyPostings accumulates postings into volumes (source.output += amount,
 // destination.input += amount) read-modify-write per cell so postings touching
 // the same cell compose, returning the post-commit volumes of the touched cells.
-func (s *LedgerState) applyPostings(postings []*commonpb.Posting, touched map[VolumeKey]bool) map[VolumeKey]VolumePair {
+// applyPostings folds postings into the running volumes in order and returns the
+// per-cell post-commit volumes. A non-forced debit from a non-world account is
+// held to its balance floor (input - output): if the amount exceeds it the whole
+// bulk is rejected with INSUFFICIENT_FUNDS (returned reason != ""). The floor is
+// evaluated against the running volumes, so an earlier posting in the same bulk
+// can fund a later source — mirroring applyPosting in processor_posting.go.
+func (s *LedgerState) applyPostings(postings []*commonpb.Posting, force bool, touched map[VolumeKey]bool) (map[VolumeKey]VolumePair, string) {
 	pcv := map[VolumeKey]VolumePair{}
 	bump := func(key VolumeKey, addIn, addOut *uint256.Int) {
 		cur := s.vol(key)
@@ -700,11 +715,21 @@ func (s *LedgerState) applyPostings(postings []*commonpb.Posting, touched map[Vo
 		var amt uint256.Int
 		p.GetAmount().IntoUint256(&amt)
 		asset := p.GetAsset()
-		bump(VolumeKey{Address: p.GetSource(), Asset: asset}, &zero, &amt)
+		srcKey := VolumeKey{Address: p.GetSource(), Asset: asset}
+
+		if !force && p.GetSource() != "world" {
+			cur := s.vol(srcKey)
+			var sum uint256.Int
+			if _, overflow := sum.AddOverflow(&cur.Output, &amt); overflow || cur.Input.Lt(&sum) {
+				return pcv, domain.ErrReasonInsufficientFunds
+			}
+		}
+
+		bump(srcKey, &zero, &amt)
 		bump(VolumeKey{Address: p.GetDestination(), Asset: asset}, &amt, &zero)
 	}
 
-	return pcv
+	return pcv, ""
 }
 
 // applyAddMetadata predicts a SaveMetadata, dispatching on the target. Metadata

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -297,6 +297,8 @@ func MetaValueString(v *commonpb.MetadataValue) string {
 		return "b:" + strconv.FormatBool(t.BoolValue)
 	case *commonpb.MetadataValue_NullValue:
 		return "n:" + t.NullValue.GetOriginal()
+	case *commonpb.MetadataValue_DatetimeValue:
+		return "d:" + strconv.FormatInt(t.DatetimeValue, 10)
 	default:
 		return "<nil>"
 	}

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -44,24 +44,6 @@ func CompareMetaKey(a, b MetaKey) int {
 	return strings.Compare(a.Key, b.Key)
 }
 
-// TxMetaKey is one (transaction reference, key) cell of the transaction-metadata
-// table. Transactions are addressed by reference (carried in the request) rather
-// than by server-assigned id, so the model can track them in the serialization
-// search where no response — hence no id — is available.
-type TxMetaKey struct {
-	Reference string
-	Key       string
-}
-
-// CompareTxMetaKey compares TxMetaKeys by reference, then key.
-func CompareTxMetaKey(a, b TxMetaKey) int {
-	if c := strings.Compare(a.Reference, b.Reference); c != 0 {
-		return c
-	}
-
-	return strings.Compare(a.Key, b.Key)
-}
-
 // VolumePair is the cumulative input/output for one (address, asset) cell.
 type VolumePair struct {
 	Input  uint256.Int
@@ -92,21 +74,16 @@ type LedgerState struct {
 	accountFieldTypes map[string]commonpb.MetadataType
 	ledgerFieldTypes  map[string]commonpb.MetadataType
 
-	// Transactions addressed by reference: txRefs maps a reference to its record
-	// (id, postings, reverted status), txMeta holds their metadata. txIDToRef maps
-	// each reference's server id back to the reference — the API now targets
-	// transactions by id (the proto dropped reference targeting in #462), so the
-	// generator resolves a tracked reference to its id and the apply path resolves
-	// the id back to the reference to reuse the reference-keyed bookkeeping.
-	txRefs                map[string]*txRecord
-	txMeta                map[TxMetaKey]*commonpb.MetadataValue
-	txIDToRef             map[uint64]string
+	// txs is the transaction log: index i holds the transaction with id i+1, so
+	// ids are dense and sequential, mirroring the server (first id is 1). Every
+	// committed create is appended — referenced and unreferenced alike (drains,
+	// transients, and reverts). The next id is len(txs)+1. Records are replaced,
+	// never mutated in place, so clones share the pointers.
+	txs []*txRecord
+	// txByRef indexes referenced transactions by reference -> id, for the
+	// generator (which targets by reference) and reference-keyed metadata writes.
+	txByRef               map[string]int
 	transactionFieldTypes map[string]commonpb.MetadataType
-
-	// Next transaction id the server assigns in this ledger (starts at 1, per
-	// processor_ledger.go), bumped per committed CreateTransaction so the model
-	// can predict the id echoed in the response.
-	nextTxID uint64
 }
 
 func NewLedgerState() LedgerState {
@@ -118,11 +95,8 @@ func NewLedgerState() LedgerState {
 		accountFieldTypes: map[string]commonpb.MetadataType{},
 		ledgerFieldTypes:  map[string]commonpb.MetadataType{},
 
-		txRefs:                map[string]*txRecord{},
-		txMeta:                map[TxMetaKey]*commonpb.MetadataValue{},
-		txIDToRef:             map[uint64]string{},
+		txByRef:               map[string]int{},
 		transactionFieldTypes: map[string]commonpb.MetadataType{},
-		nextTxID:              1,
 	}
 }
 
@@ -149,16 +123,13 @@ func (s LedgerState) clone() LedgerState {
 	ledgerFieldTypes := make(map[string]commonpb.MetadataType, len(s.ledgerFieldTypes))
 	maps.Copy(ledgerFieldTypes, s.ledgerFieldTypes)
 
-	// Records are replaced (not mutated in place) on a revert, so clones can
-	// share the pointer.
-	txRefs := make(map[string]*txRecord, len(s.txRefs))
-	maps.Copy(txRefs, s.txRefs)
+	// Records are replaced (not mutated in place) on a metadata write or revert,
+	// so a shallow copy of the log lets clones share the pointers.
+	txs := make([]*txRecord, len(s.txs))
+	copy(txs, s.txs)
 
-	txMeta := make(map[TxMetaKey]*commonpb.MetadataValue, len(s.txMeta))
-	maps.Copy(txMeta, s.txMeta)
-
-	txIDToRef := make(map[uint64]string, len(s.txIDToRef))
-	maps.Copy(txIDToRef, s.txIDToRef)
+	txByRef := make(map[string]int, len(s.txByRef))
+	maps.Copy(txByRef, s.txByRef)
 
 	transactionFieldTypes := make(map[string]commonpb.MetadataType, len(s.transactionFieldTypes))
 	maps.Copy(transactionFieldTypes, s.transactionFieldTypes)
@@ -170,11 +141,9 @@ func (s LedgerState) clone() LedgerState {
 		ledgerMeta:            ledgerMeta,
 		accountFieldTypes:     accountFieldTypes,
 		ledgerFieldTypes:      ledgerFieldTypes,
-		txRefs:                txRefs,
-		txMeta:                txMeta,
-		txIDToRef:             txIDToRef,
+		txs:                   txs,
+		txByRef:               txByRef,
 		transactionFieldTypes: transactionFieldTypes,
-		nextTxID:              s.nextTxID,
 	}
 }
 
@@ -247,26 +216,24 @@ func (s LedgerState) Hash(h io.Writer) {
 	hashFieldTypes(h, "LF", s.ledgerFieldTypes)
 	hashFieldTypes(h, "TF", s.transactionFieldTypes)
 
-	refs := make([]string, 0, len(s.txRefs))
-	for r := range s.txRefs {
-		refs = append(refs, r)
-	}
-	sort.Strings(refs)
-	for _, r := range refs {
+	// The log is already in id order; hash each tx's identity (id, reference,
+	// reverted) and its metadata. Postings are fixed at creation, so they add
+	// nothing to the canonical fingerprint.
+	for _, tx := range s.txs {
 		rev := ""
-		if s.txRefs[r].reverted {
+		if tx.reverted {
 			rev = "R"
 		}
-		_, _ = fmt.Fprintf(h, "TR|%s|%s\n", r, rev)
-	}
+		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s\n", tx.id, tx.reference, rev)
 
-	tkeys := make([]TxMetaKey, 0, len(s.txMeta))
-	for k := range s.txMeta {
-		tkeys = append(tkeys, k)
-	}
-	sort.Slice(tkeys, func(i, j int) bool { return CompareTxMetaKey(tkeys[i], tkeys[j]) < 0 })
-	for _, k := range tkeys {
-		_, _ = fmt.Fprintf(h, "TM|%s|%s|%s\n", k.Reference, k.Key, MetaValueString(s.txMeta[k]))
+		mkeys := make([]string, 0, len(tx.metadata))
+		for k := range tx.metadata {
+			mkeys = append(mkeys, k)
+		}
+		sort.Strings(mkeys)
+		for _, k := range mkeys {
+			_, _ = fmt.Fprintf(h, "TM|%d|%s|%s\n", tx.id, k, MetaValueString(tx.metadata[k]))
+		}
 	}
 }
 
@@ -409,23 +376,26 @@ type metaEffect struct {
 	saved map[string]*commonpb.MetadataValue
 }
 
-// txRecord is a committed transaction tracked by reference: its server-assigned
-// id and postings (to predict a revert's reversed postings) and whether it has
-// been reverted (a second revert is rejected). Records are replaced, never
-// mutated in place, so clones safely share the pointer.
+// txRecord is a committed transaction in the log: its server-assigned id, its
+// reference ("" for drains, transients, and reverts), its postings, its metadata
+// (set at creation and by later metadata writes), and whether it has been
+// reverted (a second revert is rejected). Records are replaced, never mutated in
+// place, so clones safely share the pointer.
 type txRecord struct {
-	id       uint64
-	postings []*commonpb.Posting
-	reverted bool
+	id        uint64
+	reference string
+	postings  []*commonpb.Posting
+	metadata  map[string]*commonpb.MetadataValue
+	reverted  bool
 }
 
 // revertEffect is a committed revert's predicted effect: the original
-// transaction id (echoed as reverted_transaction_id), the reversed postings, and
-// the metadata set on the revert transaction (echoed verbatim on its log).
+// transaction id (echoed as reverted_transaction_id) and the reversed postings.
+// The revert transaction's own metadata is verified through a read of its log
+// entry, not here.
 type revertEffect struct {
 	revertedID uint64
 	postings   []*commonpb.Posting
-	saved      map[string]*commonpb.MetadataValue
 }
 
 // ApplyResult is the predicted outcome of applying a whole bulk.
@@ -604,34 +574,32 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 		}
 	}
 
-	// A reference becomes targetable. A duplicate rejects the whole bulk; the
-	// workload uses unique references, so this guard is never exercised.
+	// A reference must be unique; a duplicate rejects the whole bulk. The workload
+	// uses unique references, so this guard is never exercised.
 	ref := ct.GetReference()
 	if ref != "" {
-		if _, exists := s.txRefs[ref]; exists {
+		if _, exists := s.txByRef[ref]; exists {
 			return OrderResult{Reason: domain.ErrReasonTransactionReferenceConflict}
 		}
 	}
 
-	id := s.nextTxID
-	s.nextTxID++
+	// Append to the log; the id is its 1-based position. Metadata is stored
+	// verbatim (the declared type is applied only on read) and echoed on the
+	// CreatedTransaction log.
+	id := uint64(len(s.txs)) + 1
+	s.txs = append(s.txs, &txRecord{
+		id:        id,
+		reference: ref,
+		postings:  ct.GetPostings(),
+		metadata:  ct.GetMetadata(),
+	})
+	if ref != "" {
+		s.txByRef[ref] = int(id)
+	}
 
 	var meta *metaEffect
-
-	if ref != "" {
-		s.txRefs[ref] = &txRecord{id: id, postings: ct.GetPostings()}
-		s.txIDToRef[id] = ref
-
-		// Metadata is stored verbatim; the declared type is applied only on read.
-		if len(ct.GetMetadata()) > 0 {
-			saved := make(map[string]*commonpb.MetadataValue, len(ct.GetMetadata()))
-			for key, val := range ct.GetMetadata() {
-				s.txMeta[TxMetaKey{Reference: ref, Key: key}] = val
-				saved[key] = val
-			}
-
-			meta = &metaEffect{saved: saved}
-		}
+	if len(ct.GetMetadata()) > 0 {
+		meta = &metaEffect{saved: ct.GetMetadata()}
 	}
 
 	return OrderResult{OK: true, PCV: pcv, Meta: meta, TxID: id}
@@ -642,23 +610,23 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 // balance check, which the model does not track), moves the volumes, marks the
 // original reverted, and consumes a new transaction id for the revert itself.
 func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touched map[VolumeKey]bool) OrderResult {
-	ref, ok := s.txIDToRef[rt.GetTransactionId()]
-	if !ok {
-		// Unknown id (id >= NextTransactionId); the server rejects with
+	id := rt.GetTransactionId()
+	if id == 0 || id > uint64(len(s.txs)) {
+		// Unknown id (past the log frontier); the server rejects with
 		// TRANSACTION_NOT_FOUND. The generator targets committed transactions, so
 		// in commit order this is unreachable, but a candidate-base ordering may
 		// not have applied the create yet.
 		return OrderResult{Reason: domain.ErrReasonTransactionNotFound}
 	}
 
-	rec := s.txRefs[ref]
+	orig := s.txs[id-1]
 
-	if rec.reverted {
+	if orig.reverted {
 		return OrderResult{Reason: domain.ErrReasonTransactionAlreadyReverted}
 	}
 
-	reversed := make([]*commonpb.Posting, len(rec.postings))
-	for i, p := range rec.postings {
+	reversed := make([]*commonpb.Posting, len(orig.postings))
+	for i, p := range orig.postings {
 		reversed[i] = &commonpb.Posting{
 			Source:      p.GetDestination(),
 			Destination: p.GetSource(),
@@ -673,16 +641,19 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 
 	pcv := s.applyPostings(reversed, touched)
 
-	id := s.nextTxID
-	s.nextTxID++
-	// Replace (don't mutate) so clones sharing the pointer are unaffected.
-	s.txRefs[ref] = &txRecord{id: rec.id, postings: rec.postings, reverted: true}
+	// Mark the original reverted (replace, don't mutate), then append the revert
+	// itself as a new unreferenced transaction carrying the reversed postings and
+	// any metadata the revert set.
+	s.txs[id-1] = &txRecord{id: orig.id, reference: orig.reference, postings: orig.postings, metadata: orig.metadata, reverted: true}
+
+	revertID := uint64(len(s.txs)) + 1
+	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata()})
 
 	return OrderResult{
 		OK:     true,
 		PCV:    pcv,
-		TxID:   id,
-		Revert: &revertEffect{revertedID: rec.id, postings: reversed, saved: rt.GetMetadata()},
+		TxID:   revertID,
+		Revert: &revertEffect{revertedID: orig.id, postings: reversed},
 	}
 }
 
@@ -772,20 +743,18 @@ func (s *LedgerState) applyAddAccountMetadata(addr string, md map[string]*common
 // applyAddTxMetadata sets transaction metadata last-writer-wins on a transaction
 // addressed by id. An unknown id rejects with TRANSACTION_NOT_FOUND.
 func (s *LedgerState) applyAddTxMetadata(id uint64, md map[string]*commonpb.MetadataValue) OrderResult {
-	ref, ok := s.txIDToRef[id]
-	if !ok {
+	if id == 0 || id > uint64(len(s.txs)) {
 		return OrderResult{Reason: domain.ErrReasonTransactionNotFound}
 	}
 
-	saved := make(map[string]*commonpb.MetadataValue, len(md))
+	old := s.txs[id-1]
+	meta := make(map[string]*commonpb.MetadataValue, len(old.metadata)+len(md))
+	maps.Copy(meta, old.metadata)
+	maps.Copy(meta, md) // last-writer-wins
+	// Replace (don't mutate) so clones sharing the pointer are unaffected.
+	s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted}
 
-	for key, val := range md {
-		tk := TxMetaKey{Reference: ref, Key: key}
-		s.txMeta[tk] = val
-		saved[key] = val
-	}
-
-	return OrderResult{OK: true, Meta: &metaEffect{saved: saved}}
+	return OrderResult{OK: true, Meta: &metaEffect{saved: md}}
 }
 
 // applyDeleteMetadata predicts a DeleteMetadata, dispatching on the target.
@@ -803,17 +772,21 @@ func (s *LedgerState) applyDeleteMetadata(cmd *commonpb.DeleteMetadataCommand) O
 
 		return OrderResult{OK: true}
 	case *commonpb.Target_TransactionId:
-		ref, ok := s.txIDToRef[t.TransactionId]
-		if !ok {
+		id := t.TransactionId
+		if id == 0 || id > uint64(len(s.txs)) {
 			return OrderResult{Reason: domain.ErrReasonTransactionNotFound}
 		}
 
-		tk := TxMetaKey{Reference: ref, Key: cmd.GetKey()}
-		if _, exists := s.txMeta[tk]; !exists {
+		old := s.txs[id-1]
+		if _, exists := old.metadata[cmd.GetKey()]; !exists {
 			return OrderResult{Reason: domain.ErrReasonMetadataNotFound}
 		}
 
-		delete(s.txMeta, tk)
+		meta := make(map[string]*commonpb.MetadataValue, len(old.metadata))
+		maps.Copy(meta, old.metadata)
+		delete(meta, cmd.GetKey())
+		// Replace (don't mutate) so clones sharing the pointer are unaffected.
+		s.txs[id-1] = &txRecord{id: old.id, reference: old.reference, postings: old.postings, metadata: meta, reverted: old.reverted}
 
 		return OrderResult{OK: true}
 	default:

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"maps"
@@ -217,17 +218,25 @@ func (s LedgerState) Hash(h io.Writer) {
 	hashFieldTypes(h, "TF", s.transactionFieldTypes)
 
 	// The log is already in id order; hash each tx's identity (id, reference,
-	// reverted), postings, and metadata. Postings belong in the fingerprint
-	// because two commuting unreferenced transactions can reach identical volumes
-	// and metadata under opposite serializations while differing only in which id
-	// holds which postings — a distinction validateTransactionRead checks by id.
+	// reverted, timestamp), postings, and metadata. Postings and timestamp belong
+	// in the fingerprint because two commuting unreferenced transactions can reach
+	// identical volumes and metadata under opposite serializations while differing
+	// only in which id holds which postings, or (for at-effective-date reverts) in
+	// the inherited timestamp — distinctions validateTransactionRead checks by id.
 	var amt uint256.Int
 	for _, tx := range s.txs {
 		rev := ""
 		if tx.reverted {
 			rev = "R"
 		}
-		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s\n", tx.id, tx.reference, rev)
+
+		// A nil timestamp (server-dated, unpredictable) must not collide with any
+		// concrete value: validateTransactionRead skips the check only when nil.
+		ts := "-"
+		if tx.timestamp != nil {
+			ts = strconv.FormatUint(tx.timestamp.GetData(), 10)
+		}
+		_, _ = fmt.Fprintf(h, "TX|%d|%s|%s|%s\n", tx.id, tx.reference, rev, ts)
 
 		for _, p := range tx.postings {
 			p.GetAmount().IntoUint256(&amt)
@@ -349,13 +358,19 @@ func (g GlobalState) Hash(h io.Writer) {
 	sort.Strings(names)
 
 	for _, n := range names {
-		ls := g.ledgers[n]
-		if len(ls.types) == 0 && len(ls.volumes) == 0 && len(ls.metadata) == 0 && len(ls.ledgerMeta) == 0 &&
-			len(ls.accountFieldTypes) == 0 && len(ls.ledgerFieldTypes) == 0 && len(ls.transactionFieldTypes) == 0 {
+		// Apply materializes a ledger entry for any ledger a bulk touches, even
+		// when the operation stores nothing (e.g. removing an undeclared field), so
+		// a present-but-stateless entry must not change the fingerprint — otherwise
+		// candidateBases treats semantically-equal bases as distinct. Derive
+		// emptiness from LedgerState.Hash's own output rather than a field list, so
+		// the guard can never fall behind the fields Hash actually renders.
+		var buf bytes.Buffer
+		g.ledgers[n].Hash(&buf)
+		if buf.Len() == 0 {
 			continue
 		}
 		_, _ = fmt.Fprintf(h, "L|%s\n", n)
-		ls.Hash(h)
+		_, _ = h.Write(buf.Bytes())
 	}
 }
 

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -661,11 +661,17 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 	// any metadata the revert set.
 	s.txs[id-1] = &txRecord{id: orig.id, reference: orig.reference, postings: orig.postings, metadata: orig.metadata, reverted: true, timestamp: orig.timestamp}
 
-	// The revert transaction's timestamp is the server's date (or, with
-	// at_effective_date, the original's) — the model leaves it nil so reads skip
-	// the check, since the server date is unpredictable.
+	// A plain revert stamps the server's current date (nil here — unpredictable,
+	// so reads skip it). With at_effective_date the revert inherits the original's
+	// timestamp (processor_revert_transaction.go), which the model knows iff the
+	// original carried a user-supplied one; otherwise it too is a server date (nil).
+	var revertTS *commonpb.Timestamp
+	if rt.GetAtEffectiveDate() {
+		revertTS = orig.timestamp
+	}
+
 	revertID := uint64(len(s.txs)) + 1
-	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata()})
+	s.txs = append(s.txs, &txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata(), timestamp: revertTS})
 
 	return OrderResult{
 		OK:     true,

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -368,3 +368,81 @@ func TestApplyRevert_AtEffectiveDate(t *testing.T) {
 	require.True(t, r3.OK)
 	require.Nil(t, r3.State.Ledger("L").Txs()[1].Timestamp())
 }
+
+func TestApplyTransaction_EmptyRejected(t *testing.T) {
+	t.Parallel()
+
+	// No postings and no script: admission rejects it as empty (VALIDATION).
+	res := NewGlobalState().Apply(bulkOf(oracletest.TxReqMulti(false)))
+	require.False(t, res.OK)
+	require.Equal(t, domain.ErrReasonValidation, res.Reason)
+}
+
+func TestApplyTransaction_DuplicateReference(t *testing.T) {
+	t.Parallel()
+
+	first := NewGlobalState().Apply(bulkOf(oracletest.TxReqRefL("L", "r1", "world", "a:1", "USD", 5)))
+	require.True(t, first.OK)
+
+	dup := first.State.Apply(bulkOf(oracletest.TxReqRefL("L", "r1", "world", "a:2", "USD", 7)))
+	require.False(t, dup.OK)
+	require.Equal(t, domain.ErrReasonTransactionReferenceConflict, dup.Reason)
+}
+
+// A duplicate reference is reported even when the same transaction would also
+// fail the balance floor: the FSM checks reference uniqueness before produce().
+func TestApplyTransaction_ReferenceConflictBeatsFloor(t *testing.T) {
+	t.Parallel()
+
+	seeded := NewGlobalState().Apply(bulkOf(oracletest.TxReqRefL("L", "r1", "world", "a:1", "USD", 5)))
+	require.True(t, seeded.OK)
+
+	// Reuses ref "r1" and overdraws a:1 (holds 5, non-forced) — the reference
+	// conflict wins over INSUFFICIENT_FUNDS.
+	res := seeded.State.Apply(bulkOf(oracletest.TxReqRefL("L", "r1", "a:1", "b:1", "USD", 100)))
+	require.False(t, res.OK)
+	require.Equal(t, domain.ErrReasonTransactionReferenceConflict, res.Reason)
+}
+
+func TestApplyTransaction_VolumeOverflow_SourceOutput(t *testing.T) {
+	t.Parallel()
+
+	// Two 2^255 sends from world to the same account: the second overflows world's
+	// running Output (2^255 + 2^255 = 2^256).
+	half := new(big.Int).Lsh(big.NewInt(1), 255)
+	res := NewGlobalState().Apply(bulkOf(oracletest.TxReqMulti(false,
+		commonpb.NewPosting("world", "d:1", "USD", half),
+		commonpb.NewPosting("world", "d:1", "USD", half),
+	)))
+	require.False(t, res.OK)
+	require.Equal(t, domain.ErrReasonVolumeOverflow, res.Reason)
+}
+
+func TestApplyTransaction_VolumeOverflow_DestInput(t *testing.T) {
+	t.Parallel()
+
+	// Two 2^255 credits into d:1 from distinct sources (forced, so the floor is
+	// skipped and neither source Output overflows): d:1's Input overflows.
+	half := new(big.Int).Lsh(big.NewInt(1), 255)
+	res := NewGlobalState().Apply(bulkOf(oracletest.TxReqMulti(true,
+		commonpb.NewPosting("world", "d:1", "USD", half),
+		commonpb.NewPosting("a:1", "d:1", "USD", half),
+	)))
+	require.False(t, res.OK)
+	require.Equal(t, domain.ErrReasonVolumeOverflow, res.Reason)
+}
+
+// A bulk mixing an empty create with an FSM-rejecting order reports VALIDATION:
+// admission validates the whole batch's structure before the FSM, so the empty
+// order rejects everything ahead of the floor/chart reason the sequential FSM
+// pass would otherwise reach.
+func TestApplyTransaction_EmptyBeatsFsmRejection(t *testing.T) {
+	t.Parallel()
+
+	res := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{
+		oracletest.TxReq("a:1", "b:1", "USD", 100), // unfunded non-world debit → INSUFFICIENT_FUNDS at the FSM
+		oracletest.TxReqMulti(false),               // empty → VALIDATION at admission
+	}})
+	require.False(t, res.OK)
+	require.Equal(t, domain.ErrReasonValidation, res.Reason)
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -311,3 +311,27 @@ func TestApplyTransaction_MultiPosting(t *testing.T) {
 	require.Equal(t, domain.ErrReasonInsufficientFunds, over.Reason)
 	require.NotContains(t, over.State.Ledger("L").volumes, VolumeKey{"a:1", "USD"})
 }
+
+func TestApplyTransaction_Timestamp(t *testing.T) {
+	t.Parallel()
+
+	// A user-supplied timestamp is stored verbatim on the transaction record.
+	req := oracletest.TxReq("world", "x:1", "USD", 5)
+	req.GetApply().GetAction().GetCreateTransaction().Timestamp = &commonpb.Timestamp{Data: 12345}
+	res := NewGlobalState().Apply(bulkOf(req))
+	require.True(t, res.OK)
+	require.Equal(t, uint64(12345), res.State.Ledger("L").Txs()[0].Timestamp().GetData())
+
+	// It survives a later metadata write — the reconstruction preserves it. (A
+	// lost timestamp would read back as nil, which reads skip, so only a unit
+	// test catches it.)
+	withMeta := res.State.Apply(bulkOf(oracletest.AddTxMetaReq(1, map[string]*commonpb.MetadataValue{"k": commonpb.NewStringValue("v")})))
+	require.True(t, withMeta.OK)
+	require.Equal(t, uint64(12345), withMeta.State.Ledger("L").Txs()[0].Timestamp().GetData())
+
+	// A transaction with no user timestamp records nil (server stamps its own
+	// unpredictable date), so the read-back check is skipped for it.
+	noTs := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "y:1", "USD", 5)))
+	require.True(t, noTs.OK)
+	require.Nil(t, noTs.State.Ledger("L").Txs()[0].Timestamp())
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -177,3 +177,22 @@ func TestGlobalState_Apply_EphemeralPurge(t *testing.T) {
 	require.True(t, zeroed.OK)
 	require.NotContains(t, zeroed.State.Ledger("L").volumes, VolumeKey{"e:1", "USD"})
 }
+
+// MetaValueString must render every MetadataValue wire kind with a distinct,
+// type-tagged prefix, so the checker compares stored values exactly across all
+// kinds (the server stores them verbatim).
+func TestMetaValueString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*commonpb.MetadataValue{
+		"s:hi":    commonpb.NewStringValue("hi"),
+		"i:-42":   commonpb.NewIntValue(-42),
+		"u:42":    commonpb.NewUintValue(42),
+		"b:true":  commonpb.NewBoolValue(true),
+		"n:orig":  commonpb.NewNullValue("orig"),
+		"d:-1000": commonpb.NewDatetimeValue(-1000),
+	}
+	for want, v := range cases {
+		require.Equal(t, want, MetaValueString(v))
+	}
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -196,3 +196,90 @@ func TestMetaValueString(t *testing.T) {
 		require.Equal(t, want, MetaValueString(v))
 	}
 }
+
+func TestApplyTransaction_BalanceFloor(t *testing.T) {
+	t.Parallel()
+
+	// Fund x:1 with 10 from world (world is overdraftable, so this always commits).
+	funded := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "x:1", "USD", 10)))
+	require.True(t, funded.OK)
+
+	// A non-forced debit within balance commits and moves the source's output.
+	ok := funded.State.Apply(bulkOf(oracletest.TxReq("x:1", "y:1", "USD", 6)))
+	require.True(t, ok.OK)
+	okLedger := ok.State.Ledger("L")
+	require.Equal(t, "6", dec(okLedger.vol(VolumeKey{"x:1", "USD"}).Output))
+
+	// Exactly the balance is allowed (input >= output+amount, equality passes).
+	require.True(t, funded.State.Apply(bulkOf(oracletest.TxReq("x:1", "y:1", "USD", 10))).OK)
+
+	// One over the balance is rejected with INSUFFICIENT_FUNDS; nothing commits.
+	over := funded.State.Apply(bulkOf(oracletest.TxReq("x:1", "y:1", "USD", 11)))
+	require.False(t, over.OK)
+	require.Equal(t, domain.ErrReasonInsufficientFunds, over.Reason)
+	overLedger := over.State.Ledger("L")
+	require.Equal(t, "0", dec(overLedger.vol(VolumeKey{"x:1", "USD"}).Output))
+
+	// Force skips the floor: an over-balance forced debit commits.
+	require.True(t, funded.State.Apply(bulkOf(oracletest.TxReqForce("x:1", "y:1", "USD", 1000, true))).OK)
+
+	// world is never floored, regardless of the amount.
+	require.True(t, NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "z:1", "USD", 1_000_000))).OK)
+}
+
+func TestApplyTransaction_BalanceFloor_RunningVolumes(t *testing.T) {
+	t.Parallel()
+
+	// Within one bulk a later transaction may spend what an earlier one funded:
+	// the floor reads the running volumes, not the drained base.
+	chain := NewGlobalState().Apply(bulkOf(
+		oracletest.TxReq("world", "a:1", "USD", 10),
+		oracletest.TxReq("a:1", "b:1", "USD", 10),
+	))
+	require.True(t, chain.OK)
+
+	// The same debit without the funding leg is rejected.
+	bare := NewGlobalState().Apply(bulkOf(oracletest.TxReq("a:1", "b:1", "USD", 10)))
+	require.False(t, bare.OK)
+	require.Equal(t, domain.ErrReasonInsufficientFunds, bare.Reason)
+}
+
+func TestApplyRevert_ForceSkipsFloor(t *testing.T) {
+	t.Parallel()
+
+	// tx1 funds x:1 with 10; x:1 then spends 6 (balance 4). Reverting tx1 debits
+	// x:1 by 10 — more than it now holds — but reverts set force, so it commits.
+	base := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "x:1", "USD", 10)))
+	require.True(t, base.OK)
+	spent := base.State.Apply(bulkOf(oracletest.TxReq("x:1", "y:1", "USD", 6)))
+	require.True(t, spent.OK)
+
+	require.True(t, spent.State.Apply(bulkOf(oracletest.RevertReqL("L", 1, true))).OK)
+
+	// Without force, the same revert would hit the floor.
+	unforced := spent.State.Apply(bulkOf(oracletest.RevertReqL("L", 1, false)))
+	require.False(t, unforced.OK)
+	require.Equal(t, domain.ErrReasonInsufficientFunds, unforced.Reason)
+}
+
+func TestApplyTransaction_FloorBeforeChart(t *testing.T) {
+	t.Parallel()
+
+	// A ledger with one account type, so the chart is enforced. "acct:{id}"
+	// matches acct:* but not x:1 / y:1.
+	typed := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReq("acct")))
+	require.True(t, typed.OK)
+
+	// A non-forced debit from an unfunded, chart-unmatched account: the server
+	// checks the balance while producing postings, BEFORE validating account
+	// types, so it reports INSUFFICIENT_FUNDS — not ACCOUNT_NOT_MATCHING_TYPE.
+	underfunded := typed.State.Apply(bulkOf(oracletest.TxReq("x:1", "y:1", "USD", 5)))
+	require.False(t, underfunded.OK)
+	require.Equal(t, domain.ErrReasonInsufficientFunds, underfunded.Reason)
+
+	// Funded from world (overdraftable, balance never fails) but the destination
+	// is chart-unmatched: now the type check is the deciding rejection.
+	unmatchedDest := typed.State.Apply(bulkOf(oracletest.TxReq("world", "y:1", "USD", 5)))
+	require.False(t, unmatchedDest.OK)
+	require.Equal(t, domain.ErrReasonAccountNotMatchingType, unmatchedDest.Reason)
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	"bytes"
 	"math/big"
 	"testing"
 
@@ -19,46 +18,6 @@ import (
 func dec(v uint256.Int) string { return v.Dec() }
 
 func bulkOf(reqs ...*servicepb.Request) Bulk { return Bulk{Requests: reqs} }
-
-// hashString renders a state's canonical fingerprint (what candidateBases hashes
-// to dedup bases) as a string, so tests can assert two states are distinguished.
-func hashString(g GlobalState) string {
-	var b bytes.Buffer
-	g.Hash(&b)
-
-	return b.String()
-}
-
-// Two unreferenced, metadata-free transactions from world to disjoint accounts
-// commute to identical volumes; the serializations differ only in which id holds
-// which postings, so the fingerprint must include postings to tell them apart —
-// validateTransactionRead compares postings by id against these bases.
-func TestHash_PostingsDistinguishCommutingTransactions(t *testing.T) {
-	t.Parallel()
-
-	txA := oracletest.TxReq("world", "a:1", "USD", 10)
-	txB := oracletest.TxReq("world", "b:1", "USD", 10)
-
-	o1 := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{txA, txB}})
-	o2 := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{txB, txA}})
-	require.True(t, o1.OK)
-	require.True(t, o2.OK)
-
-	require.NotEqual(t, hashString(o1.State), hashString(o2.State))
-}
-
-// A ledger whose only state is a transaction field type must still contribute to
-// the fingerprint; otherwise the empty-ledger guard collapses states that differ
-// only in their transaction schema (validateSchemaRead checks it).
-func TestHash_TransactionSchemaOnlyLedgerNotSkipped(t *testing.T) {
-	t.Parallel()
-
-	withField := NewGlobalState().Apply(bulkOf(
-		oracletest.SetTxFieldTypeReq("L", "k", commonpb.MetadataType_METADATA_TYPE_STRING)))
-	require.True(t, withField.OK)
-
-	require.NotEqual(t, hashString(NewGlobalState()), hashString(withField.State))
-}
 
 func TestGlobalState_Apply_ChartOps(t *testing.T) {
 	t.Parallel()

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
@@ -18,6 +19,46 @@ import (
 func dec(v uint256.Int) string { return v.Dec() }
 
 func bulkOf(reqs ...*servicepb.Request) Bulk { return Bulk{Requests: reqs} }
+
+// hashString renders a state's canonical fingerprint (what candidateBases hashes
+// to dedup bases) as a string, so tests can assert two states are distinguished.
+func hashString(g GlobalState) string {
+	var b bytes.Buffer
+	g.Hash(&b)
+
+	return b.String()
+}
+
+// Two unreferenced, metadata-free transactions from world to disjoint accounts
+// commute to identical volumes; the serializations differ only in which id holds
+// which postings, so the fingerprint must include postings to tell them apart —
+// validateTransactionRead compares postings by id against these bases.
+func TestHash_PostingsDistinguishCommutingTransactions(t *testing.T) {
+	t.Parallel()
+
+	txA := oracletest.TxReq("world", "a:1", "USD", 10)
+	txB := oracletest.TxReq("world", "b:1", "USD", 10)
+
+	o1 := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{txA, txB}})
+	o2 := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{txB, txA}})
+	require.True(t, o1.OK)
+	require.True(t, o2.OK)
+
+	require.NotEqual(t, hashString(o1.State), hashString(o2.State))
+}
+
+// A ledger whose only state is a transaction field type must still contribute to
+// the fingerprint; otherwise the empty-ledger guard collapses states that differ
+// only in their transaction schema (validateSchemaRead checks it).
+func TestHash_TransactionSchemaOnlyLedgerNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	withField := NewGlobalState().Apply(bulkOf(
+		oracletest.SetTxFieldTypeReq("L", "k", commonpb.MetadataType_METADATA_TYPE_STRING)))
+	require.True(t, withField.OK)
+
+	require.NotEqual(t, hashString(NewGlobalState()), hashString(withField.State))
+}
 
 func TestGlobalState_Apply_ChartOps(t *testing.T) {
 	t.Parallel()

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -1,97 +1,43 @@
-package main
+package oracle
 
 import (
-	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
-	"github.com/holiman/uint256"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
 )
-
-func addTypeReqP(name string, p commonpb.AccountTypePersistence) *servicepb.Request {
-	return &servicepb.Request{
-		Type: &servicepb.Request_AddAccountType{
-			AddAccountType: &servicepb.AddAccountTypeLedgerRequest{
-				Ledger: "L",
-				AccountType: &commonpb.AccountType{
-					Name:        name,
-					Pattern:     name + ":{id}",
-					Persistence: p,
-				},
-			},
-		},
-	}
-}
-
-func addTypeReq(name string) *servicepb.Request {
-	return addTypeReqP(name, commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL)
-}
-
-func removeReqL(ledger, name string) *servicepb.Request {
-	return &servicepb.Request{
-		Type: &servicepb.Request_RemoveAccountType{
-			RemoveAccountType: &servicepb.RemoveAccountTypeLedgerRequest{Ledger: ledger, Name: name},
-		},
-	}
-}
-
-func removeTypeReq(name string) *servicepb.Request {
-	return removeReqL("L", name)
-}
-
-func txReqL(ledger, src, dest, asset string, amount int64) *servicepb.Request {
-	return &servicepb.Request{
-		Type: &servicepb.Request_Apply{
-			Apply: &servicepb.LedgerApplyRequest{
-				Ledger: ledger,
-				Action: &servicepb.LedgerAction{
-					Data: &servicepb.LedgerAction_CreateTransaction{
-						CreateTransaction: &servicepb.CreateTransactionPayload{
-							Postings: []*commonpb.Posting{
-								commonpb.NewPosting(src, dest, asset, big.NewInt(amount)),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func txReq(src, dest, asset string, amount int64) *servicepb.Request {
-	return txReqL("L", src, dest, asset, amount)
-}
-
-func bulkOf(reqs ...*servicepb.Request) Bulk { return Bulk{Requests: reqs} }
 
 // dec renders a uint256 volume value (Dec has a pointer receiver, so this
 // takes an addressable copy for call sites on non-addressable map/return values).
 func dec(v uint256.Int) string { return v.Dec() }
+
+func bulkOf(reqs ...*servicepb.Request) Bulk { return Bulk{Requests: reqs} }
 
 func TestGlobalState_Apply_ChartOps(t *testing.T) {
 	t.Parallel()
 
 	base := NewGlobalState()
 
-	added := base.Apply(bulkOf(addTypeReq("T")))
+	added := base.Apply(bulkOf(oracletest.AddTypeReq("T")))
 	require.True(t, added.OK)
-	require.Contains(t, added.State.ledger("L").types, "T")
+	require.Contains(t, added.State.Ledger("L").types, "T")
 	// Immutability: deriving `added` never touched base.
-	require.NotContains(t, base.ledger("L").types, "T")
+	require.NotContains(t, base.Ledger("L").types, "T")
 
-	dup := added.State.Apply(bulkOf(addTypeReq("T")))
+	dup := added.State.Apply(bulkOf(oracletest.AddTypeReq("T")))
 	require.False(t, dup.OK)
 	require.Equal(t, domain.ErrReasonAccountTypeAlreadyExists, dup.Reason)
 
-	removed := added.State.Apply(bulkOf(removeTypeReq("T")))
+	removed := added.State.Apply(bulkOf(oracletest.RemoveTypeReq("T")))
 	require.True(t, removed.OK)
-	require.NotContains(t, removed.State.ledger("L").types, "T")
+	require.NotContains(t, removed.State.Ledger("L").types, "T")
 
-	gone := removed.State.Apply(bulkOf(removeTypeReq("T")))
+	gone := removed.State.Apply(bulkOf(oracletest.RemoveTypeReq("T")))
 	require.False(t, gone.OK)
 	require.Equal(t, domain.ErrReasonAccountTypeNotFound, gone.Reason)
 }
@@ -101,10 +47,10 @@ func TestGlobalState_Apply_AtomicRejection(t *testing.T) {
 
 	// Second request fails (remove of a non-existent type) -> the first
 	// request's add must roll back.
-	res := NewGlobalState().Apply(bulkOf(addTypeReq("A"), removeTypeReq("missing")))
+	res := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReq("A"), oracletest.RemoveTypeReq("missing")))
 	require.False(t, res.OK)
 	require.Equal(t, domain.ErrReasonAccountTypeNotFound, res.Reason)
-	require.Empty(t, res.State.ledger("L").types)
+	require.Empty(t, res.State.Ledger("L").types)
 }
 
 func TestGlobalState_Apply_CrossLedgerAtomicRejection(t *testing.T) {
@@ -114,13 +60,13 @@ func TestGlobalState_Apply_CrossLedgerAtomicRejection(t *testing.T) {
 	// remove on B. The whole bulk fails atomically, so A's transaction must
 	// NOT commit — the case a per-ledger model could not represent.
 	res := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{
-		txReqL("A", "world", "x:1", "USD", 5),
-		removeReqL("B", "missing"),
+		oracletest.TxReqL("A", "world", "x:1", "USD", 5),
+		oracletest.RemoveReqL("B", "missing"),
 	}})
 	require.False(t, res.OK)
 	require.Equal(t, domain.ErrReasonAccountTypeNotFound, res.Reason)
 
-	a := res.State.ledger("A")
+	a := res.State.Ledger("A")
 	require.NotContains(t, a.volumes, VolumeKey{"x:1", "USD"})
 	require.NotContains(t, a.volumes, VolumeKey{"world", "USD"})
 }
@@ -130,13 +76,13 @@ func TestGlobalState_Apply_CrossLedgerCommit(t *testing.T) {
 
 	// Both requests succeed on distinct ledgers; each ledger gets its own cell.
 	res := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{
-		txReqL("A", "world", "x:1", "USD", 5),
-		txReqL("B", "world", "y:1", "USD", 7),
+		oracletest.TxReqL("A", "world", "x:1", "USD", 5),
+		oracletest.TxReqL("B", "world", "y:1", "USD", 7),
 	}})
 	require.True(t, res.OK)
 
-	a := res.State.ledger("A")
-	b := res.State.ledger("B")
+	a := res.State.Ledger("A")
+	b := res.State.Ledger("B")
 	require.Equal(t, "5", dec(a.vol(VolumeKey{"x:1", "USD"}).Input))
 	require.Equal(t, "7", dec(b.vol(VolumeKey{"y:1", "USD"}).Input))
 	require.NotContains(t, a.volumes, VolumeKey{"y:1", "USD"})
@@ -146,26 +92,26 @@ func TestGlobalState_Apply_TxEnforcement(t *testing.T) {
 	t.Parallel()
 
 	// Empty chart: enforcement is off, any address is allowed.
-	empty := NewGlobalState().Apply(bulkOf(txReq("world", "x:1", "USD", 5)))
+	empty := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "x:1", "USD", 5)))
 	require.True(t, empty.OK)
 
 	// With a type declared, STRICT enforcement rejects an unmatched address...
-	withType := NewGlobalState().Apply(bulkOf(addTypeReq("t")))
+	withType := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReq("t")))
 	require.True(t, withType.OK)
 
-	bad := withType.State.Apply(bulkOf(txReq("world", "x:1", "USD", 5)))
+	bad := withType.State.Apply(bulkOf(oracletest.TxReq("world", "x:1", "USD", 5)))
 	require.False(t, bad.OK)
 	require.Equal(t, domain.ErrReasonAccountNotMatchingType, bad.Reason)
 
 	// ...but a matching address (and world) is fine.
-	good := withType.State.Apply(bulkOf(txReq("world", "t:1", "USD", 5)))
+	good := withType.State.Apply(bulkOf(oracletest.TxReq("world", "t:1", "USD", 5)))
 	require.True(t, good.OK)
 }
 
 func TestGlobalState_Apply_Volumes(t *testing.T) {
 	t.Parallel()
 
-	res := NewGlobalState().Apply(bulkOf(txReq("world", "a:1", "USD", 5)))
+	res := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "a:1", "USD", 5)))
 	require.True(t, res.OK)
 
 	// Per-tx PCV: world out=5, a:1 in=5.
@@ -175,24 +121,24 @@ func TestGlobalState_Apply_Volumes(t *testing.T) {
 	require.Equal(t, "5", dec(pcv[VolumeKey{"a:1", "USD"}].Input))
 
 	// Persisted into the resulting state (no type -> no purge).
-	ls := res.State.ledger("L")
+	ls := res.State.Ledger("L")
 	require.Equal(t, "5", dec(ls.vol(VolumeKey{"a:1", "USD"}).Input))
 }
 
 func TestGlobalState_Apply_TransientNonZero(t *testing.T) {
 	t.Parallel()
 
-	s := NewGlobalState().Apply(bulkOf(addTypeReqP("t", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT))).State
+	s := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReqP("t", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT))).State
 
 	// A single inflow leaves t:1 non-zero at end of bulk -> rejected.
-	bad := s.Apply(bulkOf(txReq("world", "t:1", "USD", 5)))
+	bad := s.Apply(bulkOf(oracletest.TxReq("world", "t:1", "USD", 5)))
 	require.False(t, bad.OK)
 	require.Equal(t, domain.ErrReasonTransientAccountNonZero, bad.Reason)
 
 	// Balanced within the bulk (in then out) -> commits, and t:1 is purged.
-	good := s.Apply(bulkOf(txReq("world", "t:1", "USD", 5), txReq("t:1", "world", "USD", 5)))
+	good := s.Apply(bulkOf(oracletest.TxReq("world", "t:1", "USD", 5), oracletest.TxReq("t:1", "world", "USD", 5)))
 	require.True(t, good.OK)
-	require.NotContains(t, good.State.ledger("L").volumes, VolumeKey{"t:1", "USD"})
+	require.NotContains(t, good.State.Ledger("L").volumes, VolumeKey{"t:1", "USD"})
 }
 
 func TestGlobalState_Apply_TransientGrandfather(t *testing.T) {
@@ -200,34 +146,34 @@ func TestGlobalState_Apply_TransientGrandfather(t *testing.T) {
 
 	// Empty chart: world->g:1 leaves g:1 with a persisted, non-zero balance
 	// (g:1 matches no type, so it isn't purged).
-	s := NewGlobalState().Apply(bulkOf(txReq("world", "g:1", "USD", 5))).State
-	sl := s.ledger("L")
+	s := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "g:1", "USD", 5))).State
+	sl := s.Ledger("L")
 	require.Equal(t, "5", dec(sl.vol(VolumeKey{"g:1", "USD"}).Input))
 
 	// A bulk now declares g as TRANSIENT and touches g:1 again, leaving it
 	// non-zero. The pre-existing balance grandfathers it, so the bulk commits
 	// rather than failing TRANSIENT_ACCOUNT_NON_ZERO.
 	res := s.Apply(bulkOf(
-		addTypeReqP("g", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
-		txReq("world", "g:1", "USD", 3),
+		oracletest.AddTypeReqP("g", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+		oracletest.TxReq("world", "g:1", "USD", 3),
 	))
 	require.True(t, res.OK)
-	rl := res.State.ledger("L")
+	rl := res.State.Ledger("L")
 	require.Equal(t, "8", dec(rl.vol(VolumeKey{"g:1", "USD"}).Input))
 }
 
 func TestGlobalState_Apply_EphemeralPurge(t *testing.T) {
 	t.Parallel()
 
-	s := NewGlobalState().Apply(bulkOf(addTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))).State
+	s := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))).State
 
 	// Non-zero EPHEMERAL persists; zero-balance EPHEMERAL is purged.
-	nonZero := s.Apply(bulkOf(txReq("world", "e:1", "USD", 5)))
+	nonZero := s.Apply(bulkOf(oracletest.TxReq("world", "e:1", "USD", 5)))
 	require.True(t, nonZero.OK)
-	nl := nonZero.State.ledger("L")
+	nl := nonZero.State.Ledger("L")
 	require.Equal(t, "5", dec(nl.vol(VolumeKey{"e:1", "USD"}).Input))
 
-	zeroed := s.Apply(bulkOf(txReq("world", "e:1", "USD", 5), txReq("e:1", "world", "USD", 5)))
+	zeroed := s.Apply(bulkOf(oracletest.TxReq("world", "e:1", "USD", 5), oracletest.TxReq("e:1", "world", "USD", 5)))
 	require.True(t, zeroed.OK)
-	require.NotContains(t, zeroed.State.ledger("L").volumes, VolumeKey{"e:1", "USD"})
+	require.NotContains(t, zeroed.State.Ledger("L").volumes, VolumeKey{"e:1", "USD"})
 }

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -335,3 +335,36 @@ func TestApplyTransaction_Timestamp(t *testing.T) {
 	require.True(t, noTs.OK)
 	require.Nil(t, noTs.State.Ledger("L").Txs()[0].Timestamp())
 }
+
+func TestApplyRevert_AtEffectiveDate(t *testing.T) {
+	t.Parallel()
+
+	// Original transaction with a user timestamp.
+	create := oracletest.TxReq("world", "x:1", "USD", 10)
+	create.GetApply().GetAction().GetCreateTransaction().Timestamp = &commonpb.Timestamp{Data: 777}
+	base := NewGlobalState().Apply(bulkOf(create))
+	require.True(t, base.OK)
+
+	// at_effective_date: the revert transaction (id 2) inherits the original's
+	// timestamp, so the model records it and reads verify it.
+	atEff := oracletest.RevertReqL("L", 1, true)
+	atEff.GetApply().GetAction().GetRevertTransaction().AtEffectiveDate = true
+	r1 := base.State.Apply(bulkOf(atEff))
+	require.True(t, r1.OK)
+	require.Equal(t, uint64(777), r1.State.Ledger("L").Txs()[1].Timestamp().GetData())
+
+	// Plain revert: the revert transaction is server-dated → nil in the model.
+	r2 := base.State.Apply(bulkOf(oracletest.RevertReqL("L", 1, true)))
+	require.True(t, r2.OK)
+	require.Nil(t, r2.State.Ledger("L").Txs()[1].Timestamp())
+
+	// at_effective_date on an original that had no user timestamp: the server
+	// inherits its (unpredictable) command date, so the model still records nil.
+	base2 := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "z:1", "USD", 10)))
+	require.True(t, base2.OK)
+	atEff2 := oracletest.RevertReqL("L", 1, true)
+	atEff2.GetApply().GetAction().GetRevertTransaction().AtEffectiveDate = true
+	r3 := base2.State.Apply(bulkOf(atEff2))
+	require.True(t, r3.OK)
+	require.Nil(t, r3.State.Ledger("L").Txs()[1].Timestamp())
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -282,4 +283,31 @@ func TestApplyTransaction_FloorBeforeChart(t *testing.T) {
 	unmatchedDest := typed.State.Apply(bulkOf(oracletest.TxReq("world", "y:1", "USD", 5)))
 	require.False(t, unmatchedDest.OK)
 	require.Equal(t, domain.ErrReasonAccountNotMatchingType, unmatchedDest.Reason)
+}
+
+func TestApplyTransaction_MultiPosting(t *testing.T) {
+	t.Parallel()
+
+	// Fund-then-spend in one transaction: world funds a:1, then a:1 pays b:1
+	// within the same tx. The per-posting floor reads the running volumes, so the
+	// second posting spends what the first funded; PCV covers every touched cell.
+	ok := NewGlobalState().Apply(bulkOf(oracletest.TxReqMulti(false,
+		commonpb.NewPosting("world", "a:1", "USD", big.NewInt(10)),
+		commonpb.NewPosting("a:1", "b:1", "USD", big.NewInt(10)),
+	)))
+	require.True(t, ok.OK)
+	ls := ok.State.Ledger("L")
+	require.Equal(t, "10", dec(ls.vol(VolumeKey{"a:1", "USD"}).Input))
+	require.Equal(t, "10", dec(ls.vol(VolumeKey{"a:1", "USD"}).Output))
+	require.Equal(t, "10", dec(ls.vol(VolumeKey{"b:1", "USD"}).Input))
+
+	// A later posting that exceeds a:1's running balance rejects the whole tx;
+	// the atomic bulk commits nothing.
+	over := NewGlobalState().Apply(bulkOf(oracletest.TxReqMulti(false,
+		commonpb.NewPosting("world", "a:1", "USD", big.NewInt(10)),
+		commonpb.NewPosting("a:1", "b:1", "USD", big.NewInt(15)),
+	)))
+	require.False(t, over.OK)
+	require.Equal(t, domain.ErrReasonInsufficientFunds, over.Reason)
+	require.NotContains(t, over.State.Ledger("L").volumes, VolumeKey{"a:1", "USD"})
 }

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -1,0 +1,65 @@
+// Package oracletest provides request builders shared by the oracle's own tests
+// and the driver's tests, so both construct model inputs identically. Builders
+// default to ledger "L"; the *L variants take an explicit ledger.
+package oracletest
+
+import (
+	"math/big"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func AddTypeReqP(name string, p commonpb.AccountTypePersistence) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_AddAccountType{
+			AddAccountType: &servicepb.AddAccountTypeLedgerRequest{
+				Ledger: "L",
+				AccountType: &commonpb.AccountType{
+					Name:        name,
+					Pattern:     name + ":{id}",
+					Persistence: p,
+				},
+			},
+		},
+	}
+}
+
+func AddTypeReq(name string) *servicepb.Request {
+	return AddTypeReqP(name, commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL)
+}
+
+func RemoveReqL(ledger, name string) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_RemoveAccountType{
+			RemoveAccountType: &servicepb.RemoveAccountTypeLedgerRequest{Ledger: ledger, Name: name},
+		},
+	}
+}
+
+func RemoveTypeReq(name string) *servicepb.Request {
+	return RemoveReqL("L", name)
+}
+
+func TxReqL(ledger, src, dest, asset string, amount int64) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: ledger,
+				Action: &servicepb.LedgerAction{
+					Data: &servicepb.LedgerAction_CreateTransaction{
+						CreateTransaction: &servicepb.CreateTransactionPayload{
+							Postings: []*commonpb.Posting{
+								commonpb.NewPosting(src, dest, asset, big.NewInt(amount)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TxReq(src, dest, asset string, amount int64) *servicepb.Request {
+	return TxReqL("L", src, dest, asset, amount)
+}

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -63,3 +63,29 @@ func TxReqL(ledger, src, dest, asset string, amount int64) *servicepb.Request {
 func TxReq(src, dest, asset string, amount int64) *servicepb.Request {
 	return TxReqL("L", src, dest, asset, amount)
 }
+
+// TxReqForce is TxReq with an explicit Force flag; Force=true skips the balance
+// floor (matches the SUT's skipBalanceCheck in applyPosting).
+func TxReqForce(src, dest, asset string, amount int64, force bool) *servicepb.Request {
+	req := TxReqL("L", src, dest, asset, amount)
+	req.GetApply().GetAction().GetCreateTransaction().Force = force
+
+	return req
+}
+
+// RevertReqL builds a RevertTransaction of txID in ledger. Force=true skips the
+// balance floor on the reversed postings (reverts always set it).
+func RevertReqL(ledger string, txID uint64, force bool) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: ledger,
+				Action: &servicepb.LedgerAction{
+					Data: &servicepb.LedgerAction_RevertTransaction{
+						RevertTransaction: &servicepb.RevertTransactionPayload{TransactionId: txID, Force: force},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -73,6 +73,15 @@ func TxReqForce(src, dest, asset string, amount int64, force bool) *servicepb.Re
 	return req
 }
 
+// TxReqRefL is TxReqL carrying a transaction reference, so tests can trigger
+// TRANSACTION_REFERENCE_CONFLICT (a second create reusing the same reference).
+func TxReqRefL(ledger, ref, src, dest, asset string, amount int64) *servicepb.Request {
+	req := TxReqL(ledger, src, dest, asset, amount)
+	req.GetApply().GetAction().GetCreateTransaction().Reference = ref
+
+	return req
+}
+
 // TxReqMulti builds a multi-posting CreateTransaction (ledger "L") with an
 // explicit Force flag. The postings compose in order — an earlier one can fund a
 // later one's source within the same transaction.

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -117,6 +117,21 @@ func RevertReqL(ledger string, txID uint64, force bool) *servicepb.Request {
 	}
 }
 
+// SetTxFieldTypeReq declares a transaction-metadata field type, so tests can
+// build a ledger whose only state is its transaction schema.
+func SetTxFieldTypeReq(ledger, key string, t commonpb.MetadataType) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_SetMetadataFieldType{
+			SetMetadataFieldType: &servicepb.SetMetadataFieldTypeRequest{
+				Ledger:     ledger,
+				TargetType: commonpb.TargetType_TARGET_TYPE_TRANSACTION,
+				Key:        key,
+				Type:       t,
+			},
+		},
+	}
+}
+
 // AddTxMetaReq builds an AddMetadata targeting transaction txID (ledger "L").
 func AddTxMetaReq(txID uint64, md map[string]*commonpb.MetadataValue) *servicepb.Request {
 	return &servicepb.Request{

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -73,6 +73,24 @@ func TxReqForce(src, dest, asset string, amount int64, force bool) *servicepb.Re
 	return req
 }
 
+// TxReqMulti builds a multi-posting CreateTransaction (ledger "L") with an
+// explicit Force flag. The postings compose in order — an earlier one can fund a
+// later one's source within the same transaction.
+func TxReqMulti(force bool, postings ...*commonpb.Posting) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: "L",
+				Action: &servicepb.LedgerAction{
+					Data: &servicepb.LedgerAction_CreateTransaction{
+						CreateTransaction: &servicepb.CreateTransactionPayload{Postings: postings, Force: force},
+					},
+				},
+			},
+		},
+	}
+}
+
 // RevertReqL builds a RevertTransaction of txID in ledger. Force=true skips the
 // balance floor on the reversed postings (reverts always set it).
 func RevertReqL(ledger string, txID uint64, force bool) *servicepb.Request {

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -107,3 +107,22 @@ func RevertReqL(ledger string, txID uint64, force bool) *servicepb.Request {
 		},
 	}
 }
+
+// AddTxMetaReq builds an AddMetadata targeting transaction txID (ledger "L").
+func AddTxMetaReq(txID uint64, md map[string]*commonpb.MetadataValue) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: "L",
+				Action: &servicepb.LedgerAction{
+					Data: &servicepb.LedgerAction_AddMetadata{
+						AddMetadata: &commonpb.SaveMetadataCommand{
+							Target:   &commonpb.Target{Target: &commonpb.Target_TransactionId{TransactionId: txID}},
+							Metadata: md,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -117,21 +117,6 @@ func RevertReqL(ledger string, txID uint64, force bool) *servicepb.Request {
 	}
 }
 
-// SetTxFieldTypeReq declares a transaction-metadata field type, so tests can
-// build a ledger whose only state is its transaction schema.
-func SetTxFieldTypeReq(ledger, key string, t commonpb.MetadataType) *servicepb.Request {
-	return &servicepb.Request{
-		Type: &servicepb.Request_SetMetadataFieldType{
-			SetMetadataFieldType: &servicepb.SetMetadataFieldTypeRequest{
-				Ledger:     ledger,
-				TargetType: commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				Key:        key,
-				Type:       t,
-			},
-		},
-	}
-}
-
 // AddTxMetaReq builds an AddMetadata targeting transaction txID (ledger "L").
 func AddTxMetaReq(txID uint64, md map[string]*commonpb.MetadataValue) *servicepb.Request {
 	return &servicepb.Request{


### PR DESCRIPTION
## Summary

Extract the model checker's state model into a standalone `tests/oracle`
library, and substantially widen the `singleton_driver_model` Antithesis
driver's coverage of the transaction and metadata surface. Test-only — no
production code changes.

## What's here

**Oracle library** — the pure forward model (`GlobalState.Apply`) moves out of
the driver into `tests/oracle`, with its own unit tests and shared request
builders (`oracletest`). The live checker and the unit tests now drive the same
model.

**Coverage** — the driver and oracle now exercise:
- **Transactions**: multi-posting (intra-tx composition), non-world debits +
  balance floor (`INSUFFICIENT_FUNDS`), force, custom timestamps,
  `ExpandVolumes: false`, all revert modes (force / non-force / at-effective-date
  / receipt-carried), and the create rejection branches
  (`TRANSACTION_REFERENCE_CONFLICT`, empty → `VALIDATION`, `VOLUME_OVERFLOW`).
- **Metadata**: every value kind, `DATETIME` field types, revert-carried and
  account metadata, and deletes — all read back and verified.
- **Reads**: id-probed `GetTransaction`, metadata-schema read-back.

**Tooling** — `MODEL_DUMP_BATCHES` dumps every submitted bulk; `tests/oracle/cmd/replay`
replays them offline (committed or dispatch order) for deterministic divergence
diagnosis.

## Testing

`just test-model` (single-worker) and `just test-model-cluster` (3-node, rolling
restarts) pass with zero findings; oracle unit tests pass.
