### PR TITLE
fix(logs): truncate console/JSON log timestamps to milliseconds

### DIFF
--- a/internal/infra/monitoring/otlplogs/module.go
+++ b/internal/infra/monitoring/otlplogs/module.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"runtime/debug"
-	"time"
 
 	"go.opentelemetry.io/contrib/bridges/otelzap"
 	"go.opentelemetry.io/otel/attribute"
@@ -22,6 +21,12 @@ import (
 
 const (
 	OTLPExporter = "otlp"
+
+	// logTimeLayout is the timestamp layout for console/JSON log lines. It pins
+	// the fractional part to exactly 3 digits (milliseconds) with a fixed width,
+	// unlike time.RFC3339Nano which emits up to 9 digits and trims trailing
+	// zeros (producing variable-length, microsecond-precision timestamps).
+	logTimeLayout = "2006-01-02T15:04:05.000Z07:00"
 )
 
 type ModuleConfig struct {
@@ -105,12 +110,12 @@ func Logger(cfg ModuleConfig) (logging.Logger, error) {
 
 	if cfg.FormatJSON {
 		encoderCfg := zap.NewProductionEncoderConfig()
-		encoderCfg.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339Nano)
+		encoderCfg.EncodeTime = zapcore.TimeEncoderOfLayout(logTimeLayout)
 		encoderCfg.EncodeLevel = logging.EncodeLevelWithTrace(encoderCfg.EncodeLevel)
 		encoder = zapcore.NewJSONEncoder(encoderCfg)
 	} else {
 		encoderCfg := zap.NewDevelopmentEncoderConfig()
-		encoderCfg.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339Nano)
+		encoderCfg.EncodeTime = zapcore.TimeEncoderOfLayout(logTimeLayout)
 		encoderCfg.EncodeLevel = logging.EncodeLevelWithTrace(encoderCfg.EncodeLevel)
 		encoder = zapcore.NewConsoleEncoder(encoderCfg)
 	}


### PR DESCRIPTION
## What

Log timestamps were rendered with `TimeEncoderOfLayout(time.RFC3339Nano)`, which emits up to 9 fractional-second digits **and trims trailing zeros** — producing variable-length, microsecond-precision timestamps:

```
2026-07-13T16:04:40.054748+02:00    INFO    Backfill progress ...
2026-07-13T16:04:42.29713+02:00 INFO    Backfill progress ...
```

## Change

Pin the fractional part to a fixed 3-digit millisecond layout (`2006-01-02T15:04:05.000Z07:00`), shared via a single `logTimeLayout` constant and applied to both the JSON and console encoders in `internal/infra/monitoring/otlplogs/module.go`.

Result:

```
2026-07-13T16:04:40.054+02:00 INFO    Backfill progress ...
2026-07-13T16:04:42.297+02:00 INFO    Backfill progress ...
```

## Notes

- Affects only the console/JSON log lines. OTLP-exported records carry a native `time.Time`; their rendered precision is decided by the backend, not this layout.
- Removed the now-unused `time` import.