### PR TITLE
feat(EN-1507): expose full account-type model through HTTP create/add APIs

### DIFF
--- a/cmd/ledgerctl/accounttypes/list.go
+++ b/cmd/ledgerctl/accounttypes/list.go
@@ -3,7 +3,6 @@ package accounttypes
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -103,26 +102,15 @@ func runList(cmd *cobra.Command, _ []string) error {
 	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
 }
 
+// FormatPersistence returns the canonical uppercase name for a persistence
+// enum. It delegates to the shared commonpb helper so the CLI, HTTP API, and
+// OpenAPI spec stay in sync.
 func FormatPersistence(p commonpb.AccountTypePersistence) string {
-	switch p {
-	case commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL:
-		return "EPHEMERAL"
-	case commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT:
-		return "TRANSIENT"
-	default:
-		return "NORMAL"
-	}
+	return commonpb.PersistenceToString(p)
 }
 
+// ParsePersistence converts a persistence string to its enum. It delegates to
+// the shared commonpb helper (case-insensitive, empty defaults to NORMAL).
 func ParsePersistence(s string) (commonpb.AccountTypePersistence, error) {
-	switch strings.ToLower(s) {
-	case "normal", "":
-		return commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL, nil
-	case "ephemeral":
-		return commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL, nil
-	case "transient":
-		return commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT, nil
-	default:
-		return 0, fmt.Errorf("unknown persistence mode %q (valid: normal, ephemeral, transient)", s)
-	}
+	return commonpb.ParsePersistence(s)
 }

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -39,15 +39,15 @@ This document compares the POC's API with the original Formance ledger API and d
 | Bulk atomic | ✅ | ✅ | System-level atomicity (cross-ledger) |
 | Bulk continueOnFailure | ✅ | ✅ | |
 | **Ledger** |
-| Create ledger | ✅ | ✅ | |
+| Create ledger | ✅ | ✅ | HTTP + gRPC accept the full model: `initialSchema`, `accountTypes` (name/pattern/persistence/segmentTypes), `defaultEnforcementMode` |
 | Create mirror ledger | ✅ | ❌ | HTTP or PostgreSQL source |
 | Promote mirror ledger | ✅ | ❌ | Mirror → Normal mode |
 | Delete ledger | ✅ | ✅ | |
 | Get ledger | ✅ | ✅ | |
 | List ledgers | ✅ | ✅ | |
 | **Account Types** |
-| Add account type | ✅ | ❌ | Pattern-based account validation |
-| List account types | ✅ | ❌ | List all types for a ledger |
+| Add account type | ✅ | ❌ | Full model over HTTP + gRPC: name, pattern, `persistence`, `segmentTypes` |
+| List account types | ✅ | ❌ | List all types for a ledger (HTTP + gRPC; includes persistence + segmentTypes) |
 | Get account type | ✅ | ❌ | Get details of a specific type |
 | Remove account type | ✅ | ❌ | Remove a type from a ledger |
 | **Accounts (Read)** |
@@ -213,7 +213,7 @@ Ledger metadata is stored separately from ledger configuration (LedgerInfo) and 
 ### 5. Ledger Management
 
 **Endpoints:**
-- `POST /v3/{ledgerName}` - Create a ledger (supports optional `chartOfAccounts` and `enforcementMode` in body)
+- `POST /v3/{ledgerName}` - Create a ledger. Optional body fields: `mode`, `mirrorSource`, `defaultEnforcementMode`, `initialSchema` (metadata field types), and `accountTypes` (full account-type model — name/pattern/persistence/segmentTypes). These mirror the gRPC `CreateLedgerRequest`.
 - `DELETE /v3/{ledgerName}` - Delete a ledger
 - `GET /v3/{ledgerName}` - Get ledger info (read)
 - `GET /v3/` - List all ledgers (read)
@@ -223,7 +223,7 @@ Ledger metadata is stored separately from ledger configuration (LedgerInfo) and 
 **Endpoints:**
 - `GET /v3/{ledgerName}/account-types` - List all account types for a ledger
 - `GET /v3/{ledgerName}/account-types/{typeName}` - Get details of a specific account type
-- `POST /v3/{ledgerName}/account-types` - Add a new account type
+- `POST /v3/{ledgerName}/account-types` - Add a new account type (body: name, pattern, optional `persistence` and `segmentTypes`)
 - `DELETE /v3/{ledgerName}/account-types/{typeName}` - Remove an account type
 
 **Features:**

--- a/internal/adapter/http/handlers_add_account_type.go
+++ b/internal/adapter/http/handlers_add_account_type.go
@@ -10,9 +10,47 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-type addAccountTypeRequest struct {
+// accountTypeBody is the camelCase JSON representation of an account type,
+// shared by the add-account-type and create-ledger handlers so both endpoints
+// accept the full model gRPC exposes.
+type accountTypeBody struct {
 	Name    string `json:"name"`
 	Pattern string `json:"pattern"`
+	// Persistence controls how account volumes are stored: NORMAL (default),
+	// EPHEMERAL, or TRANSIENT. Empty defaults to NORMAL.
+	Persistence string `json:"persistence,omitempty"`
+	// SegmentTypes maps a pattern variable name to a type constraint
+	// (regex/uuid/uint64/bytes).
+	SegmentTypes map[string]*commonpb.SegmentTypeJSON `json:"segmentTypes,omitempty"`
+}
+
+// toProto converts the HTTP request body to a proto AccountType, reusing the
+// shared commonpb conversion helpers.
+func (b accountTypeBody) toProto() (*commonpb.AccountType, error) {
+	persistence, err := commonpb.ParsePersistence(b.Persistence)
+	if err != nil {
+		return nil, err
+	}
+
+	at := &commonpb.AccountType{
+		Name:        b.Name,
+		Pattern:     b.Pattern,
+		Persistence: persistence,
+	}
+
+	if len(b.SegmentTypes) > 0 {
+		at.SegmentTypes = make(map[string]*commonpb.SegmentType, len(b.SegmentTypes))
+		for name, st := range b.SegmentTypes {
+			converted, err := commonpb.SegmentTypeFromJSON(st)
+			if err != nil {
+				return nil, fmt.Errorf("segmentTypes[%q]: %w", name, err)
+			}
+
+			at.SegmentTypes[name] = converted
+		}
+	}
+
+	return at, nil
 }
 
 // handleAddAccountType handles POST /{ledgerName}/account-types.
@@ -22,7 +60,7 @@ func (s *Server) handleAddAccountType(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var body addAccountTypeRequest
+	var body accountTypeBody
 	if err := json.UnmarshalRead(r.Body, &body); err != nil {
 		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid request body: %w", err))
 
@@ -41,14 +79,18 @@ func (s *Server) handleAddAccountType(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err := s.applyUnsigned(r.Context(), "", &servicepb.Request{
+	accountType, err := body.toProto()
+	if err != nil {
+		writeBadRequest(w, "INVALID_REQUEST", err)
+
+		return
+	}
+
+	_, err = s.applyUnsigned(r.Context(), "", &servicepb.Request{
 		Type: &servicepb.Request_AddAccountType{
 			AddAccountType: &servicepb.AddAccountTypeLedgerRequest{
-				Ledger: ledgerName,
-				AccountType: &commonpb.AccountType{
-					Name:    body.Name,
-					Pattern: body.Pattern,
-				},
+				Ledger:      ledgerName,
+				AccountType: accountType,
 			},
 		},
 	})

--- a/internal/adapter/http/handlers_add_account_type_test.go
+++ b/internal/adapter/http/handlers_add_account_type_test.go
@@ -95,6 +95,121 @@ func TestHandleAddAccountType_InvalidBody(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestHandleAddAccountType_FullModel(t *testing.T) {
+	t.Parallel()
+
+	var captured *commonpb.AccountType
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			reqs := req.GetUnsigned().GetRequests()
+			require.Len(t, reqs, 1)
+			captured = reqs[0].GetAddAccountType().GetAccountType()
+
+			return []*commonpb.Log{{}}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	body := `{
+		"name": "user-checking",
+		"pattern": "users:{id}:checking",
+		"persistence": "TRANSIENT",
+		"segmentTypes": {
+			"id": {"type": "uuid"}
+		}
+	}`
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/account-types", strings.NewReader(body), map[string]string{
+		"ledgerName": "ledger1",
+	})
+
+	srv.handleAddAccountType(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, captured)
+	require.Equal(t, "user-checking", captured.GetName())
+	require.Equal(t, "users:{id}:checking", captured.GetPattern())
+	require.Equal(t, commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT, captured.GetPersistence())
+
+	seg, ok := captured.GetSegmentTypes()["id"]
+	require.True(t, ok)
+	require.IsType(t, &commonpb.SegmentType_Uuid{}, seg.GetConstraint())
+}
+
+func TestHandleAddAccountType_RegexSegmentConstraint(t *testing.T) {
+	t.Parallel()
+
+	var captured *commonpb.AccountType
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			captured = req.GetUnsigned().GetRequests()[0].GetAddAccountType().GetAccountType()
+
+			return []*commonpb.Log{{}}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	body := `{
+		"name": "bank-main",
+		"pattern": "banks:{iban}:main",
+		"segmentTypes": {
+			"iban": {"type": "regex", "regex": "[A-Z]{2}[0-9]{14}"}
+		}
+	}`
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/account-types", strings.NewReader(body), map[string]string{
+		"ledgerName": "ledger1",
+	})
+
+	srv.handleAddAccountType(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, captured)
+	// Persistence defaults to NORMAL when omitted.
+	require.Equal(t, commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL, captured.GetPersistence())
+
+	seg := captured.GetSegmentTypes()["iban"]
+	regex, ok := seg.GetConstraint().(*commonpb.SegmentType_Regex)
+	require.True(t, ok)
+	require.Equal(t, "[A-Z]{2}[0-9]{14}", regex.Regex)
+}
+
+func TestHandleAddAccountType_InvalidPersistence(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/account-types",
+		strings.NewReader(`{"name":"users","pattern":"users:*","persistence":"BOGUS"}`), map[string]string{
+			"ledgerName": "ledger1",
+		})
+
+	srv.handleAddAccountType(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleAddAccountType_InvalidSegmentType(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/ledger1/account-types",
+		strings.NewReader(`{"name":"users","pattern":"users:{id}","segmentTypes":{"id":{"type":"nope"}}}`), map[string]string{
+			"ledgerName": "ledger1",
+		})
+
+	srv.handleAddAccountType(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestHandleAddAccountType_AlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_create_ledger.go
+++ b/internal/adapter/http/handlers_create_ledger.go
@@ -18,6 +18,38 @@ type createLedgerBody struct {
 	Mode                   string            `json:"mode,omitempty"`
 	MirrorSource           *mirrorSourceBody `json:"mirrorSource,omitempty"`
 	DefaultEnforcementMode string            `json:"defaultEnforcementMode,omitempty"`
+	// InitialSchema declares metadata field types to seed at creation time.
+	InitialSchema []metadataFieldTypeBody `json:"initialSchema,omitempty"`
+	// AccountTypes declares the initial account types (name -> full model).
+	AccountTypes map[string]accountTypeBody `json:"accountTypes,omitempty"`
+}
+
+// metadataFieldTypeBody is the camelCase JSON representation of a
+// SetMetadataFieldTypeCommand used to seed a ledger's initial metadata schema.
+type metadataFieldTypeBody struct {
+	TargetType string `json:"targetType"` // account | transaction | ledger
+	Key        string `json:"key"`
+	Type       string `json:"type"` // string | int64 | bool | uint64 | ... | datetime
+}
+
+// toProto converts the metadata field type body to its proto command, reusing
+// the shared commonpb enum parsers.
+func (b metadataFieldTypeBody) toProto() (*commonpb.SetMetadataFieldTypeCommand, error) {
+	targetType, err := commonpb.ParseTargetType(b.TargetType)
+	if err != nil {
+		return nil, err
+	}
+
+	metadataType, err := commonpb.ParseMetadataType(b.Type)
+	if err != nil {
+		return nil, err
+	}
+
+	return &commonpb.SetMetadataFieldTypeCommand{
+		TargetType: targetType,
+		Key:        b.Key,
+		Type:       metadataType,
+	}, nil
 }
 
 // mirrorSourceBody holds the mirror source configuration.
@@ -86,6 +118,31 @@ func (s *Server) handleCreateLedger(w http.ResponseWriter, r *http.Request) {
 			}
 
 			createReq.DefaultEnforcementMode = mode
+		}
+
+		for i, cmd := range body.InitialSchema {
+			converted, err := cmd.toProto()
+			if err != nil {
+				writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("initialSchema[%d]: %w", i, err))
+
+				return
+			}
+
+			createReq.InitialSchema = append(createReq.InitialSchema, converted)
+		}
+
+		if len(body.AccountTypes) > 0 {
+			createReq.AccountTypes = make(map[string]*commonpb.AccountType, len(body.AccountTypes))
+			for name, at := range body.AccountTypes {
+				converted, err := at.toProto()
+				if err != nil {
+					writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("accountTypes[%q]: %w", name, err))
+
+					return
+				}
+
+				createReq.AccountTypes[name] = converted
+			}
 		}
 	}
 

--- a/internal/adapter/http/handlers_create_ledger_test.go
+++ b/internal/adapter/http/handlers_create_ledger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,98 @@ func TestHandleCreateLedger_Success(t *testing.T) {
 	srv.handleCreateLedger(w, r)
 
 	require.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestHandleCreateLedger_InitialSchemaAndAccountTypes(t *testing.T) {
+	t.Parallel()
+
+	var captured *servicepb.CreateLedgerRequest
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+			captured = req.GetUnsigned().GetRequests()[0].GetCreateLedger()
+
+			return []*commonpb.Log{
+				{
+					Payload: &commonpb.LogPayload{
+						Type: &commonpb.LogPayload_CreateLedger{
+							CreateLedger: &commonpb.CreatedLedgerLog{Name: "test-ledger"},
+						},
+					},
+				},
+			}, nil
+		})
+	srv := newTestServer(t, backend)
+
+	body := `{
+		"initialSchema": [
+			{"targetType": "account", "key": "color", "type": "string"},
+			{"targetType": "transaction", "key": "seq", "type": "int64"}
+		],
+		"accountTypes": {
+			"user-checking": {
+				"name": "user-checking",
+				"pattern": "users:{id}:checking",
+				"persistence": "EPHEMERAL",
+				"segmentTypes": {"id": {"type": "uint64"}}
+			}
+		}
+	}`
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/test-ledger", strings.NewReader(body), map[string]string{
+		"ledgerName": "test-ledger",
+	})
+
+	srv.handleCreateLedger(w, r)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, captured)
+
+	require.Len(t, captured.GetInitialSchema(), 2)
+	require.Equal(t, commonpb.TargetType_TARGET_TYPE_ACCOUNT, captured.GetInitialSchema()[0].GetTargetType())
+	require.Equal(t, "color", captured.GetInitialSchema()[0].GetKey())
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_STRING, captured.GetInitialSchema()[0].GetType())
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, captured.GetInitialSchema()[1].GetType())
+
+	at, ok := captured.GetAccountTypes()["user-checking"]
+	require.True(t, ok)
+	require.Equal(t, "users:{id}:checking", at.GetPattern())
+	require.Equal(t, commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL, at.GetPersistence())
+	require.IsType(t, &commonpb.SegmentType_Uint64{}, at.GetSegmentTypes()["id"].GetConstraint())
+}
+
+func TestHandleCreateLedger_InvalidInitialSchema(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/test-ledger",
+		strings.NewReader(`{"initialSchema":[{"targetType":"bogus","key":"x","type":"string"}]}`), map[string]string{
+			"ledgerName": "test-ledger",
+		})
+
+	srv.handleCreateLedger(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleCreateLedger_InvalidAccountTypePersistence(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodPost, "/test-ledger",
+		strings.NewReader(`{"accountTypes":{"x":{"name":"x","pattern":"x","persistence":"WRONG"}}}`), map[string]string{
+			"ledgerName": "test-ledger",
+		})
+
+	srv.handleCreateLedger(w, r)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestHandleCreateLedger_MissingName(t *testing.T) {

--- a/internal/adapter/http/handlers_list_account_types.go
+++ b/internal/adapter/http/handlers_list_account_types.go
@@ -8,8 +8,10 @@ import (
 )
 
 type accountTypeJSON struct {
-	Name    string `json:"name"`
-	Pattern string `json:"pattern"`
+	Name         string                               `json:"name"`
+	Pattern      string                               `json:"pattern"`
+	Persistence  string                               `json:"persistence"`
+	SegmentTypes map[string]*commonpb.SegmentTypeJSON `json:"segmentTypes,omitempty"`
 }
 
 type listAccountTypesResponse struct {
@@ -17,10 +19,20 @@ type listAccountTypesResponse struct {
 }
 
 func toAccountTypeJSON(at *commonpb.AccountType) accountTypeJSON {
-	return accountTypeJSON{
-		Name:    at.GetName(),
-		Pattern: at.GetPattern(),
+	out := accountTypeJSON{
+		Name:        at.GetName(),
+		Pattern:     at.GetPattern(),
+		Persistence: commonpb.PersistenceToString(at.GetPersistence()),
 	}
+
+	if len(at.GetSegmentTypes()) > 0 {
+		out.SegmentTypes = make(map[string]*commonpb.SegmentTypeJSON, len(at.GetSegmentTypes()))
+		for name, st := range at.GetSegmentTypes() {
+			out.SegmentTypes[name] = commonpb.SegmentTypeToJSON(st)
+		}
+	}
+
+	return out
 }
 
 // handleListAccountTypes handles GET /{ledgerName}/account-types.

--- a/internal/proto/commonpb/account_type_json.go
+++ b/internal/proto/commonpb/account_type_json.go
@@ -1,0 +1,107 @@
+package commonpb
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Persistence string names. These are the canonical camelCase-context values
+// used across the HTTP API, the CLI, and the OpenAPI spec. They are uppercase
+// because they name an enum value, not a JSON property.
+const (
+	PersistenceNormal    = "NORMAL"
+	PersistenceEphemeral = "EPHEMERAL"
+	PersistenceTransient = "TRANSIENT"
+)
+
+// SegmentType constraint discriminator names, used as the "type" field of the
+// JSON SegmentType representation.
+const (
+	SegmentTypeRegex  = "regex"
+	SegmentTypeUUID   = "uuid"
+	SegmentTypeUint64 = "uint64"
+	SegmentTypeBytes  = "bytes"
+)
+
+// ParsePersistence converts a persistence string to an AccountTypePersistence
+// enum. It accepts the canonical uppercase names as well as their lowercase
+// variants; an empty string defaults to NORMAL.
+func ParsePersistence(s string) (AccountTypePersistence, error) {
+	switch strings.ToLower(s) {
+	case "", "normal":
+		return AccountTypePersistence_ACCOUNT_TYPE_NORMAL, nil
+	case "ephemeral":
+		return AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL, nil
+	case "transient":
+		return AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT, nil
+	default:
+		return 0, fmt.Errorf("unknown persistence mode %q (valid: NORMAL, EPHEMERAL, TRANSIENT)", s)
+	}
+}
+
+// PersistenceToString returns the canonical uppercase name for a persistence
+// enum. Unknown values fall back to NORMAL, matching the proto zero value.
+func PersistenceToString(p AccountTypePersistence) string {
+	switch p {
+	case AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL:
+		return PersistenceEphemeral
+	case AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT:
+		return PersistenceTransient
+	default:
+		return PersistenceNormal
+	}
+}
+
+// SegmentTypeJSON is the camelCase JSON representation of a SegmentType. The
+// `type` field discriminates the constraint; only the `regex` type carries a
+// `regex` value, the others (uuid, uint64, bytes) are pure markers.
+type SegmentTypeJSON struct {
+	Type  string `json:"type"`
+	Regex string `json:"regex,omitempty"`
+}
+
+// SegmentTypeToJSON converts a proto SegmentType to its JSON representation.
+// Returns nil when the segment type carries no constraint.
+func SegmentTypeToJSON(st *SegmentType) *SegmentTypeJSON {
+	if st == nil {
+		return nil
+	}
+
+	switch c := st.GetConstraint().(type) {
+	case *SegmentType_Regex:
+		return &SegmentTypeJSON{Type: SegmentTypeRegex, Regex: c.Regex}
+	case *SegmentType_Uuid:
+		return &SegmentTypeJSON{Type: SegmentTypeUUID}
+	case *SegmentType_Uint64:
+		return &SegmentTypeJSON{Type: SegmentTypeUint64}
+	case *SegmentType_Bytes:
+		return &SegmentTypeJSON{Type: SegmentTypeBytes}
+	default:
+		return nil
+	}
+}
+
+// SegmentTypeFromJSON converts a JSON SegmentType to its proto representation.
+func SegmentTypeFromJSON(j *SegmentTypeJSON) (*SegmentType, error) {
+	if j == nil {
+		return nil, nil
+	}
+
+	switch strings.ToLower(j.Type) {
+	case SegmentTypeRegex:
+		if j.Regex == "" {
+			return nil, fmt.Errorf("segment type %q requires a non-empty regex", SegmentTypeRegex)
+		}
+
+		return &SegmentType{Constraint: &SegmentType_Regex{Regex: j.Regex}}, nil
+	case SegmentTypeUUID:
+		return &SegmentType{Constraint: &SegmentType_Uuid{Uuid: &UUIDConstraint{}}}, nil
+	case SegmentTypeUint64:
+		return &SegmentType{Constraint: &SegmentType_Uint64{Uint64: &Uint64Constraint{}}}, nil
+	case SegmentTypeBytes:
+		return &SegmentType{Constraint: &SegmentType_Bytes{Bytes: &BytesConstraint{}}}, nil
+	default:
+		return nil, fmt.Errorf("unknown segment type %q (valid: %s, %s, %s, %s)",
+			j.Type, SegmentTypeRegex, SegmentTypeUUID, SegmentTypeUint64, SegmentTypeBytes)
+	}
+}

--- a/internal/proto/commonpb/account_type_json_test.go
+++ b/internal/proto/commonpb/account_type_json_test.go
@@ -1,0 +1,78 @@
+package commonpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePersistence(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]AccountTypePersistence{
+		"":          AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+		"normal":    AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+		"NORMAL":    AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+		"ephemeral": AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL,
+		"EPHEMERAL": AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL,
+		"transient": AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+		"TRANSIENT": AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+	}
+
+	for in, want := range cases {
+		got, err := ParsePersistence(in)
+		require.NoError(t, err, "input %q", in)
+		require.Equal(t, want, got, "input %q", in)
+	}
+
+	_, err := ParsePersistence("bogus")
+	require.Error(t, err)
+}
+
+func TestPersistenceToStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []AccountTypePersistence{
+		AccountTypePersistence_ACCOUNT_TYPE_NORMAL,
+		AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL,
+		AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+	} {
+		got, err := ParsePersistence(PersistenceToString(p))
+		require.NoError(t, err)
+		require.Equal(t, p, got)
+	}
+}
+
+func TestSegmentTypeJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []*SegmentType{
+		{Constraint: &SegmentType_Regex{Regex: "[a-z]+"}},
+		{Constraint: &SegmentType_Uuid{Uuid: &UUIDConstraint{}}},
+		{Constraint: &SegmentType_Uint64{Uint64: &Uint64Constraint{}}},
+		{Constraint: &SegmentType_Bytes{Bytes: &BytesConstraint{}}},
+	}
+
+	for _, st := range cases {
+		j := SegmentTypeToJSON(st)
+		require.NotNil(t, j)
+
+		back, err := SegmentTypeFromJSON(j)
+		require.NoError(t, err)
+		require.IsType(t, st.GetConstraint(), back.GetConstraint())
+	}
+}
+
+func TestSegmentTypeFromJSON_Errors(t *testing.T) {
+	t.Parallel()
+
+	_, err := SegmentTypeFromJSON(&SegmentTypeJSON{Type: "regex"})
+	require.Error(t, err, "regex without value must fail")
+
+	_, err = SegmentTypeFromJSON(&SegmentTypeJSON{Type: "unknown"})
+	require.Error(t, err)
+
+	got, err := SegmentTypeFromJSON(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -2928,6 +2928,28 @@ components:
           format: int64
         - type: boolean
 
+    MetadataFieldTypeCommand:
+      type: object
+      description: Declares the type of a metadata field, seeding a ledger's initial metadata schema.
+      required:
+        - targetType
+        - key
+        - type
+      properties:
+        targetType:
+          type: string
+          enum: [account, transaction, ledger]
+          description: Which entity the metadata field applies to.
+        key:
+          type: string
+          description: Metadata key.
+          example: color
+        type:
+          type: string
+          enum: [string, int64, bool, uint64, int8, int16, int32, uint8, uint16, uint32, datetime]
+          description: Declared metadata value type.
+          example: string
+
     CreateLedgerRequest:
       type: object
       properties:
@@ -2945,6 +2967,30 @@ components:
           description: Ledger mode. MIRROR creates a read-only ledger that syncs from an external v2 source.
         mirrorSource:
           $ref: '#/components/schemas/MirrorSourceConfig'
+        defaultEnforcementMode:
+          type: string
+          enum:
+            - STRICT
+            - AUDIT
+          description: Default chart-of-accounts enforcement for accounts that match no account type.
+        initialSchema:
+          type: array
+          description: Metadata field type declarations to seed at creation time.
+          items:
+            $ref: '#/components/schemas/MetadataFieldTypeCommand'
+        accountTypes:
+          type: object
+          description: Initial account types (name -> account type definition).
+          additionalProperties:
+            $ref: '#/components/schemas/AddAccountTypeRequest'
+          example:
+            user-checking:
+              name: user-checking
+              pattern: 'users:{id}:checking'
+              persistence: EPHEMERAL
+              segmentTypes:
+                id:
+                  type: uuid
 
     CreateLedgerResponse:
       type: object
@@ -3040,6 +3086,11 @@ components:
                   NORMAL: fully persisted (default).
                   EPHEMERAL: persisted, purged when zero balance.
                   TRANSIENT: never persisted, must be zero at end of batch.
+              segmentTypes:
+                type: object
+                description: Maps a pattern variable name to a type constraint.
+                additionalProperties:
+                  $ref: '#/components/schemas/SegmentType'
           nullable: true
         default_enforcement_mode:
           type: string
@@ -4795,6 +4846,28 @@ components:
           type: string
           description: Go runtime version the binary was built with
 
+    SegmentType:
+      type: object
+      description: |
+        Constraint for a variable segment in an account type pattern. The
+        `type` field discriminates the constraint kind; only `regex` carries a
+        value.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [regex, uuid, uint64, bytes]
+          description: |
+            regex: custom regular expression (requires `regex`).
+            uuid: RFC 4122 UUID format.
+            uint64: decimal uint64.
+            bytes: hex-encoded bytes (even length).
+        regex:
+          type: string
+          description: Regular expression to match the segment against. Required when `type` is `regex`.
+          example: '[A-Z]{2}[0-9]{14}'
+
     AddAccountTypeRequest:
       type: object
       required:
@@ -4804,15 +4877,36 @@ components:
         name:
           type: string
           description: Unique name for the account type
+          example: user-checking
         pattern:
           type: string
-          description: Account address pattern for validation (e.g. "users:*")
+          description: Account address pattern for validation. Variables use `{name}` segments.
+          example: 'users:{id}:checking'
+        persistence:
+          type: string
+          enum: [NORMAL, EPHEMERAL, TRANSIENT]
+          default: NORMAL
+          description: |
+            How account volumes are stored.
+            NORMAL: fully persisted (default).
+            EPHEMERAL: persisted, purged when zero balance after commit.
+            TRANSIENT: never persisted, must be zero at end of batch.
+          example: EPHEMERAL
+        segmentTypes:
+          type: object
+          description: Maps a pattern variable name to a type constraint.
+          additionalProperties:
+            $ref: '#/components/schemas/SegmentType'
+          example:
+            id:
+              type: uuid
 
     AccountTypeInfo:
       type: object
       required:
         - name
         - pattern
+        - persistence
       properties:
         name:
           type: string
@@ -4820,6 +4914,15 @@ components:
         pattern:
           type: string
           description: Account address pattern
+        persistence:
+          type: string
+          enum: [NORMAL, EPHEMERAL, TRANSIENT]
+          description: How account volumes are stored (NORMAL, EPHEMERAL, or TRANSIENT)
+        segmentTypes:
+          type: object
+          description: Maps a pattern variable name to a type constraint.
+          additionalProperties:
+            $ref: '#/components/schemas/SegmentType'
 
     ListAccountTypesResponse:
       type: object


### PR DESCRIPTION
## Summary

Brings the HTTP `create-ledger` and `add-account-type` endpoints to parity with gRPC (ref **EN-1507**). gRPC already supported richer creation than HTTP exposed; this closes the gap. No new semantics — pure HTTP-layer parity.

### Write side (the ticket)
- **`POST /v3/{ledgerName}`** now accepts `initialSchema` (metadata field type declarations) and `accountTypes` (full model), mapped to `servicepb.CreateLedgerRequest.InitialSchema` / `.AccountTypes`. Also documents the already-wired `defaultEnforcementMode`.
- **`POST /v3/{ledgerName}/account-types`** now accepts the full `AccountType` shape: `name`, `pattern`, `persistence` (NORMAL/EPHEMERAL/TRANSIENT), and `segmentTypes` (regex/uuid/uint64/bytes constraints) → `commonpb.AccountType`.

### DRY / reuse
- New shared helpers in `internal/proto/commonpb/account_type_json.go` (colocated with the proto types, mirroring `metadata_type_parse.go`): `ParsePersistence` / `PersistenceToString` and `SegmentType <-> JSON`. Both HTTP handlers use them; the `ledgerctl account-types` CLI now delegates its persistence parse/format to these instead of its own copies.
- `create-ledger` and `add-account-type` share a single `accountTypeBody` DTO.
- Metadata field type parsing reuses the existing `commonpb.ParseTargetType` / `ParseMetadataType`.

### Read side (coherence)
- `list`/`get` account-types now emit `persistence` + `segmentTypes` for round-trip coherence with the new write shape.

### Docs
- `openapi.yml`: new `SegmentType` and `MetadataFieldTypeCommand` schemas; extended `CreateLedgerRequest`, `AddAccountTypeRequest`, `AccountTypeInfo`, and `LedgerInfo.account_types` with fields + examples.
- `docs/technical/contributing/api-comparison.md` updated (create-ledger + account-types notes).

## Tests
- HTTP handler tests for **both** endpoints: full-model pass-through, non-default persistence (TRANSIENT/EPHEMERAL), regex + uuid + uint64 segment-type constraints, and invalid-input 400s.
- Round-trip unit tests for the `commonpb` persistence + segment-type helpers.

## Verification
- `GOROOT= go build ./...` clean
- `GOROOT= go test ./internal/adapter/http/... ./internal/proto/commonpb/... ./cmd/ledgerctl/...` green
- `go generate ./...` + `go mod tidy` → no diff; `golangci-lint run --fix` → 0 issues
- `openapi.yml` parses as valid YAML

## Nothing left gRPC-only
Both `initial_schema`/`account_types` (create) and `persistence`/`segment_types` (add) are now reachable over HTTP. No field intentionally withheld.