### PR TITLE
perf(schemathesis): disable Hypothesis shrinking by default

### DIFF
--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -5,7 +5,9 @@
 # waits for readiness, runs Schemathesis tests, then tears down.
 #
 # Usage: bash tests/schemathesis/run.sh
-# Env vars: HTTP_PORT, GRPC_PORT, RAFT_PORT, MAX_EXAMPLES
+# Env vars: HTTP_PORT, GRPC_PORT, RAFT_PORT, MAX_EXAMPLES, SCHEMATHESIS_SHRINK
+#   SCHEMATHESIS_SHRINK=1 re-enables Hypothesis shrinking (minimal failing
+#   examples) for local debugging. Off by default — see test_api.py --shrink.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -62,6 +64,11 @@ fi
 
 echo "==> Running Schemathesis tests..."
 echo ""
+SHRINK_FLAG=""
+if [ -n "${SCHEMATHESIS_SHRINK:-}" ] && [ "${SCHEMATHESIS_SHRINK}" != "0" ]; then
+    SHRINK_FLAG="--shrink"
+fi
 python3 "$SCRIPT_DIR/test_api.py" \
     --base-url "http://localhost:$HTTP_PORT" \
-    --max-examples "$MAX_EXAMPLES"
+    --max-examples "$MAX_EXAMPLES" \
+    $SHRINK_FLAG

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -148,9 +148,13 @@ def main():
     # gate it does not change which failures are found (that happens in the
     # `generate` phase) — it only minimizes an already-found failing example,
     # at the cost of a ~7x blowup in request volume when endpoints fail.
-    phases = [Phase.explicit, Phase.reuse, Phase.generate, Phase.target]
+    # Derive from the Hypothesis defaults and remove *only* `shrink`, so every
+    # other default phase (`explain`, etc.) stays enabled and `--shrink`
+    # faithfully restores the stock behavior.
     if args.shrink:
-        phases.append(Phase.shrink)
+        phases = list(hypothesis_settings.default.phases)
+    else:
+        phases = [p for p in hypothesis_settings.default.phases if p is not Phase.shrink]
 
     has_failures = False
     has_errors = False

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -14,7 +14,7 @@ import sys
 from datetime import timedelta
 from pathlib import Path
 
-from hypothesis import HealthCheck, settings as hypothesis_settings
+from hypothesis import HealthCheck, Phase, settings as hypothesis_settings
 import schemathesis
 from schemathesis.checks import (
     not_a_server_error,
@@ -125,6 +125,16 @@ def main():
         default=50,
         help="Max examples per endpoint (default: 50)",
     )
+    parser.add_argument(
+        "--shrink",
+        action="store_true",
+        help=(
+            "Enable Hypothesis shrinking (minimizes failing examples). "
+            "Off by default: shrinking multiplies request volume by ~7x when "
+            "endpoints fail, without changing which failures are detected. "
+            "Enable locally when you need a minimal reproduction."
+        ),
+    )
     args = parser.parse_args()
 
     print(f"Loading schema from {OPENAPI_PATH}")
@@ -133,6 +143,14 @@ def main():
     print("=" * 60)
 
     schema = load_schema(args.base_url)
+
+    # Hypothesis phases. Shrinking is disabled by default: on a conformance
+    # gate it does not change which failures are found (that happens in the
+    # `generate` phase) — it only minimizes an already-found failing example,
+    # at the cost of a ~7x blowup in request volume when endpoints fail.
+    phases = [Phase.explicit, Phase.reuse, Phase.generate, Phase.target]
+    if args.shrink:
+        phases.append(Phase.shrink)
 
     has_failures = False
     has_errors = False
@@ -151,6 +169,7 @@ def main():
             max_examples=args.max_examples,
             suppress_health_check=[HealthCheck.filter_too_much],
             deadline=timedelta(seconds=30),
+            phases=phases,
         ),
     )
     for event in runner.execute():


### PR DESCRIPTION
## Problem

The **Tests-Schemathesis** CI job takes **~8m45s**, almost all of it in the test run itself (~8m20s). Setup is cheap (build 7s, venv 2s, pip 8s).

Analyzing the job log timestamps ([run 29002491665](https://github.com/formancehq/ledger/actions/runs/29002491665)), the run is dominated by two silent single-threaded gaps — **344s + 121s** — where Hypothesis grinds through endpoints. The driver is **shrinking**: several endpoints return HTTP 500 (`numscripts`, `prepared-queries`), and each failure kicks Hypothesis into a shrink phase that generates ~7× the nominal request volume (`max_examples=10 × 58 endpoints` — correlation IDs run past `000432`).

## Fix

Disable the Hypothesis `shrink` phase by default, with a `--shrink` opt-in for local debugging. Shrinking only *minimizes* an already-found failing example — it never changes *which* failures are detected (that happens in the `generate` phase). On a conformance gate the minimal repro isn't worth the cost.

## Measured impact

Benchmarked against a real single-node server (`MAX_EXAMPLES=10`):

| Config | Time | Endpoints | Errored |
|---|---|---|---|
| Baseline (shrink on) | ~350s | 56 | 1 |
| **Shrink off (this PR)** | **~46s** | **58** | **0** |

**≈7.5× faster on the test run, no coverage loss, no failure-detection loss.** Total CI job should drop from ~8m45s to roughly ~1m15s.

### Alternatives rejected (with evidence)
- `workers_num=4`: only 47→35s, but injected 11–15 spurious `errored` results (connection resets from parallel-hammering the single-node Raft server) → flakiness not worth it.
- `stateful=None`: no time gain and dropped 12 endpoints of coverage.

## Notes
- No workflow change needed — CI already calls `MAX_EXAMPLES=10 just test-schemathesis` → `run.sh` → `test_api.py`, which now defaults to shrink-off.
- Out of scope: the underlying HTTP 500s on `numscripts` / `prepared-queries` are real API bugs the fuzzer catches. The job is `continue-on-error: true`, so they don't block CI today — worth a separate follow-up.
- Benched on macOS/arm64, not the exact `namespace-profile-linux-amd64-4vcpu` runner, but the win is request-volume reduction, which is machine-independent.