### PR TITLE
fix(antithesis): bounce the restore-mode pod gracefully

### DIFF
--- a/tests/antithesis/workload/restore-orchestrator.sh
+++ b/tests/antithesis/workload/restore-orchestrator.sh
@@ -169,10 +169,15 @@ restore_from_backup() {
 	retry 5 finalize_step || { log "restore finalize failed"; return 1; }
 
 	k apply -f "$NORMAL_SPEC" || { log "applying normal-mode cluster failed"; return 1; }
-	# The restore-mode pod does not roll on its own after the spec flip
-	# (operator e2e does the same bounce).
+	# The restore-mode pod does not roll on its own after the spec flip, so it
+	# is bounced here. Graceful delete only: it keeps the pod object (and the
+	# StatefulSet from creating the replacement) until the old container has
+	# actually exited — a force delete drops the object immediately while the
+	# kubelet is still killing the container, and the replacement then boots
+	# into the old process's live Pebble lock ("resource temporarily
+	# unavailable", exit 1) and gets flagged as an unexpected container exit.
 	sleep 5
-	k delete pod "$POD_PREFIX-0" --force --grace-period=0 2>/dev/null || true
+	k delete pod "$POD_PREFIX-0" --wait=true --timeout=120s 2>/dev/null || true
 	wait_ready_replicas "$REPLICAS" || { log "cluster did not return to $REPLICAS ready replicas"; return 1; }
 }
 


### PR DESCRIPTION
On run `b3412b1b21e50384240031b8ed31a2be-57-8` (release/v3.0 @ 52cbc80, the first fully-green model-template run with restore cycles), the one non-environmental red was `No unexpected container exits` — 7 × `container: ledger, exit code: 1`.

Trace: at each restore cycle's normal-mode flip, the orchestrator bounced pod 0 with `kubectl delete pod --force --grace-period=0`. Force delete removes the pod object immediately while the kubelet is still killing the container, so the StatefulSet schedules the replacement concurrently — which boots into the old process's live Pebble lock:

```
INFO  Opening existing database from /data/app/live
Error: opening pebble database: resource temporarily unavailable
```

exit 1, then kubelet's retry a second later succeeds. Harness-induced noise; the SUT's refusal to double-open the store is the correct behavior.

The bounce is now a plain graceful delete (`--wait --timeout=120s`): the pod object survives until the container has actually exited, so the replacement never races the lock. Cycle latency grows by at most the termination grace period, well within the orchestrator's budgets.
