### PR TITLE
fix(replay): carry typed metadata values through backup restore

### DIFF
--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -1293,9 +1293,39 @@ func (c *Checker) compareVolumes(ctx context.Context, reader dal.PebbleReader, b
 	return errorCount
 }
 
+// metaValueDisplay renders a metadata value with its type for check events, so
+// a type-only divergence (bool false vs string "false") is visible in the
+// message.
+func metaValueDisplay(v *commonpb.MetadataValue) string {
+	var kind string
+
+	switch v.GetType().(type) {
+	case *commonpb.MetadataValue_StringValue:
+		kind = "string"
+	case *commonpb.MetadataValue_IntValue:
+		kind = "int"
+	case *commonpb.MetadataValue_UintValue:
+		kind = "uint"
+	case *commonpb.MetadataValue_BoolValue:
+		kind = "bool"
+	case *commonpb.MetadataValue_DatetimeValue:
+		kind = "datetime"
+	case *commonpb.MetadataValue_NullValue:
+		kind = "null"
+	default:
+		kind = "unset"
+	}
+
+	return fmt.Sprintf("%q (%s)", commonpb.MetadataValueToString(v), kind)
+}
+
 // compareMetadata performs a 3-way merge comparison for account metadata.
-// Replay entries encode SET (flag 0x00 + value) or DELETED (flag 0x01).
-// expected = replay override if present, else baseline; compare with live.
+// Replay entries encode SET (flag 0x00 + marshaled MetadataValue) or DELETED
+// (flag 0x01). expected = replay override if present, else baseline; compare
+// with live. Values are compared as typed protos, not string renderings — the
+// FSM stores the order's MetadataValue verbatim, so a live row whose type
+// diverges from the log (bool false vs string "false") is a projection
+// mismatch even when the renderings agree.
 // `excluded` lists per-ledger accounts whose state legitimately diverges
 // (transient + purged ephemeral, sourced from the audit log) — metadata on
 // such accounts is skipped to avoid false positives.
@@ -1303,7 +1333,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 	errorCount := 0
 
 	// Collect live metadata
-	liveMetadata := make(map[string]string)
+	liveMetadata := make(map[string]*commonpb.MetadataValue)
 
 	liveIter, err := c.attrs.Metadata.NewStreamingIter(reader, nil)
 	if err != nil {
@@ -1315,7 +1345,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 
 	for liveIter.Next() {
 		e := liveIter.Entry()
-		liveMetadata[string(e.CanonicalKey)] = commonpb.MetadataValueToString(e.Value)
+		liveMetadata[string(e.CanonicalKey)] = e.Value
 	}
 
 	if err := liveIter.Close(); err != nil {
@@ -1333,7 +1363,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 	}
 
 	// Collect baseline metadata (if available)
-	baselineMetadata := make(map[string]string) // key -> string value
+	baselineMetadata := make(map[string]*commonpb.MetadataValue)
 
 	if baselineDB != nil {
 		baselineIter, err := c.attrs.Metadata.NewStreamingIter(baselineDB, nil)
@@ -1346,7 +1376,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 
 		for baselineIter.Next() {
 			e := baselineIter.Entry()
-			baselineMetadata[string(e.CanonicalKey)] = commonpb.MetadataValueToString(e.Value)
+			baselineMetadata[string(e.CanonicalKey)] = e.Value
 		}
 
 		if err := baselineIter.Close(); err != nil {
@@ -1367,7 +1397,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 	// Collect replay metadata state
 	type replayMeta struct {
 		deleted bool
-		value   string // only valid when !deleted
+		value   *commonpb.MetadataValue // only valid when !deleted
 	}
 
 	replayEntries := make(map[string]replayMeta)
@@ -1400,7 +1430,17 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 		if valBytes[0] == metaFlagDeleted {
 			replayEntries[string(canonicalKey)] = replayMeta{deleted: true}
 		} else {
-			replayEntries[string(canonicalKey)] = replayMeta{value: string(valBytes[1:])}
+			mv := &commonpb.MetadataValue{}
+			if err := mv.UnmarshalVT(valBytes[1:]); err != nil {
+				_ = replayIter.Close()
+
+				callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_METADATA_MISMATCH,
+					fmt.Sprintf("unmarshaling replay metadata value: %v", err), 0, "", "", ""))
+
+				return 1
+			}
+
+			replayEntries[string(canonicalKey)] = replayMeta{value: mv}
 		}
 	}
 
@@ -1445,7 +1485,7 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 		}
 
 		// Compute expected value
-		var expectedValue string
+		var expectedValue *commonpb.MetadataValue
 		expectedExists := false
 
 		if rm, hasReplay := replayEntries[key]; hasReplay {
@@ -1465,21 +1505,21 @@ func (c *Checker) compareMetadata(ctx context.Context, reader dal.PebbleReader, 
 		if expectedExists != actualExists {
 			if expectedExists {
 				callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_METADATA_MISMATCH,
-					fmt.Sprintf("metadata missing for %s/%s: expected %q",
-						mk.Account, mk.Key, expectedValue),
+					fmt.Sprintf("metadata missing for %s/%s: expected %s",
+						mk.Account, mk.Key, metaValueDisplay(expectedValue)),
 					0, mk.LedgerName, mk.Account, ""))
 			} else {
 				callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_METADATA_MISMATCH,
-					fmt.Sprintf("unexpected metadata for %s/%s: got %q",
-						mk.Account, mk.Key, actualValue),
+					fmt.Sprintf("unexpected metadata for %s/%s: got %s",
+						mk.Account, mk.Key, metaValueDisplay(actualValue)),
 					0, mk.LedgerName, mk.Account, ""))
 			}
 
 			errorCount++
-		} else if expectedExists && expectedValue != actualValue {
+		} else if expectedExists && !expectedValue.EqualVT(actualValue) {
 			callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_METADATA_MISMATCH,
-				fmt.Sprintf("metadata mismatch for %s/%s: expected %q, got %q",
-					mk.Account, mk.Key, expectedValue, actualValue),
+				fmt.Sprintf("metadata mismatch for %s/%s: expected %s, got %s",
+					mk.Account, mk.Key, metaValueDisplay(expectedValue), metaValueDisplay(actualValue)),
 				0, mk.LedgerName, mk.Account, ""))
 
 			errorCount++

--- a/internal/application/check/replay_store.go
+++ b/internal/application/check/replay_store.go
@@ -189,13 +189,21 @@ func (s *replayStore) MoveMetadata(oldCanonicalKey, newCanonicalKey []byte) erro
 	return s.db.Delete(oldKey, pebble.NoSync)
 }
 
-// setMetadata stores a metadata value in the replay store (pure write).
-func (s *replayStore) SetMetadata(canonicalKey []byte, value string) error {
+// setMetadata stores a metadata value in the replay store (pure write). The
+// typed value is kept intact — a marshaled MetadataValue after the flag byte —
+// so the compare pass can flag a live row whose type diverges from the log
+// (e.g. a bool stored as its string rendering).
+func (s *replayStore) SetMetadata(canonicalKey []byte, value *commonpb.MetadataValue) error {
 	key := replayKey(replayPrefixMetadata, canonicalKey)
 
-	data := make([]byte, 1+len(value))
+	encoded, err := value.MarshalVT()
+	if err != nil {
+		return fmt.Errorf("marshaling metadata value: %w", err)
+	}
+
+	data := make([]byte, 1+len(encoded))
 	data[0] = metaFlagSet
-	copy(data[1:], value)
+	copy(data[1:], encoded)
 
 	return s.db.Set(key, data, pebble.NoSync)
 }

--- a/internal/application/check/replay_store_extra_test.go
+++ b/internal/application/check/replay_store_extra_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 func TestReplayStoreMoveVolumeTransfersAndDeletes(t *testing.T) {
@@ -76,7 +78,7 @@ func TestReplayStoreMoveMetadataTransfersAndDeletes(t *testing.T) {
 	oldKey := []byte("ledger\x00old-account\x01role")
 	newKey := []byte("ledger\x00new-account\x01role")
 
-	require.NoError(t, rs.SetMetadata(oldKey, "admin"))
+	require.NoError(t, rs.SetMetadata(oldKey, commonpb.NewStringValue("admin")))
 
 	require.NoError(t, rs.MoveMetadata(oldKey, newKey))
 
@@ -85,7 +87,7 @@ func TestReplayStoreMoveMetadataTransfersAndDeletes(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
 	require.Equal(t, byte(metaFlagSet), val[0])
-	require.Equal(t, "admin", string(val[1:]))
+	require.True(t, decodeReplayMetaValue(t, val).EqualVT(commonpb.NewStringValue("admin")))
 
 	// Old key should be deleted
 	_, _, err = rs.db.Get(replayKey(replayPrefixMetadata, oldKey))
@@ -113,15 +115,15 @@ func TestReplayStoreMoveMetadataOverwritesExistingTarget(t *testing.T) {
 	oldKey := []byte("ledger\x00src\x01role")
 	newKey := []byte("ledger\x00dst\x01role")
 
-	require.NoError(t, rs.SetMetadata(newKey, "user"))
-	require.NoError(t, rs.SetMetadata(oldKey, "admin"))
+	require.NoError(t, rs.SetMetadata(newKey, commonpb.NewStringValue("user")))
+	require.NoError(t, rs.SetMetadata(oldKey, commonpb.NewStringValue("admin")))
 
 	require.NoError(t, rs.MoveMetadata(oldKey, newKey))
 
 	val, closer, err := rs.db.Get(replayKey(replayPrefixMetadata, newKey))
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
-	require.Equal(t, "admin", string(val[1:]))
+	require.True(t, decodeReplayMetaValue(t, val).EqualVT(commonpb.NewStringValue("admin")))
 }
 
 func TestReplayStoreDeleteVolume(t *testing.T) {

--- a/internal/application/check/replay_store_test.go
+++ b/internal/application/check/replay_store_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
+// decodeReplayMetaValue unmarshals the MetadataValue stored after the flag byte.
+func decodeReplayMetaValue(t *testing.T, val []byte) *commonpb.MetadataValue {
+	t.Helper()
+
+	mv := &commonpb.MetadataValue{}
+	require.NoError(t, mv.UnmarshalVT(val[1:]))
+
+	return mv
+}
+
 func newTestReplayStore(t *testing.T) *replayStore {
 	t.Helper()
 
@@ -115,14 +125,25 @@ func TestReplayStoreMetadataSetAndRead(t *testing.T) {
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00account\x00role")
 
-	require.NoError(t, rs.SetMetadata(key, "admin"))
+	require.NoError(t, rs.SetMetadata(key, commonpb.NewStringValue("admin")))
 
 	val, closer, err := rs.db.Get(replayKey(replayPrefixMetadata, key))
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
 
 	require.Equal(t, byte(metaFlagSet), val[0])
-	require.Equal(t, "admin", string(val[1:]))
+	require.True(t, decodeReplayMetaValue(t, val).EqualVT(commonpb.NewStringValue("admin")))
+
+	// Typed values keep their arm — a bool must not come back as its string
+	// rendering.
+	boolKey := []byte("ledger\x00account\x00flag")
+	require.NoError(t, rs.SetMetadata(boolKey, commonpb.NewBoolValue(true)))
+
+	boolVal, boolCloser, err := rs.db.Get(replayKey(replayPrefixMetadata, boolKey))
+	require.NoError(t, err)
+	defer func() { _ = boolCloser.Close() }()
+
+	require.True(t, decodeReplayMetaValue(t, boolVal).EqualVT(commonpb.NewBoolValue(true)))
 }
 
 func TestReplayStoreMetadataOverwrite(t *testing.T) {
@@ -131,14 +152,14 @@ func TestReplayStoreMetadataOverwrite(t *testing.T) {
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00account\x00role")
 
-	require.NoError(t, rs.SetMetadata(key, "user"))
-	require.NoError(t, rs.SetMetadata(key, "admin"))
+	require.NoError(t, rs.SetMetadata(key, commonpb.NewStringValue("user")))
+	require.NoError(t, rs.SetMetadata(key, commonpb.NewStringValue("admin")))
 
 	val, closer, err := rs.db.Get(replayKey(replayPrefixMetadata, key))
 	require.NoError(t, err)
 	defer func() { _ = closer.Close() }()
 
-	require.Equal(t, "admin", string(val[1:]))
+	require.True(t, decodeReplayMetaValue(t, val).EqualVT(commonpb.NewStringValue("admin")))
 }
 
 func TestReplayStoreMetadataDelete(t *testing.T) {
@@ -147,7 +168,7 @@ func TestReplayStoreMetadataDelete(t *testing.T) {
 	rs := newTestReplayStore(t)
 	key := []byte("ledger\x00account\x00role")
 
-	require.NoError(t, rs.SetMetadata(key, "admin"))
+	require.NoError(t, rs.SetMetadata(key, commonpb.NewStringValue("admin")))
 	require.NoError(t, rs.DeleteMetadata(key))
 
 	val, closer, err := rs.db.Get(replayKey(replayPrefixMetadata, key))
@@ -326,7 +347,7 @@ func TestReplayStorePrefixIter(t *testing.T) {
 	// Write data across all three prefixes.
 	require.NoError(t, rs.AddVolumeDelta([]byte("k1"), big.NewInt(10), big.NewInt(0)))
 	require.NoError(t, rs.AddVolumeDelta([]byte("k2"), big.NewInt(20), big.NewInt(0)))
-	require.NoError(t, rs.SetMetadata([]byte("m1"), "v1"))
+	require.NoError(t, rs.SetMetadata([]byte("m1"), commonpb.NewStringValue("v1")))
 	require.NoError(t, rs.CreateTransaction([]byte("t1"), 1, nil, nil, nil, 0))
 
 	// Volume prefix should yield exactly 2 entries.

--- a/internal/domain/replay/replay.go
+++ b/internal/domain/replay/replay.go
@@ -92,7 +92,7 @@ func ReplayLedgerLog(
 					}
 
 					if value != nil {
-						if err := w.SetMetadata(mk.Bytes(), commonpb.MetadataValueToString(value)); err != nil {
+						if err := w.SetMetadata(mk.Bytes(), value); err != nil {
 							return fmt.Errorf("setting account metadata: %w", err)
 						}
 					}
@@ -152,7 +152,7 @@ func ReplayLedgerLog(
 					}
 
 					if value != nil {
-						if err := w.SetMetadata(mk.Bytes(), commonpb.MetadataValueToString(value)); err != nil {
+						if err := w.SetMetadata(mk.Bytes(), value); err != nil {
 							return fmt.Errorf("setting metadata: %w", err)
 						}
 					}

--- a/internal/domain/replay/writer.go
+++ b/internal/domain/replay/writer.go
@@ -15,7 +15,7 @@ type Writer interface {
 	GetVolume(canonicalKey []byte) (*raftcmdpb.VolumePair, error)
 	DeleteVolume(canonicalKey []byte) error
 	MoveVolume(oldKey, newKey []byte) error
-	SetMetadata(canonicalKey []byte, value string) error
+	SetMetadata(canonicalKey []byte, value *commonpb.MetadataValue) error
 	DeleteMetadata(canonicalKey []byte) error
 	MoveMetadata(oldKey, newKey []byte) error
 	CreateTransaction(canonicalKey []byte, seq uint64, timestamp *commonpb.Timestamp, metadata map[string]*commonpb.MetadataValue, postings []*commonpb.Posting, revertsTransaction uint64) error

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -1044,11 +1044,8 @@ func (w *attributeReplayWriter) MoveVolume(oldKey, newKey []byte) error {
 	return w.DeleteVolume(oldKey)
 }
 
-func (w *attributeReplayWriter) SetMetadata(canonicalKey []byte, value string) error {
-	mv := &commonpb.MetadataValue{}
-	mv.Type = &commonpb.MetadataValue_StringValue{StringValue: value}
-
-	_, err := w.metadata.Set(w.batch, canonicalKey, mv)
+func (w *attributeReplayWriter) SetMetadata(canonicalKey []byte, value *commonpb.MetadataValue) error {
+	_, err := w.metadata.Set(w.batch, canonicalKey, value)
 
 	return err
 }

--- a/tests/e2e/cluster/restore_metadata_type_test.go
+++ b/tests/e2e/cluster/restore_metadata_type_test.go
@@ -1,0 +1,343 @@
+//go:build e2e && s3
+
+package cluster
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc"
+)
+
+// This suite pins the typed-metadata loss the model test surfaced (account read
+// mismatch after a restore: model held bool, server returned string). The live
+// FSM persists account metadata as typed MetadataValue protos, but the restore
+// rebuild replays account metadata through replay.Writer.SetMetadata, whose
+// value parameter is a plain string (internal/domain/replay/writer.go): both
+// the transaction-embedded path and the SaveMetadata path stringify the value
+// with MetadataValueToString before writing. Every non-string account-metadata
+// value inside the exported delta therefore comes back from a restore as its
+// string rendering. The store checker cannot flag it: compareMetadata
+// stringifies both sides before comparing, which normalizes away exactly the
+// information the rebuild destroys — so an end-to-end read assertion is the
+// seam that sees the divergence.
+var _ = Describe("Restore typed account metadata", Ordered, func() {
+	const (
+		httpPort   = testutil.TestSingleHTTPPort
+		grpcPort   = testutil.TestSingleGRPCPort
+		raftPort   = grpcPort - 1000
+		ledgerName = "metatype-ledger"
+		s3Bucket   = "restore-metadata-type"
+		clusterID  = "metatype-cluster"
+
+		// txAccount receives its metadata embedded in the CreateTransaction
+		// command; saveAccount through a standalone SaveMetadata command — the
+		// two ledger-log shapes that carry typed account metadata.
+		txAccount   = "acc:1"
+		saveAccount = "acc:2"
+	)
+
+	var (
+		ctx            context.Context
+		restoreWalDir  string
+		restoreDataDir string
+		minioEndpoint  string
+	)
+
+	typedValues := map[string]*commonpb.MetadataValue{
+		"flag":  commonpb.NewBoolValue(true),
+		"count": commonpb.NewIntValue(42),
+	}
+
+	// expectTypedMetadata asserts the read-back values kept their oneof arm.
+	// Used both as the live-side premise guard and as the post-restore check.
+	expectTypedMetadata := func(acct *commonpb.Account, phase string) {
+		meta := acct.GetMetadata()
+
+		flag := meta["flag"]
+		Expect(flag).ToNot(BeNil(), "%s: %s metadata flag missing", phase, acct.GetAddress())
+		Expect(flag.GetType()).To(BeAssignableToTypeOf(&commonpb.MetadataValue_BoolValue{}),
+			"%s: %s metadata flag arm (value: %v)", phase, acct.GetAddress(), flag)
+		Expect(flag.GetBoolValue()).To(BeTrue(), "%s: %s metadata flag", phase, acct.GetAddress())
+
+		count := meta["count"]
+		Expect(count).ToNot(BeNil(), "%s: %s metadata count missing", phase, acct.GetAddress())
+		Expect(count.GetType()).To(BeAssignableToTypeOf(&commonpb.MetadataValue_IntValue{}),
+			"%s: %s metadata count arm (value: %v)", phase, acct.GetAddress(), count)
+		Expect(count.GetIntValue()).To(Equal(int64(42)), "%s: %s metadata count", phase, acct.GetAddress())
+	}
+
+	storage := func() *commonpb.BackupStorage {
+		return testutil.S3BackupStorage(&commonpb.S3StorageConfig{
+			Bucket:   s3Bucket,
+			Region:   restoreS3Region,
+			Endpoint: minioEndpoint,
+		})
+	}
+
+	BeforeAll(func() {
+		ctx = logging.TestingContext()
+
+		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+			testcontainers.WithEnv(map[string]string{
+				"MINIO_ROOT_USER":     restoreMinioAccessKey,
+				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,
+			}),
+			testcontainers.WithCmd("server", "/data"),
+			testcontainers.WithExposedPorts("9000/tcp"),
+			testcontainers.WithWaitStrategy(
+				wait.ForHTTP("/minio/health/live").WithPort("9000/tcp").WithStartupTimeout(30*time.Second),
+			),
+		)
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { _ = container.Terminate(context.Background()) })
+
+		minioEndpoint, err = container.Endpoint(context.Background(), "http")
+		Expect(err).To(Succeed())
+
+		cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(restoreS3Region),
+			awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				restoreMinioAccessKey, restoreMinioSecretKey, "",
+			)),
+		)
+		Expect(err).To(Succeed())
+
+		s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(minioEndpoint)
+			o.UsePathStyle = true
+		})
+		_, err = s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(s3Bucket)})
+		Expect(err).To(Succeed())
+
+		GinkgoT().Setenv("AWS_ACCESS_KEY_ID", restoreMinioAccessKey)
+		GinkgoT().Setenv("AWS_SECRET_ACCESS_KEY", restoreMinioSecretKey)
+
+		restoreWalDir, err = os.MkdirTemp("", "metatype-restore-wal-*")
+		Expect(err).To(Succeed())
+		restoreDataDir, err = os.MkdirTemp("", "metatype-restore-data-*")
+		Expect(err).To(Succeed())
+	})
+
+	Describe("Phase 1: typed metadata in the exported delta", Ordered, func() {
+		var (
+			sourceServer  *testservice.Service
+			client        servicepb.BucketServiceClient
+			clusterClient clusterpb.ClusterServiceClient
+			grpcConn      *grpc.ClientConn
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				HTTPPort:  httpPort,
+				RaftPort:  raftPort,
+				GRPCPort:  grpcPort,
+				WalDir:    GinkgoT().TempDir(),
+				DataDir:   GinkgoT().TempDir(),
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			sourceServer = testservice.New(cmdserver.NewRunCommand, testservice.WithInstruments(instruments...))
+			Expect(sourceServer.Start(ctx)).To(Succeed())
+
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+
+			// Full checkpoint on the EMPTY store: everything after it lands in
+			// the incremental delta, so the restore reconstructs the metadata
+			// rows purely by replaying the exported log instead of copying
+			// checkpoint files.
+			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(sourceServer.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("writes typed account metadata through both command shapes", func() {
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateLedgerAction(ledgerName, nil),
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, "flag", commonpb.MetadataType_METADATA_TYPE_BOOL),
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, "count", commonpb.MetadataType_METADATA_TYPE_INT64),
+			))
+			Expect(err).To(Succeed())
+
+			// Transaction-embedded account metadata.
+			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+					actions.NewPosting("world", txAccount, big.NewInt(100), "USD"),
+				}, nil, map[string]*commonpb.MetadataMap{
+					txAccount: {Values: typedValues},
+				}),
+			))
+			Expect(err).To(Succeed())
+
+			// Standalone SaveMetadata with typed values.
+			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+					actions.NewPosting("world", saveAccount, big.NewInt(100), "USD"),
+				}, nil, nil),
+				actions.SaveTypedAccountMetadataAction(ledgerName, saveAccount, typedValues),
+			))
+			Expect(err).To(Succeed())
+		})
+
+		It("serves the typed values back on the live node", func() {
+			// Premise guard: the live write path must store typed values; if it
+			// already stringified them the restore assertions would be vacuous.
+			for _, addr := range []string{txAccount, saveAccount} {
+				acct, err := actions.GetAccount(ctx, client, ledgerName, addr)
+				Expect(err).To(Succeed())
+				expectTypedMetadata(acct, "live")
+			}
+		})
+
+		It("exports the delta", func() {
+			incResp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(incResp.GetLogEntriesExported()).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("Phase 2: restore", Ordered, func() {
+		var (
+			restoreClient restorepb.RestoreServiceClient
+			grpcConn      *grpc.ClientConn
+			server        *testservice.Service
+		)
+
+		BeforeAll(func() {
+			server = testservice.New(cmdserver.NewRunCommand,
+				testservice.WithInstruments(
+					testservice.DebugInstrumentation(testutil.Debug),
+					testservice.OutputInstrumentation(GinkgoWriter),
+					testserver.WithNodeID(1),
+					testserver.WithClusterID(clusterID),
+					testserver.WithHTTPPort(httpPort),
+					testserver.WithWalDir(restoreWalDir),
+					testserver.WithDataDir(restoreDataDir),
+					testserver.WithRaftPort(raftPort),
+					testserver.WithGRPCPort(grpcPort),
+					testserver.WithRestore(),
+				),
+			)
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var err error
+			restoreClient, grpcConn, err = newRestoreGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("downloads and finalizes the backup", func() {
+			startResp, err := restoreClient.StartDownloadBackup(ctx, &restorepb.StartDownloadBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+
+			Eventually(func() restorepb.DownloadState {
+				resp, statusErr := restoreClient.GetDownloadStatus(ctx, &restorepb.GetDownloadStatusRequest{JobId: startResp.GetJobId()})
+				Expect(statusErr).To(Succeed())
+				return resp.GetState()
+			}, 2*time.Minute, 500*time.Millisecond).Should(Equal(restorepb.DownloadState_DOWNLOAD_STATE_SUCCEEDED))
+
+			_, err = restoreClient.FinalizeRestore(ctx, &restorepb.FinalizeRestoreRequest{})
+			Expect(err).To(Succeed())
+		})
+	})
+
+	Describe("Phase 3: verify the restored metadata", Ordered, func() {
+		var (
+			client   servicepb.BucketServiceClient
+			grpcConn *grpc.ClientConn
+			server   *testservice.Service
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				HTTPPort:  httpPort,
+				RaftPort:  raftPort,
+				GRPCPort:  grpcPort,
+				WalDir:    restoreWalDir,
+				DataDir:   restoreDataDir,
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			server = testservice.New(cmdserver.NewRunCommand, testservice.WithInstruments(instruments...))
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var clusterClient clusterpb.ClusterServiceClient
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+			_ = os.RemoveAll(restoreWalDir)
+			_ = os.RemoveAll(restoreDataDir)
+		})
+
+		It("preserves the metadata value types across the rebuild", func() {
+			for _, addr := range []string{txAccount, saveAccount} {
+				acct, err := actions.GetAccount(ctx, client, ledgerName, addr)
+				Expect(err).To(Succeed())
+				GinkgoWriter.Printf("RESTORED %s metadata: %v\n", addr, acct.GetMetadata())
+				expectTypedMetadata(acct, "restored")
+			}
+		})
+	})
+})


### PR DESCRIPTION
Follow-up to #1554, found by the model test's restore cycle (`account read outside model`: model held `b:false`, server returned `s:false` after a restore).

## Bug

`replay.Writer.SetMetadata` took the value as a plain **string**, and both account-metadata replay sites (transaction-embedded and standalone SaveMetadata) funneled the log's typed `MetadataValue` through `MetadataValueToString`. The FSM stores the order's typed value verbatim, so every bool/int/uint/datetime account-metadata value inside an exported delta came back from a restore as its string rendering:

- live row: `1800` → `boolValue:false`
- rebuilt row: `0a0566616c7365` → `stringValue:"false"`

Reads served by the restored store then return the wrong value type. Transaction and ledger metadata were unaffected (typed maps/values throughout).

## Fix

- `SetMetadata` now takes `*commonpb.MetadataValue`; the rebuild stores the typed value directly and the checker's scratch store keeps the marshaled proto after the flag byte.
- **Checker strengthening**: `compareMetadata` compares typed values (`EqualVT`) instead of string renderings. It previously stringified both sides before comparing, normalizing away exactly the information the rebuild destroyed — the whole class was invisible to `Check()`. Events now render values with their type: `"false" (bool)` vs `"false" (string)`.

## Behavioral note

Stores restored with the old rebuild hold string-rendered account-metadata rows and will now correctly fail the check with `METADATA_MISMATCH` — worth knowing for existing restored environments.

## Tests

- New e2e `tests/e2e/cluster/restore_metadata_type_test.go`: writes `flag=true` (bool) and `count=42` (int64) through both command shapes, asserts the live node serves them typed, backup → restore, asserts the types survive. Fails without the fix commit, passes with it.
- Unit-level bool round-trip on the checker's replay store.