### PR TITLE
ci: upgrade third-party GitHub Actions to latest and pin to SHA

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,13 +9,13 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31.10.7
     - name: go env
       id: go-env
       shell: bash
       run: |
         nix develop --command bash -c "go env | sed -E \"s/^([^=]+)='(.*)'\$/\1=\2/\"" >> "$GITHUB_OUTPUT"
-    - uses: namespacelabs/nscloud-cache-action@v1
+    - uses: namespacelabs/nscloud-cache-action@58bf6e08898e88803c098e2b522668541cd3b2e3 # v1.6.0
       with:
         path: |
           ${{ steps.go-env.outputs.GOCACHE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -61,7 +61,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -72,7 +72,7 @@ jobs:
           nix develop --command just test-coverage
       - name: Upload coverage profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-unit
           path: build/coverage/unit.out
@@ -84,7 +84,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -95,7 +95,7 @@ jobs:
           nix develop --command just test-e2e-coverage
       - name: Upload coverage profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-e2e
           path: build/coverage/e2e.out
@@ -107,7 +107,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -118,7 +118,7 @@ jobs:
           nix develop --command just test-scenarios-coverage
       - name: Upload coverage profile
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-scenario
           path: build/coverage/scenario.out
@@ -130,7 +130,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -147,14 +147,14 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
       - name: Download all coverage profiles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-*
           merge-multiple: true
@@ -180,7 +180,7 @@ jobs:
           '
       - name: Upload to Codecov
         if: hashFiles('build/coverage/merged.out') != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: build/coverage/merged.out
           flags: unit,e2e,scenario
@@ -193,7 +193,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -210,7 +210,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -222,7 +222,7 @@ jobs:
           nix develop --command bash -c "MAX_EXAMPLES=10 just test-schemathesis"
       - name: Upload Schemathesis results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: schemathesis-report
           path: /tmp/schemathesis-*.txt
@@ -250,16 +250,16 @@ jobs:
       # See Build-PR-Image for the override semantics.
       IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'ghcr.io/formancehq/ledger' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: NumaryBot
@@ -312,7 +312,7 @@ jobs:
       # canonical `formancehq/ledger` published image.
       IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'ghcr.io/formancehq/ledger' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
@@ -323,9 +323,9 @@ jobs:
       - name: Setup Env
         uses: ./.github/actions/default
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: NumaryBot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ jobs:
   GoReleaser:
     runs-on: namespace-profile-linux-amd64-4vcpu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: namespacelabs/nscloud-setup-buildx-action@d059ed7184f0bc7c8b27e8810cea153d02bcc6dd # v0.0.23
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: NumaryBot


### PR DESCRIPTION
## What

Upgrades every third-party GitHub Action to its latest stable release and pins each reference to a **full commit SHA** (with the resolved version as a trailing comment).

## Why

Pinning to a moving tag (`@v4`, `@v0`, …) means a compromised or repointed tag executes arbitrary code in CI with our secrets. Full-SHA pinning makes each workflow run immutable — the industry-standard supply-chain hardening for GitHub Actions.

## Changes

| Action | Before | After |
|---|---|---|
| actions/checkout | `@v4` | `@9c091bb` # v7.0.0 |
| actions/upload-artifact | `@v4` | `@043fb46` # v7.0.1 |
| actions/download-artifact | `@v4` | `@3e5f45b` # v8.0.1 |
| codecov/codecov-action | `@v5` | `@fb8b358` # v7.0.0 |
| docker/login-action | `@v4` | `@af1e73f` # v4.4.0 |
| namespacelabs/nscloud-setup-buildx-action | `@v0` | `@d059ed7` # v0.0.23 |
| namespacelabs/nscloud-cache-action | `@v1` | `@58bf6e0` # v1.6.0 |
| cachix/install-nix-action | `@v31` | `@a49548c` # v31.10.7 |

Files: `.github/workflows/main.yml`, `.github/workflows/release.yml`, `.github/actions/default/action.yml`.

## Review notes

Several are **major-version bumps** carrying possible runtime/Node changes — validate a full green CI run before merging:
- **checkout v4 → v7** (Node 20 → 24); note the non-standard `dissociate: true` input (Namespace runner) — confirm still honored.
- **upload-artifact v4 → v7**, **download-artifact v4 → v8** — verify the `pattern` + `merge-multiple` usage in the Coverage job.
- **codecov-action v5 → v7** — `files`/`flags`/`fail_ci_if_error` inputs used here remain supported.

The disabled `amannn/action-semantic-pull-request@v5` (commented out) was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)