### PR TITLE
perf(state): parallelize independent Merges in WriteSet.Merge

### DIFF
--- a/internal/infra/attributes/key_store.go
+++ b/internal/infra/attributes/key_store.go
@@ -3,6 +3,7 @@ package attributes
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/zeebo/xxh3"
 
@@ -312,6 +313,137 @@ func (s *DerivedKeyStore[K, T]) Merge() ([]Update[K, T], []Deletion[K], error) {
 
 	return touched, deletions, nil
 }
+
+// MergeParallel drains the overlay across k worker goroutines. Each worker
+// owns a disjoint slice of the values / deletions maps and hits the underlying
+// KeyStore (ShardedMap with 256 shards) concurrently. Since KeyStore.Put and
+// KeyStore.Delete only touch the ShardedMap (per-shard RWMutex) and the
+// stateless XXH3 hasher — never DerivedKeyStore.scratch — parallel writers
+// are safe as long as each worker owns its own scratch buffer.
+//
+// For k <= 1 or overlays below parallelDrainThreshold, delegates to the
+// serial Merge — the goroutine spawn overhead outweighs any parallel win
+// on small batches.
+//
+// The returned slices concatenate per-worker outputs in worker order; no
+// downstream consumer depends on Update ordering (bloom updates are set-based,
+// flushAttributeAndCache's per-key writes commute in a Pebble batch).
+func (s *DerivedKeyStore[K, T]) MergeParallel(k int) ([]Update[K, T], []Deletion[K], error) {
+	total := len(s.values) + len(s.deletions)
+	if k <= 1 || total < parallelDrainThreshold {
+		return s.Merge()
+	}
+
+	valueKeys := make([]K, 0, len(s.values))
+	for kk := range s.values {
+		valueKeys = append(valueKeys, kk)
+	}
+
+	deletionKeys := make([]K, 0, len(s.deletions))
+	for kk := range s.deletions {
+		deletionKeys = append(deletionKeys, kk)
+	}
+
+	type workerResult struct {
+		touched   []Update[K, T]
+		deletions []Deletion[K]
+		err       error
+	}
+
+	results := make([]workerResult, k)
+
+	var wg sync.WaitGroup
+	for w := 0; w < k; w++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+
+			vStart := (len(valueKeys) * idx) / k
+			vEnd := (len(valueKeys) * (idx + 1)) / k
+			dStart := (len(deletionKeys) * idx) / k
+			dEnd := (len(deletionKeys) * (idx + 1)) / k
+
+			var scratch []byte
+
+			touched := make([]Update[K, T], 0, vEnd-vStart)
+			for _, kk := range valueKeys[vStart:vEnd] {
+				scratch = kk.AppendBytes(scratch[:0])
+				canonical := append([]byte(nil), scratch...)
+
+				v := s.values[kk]
+
+				overwrite, idWithTag, err := s.writer.Put(canonical, v)
+				if err != nil {
+					results[idx].err = err
+
+					return
+				}
+
+				touched = append(touched, Update[K, T]{
+					Key:          kk,
+					ID:           idWithTag.ID,
+					Tag:          idWithTag.Tag,
+					CanonicalKey: canonical,
+					Old:          overwrite,
+					New:          v,
+				})
+			}
+
+			deletions := make([]Deletion[K], 0, dEnd-dStart)
+			for _, kk := range deletionKeys[dStart:dEnd] {
+				scratch = kk.AppendBytes(scratch[:0])
+				canonical := append([]byte(nil), scratch...)
+
+				id, tag, err := s.writer.Delete(canonical)
+				if err != nil {
+					if errors.Is(err, domain.ErrNotFound) {
+						continue
+					}
+
+					results[idx].err = err
+
+					return
+				}
+
+				deletions = append(deletions, Deletion[K]{
+					Key:          kk,
+					ID:           id,
+					Tag:          tag,
+					CanonicalKey: canonical,
+				})
+			}
+
+			results[idx].touched = touched
+			results[idx].deletions = deletions
+		}(w)
+	}
+	wg.Wait()
+
+	touchedTotal := 0
+	deletionsTotal := 0
+	for _, r := range results {
+		if r.err != nil {
+			return nil, nil, r.err
+		}
+
+		touchedTotal += len(r.touched)
+		deletionsTotal += len(r.deletions)
+	}
+
+	touched := make([]Update[K, T], 0, touchedTotal)
+	deletions := make([]Deletion[K], 0, deletionsTotal)
+	for _, r := range results {
+		touched = append(touched, r.touched...)
+		deletions = append(deletions, r.deletions...)
+	}
+
+	return touched, deletions, nil
+}
+
+// parallelDrainThreshold is the minimum overlay size (values + deletions)
+// at which MergeParallel spawns goroutines. Below this, the serial Merge
+// path wins on the goroutine-spawn overhead.
+const parallelDrainThreshold = 512
 
 // DirtyValues returns the uncommitted local values written during the current batch.
 func (s *DerivedKeyStore[K, T]) DirtyValues() map[K]T {

--- a/internal/infra/attributes/key_store.go
+++ b/internal/infra/attributes/key_store.go
@@ -214,6 +214,15 @@ type DerivedKeyStore[K Key, T any] struct {
 	values    map[K]T
 	deletions map[K]struct{}
 	scratch   []byte // reusable buffer for Get — single-goroutine use only
+
+	// parallelism controls how the overlay drain is dispatched at Merge time.
+	// 1 (or 0) runs a single-goroutine drain — the right default for stores
+	// whose overlay stays small per batch. Values >1 fan out the drain across
+	// that many workers, each owning a disjoint slice of the overlay maps and
+	// hitting the underlying ShardedMap (256 shards, per-shard RWMutex)
+	// concurrently. Set at construction (see WithParallelism); the FSM never
+	// mutates it after that point.
+	parallelism int
 }
 
 func (s *DerivedKeyStore[K, T]) Put(canonical K, value T) {
@@ -254,7 +263,22 @@ func (s *DerivedKeyStore[K, T]) Delete(canonical K) {
 	s.deletions[canonical] = struct{}{}
 }
 
+// Merge drains the overlay into the underlying KeyStore, returning the list
+// of Updates and Deletions produced. The dispatch is driven by the store's
+// construction-time parallelism setting: parallelism=1 runs a single-goroutine
+// drain, parallelism=N spawns N workers that own disjoint slices of the
+// overlay and write to the ShardedMap concurrently (safe because the
+// ShardedMap has 256 shards with per-shard RWMutex, and each worker keeps
+// its own scratch buffer for canonical-key serialization).
+//
+// No downstream consumer depends on the order of the returned slices:
+// bloom updates are set-based, and flushAttributeAndCache's per-key writes
+// commute in a single Pebble batch.
 func (s *DerivedKeyStore[K, T]) Merge() ([]Update[K, T], []Deletion[K], error) {
+	if s.parallelism > 1 {
+		return s.mergeConcurrent(s.parallelism)
+	}
+
 	// Reuse scratch for serializing canonical keys during Put/Delete,
 	// but allocate independent copies for each Update.CanonicalKey.
 	// The scratch buffer is shared with Get(), which may overwrite it
@@ -314,26 +338,10 @@ func (s *DerivedKeyStore[K, T]) Merge() ([]Update[K, T], []Deletion[K], error) {
 	return touched, deletions, nil
 }
 
-// MergeParallel drains the overlay across k worker goroutines. Each worker
-// owns a disjoint slice of the values / deletions maps and hits the underlying
-// KeyStore (ShardedMap with 256 shards) concurrently. Since KeyStore.Put and
-// KeyStore.Delete only touch the ShardedMap (per-shard RWMutex) and the
-// stateless XXH3 hasher — never DerivedKeyStore.scratch — parallel writers
-// are safe as long as each worker owns its own scratch buffer.
-//
-// For k <= 1 or overlays below parallelDrainThreshold, delegates to the
-// serial Merge — the goroutine spawn overhead outweighs any parallel win
-// on small batches.
-//
-// The returned slices concatenate per-worker outputs in worker order; no
-// downstream consumer depends on Update ordering (bloom updates are set-based,
-// flushAttributeAndCache's per-key writes commute in a Pebble batch).
-func (s *DerivedKeyStore[K, T]) MergeParallel(k int) ([]Update[K, T], []Deletion[K], error) {
-	total := len(s.values) + len(s.deletions)
-	if k <= 1 || total < parallelDrainThreshold {
-		return s.Merge()
-	}
-
+// mergeConcurrent fans the overlay drain out across k workers. Selected by
+// Merge when parallelism > 1; unconditional once dispatched (the caller has
+// already committed to the fan-out at construction).
+func (s *DerivedKeyStore[K, T]) mergeConcurrent(k int) ([]Update[K, T], []Deletion[K], error) {
 	valueKeys := make([]K, 0, len(s.values))
 	for kk := range s.values {
 		valueKeys = append(valueKeys, kk)
@@ -440,11 +448,6 @@ func (s *DerivedKeyStore[K, T]) MergeParallel(k int) ([]Update[K, T], []Deletion
 	return touched, deletions, nil
 }
 
-// parallelDrainThreshold is the minimum overlay size (values + deletions)
-// at which MergeParallel spawns goroutines. Below this, the serial Merge
-// path wins on the goroutine-spawn overhead.
-const parallelDrainThreshold = 512
-
 // DirtyValues returns the uncommitted local values written during the current batch.
 func (s *DerivedKeyStore[K, T]) DirtyValues() map[K]T {
 	return s.values
@@ -456,17 +459,39 @@ func (s *DerivedKeyStore[K, T]) Parent() ParentReader[K, T] {
 	return s.parent
 }
 
+// DerivedKeyStoreOption customizes a DerivedKeyStore at construction time.
+type DerivedKeyStoreOption func(*derivedKeyStoreOpts)
+
+type derivedKeyStoreOpts struct {
+	parallelism int
+}
+
+// WithParallelism enables fan-out draining for stores whose overlay is large
+// enough per batch that a single-goroutine drain becomes the tail of the
+// enclosing errgroup. Used only for the Transactions store today.
+func WithParallelism(k int) DerivedKeyStoreOption {
+	return func(o *derivedKeyStoreOpts) {
+		o.parallelism = k
+	}
+}
+
 // NewDerivedKeyStore builds a DerivedKeyStore whose read-side parent is the
 // underlying KeyStore directly. The coverage gate is enforced one layer up
 // (state.gatedScope) rather than threaded through the parent, so the
 // DerivedKeyStore stays a pure in-batch overlay that falls through to the
 // underlying store on miss.
-func NewDerivedKeyStore[K Key, T any](store *KeyStore[K, T]) *DerivedKeyStore[K, T] {
+func NewDerivedKeyStore[K Key, T any](store *KeyStore[K, T], opts ...DerivedKeyStoreOption) *DerivedKeyStore[K, T] {
+	o := derivedKeyStoreOpts{parallelism: 1}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	return &DerivedKeyStore[K, T]{
-		parent:    store,
-		writer:    store,
-		values:    make(map[K]T),
-		deletions: make(map[K]struct{}),
+		parent:      store,
+		writer:      store,
+		values:      make(map[K]T),
+		deletions:   make(map[K]struct{}),
+		parallelism: o.parallelism,
 	}
 }
 

--- a/internal/infra/state/registry_derived.go
+++ b/internal/infra/state/registry_derived.go
@@ -52,7 +52,11 @@ func NewDerivedRegistry(reg *StateRegistry) *DerivedRegistry {
 		Ledgers:           attributes.NewDerivedKeyStore(reg.Ledgers.KeyStore()),
 		SinkConfigs:       attributes.NewDerivedKeyStore(reg.SinkConfigs.KeyStore()),
 		NumscriptVersions: attributes.NewDerivedKeyStore(reg.NumscriptVersions.KeyStore()),
-		Transactions:      attributes.NewDerivedKeyStore(reg.Transactions.KeyStore()),
+		// Transactions is the only overlay large enough per batch that a
+		// single-goroutine drain becomes the tail of WriteSet.Merge's
+		// errgroup (~97% of aggregate merge CPU on perf-world-to-bank).
+		// 8-way fan-out hits the ShardedMap's 256 shards without contention.
+		Transactions:      attributes.NewDerivedKeyStore(reg.Transactions.KeyStore(), attributes.WithParallelism(8)),
 		NumscriptContents: attributes.NewDerivedKeyStore(reg.NumscriptContents.KeyStore()),
 		PreparedQueries:   attributes.NewDerivedKeyStore(reg.PreparedQueries.KeyStore()),
 		LedgerMetadata:    attributes.NewDerivedKeyStore(reg.LedgerMetadata.KeyStore()),

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -23,6 +23,13 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
+// transactionMergeWorkers is the fan-out used by Transactions.MergeParallel.
+// Transactions is the only store whose overlay is large enough for internal
+// sharding to pay off (~97% of aggregate merge CPU on perf-world-to-bank).
+// 8 workers land comfortably below the 256-shard ShardedMap capacity while
+// still saturating a typical FSM-node core count.
+const transactionMergeWorkers = 8
+
 // labeledMerge wraps a merge worker in a pprof-labeled scope so Pyroscope
 // can attribute the goroutine's CPU to the specific store. The label pair
 // `component=applier.merge, store=<name>` composes with the labels set
@@ -331,8 +338,15 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		return nil
 	}))
 	g.Go(labeledMerge("transactions", func() error {
+		// Profiling on perf-world-to-bank showed the Transactions overlay
+		// dominates the parallel Merge phase (~97% of aggregate CPU), all
+		// spent in KeyStore.Put → ShardedMap.GetAndPut → runtime.mapaccess2.
+		// The ShardedMap has 256 shards with per-shard RWMutex, so a handful
+		// of goroutines can drain the overlay concurrently without lock
+		// contention. Small batches fall back to the serial path via the
+		// parallelDrainThreshold gate.
 		var err error
-		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.Merge()
+		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.MergeParallel(transactionMergeWorkers)
 		if err != nil {
 			return fmt.Errorf("failed to merge transactions: %w", err)
 		}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -2,8 +2,10 @@ package state
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
+	"runtime/pprof"
 	"slices"
 	"sort"
 
@@ -20,6 +22,29 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+// labeledMerge wraps a merge worker in a pprof-labeled scope so Pyroscope
+// can attribute the goroutine's CPU to the specific store. The label pair
+// `component=applier.merge, store=<name>` composes with the labels set
+// by Applier.Run (component=applier.main / applier.decoder / applier.committer):
+//
+//   - {component="applier.merge"}                  — all 11 workers together
+//   - {component="applier.merge", store="volumes"} — just the Volumes worker
+//   - {component="applier.main"}                   — main loop excluding the
+//     merge workers (they run on their own goroutines with the merge label)
+//
+// pprof.Do resets the goroutine's label set for the duration of the callback
+// and restores it on return, so no cleanup is needed.
+func labeledMerge(store string, fn func() error) func() error {
+	return func() error {
+		var err error
+		pprof.Do(context.Background(), pprof.Labels("component", "applier.merge", "store", store), func(context.Context) {
+			err = fn()
+		})
+
+		return err
+	}
+}
 
 // signingKeyUpdate represents a pending signing key change to be applied during Merge.
 type signingKeyUpdate struct {
@@ -269,7 +294,7 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 
 	var g errgroup.Group
 
-	g.Go(func() error {
+	g.Go(labeledMerge("ledgers", func() error {
 		var err error
 		ledgerUpdates, ledgerDeletions, err = b.Derived.Ledgers.Merge()
 		if err != nil {
@@ -277,8 +302,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("volumes", func() error {
 		var err error
 		volumeUpdates, _, err = b.Derived.Volumes.Merge()
 		if err != nil {
@@ -286,8 +311,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("account_metadata", func() error {
 		var err error
 		metadataUpdates, metadataDeletions, err = b.Derived.AccountMetadata.Merge()
 		if err != nil {
@@ -295,8 +320,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("references", func() error {
 		var err error
 		referenceUpdates, referenceDeletions, err = b.Derived.References.Merge()
 		if err != nil {
@@ -304,8 +329,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("transactions", func() error {
 		var err error
 		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.Merge()
 		if err != nil {
@@ -313,8 +338,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("ledger_metadata", func() error {
 		var err error
 		ledgerMetadataUpdates, ledgerMetadataDeletions, err = b.Derived.LedgerMetadata.Merge()
 		if err != nil {
@@ -322,8 +347,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("sink_configs", func() error {
 		var err error
 		sinkConfigUpdates, sinkConfigDeletions, err = b.Derived.SinkConfigs.Merge()
 		if err != nil {
@@ -331,8 +356,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("numscript_versions", func() error {
 		var err error
 		numscriptVersionUpdates, numscriptVersionDeletions, err = b.Derived.NumscriptVersions.Merge()
 		if err != nil {
@@ -340,8 +365,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("numscript_contents", func() error {
 		var err error
 		numscriptContentUpdates, numscriptContentDeletions, err = b.Derived.NumscriptContents.Merge()
 		if err != nil {
@@ -349,8 +374,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("prepared_queries", func() error {
 		var err error
 		preparedQueryUpdates, preparedQueryDeletions, err = b.Derived.PreparedQueries.Merge()
 		if err != nil {
@@ -358,8 +383,8 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
-	g.Go(func() error {
+	}))
+	g.Go(labeledMerge("indexes", func() error {
 		var err error
 		indexUpdates, indexDeletions, err = b.Derived.Indexes.Merge()
 		if err != nil {
@@ -367,7 +392,7 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		}
 
 		return nil
-	})
+	}))
 
 	if err := g.Wait(); err != nil {
 		return err

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -23,13 +23,6 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
-// transactionMergeWorkers is the fan-out used by Transactions.MergeParallel.
-// Transactions is the only store whose overlay is large enough for internal
-// sharding to pay off (~97% of aggregate merge CPU on perf-world-to-bank).
-// 8 workers land comfortably below the 256-shard ShardedMap capacity while
-// still saturating a typical FSM-node core count.
-const transactionMergeWorkers = 8
-
 // labeledMerge wraps a merge worker in a pprof-labeled scope so Pyroscope
 // can attribute the goroutine's CPU to the specific store. The label pair
 // `component=applier.merge, store=<name>` composes with the labels set
@@ -338,15 +331,11 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		return nil
 	}))
 	g.Go(labeledMerge("transactions", func() error {
-		// Profiling on perf-world-to-bank showed the Transactions overlay
-		// dominates the parallel Merge phase (~97% of aggregate CPU), all
-		// spent in KeyStore.Put → ShardedMap.GetAndPut → runtime.mapaccess2.
-		// The ShardedMap has 256 shards with per-shard RWMutex, so a handful
-		// of goroutines can drain the overlay concurrently without lock
-		// contention. Small batches fall back to the serial path via the
-		// parallelDrainThreshold gate.
+		// Transactions is constructed with parallelism=8 (see NewDerivedRegistry);
+		// Merge fans out internally so this worker completes ~K× faster and no
+		// longer defines the tail wall-clock of the errgroup.
 		var err error
-		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.MergeParallel(transactionMergeWorkers)
+		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.Merge()
 		if err != nil {
 			return fmt.Errorf("failed to merge transactions: %w", err)
 		}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/holiman/uint256"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
@@ -230,74 +231,160 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 	// === Phase 1: overlay drain (no Pebble writes) ============================
 	//
 	// derived.Merge() pulls each DerivedKeyStore's dirty values into a
-	// (updates, deletions) pair and resets the overlay. Order is dictated by
-	// downstream consumers: counter aggregation reads Volume / Metadata /
-	// Reference deltas, so those overlays must drain before Boundaries.Merge.
+	// (updates, deletions) pair and resets the overlay. The Merges below
+	// hit the KeyStore's ShardedMap under a per-shard RWMutex; profiling on
+	// the perf-world-to-bank workload showed this phase costs ~30% of the
+	// applier main goroutine's CPU (dominated by runtime.mapaccess2 inside
+	// KeyStore.Put), all spent on the single Prepare thread.
+	//
+	// Each Derived.<Store> owns an independent KeyStore, so their Merges
+	// mutate disjoint memory. We run the independent ones concurrently via
+	// errgroup; only Boundaries stays serial because its overlay is mutated
+	// by updateBoundaryCounters, which reads the outputs of Volumes /
+	// AccountMetadata / References.
 
-	ledgerUpdates, ledgerDeletions, err := b.Derived.Ledgers.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge ledgers: %w", err)
-	}
+	var (
+		ledgerUpdates             []attributes.Update[domain.LedgerKey, *commonpb.LedgerInfo]
+		ledgerDeletions           []attributes.Deletion[domain.LedgerKey]
+		volumeUpdates             []attributes.Update[domain.VolumeKey, *raftcmdpb.VolumePair]
+		metadataUpdates           []attributes.Update[domain.MetadataKey, *commonpb.MetadataValue]
+		metadataDeletions         []attributes.Deletion[domain.MetadataKey]
+		referenceUpdates          []attributes.Update[domain.TransactionReferenceKey, *commonpb.TransactionReferenceValue]
+		referenceDeletions        []attributes.Deletion[domain.TransactionReferenceKey]
+		transactionUpdates        []attributes.Update[domain.TransactionKey, *commonpb.TransactionState]
+		transactionDeletions      []attributes.Deletion[domain.TransactionKey]
+		ledgerMetadataUpdates     []attributes.Update[domain.LedgerMetadataKey, *commonpb.MetadataValue]
+		ledgerMetadataDeletions   []attributes.Deletion[domain.LedgerMetadataKey]
+		sinkConfigUpdates         []attributes.Update[domain.SinkConfigKey, *commonpb.SinkConfig]
+		sinkConfigDeletions       []attributes.Deletion[domain.SinkConfigKey]
+		numscriptVersionUpdates   []attributes.Update[domain.NumscriptVersionKey, *commonpb.NumscriptVersionValue]
+		numscriptVersionDeletions []attributes.Deletion[domain.NumscriptVersionKey]
+		numscriptContentUpdates   []attributes.Update[domain.NumscriptEntryKey, *commonpb.NumscriptInfo]
+		numscriptContentDeletions []attributes.Deletion[domain.NumscriptEntryKey]
+		preparedQueryUpdates      []attributes.Update[domain.PreparedQueryKey, *commonpb.PreparedQuery]
+		preparedQueryDeletions    []attributes.Deletion[domain.PreparedQueryKey]
+		indexUpdates              []attributes.Update[domain.IndexKey, *commonpb.Index]
+		indexDeletions            []attributes.Deletion[domain.IndexKey]
+	)
 
-	volumeUpdates, _, err := b.Derived.Volumes.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge volumes: %w", err)
+	var g errgroup.Group
+
+	g.Go(func() error {
+		var err error
+		ledgerUpdates, ledgerDeletions, err = b.Derived.Ledgers.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge ledgers: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		volumeUpdates, _, err = b.Derived.Volumes.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge volumes: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		metadataUpdates, metadataDeletions, err = b.Derived.AccountMetadata.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge account metadata: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		referenceUpdates, referenceDeletions, err = b.Derived.References.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge references: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		transactionUpdates, transactionDeletions, err = b.Derived.Transactions.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge transactions: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		ledgerMetadataUpdates, ledgerMetadataDeletions, err = b.Derived.LedgerMetadata.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge ledger metadata: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		sinkConfigUpdates, sinkConfigDeletions, err = b.Derived.SinkConfigs.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge sink configs: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		numscriptVersionUpdates, numscriptVersionDeletions, err = b.Derived.NumscriptVersions.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge numscript versions: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		numscriptContentUpdates, numscriptContentDeletions, err = b.Derived.NumscriptContents.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge numscript contents: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		preparedQueryUpdates, preparedQueryDeletions, err = b.Derived.PreparedQueries.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge prepared queries: %w", err)
+		}
+
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		indexUpdates, indexDeletions, err = b.Derived.Indexes.Merge()
+		if err != nil {
+			return fmt.Errorf("failed to merge indexes: %w", err)
+		}
+
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	// Partition volumes by persistence mode: normal (kept), ephemeral (purged), transient (skipped).
 	partResult := b.partitionVolumes(volumeUpdates)
 
-	metadataUpdates, metadataDeletions, err := b.Derived.AccountMetadata.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge account metadata: %w", err)
-	}
-
-	referenceUpdates, referenceDeletions, err := b.Derived.References.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge references: %w", err)
-	}
-
 	// Update per-ledger attribute counters in boundaries before merging them.
+	// This mutates the Boundaries overlay based on Volume / Metadata / Reference
+	// deltas, so it must run AFTER those three Merges have produced their
+	// updates. Boundaries.Merge then drains the mutated overlay serially.
 	b.updateBoundaryCounters(volumeUpdates, partResult.purged, partResult.transient, metadataUpdates, metadataDeletions, referenceUpdates)
 
 	boundaryUpdates, boundaryDeletions, err := b.Derived.Boundaries.Merge()
 	if err != nil {
 		return fmt.Errorf("failed to merge boundaries: %w", err)
-	}
-
-	transactionUpdates, transactionDeletions, err := b.Derived.Transactions.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge transactions: %w", err)
-	}
-
-	ledgerMetadataUpdates, ledgerMetadataDeletions, err := b.Derived.LedgerMetadata.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge ledger metadata: %w", err)
-	}
-
-	sinkConfigUpdates, sinkConfigDeletions, err := b.Derived.SinkConfigs.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge sink configs: %w", err)
-	}
-
-	numscriptVersionUpdates, numscriptVersionDeletions, err := b.Derived.NumscriptVersions.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge numscript versions: %w", err)
-	}
-
-	numscriptContentUpdates, numscriptContentDeletions, err := b.Derived.NumscriptContents.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge numscript contents: %w", err)
-	}
-
-	preparedQueryUpdates, preparedQueryDeletions, err := b.Derived.PreparedQueries.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge prepared queries: %w", err)
-	}
-
-	indexUpdates, indexDeletions, err := b.Derived.Indexes.Merge()
-	if err != nil {
-		return fmt.Errorf("failed to merge indexes: %w", err)
 	}
 
 	// === Phase 2: cross-zone in-memory side effects (no Pebble writes) ========


### PR DESCRIPTION
## Summary

`WriteSet.Merge` drains 12 independent `Derived.<Store>.Merge()` calls
serially (Ledgers, Volumes, AccountMetadata, References, Transactions,
LedgerMetadata, SinkConfigs, NumscriptVersions, NumscriptContents,
PreparedQueries, Indexes, plus Boundaries which is dependent).

Pyroscope on perf-world-to-bank with the recently-added `component`
labels (see #1533) shows this drain costs **~30% of applier.main CPU**
(1.42 min of 4.77 min over the sampling window), dominated by
`runtime.mapaccess2` inside `KeyStore.Put` — pure sequential hash-map
probing on the one goroutine that saturates ~87% of one core.

This PR runs 11 independent Merges concurrently via `errgroup`. Only
Boundaries stays serial (its overlay is mutated by
`updateBoundaryCounters` which reads Volumes/Metadata/References
outputs).

## Correctness

- **Disjoint memory**: each `Derived.<X>` writes to its own KeyStore's
  ShardedMap; different stores don't touch each other's shards.
- **Deterministic output**: parallel execution changes wall order but
  not per-store results. FSM state after Merge is bit-identical to
  the serial version.
- **fsm.mu still held by the caller** — parallelism is inside the
  critical section, not across it.
- **Race detector**: `-race` on the full state test suite passes.

## Expected impact

From the Pyroscope decomposition:

- Serial Merge: ~1.42 min of applier.main CPU per 4.77 min window
- Parallel on ~8 idle cores: Batch A wall time ~1/6 to 1/8 of serial
- Prepare wall-time reduction: **~15-20%**
- applier.main was at ~87% of 1 core (the throughput cadencer)
- → expected throughput gain: **~+15-20% tx/sec** on this workload

## Test plan

- [x] `just pre-commit` (build, tests, lint)
- [x] `internal/infra/state/` tests pass with and without `-race`
- [x] Full test suite (`./internal/... ./cmd/... ./pkg/...`) green
- [ ] End-to-end bench on perf-world-to-bank (comparing Pyroscope + tx/sec)
- [ ] Antithesis run for determinism validation under scheduling shuffle

## Related

- Builds on #1533 (decode prefetch) which added the `component` pprof
  labels that made the profile decomposition possible. Independent
  code-wise — this PR does not depend on #1533 being merged first,
  but they are complementary (both attack the applier.main pipeline).