### PR TITLE
fix(EN-1533): stop mutating initial account types before CreateLedger audit capture

### DIFF
--- a/internal/domain/processing/processor_ledger.go
+++ b/internal/domain/processing/processor_ledger.go
@@ -26,17 +26,34 @@ func processCreateLedger(ledger string, order *raftcmdpb.CreateLedgerOrder, ctx 
 		return nil, &domain.ErrLedgerAlreadyExists{Name: ledger}
 	}
 
-	// Validate initial account types if provided. Iterate names in sorted order
-	// so the first invalid pattern reported (chain-bound ErrInvalidPattern →
-	// AuditFailure) is identical on every replica — a raw map range could
-	// surface a different offending pattern per node (invariant #2). See
-	// EN-1521.
+	// Validate initial account types if provided, then build a canonical map
+	// for derived state. Iterate names in sorted order so the first invalid
+	// pattern reported (chain-bound ErrInvalidPattern → AuditFailure) is
+	// identical on every replica — a raw map range could surface a different
+	// offending pattern per node (invariant #2). See EN-1521.
+	//
+	// The canonical map holds CLONES of the order-owned messages with each
+	// clone's Name set to the authoritative map key. We MUST NOT mutate the
+	// messages reachable from order.AccountTypes: the accepted order is
+	// captured verbatim by marshalOrdersForAudit at apply time, so mutating
+	// an embedded Name here would make the audited order diverge from what
+	// was accepted — and, with an idempotency key, make the pre-processing
+	// frozen outcome hash disagree with the checker's hash re-derived from
+	// the audited order (EN-1533). A nil map value has GetPattern()=="" and
+	// is rejected by ValidatePattern ("pattern must not be empty") before the
+	// clone, so every entry cloned below is guaranteed non-nil.
+	var canonicalAccountTypes map[string]*commonpb.AccountType
+	if src := order.GetAccountTypes(); len(src) > 0 {
+		canonicalAccountTypes = make(map[string]*commonpb.AccountType, len(src))
+	}
 	for _, name := range slices.Sorted(maps.Keys(order.GetAccountTypes())) {
 		at := order.GetAccountTypes()[name]
 		if err := accounttype.ValidatePattern(at.GetPattern()); err != nil {
 			return nil, &domain.ErrInvalidPattern{Pattern: at.GetPattern(), Details: err.Error()}
 		}
-		at.Name = name
+		clone := at.CloneVT()
+		clone.Name = name
+		canonicalAccountTypes[name] = clone
 	}
 
 	createdAt := s.GetDate().Mutate()
@@ -49,7 +66,7 @@ func processCreateLedger(ledger string, order *raftcmdpb.CreateLedgerOrder, ctx 
 		MetadataSchema:         populateInitialSchema(order.GetInitialSchema()),
 		Mode:                   order.GetMode(),
 		MirrorSource:           order.GetMirrorSource(),
-		AccountTypes:           order.GetAccountTypes(),
+		AccountTypes:           canonicalAccountTypes,
 		DefaultEnforcementMode: order.GetDefaultEnforcementMode(),
 	}
 	s.Ledgers().Put(domain.LedgerKey{Name: ledger}, info)
@@ -62,14 +79,16 @@ func processCreateLedger(ledger string, order *raftcmdpb.CreateLedgerOrder, ctx 
 	// reconciliation) is derived from CreatedLedgerLog.Mode == MIRROR by
 	// deriveSignals — see processor.go.
 
-	// Build the log from the order — NOT from `info` which is the mutable
-	// store object. MetadataSchema and AccountTypes are cloned to avoid
-	// sharing mutable maps/pointers between the store and the immutable
-	// log payload.
+	// Build the log its OWN immutable snapshot — NOT `info.AccountTypes`
+	// (mutated in place by processAddAccountType) nor the order-owned messages
+	// (captured verbatim for audit). Clone each canonical entry so the log map
+	// shares no mutable map or message with either the store or the order. The
+	// clones carry the same map-key canonical Name, so CreatedLedgerLog.
+	// ToLedgerInfo() reconstructs a LedgerInfo identical to the FSM-built one.
 	var logAccountTypes map[string]*commonpb.AccountType
-	if src := order.GetAccountTypes(); len(src) > 0 {
-		logAccountTypes = make(map[string]*commonpb.AccountType, len(src))
-		for k, v := range src {
+	if len(canonicalAccountTypes) > 0 {
+		logAccountTypes = make(map[string]*commonpb.AccountType, len(canonicalAccountTypes))
+		for k, v := range canonicalAccountTypes {
 			logAccountTypes[k] = v.CloneVT()
 		}
 	}

--- a/internal/domain/processing/processor_ledger_test.go
+++ b/internal/domain/processing/processor_ledger_test.go
@@ -89,6 +89,87 @@ func TestProcessCreateLedger_InvalidPatternSelectionDeterministic(t *testing.T) 
 	}
 }
 
+// TestProcessCreateLedger_DoesNotMutateOrderAccountTypes pins EN-1533: the
+// accepted order is captured verbatim for the audit chain, so processCreateLedger
+// MUST NOT mutate any AccountType message reachable from
+// CreateLedgerOrder.AccountTypes — not even to normalize an embedded Name to its
+// map key. Derived state (LedgerInfo) and the created-ledger log must instead use
+// the map key as the canonical name, on their own cloned messages.
+func TestProcessCreateLedger_DoesNotMutateOrderAccountTypes(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	now := &commonpb.Timestamp{Data: 1234567890}
+
+	// One entry with a blank embedded Name, one with an embedded Name that
+	// mismatches its map key. Both should be preserved verbatim in the order,
+	// while derived state uses the map key.
+	order := &raftcmdpb.CreateLedgerOrder{
+		AccountTypes: map[string]*commonpb.AccountType{
+			"canonical-a": {Name: "", Pattern: "a:{id}"},
+			"canonical-b": {Name: "wrong-embedded-name", Pattern: "b:{id}"},
+		},
+	}
+
+	// Snapshot the deterministic bytes of the order BEFORE processing.
+	fullOrder := &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: "l",
+				Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{
+					CreateLedger: order,
+				},
+			},
+		},
+	}
+	before := fullOrder.MarshalDeterministicVT(nil)
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "l"}, nil, domain.ErrNotFound)
+	mockStore.EXPECT().IncrementNextLedgerID().Return(uint32(1))
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+
+	var storedInfo *commonpb.LedgerInfo
+	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "l"}, nil, func(_ string, info *commonpb.LedgerInfo) {
+		storedInfo = info
+	})
+	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "l"}, nil)
+
+	log, derr := processCreateLedger("l", order, &Context{Scope: mockStore})
+	require.Nil(t, derr)
+	require.NotNil(t, log)
+
+	// The order-owned messages must be untouched: both the raw embedded names
+	// and the deterministic order bytes are identical to the pre-processing
+	// snapshot.
+	require.Equal(t, "", order.GetAccountTypes()["canonical-a"].GetName(),
+		"blank embedded name must not be normalized into the order")
+	require.Equal(t, "wrong-embedded-name", order.GetAccountTypes()["canonical-b"].GetName(),
+		"mismatched embedded name must not be rewritten in the order")
+	after := fullOrder.MarshalDeterministicVT(nil)
+	require.Equal(t, before, after, "processing must not mutate the accepted order bytes")
+
+	// Derived state (LedgerInfo) uses the map key as the canonical name.
+	require.NotNil(t, storedInfo)
+	require.Equal(t, "canonical-a", storedInfo.GetAccountTypes()["canonical-a"].GetName())
+	require.Equal(t, "canonical-b", storedInfo.GetAccountTypes()["canonical-b"].GetName())
+
+	// The created-ledger log uses the map key too, on its OWN messages that
+	// share no pointer with the stored LedgerInfo.
+	createLog := log.GetCreateLedger()
+	require.NotNil(t, createLog)
+	require.Equal(t, "canonical-a", createLog.GetAccountTypes()["canonical-a"].GetName())
+	require.Equal(t, "canonical-b", createLog.GetAccountTypes()["canonical-b"].GetName())
+	require.NotSame(t, storedInfo.GetAccountTypes()["canonical-a"], createLog.GetAccountTypes()["canonical-a"],
+		"log must own an independent snapshot, not share the mutable store message")
+	require.NotSame(t, order.GetAccountTypes()["canonical-a"], createLog.GetAccountTypes()["canonical-a"],
+		"log must not share the order-owned message")
+	require.NotSame(t, order.GetAccountTypes()["canonical-a"], storedInfo.GetAccountTypes()["canonical-a"],
+		"LedgerInfo must not share the order-owned message")
+}
+
 func TestProcessCreateLedger_AlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/state/create_ledger_account_type_aliasing_test.go
+++ b/internal/infra/state/create_ledger_account_type_aliasing_test.go
@@ -1,0 +1,124 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// createLedgerOrderWithAccountTypes builds a CreateLedger order whose embedded
+// AccountType.Name values deliberately do NOT match their map keys (one blank,
+// one mismatched), so the test can prove the FSM preserves the submitted bytes
+// verbatim while canonicalizing derived state to the map key.
+func createLedgerOrderWithAccountTypes(name string, accountTypes map[string]*commonpb.AccountType) *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: name,
+				Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{
+					CreateLedger: &raftcmdpb.CreateLedgerOrder{
+						AccountTypes: accountTypes,
+					},
+				},
+			},
+		},
+	}
+}
+
+func readAuditItemsForSequence(t *testing.T, ctx context.Context, store *dal.Store, seq uint64) []*auditpb.AuditItem {
+	t.Helper()
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	items, err := query.ReadAuditItems(ctx, handle, seq)
+	require.NoError(t, err)
+
+	return items
+}
+
+// TestCreateLedger_AuditPreservesSubmittedAccountTypeNames pins EN-1533 at the
+// FSM/audit layer: with an idempotency key on the batch, the audited order bytes
+// must preserve the SUBMITTED embedded account-type names (blank / mismatched),
+// while the derived created-ledger log canonicalizes each name to its map key.
+// A replay of the identical keyed proposal must NOT surface an idempotency
+// conflict — the pre-processing frozen outcome hash (over the accepted order)
+// stays consistent with what the audit chain records.
+func TestCreateLedger_AuditPreservesSubmittedAccountTypeNames(t *testing.T) {
+	t.Parallel()
+
+	machine, dataStore, _ := newTestMachine(t)
+	ctx := context.Background()
+
+	const ledgerName = "aliasing"
+
+	order := createLedgerOrderWithAccountTypes(ledgerName, map[string]*commonpb.AccountType{
+		"canonical-a": {Name: "", Pattern: "a:{id}"},
+		"canonical-b": {Name: "wrong-embedded-name", Pattern: "b:{id}"},
+	})
+
+	proposal := makeProposal(2, order)
+	proposal.Idempotency = &commonpb.Idempotency{Key: "create-key"}
+
+	r, err := machine.ApplyEntries(ctx, dataStore, makeEntry(t, 1, proposal))
+	require.NoError(t, err)
+	require.Len(t, r.Results, 1)
+	require.NoError(t, r.Results[0].Error)
+	require.Len(t, r.Results[0].Logs, 1)
+
+	// Derived state: the created-ledger log canonicalizes each name to the map
+	// key (LedgerInfo is built from the same canonical map).
+	createLog := r.Results[0].Logs[0].GetCreatedLog().GetPayload().GetCreateLedger()
+	require.NotNil(t, createLog)
+	require.Equal(t, "canonical-a", createLog.GetAccountTypes()["canonical-a"].GetName())
+	require.Equal(t, "canonical-b", createLog.GetAccountTypes()["canonical-b"].GetName())
+
+	// The in-memory order we submitted must be untouched (no aliasing back
+	// through the CreateLedgerOrder we handed the machine).
+	require.Equal(t, "", order.GetLedgerScoped().GetCreateLedger().GetAccountTypes()["canonical-a"].GetName())
+	require.Equal(t, "wrong-embedded-name", order.GetLedgerScoped().GetCreateLedger().GetAccountTypes()["canonical-b"].GetName())
+
+	// A second, distinct apply flushes the first proposal's audit entry (and its
+	// items) to the durable read path.
+	r, err = machine.ApplyEntries(ctx, dataStore, makeEntry(t, 2, makeProposal(3, createLedgerOrder("other"))))
+	require.NoError(t, err)
+	require.NoError(t, r.Results[0].Error)
+
+	// Audited order bytes: the SerializedOrder captured into the hash chain must
+	// unmarshal back to the exact submitted embedded names — proving the accepted
+	// order was never mutated before audit capture.
+	items := readAuditItemsForSequence(t, ctx, dataStore, 1)
+	require.Len(t, items, 1)
+
+	var audited raftcmdpb.Order
+	require.NoError(t, audited.UnmarshalVT(items[0].GetSerializedOrder()))
+	auditedTypes := audited.GetLedgerScoped().GetCreateLedger().GetAccountTypes()
+	require.Equal(t, "", auditedTypes["canonical-a"].GetName(),
+		"audited order must preserve the submitted blank embedded name")
+	require.Equal(t, "wrong-embedded-name", auditedTypes["canonical-b"].GetName(),
+		"audited order must preserve the submitted mismatched embedded name")
+
+	// Replaying the identical keyed proposal must replay cleanly, with no
+	// idempotency conflict: the frozen outcome hash re-derived from the accepted
+	// order agrees with what the chain recorded.
+	replayOrder := createLedgerOrderWithAccountTypes(ledgerName, map[string]*commonpb.AccountType{
+		"canonical-a": {Name: "", Pattern: "a:{id}"},
+		"canonical-b": {Name: "wrong-embedded-name", Pattern: "b:{id}"},
+	})
+	replay := makeProposal(4, replayOrder)
+	replay.Idempotency = &commonpb.Idempotency{Key: "create-key"}
+
+	r, err = machine.ApplyEntries(ctx, dataStore, makeEntry(t, 3, replay))
+	require.NoError(t, err)
+	require.Len(t, r.Results, 1)
+	require.NoError(t, r.Results[0].Error, "identical keyed replay must not surface an idempotency conflict")
+}


### PR DESCRIPTION
## Summary

`processCreateLedger` assigned the map key into each order-owned `AccountType` message (`at.Name = name`) **before** the accepted order was captured for the audit chain. As a result the audit chain recorded a *normalized* account type rather than the accepted order. With an idempotency key on the batch, the pre-processing frozen outcome hash (over the accepted order) could then disagree with the checker's hash re-derived from the audited order, surfacing a false idempotency mismatch. This is an aliasing bug: the accepted order, the mutable `LedgerInfo`, and the generated log all shared the same messages.

## Fix

- Build a **new canonical account-type map** from proto clones (`CloneVT`) of the order-owned messages, assigning the map key to each **clone's** `Name`. The order-owned messages under `CreateLedgerOrder.AccountTypes` are never mutated.
- Use the canonical map for `LedgerInfo.AccountTypes` (map-key-authoritative — unchanged semantics).
- Give the created-ledger log its **own independent cloned snapshot**, sharing no mutable map or message with the store (which `processAddAccountType` mutates in place) or the order. The clones carry the same map-key canonical `Name`, so `CreatedLedgerLog.ToLedgerInfo()` still reconstructs an identical `LedgerInfo`.

## Preserved semantics / no regressions

- The EN-1521 deterministic sorted-key validation (first invalid pattern reported identically on every replica) is preserved.
- No new key/name validation contract or business rule: a nil map value has `GetPattern() == ""` and is rejected by `ValidatePattern` (`"pattern must not be empty"`) before the clone, so every cloned entry is guaranteed non-nil. No contract decision required.

## Tests

- **Processing** (`processor_ledger_test.go`): with blank and mismatched embedded names, snapshot the deterministic order bytes and assert the order bytes + embedded names are unchanged after processing, while `LedgerInfo` and the created log use the map-key canonical name (on independent messages). EN-1521 determinism test kept green.
- **FSM/audit** (`create_ledger_account_type_aliasing_test.go`): apply a keyed `CreateLedger` through the real machine; assert the audited `SerializedOrder` preserves the submitted embedded names verbatim while the derived log is map-key canonical; assert an identical keyed replay surfaces **no** idempotency conflict. Verified the test fails against the old mutating behavior.

## Checks

- `GOROOT= go build ./...` clean
- `go test ./internal/domain/processing/... ./internal/infra/state/... ./internal/application/check/... -count=1` green
- `go generate ./...` + `go mod tidy` produce no changes; `golangci-lint run --fix` 0 issues; tree clean