### PR TITLE
fix(bulk): (v2) map business errors to their API codes instead of INTERNAL

### DIFF
--- a/internal/api/bulking/handler_json.go
+++ b/internal/api/bulking/handler_json.go
@@ -112,6 +112,8 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 				errorCode = common.ErrInterpreterParse
 			case errors.Is(result.Error, ledgercontroller.ErrRuntime{}):
 				errorCode = common.ErrInterpreterRuntime
+			case errors.Is(result.Error, ledgercontroller.ErrAlreadyReverted{}):
+				errorCode = common.ErrAlreadyRevert
 			default:
 				errorCode = api.ErrorInternal
 			}

--- a/internal/api/bulking/handler_json.go
+++ b/internal/api/bulking/handler_json.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/transport/api"
 	"github.com/formancehq/go-libs/v5/pkg/types/collections"
 	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
+	"github.com/formancehq/numscript"
 
 	"github.com/formancehq/ledger/internal/api/common"
 	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
@@ -97,26 +98,7 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 		)
 
 		if result.Error != nil {
-			switch {
-			case errors.Is(result.Error, &ledgercontroller.ErrInsufficientFunds{}):
-				errorCode = common.ErrInsufficientFund
-			case errors.Is(result.Error, &ledgercontroller.ErrInvalidVars{}) || errors.Is(result.Error, ledgercontroller.ErrCompilationFailed{}):
-				errorCode = common.ErrCompilationFailed
-			case errors.Is(result.Error, &ledgercontroller.ErrMetadataOverride{}):
-				errorCode = common.ErrMetadataOverride
-			case errors.Is(result.Error, ledgercontroller.ErrNoPostings):
-				errorCode = common.ErrNoPostings
-			case errors.Is(result.Error, ledgerstore.ErrTransactionReferenceConflict{}):
-				errorCode = common.ErrConflict
-			case errors.Is(result.Error, ledgercontroller.ErrParsing{}):
-				errorCode = common.ErrInterpreterParse
-			case errors.Is(result.Error, ledgercontroller.ErrRuntime{}):
-				errorCode = common.ErrInterpreterRuntime
-			case errors.Is(result.Error, ledgercontroller.ErrAlreadyReverted{}):
-				errorCode = common.ErrAlreadyRevert
-			default:
-				errorCode = api.ErrorInternal
-			}
+			errorCode = mapBulkElementError(result.Error)
 			errorDescription = result.Error.Error()
 			responseType = "ERROR"
 		}
@@ -150,4 +132,37 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 type ComposedErrorResponse struct {
 	api.BaseResponse[[]APIResult]
 	api.ErrorResponse
+}
+
+// mapBulkElementError maps a controller error for a bulk element to the same API
+// error code the individual (non-bulk) endpoints return, so a business error in a
+// bulk is not reported as a generic INTERNAL. It must stay consistent with the
+// per-endpoint mappings in internal/api/v2 and common.HandleCommon*Errors.
+func mapBulkElementError(err error) string {
+	switch {
+	case errors.Is(err, &ledgercontroller.ErrInsufficientFunds{}), errors.Is(err, numscript.MissingFundsErr{}):
+		return common.ErrInsufficientFund
+	case errors.Is(err, &ledgercontroller.ErrInvalidVars{}) || errors.Is(err, ledgercontroller.ErrCompilationFailed{}):
+		return common.ErrCompilationFailed
+	case errors.Is(err, &ledgercontroller.ErrMetadataOverride{}):
+		return common.ErrMetadataOverride
+	case errors.Is(err, ledgercontroller.ErrNoPostings):
+		return common.ErrNoPostings
+	case errors.Is(err, ledgerstore.ErrTransactionReferenceConflict{}), errors.Is(err, ledgercontroller.ErrIdempotencyKeyConflict{}):
+		return common.ErrConflict
+	case errors.Is(err, ledgercontroller.ErrParsing{}):
+		return common.ErrInterpreterParse
+	case errors.Is(err, ledgercontroller.ErrRuntime{}):
+		return common.ErrInterpreterRuntime
+	case errors.Is(err, ledgercontroller.ErrAlreadyReverted{}):
+		return common.ErrAlreadyRevert
+	case errors.Is(err, ledgercontroller.ErrInvalidIdempotencyInput{}), errors.Is(err, ledgercontroller.ErrSchemaValidationError{}):
+		return common.ErrValidation
+	case errors.Is(err, ledgercontroller.ErrSchemaNotSpecified{}):
+		return common.ErrSchemaNotSpecified
+	case errors.Is(err, ledgercontroller.ErrNotFound), errors.Is(err, ledgercontroller.ErrSchemaNotFound{}):
+		return api.ErrorCodeNotFound
+	default:
+		return api.ErrorInternal
+	}
 }

--- a/internal/api/bulking/handler_json_error_test.go
+++ b/internal/api/bulking/handler_json_error_test.go
@@ -1,0 +1,47 @@
+package bulking
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/transport/api"
+	"github.com/formancehq/numscript"
+
+	"github.com/formancehq/ledger/internal/api/common"
+	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
+	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
+)
+
+// A bulk element's business error must map to the same code the individual
+// endpoints return, never the generic INTERNAL fallback.
+func TestMapBulkElementError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"insufficient funds", &ledgercontroller.ErrInsufficientFunds{}, common.ErrInsufficientFund},
+		{"numscript missing funds", numscript.MissingFundsErr{}, common.ErrInsufficientFund},
+		{"invalid vars", &ledgercontroller.ErrInvalidVars{}, common.ErrCompilationFailed},
+		{"compilation failed", ledgercontroller.ErrCompilationFailed{}, common.ErrCompilationFailed},
+		{"metadata override", &ledgercontroller.ErrMetadataOverride{}, common.ErrMetadataOverride},
+		{"no postings", ledgercontroller.ErrNoPostings, common.ErrNoPostings},
+		{"reference conflict", ledgerstore.ErrTransactionReferenceConflict{}, common.ErrConflict},
+		{"idempotency key conflict", ledgercontroller.ErrIdempotencyKeyConflict{}, common.ErrConflict},
+		{"parsing", ledgercontroller.ErrParsing{}, common.ErrInterpreterParse},
+		{"runtime", ledgercontroller.ErrRuntime{}, common.ErrInterpreterRuntime},
+		{"already reverted", ledgercontroller.ErrAlreadyReverted{}, common.ErrAlreadyRevert},
+		{"invalid idempotency input", ledgercontroller.ErrInvalidIdempotencyInput{}, common.ErrValidation},
+		{"schema validation", ledgercontroller.ErrSchemaValidationError{}, common.ErrValidation},
+		{"schema not specified", ledgercontroller.ErrSchemaNotSpecified{}, common.ErrSchemaNotSpecified},
+		{"not found", ledgercontroller.ErrNotFound, api.ErrorCodeNotFound},
+		{"schema not found", ledgercontroller.ErrSchemaNotFound{}, api.ErrorCodeNotFound},
+		{"unknown", errors.New("boom"), api.ErrorInternal},
+	} {
+		require.Equal(t, tc.want, mapBulkElementError(tc.err), tc.name)
+	}
+}

--- a/test/e2e/api_bulk_test.go
+++ b/test/e2e/api_bulk_test.go
@@ -394,4 +394,51 @@ var _ = Context("Ledger engine tests", func() {
 			})
 		})
 	})
+	When("reverting an already-reverted transaction inside a bulk", func() {
+		// Regression: a revert of an already-reverted transaction inside a bulk
+		// must report ALREADY_REVERT, like the standalone revert endpoint — not
+		// INTERNAL, which the bulk error mapping used to fall back to.
+		var (
+			err  error
+			txID *big.Int
+		)
+		BeforeEach(func(specContext SpecContext) {
+			client := Wait(specContext, DeferClient(testServer))
+			createResponse, createErr := client.Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				V2PostTransaction: components.V2PostTransaction{
+					Metadata: map[string]string{},
+					Postings: []components.V2Posting{{
+						Amount:      big.NewInt(100),
+						Asset:       "USD/2",
+						Destination: "bank",
+						Source:      "world",
+					}},
+				},
+			})
+			Expect(createErr).To(Succeed())
+			txID = createResponse.V2CreateTransactionResponse.Data.ID
+
+			_, err = client.Ledger.V2.RevertTransaction(ctx, operations.V2RevertTransactionRequest{
+				Ledger: "default",
+				ID:     txID,
+			})
+			Expect(err).To(Succeed())
+		})
+		It("should report ALREADY_REVERT for that element", func(specContext SpecContext) {
+			bulkResponse, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+				Ledger: "default",
+				RequestBody: []components.V2BulkElement{
+					components.CreateV2BulkElementRevertTransaction(components.V2BulkElementRevertTransaction{
+						Data: &components.V2BulkElementRevertTransactionData{
+							ID: txID,
+						},
+					}),
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(bulkResponse.V2BulkResponse.Data[0].Type).To(Equal(components.V2BulkElementResultType("ERROR")))
+			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("ALREADY_REVERT"))
+		})
+	})
 })

--- a/test/e2e/api_bulk_test.go
+++ b/test/e2e/api_bulk_test.go
@@ -441,4 +441,24 @@ var _ = Context("Ledger engine tests", func() {
 			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("ALREADY_REVERT"))
 		})
 	})
+	When("targeting a non-existent transaction inside a bulk", func() {
+		// Regression: a bulk element targeting a missing transaction must report
+		// NOT_FOUND, like the standalone endpoints — not INTERNAL.
+		var err error
+		It("should report NOT_FOUND for that element", func(specContext SpecContext) {
+			bulkResponse, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+				Ledger: "default",
+				RequestBody: []components.V2BulkElement{
+					components.CreateV2BulkElementRevertTransaction(components.V2BulkElementRevertTransaction{
+						Data: &components.V2BulkElementRevertTransactionData{
+							ID: big.NewInt(42),
+						},
+					}),
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(bulkResponse.V2BulkResponse.Data[0].Type).To(Equal(components.V2BulkElementResultType("ERROR")))
+			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("NOT_FOUND"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

A business error produced by an element of a `POST /v2/{ledger}/_bulk` request was
reported with error code `INTERNAL` instead of the specific code the equivalent
individual endpoint returns. Most visibly, reverting an already-reverted
transaction inside a bulk returned `INTERNAL`, whereas
`POST /v2/{ledger}/transactions/{id}/revert` returns `ALREADY_REVERT`.

`INTERNAL` is the code for a server fault, so clients and monitoring treat these
expected, client-caused rejections as 5xx-class failures, and the reported code
is inconsistent between the bulk and non-bulk paths.

## Root cause

The JSON bulk handler (`internal/api/bulking/handler_json.go`) maps each element's
controller error to an API error code with its own `switch`, which covered only a
subset of the errors the individual endpoints handle. Everything else fell through
to `default → api.ErrorInternal`.

This affected several errors reachable through the bulk API, not just reverts:

| Controller error | Before (bulk) | After (matches individual endpoints) |
| --- | --- | --- |
| `ErrAlreadyReverted` | `INTERNAL` | `ALREADY_REVERT` |
| `ErrNotFound` / `ErrSchemaNotFound` | `INTERNAL` | `NOT_FOUND` |
| `numscript.MissingFundsErr` | `INTERNAL` | `INSUFFICIENT_FUND` |
| `ErrIdempotencyKeyConflict` | `INTERNAL` | `CONFLICT` |
| `ErrInvalidIdempotencyInput` / `ErrSchemaValidationError` | `INTERNAL` | `VALIDATION` |
| `ErrSchemaNotSpecified` | `INTERNAL` | `SCHEMA_NOT_SPECIFIED` |

(The existing insufficient-funds case only matched `ErrInsufficientFunds`, so a
numscript overdraft in a bulk was already mis-reported as `INTERNAL`.)

## Changes

- Extract the element error-to-code mapping into `mapBulkElementError`, covering
  the full set of business errors so a bulk element returns the same code its
  standalone endpoint would. A comment notes it must stay in sync with the
  per-endpoint mappings in `internal/api/v2` and `common.HandleCommon*Errors`.
- Add a unit test asserting every mapping (and the `INTERNAL` fallback for an
  unknown error).
- Add two e2e regressions in `test/e2e/api_bulk_test.go`:
  - reverting an already-reverted transaction in a bulk → `ALREADY_REVERT`;
  - a bulk element targeting a missing transaction → `NOT_FOUND`.

No change to HTTP status codes (a bulk with a failing element still responds
`400`); only the per-element `errorCode` in the bulk response body is corrected.

## Testing

- `go test ./internal/api/bulking/...` — unit tests pass, including the new
  mapping test covering all cases.
- `go test -tags it ./test/e2e/ -ginkgo.focus="bulk"` — full bulk e2e suite
  passes; the two new specs fail on `main` (`INTERNAL`) and pass with this change.