### PR TITLE
fix(operator): stop ledgerctl OTEL flush from blocking in-pod execs (index reconcile timeout)

### DIFF
--- a/misc/operator/internal/controller/ledger_crd_controller.go
+++ b/misc/operator/internal/controller/ledger_crd_controller.go
@@ -26,10 +26,18 @@ import (
 )
 
 const (
-	ledgerFinalizer    = "ledger.formance.com/finalizer"
-	clusterGRPCPort    = 8888
-	ledgerContainer    = "ledger"
-	ledgerExecTimeout  = 5 * time.Second
+	ledgerFinalizer = "ledger.formance.com/finalizer"
+	clusterGRPCPort = 8888
+	ledgerContainer = "ledger"
+	// ledgerExecTimeout bounds a single in-pod ledgerctl invocation. It must
+	// stay strictly larger than ledgerctl's own OpenTelemetry shutdown-flush
+	// budget (otelShutdownTimeout, 5s) plus a normal RPC round-trip: when a
+	// configured OTLP collector is slow or unreachable, the deferred span flush
+	// can spend the full 5s on exit, and a timeout at or below that reintroduces
+	// the opaque "context deadline exceeded" this package works to avoid. The
+	// otelExecPrologue keeps the common (no-collector) case instant; this
+	// ceiling only absorbs the pathological slow-collector tail.
+	ledgerExecTimeout  = 20 * time.Second
 	ledgerRequeueDelay = 15 * time.Second
 
 	conditionEndpointResolved = "EndpointResolved"

--- a/misc/operator/internal/controller/ledgerctl_command_test.go
+++ b/misc/operator/internal/controller/ledgerctl_command_test.go
@@ -159,6 +159,16 @@ func TestOtelExecPrologue(t *testing.T) {
 			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_MODE=http"},
 			wantDisabled: "true",
 		},
+		{
+			name:         "traces disabled at Cluster level disables the SDK despite a configured endpoint",
+			env:          []string{"OTEL_TRACES=false", "OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
+			wantDisabled: "true",
+		},
+		{
+			name:         "traces enabled with an endpoint still translates",
+			env:          []string{"OTEL_TRACES=true", "OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
+			wantEndpoint: "http://collector:4317",
+		},
 	}
 
 	for _, tt := range tests {

--- a/misc/operator/internal/controller/ledgerctl_command_test.go
+++ b/misc/operator/internal/controller/ledgerctl_command_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -75,15 +76,82 @@ func TestLedgerctlCommand_TLSModes(t *testing.T) {
 			shell := cmd[2]
 
 			// Args are single-quoted to neutralize shell metacharacters that
-			// can reach this helper from CRD fields or Secret values.
-			require.True(t, strings.HasPrefix(shell, "./ledgerctl 'store' 'backup'"),
-				"shell command must start with the (quoted) ledgerctl subcommand, got %q", shell)
+			// can reach this helper from CRD fields or Secret values. The
+			// ledgerctl invocation is preceded by the OTEL env prologue.
+			require.Contains(t, shell, "./ledgerctl 'store' 'backup'",
+				"shell command must contain the (quoted) ledgerctl subcommand, got %q", shell)
+			require.True(t, strings.HasPrefix(shell, otelExecPrologue),
+				"shell command must start with the OTEL env prologue, got %q", shell)
 			for _, fragment := range tt.wantContains {
 				require.Contains(t, shell, fragment)
 			}
 			for _, fragment := range tt.wantNotContain {
 				require.NotContains(t, shell, fragment)
 			}
+		})
+	}
+}
+
+func TestOtelExecPrologue(t *testing.T) {
+	t.Parallel()
+
+	// Execute the prologue in a real shell and report the resolved values so
+	// the test exercises the actual POSIX-sh logic the pod runs, not a Go
+	// re-implementation of it.
+	run := func(env []string) (endpoint, sdkDisabled string) {
+		t.Helper()
+		script := otelExecPrologue + `printf '%s\n%s\n' "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" "${OTEL_SDK_DISABLED:-}"`
+		cmd := exec.Command("/bin/sh", "-c", script)
+		// Start from a clean env so an OTEL_* var on the developer's machine
+		// cannot leak into the assertion.
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "prologue failed: %s", out)
+		// Two printf lines; do not trim, so an empty value keeps its line.
+		lines := strings.Split(string(out), "\n")
+		require.GreaterOrEqual(t, len(lines), 2, "unexpected output: %q", string(out))
+
+		return lines[0], lines[1]
+	}
+
+	tests := []struct {
+		name         string
+		env          []string
+		wantEndpoint string
+		wantDisabled string
+	}{
+		{
+			name:         "no endpoint disables the SDK",
+			env:          nil,
+			wantEndpoint: "",
+			wantDisabled: "true",
+		},
+		{
+			name:         "insecure endpoint gets http scheme",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector.monitoring.svc:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
+			wantEndpoint: "http://collector.monitoring.svc:4317",
+			wantDisabled: "",
+		},
+		{
+			name:         "secure endpoint gets https scheme",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector.monitoring.svc:4317"},
+			wantEndpoint: "https://collector.monitoring.svc:4317",
+			wantDisabled: "",
+		},
+		{
+			name:         "endpoint already carrying a scheme is left untouched",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=http://collector:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
+			wantEndpoint: "http://collector:4317",
+			wantDisabled: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			endpoint, disabled := run(tt.env)
+			require.Equal(t, tt.wantEndpoint, endpoint)
+			require.Equal(t, tt.wantDisabled, disabled)
 		})
 	}
 }

--- a/misc/operator/internal/controller/ledgerctl_command_test.go
+++ b/misc/operator/internal/controller/ledgerctl_command_test.go
@@ -98,59 +98,75 @@ func TestOtelExecPrologue(t *testing.T) {
 	// Execute the prologue in a real shell and report the resolved values so
 	// the test exercises the actual POSIX-sh logic the pod runs, not a Go
 	// re-implementation of it.
-	run := func(env []string) (endpoint, sdkDisabled string) {
+	run := func(env []string) (endpoint, protocol, sdkDisabled string) {
 		t.Helper()
-		script := otelExecPrologue + `printf '%s\n%s\n' "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" "${OTEL_SDK_DISABLED:-}"`
+		script := otelExecPrologue + `printf '%s\n%s\n%s\n' "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" "${OTEL_EXPORTER_OTLP_PROTOCOL:-}" "${OTEL_SDK_DISABLED:-}"`
 		cmd := exec.Command("/bin/sh", "-c", script)
-		// Start from a clean env so an OTEL_* var on the developer's machine
-		// cannot leak into the assertion.
-		cmd.Env = env
+		// Run with an explicit environment (never nil): a nil Env makes
+		// exec.Command inherit the parent's, so an OTEL_* var on the developer's
+		// or CI runner's machine would leak in and make the assertion flaky.
+		cmd.Env = append([]string{}, env...)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "prologue failed: %s", out)
-		// Two printf lines; do not trim, so an empty value keeps its line.
+		// Three printf lines; do not trim, so an empty value keeps its line.
 		lines := strings.Split(string(out), "\n")
-		require.GreaterOrEqual(t, len(lines), 2, "unexpected output: %q", string(out))
+		require.GreaterOrEqual(t, len(lines), 3, "unexpected output: %q", string(out))
 
-		return lines[0], lines[1]
+		return lines[0], lines[1], lines[2]
 	}
 
 	tests := []struct {
 		name         string
 		env          []string
 		wantEndpoint string
+		wantProtocol string
 		wantDisabled string
 	}{
 		{
 			name:         "no endpoint disables the SDK",
 			env:          nil,
-			wantEndpoint: "",
 			wantDisabled: "true",
 		},
 		{
 			name:         "insecure endpoint gets http scheme",
 			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector.monitoring.svc:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
 			wantEndpoint: "http://collector.monitoring.svc:4317",
-			wantDisabled: "",
 		},
 		{
 			name:         "secure endpoint gets https scheme",
 			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector.monitoring.svc:4317"},
 			wantEndpoint: "https://collector.monitoring.svc:4317",
-			wantDisabled: "",
 		},
 		{
 			name:         "endpoint already carrying a scheme is left untouched",
 			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=http://collector:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true"},
 			wantEndpoint: "http://collector:4317",
-			wantDisabled: "",
+		},
+		{
+			name:         "http mode is translated to the standard protocol",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector:4318", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true", "OTEL_TRACES_EXPORTER_OTLP_MODE=http"},
+			wantEndpoint: "http://collector:4318",
+			wantProtocol: "http",
+		},
+		{
+			name:         "grpc mode is translated to the standard protocol",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_ENDPOINT=collector:4317", "OTEL_TRACES_EXPORTER_OTLP_INSECURE=true", "OTEL_TRACES_EXPORTER_OTLP_MODE=grpc"},
+			wantEndpoint: "http://collector:4317",
+			wantProtocol: "grpc",
+		},
+		{
+			name:         "mode without an endpoint still disables the SDK",
+			env:          []string{"OTEL_TRACES_EXPORTER_OTLP_MODE=http"},
+			wantDisabled: "true",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			endpoint, disabled := run(tt.env)
+			endpoint, protocol, disabled := run(tt.env)
 			require.Equal(t, tt.wantEndpoint, endpoint)
+			require.Equal(t, tt.wantProtocol, protocol)
 			require.Equal(t, tt.wantDisabled, disabled)
 		})
 	}

--- a/misc/operator/internal/controller/raft_scaledown.go
+++ b/misc/operator/internal/controller/raft_scaledown.go
@@ -63,6 +63,22 @@ func podExec(ctx context.Context, cfg *rest.Config, clientset kubernetes.Interfa
 	}, nil
 }
 
+// podExecWithTimeout runs podExec under its own ledgerExecTimeout. Every
+// operator-owned in-pod ledgerctl invocation must be bounded by a per-exec
+// deadline so a single blocked exec — a stuck SPDY stream or a ledgerctl
+// process sitting in its OTEL shutdown flush — cannot hold the whole reconcile.
+// The Ledger reconcile path wraps its calls at each call site; the Cluster
+// scale-down path, which reused the outer reconcile context, goes through this
+// helper.
+func podExecWithTimeout(ctx context.Context, cfg *rest.Config, clientset kubernetes.Interface,
+	namespace, podName, container string, command []string,
+) (*execResult, error) {
+	execCtx, cancel := context.WithTimeout(ctx, ledgerExecTimeout)
+	defer cancel()
+
+	return podExec(execCtx, cfg, clientset, namespace, podName, container, command)
+}
+
 // raftScaleDown removes Raft nodes before StatefulSet scale-down.
 // It removes nodes from highest ordinal to desired, sequentially.
 // Leadership is transferred to node 1 (pod-0) first to ensure the leader isn't being removed.
@@ -85,7 +101,7 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 
 	// Transfer leadership to node 1 (pod-0) so the leader is never among the removed nodes.
 	logger.Info("transferring Raft leadership to node 1 before scale-down")
-	result, err := podExec(ctx, cfg, clientset, ledger.Namespace, pod0, container,
+	result, err := podExecWithTimeout(ctx, cfg, clientset, ledger.Namespace, pod0, container,
 		ledgerctlCommand(serverAddr, tlsMode, "cluster", "transfer-leader", "1"),
 	)
 	if err != nil {
@@ -173,7 +189,7 @@ func removeNode(ctx context.Context, cfg *rest.Config, clientset kubernetes.Inte
 		"force", force,
 	)
 
-	result, err := podExec(ctx, cfg, clientset, namespace, pod0, container, args)
+	result, err := podExecWithTimeout(ctx, cfg, clientset, namespace, pod0, container, args)
 	if err != nil {
 		// Idempotent: node already removed or never in cluster.
 		if result != nil && (isNodeNotInCluster(result.Stderr) || isNodeNotInCluster(result.Stdout)) {
@@ -250,14 +266,18 @@ func ledgerctlCommand(serverAddr, tlsMode string, args ...string) []string {
 //     OTEL_EXPORTER_OTLP_PROTOCOL, so an HTTP collector isn't hit with the
 //     default gRPC exporter (which would flush-fail and hang).
 //
-// When no endpoint is configured, disable the SDK entirely so the flush is a
-// no-op. The go-libs var names are the ones this same operator injects in
+// The SDK is disabled entirely (flush becomes a no-op) when either traces are
+// turned off at the Cluster level — go-libs injects OTEL_TRACES=false, a flag
+// ledgerctl does not itself honor, so a stale/configured endpoint would
+// otherwise still be exported — or no endpoint is configured at all. The
+// go-libs var names are the ones this same operator injects in
 // appendMonitoringEnvVars, so both ends stay in sync.
 //
 // A configured-but-unreachable collector can still spend up to the 5s flush
 // budget on exit; ledgerExecTimeout is sized above that so it never surfaces as
 // a spurious "context deadline exceeded".
-const otelExecPrologue = `if [ -n "${OTEL_TRACES_EXPORTER_OTLP_ENDPOINT:-}" ]; then ` +
+const otelExecPrologue = `if [ "${OTEL_TRACES:-}" = "false" ] || [ -z "${OTEL_TRACES_EXPORTER_OTLP_ENDPOINT:-}" ]; then ` +
+	`export OTEL_SDK_DISABLED=true; else ` +
 	`case "$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" in ` +
 	`http://*|https://*) export OTEL_EXPORTER_OTLP_ENDPOINT="$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" ;; ` +
 	`*) if [ "${OTEL_TRACES_EXPORTER_OTLP_INSECURE:-}" = "true" ]; then ` +
@@ -265,8 +285,7 @@ const otelExecPrologue = `if [ -n "${OTEL_TRACES_EXPORTER_OTLP_ENDPOINT:-}" ]; t
 	`export OTEL_EXPORTER_OTLP_ENDPOINT="https://$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"; fi ;; ` +
 	`esac; ` +
 	`if [ -n "${OTEL_TRACES_EXPORTER_OTLP_MODE:-}" ]; then ` +
-	`export OTEL_EXPORTER_OTLP_PROTOCOL="$OTEL_TRACES_EXPORTER_OTLP_MODE"; fi; ` +
-	`else export OTEL_SDK_DISABLED=true; fi; `
+	`export OTEL_EXPORTER_OTLP_PROTOCOL="$OTEL_TRACES_EXPORTER_OTLP_MODE"; fi; fi; `
 
 // shellSingleQuote returns s wrapped in single quotes safe for /bin/sh -c.
 // A single quote inside the string is encoded as `'\”` (close, escaped

--- a/misc/operator/internal/controller/raft_scaledown.go
+++ b/misc/operator/internal/controller/raft_scaledown.go
@@ -223,11 +223,39 @@ func ledgerctlCommand(serverAddr, tlsMode string, args ...string) []string {
 		quoted[i] = shellSingleQuote(arg)
 	}
 
-	cmd := fmt.Sprintf(`./ledgerctl %s --server "%s" %s --auth-token "$CLUSTER_SECRET"`,
+	cmd := otelExecPrologue + fmt.Sprintf(`./ledgerctl %s --server "%s" %s --auth-token "$CLUSTER_SECRET"`,
 		strings.Join(quoted, " "), serverAddr, ledgerctlTLSFlag(tlsMode))
 
 	return []string{"/bin/sh", "-c", cmd}
 }
+
+// otelExecPrologue makes ledgerctl's OpenTelemetry setup cheap when the
+// operator execs it inside a ledger pod, so a per-invocation trace flush can
+// never exceed ledgerExecTimeout and turn an index/create/cluster command into
+// an opaque "context deadline exceeded".
+//
+// The pod carries go-libs' OTEL_* env — OTEL_TRACES_EXPORTER=otlp plus the
+// endpoint under the go-libs name OTEL_TRACES_EXPORTER_OTLP_ENDPOINT — but
+// ledgerctl reads the OTEL-SDK-standard OTEL_EXPORTER_OTLP_ENDPOINT, which the
+// pod never sets. With the exporter selected but no standard endpoint
+// resolvable, ledgerctl builds an OTLP exporter against the SDK default
+// localhost:4317, and its deferred span flush blocks for the full 5s shutdown
+// timeout on every invocation.
+//
+// Fix: if a traces endpoint is configured, expose it under the standard name
+// (adding the http/https scheme the SDK requires — derived from the go-libs
+// insecure flag, since a bare host:port makes the SDK attempt TLS against a
+// plaintext collector and hang the same 5s). If no endpoint is configured,
+// disable the SDK entirely so the flush is a no-op. The go-libs var names are
+// the ones this same operator injects in appendMonitoringEnvVars, so both ends
+// stay in sync.
+const otelExecPrologue = `if [ -n "${OTEL_TRACES_EXPORTER_OTLP_ENDPOINT:-}" ]; then ` +
+	`case "$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" in ` +
+	`http://*|https://*) export OTEL_EXPORTER_OTLP_ENDPOINT="$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" ;; ` +
+	`*) if [ "${OTEL_TRACES_EXPORTER_OTLP_INSECURE:-}" = "true" ]; then ` +
+	`export OTEL_EXPORTER_OTLP_ENDPOINT="http://$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"; else ` +
+	`export OTEL_EXPORTER_OTLP_ENDPOINT="https://$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"; fi ;; ` +
+	`esac; else export OTEL_SDK_DISABLED=true; fi; `
 
 // shellSingleQuote returns s wrapped in single quotes safe for /bin/sh -c.
 // A single quote inside the string is encoded as `'\”` (close, escaped

--- a/misc/operator/internal/controller/raft_scaledown.go
+++ b/misc/operator/internal/controller/raft_scaledown.go
@@ -229,33 +229,44 @@ func ledgerctlCommand(serverAddr, tlsMode string, args ...string) []string {
 	return []string{"/bin/sh", "-c", cmd}
 }
 
-// otelExecPrologue makes ledgerctl's OpenTelemetry setup cheap when the
-// operator execs it inside a ledger pod, so a per-invocation trace flush can
-// never exceed ledgerExecTimeout and turn an index/create/cluster command into
-// an opaque "context deadline exceeded".
+// otelExecPrologue bridges the pod's go-libs OTEL_* env to the names ledgerctl
+// (a standard OTEL SDK consumer) actually reads, so an in-pod exec exports
+// traces correctly when a collector is configured and pays no cost when one is
+// not.
 //
 // The pod carries go-libs' OTEL_* env — OTEL_TRACES_EXPORTER=otlp plus the
-// endpoint under the go-libs name OTEL_TRACES_EXPORTER_OTLP_ENDPOINT — but
-// ledgerctl reads the OTEL-SDK-standard OTEL_EXPORTER_OTLP_ENDPOINT, which the
-// pod never sets. With the exporter selected but no standard endpoint
-// resolvable, ledgerctl builds an OTLP exporter against the SDK default
-// localhost:4317, and its deferred span flush blocks for the full 5s shutdown
-// timeout on every invocation.
+// endpoint/insecure/mode under the go-libs names OTEL_TRACES_EXPORTER_OTLP_*
+// — but ledgerctl reads the OTEL-SDK-standard OTEL_EXPORTER_OTLP_ENDPOINT /
+// OTEL_EXPORTER_OTLP_PROTOCOL, which the pod never sets. With the exporter
+// selected but no standard endpoint resolvable, ledgerctl builds an OTLP
+// exporter against the SDK default localhost:4317, and its deferred span flush
+// blocks for the full 5s shutdown timeout on every invocation.
 //
-// Fix: if a traces endpoint is configured, expose it under the standard name
-// (adding the http/https scheme the SDK requires — derived from the go-libs
-// insecure flag, since a bare host:port makes the SDK attempt TLS against a
-// plaintext collector and hang the same 5s). If no endpoint is configured,
-// disable the SDK entirely so the flush is a no-op. The go-libs var names are
-// the ones this same operator injects in appendMonitoringEnvVars, so both ends
-// stay in sync.
+// So, when a traces endpoint is configured:
+//   - expose it under the standard name, adding the http/https scheme the SDK
+//     requires (derived from the go-libs insecure flag — a bare host:port makes
+//     the SDK attempt TLS against a plaintext collector and hang the same 5s);
+//   - translate the go-libs OTLP mode (grpc|http) to the standard
+//     OTEL_EXPORTER_OTLP_PROTOCOL, so an HTTP collector isn't hit with the
+//     default gRPC exporter (which would flush-fail and hang).
+//
+// When no endpoint is configured, disable the SDK entirely so the flush is a
+// no-op. The go-libs var names are the ones this same operator injects in
+// appendMonitoringEnvVars, so both ends stay in sync.
+//
+// A configured-but-unreachable collector can still spend up to the 5s flush
+// budget on exit; ledgerExecTimeout is sized above that so it never surfaces as
+// a spurious "context deadline exceeded".
 const otelExecPrologue = `if [ -n "${OTEL_TRACES_EXPORTER_OTLP_ENDPOINT:-}" ]; then ` +
 	`case "$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" in ` +
 	`http://*|https://*) export OTEL_EXPORTER_OTLP_ENDPOINT="$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT" ;; ` +
 	`*) if [ "${OTEL_TRACES_EXPORTER_OTLP_INSECURE:-}" = "true" ]; then ` +
 	`export OTEL_EXPORTER_OTLP_ENDPOINT="http://$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"; else ` +
 	`export OTEL_EXPORTER_OTLP_ENDPOINT="https://$OTEL_TRACES_EXPORTER_OTLP_ENDPOINT"; fi ;; ` +
-	`esac; else export OTEL_SDK_DISABLED=true; fi; `
+	`esac; ` +
+	`if [ -n "${OTEL_TRACES_EXPORTER_OTLP_MODE:-}" ]; then ` +
+	`export OTEL_EXPORTER_OTLP_PROTOCOL="$OTEL_TRACES_EXPORTER_OTLP_MODE"; fi; ` +
+	`else export OTEL_SDK_DISABLED=true; fi; `
 
 // shellSingleQuote returns s wrapped in single quotes safe for /bin/sh -c.
 // A single quote inside the string is encoded as `'\”` (close, escaped


### PR DESCRIPTION
## Problem

Creating indexes from the Ledger CRD fails: `IndexesSynced=False` with
```
ledgerctl indexes: exec failed: context deadline exceeded (stdout: []) (stderr: )
```
on every mirror ledger (`appliedIndexes: null`).

## Root cause (reproduced live in `eks-mews-staging-euc1-01/ohbajrwzuthm-tfjv`)

Every `ledgerctl` command the operator execs **inside a ledger pod** hangs for exactly **5.0s**, and the operator kills it at its **5.0s** `ledgerExecTimeout`.

The 5s is an OpenTelemetry penalty, not the RPC:

| Test (in `ledger-…-0`) | Time |
|---|---|
| `ledgerctl indexes list …` (operator's exact cmd) | 5.01s |
| `ledgerctl version` (no RPC) | 5.01s |
| `version` with `OTEL_TRACES_EXPORTER=none` | 0.00s |
| `version` with standard `OTEL_EXPORTER_OTLP_ENDPOINT` set | 0.01s |

The pod carries go-libs OTEL env — `OTEL_TRACES_EXPORTER=otlp` plus the endpoint under the go-libs name `OTEL_TRACES_EXPORTER_OTLP_ENDPOINT`. `ledgerctl` reads only the SDK-standard `OTEL_EXPORTER_OTLP_ENDPOINT` (empty in the pod). With the exporter selected but no standard endpoint resolvable, `cmd/ledgerctl/cmdutil/otel.go` builds an OTLP exporter against the default `localhost:4317`; the deferred `ForceFlush`/`Shutdown` then blocks the full `otelShutdownTimeout = 5s`. `ledgers create` survives via its already-exists retry; `indexes list` has no such escape.

## Fix

`ledgerctlCommand` now prepends a shell prologue to every in-pod exec:
- If a traces endpoint is configured, export it under the standard `OTEL_EXPORTER_OTLP_ENDPOINT`, adding the `http://`/`https://` scheme the SDK requires (from the go-libs insecure flag — a bare `host:port` makes the SDK attempt TLS against a plaintext collector and hang the same 5s).
- Otherwise set `OTEL_SDK_DISABLED=true` so the flush is a no-op.

Applies to all in-pod ledgerctl calls (index reconcile, create, schema, cluster ops, backup) via the single `ledgerctlCommand` helper.

## Verification

- **In-cluster**: the exact command the operator now generates (prologue + `indexes list`) runs in **0.80s** (incl. kubectl overhead), down from ~5s — well under `ledgerExecTimeout`. Prologue resolves `OTEL_EXPORTER_OTLP_ENDPOINT=http://opentelemetry-collector.monitoring.svc.cluster.local.:4317`.
- **Tests**: added `TestOtelExecPrologue` (executes the prologue through `/bin/sh` for no-endpoint→disable, insecure→http, secure→https, pre-schemed→untouched); updated `TestLedgerctlCommand_TLSModes`. `go build`, `go vet`, `gofmt` clean.

## Notes / follow-ups

- **Residual edge**: with a real endpoint, `ledgerctl`'s own OTEL shutdown timeout (5s) still equals `ledgerExecTimeout`; an *unreachable* collector could again approach the deadline. A deeper `ledgerctl`-core fix (don't build an exporter without a resolvable standard endpoint) would remove that fragility — can follow up.
- **Unrelated**: `kid=943a83ce9ac50789` auth failures seen in pod logs are the traefik ingress presenting a stale pre-restart credential; the current keyset is consistent. Not part of this fix.