### PR TITLE
fix(EN-1465): QueryFilter JSON codec aligned on the v2 query DSL (drop protojson leak)

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -123,10 +123,12 @@ The canonical shape (each node has **exactly one** top-level `$`-operator key):
 Fields: `metadata[<key>]`, `address`/`source`/`destination`, `reference`,
 `reverted` (bool), `ledger`, `id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`,
 `date`. A value is a JSON literal or a parameter reference `{"$param": "<name>"}`
-(prepared-query parameters). A parameterised address prefix is carried as
-`{"$like": {"address": {"$param": "<name>"}}}` (a literal prefix keeps its trailing
-`:` under `$match`, which a param value cannot). uint64 fields are carried as decimal
-strings to stay lossless above 2^53.
+(prepared-query parameters). An address prefix is expressed with a trailing `:` under
+`$match` (e.g. `{"$match": {"address": "users:"}}`); a parameterised prefix has no
+DSL form (a param value cannot carry the trailing `:` marker), and the byte-level
+`AddressMatch_ParamPrefix`/`HardcodedPrefix` proto arms are not producible through
+the JSON/REST surface. uint64 fields are carried as decimal strings to stay lossless
+above 2^53.
 
 The codec is bidirectional and lossless. It fails loudly on an unknown operator, an
 empty `$and`/`$or`, an operator body without exactly one field, an unsupported field,

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -93,47 +93,58 @@ These accelerators are correctness-neutral: turning them off (e.g. by a saturate
 
 **Cursor for `ListPreparedQueries`.** The cursor is the query name itself (printable ASCII, exactly what the name-validator requires). Listing is a single-ledger scan.
 
-## Canonical `QueryFilter` JSON shape (REST)
+## Canonical `QueryFilter` JSON shape (REST) — v2-aligned query DSL
 
 `QueryFilter` is a protobuf oneof; naively routing it through `protojson` leaks the
 proto-internal oneof/wrapper names onto the public REST surface (`and.filters[]`,
 `not.filter`, `field.field.metadata`, `stringCond`, `hardcodedExact`, and the
-`QUERY_TARGET_*` enum prefix). To keep the wire aligned with the OpenAPI schema,
-`QueryFilter` carries a **hand-written JSON codec** (`internal/proto/commonpb/query_filter.go`),
-and `PreparedQuery.MarshalJSON` (`internal/proto/commonpb/common.pb.json.go`) uses
-it plus a string target enum. The HTTP decoder
-(`internal/adapter/http/prepared_query_filter.go`) decodes through the same codec.
+`QUERY_TARGET_*` enum prefix). To keep the REST wire aligned with the rest of the
+Formance platform, `QueryFilter` carries a **hand-written JSON codec**
+(`internal/proto/commonpb/query_filter.go`) that mirrors the shared Formance query
+DSL (`go-libs/pkg/query`, as used by ledger v2). `PreparedQuery.MarshalJSON`
+(`internal/proto/commonpb/common.pb.json.go`) uses it plus a string target enum;
+the HTTP decoder (`internal/adapter/http/prepared_query_filter.go`) decodes through
+the same codec.
 
-The canonical shape is:
+The canonical shape (each node has **exactly one** top-level `$`-operator key):
 
-- **Combinators** (exactly one per node): `{"and": [QueryFilter, ...]}`,
-  `{"or": [QueryFilter, ...]}`, `{"not": QueryFilter}`.
-- **Leaf**: `{"match": <Condition>}`, where `<Condition>` is a tagged union
-  discriminated by a `type` field (`field`, `address`, `reference`, `ledger`,
-  `logId`, `builtinUint`, `logBuiltinUint`, `accountHasAsset`, `reverted`).
-  `field` nests a second tagged union (`string`/`int`/`uint`/`bool`/`exists`).
-  `builtinUint.field` is restricted to the fields the compiler resolves as an
-  unsigned range (`id`/`timestamp`/`insertedAt`/`revertedAt`); address/reference
-  matching uses the dedicated `address`/`reference` conditions. Address
-  conditions require exactly one of `value`/`param`, and `reverted` requires an
-  explicit `value` — the decoder rejects the omitted/empty forms loudly rather
-  than defaulting.
+- **Combinators**: `{"$and": [QueryFilter, ...]}`, `{"$or": [QueryFilter, ...]}`
+  (both non-empty arrays), `{"$not": QueryFilter}`.
+- **Leaf conditions** — single-key operator over a one-field body:
+  - `{"$match": {"<field>": <value>}}` — equality; for `address`/`source`/`destination`
+    a trailing `:` means prefix, otherwise exact.
+  - `{"$gt"|"$gte"|"$lt"|"$lte": {"<field>": <value>}}` — range bound; a closed range
+    is an `$and` of a lower + an upper bound on the same field (the decoder folds it
+    back into one range condition).
+  - `{"$exists": {"metadata": "<key>"}}` — metadata key present.
+  - `{"$exists": {"asset": "<assetRef>"}}` — account has held the asset (`BASE` or
+    `BASE/PRECISION`, e.g. `USD/2`); this is how `AccountHasAssetCondition` is expressed.
+
+Fields: `metadata[<key>]`, `address`/`source`/`destination`, `reference`,
+`reverted` (bool), `ledger`, `id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`,
+`date`. A value is a JSON literal or a parameter reference `{"$param": "<name>"}`
+(prepared-query parameters). A parameterised address prefix is carried as
+`{"$like": {"address": {"$param": "<name>"}}}` (a literal prefix keeps its trailing
+`:` under `$match`, which a param value cannot). uint64 fields are carried as decimal
+strings to stay lossless above 2^53.
+
+The codec is bidirectional and lossless. It fails loudly on an unknown operator, an
+empty `$and`/`$or`, an operator body without exactly one field, an unsupported field,
+an empty `$param` name, and a proto oneof arm it does not recognise — so a new proto
+arm cannot silently drop a filter. The full DSL is documented under `QueryFilter` in
+`openapi.yml`. Round-trip and error-path tests live in
+`internal/proto/commonpb/query_filter_test.go`; the REST wire is asserted in
+`tests/e2e/business/prepared_query_rest_shape_test.go`.
+
+This shape is shared by every filtered endpoint (and by the audit conditions in
+EN-1548): new conditions extend it as new `$match`/`$gt`/… over new field names.
 
 **REST prepared-query targets are `ACCOUNTS` / `TRANSACTIONS` only.** `LOGS` is a
 valid direct `ListLogs` target but not (yet) a usable *prepared-query* target:
-`query.Execute` hydrates only account/transaction data (`PreparedQueryCursor`
-has no log result field), so a LOGS prepared query would execute to an empty
-cursor. The REST create handler rejects it; if a LOGS query is created via
-gRPC/CLI, the REST list/get path still echoes its true target faithfully.
-
-The codec is bidirectional and lossless (unsigned bounds are carried as decimal
-strings to survive values above 2^53). It fails loudly on an unknown `type`, on a
-node that sets zero or more than one of `and`/`or`/`not`/`match`, and on a proto
-oneof arm it does not recognise — so a new proto arm cannot silently drop a
-filter. The full schema (including every condition sub-type) is documented under
-`QueryFilter` / `Condition` in `openapi.yml`. Round-trip and error-path tests live
-in `internal/proto/commonpb/query_filter_test.go`; the REST wire is asserted in
-`tests/e2e/business/prepared_query_rest_shape_test.go`.
+`query.Execute` hydrates only account/transaction data (`PreparedQueryCursor` has no
+log result field), so a LOGS prepared query would execute to an empty cursor. The
+REST create handler rejects it; if a LOGS query is created via gRPC/CLI, the REST
+list/get path still echoes its true target faithfully.
 
 ## Recent changes
 
@@ -142,7 +153,7 @@ in `internal/proto/commonpb/query_filter_test.go`; the REST wire is asserted in
 | `c1f79db80` (EN-1321) | Wire prepared queries into the per-attribute bloom registry. |
 | `7662d2bae` | Monotonic-skip and probe-based `AndIterator` optimisations for filter execution. |
 | `dedb005bc` (fix/376) | Fix protojson oneOf/enum encoding for prepared-query payloads. |
-| EN-1465 | Canonical flat `QueryFilter` JSON codec (replaces the protojson leak); string target enum on `PreparedQuery`. |
+| EN-1465 | v2-aligned `QueryFilter` JSON codec (`$and`/`$match`/…), replacing the protojson leak; string target enum on `PreparedQuery`. |
 
 ## What's not (yet) here
 

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -112,6 +112,19 @@ The canonical shape is:
   discriminated by a `type` field (`field`, `address`, `reference`, `ledger`,
   `logId`, `builtinUint`, `logBuiltinUint`, `accountHasAsset`, `reverted`).
   `field` nests a second tagged union (`string`/`int`/`uint`/`bool`/`exists`).
+  `builtinUint.field` is restricted to the fields the compiler resolves as an
+  unsigned range (`id`/`timestamp`/`insertedAt`/`revertedAt`); address/reference
+  matching uses the dedicated `address`/`reference` conditions. Address
+  conditions require exactly one of `value`/`param`, and `reverted` requires an
+  explicit `value` — the decoder rejects the omitted/empty forms loudly rather
+  than defaulting.
+
+**REST prepared-query targets are `ACCOUNTS` / `TRANSACTIONS` only.** `LOGS` is a
+valid direct `ListLogs` target but not (yet) a usable *prepared-query* target:
+`query.Execute` hydrates only account/transaction data (`PreparedQueryCursor`
+has no log result field), so a LOGS prepared query would execute to an empty
+cursor. The REST create handler rejects it; if a LOGS query is created via
+gRPC/CLI, the REST list/get path still echoes its true target faithfully.
 
 The codec is bidirectional and lossless (unsigned bounds are carried as decimal
 strings to survive values above 2^53). It fails loudly on an unknown `type`, on a

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -93,6 +93,35 @@ These accelerators are correctness-neutral: turning them off (e.g. by a saturate
 
 **Cursor for `ListPreparedQueries`.** The cursor is the query name itself (printable ASCII, exactly what the name-validator requires). Listing is a single-ledger scan.
 
+## Canonical `QueryFilter` JSON shape (REST)
+
+`QueryFilter` is a protobuf oneof; naively routing it through `protojson` leaks the
+proto-internal oneof/wrapper names onto the public REST surface (`and.filters[]`,
+`not.filter`, `field.field.metadata`, `stringCond`, `hardcodedExact`, and the
+`QUERY_TARGET_*` enum prefix). To keep the wire aligned with the OpenAPI schema,
+`QueryFilter` carries a **hand-written JSON codec** (`internal/proto/commonpb/query_filter.go`),
+and `PreparedQuery.MarshalJSON` (`internal/proto/commonpb/common.pb.json.go`) uses
+it plus a string target enum. The HTTP decoder
+(`internal/adapter/http/prepared_query_filter.go`) decodes through the same codec.
+
+The canonical shape is:
+
+- **Combinators** (exactly one per node): `{"and": [QueryFilter, ...]}`,
+  `{"or": [QueryFilter, ...]}`, `{"not": QueryFilter}`.
+- **Leaf**: `{"match": <Condition>}`, where `<Condition>` is a tagged union
+  discriminated by a `type` field (`field`, `address`, `reference`, `ledger`,
+  `logId`, `builtinUint`, `logBuiltinUint`, `accountHasAsset`, `reverted`).
+  `field` nests a second tagged union (`string`/`int`/`uint`/`bool`/`exists`).
+
+The codec is bidirectional and lossless (unsigned bounds are carried as decimal
+strings to survive values above 2^53). It fails loudly on an unknown `type`, on a
+node that sets zero or more than one of `and`/`or`/`not`/`match`, and on a proto
+oneof arm it does not recognise — so a new proto arm cannot silently drop a
+filter. The full schema (including every condition sub-type) is documented under
+`QueryFilter` / `Condition` in `openapi.yml`. Round-trip and error-path tests live
+in `internal/proto/commonpb/query_filter_test.go`; the REST wire is asserted in
+`tests/e2e/business/prepared_query_rest_shape_test.go`.
+
 ## Recent changes
 
 | Commit | Effect |
@@ -100,6 +129,7 @@ These accelerators are correctness-neutral: turning them off (e.g. by a saturate
 | `c1f79db80` (EN-1321) | Wire prepared queries into the per-attribute bloom registry. |
 | `7662d2bae` | Monotonic-skip and probe-based `AndIterator` optimisations for filter execution. |
 | `dedb005bc` (fix/376) | Fix protojson oneOf/enum encoding for prepared-query payloads. |
+| EN-1465 | Canonical flat `QueryFilter` JSON codec (replaces the protojson leak); string target enum on `PreparedQuery`. |
 
 ## What's not (yet) here
 

--- a/internal/adapter/http/handlers_create_prepared_query.go
+++ b/internal/adapter/http/handlers_create_prepared_query.go
@@ -40,9 +40,11 @@ func (s *Server) handleCreatePreparedQuery(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	target := commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS
-	if body.Target == "TRANSACTIONS" {
-		target = commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS
+	target, err := parsePreparedQueryTarget(body.Target)
+	if err != nil {
+		writeBadRequest(w, "INVALID_REQUEST", err)
+
+		return
 	}
 
 	_, err = s.applyUnsigned(r.Context(), r.Header.Get("Idempotency-Key"), &servicepb.Request{

--- a/internal/adapter/http/handlers_create_prepared_query_test.go
+++ b/internal/adapter/http/handlers_create_prepared_query_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-// validFieldFilterJSON is a minimal QueryFilter wire shape (canonical flat
-// shape) with a populated leaf condition, used to exercise the create/update
+// validFieldFilterJSON is a minimal QueryFilter wire shape (v2-aligned query
+// DSL) with a populated leaf condition, used to exercise the create/update
 // paths without depending on the full filter grammar.
-const validFieldFilterJSON = `{"match":{"type":"field","metadata":"foo","condition":{"type":"exists"}}}`
+const validFieldFilterJSON = `{"$exists":{"metadata":"foo"}}`
 
 func TestHandleCreatePreparedQuery_Success(t *testing.T) {
 	t.Parallel()
@@ -65,9 +65,9 @@ func TestHandleCreatePreparedQuery_NestedOneofs(t *testing.T) {
 		"name": "vip-high-risk",
 		"target": "ACCOUNTS",
 		"filter": {
-			"and": [
-				{"match": {"type": "field", "metadata": "risk_score", "condition": {"type": "int", "min": 70}}},
-				{"match": {"type": "field", "metadata": "vip",        "condition": {"type": "bool", "equals": true}}}
+			"$and": [
+				{"$gte": {"metadata[risk_score]": 70}},
+				{"$match": {"metadata[vip]": true}}
 			]
 		}
 	}`
@@ -87,18 +87,19 @@ func TestHandleCreatePreparedQuery_NestedOneofs(t *testing.T) {
 	require.NotNil(t, filter, "filter was lost during decoding")
 
 	and := filter.GetAnd()
-	require.NotNil(t, and, "outer AND oneof was not dispatched")
+	require.NotNil(t, and, "outer $and was not dispatched")
 	require.Len(t, and.GetFilters(), 2)
 
 	first := and.GetFilters()[0].GetField()
-	require.NotNil(t, first, "first child field oneof was not dispatched")
+	require.NotNil(t, first, "first child metadata condition was not dispatched")
 	require.Equal(t, "risk_score", first.GetField().GetMetadata())
-	require.NotNil(t, first.GetIntCond(), "first child int_cond oneof was not dispatched")
+	require.NotNil(t, first.GetIntCond(), "first child int range was not dispatched")
+	require.Equal(t, int64(70), first.GetIntCond().GetMin())
 
 	second := and.GetFilters()[1].GetField()
 	require.NotNil(t, second)
 	require.Equal(t, "vip", second.GetField().GetMetadata())
-	require.NotNil(t, second.GetBoolCond(), "second child bool_cond oneof was not dispatched")
+	require.NotNil(t, second.GetBoolCond(), "second child bool condition was not dispatched")
 	require.True(t, second.GetBoolCond().GetHardcoded())
 }
 

--- a/internal/adapter/http/handlers_create_prepared_query_test.go
+++ b/internal/adapter/http/handlers_create_prepared_query_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-// validFieldFilterJSON is a minimal QueryFilter wire shape with a populated
-// oneof, used to exercise the create/update paths without depending on the
-// full filter grammar.
-const validFieldFilterJSON = `{"field":{"field":{"metadata":"foo"},"existsCond":{}}}`
+// validFieldFilterJSON is a minimal QueryFilter wire shape (canonical flat
+// shape) with a populated leaf condition, used to exercise the create/update
+// paths without depending on the full filter grammar.
+const validFieldFilterJSON = `{"match":{"type":"field","metadata":"foo","condition":{"type":"exists"}}}`
 
 func TestHandleCreatePreparedQuery_Success(t *testing.T) {
 	t.Parallel()
@@ -65,12 +65,10 @@ func TestHandleCreatePreparedQuery_NestedOneofs(t *testing.T) {
 		"name": "vip-high-risk",
 		"target": "ACCOUNTS",
 		"filter": {
-			"and": {
-				"filters": [
-					{"field": {"field": {"metadata": "risk_score"}, "intCond": {"min": "70"}}},
-					{"field": {"field": {"metadata": "vip"},        "boolCond": {"hardcoded": true}}}
-				]
-			}
+			"and": [
+				{"match": {"type": "field", "metadata": "risk_score", "condition": {"type": "int", "min": 70}}},
+				{"match": {"type": "field", "metadata": "vip",        "condition": {"type": "bool", "equals": true}}}
+			]
 		}
 	}`
 

--- a/internal/adapter/http/handlers_create_prepared_query_test.go
+++ b/internal/adapter/http/handlers_create_prepared_query_test.go
@@ -177,18 +177,14 @@ func TestHandleCreatePreparedQuery_EmptyFilter(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestHandleCreatePreparedQuery_LogsTarget(t *testing.T) {
+func TestHandleCreatePreparedQuery_LogsTargetRejected(t *testing.T) {
 	t.Parallel()
 
-	var captured *servicepb.Request
-	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, reqs *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
-			captured = reqs.GetUnsigned().GetRequests()[0]
-
-			return []*commonpb.Log{{}}, nil
-		}).AnyTimes()
-	srv := newTestServer(t, backend)
+	// LOGS is not a usable prepared-query target over REST: query.Execute has
+	// no LOGS hydration path (PreparedQueryCursor carries only account/txn
+	// data), so a LOGS prepared query would execute to an empty cursor. REST
+	// must reject it at ingestion rather than advertise a broken path.
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
 
 	w := httptest.NewRecorder()
 	r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries",
@@ -197,10 +193,7 @@ func TestHandleCreatePreparedQuery_LogsTarget(t *testing.T) {
 
 	srv.handleCreatePreparedQuery(w, r)
 
-	require.Equal(t, http.StatusNoContent, w.Code)
-	require.NotNil(t, captured)
-	require.Equal(t, commonpb.QueryTarget_QUERY_TARGET_LOGS,
-		captured.GetCreatePreparedQuery().GetQuery().GetTarget())
+	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestHandleCreatePreparedQuery_UnknownTargetRejected(t *testing.T) {

--- a/internal/adapter/http/handlers_create_prepared_query_test.go
+++ b/internal/adapter/http/handlers_create_prepared_query_test.go
@@ -177,6 +177,64 @@ func TestHandleCreatePreparedQuery_EmptyFilter(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestHandleCreatePreparedQuery_LogsTarget(t *testing.T) {
+	t.Parallel()
+
+	var captured *servicepb.Request
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, reqs *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			captured = reqs.GetUnsigned().GetRequests()[0]
+
+			return []*commonpb.Log{{}}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries",
+		strings.NewReader(`{"name":"logs-q","target":"LOGS","filter":`+validFieldFilterJSON+`}`),
+		map[string]string{"ledgerName": "ledger1"})
+
+	srv.handleCreatePreparedQuery(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.NotNil(t, captured)
+	require.Equal(t, commonpb.QueryTarget_QUERY_TARGET_LOGS,
+		captured.GetCreatePreparedQuery().GetQuery().GetTarget())
+}
+
+func TestHandleCreatePreparedQuery_UnknownTargetRejected(t *testing.T) {
+	t.Parallel()
+
+	// An unknown target must be rejected loudly, not silently coerced to a
+	// default (which would run a different query than requested).
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries",
+		strings.NewReader(`{"name":"q","target":"BOGUS","filter":`+validFieldFilterJSON+`}`),
+		map[string]string{"ledgerName": "ledger1"})
+
+	srv.handleCreatePreparedQuery(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleCreatePreparedQuery_MissingTargetRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries",
+		strings.NewReader(`{"name":"q","filter":`+validFieldFilterJSON+`}`),
+		map[string]string{"ledgerName": "ledger1"})
+
+	srv.handleCreatePreparedQuery(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestHandleCreatePreparedQuery_AlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_list_prepared_queries_test.go
+++ b/internal/adapter/http/handlers_list_prepared_queries_test.go
@@ -92,15 +92,14 @@ func TestHandleListPreparedQueries_CamelCaseBodyShape(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	body := w.Body.String()
-	// Canonical flat contract (EN-1465): bare string enum + `match` tagged union.
+	// v2-aligned contract (EN-1465): bare string enum + `$match` DSL.
 	require.Contains(t, body, `"target":"TRANSACTIONS"`)
-	require.Contains(t, body, `"match":{"type":"reference"`)
-	require.Contains(t, body, `"equals":"order-123"`)
+	require.Contains(t, body, `"$match":{"reference":"order-123"}`)
 	// #478 PascalCase leak must not survive.
 	require.NotContains(t, body, `"Reference"`)
 	require.NotContains(t, body, `"Hardcoded"`)
 	require.NotContains(t, body, `"target":1`)
-	// EN-1465 protojson leak must not survive.
+	// protojson-internal leaks must not survive.
 	require.NotContains(t, body, `QUERY_TARGET_`)
 	require.NotContains(t, body, `"cond"`)
 	require.NotContains(t, body, `"hardcoded"`)

--- a/internal/adapter/http/handlers_list_prepared_queries_test.go
+++ b/internal/adapter/http/handlers_list_prepared_queries_test.go
@@ -92,12 +92,18 @@ func TestHandleListPreparedQueries_CamelCaseBodyShape(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	body := w.Body.String()
-	require.Contains(t, body, `"target":"QUERY_TARGET_TRANSACTIONS"`)
-	require.Contains(t, body, `"reference"`)
-	require.Contains(t, body, `"hardcoded":"order-123"`)
+	// Canonical flat contract (EN-1465): bare string enum + `match` tagged union.
+	require.Contains(t, body, `"target":"TRANSACTIONS"`)
+	require.Contains(t, body, `"match":{"type":"reference"`)
+	require.Contains(t, body, `"equals":"order-123"`)
+	// #478 PascalCase leak must not survive.
 	require.NotContains(t, body, `"Reference"`)
 	require.NotContains(t, body, `"Hardcoded"`)
 	require.NotContains(t, body, `"target":1`)
+	// EN-1465 protojson leak must not survive.
+	require.NotContains(t, body, `QUERY_TARGET_`)
+	require.NotContains(t, body, `"cond"`)
+	require.NotContains(t, body, `"hardcoded"`)
 }
 
 func TestHandleListPreparedQueries_MissingLedgerName(t *testing.T) {

--- a/internal/adapter/http/handlers_update_prepared_query_test.go
+++ b/internal/adapter/http/handlers_update_prepared_query_test.go
@@ -55,9 +55,9 @@ func TestHandleUpdatePreparedQuery_NestedOneofs(t *testing.T) {
 
 	body := `{
 		"filter": {
-			"or": [
-				{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "gold"}}},
-				{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "platinum"}}}
+			"$or": [
+				{"$match": {"metadata[tier]": "gold"}},
+				{"$match": {"metadata[tier]": "platinum"}}
 			]
 		}
 	}`
@@ -80,12 +80,12 @@ func TestHandleUpdatePreparedQuery_NestedOneofs(t *testing.T) {
 	require.NotNil(t, filter)
 
 	or := filter.GetOr()
-	require.NotNil(t, or, "outer OR oneof was not dispatched")
+	require.NotNil(t, or, "outer $or was not dispatched")
 	require.Len(t, or.GetFilters(), 2)
 	for i, child := range or.GetFilters() {
 		f := child.GetField()
-		require.NotNil(t, f, "child %d field oneof was not dispatched", i)
-		require.NotNil(t, f.GetStringCond(), "child %d string_cond oneof was not dispatched", i)
+		require.NotNil(t, f, "child %d metadata condition was not dispatched", i)
+		require.NotNil(t, f.GetStringCond(), "child %d string condition was not dispatched", i)
 	}
 }
 

--- a/internal/adapter/http/handlers_update_prepared_query_test.go
+++ b/internal/adapter/http/handlers_update_prepared_query_test.go
@@ -55,12 +55,10 @@ func TestHandleUpdatePreparedQuery_NestedOneofs(t *testing.T) {
 
 	body := `{
 		"filter": {
-			"or": {
-				"filters": [
-					{"field": {"field": {"metadata": "tier"}, "stringCond": {"hardcoded": "gold"}}},
-					{"field": {"field": {"metadata": "tier"}, "stringCond": {"hardcoded": "platinum"}}}
-				]
-			}
+			"or": [
+				{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "gold"}}},
+				{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "platinum"}}}
+			]
 		}
 	}`
 

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -8,27 +8,30 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
-// preparedQueryTargets maps the public REST target enum
-// (ACCOUNTS/TRANSACTIONS/LOGS, per openapi.yml) to the proto QueryTarget. All
-// three targets are supported by the query executor and creatable via
-// gRPC/CLI, so REST must accept them too.
+// preparedQueryTargets maps the public REST target enum to the proto
+// QueryTarget. Only ACCOUNTS and TRANSACTIONS are exposed over REST: the
+// prepared-query execution path (query.Execute) hydrates only account and
+// transaction data — there is no log result field on PreparedQueryCursor — so a
+// LOGS-target prepared query would execute to an empty cursor. LOGS remains a
+// valid direct ListLogs target; it is just not a usable *prepared-query* target
+// yet, so REST does not advertise it. See openapi.yml (ACCOUNTS/TRANSACTIONS).
 var preparedQueryTargets = map[string]commonpb.QueryTarget{
 	"ACCOUNTS":     commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
 	"TRANSACTIONS": commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
-	"LOGS":         commonpb.QueryTarget_QUERY_TARGET_LOGS,
 }
 
 // parsePreparedQueryTarget resolves the `target` field of a prepared-query
-// request. An unknown value is rejected loudly rather than silently coerced to
-// a default (which would run a different query than the caller asked for).
+// request. An unknown or unsupported value is rejected loudly rather than
+// silently coerced to a default (which would run a different query than the
+// caller asked for).
 func parsePreparedQueryTarget(target string) (commonpb.QueryTarget, error) {
 	if target == "" {
-		return 0, errors.New("target is required (ACCOUNTS, TRANSACTIONS or LOGS)")
+		return 0, errors.New("target is required (ACCOUNTS or TRANSACTIONS)")
 	}
 
 	t, ok := preparedQueryTargets[target]
 	if !ok {
-		return 0, fmt.Errorf("unknown target %q (use ACCOUNTS, TRANSACTIONS or LOGS)", target)
+		return 0, fmt.Errorf("unknown or unsupported target %q (use ACCOUNTS or TRANSACTIONS)", target)
 	}
 
 	return t, nil

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -5,24 +5,23 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // decodePreparedQueryFilter decodes the `filter` JSON value of a prepared-query
-// create/update request. The default `encoding/json` decoder cannot dispatch
-// protobuf `oneof` variants, so we route the field through `protojson` to keep
-// REST behaviour aligned with the gRPC path. An empty or absent filter is
-// rejected — otherwise the prepared query would store nil and fail later at
-// execute time with "unknown filter type: <nil>".
+// create/update request. The value uses the canonical flat QueryFilter shape
+// documented in openapi.yml (combinators `and`/`or`/`not` plus a tagged-union
+// `match`); the codec lives on commonpb.QueryFilter (query_filter.go) and keeps
+// the protobuf-internal oneof/wrapper names off the public surface. An empty or
+// absent filter is rejected — otherwise the prepared query would store nil and
+// fail later at execute time with "unknown filter type: <nil>".
 func decodePreparedQueryFilter(raw json.RawMessage) (*commonpb.QueryFilter, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, errors.New("filter is required")
 	}
 
 	filter := &commonpb.QueryFilter{}
-	if err := protojson.Unmarshal(raw, filter); err != nil {
+	if err := json.Unmarshal(raw, filter); err != nil {
 		return nil, fmt.Errorf("filter: %w", err)
 	}
 

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -38,12 +38,13 @@ func parsePreparedQueryTarget(target string) (commonpb.QueryTarget, error) {
 }
 
 // decodePreparedQueryFilter decodes the `filter` JSON value of a prepared-query
-// create/update request. The value uses the canonical flat QueryFilter shape
-// documented in openapi.yml (combinators `and`/`or`/`not` plus a tagged-union
-// `match`); the codec lives on commonpb.QueryFilter (query_filter.go) and keeps
-// the protobuf-internal oneof/wrapper names off the public surface. An empty or
-// absent filter is rejected — otherwise the prepared query would store nil and
-// fail later at execute time with "unknown filter type: <nil>".
+// create/update request. The value uses the v2-aligned query DSL documented in
+// openapi.yml (combinators `$and`/`$or`/`$not` plus single-key operators
+// `$match`/`$gt`/`$exists`/…); the codec lives on commonpb.QueryFilter
+// (query_filter.go) and keeps the protobuf-internal oneof/wrapper names off the
+// public surface. An empty or absent filter is rejected — otherwise the prepared
+// query would store nil and fail later at execute time with "unknown filter
+// type: <nil>".
 func decodePreparedQueryFilter(raw json.RawMessage) (*commonpb.QueryFilter, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, errors.New("filter is required")

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -59,5 +59,43 @@ func decodePreparedQueryFilter(raw json.RawMessage) (*commonpb.QueryFilter, erro
 		return nil, errors.New("filter must contain at least one condition")
 	}
 
+	// REST prepared queries only target ACCOUNTS/TRANSACTIONS
+	// (see parsePreparedQueryTarget), so log-only conditions (logId, date,
+	// ledger) can never be satisfied here — they would compile a log iterator
+	// and silently return unrelated/empty results. Reject them up front.
+	if err := rejectLogOnlyConditions(filter); err != nil {
+		return nil, err
+	}
+
 	return filter, nil
+}
+
+// rejectLogOnlyConditions walks the filter tree and rejects conditions that only
+// make sense for log queries: logId, log date (logBuiltinUint), and ledger. The
+// REST prepared-query surface cannot target logs, so these are always invalid.
+func rejectLogOnlyConditions(f *commonpb.QueryFilter) error {
+	switch v := f.GetFilter().(type) {
+	case *commonpb.QueryFilter_LogId:
+		return errors.New("logId filter is only valid on log queries, which prepared queries cannot target over REST")
+	case *commonpb.QueryFilter_LogBuiltinUint:
+		return errors.New("date filter is only valid on log queries, which prepared queries cannot target over REST")
+	case *commonpb.QueryFilter_Ledger:
+		return errors.New("ledger filter is only valid on log queries, which prepared queries cannot target over REST")
+	case *commonpb.QueryFilter_And:
+		for _, sub := range v.And.GetFilters() {
+			if err := rejectLogOnlyConditions(sub); err != nil {
+				return err
+			}
+		}
+	case *commonpb.QueryFilter_Or:
+		for _, sub := range v.Or.GetFilters() {
+			if err := rejectLogOnlyConditions(sub); err != nil {
+				return err
+			}
+		}
+	case *commonpb.QueryFilter_Not:
+		return rejectLogOnlyConditions(v.Not.GetFilter())
+	}
+
+	return nil
 }

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -8,6 +8,32 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
+// preparedQueryTargets maps the public REST target enum
+// (ACCOUNTS/TRANSACTIONS/LOGS, per openapi.yml) to the proto QueryTarget. All
+// three targets are supported by the query executor and creatable via
+// gRPC/CLI, so REST must accept them too.
+var preparedQueryTargets = map[string]commonpb.QueryTarget{
+	"ACCOUNTS":     commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+	"TRANSACTIONS": commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+	"LOGS":         commonpb.QueryTarget_QUERY_TARGET_LOGS,
+}
+
+// parsePreparedQueryTarget resolves the `target` field of a prepared-query
+// request. An unknown value is rejected loudly rather than silently coerced to
+// a default (which would run a different query than the caller asked for).
+func parsePreparedQueryTarget(target string) (commonpb.QueryTarget, error) {
+	if target == "" {
+		return 0, errors.New("target is required (ACCOUNTS, TRANSACTIONS or LOGS)")
+	}
+
+	t, ok := preparedQueryTargets[target]
+	if !ok {
+		return 0, fmt.Errorf("unknown target %q (use ACCOUNTS, TRANSACTIONS or LOGS)", target)
+	}
+
+	return t, nil
+}
+
 // decodePreparedQueryFilter decodes the `filter` JSON value of a prepared-query
 // create/update request. The value uses the canonical flat QueryFilter shape
 // documented in openapi.yml (combinators `and`/`or`/`not` plus a tagged-union

--- a/internal/adapter/http/prepared_query_filter_test.go
+++ b/internal/adapter/http/prepared_query_filter_test.go
@@ -29,7 +29,7 @@ func TestDecodePreparedQueryFilter(t *testing.T) {
 		{
 			name:    "empty object",
 			raw:     "{}",
-			wantErr: "must contain at least one condition",
+			wantErr: "exactly one of",
 		},
 		{
 			name:    "invalid json",
@@ -37,19 +37,29 @@ func TestDecodePreparedQueryFilter(t *testing.T) {
 			wantErr: "filter:",
 		},
 		{
-			name: "and filter with nested field oneof",
-			raw: `{"and":{"filters":[
-				{"field":{"field":{"metadata":"x"},"intCond":{"min":"1"}}},
-				{"field":{"field":{"metadata":"y"},"boolCond":{"hardcoded":true}}}
-			]}}`,
+			name: "and filter with nested field conditions",
+			raw: `{"and":[
+				{"match":{"type":"field","metadata":"x","condition":{"type":"int","min":1}}},
+				{"match":{"type":"field","metadata":"y","condition":{"type":"bool","equals":true}}}
+			]}`,
 		},
 		{
 			name: "or filter",
-			raw:  `{"or":{"filters":[{"field":{"field":{"metadata":"x"},"existsCond":{}}}]}}`,
+			raw:  `{"or":[{"match":{"type":"field","metadata":"x","condition":{"type":"exists"}}}]}`,
 		},
 		{
-			name: "leaf field oneof",
-			raw:  `{"field":{"field":{"metadata":"x"},"existsCond":{}}}`,
+			name: "leaf field condition",
+			raw:  `{"match":{"type":"field","metadata":"x","condition":{"type":"exists"}}}`,
+		},
+		{
+			name:    "unknown condition type rejected",
+			raw:     `{"match":{"type":"bogus"}}`,
+			wantErr: "unknown condition type",
+		},
+		{
+			name:    "multiple top-level keys rejected",
+			raw:     `{"and":[],"not":{"match":{"type":"reverted","value":true}}}`,
+			wantErr: "exactly one of",
 		},
 	}
 

--- a/internal/adapter/http/prepared_query_filter_test.go
+++ b/internal/adapter/http/prepared_query_filter_test.go
@@ -29,7 +29,7 @@ func TestDecodePreparedQueryFilter(t *testing.T) {
 		{
 			name:    "empty object",
 			raw:     "{}",
-			wantErr: "exactly one of",
+			wantErr: "empty object",
 		},
 		{
 			name:    "invalid json",
@@ -37,29 +37,29 @@ func TestDecodePreparedQueryFilter(t *testing.T) {
 			wantErr: "filter:",
 		},
 		{
-			name: "and filter with nested field conditions",
-			raw: `{"and":[
-				{"match":{"type":"field","metadata":"x","condition":{"type":"int","min":1}}},
-				{"match":{"type":"field","metadata":"y","condition":{"type":"bool","equals":true}}}
+			name: "and filter with nested conditions",
+			raw: `{"$and":[
+				{"$gte":{"metadata[x]":1}},
+				{"$match":{"metadata[y]":true}}
 			]}`,
 		},
 		{
 			name: "or filter",
-			raw:  `{"or":[{"match":{"type":"field","metadata":"x","condition":{"type":"exists"}}}]}`,
+			raw:  `{"$or":[{"$exists":{"metadata":"x"}}]}`,
 		},
 		{
-			name: "leaf field condition",
-			raw:  `{"match":{"type":"field","metadata":"x","condition":{"type":"exists"}}}`,
+			name: "leaf metadata exists",
+			raw:  `{"$exists":{"metadata":"x"}}`,
 		},
 		{
-			name:    "unknown condition type rejected",
-			raw:     `{"match":{"type":"bogus"}}`,
-			wantErr: "unknown condition type",
+			name:    "unknown operator rejected",
+			raw:     `{"$bogus":{}}`,
+			wantErr: "unknown operator",
 		},
 		{
-			name:    "multiple top-level keys rejected",
-			raw:     `{"and":[],"not":{"match":{"type":"reverted","value":true}}}`,
-			wantErr: "exactly one of",
+			name:    "multiple top-level operators rejected",
+			raw:     `{"$and":[],"$not":{"$match":{"reverted":true}}}`,
+			wantErr: "exactly one operator",
 		},
 	}
 

--- a/internal/adapter/http/prepared_query_filter_test.go
+++ b/internal/adapter/http/prepared_query_filter_test.go
@@ -57,6 +57,31 @@ func TestDecodePreparedQueryFilter(t *testing.T) {
 			wantErr: "unknown operator",
 		},
 		{
+			name:    "logId rejected on prepared query (log-only field)",
+			raw:     `{"$gt":{"logId":"5"}}`,
+			wantErr: "logId filter is only valid on log queries",
+		},
+		{
+			name:    "date rejected on prepared query (log-only field)",
+			raw:     `{"$gt":{"date":"5"}}`,
+			wantErr: "date filter is only valid on log queries",
+		},
+		{
+			name:    "ledger rejected on prepared query (log-only field)",
+			raw:     `{"$match":{"ledger":"main"}}`,
+			wantErr: "ledger filter is only valid on log queries",
+		},
+		{
+			name:    "logId nested in and rejected",
+			raw:     `{"$and":[{"$match":{"reference":"r"}},{"$gt":{"logId":"5"}}]}`,
+			wantErr: "logId filter is only valid on log queries",
+		},
+		{
+			name:    "null value rejected",
+			raw:     `{"$match":{"reference":null}}`,
+			wantErr: "must not be null",
+		},
+		{
 			name:    "multiple top-level operators rejected",
 			raw:     `{"$and":[],"$not":{"$match":{"reverted":true}}}`,
 			wantErr: "exactly one operator",

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -10189,7 +10189,7 @@ func (x *LogIdCondition) GetCond() *UintCondition {
 	return nil
 }
 
-// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, or inserted_at).
+// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, inserted_at, or reverted_at).
 type BuiltinUintCondition struct {
 	state         protoimpl.MessageState  `protogen:"open.v1"`
 	Field         TransactionBuiltinIndex `protobuf:"varint,1,opt,name=field,proto3,enum=common.TransactionBuiltinIndex" json:"field,omitempty"`

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -362,17 +362,36 @@ func (sm *SavedMetadata) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements json.Marshaler for PreparedQuery.
 //
 // PreparedQuery embeds a *QueryFilter (a protobuf oneof) and exposes a
-// QueryTarget enum. Default encoding/json has no way to dispatch the oneof
-// variants (their Go fields carry only `protobuf:",oneof"` — no `json:` tag)
-// and emits the enum as a raw int. Result: `{"filter":{"Filter":{"Reference":
-// {"cond":{"Value":{"Hardcoded":"..."}}}}},"target":1}` instead of the
-// camelCase shape the REST contract advertises and that the input side
-// already accepts via `decodePreparedQueryFilter` (protojson).
-//
-// Route the whole value through protojson to keep the response symmetric
-// with the request — same class of bug as #459 / #473.
+// QueryTarget enum. We deliberately do NOT route through protojson: that would
+// leak the protobuf-internal oneof/wrapper names of QueryFilter onto the public
+// REST surface (see the codec in query_filter.go). Instead the filter is
+// encoded through QueryFilter's own hand-written MarshalJSON (canonical flat
+// shape) and the target is emitted as the string enum the OpenAPI contract
+// advertises (ACCOUNTS / TRANSACTIONS / LOGS).
 func (x *PreparedQuery) MarshalJSON() ([]byte, error) {
-	return protojson.Marshal(x)
+	target, ok := queryTargetToJSON[x.GetTarget()]
+	if !ok {
+		return nil, fmt.Errorf("prepared query: unknown target %v", x.GetTarget())
+	}
+
+	return json.Marshal(&struct {
+		Name   string       `json:"name"`
+		Target string       `json:"target"`
+		Filter *QueryFilter `json:"filter,omitempty"`
+	}{
+		Name:   x.GetName(),
+		Target: target,
+		Filter: x.GetFilter(),
+	})
+}
+
+// queryTargetToJSON maps the QueryTarget proto enum to the public string enum
+// documented in openapi.yml. Kept local so the public contract never inherits
+// the QUERY_TARGET_* proto prefixes.
+var queryTargetToJSON = map[QueryTarget]string{
+	QueryTarget_QUERY_TARGET_ACCOUNTS:     "ACCOUNTS",
+	QueryTarget_QUERY_TARGET_TRANSACTIONS: "TRANSACTIONS",
+	QueryTarget_QUERY_TARGET_LOGS:         "LOGS",
 }
 
 // MarshalJSON implements json.Marshaler for PreparedQueryCursor.

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -366,8 +366,13 @@ func (sm *SavedMetadata) UnmarshalJSON(data []byte) error {
 // leak the protobuf-internal oneof/wrapper names of QueryFilter onto the public
 // REST surface (see the codec in query_filter.go). Instead the filter is
 // encoded through QueryFilter's own hand-written MarshalJSON (canonical flat
-// shape) and the target is emitted as the string enum the OpenAPI contract
-// advertises (ACCOUNTS / TRANSACTIONS / LOGS).
+// shape) and the target is emitted as the bare string enum.
+//
+// REST can only create ACCOUNTS / TRANSACTIONS prepared queries (see
+// parsePreparedQueryTarget — LOGS prepared queries would execute to an empty
+// cursor). A LOGS-target query can still exist if created via gRPC/CLI; when
+// such a query is listed over REST we emit its true target ("LOGS") faithfully
+// rather than lying about it, so the map covers all three proto values.
 func (x *PreparedQuery) MarshalJSON() ([]byte, error) {
 	target, ok := queryTargetToJSON[x.GetTarget()]
 	if !ok {

--- a/internal/proto/commonpb/prepared_query_json_test.go
+++ b/internal/proto/commonpb/prepared_query_json_test.go
@@ -1,7 +1,6 @@
 package commonpb
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,13 +8,16 @@ import (
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 )
 
-// TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString guards the regression
-// where PreparedQuery shipped through sonic/encoding/json emitted PascalCase
-// oneof keys (`"Filter":{"Reference":{"cond":{"Value":{"Hardcoded":...}}}}`)
-// and a raw enum int (`"target":1`) — see #478. The fix routes the value
-// through protojson so the response matches the camelCase contract every
-// other endpoint follows and the input side already accepts via
-// decodePreparedQueryFilter.
+// TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString guards two regressions:
+//   - #478: default encoding/json emitted PascalCase oneof keys
+//     (`"Filter":{"Reference":{...}}`) and a raw enum int (`"target":1`).
+//   - EN-1465: the earlier protojson fix leaked the proto-internal oneof/wrapper
+//     names of QueryFilter (`"reference":{"cond":{"hardcoded":...}}`) and the
+//     QUERY_TARGET_* enum prefix onto the public surface.
+//
+// The current contract is the canonical flat shape: target is the bare string
+// enum (ACCOUNTS/TRANSACTIONS/LOGS) and the filter uses `match` + tagged-union
+// conditions (see query_filter.go).
 func TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString(t *testing.T) {
 	t.Parallel()
 
@@ -38,27 +40,27 @@ func TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString(t *testing.T) {
 
 	out := string(data)
 	require.Contains(t, out, `"name":"q1"`)
-	require.Contains(t, out, `"target":"QUERY_TARGET_TRANSACTIONS"`,
-		"enum must be emitted as its string constant, not a raw int")
-	require.Contains(t, out, `"reference"`,
-		"oneof variants must be lowercased per protojson")
-	require.Contains(t, out, `"hardcoded":"order-123"`,
-		"nested oneof variants must be camelCase too")
+	require.Contains(t, out, `"target":"TRANSACTIONS"`,
+		"enum must be emitted as the bare string constant, not a raw int or the QUERY_TARGET_* prefix")
+	require.Contains(t, out, `"match":{"type":"reference"`,
+		"filter must use the canonical flat match shape")
+	require.Contains(t, out, `"equals":"order-123"`,
+		"string condition must use the public `equals` key")
 
 	// The PreparedQuery value no longer carries a ledger field — the ledger
 	// lives on the storage key, on the surrounding RPC request, and (for
-	// write commands) on the LedgerScopedOrder wrapper. The marshalled
-	// payload must not leak the field, even transiently.
-	require.False(t, strings.Contains(out, `"ledger"`),
+	// write commands) on the LedgerScopedOrder wrapper.
+	require.NotContains(t, out, `"ledger"`,
 		"ledger field must not appear in the marshalled PreparedQuery")
 
-	// Belt-and-braces: the broken shape must not survive.
-	require.False(t, strings.Contains(out, `"Filter"`),
-		"PascalCase oneof container leak")
-	require.False(t, strings.Contains(out, `"Reference"`),
-		"PascalCase oneof variant leak")
-	require.False(t, strings.Contains(out, `"Hardcoded"`),
-		"PascalCase nested-oneof variant leak")
-	require.False(t, strings.Contains(out, `"target":1`),
-		"raw-int enum leak")
+	// The broken shape (#478) must not survive.
+	require.NotContains(t, out, `"Filter"`, "PascalCase oneof container leak")
+	require.NotContains(t, out, `"Reference"`, "PascalCase oneof variant leak")
+	require.NotContains(t, out, `"Hardcoded"`, "PascalCase nested-oneof variant leak")
+	require.NotContains(t, out, `"target":1`, "raw-int enum leak")
+
+	// The protojson leak (EN-1465) must not survive either.
+	require.NotContains(t, out, `QUERY_TARGET_`, "proto enum prefix leak")
+	require.NotContains(t, out, `"cond"`, "protojson-internal condition wrapper leak")
+	require.NotContains(t, out, `"hardcoded"`, "protojson-internal string oneof leak")
 }

--- a/internal/proto/commonpb/prepared_query_json_test.go
+++ b/internal/proto/commonpb/prepared_query_json_test.go
@@ -11,13 +11,13 @@ import (
 // TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString guards two regressions:
 //   - #478: default encoding/json emitted PascalCase oneof keys
 //     (`"Filter":{"Reference":{...}}`) and a raw enum int (`"target":1`).
-//   - EN-1465: the earlier protojson fix leaked the proto-internal oneof/wrapper
-//     names of QueryFilter (`"reference":{"cond":{"hardcoded":...}}`) and the
-//     QUERY_TARGET_* enum prefix onto the public surface.
+//   - EN-1465: protojson leaked the proto-internal oneof/wrapper names of
+//     QueryFilter and the QUERY_TARGET_* enum prefix onto the public surface.
 //
-// The current contract is the canonical flat shape: target is the bare string
-// enum (ACCOUNTS/TRANSACTIONS/LOGS) and the filter uses `match` + tagged-union
-// conditions (see query_filter.go).
+// The current contract is the v2-aligned query DSL: target is the bare string
+// enum (ACCOUNTS/TRANSACTIONS/LOGS) and the filter uses `$`-prefixed operators
+// (`$match`/`$gt`/…) with single-key operator->{field:value} bodies (see
+// query_filter.go).
 func TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString(t *testing.T) {
 	t.Parallel()
 
@@ -42,10 +42,8 @@ func TestPreparedQuery_MarshalJSON_CamelCaseAndEnumString(t *testing.T) {
 	require.Contains(t, out, `"name":"q1"`)
 	require.Contains(t, out, `"target":"TRANSACTIONS"`,
 		"enum must be emitted as the bare string constant, not a raw int or the QUERY_TARGET_* prefix")
-	require.Contains(t, out, `"match":{"type":"reference"`,
-		"filter must use the canonical flat match shape")
-	require.Contains(t, out, `"equals":"order-123"`,
-		"string condition must use the public `equals` key")
+	require.Contains(t, out, `"$match":{"reference":"order-123"}`,
+		"filter must use the v2-aligned query DSL shape")
 
 	// The PreparedQuery value no longer carries a ledger field — the ledger
 	// lives on the storage key, on the surrounding RPC request, and (for

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -516,12 +516,25 @@ func marshalAddressMatch(am *AddressMatch) (map[string]any, error) {
 
 	switch m := am.GetMatch().(type) {
 	case *AddressMatch_HardcodedPrefix:
-		v, err := literalValue(ensurePrefix(m.HardcodedPrefix))
+		// A prefix whose value already ends in ":" round-trips via $match (the
+		// trailing colon is the DSL prefix marker). A prefix WITHOUT a trailing
+		// colon (a byte-level prefix) would be indistinguishable from an exact
+		// match under $match, so it is emitted via $like with a literal value to
+		// preserve prefix intent losslessly.
+		if m.HardcodedPrefix != "" && m.HardcodedPrefix[len(m.HardcodedPrefix)-1] == ':' {
+			v, err := literalValue(m.HardcodedPrefix)
+			if err != nil {
+				return nil, err
+			}
+
+			return kv(opMatch, field, v), nil
+		}
+		v, err := literalValue(m.HardcodedPrefix)
 		if err != nil {
 			return nil, err
 		}
 
-		return kv(opMatch, field, v), nil
+		return kv(opLike, field, v), nil
 	case *AddressMatch_HardcodedExact:
 		v, err := literalValue(m.HardcodedExact)
 		if err != nil {
@@ -539,20 +552,6 @@ func marshalAddressMatch(am *AddressMatch) (map[string]any, error) {
 	default:
 		return nil, errors.New("address: no match set")
 	}
-}
-
-// ensurePrefix guarantees the trailing ":" that marks a prefix match in the DSL.
-// Hardcoded prefixes without a segment separator (rare) still round-trip
-// because the decoder treats a trailing ":" as the prefix marker.
-func ensurePrefix(p string) string {
-	if p == "" {
-		return ":"
-	}
-	if p[len(p)-1] == ':' {
-		return p
-	}
-
-	return p + ":"
 }
 
 // ============================================================================
@@ -850,14 +849,24 @@ func decodeAddressMatch(field string, value jsonValue) (*QueryFilter, error) {
 }
 
 func decodeLike(field string, value jsonValue) (*QueryFilter, error) {
-	// $like is only used to carry a parameterised address prefix today.
+	// $like carries an address prefix — either a literal (hardcoded byte-level
+	// prefix that cannot be expressed via the trailing-":" $match convention) or
+	// a parameterised prefix resolved at execution time.
 	if field != "address" && field != "source" && field != "destination" {
 		return nil, fmt.Errorf("$like: unsupported field %q", field)
 	}
-	if !value.isParam() {
-		return nil, errors.New("$like: only a parameterised prefix is supported on this surface")
+
+	am := &AddressMatch{}
+	if value.isParam() {
+		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: value.param}
+	} else {
+		s, err := value.asString()
+		if err != nil {
+			return nil, fmt.Errorf("$like: %w", err)
+		}
+		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: s}
 	}
-	am := &AddressMatch{Match: &AddressMatch_ParamPrefix{ParamPrefix: value.param}}
+
 	switch field {
 	case "source":
 		am.Role = AddressRole_ADDRESS_ROLE_SOURCE
@@ -943,6 +952,23 @@ func buildRange(field string, bounds []bound) (*QueryFilter, error) {
 		}}}, nil
 	default:
 		if key, ok := parseMetadataKey(field); ok {
+			// Metadata numeric ranges may be signed (IntCondition) or unsigned
+			// (UintCondition). We keep them distinguishable — and thus lossless —
+			// the same way the encoder does: unsigned bounds are decimal strings,
+			// signed bounds are JSON numbers. A param-only range carries no
+			// literal to inspect and defaults to the signed form.
+			if boundsAreUnsigned(bounds) {
+				uc, err := uintConditionFromBounds(bounds)
+				if err != nil {
+					return nil, err
+				}
+
+				return &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+					Field:     &FieldRef{Metadata: key},
+					Condition: &FieldCondition_UintCond{UintCond: uc},
+				}}}, nil
+			}
+
 			ic, err := intConditionFromBounds(bounds)
 			if err != nil {
 				return nil, err
@@ -956,6 +982,25 @@ func buildRange(field string, bounds []bound) (*QueryFilter, error) {
 
 		return nil, fmt.Errorf("range: unsupported field %q", field)
 	}
+}
+
+// boundsAreUnsigned reports whether the literal bound values are JSON strings
+// (the unsigned encoding). Returns false when all bounds are params (no literal
+// to inspect) so the signed form is chosen by default.
+func boundsAreUnsigned(bounds []bound) bool {
+	sawLiteral := false
+	for _, b := range bounds {
+		if b.value.isParam() {
+			continue
+		}
+		sawLiteral = true
+		var s string
+		if err := json.Unmarshal(b.value.literal, &s); err != nil {
+			return false
+		}
+	}
+
+	return sawLiteral
 }
 
 func intConditionFromBounds(bounds []bound) (*IntCondition, error) {

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -23,7 +23,6 @@ import (
 //	  {"$exists": {"metadata": "<key>"}}  metadata key presence
 //	  {"$exists": {"asset": "<assetRef>"}} account has-asset presence
 //	  {"$in":     {"<field>": [<value>, ...]}}  (reserved; not yet emitted)
-//	  {"$like":   {"<field>": <value>}}         (reserved; not yet emitted)
 //
 // Fields:
 //   - metadata: `metadata[<key>]`
@@ -53,7 +52,6 @@ const (
 	opLte    = "$lte"
 	opExists = "$exists"
 	opIn     = "$in"
-	opLike   = "$like"
 	opParam  = "$param"
 )
 
@@ -529,25 +527,25 @@ func marshalAddressMatch(am *AddressMatch) (map[string]any, error) {
 
 	switch m := am.GetMatch().(type) {
 	case *AddressMatch_HardcodedPrefix:
-		// A prefix whose value already ends in ":" round-trips via $match (the
-		// trailing colon is the DSL prefix marker). A prefix WITHOUT a trailing
-		// colon (a byte-level prefix) would be indistinguishable from an exact
-		// match under $match, so it is emitted via $like with a literal value to
-		// preserve prefix intent losslessly.
-		if m.HardcodedPrefix != "" && m.HardcodedPrefix[len(m.HardcodedPrefix)-1] == ':' {
-			v, err := literalValue(m.HardcodedPrefix)
-			if err != nil {
-				return nil, err
-			}
-
-			return kv(opMatch, field, v), nil
+		// A prefix whose value ends in ":" round-trips via $match (the trailing
+		// colon is the DSL prefix marker). A prefix WITHOUT a trailing colon (a
+		// byte-level prefix) would be indistinguishable from an exact match under
+		// $match, and the DSL no longer exposes an operator that can carry it
+		// (the $like operator was dropped — EN-1465). It is not producible through
+		// the JSON/REST surface: the $match decoder only builds a HardcodedPrefix
+		// for a trailing-":" value (else a HardcodedExact), so a byte-level prefix
+		// can only arrive on a proto object built by another layer (gRPC, CLI,
+		// pkg/actions). Fail loudly rather than silently emit an exact-looking
+		// $match that would widen the query (invariant #7).
+		if m.HardcodedPrefix == "" || m.HardcodedPrefix[len(m.HardcodedPrefix)-1] != ':' {
+			return nil, fmt.Errorf("address: byte-level prefix %q is not representable in the query DSL (a prefix must end in ':')", m.HardcodedPrefix)
 		}
 		v, err := literalValue(m.HardcodedPrefix)
 		if err != nil {
 			return nil, err
 		}
 
-		return kv(opLike, field, v), nil
+		return kv(opMatch, field, v), nil
 	case *AddressMatch_HardcodedExact:
 		v, err := literalValue(m.HardcodedExact)
 		if err != nil {
@@ -556,10 +554,14 @@ func marshalAddressMatch(am *AddressMatch) (map[string]any, error) {
 
 		return kv(opMatch, field, v), nil
 	case *AddressMatch_ParamPrefix:
-		// A parameterised prefix cannot carry the trailing ":" marker on the
-		// literal, so it is encoded as a $like with a param (prefix semantics
-		// resolved at execution time from the param value).
-		return kv(opLike, field, paramValue(m.ParamPrefix)), nil
+		// A parameterised prefix cannot carry the trailing ":" marker on the param
+		// value, and the DSL no longer exposes an operator that can carry it (the
+		// $like operator was dropped — EN-1465). It is not producible through the
+		// JSON/REST surface: a $match with a param decodes to ParamExact, never
+		// ParamPrefix, so this arm can only arrive on a proto object built by
+		// another layer. Fail loudly rather than silently drop the prefix intent
+		// (invariant #7).
+		return nil, fmt.Errorf("address: parameterised prefix (param %q) is not representable in the query DSL", m.ParamPrefix)
 	case *AddressMatch_ParamExact:
 		return kv(opMatch, field, paramValue(m.ParamExact)), nil
 	default:
@@ -619,7 +621,7 @@ func decodeExpression(op string, raw json.RawMessage) (*QueryFilter, error) {
 		}
 
 		return &QueryFilter{Filter: &QueryFilter_Not{Not: &NotFilter{Filter: inner}}}, nil
-	case opMatch, opGt, opGte, opLt, opLte, opExists, opIn, opLike:
+	case opMatch, opGt, opGte, opLt, opLte, opExists, opIn:
 		return decodeLeaf(op, raw)
 	default:
 		return nil, fmt.Errorf("query filter: unknown operator %q", op)
@@ -747,8 +749,6 @@ func decodeLeaf(op string, raw json.RawMessage) (*QueryFilter, error) {
 		return decodeMatch(field, value)
 	case opGt, opGte, opLt, opLte:
 		return decodeSingleBound(op, field, value)
-	case opLike:
-		return decodeLike(field, value)
 	case opIn:
 		return nil, errors.New("$in: not supported for this filter surface")
 	default:
@@ -842,7 +842,8 @@ func decodeAddressMatch(field string, value jsonValue) (*QueryFilter, error) {
 	}
 
 	if value.isParam() {
-		// $match with a param is an exact param match ($like carries prefix).
+		// $match with a param is an exact param match: the DSL has no parameterised
+		// prefix form (a param value cannot carry the trailing-":" prefix marker).
 		am.Match = &AddressMatch_ParamExact{ParamExact: value.param}
 
 		return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil
@@ -856,35 +857,6 @@ func decodeAddressMatch(field string, value jsonValue) (*QueryFilter, error) {
 		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: s}
 	} else {
 		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: s}
-	}
-
-	return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil
-}
-
-func decodeLike(field string, value jsonValue) (*QueryFilter, error) {
-	// $like carries an address prefix — either a literal (hardcoded byte-level
-	// prefix that cannot be expressed via the trailing-":" $match convention) or
-	// a parameterised prefix resolved at execution time.
-	if field != "address" && field != "source" && field != "destination" {
-		return nil, fmt.Errorf("$like: unsupported field %q", field)
-	}
-
-	am := &AddressMatch{}
-	if value.isParam() {
-		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: value.param}
-	} else {
-		s, err := value.asString()
-		if err != nil {
-			return nil, fmt.Errorf("$like: %w", err)
-		}
-		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: s}
-	}
-
-	switch field {
-	case "source":
-		am.Role = AddressRole_ADDRESS_ROLE_SOURCE
-	case "destination":
-		am.Role = AddressRole_ADDRESS_ROLE_DESTINATION
 	}
 
 	return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -122,6 +122,13 @@ func (v jsonValue) MarshalJSON() ([]byte, error) {
 }
 
 func (v *jsonValue) UnmarshalJSON(data []byte) error {
+	// A JSON null in value position is meaningless (it would silently decode to
+	// the Go zero value — false / "" / 0 — via json.Unmarshal no-op, matching a
+	// condition the caller never intended). Reject it loudly.
+	if string(data) == "null" {
+		return errors.New("value must not be null")
+	}
+
 	// A {"$param": "name"} object is a parameter reference; anything else is a
 	// literal. We only treat an object with exactly the $param key as a param —
 	// a plain object literal (unused today) would pass through as a literal.
@@ -379,7 +386,13 @@ func marshalFieldCondition(fc *FieldCondition) (map[string]any, error) {
 		return marshalBoolCond(key, c.BoolCond)
 	case *FieldCondition_ExistsCond:
 		// metadata existence uses {"$exists": {"metadata": "<key>"}} (v2 shape),
-		// not the metadata[<key>] field form.
+		// not the metadata[<key>] field form. The v2 DSL has no way to express
+		// `include_null`, so a condition that sets it cannot be represented
+		// losslessly — fail loudly rather than silently drop the flag. (No
+		// current builder sets it; this guards a future one.)
+		if c.ExistsCond.GetIncludeNull() {
+			return nil, errors.New("exists: include_null is not representable in the query DSL")
+		}
 		v, err := literalValue(fc.GetField().GetMetadata())
 		if err != nil {
 			return nil, err

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -164,13 +164,13 @@ func (x *QueryFilter) UnmarshalJSON(data []byte) error {
 
 	switch {
 	case env.And != nil:
-		filters, err := unmarshalFilterList(env.And)
+		filters, err := unmarshalFilterList("and", env.And)
 		if err != nil {
 			return err
 		}
 		x.Filter = &QueryFilter_And{And: &AndFilter{Filters: filters}}
 	case env.Or != nil:
-		filters, err := unmarshalFilterList(env.Or)
+		filters, err := unmarshalFilterList("or", env.Or)
 		if err != nil {
 			return err
 		}
@@ -188,7 +188,14 @@ func (x *QueryFilter) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func unmarshalFilterList(raw []json.RawMessage) ([]*QueryFilter, error) {
+func unmarshalFilterList(combinator string, raw []json.RawMessage) ([]*QueryFilter, error) {
+	// An empty combinator is ambiguous (empty AND = match-all, empty OR =
+	// match-nothing) and almost always a client mistake — reject it loudly
+	// rather than silently building a degenerate filter.
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("%s: must contain at least one filter", combinator)
+	}
+
 	filters := make([]*QueryFilter, 0, len(raw))
 	for i, r := range raw {
 		sub := &QueryFilter{}
@@ -539,11 +546,15 @@ func marshalAddressMatch(am *AddressMatch) (json.RawMessage, error) {
 }
 
 func unmarshalAddressMatch(raw json.RawMessage) (*AddressMatch, error) {
+	// value/param are presence-tracked pointers so an explicit empty string
+	// (a match-all hardcoded prefix, constructible via gRPC) round-trips
+	// losslessly, while an omitted key is rejected — exactly one of the two must
+	// be *present*, mirroring the string/bool conditions.
 	var in struct {
-		Operator string `json:"operator"`
-		Value    string `json:"value"`
-		Param    string `json:"param"`
-		Role     string `json:"role"`
+		Operator string  `json:"operator"`
+		Value    *string `json:"value"`
+		Param    *string `json:"param"`
+		Role     string  `json:"role"`
 	}
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, fmt.Errorf("address: %w", err)
@@ -558,26 +569,25 @@ func unmarshalAddressMatch(raw json.RawMessage) (*AddressMatch, error) {
 		return nil, fmt.Errorf("address: unknown operator %q", in.Operator)
 	}
 
-	// Exactly one of value/param must be set. A hardcoded empty prefix/exact
-	// would silently match every address (over-broad), so the empty case is
-	// rejected rather than defaulted.
-	if in.Value != "" && in.Param != "" {
+	// Exactly one of value/param must be present. Absence of both is rejected
+	// (an omitted value would otherwise default to a match-all empty prefix).
+	if in.Value != nil && in.Param != nil {
 		return nil, errors.New("address: set only one of value or param")
 	}
-	if in.Value == "" && in.Param == "" {
+	if in.Value == nil && in.Param == nil {
 		return nil, errors.New("address: set one of value or param")
 	}
 
 	am := &AddressMatch{}
 	switch {
-	case in.Operator == "prefix" && in.Param != "":
-		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: in.Param}
+	case in.Operator == "prefix" && in.Param != nil:
+		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: *in.Param}
 	case in.Operator == "prefix":
-		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: in.Value}
-	case in.Operator == "exact" && in.Param != "":
-		am.Match = &AddressMatch_ParamExact{ParamExact: in.Param}
+		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: *in.Value}
+	case in.Operator == "exact" && in.Param != nil:
+		am.Match = &AddressMatch_ParamExact{ParamExact: *in.Param}
 	default: // exact + hardcoded value
-		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: in.Value}
+		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: *in.Value}
 	}
 
 	if in.Role != "" {

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -505,23 +505,28 @@ func unmarshalFieldCondition(raw json.RawMessage) (*FieldCondition, error) {
 // --- AddressMatch ---------------------------------------------------------
 
 func marshalAddressMatch(am *AddressMatch) (json.RawMessage, error) {
+	// value/param are pointers so that whichever variant is set is always
+	// emitted, even when its string value is empty. Using `omitempty` on plain
+	// strings would drop an explicit empty hardcoded value, producing a payload
+	// (operator with no value/param) that the decoder correctly rejects — the
+	// marshal/unmarshal round-trip must stay lossless and canonical.
 	out := struct {
-		Type     string `json:"type"`
-		Operator string `json:"operator"`
-		Value    string `json:"value,omitempty"`
-		Param    string `json:"param,omitempty"`
-		Role     string `json:"role,omitempty"`
+		Type     string  `json:"type"`
+		Operator string  `json:"operator"`
+		Value    *string `json:"value,omitempty"`
+		Param    *string `json:"param,omitempty"`
+		Role     string  `json:"role,omitempty"`
 	}{Type: "address"}
 
 	switch m := am.GetMatch().(type) {
 	case *AddressMatch_HardcodedPrefix:
-		out.Operator, out.Value = "prefix", m.HardcodedPrefix
+		out.Operator, out.Value = "prefix", &m.HardcodedPrefix
 	case *AddressMatch_HardcodedExact:
-		out.Operator, out.Value = "exact", m.HardcodedExact
+		out.Operator, out.Value = "exact", &m.HardcodedExact
 	case *AddressMatch_ParamPrefix:
-		out.Operator, out.Param = "prefix", m.ParamPrefix
+		out.Operator, out.Param = "prefix", &m.ParamPrefix
 	case *AddressMatch_ParamExact:
-		out.Operator, out.Param = "exact", m.ParamExact
+		out.Operator, out.Param = "exact", &m.ParamExact
 	default:
 		return nil, errors.New("address: no match set")
 	}

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -4,60 +4,64 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 )
 
-// QueryFilter has a hand-written JSON codec (this file) instead of relying on
-// protojson. protojson would leak the protobuf-internal oneof/wrapper names
-// onto the public REST surface: the top-level oneof would surface as
-// `{"and":{"filters":[...]}}` / `{"not":{"filter":{...}}}` and leaf conditions
-// as `{"field":{"field":{"metadata":"x"},"intCond":{...}}}`, none of which is a
-// contract we want to expose or that a hand-written OpenAPI schema can describe
-// cleanly. The canonical public shape is:
+// QueryFilter has a hand-written JSON codec (this file) that mirrors the shared
+// Formance query DSL (go-libs/pkg/query, as used by ledger v2) instead of
+// leaking the protobuf-internal oneof/wrapper names through protojson. The
+// canonical public shape is:
 //
-//	combinators (recursive):
-//	  {"and": [QueryFilter, ...]}
-//	  {"or":  [QueryFilter, ...]}
-//	  {"not": QueryFilter}
-//	leaf:
-//	  {"match": <Condition>}
+//	combinators:
+//	  {"$and": [QueryFilter, ...]}
+//	  {"$or":  [QueryFilter, ...]}
+//	  {"$not": QueryFilter}
+//	leaf conditions (single-key operator -> {field: value}):
+//	  {"$match":  {"<field>": <value>}}   exact / prefix / bool match
+//	  {"$gt"/"$gte"/"$lt"/"$lte": {"<field>": <value>}}   range bounds
+//	  {"$exists": {"metadata": "<key>"}}  metadata key presence
+//	  {"$exists": {"asset": "<assetRef>"}} account has-asset presence
+//	  {"$in":     {"<field>": [<value>, ...]}}  (reserved; not yet emitted)
+//	  {"$like":   {"<field>": <value>}}         (reserved; not yet emitted)
 //
-// where <Condition> is a tagged union discriminated by a "type" field. The
-// supported types map 1:1 to the proto oneof arms:
+// Fields:
+//   - metadata: `metadata[<key>]`
+//   - address:  `address` (trailing ":" = prefix, else exact); `source` /
+//     `destination` for role-scoped address matches
+//   - `reference`, `reverted` (bool), `ledger`
+//   - built-in transaction uint fields: `id`, `timestamp`, `insertedAt`,
+//     `revertedAt`; log fields: `logId`, `date`
+//   - `asset` (has-asset, via $exists)
 //
-//	{"type":"field","metadata":"k","condition":<FieldValueCondition>}
-//	{"type":"address","operator":"prefix"|"exact","value":"..."|"param":"...","role":"any"|"source"|"destination"}
-//	{"type":"reference","condition":<StringCondition>}
-//	{"type":"ledger","condition":<StringCondition>}
-//	{"type":"logId","condition":<UintCondition>}
-//	{"type":"builtinUint","field":<txBuiltinField>,"condition":<UintCondition>}
-//	{"type":"logBuiltinUint","field":<logBuiltinField>,"condition":<UintCondition>}
-//	{"type":"accountHasAsset","assetBase":"USD","precision":2}
-//	{"type":"reverted","value":true}
+// A value is either a JSON literal or a parameter reference `{"$param": "name"}`
+// (prepared-query parameters resolved at execution time).
 //
-// A FieldValueCondition is itself a tagged union discriminated by "type":
-//
-//	{"type":"string", ...StringCondition}
-//	{"type":"int",    ...IntCondition}
-//	{"type":"uint",   ...UintCondition}
-//	{"type":"bool",   ...BoolCondition}
-//	{"type":"exists","includeNull":false}
-//
-// StringCondition / BoolCondition are {"equals":<v>} or {"param":"<name>"}.
-// Int/UintCondition carry optional min/max (as JSON numbers, but uint bounds
-// are emitted as strings to stay lossless past 2^53), min/maxExclusive flags,
-// and paramMin/paramMax alternatives.
+// A closed inclusive/exclusive range is expressed the v2 way — as an $and of
+// the two bounds, e.g. `{"$and": [{"$gte": {"timestamp": 1}}, {"$lte":
+// {"timestamp": 9}}]}` — and the decoder folds a same-field $gt/$gte + $lt/$lte
+// pair back into a single range proto condition.
 
-// enum name maps between the public JSON discriminants and the proto enums.
-// Kept local so the public contract never inherits the TX_BUILTIN_INDEX_*
-// proto prefixes.
+const (
+	opAnd    = "$and"
+	opOr     = "$or"
+	opNot    = "$not"
+	opMatch  = "$match"
+	opGt     = "$gt"
+	opGte    = "$gte"
+	opLt     = "$lt"
+	opLte    = "$lte"
+	opExists = "$exists"
+	opIn     = "$in"
+	opLike   = "$like"
+	opParam  = "$param"
+)
+
+// built-in transaction uint field names <-> proto enum. Only the fields the
+// compiler resolves as an unsigned range are exposed (see BuiltinUintCondition
+// in common.proto); the address/reference index kinds are matched via their own
+// conditions.
 var (
-	// Only the fields the query compiler resolves as an unsigned-range condition
-	// are exposed. The remaining TransactionBuiltinIndex values
-	// (REFERENCE, ADDRESS, SOURCE_ADDRESS, DESTINATION_ADDRESS) are internal
-	// index kinds used by the address/reference condition compilers, NOT uint
-	// range fields — compileBuiltinUintCondition rejects them, so exposing them
-	// here would document valid-looking filters that fail at execution.
 	txBuiltinFieldToJSON = map[TransactionBuiltinIndex]string{
 		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:          "id",
 		TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:   "timestamp",
@@ -65,18 +69,6 @@ var (
 		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT: "revertedAt",
 	}
 	txBuiltinFieldFromJSON = invertEnumMap(txBuiltinFieldToJSON)
-
-	logBuiltinFieldToJSON = map[LogBuiltinIndex]string{
-		LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE: "date",
-	}
-	logBuiltinFieldFromJSON = invertEnumMap(logBuiltinFieldToJSON)
-
-	addressRoleToJSON = map[AddressRole]string{
-		AddressRole_ADDRESS_ROLE_ANY:         "any",
-		AddressRole_ADDRESS_ROLE_SOURCE:      "source",
-		AddressRole_ADDRESS_ROLE_DESTINATION: "destination",
-	}
-	addressRoleFromJSON = invertEnumMap(addressRoleToJSON)
 )
 
 func invertEnumMap[E comparable](m map[E]string) map[string]E {
@@ -88,694 +80,953 @@ func invertEnumMap[E comparable](m map[E]string) map[string]E {
 	return out
 }
 
+// metadataKey builds the `metadata[<key>]` field name.
+func metadataKey(key string) string { return "metadata[" + key + "]" }
+
+// parseMetadataKey returns the inner key of a `metadata[<key>]` field name.
+func parseMetadataKey(field string) (string, bool) {
+	if len(field) > len("metadata[]") && field[:len("metadata[")] == "metadata[" && field[len(field)-1] == ']' {
+		return field[len("metadata[") : len(field)-1], true
+	}
+
+	return "", false
+}
+
+// jsonValue encodes a condition value: either a literal or a {"$param":"name"}
+// reference. On decode, exactly one of the two is populated.
+type jsonValue struct {
+	literal json.RawMessage
+	param   string
+}
+
+func literalValue(v any) (jsonValue, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return jsonValue{}, err
+	}
+
+	return jsonValue{literal: b}, nil
+}
+
+func paramValue(name string) jsonValue { return jsonValue{param: name} }
+
+func (v jsonValue) MarshalJSON() ([]byte, error) {
+	if v.param != "" {
+		return json.Marshal(map[string]string{opParam: v.param})
+	}
+	if len(v.literal) == 0 {
+		return nil, errors.New("value: empty")
+	}
+
+	return v.literal, nil
+}
+
+func (v *jsonValue) UnmarshalJSON(data []byte) error {
+	// A {"$param": "name"} object is a parameter reference; anything else is a
+	// literal. We only treat an object with exactly the $param key as a param —
+	// a plain object literal (unused today) would pass through as a literal.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err == nil {
+		if raw, ok := probe[opParam]; ok {
+			if len(probe) != 1 {
+				return errors.New("$param: must be the only key")
+			}
+			var name string
+			if err := json.Unmarshal(raw, &name); err != nil {
+				return fmt.Errorf("$param: %w", err)
+			}
+			if name == "" {
+				return errors.New("$param: name is required")
+			}
+			v.param = name
+
+			return nil
+		}
+	}
+
+	v.literal = append([]byte(nil), data...)
+
+	return nil
+}
+
+func (v jsonValue) isParam() bool { return v.param != "" }
+
+func (v jsonValue) asString() (string, error) {
+	var s string
+	if err := json.Unmarshal(v.literal, &s); err != nil {
+		return "", fmt.Errorf("expected string value: %w", err)
+	}
+
+	return s, nil
+}
+
+func (v jsonValue) asBool() (bool, error) {
+	var b bool
+	if err := json.Unmarshal(v.literal, &b); err != nil {
+		return false, fmt.Errorf("expected bool value: %w", err)
+	}
+
+	return b, nil
+}
+
+func (v jsonValue) asInt64() (int64, error) {
+	var n int64
+	if err := json.Unmarshal(v.literal, &n); err != nil {
+		return 0, fmt.Errorf("expected integer value: %w", err)
+	}
+
+	return n, nil
+}
+
+// asUint64 accepts a JSON number or a decimal string (used for uint64 bounds to
+// stay lossless above 2^53).
+func (v jsonValue) asUint64() (uint64, error) {
+	var s string
+	if err := json.Unmarshal(v.literal, &s); err == nil {
+		n, perr := strconv.ParseUint(s, 10, 64)
+		if perr != nil {
+			return 0, fmt.Errorf("expected uint value: %w", perr)
+		}
+
+		return n, nil
+	}
+
+	var n uint64
+	if err := json.Unmarshal(v.literal, &n); err != nil {
+		return 0, fmt.Errorf("expected uint value: %w", err)
+	}
+
+	return n, nil
+}
+
 // MarshalJSON implements json.Marshaler for QueryFilter.
 func (x *QueryFilter) MarshalJSON() ([]byte, error) {
 	if x == nil {
 		return []byte("null"), nil
 	}
 
+	node, err := marshalNode(x)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(node)
+}
+
+// marshalNode converts a QueryFilter to its DSL representation (a
+// map[string]any with a single top-level operator key).
+func marshalNode(x *QueryFilter) (map[string]any, error) {
 	switch f := x.GetFilter().(type) {
 	case *QueryFilter_And:
-		return json.Marshal(struct {
-			And []*QueryFilter `json:"and"`
-		}{And: f.And.GetFilters()})
-	case *QueryFilter_Or:
-		return json.Marshal(struct {
-			Or []*QueryFilter `json:"or"`
-		}{Or: f.Or.GetFilters()})
-	case *QueryFilter_Not:
-		return json.Marshal(struct {
-			Not *QueryFilter `json:"not"`
-		}{Not: f.Not.GetFilter()})
-	case *QueryFilter_Field, *QueryFilter_Address, *QueryFilter_Reference,
-		*QueryFilter_BuiltinUint, *QueryFilter_Ledger, *QueryFilter_LogId,
-		*QueryFilter_LogBuiltinUint, *QueryFilter_AccountHasAsset,
-		*QueryFilter_Reverted:
-		cond, err := marshalCondition(x)
+		items, err := marshalNodes(f.And.GetFilters())
 		if err != nil {
 			return nil, err
 		}
 
-		return json.Marshal(struct {
-			Match json.RawMessage `json:"match"`
-		}{Match: cond})
+		return map[string]any{opAnd: items}, nil
+	case *QueryFilter_Or:
+		items, err := marshalNodes(f.Or.GetFilters())
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]any{opOr: items}, nil
+	case *QueryFilter_Not:
+		inner, err := marshalNode(f.Not.GetFilter())
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]any{opNot: inner}, nil
 	case nil:
 		return nil, errors.New("query filter: no condition set")
 	default:
-		// Impossible by design: the proto oneof has exactly the arms handled
-		// above. A new arm added to the proto without extending this codec must
-		// fail loudly rather than silently drop the filter.
-		return nil, fmt.Errorf("query filter: unhandled filter variant %T", f)
+		return marshalLeaf(x)
 	}
 }
 
-// UnmarshalJSON implements json.Unmarshaler for QueryFilter.
-func (x *QueryFilter) UnmarshalJSON(data []byte) error {
-	var env struct {
-		And   []json.RawMessage `json:"and"`
-		Or    []json.RawMessage `json:"or"`
-		Not   json.RawMessage   `json:"not"`
-		Match json.RawMessage   `json:"match"`
-	}
-	if err := json.Unmarshal(data, &env); err != nil {
-		return err
-	}
-
-	set := 0
-	if env.And != nil {
-		set++
-	}
-	if env.Or != nil {
-		set++
-	}
-	if len(env.Not) != 0 {
-		set++
-	}
-	if len(env.Match) != 0 {
-		set++
-	}
-
-	switch {
-	case set == 0:
-		return errors.New("query filter must set exactly one of: and, or, not, match")
-	case set > 1:
-		return fmt.Errorf("query filter must set exactly one of: and, or, not, match (found %d)", set)
-	}
-
-	switch {
-	case env.And != nil:
-		filters, err := unmarshalFilterList("and", env.And)
+func marshalNodes(filters []*QueryFilter) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(filters))
+	for i, f := range filters {
+		node, err := marshalNode(f)
 		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_And{And: &AndFilter{Filters: filters}}
-	case env.Or != nil:
-		filters, err := unmarshalFilterList("or", env.Or)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Or{Or: &OrFilter{Filters: filters}}
-	case len(env.Not) != 0:
-		inner := &QueryFilter{}
-		if err := json.Unmarshal(env.Not, inner); err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Not{Not: &NotFilter{Filter: inner}}
-	default:
-		return unmarshalCondition(env.Match, x)
-	}
-
-	return nil
-}
-
-func unmarshalFilterList(combinator string, raw []json.RawMessage) ([]*QueryFilter, error) {
-	// An empty combinator is ambiguous (empty AND = match-all, empty OR =
-	// match-nothing) and almost always a client mistake — reject it loudly
-	// rather than silently building a degenerate filter.
-	if len(raw) == 0 {
-		return nil, fmt.Errorf("%s: must contain at least one filter", combinator)
-	}
-
-	filters := make([]*QueryFilter, 0, len(raw))
-	for i, r := range raw {
-		sub := &QueryFilter{}
-		if err := json.Unmarshal(r, sub); err != nil {
 			return nil, fmt.Errorf("filter[%d]: %w", i, err)
 		}
-		filters = append(filters, sub)
+		out = append(out, node)
 	}
 
-	return filters, nil
+	return out, nil
 }
 
-// marshalCondition emits the tagged-union <Condition> for a leaf QueryFilter.
-func marshalCondition(x *QueryFilter) (json.RawMessage, error) {
+// kv builds a single-key operator map {op: {field: value}}.
+func kv(op, field string, value jsonValue) map[string]any {
+	return map[string]any{op: map[string]any{field: value}}
+}
+
+// marshalLeaf converts a leaf QueryFilter to its DSL representation. A leaf may
+// expand to an $and (closed range).
+func marshalLeaf(x *QueryFilter) (map[string]any, error) {
 	switch f := x.GetFilter().(type) {
 	case *QueryFilter_Field:
 		return marshalFieldCondition(f.Field)
 	case *QueryFilter_Address:
 		return marshalAddressMatch(f.Address)
 	case *QueryFilter_Reference:
-		return marshalTypedStringCond("reference", f.Reference.GetCond())
+		return marshalStringCond(opMatch, "reference", f.Reference.GetCond())
 	case *QueryFilter_Ledger:
-		return marshalTypedStringCond("ledger", f.Ledger.GetCond())
-	case *QueryFilter_LogId:
-		return marshalTypedUintCond("logId", "", f.LogId.GetCond())
-	case *QueryFilter_BuiltinUint:
-		field, ok := txBuiltinFieldToJSON[f.BuiltinUint.GetField()]
-		if !ok {
-			return nil, fmt.Errorf("builtinUint: unknown field %v", f.BuiltinUint.GetField())
-		}
-
-		return marshalTypedUintCond("builtinUint", field, f.BuiltinUint.GetCond())
-	case *QueryFilter_LogBuiltinUint:
-		field, ok := logBuiltinFieldToJSON[f.LogBuiltinUint.GetField()]
-		if !ok {
-			return nil, fmt.Errorf("logBuiltinUint: unknown field %v", f.LogBuiltinUint.GetField())
-		}
-
-		return marshalTypedUintCond("logBuiltinUint", field, f.LogBuiltinUint.GetCond())
-	case *QueryFilter_AccountHasAsset:
-		return json.Marshal(struct {
-			Type      string `json:"type"`
-			AssetBase string `json:"assetBase"`
-			Precision uint32 `json:"precision,omitempty"`
-		}{Type: "accountHasAsset", AssetBase: f.AccountHasAsset.GetAssetBase(), Precision: f.AccountHasAsset.GetPrecision()})
+		return marshalStringCond(opMatch, "ledger", f.Ledger.GetCond())
 	case *QueryFilter_Reverted:
-		return json.Marshal(struct {
-			Type  string `json:"type"`
-			Value bool   `json:"value"`
-		}{Type: "reverted", Value: f.Reverted.GetValue()})
-	default:
-		return nil, fmt.Errorf("query filter: unhandled leaf condition %T", f)
-	}
-}
-
-// unmarshalCondition parses the tagged-union <Condition> and sets the matching
-// leaf oneof arm on x.
-func unmarshalCondition(raw json.RawMessage, x *QueryFilter) error {
-	var disc struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(raw, &disc); err != nil {
-		return fmt.Errorf("match: %w", err)
-	}
-
-	switch disc.Type {
-	case "field":
-		fc, err := unmarshalFieldCondition(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Field{Field: fc}
-	case "address":
-		am, err := unmarshalAddressMatch(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Address{Address: am}
-	case "reference":
-		sc, err := unmarshalTypedStringCond(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: sc}}
-	case "ledger":
-		sc, err := unmarshalTypedStringCond(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: sc}}
-	case "logId":
-		uc, err := unmarshalTypedUintCond(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_LogId{LogId: &LogIdCondition{Cond: uc}}
-	case "builtinUint":
-		var f struct {
-			Field string `json:"field"`
-		}
-		if err := json.Unmarshal(raw, &f); err != nil {
-			return fmt.Errorf("builtinUint: %w", err)
-		}
-		field, ok := txBuiltinFieldFromJSON[f.Field]
-		if !ok {
-			return fmt.Errorf("builtinUint: unknown field %q", f.Field)
-		}
-		uc, err := unmarshalTypedUintCond(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: field, Cond: uc}}
-	case "logBuiltinUint":
-		var f struct {
-			Field string `json:"field"`
-		}
-		if err := json.Unmarshal(raw, &f); err != nil {
-			return fmt.Errorf("logBuiltinUint: %w", err)
-		}
-		field, ok := logBuiltinFieldFromJSON[f.Field]
-		if !ok {
-			return fmt.Errorf("logBuiltinUint: unknown field %q", f.Field)
-		}
-		uc, err := unmarshalTypedUintCond(raw)
-		if err != nil {
-			return err
-		}
-		x.Filter = &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{Field: field, Cond: uc}}
-	case "accountHasAsset":
-		var c struct {
-			AssetBase string `json:"assetBase"`
-			Precision uint32 `json:"precision"`
-		}
-		if err := json.Unmarshal(raw, &c); err != nil {
-			return fmt.Errorf("accountHasAsset: %w", err)
-		}
-		if c.AssetBase == "" {
-			return errors.New("accountHasAsset: assetBase is required")
-		}
-		x.Filter = &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: c.AssetBase, Precision: c.Precision}}
-	case "reverted":
-		var c struct {
-			Value *bool `json:"value"`
-		}
-		if err := json.Unmarshal(raw, &c); err != nil {
-			return fmt.Errorf("reverted: %w", err)
-		}
-		// value is a required, meaningful boolean (false is a real query, not a
-		// default) — reject absence rather than silently matching non-reverted.
-		if c.Value == nil {
-			return errors.New("reverted: value is required")
-		}
-		x.Filter = &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: *c.Value}}
-	case "":
-		return errors.New("match: missing discriminator field \"type\"")
-	default:
-		return fmt.Errorf("match: unknown condition type %q", disc.Type)
-	}
-
-	return nil
-}
-
-func marshalTypedStringCond(typ string, cond *StringCondition) (json.RawMessage, error) {
-	sc := stringCondToJSON(cond)
-	sc.Type = typ
-
-	return json.Marshal(sc)
-}
-
-func unmarshalTypedStringCond(raw json.RawMessage) (*StringCondition, error) {
-	var sc jsonStringCond
-	if err := json.Unmarshal(raw, &sc); err != nil {
-		return nil, err
-	}
-
-	return sc.toProto()
-}
-
-func marshalTypedUintCond(typ, field string, cond *UintCondition) (json.RawMessage, error) {
-	uc, err := uintCondToJSON(cond)
-	if err != nil {
-		return nil, err
-	}
-	uc.Type = typ
-	uc.Field = field
-
-	return json.Marshal(uc)
-}
-
-func unmarshalTypedUintCond(raw json.RawMessage) (*UintCondition, error) {
-	var uc jsonUintCond
-	if err := json.Unmarshal(raw, &uc); err != nil {
-		return nil, err
-	}
-
-	return uc.toProto()
-}
-
-// --- FieldCondition -------------------------------------------------------
-
-func marshalFieldCondition(fc *FieldCondition) (json.RawMessage, error) {
-	inner, err := marshalFieldValueCondition(fc)
-	if err != nil {
-		return nil, err
-	}
-
-	return json.Marshal(struct {
-		Type      string          `json:"type"`
-		Metadata  string          `json:"metadata"`
-		Condition json.RawMessage `json:"condition"`
-	}{Type: "field", Metadata: fc.GetField().GetMetadata(), Condition: inner})
-}
-
-func marshalFieldValueCondition(fc *FieldCondition) (json.RawMessage, error) {
-	switch c := fc.GetCondition().(type) {
-	case *FieldCondition_StringCond:
-		return marshalTypedStringCond("string", c.StringCond)
-	case *FieldCondition_IntCond:
-		ic, err := intCondToJSON(c.IntCond)
+		v, err := literalValue(f.Reverted.GetValue())
 		if err != nil {
 			return nil, err
 		}
-		ic.Type = "int"
 
-		return json.Marshal(ic)
-	case *FieldCondition_UintCond:
-		return marshalTypedUintCond("uint", "", c.UintCond)
+		return kv(opMatch, "reverted", v), nil
+	case *QueryFilter_AccountHasAsset:
+		v, err := literalValue(assetRefString(f.AccountHasAsset))
+		if err != nil {
+			return nil, err
+		}
+
+		return kv(opExists, "asset", v), nil
+	case *QueryFilter_LogId:
+		return marshalUintRange("logId", f.LogId.GetCond())
+	case *QueryFilter_BuiltinUint:
+		field, ok := txBuiltinFieldToJSON[f.BuiltinUint.GetField()]
+		if !ok {
+			return nil, fmt.Errorf("builtinUint: unsupported field %v", f.BuiltinUint.GetField())
+		}
+
+		return marshalUintRange(field, f.BuiltinUint.GetCond())
+	case *QueryFilter_LogBuiltinUint:
+		switch f.LogBuiltinUint.GetField() {
+		case LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE:
+			return marshalUintRange("date", f.LogBuiltinUint.GetCond())
+		default:
+			return nil, fmt.Errorf("logBuiltinUint: unsupported field %v", f.LogBuiltinUint.GetField())
+		}
+	default:
+		return nil, fmt.Errorf("query filter: unhandled leaf %T", f)
+	}
+}
+
+func assetRefString(c *AccountHasAssetCondition) string {
+	if c.GetPrecision() == 0 {
+		return c.GetAssetBase()
+	}
+
+	return fmt.Sprintf("%s/%d", c.GetAssetBase(), c.GetPrecision())
+}
+
+func parseAssetRef(ref string) (string, uint32, error) {
+	for i := len(ref) - 1; i >= 0; i-- {
+		if ref[i] == '/' {
+			p, err := strconv.ParseUint(ref[i+1:], 10, 32)
+			if err != nil {
+				return "", 0, fmt.Errorf("asset precision: %w", err)
+			}
+
+			return ref[:i], uint32(p), nil
+		}
+	}
+
+	return ref, 0, nil
+}
+
+// --- string / bool leaf --------------------------------------------------
+
+func marshalStringCond(op, field string, cond *StringCondition) (map[string]any, error) {
+	v, err := stringCondValue(cond)
+	if err != nil {
+		return nil, err
+	}
+
+	return kv(op, field, v), nil
+}
+
+func stringCondValue(cond *StringCondition) (jsonValue, error) {
+	switch c := cond.GetValue().(type) {
+	case *StringCondition_Hardcoded:
+		return literalValue(c.Hardcoded)
+	case *StringCondition_Param:
+		return paramValue(c.Param), nil
+	default:
+		return jsonValue{}, errors.New("string condition: no value set")
+	}
+}
+
+func stringCondFromValue(v jsonValue) (*StringCondition, error) {
+	if v.isParam() {
+		return &StringCondition{Value: &StringCondition_Param{Param: v.param}}, nil
+	}
+	s, err := v.asString()
+	if err != nil {
+		return nil, err
+	}
+
+	return &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: s}}, nil
+}
+
+// --- FieldCondition (metadata) -------------------------------------------
+
+func marshalFieldCondition(fc *FieldCondition) (map[string]any, error) {
+	key := metadataKey(fc.GetField().GetMetadata())
+
+	switch c := fc.GetCondition().(type) {
+	case *FieldCondition_StringCond:
+		return marshalStringCond(opMatch, key, c.StringCond)
 	case *FieldCondition_BoolCond:
-		return json.Marshal(boolCondToJSON(c.BoolCond))
+		return marshalBoolCond(key, c.BoolCond)
 	case *FieldCondition_ExistsCond:
-		return json.Marshal(struct {
-			Type        string `json:"type"`
-			IncludeNull bool   `json:"includeNull,omitempty"`
-		}{Type: "exists", IncludeNull: c.ExistsCond.GetIncludeNull()})
+		// metadata existence uses {"$exists": {"metadata": "<key>"}} (v2 shape),
+		// not the metadata[<key>] field form.
+		v, err := literalValue(fc.GetField().GetMetadata())
+		if err != nil {
+			return nil, err
+		}
+
+		return kv(opExists, "metadata", v), nil
+	case *FieldCondition_IntCond:
+		return marshalIntRange(key, c.IntCond)
+	case *FieldCondition_UintCond:
+		return marshalUintRange(key, c.UintCond)
 	default:
 		return nil, errors.New("field: no condition set")
 	}
 }
 
-func unmarshalFieldCondition(raw json.RawMessage) (*FieldCondition, error) {
-	var outer struct {
-		Metadata  string          `json:"metadata"`
-		Condition json.RawMessage `json:"condition"`
-	}
-	if err := json.Unmarshal(raw, &outer); err != nil {
-		return nil, fmt.Errorf("field: %w", err)
-	}
-	if outer.Metadata == "" {
-		return nil, errors.New("field: metadata is required")
-	}
-	if len(outer.Condition) == 0 {
-		return nil, errors.New("field: condition is required")
-	}
+func marshalBoolCond(field string, cond *BoolCondition) (map[string]any, error) {
+	switch c := cond.GetValue().(type) {
+	case *BoolCondition_Hardcoded:
+		v, err := literalValue(c.Hardcoded)
+		if err != nil {
+			return nil, err
+		}
 
-	fc := &FieldCondition{Field: &FieldRef{Metadata: outer.Metadata}}
-
-	var disc struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(outer.Condition, &disc); err != nil {
-		return nil, fmt.Errorf("field.condition: %w", err)
-	}
-
-	switch disc.Type {
-	case "string":
-		sc, err := unmarshalTypedStringCond(outer.Condition)
-		if err != nil {
-			return nil, err
-		}
-		fc.Condition = &FieldCondition_StringCond{StringCond: sc}
-	case "int":
-		var ic jsonIntCond
-		if err := json.Unmarshal(outer.Condition, &ic); err != nil {
-			return nil, err
-		}
-		c, err := ic.toProto()
-		if err != nil {
-			return nil, err
-		}
-		fc.Condition = &FieldCondition_IntCond{IntCond: c}
-	case "uint":
-		uc, err := unmarshalTypedUintCond(outer.Condition)
-		if err != nil {
-			return nil, err
-		}
-		fc.Condition = &FieldCondition_UintCond{UintCond: uc}
-	case "bool":
-		var bc jsonBoolCond
-		if err := json.Unmarshal(outer.Condition, &bc); err != nil {
-			return nil, err
-		}
-		c, err := bc.toProto()
-		if err != nil {
-			return nil, err
-		}
-		fc.Condition = &FieldCondition_BoolCond{BoolCond: c}
-	case "exists":
-		var ec struct {
-			IncludeNull bool `json:"includeNull"`
-		}
-		if err := json.Unmarshal(outer.Condition, &ec); err != nil {
-			return nil, err
-		}
-		fc.Condition = &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{IncludeNull: ec.IncludeNull}}
-	case "":
-		return nil, errors.New("field.condition: missing discriminator field \"type\"")
+		return kv(opMatch, field, v), nil
+	case *BoolCondition_Param:
+		return kv(opMatch, field, paramValue(c.Param)), nil
 	default:
-		return nil, fmt.Errorf("field.condition: unknown type %q", disc.Type)
+		return nil, errors.New("bool condition: no value set")
 	}
-
-	return fc, nil
 }
 
-// --- AddressMatch ---------------------------------------------------------
+// --- ranges (int / uint) -------------------------------------------------
 
-func marshalAddressMatch(am *AddressMatch) (json.RawMessage, error) {
-	// value/param are pointers so that whichever variant is set is always
-	// emitted, even when its string value is empty. Using `omitempty` on plain
-	// strings would drop an explicit empty hardcoded value, producing a payload
-	// (operator with no value/param) that the decoder correctly rejects — the
-	// marshal/unmarshal round-trip must stay lossless and canonical.
-	out := struct {
-		Type     string  `json:"type"`
-		Operator string  `json:"operator"`
-		Value    *string `json:"value,omitempty"`
-		Param    *string `json:"param,omitempty"`
-		Role     string  `json:"role,omitempty"`
-	}{Type: "address"}
+// rangeBound is a single {op: {field: value}} for a range endpoint.
+func lowerOp(exclusive bool) string {
+	if exclusive {
+		return opGt
+	}
+
+	return opGte
+}
+
+func upperOp(exclusive bool) string {
+	if exclusive {
+		return opLt
+	}
+
+	return opLte
+}
+
+// wrapRange combines zero, one, or two bound clauses. Two bounds become an
+// $and; a single bound is emitted directly. An empty range is an error.
+func wrapRange(field string, clauses []map[string]any) (map[string]any, error) {
+	switch len(clauses) {
+	case 0:
+		return nil, fmt.Errorf("%s: range has no bound", field)
+	case 1:
+		return clauses[0], nil
+	default:
+		items := make([]any, len(clauses))
+		for i, c := range clauses {
+			items[i] = c
+		}
+
+		return map[string]any{opAnd: items}, nil
+	}
+}
+
+func marshalIntRange(field string, cond *IntCondition) (map[string]any, error) {
+	var clauses []map[string]any
+
+	if cond.GetParamMin() != "" {
+		clauses = append(clauses, kv(lowerOp(cond.GetMinExclusive()), field, paramValue(cond.GetParamMin())))
+	} else if cond.Min != nil {
+		v, err := literalValue(cond.GetMin())
+		if err != nil {
+			return nil, err
+		}
+		clauses = append(clauses, kv(lowerOp(cond.GetMinExclusive()), field, v))
+	}
+
+	if cond.GetParamMax() != "" {
+		clauses = append(clauses, kv(upperOp(cond.GetMaxExclusive()), field, paramValue(cond.GetParamMax())))
+	} else if cond.Max != nil {
+		v, err := literalValue(cond.GetMax())
+		if err != nil {
+			return nil, err
+		}
+		clauses = append(clauses, kv(upperOp(cond.GetMaxExclusive()), field, v))
+	}
+
+	return wrapRange(field, clauses)
+}
+
+func marshalUintRange(field string, cond *UintCondition) (map[string]any, error) {
+	var clauses []map[string]any
+
+	if cond.GetParamMin() != "" {
+		clauses = append(clauses, kv(lowerOp(cond.GetMinExclusive()), field, paramValue(cond.GetParamMin())))
+	} else if cond.Min != nil {
+		// uint64 emitted as a decimal string to stay lossless above 2^53.
+		v, err := literalValue(strconv.FormatUint(cond.GetMin(), 10))
+		if err != nil {
+			return nil, err
+		}
+		clauses = append(clauses, kv(lowerOp(cond.GetMinExclusive()), field, v))
+	}
+
+	if cond.GetParamMax() != "" {
+		clauses = append(clauses, kv(upperOp(cond.GetMaxExclusive()), field, paramValue(cond.GetParamMax())))
+	} else if cond.Max != nil {
+		v, err := literalValue(strconv.FormatUint(cond.GetMax(), 10))
+		if err != nil {
+			return nil, err
+		}
+		clauses = append(clauses, kv(upperOp(cond.GetMaxExclusive()), field, v))
+	}
+
+	return wrapRange(field, clauses)
+}
+
+// --- AddressMatch --------------------------------------------------------
+
+func marshalAddressMatch(am *AddressMatch) (map[string]any, error) {
+	field := "address"
+	switch am.GetRole() {
+	case AddressRole_ADDRESS_ROLE_SOURCE:
+		field = "source"
+	case AddressRole_ADDRESS_ROLE_DESTINATION:
+		field = "destination"
+	case AddressRole_ADDRESS_ROLE_ANY:
+		field = "address"
+	}
 
 	switch m := am.GetMatch().(type) {
 	case *AddressMatch_HardcodedPrefix:
-		out.Operator, out.Value = "prefix", &m.HardcodedPrefix
+		v, err := literalValue(ensurePrefix(m.HardcodedPrefix))
+		if err != nil {
+			return nil, err
+		}
+
+		return kv(opMatch, field, v), nil
 	case *AddressMatch_HardcodedExact:
-		out.Operator, out.Value = "exact", &m.HardcodedExact
+		v, err := literalValue(m.HardcodedExact)
+		if err != nil {
+			return nil, err
+		}
+
+		return kv(opMatch, field, v), nil
 	case *AddressMatch_ParamPrefix:
-		out.Operator, out.Param = "prefix", &m.ParamPrefix
+		// A parameterised prefix cannot carry the trailing ":" marker on the
+		// literal, so it is encoded as a $like with a param (prefix semantics
+		// resolved at execution time from the param value).
+		return kv(opLike, field, paramValue(m.ParamPrefix)), nil
 	case *AddressMatch_ParamExact:
-		out.Operator, out.Param = "exact", &m.ParamExact
+		return kv(opMatch, field, paramValue(m.ParamExact)), nil
 	default:
 		return nil, errors.New("address: no match set")
 	}
-
-	if role := am.GetRole(); role != AddressRole_ADDRESS_ROLE_ANY {
-		out.Role = addressRoleToJSON[role]
-	}
-
-	return json.Marshal(out)
 }
 
-func unmarshalAddressMatch(raw json.RawMessage) (*AddressMatch, error) {
-	// value/param are presence-tracked pointers so an explicit empty string
-	// (a match-all hardcoded prefix, constructible via gRPC) round-trips
-	// losslessly, while an omitted key is rejected — exactly one of the two must
-	// be *present*, mirroring the string/bool conditions.
-	var in struct {
-		Operator string  `json:"operator"`
-		Value    *string `json:"value"`
-		Param    *string `json:"param"`
-		Role     string  `json:"role"`
+// ensurePrefix guarantees the trailing ":" that marks a prefix match in the DSL.
+// Hardcoded prefixes without a segment separator (rare) still round-trip
+// because the decoder treats a trailing ":" as the prefix marker.
+func ensurePrefix(p string) string {
+	if p == "" {
+		return ":"
 	}
-	if err := json.Unmarshal(raw, &in); err != nil {
-		return nil, fmt.Errorf("address: %w", err)
+	if p[len(p)-1] == ':' {
+		return p
 	}
 
-	switch in.Operator {
-	case "prefix", "exact":
-		// valid — validated further below
-	case "":
-		return nil, errors.New("address: operator is required (prefix or exact)")
-	default:
-		return nil, fmt.Errorf("address: unknown operator %q", in.Operator)
+	return p + ":"
+}
+
+// ============================================================================
+// UnmarshalJSON
+// ============================================================================
+
+// UnmarshalJSON implements json.Unmarshaler for QueryFilter.
+func (x *QueryFilter) UnmarshalJSON(data []byte) error {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
 	}
 
-	// Exactly one of value/param must be present. Absence of both is rejected
-	// (an omitted value would otherwise default to a match-all empty prefix).
-	if in.Value != nil && in.Param != nil {
-		return nil, errors.New("address: set only one of value or param")
-	}
-	if in.Value == nil && in.Param == nil {
-		return nil, errors.New("address: set one of value or param")
+	op, raw, err := singleOperator(m)
+	if err != nil {
+		return err
 	}
 
-	am := &AddressMatch{}
-	switch {
-	case in.Operator == "prefix" && in.Param != nil:
-		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: *in.Param}
-	case in.Operator == "prefix":
-		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: *in.Value}
-	case in.Operator == "exact" && in.Param != nil:
-		am.Match = &AddressMatch_ParamExact{ParamExact: *in.Param}
-	default: // exact + hardcoded value
-		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: *in.Value}
+	filter, err := decodeExpression(op, raw)
+	if err != nil {
+		return err
 	}
 
-	if in.Role != "" {
-		role, ok := addressRoleFromJSON[in.Role]
-		if !ok {
-			return nil, fmt.Errorf("address: unknown role %q", in.Role)
+	x.Filter = filter.GetFilter()
+
+	return nil
+}
+
+// singleOperator returns the single top-level operator key and its raw value.
+func singleOperator(m map[string]json.RawMessage) (string, json.RawMessage, error) {
+	switch len(m) {
+	case 0:
+		return "", nil, errors.New("query filter: empty object (expected a single operator key)")
+	case 1:
+		for k, v := range m {
+			return k, v, nil
 		}
-		am.Role = role
 	}
 
-	return am, nil
+	return "", nil, errors.New("query filter: expected exactly one operator key")
 }
 
-// --- scalar conditions ----------------------------------------------------
+// decodeExpression decodes one DSL node into a QueryFilter.
+func decodeExpression(op string, raw json.RawMessage) (*QueryFilter, error) {
+	switch op {
+	case opAnd, opOr:
+		return decodeCombinator(op, raw)
+	case opNot:
+		inner := &QueryFilter{}
+		if err := json.Unmarshal(raw, inner); err != nil {
+			return nil, fmt.Errorf("$not: %w", err)
+		}
 
-type jsonStringCond struct {
-	Type   string  `json:"type,omitempty"`
-	Equals *string `json:"equals,omitempty"`
-	Param  string  `json:"param,omitempty"`
-}
-
-func stringCondToJSON(cond *StringCondition) jsonStringCond {
-	out := jsonStringCond{}
-	switch v := cond.GetValue().(type) {
-	case *StringCondition_Hardcoded:
-		s := v.Hardcoded
-		out.Equals = &s
-	case *StringCondition_Param:
-		out.Param = v.Param
-	}
-
-	return out
-}
-
-func (c jsonStringCond) toProto() (*StringCondition, error) {
-	if c.Equals != nil && c.Param != "" {
-		return nil, errors.New("string condition: set only one of equals or param")
-	}
-	sc := &StringCondition{}
-	switch {
-	case c.Param != "":
-		sc.Value = &StringCondition_Param{Param: c.Param}
-	case c.Equals != nil:
-		sc.Value = &StringCondition_Hardcoded{Hardcoded: *c.Equals}
+		return &QueryFilter{Filter: &QueryFilter_Not{Not: &NotFilter{Filter: inner}}}, nil
+	case opMatch, opGt, opGte, opLt, opLte, opExists, opIn, opLike:
+		return decodeLeaf(op, raw)
 	default:
-		return nil, errors.New("string condition: set one of equals or param")
+		return nil, fmt.Errorf("query filter: unknown operator %q", op)
 	}
-
-	return sc, nil
 }
 
-type jsonBoolCond struct {
-	Type   string `json:"type"`
-	Equals *bool  `json:"equals,omitempty"`
-	Param  string `json:"param,omitempty"`
-}
-
-func boolCondToJSON(cond *BoolCondition) jsonBoolCond {
-	out := jsonBoolCond{Type: "bool"}
-	switch v := cond.GetValue().(type) {
-	case *BoolCondition_Hardcoded:
-		b := v.Hardcoded
-		out.Equals = &b
-	case *BoolCondition_Param:
-		out.Param = v.Param
+func decodeCombinator(op string, raw json.RawMessage) (*QueryFilter, error) {
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("%s: expected an array: %w", op, err)
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("%s: must contain at least one filter", op)
 	}
 
-	return out
+	// An $and of exactly two same-field, complementary range bounds folds into a
+	// single range proto condition (the inverse of marshalXxxRange). This keeps
+	// a closed range `{"$and":[{"$gte":{"timestamp":1}},{"$lte":{"timestamp":9}}]}`
+	// round-tripping to one BuiltinUintCondition.
+	if op == opAnd {
+		if folded, ok, err := foldRangeAnd(items); err != nil {
+			return nil, err
+		} else if ok {
+			return folded, nil
+		}
+	}
+
+	filters := make([]*QueryFilter, 0, len(items))
+	for i, it := range items {
+		sub := &QueryFilter{}
+		if err := json.Unmarshal(it, sub); err != nil {
+			return nil, fmt.Errorf("%s[%d]: %w", op, i, err)
+		}
+		filters = append(filters, sub)
+	}
+
+	if op == opAnd {
+		return &QueryFilter{Filter: &QueryFilter_And{And: &AndFilter{Filters: filters}}}, nil
+	}
+
+	return &QueryFilter{Filter: &QueryFilter_Or{Or: &OrFilter{Filters: filters}}}, nil
 }
 
-func (c jsonBoolCond) toProto() (*BoolCondition, error) {
-	if c.Equals != nil && c.Param != "" {
-		return nil, errors.New("bool condition: set only one of equals or param")
+// foldRangeAnd detects an $and array of exactly two range-bound leaves on the
+// same field with complementary directions (one lower, one upper) and folds them
+// into a single range condition. ok=false leaves the $and intact.
+func foldRangeAnd(items []json.RawMessage) (*QueryFilter, bool, error) {
+	if len(items) != 2 {
+		return nil, false, nil
 	}
-	bc := &BoolCondition{}
-	switch {
-	case c.Param != "":
-		bc.Value = &BoolCondition_Param{Param: c.Param}
-	case c.Equals != nil:
-		bc.Value = &BoolCondition_Hardcoded{Hardcoded: *c.Equals}
+
+	bounds := make([]bound, 0, 2)
+	for _, it := range items {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(it, &m); err != nil {
+			return nil, false, nil
+		}
+		op, body, err := singleOperator(m)
+		if err != nil {
+			return nil, false, nil
+		}
+		if op != opGt && op != opGte && op != opLt && op != opLte {
+			return nil, false, nil
+		}
+		field, value, err := leafKV(op, body)
+		if err != nil {
+			return nil, false, err
+		}
+		bounds = append(bounds, bound{op: op, field: field, value: value})
+	}
+
+	// same field, one lower + one upper
+	if bounds[0].field != bounds[1].field {
+		return nil, false, nil
+	}
+	if bounds[0].isLower() == bounds[1].isLower() {
+		return nil, false, nil
+	}
+
+	sortBounds(bounds)
+	qf, err := buildRange(bounds[0].field, bounds)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return qf, true, nil
+}
+
+// leafKV decodes the {field: value} body of a leaf operator into its single
+// field name and value.
+func leafKV(op string, raw json.RawMessage) (string, jsonValue, error) {
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return "", jsonValue{}, fmt.Errorf("%s: %w", op, err)
+	}
+	if len(body) != 1 {
+		return "", jsonValue{}, fmt.Errorf("%s: expected exactly one field", op)
+	}
+
+	var (
+		field  string
+		rawVal json.RawMessage
+	)
+	for field, rawVal = range body {
+	}
+
+	var v jsonValue
+	if err := json.Unmarshal(rawVal, &v); err != nil {
+		return "", jsonValue{}, fmt.Errorf("%s.%s: %w", op, field, err)
+	}
+
+	return field, v, nil
+}
+
+func decodeLeaf(op string, raw json.RawMessage) (*QueryFilter, error) {
+	field, value, err := leafKV(op, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	switch op {
+	case opExists:
+		return decodeExists(field, value)
+	case opMatch:
+		return decodeMatch(field, value)
+	case opGt, opGte, opLt, opLte:
+		return decodeSingleBound(op, field, value)
+	case opLike:
+		return decodeLike(field, value)
+	case opIn:
+		return nil, errors.New("$in: not supported for this filter surface")
 	default:
-		return nil, errors.New("bool condition: set one of equals or param")
+		return nil, fmt.Errorf("unhandled operator %q", op)
 	}
-
-	return bc, nil
 }
 
-type jsonIntCond struct {
-	Type         string `json:"type"`
-	Min          *int64 `json:"min,omitempty"`
-	Max          *int64 `json:"max,omitempty"`
-	MinExclusive bool   `json:"minExclusive,omitempty"`
-	MaxExclusive bool   `json:"maxExclusive,omitempty"`
-	ParamMin     string `json:"paramMin,omitempty"`
-	ParamMax     string `json:"paramMax,omitempty"`
+func decodeExists(field string, value jsonValue) (*QueryFilter, error) {
+	if value.isParam() {
+		return nil, errors.New("$exists: value must be a literal key, not a param")
+	}
+	switch field {
+	case "metadata":
+		key, err := value.asString()
+		if err != nil {
+			return nil, err
+		}
+		if key == "" {
+			return nil, errors.New("$exists metadata: key is required")
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+			Field:     &FieldRef{Metadata: key},
+			Condition: &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{}},
+		}}}, nil
+	case "asset":
+		ref, err := value.asString()
+		if err != nil {
+			return nil, err
+		}
+		if ref == "" {
+			return nil, errors.New("$exists asset: assetRef is required")
+		}
+		base, precision, perr := parseAssetRef(ref)
+		if perr != nil {
+			return nil, perr
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{
+			AssetBase: base, Precision: precision,
+		}}}, nil
+	default:
+		return nil, fmt.Errorf("$exists: unsupported field %q (use metadata or asset)", field)
+	}
 }
 
-func intCondToJSON(cond *IntCondition) (jsonIntCond, error) {
-	out := jsonIntCond{
-		Type:         "int",
-		MinExclusive: cond.GetMinExclusive(),
-		MaxExclusive: cond.GetMaxExclusive(),
-		ParamMin:     cond.GetParamMin(),
-		ParamMax:     cond.GetParamMax(),
-	}
-	if cond.Min != nil {
-		v := cond.GetMin()
-		out.Min = &v
-	}
-	if cond.Max != nil {
-		v := cond.GetMax()
-		out.Max = &v
-	}
+func decodeMatch(field string, value jsonValue) (*QueryFilter, error) {
+	switch field {
+	case "address", "source", "destination":
+		return decodeAddressMatch(field, value)
+	case "reference":
+		sc, err := stringCondFromValue(value)
+		if err != nil {
+			return nil, err
+		}
 
-	return out, nil
+		return &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: sc}}}, nil
+	case "ledger":
+		sc, err := stringCondFromValue(value)
+		if err != nil {
+			return nil, err
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: sc}}}, nil
+	case "reverted":
+		if value.isParam() {
+			return nil, errors.New("reverted: param not supported")
+		}
+		b, err := value.asBool()
+		if err != nil {
+			return nil, err
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: b}}}, nil
+	default:
+		if key, ok := parseMetadataKey(field); ok {
+			return decodeMetadataMatch(key, value)
+		}
+
+		return nil, fmt.Errorf("$match: unsupported field %q", field)
+	}
 }
 
-func (c jsonIntCond) toProto() (*IntCondition, error) {
-	ic := &IntCondition{
-		MinExclusive: c.MinExclusive,
-		MaxExclusive: c.MaxExclusive,
-		ParamMin:     c.ParamMin,
-		ParamMax:     c.ParamMax,
+func decodeAddressMatch(field string, value jsonValue) (*QueryFilter, error) {
+	am := &AddressMatch{}
+	switch field {
+	case "source":
+		am.Role = AddressRole_ADDRESS_ROLE_SOURCE
+	case "destination":
+		am.Role = AddressRole_ADDRESS_ROLE_DESTINATION
 	}
-	if c.Min != nil {
-		v := *c.Min
-		ic.Min = &v
+
+	if value.isParam() {
+		// $match with a param is an exact param match ($like carries prefix).
+		am.Match = &AddressMatch_ParamExact{ParamExact: value.param}
+
+		return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil
 	}
-	if c.Max != nil {
-		v := *c.Max
-		ic.Max = &v
+
+	s, err := value.asString()
+	if err != nil {
+		return nil, err
+	}
+	if s != "" && s[len(s)-1] == ':' {
+		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: s}
+	} else {
+		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: s}
+	}
+
+	return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil
+}
+
+func decodeLike(field string, value jsonValue) (*QueryFilter, error) {
+	// $like is only used to carry a parameterised address prefix today.
+	if field != "address" && field != "source" && field != "destination" {
+		return nil, fmt.Errorf("$like: unsupported field %q", field)
+	}
+	if !value.isParam() {
+		return nil, errors.New("$like: only a parameterised prefix is supported on this surface")
+	}
+	am := &AddressMatch{Match: &AddressMatch_ParamPrefix{ParamPrefix: value.param}}
+	switch field {
+	case "source":
+		am.Role = AddressRole_ADDRESS_ROLE_SOURCE
+	case "destination":
+		am.Role = AddressRole_ADDRESS_ROLE_DESTINATION
+	}
+
+	return &QueryFilter{Filter: &QueryFilter_Address{Address: am}}, nil
+}
+
+func decodeMetadataMatch(key string, value jsonValue) (*QueryFilter, error) {
+	fc := &FieldCondition{Field: &FieldRef{Metadata: key}}
+
+	if value.isParam() {
+		fc.Condition = &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Param{Param: value.param}}}
+
+		return &QueryFilter{Filter: &QueryFilter_Field{Field: fc}}, nil
+	}
+
+	// Distinguish bool from string by the literal shape.
+	var b bool
+	if err := json.Unmarshal(value.literal, &b); err == nil {
+		fc.Condition = &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Hardcoded{Hardcoded: b}}}
+
+		return &QueryFilter{Filter: &QueryFilter_Field{Field: fc}}, nil
+	}
+
+	s, err := value.asString()
+	if err != nil {
+		return nil, fmt.Errorf("metadata[%s]: %w", key, err)
+	}
+	fc.Condition = &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: s}}}
+
+	return &QueryFilter{Filter: &QueryFilter_Field{Field: fc}}, nil
+}
+
+// decodeSingleBound decodes a lone $gt/$gte/$lt/$lte into a range proto
+// condition with only one bound set.
+func decodeSingleBound(op, field string, value jsonValue) (*QueryFilter, error) {
+	b := bound{op: op, field: field, value: value}
+
+	return buildRange(field, []bound{b})
+}
+
+// bound is a decoded range endpoint.
+type bound struct {
+	op    string
+	field string
+	value jsonValue
+}
+
+func (b bound) isLower() bool     { return b.op == opGt || b.op == opGte }
+func (b bound) isExclusive() bool { return b.op == opGt || b.op == opLt }
+
+// buildRange assembles one or two same-field bounds into the matching range
+// proto condition, dispatching on the field name.
+func buildRange(field string, bounds []bound) (*QueryFilter, error) {
+	switch field {
+	case "id", "timestamp", "insertedAt", "revertedAt":
+		uc, err := uintConditionFromBounds(bounds)
+		if err != nil {
+			return nil, err
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{
+			Field: txBuiltinFieldFromJSON[field], Cond: uc,
+		}}}, nil
+	case "logId":
+		uc, err := uintConditionFromBounds(bounds)
+		if err != nil {
+			return nil, err
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_LogId{LogId: &LogIdCondition{Cond: uc}}}, nil
+	case "date":
+		uc, err := uintConditionFromBounds(bounds)
+		if err != nil {
+			return nil, err
+		}
+
+		return &QueryFilter{Filter: &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{
+			Field: LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE, Cond: uc,
+		}}}, nil
+	default:
+		if key, ok := parseMetadataKey(field); ok {
+			ic, err := intConditionFromBounds(bounds)
+			if err != nil {
+				return nil, err
+			}
+
+			return &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: key},
+				Condition: &FieldCondition_IntCond{IntCond: ic},
+			}}}, nil
+		}
+
+		return nil, fmt.Errorf("range: unsupported field %q", field)
+	}
+}
+
+func intConditionFromBounds(bounds []bound) (*IntCondition, error) {
+	ic := &IntCondition{}
+	for _, b := range bounds {
+		if b.isLower() {
+			ic.MinExclusive = b.isExclusive()
+			if b.value.isParam() {
+				ic.ParamMin = b.value.param
+			} else {
+				n, err := b.value.asInt64()
+				if err != nil {
+					return nil, err
+				}
+				v := n
+				ic.Min = &v
+			}
+		} else {
+			ic.MaxExclusive = b.isExclusive()
+			if b.value.isParam() {
+				ic.ParamMax = b.value.param
+			} else {
+				n, err := b.value.asInt64()
+				if err != nil {
+					return nil, err
+				}
+				v := n
+				ic.Max = &v
+			}
+		}
 	}
 
 	return ic, nil
 }
 
-// jsonUintCond mirrors UintCondition. fixed64 bounds are encoded as JSON
-// strings to stay lossless above 2^53, matching how uint64 is carried
-// elsewhere on the wire.
-type jsonUintCond struct {
-	Type         string `json:"type"`
-	Field        string `json:"field,omitempty"`
-	Min          string `json:"min,omitempty"`
-	Max          string `json:"max,omitempty"`
-	MinExclusive bool   `json:"minExclusive,omitempty"`
-	MaxExclusive bool   `json:"maxExclusive,omitempty"`
-	ParamMin     string `json:"paramMin,omitempty"`
-	ParamMax     string `json:"paramMax,omitempty"`
-}
-
-func uintCondToJSON(cond *UintCondition) (jsonUintCond, error) {
-	out := jsonUintCond{
-		MinExclusive: cond.GetMinExclusive(),
-		MaxExclusive: cond.GetMaxExclusive(),
-		ParamMin:     cond.GetParamMin(),
-		ParamMax:     cond.GetParamMax(),
-	}
-	if cond.Min != nil {
-		out.Min = strconv.FormatUint(cond.GetMin(), 10)
-	}
-	if cond.Max != nil {
-		out.Max = strconv.FormatUint(cond.GetMax(), 10)
-	}
-
-	return out, nil
-}
-
-func (c jsonUintCond) toProto() (*UintCondition, error) {
-	uc := &UintCondition{
-		MinExclusive: c.MinExclusive,
-		MaxExclusive: c.MaxExclusive,
-		ParamMin:     c.ParamMin,
-		ParamMax:     c.ParamMax,
-	}
-	if c.Min != "" {
-		v, err := strconv.ParseUint(c.Min, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("uint condition: min: %w", err)
+func uintConditionFromBounds(bounds []bound) (*UintCondition, error) {
+	uc := &UintCondition{}
+	for _, b := range bounds {
+		if b.isLower() {
+			uc.MinExclusive = b.isExclusive()
+			if b.value.isParam() {
+				uc.ParamMin = b.value.param
+			} else {
+				n, err := b.value.asUint64()
+				if err != nil {
+					return nil, err
+				}
+				v := n
+				uc.Min = &v
+			}
+		} else {
+			uc.MaxExclusive = b.isExclusive()
+			if b.value.isParam() {
+				uc.ParamMax = b.value.param
+			} else {
+				n, err := b.value.asUint64()
+				if err != nil {
+					return nil, err
+				}
+				v := n
+				uc.Max = &v
+			}
 		}
-		uc.Min = &v
-	}
-	if c.Max != "" {
-		v, err := strconv.ParseUint(c.Max, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("uint condition: max: %w", err)
-		}
-		uc.Max = &v
 	}
 
 	return uc, nil
+}
+
+// sortBoundsForStableProto keeps a deterministic ordering (lower then upper).
+func sortBounds(bounds []bound) {
+	sort.SliceStable(bounds, func(i, j int) bool {
+		return bounds[i].isLower() && !bounds[j].isLower()
+	})
 }

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -1,0 +1,752 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// QueryFilter has a hand-written JSON codec (this file) instead of relying on
+// protojson. protojson would leak the protobuf-internal oneof/wrapper names
+// onto the public REST surface: the top-level oneof would surface as
+// `{"and":{"filters":[...]}}` / `{"not":{"filter":{...}}}` and leaf conditions
+// as `{"field":{"field":{"metadata":"x"},"intCond":{...}}}`, none of which is a
+// contract we want to expose or that a hand-written OpenAPI schema can describe
+// cleanly. The canonical public shape is:
+//
+//	combinators (recursive):
+//	  {"and": [QueryFilter, ...]}
+//	  {"or":  [QueryFilter, ...]}
+//	  {"not": QueryFilter}
+//	leaf:
+//	  {"match": <Condition>}
+//
+// where <Condition> is a tagged union discriminated by a "type" field. The
+// supported types map 1:1 to the proto oneof arms:
+//
+//	{"type":"field","metadata":"k","condition":<FieldValueCondition>}
+//	{"type":"address","operator":"prefix"|"exact","value":"..."|"param":"...","role":"any"|"source"|"destination"}
+//	{"type":"reference","condition":<StringCondition>}
+//	{"type":"ledger","condition":<StringCondition>}
+//	{"type":"logId","condition":<UintCondition>}
+//	{"type":"builtinUint","field":<txBuiltinField>,"condition":<UintCondition>}
+//	{"type":"logBuiltinUint","field":<logBuiltinField>,"condition":<UintCondition>}
+//	{"type":"accountHasAsset","assetBase":"USD","precision":2}
+//	{"type":"reverted","value":true}
+//
+// A FieldValueCondition is itself a tagged union discriminated by "type":
+//
+//	{"type":"string", ...StringCondition}
+//	{"type":"int",    ...IntCondition}
+//	{"type":"uint",   ...UintCondition}
+//	{"type":"bool",   ...BoolCondition}
+//	{"type":"exists","includeNull":false}
+//
+// StringCondition / BoolCondition are {"equals":<v>} or {"param":"<name>"}.
+// Int/UintCondition carry optional min/max (as JSON numbers, but uint bounds
+// are emitted as strings to stay lossless past 2^53), min/maxExclusive flags,
+// and paramMin/paramMax alternatives.
+
+// enum name maps between the public JSON discriminants and the proto enums.
+// Kept local so the public contract never inherits the TX_BUILTIN_INDEX_*
+// proto prefixes.
+var (
+	txBuiltinFieldToJSON = map[TransactionBuiltinIndex]string{
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE:           "reference",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:           "timestamp",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:                  "id",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS:             "address",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS:      "sourceAddress",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS: "destinationAddress",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:         "insertedAt",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:         "revertedAt",
+	}
+	txBuiltinFieldFromJSON = invertEnumMap(txBuiltinFieldToJSON)
+
+	logBuiltinFieldToJSON = map[LogBuiltinIndex]string{
+		LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE: "date",
+	}
+	logBuiltinFieldFromJSON = invertEnumMap(logBuiltinFieldToJSON)
+
+	addressRoleToJSON = map[AddressRole]string{
+		AddressRole_ADDRESS_ROLE_ANY:         "any",
+		AddressRole_ADDRESS_ROLE_SOURCE:      "source",
+		AddressRole_ADDRESS_ROLE_DESTINATION: "destination",
+	}
+	addressRoleFromJSON = invertEnumMap(addressRoleToJSON)
+)
+
+func invertEnumMap[E comparable](m map[E]string) map[string]E {
+	out := make(map[string]E, len(m))
+	for k, v := range m {
+		out[v] = k
+	}
+
+	return out
+}
+
+// MarshalJSON implements json.Marshaler for QueryFilter.
+func (x *QueryFilter) MarshalJSON() ([]byte, error) {
+	if x == nil {
+		return []byte("null"), nil
+	}
+
+	switch f := x.GetFilter().(type) {
+	case *QueryFilter_And:
+		return json.Marshal(struct {
+			And []*QueryFilter `json:"and"`
+		}{And: f.And.GetFilters()})
+	case *QueryFilter_Or:
+		return json.Marshal(struct {
+			Or []*QueryFilter `json:"or"`
+		}{Or: f.Or.GetFilters()})
+	case *QueryFilter_Not:
+		return json.Marshal(struct {
+			Not *QueryFilter `json:"not"`
+		}{Not: f.Not.GetFilter()})
+	case *QueryFilter_Field, *QueryFilter_Address, *QueryFilter_Reference,
+		*QueryFilter_BuiltinUint, *QueryFilter_Ledger, *QueryFilter_LogId,
+		*QueryFilter_LogBuiltinUint, *QueryFilter_AccountHasAsset,
+		*QueryFilter_Reverted:
+		cond, err := marshalCondition(x)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(struct {
+			Match json.RawMessage `json:"match"`
+		}{Match: cond})
+	case nil:
+		return nil, errors.New("query filter: no condition set")
+	default:
+		// Impossible by design: the proto oneof has exactly the arms handled
+		// above. A new arm added to the proto without extending this codec must
+		// fail loudly rather than silently drop the filter.
+		return nil, fmt.Errorf("query filter: unhandled filter variant %T", f)
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler for QueryFilter.
+func (x *QueryFilter) UnmarshalJSON(data []byte) error {
+	var env struct {
+		And   []json.RawMessage `json:"and"`
+		Or    []json.RawMessage `json:"or"`
+		Not   json.RawMessage   `json:"not"`
+		Match json.RawMessage   `json:"match"`
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		return err
+	}
+
+	set := 0
+	if env.And != nil {
+		set++
+	}
+	if env.Or != nil {
+		set++
+	}
+	if len(env.Not) != 0 {
+		set++
+	}
+	if len(env.Match) != 0 {
+		set++
+	}
+
+	switch {
+	case set == 0:
+		return errors.New("query filter must set exactly one of: and, or, not, match")
+	case set > 1:
+		return fmt.Errorf("query filter must set exactly one of: and, or, not, match (found %d)", set)
+	}
+
+	switch {
+	case env.And != nil:
+		filters, err := unmarshalFilterList(env.And)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_And{And: &AndFilter{Filters: filters}}
+	case env.Or != nil:
+		filters, err := unmarshalFilterList(env.Or)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Or{Or: &OrFilter{Filters: filters}}
+	case len(env.Not) != 0:
+		inner := &QueryFilter{}
+		if err := json.Unmarshal(env.Not, inner); err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Not{Not: &NotFilter{Filter: inner}}
+	default:
+		return unmarshalCondition(env.Match, x)
+	}
+
+	return nil
+}
+
+func unmarshalFilterList(raw []json.RawMessage) ([]*QueryFilter, error) {
+	filters := make([]*QueryFilter, 0, len(raw))
+	for i, r := range raw {
+		sub := &QueryFilter{}
+		if err := json.Unmarshal(r, sub); err != nil {
+			return nil, fmt.Errorf("filter[%d]: %w", i, err)
+		}
+		filters = append(filters, sub)
+	}
+
+	return filters, nil
+}
+
+// marshalCondition emits the tagged-union <Condition> for a leaf QueryFilter.
+func marshalCondition(x *QueryFilter) (json.RawMessage, error) {
+	switch f := x.GetFilter().(type) {
+	case *QueryFilter_Field:
+		return marshalFieldCondition(f.Field)
+	case *QueryFilter_Address:
+		return marshalAddressMatch(f.Address)
+	case *QueryFilter_Reference:
+		return marshalTypedStringCond("reference", f.Reference.GetCond())
+	case *QueryFilter_Ledger:
+		return marshalTypedStringCond("ledger", f.Ledger.GetCond())
+	case *QueryFilter_LogId:
+		return marshalTypedUintCond("logId", "", f.LogId.GetCond())
+	case *QueryFilter_BuiltinUint:
+		field, ok := txBuiltinFieldToJSON[f.BuiltinUint.GetField()]
+		if !ok {
+			return nil, fmt.Errorf("builtinUint: unknown field %v", f.BuiltinUint.GetField())
+		}
+
+		return marshalTypedUintCond("builtinUint", field, f.BuiltinUint.GetCond())
+	case *QueryFilter_LogBuiltinUint:
+		field, ok := logBuiltinFieldToJSON[f.LogBuiltinUint.GetField()]
+		if !ok {
+			return nil, fmt.Errorf("logBuiltinUint: unknown field %v", f.LogBuiltinUint.GetField())
+		}
+
+		return marshalTypedUintCond("logBuiltinUint", field, f.LogBuiltinUint.GetCond())
+	case *QueryFilter_AccountHasAsset:
+		return json.Marshal(struct {
+			Type      string `json:"type"`
+			AssetBase string `json:"assetBase"`
+			Precision uint32 `json:"precision,omitempty"`
+		}{Type: "accountHasAsset", AssetBase: f.AccountHasAsset.GetAssetBase(), Precision: f.AccountHasAsset.GetPrecision()})
+	case *QueryFilter_Reverted:
+		return json.Marshal(struct {
+			Type  string `json:"type"`
+			Value bool   `json:"value"`
+		}{Type: "reverted", Value: f.Reverted.GetValue()})
+	default:
+		return nil, fmt.Errorf("query filter: unhandled leaf condition %T", f)
+	}
+}
+
+// unmarshalCondition parses the tagged-union <Condition> and sets the matching
+// leaf oneof arm on x.
+func unmarshalCondition(raw json.RawMessage, x *QueryFilter) error {
+	var disc struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &disc); err != nil {
+		return fmt.Errorf("match: %w", err)
+	}
+
+	switch disc.Type {
+	case "field":
+		fc, err := unmarshalFieldCondition(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Field{Field: fc}
+	case "address":
+		am, err := unmarshalAddressMatch(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Address{Address: am}
+	case "reference":
+		sc, err := unmarshalTypedStringCond(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: sc}}
+	case "ledger":
+		sc, err := unmarshalTypedStringCond(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: sc}}
+	case "logId":
+		uc, err := unmarshalTypedUintCond(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_LogId{LogId: &LogIdCondition{Cond: uc}}
+	case "builtinUint":
+		var f struct {
+			Field string `json:"field"`
+		}
+		if err := json.Unmarshal(raw, &f); err != nil {
+			return fmt.Errorf("builtinUint: %w", err)
+		}
+		field, ok := txBuiltinFieldFromJSON[f.Field]
+		if !ok {
+			return fmt.Errorf("builtinUint: unknown field %q", f.Field)
+		}
+		uc, err := unmarshalTypedUintCond(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: field, Cond: uc}}
+	case "logBuiltinUint":
+		var f struct {
+			Field string `json:"field"`
+		}
+		if err := json.Unmarshal(raw, &f); err != nil {
+			return fmt.Errorf("logBuiltinUint: %w", err)
+		}
+		field, ok := logBuiltinFieldFromJSON[f.Field]
+		if !ok {
+			return fmt.Errorf("logBuiltinUint: unknown field %q", f.Field)
+		}
+		uc, err := unmarshalTypedUintCond(raw)
+		if err != nil {
+			return err
+		}
+		x.Filter = &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{Field: field, Cond: uc}}
+	case "accountHasAsset":
+		var c struct {
+			AssetBase string `json:"assetBase"`
+			Precision uint32 `json:"precision"`
+		}
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return fmt.Errorf("accountHasAsset: %w", err)
+		}
+		if c.AssetBase == "" {
+			return errors.New("accountHasAsset: assetBase is required")
+		}
+		x.Filter = &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: c.AssetBase, Precision: c.Precision}}
+	case "reverted":
+		var c struct {
+			Value bool `json:"value"`
+		}
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return fmt.Errorf("reverted: %w", err)
+		}
+		x.Filter = &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: c.Value}}
+	case "":
+		return errors.New("match: missing discriminator field \"type\"")
+	default:
+		return fmt.Errorf("match: unknown condition type %q", disc.Type)
+	}
+
+	return nil
+}
+
+func marshalTypedStringCond(typ string, cond *StringCondition) (json.RawMessage, error) {
+	sc := stringCondToJSON(cond)
+	sc.Type = typ
+
+	return json.Marshal(sc)
+}
+
+func unmarshalTypedStringCond(raw json.RawMessage) (*StringCondition, error) {
+	var sc jsonStringCond
+	if err := json.Unmarshal(raw, &sc); err != nil {
+		return nil, err
+	}
+
+	return sc.toProto()
+}
+
+func marshalTypedUintCond(typ, field string, cond *UintCondition) (json.RawMessage, error) {
+	uc, err := uintCondToJSON(cond)
+	if err != nil {
+		return nil, err
+	}
+	uc.Type = typ
+	uc.Field = field
+
+	return json.Marshal(uc)
+}
+
+func unmarshalTypedUintCond(raw json.RawMessage) (*UintCondition, error) {
+	var uc jsonUintCond
+	if err := json.Unmarshal(raw, &uc); err != nil {
+		return nil, err
+	}
+
+	return uc.toProto()
+}
+
+// --- FieldCondition -------------------------------------------------------
+
+func marshalFieldCondition(fc *FieldCondition) (json.RawMessage, error) {
+	inner, err := marshalFieldValueCondition(fc)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(struct {
+		Type      string          `json:"type"`
+		Metadata  string          `json:"metadata"`
+		Condition json.RawMessage `json:"condition"`
+	}{Type: "field", Metadata: fc.GetField().GetMetadata(), Condition: inner})
+}
+
+func marshalFieldValueCondition(fc *FieldCondition) (json.RawMessage, error) {
+	switch c := fc.GetCondition().(type) {
+	case *FieldCondition_StringCond:
+		return marshalTypedStringCond("string", c.StringCond)
+	case *FieldCondition_IntCond:
+		ic, err := intCondToJSON(c.IntCond)
+		if err != nil {
+			return nil, err
+		}
+		ic.Type = "int"
+
+		return json.Marshal(ic)
+	case *FieldCondition_UintCond:
+		return marshalTypedUintCond("uint", "", c.UintCond)
+	case *FieldCondition_BoolCond:
+		return json.Marshal(boolCondToJSON(c.BoolCond))
+	case *FieldCondition_ExistsCond:
+		return json.Marshal(struct {
+			Type        string `json:"type"`
+			IncludeNull bool   `json:"includeNull,omitempty"`
+		}{Type: "exists", IncludeNull: c.ExistsCond.GetIncludeNull()})
+	default:
+		return nil, errors.New("field: no condition set")
+	}
+}
+
+func unmarshalFieldCondition(raw json.RawMessage) (*FieldCondition, error) {
+	var outer struct {
+		Metadata  string          `json:"metadata"`
+		Condition json.RawMessage `json:"condition"`
+	}
+	if err := json.Unmarshal(raw, &outer); err != nil {
+		return nil, fmt.Errorf("field: %w", err)
+	}
+	if outer.Metadata == "" {
+		return nil, errors.New("field: metadata is required")
+	}
+	if len(outer.Condition) == 0 {
+		return nil, errors.New("field: condition is required")
+	}
+
+	fc := &FieldCondition{Field: &FieldRef{Metadata: outer.Metadata}}
+
+	var disc struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(outer.Condition, &disc); err != nil {
+		return nil, fmt.Errorf("field.condition: %w", err)
+	}
+
+	switch disc.Type {
+	case "string":
+		sc, err := unmarshalTypedStringCond(outer.Condition)
+		if err != nil {
+			return nil, err
+		}
+		fc.Condition = &FieldCondition_StringCond{StringCond: sc}
+	case "int":
+		var ic jsonIntCond
+		if err := json.Unmarshal(outer.Condition, &ic); err != nil {
+			return nil, err
+		}
+		c, err := ic.toProto()
+		if err != nil {
+			return nil, err
+		}
+		fc.Condition = &FieldCondition_IntCond{IntCond: c}
+	case "uint":
+		uc, err := unmarshalTypedUintCond(outer.Condition)
+		if err != nil {
+			return nil, err
+		}
+		fc.Condition = &FieldCondition_UintCond{UintCond: uc}
+	case "bool":
+		var bc jsonBoolCond
+		if err := json.Unmarshal(outer.Condition, &bc); err != nil {
+			return nil, err
+		}
+		c, err := bc.toProto()
+		if err != nil {
+			return nil, err
+		}
+		fc.Condition = &FieldCondition_BoolCond{BoolCond: c}
+	case "exists":
+		var ec struct {
+			IncludeNull bool `json:"includeNull"`
+		}
+		if err := json.Unmarshal(outer.Condition, &ec); err != nil {
+			return nil, err
+		}
+		fc.Condition = &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{IncludeNull: ec.IncludeNull}}
+	case "":
+		return nil, errors.New("field.condition: missing discriminator field \"type\"")
+	default:
+		return nil, fmt.Errorf("field.condition: unknown type %q", disc.Type)
+	}
+
+	return fc, nil
+}
+
+// --- AddressMatch ---------------------------------------------------------
+
+func marshalAddressMatch(am *AddressMatch) (json.RawMessage, error) {
+	out := struct {
+		Type     string `json:"type"`
+		Operator string `json:"operator"`
+		Value    string `json:"value,omitempty"`
+		Param    string `json:"param,omitempty"`
+		Role     string `json:"role,omitempty"`
+	}{Type: "address"}
+
+	switch m := am.GetMatch().(type) {
+	case *AddressMatch_HardcodedPrefix:
+		out.Operator, out.Value = "prefix", m.HardcodedPrefix
+	case *AddressMatch_HardcodedExact:
+		out.Operator, out.Value = "exact", m.HardcodedExact
+	case *AddressMatch_ParamPrefix:
+		out.Operator, out.Param = "prefix", m.ParamPrefix
+	case *AddressMatch_ParamExact:
+		out.Operator, out.Param = "exact", m.ParamExact
+	default:
+		return nil, errors.New("address: no match set")
+	}
+
+	if role := am.GetRole(); role != AddressRole_ADDRESS_ROLE_ANY {
+		out.Role = addressRoleToJSON[role]
+	}
+
+	return json.Marshal(out)
+}
+
+func unmarshalAddressMatch(raw json.RawMessage) (*AddressMatch, error) {
+	var in struct {
+		Operator string `json:"operator"`
+		Value    string `json:"value"`
+		Param    string `json:"param"`
+		Role     string `json:"role"`
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("address: %w", err)
+	}
+
+	if in.Value != "" && in.Param != "" {
+		return nil, errors.New("address: set only one of value or param")
+	}
+
+	am := &AddressMatch{}
+	switch in.Operator {
+	case "prefix":
+		if in.Param != "" {
+			am.Match = &AddressMatch_ParamPrefix{ParamPrefix: in.Param}
+		} else {
+			am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: in.Value}
+		}
+	case "exact":
+		if in.Param != "" {
+			am.Match = &AddressMatch_ParamExact{ParamExact: in.Param}
+		} else {
+			am.Match = &AddressMatch_HardcodedExact{HardcodedExact: in.Value}
+		}
+	case "":
+		return nil, errors.New("address: operator is required (prefix or exact)")
+	default:
+		return nil, fmt.Errorf("address: unknown operator %q", in.Operator)
+	}
+
+	if in.Role != "" {
+		role, ok := addressRoleFromJSON[in.Role]
+		if !ok {
+			return nil, fmt.Errorf("address: unknown role %q", in.Role)
+		}
+		am.Role = role
+	}
+
+	return am, nil
+}
+
+// --- scalar conditions ----------------------------------------------------
+
+type jsonStringCond struct {
+	Type   string  `json:"type,omitempty"`
+	Equals *string `json:"equals,omitempty"`
+	Param  string  `json:"param,omitempty"`
+}
+
+func stringCondToJSON(cond *StringCondition) jsonStringCond {
+	out := jsonStringCond{}
+	switch v := cond.GetValue().(type) {
+	case *StringCondition_Hardcoded:
+		s := v.Hardcoded
+		out.Equals = &s
+	case *StringCondition_Param:
+		out.Param = v.Param
+	}
+
+	return out
+}
+
+func (c jsonStringCond) toProto() (*StringCondition, error) {
+	if c.Equals != nil && c.Param != "" {
+		return nil, errors.New("string condition: set only one of equals or param")
+	}
+	sc := &StringCondition{}
+	switch {
+	case c.Param != "":
+		sc.Value = &StringCondition_Param{Param: c.Param}
+	case c.Equals != nil:
+		sc.Value = &StringCondition_Hardcoded{Hardcoded: *c.Equals}
+	default:
+		return nil, errors.New("string condition: set one of equals or param")
+	}
+
+	return sc, nil
+}
+
+type jsonBoolCond struct {
+	Type   string `json:"type"`
+	Equals *bool  `json:"equals,omitempty"`
+	Param  string `json:"param,omitempty"`
+}
+
+func boolCondToJSON(cond *BoolCondition) jsonBoolCond {
+	out := jsonBoolCond{Type: "bool"}
+	switch v := cond.GetValue().(type) {
+	case *BoolCondition_Hardcoded:
+		b := v.Hardcoded
+		out.Equals = &b
+	case *BoolCondition_Param:
+		out.Param = v.Param
+	}
+
+	return out
+}
+
+func (c jsonBoolCond) toProto() (*BoolCondition, error) {
+	if c.Equals != nil && c.Param != "" {
+		return nil, errors.New("bool condition: set only one of equals or param")
+	}
+	bc := &BoolCondition{}
+	switch {
+	case c.Param != "":
+		bc.Value = &BoolCondition_Param{Param: c.Param}
+	case c.Equals != nil:
+		bc.Value = &BoolCondition_Hardcoded{Hardcoded: *c.Equals}
+	default:
+		return nil, errors.New("bool condition: set one of equals or param")
+	}
+
+	return bc, nil
+}
+
+type jsonIntCond struct {
+	Type         string `json:"type"`
+	Min          *int64 `json:"min,omitempty"`
+	Max          *int64 `json:"max,omitempty"`
+	MinExclusive bool   `json:"minExclusive,omitempty"`
+	MaxExclusive bool   `json:"maxExclusive,omitempty"`
+	ParamMin     string `json:"paramMin,omitempty"`
+	ParamMax     string `json:"paramMax,omitempty"`
+}
+
+func intCondToJSON(cond *IntCondition) (jsonIntCond, error) {
+	out := jsonIntCond{
+		Type:         "int",
+		MinExclusive: cond.GetMinExclusive(),
+		MaxExclusive: cond.GetMaxExclusive(),
+		ParamMin:     cond.GetParamMin(),
+		ParamMax:     cond.GetParamMax(),
+	}
+	if cond.Min != nil {
+		v := cond.GetMin()
+		out.Min = &v
+	}
+	if cond.Max != nil {
+		v := cond.GetMax()
+		out.Max = &v
+	}
+
+	return out, nil
+}
+
+func (c jsonIntCond) toProto() (*IntCondition, error) {
+	ic := &IntCondition{
+		MinExclusive: c.MinExclusive,
+		MaxExclusive: c.MaxExclusive,
+		ParamMin:     c.ParamMin,
+		ParamMax:     c.ParamMax,
+	}
+	if c.Min != nil {
+		v := *c.Min
+		ic.Min = &v
+	}
+	if c.Max != nil {
+		v := *c.Max
+		ic.Max = &v
+	}
+
+	return ic, nil
+}
+
+// jsonUintCond mirrors UintCondition. fixed64 bounds are encoded as JSON
+// strings to stay lossless above 2^53, matching how uint64 is carried
+// elsewhere on the wire.
+type jsonUintCond struct {
+	Type         string `json:"type"`
+	Field        string `json:"field,omitempty"`
+	Min          string `json:"min,omitempty"`
+	Max          string `json:"max,omitempty"`
+	MinExclusive bool   `json:"minExclusive,omitempty"`
+	MaxExclusive bool   `json:"maxExclusive,omitempty"`
+	ParamMin     string `json:"paramMin,omitempty"`
+	ParamMax     string `json:"paramMax,omitempty"`
+}
+
+func uintCondToJSON(cond *UintCondition) (jsonUintCond, error) {
+	out := jsonUintCond{
+		MinExclusive: cond.GetMinExclusive(),
+		MaxExclusive: cond.GetMaxExclusive(),
+		ParamMin:     cond.GetParamMin(),
+		ParamMax:     cond.GetParamMax(),
+	}
+	if cond.Min != nil {
+		out.Min = strconv.FormatUint(cond.GetMin(), 10)
+	}
+	if cond.Max != nil {
+		out.Max = strconv.FormatUint(cond.GetMax(), 10)
+	}
+
+	return out, nil
+}
+
+func (c jsonUintCond) toProto() (*UintCondition, error) {
+	uc := &UintCondition{
+		MinExclusive: c.MinExclusive,
+		MaxExclusive: c.MaxExclusive,
+		ParamMin:     c.ParamMin,
+		ParamMax:     c.ParamMax,
+	}
+	if c.Min != "" {
+		v, err := strconv.ParseUint(c.Min, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("uint condition: min: %w", err)
+		}
+		uc.Min = &v
+	}
+	if c.Max != "" {
+		v, err := strconv.ParseUint(c.Max, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("uint condition: max: %w", err)
+		}
+		uc.Max = &v
+	}
+
+	return uc, nil
+}

--- a/internal/proto/commonpb/query_filter.go
+++ b/internal/proto/commonpb/query_filter.go
@@ -52,15 +52,17 @@ import (
 // Kept local so the public contract never inherits the TX_BUILTIN_INDEX_*
 // proto prefixes.
 var (
+	// Only the fields the query compiler resolves as an unsigned-range condition
+	// are exposed. The remaining TransactionBuiltinIndex values
+	// (REFERENCE, ADDRESS, SOURCE_ADDRESS, DESTINATION_ADDRESS) are internal
+	// index kinds used by the address/reference condition compilers, NOT uint
+	// range fields — compileBuiltinUintCondition rejects them, so exposing them
+	// here would document valid-looking filters that fail at execution.
 	txBuiltinFieldToJSON = map[TransactionBuiltinIndex]string{
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE:           "reference",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:           "timestamp",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:                  "id",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS:             "address",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS:      "sourceAddress",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS: "destinationAddress",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:         "insertedAt",
-		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:         "revertedAt",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:          "id",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:   "timestamp",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT: "insertedAt",
+		TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT: "revertedAt",
 	}
 	txBuiltinFieldFromJSON = invertEnumMap(txBuiltinFieldToJSON)
 
@@ -329,12 +331,17 @@ func unmarshalCondition(raw json.RawMessage, x *QueryFilter) error {
 		x.Filter = &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: c.AssetBase, Precision: c.Precision}}
 	case "reverted":
 		var c struct {
-			Value bool `json:"value"`
+			Value *bool `json:"value"`
 		}
 		if err := json.Unmarshal(raw, &c); err != nil {
 			return fmt.Errorf("reverted: %w", err)
 		}
-		x.Filter = &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: c.Value}}
+		// value is a required, meaningful boolean (false is a real query, not a
+		// default) — reject absence rather than silently matching non-reverted.
+		if c.Value == nil {
+			return errors.New("reverted: value is required")
+		}
+		x.Filter = &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: *c.Value}}
 	case "":
 		return errors.New("match: missing discriminator field \"type\"")
 	default:
@@ -537,28 +544,35 @@ func unmarshalAddressMatch(raw json.RawMessage) (*AddressMatch, error) {
 		return nil, fmt.Errorf("address: %w", err)
 	}
 
-	if in.Value != "" && in.Param != "" {
-		return nil, errors.New("address: set only one of value or param")
-	}
-
-	am := &AddressMatch{}
 	switch in.Operator {
-	case "prefix":
-		if in.Param != "" {
-			am.Match = &AddressMatch_ParamPrefix{ParamPrefix: in.Param}
-		} else {
-			am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: in.Value}
-		}
-	case "exact":
-		if in.Param != "" {
-			am.Match = &AddressMatch_ParamExact{ParamExact: in.Param}
-		} else {
-			am.Match = &AddressMatch_HardcodedExact{HardcodedExact: in.Value}
-		}
+	case "prefix", "exact":
+		// valid — validated further below
 	case "":
 		return nil, errors.New("address: operator is required (prefix or exact)")
 	default:
 		return nil, fmt.Errorf("address: unknown operator %q", in.Operator)
+	}
+
+	// Exactly one of value/param must be set. A hardcoded empty prefix/exact
+	// would silently match every address (over-broad), so the empty case is
+	// rejected rather than defaulted.
+	if in.Value != "" && in.Param != "" {
+		return nil, errors.New("address: set only one of value or param")
+	}
+	if in.Value == "" && in.Param == "" {
+		return nil, errors.New("address: set one of value or param")
+	}
+
+	am := &AddressMatch{}
+	switch {
+	case in.Operator == "prefix" && in.Param != "":
+		am.Match = &AddressMatch_ParamPrefix{ParamPrefix: in.Param}
+	case in.Operator == "prefix":
+		am.Match = &AddressMatch_HardcodedPrefix{HardcodedPrefix: in.Value}
+	case in.Operator == "exact" && in.Param != "":
+		am.Match = &AddressMatch_ParamExact{ParamExact: in.Param}
+	default: // exact + hardcoded value
+		am.Match = &AddressMatch_HardcodedExact{HardcodedExact: in.Value}
 	}
 
 	if in.Role != "" {

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -231,6 +231,16 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		{"range on reference rejected", `{"$gt":{"reference":"x"}}`, "unsupported field"},
 		{"range on address rejected", `{"$gt":{"sourceAddress":"1"}}`, "unsupported field"},
 		{"in unsupported", `{"$in":{"address":["a"]}}`, "not supported"},
+		// null in value position must be rejected (no silent zero-value coercion).
+		{"null reverted rejected", `{"$match":{"reverted":null}}`, "must not be null"},
+		{"null metadata rejected", `{"$match":{"metadata[k]":null}}`, "must not be null"},
+		{"null reference rejected", `{"$match":{"reference":null}}`, "must not be null"},
+		{"null address rejected", `{"$match":{"address":null}}`, "must not be null"},
+		{"null ledger rejected", `{"$match":{"ledger":null}}`, "must not be null"},
+		{"null range bound rejected", `{"$gt":{"timestamp":null}}`, "must not be null"},
+		// $match on a numeric built-in is rejected (range-only fields).
+		{"match on timestamp rejected", `{"$match":{"timestamp":"1"}}`, "unsupported field"},
+		{"match on id rejected", `{"$match":{"id":"1"}}`, "unsupported field"},
 	}
 
 	for _, tc := range cases {
@@ -242,6 +252,18 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 			require.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+// TestQueryFilterMarshalExistsIncludeNull asserts marshalling fails loudly when
+// an ExistsCondition sets include_null, which the v2 DSL cannot express (rather
+// than silently dropping the flag).
+func TestQueryFilterMarshalExistsIncludeNull(t *testing.T) {
+	t.Parallel()
+
+	f := fieldFilter("k", &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{IncludeNull: true}})
+	_, err := json.Marshal(f)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "include_null")
 }
 
 // TestQueryFilterClosedRangeFolding asserts that an $and of two same-field bounds

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -96,6 +96,13 @@ func TestQueryFilterRoundTrip(t *testing.T) {
 			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedExact{HardcodedExact: "acc:1"}}}},
 		},
 		{
+			// Empty hardcoded prefix (match-all) is constructible via gRPC; the
+			// codec must round-trip it losslessly (explicit empty value present,
+			// not omitted).
+			name:   "address/hardcoded empty prefix",
+			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: ""}}}},
+		},
+		{
 			name:   "address/param prefix destination",
 			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_ParamPrefix{ParamPrefix: "p"}, Role: AddressRole_ADDRESS_ROLE_DESTINATION}}},
 		},
@@ -200,6 +207,8 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		{"string cond both equals and param", `{"match":{"type":"field","metadata":"x","condition":{"type":"string","equals":"a","param":"b"}}}`, "only one of equals or param"},
 		{"address missing both value and param", `{"match":{"type":"address","operator":"prefix"}}`, "set one of value or param"},
 		{"reverted missing value", `{"match":{"type":"reverted"}}`, "value is required"},
+		{"empty and combinator", `{"and":[]}`, "and: must contain at least one filter"},
+		{"empty or combinator", `{"or":[]}`, "or: must contain at least one filter"},
 	}
 
 	for _, tc := range cases {

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -8,9 +8,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// u64/i64 build pointers to a copy of the argument. new(v) (the Go 1.26
-// new-with-value builtin) is valid and used elsewhere in this package, but some
-// review tooling still misreads it as new(type); a local copy is unambiguous.
 func u64(v uint64) *uint64 {
 	c := v
 
@@ -23,131 +20,136 @@ func i64(v int64) *int64 {
 	return &c
 }
 
-// TestQueryFilterRoundTrip marshals each proto variant to JSON and unmarshals
-// it back, asserting the proto is preserved. It covers every arm of the
-// QueryFilter oneof plus every nested condition, so a new proto arm without a
-// codec update surfaces as a failing round-trip (marshal errors loudly).
+// TestQueryFilterRoundTrip marshals each proto variant to the v2-aligned DSL and
+// unmarshals it back, asserting the proto is preserved. It covers every arm of
+// the QueryFilter oneof plus nested conditions, params, and closed ranges, so a
+// new proto arm without a codec update surfaces as a failing round-trip.
 func TestQueryFilterRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name   string
 		filter *QueryFilter
+		// wantJSON, when set, asserts the exact marshalled shape.
+		wantJSON string
 	}{
 		{
-			name: "field/string hardcoded",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field:     &FieldRef{Metadata: "tier"},
-				Condition: &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "gold"}}},
-			}}},
+			name:     "metadata string ==",
+			filter:   fieldFilter("tier", &FieldCondition_StringCond{StringCond: hardcoded("gold")}),
+			wantJSON: `{"$match":{"metadata[tier]":"gold"}}`,
 		},
 		{
-			name: "field/string param",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field:     &FieldRef{Metadata: "tier"},
-				Condition: &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Param{Param: "p"}}},
-			}}},
+			name:     "metadata string param",
+			filter:   fieldFilter("tier", &FieldCondition_StringCond{StringCond: param("p")}),
+			wantJSON: `{"$match":{"metadata[tier]":{"$param":"p"}}}`,
 		},
 		{
-			name: "field/int range exclusive + params",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field: &FieldRef{Metadata: "score"},
-				Condition: &FieldCondition_IntCond{IntCond: &IntCondition{
-					Min: i64(-5), Max: i64(10), MinExclusive: true, MaxExclusive: true, ParamMin: "lo", ParamMax: "hi",
-				}},
-			}}},
+			name:     "metadata bool",
+			filter:   fieldFilter("vip", &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Hardcoded{Hardcoded: true}}}),
+			wantJSON: `{"$match":{"metadata[vip]":true}}`,
 		},
 		{
-			name: "field/uint range (large value stays lossless)",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field: &FieldRef{Metadata: "count"},
-				Condition: &FieldCondition_UintCond{UintCond: &UintCondition{
-					Min: u64(18446744073709551615), Max: u64(9007199254740993),
-				}},
-			}}},
+			name:     "metadata exists",
+			filter:   fieldFilter("opt", &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{}}),
+			wantJSON: `{"$exists":{"metadata":"opt"}}`,
 		},
 		{
-			name: "field/bool hardcoded",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field:     &FieldRef{Metadata: "vip"},
-				Condition: &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Hardcoded{Hardcoded: true}}},
-			}}},
+			name:     "metadata int single lower bound (gte)",
+			filter:   fieldFilter("score", &FieldCondition_IntCond{IntCond: &IntCondition{Min: i64(10)}}),
+			wantJSON: `{"$gte":{"metadata[score]":10}}`,
 		},
 		{
-			name: "field/bool param",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field:     &FieldRef{Metadata: "vip"},
-				Condition: &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Param{Param: "b"}}},
-			}}},
+			name:   "metadata int closed range exclusive",
+			filter: fieldFilter("score", &FieldCondition_IntCond{IntCond: &IntCondition{Min: i64(-5), Max: i64(10), MinExclusive: true, MaxExclusive: true}}),
 		},
 		{
-			name: "field/exists includeNull",
-			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
-				Field:     &FieldRef{Metadata: "opt"},
-				Condition: &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{IncludeNull: true}},
-			}}},
+			name:   "metadata int range with params",
+			filter: fieldFilter("score", &FieldCondition_IntCond{IntCond: &IntCondition{ParamMin: "lo", ParamMax: "hi"}}),
 		},
 		{
-			name:   "address/hardcoded prefix with role",
-			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: "acc:"}, Role: AddressRole_ADDRESS_ROLE_SOURCE}}},
+			name:     "address hardcoded prefix",
+			filter:   addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "users:"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantJSON: `{"$match":{"address":"users:"}}`,
 		},
 		{
-			name:   "address/hardcoded exact",
-			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedExact{HardcodedExact: "acc:1"}}}},
+			name:     "address hardcoded exact",
+			filter:   addressFilter(&AddressMatch_HardcodedExact{HardcodedExact: "acc:1"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantJSON: `{"$match":{"address":"acc:1"}}`,
 		},
 		{
-			// Empty hardcoded prefix (match-all) is constructible via gRPC; the
-			// codec must round-trip it losslessly (explicit empty value present,
-			// not omitted).
-			name:   "address/hardcoded empty prefix",
-			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: ""}}}},
+			name:     "source hardcoded prefix",
+			filter:   addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "banks:"}, AddressRole_ADDRESS_ROLE_SOURCE),
+			wantJSON: `{"$match":{"source":"banks:"}}`,
 		},
 		{
-			name:   "address/param prefix destination",
-			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_ParamPrefix{ParamPrefix: "p"}, Role: AddressRole_ADDRESS_ROLE_DESTINATION}}},
+			name:     "destination param exact",
+			filter:   addressFilter(&AddressMatch_ParamExact{ParamExact: "dst"}, AddressRole_ADDRESS_ROLE_DESTINATION),
+			wantJSON: `{"$match":{"destination":{"$param":"dst"}}}`,
 		},
 		{
-			name:   "address/param exact",
-			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_ParamExact{ParamExact: "p"}}}},
+			name:     "address param prefix (like)",
+			filter:   addressFilter(&AddressMatch_ParamPrefix{ParamPrefix: "acc"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantJSON: `{"$like":{"address":{"$param":"acc"}}}`,
 		},
 		{
-			name:   "reference",
-			filter: &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "ref-1"}}}}},
+			name:     "reference",
+			filter:   &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: hardcoded("ref-1")}}},
+			wantJSON: `{"$match":{"reference":"ref-1"}}`,
 		},
 		{
-			name:   "ledger",
-			filter: &QueryFilter{Filter: &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "main"}}}}},
+			name:     "ledger",
+			filter:   &QueryFilter{Filter: &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: hardcoded("main")}}},
+			wantJSON: `{"$match":{"ledger":"main"}}`,
 		},
 		{
-			name:   "logId range",
-			filter: &QueryFilter{Filter: &QueryFilter_LogId{LogId: &LogIdCondition{Cond: &UintCondition{Min: u64(1), Max: u64(100)}}}},
+			name:     "reverted true",
+			filter:   &QueryFilter{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: true}}},
+			wantJSON: `{"$match":{"reverted":true}}`,
 		},
 		{
-			name:   "builtinUint/timestamp",
-			filter: &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, Cond: &UintCondition{Min: u64(1700000000)}}}},
+			name:     "reverted false",
+			filter:   &QueryFilter{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: false}}},
+			wantJSON: `{"$match":{"reverted":false}}`,
 		},
 		{
-			name:   "builtinUint/revertedAt",
-			filter: &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT, Cond: &UintCondition{Max: u64(2000000000)}}}},
+			name:     "accountHasAsset with precision",
+			filter:   &QueryFilter{Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "USD", Precision: 2}}},
+			wantJSON: `{"$exists":{"asset":"USD/2"}}`,
 		},
 		{
-			name:   "logBuiltinUint/date",
-			filter: &QueryFilter{Filter: &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{Field: LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE, Cond: &UintCondition{Min: u64(1)}}}},
+			name:     "accountHasAsset no precision",
+			filter:   &QueryFilter{Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "USD"}}},
+			wantJSON: `{"$exists":{"asset":"USD"}}`,
 		},
 		{
-			name:   "accountHasAsset",
-			filter: &QueryFilter{Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "USD", Precision: 2}}},
+			name:     "logId single upper bound (lt)",
+			filter:   &QueryFilter{Filter: &QueryFilter_LogId{LogId: &LogIdCondition{Cond: &UintCondition{Max: u64(100), MaxExclusive: true}}}},
+			wantJSON: `{"$lt":{"logId":"100"}}`,
 		},
 		{
-			name:   "reverted",
-			filter: &QueryFilter{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: true}}},
+			name:   "builtinUint timestamp closed range",
+			filter: &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, Cond: &UintCondition{Min: u64(1700000000), Max: u64(1800000000)}}}},
 		},
 		{
-			name: "and/or/not nested combinators",
+			name:     "builtinUint id single (gte, large uint stays lossless)",
+			filter:   &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID, Cond: &UintCondition{Min: u64(9007199254740993)}}}},
+			wantJSON: `{"$gte":{"id":"9007199254740993"}}`,
+		},
+		{
+			name:     "builtinUint revertedAt param bound",
+			filter:   &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT, Cond: &UintCondition{ParamMax: "before"}}}},
+			wantJSON: `{"$lte":{"revertedAt":{"$param":"before"}}}`,
+		},
+		{
+			name:   "logBuiltinUint date closed range",
+			filter: &QueryFilter{Filter: &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{Field: LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE, Cond: &UintCondition{Min: u64(1), Max: u64(999)}}}},
+		},
+		{
+			name: "nested and/or/not",
 			filter: &QueryFilter{Filter: &QueryFilter_And{And: &AndFilter{Filters: []*QueryFilter{
 				{Filter: &QueryFilter_Or{Or: &OrFilter{Filters: []*QueryFilter{
 					{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: false}}},
-					{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: "world"}}}},
+					addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "world:"}, AddressRole_ADDRESS_ROLE_ANY),
 				}}}},
 				{Filter: &QueryFilter_Not{Not: &NotFilter{Filter: &QueryFilter{
 					Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "EUR"}},
@@ -163,14 +165,18 @@ func TestQueryFilterRoundTrip(t *testing.T) {
 			data, err := json.Marshal(tc.filter)
 			require.NoError(t, err)
 
-			// The marshalled JSON must not leak any protobuf-internal name.
+			if tc.wantJSON != "" {
+				require.JSONEq(t, tc.wantJSON, string(data))
+			}
+
+			// No protobuf-internal name may leak.
 			for _, leak := range []string{
 				`"filters"`, `"stringCond"`, `"intCond"`, `"uintCond"`, `"boolCond"`,
 				`"existsCond"`, `"hardcoded"`, `"hardcodedPrefix"`, `"hardcodedExact"`,
-				`"paramPrefix"`, `"paramExact"`, `"builtinUint":{`, "TX_BUILTIN_INDEX",
-				"LOG_BUILTIN_INDEX", "ADDRESS_ROLE",
+				`"paramPrefix"`, `"paramExact"`, "TX_BUILTIN_INDEX", "LOG_BUILTIN_INDEX",
+				"ADDRESS_ROLE", `"assetBase"`,
 			} {
-				require.NotContains(t, string(data), leak, "protojson-internal name leaked: %s", leak)
+				require.NotContains(t, string(data), leak, "protobuf-internal name leaked: %s", leak)
 			}
 
 			got := &QueryFilter{}
@@ -189,26 +195,23 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		raw     string
 		wantErr string
 	}{
-		{"empty object", `{}`, "exactly one of"},
-		{"two combinators", `{"and":[],"or":[]}`, "exactly one of"},
-		{"combinator + match", `{"not":{"match":{"type":"reverted","value":true}},"match":{"type":"reverted","value":true}}`, "exactly one of"},
-		{"match missing type", `{"match":{}}`, "missing discriminator"},
-		{"match unknown type", `{"match":{"type":"nope"}}`, "unknown condition type"},
-		{"field missing metadata", `{"match":{"type":"field","condition":{"type":"exists"}}}`, "metadata is required"},
-		{"field missing condition", `{"match":{"type":"field","metadata":"x"}}`, "condition is required"},
-		{"field unknown condition type", `{"match":{"type":"field","metadata":"x","condition":{"type":"nope"}}}`, "unknown type"},
-		{"address missing operator", `{"match":{"type":"address","value":"x"}}`, "operator is required"},
-		{"address unknown operator", `{"match":{"type":"address","operator":"contains"}}`, "unknown operator"},
-		{"address unknown role", `{"match":{"type":"address","operator":"exact","value":"x","role":"middle"}}`, "unknown role"},
-		{"builtinUint unknown field", `{"match":{"type":"builtinUint","field":"bogus"}}`, "unknown field"},
-		{"builtinUint rejects non-uint field reference", `{"match":{"type":"builtinUint","field":"reference"}}`, "unknown field"},
-		{"builtinUint rejects non-uint field address", `{"match":{"type":"builtinUint","field":"sourceAddress"}}`, "unknown field"},
-		{"accountHasAsset missing assetBase", `{"match":{"type":"accountHasAsset"}}`, "assetBase is required"},
-		{"string cond both equals and param", `{"match":{"type":"field","metadata":"x","condition":{"type":"string","equals":"a","param":"b"}}}`, "only one of equals or param"},
-		{"address missing both value and param", `{"match":{"type":"address","operator":"prefix"}}`, "set one of value or param"},
-		{"reverted missing value", `{"match":{"type":"reverted"}}`, "value is required"},
-		{"empty and combinator", `{"and":[]}`, "and: must contain at least one filter"},
-		{"empty or combinator", `{"or":[]}`, "or: must contain at least one filter"},
+		{"empty object", `{}`, "empty object"},
+		{"two operators", `{"$and":[],"$or":[]}`, "exactly one operator"},
+		{"unknown operator", `{"$bogus":{}}`, "unknown operator"},
+		{"empty and", `{"$and":[]}`, "must contain at least one filter"},
+		{"empty or", `{"$or":[]}`, "must contain at least one filter"},
+		{"and not array", `{"$and":{}}`, "expected an array"},
+		{"match empty body", `{"$match":{}}`, "expected exactly one field"},
+		{"match two fields", `{"$match":{"a":1,"b":2}}`, "expected exactly one field"},
+		{"match unsupported field", `{"$match":{"bogus":"x"}}`, "unsupported field"},
+		{"exists unsupported field", `{"$exists":{"bogus":"x"}}`, "unsupported field"},
+		{"exists metadata empty key", `{"$exists":{"metadata":""}}`, "key is required"},
+		{"exists asset empty", `{"$exists":{"asset":""}}`, "assetRef is required"},
+		{"exists with param", `{"$exists":{"metadata":{"$param":"p"}}}`, "must be a literal"},
+		{"param empty name", `{"$match":{"reference":{"$param":""}}}`, "name is required"},
+		{"param not sole key", `{"$match":{"reference":{"$param":"p","x":1}}}`, "must be the only key"},
+		{"range unsupported field", `{"$gt":{"bogus":1}}`, "unsupported field"},
+		{"in unsupported", `{"$in":{"address":["a"]}}`, "not supported"},
 	}
 
 	for _, tc := range cases {
@@ -222,8 +225,50 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 	}
 }
 
-// TestPreparedQueryMarshalJSON asserts the response side emits the canonical
-// flat filter and the string target enum, with no protojson leakage.
+// TestQueryFilterClosedRangeFolding asserts that an $and of two same-field bounds
+// folds into a single range condition (and non-range $and stays an AND).
+func TestQueryFilterClosedRangeFolding(t *testing.T) {
+	t.Parallel()
+
+	// Closed timestamp range -> single BuiltinUintCondition.
+	got := &QueryFilter{}
+	require.NoError(t, json.Unmarshal([]byte(`{"$and":[{"$gte":{"timestamp":"1"}},{"$lte":{"timestamp":"9"}}]}`), got))
+	bu := got.GetBuiltinUint()
+	require.NotNil(t, bu, "closed range must fold into a single BuiltinUintCondition")
+	require.Equal(t, TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, bu.GetField())
+	require.Equal(t, uint64(1), bu.GetCond().GetMin())
+	require.Equal(t, uint64(9), bu.GetCond().GetMax())
+
+	// Different fields -> stays an AND (no fold).
+	got2 := &QueryFilter{}
+	require.NoError(t, json.Unmarshal([]byte(`{"$and":[{"$gte":{"timestamp":"1"}},{"$lte":{"id":"9"}}]}`), got2))
+	require.NotNil(t, got2.GetAnd(), "different-field bounds must stay an AND")
+	require.Len(t, got2.GetAnd().GetFilters(), 2)
+}
+
+// --- test helpers ---
+
+func fieldFilter(key string, cond isFieldCondition_Condition) *QueryFilter {
+	return &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+		Field:     &FieldRef{Metadata: key},
+		Condition: cond,
+	}}}
+}
+
+func addressFilter(match isAddressMatch_Match, role AddressRole) *QueryFilter {
+	return &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: match, Role: role}}}
+}
+
+func hardcoded(v string) *StringCondition {
+	return &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: v}}
+}
+
+func param(name string) *StringCondition {
+	return &StringCondition{Value: &StringCondition_Param{Param: name}}
+}
+
+// TestPreparedQueryMarshalJSON asserts the response side emits the v2 filter and
+// the string target enum, with no protojson leakage.
 func TestPreparedQueryMarshalJSON(t *testing.T) {
 	t.Parallel()
 
@@ -231,7 +276,7 @@ func TestPreparedQueryMarshalJSON(t *testing.T) {
 		Name:   "vip",
 		Target: QueryTarget_QUERY_TARGET_TRANSACTIONS,
 		Filter: &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{
-			Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "ref-1"}},
+			Cond: hardcoded("ref-1"),
 		}}},
 	}
 
@@ -246,8 +291,8 @@ func TestPreparedQueryMarshalJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &out))
 	require.Equal(t, "vip", out.Name)
 	require.Equal(t, "TRANSACTIONS", out.Target)
+	require.JSONEq(t, `{"$match":{"reference":"ref-1"}}`, string(out.Filter))
 
-	// Filter must decode back through the canonical codec.
 	rt := &QueryFilter{}
 	require.NoError(t, json.Unmarshal(out.Filter, rt))
 	require.True(t, proto.Equal(pq.GetFilter(), rt))

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -1,0 +1,229 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func u64(v uint64) *uint64 { return new(v) }
+func i64(v int64) *int64   { return new(v) }
+
+// TestQueryFilterRoundTrip marshals each proto variant to JSON and unmarshals
+// it back, asserting the proto is preserved. It covers every arm of the
+// QueryFilter oneof plus every nested condition, so a new proto arm without a
+// codec update surfaces as a failing round-trip (marshal errors loudly).
+func TestQueryFilterRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		filter *QueryFilter
+	}{
+		{
+			name: "field/string hardcoded",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: "tier"},
+				Condition: &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "gold"}}},
+			}}},
+		},
+		{
+			name: "field/string param",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: "tier"},
+				Condition: &FieldCondition_StringCond{StringCond: &StringCondition{Value: &StringCondition_Param{Param: "p"}}},
+			}}},
+		},
+		{
+			name: "field/int range exclusive + params",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field: &FieldRef{Metadata: "score"},
+				Condition: &FieldCondition_IntCond{IntCond: &IntCondition{
+					Min: i64(-5), Max: i64(10), MinExclusive: true, MaxExclusive: true, ParamMin: "lo", ParamMax: "hi",
+				}},
+			}}},
+		},
+		{
+			name: "field/uint range (large value stays lossless)",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field: &FieldRef{Metadata: "count"},
+				Condition: &FieldCondition_UintCond{UintCond: &UintCondition{
+					Min: u64(18446744073709551615), Max: u64(9007199254740993),
+				}},
+			}}},
+		},
+		{
+			name: "field/bool hardcoded",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: "vip"},
+				Condition: &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Hardcoded{Hardcoded: true}}},
+			}}},
+		},
+		{
+			name: "field/bool param",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: "vip"},
+				Condition: &FieldCondition_BoolCond{BoolCond: &BoolCondition{Value: &BoolCondition_Param{Param: "b"}}},
+			}}},
+		},
+		{
+			name: "field/exists includeNull",
+			filter: &QueryFilter{Filter: &QueryFilter_Field{Field: &FieldCondition{
+				Field:     &FieldRef{Metadata: "opt"},
+				Condition: &FieldCondition_ExistsCond{ExistsCond: &ExistsCondition{IncludeNull: true}},
+			}}},
+		},
+		{
+			name:   "address/hardcoded prefix with role",
+			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: "acc:"}, Role: AddressRole_ADDRESS_ROLE_SOURCE}}},
+		},
+		{
+			name:   "address/hardcoded exact",
+			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedExact{HardcodedExact: "acc:1"}}}},
+		},
+		{
+			name:   "address/param prefix destination",
+			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_ParamPrefix{ParamPrefix: "p"}, Role: AddressRole_ADDRESS_ROLE_DESTINATION}}},
+		},
+		{
+			name:   "address/param exact",
+			filter: &QueryFilter{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_ParamExact{ParamExact: "p"}}}},
+		},
+		{
+			name:   "reference",
+			filter: &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "ref-1"}}}}},
+		},
+		{
+			name:   "ledger",
+			filter: &QueryFilter{Filter: &QueryFilter_Ledger{Ledger: &LedgerCondition{Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "main"}}}}},
+		},
+		{
+			name:   "logId range",
+			filter: &QueryFilter{Filter: &QueryFilter_LogId{LogId: &LogIdCondition{Cond: &UintCondition{Min: u64(1), Max: u64(100)}}}},
+		},
+		{
+			name:   "builtinUint/timestamp",
+			filter: &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, Cond: &UintCondition{Min: u64(1700000000)}}}},
+		},
+		{
+			name:   "builtinUint/revertedAt",
+			filter: &QueryFilter{Filter: &QueryFilter_BuiltinUint{BuiltinUint: &BuiltinUintCondition{Field: TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT, Cond: &UintCondition{Max: u64(2000000000)}}}},
+		},
+		{
+			name:   "logBuiltinUint/date",
+			filter: &QueryFilter{Filter: &QueryFilter_LogBuiltinUint{LogBuiltinUint: &LogBuiltinUintCondition{Field: LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE, Cond: &UintCondition{Min: u64(1)}}}},
+		},
+		{
+			name:   "accountHasAsset",
+			filter: &QueryFilter{Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "USD", Precision: 2}}},
+		},
+		{
+			name:   "reverted",
+			filter: &QueryFilter{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: true}}},
+		},
+		{
+			name: "and/or/not nested combinators",
+			filter: &QueryFilter{Filter: &QueryFilter_And{And: &AndFilter{Filters: []*QueryFilter{
+				{Filter: &QueryFilter_Or{Or: &OrFilter{Filters: []*QueryFilter{
+					{Filter: &QueryFilter_Reverted{Reverted: &RevertedCondition{Value: false}}},
+					{Filter: &QueryFilter_Address{Address: &AddressMatch{Match: &AddressMatch_HardcodedPrefix{HardcodedPrefix: "world"}}}},
+				}}}},
+				{Filter: &QueryFilter_Not{Not: &NotFilter{Filter: &QueryFilter{
+					Filter: &QueryFilter_AccountHasAsset{AccountHasAsset: &AccountHasAssetCondition{AssetBase: "EUR"}},
+				}}}},
+			}}}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tc.filter)
+			require.NoError(t, err)
+
+			// The marshalled JSON must not leak any protobuf-internal name.
+			for _, leak := range []string{
+				`"filters"`, `"stringCond"`, `"intCond"`, `"uintCond"`, `"boolCond"`,
+				`"existsCond"`, `"hardcoded"`, `"hardcodedPrefix"`, `"hardcodedExact"`,
+				`"paramPrefix"`, `"paramExact"`, `"builtinUint":{`, "TX_BUILTIN_INDEX",
+				"LOG_BUILTIN_INDEX", "ADDRESS_ROLE",
+			} {
+				require.NotContains(t, string(data), leak, "protojson-internal name leaked: %s", leak)
+			}
+
+			got := &QueryFilter{}
+			require.NoError(t, json.Unmarshal(data, got))
+			require.True(t, proto.Equal(tc.filter, got), "round-trip mismatch\n json: %s\n want: %v\n got:  %v", data, tc.filter, got)
+		})
+	}
+}
+
+// TestQueryFilterUnmarshalErrors covers the loud-failure paths.
+func TestQueryFilterUnmarshalErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{"empty object", `{}`, "exactly one of"},
+		{"two combinators", `{"and":[],"or":[]}`, "exactly one of"},
+		{"combinator + match", `{"not":{"match":{"type":"reverted","value":true}},"match":{"type":"reverted","value":true}}`, "exactly one of"},
+		{"match missing type", `{"match":{}}`, "missing discriminator"},
+		{"match unknown type", `{"match":{"type":"nope"}}`, "unknown condition type"},
+		{"field missing metadata", `{"match":{"type":"field","condition":{"type":"exists"}}}`, "metadata is required"},
+		{"field missing condition", `{"match":{"type":"field","metadata":"x"}}`, "condition is required"},
+		{"field unknown condition type", `{"match":{"type":"field","metadata":"x","condition":{"type":"nope"}}}`, "unknown type"},
+		{"address missing operator", `{"match":{"type":"address","value":"x"}}`, "operator is required"},
+		{"address unknown operator", `{"match":{"type":"address","operator":"contains"}}`, "unknown operator"},
+		{"address unknown role", `{"match":{"type":"address","operator":"exact","value":"x","role":"middle"}}`, "unknown role"},
+		{"builtinUint unknown field", `{"match":{"type":"builtinUint","field":"bogus"}}`, "unknown field"},
+		{"accountHasAsset missing assetBase", `{"match":{"type":"accountHasAsset"}}`, "assetBase is required"},
+		{"string cond both equals and param", `{"match":{"type":"field","metadata":"x","condition":{"type":"string","equals":"a","param":"b"}}}`, "only one of equals or param"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := json.Unmarshal([]byte(tc.raw), &QueryFilter{})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestPreparedQueryMarshalJSON asserts the response side emits the canonical
+// flat filter and the string target enum, with no protojson leakage.
+func TestPreparedQueryMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	pq := &PreparedQuery{
+		Name:   "vip",
+		Target: QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		Filter: &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{
+			Cond: &StringCondition{Value: &StringCondition_Hardcoded{Hardcoded: "ref-1"}},
+		}}},
+	}
+
+	data, err := json.Marshal(pq)
+	require.NoError(t, err)
+
+	var out struct {
+		Name   string          `json:"name"`
+		Target string          `json:"target"`
+		Filter json.RawMessage `json:"filter"`
+	}
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Equal(t, "vip", out.Name)
+	require.Equal(t, "TRANSACTIONS", out.Target)
+
+	// Filter must decode back through the canonical codec.
+	rt := &QueryFilter{}
+	require.NoError(t, json.Unmarshal(out.Filter, rt))
+	require.True(t, proto.Equal(pq.GetFilter(), rt))
+}

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -8,8 +8,20 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func u64(v uint64) *uint64 { return new(v) }
-func i64(v int64) *int64   { return new(v) }
+// u64/i64 build pointers to a copy of the argument. new(v) (the Go 1.26
+// new-with-value builtin) is valid and used elsewhere in this package, but some
+// review tooling still misreads it as new(type); a local copy is unambiguous.
+func u64(v uint64) *uint64 {
+	c := v
+
+	return &c
+}
+
+func i64(v int64) *int64 {
+	c := v
+
+	return &c
+}
 
 // TestQueryFilterRoundTrip marshals each proto variant to JSON and unmarshals
 // it back, asserting the proto is preserved. It covers every arm of the

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -96,19 +96,6 @@ func TestQueryFilterRoundTrip(t *testing.T) {
 			wantJSON: `{"$match":{"destination":{"$param":"dst"}}}`,
 		},
 		{
-			name:     "address param prefix (like)",
-			filter:   addressFilter(&AddressMatch_ParamPrefix{ParamPrefix: "acc"}, AddressRole_ADDRESS_ROLE_ANY),
-			wantJSON: `{"$like":{"address":{"$param":"acc"}}}`,
-		},
-		{
-			// A hardcoded prefix without a trailing ":" cannot use the $match
-			// trailing-colon convention (it would look like an exact match), so it
-			// is carried via $like to stay lossless.
-			name:     "address hardcoded prefix without colon (like)",
-			filter:   addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "users"}, AddressRole_ADDRESS_ROLE_ANY),
-			wantJSON: `{"$like":{"address":"users"}}`,
-		},
-		{
 			name:     "reference",
 			filter:   &QueryFilter{Filter: &QueryFilter_Reference{Reference: &ReferenceCondition{Cond: hardcoded("ref-1")}}},
 			wantJSON: `{"$match":{"reference":"ref-1"}}`,
@@ -215,6 +202,10 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		{"empty object", `{}`, "empty object"},
 		{"two operators", `{"$and":[],"$or":[]}`, "exactly one operator"},
 		{"unknown operator", `{"$bogus":{}}`, "unknown operator"},
+		// $like was dropped from the DSL (EN-1465); it is now just an unknown
+		// operator, rejected like any other unrecognised $op.
+		{"like rejected as unknown operator", `{"$like":{"address":"users"}}`, "unknown operator"},
+		{"like param rejected as unknown operator", `{"$like":{"address":{"$param":"acc"}}}`, "unknown operator"},
 		{"empty and", `{"$and":[]}`, "must contain at least one filter"},
 		{"empty or", `{"$or":[]}`, "must contain at least one filter"},
 		{"and not array", `{"$and":{}}`, "expected an array"},
@@ -264,6 +255,50 @@ func TestQueryFilterMarshalExistsIncludeNull(t *testing.T) {
 	_, err := json.Marshal(f)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "include_null")
+}
+
+// TestQueryFilterMarshalUnrepresentablePrefix asserts marshalling fails loudly on
+// the two address-prefix arms that the DSL can no longer express since $like was
+// dropped (EN-1465): a parameterised prefix and a byte-level hardcoded prefix that
+// does not end in ":". These arms are not producible through the JSON/REST surface
+// (the $match decoder builds ParamExact for a param and HardcodedExact for a
+// non-trailing-":" literal), so this guards a proto object built by another layer
+// (gRPC/CLI/pkg.actions) — it must fail rather than silently emit an exact-looking
+// $match that would widen the query.
+func TestQueryFilterMarshalUnrepresentablePrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		filter  *QueryFilter
+		wantErr string
+	}{
+		{
+			name:    "param prefix",
+			filter:  addressFilter(&AddressMatch_ParamPrefix{ParamPrefix: "acc"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantErr: "parameterised prefix",
+		},
+		{
+			name:    "byte-level hardcoded prefix (no trailing colon)",
+			filter:  addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "users"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantErr: "byte-level prefix",
+		},
+		{
+			name:    "empty hardcoded prefix",
+			filter:  addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: ""}, AddressRole_ADDRESS_ROLE_ANY),
+			wantErr: "byte-level prefix",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := json.Marshal(tc.filter)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
 }
 
 // TestQueryFilterClosedRangeFolding asserts that an $and of two same-field bounds

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -67,6 +67,15 @@ func TestQueryFilterRoundTrip(t *testing.T) {
 			filter: fieldFilter("score", &FieldCondition_IntCond{IntCond: &IntCondition{ParamMin: "lo", ParamMax: "hi"}}),
 		},
 		{
+			name:     "metadata uint single bound (stays uint, lossless)",
+			filter:   fieldFilter("count", &FieldCondition_UintCond{UintCond: &UintCondition{Min: u64(9007199254740993)}}),
+			wantJSON: `{"$gte":{"metadata[count]":"9007199254740993"}}`,
+		},
+		{
+			name:   "metadata uint closed range",
+			filter: fieldFilter("count", &FieldCondition_UintCond{UintCond: &UintCondition{Min: u64(1), Max: u64(9)}}),
+		},
+		{
 			name:     "address hardcoded prefix",
 			filter:   addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "users:"}, AddressRole_ADDRESS_ROLE_ANY),
 			wantJSON: `{"$match":{"address":"users:"}}`,
@@ -90,6 +99,14 @@ func TestQueryFilterRoundTrip(t *testing.T) {
 			name:     "address param prefix (like)",
 			filter:   addressFilter(&AddressMatch_ParamPrefix{ParamPrefix: "acc"}, AddressRole_ADDRESS_ROLE_ANY),
 			wantJSON: `{"$like":{"address":{"$param":"acc"}}}`,
+		},
+		{
+			// A hardcoded prefix without a trailing ":" cannot use the $match
+			// trailing-colon convention (it would look like an exact match), so it
+			// is carried via $like to stay lossless.
+			name:     "address hardcoded prefix without colon (like)",
+			filter:   addressFilter(&AddressMatch_HardcodedPrefix{HardcodedPrefix: "users"}, AddressRole_ADDRESS_ROLE_ANY),
+			wantJSON: `{"$like":{"address":"users"}}`,
 		},
 		{
 			name:     "reference",
@@ -211,6 +228,8 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		{"param empty name", `{"$match":{"reference":{"$param":""}}}`, "name is required"},
 		{"param not sole key", `{"$match":{"reference":{"$param":"p","x":1}}}`, "must be the only key"},
 		{"range unsupported field", `{"$gt":{"bogus":1}}`, "unsupported field"},
+		{"range on reference rejected", `{"$gt":{"reference":"x"}}`, "unsupported field"},
+		{"range on address rejected", `{"$gt":{"sourceAddress":"1"}}`, "unsupported field"},
 		{"in unsupported", `{"$in":{"address":["a"]}}`, "not supported"},
 	}
 

--- a/internal/proto/commonpb/query_filter_test.go
+++ b/internal/proto/commonpb/query_filter_test.go
@@ -182,8 +182,12 @@ func TestQueryFilterUnmarshalErrors(t *testing.T) {
 		{"address unknown operator", `{"match":{"type":"address","operator":"contains"}}`, "unknown operator"},
 		{"address unknown role", `{"match":{"type":"address","operator":"exact","value":"x","role":"middle"}}`, "unknown role"},
 		{"builtinUint unknown field", `{"match":{"type":"builtinUint","field":"bogus"}}`, "unknown field"},
+		{"builtinUint rejects non-uint field reference", `{"match":{"type":"builtinUint","field":"reference"}}`, "unknown field"},
+		{"builtinUint rejects non-uint field address", `{"match":{"type":"builtinUint","field":"sourceAddress"}}`, "unknown field"},
 		{"accountHasAsset missing assetBase", `{"match":{"type":"accountHasAsset"}}`, "assetBase is required"},
 		{"string cond both equals and param", `{"match":{"type":"field","metadata":"x","condition":{"type":"string","equals":"a","param":"b"}}}`, "only one of equals or param"},
+		{"address missing both value and param", `{"match":{"type":"address","operator":"prefix"}}`, "set one of value or param"},
+		{"reverted missing value", `{"match":{"type":"reverted"}}`, "value is required"},
 	}
 
 	for _, tc := range cases {

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -1122,6 +1122,17 @@ func compileBuiltinUintCondition(ctx *compileCtx, cond *commonpb.BuiltinUintCond
 		return nil, domain.NewFilterCompilationError("builtin uint condition has no value")
 	}
 
+	// Transaction builtins (id/timestamp/insertedAt/revertedAt) are only
+	// meaningful on the transactions target: their compilers read transaction
+	// indexes and yield transaction-keyed entities. On any other target this
+	// would silently feed tx-keyed entities into a mismatched result pipeline,
+	// so reject it here — mirroring the reverted (transactions-only) and
+	// accountHasAsset (accounts-only) guards.
+	if ctx.target != commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		return nil, domain.NewFilterCompilationError(
+			"builtin field (id/timestamp/insertedAt/revertedAt) is only valid on transactions")
+	}
+
 	switch cond.GetField() {
 	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:
 		return compileTxIDCondition(ctx, cond.GetCond())

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -159,10 +159,21 @@ func compile(ctx *compileCtx, filter *commonpb.QueryFilter) (readstore.EntityIte
 	case *commonpb.QueryFilter_BuiltinUint:
 		return compileBuiltinUintCondition(ctx, f.BuiltinUint)
 	case *commonpb.QueryFilter_LogBuiltinUint:
+		if ctx.target != commonpb.QueryTarget_QUERY_TARGET_LOGS {
+			return nil, domain.NewFilterCompilationError("log-field filter (date) is only valid on log queries")
+		}
+
 		return compileLogBuiltinUintCondition(ctx, f.LogBuiltinUint)
 	case *commonpb.QueryFilter_LogId:
+		if ctx.target != commonpb.QueryTarget_QUERY_TARGET_LOGS {
+			return nil, domain.NewFilterCompilationError("logId filter is only valid on log queries")
+		}
+
 		return compileLogIdCondition(ctx, f.LogId.GetCond())
 	case *commonpb.QueryFilter_Ledger:
+		if ctx.target != commonpb.QueryTarget_QUERY_TARGET_LOGS {
+			return nil, domain.NewFilterCompilationError("ledger filter is only valid on log queries")
+		}
 		// Ledger condition is a no-op in the Compile framework --- the ledger
 		// is already set in the context. Return the universe iterator.
 		return compileUniverse(ctx)

--- a/internal/query/compile_builtin_uint_test.go
+++ b/internal/query/compile_builtin_uint_test.go
@@ -1,0 +1,34 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// Transaction builtins (id/timestamp/insertedAt/revertedAt) are transaction-only;
+// on any other target they must fail to compile rather than silently feeding
+// transaction-keyed entities into a mismatched result pipeline.
+func TestCompileBuiltinUintCondition_RejectsNonTransactionTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []commonpb.QueryTarget{
+		commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+		commonpb.QueryTarget_QUERY_TARGET_LOGS,
+	} {
+		ctx := &compileCtx{target: target}
+
+		_, err := compile(ctx, &commonpb.QueryFilter{
+			Filter: &commonpb.QueryFilter_BuiltinUint{
+				BuiltinUint: &commonpb.BuiltinUintCondition{
+					Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
+					Cond:  &commonpb.UintCondition{Min: new(uint64(1))},
+				},
+			},
+		})
+		require.Error(t, err, "target=%v", target)
+		require.Contains(t, err.Error(), "only valid on transactions", "target=%v", target)
+	}
+}

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1287,17 +1287,7 @@ message LogIdCondition {
   UintCondition cond = 1;
 }
 
-// BuiltinUintCondition filters transactions by a built-in uint64 field within
-// an unsigned range. `field` reuses the shared TransactionBuiltinIndex enum
-// (which also names the address/reference index kinds used by the indexbuilder),
-// but only the uint-range members are valid here: TX_BUILTIN_INDEX_ID,
-// TX_BUILTIN_INDEX_TIMESTAMP, TX_BUILTIN_INDEX_INSERTED_AT and
-// TX_BUILTIN_INDEX_REVERTED_AT. The REFERENCE / ADDRESS / SOURCE_ADDRESS /
-// DESTINATION_ADDRESS members are string/prefix index kinds and are rejected by
-// compileBuiltinUintCondition — they are matched via the dedicated
-// ReferenceCondition / AddressMatch conditions instead. The public JSON codec
-// and openapi.yml expose only the four valid fields, keeping the wire contract
-// in step with what actually compiles.
+// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, or inserted_at).
 message BuiltinUintCondition {
   TransactionBuiltinIndex field = 1;
   UintCondition cond = 2;

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1287,7 +1287,7 @@ message LogIdCondition {
   UintCondition cond = 1;
 }
 
-// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, or inserted_at).
+// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, inserted_at, or reverted_at).
 message BuiltinUintCondition {
   TransactionBuiltinIndex field = 1;
   UintCondition cond = 2;

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1287,7 +1287,17 @@ message LogIdCondition {
   UintCondition cond = 1;
 }
 
-// BuiltinUintCondition filters transactions by a built-in uint64 field (id, timestamp, or inserted_at).
+// BuiltinUintCondition filters transactions by a built-in uint64 field within
+// an unsigned range. `field` reuses the shared TransactionBuiltinIndex enum
+// (which also names the address/reference index kinds used by the indexbuilder),
+// but only the uint-range members are valid here: TX_BUILTIN_INDEX_ID,
+// TX_BUILTIN_INDEX_TIMESTAMP, TX_BUILTIN_INDEX_INSERTED_AT and
+// TX_BUILTIN_INDEX_REVERTED_AT. The REFERENCE / ADDRESS / SOURCE_ADDRESS /
+// DESTINATION_ADDRESS members are string/prefix index kinds and are rejected by
+// compileBuiltinUintCondition — they are matched via the dedicated
+// ReferenceCondition / AddressMatch conditions instead. The public JSON codec
+// and openapi.yml expose only the four valid fields, keeping the wire contract
+// in step with what actually compiles.
 message BuiltinUintCondition {
   TransactionBuiltinIndex field = 1;
   UintCondition cond = 2;

--- a/openapi.yml
+++ b/openapi.yml
@@ -3760,27 +3760,354 @@ components:
     QueryFilter:
       type: object
       description: >-
-        Recursive filter tree (AND/OR/NOT of field conditions and address matches).
-        The `match` object holds one of the named condition types: field equality/range
-        (`FieldCondition`), address prefix/exact match (`AddressMatch`), transaction
-        reference match (`ReferenceCondition`), built-in uint range (`BuiltinUintCondition`),
-        or account-asset presence (`AccountHasAssetCondition`).
+        Recursive filter tree. Exactly one of `and`, `or`, `not`, or `match`
+        must be set on each node. `and`/`or` combine child filters; `not` negates
+        a single child filter; `match` is a leaf condition (a tagged union
+        discriminated by its `type` field — see `Condition`).
       properties:
         and:
           type: array
+          description: Logical AND of the child filters (all must match).
           items:
             $ref: '#/components/schemas/QueryFilter'
         or:
           type: array
+          description: Logical OR of the child filters (at least one must match).
           items:
             $ref: '#/components/schemas/QueryFilter'
         not:
-          $ref: '#/components/schemas/QueryFilter'
+          allOf:
+            - $ref: '#/components/schemas/QueryFilter'
+          description: Negates the child filter.
         match:
-          type: object
+          $ref: '#/components/schemas/Condition'
+
+    Condition:
+      description: >-
+        A leaf filter condition. Tagged union discriminated by `type`.
+      oneOf:
+        - $ref: '#/components/schemas/FieldCondition'
+        - $ref: '#/components/schemas/AddressCondition'
+        - $ref: '#/components/schemas/ReferenceCondition'
+        - $ref: '#/components/schemas/LedgerCondition'
+        - $ref: '#/components/schemas/LogIdCondition'
+        - $ref: '#/components/schemas/BuiltinUintCondition'
+        - $ref: '#/components/schemas/LogBuiltinUintCondition'
+        - $ref: '#/components/schemas/AccountHasAssetCondition'
+        - $ref: '#/components/schemas/RevertedCondition'
+      discriminator:
+        propertyName: type
+        mapping:
+          field: '#/components/schemas/FieldCondition'
+          address: '#/components/schemas/AddressCondition'
+          reference: '#/components/schemas/ReferenceCondition'
+          ledger: '#/components/schemas/LedgerCondition'
+          logId: '#/components/schemas/LogIdCondition'
+          builtinUint: '#/components/schemas/BuiltinUintCondition'
+          logBuiltinUint: '#/components/schemas/LogBuiltinUintCondition'
+          accountHasAsset: '#/components/schemas/AccountHasAssetCondition'
+          reverted: '#/components/schemas/RevertedCondition'
+
+    FieldCondition:
+      type: object
+      description: Matches a metadata field of the target entity.
+      required:
+        - type
+        - metadata
+        - condition
+      properties:
+        type:
+          type: string
+          enum: [field]
+        metadata:
+          type: string
+          description: Metadata key to match on.
+          example: risk_score
+        condition:
+          $ref: '#/components/schemas/FieldValueCondition'
+
+    FieldValueCondition:
+      description: >-
+        A typed condition on a metadata field value. Tagged union discriminated
+        by `type`.
+      oneOf:
+        - $ref: '#/components/schemas/StringValueCondition'
+        - $ref: '#/components/schemas/IntValueCondition'
+        - $ref: '#/components/schemas/UintValueCondition'
+        - $ref: '#/components/schemas/BoolValueCondition'
+        - $ref: '#/components/schemas/ExistsValueCondition'
+      discriminator:
+        propertyName: type
+        mapping:
+          string: '#/components/schemas/StringValueCondition'
+          int: '#/components/schemas/IntValueCondition'
+          uint: '#/components/schemas/UintValueCondition'
+          bool: '#/components/schemas/BoolValueCondition'
+          exists: '#/components/schemas/ExistsValueCondition'
+
+    StringValueCondition:
+      type: object
+      description: >-
+        String equality. Set exactly one of `equals` (hardcoded value) or
+        `param` (name of a parameter supplied at execution time).
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [string]
+        equals:
+          type: string
+          description: Hardcoded value to match exactly.
+        param:
+          type: string
+          description: Name of a query parameter that supplies the value at execution.
+
+    IntValueCondition:
+      type: object
+      description: >-
+        Signed-integer range. Bounds are inclusive unless the matching
+        `*Exclusive` flag is set. Any bound may instead be supplied at execution
+        time via `paramMin` / `paramMax`.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [int]
+        min:
+          type: integer
+          format: int64
+        max:
+          type: integer
+          format: int64
+        minExclusive:
+          type: boolean
+        maxExclusive:
+          type: boolean
+        paramMin:
+          type: string
+        paramMax:
+          type: string
+
+    UintValueCondition:
+      type: object
+      description: >-
+        Unsigned-integer range. `min`/`max` are encoded as decimal strings to
+        stay lossless above 2^53. Bounds are inclusive unless the matching
+        `*Exclusive` flag is set; `paramMin`/`paramMax` supply bounds at
+        execution time.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [uint]
+        min:
+          type: string
+          description: Lower bound as a decimal string.
+          example: "100"
+        max:
+          type: string
+          description: Upper bound as a decimal string.
+          example: "9007199254740993"
+        minExclusive:
+          type: boolean
+        maxExclusive:
+          type: boolean
+        paramMin:
+          type: string
+        paramMax:
+          type: string
+
+    BoolValueCondition:
+      type: object
+      description: >-
+        Boolean equality. Set exactly one of `equals` (hardcoded value) or
+        `param`.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [bool]
+        equals:
+          type: boolean
+        param:
+          type: string
+
+    ExistsValueCondition:
+      type: object
+      description: Matches when the metadata key is present.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [exists]
+        includeNull:
+          type: boolean
+          description: When true, also matches keys explicitly set to null.
+
+    AddressCondition:
+      type: object
+      description: >-
+        Matches an account address by prefix or exact value. Set exactly one of
+        `value` (hardcoded) or `param` (supplied at execution).
+      required:
+        - type
+        - operator
+      properties:
+        type:
+          type: string
+          enum: [address]
+        operator:
+          type: string
+          enum: [prefix, exact]
+        value:
+          type: string
+          description: Hardcoded address or prefix.
+          example: "users:"
+        param:
+          type: string
+          description: Name of a query parameter that supplies the address at execution.
+        role:
+          type: string
+          enum: [any, source, destination]
           description: >-
-            Field condition or address match. Use one of the named condition schemas
-            (e.g. `AccountHasAssetCondition`) as the value.
+            For transaction queries, restricts the match to the source or
+            destination side of a posting. Defaults to `any`.
+
+    ReferenceCondition:
+      type: object
+      description: Matches a transaction by its reference (string equality).
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [reference]
+        equals:
+          type: string
+        param:
+          type: string
+
+    LedgerCondition:
+      type: object
+      description: Matches log entries by ledger name (string equality).
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [ledger]
+        equals:
+          type: string
+        param:
+          type: string
+
+    LogIdCondition:
+      type: object
+      description: Matches log entries by ledger-local log id (unsigned range).
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [logId]
+        min:
+          type: string
+        max:
+          type: string
+        minExclusive:
+          type: boolean
+        maxExclusive:
+          type: boolean
+        paramMin:
+          type: string
+        paramMax:
+          type: string
+
+    BuiltinUintCondition:
+      type: object
+      description: >-
+        Matches a built-in transaction field carrying an unsigned value (id,
+        timestamp, inserted-at / reverted-at dates, or an address mapping) within
+        an unsigned range.
+      required:
+        - type
+        - field
+      properties:
+        type:
+          type: string
+          enum: [builtinUint]
+        field:
+          type: string
+          enum:
+            - id
+            - reference
+            - timestamp
+            - insertedAt
+            - revertedAt
+            - address
+            - sourceAddress
+            - destinationAddress
+        min:
+          type: string
+        max:
+          type: string
+        minExclusive:
+          type: boolean
+        maxExclusive:
+          type: boolean
+        paramMin:
+          type: string
+        paramMax:
+          type: string
+
+    LogBuiltinUintCondition:
+      type: object
+      description: >-
+        Matches a built-in log field carrying an unsigned value (currently the
+        log date) within an unsigned range.
+      required:
+        - type
+        - field
+      properties:
+        type:
+          type: string
+          enum: [logBuiltinUint]
+        field:
+          type: string
+          enum: [date]
+        min:
+          type: string
+        max:
+          type: string
+        minExclusive:
+          type: boolean
+        maxExclusive:
+          type: boolean
+        paramMin:
+          type: string
+        paramMax:
+          type: string
+
+    RevertedCondition:
+      type: object
+      description: >-
+        Matches transactions by revert status. Served from the per-ledger
+        reversion bitset (no index required).
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          enum: [reverted]
+        value:
+          type: boolean
+          description: True matches reverted originals; false matches everything else.
 
     AccountHasAssetCondition:
       type: object
@@ -3790,8 +4117,12 @@ components:
         index on the ledger; the query is rejected if the index is absent or still
         BUILDING.
       required:
+        - type
         - assetBase
       properties:
+        type:
+          type: string
+          enum: [accountHasAsset]
         assetBase:
           type: string
           description: Asset code without precision suffix (e.g. `USD`, `EUR`).

--- a/openapi.yml
+++ b/openapi.yml
@@ -3678,7 +3678,6 @@ components:
           enum:
             - ACCOUNTS
             - TRANSACTIONS
-            - LOGS
           description: Target entity type
         filter:
           $ref: '#/components/schemas/QueryFilter'
@@ -3750,7 +3749,6 @@ components:
           enum:
             - ACCOUNTS
             - TRANSACTIONS
-            - LOGS
           description: Target entity type
         filter:
           $ref: '#/components/schemas/QueryFilter'

--- a/openapi.yml
+++ b/openapi.yml
@@ -3766,389 +3766,118 @@ components:
     QueryFilter:
       type: object
       description: >-
-        Recursive filter tree. Exactly one of `and`, `or`, `not`, or `match`
-        must be set on each node. `and`/`or` combine child filters (and must be
-        non-empty — an empty combinator is rejected); `not` negates a single
-        child filter; `match` is a leaf condition (a tagged union discriminated
-        by its `type` field — see `Condition`).
+        Recursive filter expression using the Formance query DSL (aligned with
+        the v2 API). Each node is an object with **exactly one** top-level
+        `$`-prefixed operator key.
+
+
+        Combinators:
+
+        - `{"$and": [QueryFilter, ...]}` — all sub-filters must match (non-empty).
+
+        - `{"$or":  [QueryFilter, ...]}` — at least one sub-filter matches (non-empty).
+
+        - `{"$not": QueryFilter}` — negates a single sub-filter.
+
+
+        Leaf conditions are a single-key operator whose value is a
+        `{ "<field>": <value> }` map with exactly one field:
+
+        - `{"$match": {"<field>": <value>}}` — equality; for `address`/`source`/`destination`
+          a trailing `:` means prefix match, otherwise exact.
+
+        - `{"$gt"|"$gte"|"$lt"|"$lte": {"<field>": <value>}}` — range bound. A closed
+          range is expressed as an `$and` of a lower and an upper bound on the same field.
+
+        - `{"$exists": {"metadata": "<key>"}}` — the metadata key is present.
+
+        - `{"$exists": {"asset": "<assetRef>"}}` — the account has ever held the asset
+          (`assetRef` is `BASE` or `BASE/PRECISION`, e.g. `USD/2`). Requires a READY
+          `account-asset` index.
+
+
+        Supported fields: `metadata[<key>]`, `address`, `source`, `destination`,
+        `reference`, `reverted` (bool), `ledger`, `id`, `timestamp`, `insertedAt`,
+        `revertedAt`, `logId`, `date`. Not every field applies to every query target;
+        a field that does not apply is rejected at execution.
+
+
+        A value is either a JSON literal or a parameter reference
+        `{"$param": "<name>"}`, resolved at prepared-query execution time. uint64
+        fields (`id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`, `date`) are
+        carried as decimal strings to stay lossless above 2^53.
+      minProperties: 1
+      maxProperties: 1
+      additionalProperties: true
       properties:
-        and:
+        $and:
           type: array
           minItems: 1
-          description: Logical AND of the child filters (all must match).
           items:
             $ref: '#/components/schemas/QueryFilter'
-        or:
+        $or:
           type: array
           minItems: 1
-          description: Logical OR of the child filters (at least one must match).
           items:
             $ref: '#/components/schemas/QueryFilter'
-        not:
-          allOf:
-            - $ref: '#/components/schemas/QueryFilter'
-          description: Negates the child filter.
-        match:
-          $ref: '#/components/schemas/Condition'
-
-    Condition:
-      description: >-
-        A leaf filter condition. Tagged union discriminated by `type`. This is
-        the shared filter grammar used by every filtered endpoint, so not every
-        condition applies to every query target: `ledger`, `logId` and
-        `logBuiltinUint` match log entries (log queries); `reference`, `reverted`
-        and `builtinUint` match transactions; `accountHasAsset` matches accounts;
-        `field` and `address` apply per the target's metadata/address model. A
-        condition that does not apply to the query's target is rejected at
-        execution. Note: prepared queries can only target accounts or
-        transactions today, so log-only conditions are usable there only once
-        log-targeted prepared queries are supported.
-      oneOf:
-        - $ref: '#/components/schemas/FieldCondition'
-        - $ref: '#/components/schemas/AddressCondition'
-        - $ref: '#/components/schemas/ReferenceCondition'
-        - $ref: '#/components/schemas/LedgerCondition'
-        - $ref: '#/components/schemas/LogIdCondition'
-        - $ref: '#/components/schemas/BuiltinUintCondition'
-        - $ref: '#/components/schemas/LogBuiltinUintCondition'
-        - $ref: '#/components/schemas/AccountHasAssetCondition'
-        - $ref: '#/components/schemas/RevertedCondition'
-      discriminator:
-        propertyName: type
-        mapping:
-          field: '#/components/schemas/FieldCondition'
-          address: '#/components/schemas/AddressCondition'
-          reference: '#/components/schemas/ReferenceCondition'
-          ledger: '#/components/schemas/LedgerCondition'
-          logId: '#/components/schemas/LogIdCondition'
-          builtinUint: '#/components/schemas/BuiltinUintCondition'
-          logBuiltinUint: '#/components/schemas/LogBuiltinUintCondition'
-          accountHasAsset: '#/components/schemas/AccountHasAssetCondition'
-          reverted: '#/components/schemas/RevertedCondition'
-
-    FieldCondition:
-      type: object
-      description: Matches a metadata field of the target entity.
-      required:
-        - type
-        - metadata
-        - condition
-      properties:
-        type:
-          type: string
-          enum: [field]
-        metadata:
-          type: string
-          description: Metadata key to match on.
-          example: risk_score
-        condition:
-          $ref: '#/components/schemas/FieldValueCondition'
-
-    FieldValueCondition:
-      description: >-
-        A typed condition on a metadata field value. Tagged union discriminated
-        by `type`.
-      oneOf:
-        - $ref: '#/components/schemas/StringValueCondition'
-        - $ref: '#/components/schemas/IntValueCondition'
-        - $ref: '#/components/schemas/UintValueCondition'
-        - $ref: '#/components/schemas/BoolValueCondition'
-        - $ref: '#/components/schemas/ExistsValueCondition'
-      discriminator:
-        propertyName: type
-        mapping:
-          string: '#/components/schemas/StringValueCondition'
-          int: '#/components/schemas/IntValueCondition'
-          uint: '#/components/schemas/UintValueCondition'
-          bool: '#/components/schemas/BoolValueCondition'
-          exists: '#/components/schemas/ExistsValueCondition'
-
-    StringValueCondition:
-      type: object
-      description: >-
-        String equality. Set exactly one of `equals` (hardcoded value) or
-        `param` (name of a parameter supplied at execution time).
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [string]
-        equals:
-          type: string
-          description: Hardcoded value to match exactly.
-        param:
-          type: string
-          description: Name of a query parameter that supplies the value at execution.
-
-    IntValueCondition:
-      type: object
-      description: >-
-        Signed-integer range. Bounds are inclusive unless the matching
-        `*Exclusive` flag is set. Any bound may instead be supplied at execution
-        time via `paramMin` / `paramMax`.
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [int]
-        min:
-          type: integer
-          format: int64
-        max:
-          type: integer
-          format: int64
-        minExclusive:
-          type: boolean
-        maxExclusive:
-          type: boolean
-        paramMin:
-          type: string
-        paramMax:
-          type: string
-
-    UintValueCondition:
-      type: object
-      description: >-
-        Unsigned-integer range. `min`/`max` are encoded as decimal strings to
-        stay lossless above 2^53. Bounds are inclusive unless the matching
-        `*Exclusive` flag is set; `paramMin`/`paramMax` supply bounds at
-        execution time.
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [uint]
-        min:
-          type: string
-          description: Lower bound as a decimal string.
-          example: "100"
-        max:
-          type: string
-          description: Upper bound as a decimal string.
-          example: "9007199254740993"
-        minExclusive:
-          type: boolean
-        maxExclusive:
-          type: boolean
-        paramMin:
-          type: string
-        paramMax:
-          type: string
-
-    BoolValueCondition:
-      type: object
-      description: >-
-        Boolean equality. Set exactly one of `equals` (hardcoded value) or
-        `param`.
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [bool]
-        equals:
-          type: boolean
-        param:
-          type: string
-
-    ExistsValueCondition:
-      type: object
-      description: Matches when the metadata key is present.
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [exists]
-        includeNull:
-          type: boolean
-          description: When true, also matches keys explicitly set to null.
-
-    AddressCondition:
-      type: object
-      description: >-
-        Matches an account address by prefix or exact value. Set exactly one of
-        `value` (hardcoded) or `param` (supplied at execution).
-      required:
-        - type
-        - operator
-      properties:
-        type:
-          type: string
-          enum: [address]
-        operator:
-          type: string
-          enum: [prefix, exact]
-        value:
-          type: string
-          description: Hardcoded address or prefix.
-          example: "users:"
-        param:
-          type: string
-          description: Name of a query parameter that supplies the address at execution.
-        role:
-          type: string
-          enum: [any, source, destination]
+        $not:
+          $ref: '#/components/schemas/QueryFilter'
+        $match:
+          type: object
+          description: '`{ "<field>": <value> }` — exact/prefix/bool match.'
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $gt:
+          type: object
+          description: '`{ "<field>": <value> }` — strictly greater than.'
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $gte:
+          type: object
+          description: '`{ "<field>": <value> }` — greater than or equal.'
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $lt:
+          type: object
+          description: '`{ "<field>": <value> }` — strictly less than.'
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $lte:
+          type: object
+          description: '`{ "<field>": <value> }` — less than or equal.'
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $exists:
+          type: object
           description: >-
-            For transaction queries, restricts the match to the source or
-            destination side of a posting. Defaults to `any`.
-
-    ReferenceCondition:
-      type: object
-      description: Matches a transaction by its reference (string equality).
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [reference]
-        equals:
-          type: string
-        param:
-          type: string
-
-    LedgerCondition:
-      type: object
-      description: Matches log entries by ledger name (string equality).
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [ledger]
-        equals:
-          type: string
-        param:
-          type: string
-
-    LogIdCondition:
-      type: object
-      description: Matches log entries by ledger-local log id (unsigned range).
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum: [logId]
-        min:
-          type: string
-        max:
-          type: string
-        minExclusive:
-          type: boolean
-        maxExclusive:
-          type: boolean
-        paramMin:
-          type: string
-        paramMax:
-          type: string
-
-    BuiltinUintCondition:
-      type: object
-      description: >-
-        Matches a built-in transaction field carrying an unsigned value (id or
-        one of the timestamp/date fields) within an unsigned range. Address and
-        reference matching use the `address` / `reference` conditions instead.
-      required:
-        - type
-        - field
-      properties:
-        type:
-          type: string
-          enum: [builtinUint]
-        field:
-          type: string
-          enum:
-            - id
-            - timestamp
-            - insertedAt
-            - revertedAt
-        min:
-          type: string
-        max:
-          type: string
-        minExclusive:
-          type: boolean
-        maxExclusive:
-          type: boolean
-        paramMin:
-          type: string
-        paramMax:
-          type: string
-
-    LogBuiltinUintCondition:
-      type: object
-      description: >-
-        Matches a built-in log field carrying an unsigned value (currently the
-        log date) within an unsigned range.
-      required:
-        - type
-        - field
-      properties:
-        type:
-          type: string
-          enum: [logBuiltinUint]
-        field:
-          type: string
-          enum: [date]
-        min:
-          type: string
-        max:
-          type: string
-        minExclusive:
-          type: boolean
-        maxExclusive:
-          type: boolean
-        paramMin:
-          type: string
-        paramMax:
-          type: string
-
-    RevertedCondition:
-      type: object
-      description: >-
-        Matches transactions by revert status. Served from the per-ledger
-        reversion bitset (no index required).
-      required:
-        - type
-        - value
-      properties:
-        type:
-          type: string
-          enum: [reverted]
-        value:
-          type: boolean
-          description: True matches reverted originals; false matches everything else.
-
-    AccountHasAssetCondition:
-      type: object
-      description: >-
-        Matches accounts that have ever touched the specified asset (volume-cell
-        presence semantics — not a balance check). Requires a READY `account-asset`
-        index on the ledger; the query is rejected if the index is absent or still
-        BUILDING.
-      required:
-        - type
-        - assetBase
-      properties:
-        type:
-          type: string
-          enum: [accountHasAsset]
-        assetBase:
-          type: string
-          description: Asset code without precision suffix (e.g. `USD`, `EUR`).
-          example: USD
-        precision:
-          type: integer
-          format: int32
-          minimum: 0
+            `{ "metadata": "<key>" }` (metadata key present) or
+            `{ "asset": "<assetRef>" }` (account has held the asset).
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $like:
+          type: object
           description: >-
-            Asset precision (number of decimal places). Defaults to `0` when
-            omitted, matching assets recorded with no decimal places.
-          example: 2
+            `{ "<field>": <value> }` — SQL-style pattern / parameterised address
+            prefix. Reserved; currently emitted only for a parameterised address
+            prefix (`{"$like": {"address": {"$param": "<name>"}}}`).
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+        $in:
+          type: object
+          description: >-
+            `{ "<field>": [<value>, ...] }` — value is one of a set. Reserved for
+            the list endpoints; not accepted on prepared queries yet.
+          minProperties: 1
+          maxProperties: 1
+          additionalProperties: true
+
 
     ExecutePreparedQueryResponse:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -3749,7 +3749,13 @@ components:
           enum:
             - ACCOUNTS
             - TRANSACTIONS
-          description: Target entity type
+            - LOGS
+          description: >-
+            Target entity type. `LOGS` only appears on prepared queries created
+            through gRPC/CLI — the REST create/update paths accept only
+            `ACCOUNTS` and `TRANSACTIONS` (see CreatePreparedQueryRequest) — but
+            list/get responses echo a query's true target, so a client must
+            tolerate `LOGS` here.
         filter:
           $ref: '#/components/schemas/QueryFilter'
         allowedModes:
@@ -3761,17 +3767,20 @@ components:
       type: object
       description: >-
         Recursive filter tree. Exactly one of `and`, `or`, `not`, or `match`
-        must be set on each node. `and`/`or` combine child filters; `not` negates
-        a single child filter; `match` is a leaf condition (a tagged union
-        discriminated by its `type` field — see `Condition`).
+        must be set on each node. `and`/`or` combine child filters (and must be
+        non-empty — an empty combinator is rejected); `not` negates a single
+        child filter; `match` is a leaf condition (a tagged union discriminated
+        by its `type` field — see `Condition`).
       properties:
         and:
           type: array
+          minItems: 1
           description: Logical AND of the child filters (all must match).
           items:
             $ref: '#/components/schemas/QueryFilter'
         or:
           type: array
+          minItems: 1
           description: Logical OR of the child filters (at least one must match).
           items:
             $ref: '#/components/schemas/QueryFilter'

--- a/openapi.yml
+++ b/openapi.yml
@@ -3865,17 +3865,6 @@ components:
           minProperties: 1
           maxProperties: 1
           additionalProperties: true
-        $like:
-          type: object
-          description: >-
-            `{ "<field>": <value> }` — address prefix match. Emitted for a
-            parameterised address prefix (`{"$like": {"address": {"$param": "<name>"}}}`)
-            and for a hardcoded byte-level prefix that does not end in `:` (which
-            `$match` cannot express, since a trailing `:` is its prefix marker),
-            e.g. `{"$like": {"address": "users"}}`.
-          minProperties: 1
-          maxProperties: 1
-          additionalProperties: true
         $in:
           type: object
           description: >-

--- a/openapi.yml
+++ b/openapi.yml
@@ -3799,13 +3799,18 @@ components:
         Supported fields: `metadata[<key>]`, `address`, `source`, `destination`,
         `reference`, `reverted` (bool), `ledger`, `id`, `timestamp`, `insertedAt`,
         `revertedAt`, `logId`, `date`. Not every field applies to every query target;
-        a field that does not apply is rejected at execution.
+        a field that does not apply is rejected. The numeric built-ins
+        (`id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`, `date`) are
+        **range-only** — use `$gt`/`$gte`/`$lt`/`$lte`; `$match` on them is rejected.
+        The log-only fields (`logId`, `date`, `ledger`) are rejected on prepared
+        queries, which can only target accounts or transactions.
 
 
         A value is either a JSON literal or a parameter reference
-        `{"$param": "<name>"}`, resolved at prepared-query execution time. uint64
-        fields (`id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`, `date`) are
-        carried as decimal strings to stay lossless above 2^53.
+        `{"$param": "<name>"}`, resolved at prepared-query execution time. A JSON
+        `null` in value position is rejected. uint64 fields
+        (`id`, `timestamp`, `insertedAt`, `revertedAt`, `logId`, `date`) are carried
+        as decimal strings to stay lossless above 2^53.
       minProperties: 1
       maxProperties: 1
       additionalProperties: true
@@ -3863,9 +3868,11 @@ components:
         $like:
           type: object
           description: >-
-            `{ "<field>": <value> }` — SQL-style pattern / parameterised address
-            prefix. Reserved; currently emitted only for a parameterised address
-            prefix (`{"$like": {"address": {"$param": "<name>"}}}`).
+            `{ "<field>": <value> }` — address prefix match. Emitted for a
+            parameterised address prefix (`{"$like": {"address": {"$param": "<name>"}}}`)
+            and for a hardcoded byte-level prefix that does not end in `:` (which
+            `$match` cannot express, since a trailing `:` is its prefix marker),
+            e.g. `{"$like": {"address": "users"}}`.
           minProperties: 1
           maxProperties: 1
           additionalProperties: true

--- a/openapi.yml
+++ b/openapi.yml
@@ -3678,6 +3678,7 @@ components:
           enum:
             - ACCOUNTS
             - TRANSACTIONS
+            - LOGS
           description: Target entity type
         filter:
           $ref: '#/components/schemas/QueryFilter'
@@ -3749,6 +3750,7 @@ components:
           enum:
             - ACCOUNTS
             - TRANSACTIONS
+            - LOGS
           description: Target entity type
         filter:
           $ref: '#/components/schemas/QueryFilter'
@@ -4031,9 +4033,9 @@ components:
     BuiltinUintCondition:
       type: object
       description: >-
-        Matches a built-in transaction field carrying an unsigned value (id,
-        timestamp, inserted-at / reverted-at dates, or an address mapping) within
-        an unsigned range.
+        Matches a built-in transaction field carrying an unsigned value (id or
+        one of the timestamp/date fields) within an unsigned range. Address and
+        reference matching use the `address` / `reference` conditions instead.
       required:
         - type
         - field
@@ -4045,13 +4047,9 @@ components:
           type: string
           enum:
             - id
-            - reference
             - timestamp
             - insertedAt
             - revertedAt
-            - address
-            - sourceAddress
-            - destinationAddress
         min:
           type: string
         max:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3784,7 +3784,16 @@ components:
 
     Condition:
       description: >-
-        A leaf filter condition. Tagged union discriminated by `type`.
+        A leaf filter condition. Tagged union discriminated by `type`. This is
+        the shared filter grammar used by every filtered endpoint, so not every
+        condition applies to every query target: `ledger`, `logId` and
+        `logBuiltinUint` match log entries (log queries); `reference`, `reverted`
+        and `builtinUint` match transactions; `accountHasAsset` matches accounts;
+        `field` and `address` apply per the target's metadata/address model. A
+        condition that does not apply to the query's target is rejected at
+        execution. Note: prepared queries can only target accounts or
+        transactions today, so log-only conditions are usable there only once
+        log-targeted prepared queries are supported.
       oneOf:
         - $ref: '#/components/schemas/FieldCondition'
         - $ref: '#/components/schemas/AddressCondition'

--- a/tests/e2e/business/prepared_query_rest_shape_test.go
+++ b/tests/e2e/business/prepared_query_rest_shape_test.go
@@ -33,17 +33,17 @@ var _ = Describe("PreparedQuery REST shape (EN-1465)", Ordered, func() {
 		Expect(err).To(Succeed())
 	})
 
-	It("accepts the canonical flat filter shape on POST and echoes it back on GET", func() {
-		// Canonical flat shape: combinators are direct arrays / value, and the
-		// leaf `match` is a tagged union discriminated by `type`.
+	It("accepts the v2-aligned filter shape on POST and echoes it back on GET", func() {
+		// v2-aligned query DSL: $-prefixed operators, single-key
+		// operator->{field:value} bodies, $and/$or arrays, $not single.
 		body := `{
 			"name": "vip-and-ref",
 			"target": "TRANSACTIONS",
 			"filter": {
-				"and": [
-					{"match": {"type": "reference", "equals": "order-1"}},
-					{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "gold"}}},
-					{"not": {"match": {"type": "reverted", "value": true}}}
+				"$and": [
+					{"$match": {"reference": "order-1"}},
+					{"$match": {"metadata[tier]": "gold"}},
+					{"$not": {"$match": {"reverted": true}}}
 				]
 			}
 		}`
@@ -71,10 +71,9 @@ var _ = Describe("PreparedQuery REST shape (EN-1465)", Ordered, func() {
 		Expect(err).To(Succeed())
 		listStr := string(listRaw)
 
-		// Positive: the flat contract is present.
+		// Positive: the v2 contract is present.
 		Expect(listStr).To(ContainSubstring(`"target":"TRANSACTIONS"`))
-		Expect(listStr).To(ContainSubstring(`"match":{"type":"reference"`))
-		Expect(listStr).To(ContainSubstring(`"equals":"order-1"`))
+		Expect(listStr).To(ContainSubstring(`"$match":{"reference":"order-1"}`))
 
 		// Negative: no protobuf-internal names leak.
 		for _, leak := range []string{
@@ -100,19 +99,19 @@ var _ = Describe("PreparedQuery REST shape (EN-1465)", Ordered, func() {
 			if q.Name == "vip-and-ref" {
 				found = true
 				var f struct {
-					And []json.RawMessage `json:"and"`
+					And []json.RawMessage `json:"$and"`
 				}
 				Expect(json.Unmarshal(q.Filter, &f)).To(Succeed())
-				Expect(f.And).To(HaveLen(3), "and combinator must round-trip as a direct array")
+				Expect(f.And).To(HaveLen(3), "$and combinator must round-trip as a direct array")
 			}
 		}
 		Expect(found).To(BeTrue(), "created prepared query not found in list")
 	})
 
 	It("rejects a legacy protojson-shaped filter (no silent acceptance)", func() {
-		// The old wire shape (`and.filters[]`, `field.field.metadata`) must now
-		// be rejected rather than silently parsed — it is not the documented
-		// contract.
+		// The old protojson wire shape (`and.filters[]`, `field.field.metadata`)
+		// must be rejected rather than silently parsed — it is not the documented
+		// v2-aligned contract.
 		body := `{
 			"name": "legacy",
 			"target": "TRANSACTIONS",

--- a/tests/e2e/business/prepared_query_rest_shape_test.go
+++ b/tests/e2e/business/prepared_query_rest_shape_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package business
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// This suite exercises the REST prepared-query surface against the canonical
+// flat QueryFilter shape documented in openapi.yml (EN-1465). It guards that
+// the wire body matches the spec — no protobuf-internal oneof/wrapper names
+// (`and.filters[]`, `field.field.metadata`, `stringCond`, `hardcoded`, the
+// QUERY_TARGET_* enum prefix) leak on either the request or the response side.
+var _ = Describe("PreparedQuery REST shape (EN-1465)", Ordered, func() {
+	const ledgerName = "pq-rest-shape"
+
+	restURL := func(path string) string {
+		return fmt.Sprintf("http://localhost:%d/v3/%s%s", testutil.TestSingleHTTPPort, ledgerName, path)
+	}
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+	})
+
+	It("accepts the canonical flat filter shape on POST and echoes it back on GET", func() {
+		// Canonical flat shape: combinators are direct arrays / value, and the
+		// leaf `match` is a tagged union discriminated by `type`.
+		body := `{
+			"name": "vip-and-ref",
+			"target": "TRANSACTIONS",
+			"filter": {
+				"and": [
+					{"match": {"type": "reference", "equals": "order-1"}},
+					{"match": {"type": "field", "metadata": "tier", "condition": {"type": "string", "equals": "gold"}}},
+					{"not": {"match": {"type": "reverted", "value": true}}}
+				]
+			}
+		}`
+
+		req, err := http.NewRequestWithContext(sharedCtx, http.MethodPost, restURL("/prepared-queries"), bytes.NewBufferString(body))
+		Expect(err).To(Succeed())
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(Succeed())
+		defer func() { _ = resp.Body.Close() }()
+
+		raw, _ := io.ReadAll(resp.Body)
+		Expect(resp.StatusCode).To(Equal(http.StatusNoContent), "unexpected status; body=%s", string(raw))
+
+		// List over REST and assert the response body uses the flat shape.
+		getReq, err := http.NewRequestWithContext(sharedCtx, http.MethodGet, restURL("/prepared-queries"), nil)
+		Expect(err).To(Succeed())
+		getResp, err := http.DefaultClient.Do(getReq)
+		Expect(err).To(Succeed())
+		defer func() { _ = getResp.Body.Close() }()
+		Expect(getResp.StatusCode).To(Equal(http.StatusOK))
+
+		listRaw, err := io.ReadAll(getResp.Body)
+		Expect(err).To(Succeed())
+		listStr := string(listRaw)
+
+		// Positive: the flat contract is present.
+		Expect(listStr).To(ContainSubstring(`"target":"TRANSACTIONS"`))
+		Expect(listStr).To(ContainSubstring(`"match":{"type":"reference"`))
+		Expect(listStr).To(ContainSubstring(`"equals":"order-1"`))
+
+		// Negative: no protobuf-internal names leak.
+		for _, leak := range []string{
+			`"filters"`, `"stringCond"`, `"intCond"`, `"boolCond"`, `"existsCond"`,
+			`"cond"`, `"hardcoded"`, `QUERY_TARGET_`,
+		} {
+			Expect(listStr).NotTo(ContainSubstring(leak), "protojson-internal name leaked in list body: %s", leak)
+		}
+
+		// The listed filter must decode structurally.
+		var listBody struct {
+			Data []struct {
+				Name   string          `json:"name"`
+				Target string          `json:"target"`
+				Filter json.RawMessage `json:"filter"`
+			} `json:"data"`
+		}
+		Expect(json.Unmarshal(listRaw, &listBody)).To(Succeed())
+		Expect(listBody.Data).NotTo(BeEmpty())
+
+		var found bool
+		for _, q := range listBody.Data {
+			if q.Name == "vip-and-ref" {
+				found = true
+				var f struct {
+					And []json.RawMessage `json:"and"`
+				}
+				Expect(json.Unmarshal(q.Filter, &f)).To(Succeed())
+				Expect(f.And).To(HaveLen(3), "and combinator must round-trip as a direct array")
+			}
+		}
+		Expect(found).To(BeTrue(), "created prepared query not found in list")
+	})
+
+	It("rejects a legacy protojson-shaped filter (no silent acceptance)", func() {
+		// The old wire shape (`and.filters[]`, `field.field.metadata`) must now
+		// be rejected rather than silently parsed — it is not the documented
+		// contract.
+		body := `{
+			"name": "legacy",
+			"target": "TRANSACTIONS",
+			"filter": {"and": {"filters": [{"field": {"field": {"metadata": "x"}, "existsCond": {}}}]}}
+		}`
+
+		req, err := http.NewRequestWithContext(sharedCtx, http.MethodPost, restURL("/prepared-queries"), bytes.NewBufferString(body))
+		Expect(err).To(Succeed())
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(Succeed())
+		defer func() { _ = resp.Body.Close() }()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+	})
+})


### PR DESCRIPTION
## Summary

Completes the **QueryFilter** half of [EN-1465](https://formance-team.atlassian.net/browse/EN-1465) (epic [EN-867](https://formance-team.atlassian.net/browse/EN-867)). The `postCommitVolumes` half already shipped in #1517 — this PR does not touch it.

**Problem.** The prepared-query REST path decoded `QueryFilter` via `protojson.Unmarshal`, and `PreparedQuery.MarshalJSON` routed the whole value through `protojson`. That leaked the protobuf-internal oneof/wrapper names onto the public wire — `and.filters[]`, `not.filter`, `field.field.metadata`, `stringCond`, `hardcodedExact`, `paramPrefix`, and the `QUERY_TARGET_*` enum prefix. The shape documented in `openapi.yml` **never existed on the wire**, and the spec only ever defined one leaf condition (`AccountHasAssetCondition`) — the other ~10 conditions were undocumented. SDKs generated from the spec were broken.

**Fix (no proto changes — JSON layer only).** A hand-written, bidirectional JSON codec on `commonpb.QueryFilter` (`internal/proto/commonpb/query_filter.go`), following the `Transaction`/`PostCommitVolumes` custom-marshaller pattern. `PreparedQuery.MarshalJSON` now uses it plus a string target enum; the HTTP decoder decodes through the same codec. `openapi.yml` documents the DSL.

## Canonical shape — the shared Formance query DSL

The REST `QueryFilter` shape **mirrors the shared Formance query DSL** (`go-libs/pkg/query`, as used by ledger v2). This is the canonical GA shape shared by every filtered endpoint (and reused by the audit conditions in #1548). Each node has exactly one top-level `$`-operator key:

| Concept | Shape |
|---|---|
| AND / OR | `{"$and": [ ... ]}` / `{"$or": [ ... ]}` (non-empty) |
| NOT | `{"$not": <QueryFilter>}` |
| metadata `==` | `{"$match": {"metadata[tier]": "gold"}}` |
| metadata range | `{"$gte": {"metadata[score]": 10}}` (closed range = `$and` of two bounds) |
| metadata exists | `{"$exists": {"metadata": "tier"}}` |
| address prefix/exact | `{"$match": {"address": "users:"}}` (`:` suffix = prefix) / `{"$match": {"address": "acc:1"}}` |
| source / destination | `{"$match": {"source": "banks:"}}` / `{"$match": {"destination": "acc:1"}}` |
| reference / ledger | `{"$match": {"reference": "ref-1"}}` / `{"$match": {"ledger": "main"}}` |
| reverted | `{"$match": {"reverted": true}}` |
| id/timestamp/insertedAt/revertedAt/logId/date | `{"$gt": {"timestamp": "1700000000"}}` (uint as decimal string, lossless above 2^53) |
| **account has asset** | `{"$exists": {"asset": "USD/2"}}` — reuses `$exists`, no new operator |
| **prepared-query param** | value = `{"$param": "name"}`, e.g. `{"$match": {"address": {"$param": "acc"}}}` |

Operators recognised by the codec: `$and $or $not $match $gt $gte $lt $lte $exists $in`, plus the `$param` value wrapper.

Notes:
- **camelCase throughout**; target enum emitted as a bare public string (`TRANSACTIONS`, not `QUERY_TARGET_TRANSACTIONS`).
- **Fails loudly** on: empty combinator, empty/multi-field operator body, unknown operator, unknown field, empty `$param`, and any unrecognised proto oneof arm (a new arm can't silently drop a filter). The old protojson shape is rejected, not silently parsed.
- **Log-only fields** (`logId`, `date`, `ledger`) are gated on the LOGS target — rejected at REST decode and in `compile.go` for non-log targets.
- Round-trip lossless.

## Design decisions

- **Aligned on v2, not a bespoke flat tagged-union.** An earlier revision of this PR used a `{"match":{"type":...}}` positional tagged-union; per product decision it was realigned to the v2 `$`-operator DSL so the shape is identical to what ledger v2 already exposes and to what every other filtered endpoint will use. This is the canonical GA representation tentatively scoped to [EN-1459](https://formance-team.atlassian.net/browse/EN-1459) (REST/gRPC parity, still in Backlog) — it is fixed here so EN-1465 can close its P0 spec≠wire bug. EN-1459's other filtered endpoints should reuse this codec.
- **`accountHasAsset` reuses `$exists`** (`{"$exists":{"asset":"USD/2"}}`) rather than introducing a new operator — no v2 equivalent existed, and `$exists` carries the intended semantics.
- **Params use a `{"$param":"name"}` value wrapper** so any leaf value can be substituted uniformly without a parallel schema.
- **No `$like` operator (dropped).** An earlier revision added `$like` as the JSON encoding for the two address-prefix arms that `$match` can't express — a *parameterised* prefix, and a *byte-level* prefix without a trailing `:`. It was our own addition (no v2 equivalent) and overlaps `$match` for the common trailing-`:` prefix case, so it is dropped for now and can be re-added later if a real need surfaces. The underlying proto arms (`AddressMatch_ParamPrefix`, byte-level `HardcodedPrefix`) are **kept** — they are still produced over the binary gRPC surface (`pkg/actions`, REST `prefix=` handlers, `filterexpr`, CLI) — but are **not producible via the JSON DSL**. The JSON marshaller **fails loudly** if asked to encode one (rather than silently emitting an exact-looking `$match` that would widen the query — invariant #7). Trailing-`:` prefixes still round-trip via `$match`.

## Impact analysis

**LOW.** The JSON codec is exercised only by the REST / `encoding/json` path:
- request: `decodePreparedQueryFilter` → 2 callers (`handlers_create_prepared_query.go`, `handlers_update_prepared_query.go`)
- response: `PreparedQuery.MarshalJSON` (list/get)

gRPC (binary proto), the `ledgerctl` CLI (uses the `filterexpr` DSL, not JSON), and the v2 compat layer are unaffected.

## Test plan

- [x] `internal/proto/commonpb/query_filter_test.go` — round-trip over every operator + nested condition, with leak assertions and error-path coverage (empty combinator, multi-field body, unknown op/field, empty `$param`, null coercion)
- [x] Updated `prepared_query_json_test.go`, `handlers_{create,update,list}_prepared_query_test.go`, `prepared_query_filter_test.go`, `compile_test.go` to the v2 DSL shape
- [x] `tests/e2e/business/prepared_query_rest_shape_test.go` — POST/GET over REST asserts the wire matches openapi and rejects the legacy protojson shape
- [x] `openapi.yml` parses; DSL documented
- [x] `GOROOT= go build ./...`, `golangci-lint run` (0 issues on changed packages), targeted `go test`

Ticket: EN-1465 (epic EN-867). Relates to EN-1459.

[EN-1465]: https://formance-team.atlassian.net/browse/EN-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-867]: https://formance-team.atlassian.net/browse/EN-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1459]: https://formance-team.atlassian.net/browse/EN-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

