### PR TITLE
feat(EN-1549): harmonize audit filter DSL — bare target-aware fields

### DIFF
--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -64,7 +65,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 	minLogSeq, _ := cmd.Flags().GetUint64("min-log-sequence")
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 
-	filter, err := cmdutil.BuildQueryFilter(filterExpr, prefix)
+	filter, err := cmdutil.BuildQueryFilter(filterExpr, prefix, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	if err != nil {
 		return err
 	}

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -77,7 +77,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	cns := cmdutil.GetConsistencyFlags(cmd)
 	showProfile, _ := cmd.Flags().GetBool("analyze")
 
-	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix)
+	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	if err != nil {
 		return err
 	}

--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -29,17 +29,17 @@ func NewListCommand() *cobra.Command {
 Entries are shown oldest first by default (chronological); use --reverse for newest first.
 
 Filtering is done entirely through the generic --filter flag (same DSL as the
-other list commands); there are no audit-specific flags. It accepts audit[...]
-conditions combined with and/or:
-  audit[outcome] == failure
-  audit[ledger] == main
-  audit[ledger] == main and audit[order_type] == create_transaction
-  audit[order_type] in (create_transaction, revert_transaction)
-  audit[caller_subject] == "svc:payments"
-  audit[seq] between 1000 and 2000
-  audit[proposal_id] == 42
-  audit[timestamp] >= "2023-11-14T22:13:20Z"    # RFC3339 or raw unix microseconds
-  audit[log_seq] == 500
+other list commands); there are no audit-specific flags. On the audit endpoint
+the audit fields are bare (no audit[...] prefix), combined with and/or:
+  outcome == failure
+  ledger == main
+  ledger == main and order_type == create_transaction
+  order_type in (create_transaction, revert_transaction)
+  caller_subject == "svc:payments"
+  seq between 1000 and 2000
+  proposal_id == 42
+  timestamp >= "2023-11-14T22:13:20Z"    # RFC3339 or raw unix microseconds
+  log_seq == 500
 
 Supported fields: seq, proposal_id, log_seq (numeric); timestamp
 (RFC3339 or unix microseconds); outcome (success|failure), ledger,
@@ -49,8 +49,8 @@ Unsupported conditions (not, non-indexed fields) are rejected.
 Examples:
   ledgerctl audit list
   ledgerctl audit list --reverse
-  ledgerctl audit list --filter 'audit[outcome] == failure'
-  ledgerctl audit list --filter 'audit[ledger] == "my-ledger"'
+  ledgerctl audit list --filter 'outcome == failure'
+  ledgerctl audit list --filter 'ledger == "my-ledger"'
   ledgerctl audit list --checkpoint-id 7`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,

--- a/cmd/ledgerctl/audit/list.go
+++ b/cmd/ledgerctl/audit/list.go
@@ -93,7 +93,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 		return errors.New("--expand cannot be combined with --checkpoint-id: audit entry expansion always reads the live store")
 	}
 
-	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix)
+	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_AUDIT)
 	if err != nil {
 		return err
 	}

--- a/cmd/ledgerctl/cmdutil/flags.go
+++ b/cmd/ledgerctl/cmdutil/flags.go
@@ -278,17 +278,21 @@ func GetFilterFlags(cmd *cobra.Command) FilterFlags {
 // a single QueryFilter. Returns nil when both inputs are empty.
 //
 // --filter accepts either the textual filterexpr grammar or the structured v2
-// JSON DSL (EN-1511); the shared dual-format decoder detects the form. The
-// per-target validity gate is left to the server (the CLI does not resolve the
-// target here). The prefix is applied as an AddressMatch_HardcodedPrefix; when
-// --filter is also set, the two are AND-combined.
-func BuildQueryFilter(filterExpr, prefix string) (*commonpb.QueryFilter, error) {
+// JSON DSL (EN-1511); the shared dual-format decoder detects the form. `target`
+// is the query target of the endpoint the command hits — it drives bare-field
+// resolution (EN-1549) so, e.g., `audit list` (target = QUERY_TARGET_AUDIT)
+// resolves bare `outcome`/`ledger`/`timestamp` to the audit arm while the other
+// list commands resolve them to the transaction/log/ledger arms. The per-target
+// validity gate itself is left to the server. The prefix is applied as an
+// AddressMatch_HardcodedPrefix; when --filter is also set, the two are
+// AND-combined.
+func BuildQueryFilter(filterExpr, prefix string, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	var parsed *commonpb.QueryFilter
 
 	if filterExpr != "" {
 		var err error
 
-		parsed, err = filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr))
+		parsed, err = filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr), target)
 		if err != nil {
 			return nil, fmt.Errorf("invalid filter expression: %w", err)
 		}

--- a/cmd/ledgerctl/cmdutil/flags_test.go
+++ b/cmd/ledgerctl/cmdutil/flags_test.go
@@ -115,7 +115,7 @@ func TestBuildListOptions(t *testing.T) {
 
 	t.Run("with filter", func(t *testing.T) {
 		t.Parallel()
-		f, err := cmdutil.BuildQueryFilter("", "users:")
+		f, err := cmdutil.BuildQueryFilter("", "users:", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.NoError(t, err)
 
 		opts := cmdutil.BuildListOptions(cmdutil.PaginationFlags{}, cmdutil.ConsistencyFlags{}, f)
@@ -195,7 +195,7 @@ func TestBuildQueryFilter(t *testing.T) {
 	t.Run("empty inputs return nil", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := cmdutil.BuildQueryFilter("", "")
+		f, err := cmdutil.BuildQueryFilter("", "", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.NoError(t, err)
 		require.Nil(t, f)
 	})
@@ -203,7 +203,7 @@ func TestBuildQueryFilter(t *testing.T) {
 	t.Run("prefix only", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := cmdutil.BuildQueryFilter("", "users:")
+		f, err := cmdutil.BuildQueryFilter("", "users:", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.NoError(t, err)
 		require.NotNil(t, f)
 
@@ -215,7 +215,7 @@ func TestBuildQueryFilter(t *testing.T) {
 	t.Run("filter only", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := cmdutil.BuildQueryFilter(`metadata[k] == "v"`, "")
+		f, err := cmdutil.BuildQueryFilter(`metadata[k] == "v"`, "", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.NoError(t, err)
 		require.NotNil(t, f)
 		// filterexpr.Parse produces a FieldCondition oneof variant for metadata.
@@ -225,7 +225,7 @@ func TestBuildQueryFilter(t *testing.T) {
 	t.Run("filter + prefix combined", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := cmdutil.BuildQueryFilter(`metadata[k] == "v"`, "users:")
+		f, err := cmdutil.BuildQueryFilter(`metadata[k] == "v"`, "users:", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.NoError(t, err)
 		require.NotNil(t, f)
 		require.NotNil(t, f.GetAnd())
@@ -238,9 +238,39 @@ func TestBuildQueryFilter(t *testing.T) {
 	t.Run("invalid filter expression", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := cmdutil.BuildQueryFilter("@@invalid@@", "")
+		_, err := cmdutil.BuildQueryFilter("@@invalid@@", "", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid filter expression")
+	})
+
+	// EN-1549: the `ledgerctl audit list` path builds its filter through
+	// BuildQueryFilter with QUERY_TARGET_AUDIT, so a bare audit field must resolve
+	// to the audit arm. This is the CLI-path regression guard for the audit list
+	// command — before threading the target it decoded as TRANSACTIONS and a bare
+	// audit-only field (outcome) failed to parse.
+	t.Run("bare audit field resolves on the audit target", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := cmdutil.BuildQueryFilter("outcome == failure", "", commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		ac := f.GetAudit()
+		require.NotNil(t, ac, "outcome must resolve to the audit arm on the audit target")
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_OUTCOME, ac.GetField())
+		require.Equal(t, "failure", ac.GetStringCond().GetHardcoded())
+	})
+
+	// A bare shared field (ledger) must also resolve to the audit arm on the audit
+	// target, not the top-level LedgerCondition arm.
+	t.Run("bare ledger resolves to the audit arm on the audit target", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := cmdutil.BuildQueryFilter("ledger == main", "", commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+		require.NoError(t, err)
+		require.NotNil(t, f)
+		require.NotNil(t, f.GetAudit(), "ledger must resolve to the audit arm on the audit target")
+		require.Equal(t, commonpb.AuditField_AUDIT_FIELD_LEDGER, f.GetAudit().GetField())
 	})
 }
 

--- a/cmd/ledgerctl/ledgers/config_model.go
+++ b/cmd/ledgerctl/ledgers/config_model.go
@@ -616,7 +616,7 @@ func diffPreparedQueries(ledgerName string, current, desired *EditableConfig) ([
 			var filter *commonpb.QueryFilter
 			if desiredPQ.Filter != "" {
 				var err error
-				filter, err = filterexpr.Parse(desiredPQ.Filter)
+				filter, err = filterexpr.Parse(desiredPQ.Filter, target)
 				if err != nil {
 					return nil, fmt.Errorf("prepared query %q filter: %w", name, err)
 				}
@@ -652,7 +652,7 @@ func diffPreparedQueries(ledgerName string, current, desired *EditableConfig) ([
 			var filter *commonpb.QueryFilter
 			if desiredPQ.Filter != "" {
 				var err error
-				filter, err = filterexpr.Parse(desiredPQ.Filter)
+				filter, err = filterexpr.Parse(desiredPQ.Filter, target)
 				if err != nil {
 					return nil, fmt.Errorf("prepared query %q filter: %w", name, err)
 				}
@@ -695,10 +695,12 @@ func diffPreparedQueries(ledgerName string, current, desired *EditableConfig) ([
 
 		// Same target — only Filter can have moved. Use the in-place update.
 		if currentPQ.Filter != desiredPQ.Filter {
+			target := parseQueryTarget(desiredPQ.Target)
+
 			var filter *commonpb.QueryFilter
 			if desiredPQ.Filter != "" {
 				var err error
-				filter, err = filterexpr.Parse(desiredPQ.Filter)
+				filter, err = filterexpr.Parse(desiredPQ.Filter, target)
 				if err != nil {
 					return nil, fmt.Errorf("prepared query %q filter: %w", name, err)
 				}

--- a/cmd/ledgerctl/logs/list.go
+++ b/cmd/ledgerctl/logs/list.go
@@ -56,7 +56,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 		return errors.New("--ledger flag is required")
 	}
 
-	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix)
+	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_LOGS)
 	if err != nil {
 		return err
 	}

--- a/cmd/ledgerctl/queries/create.go
+++ b/cmd/ledgerctl/queries/create.go
@@ -63,7 +63,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	var filter *commonpb.QueryFilter
 	if filterExpr != "" {
-		filter, err = filterexpr.Parse(filterExpr)
+		filter, err = filterexpr.Parse(filterExpr, target)
 		if err != nil {
 			return fmt.Errorf("invalid filter expression: %w", err)
 		}

--- a/cmd/ledgerctl/queries/update.go
+++ b/cmd/ledgerctl/queries/update.go
@@ -1,6 +1,7 @@
 package queries
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pterm/pterm"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -51,15 +53,29 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	filterExpr, _ := cmd.Flags().GetString("filter")
 
+	// An update replaces the stored filter, so an empty --filter would decode to a
+	// nil filter and silently erase the prepared query's filter on the server
+	// (ValidateFilterForTarget accepts nil). Require a non-empty filter, matching
+	// the HTTP update handler's guard (handlers_update_prepared_query.go).
+	if filterExpr == "" {
+		return errors.New("--filter is required")
+	}
+
 	// The update carries only the new filter, not the target — the target is
 	// immutable and lives on the stored prepared query (the FSM re-validates the
 	// filter against it). DecodeDualFormatStructuralOnly is the shared "target not
 	// known here" entry point: it resolves bare fields with a non-audit target
 	// (prepared queries are never audit) and defers the per-target validity gate
 	// to the server (EN-1549).
-	filter, err := filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr))
+	filter, err := filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 	if err != nil {
 		return fmt.Errorf("invalid filter expression: %w", err)
+	}
+
+	// A structurally-valid but conditionless filter (e.g. `""` quoted, whitespace)
+	// also decodes to nil; reject it for the same reason.
+	if filter == nil {
+		return errors.New("--filter must contain at least one condition")
 	}
 
 	ctx, cancel := cmdutil.GetContext(cmd)

--- a/cmd/ledgerctl/queries/update.go
+++ b/cmd/ledgerctl/queries/update.go
@@ -51,7 +51,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	filterExpr, _ := cmd.Flags().GetString("filter")
 
-	filter, err := filterexpr.Parse(filterExpr)
+	// The update carries only the new filter, not the target — the target is
+	// immutable and lives on the stored prepared query (the FSM re-validates the
+	// filter against it). DecodeDualFormatStructuralOnly is the shared "target not
+	// known here" entry point: it resolves bare fields with a non-audit target
+	// (prepared queries are never audit) and defers the per-target validity gate
+	// to the server (EN-1549).
+	filter, err := filterexpr.DecodeDualFormatStructuralOnly([]byte(filterExpr))
 	if err != nil {
 		return fmt.Errorf("invalid filter expression: %w", err)
 	}

--- a/cmd/ledgerctl/transactions/list.go
+++ b/cmd/ledgerctl/transactions/list.go
@@ -81,7 +81,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	cns := cmdutil.GetConsistencyFlags(cmd)
 	showProfile, _ := cmd.Flags().GetBool("analyze")
 
-	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix)
+	filter, err := cmdutil.BuildQueryFilter(flt.Expr, flt.Prefix, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 	if err != nil {
 		return err
 	}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1000,11 +1000,16 @@ has_asset_cond := "has" "asset" ASSET_BASE ["/" PRECISION]
 A bare `KEY` or `VALUE` is a plain-alphanumeric identifier (`[a-zA-Z_][a-zA-Z0-9_]*`).
 Any key or value that contains a special character — `-`, `:`, `.`, `/`, spaces, etc.
 — **must be quoted** (e.g. `metadata["x-request-id"] == "user:42"`,
-`address ^= "users:"`, `audit[ledger] == "my-ledger"`). The one exception is the
+`address ^= "users:"`, `ledger == "my-ledger"`). The one exception is the
 asset reference in `has asset BASE/PRECISION`, whose `/` is part of the grammar
 (e.g. `has asset USD/2`).
 
-`audit[...]` conditions are only valid on `audit list` (see [audit list](#audit-list) for the field/operator matrix). They are rejected on other list endpoints.
+Bare audit fields (`outcome`, `ledger`, `seq`, `proposal_id`, `timestamp`,
+`log_seq`, `caller_subject`, `order_type`) are only valid on `audit list` (see
+[audit list](#audit-list) for the field/operator matrix). They are written
+without any prefix and resolved against the audit query target (EN-1549 — this
+replaced the old `audit[...]` namespaced syntax, a breaking change with no
+backward compatibility). They are rejected on other list endpoints.
 
 **Conditions:**
 
@@ -2258,14 +2263,20 @@ ledgerctl audit list [flags]
 
 Audit has **no dedicated filter flags** — there is no `--failures-only` and no
 `--ledger`. Selecting failures or scoping to a ledger is done through the generic
-`--filter` (e.g. `--filter 'audit[outcome] == failure'`,
-`--filter 'audit[ledger] == main'`), exactly like every other list command.
+`--filter` (e.g. `--filter 'outcome == failure'`,
+`--filter 'ledger == main'`), exactly like every other list command.
 
 Also honors the full [Shared Flag Contract](#shared-flag-contract) (`--page-size`, `--cursor`, `--reverse`, `--filter`, `--checkpoint-id`, `--min-log-sequence`, `--json`, `--yaml`, `--timeout`).
 
 **Audit filter grammar (`--filter`):** the audit trail is queried through its
-secondary index, so `--filter` accepts `audit[<field>] <op> <value>` conditions
-combined with `and` / `or`:
+secondary index, so `--filter` accepts bare `<field> <op> <value>` conditions
+combined with `and` / `or`. The field names are written without any prefix and
+are resolved against the audit query target (EN-1549 — this replaced the old
+`audit[<field>]` namespaced syntax, a breaking change with no backward
+compatibility). Because bare `timestamp` and `ledger` otherwise collide with
+the transaction `timestamp` field and the top-level `ledger` condition, these
+fields resolve to the audit condition only on the audit target, which is why
+they are valid on `audit list` alone:
 
 | Field | Type | Operators | Notes |
 |-------|------|-----------|-------|
@@ -2286,10 +2297,10 @@ full-chain scan.
 
 > **Consistency note.** The audit secondary index is maintained by an
 > asynchronous per-node worker, so any *filtered* audit read (including an
-> `audit[ledger]` or `audit[outcome]` filter) is eventually consistent — a
+> `ledger` or `outcome` filter) is eventually consistent — a
 > just-applied entry may take up to ~200 ms to appear. `--min-log-sequence`
 > gates the read-side log index, not the audit index. An *unfiltered* read
-> (plain `audit list`, optionally with `--reverse` / `audit[seq]` bounds) reads
+> (plain `audit list`, optionally with `--reverse` / `seq` bounds) reads
 > the audit zone directly and is strongly consistent.
 >
 > **Checkpoint + filter caveat.** A query checkpoint snapshots the audit index
@@ -2321,19 +2332,19 @@ ledgerctl audit list
 ledgerctl audit list --reverse
 
 # Show only failures (via the generic filter — no dedicated flag)
-ledgerctl audit list --filter 'audit[outcome] == failure'
+ledgerctl audit list --filter 'outcome == failure'
 
 # Scope to a ledger (via the generic filter — no dedicated flag)
-ledgerctl audit list --filter 'audit[ledger] == "my-ledger"'
+ledgerctl audit list --filter 'ledger == "my-ledger"'
 
 # Combine outcome and ledger
-ledgerctl audit list --filter 'audit[outcome] == failure and audit[ledger] == main'
+ledgerctl audit list --filter 'outcome == failure and ledger == main'
 
 # Filter by order type
-ledgerctl audit list --filter 'audit[order_type] in (create_transaction, revert_transaction)'
+ledgerctl audit list --filter 'order_type in (create_transaction, revert_transaction)'
 
 # Sequence range
-ledgerctl audit list --filter 'audit[seq] between 1000 and 2000'
+ledgerctl audit list --filter 'seq between 1000 and 2000'
 
 # Read from a query checkpoint instead of the live store
 ledgerctl audit list --checkpoint-id 7

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -365,12 +365,18 @@ Query parameters:
 - `pageSize`: max entries (default 100, capped at 1000)
 - `after`: audit sequence to start after (exclusive, opaque cursor)
 - `reverse`: `true` iterates newest-first
-- `filter`: a filter expression restricted to `audit[...]` conditions, using the
-  same grammar as `ledgerctl audit list --filter` (e.g.
-  `audit[outcome] == failure`, `audit[ledger] == main`,
-  `audit[order_type] in (create_transaction, revert_transaction)`). This is the
-  shared `filterexpr` DSL — **not** the JSON `QueryFilter` DSL used by prepared
-  queries, which cannot represent audit conditions. Filtered reads are served by
+- `filter`: a filter expression restricted to bare audit fields (`outcome`,
+  `ledger`, `seq`, `proposal_id`, `timestamp`, `log_seq`, `caller_subject`,
+  `order_type`), using the same grammar as `ledgerctl audit list --filter` (e.g.
+  `outcome == failure`, `ledger == main`,
+  `order_type in (create_transaction, revert_transaction)`). The fields are
+  written without any prefix and resolved against the audit query target
+  (EN-1549 — this replaced the old `audit[...]` namespaced syntax, a breaking
+  change with no backward compatibility); bare `timestamp` and `ledger` resolve
+  to the audit condition only on the audit target, which is why audit fields are
+  valid on this endpoint alone. This is the shared `filterexpr` DSL — **not** the
+  JSON `QueryFilter` DSL used by prepared queries, which cannot represent audit
+  conditions. Filtered reads are served by
   the asynchronous audit index; the consistency guarantee matches the gRPC
   surface.
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -70,8 +70,15 @@ account prefix is now `address ^= "..."`, transaction reference is structured
 `{"$match":{"reference":"..."}}`); prepared-query
 create/update decode the JSON `filter` body field through the same helper; and
 `ledgerctl --filter` routes through it in `cmdutil.BuildQueryFilter`. Audit
-conditions (`audit[...]`) exist only in the textual form — the JSON codec has no
-representation for them (EN-1241) — so the textual form is canonical for
+fields are written **bare** (`outcome`, `ledger`, `seq`, `proposal_id`,
+`timestamp`, `log_seq`, `caller_subject`, `order_type`) and resolved against the
+audit query target (EN-1549 — this replaced the old `audit[...]` namespaced
+syntax, a breaking change with no backward compatibility). Bare `timestamp` and
+`ledger` collide with the transaction `timestamp` field and the top-level
+`ledger` condition, so they resolve to the audit condition only on the audit
+target — which is why audit fields are valid on that endpoint alone. Audit
+conditions exist only in the textual form — the JSON codec has no representation
+for them (EN-1241) — so the textual form is canonical for
 `GET /v3/_/audit-entries`. See
 [api-comparison.md](../../../contributing/api-comparison.md#filter-input-formats-dual-format-contract-en-1511)
 for the full contract.
@@ -87,7 +94,7 @@ date bound written as **either** an RFC3339 timestamp (e.g.
 |--------|---------|------------|
 | transactions | `timestamp >= "2023-11-14T22:13:20Z"` | `{"$gte":{"timestamp":"2023-11-14T22:13:20Z"}}` |
 | logs | `date >= "2023-11-14T22:13:20Z"` | `{"$gte":{"date":"2023-11-14T22:13:20Z"}}` |
-| audit | `audit[timestamp] >= "2023-11-14T22:13:20Z"` | — (audit is text-only) |
+| audit | `timestamp >= "2023-11-14T22:13:20Z"` (bare, resolved on the audit target) | — (audit is text-only) |
 
 The raw-microsecond form of each still parses (`timestamp >= 1700000000000000`),
 so this is purely additive. All three surfaces (audit, transactions, logs) funnel

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -74,7 +74,7 @@ This document compares the POC's API with the original Formance ledger API and d
 | Delete numscript | ✅ | ❌ | Per-ledger, deletes latest version entry |
 | **Audit Log** |
 | Audit log (success + failure) | ✅ | ❌ | Replicated via Raft, stored in Pebble |
-| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + `audit[...]` filter expression (textual form; audit has no structured JSON form — see [Filter input formats](#filter-input-formats-dual-format-contract-en-1511)) |
+| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + a bare-audit-field filter expression (`outcome`, `ledger`, `seq`, `proposal_id`, `timestamp`, `log_seq`, `caller_subject`, `order_type`, resolved against the audit query target — EN-1549 replaced the old `audit[...]` namespaced syntax; textual form only, audit has no structured JSON form — see [Filter input formats](#filter-input-formats-dual-format-contract-en-1511)) |
 | Get audit entry by sequence | ✅ | ❌ | `GET /v3/_/audit-entries/{sequence}` (HTTP) + gRPC. Populates per-order `items` |
 | Audit log disable/enable | ❌ | ❌ | Not implemented |
 | **Error Handling** |
@@ -412,12 +412,17 @@ non-whitespace byte:
   object is the structured form; a JSON string (`"filter": "metadata[k] == v"`)
   is the textual form.
 
-**Audit is text-only.** Audit conditions (`audit[...]`) have no structured JSON
-representation — their field names (`ledger`, `timestamp`, …) collide with the
-transaction/log conditions the JSON DSL already claims (EN-1241) — so the JSON
-codec rejects them. The dual-format decoder still accepts both forms as input on
-the audit endpoint; the textual form is simply the only one that can carry an
-audit condition, so it is the canonical representation for
+**Audit is text-only.** Audit fields are written **bare** (`outcome`, `ledger`,
+`seq`, `proposal_id`, `timestamp`, `log_seq`, `caller_subject`, `order_type`) and
+resolved against the audit query target (EN-1549 — this replaced the old
+`audit[...]` namespaced syntax, a breaking change with no backward
+compatibility). They have no structured JSON representation — bare `timestamp`
+and `ledger` collide with the transaction `timestamp` field and the top-level
+`ledger` condition the JSON DSL already claims (EN-1241), which is why the audit
+resolution is target-aware and audit fields are valid on the audit endpoint only
+— so the JSON codec rejects them. The dual-format decoder still accepts both
+forms as input on the audit endpoint; the textual form is simply the only one
+that can carry an audit condition, so it is the canonical representation for
 `GET /v3/_/audit-entries`.
 
 **Date fields accept RFC3339 or raw microseconds (EN-1544).** The builtin date
@@ -428,7 +433,7 @@ RFC3339 timestamp **or** the raw-microsecond form, in both representations:
 |--------|-------|---------|------------|
 | transactions | `timestamp` (also `insertedAt`, `revertedAt`) | `timestamp >= "2023-11-14T22:13:20Z"` | `{"$gte":{"timestamp":"2023-11-14T22:13:20Z"}}` |
 | logs | `date` | `date >= "2023-11-14T22:13:20Z"` | `{"$gte":{"date":"2023-11-14T22:13:20Z"}}` |
-| audit | `audit[timestamp]` | `audit[timestamp] >= "2023-11-14T22:13:20Z"` | — (audit is text-only) |
+| audit | `timestamp` (bare, resolved on the audit target) | `timestamp >= "2023-11-14T22:13:20Z"` | — (audit is text-only) |
 
 The raw form still parses (`timestamp >= 1700000000000000`), so this is purely
 additive. RFC3339 acceptance and pre-epoch rejection are defined once, in the
@@ -832,7 +837,7 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `ListNumscripts` | List all saved numscripts | ✅ |
 | `Apply(CloseChapter)` | Close the current open chapter | ✅ |
 | `ListChapters` | Stream all chapters | ✅ |
-| `ListAuditEntries` | Stream audit log entries (success + failure). Request is `{ options }` only — no dedicated filter fields. Follows the shared `ListOptions` contract: cursor/page_size/reverse/checkpoint_id plus an `audit[...]` `QueryFilter` (outcome, ledger, caller_subject, order_type, seq, proposal_id, timestamp, log_seq) resolved through the audit secondary index. Ledger scope and outcome selection are expressed as filter conditions | ✅ |
+| `ListAuditEntries` | Stream audit log entries (success + failure). Request is `{ options }` only — no dedicated filter fields. Follows the shared `ListOptions` contract: cursor/page_size/reverse/checkpoint_id plus a bare-audit-field `QueryFilter` (outcome, ledger, caller_subject, order_type, seq, proposal_id, timestamp, log_seq — bare fields resolved against the audit query target, EN-1549 replacing the old `audit[...]` syntax) resolved through the audit secondary index. Ledger scope and outcome selection are expressed as filter conditions | ✅ |
 | `GetAuditEntry` | Get a single audit entry by sequence number | ✅ |
 | `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination) | ✅ |
 | `GetLog` | Get a single system log by sequence number | ✅ |

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -977,7 +977,7 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 
 	opts := req.GetOptions()
 
-	// Audit listing is fully under the shared contract: filter (audit[...]
+	// Audit listing is fully under the shared contract: filter (bare audit fields
 	// conditions), reverse, and checkpoint_id are all honored (EN-1241).
 	if err := ValidateListOptions(opts, ListOptionsSupport{Filter: true, Reverse: true, CheckpointID: true}); err != nil {
 		return err

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -93,7 +93,7 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 	// A gRPC InvalidArgument status is a caller error, not a server fault, and
 	// must not degrade to a 500. The audit-filter compiler (query.CompileAuditFilter,
 	// shared with the gRPC surface) rejects filters that parse but are not
-	// audit-supported — `not audit[...]`, a non-audit condition, an unknown
+	// audit-supported — `not outcome == failure`, a non-audit condition, an unknown
 	// field — as codes.InvalidArgument; surface that as a 400. Only
 	// InvalidArgument is translated here; other status codes keep the generic
 	// 500 fallthrough deliberately, since no other HTTP handler is expected to

--- a/internal/adapter/http/handlers_list_audit_entries.go
+++ b/internal/adapter/http/handlers_list_audit_entries.go
@@ -20,9 +20,9 @@ import (
 //   - after:    exclusive lower bound on the audit sequence (opaque cursor from
 //     a previous page; a decimal uint64, matching the gRPC cursor)
 //   - reverse:  iterate newest-first when "true"
-//   - filter:   filterexpr DSL restricted to audit[...] conditions, e.g.
-//     `audit[outcome] == failure`, `audit[ledger] == main`,
-//     `audit[order_type] in (create_transaction, revert_transaction)`.
+//   - filter:   filterexpr DSL restricted to bare audit fields, e.g.
+//     `outcome == failure`, `ledger == main`,
+//     `order_type in (create_transaction, revert_transaction)`.
 //
 // This exposes the same audit data and filter representation as the gRPC
 // BucketService.ListAuditEntries surface (EN-1241): it consumes the same

--- a/internal/adapter/http/handlers_list_audit_entries_test.go
+++ b/internal/adapter/http/handlers_list_audit_entries_test.go
@@ -162,8 +162,9 @@ func TestHandleListAuditEntries_InvalidPageSize(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestHandleListAuditEntries_LedgerFilter checks that a `filter` with an
-// audit[ledger] condition is parsed via filterexpr and forwarded to the backend.
+// TestHandleListAuditEntries_LedgerFilter checks that a `filter` with a
+// bare `ledger` condition is parsed via filterexpr (audit target) and
+// forwarded to the backend.
 func TestHandleListAuditEntries_LedgerFilter(t *testing.T) {
 	t.Parallel()
 
@@ -181,7 +182,7 @@ func TestHandleListAuditEntries_LedgerFilter(t *testing.T) {
 	srv := newTestServer(t, backend)
 
 	w := httptest.NewRecorder()
-	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("audit[ledger] == main"), nil, nil)
+	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("ledger == main"), nil, nil)
 
 	srv.handleListAuditEntries(w, r)
 
@@ -204,7 +205,7 @@ func TestHandleListAuditEntries_OutcomeFilter(t *testing.T) {
 	srv := newTestServer(t, backend)
 
 	w := httptest.NewRecorder()
-	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("audit[outcome] == failure"), nil, nil)
+	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("outcome == failure"), nil, nil)
 
 	srv.handleListAuditEntries(w, r)
 
@@ -226,7 +227,7 @@ func TestHandleListAuditEntries_InvalidFilter(t *testing.T) {
 
 // TestHandleListAuditEntries_UnsupportedFilterMapsTo400 covers a filter that
 // parses (filterexpr accepts it) but the audit compiler rejects with a gRPC
-// codes.InvalidArgument (e.g. `not audit[...]`, a non-audit condition). Such an
+// codes.InvalidArgument (e.g. `not outcome == failure`, a non-audit condition). Such an
 // error must surface as a 400, not a 500.
 func TestHandleListAuditEntries_UnsupportedFilterMapsTo400(t *testing.T) {
 	t.Parallel()
@@ -239,8 +240,8 @@ func TestHandleListAuditEntries_UnsupportedFilterMapsTo400(t *testing.T) {
 	srv := newTestServer(t, backend)
 
 	w := httptest.NewRecorder()
-	// `not audit[...]` parses fine but the compiler rejects it.
-	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("not audit[outcome] == failure"), nil, nil)
+	// `not outcome == failure` parses fine but the compiler rejects it.
+	r := newRequest(t, http.MethodGet, "/_/audit-entries?filter="+url.QueryEscape("not outcome == failure"), nil, nil)
 
 	srv.handleListAuditEntries(w, r)
 

--- a/internal/adapter/http/handlers_update_prepared_query.go
+++ b/internal/adapter/http/handlers_update_prepared_query.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/filterexpr"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -42,8 +43,10 @@ func (s *Server) handleUpdatePreparedQuery(w http.ResponseWriter, r *http.Reques
 	// cannot smuggle in a condition invalid for the query's target (EN-1504).
 	// This handler stays purely structural: it accepts either the structured v2
 	// JSON DSL or a JSON-quoted textual filterexpr expression (EN-1511) and defers
-	// the target gate to the FSM.
-	filter, err := filterexpr.DecodeDualFormatStructuralOnly(body.Filter)
+	// the target gate to the FSM. Bare-field resolution uses a non-audit target
+	// (EN-1549): prepared queries are only ever ACCOUNTS/TRANSACTIONS/LOGS, all of
+	// which resolve the bare intrinsic fields identically.
+	filter, err := filterexpr.DecodeDualFormatStructuralOnly(body.Filter, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 	if err != nil {
 		writeBadRequest(w, "INVALID_REQUEST", err)
 

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1630,7 +1630,7 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 // delegates to ListAuditEntriesFrom bound to the controller's own stores.
 //
 // Audit has no dedicated top-level filters: ledger scope and outcome selection
-// are expressed entirely through filter (audit[ledger], audit[outcome], …).
+// are expressed entirely through filter (bare audit fields: ledger, outcome, …).
 //
 // Ordering: the audit trail is chronological, so the default (reverse=false)
 // iterates ascending by sequence (oldest first) — this is the audit trail's

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -406,6 +406,11 @@ var (
 	ErrPreparedQueryNameInvalidChar   = NewValidationSentinel("prepared query name must contain only printable ASCII (0x20–0x7E)")
 	ErrPreparedQueryNameTooLong       = NewValidationSentinel("prepared query name exceeds maximum length of 256 bytes")
 	ErrPreparedQueryTargetUnsupported = NewValidationSentinel("prepared query target is not supported (use ACCOUNTS, TRANSACTIONS or LOGS)")
+	// ErrPreparedQueryFilterRequired guards the update path: an update replaces the
+	// stored filter, so a nil filter would silently erase it (a prepared query is
+	// defined by its filter). Rejecting nil keeps the stored query intact and the
+	// audit trail deterministic on wire-replay.
+	ErrPreparedQueryFilterRequired = NewValidationSentinel("prepared query filter is required")
 	// Signing-key identifier sentinels stay local: request signing is a
 	// ledger-internal feature, not part of the Formance-wide invariants in
 	// github.com/formancehq/invariants.

--- a/internal/domain/processing/processor_prepared_query.go
+++ b/internal/domain/processing/processor_prepared_query.go
@@ -106,6 +106,15 @@ func processUpdatePreparedQuery(ledger string, order *raftcmdpb.UpdatePreparedQu
 
 	updated := existing.Mutate()
 
+	// An update replaces the stored filter, so a nil filter would silently erase
+	// it — ValidateFilterForTarget accepts nil (it means "no filter"), so without
+	// this guard `updated.Filter = nil` would persist and the prepared query would
+	// lose its definition. Reject it at the FSM (the audit/replay-determinism layer
+	// of the dual-layer rule) as well as at admission (CLI/HTTP, for UX).
+	if order.GetFilter() == nil {
+		return nil, domain.ErrPreparedQueryFilterRequired
+	}
+
 	// An update carries only the new filter; the target is fixed at creation and
 	// read here from the stored query (the cache, per invariant #3).
 	//

--- a/internal/domain/processing/processor_prepared_query_test.go
+++ b/internal/domain/processing/processor_prepared_query_test.go
@@ -112,6 +112,38 @@ func TestProcessUpdatePreparedQuery_RejectsFilterInvalidForStoredTarget(t *testi
 	require.Contains(t, derr.Error(), "accounts")
 }
 
+// TestProcessUpdatePreparedQuery_RejectsNilFilter guards against silently erasing
+// a stored prepared query's filter: an update replaces the filter, and a nil
+// filter passes ValidateFilterForTarget (nil == "no filter"), so without an
+// explicit guard `updated.Filter = nil` would persist and drop the query's
+// definition. The FSM must reject a nil filter (and never call Put).
+func TestProcessUpdatePreparedQuery_RejectsNilFilter(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, (&commonpb.LedgerInfo{Name: "test-ledger"}).AsReader(), nil)
+
+	pq := setupPreparedQueriesStub(mockStore)
+	pq.onGet(func(_ domain.PreparedQueryKey) (commonpb.PreparedQueryReader, error) {
+		return (&commonpb.PreparedQuery{
+			Name:   "q1",
+			Target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			Filter: &commonpb.QueryFilter{},
+		}).AsReader(), nil
+	})
+	pq.onPut(func(domain.PreparedQueryKey, *commonpb.PreparedQuery) {
+		t.Fatal("Put must not be called when the update carries a nil filter")
+	})
+
+	order := &raftcmdpb.UpdatePreparedQueryOrder{Name: "q1"} // Filter left nil
+	_, derr := processUpdatePreparedQuery("test-ledger", order, &Context{Scope: mockStore})
+	require.NotNil(t, derr, "a nil filter must be rejected, not persisted over the stored filter")
+	require.ErrorIs(t, derr, domain.ErrPreparedQueryFilterRequired)
+}
+
 // TestProcessUpdatePreparedQuery_RejectsNonExecutableStoredTarget covers a
 // legacy escape hatch: CLI/gRPC creation used to accept non-executable targets
 // (e.g. AUDIT) before EN-1504, so such a query can already sit in storage. An

--- a/internal/pkg/filterexpr/audit_test.go
+++ b/internal/pkg/filterexpr/audit_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
+// audit is the query target under which the bare audit fields resolve to the
+// AuditCondition arm (EN-1549).
+const audit = commonpb.QueryTarget_QUERY_TARGET_AUDIT
+
 func TestParseAudit_OutcomeEquality(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[outcome] == failure")
+	filter, err := Parse("outcome == failure", audit)
 	require.NoError(t, err)
 
 	ac := filter.GetAudit()
@@ -24,8 +28,9 @@ func TestParseAudit_OutcomeEquality(t *testing.T) {
 func TestParseAudit_LedgerKeyword(t *testing.T) {
 	t.Parallel()
 
-	// "ledger" is a keyword; the audit field key must still parse.
-	filter, err := Parse("audit[ledger] == main")
+	// "ledger" is a keyword; the bare audit field must still resolve on the audit
+	// target (to the audit ledger arm, not the LedgerCondition arm).
+	filter, err := Parse("ledger == main", audit)
 	require.NoError(t, err)
 
 	ac := filter.GetAudit()
@@ -37,7 +42,7 @@ func TestParseAudit_LedgerKeyword(t *testing.T) {
 func TestParseAudit_CallerSubjectQuoted(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse(`audit[caller_subject] == "svc:payments"`)
+	filter, err := Parse(`caller_subject == "svc:payments"`, audit)
 	require.NoError(t, err)
 
 	ac := filter.GetAudit()
@@ -54,10 +59,10 @@ func TestParseAudit_TimestampRFC3339(t *testing.T) {
 
 	// RFC3339 (quoted) and raw microseconds must both parse to the same bound.
 	for _, in := range []string{
-		`audit[timestamp] >= "2023-11-14T22:13:20Z"`,
-		"audit[timestamp] >= 1700000000000000",
+		`timestamp >= "2023-11-14T22:13:20Z"`,
+		"timestamp >= 1700000000000000",
 	} {
-		filter, err := Parse(in)
+		filter, err := Parse(in, audit)
 		require.NoError(t, err, in)
 
 		ac := filter.GetAudit()
@@ -70,7 +75,7 @@ func TestParseAudit_TimestampRFC3339(t *testing.T) {
 func TestParseAudit_TimestampRejectsPreEpoch(t *testing.T) {
 	t.Parallel()
 
-	_, err := Parse(`audit[timestamp] >= "1969-12-31T00:00:00Z"`)
+	_, err := Parse(`timestamp >= "1969-12-31T00:00:00Z"`, audit)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Unix epoch")
 }
@@ -78,7 +83,7 @@ func TestParseAudit_TimestampRejectsPreEpoch(t *testing.T) {
 func TestParseAudit_OrderTypeIn(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[order_type] in (create_transaction, revert_transaction)")
+	filter, err := Parse("order_type in (create_transaction, revert_transaction)", audit)
 	require.NoError(t, err)
 
 	or := filter.GetOr()
@@ -91,7 +96,7 @@ func TestParseAudit_OrderTypeIn(t *testing.T) {
 func TestParseAudit_SeqBetween(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[seq] between 1000 and 2000")
+	filter, err := Parse("seq between 1000 and 2000", audit)
 	require.NoError(t, err)
 
 	ac := filter.GetAudit()
@@ -106,7 +111,7 @@ func TestParseAudit_SeqBetween(t *testing.T) {
 func TestParseAudit_ProposalIDEquality(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[proposal_id] == 42")
+	filter, err := Parse("proposal_id == 42", audit)
 	require.NoError(t, err)
 
 	ac := filter.GetAudit()
@@ -120,7 +125,7 @@ func TestParseAudit_ProposalIDEquality(t *testing.T) {
 func TestParseAudit_TimestampGte(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[timestamp] >= 1700000000000000")
+	filter, err := Parse("timestamp >= 1700000000000000", audit)
 	require.NoError(t, err)
 
 	uc := filter.GetAudit().GetUintCond()
@@ -132,7 +137,7 @@ func TestParseAudit_TimestampGte(t *testing.T) {
 func TestParseAudit_Composition(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse("audit[outcome] == failure and audit[ledger] == main")
+	filter, err := Parse("outcome == failure and ledger == main", audit)
 	require.NoError(t, err)
 
 	and := filter.GetAnd()
@@ -145,7 +150,7 @@ func TestParseAudit_Composition(t *testing.T) {
 func TestParseAudit_UnknownField(t *testing.T) {
 	t.Parallel()
 
-	_, err := Parse("audit[bogus] == x")
+	_, err := Parse("bogus == x", audit)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown audit field")
 }
@@ -153,7 +158,7 @@ func TestParseAudit_UnknownField(t *testing.T) {
 func TestParseAudit_UintFieldRejectsNonNumeric(t *testing.T) {
 	t.Parallel()
 
-	_, err := Parse("audit[seq] == notanumber")
+	_, err := Parse("seq == notanumber", audit)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsigned integer")
 }
@@ -162,32 +167,58 @@ func TestParseAudit_StringFieldRejectsNotEqual(t *testing.T) {
 	t.Parallel()
 
 	// != would require a NOT wrapper that the audit access path cannot serve.
-	_, err := Parse("audit[outcome] != failure")
+	_, err := Parse("outcome != failure", audit)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "== and in only")
 }
 
-// TestParseAudit_KeywordAsBareValue guards that introducing the `audit`
-// keyword (and the pre-existing field keywords) does not stop them being used
-// as unquoted right-hand-side values, while structural operators stay reserved.
+// TestParseAudit_AuditFieldsRejectedOffAuditTarget guards that the audit-only
+// field names carry no meaning on a non-audit target: they must be rejected
+// rather than silently resolving to nothing (EN-1549).
+func TestParseAudit_AuditFieldsRejectedOffAuditTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		"outcome == failure",
+		"seq between 1 and 2",
+		"proposal_id == 42",
+		"log_seq == 500",
+		"caller_subject == svc",
+		"order_type == create_transaction",
+	} {
+		for _, target := range []commonpb.QueryTarget{
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+			commonpb.QueryTarget_QUERY_TARGET_LOGS,
+		} {
+			_, err := Parse(in, target)
+			require.Error(t, err, "%q must be rejected on %s", in, target)
+			assert.Contains(t, err.Error(), "unknown field", in)
+		}
+	}
+}
+
+// TestParseAudit_KeywordAsBareValue guards that the field keywords can still be
+// used as unquoted right-hand-side values, while structural operators stay
+// reserved. (`audit` is no longer a keyword after EN-1549.)
 func TestParseAudit_KeywordAsBareValue(t *testing.T) {
 	t.Parallel()
 
 	// Reserved "noun" keywords must still parse as bare values.
-	for _, kw := range []string{"audit", "ledger", "source", "destination", "metadata", "address", "exists"} {
-		f, err := Parse("metadata[type] == " + kw)
+	for _, kw := range []string{"ledger", "source", "destination", "metadata", "address", "exists"} {
+		f, err := Parse("metadata[type] == "+kw, audit)
 		require.NoError(t, err, "metadata[type] == %s should parse", kw)
 		assert.Equal(t, kw, f.GetField().GetStringCond().GetHardcoded())
 	}
 
 	// Structural operators must NOT be swallowed as values.
 	for _, op := range []string{"and", "or", "not", "in", "between"} {
-		_, err := Parse("metadata[type] == " + op)
+		_, err := Parse("metadata[type] == "+op, audit)
 		require.Error(t, err, "metadata[type] == %s must not parse (structural keyword)", op)
 	}
 
-	// Composition still works after the value change.
-	f, err := Parse("metadata[a] == audit and metadata[b] == ledger")
+	// `audit` is now an ordinary identifier and parses as a bare value.
+	f, err := Parse("metadata[a] == audit and metadata[b] == ledger", audit)
 	require.NoError(t, err)
 	require.NotNil(t, f.GetAnd())
 	require.Len(t, f.GetAnd().GetFilters(), 2)
@@ -197,18 +228,18 @@ func TestFormatAudit_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	for _, in := range []string{
-		"audit[outcome] == failure",
-		"audit[ledger] == main",
+		"outcome == failure",
+		"ledger == main",
 		// A value with a special char (`:`) must be quoted (EN-1547); Format emits
 		// and Parse reads the quoted form.
-		`audit[caller_subject] == "svc:payments"`,
-		"audit[seq] == 42",
-		"audit[seq] between 1000 and 2000",
-		`audit[timestamp] >= "2023-11-14T22:13:20Z"`,
-		"audit[proposal_id] < 100",
-		"audit[outcome] == failure and audit[ledger] == main",
+		`caller_subject == "svc:payments"`,
+		"seq == 42",
+		"seq between 1000 and 2000",
+		`timestamp >= "2023-11-14T22:13:20Z"`,
+		"proposal_id < 100",
+		"outcome == failure and ledger == main",
 	} {
-		f, err := Parse(in)
+		f, err := Parse(in, audit)
 		require.NoError(t, err, in)
 		assert.Equal(t, in, Format(f), "round-trip for %q", in)
 	}

--- a/internal/pkg/filterexpr/date_test.go
+++ b/internal/pkg/filterexpr/date_test.go
@@ -296,11 +296,11 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			min := tc.v
+			minMicros := tc.v
 			f := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
 				BuiltinUint: &commonpb.BuiltinUintCondition{
 					Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
-					Cond:  &commonpb.UintCondition{Min: &min},
+					Cond:  &commonpb.UintCondition{Min: &minMicros},
 				},
 			}}
 
@@ -318,12 +318,12 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 	t.Run("audit timestamp above MaxInt64", func(t *testing.T) {
 		t.Parallel()
 
-		min := uint64(18446744073709551615)
+		minMicros := uint64(18446744073709551615)
 		f := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{
 			Audit: &commonpb.AuditCondition{
 				Field: commonpb.AuditField_AUDIT_FIELD_TIMESTAMP,
 				Condition: &commonpb.AuditCondition_UintCond{
-					UintCond: &commonpb.UintCondition{Min: &min},
+					UintCond: &commonpb.UintCondition{Min: &minMicros},
 				},
 			},
 		}}

--- a/internal/pkg/filterexpr/date_test.go
+++ b/internal/pkg/filterexpr/date_test.go
@@ -14,6 +14,11 @@ import (
 // 2023-11-14T22:13:20Z == 1_700_000_000 s == 1_700_000_000_000_000 µs.
 const wantDateMicros = uint64(1_700_000_000_000_000)
 
+// tx is a non-audit target under which the bare intrinsic fields (date,
+// timestamp, ledger) resolve to their own arms (EN-1549). Any non-audit target
+// resolves them identically; TRANSACTIONS is the representative choice.
+const tx = commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS
+
 func TestParseDate_LogRFC3339AndRawMatch(t *testing.T) {
 	t.Parallel()
 
@@ -23,7 +28,7 @@ func TestParseDate_LogRFC3339AndRawMatch(t *testing.T) {
 		`date >= "2023-11-14T22:13:20Z"`,
 		"date >= 1700000000000000",
 	} {
-		filter, err := Parse(in)
+		filter, err := Parse(in, tx)
 		require.NoError(t, err, in)
 
 		lc := filter.GetLogBuiltinUint()
@@ -41,7 +46,7 @@ func TestParseTimestamp_TxRFC3339AndRawMatch(t *testing.T) {
 		`timestamp >= "2023-11-14T22:13:20Z"`,
 		"timestamp >= 1700000000000000",
 	} {
-		filter, err := Parse(in)
+		filter, err := Parse(in, tx)
 		require.NoError(t, err, in)
 
 		bc := filter.GetBuiltinUint()
@@ -58,7 +63,7 @@ func TestParseTimestamp_TxRFC3339AndRawMatch(t *testing.T) {
 func TestParseDate_ClosedRange(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse(`date >= "2023-11-14T22:13:20Z" and date < "2023-11-15T22:13:20Z"`)
+	filter, err := Parse(`date >= "2023-11-14T22:13:20Z" and date < "2023-11-15T22:13:20Z"`, tx)
 	require.NoError(t, err)
 
 	// No enclosing $and: the two complementary bounds fold into one range.
@@ -92,7 +97,7 @@ func TestParseDate_FoldOnlyComplementaryBounds(t *testing.T) {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
 
-			filter, err := Parse(in)
+			filter, err := Parse(in, tx)
 			require.NoError(t, err, in)
 			require.NotNil(t, filter.GetAnd(), "expected an unfolded AndFilter for %q", in)
 		})
@@ -102,7 +107,7 @@ func TestParseDate_FoldOnlyComplementaryBounds(t *testing.T) {
 func TestParseDate_Between(t *testing.T) {
 	t.Parallel()
 
-	filter, err := Parse(`timestamp between "2023-11-14T22:13:20Z" and 1700086400000000`)
+	filter, err := Parse(`timestamp between "2023-11-14T22:13:20Z" and 1700086400000000`, tx)
 	require.NoError(t, err)
 
 	bc := filter.GetBuiltinUint()
@@ -135,14 +140,14 @@ func TestFormatDate_RoundTrip(t *testing.T) {
 		t.Run(tc.in, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := Parse(tc.in)
+			f, err := Parse(tc.in, tx)
 			require.NoError(t, err)
 
 			got := Format(f)
 			require.Equal(t, tc.want, got)
 
 			// And the formatted string must parse back to an equivalent filter.
-			reparsed, err := Parse(got)
+			reparsed, err := Parse(got, tx)
 			require.NoError(t, err)
 			require.True(t, proto.Equal(f, reparsed),
 				"Format output must round-trip\n first: %v\n reparsed: %v", f, reparsed)
@@ -199,7 +204,7 @@ func TestFormatDate_PreservesExclusiveClosedRange(t *testing.T) {
 			got := Format(folded)
 			require.Equal(t, tc.wantText, got)
 
-			reparsed, err := Parse(got)
+			reparsed, err := Parse(got, tx)
 			require.NoError(t, err)
 			require.True(t, proto.Equal(folded, reparsed),
 				"Format output must round-trip to the original exclusive range\n first: %v\n reparsed: %v", folded, reparsed)
@@ -252,7 +257,7 @@ func TestFormatDate_NotWrapsExclusiveRange(t *testing.T) {
 			got := Format(notFilter)
 			require.Equal(t, tc.wantText, got)
 
-			reparsed, err := Parse(got)
+			reparsed, err := Parse(got, tx)
 			require.NoError(t, err)
 			require.True(t, proto.Equal(notFilter, reparsed),
 				"Format output must round-trip under not\n first: %v\n reparsed: %v", notFilter, reparsed)
@@ -302,15 +307,15 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 			got := Format(f)
 			require.Equal(t, tc.want, got, "must render raw micros, not an unparseable RFC3339 string")
 
-			reparsed, err := Parse(got)
+			reparsed, err := Parse(got, tx)
 			require.NoError(t, err, "raw-micros output must parse back")
 			require.True(t, proto.Equal(f, reparsed),
 				"Format output must round-trip for out-of-RFC3339-range bounds\n first: %v\n reparsed: %v", f, reparsed)
 		})
 	}
 
-	// Same guarantee on the audit[timestamp] arm.
-	t.Run("audit[timestamp] above MaxInt64", func(t *testing.T) {
+	// Same guarantee on the bare audit timestamp arm (EN-1549).
+	t.Run("audit timestamp above MaxInt64", func(t *testing.T) {
 		t.Parallel()
 
 		min := uint64(18446744073709551615)
@@ -324,11 +329,11 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 		}}
 
 		got := Format(f)
-		require.Equal(t, `audit[timestamp] >= 18446744073709551615`, got)
+		require.Equal(t, `timestamp >= 18446744073709551615`, got)
 
-		reparsed, err := Parse(got)
+		reparsed, err := Parse(got, audit)
 		require.NoError(t, err)
-		require.True(t, proto.Equal(f, reparsed), "audit[timestamp] raw micros must round-trip")
+		require.True(t, proto.Equal(f, reparsed), "audit timestamp raw micros must round-trip")
 	})
 }
 
@@ -366,10 +371,10 @@ func TestFormatDate_OnlyEmitsParseableFields(t *testing.T) {
 			t.Run(in, func(t *testing.T) {
 				t.Parallel()
 
-				f, err := Parse(in)
+				f, err := Parse(in, tx)
 				require.NoError(t, err)
 				got := Format(f)
-				reparsed, err := Parse(got)
+				reparsed, err := Parse(got, tx)
 				require.NoError(t, err, got)
 				require.True(t, proto.Equal(f, reparsed),
 					"Format must emit a parseable field\n first: %v\n reparsed: %v", f, reparsed)
@@ -385,7 +390,7 @@ func TestParseDate_RejectsPreEpoch(t *testing.T) {
 		`date >= "1969-12-31T00:00:00Z"`,
 		`timestamp >= "1969-12-31T00:00:00Z"`,
 	} {
-		_, err := Parse(in)
+		_, err := Parse(in, tx)
 		require.Error(t, err, in)
 		assert.Contains(t, err.Error(), "Unix epoch", in)
 	}
@@ -394,7 +399,7 @@ func TestParseDate_RejectsPreEpoch(t *testing.T) {
 func TestParseDate_RejectsGarbageValue(t *testing.T) {
 	t.Parallel()
 
-	_, err := Parse(`date >= "not-a-date"`)
+	_, err := Parse(`date >= "not-a-date"`, tx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "RFC3339")
 }
@@ -405,7 +410,7 @@ func TestParseDate_RejectsParam(t *testing.T) {
 	// date/timestamp are index-resolved range fields evaluated without a
 	// parameter-resolution context; a $param operand is rejected, mirroring the
 	// audit datetime field.
-	_, err := Parse(`date >= $since`)
+	_, err := Parse(`date >= $since`, tx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support parameters")
 }
@@ -420,7 +425,7 @@ func TestParseDate_KeywordsUsableAsBareValues(t *testing.T) {
 		"metadata[kind] == date",
 		"metadata[kind] == timestamp",
 	} {
-		filter, err := Parse(in)
+		filter, err := Parse(in, tx)
 		require.NoError(t, err, in)
 		require.NotNil(t, filter.GetField(), in)
 	}
@@ -456,7 +461,7 @@ func TestParseDate_DoesNotMistokenizeIdentifierPrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			filter, err := Parse(tc.in)
+			filter, err := Parse(tc.in, tx)
 			require.NoError(t, err, tc.in)
 			require.NotNil(t, filter.GetField(), tc.in)
 		})

--- a/internal/pkg/filterexpr/decode.go
+++ b/internal/pkg/filterexpr/decode.go
@@ -23,7 +23,12 @@ import (
 //   - structured — the v2 QueryFilter JSON DSL ($and/$or/$not + $match/$gt/…),
 //     decoded by commonpb.QueryFilter.UnmarshalJSON (query_filter.go);
 //   - textual    — the human-readable filterexpr grammar (metadata[k] == v,
-//     audit[outcome] == failure, …), parsed by Parse.
+//     outcome == failure, …), parsed by Parse. The textual grammar resolves a
+//     handful of bare fields against `target` (EN-1549): on QUERY_TARGET_AUDIT
+//     the bare audit fields (outcome, ledger, seq, timestamp, …) resolve to the
+//     audit arm, so the target must be threaded into the parse — a bare
+//     `timestamp`/`ledger` means the audit condition here, but the transaction
+//     timestamp / ledger condition on the other targets.
 //
 // Form detection is purely structural and does not depend on the transport: the
 // first non-whitespace byte of the raw value decides. A leading '{' is the
@@ -41,15 +46,16 @@ import (
 // already claim them; see commonpb/query_filter.go, EN-1241). This is not a
 // special case here: the structured decoder rejects audit conditions on its own,
 // so a structured-form audit filter fails with that codec's error, while the
-// textual form parses the audit arm natively. Callers that read AUDIT should
-// document the textual form as the canonical one.
+// textual form parses the audit arm natively (the bare audit fields resolve to
+// the audit arm precisely because `target` is QUERY_TARGET_AUDIT). Callers that
+// read AUDIT should document the textual form as the canonical one.
 //
 // A nil/empty raw value yields (nil, nil): "no filter" is a valid unfiltered
 // read for the list endpoints. Callers that require a filter (prepared queries)
 // check for nil themselves — the same contract the previous per-endpoint
 // decoders had.
 func DecodeDualFormat(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
-	filter, err := decodeDualFormat(raw)
+	filter, err := decodeDualFormat(raw, target)
 	if err != nil {
 		return nil, err
 	}
@@ -71,12 +77,22 @@ func DecodeDualFormat(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryF
 // FSM applies the gate against it — see handlers_update_prepared_query.go). Every
 // other caller MUST use DecodeDualFormat so form and validity are checked in one
 // place.
+//
+// Bare-field resolution still needs a target (EN-1549), and here it is fixed to a
+// non-audit target. This is sound because prepared queries are only ever
+// ACCOUNTS/TRANSACTIONS/LOGS (audit is gRPC-only, never a prepared-query target —
+// see http.preparedQueryTargets), and every non-audit target resolves the bare
+// intrinsic fields identically (`timestamp` → transaction range, `date` → log
+// range, `ledger` → LedgerCondition). Whether the resolved field is actually
+// valid on the query's specific stored target is still enforced downstream by the
+// FSM's ValidateFilterForTarget — this path only picks the proto arm, not the
+// validity.
 func DecodeDualFormatStructuralOnly(raw []byte) (*commonpb.QueryFilter, error) {
-	return decodeDualFormat(raw)
+	return decodeDualFormat(raw, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 }
 
 // decodeDualFormat performs form detection + parse, without the validity gate.
-func decodeDualFormat(raw []byte) (*commonpb.QueryFilter, error) {
+func decodeDualFormat(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || string(trimmed) == "null" {
 		return nil, nil
@@ -108,23 +124,24 @@ func decodeDualFormat(raw []byte) (*commonpb.QueryFilter, error) {
 			return nil, fmt.Errorf("filter: %w", err)
 		}
 
-		return parseTextual(expr)
+		return parseTextual(expr, target)
 
 	default:
 		// Raw textual filterexpr (query-string form).
-		return parseTextual(string(trimmed))
+		return parseTextual(string(trimmed), target)
 	}
 }
 
-// parseTextual parses a textual filterexpr expression, treating an empty string
-// as "no filter" for symmetry with the empty-raw case (a body field of `""` or a
-// query param of `?filter=` is an explicit no-op, not a parse error).
-func parseTextual(expr string) (*commonpb.QueryFilter, error) {
+// parseTextual parses a textual filterexpr expression, resolving bare fields
+// against target, and treating an empty string as "no filter" for symmetry with
+// the empty-raw case (a body field of `""` or a query param of `?filter=` is an
+// explicit no-op, not a parse error).
+func parseTextual(expr string, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if expr == "" {
 		return nil, nil
 	}
 
-	filter, err := Parse(expr)
+	filter, err := Parse(expr, target)
 	if err != nil {
 		return nil, fmt.Errorf("filter: %w", err)
 	}

--- a/internal/pkg/filterexpr/decode.go
+++ b/internal/pkg/filterexpr/decode.go
@@ -72,23 +72,25 @@ func DecodeDualFormat(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryF
 }
 
 // DecodeDualFormatStructuralOnly is DecodeDualFormat without the per-target
-// validity gate. It exists for the prepared-query update path, which does not
-// see the target (the target is immutable and lives on the stored query, so the
-// FSM applies the gate against it — see handlers_update_prepared_query.go). Every
-// other caller MUST use DecodeDualFormat so form and validity are checked in one
-// place.
+// validity gate: it resolves bare fields against target (EN-1549) but leaves the
+// validity check to the server. Two kinds of caller use it:
 //
-// Bare-field resolution still needs a target (EN-1549), and here it is fixed to a
-// non-audit target. This is sound because prepared queries are only ever
-// ACCOUNTS/TRANSACTIONS/LOGS (audit is gRPC-only, never a prepared-query target —
-// see http.preparedQueryTargets), and every non-audit target resolves the bare
-// intrinsic fields identically (`timestamp` → transaction range, `date` → log
-// range, `ledger` → LedgerCondition). Whether the resolved field is actually
-// valid on the query's specific stored target is still enforced downstream by the
-// FSM's ValidateFilterForTarget — this path only picks the proto arm, not the
-// validity.
-func DecodeDualFormatStructuralOnly(raw []byte) (*commonpb.QueryFilter, error) {
-	return decodeDualFormat(raw, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+//   - the prepared-query UPDATE path, which does not see the target (the target
+//     is immutable and lives on the stored query, so the FSM applies the gate
+//     against it — see handlers_update_prepared_query.go). It passes a non-audit
+//     target for resolution, which is sound because prepared queries are only
+//     ever ACCOUNTS/TRANSACTIONS/LOGS (audit is gRPC-only, never a prepared-query
+//     target — see http.preparedQueryTargets) and every non-audit target resolves
+//     the bare intrinsic fields identically (`timestamp` → transaction range,
+//     `date` → log range, `ledger` → LedgerCondition);
+//   - the ledgerctl list commands, which DO know their endpoint's target and pass
+//     it (audit list passes QUERY_TARGET_AUDIT so bare audit fields resolve to the
+//     audit arm) but let the server run the authoritative validity gate.
+//
+// Every server-side list handler MUST use DecodeDualFormat instead, so form and
+// validity are checked in one place.
+func DecodeDualFormatStructuralOnly(raw []byte, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
+	return decodeDualFormat(raw, target)
 }
 
 // decodeDualFormat performs form detection + parse, without the validity gate.

--- a/internal/pkg/filterexpr/decode_test.go
+++ b/internal/pkg/filterexpr/decode_test.go
@@ -290,7 +290,7 @@ func TestDecodeDualFormat_Malformed(t *testing.T) {
 func TestDecodeDualFormat_AuditTextOnly(t *testing.T) {
 	t.Parallel()
 
-	fromText, err := DecodeDualFormat([]byte(`audit[outcome] == failure`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	fromText, err := DecodeDualFormat([]byte(`outcome == failure`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
 	require.NoError(t, err, "textual audit filter must decode")
 	require.NotNil(t, fromText)
 	require.IsType(t, &commonpb.QueryFilter_Audit{}, fromText.GetFilter())
@@ -300,6 +300,40 @@ func TestDecodeDualFormat_AuditTextOnly(t *testing.T) {
 	// transaction/log conditions the JSON DSL already claims).
 	_, err = DecodeDualFormat([]byte(`{"$match":{"outcome":"failure"}}`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
 	require.Error(t, err, "audit has no structured JSON form; a structured filter must not decode to a valid audit condition")
+}
+
+// TestDecodeDualFormat_BareFieldTargetAwareResolution is the core EN-1549 check:
+// the SAME bare field name resolves to a different proto arm depending on the
+// query target. `timestamp` and `ledger` collide between the audit arm and the
+// transaction/ledger arms; the target is what disambiguates them.
+func TestDecodeDualFormat_BareFieldTargetAwareResolution(t *testing.T) {
+	t.Parallel()
+
+	// timestamp: audit arm on AUDIT, transaction builtin arm on TRANSACTIONS.
+	auditTs, err := DecodeDualFormat([]byte(`timestamp >= "2023-11-14T22:13:20Z"`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	require.NoError(t, err)
+	require.NotNil(t, auditTs.GetAudit(), "timestamp on AUDIT must resolve to the audit arm")
+	require.Equal(t, commonpb.AuditField_AUDIT_FIELD_TIMESTAMP, auditTs.GetAudit().GetField())
+
+	txTs, err := DecodeDualFormat([]byte(`timestamp >= "2023-11-14T22:13:20Z"`), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+	require.NoError(t, err)
+	require.NotNil(t, txTs.GetBuiltinUint(), "timestamp on TRANSACTIONS must resolve to the transaction builtin arm")
+
+	// ledger: audit ledger arm on AUDIT, LedgerCondition on LOGS.
+	auditLedger, err := DecodeDualFormat([]byte(`ledger == main`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	require.NoError(t, err)
+	require.NotNil(t, auditLedger.GetAudit(), "ledger on AUDIT must resolve to the audit arm")
+	require.Equal(t, commonpb.AuditField_AUDIT_FIELD_LEDGER, auditLedger.GetAudit().GetField())
+
+	logLedger, err := DecodeDualFormat([]byte(`ledger == main`), commonpb.QueryTarget_QUERY_TARGET_LOGS)
+	require.NoError(t, err)
+	require.NotNil(t, logLedger.GetLedger(), "ledger on LOGS must resolve to the LedgerCondition arm")
+
+	// An audit-only field name (outcome) has no meaning off the audit target: it
+	// is rejected at parse time on a non-audit target.
+	_, err = DecodeDualFormat([]byte(`outcome == failure`), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+	require.Error(t, err, "outcome must not resolve on a non-audit target")
+	require.Contains(t, err.Error(), "unknown field")
 }
 
 // TestDecodeDualFormatStructuralOnly_SkipsTargetGate confirms the update-path

--- a/internal/pkg/filterexpr/decode_test.go
+++ b/internal/pkg/filterexpr/decode_test.go
@@ -342,16 +342,32 @@ func TestDecodeDualFormat_BareFieldTargetAwareResolution(t *testing.T) {
 func TestDecodeDualFormatStructuralOnly_SkipsTargetGate(t *testing.T) {
 	t.Parallel()
 
-	// `ledger` is invalid on ACCOUNTS, but the structural-only decoder does not
-	// know the target and must accept it (the gate runs later against the stored
-	// target) in both forms.
-	fromText, err := DecodeDualFormatStructuralOnly([]byte(`ledger == "main"`))
+	// `ledger` is invalid on ACCOUNTS, but the structural-only decoder skips the
+	// per-target validity gate and must accept it (the gate runs later against the
+	// stored target) in both forms. The target is used only for bare-field
+	// resolution: on ACCOUNTS `ledger` resolves to the LedgerCondition arm,
+	// matching the JSON `$match` form.
+	fromText, err := DecodeDualFormatStructuralOnly([]byte(`ledger == "main"`), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	require.NoError(t, err)
 	require.NotNil(t, fromText)
 
-	fromJSON, err := DecodeDualFormatStructuralOnly([]byte(`{"$match":{"ledger":"main"}}`))
+	fromJSON, err := DecodeDualFormatStructuralOnly([]byte(`{"$match":{"ledger":"main"}}`), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 	require.NoError(t, err)
 	require.NotNil(t, fromJSON)
 
 	require.True(t, proto.Equal(fromText, fromJSON))
+}
+
+// TestDecodeDualFormatStructuralOnly_AuditTargetResolvesAuditArm confirms the
+// structural-only decoder honours QUERY_TARGET_AUDIT for bare-field resolution
+// (EN-1549) — the ledgerctl audit list path relies on this. A bare audit field
+// resolves to the audit arm and skips the validity gate.
+func TestDecodeDualFormatStructuralOnly_AuditTargetResolvesAuditArm(t *testing.T) {
+	t.Parallel()
+
+	f, err := DecodeDualFormatStructuralOnly([]byte(`outcome == failure`), commonpb.QueryTarget_QUERY_TARGET_AUDIT)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	require.NotNil(t, f.GetAudit())
+	require.Equal(t, commonpb.AuditField_AUDIT_FIELD_OUTCOME, f.GetAudit().GetField())
 }

--- a/internal/pkg/filterexpr/format.go
+++ b/internal/pkg/filterexpr/format.go
@@ -46,6 +46,8 @@ func formatFilter(f *commonpb.QueryFilter) (string, int) {
 		return formatNot(v.Not)
 	case *commonpb.QueryFilter_AccountHasAsset:
 		return formatAccountHasAsset(v.AccountHasAsset), precLeaf
+	case *commonpb.QueryFilter_Ledger:
+		return formatLedgerCondition(v.Ledger), precLeaf
 	case *commonpb.QueryFilter_Audit:
 		return formatAuditCondition(v.Audit)
 	case *commonpb.QueryFilter_BuiltinUint:
@@ -236,6 +238,17 @@ func formatAuditUintCondition(key string, field commonpb.AuditField, uc *commonp
 	}
 
 	return key + " <uint?>"
+}
+
+// formatLedgerCondition renders a non-audit LedgerCondition as `ledger == value`,
+// the inverse of the parser's `ledger == VALUE` production (a bare `ledger` field
+// on a non-audit target). The value renders as a `$param` reference or a
+// quote-if-needed hardcoded string, the same value path every other string
+// condition uses. On the audit target the ledger field is carried by the
+// AuditCondition arm instead (formatAuditCondition), so this only ever sees the
+// transaction/log/account ledger condition.
+func formatLedgerCondition(lc *commonpb.LedgerCondition) string {
+	return "ledger == " + formatStringCondValue(lc.GetCond())
 }
 
 // formatAccountHasAsset renders an AccountHasAssetCondition as `has asset BASE`

--- a/internal/pkg/filterexpr/format.go
+++ b/internal/pkg/filterexpr/format.go
@@ -92,7 +92,8 @@ func formatLogBuiltinUintCondition(lc *commonpb.LogBuiltinUintCondition) (string
 // clauses joined by `and` — `field > lo and field < hi` — which the parser folds
 // back into the same single condition (see foldDateRangeAnd), so the exclusivity
 // survives the round-trip instead of being silently widened. This is the
-// top-level counterpart of formatAuditUintCondition (prefixed with `audit[...]`).
+// transaction/log counterpart of formatAuditUintCondition; both now emit bare
+// field names, disambiguated only by the re-parse target (EN-1549).
 func formatDateUintCondition(field string, uc *commonpb.UintCondition) (string, int) {
 	render := renderDatetimeBound
 
@@ -173,30 +174,35 @@ var auditFieldNames = map[commonpb.AuditField]string{
 	commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE:     "order_type",
 }
 
-// formatAuditCondition renders an AuditCondition back into `audit[field] OP
-// value`, inverse of the parser's AuditCond production.
+// formatAuditCondition renders an AuditCondition back into the bare `field OP
+// value` form, inverse of the parser's FieldCond production on the audit target
+// (EN-1549). The `audit[...]` namespace prefix is gone: the audit fields are bare
+// (`outcome == failure`, `ledger == main`, `timestamp >= "…"`). The output is
+// only unambiguous when re-parsed on the audit target — `ledger`/`timestamp`
+// collide with the transaction/log arms otherwise — which is exactly the contract
+// (an audit filter is always re-parsed with QUERY_TARGET_AUDIT).
 func formatAuditCondition(ac *commonpb.AuditCondition) (string, int) {
 	key, ok := auditFieldNames[ac.GetField()]
 	if !ok {
-		return "audit[<unknown>]", precLeaf
+		return "<unknown audit field>", precLeaf
 	}
 
 	switch cond := ac.GetCondition().(type) {
 	case *commonpb.AuditCondition_StringCond:
-		return fmt.Sprintf("audit[%s] == %s", key, formatStringCondValue(cond.StringCond)), precLeaf
+		return fmt.Sprintf("%s == %s", key, formatStringCondValue(cond.StringCond)), precLeaf
 	case *commonpb.AuditCondition_UintCond:
 		// Audit ranges always render as `between`/single-bound (never an
 		// `and`-join), so they are always leaf-precedence.
 		return formatAuditUintCondition(key, ac.GetField(), cond.UintCond), precLeaf
 	default:
-		return fmt.Sprintf("audit[%s] <unknown>", key), precLeaf
+		return key + " <unknown>", precLeaf
 	}
 }
 
-// formatAuditUintCondition renders a UintCondition on an audit field. The audit
-// DSL only produces hardcoded bounds (no params), so only those are formatted.
-// The timestamp field is a datetime: its bounds render as quoted RFC3339 so the
-// output round-trips through the datetime-aware parser.
+// formatAuditUintCondition renders a UintCondition on a bare audit field. The
+// audit DSL only produces hardcoded bounds (no params), so only those are
+// formatted. The timestamp field is a datetime: its bounds render as quoted
+// RFC3339 so the output round-trips through the datetime-aware parser.
 func formatAuditUintCondition(key string, field commonpb.AuditField, uc *commonpb.UintCondition) string {
 	render := func(v uint64) string { return strconv.FormatUint(v, 10) }
 	if field == commonpb.AuditField_AUDIT_FIELD_TIMESTAMP {
@@ -204,11 +210,11 @@ func formatAuditUintCondition(key string, field commonpb.AuditField, uc *commonp
 	}
 
 	if uc.Min != nil && uc.Max != nil && uc.GetMin() == uc.GetMax() && !uc.GetMinExclusive() && !uc.GetMaxExclusive() {
-		return fmt.Sprintf("audit[%s] == %s", key, render(uc.GetMin()))
+		return fmt.Sprintf("%s == %s", key, render(uc.GetMin()))
 	}
 
 	if uc.Min != nil && uc.Max != nil {
-		return fmt.Sprintf("audit[%s] between %s and %s", key, render(uc.GetMin()), render(uc.GetMax()))
+		return fmt.Sprintf("%s between %s and %s", key, render(uc.GetMin()), render(uc.GetMax()))
 	}
 
 	if uc.Min != nil {
@@ -217,7 +223,7 @@ func formatAuditUintCondition(key string, field commonpb.AuditField, uc *commonp
 			op = ">"
 		}
 
-		return fmt.Sprintf("audit[%s] %s %s", key, op, render(uc.GetMin()))
+		return fmt.Sprintf("%s %s %s", key, op, render(uc.GetMin()))
 	}
 
 	if uc.Max != nil {
@@ -226,10 +232,10 @@ func formatAuditUintCondition(key string, field commonpb.AuditField, uc *commonp
 			op = "<"
 		}
 
-		return fmt.Sprintf("audit[%s] %s %s", key, op, render(uc.GetMax()))
+		return fmt.Sprintf("%s %s %s", key, op, render(uc.GetMax()))
 	}
 
-	return fmt.Sprintf("audit[%s] <uint?>", key)
+	return key + " <uint?>"
 }
 
 // formatAccountHasAsset renders an AccountHasAssetCondition as `has asset BASE`

--- a/internal/pkg/filterexpr/format_test.go
+++ b/internal/pkg/filterexpr/format_test.go
@@ -490,6 +490,12 @@ func TestFormatRoundTrip(t *testing.T) {
 		{"between mixed param/literal", "metadata[age] between 18 and $max", ""},
 		{"AND of ranges round-trips as between", "metadata[age] >= 18 and metadata[age] < 65", "metadata[age] >= 18 and metadata[age] < 65"},
 		{"complex: source and destination", `source ^= "a:" and destination ^= "b:"`, ""},
+		// EN-1549: a bare `ledger` condition on a non-audit target renders back to
+		// the same textual form (previously formatted as "<unknown filter>", which
+		// broke the prepared-query config export/apply round-trip).
+		{"ledger exact", "ledger == main", ""},
+		{"ledger quoted value", `ledger == "my-ledger"`, ""},
+		{"ledger param", "ledger == $name", ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/filterexpr/format_test.go
+++ b/internal/pkg/filterexpr/format_test.go
@@ -33,7 +33,7 @@ func TestFormatAccountHasAsset(t *testing.T) {
 	t.Run("round-trips through Parse", func(t *testing.T) {
 		t.Parallel()
 		for _, in := range []string{"has asset USD", "has asset USD/2"} {
-			f, err := Parse(in)
+			f, err := Parse(in, tx)
 			require.NoError(t, err)
 			assert.Equal(t, in, Format(f), "round-trip for %q", in)
 		}
@@ -495,7 +495,7 @@ func TestFormatRoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			parsed, err := Parse(tt.input)
+			parsed, err := Parse(tt.input, tx)
 			require.NoError(t, err)
 
 			got := Format(parsed)

--- a/internal/pkg/filterexpr/fuzz_test.go
+++ b/internal/pkg/filterexpr/fuzz_test.go
@@ -2,6 +2,8 @@ package filterexpr
 
 import (
 	"testing"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // FuzzFilterExprParse fuzzes the filter expression DSL parser.
@@ -43,10 +45,24 @@ func FuzzFilterExprParse(f *testing.F) {
 	f.Add(`metadata[key] == ""`)
 	f.Add(`metadata[key] == -9223372036854775808`)
 	f.Add(`address == "a:b:c:d:e:f:g"`)
+	// Bare, target-aware fields (EN-1549): resolved differently per target.
+	f.Add(`timestamp >= "2023-11-14T22:13:20Z"`)
+	f.Add(`ledger == main`)
+	f.Add(`outcome == failure`)
+	f.Add(`seq between 1000 and 2000`)
+	f.Add(`order_type in (create_transaction, revert_transaction)`)
+	f.Add(`proposal_id == 42`)
+	f.Add(`outcome == failure and ledger == main`)
 
 	f.Fuzz(func(t *testing.T, input string) {
-		// Parse must not panic on any input.
-		// Errors are expected for invalid input.
-		_, _ = Parse(input)
+		// Parse must not panic on any input, on any target. Errors are expected
+		// for invalid input; the audit target additionally exercises the bare
+		// audit-field resolution path.
+		for _, target := range []commonpb.QueryTarget{
+			commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+			commonpb.QueryTarget_QUERY_TARGET_AUDIT,
+		} {
+			_, _ = Parse(input, target)
+		}
 	})
 }

--- a/internal/pkg/filterexpr/parser.go
+++ b/internal/pkg/filterexpr/parser.go
@@ -31,8 +31,8 @@ const MaxParseDepth = 200
 var ErrFilterTooDeep = fmt.Errorf("filter expression nesting exceeds maximum depth (%d)", MaxParseDepth)
 
 // Custom lexer: Keywords are matched before Ident so that reserved words
-// (and, or, not, between, metadata, address, source, destination, exists,
-// true, false) cannot be consumed as bare values.
+// (and, or, not, in, between, metadata, address, source, destination, ledger,
+// exists, true, false) cannot be consumed as bare values.
 //
 // A bare Ident is plain-alphanumeric (`[a-zA-Z_][a-zA-Z0-9_]*`): it does NOT
 // include `-`, `:`, `.`, `/`. Any key or value that contains one of those special
@@ -60,7 +60,7 @@ var filterLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Dollar", Pattern: `\$`},
 	{Name: "String", Pattern: `"[^"]*"|'[^']*'`},
 	{Name: "Comma", Pattern: `,`},
-	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|audit|exists|true|false)\b`},
+	{Name: "Keyword", Pattern: `\b(and|or|not|in|between|metadata|address|source|destination|ledger|exists|true|false)\b`},
 	{Name: "Number", Pattern: `-?[0-9]+`},
 	// AssetRef is the base/precision asset reference (e.g. USD/2) used only in the
 	// `has asset` position. It is its own token — matched before Ident — because
@@ -75,7 +75,20 @@ var filterParser = participle.MustBuild[OrExpr](
 	participle.Elide("Whitespace"),
 )
 
-// Parse parses a human-readable filter expression into a QueryFilter.
+// Parse parses a human-readable filter expression into a QueryFilter, resolving
+// bare field names against target.
+//
+// The grammar is context-free, but a handful of bare fields are target-aware:
+// their proto arm depends on the query target. On QUERY_TARGET_AUDIT the bare
+// audit fields (seq, proposal_id, timestamp, log_seq, outcome, caller_subject,
+// ledger, order_type) resolve to the AuditCondition arm; on every other target
+// the intrinsic fields resolve to their own arms — `timestamp` to the
+// transaction builtin range, `date` to the log builtin range, `ledger` to the
+// LedgerCondition — and the audit-only field names are rejected (they carry no
+// meaning off the audit target). This is what lets a single flat DSL serve both
+// audit reads (`outcome == failure`, `ledger == main`, `timestamp >= "…"`) and
+// transaction/log reads (`timestamp >= "…"`, `ledger == main`) without an
+// `audit[…]` namespace prefix (EN-1549).
 //
 // Grammar:
 //
@@ -84,11 +97,12 @@ var filterParser = participle.MustBuild[OrExpr](
 //	and_expr       := unary_expr ("and" unary_expr)*
 //	unary_expr     := "not" unary_expr | primary
 //	:= "(" expression ")" | condition
-//	:= metadata_cond | address_cond | source_cond | destination_cond
+//	:= asset_cond | metadata_cond | address_cond | field_cond
 //	metadata_cond  := "metadata" "[" KEY "]" ("==" VALUE | "!=" VALUE | ">" VALUE | ">=" VALUE | "<" VALUE | "<=" VALUE | "between" VALUE "and" VALUE | "exists" | "in" "(" VALUE ("," VALUE)* ")")
 //	address_cond   := ("address" | "source" | "destination") ("==" VALUE | "^=" VALUE | "in" "(" VALUE ("," VALUE)* ")")
+//	field_cond     := FIELD ("==" VALUE | ">" VALUE | ">=" VALUE | "<" VALUE | "<=" VALUE | "between" VALUE "and" VALUE | "in" "(" VALUE ("," VALUE)* ")")
 //	value          := "$" Ident | "true" | "false" | String | Number | Ident
-func Parse(input string) (*commonpb.QueryFilter, error) {
+func Parse(input string, target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	// Reject pathologically nested inputs BEFORE handing them to
 	// participle. Participle's recursive-descent parser would
 	// otherwise stack-overflow on counts beyond a few thousand,
@@ -103,7 +117,7 @@ func Parse(input string) (*commonpb.QueryFilter, error) {
 		return nil, fmt.Errorf("parse error: %w", err)
 	}
 
-	return ast.toProto()
+	return ast.toProto(target)
 }
 
 // --- AST types ---
@@ -112,14 +126,14 @@ type OrExpr struct {
 	Operands []*AndExpr `parser:"@@ ('or' @@)*"`
 }
 
-func (e *OrExpr) toProto() (*commonpb.QueryFilter, error) {
+func (e *OrExpr) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if len(e.Operands) == 1 {
-		return e.Operands[0].toProto()
+		return e.Operands[0].toProto(target)
 	}
 
 	filters := make([]*commonpb.QueryFilter, len(e.Operands))
 	for i, op := range e.Operands {
-		f, err := op.toProto()
+		f, err := op.toProto(target)
 		if err != nil {
 			return nil, err
 		}
@@ -138,14 +152,14 @@ type AndExpr struct {
 	Operands []*UnaryExpr `parser:"@@ ('and' @@)*"`
 }
 
-func (e *AndExpr) toProto() (*commonpb.QueryFilter, error) {
+func (e *AndExpr) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if len(e.Operands) == 1 {
-		return e.Operands[0].toProto()
+		return e.Operands[0].toProto(target)
 	}
 
 	filters := make([]*commonpb.QueryFilter, len(e.Operands))
 	for i, op := range e.Operands {
-		f, err := op.toProto()
+		f, err := op.toProto(target)
 		if err != nil {
 			return nil, err
 		}
@@ -257,9 +271,9 @@ type UnaryExpr struct {
 	Primary *Primary   `parser:"| @@"`
 }
 
-func (e *UnaryExpr) toProto() (*commonpb.QueryFilter, error) {
+func (e *UnaryExpr) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if e.Not != nil {
-		inner, err := e.Not.toProto()
+		inner, err := e.Not.toProto(target)
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +285,7 @@ func (e *UnaryExpr) toProto() (*commonpb.QueryFilter, error) {
 		}, nil
 	}
 
-	return e.Primary.toProto()
+	return e.Primary.toProto(target)
 }
 
 type Primary struct {
@@ -279,24 +293,28 @@ type Primary struct {
 	Condition *Condition `parser:"| @@"`
 }
 
-func (p *Primary) toProto() (*commonpb.QueryFilter, error) {
+func (p *Primary) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if p.Group != nil {
-		return p.Group.toProto()
+		return p.Group.toProto(target)
 	}
 
-	return p.Condition.toProto()
+	return p.Condition.toProto(target)
 }
 
+// Condition tries the specialized productions first (asset / metadata / address),
+// then falls back to the generic FieldCond for every bare `field OP value` form
+// — the intrinsic fields (`timestamp`, `date`, `ledger`) and the bare audit
+// fields. PEG alternation ordering matters: FieldCond's `@(Ident | Keyword)`
+// would otherwise swallow the `has`/`metadata`/`address` lead tokens, so it must
+// come last.
 type Condition struct {
 	Asset    *AssetCond    `parser:"  @@"`
 	Metadata *MetadataCond `parser:"| @@"`
-	Audit    *AuditCond    `parser:"| @@"`
-	Date     *DateCond     `parser:"| @@"`
 	Address  *AddressCond  `parser:"| @@"`
-	Ledger   *LedgerCond   `parser:"| @@"`
+	Field    *FieldCond    `parser:"| @@"`
 }
 
-func (c *Condition) toProto() (*commonpb.QueryFilter, error) {
+func (c *Condition) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
 	if c.Asset != nil {
 		return c.Asset.toProto()
 	}
@@ -305,31 +323,40 @@ func (c *Condition) toProto() (*commonpb.QueryFilter, error) {
 		return c.Metadata.toProto()
 	}
 
-	if c.Audit != nil {
-		return c.Audit.toProto()
-	}
-
-	if c.Date != nil {
-		return c.Date.toProto()
-	}
-
-	if c.Ledger != nil {
-		return c.Ledger.toProto()
+	if c.Field != nil {
+		return c.Field.toProto(target)
 	}
 
 	return c.Address.toProto()
 }
 
-// --- Audit conditions ---
+// --- Bare field conditions ---
 
-// AuditCond is the `audit[field] OP value` filter over the audit trail. It maps
-// to a commonpb.AuditCondition resolved by the readstore audit index. Only the
-// index-answerable fields are accepted; NOT-style operators (`!=`) are not
-// exposed because the audit access path has no complement, so they would have
-// to fall back to a full scan.
-type AuditCond struct {
-	Field string      `parser:"'audit' '[' @(Ident | Keyword) ']'"`
+// FieldCond is the generic `field OP value` production for bare, target-aware
+// field names: the intrinsic fields (`timestamp`, `date`, `ledger`) and — on the
+// audit target — the audit fields (seq, proposal_id, timestamp, log_seq, outcome,
+// caller_subject, ledger, order_type). Which proto arm the field resolves to is
+// decided at toProto time from the query target (EN-1549), not by the grammar.
+//
+// `@(Ident | Keyword)` admits both a plain identifier field (`timestamp`, `seq`,
+// `date`) and a keyword field (`ledger` is a lexer keyword). It deliberately sits
+// last in the Condition alternation so the specialized asset/metadata/address
+// productions win their lead tokens first.
+type FieldCond struct {
+	Field string      `parser:"@(Ident | Keyword)"`
 	Op    *MetadataOp `parser:"@@"`
+}
+
+func (a *FieldCond) toProto(target commonpb.QueryTarget) (*commonpb.QueryFilter, error) {
+	if a.Op == nil {
+		return nil, fmt.Errorf("field %q requires an operator", a.Field)
+	}
+
+	if target == commonpb.QueryTarget_QUERY_TARGET_AUDIT {
+		return a.auditToProto()
+	}
+
+	return a.intrinsicToProto()
 }
 
 type auditFieldKind int
@@ -362,14 +389,12 @@ var auditFieldKeys = map[string]auditFieldSpec{
 	"order_type":     {commonpb.AuditField_AUDIT_FIELD_ORDER_TYPE, auditKindString},
 }
 
-func (a *AuditCond) toProto() (*commonpb.QueryFilter, error) {
+// auditToProto resolves a bare field on the AUDIT target into the matching
+// AuditCondition arm.
+func (a *FieldCond) auditToProto() (*commonpb.QueryFilter, error) {
 	spec, ok := auditFieldKeys[a.Field]
 	if !ok {
 		return nil, fmt.Errorf("unknown audit field %q", a.Field)
-	}
-
-	if a.Op == nil {
-		return nil, fmt.Errorf("audit field %q requires an operator", a.Field)
 	}
 
 	switch spec.kind {
@@ -384,13 +409,33 @@ func (a *AuditCond) toProto() (*commonpb.QueryFilter, error) {
 	}
 }
 
+// intrinsicToProto resolves a bare field on a non-audit target (transactions /
+// logs / accounts) into its own proto arm: `timestamp` → transaction builtin
+// range, `date` → log builtin range, `ledger` → LedgerCondition. Any other bare
+// name (including the audit-only fields) is rejected: those field names carry no
+// meaning off the audit target and would otherwise silently vanish. Whether a
+// resolved field is valid on the SPECIFIC non-audit target (e.g. `date` on
+// transactions) is not decided here — the downstream per-target validity gate
+// (domain.ValidateFilterForTarget) handles that, the same way the structured JSON
+// DSL does.
+func (a *FieldCond) intrinsicToProto() (*commonpb.QueryFilter, error) {
+	switch a.Field {
+	case "timestamp", "date":
+		return a.dateToProto()
+	case "ledger":
+		return a.ledgerToProto()
+	default:
+		return nil, fmt.Errorf("unknown field %q", a.Field)
+	}
+}
+
 func auditQF(field commonpb.AuditField, cond *commonpb.AuditCondition) *commonpb.QueryFilter {
 	cond.Field = field
 
 	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: cond}}
 }
 
-func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+func (a *FieldCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
 	parse := func(v *Value) (uint64, error) {
 		if v.Param != "" {
 			return 0, fmt.Errorf("audit field %q does not support parameters", a.Field)
@@ -412,7 +457,7 @@ func (a *AuditCond) uintToProto(field commonpb.AuditField) (*commonpb.QueryFilte
 // microseconds. Both forms coerce to the uint64 microseconds the audit index
 // stores, through the shared commonpb.CoerceDatetimeMicros (the same coercion the
 // structured JSON DSL and the top-level date/timestamp fields use, EN-1544).
-func (a *AuditCond) datetimeToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+func (a *FieldCond) datetimeToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
 	parse := func(v *Value) (uint64, error) {
 		if v.Param != "" {
 			return 0, fmt.Errorf("audit field %q does not support parameters", a.Field)
@@ -427,7 +472,7 @@ func (a *AuditCond) datetimeToProto(field commonpb.AuditField) (*commonpb.QueryF
 // coerceDatetimeValue turns a resolved DSL Value into the uint64 microseconds a
 // date index stores, accepting an RFC3339 timestamp or raw unsigned microseconds
 // through the single shared coercion (commonpb.CoerceDatetimeMicros). Pre-epoch
-// RFC3339 values are rejected there. Shared by the audit[timestamp] field and the
+// RFC3339 values are rejected there. Shared by the audit timestamp field and the
 // top-level date/timestamp fields (EN-1544) so all three define the accepted
 // forms once. Callers reject $param operands before calling this.
 func coerceDatetimeValue(v *Value) (uint64, error) {
@@ -437,7 +482,7 @@ func coerceDatetimeValue(v *Value) (uint64, error) {
 // uintProtoWithParse assembles a uint audit condition from the operator, using
 // parse to turn each operand into a uint64. Shared by plain-uint fields and the
 // datetime timestamp field.
-func (a *AuditCond) uintProtoWithParse(field commonpb.AuditField, parse func(*Value) (uint64, error)) (*commonpb.QueryFilter, error) {
+func (a *FieldCond) uintProtoWithParse(field commonpb.AuditField, parse func(*Value) (uint64, error)) (*commonpb.QueryFilter, error) {
 	uc, err := uintConditionFromOp(a.Op, parse)
 	if err != nil {
 		return nil, fmt.Errorf("audit field %q: %w", a.Field, err)
@@ -505,7 +550,7 @@ func uintConditionFromOp(op *MetadataOp, parse func(*Value) (uint64, error)) (*c
 	return uc, nil
 }
 
-func (a *AuditCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
+func (a *FieldCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFilter, error) {
 	op := a.Op
 
 	// Audit filters are evaluated without a parameter-resolution context, so a
@@ -542,35 +587,26 @@ func (a *AuditCond) stringToProto(field commonpb.AuditField) (*commonpb.QueryFil
 
 // --- Date / timestamp conditions ---
 
-// DateCond is the top-level `date OP value` (logs) / `timestamp OP value`
-// (transactions) range filter over a builtin date index (EN-1544). The operand
-// is an RFC3339 timestamp (quoted, e.g. "2023-11-14T22:13:20Z") or raw unsigned
-// microseconds — the same forms audit[timestamp] accepts, coerced through the one
-// shared datetime coercion. `date` compiles to a log date condition
-// (LogBuiltinIndex_DATE); `timestamp` to a transaction timestamp condition
-// (TransactionBuiltinIndex_TIMESTAMP). Which target each is valid on is NOT
-// decided here: the field just selects the proto arm, and the per-target validity
-// gate (domain.ValidateFilterForTarget) rejects `date` on a non-logs target and
-// `timestamp` on a non-transactions target downstream — the same gate the
-// structured JSON DSL goes through.
+// dateToProto is the non-audit resolution of the bare `date OP value` (logs) /
+// `timestamp OP value` (transactions) range filter over a builtin date index
+// (EN-1544). The operand is an RFC3339 timestamp (quoted, e.g.
+// "2023-11-14T22:13:20Z") or raw unsigned microseconds — the same forms the audit
+// timestamp field accepts, coerced through the one shared datetime coercion.
+// `date` compiles to a log date condition (LogBuiltinIndex_DATE); `timestamp` to
+// a transaction timestamp condition (TransactionBuiltinIndex_TIMESTAMP). Which
+// target each is valid on is NOT decided here: the field just selects the proto
+// arm, and the per-target validity gate (domain.ValidateFilterForTarget) rejects
+// `date` on a non-logs target and `timestamp` on a non-transactions target
+// downstream — the same gate the structured JSON DSL goes through.
 //
-// `date`/`timestamp` are deliberately NOT lexer keywords: participle matches the
-// `'date'`/`'timestamp'` grammar literals against the plain `Ident` token by
-// value, so they act as field names at condition position while remaining usable
-// as ordinary identifiers everywhere else. Making them keywords would tokenize
-// only the prefix of an identifier that continues with an Ident-continuation char
-// (`-`, `:`, `.`, `/`) — e.g. `metadata[date-range]` — because the keyword `\b`
-// boundary matches before those characters, breaking filters that parsed before.
-type DateCond struct {
-	Field string      `parser:"@('date' | 'timestamp')"`
-	Op    *MetadataOp `parser:"@@"`
-}
-
-func (d *DateCond) toProto() (*commonpb.QueryFilter, error) {
-	if d.Op == nil {
-		return nil, fmt.Errorf("%s field requires an operator", d.Field)
-	}
-
+// `date`/`timestamp` are matched by the generic FieldCond production against the
+// plain `Ident` token (they are NOT lexer keywords), so they act as field names
+// at condition position while remaining usable as ordinary identifiers everywhere
+// else. Making them keywords would tokenize only the prefix of an identifier that
+// continues with an Ident-continuation char (`-`, `:`, `.`, `/`) — e.g.
+// `metadata[date-range]` — because the keyword `\b` boundary matches before those
+// characters, breaking filters that parsed before.
+func (d *FieldCond) dateToProto() (*commonpb.QueryFilter, error) {
 	parse := func(v *Value) (uint64, error) {
 		if v.Param != "" {
 			return 0, fmt.Errorf("%s field does not support parameters", d.Field)
@@ -600,7 +636,7 @@ func (d *DateCond) toProto() (*commonpb.QueryFilter, error) {
 			},
 		}}, nil
 	default:
-		// Unreachable: the grammar only admits "date" | "timestamp".
+		// Unreachable: intrinsicToProto only routes "date"/"timestamp" here.
 		return nil, fmt.Errorf("invariant: unhandled date field %q", d.Field)
 	}
 }
@@ -733,16 +769,22 @@ func (op *MetadataOp) toProto(field *commonpb.FieldRef) (*commonpb.QueryFilter, 
 
 // --- Ledger conditions ---
 
-type LedgerCond struct {
-	Exact *Value `parser:"'ledger' '==' @@"`
-}
+// ledgerToProto is the non-audit resolution of the bare `ledger == value` filter
+// into a LedgerCondition. Only equality is meaningful (the ledger name is an
+// exact string match, and a param is honored at execution time), so any other
+// operator is rejected — mirroring the pre-EN-1549 `ledger == VALUE`-only
+// grammar. On the audit target the same `ledger ==` shape resolves to the audit
+// ledger arm instead (see auditToProto).
+func (l *FieldCond) ledgerToProto() (*commonpb.QueryFilter, error) {
+	if l.Op.Eq == nil {
+		return nil, errors.New("ledger field supports == only")
+	}
 
-func (l *LedgerCond) toProto() (*commonpb.QueryFilter, error) {
 	cond := &commonpb.StringCondition{}
-	if l.Exact.Param != "" {
-		cond.Value = &commonpb.StringCondition_Param{Param: l.Exact.Param}
+	if l.Op.Eq.Param != "" {
+		cond.Value = &commonpb.StringCondition_Param{Param: l.Op.Eq.Param}
 	} else {
-		cond.Value = &commonpb.StringCondition_Hardcoded{Hardcoded: l.Exact.resolve()}
+		cond.Value = &commonpb.StringCondition_Hardcoded{Hardcoded: l.Op.Eq.resolve()}
 	}
 
 	return &commonpb.QueryFilter{
@@ -809,11 +851,11 @@ type Value struct {
 	Bool  string `parser:"| @('true' | 'false')"`
 	// Kw accepts the "noun" keywords as bare right-hand-side values so that a
 	// reserved word can still be used as an unquoted value (e.g.
-	// `metadata[type] == audit` / `== ledger` / `== source`). Only field/prefix
-	// keywords are listed — the structural operators (and/or/not/in/between)
-	// are deliberately excluded so they keep terminating expressions rather
-	// than being swallowed as values. true/false are handled by Bool above.
-	Kw   string `parser:"| @('metadata' | 'address' | 'source' | 'destination' | 'ledger' | 'audit' | 'exists')"`
+	// `metadata[type] == ledger` / `== source`). Only field/prefix keywords are
+	// listed — the structural operators (and/or/not/in/between) are deliberately
+	// excluded so they keep terminating expressions rather than being swallowed
+	// as values. true/false are handled by Bool above.
+	Kw   string `parser:"| @('metadata' | 'address' | 'source' | 'destination' | 'ledger' | 'exists')"`
 	Bare string `parser:"| @Ident"`
 }
 

--- a/internal/pkg/filterexpr/parser_test.go
+++ b/internal/pkg/filterexpr/parser_test.go
@@ -16,7 +16,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata string equality", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] == premium")
+		filter, err := Parse("metadata[category] == premium", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -30,7 +30,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata quoted value", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`metadata[name] == "hello world"`)
+		filter, err := Parse(`metadata[name] == "hello world"`, tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -44,7 +44,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata single-quoted value", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[name] == 'hello world'")
+		filter, err := Parse("metadata[name] == 'hello world'", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -57,7 +57,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata boolean true", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[active] == true")
+		filter, err := Parse("metadata[active] == true", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -70,7 +70,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata boolean false", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[active] == false")
+		filter, err := Parse("metadata[active] == false", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -86,7 +86,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata integer", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] == 42")
+		filter, err := Parse("metadata[age] == 42", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -102,7 +102,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata negative integer", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[score] == -5")
+		filter, err := Parse("metadata[score] == -5", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -116,7 +116,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata exists", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] exists")
+		filter, err := Parse("metadata[category] exists", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -128,7 +128,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata not equal desugars to not", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] != premium")
+		filter, err := Parse("metadata[category] != premium", tx)
 		require.NoError(t, err)
 
 		notF := filter.GetNot()
@@ -144,7 +144,7 @@ func TestParse(t *testing.T) {
 	t.Run("address exact", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`address == "users:alice"`)
+		filter, err := Parse(`address == "users:alice"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -155,7 +155,7 @@ func TestParse(t *testing.T) {
 	t.Run("address prefix", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`address ^= "users:"`)
+		filter, err := Parse(`address ^= "users:"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -167,7 +167,7 @@ func TestParse(t *testing.T) {
 		t.Parallel()
 
 		// A `:` is not a bare-Ident char (EN-1547): the prefix must be quoted.
-		filter, err := Parse(`address ^= "users:"`)
+		filter, err := Parse(`address ^= "users:"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -175,14 +175,14 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, "users:", am.GetHardcodedPrefix())
 
 		// The bare (unquoted) punctuated form is rejected.
-		_, err = Parse("address ^= users:")
+		_, err = Parse("address ^= users:", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("AND", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[a] == x and metadata[b] == y")
+		filter, err := Parse("metadata[a] == x and metadata[b] == y", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 	t.Run("OR", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[a] == x or metadata[b] == y")
+		filter, err := Parse("metadata[a] == x or metadata[b] == y", tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -212,7 +212,7 @@ func TestParse(t *testing.T) {
 	t.Run("precedence: and binds tighter than or", func(t *testing.T) {
 		t.Parallel()
 		// "a or b and c" should parse as "a or (b and c)"
-		filter, err := Parse("metadata[a] == x or metadata[b] == y and metadata[c] == z")
+		filter, err := Parse("metadata[a] == x or metadata[b] == y and metadata[c] == z", tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -231,7 +231,7 @@ func TestParse(t *testing.T) {
 	t.Run("grouping overrides precedence", func(t *testing.T) {
 		t.Parallel()
 		// "(a or b) and c" should have AND at top level
-		filter, err := Parse("(metadata[a] == x or metadata[b] == y) and metadata[c] == z")
+		filter, err := Parse("(metadata[a] == x or metadata[b] == y) and metadata[c] == z", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -247,7 +247,7 @@ func TestParse(t *testing.T) {
 	t.Run("NOT", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("not metadata[a] == x")
+		filter, err := Parse("not metadata[a] == x", tx)
 		require.NoError(t, err)
 
 		notF := filter.GetNot()
@@ -258,7 +258,7 @@ func TestParse(t *testing.T) {
 	t.Run("NOT with grouping", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("not (metadata[a] == x or metadata[b] == y)")
+		filter, err := Parse("not (metadata[a] == x or metadata[b] == y)", tx)
 		require.NoError(t, err)
 
 		notF := filter.GetNot()
@@ -271,7 +271,7 @@ func TestParse(t *testing.T) {
 	t.Run("multiple AND operands", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[a] == x and metadata[b] == y and metadata[c] == z")
+		filter, err := Parse("metadata[a] == x and metadata[b] == y and metadata[c] == z", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -282,28 +282,28 @@ func TestParse(t *testing.T) {
 	t.Run("error: empty expression", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("")
+		_, err := Parse("", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("error: missing operator", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("metadata[key]")
+		_, err := Parse("metadata[key]", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("error: missing value", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("metadata[key] ==")
+		_, err := Parse("metadata[key] ==", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("source exact", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`source == "merchants:alice"`)
+		filter, err := Parse(`source == "merchants:alice"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -315,7 +315,7 @@ func TestParse(t *testing.T) {
 	t.Run("source prefix", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`source ^= "merchants:"`)
+		filter, err := Parse(`source ^= "merchants:"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -327,7 +327,7 @@ func TestParse(t *testing.T) {
 	t.Run("destination exact", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`destination == "users:bob"`)
+		filter, err := Parse(`destination == "users:bob"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -339,7 +339,7 @@ func TestParse(t *testing.T) {
 	t.Run("destination prefix", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`destination ^= "users:"`)
+		filter, err := Parse(`destination ^= "users:"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -351,7 +351,7 @@ func TestParse(t *testing.T) {
 	t.Run("source and destination combined", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`source ^= "a:" and destination ^= "b:"`)
+		filter, err := Parse(`source ^= "a:" and destination ^= "b:"`, tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -372,7 +372,7 @@ func TestParse(t *testing.T) {
 	t.Run("address has ANY role by default", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`address == "users:alice"`)
+		filter, err := Parse(`address == "users:alice"`, tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -383,7 +383,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata greater than", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] > 18")
+		filter, err := Parse("metadata[age] > 18", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -400,7 +400,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata greater than or equal", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] >= 18")
+		filter, err := Parse("metadata[age] >= 18", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -417,7 +417,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata less than", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] < 65")
+		filter, err := Parse("metadata[age] < 65", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -434,7 +434,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata less than or equal", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] <= 65")
+		filter, err := Parse("metadata[age] <= 65", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -451,7 +451,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata range combined with AND", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] >= 18 and metadata[age] < 65")
+		filter, err := Parse("metadata[age] >= 18 and metadata[age] < 65", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -478,7 +478,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata negative integer range", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[score] > -10")
+		filter, err := Parse("metadata[score] > -10", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -493,7 +493,7 @@ func TestParse(t *testing.T) {
 	t.Run("error: string range not supported", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse(`metadata[name] > "alice"`)
+		_, err := Parse(`metadata[name] > "alice"`, tx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "range operators only support integer values")
 	})
@@ -501,7 +501,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata between inclusive range", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[block_height] between 800000 and 800099")
+		filter, err := Parse("metadata[block_height] between 800000 and 800099", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -522,7 +522,7 @@ func TestParse(t *testing.T) {
 
 		// `between X and X` compiles to a single value — same shape as `== X`,
 		// so the downstream PrefixIterator fast path applies.
-		filter, err := Parse("metadata[age] between 42 and 42")
+		filter, err := Parse("metadata[age] between 42 and 42", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -536,7 +536,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata between with parameters", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] between $low and $high")
+		filter, err := Parse("metadata[age] between $low and $high", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -552,7 +552,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata between mixed param and literal", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] between 18 and $max")
+		filter, err := Parse("metadata[age] between 18 and $max", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -568,7 +568,7 @@ func TestParse(t *testing.T) {
 		t.Parallel()
 
 		// The inner `and` belongs to BetweenRange; the outer `and` to AndExpr.
-		filter, err := Parse("metadata[a] between 1 and 10 and metadata[b] == foo")
+		filter, err := Parse("metadata[a] between 1 and 10 and metadata[b] == foo", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -588,7 +588,7 @@ func TestParse(t *testing.T) {
 	t.Run("error: between with reversed bounds", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("metadata[age] between 100 and 10")
+		_, err := Parse("metadata[age] between 100 and 10", tx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of order")
 	})
@@ -596,7 +596,7 @@ func TestParse(t *testing.T) {
 	t.Run("error: between with non-integer value", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse(`metadata[name] between "alice" and "bob"`)
+		_, err := Parse(`metadata[name] between "alice" and "bob"`, tx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "range operators only support integer values")
 	})
@@ -605,7 +605,7 @@ func TestParse(t *testing.T) {
 		t.Parallel()
 
 		// Exercises the param-branch high-side parseIntValue error path.
-		_, err := Parse(`metadata[name] between $lo and "bob"`)
+		_, err := Parse(`metadata[name] between $lo and "bob"`, tx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "range operators only support integer values")
 	})
@@ -614,7 +614,7 @@ func TestParse(t *testing.T) {
 		t.Parallel()
 
 		// Exercises the param-branch low-side parseIntValue error path.
-		_, err := Parse(`metadata[name] between "alice" and $hi`)
+		_, err := Parse(`metadata[name] between "alice" and $hi`, tx)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "range operators only support integer values")
 	})
@@ -622,21 +622,21 @@ func TestParse(t *testing.T) {
 	t.Run("error: unknown keyword", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("foobar == 42")
+		_, err := Parse("foobar == 42", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("error: trailing tokens", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("metadata[key] == val extra")
+		_, err := Parse("metadata[key] == val extra", tx)
 		require.Error(t, err)
 	})
 
 	t.Run("error: unclosed parenthesis", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("(metadata[key] == val")
+		_, err := Parse("(metadata[key] == val", tx)
 		require.Error(t, err)
 	})
 
@@ -645,7 +645,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata string equality", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] == $val")
+		filter, err := Parse("metadata[category] == $val", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -659,7 +659,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata != desugars to not param", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] != $val")
+		filter, err := Parse("metadata[category] != $val", tx)
 		require.NoError(t, err)
 
 		notF := filter.GetNot()
@@ -674,7 +674,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata greater than", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] > $min")
+		filter, err := Parse("metadata[age] > $min", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -689,7 +689,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata greater than or equal", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] >= $min")
+		filter, err := Parse("metadata[age] >= $min", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -703,7 +703,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata less than", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] < $max")
+		filter, err := Parse("metadata[age] < $max", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -718,7 +718,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: metadata less than or equal", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] <= $max")
+		filter, err := Parse("metadata[age] <= $max", tx)
 		require.NoError(t, err)
 
 		fc := filter.GetField()
@@ -732,7 +732,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: address exact", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("address == $addr")
+		filter, err := Parse("address == $addr", tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -744,7 +744,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: address prefix", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("address ^= $prefix")
+		filter, err := Parse("address ^= $prefix", tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -755,7 +755,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: source exact", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("source == $src")
+		filter, err := Parse("source == $src", tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -767,7 +767,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: destination prefix", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("destination ^= $dst")
+		filter, err := Parse("destination ^= $dst", tx)
 		require.NoError(t, err)
 
 		am := filter.GetAddress()
@@ -779,7 +779,7 @@ func TestParse(t *testing.T) {
 	t.Run("param: combined with hardcoded in AND", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[tier] == $tier and metadata[age] >= $min_age")
+		filter, err := Parse("metadata[tier] == $tier and metadata[age] >= $min_age", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -805,7 +805,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in with strings", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`metadata[category] in (premium, gold, silver)`)
+		filter, err := Parse(`metadata[category] in (premium, gold, silver)`, tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -825,7 +825,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in with quoted strings", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`metadata[name] in ("hello world", "foo bar")`)
+		filter, err := Parse(`metadata[name] in ("hello world", "foo bar")`, tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -844,7 +844,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in with integers", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[age] in (18, 25, 30)")
+		filter, err := Parse("metadata[age] in (18, 25, 30)", tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -862,7 +862,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in with single value collapses", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] in (premium)")
+		filter, err := Parse("metadata[category] in (premium)", tx)
 		require.NoError(t, err)
 
 		// Single value: no OrFilter wrapper, direct field condition.
@@ -877,7 +877,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in with params", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] in ($a, $b)")
+		filter, err := Parse("metadata[category] in ($a, $b)", tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -891,7 +891,7 @@ func TestParse(t *testing.T) {
 	t.Run("address in", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`address in ("users:alice", "users:bob")`)
+		filter, err := Parse(`address in ("users:alice", "users:bob")`, tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -911,7 +911,7 @@ func TestParse(t *testing.T) {
 	t.Run("source in", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse(`source in ("bank:main", "bank:secondary")`)
+		filter, err := Parse(`source in ("bank:main", "bank:secondary")`, tx)
 		require.NoError(t, err)
 
 		orF := filter.GetOr()
@@ -927,7 +927,7 @@ func TestParse(t *testing.T) {
 	t.Run("metadata in combined with AND", func(t *testing.T) {
 		t.Parallel()
 
-		filter, err := Parse("metadata[category] in (a, b) and metadata[status] == active")
+		filter, err := Parse("metadata[category] in (a, b) and metadata[status] == active", tx)
 		require.NoError(t, err)
 
 		andF := filter.GetAnd()
@@ -948,7 +948,7 @@ func TestParse(t *testing.T) {
 	t.Run("error: metadata in empty list", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := Parse("metadata[category] in ()")
+		_, err := Parse("metadata[category] in ()", tx)
 		require.Error(t, err)
 	})
 
@@ -961,7 +961,7 @@ func TestParse(t *testing.T) {
 
 		input := strings.Repeat("not ", MaxParseDepth+5) + "metadata[x] == y"
 
-		_, err := Parse(input)
+		_, err := Parse(input, tx)
 		require.ErrorIs(t, err, ErrFilterTooDeep,
 			"deeply-nested `not` chain must trip the depth guard before participle (#341)")
 	})
@@ -972,7 +972,7 @@ func TestParse(t *testing.T) {
 		opens := strings.Repeat("(", MaxParseDepth+5)
 		closes := strings.Repeat(")", MaxParseDepth+5)
 
-		_, err := Parse(opens + "metadata[x] == y" + closes)
+		_, err := Parse(opens+"metadata[x] == y"+closes, tx)
 		require.ErrorIs(t, err, ErrFilterTooDeep,
 			"deeply-nested parens must trip the depth guard before participle (#341)")
 	})
@@ -984,7 +984,7 @@ func TestParse_HasAsset(t *testing.T) {
 	t.Run("bare asset is precision 0", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := Parse("has asset USD")
+		f, err := Parse("has asset USD", tx)
 		require.NoError(t, err)
 		c := f.GetAccountHasAsset()
 		require.NotNil(t, c)
@@ -995,7 +995,7 @@ func TestParse_HasAsset(t *testing.T) {
 	t.Run("asset with precision", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := Parse("has asset USD/4")
+		f, err := Parse("has asset USD/4", tx)
 		require.NoError(t, err)
 		c := f.GetAccountHasAsset()
 		require.NotNil(t, c)
@@ -1006,7 +1006,7 @@ func TestParse_HasAsset(t *testing.T) {
 	t.Run("combined with metadata", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := Parse("has asset USD and metadata[type] == premium")
+		f, err := Parse("has asset USD and metadata[type] == premium", tx)
 		require.NoError(t, err)
 		require.NotNil(t, f.GetAnd())
 		require.Len(t, f.GetAnd().GetFilters(), 2)
@@ -1024,8 +1024,8 @@ func TestParse_HasAsset(t *testing.T) {
 			"has asset USD/abc", "has asset USD/256", "has asset USD/2/3", "has asset USD/",
 			"has asset USD/0", "has asset USD/02", "has asset USD/00",
 		} {
-			_, err := Parse(in)
-			require.Error(t, err, "Parse(%q) should reject the non-canonical precision", in)
+			_, err := Parse(in, tx)
+			require.Error(t, err, "Parse(%q, tx) should reject the non-canonical precision", in)
 		}
 	})
 }
@@ -1039,7 +1039,7 @@ func TestParse_HasAssetKeywordsNotReserved(t *testing.T) {
 	t.Run("has is a usable bare address value", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := Parse("address == has")
+		f, err := Parse("address == has", tx)
 		require.NoError(t, err)
 		assert.Equal(t, "has", f.GetAddress().GetHardcodedExact())
 	})
@@ -1047,7 +1047,7 @@ func TestParse_HasAssetKeywordsNotReserved(t *testing.T) {
 	t.Run("asset is a usable bare metadata value", func(t *testing.T) {
 		t.Parallel()
 
-		f, err := Parse("metadata[k] == asset")
+		f, err := Parse("metadata[k] == asset", tx)
 		require.NoError(t, err)
 		assert.Equal(t, "asset", f.GetField().GetStringCond().GetHardcoded())
 	})
@@ -1056,11 +1056,11 @@ func TestParse_HasAssetKeywordsNotReserved(t *testing.T) {
 		t.Parallel()
 
 		// The `:` makes this not a bare Ident (EN-1547): quote it.
-		f, err := Parse(`address ^= "has:wallet"`)
+		f, err := Parse(`address ^= "has:wallet"`, tx)
 		require.NoError(t, err)
 		assert.Equal(t, "has:wallet", f.GetAddress().GetHardcodedPrefix())
 
-		_, err = Parse("address ^= has:wallet")
+		_, err = Parse("address ^= has:wallet", tx)
 		require.Error(t, err)
 	})
 }

--- a/internal/pkg/filterexpr/quoting_test.go
+++ b/internal/pkg/filterexpr/quoting_test.go
@@ -27,13 +27,13 @@ func TestQuoting_MetadataKeyRequiresQuotingForSpecialChars(t *testing.T) {
 
 			// Quoted: parses, key preserved verbatim.
 			quoted := fmt.Sprintf(`metadata["%s"] == "v"`, key)
-			f, err := Parse(quoted)
+			f, err := Parse(quoted, tx)
 			require.NoError(t, err, quoted)
 			require.Equal(t, key, f.GetField().GetField().GetMetadata(), quoted)
 
 			// Bare: rejected.
 			bare := fmt.Sprintf(`metadata[%s] == "v"`, key)
-			_, err = Parse(bare)
+			_, err = Parse(bare, tx)
 			require.Error(t, err, bare)
 		})
 	}
@@ -85,12 +85,12 @@ func TestQuoting_ValueRequiresQuotingForSpecialChars(t *testing.T) {
 				t.Parallel()
 
 				quoted := fmt.Sprintf(tc.quotedTmpl, val)
-				f, err := Parse(quoted)
+				f, err := Parse(quoted, tx)
 				require.NoError(t, err, quoted)
 				require.Equal(t, val, tc.get(f), quoted)
 
 				bare := fmt.Sprintf(tc.bareTmpl, val)
-				_, err = Parse(bare)
+				_, err = Parse(bare, tx)
 				require.Error(t, err, bare)
 			})
 		}
@@ -102,18 +102,18 @@ func TestQuoting_ValueRequiresQuotingForSpecialChars(t *testing.T) {
 func TestQuoting_AuditValueRequiresQuoting(t *testing.T) {
 	t.Parallel()
 
-	f, err := Parse(`audit[caller_subject] == "svc:payments"`)
+	f, err := Parse(`caller_subject == "svc:payments"`, audit)
 	require.NoError(t, err)
 	require.Equal(t, "svc:payments", f.GetAudit().GetStringCond().GetHardcoded())
 
-	_, err = Parse("audit[caller_subject] == svc:payments")
+	_, err = Parse("caller_subject == svc:payments", audit)
 	require.Error(t, err)
 
-	f, err = Parse(`audit[ledger] == "my-ledger"`)
+	f, err = Parse(`ledger == "my-ledger"`, audit)
 	require.NoError(t, err)
 	require.Equal(t, "my-ledger", f.GetAudit().GetStringCond().GetHardcoded())
 
-	_, err = Parse("audit[ledger] == my-ledger")
+	_, err = Parse("ledger == my-ledger", audit)
 	require.Error(t, err)
 }
 
@@ -123,12 +123,12 @@ func TestQuoting_AuditValueRequiresQuoting(t *testing.T) {
 func TestQuoting_AssetRefStillBare(t *testing.T) {
 	t.Parallel()
 
-	f, err := Parse("has asset USD/2")
+	f, err := Parse("has asset USD/2", tx)
 	require.NoError(t, err)
 	require.Equal(t, "USD", f.GetAccountHasAsset().GetAssetBase())
 	require.Equal(t, uint32(2), f.GetAccountHasAsset().GetPrecision())
 
-	f, err = Parse("has asset USD")
+	f, err = Parse("has asset USD", tx)
 	require.NoError(t, err)
 	require.Equal(t, "USD", f.GetAccountHasAsset().GetAssetBase())
 	require.Equal(t, uint32(0), f.GetAccountHasAsset().GetPrecision())
@@ -146,15 +146,15 @@ func TestQuoting_PlainFormsStillBare(t *testing.T) {
 		"ledger == main",
 		"metadata[flag] == true",
 		"metadata[n] == 42",
-		"audit[outcome] == failure",
-		// noun words usable as bare values (still lexer keywords, via Value.Kw)
+		// `audit` is now an ordinary identifier (no longer a keyword) usable bare;
+		// `ledger` remains a lexer keyword usable as a bare value via Value.Kw.
 		"metadata[type] == audit",
 		"metadata[type] == ledger",
 	} {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := Parse(in)
+			_, err := Parse(in, tx)
 			require.NoError(t, err, in)
 		})
 	}
@@ -171,7 +171,6 @@ func TestQuoting_FormatRoundTripsSpecialChars(t *testing.T) {
 		`metadata[k] == "foo.bar"`,
 		`address ^= "users:"`,
 		`source == "merchants:alice"`,
-		`audit[caller_subject] == "svc:payments"`,
 		"has asset USD/2",
 		// reserved operators as string values must be quoted by Format
 		`metadata[k] == "in"`,
@@ -180,16 +179,30 @@ func TestQuoting_FormatRoundTripsSpecialChars(t *testing.T) {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := Parse(in)
+			f, err := Parse(in, tx)
 			require.NoError(t, err, in)
 
 			out := Format(f)
-			reparsed, err := Parse(out)
+			reparsed, err := Parse(out, tx)
 			require.NoError(t, err, "Format output %q must reparse", out)
 			require.True(t, proto.Equal(f, reparsed),
 				"round-trip mismatch: in=%q Format=%q", in, out)
 		})
 	}
+
+	// The bare audit field value with a special char round-trips on the audit
+	// target (EN-1549): Format emits the quoted form, which reparses identically.
+	t.Run("audit caller_subject quoted", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := Parse(`caller_subject == "svc:payments"`, audit)
+		require.NoError(t, err)
+
+		out := Format(f)
+		reparsed, err := Parse(out, audit)
+		require.NoError(t, err, "Format output %q must reparse", out)
+		require.True(t, proto.Equal(f, reparsed), "audit round-trip mismatch: Format=%q", out)
+	})
 }
 
 // structuralKeywords are the words that remain reserved lexer keywords after
@@ -216,23 +229,23 @@ func TestQuoting_StructuralKeywordPrefixes(t *testing.T) {
 
 				// (a) quoted key parses; bare punctuated key rejected.
 				quotedKey := fmt.Sprintf(`metadata["%s"] == "v"`, punct)
-				fk, err := Parse(quotedKey)
+				fk, err := Parse(quotedKey, tx)
 				require.NoError(t, err, quotedKey)
 				require.Equal(t, punct, fk.GetField().GetField().GetMetadata(), quotedKey)
 
 				bareKey := fmt.Sprintf(`metadata[%s] == "v"`, punct)
-				_, err = Parse(bareKey)
+				_, err = Parse(bareKey, tx)
 				require.Error(t, err, bareKey)
 
 				// (b) quoted value parses.
 				quotedVal := fmt.Sprintf(`metadata[k] == "%s"`, punct)
-				fv, err := Parse(quotedVal)
+				fv, err := Parse(quotedVal, tx)
 				require.NoError(t, err, quotedVal)
 				require.Equal(t, punct, fv.GetField().GetStringCond().GetHardcoded(), quotedVal)
 
 				// (c) Format round-trips the punctuated value (Format quotes it).
 				out := Format(fv)
-				rp, err := Parse(out)
+				rp, err := Parse(out, tx)
 				require.NoError(t, err, out)
 				require.True(t, proto.Equal(fv, rp), "round-trip: value=%q Format=%q", punct, out)
 			})
@@ -243,17 +256,17 @@ func TestQuoting_StructuralKeywordPrefixes(t *testing.T) {
 		t.Run(kw+"_exact_value", func(t *testing.T) {
 			t.Parallel()
 
-			f, err := Parse(fmt.Sprintf(`metadata[k] == "%s"`, kw))
+			f, err := Parse(fmt.Sprintf(`metadata[k] == "%s"`, kw), tx)
 			require.NoError(t, err)
 			require.Equal(t, kw, f.GetField().GetStringCond().GetHardcoded())
 
 			out := Format(f)
-			rp, err := Parse(out)
+			rp, err := Parse(out, tx)
 			require.NoError(t, err, out)
 			require.True(t, proto.Equal(f, rp), "exact round-trip: %q Format=%q", kw, out)
 
 			// The bare operator word is NOT a valid value (it terminates the expr).
-			_, err = Parse("metadata[k] == " + kw)
+			_, err = Parse("metadata[k] == "+kw, tx)
 			require.Error(t, err)
 		})
 	}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -1085,8 +1085,10 @@ const (
 	// audit condition validity lives in the same source of truth as the other
 	// targets (EN-1241 / EN-1305 / EN-1339 / EN-1481 move ListAuditEntries onto
 	// the shared ListOptions.filter contract). CompileAuditFilter accepts only
-	// audit[...] leaves combined with and/or — not, and every non-audit
-	// condition, are rejected — which the per-arm annotations below reflect.
+	// audit-condition leaves combined with and/or — not, and every non-audit
+	// condition, are rejected — which the per-arm annotations below reflect. On
+	// the textual DSL these are the bare audit fields (outcome, ledger, seq, …)
+	// resolved against QUERY_TARGET_AUDIT (EN-1549).
 	QueryTarget_QUERY_TARGET_AUDIT QueryTarget = 3
 )
 

--- a/internal/proto/commonpb/metadata_convert.go
+++ b/internal/proto/commonpb/metadata_convert.go
@@ -105,7 +105,7 @@ var ErrDatetimeBeforeEpoch = errors.New("dates before the Unix epoch (1970-01-01
 // ("1700000000000000") into the uint64 microseconds the index stores. It is the
 // single coercion the whole filter surface shares (EN-1544): the structured
 // QueryFilter JSON DSL date/timestamp bounds, the textual filterexpr
-// date/timestamp field, and the audit[timestamp] datetime field all funnel
+// date/timestamp field, and the audit timestamp datetime field all funnel
 // through it so RFC3339 acceptance and pre-epoch rejection are defined once.
 //
 // An RFC3339 value before the Unix epoch returns ErrDatetimeBeforeEpoch. A value

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -5609,8 +5609,8 @@ type ListAuditEntriesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// options carries the whole read contract. Audit has NO dedicated top-level
 	// filters: ledger scope and outcome selection are expressed through
-	// options.filter (e.g. `audit[ledger] == <name>`, `audit[outcome] ==
-	// failure`), exactly like every other filtered list endpoint.
+	// options.filter with bare audit fields (e.g. `ledger == <name>`,
+	// `outcome == failure`), exactly like every other filtered list endpoint.
 	Options       *commonpb.ListOptions `protobuf:"bytes,1,opt,name=options,proto3" json:"options,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/query/audit.go
+++ b/internal/query/audit.go
@@ -81,8 +81,8 @@ func ReadAuditEntries(ctx context.Context, reader dal.PebbleReader, afterSequenc
 //     narrowed is true, candidateSeqs is the ascending set of matching audit
 //     sequences and only those are materialized. When false, every entry in
 //     [loSeq, hiSeq] is a candidate.
-//   - loSeq, hiSeq: inclusive audit-sequence bounds (from audit[seq] and from
-//     the compiled filter). Defaults span the whole zone.
+//   - loSeq, hiSeq: inclusive audit-sequence bounds (from the bare seq field and
+//     from the compiled filter). Defaults span the whole zone.
 //   - afterSeq: opaque cursor; 0 means "from the head". Exclusive.
 //   - reverse: false streams ascending by sequence (oldest first); true streams
 //     descending (newest first).

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -86,13 +86,13 @@ func compileAuditNode(idx AuditIndexReader, filter *commonpb.QueryFilter, depth 
 	// table): only condition kinds declared valid on QUERY_TARGET_AUDIT reach a
 	// compiler. This is the same table query.Compile consults for the other
 	// targets, so audit-condition validity is declared alongside them rather
-	// than as an undocumented exception. Concretely it admits audit[...] leaves
+	// than as an undocumented exception. Concretely it admits audit-condition leaves
 	// and and/or, and rejects not and every non-audit condition — matching the
 	// dispatch below.
 	kind := commonpb.ConditionKindOf(filter)
 	if !commonpb.ConditionValidForTarget(commonpb.QueryTarget_QUERY_TARGET_AUDIT, kind) {
 		return auditCompiled{}, status.Errorf(codes.InvalidArgument,
-			"unsupported filter for audit entries: only audit[...] conditions combined with and/or are allowed")
+			"unsupported filter for audit entries: only bare audit fields combined with and/or are allowed")
 	}
 
 	switch f := filter.GetFilter().(type) {
@@ -107,7 +107,7 @@ func compileAuditNode(idx AuditIndexReader, filter *commonpb.QueryFilter, depth 
 		// audit target. Kept as a defensive loud failure (invariant #7) in case
 		// the table and this dispatch ever diverge.
 		return auditCompiled{}, status.Errorf(codes.InvalidArgument,
-			"unsupported filter for audit entries: only audit[...] conditions combined with and/or are allowed")
+			"unsupported filter for audit entries: only bare audit fields combined with and/or are allowed")
 	}
 }
 
@@ -148,12 +148,12 @@ func compileAuditSeqBound(cond *commonpb.AuditCondition) (auditCompiled, error) 
 	uc := cond.GetUintCond()
 	if uc == nil {
 		return auditCompiled{}, status.Error(codes.InvalidArgument,
-			"audit[seq] requires a numeric condition")
+			"seq requires a numeric condition")
 	}
 
 	bounds, err := resolveUintBounds(uc, nil)
 	if err != nil {
-		return auditCompiled{}, status.Errorf(codes.InvalidArgument, "audit[seq]: %v", err)
+		return auditCompiled{}, status.Errorf(codes.InvalidArgument, "seq: %v", err)
 	}
 
 	out := unconstrained()
@@ -182,7 +182,7 @@ func compileAuditOutcome(idx AuditIndexReader, cond *commonpb.AuditCondition) (a
 	sc := cond.GetStringCond()
 	if sc == nil {
 		return auditCompiled{}, status.Error(codes.InvalidArgument,
-			"audit[outcome] requires a string condition")
+			"outcome requires a string condition")
 	}
 
 	val := sc.GetHardcoded()
@@ -194,7 +194,7 @@ func compileAuditOutcome(idx AuditIndexReader, cond *commonpb.AuditCondition) (a
 		success = false
 	default:
 		return auditCompiled{}, status.Errorf(codes.InvalidArgument,
-			"audit[outcome] must be \"success\" or \"failure\", got %q", val)
+			"outcome must be \"success\" or \"failure\", got %q", val)
 	}
 
 	seqs, err := idx.AuditSeqsByOutcome(success)
@@ -302,7 +302,7 @@ func compileAuditOr(idx AuditIndexReader, filters []*commonpb.QueryFilter, depth
 		// index set. Reject rather than over-match.
 		if !c.narrowed {
 			return auditCompiled{}, status.Error(codes.InvalidArgument,
-				"audit[seq] cannot appear inside an or; combine sequence bounds with and, or filter on an indexed field")
+				"seq cannot appear inside an or; combine sequence bounds with and, or filter on an indexed field")
 		}
 
 		if first {

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -157,7 +157,7 @@ func TestCompileAuditFilter_Or_Unions(t *testing.T) {
 func TestCompileAuditFilter_SeqRange_BoundsOnly(t *testing.T) {
 	t.Parallel()
 
-	// audit[seq] between 10 and 20 -> zone bounds, not index-narrowed.
+	// seq between 10 and 20 -> zone bounds, not index-narrowed.
 	seqs, lo, hi, narrowed, err := CompileAuditFilter(&fakeAuditIndex{},
 		auditUint(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, new(uint64(10)), new(uint64(20))))
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestCompileAuditFilter_SeqRange_BoundsOnly(t *testing.T) {
 func TestCompileAuditFilter_SeqRange_AndWithIndex(t *testing.T) {
 	t.Parallel()
 
-	// audit[outcome]==failure and audit[seq] >= 3 -> failures {1,3,7} filtered
+	// outcome==failure and seq >= 3 -> failures {1,3,7} filtered
 	// to seq>=3 = {3,7}, with the bound baked into the seq set (window reset to
 	// full) so an enclosing OR cannot lose it.
 	idx := &fakeAuditIndex{byOutcome: map[bool][]uint64{false: {1, 3, 7}}}
@@ -413,7 +413,7 @@ func TestCompileAuditFilter_EmptyAndIsUnconstrained(t *testing.T) {
 func TestCompileAuditFilter_AndOfTwoSeqBounds(t *testing.T) {
 	t.Parallel()
 
-	// audit[seq] >= 5 and audit[seq] <= 20 -> both non-narrowed, bounds intersect
+	// seq >= 5 and seq <= 20 -> both non-narrowed, bounds intersect
 	// to [5,20]; the index is never consulted.
 	filter := &commonpb.QueryFilter{
 		Filter: &commonpb.QueryFilter_And{
@@ -435,7 +435,7 @@ func TestCompileAuditFilter_AndOfTwoSeqBounds(t *testing.T) {
 func TestCompileAuditFilter_OrDoesNotLeakBranchSeqBound(t *testing.T) {
 	t.Parallel()
 
-	// (audit[outcome] == failure and audit[seq] < 10) or audit[ledger] == main
+	// (outcome == failure and seq < 10) or ledger == main
 	// Failures are seqs {3, 12, 20}; the seq<10 bound must keep only {3} from
 	// that branch, then union with ledger==main {50}. Without baking the branch
 	// bound, 12 and 20 would leak in.
@@ -475,7 +475,7 @@ func TestCompileAuditFilter_OrDoesNotLeakBranchSeqBound(t *testing.T) {
 func TestCompileAuditFilter_AndBakesSeqBoundIntoSeqs(t *testing.T) {
 	t.Parallel()
 
-	// audit[outcome] == failure and audit[seq] <= 9 -> {3} (bound baked into seqs,
+	// outcome == failure and seq <= 9 -> {3} (bound baked into seqs,
 	// window reset to full).
 	idx := &fakeAuditIndex{byOutcome: map[bool][]uint64{false: {3, 12, 20}}}
 

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -823,8 +823,8 @@ message CheckStoreProgress {
 message ListAuditEntriesRequest {
   // options carries the whole read contract. Audit has NO dedicated top-level
   // filters: ledger scope and outcome selection are expressed through
-  // options.filter (e.g. `audit[ledger] == <name>`, `audit[outcome] ==
-  // failure`), exactly like every other filtered list endpoint.
+  // options.filter with bare audit fields (e.g. `ledger == <name>`,
+  // `outcome == failure`), exactly like every other filtered list endpoint.
   common.ListOptions options = 1;
 }
 

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1566,8 +1566,10 @@ enum QueryTarget {
   // audit condition validity lives in the same source of truth as the other
   // targets (EN-1241 / EN-1305 / EN-1339 / EN-1481 move ListAuditEntries onto
   // the shared ListOptions.filter contract). CompileAuditFilter accepts only
-  // audit[...] leaves combined with and/or — not, and every non-audit
-  // condition, are rejected — which the per-arm annotations below reflect.
+  // audit-condition leaves combined with and/or — not, and every non-audit
+  // condition, are rejected — which the per-arm annotations below reflect. On
+  // the textual DSL these are the bare audit fields (outcome, ledger, seq, …)
+  // resolved against QUERY_TARGET_AUDIT (EN-1549).
   QUERY_TARGET_AUDIT = 3;
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -449,21 +449,28 @@ paths:
           description: |
             A filter, decoded by the same shared dual-format decoder every list
             endpoint uses (see the `ListFilter` parameter). In practice audit
-            filters use the **textual** representation, restricted to `audit[...]`
-            conditions:
-              - `audit[outcome] == failure`
-              - `audit[ledger] == main`
-              - `audit[order_type] in (create_transaction, revert_transaction)`
-              - `audit[seq] between 1000 and 2000`
-              - `audit[timestamp] >= "2023-11-14T22:13:20Z"`
+            filters use the **textual** representation, restricted to bare
+            audit fields (`outcome`, `ledger`, `seq`, `proposal_id`,
+            `timestamp`, `log_seq`, `caller_subject`, `order_type`). These are
+            written without any prefix and are resolved against the audit query
+            target (EN-1549 — this replaced the old `audit[...]` namespaced
+            syntax; it is a breaking change with no backward compatibility):
+              - `outcome == failure`
+              - `ledger == main`
+              - `order_type in (create_transaction, revert_transaction)`
+              - `seq between 1000 and 2000`
+              - `timestamp >= "2023-11-14T22:13:20Z"`
             Supported fields: `seq`, `proposal_id`, `log_seq` (numeric);
             `timestamp` (RFC3339 or unix microseconds); `outcome`
             (success|failure), `ledger`, `caller_subject`, `order_type`
-            (string). Audit conditions have NO structured JSON QueryFilter
-            representation (their field names collide with the transaction/log
-            conditions the JSON DSL already claims), so the textual form is the
-            canonical one here; a JSON QueryFilter cannot carry an audit
-            condition and is rejected.
+            (string). Bare audit fields are resolved against the audit query
+            target: `timestamp` and `ledger` collide with the transaction
+            `timestamp` field and the top-level `ledger` condition, so on the
+            audit target they resolve to the audit condition (and only there —
+            hence audit fields are valid on this endpoint only). Audit
+            conditions have NO structured JSON QueryFilter representation, so
+            the textual form is the canonical one here; a JSON QueryFilter
+            cannot carry an audit condition and is rejected.
       responses:
         '200':
           description: List of audit entries
@@ -2873,8 +2880,9 @@ components:
         on logs `date` (e.g. `filter=date >= "2023-11-14T22:13:20Z"`). An RFC3339
         value before the Unix epoch (1970-01-01) is rejected with 400.
 
-        Note: audit conditions (`audit[...]`) have no structured JSON form and
-        must be passed in the textual representation.
+        Note: bare audit fields (`outcome`, `ledger`, `seq`, `proposal_id`,
+        `timestamp`, `log_seq`, `caller_subject`, `order_type`) have no
+        structured JSON form and must be passed in the textual representation.
 
   responses:
     ServiceUnavailable:

--- a/pkg/actions/read.go
+++ b/pkg/actions/read.go
@@ -330,7 +330,7 @@ func AggregateVolumes(ctx context.Context, client servicepb.BucketServiceClient,
 }
 
 // ListAuditEntries collects all audit entries from the streaming RPC. When
-// failuresOnly is true it applies the shared filter `audit[outcome] == failure`
+// failuresOnly is true it applies the shared filter `outcome == failure`
 // (failures_only is no longer a top-level request field — EN-1241).
 //
 // Consistency: with failuresOnly=false the read streams the audit zone directly
@@ -350,7 +350,7 @@ func ListAuditEntries(ctx context.Context, client servicepb.BucketServiceClient,
 }
 
 // AuditOutcomeFilter builds the QueryFilter matching audit entries by outcome:
-// success=true -> `audit[outcome] == success`, success=false -> failure.
+// success=true -> `outcome == success`, success=false -> failure.
 func AuditOutcomeFilter(success bool) *commonpb.QueryFilter {
 	val := "failure"
 	if success {

--- a/tests/e2e/business/accounts_test.go
+++ b/tests/e2e/business/accounts_test.go
@@ -552,7 +552,7 @@ var _ = Describe("Accounts", Ordered, func() {
 
 		It("Should filter accounts with `between` (inclusive bounds)", func() {
 			// age between 30 and 50 should match bob(35), charlie(50)
-			filter, err := filterexpr.Parse("metadata[age] between 30 and 50")
+			filter, err := filterexpr.Parse("metadata[age] between 30 and 50", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)
@@ -565,10 +565,10 @@ var _ = Describe("Accounts", Ordered, func() {
 			// `age >= 30 and age < 60` is coalesced into a single bounded
 			// IntCondition; must match the same set as `between 30 and 59`
 			// (bob=35, charlie=50).
-			fromAnd, err := filterexpr.Parse("metadata[age] >= 30 and metadata[age] < 60")
+			fromAnd, err := filterexpr.Parse("metadata[age] >= 30 and metadata[age] < 60", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
-			fromBetween, err := filterexpr.Parse("metadata[age] between 30 and 59")
+			fromBetween, err := filterexpr.Parse("metadata[age] between 30 and 59", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			fromAndAccts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", fromAnd)
@@ -688,7 +688,7 @@ var _ = Describe("Accounts", Ordered, func() {
 
 		It("Should filter accounts matching any value in the list", func() {
 			// metadata[role] in (admin, viewer) → alice, charlie, dave
-			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer)`)
+			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer)`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			Eventually(func(g Gomega) {
@@ -705,7 +705,7 @@ var _ = Describe("Accounts", Ordered, func() {
 
 		It("Should filter accounts with single value in list", func() {
 			// metadata[role] in (user) → bob only
-			filter, err := filterexpr.Parse(`metadata[role] in (user)`)
+			filter, err := filterexpr.Parse(`metadata[role] in (user)`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)
@@ -715,7 +715,7 @@ var _ = Describe("Accounts", Ordered, func() {
 		})
 
 		It("Should return empty when no values match", func() {
-			filter, err := filterexpr.Parse(`metadata[role] in (superadmin, moderator)`)
+			filter, err := filterexpr.Parse(`metadata[role] in (superadmin, moderator)`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)
@@ -725,7 +725,7 @@ var _ = Describe("Accounts", Ordered, func() {
 
 		It("Should combine in filter with AND", func() {
 			// metadata[role] in (admin, user) and address ^= "a" → alice only
-			filter, err := filterexpr.Parse(`metadata[role] in (admin, user) and address ^= "a"`)
+			filter, err := filterexpr.Parse(`metadata[role] in (admin, user) and address ^= "a"`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)
@@ -762,7 +762,7 @@ var _ = Describe("Accounts", Ordered, func() {
 
 		It("Should filter accounts by exact address list", func() {
 			// address in ("users:alice", "merchants:shop1") → 2 accounts
-			filter, err := filterexpr.Parse(`address in ("users:alice", "merchants:shop1")`)
+			filter, err := filterexpr.Parse(`address in ("users:alice", "merchants:shop1")`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)
@@ -773,7 +773,7 @@ var _ = Describe("Accounts", Ordered, func() {
 		})
 
 		It("Should return empty when no addresses match", func() {
-			filter, err := filterexpr.Parse(`address in ("nonexistent:a", "nonexistent:b")`)
+			filter, err := filterexpr.Parse(`address in ("nonexistent:a", "nonexistent:b")`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", filter)

--- a/tests/e2e/business/audit_test.go
+++ b/tests/e2e/business/audit_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Audit Log", Ordered, func() {
 		}, nil, nil)))
 		Expect(err).To(Succeed())
 
-		// Filter by the original ledger via `audit[ledger] == <name>` — should not
+		// Filter by the original ledger via the bare `ledger == <name>` field — should not
 		// include the second ledger's entries. The ledger scope is served by the
 		// async audit index, so poll until it has caught up (Eventually).
 		Eventually(func(g Gomega) {
@@ -486,7 +486,7 @@ var _ = Describe("Audit Log", Ordered, func() {
 		}, nil, nil)))
 		Expect(err).To(Succeed())
 
-		// audit[ledger] == orderTypeLedger and audit[order_type] == create_transaction
+		// ledger == orderTypeLedger and order_type == create_transaction
 		filter := &commonpb.QueryFilter{
 			Filter: &commonpb.QueryFilter_And{
 				And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
@@ -527,7 +527,7 @@ var _ = Describe("Audit Log", Ordered, func() {
 		Expect(desc[len(desc)-1].GetSequence()).To(Equal(asc[0].GetSequence()))
 	})
 
-	It("Should honor options.filter for audit[seq] range", func() {
+	It("Should honor options.filter for the bare seq range", func() {
 		all, err := collectAuditEntries(sharedCtx, sharedClient, &servicepb.ListAuditEntriesRequest{})
 		Expect(err).To(Succeed())
 		Expect(len(all)).To(BeNumerically(">=", 3))

--- a/tests/e2e/business/prepared_queries_test.go
+++ b/tests/e2e/business/prepared_queries_test.go
@@ -1039,7 +1039,7 @@ var _ = Describe("PreparedQueries", Ordered, func() {
 
 		It("Should return accounts matching any role in the list", func() {
 			// metadata[role] in (admin, viewer) → alice, charlie, diana
-			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer)`)
+			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer)`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{
@@ -1071,7 +1071,7 @@ var _ = Describe("PreparedQueries", Ordered, func() {
 
 		It("Should combine in filter with AND on different fields", func() {
 			// metadata[role] in (admin, viewer) and metadata[tier] in (gold) → alice, diana
-			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer) and metadata[tier] in (gold)`)
+			filter, err := filterexpr.Parse(`metadata[role] in (admin, viewer) and metadata[tier] in (gold)`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{
@@ -1103,7 +1103,7 @@ var _ = Describe("PreparedQueries", Ordered, func() {
 
 		It("Should support in with quoted string values", func() {
 			// metadata[tier] in ("gold", "silver") → alice, bob, diana
-			filter, err := filterexpr.Parse(`metadata[tier] in ("gold", "silver")`)
+			filter, err := filterexpr.Parse(`metadata[tier] in ("gold", "silver")`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{
@@ -1162,7 +1162,7 @@ var _ = Describe("PreparedQueries", Ordered, func() {
 
 		It("Should return transactions involving any address in the list", func() {
 			// address in ("alice", "charlie") → tx0 (world→alice), tx2 (alice→charlie)
-			filter, err := filterexpr.Parse(`address in ("alice", "charlie")`)
+			filter, err := filterexpr.Parse(`address in ("alice", "charlie")`, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{
@@ -1236,7 +1236,7 @@ var _ = Describe("PreparedQueries", Ordered, func() {
 			// `between 30 and 60` matches bob(35) and charlie(50).
 			// Proves the IntCondition survives store + retrieve through the
 			// prepared-query proto round trip.
-			filter, err := filterexpr.Parse("metadata[age] between 30 and 60")
+			filter, err := filterexpr.Parse("metadata[age] between 30 and 60", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 			Expect(err).To(Succeed())
 
 			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{

--- a/tests/e2e/business/transactions_test.go
+++ b/tests/e2e/business/transactions_test.go
@@ -1249,7 +1249,7 @@ var _ = Describe("Transactions", Ordered, func() {
 
 		It("Should filter transactions with `between` (inclusive bounds)", func() {
 			// score between 30 and 50 should match tx2(30), tx3(50)
-			filter, err := filterexpr.Parse("metadata[score] between 30 and 50")
+			filter, err := filterexpr.Parse("metadata[score] between 30 and 50", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(Succeed())
 
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, filter)
@@ -1259,7 +1259,7 @@ var _ = Describe("Transactions", Ordered, func() {
 
 		It("Should treat `between X and X` like equality", func() {
 			// score between 50 and 50 should match only tx3
-			filter, err := filterexpr.Parse("metadata[score] between 50 and 50")
+			filter, err := filterexpr.Parse("metadata[score] between 50 and 50", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(Succeed())
 
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, filter)
@@ -1269,7 +1269,7 @@ var _ = Describe("Transactions", Ordered, func() {
 
 		It("Should return empty when between bounds match nothing", func() {
 			// score between 80 and 100: tx4 is 70, no data in [80,100]
-			filter, err := filterexpr.Parse("metadata[score] between 80 and 100")
+			filter, err := filterexpr.Parse("metadata[score] between 80 and 100", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(Succeed())
 
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, filter)
@@ -1282,10 +1282,10 @@ var _ = Describe("Transactions", Ordered, func() {
 			// IntCondition by mergeFieldRanges, then compiled as a single
 			// bounded range scan. Must match exactly the same set as
 			// `between 30 and 69` (tx2=30, tx3=50).
-			fromAnd, err := filterexpr.Parse("metadata[score] >= 30 and metadata[score] < 70")
+			fromAnd, err := filterexpr.Parse("metadata[score] >= 30 and metadata[score] < 70", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(Succeed())
 
-			fromBetween, err := filterexpr.Parse("metadata[score] between 30 and 69")
+			fromBetween, err := filterexpr.Parse("metadata[score] between 30 and 69", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(Succeed())
 
 			fromAndTxs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, fromAnd)
@@ -1303,6 +1303,7 @@ var _ = Describe("Transactions", Ordered, func() {
 			// `score between 40 and 79`, matching tx3(50), tx4(70).
 			filter, err := filterexpr.Parse(
 				"metadata[score] >= 20 and metadata[score] < 80 and metadata[score] >= 40",
+				commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
 			)
 			Expect(err).To(Succeed())
 
@@ -1312,7 +1313,7 @@ var _ = Describe("Transactions", Ordered, func() {
 		})
 
 		It("Should reject `between` with reversed bounds at parse time", func() {
-			_, err := filterexpr.Parse("metadata[score] between 100 and 10")
+			_, err := filterexpr.Parse("metadata[score] between 100 and 10", commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("out of order"))
 		})


### PR DESCRIPTION
## What & why

The filter DSL was asymmetric: audit fields used a namespaced bracket syntax (`audit[outcome] == failure`, `audit[ledger] == main`, `audit[seq] between 1000 and 2000`, …) while transaction/log fields were bare (`timestamp`, `date`, `ledger`, `has asset`, `metadata[key]`). EN-1549 harmonizes this by **dropping the `audit[...]` prefix** and exposing audit fields as **bare, target-aware** names:

| Before | After |
|---|---|
| `audit[outcome] == failure` | `outcome == failure` |
| `audit[ledger] == main` | `ledger == main` |
| `audit[seq] between 1000 and 2000` | `seq between 1000 and 2000` |
| `audit[timestamp] >= "2023-11-14T22:13:20Z"` | `timestamp >= "2023-11-14T22:13:20Z"` |
| `audit[order_type] in (create_transaction, revert_transaction)` | `order_type in (...)` |
| `audit[proposal_id] == 42` / `audit[log_seq] == 500` / `audit[caller_subject] == "svc:payments"` | `proposal_id == 42` / `log_seq == 500` / `caller_subject == "svc:payments"` |

## Target-aware resolution (the crux)

The DSL is context-free, but a few bare fields are ambiguous across targets:
- bare `timestamp` collides with the transaction `timestamp` (BuiltinUint arm) and the audit timestamp field;
- bare `ledger` collides with the top-level `LedgerCondition` and the audit ledger field.

Resolution is threaded through **`Parse(input string, target commonpb.QueryTarget)`** and dispatched at `toProto` time:
- **`QUERY_TARGET_AUDIT`** → all 8 audit fields resolve to the `AuditCondition` arm.
- **transactions / logs / accounts** → `timestamp` → transaction builtin range, `date` → log range, `ledger` → `LedgerCondition`; audit-only field names (`outcome`, `seq`, …) are rejected with `unknown field` (they carry no meaning off the audit target).

The existing per-target validity gate (`domain.ValidateFilterForTarget`, EN-1504/EN-1503) runs downstream unchanged and still rejects e.g. `date` on transactions.

Implementation: the grammar's separate `AuditCond` / `DateCond` / `LedgerCond` productions are unified into a single generic **`FieldCond`** (`FIELD OP value`) placed last in the `Condition` alternation (so the specialized `asset`/`metadata`/`address` productions keep winning their lead tokens). The `audit` lexer keyword is removed (it is now an ordinary identifier). The shared entry points already carry the target:
- `DecodeDualFormat(raw, target)` threads it straight through;
- `DecodeDualFormatStructuralOnly(raw)` (prepared-query update, which never sees the target — it lives on the stored query and the FSM re-validates) resolves with a fixed non-audit target. This is sound because prepared queries are only ever ACCOUNTS/TRANSACTIONS/LOGS (audit is gRPC-only) and every non-audit target resolves the bare intrinsic fields identically.

## Formatter

`Format` emits bare audit field names (inverse of `Parse` on the audit target). `Parse(Format(f))` round-trips for every audit filter shape — an audit filter is always re-parsed with `QUERY_TARGET_AUDIT`, which is what disambiguates the shared `timestamp`/`ledger` renderings.

## Breaking change (no compat)

This is a **breaking DSL change** and intentionally ships **without any backward-compatibility shim** — the old `audit[...]` syntax no longer parses. Pre-GA, coherence over stability.

## Out of scope

Unifying the `date` (log) vs `timestamp` (transaction) naming is explicitly **NOT** part of EN-1549 — those remain distinct field names. `metadata[key]` bracket syntax is untouched (a genuine key namespace, not a field prefix).

## Coverage
- **Parser/format/decode**: rewrote the filterexpr audit tests to the bare form; added target-aware resolution tests (bare `timestamp`/`ledger` resolve to different arms per target, audit-only fields rejected off-audit), round-trip tests, and fuzz seeds for the bare grammar (fuzzed across TRANSACTIONS + AUDIT targets, no crashes).
- **Query/adapter**: updated `audit_filter*` error messages/comments to bare fields; updated HTTP audit handler tests.
- **E2E**: updated `filterexpr.Parse` call sites (now target-parameterized) and audit test comments.
- **Docs**: `docs/ops/cli.md`, `docs/technical/contributing/api-comparison.md`, `docs/technical/architecture/subsystems/read-path/query-pipeline.md`, `docs/technical/architecture/subsystems/api/http-api.md`, `openapi.yml`, and the `.proto` comments (+ synced generated `.pb.go` comments) — every `audit[...]` example replaced with the bare form.

## Verification
- `GOROOT= go build ./...` — clean
- `GOROOT= go test ./internal/pkg/filterexpr/ ./internal/query/... ./internal/adapter/http/... ./internal/proto/commonpb/...` — pass
- `go test -tags e2e ./tests/e2e/...` compiles clean
- fuzz `FuzzFilterExprParse` — no crashes