### PR TITLE
fix(EN-1540): remove redundant account prefix and transaction reference HTTP filter aliases

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -63,8 +63,11 @@ which detects the form from the first non-whitespace byte, parses to the same
 proto, and applies the single per-target validity gate
 (`domain.ValidateFilterForTarget`). The HTTP list handlers call it via
 `parseListFilter` (`internal/adapter/http/list_filter.go`) for the `?filter=`
-query parameter and AND-combine the result with the endpoint's convenience params
-(`reference`, `prefix`, date range) through `combineFilters`; prepared-query
+query parameter and AND-combine the result with the transactions endpoint's
+remaining convenience param — the `startDate`/`endDate` range — through
+`combineFilters` (the `reference` and `prefix` aliases were removed in EN-1540:
+account prefix is now `address ^= "..."`, transaction reference is structured
+`{"$match":{"reference":"..."}}`); prepared-query
 create/update decode the JSON `filter` body field through the same helper; and
 `ledgerctl --filter` routes through it in `cmdutil.BuildQueryFilter`. Audit
 conditions (`audit[...]`) exist only in the textual form — the JSON codec has no

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -399,8 +399,15 @@ non-whitespace byte:
 - **Query-string endpoints** (`?filter=`): the value is textual `filterexpr`
   passed verbatim (URL-encoded). To pass the structured form, URL-encode the JSON
   object as the value (`?filter=%7B%22%24match%22%3A…%7D`). The generic `filter`
-  parameter is AND-combined with the endpoint's convenience params (`reference`,
-  `prefix`, `startDate`/`endDate`).
+  parameter is AND-combined with the endpoint's remaining convenience params (the
+  transactions `startDate`/`endDate` timestamp range). It has no dedicated
+  address-prefix or reference aliases: an account address prefix is the textual
+  `filter=address ^= "users:"` (or structured
+  `?filter=%7B%22%24match%22%3A%7B%22address%22%3A%22users%3A%22%7D%7D`, i.e.
+  `{"$match":{"address":"users:"}}` with the trailing `:` marking a prefix
+  match), and a transaction reference is the structured
+  `?filter=%7B%22%24match%22%3A%7B%22reference%22%3A%22ref-1%22%7D%7D`
+  (`{"$match":{"reference":"ref-1"}}`) or the textual `filter=reference == "ref-1"`.
 - **JSON-body endpoints** (prepared-query create/update `filter` field): a JSON
   object is the structured form; a JSON string (`"filter": "metadata[k] == v"`)
   is the textual form.
@@ -719,7 +726,7 @@ Read endpoints comparison with the original ledger:
 | `POST /v3/{ledgerName}/account-types` | ✅ | ❌ | Add account type |
 | `DELETE /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Remove account type |
 | `PUT /v3/{ledgerName}/account-types/default-enforcement-mode` | ✅ | ❌ | Set default enforcement mode (STRICT/AUDIT) |
-| `GET /v3/{ledgerName}/transactions` | ✅ | ❌ | List transactions with cursor pagination + reference/date filters |
+| `GET /v3/{ledgerName}/transactions` | ✅ | ❌ | List transactions: cursor pagination, `startDate`/`endDate` range, and the generic `filter` (reference selection via `filter={"$match":{"reference":"..."}}`) |
 | `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
 | `GET /v3/_/chapter-schedule` | ✅ | ❌ | Get the auto-rotation cron for chapters |

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -799,31 +799,10 @@ func TestHandleListAccounts_CursorIterationError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestHandleListAccounts_WithPrefix(t *testing.T) {
-	t.Parallel()
-
-	var capturedFilter *commonpb.QueryFilter
-
-	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAccounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ string, _ uint32, _ string, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Account], error) {
-			capturedFilter = filter
-
-			return cursor.NewSliceCursor[*commonpb.Account](nil), nil
-		}).AnyTimes()
-	srv := newTestServer(t, backend)
-
-	w := httptest.NewRecorder()
-	r := newRequest(t, http.MethodGet, "/ledger1/accounts?prefix=users:", nil, map[string]string{
-		"ledgerName": "ledger1",
-	})
-
-	srv.handleListAccounts(w, r)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	require.NotNil(t, capturedFilter)
-	require.Equal(t, "users:", capturedFilter.GetAddress().GetHardcodedPrefix())
-}
+// The removed `prefix=` account alias (EN-1540) and its canonical `filter=address
+// ^= "..."` replacement are covered by
+// TestHandleListAccounts_PrefixFilterCanonicalReplacement in
+// handlers_list_accounts_test.go.
 
 // --------------------------------------------------------------------------
 // handlers_list_all_ledgers.go: cursor iteration error

--- a/internal/adapter/http/handlers_list_accounts.go
+++ b/internal/adapter/http/handlers_list_accounts.go
@@ -21,29 +21,15 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	afterAddress := r.URL.Query().Get("after")
-	prefix := r.URL.Query().Get("prefix")
 
-	// Build an optional address-prefix filter from query parameter
-	var prefixFilter *commonpb.QueryFilter
-	if prefix != "" {
-		prefixFilter = &commonpb.QueryFilter{
-			Filter: &commonpb.QueryFilter_Address{
-				Address: &commonpb.AddressMatch{
-					Match: &commonpb.AddressMatch_HardcodedPrefix{HardcodedPrefix: prefix},
-				},
-			},
-		}
-	}
-
-	// The generic `filter` query parameter accepts either the textual filterexpr
-	// grammar or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
-	// `prefix` convenience param above.
-	generic, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	// The `filter` query parameter accepts either the textual filterexpr grammar
+	// or the structured v2 JSON DSL (EN-1511). An address-prefix selection is
+	// expressed through it as the textual `address ^= "<prefix>"` (or structured
+	// `{"$match":{"address":"<prefix>:"}}`); there is no separate `prefix` alias.
+	filter, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	if !ok {
 		return
 	}
-
-	filter := combineFilters(prefixFilter, generic)
 
 	reverse := r.URL.Query().Get("reverse") == "true"
 

--- a/internal/adapter/http/handlers_list_accounts_test.go
+++ b/internal/adapter/http/handlers_list_accounts_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -70,6 +71,50 @@ func TestHandleListAccounts_WithPagination(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, uint32(10), capturedPageSize)
 	require.Equal(t, "users:005", capturedAfter)
+}
+
+// TestHandleListAccounts_PrefixFilterCanonicalReplacement proves the canonical
+// replacement for the removed `prefix=` alias: an address-prefix selection
+// passed through the generic `filter` as the textual `address ^= "<prefix>"`
+// reaches the backend as the same AddressMatch_HardcodedPrefix the old alias
+// produced, and the removed alias is no longer interpreted.
+func TestHandleListAccounts_PrefixFilterCanonicalReplacement(t *testing.T) {
+	t.Parallel()
+
+	capture := func(t *testing.T, target string) *commonpb.QueryFilter {
+		t.Helper()
+
+		var captured *commonpb.QueryFilter
+
+		backend := NewMockBackend(gomock.NewController(t))
+		backend.EXPECT().ListAccounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ uint32, _ string, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Account], error) {
+				captured = filter
+
+				return cursor.NewSliceCursor[*commonpb.Account](nil), nil
+			}).AnyTimes()
+		srv := newTestServer(t, backend)
+
+		w := httptest.NewRecorder()
+		r := newRequest(t, http.MethodGet, target, nil, map[string]string{"ledgerName": "ledger1"})
+		srv.handleListAccounts(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		return captured
+	}
+
+	// Canonical textual replacement → a bare AddressMatch_HardcodedPrefix (the
+	// sole filter is not wrapped in a redundant 1-element $and).
+	fromFilter := capture(t, "/ledger1/accounts?filter="+url.QueryEscape(`address ^= "users:"`))
+	require.NotNil(t, fromFilter)
+	require.Equal(t, "users:", fromFilter.GetAddress().GetHardcodedPrefix(),
+		"textual address-prefix filter must reach the backend as HardcodedPrefix")
+
+	// The removed `prefix=` alias must no longer be interpreted: passed alone
+	// (no `filter=`), it yields an unfiltered read (nil filter).
+	aliasOnly := capture(t, "/ledger1/accounts?prefix=users:")
+	require.Nil(t, aliasOnly, "the removed prefix= alias must not build a filter")
 }
 
 func TestHandleListAccounts_InvalidPageSize(t *testing.T) {

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -46,7 +46,10 @@ func parseFilterDateMicros(w http.ResponseWriter, param, raw string) (uint64, bo
 //   - startDate/endDate  RFC3339, filter on transaction timestamp.
 //     Requires the builtin `TX_BUILTIN_INDEX_TIMESTAMP` index to be
 //     enabled on the ledger via `CreateIndex`.
-//   - reference          exact-match reference filter
+//   - filter             textual filterexpr grammar OR structured v2 JSON DSL
+//     (EN-1511). A reference selection is expressed through it as the structured
+//     `{"$match":{"reference":"<ref>"}}` (or textual `reference == "<ref>"`);
+//     there is no separate `reference` alias.
 //
 // Ordering convention (mirrors `ctrl.Controller.ListTransactions`): the
 // default (reverse=false) returns newest-first (descending transaction id);
@@ -88,18 +91,6 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 
 	var filters []*commonpb.QueryFilter
 
-	if ref := r.URL.Query().Get("reference"); ref != "" {
-		filters = append(filters, &commonpb.QueryFilter{
-			Filter: &commonpb.QueryFilter_Reference{
-				Reference: &commonpb.ReferenceCondition{
-					Cond: &commonpb.StringCondition{
-						Value: &commonpb.StringCondition_Hardcoded{Hardcoded: ref},
-					},
-				},
-			},
-		})
-	}
-
 	dateCond := &commonpb.UintCondition{}
 	hasDateFilter := false
 
@@ -135,9 +126,9 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 		})
 	}
 
-	// The generic `filter` query parameter accepts either the textual filterexpr
-	// grammar or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
-	// convenience params (reference, startDate/endDate) above.
+	// The `filter` query parameter accepts either the textual filterexpr grammar
+	// or the structured v2 JSON DSL (EN-1511); it is AND-combined with the
+	// startDate/endDate timestamp range above.
 	generic, ok := parseListFilter(w, r, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 	if !ok {
 		return

--- a/internal/adapter/http/handlers_list_transactions_test.go
+++ b/internal/adapter/http/handlers_list_transactions_test.go
@@ -81,33 +81,64 @@ func TestHandleListTransactions_WithPaginationAndReverse(t *testing.T) {
 	require.True(t, capturedReverse)
 }
 
-func TestHandleListTransactions_WithReferenceAndDateFilters(t *testing.T) {
+// TestHandleListTransactions_ReferenceFilterAndDateRange proves the canonical
+// replacement for the removed `reference=` alias: a reference selection passed
+// through the generic `filter` as the structured `{"$match":{"reference":...}}`
+// is AND-combined with the startDate/endDate timestamp range, exactly as the old
+// alias was. The removed alias must no longer be interpreted.
+func TestHandleListTransactions_ReferenceFilterAndDateRange(t *testing.T) {
 	t.Parallel()
 
-	var capturedFilter *commonpb.QueryFilter
+	capture := func(t *testing.T, target string) *commonpb.QueryFilter {
+		t.Helper()
 
-	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListTransactions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ string, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Transaction], error) {
-			capturedFilter = filter
+		var capturedFilter *commonpb.QueryFilter
 
-			return cursor.NewSliceCursor[*commonpb.Transaction](nil), nil
-		}).AnyTimes()
-	srv := newTestServer(t, backend)
+		backend := NewMockBackend(gomock.NewController(t))
+		backend.EXPECT().ListTransactions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Transaction], error) {
+				capturedFilter = filter
 
-	w := httptest.NewRecorder()
-	r := newRequest(t, http.MethodGet,
-		"/ledger1/transactions?reference=ref-1&startDate=2026-01-01T00:00:00Z&endDate=2026-02-01T00:00:00Z",
-		nil, map[string]string{"ledgerName": "ledger1"})
+				return cursor.NewSliceCursor[*commonpb.Transaction](nil), nil
+			}).AnyTimes()
+		srv := newTestServer(t, backend)
 
-	srv.handleListTransactions(w, r)
+		w := httptest.NewRecorder()
+		r := newRequest(t, http.MethodGet, target, nil, map[string]string{"ledgerName": "ledger1"})
+		srv.handleListTransactions(w, r)
 
-	require.Equal(t, http.StatusOK, w.Code)
-	require.NotNil(t, capturedFilter)
-	// reference + date range → wrapped in QueryFilter_And
-	and := capturedFilter.GetAnd()
-	require.NotNil(t, and)
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+		return capturedFilter
+	}
+
+	// Canonical reference selection via the structured `filter`, AND-combined
+	// with the date range → a 2-element $and (date range + reference).
+	refFilter := url.QueryEscape(`{"$match":{"reference":"ref-1"}}`)
+	combined := capture(t, "/ledger1/transactions?filter="+refFilter+
+		"&startDate=2026-01-01T00:00:00Z&endDate=2026-02-01T00:00:00Z")
+	require.NotNil(t, combined)
+	and := combined.GetAnd()
+	require.NotNil(t, and, "reference filter + date range must AND-combine")
 	require.Len(t, and.GetFilters(), 2)
+
+	// The reference selection reaches the backend as a ReferenceCondition, i.e.
+	// the same QueryFilter the removed `reference=` alias produced. Locate the
+	// non-date sub-filter and assert its shape.
+	var refCond *commonpb.QueryFilter
+	for _, f := range and.GetFilters() {
+		if f.GetBuiltinUint() == nil {
+			refCond = f
+		}
+	}
+	require.NotNil(t, refCond, "reference sub-filter must be present alongside the date range")
+	require.Equal(t, "ref-1", refCond.GetReference().GetCond().GetHardcoded())
+
+	// The removed `reference=` alias must no longer be interpreted: passed alone
+	// (no `filter=`), it yields an unfiltered read (nil filter), not a reference
+	// selection.
+	aliasOnly := capture(t, "/ledger1/transactions?reference=ref-1")
+	require.Nil(t, aliasOnly, "the removed reference= alias must not build a filter")
 }
 
 // TestHandleListTransactions_DualFormatFilter is the endpoint-level EN-1511

--- a/openapi.yml
+++ b/openapi.yml
@@ -637,8 +637,10 @@ paths:
         Lists transactions for a specific ledger. The default order is
         newest-first (descending transaction id); pass `reverse=true` to
         get oldest-first (ascending). Supports cursor pagination via the
-        `after` query parameter and optional date-range and reference
-        filters. Requires `ledger:TransactionRead` scope.
+        `after` query parameter, an optional date range (`startDate`/`endDate`),
+        and the generic `filter` parameter (e.g. reference selection via
+        `filter={"$match":{"reference":"..."}}`, URL-encoded). Requires
+        `ledger:TransactionRead` scope.
 
         This is a live, best-effort read of the current committed state.
         Unlike the gRPC API, it does not accept read-consistency options
@@ -693,11 +695,6 @@ paths:
           description: |
             Filter transactions with timestamp < endDate (exclusive, RFC3339 format).
             Requires the builtin `TX_BUILTIN_INDEX_TIMESTAMP` index to be enabled on the ledger.
-        - name: reference
-          in: query
-          schema:
-            type: string
-          description: Filter by exact-match transaction reference.
         - $ref: '#/components/parameters/ListFilter'
       responses:
         '200':
@@ -767,7 +764,11 @@ paths:
   /v3/{ledgerName}/accounts:
     get:
       summary: List accounts
-      description: Lists accounts in a ledger in alphabetical order with optional prefix filtering and cursor pagination. Requires `ledger:read` scope.
+      description: |
+        Lists accounts in a ledger in alphabetical order with cursor
+        pagination and an optional generic `filter` (e.g. address-prefix
+        selection via `filter=address ^= "users:"`). Requires `ledger:read`
+        scope.
       operationId: listAccounts
       security:
         - BearerAuth: []
@@ -783,15 +784,6 @@ paths:
         - name: after
           in: query
           description: Account address to start after (for cursor pagination, exclusive)
-          schema:
-            type: string
-        - name: prefix
-          in: query
-          description: |
-            Filter accounts whose address starts with this raw byte-level
-            prefix (e.g. `users:` matches `users:alice`, `users:bob`, ...).
-            Matching is not path-segment aware: `acc:1` also matches
-            `acc:10`, `acc:11`, etc. Do not use for exact-address lookups.
           schema:
             type: string
         - $ref: '#/components/parameters/ListFilter'
@@ -876,8 +868,9 @@ paths:
           in: query
           description: |
             Filter accounts whose address starts with this raw byte-level
-            prefix. Matching is not path-segment aware (see the note on the
-            `prefix` query parameter of `GET /v3/{ledgerName}/accounts`).
+            prefix (e.g. `users:` matches `users:alice`, `users:bob`, ...).
+            Matching is not path-segment aware: `acc:1` also matches `acc:10`,
+            `acc:11`, etc. Do not use for exact-address lookups.
           schema:
             type: string
         - name: useMaxPrecision
@@ -2863,7 +2856,11 @@ components:
         A condition that is not valid on the endpoint's target (e.g. a
         transaction-only condition on the accounts list) is rejected with 400.
         This generic filter is AND-combined with any convenience parameters the
-        endpoint also exposes (e.g. `reference`, `prefix`, `startDate`/`endDate`).
+        endpoint also exposes (e.g. the transactions `startDate`/`endDate`
+        timestamp range). Selections that used to have dedicated aliases are
+        expressed through this filter: an account address prefix via
+        `filter=address ^= "users:"`, a transaction reference via
+        `filter={"$match":{"reference":"..."}}` (URL-encoded).
 
         Note: audit conditions (`audit[...]`) have no structured JSON form and
         must be passed in the textual representation.


### PR DESCRIPTION
## What

Removes two redundant HTTP convenience query params now that the shared dual-format `filter` parameter (EN-1511, #1575) is the canonical query-selection surface. This is an alpha v3 API, so no deprecated aliases / compat shims are retained.

- `GET /v3/{ledgerName}/accounts?prefix=…` — removed. Canonical replacement: `filter=address ^= "users:"` (textual) or the structured `{"$match":{"address":"users:"}}` (trailing `:` = prefix match), URL-encoded.
- `GET /v3/{ledgerName}/transactions?reference=…` — removed. Canonical replacement: `filter={"$match":{"reference":"ref-1"}}` (structured, URL-encoded) or textual `reference == "ref-1"`.

## Why

Both aliases were pure sugar over conditions the canonical `filter` already expresses identically (`prefix=` built an `AddressMatch_HardcodedPrefix`; `reference=` built a `ReferenceCondition`). Keeping them is redundant API surface.

## Kept unchanged

`pageSize`, `after`, `reverse`, and the transactions `startDate`/`endDate` RFC3339 range (the timestamp coercion the DSL does not replace). The date range still AND-combines with the canonical `filter`. Both textual and structured forms of `filter` remain accepted.

## Handler / OpenAPI / doc changes

- `internal/adapter/http/handlers_list_accounts.go` — drop `prefix` parse + `prefixFilter` build; `filter` is now taken directly from `parseListFilter`.
- `internal/adapter/http/handlers_list_transactions.go` — drop the `reference` parse/`ReferenceCondition` block; date range + generic `filter` still AND-combine via `combineFilters`. Updated the handler doc comment.
- `openapi.yml` — removed the accounts `prefix` param and the transactions `reference` param; updated both endpoint descriptions, the shared `ListFilter` note, and re-inlined the `/volumes` `prefix` description (it kept its own `prefix`; the note that cross-referenced the now-removed accounts param would otherwise dangle). `/volumes?prefix=` is out of scope and untouched behaviorally.
- `docs/technical/contributing/api-comparison.md` — updated the dual-format section and the transactions read-feature row to show the canonical replacements with URL-encoding for the structured form.

## Tests

- `TestHandleListAccounts_PrefixFilterCanonicalReplacement` — `filter=address ^= "users:"` reaches the backend as `AddressMatch_HardcodedPrefix{"users:"}` (identical to what the old alias produced); the removed `prefix=` alias alone yields a nil (unfiltered) filter.
- `TestHandleListTransactions_ReferenceFilterAndDateRange` — structured reference `filter` AND-combines with `startDate`/`endDate` into a 2-element `$and` (date range + `ReferenceCondition{Hardcoded:"ref-1"}`); the removed `reference=` alias alone yields a nil filter.
- Removed the now-superseded `TestHandleListAccounts_WithPrefix` (asserted old alias behavior); replaced by the above.
- Existing dual-format / date / pagination / ordering tests unchanged and green.

`GOROOT= go build ./...` and `go test ./internal/adapter/http/...` pass; `go generate ./... && go mod tidy` produce no drift; golangci-lint reports 0 issues.

Closes EN-1540
