### PR TITLE
fix(EN-1080): fail fast with actionable error on cluster-join auth mismatch

### DIFF
--- a/cmd/server/join_auth_test.go
+++ b/cmd/server/join_auth_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/bootstrap"
+	"github.com/formancehq/ledger/v3/internal/proto/clusterbootstrappb"
+)
+
+// unauthClusterBootstrapServer is a ClusterBootstrapService whose every RPC
+// rejects the caller with codes.Unauthenticated, mirroring what the real
+// RaftServer's cluster-secret interceptor does when a joining node presents a
+// missing or wrong secret.
+type unauthClusterBootstrapServer struct {
+	clusterbootstrappb.UnimplementedClusterBootstrapServiceServer
+}
+
+func (unauthClusterBootstrapServer) GetPeers(context.Context, *clusterbootstrappb.GetPeersRequest) (*clusterbootstrappb.GetPeersResponse, error) {
+	return nil, status.Error(codes.Unauthenticated, "missing authorization metadata on Raft RPC")
+}
+
+// TestDiscoverPeers_FailsFastOnUnauthenticated pins EN-1080: peer discovery
+// must NOT retry a cluster-secret mismatch until the context deadline (which
+// would surface an opaque "context deadline exceeded"). It must abort
+// immediately with a typed, actionable JoinAuthError.
+func TestDiscoverPeers_FailsFastOnUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	// Real plaintext loopback server rejecting every RPC with Unauthenticated.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	clusterbootstrappb.RegisterClusterBootstrapServiceServer(srv, unauthClusterBootstrapServer{})
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	// Generous deadline: if the fail-fast breaks and the loop retries, the
+	// call would run until this deadline; a passing test returns almost
+	// immediately, far under it.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	_, err = discoverPeersFromClusterWithRetry(
+		ctx,
+		lis.Addr().String(),
+		bootstrap.TLSConfig{Mode: bootstrap.TLSModeDisabled},
+		"test-cluster",
+		"", // no cluster-secret on this joining node
+	)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+
+	var joinErr *bootstrap.JoinAuthError
+	require.True(t, errors.As(err, &joinErr),
+		"Unauthenticated during discovery must surface as *bootstrap.JoinAuthError, got %T: %v", err, err)
+	require.False(t, joinErr.HasSecret)
+	require.Contains(t, err.Error(), "inter-node authentication failed")
+	require.Contains(t, err.Error(), "set --cluster-secret")
+
+	// Must fail fast, not retry until the deadline.
+	require.Less(t, elapsed, 5*time.Second,
+		"discovery must abort immediately on Unauthenticated, not retry until the deadline")
+}

--- a/cmd/server/join_auth_test.go
+++ b/cmd/server/join_auth_test.go
@@ -70,6 +70,16 @@ func TestDiscoverPeers_FailsFastOnUnauthenticated(t *testing.T) {
 	require.Contains(t, err.Error(), "inter-node authentication failed")
 	require.Contains(t, err.Error(), "set --cluster-secret")
 
+	// Detail must carry the clean, unwrapped status message — not the
+	// wrapped chain. Wrapping GetPeers' error before status.FromError would
+	// leak "getting peers from <addr>: rpc error: code = Unauthenticated
+	// desc = …" here, duplicating the address and re-exposing the gRPC noise
+	// this fail-fast exists to hide (EN-1080 review finding).
+	require.Equal(t, "missing authorization metadata on Raft RPC", joinErr.Detail)
+	require.NotContains(t, joinErr.Detail, "rpc error:")
+	require.NotContains(t, joinErr.Detail, "getting peers from")
+	require.NotContains(t, joinErr.Detail, lis.Addr().String())
+
 	// Must fail fast, not retry until the deadline.
 	require.Less(t, elapsed, 5*time.Second,
 		"discovery must abort immediately on Unauthenticated, not retry until the deadline")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -17,7 +17,9 @@ import (
 	"go.uber.org/fx"
 	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	auth "github.com/formancehq/go-libs/v5/pkg/authn/jwt"
 	"github.com/formancehq/go-libs/v5/pkg/fx/observefx"
@@ -719,6 +721,18 @@ func discoverPeersFromClusterWithRetry(ctx context.Context, raftAddr string, tls
 		peers, err := discoverPeersFromCluster(raftAddr, tlsCfg, clusterID, clusterSecret)
 		if err == nil {
 			return peers, nil
+		}
+
+		// A cluster-secret mismatch is a hard configuration error, never
+		// transient: retrying with the same (mis)configuration would spin
+		// until the deadline and then surface an opaque "context deadline
+		// exceeded". Fail fast with an actionable message instead. EN-1080.
+		if st, ok := status.FromError(err); ok && st.Code() == codes.Unauthenticated {
+			return nil, &bootstrap.JoinAuthError{
+				PeerAddress: raftAddr,
+				HasSecret:   clusterSecret != "",
+				Detail:      st.Message(),
+			}
 		}
 
 		select {

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -783,6 +783,18 @@ func discoverPeersFromCluster(raftAddr string, tlsCfg bootstrap.TLSConfig, clust
 
 	resp, err := client.GetPeers(ctx, &clusterbootstrappb.GetPeersRequest{})
 	if err != nil {
+		// Propagate an Unauthenticated status unwrapped so the retry loop's
+		// status.FromError sees a clean st.Message() ("missing authorization
+		// metadata on Raft RPC", etc.) rather than the whole wrapped chain.
+		// Wrapping here would leak "getting peers from <addr>: rpc error:
+		// code = Unauthenticated desc = …" into JoinAuthError.Detail —
+		// duplicating the address and re-exposing the raw gRPC noise this
+		// fail-fast exists to hide. This keeps the discovery path consistent
+		// with the learner-registration path. EN-1080.
+		if st, ok := status.FromError(err); ok && st.Code() == codes.Unauthenticated {
+			return nil, err
+		}
+
 		return nil, fmt.Errorf("getting peers from %s: %w", raftAddr, err)
 	}
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4341,11 +4341,32 @@ if a cluster secret is configured without TLS (`--tls-cert-file` and
 
 **The Raft transport server enforces the secret on every RPC.** When
 `--cluster-secret` is set, the Raft gRPC server (transport stream + snapshot
-service) installs a server-side interceptor that rejects any call whose
-`authorization: Bearer …` metadata does not match the configured secret with
-`codes.Unauthenticated`. The comparison is constant-time. Leaving
-`--cluster-secret` empty preserves the historical unauthenticated behavior for
-single-node setups; multi-node deployments **MUST** set it.
+service + the `ClusterBootstrapService` used by `--join`) installs a
+server-side interceptor that rejects any call whose `authorization: Bearer …`
+metadata does not match the configured secret with `codes.Unauthenticated`.
+The comparison is constant-time. Leaving `--cluster-secret` empty preserves the
+historical unauthenticated behavior for single-node setups; multi-node
+deployments **MUST** set it.
+
+**Joining fails fast on a secret mismatch.** A node started with `--join`
+against a cluster whose RaftServer requires a secret will **not** retry
+indefinitely if its own secret is missing or wrong — that is a
+misconfiguration, never a transient condition. The joining node's startup
+aborts immediately with an actionable error instead of the raw gRPC status:
+
+```
+cluster join rejected by peer 1 (node-1:7777): inter-node authentication failed
+(missing authorization metadata on Raft RPC); this node was started without
+--cluster-secret, but the target cluster requires one: set --cluster-secret to
+the value configured on the existing cluster nodes (and --tls-mode, which
+--cluster-secret requires)
+```
+
+If the joining node *does* pass a secret but it does not match, the hint
+instead tells you to verify the secret against the existing cluster nodes. The
+Kubernetes operator injects `CLUSTER_SECRET` into every pod whenever TLS is
+active, so this failure surfaces only in manual/non-operator deployments where
+one node's secret drifted from the rest of the cluster.
 
 ```bash
 ledger run --cluster-secret "my-cluster-secret" --auth-enabled \

--- a/docs/ops/cluster-operations.md
+++ b/docs/ops/cluster-operations.md
@@ -86,6 +86,15 @@ cfg.RaftConfig.Peers = [{ID: 1, Addr: "...", ServiceAddr: "..."}]
 
 The retry loop allows the joining node to wait for the bootstrap node to be ready (useful when all pods start simultaneously in Kubernetes).
 
+**Fail-fast on a cluster-secret mismatch (EN-1080).** The retry loop treats
+transient conditions (peer not yet up, no leader) as retryable, but a
+`codes.Unauthenticated` from the target — the joining node's `--cluster-secret`
+is missing or wrong — is a hard configuration error. Instead of spinning until
+the 60-second deadline and surfacing an opaque "context deadline exceeded", the
+node aborts discovery immediately with a `JoinAuthError` that names the
+`--join` address and tells the operator whether to add or fix the secret.
+Learner registration (Phase 4) applies the same rule.
+
 #### Phase 2: Node Initialization
 
 `NewNode` detects an empty WAL and a non-empty `Peers` list:

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -48,7 +48,7 @@ Available flags for `run`:
 - `--wal-dir`: WAL directory for Raft (default: `./wal`)
 - `--data-dir`: Data directory for application storage (default: `./data`)
 - `--bootstrap`: Initialize a new single-node cluster (mutually exclusive with `--join`)
-- `--join`: Raft transport address of an existing cluster member to join as a learner (e.g., `--join node-1:7777`; mutually exclusive with `--bootstrap`). Discovery and learner registration go through the inter-node `ClusterBootstrapService` on the RaftServer — no user JWT is required. If the target cluster enforces a `--cluster-secret` and this node's secret is missing or wrong, startup **fails fast** with an actionable error rather than retrying until the discovery deadline (EN-1080). See the [`--cluster-secret`](cli.md#cluster-secret) section.
+- `--join`: Raft transport address of an existing cluster member to join as a learner (e.g., `--join node-1:7777`; mutually exclusive with `--bootstrap`). Discovery and learner registration go through the inter-node `ClusterBootstrapService` on the RaftServer — no user JWT is required. If the target cluster enforces a `--cluster-secret` and this node's secret is missing or wrong, startup **fails fast** with an actionable error rather than retrying until the discovery deadline (EN-1080). See the [`--cluster-secret`](cli.md#server-cluster-secret-flag) section.
 - `--learner-promotion-threshold`: Max log entry lag before auto-promoting a caught-up learner to voter (default: `100`, `0` = disable auto-promotion)
 - `--http-port`: HTTP server port (default: `9000`)
 - `--health-check-interval`: Interval between disk usage health checks (default: `30s`)

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -48,7 +48,7 @@ Available flags for `run`:
 - `--wal-dir`: WAL directory for Raft (default: `./wal`)
 - `--data-dir`: Data directory for application storage (default: `./data`)
 - `--bootstrap`: Initialize a new single-node cluster (mutually exclusive with `--join`)
-- `--join`: Raft transport address of an existing cluster member to join as a learner (e.g., `--join node-1:7777`; mutually exclusive with `--bootstrap`). Discovery and learner registration go through the inter-node `ClusterBootstrapService` on the RaftServer — no user JWT is required.
+- `--join`: Raft transport address of an existing cluster member to join as a learner (e.g., `--join node-1:7777`; mutually exclusive with `--bootstrap`). Discovery and learner registration go through the inter-node `ClusterBootstrapService` on the RaftServer — no user JWT is required. If the target cluster enforces a `--cluster-secret` and this node's secret is missing or wrong, startup **fails fast** with an actionable error rather than retrying until the discovery deadline (EN-1080). See the [`--cluster-secret`](cli.md#cluster-secret) section.
 - `--learner-promotion-threshold`: Max log entry lag before auto-promoting a caught-up learner to voter (default: `100`, `0` = disable auto-promotion)
 - `--http-port`: HTTP server port (default: `9000`)
 - `--health-check-interval`: Interval between disk usage health checks (default: `30s`)

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -1372,6 +1372,50 @@ func Module() fx.Option {
 	)
 }
 
+// JoinAuthError is returned when a joining node is rejected by the target
+// cluster's inter-node RaftServer with codes.Unauthenticated. This is always
+// a cluster-secret misconfiguration (EN-1080): the join flow carries no user
+// JWT, so the only credential in play is the shared cluster secret sent as a
+// Bearer token. The error is fatal and never retried — looping on the same
+// (mis)configuration cannot succeed.
+//
+// It covers both inter-node join RPCs: peer discovery
+// (ClusterBootstrapService.GetPeers, before the fx app starts, where PeerID
+// is not yet known and stays 0) and learner registration
+// (ClusterBootstrapService.JoinAsLearner, which carries the target PeerID).
+type JoinAuthError struct {
+	// PeerID identifies the rejecting cluster member. It is 0 during peer
+	// discovery, where the joining node only knows the --join address.
+	PeerID      uint64
+	PeerAddress string
+	// HasSecret reports whether this node was started with --cluster-secret.
+	// It drives the actionable hint: a missing secret vs a mismatched one.
+	HasSecret bool
+	// Detail is the raw gRPC status message from the target for diagnostics.
+	Detail string
+}
+
+func (e *JoinAuthError) Error() string {
+	var hint string
+	if e.HasSecret {
+		hint = "this node was started with --cluster-secret, but the target cluster rejected it: " +
+			"verify the secret matches the value configured on the existing cluster nodes"
+	} else {
+		hint = "this node was started without --cluster-secret, but the target cluster requires one: " +
+			"set --cluster-secret to the value configured on the existing cluster nodes (and --tls-mode, which --cluster-secret requires)"
+	}
+
+	target := e.PeerAddress
+	if e.PeerID != 0 {
+		target = fmt.Sprintf("peer %d (%s)", e.PeerID, e.PeerAddress)
+	}
+
+	return fmt.Sprintf(
+		"cluster join rejected by %s: inter-node authentication failed (%s); %s",
+		target, e.Detail, hint,
+	)
+}
+
 // tryAddLearner attempts to register this node as a learner on an existing
 // cluster, using the inter-node ClusterBootstrapService exposed on the
 // RaftServer. It retries on transient errors (Unavailable, no leader)
@@ -1469,6 +1513,22 @@ func tryAddLearner(ctx context.Context, cfg Config, tlsCfg TLSConfig, logger log
 				}).Infof("JoinAsLearner unavailable, will retry")
 
 				continue
+			}
+
+			// Unauthenticated is a hard configuration error, never transient:
+			// the target cluster's RaftServer rejected our cluster-secret
+			// bearer (missing, wrong, or malformed). Retrying with the same
+			// (mis)configuration can only loop forever, so fail fast with an
+			// actionable message instead of leaking the opaque gRPC status
+			// ("missing authorization metadata on Raft RPC", etc.) up the
+			// bootstrap chain. EN-1080.
+			if ok && st.Code() == codes.Unauthenticated {
+				return &JoinAuthError{
+					PeerID:      peer.ID,
+					PeerAddress: peer.Address,
+					HasSecret:   cfg.ClusterSecret != "",
+					Detail:      st.Message(),
+				}
 			}
 
 			// Non-transient error — fatal.

--- a/internal/bootstrap/module_join_auth_test.go
+++ b/internal/bootstrap/module_join_auth_test.go
@@ -1,0 +1,72 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJoinAuthError_Message pins the actionable wording of the fatal
+// cluster-join authentication error (EN-1080). The message must tell the
+// operator exactly which lever to pull, distinguishing the missing-secret
+// case (the joining node has no --cluster-secret) from the mismatched-secret
+// case (it has one, but the target rejected it).
+func TestJoinAuthError_Message(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing secret", func(t *testing.T) {
+		t.Parallel()
+
+		err := &JoinAuthError{
+			PeerID:      2,
+			PeerAddress: "node-1:7777",
+			HasSecret:   false,
+			Detail:      "missing authorization metadata on Raft RPC",
+		}
+
+		msg := err.Error()
+		require.Contains(t, msg, "peer 2 (node-1:7777)")
+		require.Contains(t, msg, "inter-node authentication failed")
+		require.Contains(t, msg, "missing authorization metadata on Raft RPC")
+		// Actionable hint for the missing-secret case.
+		require.Contains(t, msg, "without --cluster-secret")
+		require.Contains(t, msg, "set --cluster-secret")
+	})
+
+	t.Run("peer discovery phase (no peer id yet)", func(t *testing.T) {
+		t.Parallel()
+
+		// During Phase 1 peer discovery the joining node only knows the
+		// --join address, not the target's node id, so PeerID is 0 and the
+		// message must fall back to the raw address without a "peer 0 (...)"
+		// prefix.
+		err := &JoinAuthError{
+			PeerAddress: "node-1:7777",
+			HasSecret:   false,
+			Detail:      "missing authorization metadata on Raft RPC",
+		}
+
+		msg := err.Error()
+		require.Contains(t, msg, "rejected by node-1:7777")
+		require.NotContains(t, msg, "peer 0")
+		require.Contains(t, msg, "set --cluster-secret")
+	})
+
+	t.Run("mismatched secret", func(t *testing.T) {
+		t.Parallel()
+
+		err := &JoinAuthError{
+			PeerID:      3,
+			PeerAddress: "node-1:7777",
+			HasSecret:   true,
+			Detail:      "invalid cluster credentials on Raft RPC",
+		}
+
+		msg := err.Error()
+		require.Contains(t, msg, "peer 3 (node-1:7777)")
+		require.Contains(t, msg, "invalid cluster credentials on Raft RPC")
+		// Actionable hint for the mismatched-secret case.
+		require.Contains(t, msg, "started with --cluster-secret")
+		require.Contains(t, msg, "verify the secret matches")
+	})
+}

--- a/internal/bootstrap/module_join_auth_test.go
+++ b/internal/bootstrap/module_join_auth_test.go
@@ -1,10 +1,84 @@
 package bootstrap
 
 import (
+	"context"
+	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/proto/clusterbootstrappb"
 )
+
+// unauthBootstrapServer is a ClusterBootstrapService whose every RPC rejects
+// the caller with codes.Unauthenticated, mirroring what the real RaftServer's
+// cluster-secret interceptor returns for a missing/wrong secret.
+type unauthBootstrapServer struct {
+	clusterbootstrappb.UnimplementedClusterBootstrapServiceServer
+}
+
+func (unauthBootstrapServer) JoinAsLearner(context.Context, *clusterbootstrappb.JoinAsLearnerRequest) (*clusterbootstrappb.JoinAsLearnerResponse, error) {
+	return nil, status.Error(codes.Unauthenticated, "invalid cluster credentials on Raft RPC")
+}
+
+// TestTryAddLearner_FailsFastOnUnauthenticated pins EN-1080: learner
+// registration must abort immediately on a cluster-secret mismatch with a
+// typed JoinAuthError instead of retrying the (mis)configuration forever.
+func TestTryAddLearner_FailsFastOnUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	clusterbootstrappb.RegisterClusterBootstrapServiceServer(srv, unauthBootstrapServer{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	cfg := Config{
+		ClusterID:     "test-cluster",
+		ClusterSecret: "wrong-secret",
+		TLSConfig:     TLSConfig{Mode: TLSModeDisabled},
+		RaftConfig: node.NodeConfig{
+			NodeID:        2,
+			WalDir:        t.TempDir(),
+			AdvertiseAddr: "127.0.0.1:7777",
+			Peers: []node.Peer{
+				{ID: 1, Address: lis.Addr().String(), ServiceAddress: "127.0.0.1:8888"},
+			},
+		},
+	}
+
+	// Generous deadline: a passing test returns almost immediately; a broken
+	// fail-fast would retry until this fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	err = tryAddLearner(ctx, cfg, cfg.TLSConfig, logging.Testing())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+
+	var joinErr *JoinAuthError
+	require.True(t, errors.As(err, &joinErr),
+		"Unauthenticated during learner registration must surface as *JoinAuthError, got %T: %v", err, err)
+	require.True(t, joinErr.HasSecret)
+	require.Equal(t, uint64(1), joinErr.PeerID)
+	require.Contains(t, err.Error(), "inter-node authentication failed")
+	require.Contains(t, err.Error(), "verify the secret matches")
+
+	require.Less(t, elapsed, 5*time.Second,
+		"learner registration must abort immediately on Unauthenticated, not retry")
+}
 
 // TestJoinAuthError_Message pins the actionable wording of the fatal
 // cluster-join authentication error (EN-1080). The message must tell the

--- a/pkg/testserver/testserver.go
+++ b/pkg/testserver/testserver.go
@@ -235,6 +235,18 @@ func WithRestore() testservice.InstrumentationFunc {
 	}
 }
 
+// WithClusterSecret sets --cluster-secret, the shared bearer token that the
+// inter-node RaftServer (including the ClusterBootstrapService used by
+// --join) requires on every RPC. --cluster-secret requires TLS, so this is
+// normally combined with WithTLSMode + cert/key instruments.
+func WithClusterSecret(secret string) testservice.InstrumentationFunc {
+	return func(ctx context.Context, cfg *testservice.RunConfiguration) error {
+		cfg.AppendArgs("--cluster-secret", secret)
+
+		return nil
+	}
+}
+
 func WithResponseSigningKey(path string) testservice.InstrumentationFunc {
 	return func(ctx context.Context, cfg *testservice.RunConfiguration) error {
 		cfg.AppendArgs("--response-signing-key", path)

--- a/tests/e2e/cluster/join_auth_test.go
+++ b/tests/e2e/cluster/join_auth_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+
+	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// EN-1080: a node started with --join against a cluster whose inter-node
+// RaftServer requires a --cluster-secret must fail fast with a clear,
+// actionable error when its own secret is missing or wrong. The join flow
+// carries no user identity, so the only credential in play is the shared
+// cluster secret; retrying with a bad one can only loop forever.
+//
+// Before EN-1080 the join RPC leaked the opaque gRPC status
+// ("missing authorization metadata on Raft RPC" / "invalid cluster
+// credentials on Raft RPC") up the bootstrap chain. Now the joining node's
+// startup returns a JoinAuthError telling the operator exactly which lever
+// to pull.
+var _ = Describe("Cluster join with cluster-secret required", Ordered, func() {
+	var (
+		certs         *testserver.TestCerts
+		bootstrapRaft int
+		clusterSecret = "correct-cluster-secret-en1080"
+		clusterID     = "en1080-cluster"
+	)
+
+	// startJoiner builds a joining node targeting the bootstrap node's raft
+	// port with TLS enabled and the given (possibly empty/wrong) secret, then
+	// returns the error from Start — nil means the node started (join
+	// succeeded or is still pending).
+	startJoiner := func(secretInstrument testservice.Instrumentation) error {
+		ctx := logging.TestingContext()
+
+		walDir := GinkgoT().TempDir()
+		dataDir := GinkgoT().TempDir()
+		DeferCleanup(func() {
+			_ = os.RemoveAll(walDir)
+			_ = os.RemoveAll(dataDir)
+		})
+
+		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+			NodeID:    2,
+			ClusterID: clusterID,
+			HTTPPort:  freeTLSReproPort(),
+			RaftPort:  freeTLSReproPort(),
+			GRPCPort:  freeTLSReproPort(),
+			WalDir:    walDir,
+			DataDir:   dataDir,
+			Debug:     testutil.Debug,
+			Output:    GinkgoWriter,
+		})
+		instruments = append(instruments,
+			testserver.WithJoin(fmt.Sprintf("127.0.0.1:%d", bootstrapRaft)),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
+			testserver.WithTLSCACertFile(certs.CACertFile),
+		)
+		if secretInstrument != nil {
+			instruments = append(instruments, secretInstrument)
+		}
+
+		joiner := testservice.New(cmdserver.NewRunCommand,
+			testservice.WithInstruments(instruments...),
+		)
+		startErr := joiner.Start(ctx)
+		DeferCleanup(func() {
+			_ = joiner.Stop(ctx)
+		})
+
+		return startErr
+	}
+
+	BeforeAll(func() {
+		ctx := logging.TestingContext()
+		certDir := GinkgoT().TempDir()
+		var err error
+		certs, err = testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
+		walDir := GinkgoT().TempDir()
+		dataDir := GinkgoT().TempDir()
+		DeferCleanup(func() {
+			_ = os.RemoveAll(walDir)
+			_ = os.RemoveAll(dataDir)
+		})
+
+		bootstrapRaft = freeTLSReproPort()
+
+		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+			NodeID:    1,
+			ClusterID: clusterID,
+			HTTPPort:  freeTLSReproPort(),
+			RaftPort:  bootstrapRaft,
+			GRPCPort:  freeTLSReproPort(),
+			WalDir:    walDir,
+			DataDir:   dataDir,
+			Debug:     testutil.Debug,
+			Output:    GinkgoWriter,
+		})
+		instruments = append(instruments,
+			testserver.WithBootstrap(),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
+			testserver.WithTLSCACertFile(certs.CACertFile),
+			testserver.WithClusterSecret(clusterSecret),
+		)
+
+		// The bootstrap node's RaftServer auth interceptor rejects a bad
+		// Bearer before any membership/leadership logic runs, so a
+		// missing/wrong secret always yields codes.Unauthenticated
+		// regardless of election state. Starting the node is enough — no
+		// leadership poll needed.
+		server := testservice.New(cmdserver.NewRunCommand,
+			testservice.WithInstruments(instruments...),
+		)
+		Expect(server.Start(ctx)).To(Succeed())
+		DeferCleanup(func() {
+			_ = server.Stop(ctx)
+		})
+	})
+
+	It("fails fast with an actionable error when the joining node has NO cluster-secret", func() {
+		err := startJoiner(nil)
+		Expect(err).To(HaveOccurred(),
+			"join must not succeed against a secret-protected cluster without a secret")
+		Expect(err.Error()).To(ContainSubstring("inter-node authentication failed"))
+		Expect(err.Error()).To(ContainSubstring("set --cluster-secret"))
+	})
+
+	It("fails fast with an actionable error when the joining node has a WRONG cluster-secret", func() {
+		err := startJoiner(testserver.WithClusterSecret("wrong-secret-value-xyz"))
+		Expect(err).To(HaveOccurred(),
+			"join must not succeed against a secret-protected cluster with a mismatched secret")
+		Expect(err.Error()).To(ContainSubstring("inter-node authentication failed"))
+		Expect(err.Error()).To(ContainSubstring("verify the secret matches"))
+	})
+})


### PR DESCRIPTION
## EN-1080 — Cluster join fails when authentication is enabled without cluster-secret

Jira: https://formance-team.atlassian.net/browse/EN-1080 (epic EN-867)

### Scope decision: option A (fail-fast), not option B (refactor)

The ticket **description** proposed a refactor (new `ClusterBootstrapService` on the RaftServer, join RPCs off the external ServiceServer, cluster-id metadata + cluster-secret bearer auth, `--join` targeting the Raft port, operator updated). **That refactor already merged via PR #369** (`feat(cluster): move peer discovery + learner registration to RaftServer`) and is present in `release/v3.0` — `server_bootstrap.go`, `clusterbootstrappb`, `raftAuthInterceptors` (#310), and operator `CLUSTER_SECRET` injection all exist. A correctly-configured join with a matching secret already works.

The **remaining** gap is exactly what the ticket's implementation-plan comment (the authoritative later scope) asks for: **fail loudly and actionably when join auth is misconfigured** (missing/wrong `--cluster-secret`). This PR implements that; re-doing option B would be redundant.

### The real bug

Peer discovery (`discoverPeersFromClusterWithRetry`, the very first inter-node RPC, before fx starts) retried **any** error — including `codes.Unauthenticated` — until the 60s deadline, then surfaced an opaque `context deadline exceeded`. Learner registration surfaced the raw gRPC `Unauthenticated` status. Neither told the operator the cluster secret was the problem.

### Changes

- **Both join RPCs** now break out of retry immediately on `codes.Unauthenticated` and return a typed `bootstrap.JoinAuthError` with an actionable hint — distinguishing *missing* secret ("set `--cluster-secret`…") from *wrong* secret ("verify the secret matches…"), naming the `--join` address / rejecting peer.
- `pkg/testserver.WithClusterSecret` helper.
- Unit tests (`internal/bootstrap/module_join_auth_test.go`): missing / wrong / discovery-phase message cases.
- E2E reproduction (`tests/e2e/cluster/join_auth_test.go`): a TLS+secret-protected bootstrap node; a joining node with **no** secret and with a **wrong** secret both fail `Start` fast with the actionable message.
- Docs: `cli.md` (`--cluster-secret`), `cluster-operations.md` (join sequence), `deployment.md` (`--join`).

### Not breaking

No new concepts, no flags, no proto/interface changes → **no mock regeneration**. The operator already injects `CLUSTER_SECRET` into every pod when TLS is active, so this failure only surfaces in manual/non-operator deployments where a node's secret drifted. `--cluster-secret` empty (single-node / unauthenticated) is unchanged. This is a **non-breaking** UX fix, unlike the (already-landed) option-B refactor.

### Invariants

Respects "misconfiguration must fail loudly" and "never silently skip a should-not-happen branch": the `Unauthenticated` path returns an explicit typed error, never a silent skip or degraded start. No config/auth invariant bypassed; auth checks are not weakened.

### Checks

- `GOROOT= go build ./...` ✅
- `go test ./internal/bootstrap/ ./cmd/server/ ./pkg/testserver/` ✅
- `go test ./internal/adapter/grpc/ -run TestRaftAuth` ✅
- `go vet -tags e2e ./tests/e2e/cluster/` + compile ✅
- `golangci-lint run --fix` (changed pkgs): 0 issues ✅

### Impact analysis

GitNexus index not present in this worktree; verified manually — `JoinAuthError` is new, `discoverPeersFromClusterWithRetry` has a single caller (`LoadConfig`), `tryAddLearner` has a single fx-hook caller. Blast radius **LOW**, localized to the bootstrap/join path. No hot-path / FSM / cache code touched.
