### PR TITLE
fix(revert): (v2) return 409/400 for idempotency errors instead of 500

### DIFF
--- a/internal/api/v2/controllers_transactions_revert.go
+++ b/internal/api/v2/controllers_transactions_revert.go
@@ -54,7 +54,10 @@ func revertTransaction(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, ledgercontroller.ErrNotFound):
 			api.NotFound(w, err)
 		default:
-			common.HandleCommonErrors(w, r, err)
+			// RevertTransaction carries an idempotency key, so route through the
+			// write-error handler: an idempotency conflict / invalid input is a
+			// 409/400, not a 500.
+			common.HandleCommonWriteErrors(w, r, err)
 		}
 		return
 	}

--- a/test/e2e/api_transactions_revert_test.go
+++ b/test/e2e/api_transactions_revert_test.go
@@ -417,4 +417,49 @@ var _ = Context("Ledger revert transactions API tests", func() {
 			})
 		})
 	})
+	When("reverting two different transactions with the same idempotency key", func() {
+		// Regression: RevertTransaction carries an idempotency key, so reusing it
+		// with a different input must be a 400 VALIDATION, not a 500 — the endpoint
+		// used to route this through the non-write common error handler.
+		var (
+			txA, txB *operations.V2CreateTransactionResponse
+			err      error
+		)
+		create := func(specContext SpecContext, destination string) *operations.V2CreateTransactionResponse {
+			res, cErr := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				V2PostTransaction: components.V2PostTransaction{
+					Metadata: map[string]string{},
+					Postings: []components.V2Posting{{
+						Amount:      big.NewInt(100),
+						Asset:       "USD",
+						Source:      "world",
+						Destination: destination,
+					}},
+				},
+			})
+			Expect(cErr).ToNot(HaveOccurred())
+			return res
+		}
+		BeforeEach(func(specContext SpecContext) {
+			txA = create(specContext, "alice")
+			txB = create(specContext, "bob")
+		})
+		It("should reject the second revert with VALIDATION, not INTERNAL", func(specContext SpecContext) {
+			client := Wait(specContext, DeferClient(testServer))
+			_, err = client.Ledger.V2.RevertTransaction(ctx, operations.V2RevertTransactionRequest{
+				Ledger:         "default",
+				ID:             txA.V2CreateTransactionResponse.Data.ID,
+				IdempotencyKey: pointer.For("reuse-key"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = client.Ledger.V2.RevertTransaction(ctx, operations.V2RevertTransactionRequest{
+				Ledger:         "default",
+				ID:             txB.V2CreateTransactionResponse.Data.ID,
+				IdempotencyKey: pointer.For("reuse-key"),
+			})
+			Expect(err).To(HaveErrorCode(string(components.V2ErrorsEnumValidation)))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

`POST /v2/{ledger}/transactions/{id}/revert` carries an idempotency key but
routed its fallback errors through the non-write error handler, so an
idempotency-key conflict returned `500` and reusing a key with a different input
returned `500` instead of `400 VALIDATION`. `INTERNAL` reads as a server fault,
so clients and monitoring treat these expected rejections as 5xx-class failures.

## Root cause

`internal/api/v2/controllers_transactions_revert.go` builds its command with
`getCommandParameters` (which attaches the `Idempotency-Key`), but its `default`
case fell through to `common.HandleCommonErrors`, which does not handle the
idempotency cases. `common.HandleCommonWriteErrors` does (idempotency conflict →
`409 CONFLICT`, invalid idempotency input → `400 VALIDATION`).

Revert was the only idempotency-key-carrying write endpoint using the non-write
handler; the create/metadata endpoints already use `HandleCommonWriteErrors`.

## Changes

- Route the revert error fallback through `common.HandleCommonWriteErrors`.
- Add an e2e regression in `test/e2e/api_transactions_revert_test.go`: reverting
  two different transactions with the same idempotency key now returns
  `400 VALIDATION`.

Only the error code/status of already-failing requests changes; success paths and
which requests succeed are unaffected.

## Testing

- `go test -tags it ./test/e2e/ -ginkgo.focus="same idempotency key"` — the new
  spec fails on `main` (`INTERNAL`) and passes with this change (`VALIDATION`).