### PR TITLE
feat(ledgerctl): add --tls-server-name to verify by name while dialing by IP

### DIFF
--- a/cmd/ledgerctl/auth/login.go
+++ b/cmd/ledgerctl/auth/login.go
@@ -187,6 +187,14 @@ func syncProfile(cmd *cobra.Command, server string) error {
 		signingKeyID, _ = cmd.Flags().GetString("key-id")
 	}
 
+	// Reject contradictory TLS flags before bootstrapping the profile — this
+	// path persists without opening a connection, so GetClientTransportCredentials'
+	// guard never runs; without this check we'd store a profile every subsequent
+	// command immediately rejects. --insecure may arrive via LEDGERCTL_INSECURE.
+	if err := cmdutil.ValidateTLSFlags(insecure, tlsCaCert, tlsServerName); err != nil {
+		return err
+	}
+
 	cfg.Profiles[profileName] = cmdutil.Profile{
 		Server:            server,
 		Insecure:          insecure,

--- a/cmd/ledgerctl/auth/login.go
+++ b/cmd/ledgerctl/auth/login.go
@@ -172,6 +172,7 @@ func syncProfile(cmd *cobra.Command, server string) error {
 
 	insecure, _ := cmd.Flags().GetBool("insecure")
 	tlsCaCert, _ := cmd.Flags().GetString("tls-ca-cert")
+	tlsServerName, _ := cmd.Flags().GetString("tls-server-name")
 	signingKey, _ := cmd.Flags().GetString("signing-key")
 	responseVerifyKey, _ := cmd.Flags().GetString("response-verify-key")
 
@@ -190,6 +191,7 @@ func syncProfile(cmd *cobra.Command, server string) error {
 		Server:            server,
 		Insecure:          insecure,
 		TLSCaCert:         tlsCaCert,
+		TLSServerName:     tlsServerName,
 		SigningKey:        signingKey,
 		SigningKeyID:      signingKeyID,
 		ResponseVerifyKey: responseVerifyKey,

--- a/cmd/ledgerctl/cmdutil/client.go
+++ b/cmd/ledgerctl/cmdutil/client.go
@@ -51,12 +51,8 @@ func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCre
 	caCertPath, _ := cmd.Flags().GetString("tls-ca-cert")
 	serverName, _ := cmd.Flags().GetString("tls-server-name")
 
-	if insecureMode && caCertPath != "" {
-		return nil, errors.New("--insecure and --tls-ca-cert are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
-	}
-
-	if insecureMode && serverName != "" {
-		return nil, errors.New("--insecure and --tls-server-name are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
+	if err := ValidateTLSFlags(insecureMode, caCertPath, serverName); err != nil {
+		return nil, err
 	}
 
 	if insecureMode {
@@ -69,6 +65,29 @@ func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCre
 	}
 
 	return credentials.NewTLS(tlsConfig), nil
+}
+
+// ValidateTLSFlags rejects contradictory TLS flag combinations: --insecure
+// (no TLS at all) cannot be paired with --tls-ca-cert or --tls-server-name,
+// which only make sense when verifying a TLS connection.
+//
+// It is the single source of truth for that rule, shared by the connection path
+// (GetClientTransportCredentials) and the profile-persistence paths (profile
+// create, auth login). Persisting the conflict would store a profile every
+// subsequent TLS-aware command immediately rejects; validating here lets those
+// commands fail fast at write time instead. Mentioning LEDGERCTL_INSECURE keeps
+// the message actionable when --insecure was injected via the environment (a
+// stray container-image default was the original "server preface: EOF" cause).
+func ValidateTLSFlags(insecureMode bool, caCertPath, serverName string) error {
+	if insecureMode && caCertPath != "" {
+		return errors.New("--insecure and --tls-ca-cert are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
+	}
+
+	if insecureMode && serverName != "" {
+		return errors.New("--insecure and --tls-server-name are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
+	}
+
+	return nil
 }
 
 // buildClientTLSConfig assembles the *tls.Config for a verifying (non-insecure)

--- a/cmd/ledgerctl/cmdutil/client.go
+++ b/cmd/ledgerctl/cmdutil/client.go
@@ -30,19 +30,33 @@ const (
 
 // GetClientTransportCredentials returns the transport credentials based on CLI flags.
 // If --insecure is set, returns insecure credentials.
-// Otherwise, returns TLS credentials, optionally using a custom CA from --tls-ca-cert.
+// Otherwise, returns TLS credentials, optionally using a custom CA from --tls-ca-cert
+// and a custom verification hostname from --tls-server-name.
 //
-// Setting --insecure together with --tls-ca-cert is rejected: those flags
-// encode conflicting intent (no TLS vs. verify with this CA), and silently
-// preferring one of them — as the older code did — masks env-var leakage like
-// a stray LEDGERCTL_INSECURE=true in a container image (the original cause of
-// the "error reading server preface: EOF" production incident).
+// Setting --insecure together with --tls-ca-cert or --tls-server-name is
+// rejected: those flags encode conflicting intent (no TLS vs. verify with this
+// CA / against this hostname), and silently preferring one of them — as the
+// older code did — masks env-var leakage like a stray LEDGERCTL_INSECURE=true
+// in a container image (the original cause of the "error reading server
+// preface: EOF" production incident).
+//
+// --tls-server-name overrides the hostname the certificate is verified against
+// (SNI + SAN match), decoupling it from the dial address in --server. This is
+// what lets a client dial by IP (e.g. 127.0.0.1:8888 from inside a pod, or a
+// LoadBalancer VIP) while still validating an operator-issued certificate whose
+// SANs only cover the in-cluster DNS names (e.g.
+// <pod>.<cluster>-headless.<ns>.svc.cluster.local), never localhost/127.0.0.1.
 func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCredentials, error) {
 	insecureMode, _ := cmd.Flags().GetBool("insecure")
 	caCertPath, _ := cmd.Flags().GetString("tls-ca-cert")
+	serverName, _ := cmd.Flags().GetString("tls-server-name")
 
 	if insecureMode && caCertPath != "" {
 		return nil, errors.New("--insecure and --tls-ca-cert are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
+	}
+
+	if insecureMode && serverName != "" {
+		return nil, errors.New("--insecure and --tls-server-name are mutually exclusive (--insecure may also come from the LEDGERCTL_INSECURE env var; unset it to use TLS)")
 	}
 
 	if insecureMode {
@@ -50,6 +64,12 @@ func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCre
 	}
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	// Override the name verified against the server certificate's SANs, so the
+	// dial address (--server) and the verification identity can differ.
+	if serverName != "" {
+		tlsConfig.ServerName = serverName
+	}
 
 	if caCertPath != "" {
 		caPEM, err := os.ReadFile(caCertPath)

--- a/cmd/ledgerctl/cmdutil/client.go
+++ b/cmd/ledgerctl/cmdutil/client.go
@@ -63,6 +63,21 @@ func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCre
 		return insecure.NewCredentials(), nil
 	}
 
+	tlsConfig, err := buildClientTLSConfig(caCertPath, serverName)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentials.NewTLS(tlsConfig), nil
+}
+
+// buildClientTLSConfig assembles the *tls.Config for a verifying (non-insecure)
+// client connection. Split out from GetClientTransportCredentials so the
+// resulting config is directly assertable in tests: credentials.NewTLS wraps it
+// in an opaque type whose only exported accessor (ProtocolInfo.ServerName) is
+// deprecated, so the config is the sole reliable place to verify ServerName and
+// RootCAs were applied.
+func buildClientTLSConfig(caCertPath, serverName string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 
 	// Override the name verified against the server certificate's SANs, so the
@@ -85,7 +100,7 @@ func GetClientTransportCredentials(cmd *cobra.Command) (credentials.TransportCre
 		tlsConfig.RootCAs = certPool
 	}
 
-	return credentials.NewTLS(tlsConfig), nil
+	return tlsConfig, nil
 }
 
 // GetClient creates a gRPC client connection and returns the client.

--- a/cmd/ledgerctl/cmdutil/client_test.go
+++ b/cmd/ledgerctl/cmdutil/client_test.go
@@ -24,6 +24,7 @@ func newTLSFlagCommand() *cobra.Command {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().Bool("insecure", false, "")
 	cmd.Flags().String("tls-ca-cert", "", "")
+	cmd.Flags().String("tls-server-name", "", "")
 
 	return cmd
 }
@@ -51,6 +52,36 @@ func TestGetClientTransportCredentials_InsecureOnly(t *testing.T) {
 
 	cmd := newTLSFlagCommand()
 	require.NoError(t, cmd.Flags().Set("insecure", "true"))
+
+	creds, err := GetClientTransportCredentials(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, creds)
+}
+
+// --tls-server-name only makes sense when TLS is active; pairing it with
+// --insecure is rejected for the same reason as --tls-ca-cert — it catches a
+// stray LEDGERCTL_INSECURE leaking in and silently disabling verification.
+func TestGetClientTransportCredentials_InsecureWithServerNameIsRejected(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTLSFlagCommand()
+	require.NoError(t, cmd.Flags().Set("insecure", "true"))
+	require.NoError(t, cmd.Flags().Set("tls-server-name", "ledger.svc.cluster.local"))
+
+	_, err := GetClientTransportCredentials(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--insecure and --tls-server-name are mutually exclusive")
+}
+
+// A --tls-server-name without --insecure is the supported case: dial by IP,
+// verify against the cert SANs by name. This is what unblocks ledgerctl from
+// inside a TLS cluster pod, where the operator-issued cert covers the in-cluster
+// DNS names but never 127.0.0.1/localhost.
+func TestGetClientTransportCredentials_TLSWithServerName(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTLSFlagCommand()
+	require.NoError(t, cmd.Flags().Set("tls-server-name", "ledger.svc.cluster.local"))
 
 	creds, err := GetClientTransportCredentials(cmd)
 	require.NoError(t, err)

--- a/cmd/ledgerctl/cmdutil/client_test.go
+++ b/cmd/ledgerctl/cmdutil/client_test.go
@@ -109,6 +109,53 @@ func TestGetClientTransportCredentials_TLSWithCustomCA(t *testing.T) {
 	require.NotNil(t, creds)
 }
 
+// ValidateTLSFlags is the single source of truth for the mutual-exclusion
+// rules, shared by the connection path and the profile-persistence paths
+// (profile create, auth login). Cover it directly so a persistence caller that
+// forgets to route through it can't quietly regress the guard.
+func TestValidateTLSFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		insecure   bool
+		caCert     string
+		serverName string
+		wantErr    string
+	}{
+		{name: "no flags is valid"},
+		{name: "tls-ca-cert alone is valid", caCert: "/tls/ca.crt"},
+		{name: "tls-server-name alone is valid", serverName: "ledger.svc.cluster.local"},
+		{name: "insecure alone is valid", insecure: true},
+		{
+			name:     "insecure + tls-ca-cert rejected",
+			insecure: true, caCert: "/tls/ca.crt",
+			wantErr: "--insecure and --tls-ca-cert are mutually exclusive",
+		},
+		{
+			name:     "insecure + tls-server-name rejected",
+			insecure: true, serverName: "ledger.svc.cluster.local",
+			wantErr: "--insecure and --tls-server-name are mutually exclusive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateTLSFlags(tc.insecure, tc.caCert, tc.serverName)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
 // writeTestCA generates a self-signed CA cert and returns the PEM bytes.
 // The cert is only used to exercise the AppendCertsFromPEM path — no
 // connection is opened in the unit test.

--- a/cmd/ledgerctl/cmdutil/client_test.go
+++ b/cmd/ledgerctl/cmdutil/client_test.go
@@ -86,6 +86,13 @@ func TestGetClientTransportCredentials_TLSWithServerName(t *testing.T) {
 	creds, err := GetClientTransportCredentials(cmd)
 	require.NoError(t, err)
 	require.NotNil(t, creds)
+
+	// Assert the override actually reached the tls.Config — plain TLS creds are
+	// also non-nil, so only checking creds is not enough to guard the
+	// load-bearing ServerName assignment.
+	cfg, err := buildClientTLSConfig("", "ledger.svc.cluster.local")
+	require.NoError(t, err)
+	require.Equal(t, "ledger.svc.cluster.local", cfg.ServerName)
 }
 
 func TestGetClientTransportCredentials_TLSWithCustomCA(t *testing.T) {

--- a/cmd/ledgerctl/cmdutil/config.go
+++ b/cmd/ledgerctl/cmdutil/config.go
@@ -18,6 +18,7 @@ type Profile struct {
 	Server            string `json:"server"`
 	Insecure          bool   `json:"insecure,omitempty"`
 	TLSCaCert         string `json:"tlsCaCert,omitempty"`
+	TLSServerName     string `json:"tlsServerName,omitempty"`
 	SigningKey        string `json:"signingKey,omitempty"`
 	SigningKeyID      string `json:"signingKeyId,omitempty"`
 	ResponseVerifyKey string `json:"responseVerifyKey,omitempty"`
@@ -160,6 +161,8 @@ func ProfileFlagValue(p *Profile, flagName string) string {
 		return ""
 	case "tls-ca-cert":
 		return p.TLSCaCert
+	case "tls-server-name":
+		return p.TLSServerName
 	case "signing-key":
 		return p.SigningKey
 	case "signing-key-id":

--- a/cmd/ledgerctl/cmdutil/resolve.go
+++ b/cmd/ledgerctl/cmdutil/resolve.go
@@ -56,6 +56,7 @@ func ResolveConnectionFlags(cmd *cobra.Command) error {
 	resolveFlag(cmd, "server", "LEDGERCTL_SERVER", ProfileFlagValue(p, "server"))
 	resolveFlag(cmd, "insecure", "LEDGERCTL_INSECURE", ProfileFlagValue(p, "insecure"))
 	resolveFlag(cmd, "tls-ca-cert", "LEDGERCTL_TLS_CA_CERT", ProfileFlagValue(p, "tls-ca-cert"))
+	resolveFlag(cmd, "tls-server-name", "LEDGERCTL_TLS_SERVER_NAME", ProfileFlagValue(p, "tls-server-name"))
 	resolveFlag(cmd, "consistency", "LEDGERCTL_CONSISTENCY", "")
 	resolveFlag(cmd, "auth-token", "LEDGERCTL_AUTH_TOKEN", "")
 	resolveFlag(cmd, "signing-key", "LEDGERCTL_SIGNING_KEY", ProfileFlagValue(p, "signing-key"))

--- a/cmd/ledgerctl/cmdutil/resolve_test.go
+++ b/cmd/ledgerctl/cmdutil/resolve_test.go
@@ -18,6 +18,7 @@ func newConnCmd() *cobra.Command {
 	cmd.Flags().String("server", "localhost:8888", "")
 	cmd.Flags().Bool("insecure", false, "")
 	cmd.Flags().String("tls-ca-cert", "", "")
+	cmd.Flags().String("tls-server-name", "", "")
 	cmd.Flags().String("consistency", "", "")
 	cmd.Flags().String("auth-token", "", "")
 	cmd.Flags().String("signing-key", "", "")
@@ -61,6 +62,30 @@ func TestResolveConnectionFlagsAppliesActiveProfile(t *testing.T) {
 
 	insecure, _ := cmd.Flags().GetBool("insecure")
 	require.True(t, insecure, "insecure must come from the active profile")
+}
+
+// TestResolveConnectionFlagsAppliesServerName asserts the profile's
+// tlsServerName reaches the --tls-server-name flag through the shared resolver,
+// so a profile can pin the verification hostname without repeating it on every
+// invocation.
+func TestResolveConnectionFlagsAppliesServerName(t *testing.T) {
+	isolateConfigDir(t)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+	t.Setenv("LEDGERCTL_TLS_SERVER_NAME", "")
+
+	require.NoError(t, SaveConfig(Config{
+		Profiles: map[string]Profile{
+			"prod": {Server: "10.0.0.5:8888", TLSServerName: "ledger.svc.cluster.local"},
+		},
+	}))
+
+	cmd := newConnCmd()
+	require.NoError(t, cmd.Flags().Set("profile", "prod"))
+
+	require.NoError(t, ResolveConnectionFlags(cmd))
+
+	serverName, _ := cmd.Flags().GetString("tls-server-name")
+	require.Equal(t, "ledger.svc.cluster.local", serverName, "tls-server-name must come from the active profile")
 }
 
 // TestResolveConnectionFlagsExplicitFlagWins guards the precedence: an explicit

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -197,6 +197,7 @@ var ledgerctlOwnedFlagNames = map[string]struct{}{
 	"server":              {},
 	"insecure":            {},
 	"tls-ca-cert":         {},
+	"tls-server-name":     {},
 	"consistency":         {},
 	"auth-token":          {},
 	"signing-key":         {},

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -109,6 +109,7 @@ func newRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().String("server", "localhost:8888", "gRPC server address (env: LEDGERCTL_SERVER)")
 	rootCmd.PersistentFlags().Bool("insecure", false, "Use insecure connection (no TLS) (env: LEDGERCTL_INSECURE)")
 	rootCmd.PersistentFlags().String("tls-ca-cert", "", "Path to CA certificate file (PEM) for server verification (env: LEDGERCTL_TLS_CA_CERT)")
+	rootCmd.PersistentFlags().String("tls-server-name", "", "Hostname to verify against the server certificate SANs, overriding the --server host (use when dialing by IP or a name not covered by the cert, e.g. from inside a TLS cluster pod) (env: LEDGERCTL_TLS_SERVER_NAME)")
 
 	// Add persistent flags for request signing.
 	rootCmd.PersistentFlags().String("signing-key", "", "Path to Ed25519 private key file (seed: 32 bytes raw or hex-encoded) (env: LEDGERCTL_SIGNING_KEY)")

--- a/cmd/ledgerctl/main_test.go
+++ b/cmd/ledgerctl/main_test.go
@@ -165,6 +165,15 @@ func TestSubcommandLocalFlagsIgnoreBareEnv(t *testing.T) {
 			bareEnv: "SIGNING_KEY",
 		},
 		{
+			// tls-server-name is owned: profile create redeclares it locally, so a
+			// stray bare TLS_SERVER_NAME must not populate --tls-server-name and
+			// get persisted into the profile — only LEDGERCTL_TLS_SERVER_NAME may.
+			name:    "profile create --tls-server-name ignores bare TLS_SERVER_NAME",
+			path:    []string{"profile", "create"},
+			flag:    "tls-server-name",
+			bareEnv: "TLS_SERVER_NAME",
+		},
+		{
 			name:    "auth generate-token --signing-key ignores bare SIGNING_KEY",
 			path:    []string{"auth", "generate-token"},
 			flag:    "signing-key",

--- a/cmd/ledgerctl/profile/create.go
+++ b/cmd/ledgerctl/profile/create.go
@@ -26,6 +26,7 @@ Use --use to activate it immediately even when other profiles already exist.`,
 	cmd.Flags().String("server", "", "gRPC server address (required)")
 	cmd.Flags().Bool("insecure", false, "Use insecure connection (no TLS)")
 	cmd.Flags().String("tls-ca-cert", "", "Path to CA certificate file (PEM)")
+	cmd.Flags().String("tls-server-name", "", "Hostname to verify against the server certificate SANs, overriding the --server host")
 	cmd.Flags().String("signing-key", "", "Path to Ed25519 private key file for request signing")
 	cmd.Flags().String("signing-key-id", "", "Key ID for request signatures")
 	cmd.Flags().String("response-verify-key", "", "Path to Ed25519 seed file for verifying server response signatures")
@@ -52,6 +53,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	server, _ := cmd.Flags().GetString("server")
 	insecure, _ := cmd.Flags().GetBool("insecure")
 	tlsCaCert, _ := cmd.Flags().GetString("tls-ca-cert")
+	tlsServerName, _ := cmd.Flags().GetString("tls-server-name")
 	signingKey, _ := cmd.Flags().GetString("signing-key")
 	signingKeyID, _ := cmd.Flags().GetString("signing-key-id")
 	responseVerifyKey, _ := cmd.Flags().GetString("response-verify-key")
@@ -61,6 +63,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		Server:            server,
 		Insecure:          insecure,
 		TLSCaCert:         tlsCaCert,
+		TLSServerName:     tlsServerName,
 		SigningKey:        signingKey,
 		SigningKeyID:      signingKeyID,
 		ResponseVerifyKey: responseVerifyKey,

--- a/cmd/ledgerctl/profile/create.go
+++ b/cmd/ledgerctl/profile/create.go
@@ -59,6 +59,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	responseVerifyKey, _ := cmd.Flags().GetString("response-verify-key")
 	useFlag, _ := cmd.Flags().GetBool("use")
 
+	// Reject contradictory TLS flags before persisting, so we never store a
+	// profile that every subsequent TLS-aware command would immediately reject.
+	if err := cmdutil.ValidateTLSFlags(insecure, tlsCaCert, tlsServerName); err != nil {
+		return err
+	}
+
 	p := cmdutil.Profile{
 		Server:            server,
 		Insecure:          insecure,

--- a/cmd/ledgerctl/profile/list.go
+++ b/cmd/ledgerctl/profile/list.go
@@ -41,7 +41,7 @@ func runList(_ *cobra.Command, _ []string) error {
 
 	sort.Strings(names)
 
-	data := pterm.TableData{{"", "NAME", "SERVER", "INSECURE", "TLS CA CERT"}}
+	data := pterm.TableData{{"", "NAME", "SERVER", "INSECURE", "TLS CA CERT", "TLS SERVER NAME"}}
 
 	for _, name := range names {
 		p := cfg.Profiles[name]
@@ -56,7 +56,7 @@ func runList(_ *cobra.Command, _ []string) error {
 			insecure = "true"
 		}
 
-		data = append(data, []string{marker, name, p.Server, insecure, p.TLSCaCert})
+		data = append(data, []string{marker, name, p.Server, insecure, p.TLSCaCert, p.TLSServerName})
 	}
 
 	return pterm.DefaultTable.WithHasHeader().WithData(data).Render()

--- a/cmd/ledgerctl/profile/show.go
+++ b/cmd/ledgerctl/profile/show.go
@@ -66,6 +66,11 @@ func runShow(cmd *cobra.Command, args []string) error {
 		tlsCaCert = p.TLSCaCert
 	}
 
+	tlsServerName := "(none)"
+	if p.TLSServerName != "" {
+		tlsServerName = p.TLSServerName
+	}
+
 	kr := cmdutil.GetKeyring(cmd)
 
 	authStatus := pterm.Yellow("no token stored")
@@ -93,6 +98,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 		{"Server", p.Server},
 		{"Insecure", insecure},
 		{"TLS CA Cert", tlsCaCert},
+		{"TLS Server Name", tlsServerName},
 		{"Signing Key", signingKey},
 		{"Signing Key ID", signingKeyID},
 		{"Response Verify Key", responseVerifyKey},

--- a/cmd/ledgerctl/restore/command.go
+++ b/cmd/ledgerctl/restore/command.go
@@ -1,15 +1,13 @@
 package restore
 
 import (
-	"crypto/tls"
 	"fmt"
 
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
 )
 
@@ -31,15 +29,15 @@ func NewCommand() *cobra.Command {
 // getRestoreClient creates a gRPC client connection and returns the RestoreService client.
 func getRestoreClient(cmd *cobra.Command) (restorepb.RestoreServiceClient, *grpc.ClientConn, error) {
 	serverAddr, _ := cmd.Flags().GetString("server")
-	insecureMode, _ := cmd.Flags().GetBool("insecure")
 
-	var creds credentials.TransportCredentials
-	if insecureMode {
-		creds = insecure.NewCredentials()
-	} else {
-		creds = credentials.NewTLS(&tls.Config{
-			MinVersion: tls.VersionTLS12,
-		})
+	// Share the root command's credential resolution so restore honors the same
+	// --insecure / --tls-ca-cert / --tls-server-name persistent flags (and their
+	// mutual-exclusion guard) as every other command. The restore server is
+	// commonly dialed from inside a pod, where --tls-server-name is needed to
+	// match a cert whose SANs cover only the in-cluster DNS names.
+	creds, err := cmdutil.GetClientTransportCredentials(cmd)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	conn, err := grpc.NewClient(serverAddr,

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3075,7 +3075,7 @@ ledgerctl profile list
 
 ```bash
 ledgerctl profile list
-#    NAME     SERVER                          INSECURE  TLS CA CERT
+#    NAME     SERVER                          INSECURE  TLS CA CERT       TLS SERVER NAME
 # *  prod     ledger.prod.example.com:443
 #    local    localhost:8888                  true
 #    staging  ledger.staging.example.com:443            /path/to/ca.pem

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -26,11 +26,46 @@ These flags are available for all commands:
 | `--server` | `localhost:8888` | gRPC server address |
 | `--insecure` | `false` | Use insecure connection (no TLS) |
 | `--tls-ca-cert` | | Path to CA certificate file (PEM) for server verification |
+| `--tls-server-name` | | Hostname to verify against the server certificate SANs, overriding the `--server` host. Use when dialing by IP or a name the certificate does not cover (env: `LEDGERCTL_TLS_SERVER_NAME`) |
 | `--signing-key` | | Path to Ed25519 private key file (seed: 32 bytes raw or hex-encoded) |
 | `--signing-key-id` | `default` | Key ID for request signatures |
 | `--response-verify-key` | | Path to Ed25519 public key file for verifying server response signatures |
 | `--consistency` | | Read consistency level: `stale`, `leader`, or `linearizable` (default) |
 | `--auth-token` | | Bearer token for authentication (JWT string or `@path-to-file`) |
+
+### TLS server name (verifying by name while dialing by IP)
+
+TLS verification matches the hostname in `--server` against the server
+certificate's Subject Alternative Names (SANs). When the two cannot line up, use
+`--tls-server-name` to override the verification hostname independently of the
+dial address.
+
+The common case is running `ledgerctl` **from inside a TLS cluster pod**. The
+operator-issued certificate covers the in-cluster DNS names only
+(`<pod>.<cluster>-headless.<namespace>.svc.cluster.local`,
+`<cluster>.<namespace>.svc.cluster.local`) and deliberately never `localhost`
+or `127.0.0.1`. Dialing the default `localhost:8888` therefore fails with a
+certificate name mismatch. Two ways to fix it:
+
+```bash
+# Option A — dial the in-cluster FQDN directly (matches the cert SANs)
+ledgerctl \
+  --server "$HOSTNAME.ledger-<cluster>-headless.$POD_NAMESPACE.svc.cluster.local:8888" \
+  --tls-ca-cert "$TLS_CA_CERT_FILE" \
+  ledgers list
+
+# Option B — dial by IP/loopback, verify against the cert name
+ledgerctl \
+  --server 127.0.0.1:8888 \
+  --tls-server-name "ledger-<cluster>.<namespace>.svc.cluster.local" \
+  --tls-ca-cert "$TLS_CA_CERT_FILE" \
+  ledgers list
+```
+
+`--tls-server-name` is rejected together with `--insecure` (conflicting intent —
+no TLS vs. verify against this name), matching the `--tls-ca-cert` behavior. It
+can also be pinned in a profile (`tlsServerName`) so it does not have to be
+repeated on every invocation.
 
 ### Read Consistency
 
@@ -3000,6 +3035,7 @@ ledgerctl profile create <name> --server <addr> [flags]
 | `--server` | *(required)* | gRPC server address |
 | `--insecure` | `false` | Use insecure connection (no TLS) |
 | `--tls-ca-cert` | | Path to CA certificate file (PEM) |
+| `--tls-server-name` | | Hostname to verify against the server certificate SANs, overriding the `--server` host |
 | `--use` | `false` | Set this profile as the active profile |
 
 **Behavior:**


### PR DESCRIPTION
## Problem

On a TLS-enabled cluster, `ledgerctl` is unusable when run **from inside a pod** (e.g. `kubectl exec`). TLS verification matches the `--server` host against the server certificate's SANs, and the client never sets `ServerName` — so it verifies against whatever host is in `--server`. The default `localhost:8888` fails because the operator-issued cert covers only the in-cluster DNS names (`<pod>.<cluster>-headless.<ns>.svc.cluster.local`, `<cluster>.<ns>.svc.cluster.local`) and deliberately **never** `localhost`/`127.0.0.1`.

## Fix

Add a persistent `--tls-server-name` flag that overrides the verification hostname independently of the dial address — the `curl --resolve` / `openssl -servername` equivalent. This lets a client dial by IP/loopback while still validating an FQDN-only certificate.

```sh
ledgerctl --server 127.0.0.1:8888 \
  --tls-server-name "ledger-<cluster>.<ns>.svc.cluster.local" \
  --tls-ca-cert "$TLS_CA_CERT_FILE" ledgers list
```

The inter-node transport already does exactly this (`connection_pool.go` sets `cfg.ServerName`), so this brings `ledgerctl` in line with the existing pattern.

## Details

- Persistent flag `--tls-server-name`, env `LEDGERCTL_TLS_SERVER_NAME`, profile field `tlsServerName` (full CLI > env > profile > default precedence).
- Sets `tls.Config.ServerName` in `GetClientTransportCredentials`.
- Rejected together with `--insecure` (conflicting intent), matching the existing `--tls-ca-cert` guard — also catches a stray `LEDGERCTL_INSECURE` leaking in.
- Wired into `profile create`, `auth login` (not dropped on re-login), and `profile show`.
- Docs: `docs/ops/cli.md` global-flags table, `profile create` table, and a new subsection covering the in-pod use case (dial-FQDN vs dial-by-IP options).

## Not included

No operator change: the operator already dials the in-cluster FQDN (`podSelfServerAddr`, `backupServerAddr`), so it has no mismatch and doesn't need the flag.

## Tests

- `insecure` + `tls-server-name` rejected; TLS-with-server-name succeeds.
- Profile resolution of `tlsServerName` through the shared resolver.
- `go build ./...`, `go vet`, and all `./cmd/ledgerctl/...` tests green.