### PR TITLE
feat(EN-1511): dual-format filter input on all filtered endpoints

### DIFF
--- a/cmd/ledgerctl/cmdutil/flags.go
+++ b/cmd/ledgerctl/cmdutil/flags.go
@@ -242,10 +242,13 @@ type FilterOptions struct {
 	PrefixHelp string
 }
 
-// AddFilterFlags registers --filter (filterexpr DSL) on cmd, plus --prefix when
-// SupportsPrefix is set.
+// AddFilterFlags registers --filter on cmd, plus --prefix when SupportsPrefix
+// is set. --filter accepts either the textual filterexpr grammar
+// ("metadata[k] == v") or the structured v2 JSON DSL ('{"$match":{...}}') — the
+// same dual-format contract every server-side filtered endpoint honors
+// (EN-1511).
 func AddFilterFlags(cmd *cobra.Command, opts FilterOptions) {
-	cmd.Flags().String("filter", "", `Filter expression (see "filterexpr" grammar; e.g. "metadata[k] == v")`)
+	cmd.Flags().String("filter", "", `Filter expression: textual grammar ("metadata[k] == v") or JSON DSL ('{"$match":{"metadata[k]":"v"}}')`)
 
 	if opts.SupportsPrefix {
 		help := opts.PrefixHelp
@@ -274,15 +277,18 @@ func GetFilterFlags(cmd *cobra.Command) FilterFlags {
 // BuildQueryFilter combines a --filter expression and an optional --prefix into
 // a single QueryFilter. Returns nil when both inputs are empty.
 //
-// The prefix is applied as an AddressMatch_HardcodedPrefix; when --filter is
-// also set, the two are AND-combined.
+// --filter accepts either the textual filterexpr grammar or the structured v2
+// JSON DSL (EN-1511); the shared dual-format decoder detects the form. The
+// per-target validity gate is left to the server (the CLI does not resolve the
+// target here). The prefix is applied as an AddressMatch_HardcodedPrefix; when
+// --filter is also set, the two are AND-combined.
 func BuildQueryFilter(filterExpr, prefix string) (*commonpb.QueryFilter, error) {
 	var parsed *commonpb.QueryFilter
 
 	if filterExpr != "" {
 		var err error
 
-		parsed, err = filterexpr.Parse(filterExpr)
+		parsed, err = filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr))
 		if err != nil {
 			return nil, fmt.Errorf("invalid filter expression: %w", err)
 		}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -97,7 +97,7 @@ scripting against the CLI predictable across resources.
 | Pagination | `--cursor` | string | Opaque cursor returned by the previous page. Parsed per-resource into the appropriate type (string address, uint64 sequence, …). |
 | Pagination | `--reverse` | bool | Reverse iteration order. Available on commands whose server endpoint supports it. |
 | Pagination | `--all` | bool | Fetch every page at once (no interactive pagination). Available on `accounts` and `transactions`. |
-| Filter | `--filter` | string | Boolean filter expression (see `filterexpr` grammar). |
+| Filter | `--filter` | string | Boolean filter expression — textual `filterexpr` grammar OR the structured JSON `QueryFilter` DSL (dual-format, EN-1511). |
 | Filter | `--prefix` | string | Account-address prefix shortcut. Only on `accounts list` (server-side `HardcodedPrefix` optimization). |
 | Consistency | `--checkpoint-id` | uint64 | Read from a named query checkpoint instead of the live store. |
 | Consistency | `--min-log-sequence` | uint64 | Require the server to have applied at least this log sequence before reading. `FailedPrecondition` if not. |
@@ -971,6 +971,14 @@ ledgerctl accounts list --ledger my-ledger --json
 ##### Filter Expression Syntax
 
 The `--filter` flag accepts a human-readable boolean expression that maps to the underlying `QueryFilter` model.
+
+> **Two interchangeable forms (EN-1511).** `--filter` also accepts the structured
+> JSON `QueryFilter` DSL, e.g. `--filter '{"$match":{"metadata[category]":"premium"}}'`.
+> The textual grammar below and the JSON DSL parse to the same filter and are
+> validated against the same per-target rules, so either form works everywhere
+> `--filter` is accepted (the same dual-format contract every server-side
+> filtered endpoint honors). The textual form is the recommended, more concise
+> one for CLI use.
 
 **Grammar:**
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -52,6 +52,27 @@ sequenceDiagram
 
 The HTTP REST surface (`internal/adapter/http/`) is a thin wrapper that routes to the same controller methods.
 
+### Filter input: dual-format decode (EN-1511)
+
+Whatever the transport, a filter reaches the pipeline as a single
+`*commonpb.QueryFilter`. Callers may express it in **either** the textual
+`filterexpr` grammar (`metadata[k] == v`) or the structured v2 JSON
+`QueryFilter` DSL (`{"$match":{"metadata[k]":"v"}}`); both are decoded by the one
+shared helper `filterexpr.DecodeDualFormat` (`internal/pkg/filterexpr/decode.go`),
+which detects the form from the first non-whitespace byte, parses to the same
+proto, and applies the single per-target validity gate
+(`domain.ValidateFilterForTarget`). The HTTP list handlers call it via
+`parseListFilter` (`internal/adapter/http/list_filter.go`) for the `?filter=`
+query parameter and AND-combine the result with the endpoint's convenience params
+(`reference`, `prefix`, date range) through `combineFilters`; prepared-query
+create/update decode the JSON `filter` body field through the same helper; and
+`ledgerctl --filter` routes through it in `cmdutil.BuildQueryFilter`. Audit
+conditions (`audit[...]`) exist only in the textual form — the JSON codec has no
+representation for them (EN-1241) — so the textual form is canonical for
+`GET /v3/_/audit-entries`. See
+[api-comparison.md](../../../contributing/api-comparison.md#filter-input-formats-dual-format-contract-en-1511)
+for the full contract.
+
 ## Linearizability — `ReadIndex`
 
 `internal/infra/node/read_index.go:101` — `ReadIndexAndWait(ctx)`:

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -73,7 +73,7 @@ This document compares the POC's API with the original Formance ledger API and d
 | Delete numscript | ✅ | ❌ | Per-ledger, deletes latest version entry |
 | **Audit Log** |
 | Audit log (success + failure) | ✅ | ❌ | Replicated via Raft, stored in Pebble |
-| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + `audit[...]` filter expression |
+| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + `audit[...]` filter expression (textual form; audit has no structured JSON form — see [Filter input formats](#filter-input-formats-dual-format-contract-en-1511)) |
 | Get audit entry by sequence | ✅ | ❌ | `GET /v3/_/audit-entries/{sequence}` (HTTP) + gRPC. Populates per-order `items` |
 | Audit log disable/enable | ❌ | ❌ | Not implemented |
 | **Error Handling** |
@@ -369,6 +369,48 @@ When retrieving a numscript via `GET /v3/{ledgerName}/numscripts/{name}`, the `v
 - `content` (string): Numscript source code
 - `version` (string): Semver version (e.g. `"1.0.0"`)
 - `createdAt` (string, date-time): Timestamp
+
+### Filter input formats (dual-format contract, EN-1511)
+
+Every filtered surface — the list endpoints (`GET .../transactions`,
+`.../accounts`, `.../logs`, `GET /v3/_/audit-entries`), prepared-query
+create/update, and `ledgerctl --filter` — accepts a filter in **either** of two
+interchangeable representations. Both parse into the same `*commonpb.QueryFilter`
+and flow through the same compile/validate path (the per-target validity gate,
+`domain.ValidateFilterForTarget`), so a caller never needs to know which syntax a
+given endpoint "wants":
+
+| Representation | Looks like | Parsed by |
+|----------------|-----------|-----------|
+| **Textual** (`filterexpr` grammar) | `metadata[status] == "active"`, `address ^= "users:"`, `ledger == "main"` | `filterexpr.Parse` |
+| **Structured** (v2 JSON `QueryFilter` DSL) | `{"$match":{"metadata[status]":"active"}}` | `commonpb.QueryFilter.UnmarshalJSON` |
+
+Both go through one shared decoder, `filterexpr.DecodeDualFormat` (in
+`internal/pkg/filterexpr/decode.go`), which detects the form from the first
+non-whitespace byte:
+
+- `{` → structured JSON `QueryFilter` DSL;
+- `"` → a JSON-quoted string carrying textual `filterexpr` (body-field form);
+- anything else → raw textual `filterexpr` (query-string form).
+
+**How each form is passed over HTTP:**
+
+- **Query-string endpoints** (`?filter=`): the value is textual `filterexpr`
+  passed verbatim (URL-encoded). To pass the structured form, URL-encode the JSON
+  object as the value (`?filter=%7B%22%24match%22%3A…%7D`). The generic `filter`
+  parameter is AND-combined with the endpoint's convenience params (`reference`,
+  `prefix`, `startDate`/`endDate`).
+- **JSON-body endpoints** (prepared-query create/update `filter` field): a JSON
+  object is the structured form; a JSON string (`"filter": "metadata[k] == v"`)
+  is the textual form.
+
+**Audit is text-only.** Audit conditions (`audit[...]`) have no structured JSON
+representation — their field names (`ledger`, `timestamp`, …) collide with the
+transaction/log conditions the JSON DSL already claims (EN-1241) — so the JSON
+codec rejects them. The dual-format decoder still accepts both forms as input on
+the audit endpoint; the textual form is simply the only one that can carry an
+audit condition, so it is the canonical representation for
+`GET /v3/_/audit-entries`.
 
 ### 10. Prepared Queries and User-Configurable Indexes
 

--- a/internal/adapter/http/handlers_create_prepared_query.go
+++ b/internal/adapter/http/handlers_create_prepared_query.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -41,18 +41,20 @@ func (s *Server) handleCreatePreparedQuery(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	filter, err := decodePreparedQueryFilter(body.Filter)
+	// The `filter` field accepts either the structured v2 JSON DSL or a
+	// JSON-quoted textual filterexpr expression (EN-1511); DecodeDualFormat
+	// detects the form and runs the per-target validity gate for `target` — the
+	// same domain.ValidateFilterForTarget admission + FSM re-run, so gRPC callers
+	// and the update path are covered too (EN-1504).
+	filter, err := filterexpr.DecodeDualFormat(body.Filter, target)
 	if err != nil {
 		writeBadRequest(w, "INVALID_REQUEST", err)
 
 		return
 	}
 
-	// Reject conditions invalid on this query's specific target early (precise
-	// 400). Admission + FSM re-validate with the same domain helper, so gRPC
-	// callers and the update path are covered too (EN-1504).
-	if verr := domain.ValidateFilterForTarget(filter, target); verr != nil {
-		writeBadRequest(w, "INVALID_REQUEST", verr)
+	if filter == nil {
+		writeBadRequest(w, "INVALID_REQUEST", errors.New("filter is required"))
 
 		return
 	}

--- a/internal/adapter/http/handlers_create_prepared_query_test.go
+++ b/internal/adapter/http/handlers_create_prepared_query_test.go
@@ -161,6 +161,7 @@ func TestHandleCreatePreparedQuery_MissingFilter(t *testing.T) {
 	srv.handleCreatePreparedQuery(w, r)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "filter is required")
 }
 
 func TestHandleCreatePreparedQuery_EmptyFilter(t *testing.T) {
@@ -168,14 +169,17 @@ func TestHandleCreatePreparedQuery_EmptyFilter(t *testing.T) {
 
 	srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
 
+	// A target is set so the request reaches the filter-decode branch (an empty
+	// `{}` filter), not the earlier target-required check.
 	w := httptest.NewRecorder()
 	r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries",
-		strings.NewReader(`{"name":"my-query","filter":{}}`),
+		strings.NewReader(`{"name":"my-query","target":"ACCOUNTS","filter":{}}`),
 		map[string]string{"ledgerName": "ledger1"})
 
 	srv.handleCreatePreparedQuery(w, r)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "empty object")
 }
 
 func TestHandleCreatePreparedQuery_LogsTargetAccepted(t *testing.T) {

--- a/internal/adapter/http/handlers_list_accounts.go
+++ b/internal/adapter/http/handlers_list_accounts.go
@@ -24,9 +24,9 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 	prefix := r.URL.Query().Get("prefix")
 
 	// Build an optional address-prefix filter from query parameter
-	var filter *commonpb.QueryFilter
+	var prefixFilter *commonpb.QueryFilter
 	if prefix != "" {
-		filter = &commonpb.QueryFilter{
+		prefixFilter = &commonpb.QueryFilter{
 			Filter: &commonpb.QueryFilter_Address{
 				Address: &commonpb.AddressMatch{
 					Match: &commonpb.AddressMatch_HardcodedPrefix{HardcodedPrefix: prefix},
@@ -34,6 +34,16 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 	}
+
+	// The generic `filter` query parameter accepts either the textual filterexpr
+	// grammar or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
+	// `prefix` convenience param above.
+	generic, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	if !ok {
+		return
+	}
+
+	filter := combineFilters(prefixFilter, generic)
 
 	reverse := r.URL.Query().Get("reverse") == "true"
 

--- a/internal/adapter/http/handlers_list_audit_entries.go
+++ b/internal/adapter/http/handlers_list_audit_entries.go
@@ -2,11 +2,9 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 
-	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -88,20 +86,17 @@ func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) 
 }
 
 // parseAuditFilter parses the optional `filter` query parameter into a
-// QueryFilter using the shared filterexpr grammar. An absent filter yields a nil
-// filter (unfiltered read). A malformed filter is a 400.
+// QueryFilter via the shared dual-format decoder (EN-1511), the same one every
+// other list endpoint uses. An absent filter yields a nil filter (unfiltered
+// read). A malformed filter, or one carrying a condition invalid on the AUDIT
+// target, is a 400.
+//
+// In practice audit filters are textual: the structured v2 JSON DSL has no
+// representation for audit conditions (their field names collide with the
+// transaction/log conditions the codec already claims — EN-1241), so the codec
+// rejects them. The decoder still accepts the structured form as input; it just
+// cannot carry an audit condition, so the textual form is the canonical one for
+// this endpoint. See the handler doc above and commonpb/query_filter.go.
 func parseAuditFilter(w http.ResponseWriter, r *http.Request) (*commonpb.QueryFilter, bool) {
-	expr := r.URL.Query().Get("filter")
-	if expr == "" {
-		return nil, true
-	}
-
-	filter, err := filterexpr.Parse(expr)
-	if err != nil {
-		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid filter: %w", err))
-
-		return nil, false
-	}
-
-	return filter, true
+	return parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_AUDIT)
 }

--- a/internal/adapter/http/handlers_list_ledger_logs.go
+++ b/internal/adapter/http/handlers_list_ledger_logs.go
@@ -87,16 +87,17 @@ func (s *Server) handleListLedgerLogs(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	var filter *commonpb.QueryFilter
-	if len(filters) == 1 {
-		filter = filters[0]
-	} else if len(filters) > 1 {
-		filter = &commonpb.QueryFilter{
-			Filter: &commonpb.QueryFilter_And{
-				And: &commonpb.AndFilter{Filters: filters},
-			},
-		}
+	// The generic `filter` query parameter accepts either the textual filterexpr
+	// grammar or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
+	// after/startDate/endDate convenience params above.
+	generic, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_LOGS)
+	if !ok {
+		return
 	}
+
+	filters = append(filters, generic)
+
+	filter := combineFilters(filters...)
 
 	cursor, err := s.backend.ListLogs(r.Context(), ledgerName, 0, pageSize, filter)
 	if err != nil {

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -135,16 +135,17 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
-	var filter *commonpb.QueryFilter
-	if len(filters) == 1 {
-		filter = filters[0]
-	} else if len(filters) > 1 {
-		filter = &commonpb.QueryFilter{
-			Filter: &commonpb.QueryFilter_And{
-				And: &commonpb.AndFilter{Filters: filters},
-			},
-		}
+	// The generic `filter` query parameter accepts either the textual filterexpr
+	// grammar or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
+	// convenience params (reference, startDate/endDate) above.
+	generic, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+	if !ok {
+		return
 	}
+
+	filters = append(filters, generic)
+
+	filter := combineFilters(filters...)
 
 	ctx, profile := query.WithProfile(r.Context())
 

--- a/internal/adapter/http/handlers_list_transactions_test.go
+++ b/internal/adapter/http/handlers_list_transactions_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -106,6 +108,64 @@ func TestHandleListTransactions_WithReferenceAndDateFilters(t *testing.T) {
 	and := capturedFilter.GetAnd()
 	require.NotNil(t, and)
 	require.Len(t, and.GetFilters(), 2)
+}
+
+// TestHandleListTransactions_DualFormatFilter is the endpoint-level EN-1511
+// acceptance check: the same logical filter passed via `?filter=` in the textual
+// form and in the structured JSON form reaches the backend as the same
+// QueryFilter.
+func TestHandleListTransactions_DualFormatFilter(t *testing.T) {
+	t.Parallel()
+
+	capture := func(t *testing.T, target string) *commonpb.QueryFilter {
+		t.Helper()
+
+		var captured *commonpb.QueryFilter
+
+		backend := NewMockBackend(gomock.NewController(t))
+		backend.EXPECT().ListTransactions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Transaction], error) {
+				captured = filter
+
+				return cursor.NewSliceCursor[*commonpb.Transaction](nil), nil
+			}).AnyTimes()
+		srv := newTestServer(t, backend)
+
+		w := httptest.NewRecorder()
+		r := newRequest(t, http.MethodGet, target, nil, map[string]string{"ledgerName": "ledger1"})
+		srv.handleListTransactions(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		require.NotNil(t, captured)
+
+		return captured
+	}
+
+	// url.QueryEscape both values so the JSON braces / spaces survive the query
+	// string.
+	fromText := capture(t, "/ledger1/transactions?filter="+url.QueryEscape(`metadata[status] == "active"`))
+	fromJSON := capture(t, "/ledger1/transactions?filter="+url.QueryEscape(`{"$match":{"metadata[status]":"active"}}`))
+
+	require.True(t, proto.Equal(fromText, fromJSON),
+		"textual and JSON ?filter= forms must reach the backend as the same QueryFilter\n text: %v\n json: %v",
+		fromText, fromJSON)
+}
+
+// TestHandleListTransactions_FilterInvalidForTarget checks that a condition
+// invalid on the transactions target is rejected with a 400 for both forms.
+func TestHandleListTransactions_FilterInvalidForTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{`ledger == "main"`, `{"$match":{"ledger":"main"}}`} {
+		srv := newTestServer(t, NewMockBackend(gomock.NewController(t)))
+
+		w := httptest.NewRecorder()
+		r := newRequest(t, http.MethodGet, "/ledger1/transactions?filter="+url.QueryEscape(raw), nil,
+			map[string]string{"ledgerName": "ledger1"})
+		srv.handleListTransactions(w, r)
+
+		require.Equal(t, http.StatusBadRequest, w.Code, "raw: %s", raw)
+	}
 }
 
 func TestHandleListTransactions_InvalidAfter(t *testing.T) {

--- a/internal/adapter/http/handlers_update_prepared_query.go
+++ b/internal/adapter/http/handlers_update_prepared_query.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -39,10 +40,18 @@ func (s *Server) handleUpdatePreparedQuery(w http.ResponseWriter, r *http.Reques
 	// stored target by the FSM (processUpdatePreparedQuery →
 	// domain.ValidateFilterForTarget), the only layer that sees it — so an update
 	// cannot smuggle in a condition invalid for the query's target (EN-1504).
-	// This handler stays purely structural.
-	filter, err := decodePreparedQueryFilter(body.Filter)
+	// This handler stays purely structural: it accepts either the structured v2
+	// JSON DSL or a JSON-quoted textual filterexpr expression (EN-1511) and defers
+	// the target gate to the FSM.
+	filter, err := filterexpr.DecodeDualFormatStructuralOnly(body.Filter)
 	if err != nil {
 		writeBadRequest(w, "INVALID_REQUEST", err)
+
+		return
+	}
+
+	if filter == nil {
+		writeBadRequest(w, "INVALID_REQUEST", errors.New("filter is required"))
 
 		return
 	}

--- a/internal/adapter/http/list_filter.go
+++ b/internal/adapter/http/list_filter.go
@@ -13,6 +13,10 @@ import (
 // for one, so a single-condition query is not needlessly wrapped in a 1-element
 // $and. This is the shared version of the ad-hoc combine logic the list handlers
 // used to each carry.
+//
+// NOTE: it compacts in place over the passed slice's backing array, so a caller
+// that spreads a slice (combineFilters(s...)) must treat s as consumed and not
+// read it afterward. All current callers do this as their last use of the slice.
 func combineFilters(filters ...*commonpb.QueryFilter) *commonpb.QueryFilter {
 	compact := filters[:0]
 	for _, f := range filters {

--- a/internal/adapter/http/list_filter.go
+++ b/internal/adapter/http/list_filter.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// combineFilters AND-combines the non-nil filters into a single QueryFilter.
+// Returns nil for zero filters (unfiltered read) and the sole filter unwrapped
+// for one, so a single-condition query is not needlessly wrapped in a 1-element
+// $and. This is the shared version of the ad-hoc combine logic the list handlers
+// used to each carry.
+func combineFilters(filters ...*commonpb.QueryFilter) *commonpb.QueryFilter {
+	compact := filters[:0]
+	for _, f := range filters {
+		if f != nil {
+			compact = append(compact, f)
+		}
+	}
+
+	switch len(compact) {
+	case 0:
+		return nil
+	case 1:
+		return compact[0]
+	default:
+		return &commonpb.QueryFilter{
+			Filter: &commonpb.QueryFilter_And{
+				And: &commonpb.AndFilter{Filters: compact},
+			},
+		}
+	}
+}
+
+// parseListFilter decodes the optional `filter` query parameter of a list
+// endpoint into a QueryFilter, accepting BOTH the textual filterexpr grammar and
+// the structured v2 JSON DSL interchangeably (EN-1511): the value is handed to
+// filterexpr.DecodeDualFormat, which detects the form and runs the per-target
+// validity gate for `target`. An absent/empty filter yields (nil, true) — an
+// unfiltered read. A malformed filter or one carrying a condition invalid on the
+// target is a 400; the response is written and ok=false is returned so the
+// caller returns immediately.
+//
+// The structured form is passed over the query string by URL-encoding the JSON
+// object as the value (`?filter=%7B%22%24match%22%3A…%7D`); the textual form is
+// passed verbatim (`?filter=metadata[k]==v`). Both compile through the same
+// downstream path as the endpoint's structured query-param filters, which the
+// caller AND-combines via combineFilters.
+func parseListFilter(w http.ResponseWriter, r *http.Request, target commonpb.QueryTarget) (*commonpb.QueryFilter, bool) {
+	raw := r.URL.Query().Get("filter")
+	if raw == "" {
+		return nil, true
+	}
+
+	filter, err := filterexpr.DecodeDualFormat([]byte(raw), target)
+	if err != nil {
+		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid filter: %w", err))
+
+		return nil, false
+	}
+
+	return filter, true
+}

--- a/internal/adapter/http/prepared_query_filter.go
+++ b/internal/adapter/http/prepared_query_filter.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -33,36 +32,4 @@ func parsePreparedQueryTarget(target string) (commonpb.QueryTarget, error) {
 	}
 
 	return t, nil
-}
-
-// decodePreparedQueryFilter decodes the `filter` JSON value of a prepared-query
-// create/update request. The value uses the v2-aligned query DSL documented in
-// openapi.yml (combinators `$and`/`$or`/`$not` plus single-key operators
-// `$match`/`$gt`/`$exists`/…); the codec lives on commonpb.QueryFilter
-// (query_filter.go) and keeps the protobuf-internal oneof/wrapper names off the
-// public surface. An empty or absent filter is rejected — otherwise the prepared
-// query would store nil and fail later at execute time with "unknown filter
-// type: <nil>".
-func decodePreparedQueryFilter(raw json.RawMessage) (*commonpb.QueryFilter, error) {
-	if len(raw) == 0 || string(raw) == "null" {
-		return nil, errors.New("filter is required")
-	}
-
-	filter := &commonpb.QueryFilter{}
-	if err := json.Unmarshal(raw, filter); err != nil {
-		return nil, fmt.Errorf("filter: %w", err)
-	}
-
-	if filter.GetFilter() == nil {
-		return nil, errors.New("filter must contain at least one condition")
-	}
-
-	// Per-target validity (a condition must be valid on the query's specific
-	// target — logId/date/ledger are valid on LOGS but not on
-	// ACCOUNTS/TRANSACTIONS) is enforced by domain.ValidateFilterForTarget at the
-	// admission + FSM layers, which know the concrete target for both create
-	// (from the request) and update (from the stored query). The create handler
-	// also runs it here for an early, precise 400; this decoder stays purely
-	// structural.
-	return filter, nil
 }

--- a/internal/adapter/http/prepared_query_filter_test.go
+++ b/internal/adapter/http/prepared_query_filter_test.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,97 +8,9 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
-func TestDecodePreparedQueryFilter(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		raw       string
-		wantErr   string
-		assertion func(t *testing.T, filter any)
-	}{
-		{
-			name:    "missing",
-			raw:     "",
-			wantErr: "filter is required",
-		},
-		{
-			name:    "json null",
-			raw:     "null",
-			wantErr: "filter is required",
-		},
-		{
-			name:    "empty object",
-			raw:     "{}",
-			wantErr: "empty object",
-		},
-		{
-			name:    "invalid json",
-			raw:     "not-json",
-			wantErr: "filter:",
-		},
-		{
-			name: "and filter with nested conditions",
-			raw: `{"$and":[
-				{"$gte":{"metadata[x]":1}},
-				{"$match":{"metadata[y]":true}}
-			]}`,
-		},
-		{
-			name: "or filter",
-			raw:  `{"$or":[{"$exists":{"metadata":"x"}}]}`,
-		},
-		{
-			name: "leaf metadata exists",
-			raw:  `{"$exists":{"metadata":"x"}}`,
-		},
-		{
-			name:    "unknown operator rejected",
-			raw:     `{"$bogus":{}}`,
-			wantErr: "unknown operator",
-		},
-		// Per-target validity (rejecting a condition invalid on the query's
-		// specific target, e.g. logId/date/ledger on an ACCOUNTS query, and
-		// accepting them for LOGS) is enforced by domain.ValidateFilterForTarget
-		// at the admission/FSM layers and by the create handler — see
-		// TestValidateFilterForTarget (internal/domain) and the admission
-		// validate_order tests. This decoder is purely structural, so any
-		// syntactically valid condition — including log-only ones — decodes fine
-		// here regardless of target.
-		{
-			name: "log-only condition decodes (target validity checked later)",
-			raw:  `{"$gt":{"logId":"5"}}`,
-		},
-		{
-			name:    "null value rejected",
-			raw:     `{"$match":{"reference":null}}`,
-			wantErr: "must not be null",
-		},
-		{
-			name:    "multiple top-level operators rejected",
-			raw:     `{"$and":[],"$not":{"$match":{"reverted":true}}}`,
-			wantErr: "exactly one operator",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			filter, err := decodePreparedQueryFilter(json.RawMessage(tc.raw))
-			if tc.wantErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.wantErr)
-
-				return
-			}
-
-			require.NoError(t, err)
-			require.NotNil(t, filter)
-			require.NotNil(t, filter.GetFilter(), "oneof discriminator must be populated")
-		})
-	}
-}
+// Structural decode of the `filter` field (JSON DSL and textual filterexpr) now
+// lives in the shared filterexpr.DecodeDualFormat helper; see
+// internal/pkg/filterexpr/decode_test.go for its coverage.
 
 func TestParsePreparedQueryTarget(t *testing.T) {
 	t.Parallel()

--- a/internal/pkg/filterexpr/decode.go
+++ b/internal/pkg/filterexpr/decode.go
@@ -90,6 +90,11 @@ func decodeDualFormat(raw []byte) (*commonpb.QueryFilter, error) {
 			return nil, fmt.Errorf("filter: %w", err)
 		}
 
+		// Defensive: the codec already rejects a structurally-empty object (`{}`
+		// fails with "empty object"), so a successful unmarshal normally populates
+		// the oneof. Guard the residual case where it does not, rather than passing
+		// an empty filter downstream (which would fail later at execute time with
+		// "unknown filter type: <nil>").
 		if filter.GetFilter() == nil {
 			return nil, errors.New("filter must contain at least one condition")
 		}

--- a/internal/pkg/filterexpr/decode.go
+++ b/internal/pkg/filterexpr/decode.go
@@ -1,0 +1,128 @@
+package filterexpr
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// DecodeDualFormat parses a filter supplied in EITHER of the two supported
+// representations into the SAME *commonpb.QueryFilter, then runs the single
+// per-target validity gate (domain.ValidateFilterForTarget) on the result. It is
+// the one entry point every filtered surface (list endpoints, prepared queries,
+// audit reads, ledgerctl --filter) uses, so a caller never has to know which
+// syntax an endpoint "wants": both are accepted interchangeably and compile
+// through the same downstream path (EN-1511).
+//
+// The two representations are:
+//
+//   - structured — the v2 QueryFilter JSON DSL ($and/$or/$not + $match/$gt/…),
+//     decoded by commonpb.QueryFilter.UnmarshalJSON (query_filter.go);
+//   - textual    — the human-readable filterexpr grammar (metadata[k] == v,
+//     audit[outcome] == failure, …), parsed by Parse.
+//
+// Form detection is purely structural and does not depend on the transport: the
+// first non-whitespace byte of the raw value decides. A leading '{' is the
+// structured JSON DSL (every DSL node is a JSON object). A leading '"' is a
+// JSON-quoted string whose contents are textual filterexpr — this lets a JSON
+// body field carry either form (`"filter": {"$match": …}` or
+// `"filter": "metadata[k] == v"`). Anything else is treated as raw textual
+// filterexpr, which is how a query-string value (`?filter=metadata[k]==v`)
+// arrives. A caller passing the structured form over a query string simply
+// URL-encodes the JSON object as the value.
+//
+// AUDIT is text-only: an audit condition has no structured JSON representation
+// (the field-dispatched DSL cannot round-trip audit field names — ledger,
+// timestamp, … — without colliding with the transaction/log conditions that
+// already claim them; see commonpb/query_filter.go, EN-1241). This is not a
+// special case here: the structured decoder rejects audit conditions on its own,
+// so a structured-form audit filter fails with that codec's error, while the
+// textual form parses the audit arm natively. Callers that read AUDIT should
+// document the textual form as the canonical one.
+//
+// A nil/empty raw value yields (nil, nil): "no filter" is a valid unfiltered
+// read for the list endpoints. Callers that require a filter (prepared queries)
+// check for nil themselves — the same contract the previous per-endpoint
+// decoders had.
+func DecodeDualFormat(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
+	filter, err := decodeDualFormat(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if filter == nil {
+		return nil, nil
+	}
+
+	if verr := domain.ValidateFilterForTarget(filter, target); verr != nil {
+		return nil, verr
+	}
+
+	return filter, nil
+}
+
+// DecodeDualFormatStructuralOnly is DecodeDualFormat without the per-target
+// validity gate. It exists for the prepared-query update path, which does not
+// see the target (the target is immutable and lives on the stored query, so the
+// FSM applies the gate against it — see handlers_update_prepared_query.go). Every
+// other caller MUST use DecodeDualFormat so form and validity are checked in one
+// place.
+func DecodeDualFormatStructuralOnly(raw []byte) (*commonpb.QueryFilter, error) {
+	return decodeDualFormat(raw)
+}
+
+// decodeDualFormat performs form detection + parse, without the validity gate.
+func decodeDualFormat(raw []byte) (*commonpb.QueryFilter, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+
+	switch trimmed[0] {
+	case '{':
+		// Structured v2 QueryFilter JSON DSL.
+		filter := &commonpb.QueryFilter{}
+		if err := json.Unmarshal(trimmed, filter); err != nil {
+			return nil, fmt.Errorf("filter: %w", err)
+		}
+
+		if filter.GetFilter() == nil {
+			return nil, errors.New("filter must contain at least one condition")
+		}
+
+		return filter, nil
+
+	case '"':
+		// JSON-quoted string carrying textual filterexpr (body-field form).
+		var expr string
+		if err := json.Unmarshal(trimmed, &expr); err != nil {
+			return nil, fmt.Errorf("filter: %w", err)
+		}
+
+		return parseTextual(expr)
+
+	default:
+		// Raw textual filterexpr (query-string form).
+		return parseTextual(string(trimmed))
+	}
+}
+
+// parseTextual parses a textual filterexpr expression, treating an empty string
+// as "no filter" for symmetry with the empty-raw case (a body field of `""` or a
+// query param of `?filter=` is an explicit no-op, not a parse error).
+func parseTextual(expr string) (*commonpb.QueryFilter, error) {
+	if expr == "" {
+		return nil, nil
+	}
+
+	filter, err := Parse(expr)
+	if err != nil {
+		return nil, fmt.Errorf("filter: %w", err)
+	}
+
+	return filter, nil
+}

--- a/internal/pkg/filterexpr/decode_test.go
+++ b/internal/pkg/filterexpr/decode_test.go
@@ -1,0 +1,211 @@
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// TestDecodeDualFormat_Equivalence is the core EN-1511 acceptance check: the
+// textual filterexpr form and the structured v2 JSON DSL form of the SAME
+// logical filter decode to an identical *commonpb.QueryFilter.
+func TestDecodeDualFormat_Equivalence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		text   string
+		json   string
+		target commonpb.QueryTarget
+	}{
+		{
+			name:   "metadata match",
+			text:   `metadata[status] == "active"`,
+			json:   `{"$match":{"metadata[status]":"active"}}`,
+			target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+		},
+		{
+			name:   "address prefix",
+			text:   `address ^= "users:"`,
+			json:   `{"$match":{"address":"users:"}}`,
+			target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+		},
+		{
+			// Values are non-numeric strings on purpose: the textual grammar
+			// coerces a bare/quoted numeric metadata value to an IntCondition, while
+			// the JSON $match value stays a StringCondition, so the two forms only
+			// decode byte-for-byte identically for genuinely string-typed values.
+			name:   "and of two conditions",
+			text:   `metadata[a] == "x" and metadata[b] == "y"`,
+			json:   `{"$and":[{"$match":{"metadata[a]":"x"}},{"$match":{"metadata[b]":"y"}}]}`,
+			target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		},
+		{
+			name:   "or of two conditions",
+			text:   `metadata[a] == "x" or metadata[b] == "y"`,
+			json:   `{"$or":[{"$match":{"metadata[a]":"x"}},{"$match":{"metadata[b]":"y"}}]}`,
+			target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		},
+		{
+			name:   "ledger condition on logs",
+			text:   `ledger == "main"`,
+			json:   `{"$match":{"ledger":"main"}}`,
+			target: commonpb.QueryTarget_QUERY_TARGET_LOGS,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fromText, err := DecodeDualFormat([]byte(tc.text), tc.target)
+			require.NoError(t, err, "textual form must decode")
+			require.NotNil(t, fromText)
+
+			fromJSON, err := DecodeDualFormat([]byte(tc.json), tc.target)
+			require.NoError(t, err, "structured form must decode")
+			require.NotNil(t, fromJSON)
+
+			require.True(t, proto.Equal(fromText, fromJSON),
+				"text and JSON forms must decode to the same QueryFilter\n text: %v\n json: %v",
+				fromText, fromJSON)
+		})
+	}
+}
+
+// TestDecodeDualFormat_JSONQuotedText covers the body-field form where textual
+// filterexpr is carried inside a JSON string ("filter": "metadata[k] == v").
+func TestDecodeDualFormat_JSONQuotedText(t *testing.T) {
+	t.Parallel()
+
+	quoted := []byte(`"metadata[status] == \"active\""`)
+	fromQuoted, err := DecodeDualFormat(quoted, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	require.NoError(t, err)
+	require.NotNil(t, fromQuoted)
+
+	fromBare, err := DecodeDualFormat([]byte(`metadata[status] == "active"`), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	require.NoError(t, err)
+
+	require.True(t, proto.Equal(fromQuoted, fromBare),
+		"JSON-quoted textual filter must decode identically to the bare textual form")
+}
+
+// TestDecodeDualFormat_Empty covers the no-filter cases: nil, empty, whitespace,
+// JSON null, empty JSON string.
+func TestDecodeDualFormat_Empty(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"", "   ", "null", `""`} {
+		filter, err := DecodeDualFormat([]byte(raw), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+		require.NoError(t, err, "empty-ish input %q must not error", raw)
+		require.Nil(t, filter, "empty-ish input %q must yield a nil filter", raw)
+	}
+
+	filter, err := DecodeDualFormat(nil, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	require.NoError(t, err)
+	require.Nil(t, filter)
+}
+
+// TestDecodeDualFormat_Malformed covers rejection of malformed input in each
+// form, and rejection of a condition invalid on the given target.
+func TestDecodeDualFormat_Malformed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		target  commonpb.QueryTarget
+		wantErr string
+	}{
+		{
+			name:    "malformed textual",
+			raw:     `metadata[k] ==`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "filter:",
+		},
+		{
+			name:    "malformed json - unknown operator",
+			raw:     `{"$bogus":{}}`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "unknown operator",
+		},
+		{
+			name:    "malformed json - empty object",
+			raw:     `{}`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "empty object",
+		},
+		{
+			name:    "malformed json - not an object body",
+			raw:     `{"$match":42}`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "filter:",
+		},
+		{
+			// `ledger` is a valid textual condition but is only valid on LOGS/AUDIT
+			// targets, so it is rejected on ACCOUNTS by the per-target gate.
+			name:    "condition invalid on target (textual)",
+			raw:     `ledger == "main"`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "not valid on accounts",
+		},
+		{
+			name:    "condition invalid on target (json)",
+			raw:     `{"$match":{"reference":"x"}}`,
+			target:  commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			wantErr: "not valid on accounts",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := DecodeDualFormat([]byte(tc.raw), tc.target)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestDecodeDualFormat_AuditTextOnly documents and locks the audit-arm decision:
+// an audit condition parses only via the textual form; the structured JSON DSL
+// has no representation for it and is rejected by the codec (EN-1241). Both flow
+// through the single shared decoder.
+func TestDecodeDualFormat_AuditTextOnly(t *testing.T) {
+	t.Parallel()
+
+	fromText, err := DecodeDualFormat([]byte(`audit[outcome] == failure`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	require.NoError(t, err, "textual audit filter must decode")
+	require.NotNil(t, fromText)
+	require.IsType(t, &commonpb.QueryFilter_Audit{}, fromText.GetFilter())
+
+	// There is no structured JSON representation of an audit condition — the codec
+	// rejects any attempt to carry one (its field names collide with the
+	// transaction/log conditions the JSON DSL already claims).
+	_, err = DecodeDualFormat([]byte(`{"$match":{"outcome":"failure"}}`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	require.Error(t, err, "audit has no structured JSON form; a structured filter must not decode to a valid audit condition")
+}
+
+// TestDecodeDualFormatStructuralOnly_SkipsTargetGate confirms the update-path
+// variant decodes both forms but does NOT apply the per-target validity gate
+// (the FSM applies it against the stored target).
+func TestDecodeDualFormatStructuralOnly_SkipsTargetGate(t *testing.T) {
+	t.Parallel()
+
+	// `ledger` is invalid on ACCOUNTS, but the structural-only decoder does not
+	// know the target and must accept it (the gate runs later against the stored
+	// target) in both forms.
+	fromText, err := DecodeDualFormatStructuralOnly([]byte(`ledger == "main"`))
+	require.NoError(t, err)
+	require.NotNil(t, fromText)
+
+	fromJSON, err := DecodeDualFormatStructuralOnly([]byte(`{"$match":{"ledger":"main"}}`))
+	require.NoError(t, err)
+	require.NotNil(t, fromJSON)
+
+	require.True(t, proto.Equal(fromText, fromJSON))
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -365,6 +365,7 @@ paths:
           description: |
             Filter logs with date < endDate (exclusive, RFC3339 format).
             Requires the builtin `LOG_DATE` index to be enabled on the ledger.
+        - $ref: '#/components/parameters/ListFilter'
       responses:
         '200':
           description: Logs retrieved successfully
@@ -442,9 +443,10 @@ paths:
           schema:
             type: string
           description: |
-            Filter expression restricted to `audit[...]` conditions, using the
-            shared filter grammar (the same one accepted by `ledgerctl audit
-            list --filter`). Examples:
+            A filter, decoded by the same shared dual-format decoder every list
+            endpoint uses (see the `ListFilter` parameter). In practice audit
+            filters use the **textual** representation, restricted to `audit[...]`
+            conditions:
               - `audit[outcome] == failure`
               - `audit[ledger] == main`
               - `audit[order_type] in (create_transaction, revert_transaction)`
@@ -453,8 +455,11 @@ paths:
             Supported fields: `seq`, `proposal_id`, `log_seq` (numeric);
             `timestamp` (RFC3339 or unix microseconds); `outcome`
             (success|failure), `ledger`, `caller_subject`, `order_type`
-            (string). This is deliberately NOT the JSON QueryFilter DSL used by
-            prepared queries, which cannot represent audit conditions.
+            (string). Audit conditions have NO structured JSON QueryFilter
+            representation (their field names collide with the transaction/log
+            conditions the JSON DSL already claims), so the textual form is the
+            canonical one here; a JSON QueryFilter cannot carry an audit
+            condition and is rejected.
       responses:
         '200':
           description: List of audit entries
@@ -693,6 +698,7 @@ paths:
           schema:
             type: string
           description: Filter by exact-match transaction reference.
+        - $ref: '#/components/parameters/ListFilter'
       responses:
         '200':
           description: Transactions retrieved successfully.
@@ -788,6 +794,7 @@ paths:
             `acc:10`, `acc:11`, etc. Do not use for exact-address lookups.
           schema:
             type: string
+        - $ref: '#/components/parameters/ListFilter'
       responses:
         '200':
           description: List of accounts
@@ -2834,6 +2841,33 @@ components:
         maxLength: 256
       description: Idempotency key for the request
 
+    ListFilter:
+      name: filter
+      in: query
+      required: false
+      schema:
+        type: string
+      description: |
+        A filter, accepted in EITHER of two interchangeable representations that
+        parse to the same filter and are validated against the same per-target
+        rules:
+
+          - **Textual** — the human-readable filter grammar, e.g.
+            `metadata[status] == "active"`, `address ^= "users:"`,
+            `metadata[a] == "x" and metadata[b] == "y"`. Passed verbatim as the
+            query-parameter value (URL-encoded).
+          - **Structured** — the JSON QueryFilter DSL (see the `QueryFilter`
+            schema: `$and`/`$or`/`$not` + `$match`/`$gt`/`$exists`/…). Passed by
+            URL-encoding the JSON object as the query-parameter value.
+
+        A condition that is not valid on the endpoint's target (e.g. a
+        transaction-only condition on the accounts list) is rejected with 400.
+        This generic filter is AND-combined with any convenience parameters the
+        endpoint also exposes (e.g. `reference`, `prefix`, `startDate`/`endDate`).
+
+        Note: audit conditions (`audit[...]`) have no structured JSON form and
+        must be passed in the textual representation.
+
   responses:
     ServiceUnavailable:
       description: Service unavailable (no leader available)
@@ -4555,7 +4589,7 @@ components:
             filter fields (`logId`, `date`, `ledger`) are valid only when the
             target is `LOGS`.
         filter:
-          $ref: '#/components/schemas/QueryFilter'
+          $ref: '#/components/schemas/PreparedQueryFilterInput'
 
     UpdatePreparedQueryRequest:
       type: object
@@ -4563,7 +4597,7 @@ components:
         - filter
       properties:
         filter:
-          $ref: '#/components/schemas/QueryFilter'
+          $ref: '#/components/schemas/PreparedQueryFilterInput'
 
     ExecutePreparedQueryRequest:
       type: object
@@ -4747,6 +4781,25 @@ components:
           maxProperties: 1
           additionalProperties: true
 
+    PreparedQueryFilterInput:
+      description: >-
+        A filter supplied to a prepared-query create/update request, accepted in
+        EITHER of two interchangeable representations that parse to the same
+        filter and are validated against the same per-target rules (EN-1511):
+
+
+        - the structured JSON QueryFilter object (see `QueryFilter`); or
+
+        - the textual filter grammar carried as a JSON string, e.g.
+          `"metadata[status] == \"active\""`.
+
+
+        Responses always echo the stored filter back in the structured
+        `QueryFilter` form.
+      oneOf:
+        - $ref: '#/components/schemas/QueryFilter'
+        - type: string
+          description: Textual filter expression (filter grammar).
 
     ExecutePreparedQueryResponse:
       type: object


### PR DESCRIPTION
## What & why

Ref **EN-1511**. Filter input was inconsistent per endpoint: prepared queries (REST) consumed the structured `QueryFilter` JSON DSL, while `ledgerctl --filter` and audit HTTP consumed the textual `filterexpr` DSL. Callers had to know which one each endpoint wanted.

Now **every filtered surface accepts BOTH representations interchangeably**, both parsing into the same `*commonpb.QueryFilter` and flowing through the same per-target validity gate (EN-1504 `domain.ValidateFilterForTarget`):

- list transactions / accounts / logs (`?filter=`)
- audit HTTP (`GET /v3/_/audit-entries?filter=`)
- prepared-query create / update (`filter` body field)
- `ledgerctl --filter`

## Shared decoder

One helper, `filterexpr.DecodeDualFormat` (`internal/pkg/filterexpr/decode.go`), detects the form from the first non-whitespace byte and applies the per-target gate:

- `{` → structured v2 JSON `QueryFilter` DSL
- `"` → JSON-quoted textual `filterexpr` (body-field form)
- else → raw textual `filterexpr` (query-string form)

HTTP list handlers consume it via `parseListFilter` (`internal/adapter/http/list_filter.go`) for the generic `?filter=` param and AND-combine it with each endpoint's convenience params (`reference`, `prefix`, `startDate`/`endDate`) through `combineFilters` (which also replaces the duplicated ad-hoc AND-combine logic the list handlers each carried). `DecodeDualFormatStructuralOnly` is the target-less variant for the prepared-query update path (the FSM applies the gate against the immutable stored target).

## Decisions

- **Audit arm → kept text-only, documented.** Audit conditions (`audit[...]`) have no structured JSON representation — their field names (`ledger`, `timestamp`, …) collide with the transaction/log conditions the JSON DSL already claims (EN-1241), and the codec fails loud rather than round-trip to the wrong condition. Lower-risk than inventing a disambiguating JSON wrapper (which would be a third syntax). The dual-format decoder still accepts both forms as input on the audit endpoint; textual is simply the only one that can carry an audit condition.
- **Query-param vs body form (consistent across endpoints).** Query-string endpoints (`?filter=`): textual passed verbatim, structured passed by URL-encoding the JSON object. JSON-body endpoints (prepared queries): a JSON object is structured, a JSON string is textual.
- read-side only; no new persisted projection; camelCase JSON; EN-1504 per-target validity stays the single gate.

## Tests

- `internal/pkg/filterexpr/decode_test.go` — text→QueryFilter, JSON→QueryFilter, **equivalence** of the two for the same logical filter (`proto.Equal`), JSON-quoted-text form, empty/no-op inputs, malformed rejection in each form, per-target rejection in each form, audit text-only, structural-only skips the gate.
- `internal/adapter/http/handlers_list_transactions_test.go` — endpoint-level acceptance: the same filter via `?filter=` in both forms reaches the backend as the same `QueryFilter`; both forms rejected with 400 for a target-invalid condition.

## Docs

`openapi.yml` (shared `ListFilter` query param on the list endpoints + `PreparedQueryFilterInput` `oneOf` on prepared-query request bodies), `api-comparison.md` (new "Filter input formats" section), `cli.md`, `query-pipeline.md`.

## Verification

- `GOROOT= go build ./...` clean
- `GOROOT= go test ./internal/adapter/http/... ./internal/pkg/filterexpr/... ./internal/proto/commonpb/... ./internal/query/... -count=1` green
- `go generate ./... && go mod tidy` → tree clean (no proto touched); `golangci-lint run --fix` → 0 issues