### PR TITLE
refactor(EN-1334): drop impossible primary-store-rollback detection from auditindexer

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -228,7 +228,6 @@ func NewRunCommand() *cobra.Command {
 
 	// Audit index configuration
 	runCmd.Flags().Int("audit-index-batch-size", 0, "Audit entries per Pebble batch commit (0 = default 1000)")
-	runCmd.Flags().Uint64("audit-index-rebuild-threshold", 0, "Drop+rebuild the audit index on boot when the cursor is this far behind (0 = never)")
 	runCmd.Flags().Bool("disable-audit-index", false, "Disable the audit secondary index worker")
 
 	// Query profiling
@@ -663,12 +662,10 @@ func LoadConfig(ctx context.Context, cmd *cobra.Command) (*bootstrap.Config, err
 
 	// Audit index configuration
 	auditBatchSize, _ := cmd.Flags().GetInt("audit-index-batch-size")
-	auditRebuildThreshold, _ := cmd.Flags().GetUint64("audit-index-rebuild-threshold")
 	auditDisabled, _ := cmd.Flags().GetBool("disable-audit-index")
 	cfg.AuditIndexConfig = bootstrap.AuditIndexConfig{
-		BatchSize:        auditBatchSize,
-		RebuildThreshold: auditRebuildThreshold,
-		Disabled:         auditDisabled,
+		BatchSize: auditBatchSize,
+		Disabled:  auditDisabled,
 	}
 
 	// Query profiling

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3981,7 +3981,6 @@ The Pebble-based read index store is always active. An index builder tails the s
 | `--read-index-max-concurrent-compactions` | int | `1` | Read index max concurrent compactions |
 | `--read-index-compression` | string | `fastest,...,fast,fast,balanced` | Read index per-level compression L0-L6, comma-separated (`none\|snappy\|zstd\|fastest\|fast\|balanced\|good\|default`) |
 | `--audit-index-batch-size` | int | `1000` | Audit entries per Pebble batch commit when building the audit secondary index (0 = default 1000). |
-| `--audit-index-rebuild-threshold` | int | `0` | Drop and rebuild the audit index on boot when the cursor is this many entries behind the head (0 = never auto-rebuild). |
 | `--disable-audit-index` | bool | `false` | Disable the audit secondary index worker. When set, no audit index is built or maintained. |
 
 ```bash

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -27,11 +27,6 @@ type Config struct {
 	// Defaults to DefaultBatchSize when zero.
 	BatchSize int
 
-	// RebuildThreshold triggers a full drop+rebuild on boot when the cursor
-	// lags the last audit sequence by more than this many entries (0 disables
-	// gap-based rebuild). See shouldRebuildOnBoot.
-	RebuildThreshold uint64
-
 	// Disabled prevents ProcessOnce from doing any work when true.
 	Disabled bool
 }
@@ -157,30 +152,19 @@ func (i *Indexer) Rebuild(ctx context.Context) error {
 }
 
 // shouldRebuildOnBoot reports whether boot should drop+rebuild instead of an
-// incremental catch-up: cursor missing (0) with entries present, or the gap
-// exceeds the configured threshold.
+// incremental catch-up. The only such case is a missing cursor (0) with entries
+// present: a fresh install / discarded read index against a populated audit
+// zone, where there is no partial progress to resume.
+//
+// There is no "cursor ahead of head" case: the audit chain is append-only and
+// monotone (writeAuditEntry runs only in Machine.applyProposal, fed exclusively
+// from committed Raft entries), and RestoreCheckpoint only ever ADVANCES a node
+// that is behind (sync gates on IsStoreUpToDate, i.e. LastAppliedIndex <
+// SnapshotIndex). The persisted cursor therefore can never legitimately sit
+// ahead of the audit head, so there is nothing to rebuild away from.
 func (i *Indexer) shouldRebuildOnBoot(cursor, last uint64) bool {
-	if cursor == 0 && last > 0 {
-		return true
-	}
-	if cursorAheadOfHead(cursor, last) {
-		return true
-	}
-	if i.cfg.RebuildThreshold > 0 && last > cursor && last-cursor > i.cfg.RebuildThreshold {
-		return true
-	}
-
-	return false
+	return cursor == 0 && last > 0
 }
-
-// cursorAheadOfHead reports the post-restore rollback signature: the persisted
-// cursor sits beyond the current audit head. This is only possible after a
-// main-store restore/rollback to an earlier checkpoint with the read index
-// retained (e.g. follower sync via SynchronizeWithLeader/RestoreCheckpoint).
-// Steady-state ProcessOnce would scan past the surviving (lower-seq) entries
-// forever, so both boot and the steady-state tick force a full rebuild here
-// (which resets the cursor to 0 and re-indexes from the earliest survivor).
-func cursorAheadOfHead(cursor, last uint64) bool { return cursor > last }
 
 // processBatch indexes up to batchSize audit entries whose sequence is strictly
 // greater than after, commits a single readstore batch, and returns the new
@@ -299,10 +283,10 @@ func (i *Indexer) Stop() {
 }
 
 // boot runs once before the tail loop: it seeds the audit-head gauge and, when
-// the persisted cursor is missing / lagging beyond threshold / ahead of the
-// head, performs a full drop+rebuild. A cursor read error aborts the loop
-// (returned to tailworker, which logs and stops); a rebuild error is logged
-// and swallowed so steady-state indexing still starts.
+// the persisted cursor is missing with entries present (fresh index over a
+// populated audit zone), performs a full drop+rebuild. A cursor read error
+// aborts the loop (returned to tailworker, which logs and stops); a rebuild
+// error is logged and swallowed so steady-state indexing still starts.
 func (i *Indexer) boot(ctx context.Context) error {
 	cursor, err := i.readStore.ReadAuditProgress()
 	if err != nil {
@@ -321,28 +305,13 @@ func (i *Indexer) boot(ctx context.Context) error {
 	return nil
 }
 
-// processTick runs one steady-state iteration: refresh the audit-head gauge,
-// rebuild if the persisted cursor has overtaken the audit head, otherwise index
-// incrementally. The cursor-ahead check is what catches a runtime main-store
-// restore (SynchronizeWithLeader/RestoreCheckpoint) that drops the audit head
-// below the persisted cursor while this loop is already running — the boot
-// shouldRebuildOnBoot check runs only once, before the ticker, so without this
-// re-check ProcessOnce would scan past every surviving entry forever. Only the
-// cursor-ahead condition is re-evaluated per tick, not the full
-// shouldRebuildOnBoot: its RebuildThreshold branch is a boot-only heuristic that
-// would spuriously trigger a full rebuild whenever a normal burst exceeds the
-// threshold between ticks.
+// processTick runs one steady-state iteration: refresh the audit-head gauge and
+// index incrementally. The audit chain is append-only and monotone, so the
+// persisted cursor never overtakes the audit head at runtime — there is no
+// rollback to detect and self-heal from here (see shouldRebuildOnBoot).
 func (i *Indexer) processTick(ctx context.Context) error {
 	if last, err := i.lastAuditSequence(); err == nil {
 		i.auditLast.Store(last)
-
-		cursor, cursorErr := i.readStore.ReadAuditProgress()
-		if cursorErr == nil && cursorAheadOfHead(cursor, last) {
-			i.logger.WithFields(map[string]any{"cursor": cursor, "last": last}).
-				Infof("Audit index rebuild: cursor overtook audit head")
-
-			return i.Rebuild(ctx)
-		}
 	}
 
 	_, err := i.ProcessOnce(ctx)

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -89,65 +89,19 @@ func TestRebuildYieldsIdenticalIndex(t *testing.T) {
 	require.Equal(t, uint64(5), cursor)
 }
 
+// TestShouldRebuildOnBoot covers the sole retained rebuild trigger: a missing
+// cursor (0) with entries present (fresh index over a populated audit zone).
+// The audit chain is append-only and monotone, so a "cursor ahead of head"
+// state is unreachable and no gap-based heuristic exists — a lagging cursor is
+// resumed incrementally, never rebuilt from 0.
 func TestShouldRebuildOnBoot(t *testing.T) {
 	t.Parallel()
 	idx, _, _ := newIndexerForTest(t)
-	idx.cfg.RebuildThreshold = 100
 
 	require.True(t, idx.shouldRebuildOnBoot(0, 5), "missing cursor with entries -> rebuild")
 	require.False(t, idx.shouldRebuildOnBoot(0, 0), "empty store -> no rebuild")
-	require.False(t, idx.shouldRebuildOnBoot(5, 10), "small gap -> no rebuild")
-	require.True(t, idx.shouldRebuildOnBoot(5, 200), "gap beyond threshold -> rebuild")
-	require.True(t, idx.shouldRebuildOnBoot(10, 5), "cursor ahead of audit head (post-restore) -> rebuild")
-	require.True(t, idx.shouldRebuildOnBoot(10, 0), "cursor set but store emptied below it -> rebuild")
-
-	idx.cfg.RebuildThreshold = 0
-	require.False(t, idx.shouldRebuildOnBoot(5, 1_000_000), "threshold 0 disables gap-based rebuild")
-}
-
-// TestBootRebuildOnStaleCursor drives the boot path (loop -> shouldRebuildOnBoot
-// -> Rebuild): entries present and the persisted cursor lagging the last audit
-// sequence beyond RebuildThreshold must trigger a drop+rebuild on Start, leaving
-// the index fully repopulated and the cursor at the latest sequence.
-func TestBootRebuildOnStaleCursor(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	idx, mainStore, rs := newIndexerForTest(t)
-	idx.cfg.RebuildThreshold = 1
-	idx.batchSize = 1
-
-	for s := uint64(1); s <= 3; s++ {
-		writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
-			Sequence: s, ProposalId: s, Timestamp: &commonpb.Timestamp{Data: s * 1_000_000},
-			Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
-			Ledgers: []string{"main"},
-		})
-	}
-
-	// Index the first entry only, then write a stale low cursor so the boot gap
-	// (last=3, cursor=1) exceeds the threshold and forces a rebuild branch.
-	_, _, err := idx.processBatch(ctx, 0)
-	require.NoError(t, err)
-	cursor, err := rs.ReadAuditProgress()
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), cursor)
-
-	last, err := idx.lastAuditSequence()
-	require.NoError(t, err)
-	require.True(t, idx.shouldRebuildOnBoot(cursor, last), "stale cursor beyond threshold must rebuild on boot")
-
-	idx.Start()
-	t.Cleanup(idx.Stop)
-
-	require.Eventually(t, func() bool {
-		c, err := rs.ReadAuditProgress()
-
-		return err == nil && c == 3
-	}, 5*time.Second, 20*time.Millisecond)
-
-	seqs, err := rs.AuditSeqsByString(readstore.AuditFieldLedger, "main")
-	require.NoError(t, err)
-	require.Equal(t, []uint64{1, 2, 3}, seqs)
+	require.False(t, idx.shouldRebuildOnBoot(5, 10), "cursor lagging head -> incremental catch-up, no rebuild")
+	require.False(t, idx.shouldRebuildOnBoot(5, 1_000_000), "large lag -> incremental catch-up, no rebuild")
 }
 
 func TestIndexerCatchUpAndResume(t *testing.T) {
@@ -328,58 +282,4 @@ func TestIndexerKeepsUpUnderLoad(t *testing.T) {
 	seqs, err := rs.AuditSeqsByString(readstore.AuditFieldLedger, "main")
 	require.NoError(t, err)
 	require.Len(t, seqs, total)
-}
-
-// TestProcessTickRebuildsWhenCursorAheadOfHead reproduces the runtime main-store
-// restore scenario: SynchronizeWithLeader/RestoreCheckpoint replaces the main
-// store in place and can drop the audit head below the persisted readstore
-// cursor (a separate DB, untouched by restore). The boot shouldRebuildOnBoot
-// check runs only once, before the ticker, so the already-running loop must
-// self-heal via processTick — a bare ProcessOnce would scan past every surviving
-// lower-sequence entry forever, leaving them permanently unindexed.
-func TestProcessTickRebuildsWhenCursorAheadOfHead(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	idx, mainStore, rs := newIndexerForTest(t)
-
-	// Surviving audit head after the (simulated) rollback: entries 1..3.
-	for s := uint64(1); s <= 3; s++ {
-		writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
-			Sequence: s, ProposalId: s, Timestamp: &commonpb.Timestamp{Data: s * 1_000_000},
-			Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
-			Ledgers: []string{"main"},
-		})
-	}
-
-	// Persist a stale-high cursor (as if the pre-rollback head was 5) with the
-	// surviving entries unindexed — the state a runtime restore leaves behind.
-	batch := rs.NewBatch()
-	require.NoError(t, rs.WriteAuditProgress(batch, 5))
-	require.NoError(t, batch.Commit())
-
-	last, err := idx.lastAuditSequence()
-	require.NoError(t, err)
-	require.Equal(t, uint64(3), last)
-	require.True(t, cursorAheadOfHead(5, last))
-
-	// A bare ProcessOnce scans from the stale cursor (5), finds nothing after it,
-	// and strands entries 1..3 with the cursor still at 5 — the bug this fixes.
-	reached, err := idx.ProcessOnce(ctx)
-	require.NoError(t, err)
-	require.Equal(t, uint64(5), reached)
-	seqs, err := rs.AuditSeqsByString(readstore.AuditFieldLedger, "main")
-	require.NoError(t, err)
-	require.Empty(t, seqs, "bare ProcessOnce cannot self-heal a stale-high cursor")
-
-	// processTick detects cursor > head and rebuilds, resetting the cursor to the
-	// surviving head and re-indexing every entry at/below it.
-	require.NoError(t, idx.processTick(ctx))
-
-	cursor, err := rs.ReadAuditProgress()
-	require.NoError(t, err)
-	require.Equal(t, uint64(3), cursor, "rebuild resets the cursor to the surviving audit head")
-
-	seqs, err = rs.AuditSeqsByString(readstore.AuditFieldLedger, "main")
-	require.NoError(t, err)
-	require.Equal(t, []uint64{1, 2, 3}, seqs, "surviving entries must be re-indexed after rollback")
 }

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -107,9 +107,8 @@ type ReadIndexConfig struct {
 
 // AuditIndexConfig holds configuration for the audit secondary index worker.
 type AuditIndexConfig struct {
-	BatchSize        int    // audit entries per Pebble batch (0 = default 1000)
-	RebuildThreshold uint64 // boot drop+rebuild when (last - cursor) exceeds this (0 = never)
-	Disabled         bool   // ops kill switch
+	BatchSize int  // audit entries per Pebble batch (0 = default 1000)
+	Disabled  bool // ops kill switch
 }
 
 // SnapshotSyncConfig holds configuration for the session-based snapshot sync protocol.

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -656,9 +656,8 @@ func Module() fx.Option {
 			func(store *dal.Store, rs *readstore.Store, logger logging.Logger, meterProvider metric.MeterProvider, cfg Config) *auditindexer.Indexer {
 				return auditindexer.New(
 					auditindexer.Config{
-						BatchSize:        cfg.AuditIndexConfig.BatchSize,
-						RebuildThreshold: cfg.AuditIndexConfig.RebuildThreshold,
-						Disabled:         cfg.AuditIndexConfig.Disabled,
+						BatchSize: cfg.AuditIndexConfig.BatchSize,
+						Disabled:  cfg.AuditIndexConfig.Disabled,
 					},
 					store, rs, logger, meterProvider.Meter("audit.index"),
 				)


### PR DESCRIPTION
## Summary

Removes dead primary-store-rollback detection from the audit indexer. This mirrors the identical removal just made on the usagebuilder (PR #1464, commit b09f82457).

## Why the rollback guard is unreachable

The audit chain is **append-only and monotone**:

- `writeAuditEntry` runs **only** inside `Machine.applyProposal` (`internal/infra/state/machine.go`).
- The applier feeds `applyProposal` **exclusively** from committed Raft entries: `node.applier.Submit(rd.CommittedEntries, …)` (`internal/infra/node/node.go:1411`), and etcd/raft only emits `MsgStorageApply` when `CommittedEntries > 0` (`node.go:1404-1407`).
- By **Raft leader-completeness**, a committed entry is present on every future leader — once an audit entry is written it can never be un-written or superseded.
- `RestoreCheckpoint` only ever **advances** a node that is behind: sync runs solely when `IsStoreUpToDate` is false, i.e. `LastAppliedIndex < SnapshotIndex` (`internal/infra/state/synchronizer.go:148`), and the leader's checkpoint is at an index ≥ ours.

Therefore the persisted audit-index cursor can **never legitimately sit ahead of the audit head**, and the "cursor overtook head after a rollback" scenario is unreachable.

## What was removed

- `cursorAheadOfHead(cursor, last)` and both its call sites: the boot-time branch in `shouldRebuildOnBoot` and the per-tick re-check + `Rebuild` call in `processTick`.
- The `RebuildThreshold` gap branch in `shouldRebuildOnBoot` (`i.cfg.RebuildThreshold > 0 && last > cursor && last-cursor > i.cfg.RebuildThreshold`). It was framed as a "rollback net", but a rebuild-from-0 re-indexes `[0,cursor]` on top of the `[cursor,last]` range that incremental catch-up already covers — it is **strictly more work** than catch-up, not a perf optimization. With rollback impossible its only purpose is void.
- The now-inert `RebuildThreshold` config field (`AuditIndexConfig.RebuildThreshold`), its `--audit-index-rebuild-threshold` CLI flag (`cmd/server/server.go`), and the `docs/ops/cli.md` entry. auditindexer was its only consumer, and the surface is self-contained (one flag, one config field, one wiring site, one docs line), so it was removed rather than left inert.
- Obsolete tests: `TestBootRebuildOnStaleCursor`, `TestProcessTickRebuildsWhenCursorAheadOfHead`, and the `RebuildThreshold`/cursor-ahead cases in `TestShouldRebuildOnBoot`.

## What was kept

- The legitimate **fresh-build** case in `shouldRebuildOnBoot`: `cursor == 0 && last > 0` (empty cursor, entries exist → build the index). This is **not** rollback detection.
- `TestShouldRebuildOnBoot` retains coverage of that case, and now asserts a lagging cursor is resumed incrementally (never rebuilt from 0).
- `processTick` still refreshes the audit-head gauge and calls `ProcessOnce`.

## Related

- Companion usagebuilder removal: PR #1464, commit `b09f82457`.
- PR #1568 (the indexbuilder watermark) and the #1464 restore-generation watermark were reverted for the same monotonicity reason.

## Verification

- `GOROOT= go build ./...` — clean
- `GOROOT= go test ./internal/application/auditindexer/... -count=1` — green
- `go vet` + `golangci-lint run --fix` on the changed packages — 0 issues