### PR TITLE
fix(EN-1509): preserve typed metadata in HTTP revert-transaction requests

### DIFF
--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -159,7 +159,7 @@ See [Numscript Guide](./numscript.md) for complete documentation.
 - ✅ Standard revert
 - ✅ `force` option (ignore insufficient balances)
 - ✅ `atEffectiveDate` option (use original transaction timestamp)
-- ✅ Revert metadata
+- ✅ Revert metadata (typed values — string, integer, boolean — preserved losslessly; unsupported values rejected with `400 INVALID_REQUEST`)
 - ✅ Verification that transaction is not already reverted
 
 **Navigable revert relationship.** The revert link is a first-class part of the

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -41,15 +41,19 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 	// Extract optional fields from request body
 	if reqBody != nil {
 		if metadata, ok := reqBody["metadata"].(map[string]any); ok {
-			metadataMap := make(map[string]string)
+			// Decode metadata through the shared typed-metadata path so numeric,
+			// boolean and other non-string values survive losslessly (parity with
+			// create-transaction / set-metadata). Invalid values (objects, arrays,
+			// non-integer floats) are rejected with 400 INVALID_REQUEST instead of
+			// being silently dropped (EN-1509).
+			ms, err := commonpb.MetadataFromAnyMap(metadata)
+			if err != nil {
+				writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid metadata: %w", err))
 
-			for k, v := range metadata {
-				if strVal, ok := v.(string); ok {
-					metadataMap[k] = strVal
-				}
+				return
 			}
 
-			payload.Metadata = commonpb.MetadataFromGoMap(metadataMap)
+			payload.Metadata = ms
 		}
 
 		if force, ok := reqBody["force"].(bool); ok {

--- a/internal/adapter/http/handlers_revert_transaction_test.go
+++ b/internal/adapter/http/handlers_revert_transaction_test.go
@@ -160,3 +160,132 @@ func TestHandleRevertTransaction_WithBody(t *testing.T) {
 
 	require.Equal(t, http.StatusCreated, w.Code)
 }
+
+// revertPayloadFromApply extracts the RevertTransactionPayload that the handler
+// forwarded to the backend, so tests can assert the metadata mapping.
+func revertPayloadFromApply(t *testing.T, req *servicepb.ApplyRequest) *servicepb.RevertTransactionPayload {
+	t.Helper()
+
+	requests := req.GetUnsigned().GetRequests()
+	require.Len(t, requests, 1)
+
+	action := requests[0].GetApply().GetAction()
+	rt, ok := action.GetData().(*servicepb.LedgerAction_RevertTransaction)
+	require.True(t, ok, "expected a revert-transaction action")
+
+	return rt.RevertTransaction
+}
+
+func revertBackendReturningLog(t *testing.T, captured **servicepb.RevertTransactionPayload) *MockBackend {
+	t.Helper()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			if captured != nil {
+				*captured = revertPayloadFromApply(t, req)
+			}
+
+			return []*commonpb.Log{
+				{
+					Payload: &commonpb.LogPayload{
+						Type: &commonpb.LogPayload_Apply{
+							Apply: &commonpb.ApplyLedgerLog{
+								Log: &commonpb.LedgerLog{
+									Data: &commonpb.LedgerLogPayload{
+										Payload: &commonpb.LedgerLogPayload_RevertedTransaction{
+											RevertedTransaction: &commonpb.RevertedTransaction{
+												RevertTransaction: &commonpb.Transaction{Id: 2},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		}).AnyTimes()
+
+	return backend
+}
+
+// TestHandleRevertTransaction_TypedMetadata verifies that typed metadata values
+// (string, numeric, boolean, and date-as-string) survive the HTTP revert path
+// without being coerced or dropped (EN-1509).
+func TestHandleRevertTransaction_TypedMetadata(t *testing.T) {
+	t.Parallel()
+
+	var captured *servicepb.RevertTransactionPayload
+	backend := revertBackendReturningLog(t, &captured)
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"metadata":{"reason":"fraud","count":42,"negative":-7,"active":true,"effectiveAt":"2026-07-11T00:00:00Z"}}`)
+	r := newRequest(t, http.MethodPost, "/ledger1/transactions/1/revert", body, map[string]string{
+		"ledgerName":    "ledger1",
+		"transactionId": "1",
+	})
+	r.ContentLength = int64(body.Len())
+
+	srv.handleRevertTransaction(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, captured)
+
+	got := commonpb.MetadataToAnyMap(captured.GetMetadata())
+	require.Equal(t, "fraud", got["reason"])
+	require.EqualValues(t, uint64(42), got["count"])
+	require.EqualValues(t, int64(-7), got["negative"])
+	require.Equal(t, true, got["active"])
+	require.Equal(t, "2026-07-11T00:00:00Z", got["effectiveAt"])
+}
+
+// TestHandleRevertTransaction_StringMetadata keeps the plain string-metadata
+// contract green alongside the typed one.
+func TestHandleRevertTransaction_StringMetadata(t *testing.T) {
+	t.Parallel()
+
+	var captured *servicepb.RevertTransactionPayload
+	backend := revertBackendReturningLog(t, &captured)
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"metadata":{"reason":"duplicate"}}`)
+	r := newRequest(t, http.MethodPost, "/ledger1/transactions/1/revert", body, map[string]string{
+		"ledgerName":    "ledger1",
+		"transactionId": "1",
+	})
+	r.ContentLength = int64(body.Len())
+
+	srv.handleRevertTransaction(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, captured)
+
+	got := commonpb.MetadataToAnyMap(captured.GetMetadata())
+	require.Equal(t, "duplicate", got["reason"])
+}
+
+// TestHandleRevertTransaction_InvalidMetadata verifies unsupported metadata
+// values (objects/arrays) are rejected with 400 INVALID_REQUEST instead of
+// being silently dropped (EN-1509).
+func TestHandleRevertTransaction_InvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"metadata":{"nested":{"not":"allowed"}}}`)
+	r := newRequest(t, http.MethodPost, "/ledger1/transactions/1/revert", body, map[string]string{
+		"ledgerName":    "ledger1",
+		"transactionId": "1",
+	})
+	r.ContentLength = int64(body.Len())
+
+	srv.handleRevertTransaction(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeResponse[ErrorResponse](t, w)
+	require.Equal(t, "INVALID_REQUEST", resp.ErrorCode)
+}


### PR DESCRIPTION
## Summary

Ref EN-1509 (Medium bug — "Preserve typed metadata values in HTTP revert-transaction requests").

`RevertTransactionPayload.metadata` is a `map<string, common.MetadataValue>` (typed), but `internal/adapter/http/handlers_revert_transaction.go` decoded the JSON `metadata` field as `map[string]any`, kept **only** string values in a `map[string]string`, and converted via `commonpb.MetadataFromGoMap`. Typed (numeric / boolean) values a client sent were **silently dropped** — a client got a successful revert with metadata missing (data-loss + parity bug).

## Fix

- Decode `metadata` through the shared typed-metadata path `commonpb.MetadataFromAnyMap` — the same decoder the set-metadata HTTP handlers use (`parseMetadataBody`) and consistent with create-transaction's typed proto-JSON codec. No new decoder was forked.
- All supported `MetadataValue` kinds (string, integer, boolean) are mapped losslessly to `RevertTransactionPayload.Metadata`.
- Unsupported values (objects, arrays, non-integer floats) are now **rejected with `400 INVALID_REQUEST`** instead of being silently dropped.

## Reused decoder

`internal/proto/commonpb/metadata.go` — `MetadataFromAnyMap` (built on `MetadataValueFromAny`), the exact path behind `parseMetadataBody` used by `handleSaveTransactionMetadata` / `handleSaveAccountMetadata`.

## Files

- `internal/adapter/http/handlers_revert_transaction.go` — typed decode + 400 on invalid.
- `internal/adapter/http/handlers_revert_transaction_test.go` — tests: string, numeric (uint + negative int), boolean, date-as-string (all asserted losslessly on the forwarded payload); invalid (nested object) → 400 INVALID_REQUEST.
- `docs/technical/contributing/api-comparison.md` — note typed-metadata support + 400 behavior on revert.

## OpenAPI

`openapi.yml` already documented `RevertTransactionRequestBody.metadata` as `additionalProperties: $ref MetadataValue` (typed). The spec was correct; the handler had diverged from it — this restores parity. No schema change needed.

## Verification

- `GOROOT= go build ./...` — OK
- `GOROOT= go test ./internal/adapter/http/... -count=1` — OK
- `go generate ./... && go mod tidy && golangci-lint run --fix` — tree clean (only the 3 intended files changed)