### PR TITLE
fix(EN-1524): preflight technical-update envelopes before mutation

### DIFF
--- a/internal/infra/state/machine_technical_updates.go
+++ b/internal/infra/state/machine_technical_updates.go
@@ -32,6 +32,18 @@ import (
 // those and converts them into ApplyResult.Error so the proposer learns
 // about the rejection without an FSM-level abort.
 func (fsm *Machine) applyTechnicalUpdates(scopeFactory processing.ScopeFactory, batch *dal.WriteSession, raftIndex uint64, proposal *raftcmdpb.Proposal) error {
+	// Preflight the WHOLE technical-update envelope before dispatching a
+	// single handler. applyTechnicalUpdates below mutates state as it
+	// walks the slice (applyClusterConfig resets the cache, applyBackupOrder
+	// touches BackupJobsState, applyMirrorSyncUpdate queues into the
+	// WriteSet, …) — so a malformed later update, or an unsupported mixture
+	// of orders and technical updates, must be caught FIRST. Otherwise an
+	// earlier handler's direct mutation lands before the later update is
+	// rejected. See EN-1524.
+	if err := preflightTechnicalUpdates(proposal); err != nil {
+		return err
+	}
+
 	for i, tu := range proposal.GetTechnicalUpdates() {
 		scope, scopeErr := scopeFactory.NewScope(tu.GetCoverageBits())
 		if scopeErr != nil {
@@ -89,6 +101,100 @@ func (fsm *Machine) applyTechnicalUpdates(scopeFactory processing.ScopeFactory, 
 			// rather than discover stale forward indexes later.
 			return fmt.Errorf("technical_updates[%d]: unsupported kind %T (drain Raft commits before upgrading past EN-1323)", i, kind)
 		}
+	}
+
+	return nil
+}
+
+// preflightTechnicalUpdates is a mutation-free pass over the WHOLE
+// technical-update envelope, run before applyTechnicalUpdates dispatches
+// any handler. It exists because the dispatch loop interleaves validation
+// with mutation: a handler mutates state (cache reset, backup-job map,
+// WriteSet queue) the instant it is reached, so a malformed later update
+// discovered mid-loop would land AFTER an earlier handler already mutated.
+// The preflight moves every cheap structural check ahead of the first
+// mutation. See EN-1524.
+//
+// Three classes of check, each mapped to the surfacing the FSM already
+// uses for that class:
+//
+//  1. Coverage bitset well-formedness — validated against the SAME
+//     execution plan the handlers' scopes will use, via the shared
+//     validateCoverageBits. A bit past the plan slice, a plan with a
+//     malformed AttributeID, or an attr_code the FSM does not handle
+//     surfaces as *domain.ErrInvalidExecutionPlan — a business rejection
+//     (planInvariantDescribable in machine.go recognises it), never an
+//     FSM abort, because no mutation has landed yet.
+//
+//  2. Producer-shape enforcement — the current producers emit exactly one
+//     shape each (see the proposal builders in bootstrap/module.go,
+//     application/events/emitter.go, application/backup/orchestrator.go,
+//     application/mirror/worker.go): (a) a non-MirrorSync technical update
+//     is technical-only and is the SOLE update in a zero-order proposal;
+//     (b) MirrorSync may coexist with its mirror-ingest order batch but
+//     remains the sole technical update in that proposal. A proposal that
+//     violates either — multiple technical updates, or non-MirrorSync
+//     updates riding alongside orders — is a producer bug, surfaced as
+//     *domain.ErrInvalidExecutionPlan (KindInternal) for the same
+//     no-mutation reason as (1).
+//
+//  3. nil / unsupported kind — surfaced FSM-fatally, identical to the
+//     dispatch loop's default arm. Per CLAUDE.md invariant #7 and the
+//     EN-1323 rolling-upgrade note there, a nil-kind technical update is
+//     an FSM-divergence signal (old nodes apply the pre-cutover payload,
+//     new nodes see nil), so it must fail loudly on every new node rather
+//     than degrade to a per-proposal business rejection.
+func preflightTechnicalUpdates(proposal *raftcmdpb.Proposal) error {
+	updates := proposal.GetTechnicalUpdates()
+	if len(updates) == 0 {
+		return nil
+	}
+
+	var plans []*raftcmdpb.AttributeCoverage
+	if plan := proposal.GetExecutionPlan(); plan != nil {
+		plans = plan.GetAttributes()
+	}
+
+	// Shape: at most one technical update per proposal. Every current
+	// producer emits exactly one; more than one means a producer bug or a
+	// forged proposal, and the two-shape contract below (which reasons
+	// about "the" technical update) only holds for a single update.
+	if len(updates) > 1 {
+		return &domain.ErrInvalidExecutionPlan{
+			Reason_: fmt.Sprintf("proposal carries %d technical updates; at most one is supported per proposal", len(updates)),
+		}
+	}
+
+	tu := updates[0]
+
+	// Coverage: validate the update's bitset against the final execution
+	// plan without touching any coverage slot (the mutation applyPlans
+	// would do). NewScope re-runs the mutating variant per handler; here we
+	// only need the reject-before-mutation guarantee.
+	if err := validateCoverageBits(plans, tu.GetCoverageBits(), nil); err != nil {
+		return fmt.Errorf("technical_updates[0]: %w", err)
+	}
+
+	// Kind + order coexistence. MirrorSync is the only kind allowed to ride
+	// alongside an order batch; every other kind is technical-only.
+	switch tu.GetKind().(type) {
+	case *raftcmdpb.TechnicalUpdate_MirrorSync:
+		// Allowed with or without orders (data batch vs. error report).
+	case *raftcmdpb.TechnicalUpdate_ClusterConfig,
+		*raftcmdpb.TechnicalUpdate_EventsSink,
+		*raftcmdpb.TechnicalUpdate_IdempotencyEviction,
+		*raftcmdpb.TechnicalUpdate_BackupOrder,
+		*raftcmdpb.TechnicalUpdate_IncrementalBackupOrder:
+		if len(proposal.GetOrders()) != 0 {
+			return &domain.ErrInvalidExecutionPlan{
+				Reason_: fmt.Sprintf("technical_updates[0]: %T is technical-only and cannot coexist with %d order(s)", tu.GetKind(), len(proposal.GetOrders())),
+			}
+		}
+	default:
+		// nil kind (rolling-upgrade IndexReady cutover) or a kind added
+		// without a preflight arm. FSM-fatal, matching the dispatch loop's
+		// default arm — see that comment and CLAUDE.md invariant #7.
+		return fmt.Errorf("technical_updates[0]: unsupported kind %T (drain Raft commits before upgrading past EN-1323)", tu.GetKind())
 	}
 
 	return nil

--- a/internal/infra/state/machine_technical_updates_test.go
+++ b/internal/infra/state/machine_technical_updates_test.go
@@ -1,0 +1,332 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// --- Producer-shape helpers ------------------------------------------------
+//
+// Each helper mirrors exactly one producer's emitted proposal shape (see the
+// proposal builders referenced in each comment). If a producer's shape drifts,
+// the corresponding accept-test below must be updated in lock-step — that is
+// the point: these tests pin the shape contract preflightTechnicalUpdates
+// enforces.
+
+// clusterConfigProposal mirrors bootstrap/module.go proposeClusterConfigUpdate:
+// zero orders, exactly one ClusterConfig technical update, empty coverage bits.
+func clusterConfigProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_ClusterConfig{
+				ClusterConfig: &commonpb.ClusterConfig{RotationThreshold: 1000},
+			},
+		}},
+	}
+}
+
+// sinkCursorProposal mirrors application/events/emitter.go proposeSinkUpdateOnce.
+func sinkCursorProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_EventsSink{
+				EventsSink: &raftcmdpb.EventsSinkUpdate{SinkName: "sink-a", Cursor: 5},
+			},
+		}},
+	}
+}
+
+// idempotencyEvictionProposal mirrors bootstrap/module.go's idempotency
+// eviction scheduler.
+func idempotencyEvictionProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_IdempotencyEviction{
+				IdempotencyEviction: &raftcmdpb.IdempotencyEviction{CutoffMicros: 42},
+			},
+		}},
+	}
+}
+
+// backupOrderProposal mirrors application/backup/orchestrator.go
+// wrapFullBackupOrder.
+func backupOrderProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_BackupOrder{
+				BackupOrder: &raftcmdpb.BackupOrder{
+					Op: &raftcmdpb.BackupOrder_Start{Start: &raftcmdpb.BackupOrderStart{JobId: 1}},
+				},
+			},
+		}},
+	}
+}
+
+// incrementalBackupOrderProposal mirrors wrapIncrementalBackupOrder.
+func incrementalBackupOrderProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_IncrementalBackupOrder{
+				IncrementalBackupOrder: &raftcmdpb.IncrementalBackupOrder{
+					Op: &raftcmdpb.IncrementalBackupOrder_Start{Start: &raftcmdpb.BackupOrderStart{JobId: 1}},
+				},
+			},
+		}},
+	}
+}
+
+// mirrorSyncErrorProposal mirrors application/mirror/worker.go reportError:
+// a technical-only MirrorSync (no orders).
+func mirrorSyncErrorProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date: &commonpb.Timestamp{Data: 1700000000},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_MirrorSync{
+				MirrorSync: &raftcmdpb.MirrorSyncUpdate{LedgerName: "ledger-a"},
+			},
+		}},
+	}
+}
+
+// mirrorSyncDataProposal mirrors application/mirror/worker.go's data batch:
+// N mirror-ingest orders coexisting with exactly one MirrorSync cursor update.
+func mirrorSyncDataProposal() *raftcmdpb.Proposal {
+	return &raftcmdpb.Proposal{
+		Date:   &commonpb.Timestamp{Data: 1700000000},
+		Orders: []*raftcmdpb.Order{createTransactionOrder("ledger-a", true, newPosting("world", "acct", "EUR", 10))},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{
+			Kind: &raftcmdpb.TechnicalUpdate_MirrorSync{
+				MirrorSync: &raftcmdpb.MirrorSyncUpdate{LedgerName: "ledger-a", Cursor: 7},
+			},
+		}},
+	}
+}
+
+// TestPreflightTechnicalUpdates_ProducerShapesAccepted proves every current
+// proposal builder emits a shape the preflight accepts. If any of these fail,
+// a legitimate producer would be spuriously rejected — that is what the
+// per-shape helpers guard against.
+func TestPreflightTechnicalUpdates_ProducerShapesAccepted(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*raftcmdpb.Proposal{
+		"cluster config":         clusterConfigProposal(),
+		"sink cursor":            sinkCursorProposal(),
+		"idempotency eviction":   idempotencyEvictionProposal(),
+		"backup order":           backupOrderProposal(),
+		"incremental backup":     incrementalBackupOrderProposal(),
+		"mirror sync error only": mirrorSyncErrorProposal(),
+		"mirror sync + ingest":   mirrorSyncDataProposal(),
+	}
+
+	for name, proposal := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, preflightTechnicalUpdates(proposal))
+		})
+	}
+
+	t.Run("no technical updates is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, preflightTechnicalUpdates(&raftcmdpb.Proposal{
+			Orders: []*raftcmdpb.Order{createLedgerOrder("ledger-a")},
+		}))
+	})
+}
+
+// TestPreflightTechnicalUpdates_ForgedShapesRejected proves the preflight
+// rejects the shapes no producer emits: multiple technical updates, a
+// technical-only update riding alongside orders, and (as a business error vs.
+// FSM-fatal split) an unknown/nil kind.
+func TestPreflightTechnicalUpdates_ForgedShapesRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multiple technical updates rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := clusterConfigProposal()
+		// Forge a second update alongside the legitimate first one.
+		p.TechnicalUpdates = append(p.TechnicalUpdates, sinkCursorProposal().GetTechnicalUpdates()...)
+
+		err := preflightTechnicalUpdates(p)
+		var invalid *domain.ErrInvalidExecutionPlan
+		require.ErrorAs(t, err, &invalid, "multi-update proposal must be a business rejection")
+	})
+
+	t.Run("mirror sync alongside another update rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := mirrorSyncDataProposal()
+		p.TechnicalUpdates = append(p.TechnicalUpdates, sinkCursorProposal().GetTechnicalUpdates()...)
+
+		err := preflightTechnicalUpdates(p)
+		var invalid *domain.ErrInvalidExecutionPlan
+		require.ErrorAs(t, err, &invalid)
+	})
+
+	for name, factory := range map[string]func() *raftcmdpb.Proposal{
+		"cluster config with orders":       clusterConfigProposal,
+		"sink cursor with orders":          sinkCursorProposal,
+		"idempotency eviction with orders": idempotencyEvictionProposal,
+		"backup order with orders":         backupOrderProposal,
+		"incremental backup with orders":   incrementalBackupOrderProposal,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := factory()
+			p.Orders = []*raftcmdpb.Order{createLedgerOrder("ledger-a")}
+
+			err := preflightTechnicalUpdates(p)
+			var invalid *domain.ErrInvalidExecutionPlan
+			require.ErrorAs(t, err, &invalid, "technical-only update must not coexist with orders")
+		})
+	}
+
+	t.Run("nil kind is FSM-fatal, not a business error", func(t *testing.T) {
+		t.Parallel()
+
+		p := &raftcmdpb.Proposal{
+			Date:             &commonpb.Timestamp{Data: 1700000000},
+			TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{{}}, // no Kind set
+		}
+
+		err := preflightTechnicalUpdates(p)
+		require.Error(t, err)
+		// A nil kind is the EN-1323 rolling-upgrade divergence signal: it
+		// must surface FSM-fatally, NOT degrade to a per-proposal business
+		// rejection (planInvariantDescribable must not recognise it).
+		require.Nil(t, planInvariantDescribable(err),
+			"nil-kind update must stay FSM-fatal")
+	})
+
+	t.Run("coverage bits past plans length rejected", func(t *testing.T) {
+		t.Parallel()
+
+		p := clusterConfigProposal()
+		// No execution plan declared, but a coverage bit flags position 0.
+		p.TechnicalUpdates[0].CoverageBits = []byte{0x01}
+
+		err := preflightTechnicalUpdates(p)
+		var invalid *domain.ErrInvalidExecutionPlan
+		require.ErrorAs(t, err, &invalid, "out-of-range coverage bit must be a business rejection")
+	})
+}
+
+// TestPreflightTechnicalUpdates_NoMutationBeforeRejection is the core EN-1524
+// regression: a forged proposal whose FIRST technical update is a legitimate,
+// mutation-heavy ClusterConfig (threshold change → cache reset + epoch bump)
+// followed by a SECOND update must be rejected by the preflight BEFORE the
+// ClusterConfig handler runs. If the preflight were absent, applyTechnicalUpdates
+// would dispatch the ClusterConfig, reset the cache and bump the epoch, and only
+// THEN reach the second update — leaving the cache mutated by a proposal that is
+// ultimately rejected. We assert the reject arrives with the cache untouched.
+func TestPreflightTechnicalUpdates_NoMutationBeforeRejection(t *testing.T) {
+	t.Parallel()
+
+	fsm, store, _ := newTestMachine(t)
+	ctx := context.Background()
+
+	const defaultThreshold = 1000 // newTestMachine's threshold
+
+	epochBefore := fsm.Registry.Cache.Epoch()
+	require.Equal(t, uint64(defaultThreshold), fsm.Registry.Cache.GenerationThreshold())
+
+	// Forge: a threshold-changing ClusterConfig (would reset the cache) as the
+	// first update, plus a second sink-cursor update. Two updates violate the
+	// one-per-proposal contract, so the preflight rejects the whole envelope.
+	forged := &raftcmdpb.Proposal{
+		Id:   77,
+		Date: &commonpb.Timestamp{Data: 1700000077},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{
+			{
+				Kind: &raftcmdpb.TechnicalUpdate_ClusterConfig{
+					ClusterConfig: &commonpb.ClusterConfig{RotationThreshold: defaultThreshold + 500},
+				},
+			},
+			{
+				Kind: &raftcmdpb.TechnicalUpdate_EventsSink{
+					EventsSink: &raftcmdpb.EventsSinkUpdate{SinkName: "sink-a", Cursor: 5},
+				},
+			},
+		},
+	}
+
+	result, err := fsm.ApplyEntries(ctx, store, makeEntry(t, 1, forged))
+	require.NoError(t, err, "a forged envelope must be a business rejection, never an FSM-fatal apply error")
+	require.Len(t, result.Results, 1)
+	require.Error(t, result.Results[0].Error, "forged multi-update proposal must be rejected")
+
+	var invalid *domain.ErrInvalidExecutionPlan
+	require.ErrorAs(t, result.Results[0].Error, &invalid)
+
+	// The ClusterConfig handler never ran: threshold and epoch are untouched.
+	require.Equal(t, uint64(defaultThreshold), fsm.Registry.Cache.GenerationThreshold(),
+		"generation threshold must be unchanged — ClusterConfig must not have dispatched")
+	require.Equal(t, epochBefore, fsm.Registry.Cache.Epoch(),
+		"cache epoch must be unchanged — no cache reset must have landed")
+	require.Nil(t, fsm.State.LastClusterConfig,
+		"cluster config state must be unchanged — no UpdateClusterConfig must have run")
+}
+
+// TestPreflightTechnicalUpdates_BackupNotStartedBeforeRejection proves the same
+// no-mutation guarantee for the backup lifecycle: a forged proposal whose first
+// update is a legitimate BackupOrder Start (which would occupy the active
+// destination slot in BackupJobsState) followed by a second update must be
+// rejected without ever registering the backup job.
+func TestPreflightTechnicalUpdates_BackupNotStartedBeforeRejection(t *testing.T) {
+	t.Parallel()
+
+	fsm, store, _ := newTestMachine(t)
+	ctx := context.Background()
+
+	dst := &raftcmdpb.BackupDestination{
+		BucketId: "bucket-x",
+		Target: &raftcmdpb.BackupDestination_S3{
+			S3: &raftcmdpb.S3BackupTarget{Bucket: "ledger-backups", Region: "eu-west-1"},
+		},
+	}
+
+	forged := &raftcmdpb.Proposal{
+		Id:   88,
+		Date: &commonpb.Timestamp{Data: 1700000088},
+		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{
+			{
+				Kind: &raftcmdpb.TechnicalUpdate_BackupOrder{
+					BackupOrder: &raftcmdpb.BackupOrder{
+						Op: &raftcmdpb.BackupOrder_Start{Start: &raftcmdpb.BackupOrderStart{
+							JobId:       42,
+							Destination: dst,
+						}},
+					},
+				},
+			},
+			{
+				Kind: &raftcmdpb.TechnicalUpdate_EventsSink{
+					EventsSink: &raftcmdpb.EventsSinkUpdate{SinkName: "sink-a", Cursor: 5},
+				},
+			},
+		},
+	}
+
+	result, err := fsm.ApplyEntries(ctx, store, makeEntry(t, 1, forged))
+	require.NoError(t, err)
+	require.Len(t, result.Results, 1)
+	require.Error(t, result.Results[0].Error)
+
+	require.Nil(t, fsm.Registry.BackupJobs.ActiveByDestination(dst),
+		"backup job must not have been registered — Start must not have dispatched before rejection")
+}

--- a/internal/infra/state/scope.go
+++ b/internal/infra/state/scope.go
@@ -147,6 +147,44 @@ func validatePlan(plan *raftcmdpb.AttributeCoverage, idx int) *domain.ErrInvalid
 	return nil
 }
 
+// validateCoverageBits walks the bits set in coverageBits (LSB-first) and
+// checks each flagged plan WITHOUT mutating any coverage slot: every bit
+// must index a real plan entry, and every selected plan must carry a
+// 16-byte AttributeID plus an attr_code the FSM handles. The optional
+// visit callback fires once per set bit (in ascending bit order) so the
+// mutating caller (applyPlans) can count selected plans per slot without
+// re-walking the bitset.
+//
+// Extracted so both the scope-construction path (applyPlans) and the
+// mutation-free technical-update preflight (preflightTechnicalUpdates)
+// validate a coverage bitset against the same rules — the preflight must
+// reject a malformed bitset BEFORE any handler runs, so it cannot afford
+// applyPlans' slot mutation.
+func validateCoverageBits(plans []*raftcmdpb.AttributeCoverage, coverageBits []byte, visit func(bit int)) *domain.ErrInvalidExecutionPlan {
+	for byteIdx, b := range coverageBits {
+		for b != 0 {
+			bit := byteIdx*8 + lsbIndex(b)
+			b &= b - 1
+
+			if bit >= len(plans) {
+				return &domain.ErrInvalidExecutionPlan{
+					Reason_: fmt.Sprintf("coverage_bits flags position %d past plans length %d", bit, len(plans)),
+				}
+			}
+
+			if err := validatePlan(plans[bit], bit); err != nil {
+				return err
+			}
+
+			if visit != nil {
+				visit(bit)
+			}
+		}
+	}
+
+	return nil
+}
+
 // applyPlans walks the plans slice narrowed to the entries flagged in
 // coverageBits (LSB-first) and appends each selected plan's U128 to the
 // matching coverage slot. Empty coverageBits means "admit no plan" —
@@ -183,23 +221,10 @@ func applyPlans(coverage *coverageSlots, plans []*raftcmdpb.AttributeCoverage, c
 
 	var counts [len(cacheAttrKinds)]int
 
-	for byteIdx, b := range coverageBits {
-		for b != 0 {
-			bit := byteIdx*8 + lsbIndex(b)
-			b &= b - 1
-
-			if bit >= len(plans) {
-				return &domain.ErrInvalidExecutionPlan{
-					Reason_: fmt.Sprintf("coverage_bits flags position %d past plans length %d", bit, len(plans)),
-				}
-			}
-
-			if err := validatePlan(plans[bit], bit); err != nil {
-				return err
-			}
-
-			counts[coverageSlotIndex[byte(plans[bit].GetAttrCode())]]++
-		}
+	if err := validateCoverageBits(plans, coverageBits, func(bit int) {
+		counts[coverageSlotIndex[byte(plans[bit].GetAttrCode())]]++
+	}); err != nil {
+		return err
 	}
 
 	for i, n := range counts {

--- a/internal/infra/state/scope_test.go
+++ b/internal/infra/state/scope_test.go
@@ -12,21 +12,27 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
-// TestScope_TechnicalUpdate_CoverageMissShortCircuits pins that an
+// TestScope_TechnicalUpdate_CoverageMissPropagates pins that an
 // undeclared ledger read in a technical-update handler propagates the
-// *ErrCoverageMiss out of applyTechnicalUpdates, short-circuiting any
-// later handlers in the loop. Coverage miss = malformed plan, surfaced
-// as a business rejection — handlers that swallowed read errors before
-// the refactor no longer mask an admission bug.
-func TestScope_TechnicalUpdate_CoverageMissShortCircuits(t *testing.T) {
+// *ErrCoverageMiss out of applyTechnicalUpdates rather than being
+// swallowed. Coverage miss = malformed plan, surfaced as a business
+// rejection — handlers that swallowed read errors before the refactor no
+// longer mask an admission bug.
+//
+// EN-1524 caps a proposal at one technical update, so the historical
+// two-TU variant of this test (which also asserted a later handler was
+// short-circuited) is now covered by the single-TU shape: the sole
+// MirrorSync handler reads an undeclared ledger and its coverage miss
+// must reach the caller.
+func TestScope_TechnicalUpdate_CoverageMissPropagates(t *testing.T) {
 	t.Parallel()
 
 	fsm, dataStore, _ := newTestMachine(t)
 
 	const gen0Byte byte = 0
 
-	// Seed the "ok" ledger in the cache + global store so the second
-	// handler would have a real entry to read if it were reached.
+	// Seed the "ok" ledger in the cache + global store so the plan has a
+	// real declared entry that is simply not the one the handler reads.
 	okKey := domain.LedgerKey{Name: "ok"}
 	okInfo := &commonpb.LedgerInfo{Id: 1, Name: "ok"}
 
@@ -36,8 +42,8 @@ func TestScope_TechnicalUpdate_CoverageMissShortCircuits(t *testing.T) {
 	require.NoError(t, SaveLedger(seedBatch, okInfo))
 	require.NoError(t, seedBatch.Commit())
 
-	// ExecutionPlan declares ONLY "ok" — "missed" is intentionally absent so
-	// the first handler hits a coverage miss.
+	// ExecutionPlan declares ONLY "ok" — the TU targets "missed", which is
+	// intentionally absent so the handler hits a coverage miss.
 	okID, _ := attributes.MakeKey(okKey.Bytes())
 	executionPlan := &raftcmdpb.ExecutionPlan{
 		LastPersistedIndex: fsm.Registry.Cache.BaseIndex.Gen0,
@@ -46,18 +52,16 @@ func TestScope_TechnicalUpdate_CoverageMissShortCircuits(t *testing.T) {
 		},
 	}
 
-	// Build the proposal with TWO MirrorSyncUpdate TechnicalUpdates.
-	// Order matters: "missed" first so its short-circuit happens BEFORE
-	// the second handler would queue a mirror-sync write. MirrorSync's
-	// handler calls scope.GetLedger — so the coverage miss surfaces
-	// from the same code path the historical IndexReady test exercised.
+	// A single MirrorSyncUpdate reading the undeclared ledger "missed".
+	// MirrorSync's handler calls scope.GetLedger, so the coverage miss
+	// surfaces from the same code path the historical IndexReady test
+	// exercised.
 	proposal := &raftcmdpb.Proposal{
 		Id:            1,
 		Date:          &commonpb.Timestamp{Data: 1700000000},
 		ExecutionPlan: executionPlan,
 		TechnicalUpdates: []*raftcmdpb.TechnicalUpdate{
 			{Kind: &raftcmdpb.TechnicalUpdate_MirrorSync{MirrorSync: &raftcmdpb.MirrorSyncUpdate{LedgerName: "missed", Cursor: 1}}},
-			{Kind: &raftcmdpb.TechnicalUpdate_MirrorSync{MirrorSync: &raftcmdpb.MirrorSyncUpdate{LedgerName: "ok", Cursor: 2}}},
 		},
 	}
 
@@ -73,15 +77,11 @@ func TestScope_TechnicalUpdate_CoverageMissShortCircuits(t *testing.T) {
 
 	var miss *ErrCoverageMiss
 	require.ErrorAs(t, err, &miss, "the propagated error must wrap *ErrCoverageMiss")
-	// applyIndexReady reads LedgerInfo before the Index (to soft-skip on
-	// DeletedAt), so the first undeclared key the gate rejects is "ledgers".
 	require.Equal(t, "ledgers", miss.Attribute)
 
-	// The second handler MUST NOT have been reached — the first
-	// handler's coverage miss short-circuits the loop before "ok" is
-	// touched. A successful second handler would have queued a
-	// MirrorSyncWrite for "ok".
-	require.Empty(t, buffer.pendingMirrorSyncs, "later handler must not have queued an update — short-circuit failed")
+	// No mirror-sync write must have been queued: the coverage miss
+	// aborts the handler before QueueMirrorSync runs.
+	require.Empty(t, buffer.pendingMirrorSyncs, "handler must not have queued an update after a coverage miss")
 }
 
 // TestScope_TechnicalUpdate_PerUpdateCoverageIsolation pins that the


### PR DESCRIPTION
## EN-1524 — FSM: preflight technical-update envelopes before mutation

### Problem
`applyTechnicalUpdates` validated scopes and kinds **sequentially while dispatching**, so a malformed later `TechnicalUpdate` — or an unsupported mixture of orders + technical updates — could be discovered only **after** an earlier handler had already mutated state (cache reset via `applyClusterConfig`, backup-job map via `applyBackupOrder`, WriteSet queue via `applyMirrorSyncUpdate`).

### Fix
A mutation-free **preflight** over the whole envelope runs before the first handler dispatch (`preflightTechnicalUpdates`, `internal/infra/state/machine_technical_updates.go`). It performs three classes of check, each mapped to the surfacing the FSM already uses:

1. **Coverage bitset well-formedness** — validated against the same execution plan the handlers' scopes will use, via a shared `validateCoverageBits` extracted from `applyPlans` (`scope.go`) so both paths use identical rules with **no slot mutation**. Malformed → `*domain.ErrInvalidExecutionPlan` (business rejection, recognised by `planInvariantDescribable`).
2. **Producer-shape enforcement** — at most one `TechnicalUpdate` per proposal; non-MirrorSync updates are technical-only (zero orders); MirrorSync may coexist with its mirror-ingest order batch and remains the sole update. Violations → `*domain.ErrInvalidExecutionPlan`.
3. **nil / unknown kind** — stays **FSM-fatal**, identical to the dispatch loop's `default` arm and the EN-1323 rolling-upgrade divergence contract (invariant #7).

Handlers run only after the preflight succeeds. MirrorSync's WriteSet queue and the existing handler order are preserved. Coordinated with the merged PR #1558: complete execution-plan validation runs before any preload mutation; this adds the symmetric guarantee for the technical-update phase.

### Non-goals (per ticket)
No staging/cloning of cluster config / backup jobs / idempotency / sink state; no rollback / copy-on-write / prepared-effect framework; no broadening of TechnicalUpdate business semantics. Post-mutation I/O failure handling is EN-1302.

### Where
- `internal/infra/state/machine_technical_updates.go` — `preflightTechnicalUpdates`, called first in `applyTechnicalUpdates`.
- `internal/infra/state/scope.go` — extracted `validateCoverageBits` (shared by `applyPlans`, DRY).

### Tests
- `machine_technical_updates_test.go` (new): producer-shape acceptance for every builder (cluster config, sink cursor, idempotency eviction, full/incremental backup, MirrorSync data + error); forged multi-update / order-coexistence / nil-kind / out-of-range-coverage rejection; **FSM-level no-mutation-before-reject** for ClusterConfig (threshold + epoch untouched, `LastClusterConfig` nil) and backup Start (job not registered in `BackupJobsState`).
- `scope_test.go`: the historical two-TU `CoverageMissShortCircuits` test is retargeted to the now-canonical single-TU shape (`CoverageMissPropagates`) — the short-circuit-between-handlers concern is subsumed by the one-per-proposal cap.

### Verification
- `GOROOT= go build ./...` — clean
- `GOROOT= go test ./internal/infra/state/... ./internal/application/... -count=1` — pass
- `go generate ./...` + `go mod tidy` — tree clean
- `golangci-lint run --fix` — 0 issues