### PR TITLE
fix(EN-1502): gate filtered audit reads on audit-index progress

### DIFF
--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -569,6 +569,55 @@ func (impl *BucketServiceServerImpl) waitMinLogSequence(ctx context.Context, min
 	return impl.readStore.WaitForSequence(ctx, minLogSequence)
 }
 
+// waitFilteredAuditConsistency gives a live, filtered ListAuditEntries read a
+// read-your-writes guarantee against the async audit secondary index.
+//
+// min_log_sequence is a LOG sequence, but a filtered audit read resolves through
+// the audit index whose cursor (ReadAuditProgress) is an AUDIT sequence. The two
+// spaces diverge — the audit sequence advances on every proposal, including
+// failures that emit no log — so waiting for audit_progress >= min_log_sequence
+// would be incorrect. Instead, conservatively:
+//
+//  1. wait for the log index to reach min_log_sequence (waitMinLogSequence);
+//  2. read the current live audit head from the main store;
+//  3. wait for the audit index cursor to reach that observed head.
+//
+// This can over-wait (the head observed in step 2 may include audit entries
+// produced after min_log_sequence), which is acceptable for v3.0 and avoids a
+// new min_audit_sequence API. A minLogSeq of 0 means "no consistency bound
+// requested", so this is a no-op.
+//
+// Only the LIVE filtered path calls this. Unfiltered reads scan the Cold/Audit
+// zone directly and are always current, so they keep the direct fast path.
+// Checkpoint reads are frozen snapshots and are handled (and documented) at the
+// checkpoint-creation boundary, out of scope here.
+func (impl *BucketServiceServerImpl) waitFilteredAuditConsistency(ctx context.Context, minLogSeq uint64) error {
+	if minLogSeq == 0 {
+		return nil
+	}
+
+	if err := impl.waitMinLogSequence(ctx, minLogSeq); err != nil {
+		return err
+	}
+
+	handle, err := impl.store.NewDirectReadHandle()
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "opening read handle for audit head: %v", err)
+	}
+
+	auditHead, err := query.ReadLastAuditSequence(handle)
+	// Close before waiting: the handle holds dbMu.RLock for its lifetime, and the
+	// wait below can block for a while. We only need the head value, not the
+	// handle, past this point.
+	_ = handle.Close()
+
+	if err != nil {
+		return status.Errorf(codes.Internal, "reading live audit head: %v", err)
+	}
+
+	return impl.readStore.WaitForAuditSequence(ctx, auditHead)
+}
+
 func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransactionsRequest, stream servicepb.BucketService_ListTransactionsServer) error {
 	ctx, span := bucketTracer.Start(stream.Context(), "grpc.ListTransactions",
 		trace.WithAttributes(attribute.String("ledger", req.GetLedger())))
@@ -1241,7 +1290,19 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 		// log-index WaitForSequence); it is out of scope here.
 		c, err = impl.localCtrl.ListAuditEntriesFrom(ctx, mainStore, readIdx, fetchSize, afterSeq, opts.GetFilter(), opts.GetReverse())
 	} else {
-		if waitErr := impl.waitMinLogSequence(ctx, opts.GetRead().GetMinLogSequence()); waitErr != nil {
+		minLogSeq := opts.GetRead().GetMinLogSequence()
+
+		// A filtered live read resolves through the async audit secondary index,
+		// which lags the audit zone independently of the log index. Gate it on the
+		// audit-index progress so the requested consistency bound actually covers
+		// the index this read consults. An unfiltered read scans the Cold/Audit
+		// zone directly and is always current, so it keeps the plain log-index wait
+		// (its fast path is unchanged).
+		if opts.GetFilter() != nil {
+			if waitErr := impl.waitFilteredAuditConsistency(ctx, minLogSeq); waitErr != nil {
+				return waitErr
+			}
+		} else if waitErr := impl.waitMinLogSequence(ctx, minLogSeq); waitErr != nil {
 			return waitErr
 		}
 

--- a/internal/adapter/grpc/server_bucket_audit_consistency_test.go
+++ b/internal/adapter/grpc/server_bucket_audit_consistency_test.go
@@ -1,0 +1,300 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/application/ctrl/ctrlmock"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// auditStream is a minimal streaming server whose Context is caller-controlled,
+// so a test can cancel the request while a handler blocks in a wait. The
+// fakeServerStream helper hardcodes context.Background(), which cannot be
+// cancelled; the audit-consistency waits need a cancellable one.
+func newAuditStream(t *testing.T, ctx context.Context) *fakeAuditStream {
+	t.Helper()
+
+	f := &fakeAuditStream{
+		MockServerStreamingServer: NewMockServerStreamingServer[auditpb.AuditEntry](gomock.NewController(t)),
+	}
+	f.MockServerStreamingServer.EXPECT().Context().Return(ctx).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().SetTrailer(gomock.Any()).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().SetHeader(gomock.Any()).Return(nil).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().SendHeader(gomock.Any()).Return(nil).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().SendMsg(gomock.Any()).Return(nil).AnyTimes()
+	f.MockServerStreamingServer.EXPECT().RecvMsg(gomock.Any()).Return(nil).AnyTimes()
+
+	return f
+}
+
+type fakeAuditStream struct {
+	*MockServerStreamingServer[auditpb.AuditEntry]
+}
+
+// writeMainAuditEntry writes an audit entry into the main store's Cold/Audit
+// zone so ReadLastAuditSequence observes it as the live audit head.
+func writeMainAuditEntry(t *testing.T, store *dal.Store, seq uint64) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	kb := dal.NewKeyBuilder()
+	val, err := proto.Marshal(&auditpb.AuditEntry{
+		Sequence: seq,
+		Outcome:  &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, batch.SetBytes(
+		kb.PutZonePrefix(dal.ZoneCold, dal.SubColdAudit).PutUint64(seq).Build(),
+		val,
+	))
+	require.NoError(t, batch.Commit())
+}
+
+// writeReadstoreLogProgress advances the log-index cursor so waitMinLogSequence
+// is satisfied.
+func writeReadstoreLogProgress(t *testing.T, rs *readstore.Store, seq uint64) {
+	t.Helper()
+
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteProgress(batch, seq))
+	require.NoError(t, batch.Commit())
+}
+
+// writeReadstoreAuditProgress advances the audit-index cursor.
+func writeReadstoreAuditProgress(t *testing.T, rs *readstore.Store, seq uint64) {
+	t.Helper()
+
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteAuditProgress(batch, seq))
+	require.NoError(t, batch.Commit())
+}
+
+func newAuditConsistencyHarness(t *testing.T) (*BucketServiceServerImpl, *ctrlmock.MockController, *dal.Store, *readstore.Store) {
+	t.Helper()
+
+	logger := logging.FromContext(logging.TestingContext())
+	meter := noop.NewMeterProvider().Meter("test")
+
+	mainStore, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mainStore.Close() })
+
+	rs, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rs.Close() })
+
+	mockCtrl := ctrlmock.NewMockController(gomock.NewController(t))
+
+	impl := &BucketServiceServerImpl{
+		logger:    noopLogger{},
+		ctrl:      mockCtrl,
+		store:     mainStore,
+		readStore: rs,
+		authCfg:   internalauth.AuthConfig{}, // disabled → Authenticate is a no-op
+	}
+
+	return impl, mockCtrl, mainStore, rs
+}
+
+// singleFieldFilter builds a minimal non-nil QueryFilter so the handler takes
+// the filtered branch. Its content is irrelevant here: the controller is mocked,
+// so the filter is never actually compiled — only its presence matters.
+func singleFieldFilter() *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{}},
+	}
+}
+
+// TestListAuditEntriesFilteredWaitsForAuditProgress verifies a live, filtered
+// ListAuditEntries with min_log_sequence>0 blocks until the audit index catches
+// up to the live audit head, even when the log index is already caught up.
+func TestListAuditEntriesFilteredWaitsForAuditProgress(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+
+	// Log index already caught up to the requested bound.
+	writeReadstoreLogProgress(t, rs, 5)
+	// Live audit head is at seq 9 (audit space diverges from log space).
+	writeMainAuditEntry(t, mainStore, 9)
+	// Audit index lags: cursor at 3.
+	writeReadstoreAuditProgress(t, rs, 3)
+
+	// The controller must only be called AFTER the audit index catches up.
+	controllerCalled := make(chan struct{})
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+			close(controllerCalled)
+
+			return cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	handlerErr := make(chan error, 1)
+	go func() {
+		stream := newAuditStream(t, ctx)
+		req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+			PageSize: 2,
+			Filter:   singleFieldFilter(),
+			Read:     &commonpb.ReadOptions{MinLogSequence: 5},
+		}}
+		handlerErr <- impl.ListAuditEntries(req, stream)
+	}()
+
+	// The handler must be blocked on WaitForAuditSequence (audit cursor 3 < head 9).
+	select {
+	case <-controllerCalled:
+		t.Fatal("controller called before audit index caught up to the live audit head")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Advance the audit index to the live head and wake waiters, as the indexer
+	// would after committing a batch.
+	writeReadstoreAuditProgress(t, rs, 9)
+	rs.NotifyProgress()
+
+	select {
+	case <-controllerCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("controller not called after audit index caught up")
+	}
+
+	select {
+	case err := <-handlerErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after controller call")
+	}
+}
+
+// TestListAuditEntriesFilteredDoesNotWaitOnLogSequenceInAuditSpace is the
+// regression for the sequence-space mismatch: the audit head (2) sits BELOW
+// min_log_sequence (10) because an intervening failed proposal advanced the log
+// space without producing an audit entry above 2. A naive implementation that
+// waited for audit_progress >= min_log_sequence would block forever (the audit
+// index can never exceed the audit head of 2). The correct implementation waits
+// only for audit_progress >= live audit head, so it must proceed.
+func TestListAuditEntriesFilteredDoesNotWaitOnLogSequenceInAuditSpace(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+
+	writeReadstoreLogProgress(t, rs, 10)
+	// Live audit head is only 2 — far below min_log_sequence.
+	writeMainAuditEntry(t, mainStore, 2)
+	// Audit index already at the head.
+	writeReadstoreAuditProgress(t, rs, 2)
+
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		Return(cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream := newAuditStream(t, ctx)
+	req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+		PageSize: 2,
+		Filter:   singleFieldFilter(),
+		Read:     &commonpb.ReadOptions{MinLogSequence: 10},
+	}}
+
+	// Must return promptly: audit_progress(2) >= audit head(2), regardless of
+	// min_log_sequence(10). A wait on audit_progress >= 10 would hit the ctx
+	// deadline instead.
+	require.NoError(t, impl.ListAuditEntries(req, stream))
+}
+
+// TestListAuditEntriesUnfilteredDoesNotWaitOnAuditProgress verifies an
+// unfiltered live read gates only on the log index and never blocks on audit
+// progress: the audit index lags (cursor 0, head 9) but the read still returns.
+func TestListAuditEntriesUnfilteredDoesNotWaitOnAuditProgress(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+
+	writeReadstoreLogProgress(t, rs, 5)
+	writeMainAuditEntry(t, mainStore, 9)
+	// Audit index deliberately left at 0 — an unfiltered read must not care.
+
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any()).
+		Return(cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream := newAuditStream(t, ctx)
+	req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+		PageSize: 2,
+		// no Filter → unfiltered fast path
+		Read: &commonpb.ReadOptions{MinLogSequence: 5},
+	}}
+
+	require.NoError(t, impl.ListAuditEntries(req, stream))
+}
+
+// TestListAuditEntriesFilteredContextCancelWhileWaiting verifies a filtered read
+// blocked on audit progress returns promptly with a context error when the
+// request context is cancelled, rather than hanging.
+func TestListAuditEntriesFilteredContextCancelWhileWaiting(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+
+	writeReadstoreLogProgress(t, rs, 5)
+	writeMainAuditEntry(t, mainStore, 100)
+	writeReadstoreAuditProgress(t, rs, 1) // will never catch up in this test
+
+	// Controller must never be reached.
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	handlerErr := make(chan error, 1)
+	go func() {
+		stream := newAuditStream(t, ctx)
+		req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+			PageSize: 2,
+			Filter:   singleFieldFilter(),
+			Read:     &commonpb.ReadOptions{MinLogSequence: 5},
+		}}
+		handlerErr <- impl.ListAuditEntries(req, stream)
+	}()
+
+	select {
+	case err := <-handlerErr:
+		t.Fatalf("handler returned before cancel: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-handlerErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after context cancel")
+	}
+}

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -247,6 +247,11 @@ func (i *Indexer) processBatch(ctx context.Context, after uint64) (uint64, bool,
 
 	i.lastIndexed.Store(cursor)
 
+	// Wake any live filtered-audit reader blocked in WaitForAuditSequence so it
+	// picks up the just-committed cursor immediately, instead of waiting for an
+	// unrelated log-index NotifyProgress or the next tick.
+	i.readStore.NotifyProgress()
+
 	return cursor, true, nil
 }
 

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -204,6 +204,52 @@ func TestIndexerCatchUpAndResume(t *testing.T) {
 	require.Equal(t, []uint64{1, 2}, seqs)
 }
 
+// TestProcessOnceWakesAuditWaiters verifies the indexer wakes readers blocked in
+// WaitForAuditSequence as soon as it commits the audit cursor, rather than
+// leaving them parked until an unrelated log-index notification or the next tick.
+// This is the wakeup the filtered-audit read-your-writes gate depends on.
+func TestProcessOnceWakesAuditWaiters(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	idx, mainStore, rs := newIndexerForTest(t)
+
+	// A waiter for an audit entry that does not exist yet must block.
+	waitErr := make(chan error, 1)
+	go func() {
+		wctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		waitErr <- rs.WaitForAuditSequence(wctx, 1)
+	}()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForAuditSequence returned before the entry was indexed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Write the audit entry and index it. processBatch commits the cursor then
+	// calls NotifyProgress, which must wake the waiter.
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence:   1,
+		ProposalId: 7,
+		Timestamp:  &commonpb.Timestamp{Data: 1_000_000},
+		Outcome:    &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers:    []string{"main"},
+	})
+
+	processed, err := idx.ProcessOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), processed)
+
+	select {
+	case err := <-waitErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForAuditSequence did not wake after ProcessOnce committed the cursor")
+	}
+}
+
 func TestStartStopIndexes(t *testing.T) {
 	t.Parallel()
 	idx, mainStore, rs := newIndexerForTest(t)

--- a/internal/storage/readstore/audit_index.go
+++ b/internal/storage/readstore/audit_index.go
@@ -1,6 +1,7 @@
 package readstore
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"slices"
@@ -13,6 +14,69 @@ import (
 // ReadAuditProgress returns the last indexed audit sequence (0 if unset).
 func (s *Store) ReadAuditProgress() (uint64, error) {
 	return auditCursor.Read(s.db)
+}
+
+// LastIndexedAuditSequence returns the last indexed audit sequence (read-only).
+// It is the audit-index counterpart of LastIndexedSequence: the log index and
+// the audit index advance independently, so a filtered audit read must gate on
+// this cursor, not on the log-index cursor.
+func (s *Store) LastIndexedAuditSequence() (uint64, error) {
+	return s.ReadAuditProgress()
+}
+
+// WaitForAuditSequence blocks until LastIndexedAuditSequence >= minSeq or the
+// context is cancelled. It shares the progressMu/progressCond mechanism with
+// WaitForSequence / WaitForCheckpoint: the audit indexer calls NotifyProgress
+// after committing each audit-index batch, waking waiters to re-check the
+// cursor.
+//
+// The cancellation broadcast is issued while holding progressMu (mirroring
+// WaitForCheckpoint): the wait loop holds progressMu across both the ctx.Err()
+// check and cond.Wait(), and Wait atomically releases the lock only once parked,
+// so a cancellation broadcast can never slip between the check and the park.
+func (s *Store) WaitForAuditSequence(ctx context.Context, minSeq uint64) error {
+	// Fast path: already caught up.
+	cur, err := s.LastIndexedAuditSequence()
+	if err != nil {
+		return fmt.Errorf("reading audit index progress: %w", err)
+	}
+
+	if cur >= minSeq {
+		return nil
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.progressMu.Lock()
+			s.progressCond.Broadcast()
+			s.progressMu.Unlock()
+		case <-done:
+		}
+	}()
+
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		cur, err = s.LastIndexedAuditSequence()
+		if err != nil {
+			return fmt.Errorf("reading audit index progress: %w", err)
+		}
+
+		if cur >= minSeq {
+			return nil
+		}
+
+		s.progressCond.Wait()
+	}
 }
 
 // WriteAuditProgress persists the audit indexing cursor in the batch.

--- a/internal/storage/readstore/wait_audit_test.go
+++ b/internal/storage/readstore/wait_audit_test.go
@@ -1,0 +1,148 @@
+package readstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeAuditProgress commits the audit cursor to seq through a batch.
+func writeAuditProgress(t *testing.T, s *Store, seq uint64) {
+	t.Helper()
+	batch := s.NewBatch()
+	require.NoError(t, s.WriteAuditProgress(batch, seq))
+	require.NoError(t, batch.Commit())
+}
+
+// TestWaitForAuditSequenceFastPath returns immediately when the audit cursor is
+// already at or beyond the requested sequence.
+func TestWaitForAuditSequenceFastPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		progress uint64
+		minSeq   uint64
+	}{
+		{name: "equal", progress: 5, minSeq: 5},
+		{name: "ahead", progress: 10, minSeq: 5},
+		{name: "zero bound with zero progress", progress: 0, minSeq: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := newTestStore(t)
+			if tc.progress > 0 {
+				writeAuditProgress(t, s, tc.progress)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			require.NoError(t, s.WaitForAuditSequence(ctx, tc.minSeq))
+		})
+	}
+}
+
+// TestWaitForAuditSequenceBlocksUntilProgress verifies a waiter blocks while the
+// audit cursor lags and unblocks once the cursor reaches the target and
+// NotifyProgress fires — the wakeup path the audit indexer drives.
+func TestWaitForAuditSequenceBlocksUntilProgress(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	waitErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		waitErr <- s.WaitForAuditSequence(ctx, 7)
+	}()
+
+	// The waiter must not return yet — the cursor is still 0.
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForAuditSequence returned before progress: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A commit below the target must not unblock the waiter.
+	writeAuditProgress(t, s, 3)
+	s.NotifyProgress()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForAuditSequence returned before reaching target: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Reaching the target unblocks the waiter, exactly as processBatch does
+	// (WriteAuditProgress commit followed by NotifyProgress).
+	writeAuditProgress(t, s, 7)
+	s.NotifyProgress()
+
+	select {
+	case err := <-waitErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForAuditSequence did not return after progress reached target")
+	}
+}
+
+// TestWaitForAuditSequenceContextCancel unblocks promptly on context
+// cancellation and returns the context error. Exercises the missed-wakeup fix:
+// the cancellation broadcast is delivered while holding progressMu.
+func TestWaitForAuditSequenceContextCancel(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- s.WaitForAuditSequence(ctx, 100)
+	}()
+
+	select {
+	case err := <-waitErr:
+		t.Fatalf("WaitForAuditSequence returned before cancel: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case err := <-waitErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForAuditSequence did not return after context cancel")
+	}
+}
+
+// TestLastIndexedAuditSequence reflects the committed audit cursor and is
+// distinct from LastIndexedSequence (the log cursor).
+func TestLastIndexedAuditSequence(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	got, err := s.LastIndexedAuditSequence()
+	require.NoError(t, err)
+	require.Zero(t, got)
+
+	writeAuditProgress(t, s, 42)
+
+	got, err = s.LastIndexedAuditSequence()
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), got)
+
+	// The log-index cursor is independent and must remain untouched.
+	logSeq, err := s.LastIndexedSequence()
+	require.NoError(t, err)
+	require.Zero(t, logSeq)
+}


### PR DESCRIPTION
## What & why

Fixes [EN-1502](https://formance-team.atlassian.net/browse/EN-1502) (follow-up to the EN-1241 audit-list contract, PR #1548).

`ListAuditEntries` filtered live reads resolve through the **audit** secondary index (`internal/application/auditindexer`, cursor `ReadAuditProgress`), but `options.read.min_log_sequence` only waited on the **log** index (`readStore.WaitForSequence` / `LastIndexedSequence`). A filtered audit read issued right after a write could therefore miss the just-written entry until the async audit indexer caught up — with no knob to force consistency, diverging from `ListTransactions` / `ListAccounts` where `min_log_sequence` gates the very index those reads consult.

## Approach (conservative, no proto/API change)

`min_log_sequence` is a **log** sequence; `ReadAuditProgress` is an **audit** sequence. They diverge (audit advances on every proposal, including failures that emit no log), so comparing `audit_progress >= min_log_sequence` is **not** a correct read-your-writes guarantee. Instead, for a live *filtered* read:

1. wait for the log index to reach `min_log_sequence` (existing `waitMinLogSequence`);
2. read the current live audit head from the main store (`query.ReadLastAuditSequence` on a direct read handle);
3. wait for the audit-index cursor to reach that observed head (`WaitForAuditSequence`);
4. only then compile + read the audit filter.

This can slightly over-wait, which is acceptable for v3.0 and avoids inventing a `min_audit_sequence` API.

## Changes

- **`internal/storage/readstore`**: `LastIndexedAuditSequence()` + `WaitForAuditSequence(ctx, minSeq)`, reusing the same `progressMu`/`progressCond` mechanism, with the correct `WaitForCheckpoint`-style missed-wakeup / cancellation locking (cancellation broadcast holds `progressMu`).
- **`internal/application/auditindexer`**: call `readStore.NotifyProgress()` after each committed audit-index batch so audit waiters wake immediately (lifecycle path, not FSM/hot path).
- **`internal/adapter/grpc` (`BucketServiceServerImpl`)**: `waitFilteredAuditConsistency`; wired into the live `ListAuditEntries` branch for `opts.GetFilter() != nil`. Unfiltered reads keep the direct Cold/Audit fast path unchanged. Errors from the audit-head read / waits bubble as gRPC codes (Unavailable/Internal) or the context error — never swallowed (CLAUDE.md invariant #7).

**Out of scope (documented):** checkpoint-scoped filtered audit reads (frozen snapshots) belong at the checkpoint-creation boundary — the existing caveat comment in `ListAuditEntries` points there.

## Guardrails

- No proto/API change (keeps `min_log_sequence` semantics).
- No FSM changes; no new Pebble reads on the hot path.
- No mockgen interface changed (methods added on concrete `*readstore.Store` / `*auditindexer.Indexer`).

## Tests

- `readstore.WaitForAuditSequence`: fast path (equal/ahead/zero), block-until-progress + wakeup after `NotifyProgress`, context cancellation returns promptly; `LastIndexedAuditSequence` independent of the log cursor.
- `auditindexer`: `ProcessOnce` wakes audit waiters after committing the cursor.
- gRPC: live filtered read waits until audit progress catches up to the live head; **regression** — audit head below `min_log_sequence` (intervening failed proposal, no log) does NOT block; unfiltered read does not wait on audit progress; context cancel while waiting returns promptly.

Table/parallel tests, `require.Eventually`-style channel waits (no `time.Sleep`), no hand-rolled mocks. Race detector clean.

## Stacking

Stacked on #1548 (`feat/en-1241-audit-list-contract`) since it depends on that PR's audit-list code. Will auto-retarget to `release/v3.0` when #1548 merges.

[EN-1502]: https://formance-team.atlassian.net/browse/EN-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ