### PR TITLE
fix(EN-1542): reject pre-epoch RFC3339 bounds in HTTP log queries

### DIFF
--- a/internal/adapter/http/handlers_list_ledger_logs.go
+++ b/internal/adapter/http/handlers_list_ledger_logs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -50,27 +49,21 @@ func (s *Server) handleListLedgerLogs(w http.ResponseWriter, r *http.Request) {
 	hasDateFilter := false
 
 	if sd := r.URL.Query().Get("startDate"); sd != "" {
-		t, err := time.Parse(time.RFC3339, sd)
-		if err != nil {
-			writeBadRequest(w, "INVALID_REQUEST", errors.New("invalid startDate parameter, expected RFC3339 format"))
-
+		v, ok := parseFilterDateMicros(w, "startDate", sd)
+		if !ok {
 			return
 		}
 
-		v := uint64(t.UnixMicro())
 		dateCond.Min = &v
 		hasDateFilter = true
 	}
 
 	if ed := r.URL.Query().Get("endDate"); ed != "" {
-		t, err := time.Parse(time.RFC3339, ed)
-		if err != nil {
-			writeBadRequest(w, "INVALID_REQUEST", errors.New("invalid endDate parameter, expected RFC3339 format"))
-
+		v, ok := parseFilterDateMicros(w, "endDate", ed)
+		if !ok {
 			return
 		}
 
-		v := uint64(t.UnixMicro())
 		dateCond.Max = &v
 		dateCond.MaxExclusive = true
 		hasDateFilter = true

--- a/internal/adapter/http/handlers_list_ledger_logs_test.go
+++ b/internal/adapter/http/handlers_list_ledger_logs_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -150,6 +151,179 @@ func TestHandleListLedgerLogs_WithDateFilters(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
+
+// TestHandleListLedgerLogs_DateBounds is the EN-1542 acceptance suite: it
+// validates that pre-epoch and malformed startDate/endDate values are rejected
+// with a 400 BEFORE the backend is invoked, and that epoch / post-epoch values
+// produce exact microsecond bounds with start-inclusive / end-exclusive
+// semantics. It shares parseFilterDateMicros with handleListTransactions.
+func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
+	t.Parallel()
+
+	// mustMicros mirrors the handler's RFC3339 -> unsigned micros conversion so
+	// the expected bounds below are derived from the same source of truth.
+	mustMicros := func(rfc3339 string) uint64 {
+		ts, err := time.Parse(time.RFC3339, rfc3339)
+		require.NoError(t, err)
+
+		return uint64(ts.UnixMicro())
+	}
+
+	type expectBound struct {
+		min          *uint64
+		max          *uint64
+		maxExclusive bool
+	}
+
+	for _, tc := range []struct {
+		name string
+		// query is the raw query string (without the leading '?').
+		query string
+		// wantStatus is the expected HTTP status.
+		wantStatus int
+		// wantBackend is whether the backend is expected to be invoked. On a
+		// validation error it MUST NOT be called.
+		wantBackend bool
+		// wantBodyContains, when non-empty, is asserted against the error body.
+		wantBodyContains string
+		// bound, when wantBackend is true, is the expected date UintCondition.
+		bound *expectBound
+	}{
+		{
+			name:             "pre-epoch startDate rejected",
+			query:            "startDate=1960-01-01T00:00:00Z",
+			wantStatus:       http.StatusBadRequest,
+			wantBackend:      false,
+			wantBodyContains: "startDate parameter, dates before 1970-01-01",
+		},
+		{
+			name:             "pre-epoch endDate rejected",
+			query:            "endDate=1969-12-31T23:59:59Z",
+			wantStatus:       http.StatusBadRequest,
+			wantBackend:      false,
+			wantBodyContains: "endDate parameter, dates before 1970-01-01",
+		},
+		{
+			name:             "malformed startDate rejected",
+			query:            "startDate=not-a-date",
+			wantStatus:       http.StatusBadRequest,
+			wantBackend:      false,
+			wantBodyContains: "startDate parameter, expected RFC3339",
+		},
+		{
+			name:             "malformed endDate rejected",
+			query:            "endDate=2024-13-99",
+			wantStatus:       http.StatusBadRequest,
+			wantBackend:      false,
+			wantBodyContains: "endDate parameter, expected RFC3339",
+		},
+		{
+			name:        "epoch startDate is an exact inclusive bound",
+			query:       "startDate=1970-01-01T00:00:00Z",
+			wantStatus:  http.StatusOK,
+			wantBackend: true,
+			bound: &expectBound{
+				min: ptrUint64(mustMicros("1970-01-01T00:00:00Z")), // == 0
+			},
+		},
+		{
+			name:        "post-epoch startDate is an exact inclusive bound",
+			query:       "startDate=2024-01-01T00:00:00Z",
+			wantStatus:  http.StatusOK,
+			wantBackend: true,
+			bound: &expectBound{
+				min: ptrUint64(mustMicros("2024-01-01T00:00:00Z")),
+			},
+		},
+		{
+			name:        "post-epoch endDate is an exact exclusive bound",
+			query:       "endDate=2024-12-31T23:59:59Z",
+			wantStatus:  http.StatusOK,
+			wantBackend: true,
+			bound: &expectBound{
+				max:          ptrUint64(mustMicros("2024-12-31T23:59:59Z")),
+				maxExclusive: true,
+			},
+		},
+		{
+			name:        "range is start-inclusive end-exclusive",
+			query:       "startDate=2024-01-01T00:00:00Z&endDate=2024-12-31T23:59:59Z",
+			wantStatus:  http.StatusOK,
+			wantBackend: true,
+			bound: &expectBound{
+				min:          ptrUint64(mustMicros("2024-01-01T00:00:00Z")),
+				max:          ptrUint64(mustMicros("2024-12-31T23:59:59Z")),
+				maxExclusive: true,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedFilter *commonpb.QueryFilter
+
+			backend := NewMockBackend(gomock.NewController(t))
+			if tc.wantBackend {
+				backend.EXPECT().ListLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ string, _ uint64, _ uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*commonpb.Log], error) {
+						capturedFilter = filter
+
+						return cursor.NewSliceCursor[*commonpb.Log](nil), nil
+					}).Times(1)
+			} else {
+				// On a validation error the backend must never be reached: any
+				// call fails the test.
+				backend.EXPECT().ListLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			}
+
+			srv := newTestServer(t, backend)
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodGet, "/ledger1/logs?"+tc.query, nil, map[string]string{
+				"ledgerName": "ledger1",
+			})
+
+			srv.handleListLedgerLogs(w, r)
+
+			require.Equal(t, tc.wantStatus, w.Code, "body: %s", w.Body.String())
+
+			if tc.wantBodyContains != "" {
+				require.Contains(t, w.Body.String(), tc.wantBodyContains)
+			}
+
+			if tc.bound == nil {
+				return
+			}
+
+			require.NotNil(t, capturedFilter)
+			cond := capturedFilter.GetLogBuiltinUint()
+			require.NotNil(t, cond, "expected a LogBuiltinUint date condition")
+			require.Equal(t, commonpb.LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE, cond.GetField())
+
+			uc := cond.GetCond()
+			require.NotNil(t, uc)
+
+			if tc.bound.min != nil {
+				require.NotNil(t, uc.Min)
+				require.Equal(t, *tc.bound.min, uc.GetMin())
+				// start bound is inclusive
+				require.False(t, uc.GetMinExclusive())
+			} else {
+				require.Nil(t, uc.Min)
+			}
+
+			if tc.bound.max != nil {
+				require.NotNil(t, uc.Max)
+				require.Equal(t, *tc.bound.max, uc.GetMax())
+				require.Equal(t, tc.bound.maxExclusive, uc.GetMaxExclusive())
+			} else {
+				require.Nil(t, uc.Max)
+			}
+		})
+	}
+}
+
+func ptrUint64(v uint64) *uint64 { return &v }
 
 func TestHandleListLedgerLogs_WithAfterParam(t *testing.T) {
 	t.Parallel()

--- a/internal/adapter/http/handlers_list_ledger_logs_test.go
+++ b/internal/adapter/http/handlers_list_ledger_logs_test.go
@@ -223,7 +223,7 @@ func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBackend: true,
 			bound: &expectBound{
-				min: ptrUint64(mustMicros("1970-01-01T00:00:00Z")), // == 0
+				min: new(mustMicros("1970-01-01T00:00:00Z")), // == 0
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBackend: true,
 			bound: &expectBound{
-				min: ptrUint64(mustMicros("2024-01-01T00:00:00Z")),
+				min: new(mustMicros("2024-01-01T00:00:00Z")),
 			},
 		},
 		{
@@ -241,7 +241,7 @@ func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBackend: true,
 			bound: &expectBound{
-				max:          ptrUint64(mustMicros("2024-12-31T23:59:59Z")),
+				max:          new(mustMicros("2024-12-31T23:59:59Z")),
 				maxExclusive: true,
 			},
 		},
@@ -251,8 +251,8 @@ func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
 			wantStatus:  http.StatusOK,
 			wantBackend: true,
 			bound: &expectBound{
-				min:          ptrUint64(mustMicros("2024-01-01T00:00:00Z")),
-				max:          ptrUint64(mustMicros("2024-12-31T23:59:59Z")),
+				min:          new(mustMicros("2024-01-01T00:00:00Z")),
+				max:          new(mustMicros("2024-12-31T23:59:59Z")),
 				maxExclusive: true,
 			},
 		},
@@ -322,8 +322,6 @@ func TestHandleListLedgerLogs_DateBounds(t *testing.T) {
 		})
 	}
 }
-
-func ptrUint64(v uint64) *uint64 { return &v }
 
 func TestHandleListLedgerLogs_WithAfterParam(t *testing.T) {
 	t.Parallel()

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -2,40 +2,12 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 )
-
-// parseFilterDateMicros parses an RFC3339 date query parameter and returns it
-// as Unix microseconds for a UintCondition bound. Transaction timestamps are
-// stored as unsigned microseconds, so a pre-epoch (negative UnixMicro) date
-// has no representable bound: casting it to uint64 would wrap to a huge value
-// and silently corrupt the filter (a start bound would exclude everything, an
-// end bound would include everything). Such dates are rejected with 400 rather
-// than accepted with garbage semantics. On error it writes the response and
-// returns ok=false; the caller must return immediately.
-func parseFilterDateMicros(w http.ResponseWriter, param, raw string) (uint64, bool) {
-	t, err := time.Parse(time.RFC3339, raw)
-	if err != nil {
-		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid %s parameter, expected RFC3339 format", param))
-
-		return 0, false
-	}
-
-	micros := t.UnixMicro()
-	if micros < 0 {
-		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid %s parameter, dates before 1970-01-01 are not supported", param))
-
-		return 0, false
-	}
-
-	return uint64(micros), true
-}
 
 // handleListTransactions handles GET /{ledgerName}/transactions to list a
 // ledger's transactions. Query params:

--- a/internal/adapter/http/list_filter.go
+++ b/internal/adapter/http/list_filter.go
@@ -3,10 +3,41 @@ package http
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
+
+// parseFilterDateMicros parses an RFC3339 date query parameter and returns it
+// as Unix microseconds for a UintCondition bound. Builtin date indexes (both
+// transaction timestamps and log dates) are stored as unsigned microseconds, so
+// a pre-epoch (negative UnixMicro) date has no representable bound: casting it
+// to uint64 would wrap to a huge value and silently corrupt the filter (a start
+// bound would exclude everything, an end bound would include everything). Such
+// dates are rejected with 400 rather than accepted with garbage semantics. On
+// error it writes the response and returns ok=false; the caller must return
+// immediately.
+//
+// Shared by handleListTransactions and handleListLedgerLogs so both list
+// endpoints validate startDate/endDate identically (EN-1542).
+func parseFilterDateMicros(w http.ResponseWriter, param, raw string) (uint64, bool) {
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid %s parameter, expected RFC3339 format", param))
+
+		return 0, false
+	}
+
+	micros := t.UnixMicro()
+	if micros < 0 {
+		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid %s parameter, dates before 1970-01-01 are not supported", param))
+
+		return 0, false
+	}
+
+	return uint64(micros), true
+}
 
 // combineFilters AND-combines the non-nil filters into a single QueryFilter.
 // Returns nil for zero filters (unfiltered read) and the sole filter unwrapped

--- a/openapi.yml
+++ b/openapi.yml
@@ -356,6 +356,8 @@ paths:
             format: date-time
           description: |
             Filter logs with date >= startDate (inclusive, RFC3339 format).
+            Must be on or after the Unix epoch (1970-01-01T00:00:00Z); earlier
+            dates are rejected with a 400.
             Requires the builtin `LOG_DATE` index to be enabled on the ledger.
         - name: endDate
           in: query
@@ -364,6 +366,8 @@ paths:
             format: date-time
           description: |
             Filter logs with date < endDate (exclusive, RFC3339 format).
+            Must be on or after the Unix epoch (1970-01-01T00:00:00Z); earlier
+            dates are rejected with a 400.
             Requires the builtin `LOG_DATE` index to be enabled on the ledger.
         - $ref: '#/components/parameters/ListFilter'
       responses:


### PR DESCRIPTION
## Problem

`GET /v3/{ledgerName}/logs` parsed `startDate`/`endDate` as RFC3339 then cast `time.Time.UnixMicro()` **directly** to `uint64`. A valid RFC3339 date before the Unix epoch (e.g. `1960-01-01T00:00:00Z`) has a negative `UnixMicro()` that wraps into a huge positive `uint64`, silently running the wrong query (a bad `startDate` excludes everything; a bad `endDate` includes everything).

The transaction-list endpoint already rejected this via `parseFilterDateMicros`; the logs endpoint carried a duplicate, weaker parser without the pre-epoch guard.

This is a transport validation bug only — no FSM / storage / QueryFilter semantics change.

## Fix

- Moved the existing `parseFilterDateMicros` (RFC3339 → non-negative unsigned micros, 400 on malformed **and** pre-epoch, per-param error message) into the shared HTTP helper file `internal/adapter/http/list_filter.go`.
- Both `handleListTransactions` and `handleListLedgerLogs` now call the single shared parser (DRY). Removed the logs handler's duplicate inline parsing.
- Validation runs **before** the backend/controller is invoked.
- Range semantics preserved: start inclusive, end exclusive; epoch and post-epoch values map to exact microsecond bounds.

## Tests

Added table-driven tests for the logs endpoint (`TestHandleListLedgerLogs_DateBounds`):
- pre-epoch `startDate` → 400 (names `startDate`)
- pre-epoch `endDate` → 400 (names `endDate`)
- malformed RFC3339 `startDate`/`endDate` → 400
- epoch `startDate` → exact inclusive bound (`micros == 0`)
- post-epoch `startDate` → exact inclusive bound
- post-epoch `endDate` → exact exclusive bound
- full range → start-inclusive / end-exclusive, exact micros on both bounds

Controller-not-called on validation error is asserted with the generated `MockBackend` using `EXPECT().ListLogs(...).Times(0)`; the success cases use `.Times(1)` and capture the `QueryFilter` to assert the exact `LOG_BUILTIN_INDEX_DATE` bounds.

Transaction handler tests re-run as regression coverage after sharing the helper.

## Docs

- `openapi.yml`: clarified that the log `startDate`/`endDate` params must be on or after the Unix epoch (earlier dates → 400).

Closes EN-1542