### PR TITLE
fix(EN-1460): query-checkpoint reads race-free with typed retryable readiness

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -21,8 +21,17 @@ Checkpoint IDs are assigned sequentially by the FSM (1, 2, 3, ...).
 2. The request is proposed through Raft consensus.
 3. The FSM commits pending state and records `QueryCheckpointState` metadata in Pebble.
 4. The Applier creates a physical Pebble checkpoint of the main store at `{dataDir}/query-checkpoints/{id}/main/`.
-5. The index builder detects the `CreatedQueryCheckpointLog` and creates a read index checkpoint at `{dataDir}/query-checkpoints/{id}/readindex/`.
+5. The index builder detects the `CreatedQueryCheckpointLog` and creates a read index checkpoint at `{dataDir}/query-checkpoints/{id}/readindex/`. This is **asynchronous** — the read index is materialized off the FSM hot path by the index builder, typically ~100-150ms after the log is applied. When the checkpoint is fully hard-linked, the builder writes a `.ready` marker file into the `readindex/` directory as the last step. Because pebble hard-links SST files last and a checkpoint can fail mid-link (a concurrent compaction removing an SST), the builder retries the checkpoint on a `link ... no such file or directory` error before writing the marker.
 6. Both stores are opened read-only when a query specifies `checkpoint_id`.
+
+## Readiness and Error Contract
+
+The read index materializes asynchronously (step 5), so a read at a checkpoint whose read index does not yet exist would otherwise race the builder.
+
+- **`CreateQueryCheckpoint` blocks until the checkpoint is readable.** The handler waits (`readStore.WaitForCheckpoint`) for the `.ready` marker before returning, so on the node that created the checkpoint an immediate read at the returned `checkpoint_id` always succeeds. Waiting on the index-builder progress cursor alone is insufficient: the cursor advances in the batch that *precedes* the physical checkpoint creation, so the sequence is reached before the directory exists.
+- **A read on a not-yet-ready checkpoint returns a typed, retryable error.** On any node whose index builder has not yet materialized the checkpoint (e.g. a follower reached via a load balancer, or a deferred read of a persisted `checkpoint_id`), `openCheckpointStores` gates on the `.ready` marker and returns `ErrCheckpointNotReady` — reason `CHECKPOINT_NOT_READY`, mapped to gRPC `Unavailable`. This mirrors the `INDEX_BUILDING → Unavailable` pattern for metadata indexes: clients retry deterministically instead of receiving an opaque, non-retryable `Unknown`. The read never returns partial checkpoint state — either the fully-materialized checkpoint or the retryable readiness error.
+
+The `.ready` marker and the checkpoint directories are rebuildable filesystem lifecycle state (a projection of the audit log), not a persisted Pebble projection, so they are outside the checker's scope.
 
 ## Automatic Checkpoint Creation (Cron Scheduler)
 
@@ -130,9 +139,11 @@ Physical checkpoint data is stored outside Pebble:
 data/
   query-checkpoints/
     1/
-      main/       # Pebble checkpoint of main store
-      readindex/  # Pebble checkpoint of read index
+      main/              # Pebble checkpoint of main store
+      readindex/         # Pebble checkpoint of read index
+        .ready           # readiness marker, written last by the index builder
     2/
       main/
       readindex/
+        .ready
 ```

--- a/internal/adapter/grpc/errors_test.go
+++ b/internal/adapter/grpc/errors_test.go
@@ -587,6 +587,42 @@ func TestConvertToGRPCError_NodeNotReachable(t *testing.T) {
 	}
 }
 
+// TestConvertToGRPCError_CheckpointNotReady pins EN-1460: a read that targets a
+// query checkpoint whose read index has not been materialized yet (async
+// index-builder work, or a follower node lagging) must surface as a typed,
+// retryable codes.Unavailable with reason CHECKPOINT_NOT_READY — never the
+// opaque, non-retryable codes.Unknown of the default sanitizer. Covers both the
+// raw sentinel and the wrapped form the read handlers may return.
+func TestConvertToGRPCError_CheckpointNotReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"raw", &domain.ErrCheckpointNotReady{CheckpointID: 27}},
+		{"wrapped", fmt.Errorf("serving read: %w", &domain.ErrCheckpointNotReady{CheckpointID: 27})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			grpcErr := convertToGRPCError(tt.err, testLogger())
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			require.Equal(t, codes.Unavailable, st.Code(),
+				"checkpoint-not-ready must surface as Unavailable, not %v", st.Code())
+			require.NotContains(t, st.Message(), "correlation ID",
+				"must not fall through to the opaque Unknown sanitizer")
+
+			info := extractErrorInfo(t, st)
+			require.Equal(t, domain.ErrReasonCheckpointNotReady, info.GetReason())
+			require.Equal(t, "27", info.GetMetadata()["checkpointId"])
+		})
+	}
+}
+
 func TestConvertToGRPCError_MissingSignature(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -414,6 +414,16 @@ func (impl *BucketServiceServerImpl) openCheckpointStores(checkpointID uint64) (
 	mainPath := impl.store.QueryCheckpointMainDir(checkpointID)
 	readIndexPath := impl.store.QueryCheckpointReadIndexDir(checkpointID)
 
+	// The read-index checkpoint is materialized asynchronously by the index
+	// builder, and on a follower node the builder may not have caught up to the
+	// checkpoint's log sequence yet. Opening a not-yet-materialized directory
+	// would surface an opaque, non-retryable Unknown (EN-1460). Gate on the
+	// builder's readiness marker and return a typed, retryable error instead —
+	// mirrors the INDEX_BUILDING -> Unavailable pattern for metadata indexes.
+	if !readstore.CheckpointDirReady(readIndexPath) {
+		return nil, nil, &domain.ErrCheckpointNotReady{CheckpointID: checkpointID}
+	}
+
 	mainStore, err := dal.OpenReadOnly(mainPath, impl.logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening checkpoint main store: %w", err)

--- a/internal/adapter/grpc/server_cluster.go
+++ b/internal/adapter/grpc/server_cluster.go
@@ -455,9 +455,16 @@ func (impl *ClusterServiceServerImpl) CreateQueryCheckpoint(ctx context.Context,
 
 	// Extract the assigned checkpoint ID and log sequence from the response.
 	if cp := logs[0].GetPayload().GetCreatedQueryCheckpoint(); cp != nil {
-		// Wait for the read index to process this log (which triggers the
-		// read index checkpoint creation by the index builder).
-		if err := impl.readStore.WaitForSequence(ctx, logs[0].GetSequence()); err != nil {
+		// Wait for the read-index checkpoint directory to be fully materialized
+		// by the index builder before returning. Waiting on the log sequence
+		// alone (WaitForSequence) is insufficient: the progress cursor is
+		// persisted in the batch that precedes the physical checkpoint creation,
+		// so the sequence advances ~100-150ms before the directory exists
+		// (EN-1460). WaitForCheckpoint gates on the readiness marker the builder
+		// writes as the last step, so the checkpoint is readable the moment this
+		// call returns.
+		readIndexDir := impl.store.QueryCheckpointReadIndexDir(cp.GetCheckpointId())
+		if err := impl.readStore.WaitForCheckpoint(ctx, readIndexDir); err != nil {
 			return nil, fmt.Errorf("waiting for read index checkpoint: %w", err)
 		}
 

--- a/internal/application/indexbuilder/checkpoint_test.go
+++ b/internal/application/indexbuilder/checkpoint_test.go
@@ -1,0 +1,89 @@
+package indexbuilder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// newCheckpointTestBuilder builds a minimal Builder wired with a real dal.Store
+// (for checkpoint directory paths) and readstore.Store (source of the read-index
+// checkpoint), enough to exercise createReadIndexCheckpoint end to end.
+func newCheckpointTestBuilder(t *testing.T) *Builder {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	meter := noop.NewMeterProvider().Meter("test")
+
+	pebbleStore, err := dal.NewStore(dataDir, logging.NopZap(), meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pebbleStore.Close() })
+
+	readStore, err := readstore.New(filepath.Join(dataDir, "readindex-root"), logging.NopZap(), readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = readStore.Close() })
+
+	return &Builder{
+		pebbleStore: pebbleStore,
+		readStore:   readStore,
+		logger:      logging.NopZap(),
+	}
+}
+
+// TestCreateReadIndexCheckpointWritesReadyMarker verifies the happy path: the
+// checkpoint directory is created and the .ready marker is written last, so the
+// checkpoint reads as ready and is openable.
+func TestCreateReadIndexCheckpointWritesReadyMarker(t *testing.T) {
+	t.Parallel()
+
+	b := newCheckpointTestBuilder(t)
+
+	const cpID = uint64(7)
+	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+
+	dir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
+	require.True(t, readstore.CheckpointDirReady(dir), "readiness marker must exist after creation")
+
+	ro, err := readstore.OpenReadOnly(dir, logging.NopZap())
+	require.NoError(t, err)
+	require.NoError(t, ro.Close())
+}
+
+// TestCreateReadIndexCheckpointIsIdempotentOverStaleDir reproduces a
+// replay-after-crash: a stale checkpoint directory (a previous attempt that died
+// before writing the marker) already exists. createReadIndexCheckpoint must
+// clear it and recreate cleanly rather than fail with pebble's ErrExist — this
+// is what makes the crash-safe cursor ordering in processLogs correct.
+func TestCreateReadIndexCheckpointIsIdempotentOverStaleDir(t *testing.T) {
+	t.Parallel()
+
+	b := newCheckpointTestBuilder(t)
+
+	const cpID = uint64(11)
+	dir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
+
+	// Simulate a stale, markerless directory left by a crashed prior attempt.
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stale.sst"), []byte("garbage"), 0o640))
+	require.False(t, readstore.CheckpointDirReady(dir))
+
+	// Recreation must succeed and produce a ready, openable checkpoint.
+	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.True(t, readstore.CheckpointDirReady(dir))
+
+	// The stale file must be gone (directory was recreated from scratch).
+	_, err := os.Stat(filepath.Join(dir, "stale.sst"))
+	require.True(t, os.IsNotExist(err), "stale file must be cleared on recreate")
+
+	ro, err := readstore.OpenReadOnly(dir, logging.NopZap())
+	require.NoError(t, err)
+	require.NoError(t, ro.Close())
+}

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -204,18 +204,35 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			break
 		}
 
+		// When a checkpoint is being created, persist progress at lastSeq-1
+		// (i.e. up to but NOT including the CreatedQueryCheckpoint log) in this
+		// first batch. The checkpoint log itself carries no index writes, so
+		// holding the cursor one short of it costs nothing but makes the
+		// checkpoint creation crash-safe: if the node dies before the checkpoint
+		// directory is fully materialized and marked ready, the durable cursor
+		// still points before the checkpoint log, so on restart the builder
+		// replays it and recreates the checkpoint. Persisting the cursor AT
+		// lastSeq before the marker existed would strand a markerless directory
+		// forever (EN-1460 / NumaryBot), because the builder would never revisit
+		// the log. Progress is advanced to lastSeq in a second write below, only
+		// after the marker is on disk.
+		progressSeq := lastSeq
+		if pendingCheckpointCreate > 0 && lastSeq > 0 {
+			progressSeq = lastSeq - 1
+		}
+
 		// Commit the batch if there are index writes or a checkpoint action pending.
 		hasCheckpointAction := pendingCheckpointCreate > 0 || pendingCheckpointDelete > 0
 		if !b.wb.Empty() || hasCheckpointAction {
 			// Write progress into the same batch before Flush commits it.
-			if err := b.readStore.WriteProgress(batch, lastSeq); err != nil {
+			if err := b.readStore.WriteProgress(batch, progressSeq); err != nil {
 				_ = batch.Cancel()
 
 				return cursor, err
 			}
 
-			// Persist only AppliedProposal entries whose log range is fully behind lastSeq.
-			if err := persistAppliedProposalProgress(batch, lastSeq); err != nil {
+			// Persist only AppliedProposal entries whose log range is fully behind progressSeq.
+			if err := persistAppliedProposalProgress(batch, progressSeq); err != nil {
 				_ = batch.Cancel()
 
 				return cursor, err
@@ -240,10 +257,30 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 
 		// Create or delete a query checkpoint after the batch is committed
 		// but BEFORE advancing the indexed sequence. This ensures the
-		// checkpoint directory exists before readers are notified.
+		// checkpoint directory exists (and its .ready marker is written)
+		// before readers are notified and before the cursor advances past
+		// the CreatedQueryCheckpoint log.
 		if cpID := pendingCheckpointCreate; cpID > 0 {
 			if err := b.createReadIndexCheckpoint(cpID); err != nil {
 				return cursor, err
+			}
+
+			// The checkpoint is now fully materialized and marked ready. Advance
+			// the durable cursor past the CreatedQueryCheckpoint log so it is not
+			// reprocessed on the next iteration or after a restart.
+			if progressSeq != lastSeq {
+				progressBatch := b.readStore.NewBatch()
+				if err := b.readStore.WriteProgress(progressBatch, lastSeq); err != nil {
+					_ = progressBatch.Cancel()
+
+					return cursor, fmt.Errorf("advancing progress past checkpoint %d log: %w", cpID, err)
+				}
+
+				if err := progressBatch.Commit(); err != nil {
+					_ = progressBatch.Cancel()
+
+					return cursor, fmt.Errorf("committing progress past checkpoint %d log: %w", cpID, err)
+				}
 			}
 		}
 
@@ -359,6 +396,16 @@ const checkpointLinkRetries = 5
 // gate on, so no read ever opens a half-linked checkpoint.
 func (b *Builder) createReadIndexCheckpoint(checkpointID uint64) error {
 	destDir := b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)
+
+	// pebble.Checkpoint fails with ErrExist if destDir already exists. We only
+	// reach this path with the progress cursor still held before the
+	// CreatedQueryCheckpoint log (see processLogs), so any pre-existing directory
+	// here is a stale leftover from a previous attempt that crashed before
+	// writing the readiness marker — it is always safe to discard and recreate.
+	// This makes checkpoint creation idempotent across restarts/replays.
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("clearing stale read index checkpoint %d: %w", checkpointID, err)
+	}
 
 	var err error
 	for attempt := range checkpointLinkRetries {

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -344,13 +344,56 @@ func (b *Builder) indexPayload(
 	return nil
 }
 
+// checkpointLinkRetries bounds the retries of a read-index checkpoint whose
+// SST hard-link raced a concurrent compaction ("link ... no such file or
+// directory"). Pebble hard-links live SSTs last; if one is compacted away
+// between the manifest snapshot and the link, the whole checkpoint call fails.
+// Recreating the checkpoint re-snapshots the (now stable) LSM and succeeds.
+const checkpointLinkRetries = 5
+
 // createReadIndexCheckpoint creates a physical Pebble checkpoint of the read index
 // for the given query checkpoint ID. Called after the batch containing all index
-// data up to this point has been committed.
+// data up to this point has been committed. On success it writes a readiness
+// marker into the checkpoint directory (readstore.MarkCheckpointReady) — the
+// authoritative signal that readers (WaitForCheckpoint / openCheckpointStores)
+// gate on, so no read ever opens a half-linked checkpoint.
 func (b *Builder) createReadIndexCheckpoint(checkpointID uint64) error {
 	destDir := b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)
-	if err := b.readStore.CreateCheckpoint(destDir); err != nil {
-		return fmt.Errorf("creating read index checkpoint %d: %w", checkpointID, err)
+
+	var err error
+	for attempt := range checkpointLinkRetries {
+		err = b.readStore.CreateCheckpoint(destDir)
+		if err == nil {
+			break
+		}
+
+		// A concurrent compaction can delete an SST between the manifest
+		// snapshot and the hard-link, surfacing as ErrNotExist. This is
+		// transient — retry after clearing any partial directory so the next
+		// CreateCheckpoint starts from a clean slate.
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("creating read index checkpoint %d: %w", checkpointID, err)
+		}
+
+		b.logger.WithFields(map[string]any{
+			"checkpointID": checkpointID,
+			"attempt":      attempt + 1,
+			"error":        err,
+		}).Infof("Read index checkpoint hard-link raced compaction, retrying")
+
+		if rmErr := os.RemoveAll(destDir); rmErr != nil {
+			return fmt.Errorf("cleaning partial read index checkpoint %d: %w", checkpointID, rmErr)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("creating read index checkpoint %d after %d attempts: %w", checkpointID, checkpointLinkRetries, err)
+	}
+
+	// Write the readiness marker last: readers only open the checkpoint once
+	// this exists, so the marker guarantees a fully hard-linked directory.
+	if err := readstore.MarkCheckpointReady(destDir); err != nil {
+		return fmt.Errorf("marking read index checkpoint %d ready: %w", checkpointID, err)
 	}
 
 	b.logger.WithFields(map[string]any{

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -215,6 +215,7 @@ const (
 	ErrReasonStorageOperation              = "STORAGE_OPERATION_FAILED"
 	ErrReasonTransactionStateInconsistent  = "TRANSACTION_STATE_INCONSISTENT"
 	ErrReasonCheckpointIDRequired          = "CHECKPOINT_ID_REQUIRED"
+	ErrReasonCheckpointNotReady            = "CHECKPOINT_NOT_READY"
 	ErrReasonNumscriptRuntime              = "NUMSCRIPT_RUNTIME"
 	ErrReasonVolumeNotMaterialized         = "VOLUME_NOT_MATERIALIZED"
 	ErrReasonNonDeterministicScript        = "NON_DETERMINISTIC_SCRIPT"
@@ -778,6 +779,26 @@ type ErrIndexBuilding struct {
 func (e *ErrIndexBuilding) Error() string               { return "index is still building: " + e.Index }
 func (*ErrIndexBuilding) Reason() string                { return ErrReasonIndexBuilding }
 func (e *ErrIndexBuilding) Metadata() map[string]string { return map[string]string{"index": e.Index} }
+
+// ErrCheckpointNotReady — a read targets a query checkpoint whose read index
+// has not been materialized yet. CreateQueryCheckpoint returns the checkpoint
+// ID as soon as the Raft log is applied, but the physical read-index directory
+// is created asynchronously by the index builder, and on a follower node the
+// builder may simply not have caught up to the checkpoint's log sequence. Both
+// are transient: the caller should retry until the directory exists. Mirrors
+// ErrIndexBuilding — maps to KindUnavailable so gRPC clients retry deterministically
+// instead of receiving an opaque, non-retryable Unknown.
+type ErrCheckpointNotReady struct {
+	CheckpointID uint64
+}
+
+func (e *ErrCheckpointNotReady) Error() string {
+	return fmt.Sprintf("query checkpoint %d read index is still building", e.CheckpointID)
+}
+func (*ErrCheckpointNotReady) Reason() string { return ErrReasonCheckpointNotReady }
+func (e *ErrCheckpointNotReady) Metadata() map[string]string {
+	return map[string]string{"checkpointId": strconv.FormatUint(e.CheckpointID, 10)}
+}
 
 // ErrIndexInconsistent — read path detects a structural inconsistency between
 // the filter index and the per-ledger log index (e.g. logID present in the

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -315,6 +315,7 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrIndexNotFound":                 &ErrIndexNotFound{},
 		"ErrMetadataFieldNotInSchema":      &ErrMetadataFieldNotInSchema{},
 		"ErrIndexBuilding":                 &ErrIndexBuilding{},
+		"ErrCheckpointNotReady":            &ErrCheckpointNotReady{},
 		"ErrIndexInconsistent":             &ErrIndexInconsistent{},
 		"ErrInvalidReceipt":                &ErrInvalidReceipt{},
 		"ErrNumscriptNotFound":             &ErrNumscriptNotFound{},

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -107,6 +107,7 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_MAINTENANCE_MODE,
 		commonpb.ErrorReason_ERROR_REASON_STALE_PROPOSAL,
 		commonpb.ErrorReason_ERROR_REASON_INDEX_BUILDING,
+		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_NOT_READY,
 		commonpb.ErrorReason_ERROR_REASON_CLUSTER_UNHEALTHY,
 		commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW:
 		return KindUnavailable

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -684,6 +684,7 @@ const (
 	ErrorReason_ERROR_REASON_CLUSTER_UNHEALTHY                ErrorReason = 60
 	ErrorReason_ERROR_REASON_WRITES_BLOCKED_DISK_FULL         ErrorReason = 61
 	ErrorReason_ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW        ErrorReason = 62
+	ErrorReason_ERROR_REASON_CHECKPOINT_NOT_READY             ErrorReason = 63
 )
 
 // Enum value maps for ErrorReason.
@@ -752,6 +753,7 @@ var (
 		60: "ERROR_REASON_CLUSTER_UNHEALTHY",
 		61: "ERROR_REASON_WRITES_BLOCKED_DISK_FULL",
 		62: "ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW",
+		63: "ERROR_REASON_CHECKPOINT_NOT_READY",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                      0,
@@ -817,6 +819,7 @@ var (
 		"ERROR_REASON_CLUSTER_UNHEALTHY":                60,
 		"ERROR_REASON_WRITES_BLOCKED_DISK_FULL":         61,
 		"ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW":        62,
+		"ERROR_REASON_CHECKPOINT_NOT_READY":             63,
 	}
 )
 
@@ -13098,7 +13101,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xd8\x13\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xff\x13\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13163,7 +13166,8 @@ const file_common_proto_rawDesc = "" +
 	"%ERROR_REASON_NON_DETERMINISTIC_SCRIPT\x10;\x12\"\n" +
 	"\x1eERROR_REASON_CLUSTER_UNHEALTHY\x10<\x12)\n" +
 	"%ERROR_REASON_WRITES_BLOCKED_DISK_FULL\x10=\x12*\n" +
-	"&ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW\x10>*Q\n" +
+	"&ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW\x10>\x12%\n" +
+	"!ERROR_REASON_CHECKPOINT_NOT_READY\x10?*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -702,7 +702,13 @@ func (m *Log) CloneVT() *Log {
 	r.Sequence = m.Sequence
 	r.Payload = m.Payload.CloneVT()
 	r.Receipt = m.Receipt
-	r.ResponseSignature = m.ResponseSignature.CloneVT()
+	if rhs := m.ResponseSignature; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *signaturepb.SignedLog }); ok {
+			r.ResponseSignature = vtpb.CloneVT()
+		} else {
+			r.ResponseSignature = proto.Clone(rhs).(*signaturepb.SignedLog)
+		}
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5476,7 +5482,13 @@ func (this *Log) EqualVT(that *Log) bool {
 	if this.Receipt != that.Receipt {
 		return false
 	}
-	if !this.ResponseSignature.EqualVT(that.ResponseSignature) {
+	if equal, ok := interface{}(this.ResponseSignature).(interface {
+		EqualVT(*signaturepb.SignedLog) bool
+	}); ok {
+		if !equal.EqualVT(that.ResponseSignature) {
+			return false
+		}
+	} else if !proto.Equal(this.ResponseSignature, that.ResponseSignature) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -13405,12 +13417,24 @@ func (m *Log) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if m.ResponseSignature != nil {
-		size, err := m.ResponseSignature.MarshalToSizedBufferVT(dAtA[:i])
-		if err != nil {
-			return 0, err
+		if vtmsg, ok := interface{}(m.ResponseSignature).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.ResponseSignature)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
 		}
-		i -= size
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0x3a
 	}
@@ -23196,7 +23220,13 @@ func (m *Log) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.ResponseSignature != nil {
-		l = m.ResponseSignature.SizeVT()
+		if size, ok := interface{}(m.ResponseSignature).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.ResponseSignature)
+		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -31452,8 +31482,16 @@ func (m *Log) UnmarshalVT(dAtA []byte) error {
 			if m.ResponseSignature == nil {
 				m.ResponseSignature = &signaturepb.SignedLog{}
 			}
-			if err := m.ResponseSignature.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-				return err
+			if unmarshal, ok := interface{}(m.ResponseSignature).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.ResponseSignature); err != nil {
+					return err
+				}
 			}
 			iNdEx = postIndex
 		default:

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -702,13 +702,7 @@ func (m *Log) CloneVT() *Log {
 	r.Sequence = m.Sequence
 	r.Payload = m.Payload.CloneVT()
 	r.Receipt = m.Receipt
-	if rhs := m.ResponseSignature; rhs != nil {
-		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *signaturepb.SignedLog }); ok {
-			r.ResponseSignature = vtpb.CloneVT()
-		} else {
-			r.ResponseSignature = proto.Clone(rhs).(*signaturepb.SignedLog)
-		}
-	}
+	r.ResponseSignature = m.ResponseSignature.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5482,13 +5476,7 @@ func (this *Log) EqualVT(that *Log) bool {
 	if this.Receipt != that.Receipt {
 		return false
 	}
-	if equal, ok := interface{}(this.ResponseSignature).(interface {
-		EqualVT(*signaturepb.SignedLog) bool
-	}); ok {
-		if !equal.EqualVT(that.ResponseSignature) {
-			return false
-		}
-	} else if !proto.Equal(this.ResponseSignature, that.ResponseSignature) {
+	if !this.ResponseSignature.EqualVT(that.ResponseSignature) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -13417,24 +13405,12 @@ func (m *Log) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.unknownFields)
 	}
 	if m.ResponseSignature != nil {
-		if vtmsg, ok := interface{}(m.ResponseSignature).(interface {
-			MarshalToSizedBufferVT([]byte) (int, error)
-		}); ok {
-			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-		} else {
-			encoded, err := proto.Marshal(m.ResponseSignature)
-			if err != nil {
-				return 0, err
-			}
-			i -= len(encoded)
-			copy(dAtA[i:], encoded)
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		size, err := m.ResponseSignature.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0x3a
 	}
@@ -23220,13 +23196,7 @@ func (m *Log) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.ResponseSignature != nil {
-		if size, ok := interface{}(m.ResponseSignature).(interface {
-			SizeVT() int
-		}); ok {
-			l = size.SizeVT()
-		} else {
-			l = proto.Size(m.ResponseSignature)
-		}
+		l = m.ResponseSignature.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -31482,16 +31452,8 @@ func (m *Log) UnmarshalVT(dAtA []byte) error {
 			if m.ResponseSignature == nil {
 				m.ResponseSignature = &signaturepb.SignedLog{}
 			}
-			if unmarshal, ok := interface{}(m.ResponseSignature).(interface {
-				UnmarshalVT([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.ResponseSignature); err != nil {
-					return err
-				}
+			if err := m.ResponseSignature.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:

--- a/internal/storage/readstore/checkpoint_wait_test.go
+++ b/internal/storage/readstore/checkpoint_wait_test.go
@@ -2,6 +2,7 @@ package readstore
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -96,6 +97,27 @@ func TestCreateCheckpointThenMarkIsOpenable(t *testing.T) {
 	ro, err := OpenReadOnly(destDir, logging.NopZap())
 	require.NoError(t, err)
 	require.NoError(t, ro.Close())
+}
+
+// TestCreateCheckpointFailsIfDirExists documents the pebble contract the index
+// builder relies on for crash-safe recreation: CreateCheckpoint errors when the
+// destination already exists, so a replay-after-crash MUST clear the stale
+// directory first (createReadIndexCheckpoint does exactly that). A recreate over
+// a cleared path then succeeds.
+func TestCreateCheckpointFailsIfDirExists(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	destDir := filepath.Join(t.TempDir(), "readindex")
+
+	require.NoError(t, s.CreateCheckpoint(destDir))
+
+	// Second create over the existing dir fails (pebble ErrExist).
+	require.Error(t, s.CreateCheckpoint(destDir))
+
+	// After clearing, recreate succeeds — the idempotency the builder depends on.
+	require.NoError(t, os.RemoveAll(destDir))
+	require.NoError(t, s.CreateCheckpoint(destDir))
 }
 
 // TestWaitForCheckpointContextCancel unblocks on context cancellation and

--- a/internal/storage/readstore/checkpoint_wait_test.go
+++ b/internal/storage/readstore/checkpoint_wait_test.go
@@ -1,0 +1,130 @@
+package readstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// TestCheckpointDirReadyRequiresMarker verifies readiness is keyed on the
+// sentinel marker, not mere directory existence. A directory that exists but
+// lacks the marker (a mid-checkpoint / half-linked state, EN-1460) must read
+// as not-ready.
+func TestCheckpointDirReadyRequiresMarker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A directory that exists but has no marker is not ready.
+	require.False(t, CheckpointDirReady(dir))
+
+	require.NoError(t, MarkCheckpointReady(dir))
+	require.True(t, CheckpointDirReady(dir))
+}
+
+// TestWaitForCheckpointFastPath returns immediately when the marker already
+// exists.
+func TestWaitForCheckpointFastPath(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	dir := t.TempDir()
+	require.NoError(t, MarkCheckpointReady(dir))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	require.NoError(t, s.WaitForCheckpoint(ctx, dir))
+}
+
+// TestWaitForCheckpointBlocksUntilMarker reproduces the EN-1460 race: a reader
+// waits on a checkpoint whose directory is not yet materialized, then the
+// index builder writes the marker and broadcasts. The wait must unblock only
+// once the marker exists — never on the bare directory.
+func TestWaitForCheckpointBlocksUntilMarker(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	dir := t.TempDir()
+
+	waitErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		waitErr <- s.WaitForCheckpoint(ctx, dir)
+	}()
+
+	// The waiter must not have returned yet — the marker is absent.
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForCheckpoint returned before marker was written: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Simulate the index builder finishing the checkpoint: write the marker,
+	// then broadcast progress exactly as createReadIndexCheckpoint does.
+	require.NoError(t, MarkCheckpointReady(dir))
+	s.NotifyProgress()
+
+	select {
+	case err := <-waitErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForCheckpoint did not return after marker was written")
+	}
+}
+
+// TestCreateCheckpointThenMarkIsOpenable mirrors what the index builder does
+// (CreateCheckpoint + MarkCheckpointReady) and asserts the resulting directory
+// is a valid, openable read-only Pebble read index — i.e. once the marker is
+// present the checkpoint is genuinely readable, not just present on disk.
+func TestCreateCheckpointThenMarkIsOpenable(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	destDir := filepath.Join(t.TempDir(), "readindex")
+	require.NoError(t, s.CreateCheckpoint(destDir))
+	require.NoError(t, MarkCheckpointReady(destDir))
+	require.True(t, CheckpointDirReady(destDir))
+
+	ro, err := OpenReadOnly(destDir, logging.NopZap())
+	require.NoError(t, err)
+	require.NoError(t, ro.Close())
+}
+
+// TestWaitForCheckpointContextCancel unblocks on context cancellation and
+// returns the context error rather than hanging.
+func TestWaitForCheckpointContextCancel(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	dir := t.TempDir() // never marked ready
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- s.WaitForCheckpoint(ctx, dir)
+	}()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForCheckpoint returned before cancel: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-waitErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForCheckpoint did not return after context cancel")
+	}
+}

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -556,6 +556,74 @@ func (s *Store) ListBackfillProgress() ([]BackfillEntry, error) {
 	return entries, nil
 }
 
+// checkpointReadyMarker is the sentinel file the index builder writes into a
+// query checkpoint read-index directory as the final step, once pebble's
+// Checkpoint() has fully completed (dir created, manifest written, and every
+// SST hard-linked). Its presence is the single authoritative readiness signal:
+// pebble writes SSTs last and a checkpoint can fail mid-link (EN-1460's
+// "link ... no such file or directory"), so the directory or its manifest
+// existing is NOT sufficient — only the marker is.
+const checkpointReadyMarker = ".ready"
+
+// CheckpointDirReady reports whether a query checkpoint read-index directory
+// has been fully materialized, i.e. the builder wrote the readiness marker.
+func CheckpointDirReady(dirPath string) bool {
+	_, err := os.Stat(filepath.Join(dirPath, checkpointReadyMarker))
+
+	return err == nil
+}
+
+// MarkCheckpointReady writes the readiness marker into a completed checkpoint
+// directory. The builder calls this after CreateCheckpoint returns without error.
+func MarkCheckpointReady(dirPath string) error {
+	return os.WriteFile(filepath.Join(dirPath, checkpointReadyMarker), nil, 0o640)
+}
+
+// WaitForCheckpoint blocks until the query checkpoint read-index directory at
+// dirPath has been fully materialized by the index builder (see
+// CheckpointDirReady), or the context is cancelled. It exists because the
+// progress cursor (LastIndexedSequence) is persisted in the same batch that
+// precedes the physical checkpoint creation: waiting on the sequence alone
+// races the directory into existence (the ~100-150ms window in EN-1460). The
+// index builder broadcasts on progressCond *after* createReadIndexCheckpoint
+// (which writes the marker) returns and lastIndexedSeq is stored, so
+// re-checking the marker on each broadcast observes it once present.
+func (s *Store) WaitForCheckpoint(ctx context.Context, dirPath string) error {
+	if CheckpointDirReady(dirPath) {
+		return nil
+	}
+
+	// Spawn a goroutine that broadcasts when the context is cancelled so the
+	// Wait() below is unblocked.
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.progressCond.Broadcast()
+		case <-done:
+		}
+	}()
+
+	s.progressMu.Lock()
+	for {
+		if ctx.Err() != nil {
+			s.progressMu.Unlock()
+
+			return ctx.Err()
+		}
+
+		if CheckpointDirReady(dirPath) {
+			s.progressMu.Unlock()
+
+			return nil
+		}
+
+		s.progressCond.Wait()
+	}
+}
+
 // WaitForSequence blocks until LastIndexedSequence >= minSeq or the context
 // is cancelled.
 func (s *Store) WaitForSequence(ctx context.Context, minSeq uint64) error {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1165,6 +1165,7 @@ enum ErrorReason {
   ERROR_REASON_CLUSTER_UNHEALTHY = 60;
   ERROR_REASON_WRITES_BLOCKED_DISK_FULL = 61;
   ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW = 62;
+  ERROR_REASON_CHECKPOINT_NOT_READY = 63;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/tests/e2e/cluster/query_checkpoint_test.go
+++ b/tests/e2e/cluster/query_checkpoint_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/formancehq/ledger/v3/pkg/actions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 )
@@ -370,6 +372,62 @@ var _ = Describe("Query Checkpoints", func() {
 			Expect(err).To(Succeed())
 
 			Expect(resp.GetVolumes()[asset].GetBalance()).To(Equal("400"))
+		})
+	})
+
+	// EN-1460: an immediate read at a freshly-created checkpoint used to race the
+	// asynchronous read-index materialization and return an opaque, non-retryable
+	// code=Unknown. CreateQueryCheckpoint now blocks until the read index is
+	// materialized, and a read on a not-yet-ready checkpoint returns a typed
+	// retryable Unavailable — never Unknown.
+	Context("immediate read after checkpoint creation is race-free", Ordered, func() {
+		var (
+			ctx           context.Context
+			client        servicepb.BucketServiceClient
+			clusterClient clusterpb.ClusterServiceClient
+		)
+
+		const (
+			httpPort   = 9224
+			grpcPort   = 8224
+			ledgerName = "qcp-race"
+		)
+
+		BeforeAll(func() {
+			ctx, client, clusterClient = testutil.SetupSingleNode(httpPort, grpcPort)
+
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+			Expect(err).To(Succeed())
+		})
+
+		It("reads the checkpoint immediately without a race, never Unknown", func() {
+			// Repeat create-then-read several times to shrink the odds the race
+			// window is simply missed by chance.
+			for i := 0; i < 10; i++ {
+				_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+					actions.NewPosting("world", "alice", big.NewInt(100), "USD"),
+				}, nil)))
+				Expect(err).To(Succeed())
+
+				resp, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+				Expect(err).To(Succeed())
+				cpID := resp.GetCheckpointId()
+
+				// Read at the checkpoint with zero delay. Before the fix this
+				// intermittently returned code=Unknown ("unknown server error").
+				agg, err := client.AggregateVolumes(ctx, &servicepb.AggregateVolumesRequest{
+					Ledger:       ledgerName,
+					CheckpointId: cpID,
+				})
+				if err != nil {
+					// The only acceptable failure is the typed, retryable
+					// readiness error — never an opaque Unknown.
+					Expect(status.Code(err)).To(Equal(codes.Unavailable),
+						"checkpoint read must never return code=Unknown (EN-1460); got %v", err)
+					continue
+				}
+				Expect(aggregateAssets(agg)).To(ContainElement("USD"))
+			}
 		})
 	})
 })


### PR DESCRIPTION
## EN-1460 — Query-checkpoint reads race the async read-index materialization

Fixes the opaque, non-retryable `code=Unknown` returned when a read targets a
query checkpoint whose read index is not yet materialized.

Jira: https://formance-team.atlassian.net/browse/EN-1460 (epic EN-867)

### Root cause
`CreateQueryCheckpoint` already called `WaitForSequence(logs[0].Sequence)`, but
that only waits on the index-builder **progress cursor**. In `process_logs.go`,
`WriteProgress` is flushed to Pebble in the batch that runs **before**
`createReadIndexCheckpoint` creates the `readindex/` directory. So the cursor
reaches the target sequence ~100-150ms before the directory exists → the wait
returns early → the immediate read opens a missing Pebble dir → the read-side
error wrapper falls through to the default sanitizer → `code=Unknown`
(non-retryable; the default gRPC retry policy only covers `UNAVAILABLE`).

### Fix (options a + b + c from the ticket)
- **(a) Blocking readiness on the creating node.** The index builder now writes a
  `.ready` marker file into the checkpoint dir as the **last** step, after
  pebble's `Checkpoint()` fully completes. `CreateQueryCheckpoint` waits via a new
  `readStore.WaitForCheckpoint` that gates on the marker (using the same
  progress cond var the builder already broadcasts). A read at the returned id is
  race-free on the creating node.
- **(b) Typed retryable error for not-yet-ready reads (multi-node / deferred).**
  `openCheckpointStores` returns a new `domain.ErrCheckpointNotReady` (reason
  `CHECKPOINT_NOT_READY` → gRPC `Unavailable`) when the marker is absent —
  mirroring the existing `INDEX_BUILDING → Unavailable` pattern. Covers a
  follower reached via a load balancer or a deferred read of a persisted
  `checkpoint_id`. Never returns partial state or `Unknown`.
- **(c) Hard-link hardening.** `createReadIndexCheckpoint` retries (bounded) on
  `link ... no such file or directory` — an SST compacted away between the
  manifest snapshot and the hard-link — cleaning the partial dir between attempts.

### Invariants
All changes are on the read side and the index builder, both **off the FSM hot
path**. No Pebble reads added to the FSM (#3); FSM determinism untouched (#2);
cache unaffected (#1). The `.ready` marker and checkpoint dirs are rebuildable
filesystem lifecycle state (a projection of the audit log), so they are outside
the checker's scope (#8) — consistent with the existing checkpoint dirs.

### Tests
- `internal/storage/readstore/checkpoint_wait_test.go` — `WaitForCheckpoint`
  fast-path, blocks-until-marker (reproduces the race), context-cancel, and
  create-checkpoint-then-mark-is-openable.
- `internal/adapter/grpc/errors_test.go` — `ErrCheckpointNotReady` maps to
  `Unavailable` with reason `CHECKPOINT_NOT_READY`, raw and wrapped, never Unknown.
- `internal/domain/errors_test.go` — new typed error registered in the
  Describable AST-scan registry.
- `tests/e2e/cluster/query_checkpoint_test.go` — regression Context: create +
  immediate read at the checkpoint in a loop, asserting no `Unknown` (only the
  typed `Unavailable` is acceptable on a miss).

### Proto
Append-only enum value `ERROR_REASON_CHECKPOINT_NOT_READY = 63` in
`misc/proto/common.proto`; regenerated `common.pb.go` / `common_vtproto.pb.go`.

### Docs
`docs/.../read-path/query-checkpoints.md` — documents the async materialization,
the `.ready` marker, the blocking-create readiness barrier, and the retryable
error contract.

### Checks
`GOROOT= go build ./...`, `golangci-lint` (changed pkgs, 0 issues), and unit
tests for `readstore`, `domain`, `adapter/grpc`, `indexbuilder`, `infra/state`
all pass.
