### PR TITLE
fix(indexbuilder): detect primary-store rollback via restore generation

### DIFF
--- a/cmd/ledgerctl/store/rebuild_indexes.go
+++ b/cmd/ledgerctl/store/rebuild_indexes.go
@@ -87,7 +87,9 @@ func runRebuildIndexes(cmd *cobra.Command, _ []string) error {
 	// Rebuild.
 	spinner, _ = pterm.DefaultSpinner.Start("Rebuilding indexes from system logs...")
 
-	builder := indexbuilder.NewBuilder(pebbleStore, rs, attributes.New(), logger, noop.Meter{}, batchSize)
+	// rebuildThreshold is irrelevant offline: RebuildAll replays from cursor 0
+	// against a fresh/target read index, so the boot rollback guard never runs.
+	builder := indexbuilder.NewBuilder(pebbleStore, rs, attributes.New(), logger, noop.Meter{}, batchSize, 0)
 
 	lastSeq, err := builder.RebuildAll()
 	if err != nil {

--- a/docs/technical/architecture/subsystems/indexer/README.md
+++ b/docs/technical/architecture/subsystems/indexer/README.md
@@ -13,4 +13,5 @@ The background worker (`internal/application/indexbuilder`) that turns committed
 
 - [Read path](../read-path/) — query consumer of the inverted index.
 - [Storage](../storage/) — the read store is a separate Pebble DB with WAL disabled.
+- [Restore-generation watermark](../storage/restore-generation-watermark.md) — how `indexbuilder` and `auditindexer` detect a primary-store rollback (the catch-up race) and rebuild.
 - [Attributes](../attributes/) — the same source attributes the indexer projects from.

--- a/docs/technical/architecture/subsystems/storage/README.md
+++ b/docs/technical/architecture/subsystems/storage/README.md
@@ -9,6 +9,7 @@ The persistence layer (`internal/storage/dal`, `internal/storage/wal`, `internal
 | [storage.md](storage.md) | WAL, snapshots, runtime stores, persistence, and recovery. |
 | [storage-drivers.md](storage-drivers.md) | Pebble storage driver characteristics and configuration. |
 | [spool.md](spool.md) | Committed entry buffer between Raft and FSM synchronization. |
+| [restore-generation-watermark.md](restore-generation-watermark.md) | How projection tail-workers detect a primary-store rollback (the catch-up race) and rebuild. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/storage/restore-generation-watermark.md
+++ b/docs/technical/architecture/subsystems/storage/restore-generation-watermark.md
@@ -1,0 +1,124 @@
+# Restore-generation watermark
+
+How the projection tail-workers (`usagebuilder`, `auditindexer`, `indexbuilder`)
+detect a primary-store rollback they would otherwise silently skip.
+
+## The problem: the catch-up race
+
+Each projection tail-worker advances a **persisted cursor** over the primary
+store's log/audit stream: on every tick it reads entries *since* its cursor,
+projects them, and persists the new cursor. The cursor lives in a rebuildable
+side store (the `usagestore` for `usagebuilder`; the read store for
+`auditindexer` and `indexbuilder`) — never in the main store it is tailing.
+
+A follower that falls behind is repaired by `Store.RestoreCheckpoint`
+(`internal/storage/dal/store.go:1211`), reached at runtime through
+`Synchronizer` → `SynchronizeWithLeader`. It hard-links a leader checkpoint into
+the live directory and republishes it by rename, which **rolls the primary
+store's head backwards** — potentially *below* a projection cursor that had
+already advanced past that point.
+
+The obvious guard is a point-in-time comparison, `cursor > head`
+(`cursorAheadOfHead`): if the cursor sits ahead of the restored head, reset and
+rebuild. That guard is **not sufficient on its own**, because it is momentary.
+Consider:
+
+```
+cursor = 100, head = 100
+  └─ RestoreCheckpoint rolls head back to 60      (cursor now ahead: 100 > 60)
+  └─ new writes arrive, head re-grows to 100+      (cursor no longer ahead)
+  └─ worker samples head only now → sees head ≥ cursor → guard does NOT fire
+  └─ worker resumes from cursor 100, having never projected the *restored*
+     entries 61..100 → the projection is permanently wrong for that range
+```
+
+The rollback happened, but by the time the worker looked, the head had caught
+back up and erased the `cursor > head` signature. A gap-size threshold
+(`gapExceedsThreshold` / `RebuildThreshold`) narrows the window but cannot close
+it — a rollback smaller than the threshold, or any rollback fully masked by
+catch-up, still slips through.
+
+## The mechanism: a monotonic restore counter
+
+`dal.Store` carries a **process-local monotonic counter**,
+`restoreGeneration atomic.Uint64` (`internal/storage/dal/store.go:125`).
+`RestoreCheckpoint` bumps it exactly once, on success, after the new checkpoint
+is published (`store.go:1421`). Readers observe it through
+`Store.RestoreGeneration()` (`store.go:1436`).
+
+The counter is a **fingerprint of "how many times this store was rolled back",
+independent of position**. A worker records the generation it is running under
+and re-reads it every tick; if the value ever differs from what it recorded, a
+restore happened since it last projected — regardless of where the head landed
+relative to the cursor — so it resets and rebuilds.
+
+Every tail-worker uses the identical shape:
+
+1. **Seed at boot** — snapshot `RestoreGeneration()` into a local
+   `restoreGen atomic.Uint64` *before* reading the cursor, so a restore that
+   races boot is re-detected on the first tick rather than swallowed.
+2. **Gate every tick** — `if store.RestoreGeneration() != restoreGen.Load()`
+   → reset the projection, re-sync `restoreGen` inside the reset (so a restore
+   *during* the rebuild is caught again), and rebuild from scratch.
+
+| Worker | field | boot seed | tick gate | reset action |
+|--------|-------|-----------|-----------|--------------|
+| `usagebuilder` | `builder.go:87` | `builder.go:178` | `builder.go:268` | `resetProjection()` — wipe + replay the `usagestore` counters |
+| `auditindexer` | `indexer.go:71` | `indexer.go:147` | `processTick` (`indexer.go:341`) | rebuild the audit index in the read store |
+| `indexbuilder` | `builder.go:66` | `builder.go:624` | `maybeResetOnRestore` (`builder.go:569`) | `resetAndReinit()` — see below |
+
+## Two layers of defence
+
+The watermark does not replace the position heuristic; the two cover disjoint
+cases.
+
+- **Runtime catch-up race → the generation watermark.** `RestoreCheckpoint`
+  only runs while the process is live (via `SynchronizeWithLeader`), and
+  stopping background tasks does **not** stop these pollers, so the bump is
+  always observed on the next tick. This is the case the point-in-time guard
+  cannot see.
+- **Process-restart-after-offline-restore → the boot position heuristic.**
+  `restoreGeneration` is process-local; a restart resets it to `0` on both the
+  store and every worker, so the generation gate is inert across a restart. That
+  case is instead caught at boot by `shouldRebuildOnBoot` = `cursorAheadOfHead`
+  **OR** a boot-only gap-threshold check
+  (`usagebuilder` `gapExceedsThreshold` / `auditindexer` &
+  `indexbuilder` `RebuildThreshold`). This is exactly the offline
+  backup/restore scenario that heuristic was built for, and it is now applied
+  uniformly across all three workers.
+
+An in-memory counter is therefore *correct*, not a shortcut: the only rollback a
+restart can hide is an offline one, which the boot heuristic already owns.
+
+## Per-worker reset cost
+
+The gate is identical; the reset behind it is not.
+
+- `usagebuilder` / `auditindexer` reset is close to "rewind the cursor to 0 and
+  replay" over their rebuildable side store.
+- `indexbuilder` is heavier: a read-index rebuild must also re-derive backfill
+  tasks, schema-rewrite progress, and index-version state, so its tick-time
+  reset routes through a **boot-equivalent re-init** (`resetAndReinit`,
+  `builder.go:672`) rather than a bare cursor rewind. `readstore.ResetIndexes`
+  wipes only the builder-owned keyspace (index rows, log/applied-proposal
+  cursors, backfill cursors, version state) and then re-runs `initIndexConfig`
+  against the emptied store. It deliberately **does not** touch the
+  `auditindexer`-owned audit index — that worker owns its own detector and its
+  own reset — a boundary pinned by a dedicated test.
+
+## Invariants
+
+This lives entirely on the projection/side-store path: no FSM hot-path Pebble
+reads (invariant #3), deterministic per-replica (the counter is node-local and
+touches no Raft state, so it cannot desync the FSM), and reset/rebuild is the
+rebuildable-projection recovery path — the audit hash chain, the sole source of
+truth (invariant #8), is never involved. A corrupted or stale projection is an
+availability/eventual-consistency concern with an operator escape hatch
+(`ledgerctl store rebuild-usage`, `ledgerctl store rebuild-indexes`), not a
+tampering vector.
+
+## Related
+
+- [storage.md](storage.md) — `RestoreCheckpoint`, checkpoints, and follower sync.
+- [Usage](../usage/) — `usagebuilder` and the `usagestore` projection.
+- [Indexer](../indexer/) — `indexbuilder`, `auditindexer`, and the read store.

--- a/docs/technical/architecture/subsystems/usage/README.md
+++ b/docs/technical/architecture/subsystems/usage/README.md
@@ -17,3 +17,4 @@ The projections it maintains are exposed by the API — `GET /v3/{ledger}/stats`
 - [Indexer](../indexer/) — sibling subsystem with the same audit-tailing shape, but writes to a different secondary store (`readstore`).
 - [Checker](../checker/) — verifies the projections against the audit chain (`compareExclusionProjections` for ephemeral/transient tuples).
 - [Storage](../storage/) — the usage store is a peer Pebble instance to the readstore, WAL disabled, own comparer, own Pebble tuning.
+- [Restore-generation watermark](../storage/restore-generation-watermark.md) — how the builder detects a primary-store rollback (the catch-up race) and rebuilds the counters.

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -46,6 +46,25 @@ type Builder struct {
 	metricsRegistration     metric.Registration // tailworker gauge triplet
 	logsIndexedRegistration metric.Registration // builder-specific logs_indexed_total gauge
 
+	// rebuildThreshold forces a boot-time reset+rebuild when the log head leads
+	// the persisted cursor by more than this many entries (0 disables the
+	// gap-based net). Boot-only, mirroring auditindexer.shouldRebuildOnBoot and
+	// usagebuilder.gapExceedsThreshold: it is the secondary catch of a rollback
+	// whose restored gap re-grew past the cursor before pebbleLast was sampled,
+	// so the direct cursorAheadOfHead signature was never observable.
+	rebuildThreshold uint64
+
+	// restoreGen is the primary-store restore generation this builder last
+	// processed under (see dal.Store.RestoreGeneration). Seeded on boot, re-read
+	// every steady-state tick: a change means the primary store was rolled back
+	// beneath the cursor at runtime, so a full reset+rebuild is forced regardless
+	// of where the log head landed relative to the cursor — the position-based
+	// cursorAheadOfHead / rebuildThreshold signals can be erased by a catch-up
+	// race (rollback below cursor, head re-grows past the old cursor before the
+	// next tick re-samples). Mirrors auditindexer.Indexer.restoreGen and
+	// usagebuilder.Builder.restoreGen.
+	restoreGen atomic.Uint64
+
 	// Per-ledger index configuration cache.
 	indexConfig map[string]*ledgerIndexConfig
 
@@ -324,6 +343,10 @@ func (b *Builder) coerceForLedger(ledger string, target commonpb.TargetType, key
 // NewBuilder creates a new index builder.
 // batchSize controls how many log entries are buffered per Pebble batch commit.
 // Use 0 for the default (DefaultBatchSize).
+// rebuildThreshold forces a boot-time reset+rebuild when the log head leads the
+// persisted cursor by more than this many entries (0 disables the gap net); it
+// is the boot-only secondary net for a primary-store rollback (see the
+// rebuildThreshold field comment).
 func NewBuilder(
 	pebbleStore *dal.Store,
 	readStore *readstore.Store,
@@ -331,23 +354,25 @@ func NewBuilder(
 	logger logging.Logger,
 	meter metric.Meter,
 	batchSize int,
+	rebuildThreshold uint64,
 ) *Builder {
 	if batchSize <= 0 {
 		batchSize = DefaultBatchSize
 	}
 
 	return &Builder{
-		pebbleStore:    pebbleStore,
-		readStore:      readStore,
-		attrs:          attrs,
-		logger:         logger.WithFields(map[string]any{"cmp": "index-builder"}),
-		meter:          meter,
-		batchSize:      batchSize,
-		backfillBudget: 50 * time.Millisecond,
-		indexConfig:    make(map[string]*ledgerIndexConfig),
-		kb:             dal.NewKeyBuilder(),
-		wb:             readstore.NewWriteBatch(),
-		accounts:       make(map[string]struct{}, 64),
+		pebbleStore:      pebbleStore,
+		readStore:        readStore,
+		attrs:            attrs,
+		logger:           logger.WithFields(map[string]any{"cmp": "index-builder"}),
+		meter:            meter,
+		batchSize:        batchSize,
+		rebuildThreshold: rebuildThreshold,
+		backfillBudget:   50 * time.Millisecond,
+		indexConfig:      make(map[string]*ledgerIndexConfig),
+		kb:               dal.NewKeyBuilder(),
+		wb:               readstore.NewWriteBatch(),
+		accounts:         make(map[string]struct{}, 64),
 	}
 }
 
@@ -541,6 +566,12 @@ func (b *Builder) loop(ctx context.Context) {
 		case <-ticker.C:
 		}
 
+		if newCursor, reset, err := b.maybeResetOnRestore(ctx, cursor); err != nil {
+			b.logger.Errorf("Error resetting read index after restore: %v", err)
+		} else if reset {
+			cursor = newCursor
+		}
+
 		// Fast path: skip Pebble iterator + batch commit when the FSM
 		// hasn't advanced past our cursor.
 		logsProcessed := false
@@ -588,6 +619,10 @@ func (b *Builder) loop(ctx context.Context) {
 // and query.ReadLastSequence stay best-effort (they tolerate failure today);
 // only initIndexConfig, LastIndexedSequence, and NewDirectReadHandle are fatal.
 func (b *Builder) bootInit(ctx context.Context) (cursor uint64, pebbleLast uint64, err error) {
+	// Snapshot the restore generation before any processing so the steady-state
+	// loop can detect a primary-store rollback that lands after boot.
+	b.restoreGen.Store(b.pebbleStore.RestoreGeneration())
+
 	if err := b.initIndexConfig(ctx); err != nil {
 		return 0, 0, fmt.Errorf("initializing index config: %w", err)
 	}
@@ -620,5 +655,105 @@ func (b *Builder) bootInit(ctx context.Context) (cursor uint64, pebbleLast uint6
 
 	_ = handle.Close()
 
+	// Primary-store rollback guard (parity with auditindexer.shouldRebuildOnBoot
+	// and usagebuilder.rewindOnRollback boot path). When the persisted cursor
+	// overtakes the log head — the direct signature of a restore/rollback to an
+	// earlier head while the read index was retained — or the head leads the
+	// cursor by more than rebuildThreshold, the retained index rows reflect logs
+	// that no longer exist. An incremental catch-up from the stale cursor would
+	// scan past every surviving (lower-seq) log forever, so wipe the read index
+	// and rebuild from sequence 0.
+	if b.shouldRebuildOnBoot(cursor, pebbleLast) {
+		b.logger.WithFields(map[string]any{
+			"cursor":     cursor,
+			"pebbleLast": pebbleLast,
+		}).Infof("Index builder rebuild on boot: primary store rollback detected")
+
+		if newCursor, err := b.resetAndReinit(ctx); err != nil {
+			return 0, 0, fmt.Errorf("resetting read index on boot rollback: %w", err)
+		} else {
+			cursor = newCursor
+		}
+	}
+
 	return cursor, pebbleLast, nil
+}
+
+// shouldRebuildOnBoot reports whether boot should wipe+rebuild the read index
+// instead of an incremental catch-up: the persisted cursor sits beyond the log
+// head (cursorAheadOfHead — the direct rollback signature), or the head leads
+// the cursor by more than rebuildThreshold (the boot-only gap net). Mirrors
+// auditindexer.shouldRebuildOnBoot. A missing cursor (0) is NOT a rebuild
+// trigger here: a fresh read index legitimately starts at 0 and catches up
+// incrementally.
+func (b *Builder) shouldRebuildOnBoot(cursor, pebbleLast uint64) bool {
+	if cursorAheadOfHead(cursor, pebbleLast) {
+		return true
+	}
+
+	return b.rebuildThreshold > 0 && pebbleLast > cursor && pebbleLast-cursor > b.rebuildThreshold
+}
+
+// cursorAheadOfHead reports the post-rollback signature: the persisted read
+// index cursor sits beyond the current log head. Only possible after the
+// primary Pebble store was restored/truncated to an earlier head while the read
+// index directory was retained (boot after a backup restore, or a runtime
+// follower sync via SynchronizeWithLeader/RestoreCheckpoint). Mirrors the
+// identically named helper in auditindexer / usagebuilder.
+func cursorAheadOfHead(cursor, pebbleLast uint64) bool { return cursor > pebbleLast }
+
+// resetAndReinit wipes every index-builder-owned keyspace in the read store and
+// re-derives all in-memory init state (index config, per-replica version cache,
+// backfill/rewrite tasks) from the now-empty store, so a rebuild replays from
+// log sequence 0. It re-syncs restoreGen up-front so a RestoreCheckpoint that
+// lands during the subsequent replay bumps past this value and is re-detected
+// on the next tick (rather than being silently swallowed). Returns the reset
+// cursor (always 0). Mirrors usagebuilder.resetProjection, adapted for the
+// heavier read-index reset: a bare cursor=0 is not enough — the index rows,
+// backfill cursors, and version state must be wiped and re-seeded too.
+func (b *Builder) resetAndReinit(ctx context.Context) (uint64, error) {
+	b.restoreGen.Store(b.pebbleStore.RestoreGeneration())
+
+	if err := b.readStore.ResetIndexes(); err != nil {
+		return 0, fmt.Errorf("resetting read index after primary-store rollback: %w", err)
+	}
+
+	// Re-derive init state against the now-empty read store. initIndexConfig
+	// resets its own in-memory maps/tasks first (idempotent), and with the
+	// version state wiped every BUILDING index re-enters loadIndexRegistry with
+	// current_version == 0, so backfills are re-scheduled from scratch.
+	if err := b.initIndexConfig(ctx); err != nil {
+		return 0, fmt.Errorf("re-initializing index config after reset: %w", err)
+	}
+
+	b.lastAppliedProposalSeq = 0
+	b.lastIndexedSeq.Store(0)
+
+	return 0, nil
+}
+
+// maybeResetOnRestore is the steady-state rollback gate, run once per loop tick
+// before processLogs. The restore-generation change is the authoritative
+// rollback signal: it fires on any RestoreCheckpoint regardless of where the
+// log head landed, so it catches the catch-up race that erases the boot
+// cursorAheadOfHead position signal (restore below cursor, then the head
+// re-grows past the old cursor before this tick re-samples). resetAndReinit
+// re-syncs restoreGen, so this fires exactly once per restore. Returns the new
+// cursor (0) and reset=true when a reset was performed. Mirrors
+// auditindexer.processTick / usagebuilder.tick.
+func (b *Builder) maybeResetOnRestore(ctx context.Context, cursor uint64) (uint64, bool, error) {
+	gen := b.pebbleStore.RestoreGeneration()
+	if gen == b.restoreGen.Load() {
+		return cursor, false, nil
+	}
+
+	b.logger.WithFields(map[string]any{"from": b.restoreGen.Load(), "to": gen}).
+		Infof("Index builder rebuild: primary store restore detected (generation changed)")
+
+	newCursor, err := b.resetAndReinit(ctx)
+	if err != nil {
+		return cursor, false, err
+	}
+
+	return newCursor, true, nil
 }

--- a/internal/application/indexbuilder/builder_restore_test.go
+++ b/internal/application/indexbuilder/builder_restore_test.go
@@ -1,0 +1,226 @@
+package indexbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// countReadStoreKeys returns the number of read-store keys under prefix.
+func countReadStoreKeys(t *testing.T, rs *readstore.Store, prefix []byte) int {
+	t.Helper()
+
+	iter, err := rs.DB().NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: readstore.IncrementBytes(prefix),
+	})
+	require.NoError(t, err)
+
+	defer func() { _ = iter.Close() }()
+
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+	require.NoError(t, iter.Error())
+
+	return n
+}
+
+// TestResetIndexes_WipesBuilderKeyspaceButNotAuditIndex pins the reset boundary:
+// ResetIndexes must wipe every index-builder-owned keyspace (ledger-scoped index
+// rows + the builder's internal cursors/version state) while leaving the
+// auditindexer-owned keyspace (audit index rows + audit cursor) untouched — the
+// audit indexer has its own independent rollback detector.
+func TestResetIndexes_WipesBuilderKeyspaceButNotAuditIndex(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	rs := b.readStore
+	kb := dal.NewKeyBuilder()
+
+	// Seed builder-owned rows: a ledger-log index row, a backfill cursor, an
+	// index-version state entry, and the log/applied-proposal progress cursors.
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteProgress(batch, 500))
+	require.NoError(t, rs.WriteAppliedProposalProgress(batch, 400))
+	require.NoError(t, batch.SetBytes(readstore.LedgerLogKey(kb, "l1", 10), []byte{1}))
+	require.NoError(t, rs.WriteBackfillProgress(batch, []byte("l1-key"), 99))
+	require.NoError(t, rs.WriteIndexVersionState(batch, "l1", "canon", readstore.IndexVersionState{CurrentVersion: 1}))
+	require.NoError(t, batch.Commit())
+
+	// Seed auditindexer-owned rows: an audit index entry + the audit cursor.
+	// These must survive the reset.
+	auditBatch := rs.NewBatch()
+	require.NoError(t, auditBatch.SetBytes(readstore.AuditIndexByteKey(kb, readstore.AuditFieldOutcome, 1, 7), nil))
+	require.NoError(t, rs.WriteAuditProgress(auditBatch, 7))
+	require.NoError(t, auditBatch.Commit())
+
+	require.NoError(t, b.readStore.ResetIndexes())
+
+	// Builder-owned keyspace fully wiped.
+	assert.Equal(t, 0, countReadStoreKeys(t, rs, readstore.LedgerLogPrefix(kb, "l1")), "ledger log index rows must be wiped")
+	assert.Equal(t, 0, countReadStoreKeys(t, rs, readstore.BackfillKeyPrefix()), "backfill cursors must be wiped")
+	assert.Equal(t, 0, countReadStoreKeys(t, rs, readstore.IndexVersionStatePrefix()), "index version state must be wiped")
+
+	cursor, err := rs.LastIndexedSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), cursor, "log progress cursor must be wiped to 0")
+
+	ap, err := rs.ReadAppliedProposalProgress()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), ap, "applied-proposal cursor must be wiped to 0")
+
+	// Auditindexer-owned keyspace untouched.
+	assert.Equal(t, 1, countReadStoreKeys(t, rs, readstore.AuditIndexPrefix()), "audit index rows must survive the builder reset")
+
+	auditCursor, err := rs.ReadAuditProgress()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(7), auditCursor, "audit cursor must survive the builder reset")
+}
+
+// TestShouldRebuildOnBoot covers the boot rollback guard's decision table.
+func TestShouldRebuildOnBoot(t *testing.T) {
+	t.Parallel()
+
+	b := &Builder{}
+
+	// cursorAheadOfHead: the direct rollback signature.
+	assert.True(t, b.shouldRebuildOnBoot(500, 120), "cursor ahead of head must rebuild")
+	assert.False(t, b.shouldRebuildOnBoot(100, 300), "cursor behind head is normal catch-up")
+	assert.False(t, b.shouldRebuildOnBoot(300, 300), "cursor == head is not ahead")
+	assert.False(t, b.shouldRebuildOnBoot(0, 300), "fresh cursor (0) is normal catch-up, not a rollback")
+
+	// Gap threshold (boot-only net for the catch-up race).
+	b.rebuildThreshold = 1000
+	assert.True(t, b.shouldRebuildOnBoot(500, 5000), "gap over threshold must rebuild even when cursor is behind head")
+	assert.False(t, b.shouldRebuildOnBoot(500, 900), "gap within threshold is normal catch-up")
+
+	// Threshold disabled (0): only the cursor-ahead signature remains.
+	b.rebuildThreshold = 0
+	assert.False(t, b.shouldRebuildOnBoot(500, 5000), "gap net is inert when threshold is 0")
+}
+
+// TestBootInit_ResetsOnPrimaryStoreRollback exercises the boot path end to end:
+// a read index that consumed up to log seq 3, then a real RestoreCheckpoint
+// rolls the primary log head back to 1 (below the cursor). bootInit must detect
+// the cursor-ahead signature, wipe the read index, and return cursor 0 so the
+// surviving chain is re-indexed from the start.
+func TestBootInit_ResetsOnPrimaryStoreRollback(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	kb := dal.NewKeyBuilder()
+	ctx := context.Background()
+
+	// Surviving primary-store chain [1] + a checkpoint to roll back to.
+	writeLogToFSM(t, b, makeCreatedTxLog(1, "l1", 100, []*commonpb.Posting{
+		{Source: "a", Destination: "b", Asset: "USD/2"},
+	}))
+	checkpointID, err := b.pebbleStore.CreateSnapshot()
+	require.NoError(t, err)
+
+	// Grow the head to 3, then roll back to the checkpoint (head returns to 1).
+	writeLogToFSM(t, b, makeCreatedTxLog(2, "l1", 101, []*commonpb.Posting{{Source: "b", Destination: "c", Asset: "USD/2"}}))
+	writeLogToFSM(t, b, makeCreatedTxLog(3, "l1", 102, []*commonpb.Posting{{Source: "c", Destination: "d", Asset: "USD/2"}}))
+
+	// Read index had consumed up to 3, with a stale ledger-log row for logID 102.
+	batch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteProgress(batch, 3))
+	require.NoError(t, batch.SetBytes(readstore.LedgerLogKey(kb, "l1", 102), []byte{1}))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, b.pebbleStore.RestoreCheckpoint(checkpointID))
+
+	head, err := query.ReadLastSequence(mustReadHandle(t, b))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), head, "primary head rolled back below the read cursor")
+
+	cursor, pebbleLast, err := b.bootInit(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), pebbleLast)
+	assert.Equal(t, uint64(0), cursor, "boot must reset the cursor to 0 on rollback")
+
+	// Read index cursor and the stale rows are wiped.
+	persisted, err := b.readStore.LastIndexedSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), persisted, "persisted cursor must be wiped")
+	assert.Equal(t, 0, countReadStoreKeys(t, b.readStore, readstore.LedgerLogPrefix(kb, "l1")), "stale ledger-log rows must be wiped")
+}
+
+// TestMaybeResetOnRestore_CatchUpRace is the core regression: it reproduces the
+// exact race the position-only cursorAheadOfHead guard cannot catch. The read
+// index advances to log seq 3; a RestoreCheckpoint rolls the primary head back
+// below the cursor; then the head RE-GROWS past the old cursor before the loop
+// re-samples — so cursorAheadOfHead(cursor, head) is FALSE. The restore-
+// generation change is the only surviving rollback signal, and the steady-state
+// gate must force a reset+rebuild. Mirrors usagebuilder.TestTickResetsOnRestoreGenerationChange.
+func TestMaybeResetOnRestore_CatchUpRace(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	kb := dal.NewKeyBuilder()
+	ctx := context.Background()
+
+	// Surviving chain [1..3] + a checkpoint at head 3 (the rollback target).
+	for s := uint64(1); s <= 3; s++ {
+		writeLogToFSM(t, b, makeCreatedTxLog(s, "l1", 100+s, []*commonpb.Posting{
+			{Source: "a", Destination: "b", Asset: "USD/2"},
+		}))
+	}
+	checkpointID, err := b.pebbleStore.CreateSnapshot()
+	require.NoError(t, err)
+
+	// Read index had consumed up to 3, with a stale ledger-log row.
+	batch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteProgress(batch, 3))
+	require.NoError(t, batch.SetBytes(readstore.LedgerLogKey(kb, "l1", 999), []byte{1}))
+	require.NoError(t, batch.Commit())
+
+	// boot seeds the generation baseline (head 3 == cursor 3, so no boot rewind).
+	cursor, _, err := b.bootInit(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cursor)
+
+	// Runtime rollback: RestoreCheckpoint bumps the generation, then the head
+	// RE-GROWS to 5 — strictly ABOVE the stale cursor (3), so the position
+	// signal is inert and only the generation change can fire.
+	require.NoError(t, b.pebbleStore.RestoreCheckpoint(checkpointID))
+	for s := uint64(4); s <= 5; s++ {
+		writeLogToFSM(t, b, makeCreatedTxLog(s, "l1", 100+s, []*commonpb.Posting{
+			{Source: "a", Destination: "b", Asset: "USD/2"},
+		}))
+	}
+
+	head, err := query.ReadLastSequence(mustReadHandle(t, b))
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), head)
+	require.False(t, cursorAheadOfHead(cursor, head), "head re-grew past cursor: the position guard is inert")
+
+	// The position-only boot guard would stay inert on this (cursor, head)...
+	require.False(t, b.shouldRebuildOnBoot(cursor, head), "position guard must NOT fire — this is the race it misses")
+
+	// ...but the generation gate must force a reset+rebuild.
+	newCursor, reset, err := b.maybeResetOnRestore(ctx, cursor)
+	require.NoError(t, err)
+	require.True(t, reset, "generation change must force a reset")
+	assert.Equal(t, uint64(0), newCursor, "reset rewinds the cursor to 0")
+
+	persisted, err := b.readStore.LastIndexedSequence()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), persisted, "persisted cursor must rewind to 0")
+	assert.Equal(t, 0, countReadStoreKeys(t, b.readStore, readstore.LedgerLogPrefix(kb, "l1")), "stale ledger-log rows must be wiped by the reset")
+
+	// A second call with no further restore must NOT reset (generation resync).
+	_, reset, err = b.maybeResetOnRestore(ctx, 0)
+	require.NoError(t, err)
+	assert.False(t, reset, "no reset without a new restore (restoreGen was re-synced)")
+}

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -654,7 +654,7 @@ func Module() fx.Option {
 			},
 			// Index builder — tails the Raft log to populate the read index
 			func(store *dal.Store, rs *readstore.Store, attrs *attributes.Attributes, logger logging.Logger, meterProvider metric.MeterProvider, cfg Config) *indexbuilder.Builder {
-				return indexbuilder.NewBuilder(store, rs, attrs, logger, meterProvider.Meter("index.builder"), cfg.ReadIndexConfig.BatchSize)
+				return indexbuilder.NewBuilder(store, rs, attrs, logger, meterProvider.Meter("index.builder"), cfg.ReadIndexConfig.BatchSize, cfg.AuditIndexConfig.RebuildThreshold)
 			},
 			// Audit indexer — tails the Audit zone to populate the readstore audit index.
 			func(store *dal.Store, rs *readstore.Store, logger logging.Logger, meterProvider metric.MeterProvider, cfg Config) *auditindexer.Indexer {

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -205,6 +205,64 @@ func (s *Store) LastIndexedSequence() (uint64, error) {
 	return s.ReadProgress()
 }
 
+// ResetIndexes wipes every keyspace owned by the index builder so a rebuild can
+// repopulate from log sequence 0. It deletes the two contiguous regions the
+// builder writes:
+//
+//   - the ledger-scoped forward/reverse index prefixes 0x01..0x0D (one
+//     DeleteRange over [0x01, 0x0E) covers them all), and
+//   - the builder's internal progress cursors: log progress ([0xFE][0x01]),
+//     AppliedProposal progress ([0xFE][0x02]), backfill cursors ([0xFE][0x03]),
+//     and per-index version state ([0xFE][0x04]).
+//
+// It deliberately leaves the audit-index keyspace ([0xFE][0x05]) and the audit
+// cursor ([0xFE][0x06]) untouched: those are owned by the auditindexer worker,
+// which has its own rollback detector (auditindexer.Rebuild) and must reset
+// independently.
+//
+// A crash mid-reset is safe: the log progress cursor is either still ahead of
+// the rolled-back head (rollback re-detected next boot via cursorAheadOfHead)
+// or already gone (replay from 0), so index rows can never survive with a stale
+// non-zero cursor. Mirrors usagestore.Store.Reset for the read index.
+func (s *Store) ResetIndexes() error {
+	batch := s.NewBatch()
+	defer func() { _ = batch.Cancel() }()
+
+	// Ledger-scoped index prefixes 0x01..0x0D are contiguous; PrefixInternal is
+	// 0xFE, so [0x01, PrefixMetadataIndex+0x0D+1) == [0x01, 0x0E) never reaches
+	// the internal keys, which are deleted point-wise / by sub-prefix below.
+	if err := batch.DeleteRangeNoSync(
+		[]byte{PrefixMetadataIndex},
+		[]byte{PrefixTransactionRevertedAt + 1},
+	); err != nil {
+		return fmt.Errorf("deleting ledger-scoped index rows during reset: %w", err)
+	}
+
+	if err := batch.DeleteKey(ProgressKey()); err != nil {
+		return fmt.Errorf("deleting log progress cursor during reset: %w", err)
+	}
+
+	if err := batch.DeleteKey(AppliedProposalProgressKey()); err != nil {
+		return fmt.Errorf("deleting applied-proposal cursor during reset: %w", err)
+	}
+
+	backfillPrefix := BackfillKeyPrefix()
+	if err := batch.DeleteRangeNoSync(backfillPrefix, prefixUpperBound(backfillPrefix)); err != nil {
+		return fmt.Errorf("deleting backfill cursors during reset: %w", err)
+	}
+
+	versionPrefix := IndexVersionStatePrefix()
+	if err := batch.DeleteRangeNoSync(versionPrefix, prefixUpperBound(versionPrefix)); err != nil {
+		return fmt.Errorf("deleting index version state during reset: %w", err)
+	}
+
+	if err := batch.Commit(); err != nil {
+		return fmt.Errorf("committing read index reset: %w", err)
+	}
+
+	return nil
+}
+
 // NotifyProgress wakes all goroutines waiting in WaitForSequence /
 // WaitForCheckpoint. Must be called after WriteProgress commits successfully.
 //


### PR DESCRIPTION
## Stacked on #1464

**This PR is stacked on #1464** (`feat/EN-1334-usagebuilder`) — it needs `dal.Store.RestoreGeneration()` and the `restoreGeneration` bump in `RestoreCheckpoint`, which exist only on that branch. Base is set to `feat/EN-1334-usagebuilder` to keep this diff limited to the indexbuilder change. **Retarget to `release/v3.0` after #1464 merges.**

## The gap

The read-side index builder (`internal/application/indexbuilder`) had **no primary-store rollback detector at all** — unlike the usage builder and audit indexer, which #1464 gave the restore-generation watermark. It was missing **both**:

- the boot-time `cursorAheadOfHead` guard, and
- the runtime generation watermark.

After a `RestoreCheckpoint` rolled the primary log head back below the persisted read-index cursor, the builder resumed its incremental catch-up from the stale cursor and **skipped every surviving (lower-seq) log forever** — the rolled-back-then-regrown gap was never re-indexed. This is a confirmed, currently-open primary-store-rollback catch-up gap.

## The fix (parity with auditindexer / usagebuilder)

**Boot guard** — `bootInit` now wipes+rebuilds the read index when:
- the persisted cursor overtakes the log head (`cursorAheadOfHead` — the direct rollback signature), or
- the head leads the cursor by more than `rebuildThreshold` (the boot-only gap net for a rollback whose restored gap re-grew before the head was sampled).

**Runtime watermark** — a `restoreGen atomic.Uint64` seeded at boot and re-checked at the top of every steady-state tick (`maybeResetOnRestore`). A `dal.Store.RestoreGeneration()` change is the **authoritative** rollback signal: it fires on any `RestoreCheckpoint` regardless of where the head landed, so it catches the **catch-up race** that erases the position signal (restore below cursor → head re-grows past the old cursor before the next tick re-samples → `cursorAheadOfHead` is inert).

## Heavier reset path (boot-equivalent re-init)

A read-index rebuild is **not** a bare `cursor = 0`. The reset routes through a boot-equivalent re-init:

- `readstore.ResetIndexes()` wipes the **builder-owned** keyspace only — ledger-scoped index rows (prefixes `0x01..0x0D`), the log/applied-proposal progress cursors, backfill cursors, and per-index version state. It deliberately **leaves the auditindexer-owned audit index (`0xFE05`/`0xFE06`) untouched** — that worker has its own rollback detector.
- `resetAndReinit` re-syncs `restoreGen`, then re-runs `initIndexConfig` against the now-empty store, so index config, the per-replica version cache, and backfill/rewrite tasks are all re-derived and backfills replay from scratch.

Blast radius stayed contained: the boot init + reset machinery `initIndexConfig` already provided was reusable as-is; no wider refactor was needed. `NewBuilder` gained one `rebuildThreshold uint64` param, wired from `cfg.AuditIndexConfig.RebuildThreshold` (same knob the sibling workers use); the offline CLI rebuild passes `0`.

## Invariants

Poller/side-store path — the read index lives in the readstore (separate Pebble instance), so no FSM hot-path Pebble reads are involved. Reset is deterministic; the reset error paths log-and-continue in the loop (matching the existing catch-up error handling), and the reset helper returns errors loudly.

## Tests

`internal/application/indexbuilder/builder_restore_test.go`:
- `TestMaybeResetOnRestore_CatchUpRace` — the exact race: cursor advanced to 3, `RestoreCheckpoint` rolls head back, head re-grows to 5 (**past** the old cursor). Proves `shouldRebuildOnBoot`/`cursorAheadOfHead` stay inert while the generation gate forces a reset+rebuild, and that a second tick does not re-reset (generation resync). Mirrors `usagebuilder.TestTickResetsOnRestoreGenerationChange`.
- `TestBootInit_ResetsOnPrimaryStoreRollback` — real `RestoreCheckpoint` with head below cursor; boot wipes and returns cursor 0.
- `TestResetIndexes_WipesBuilderKeyspaceButNotAuditIndex` — pins the reset boundary (audit index + cursor survive).
- `TestShouldRebuildOnBoot` — boot guard decision table.

## Verification
- `GOROOT= go build ./...` clean (also full-feature build with all tags).
- `GOROOT= go test ./internal/application/indexbuilder/... ./internal/storage/readstore/...` green.
- `go vet` + `golangci-lint run --fix` on the changed packages: 0 issues.