### PR TITLE
perf(ci): cache the Nix store on the Namespace volume

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -8,6 +8,13 @@ inputs:
 runs:
   using: composite
   steps:
+    # Restore the Nix store from the Namespace cache volume BEFORE installing
+    # Nix, so `nix develop` reuses the dev-shell closure instead of re-fetching
+    # it from cache.nixos.org on every run. Must run before Install Nix.
+    - name: Set up Nix store cache
+      uses: namespacelabs/nscloud-cache-action@58bf6e08898e88803c098e2b522668541cd3b2e3 # v1.6.0
+      with:
+        path: /nix
     - name: Install Nix
       uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c # v31.10.7
     - name: go env


### PR DESCRIPTION
## Summary

Every job in `main.yml` (and the release job) routes through the `.github/actions/default` composite action, which runs `nix develop`. Today the dev-shell closure is re-fetched from `cache.nixos.org` on every run.

This adds an `nscloud-cache-action` step that caches `/nix` on the Namespace cache volume, so the Nix store persists across runs — the pattern Namespace recommends for their runners ([nix-cache-example, "option 2"](https://github.com/namespace-integration-demos/nix-cache-example/blob/main/.github/workflows/demo.yaml)).

The step is placed **before** `Install Nix`: the store must be restored before Nix reads it. It cannot be folded into the existing Go-cache step, which runs after `go env` (and therefore after Nix is already installed and used).

## Changes

- New "Set up Nix store cache" step (`nscloud-cache-action@v1.6.0`, `path: /nix`) at the top of the `default` composite action, before `Install Nix`.
- Existing Go cache step (GOCACHE / GOMODCACHE / golangci-lint) unchanged.

## Test plan

- [x] `action.yml` passes YAML parsing
- [ ] Confirmed on Namespace runners: first run populates `/nix`, subsequent runs restore it and `nix develop` is faster (only reproducible in CI on Namespace runners)

## Notes

- `install-nix-action@v31` running on top of a pre-restored `/nix` follows the sanctioned Namespace demo pattern (demo uses v26); not locally verifiable.
- Separate concern from #1585 (the `dissociate`/checkout fix); intentionally its own PR.