### PR TITLE
fix(filterexpr): rename test var `min` shadowing the builtin (predeclared lint)

### DIFF
--- a/internal/pkg/filterexpr/date_test.go
+++ b/internal/pkg/filterexpr/date_test.go
@@ -291,11 +291,11 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			min := tc.v
+			minVal := tc.v
 			f := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
 				BuiltinUint: &commonpb.BuiltinUintCondition{
 					Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
-					Cond:  &commonpb.UintCondition{Min: &min},
+					Cond:  &commonpb.UintCondition{Min: &minVal},
 				},
 			}}
 
@@ -313,12 +313,12 @@ func TestFormatDate_RawMicrosOutsideRFC3339Range(t *testing.T) {
 	t.Run("audit[timestamp] above MaxInt64", func(t *testing.T) {
 		t.Parallel()
 
-		min := uint64(18446744073709551615)
+		minVal := uint64(18446744073709551615)
 		f := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{
 			Audit: &commonpb.AuditCondition{
 				Field: commonpb.AuditField_AUDIT_FIELD_TIMESTAMP,
 				Condition: &commonpb.AuditCondition_UintCond{
-					UintCond: &commonpb.UintCondition{Min: &min},
+					UintCond: &commonpb.UintCondition{Min: &minVal},
 				},
 			},
 		}}


### PR DESCRIPTION
## Summary

The `Dirty` CI job on `release/v3.0` (and every PR targeting it, e.g. #1586) fails at `nix develop --command just pre-commit` with exit code 1. Root cause is a `predeclared` lint error, **not** a dirty tree:

```
internal/pkg/filterexpr/date_test.go:294:4: variable min has same name as predeclared identifier (predeclared)
internal/pkg/filterexpr/date_test.go:316:3: variable min has same name as predeclared identifier (predeclared)
```

Two subtests (added with the date-DSL work in #1580/#1582) declare a local `min`, shadowing the Go 1.21+ builtin, which the `predeclared` linter rejects.

## Changes

- Rename the two local `min` variables to `minVal` in `internal/pkg/filterexpr/date_test.go`. Pure test-local rename, no behavior change.

## Test plan

- [x] `golangci-lint run ./internal/pkg/filterexpr/...` → `0 issues` (was `predeclared: 2`)
- [x] `just pre-commit` lint step now passes

Unblocks the `Dirty` job for all open PRs against `release/v3.0`.