### PR TITLE
fix(EN-1521): make FSM map-dependent outcomes deterministic

### DIFF
--- a/internal/domain/accounttype/validate.go
+++ b/internal/domain/accounttype/validate.go
@@ -2,7 +2,9 @@ package accounttype
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
+	"slices"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -26,7 +28,14 @@ func ValidateSegmentTypes(segments []PatternSegment, segTypes map[string]*common
 		}
 	}
 
-	for name, st := range segTypes {
+	// Iterate names in sorted order so the first validation error reported is
+	// identical on every replica: this runs on the FSM apply path (via
+	// processAddAccountType / processCreateLedger) and its error is chain-bound
+	// through ErrInvalidPattern → AuditFailure, so a raw map range could select
+	// a different offending segment per node (invariant #2). See EN-1521. The
+	// matcher assignments below are per-index and order-independent.
+	for _, name := range slices.Sorted(maps.Keys(segTypes)) {
+		st := segTypes[name]
 		idx, ok := vars[name]
 		if !ok {
 			return fmt.Errorf("segment_types references unknown variable %q", name)

--- a/internal/domain/accounttype/validate_test.go
+++ b/internal/domain/accounttype/validate_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
+// TestValidateSegmentTypes_UnknownVariableSelectionDeterministic pins EN-1521:
+// when several segment_types reference unknown variables, the reported error
+// must always name the lexicographically-first one. ValidateSegmentTypes runs
+// on the FSM apply path and its error is chain-bound (ErrInvalidPattern →
+// AuditFailure), so a raw map range could pick a different offending name per
+// replica (invariant #2).
+func TestValidateSegmentTypes_UnknownVariableSelectionDeterministic(t *testing.T) {
+	t.Parallel()
+
+	segments, err := ParsePattern("foo:{x}")
+	require.NoError(t, err)
+
+	// Neither "aaa" nor "zzz" is a variable in the pattern ({x}), so both are
+	// "unknown"; "aaa" sorts first.
+	segTypes := map[string]*commonpb.SegmentType{
+		"zzz": {},
+		"aaa": {},
+	}
+
+	for range 64 {
+		verr := ValidateSegmentTypes(segments, segTypes)
+		require.Error(t, verr)
+		require.Contains(t, verr.Error(), `unknown variable "aaa"`,
+			"the first unknown-variable error must be the lexicographically-first, deterministically")
+	}
+}
+
 func TestValidateSegmentTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/crypto/keystore/keystore.go
+++ b/internal/domain/crypto/keystore/keystore.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"crypto/ed25519"
+	"slices"
 	"sync"
 )
 
@@ -63,6 +64,12 @@ func (ks *KeyStore) GetChildren(keyID string) []string {
 			children = append(children, childID)
 		}
 	}
+
+	// Sort for determinism: this feeds signing-key revocation cascades whose
+	// RevokedSigningKeyLog.cascadedKeyIds (and BFS traversal order) are
+	// chain-bound FSM output. A raw map range would let two replicas emit
+	// different orderings for identical state (invariant #2). See EN-1521.
+	slices.Sort(children)
 
 	return children
 }

--- a/internal/domain/crypto/keystore/keystore_test.go
+++ b/internal/domain/crypto/keystore/keystore_test.go
@@ -88,6 +88,37 @@ func TestGetChildren_WithParent(t *testing.T) {
 	require.Empty(t, ks.GetChildren("nonexistent"))
 }
 
+// TestGetChildren_SortedDeterministic pins EN-1521: GetChildren feeds signing
+// cascade revocation (RevokedSigningKeyLog.cascadedKeyIds + BFS order), which is
+// chain-bound FSM output, so it must return children in a canonical order
+// independent of the underlying map's iteration order (invariant #2). The keys
+// are registered in a non-sorted order to prove the returned slice is sorted,
+// not merely insertion-ordered.
+func TestGetChildren_SortedDeterministic(t *testing.T) {
+	t.Parallel()
+
+	pub := func() ed25519.PublicKey {
+		p, _, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		return p
+	}
+
+	ks := NewKeyStore()
+	ks.AddPublicKey("root", pub(), "")
+	for _, child := range []string{"child-m", "child-a", "child-z", "child-b"} {
+		ks.AddPublicKey(child, pub(), "root")
+	}
+
+	want := []string{"child-a", "child-b", "child-m", "child-z"}
+	// Repeat: Go randomizes map iteration order per range, so a raw map range
+	// would eventually return an unsorted slice.
+	for range 32 {
+		require.Equal(t, want, ks.GetChildren("root"),
+			"GetChildren must return a canonically-sorted, deterministic slice")
+	}
+}
+
 func TestRemovePublicKey_ClearsParent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/processing/processor_account_type.go
+++ b/internal/domain/processing/processor_account_type.go
@@ -1,6 +1,9 @@
 package processing
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -38,8 +41,13 @@ func processAddAccountType(ledger string, order *raftcmdpb.AddAccountTypeOrder, 
 		return nil, &domain.ErrAccountTypeAlreadyExists{Name: at.GetName()}
 	}
 
-	// Check for conflicts with existing account types.
-	for existingName, existing := range info.GetAccountTypes() {
+	// Check for conflicts with existing account types. Iterate names in sorted
+	// order so the selected conflict (surfaced in the chain-bound
+	// ErrAccountTypeConflict → AuditFailure) is identical on every replica —
+	// a raw map range could pick a different conflicting type per node
+	// (invariant #2). See EN-1521.
+	for _, existingName := range slices.Sorted(maps.Keys(info.GetAccountTypes())) {
+		existing := info.GetAccountTypes()[existingName]
 		existingSegments, parseErr := accounttype.ParsePattern(existing.GetPattern())
 		if parseErr != nil {
 			continue

--- a/internal/domain/processing/processor_account_type_test.go
+++ b/internal/domain/processing/processor_account_type_test.go
@@ -1,0 +1,59 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// TestProcessAddAccountType_ConflictSelectionDeterministic pins EN-1521: when a
+// new account type conflicts with more than one existing type, the selected
+// conflict (surfaced in the chain-bound ErrAccountTypeConflict → AuditFailure)
+// must be the same on every replica. The processor iterates the existing-types
+// map in sorted key order, so the lexicographically-first conflicting name is
+// always chosen — never whichever the Go map range happened to visit first.
+//
+// Go randomizes map iteration order per range, so running the apply repeatedly
+// would surface both orderings before the fix; asserting a constant result
+// across many runs is the determinism proof.
+func TestProcessAddAccountType_ConflictSelectionDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// "aaa" and "zzz" have identical two-segment structure (fixed + variable),
+	// so both conflict with the new "users:{z}" pattern. "aaa" sorts first.
+	existing := &commonpb.LedgerInfo{
+		Name: "l",
+		AccountTypes: map[string]*commonpb.AccountType{
+			"zzz": {Name: "zzz", Pattern: "users:{y}"},
+			"aaa": {Name: "aaa", Pattern: "users:{x}"},
+		},
+	}
+
+	const runs = 64
+	for range runs {
+		ctrl := gomock.NewController(t)
+		mockStore := NewMockScope(ctrl)
+		expectGetLedger(mockStore, domain.LedgerKey{Name: "l"}, existing.AsReader(), nil)
+
+		order := &raftcmdpb.AddAccountTypeOrder{
+			AccountType: &commonpb.AccountType{Name: "new-type", Pattern: "users:{z}"},
+		}
+
+		_, derr := processAddAccountType("l", order, &Context{Scope: mockStore})
+		require.NotNil(t, derr)
+
+		var conflict *domain.ErrAccountTypeConflict
+		require.ErrorAs(t, derr, &conflict,
+			"a multi-conflict add must surface ErrAccountTypeConflict")
+		require.Equal(t, "aaa", conflict.ExistingName,
+			"the selected conflict must be the lexicographically-first name, deterministically")
+		require.Equal(t, "users:{x}", conflict.ExistingPattern)
+
+		ctrl.Finish()
+	}
+}

--- a/internal/domain/processing/processor_ledger.go
+++ b/internal/domain/processing/processor_ledger.go
@@ -2,6 +2,8 @@ package processing
 
 import (
 	"errors"
+	"maps"
+	"slices"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
@@ -24,8 +26,13 @@ func processCreateLedger(ledger string, order *raftcmdpb.CreateLedgerOrder, ctx 
 		return nil, &domain.ErrLedgerAlreadyExists{Name: ledger}
 	}
 
-	// Validate initial account types if provided
-	for name, at := range order.GetAccountTypes() {
+	// Validate initial account types if provided. Iterate names in sorted order
+	// so the first invalid pattern reported (chain-bound ErrInvalidPattern →
+	// AuditFailure) is identical on every replica — a raw map range could
+	// surface a different offending pattern per node (invariant #2). See
+	// EN-1521.
+	for _, name := range slices.Sorted(maps.Keys(order.GetAccountTypes())) {
+		at := order.GetAccountTypes()[name]
 		if err := accounttype.ValidatePattern(at.GetPattern()); err != nil {
 			return nil, &domain.ErrInvalidPattern{Pattern: at.GetPattern(), Details: err.Error()}
 		}

--- a/internal/domain/processing/processor_ledger_test.go
+++ b/internal/domain/processing/processor_ledger_test.go
@@ -56,6 +56,39 @@ func TestProcessCreateLedger(t *testing.T) {
 	require.Equal(t, uint32(1), createLedgerLog.GetId(), "CreatedLedgerLog should have Id == 1")
 }
 
+// TestProcessCreateLedger_InvalidPatternSelectionDeterministic pins EN-1521:
+// when several initial account types have invalid patterns, the first-reported
+// invalid pattern (chain-bound ErrInvalidPattern → AuditFailure) must be the
+// same on every replica. The processor iterates the account-types map in sorted
+// key order, so the lexicographically-first name's pattern is always chosen.
+func TestProcessCreateLedger_InvalidPatternSelectionDeterministic(t *testing.T) {
+	t.Parallel()
+
+	const runs = 64
+	for range runs {
+		ctrl := gomock.NewController(t)
+		mockStore := NewMockScope(ctrl)
+		expectGetLedger(mockStore, domain.LedgerKey{Name: "l"}, nil, domain.ErrNotFound)
+
+		order := &raftcmdpb.CreateLedgerOrder{
+			AccountTypes: map[string]*commonpb.AccountType{
+				"zzz": {Pattern: "z b"},  // invalid: space in a fixed segment
+				"aaa": {Pattern: "a::x"}, // invalid: empty segment
+			},
+		}
+
+		_, derr := processCreateLedger("l", order, &Context{Scope: mockStore})
+		require.NotNil(t, derr)
+
+		var invalid *domain.ErrInvalidPattern
+		require.ErrorAs(t, derr, &invalid)
+		require.Equal(t, "a::x", invalid.Pattern,
+			"the first invalid pattern reported must be the lexicographically-first name's, deterministically")
+
+		ctrl.Finish()
+	}
+}
+
 func TestProcessCreateLedger_AlreadyExists(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

EN-1520 found Go map ranges reachable from FSM apply whose **iteration order can change observable, chain-bound output**. Two replicas applying the same committed proposal could select different errors or emit different repeated-field order — breaking FSM determinism (invariant #2) even with deterministic protobuf encoding.

## Fix

Canonicalize the confirmed decision boundaries by iterating stable keys in sorted order (`slices.Sorted(maps.Keys(...))` / `slices.Sort`):

- **`keystore.GetChildren`** returns sorted children — feeds signing-key revocation cascades (`RevokedSigningKeyLog.cascadedKeyIds` + BFS order).
- **`processAddAccountType`** selects the first conflicting existing type by sorted name (chain-bound `ErrAccountTypeConflict`).
- **`processCreateLedger`** reports the first invalid initial account-type pattern by sorted name (chain-bound `ErrInvalidPattern`).
- **`accounttype.ValidateSegmentTypes`** reports the first unknown-variable / bad matcher by sorted name (chain-bound via `ErrInvalidPattern`).

The metadata apply loops (`processor_metadata` / `processor_ledger_metadata`) are apply-all cache Puts keyed independently and remain intentionally order-insensitive.

## Tests

Each corrected site has a test that builds logically identical state and asserts a **constant selection across many runs** — Go randomizes map iteration order per range, so a raw range would vary before the fix.

## Acceptance criteria

- Multi-conflict account-type proposals produce the same error metadata (hence audit hash). ✅
- Signing cascades emit the same ordered IDs. ✅
- No time/randomness/node-local input introduced. ✅
- `GOROOT= go build ./...`, affected-package tests, gofmt, golangci-lint all pass. ✅

Refs EN-1520.