### PR TITLE
fix(operator): bound Ledger CRD metadata-index rule to fit CEL cost budget

### DIFF
--- a/misc/operator/api/v1alpha1/ledger_crd_types.go
+++ b/misc/operator/api/v1alpha1/ledger_crd_types.go
@@ -80,6 +80,7 @@ type LedgerIndexesSpec struct {
 	// Metadata lists the metadata-key indexes to maintain on account or
 	// transaction metadata. Each (target, key) pair must be unique.
 	// +optional
+	// +kubebuilder:validation:MaxItems=64
 	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, y.target == x.target && y.key == x.key))",message="metadata index (target,key) pairs must be unique"
 	Metadata []MetadataIndexSpec `json:"metadata,omitempty"`
 }
@@ -97,6 +98,7 @@ type MetadataIndexSpec struct {
 
 	// Key is the metadata key name to index.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
 	Key string `json:"key"`
 
 	// Type is the metadata field type declared before indexing.

--- a/misc/operator/config/crd/bases/ledger.formance.com_ledgers.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_ledgers.yaml
@@ -99,6 +99,7 @@ spec:
                       properties:
                         key:
                           description: Key is the metadata key name to index.
+                          maxLength: 256
                           minLength: 1
                           type: string
                         target:
@@ -128,6 +129,7 @@ spec:
                       - target
                       - type
                       type: object
+                    maxItems: 64
                     type: array
                     x-kubernetes-validations:
                     - message: metadata index (target,key) pairs must be unique

--- a/misc/operator/helm/crds/templates/ledger.formance.com_ledgers.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_ledgers.yaml
@@ -99,6 +99,7 @@ spec:
                       properties:
                         key:
                           description: Key is the metadata key name to index.
+                          maxLength: 256
                           minLength: 1
                           type: string
                         target:
@@ -128,6 +129,7 @@ spec:
                       - target
                       - type
                       type: object
+                    maxItems: 64
                     type: array
                     x-kubernetes-validations:
                     - message: metadata index (target,key) pairs must be unique


### PR DESCRIPTION
## Summary

The declarative-indexes feature (#1539) added an O(n²) CEL uniqueness rule on `Indexes.Metadata`:

```
self.all(x, self.exists_one(y, y.target == x.target && y.key == x.key))
```

over an **unbounded** array with an **unbounded** `Key` string. The kube-apiserver estimates CEL cost as *per-element cost × maximum element count*, so this blew past the budget by >100x and the apiserver **rejected the entire `ledgers` CRD**:

```
Forbidden: estimated rule cost exceeds budget by factor of more than 100x
```

Because Helm applies the CRD chart (`ledger-operator-crds`) atomically, this one invalid CRD **blocked the renamed `clusters`/`credentials` CRDs (#1481) from installing**, which in turn crashlooped the operator — its informer caches for `Cluster`/`Credentials` never synced (`timed out waiting for cache to be synced`), surfacing as `forbidden` RBAC errors. Observed in `3.0.0-alpha.9`.

## Fix

Bound both the array and the string in the kubebuilder markers so the estimator computes a finite, in-budget cost:

- `Indexes.Metadata`: `+kubebuilder:validation:MaxItems=64`
- `MetadataIndexSpec.Key`: `+kubebuilder:validation:MaxLength=256`

Estimated cost is now ~64×64×256 ≈ 1M, comfortably under the 10M per-rule budget and the schema total. CRDs regenerated via `just generate` (controller-gen + chart sync).

These introduce two new hard CRD limits: **max 64 metadata indexes per ledger** and **max 256-char metadata keys** — both generous for real usage.

## Test plan

- [x] `GOROOT= go build ./...` (operator module) passes
- [x] Regenerated `ledgers` CRD shows `maxItems: 64` on the metadata array and `maxLength: 256` on the key
- [ ] **Server-side validation** — could not run locally (no reachable cluster). Verify with either:
  - `kubectl apply --server-side --dry-run=server -f misc/operator/helm/crds/templates/ledger.formance.com_ledgers.yaml`, or
  - `just test-e2e` (kind cluster + chart install — this is what would have caught the original regression)