### PR TITLE
fix(ci): use nscloud-checkout-action so `dissociate` is a valid input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -61,7 +61,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -84,7 +84,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -107,7 +107,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -130,7 +130,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -147,7 +147,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -193,7 +193,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -210,7 +210,7 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -250,7 +250,7 @@ jobs:
       # See Build-PR-Image for the override semantics.
       IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'ghcr.io/formancehq/ledger' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true
@@ -300,7 +300,7 @@ jobs:
     permissions:
       # Job-level `permissions:` REPLACES the workflow-level set (it does
       # not merge), so we must restate `contents: read` here — otherwise
-      # actions/checkout cannot clone this private repo and fails with
+      # the checkout action cannot clone this private repo and fails with
       # "repository not found".
       contents: read
       packages: write
@@ -312,7 +312,7 @@ jobs:
       # canonical `formancehq/ledger` published image.
       IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'ghcr.io/formancehq/ledger' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   GoReleaser:
     runs-on: namespace-profile-linux-amd64-4vcpu
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
         with:
           fetch-depth: 0
           dissociate: true


### PR DESCRIPTION
## Summary

The GoReleaser (and every `main.yml`) job emitted a GitHub Actions annotation:

> `Unexpected input(s) 'dissociate', valid inputs are ['repository', 'ref', 'token', ...]`

`dissociate: true` was being passed to `actions/checkout`, which has no such input, so it was **silently ignored** and only produced the warning.

The Namespace runner migration (`998e23c0a`) intended git's `--dissociate` behavior — detaching the checkout from the Namespace Git mirror cache (those runners have "Git Mirror Cache: Enabled"). But that flag is only exposed by [`namespacelabs/nscloud-checkout-action`](https://github.com/namespacelabs/nscloud-checkout-action), not GitHub's `actions/checkout`.

This swaps all 11 checkout steps to `nscloud-checkout-action@v9` (SHA-pinned, matching repo convention) and keeps `dissociate: true`, so the input is now **honored** and the warning clears.

## Changes

- `actions/checkout@v7.0.0` → `namespacelabs/nscloud-checkout-action@445c25d…` (`# v9`) across `release.yml` (1) and `main.yml` (10)
- `dissociate: true` retained under each checkout `with:` block
- Fixed one stale comment that named `actions/checkout`

Only `fetch-depth`, `dissociate`, and `ref` are used across the blocks — all three are valid `nscloud-checkout-action@v9` inputs.

## Test plan

- [x] Both workflow files pass YAML parsing
- [x] No `actions/checkout` uses remain (only a corrected comment mentions it)
- [ ] Confirmed green on next push/tag CI run (workflows only run on Namespace runners; not reproducible locally)