### PR TITLE
fix(EN-1553): require TLS when --auth-enabled

### DIFF
--- a/docs/ops/authentication.md
+++ b/docs/ops/authentication.md
@@ -9,16 +9,23 @@ ledger run \
   --node-id 1 \
   --cluster-id prod-ledger \
   --bootstrap \
+  --tls-mode required \
+  --tls-cert-file /etc/ledger/tls.crt \
+  --tls-key-file /etc/ledger/tls.key \
   --auth-enabled \
   --auth-issuer https://auth.example.com \
   --auth-service ledger
 ```
 
+> `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`);
+> the server refuses to start with `--tls-mode=disabled` so bearer tokens are
+> never sent in plaintext. See [Configuration Invariants](#configuration-invariants).
+
 ## CLI Flags
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization |
+| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires TLS (`--tls-mode` `optional` or `required`) — rejected with `--tls-mode=disabled` |
 | `--auth-issuer` | string | `""` | OIDC issuer URL (used for discovery and token validation) |
 | `--auth-service` | string | `""` | Service name prefix for scopes (e.g., `ledger` for `ledger:read`) |
 
@@ -59,6 +66,13 @@ The server enforces the following rules at startup:
 - `--auth-enabled` requires at least one of `--auth-issuer` (OIDC) or
   `--auth-ed25519-keys` (Ed25519 key file). The server refuses to start
   without a credential source.
+- `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`).
+  Over a plaintext transport the bearer JWT/Ed25519 tokens would be sent in the
+  clear and could be intercepted and replayed by an on-path attacker, so the
+  combination `--tls-mode=disabled --auth-enabled` is rejected at startup. This
+  mirrors the `--cluster-secret` rule, which likewise requires TLS. There is no
+  opt-out; terminate TLS on the ledger process itself even when an ingress or
+  service mesh also terminates TLS upstream.
 - Setting auth-related flags (`--auth-issuer`, `--auth-ed25519-keys`,
   `--auth-scope-mapping-file`) without `--auth-enabled` is rejected to
   prevent operators from believing authentication is active when it is not.
@@ -82,6 +96,7 @@ The writes-only configuration is:
 
 ```bash
 ledger run --auth-enabled --auth-issuer https://auth.example.com \
+  --tls-mode required --tls-cert-file /etc/ledger/tls.crt --tls-key-file /etc/ledger/tls.key \
   --auth-anonymous-scopes "*:read"
 ```
 

--- a/docs/ops/authentication.md
+++ b/docs/ops/authentication.md
@@ -17,15 +17,15 @@ ledger run \
   --auth-service ledger
 ```
 
-> `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`);
-> the server refuses to start with `--tls-mode=disabled` so bearer tokens are
-> never sent in plaintext. See [Configuration Invariants](#configuration-invariants).
+> `--auth-enabled` requires `--tls-mode=required`; the server refuses to start
+> with `--tls-mode=disabled` or `--tls-mode=optional` so bearer tokens are never
+> exposed to plaintext. See [Configuration Invariants](#configuration-invariants).
 
 ## CLI Flags
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires TLS (`--tls-mode` `optional` or `required`) — rejected with `--tls-mode=disabled` |
+| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires `--tls-mode=required` — rejected with `--tls-mode=disabled` or `--tls-mode=optional` |
 | `--auth-issuer` | string | `""` | OIDC issuer URL (used for discovery and token validation) |
 | `--auth-service` | string | `""` | Service name prefix for scopes (e.g., `ledger` for `ledger:read`) |
 
@@ -66,11 +66,15 @@ The server enforces the following rules at startup:
 - `--auth-enabled` requires at least one of `--auth-issuer` (OIDC) or
   `--auth-ed25519-keys` (Ed25519 key file). The server refuses to start
   without a credential source.
-- `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`).
-  Over a plaintext transport the bearer JWT/Ed25519 tokens would be sent in the
-  clear and could be intercepted and replayed by an on-path attacker, so the
-  combination `--tls-mode=disabled --auth-enabled` is rejected at startup. This
-  mirrors the `--cluster-secret` rule, which likewise requires TLS. There is no
+- `--auth-enabled` requires `--tls-mode=required`. Over a plaintext transport
+  the bearer JWT/Ed25519 tokens would be sent in the clear and could be
+  intercepted and replayed by an on-path attacker, so both
+  `--tls-mode=disabled` and `--tls-mode=optional` are rejected at startup —
+  `optional` runs a dual listener that still accepts plaintext client
+  connections, so it is not sufficient. This is intentionally stricter than the
+  `--cluster-secret` rule (which permits `optional`): the operator drives
+  zero-downtime inter-node TLS migration through the transitional `optional`
+  mode, but the external service API has no such requirement. There is no
   opt-out; terminate TLS on the ledger process itself even when an ingress or
   service mesh also terminates TLS upstream.
 - Setting auth-related flags (`--auth-issuer`, `--auth-ed25519-keys`,

--- a/docs/ops/authentication.md
+++ b/docs/ops/authentication.md
@@ -19,7 +19,10 @@ ledger run \
 
 > `--auth-enabled` requires `--tls-mode=required`; the server refuses to start
 > with `--tls-mode=disabled` or `--tls-mode=optional` so bearer tokens are never
-> exposed to plaintext. See [Configuration Invariants](#configuration-invariants).
+> exposed to plaintext **on the gRPC service transport**. The HTTP REST-compat
+> listener is not covered by `--tls-mode` and must be TLS-terminated separately
+> (HTTPS at the ingress/proxy) when authentication is enabled.
+> See [Configuration Invariants](#configuration-invariants).
 
 ## CLI Flags
 
@@ -76,7 +79,10 @@ The server enforces the following rules at startup:
   zero-downtime inter-node TLS migration through the transitional `optional`
   mode, but the external service API has no such requirement. There is no
   opt-out; terminate TLS on the ledger process itself even when an ingress or
-  service mesh also terminates TLS upstream.
+  service mesh also terminates TLS upstream. Note this guard covers the
+  **gRPC service transport** only — `--tls-mode` does not govern the HTTP
+  REST-compat listener, which remains plaintext and must be protected by
+  separate HTTPS termination (ingress/proxy) when authentication is enabled.
 - Setting auth-related flags (`--auth-issuer`, `--auth-ed25519-keys`,
   `--auth-scope-mapping-file`) without `--auth-enabled` is rejected to
   prevent operators from believing authentication is active when it is not.

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4449,6 +4449,7 @@ one node's secret drifted from the rest of the cluster.
 
 ```bash
 ledger run --cluster-secret "my-cluster-secret" --auth-enabled \
+  --tls-mode required \
   --tls-cert-file /etc/ledger/tls.crt --tls-key-file /etc/ledger/tls.key \
   [other flags...]
 ```

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4638,7 +4638,7 @@ Enable JWT/OIDC authentication with scope-based authorization. See [Authenticati
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires TLS (`--tls-mode` `optional` or `required`) — rejected with `--tls-mode=disabled` |
+| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires `--tls-mode=required` — rejected with `--tls-mode=disabled` or `--tls-mode=optional` (`optional` still accepts plaintext client connections) |
 | `--auth-issuer` | string | `""` | OIDC issuer URL (used for discovery and token validation) |
 | `--auth-service` | string | `""` | Service name prefix for scopes (e.g., `ledger` for `ledger:read`) |
 | `--auth-read-key-set-max-retries` | int | `10` | Maximum retries when fetching the JWKS key set |

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4515,6 +4515,7 @@ ledger run --auth-scope-mapping-file /etc/ledger/scope-mapping.json [other flags
 
 ```bash
 ledger run --auth-enabled --auth-issuer https://auth.example.com \
+  --tls-mode required --tls-cert-file /etc/ledger/tls.crt --tls-key-file /etc/ledger/tls.key \
   --auth-anonymous-scopes "*:read"
 ```
 
@@ -4636,7 +4637,7 @@ Enable JWT/OIDC authentication with scope-based authorization. See [Authenticati
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization |
+| `--auth-enabled` | bool | `false` | Enable JWT authentication and scope-based authorization. Requires TLS (`--tls-mode` `optional` or `required`) — rejected with `--tls-mode=disabled` |
 | `--auth-issuer` | string | `""` | OIDC issuer URL (used for discovery and token validation) |
 | `--auth-service` | string | `""` | Service name prefix for scopes (e.g., `ledger` for `ledger:read`) |
 | `--auth-read-key-set-max-retries` | int | `10` | Maximum retries when fetching the JWKS key set |

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -753,7 +753,7 @@ kubectl cp ledger-0:/tmp/backup.tar.gz ./backup.tar.gz
 ### Production Recommendations
 
 1. **TLS/HTTPS**: Configure TLS for all communications. To enable or disable TLS on a running cluster without downtime, see [TLS migration](tls-migration.md).
-2. **Authentication**: Add API authentication (JWT, OAuth2). `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`) and the server refuses to start with `--tls-mode=disabled` — bearer tokens would otherwise travel in plaintext. This mirrors the `--cluster-secret` rule. See [Authentication](authentication.md#configuration-invariants).
+2. **Authentication**: Add API authentication (JWT, OAuth2). `--auth-enabled` requires `--tls-mode=required` and the server refuses to start with `--tls-mode=disabled` or `--tls-mode=optional` — bearer tokens would otherwise be exposed to plaintext interception (`optional` still accepts plaintext client connections). This is intentionally stricter than the `--cluster-secret` rule, which permits `optional` for zero-downtime migration. See [Authentication](authentication.md#configuration-invariants).
 3. **Network Policies**: Restrict network communications
 4. **Secrets Management**: Use Kubernetes Secrets or Vault
 5. **RBAC**: Configure appropriate Kubernetes permissions

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -753,7 +753,7 @@ kubectl cp ledger-0:/tmp/backup.tar.gz ./backup.tar.gz
 ### Production Recommendations
 
 1. **TLS/HTTPS**: Configure TLS for all communications. To enable or disable TLS on a running cluster without downtime, see [TLS migration](tls-migration.md).
-2. **Authentication**: Add API authentication (JWT, OAuth2)
+2. **Authentication**: Add API authentication (JWT, OAuth2). `--auth-enabled` requires TLS (`--tls-mode` set to `optional` or `required`) and the server refuses to start with `--tls-mode=disabled` — bearer tokens would otherwise travel in plaintext. This mirrors the `--cluster-secret` rule. See [Authentication](authentication.md#configuration-invariants).
 3. **Network Policies**: Restrict network communications
 4. **Secrets Management**: Use Kubernetes Secrets or Vault
 5. **RBAC**: Configure appropriate Kubernetes permissions

--- a/docs/ops/tls-migration.md
+++ b/docs/ops/tls-migration.md
@@ -96,6 +96,19 @@ and provide --tls-cert-file / --tls-key-file)
 --tls-key-file)
 ```
 
+Because `--auth-enabled` demands `required`, the operator coordinates auth
+with the TLS state machine so a single CR edit that turns on both TLS and
+auth does not deadlock:
+
+- If you set `auth.enabled: true` while `tls.enabled` is false, the operator
+  **rejects** the CR (it would otherwise reconcile into a silently
+  unauthenticated cluster). Enable TLS first.
+- When both are enabled together on an existing plaintext cluster, the
+  operator holds auth **off** while the StatefulSet rolls through the
+  transitional `optional` mode, then enables auth once TLS has converged to
+  `required`. The API is briefly unauthenticated during that window — no
+  worse than the plaintext state you are migrating away from.
+
 ## Direct (non-operator) deployments
 
 When running the ledger binary directly (no operator), use:

--- a/docs/ops/tls-migration.md
+++ b/docs/ops/tls-migration.md
@@ -75,14 +75,25 @@ when TLS is at least partially active (`mode != disabled`). Sending a
 static token over plaintext is an anti-pattern, so the secret only exists
 when the wire is encrypted.
 
-This means **authentication requires TLS**. If you intend to enable
-`--auth-enabled`, enable TLS first.
+This means **authentication requires TLS**. Note the two guards differ in
+strictness:
 
-The server enforces this invariant at startup:
+- `--cluster-secret` (inter-node static bearer token) requires `mode != disabled`,
+  i.e. `optional` or `required` — it must tolerate `optional` because the
+  operator drives the migration *through* that transitional mode.
+- `--auth-enabled` (external service API JWT/Ed25519) requires `--tls-mode=required`.
+  `optional` is rejected because its dual listener still accepts plaintext client
+  connections, so bearer tokens could travel in the clear. Bring the cluster to
+  `required` before enabling `--auth-enabled`.
+
+The server enforces these invariants at startup:
 
 ```
 --cluster-secret requires TLS (set --tls-mode to optional or required
 and provide --tls-cert-file / --tls-key-file)
+
+--auth-enabled requires --tls-mode=required (with --tls-cert-file /
+--tls-key-file)
 ```
 
 ## Direct (non-operator) deployments

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -336,6 +336,13 @@ func (c Config) validateAuthConfig() error {
 			return errors.New("--auth-enabled requires either --auth-issuer (OIDC) or --auth-ed25519-keys (Ed25519)")
 		}
 
+		// Reject auth without TLS — bearer JWT/Ed25519 tokens would travel in
+		// plaintext over the external gRPC API. Mirrors the --cluster-secret rule
+		// in Validate() so both bearer credentials are protected symmetrically.
+		if c.TLSConfig.Mode == TLSModeDisabled {
+			return errors.New("--auth-enabled requires TLS (set --tls-mode to optional or required and provide --tls-cert-file / --tls-key-file); bearer tokens would be sent in plaintext otherwise")
+		}
+
 		return nil
 	}
 

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -336,11 +336,15 @@ func (c Config) validateAuthConfig() error {
 			return errors.New("--auth-enabled requires either --auth-issuer (OIDC) or --auth-ed25519-keys (Ed25519)")
 		}
 
-		// Reject auth without TLS — bearer JWT/Ed25519 tokens would travel in
-		// plaintext over the external gRPC API. Mirrors the --cluster-secret rule
-		// in Validate() so both bearer credentials are protected symmetrically.
-		if c.TLSConfig.Mode == TLSModeDisabled {
-			return errors.New("--auth-enabled requires TLS (set --tls-mode to optional or required and provide --tls-cert-file / --tls-key-file); bearer tokens would be sent in plaintext otherwise")
+		// Reject auth without full TLS — bearer JWT/Ed25519 tokens would be
+		// exposed to plaintext interception otherwise. Unlike the --cluster-secret
+		// guard in Validate() (which permits `optional` because the operator drives
+		// zero-downtime inter-node TLS migration through that transitional
+		// dual-listener), the external service API demands `required`: `optional`
+		// still accepts plaintext client connections, so a client could send
+		// Authorization metadata in cleartext.
+		if c.TLSConfig.Mode != TLSModeRequired {
+			return errors.New("--auth-enabled requires --tls-mode=required (with --tls-cert-file / --tls-key-file); bearer tokens would otherwise be exposed to plaintext interception (--tls-mode=optional still accepts plaintext connections)")
 		}
 
 		return nil

--- a/internal/bootstrap/config_test.go
+++ b/internal/bootstrap/config_test.go
@@ -214,10 +214,10 @@ func TestValidateAuthConfig(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name:    "auth enabled with issuer over TLS optional",
+			name:    "auth enabled with issuer over TLS optional is rejected",
 			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com"},
 			tlsMode: TLSModeOptional,
-			wantErr: "",
+			wantErr: "--auth-enabled requires --tls-mode=required",
 		},
 		{
 			name:    "auth enabled with ed25519 keys file over TLS",
@@ -235,7 +235,7 @@ func TestValidateAuthConfig(t *testing.T) {
 			name:    "auth enabled with credentials but TLS disabled",
 			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com"},
 			tlsMode: TLSModeDisabled,
-			wantErr: "--auth-enabled requires TLS",
+			wantErr: "--auth-enabled requires --tls-mode=required",
 		},
 		{
 			name:    "auth enabled without credentials",

--- a/internal/bootstrap/config_test.go
+++ b/internal/bootstrap/config_test.go
@@ -204,36 +204,55 @@ func TestValidateAuthConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		auth    AuthFlagConfig
+		tlsMode TLSMode
 		wantErr string
 	}{
 		{
-			name:    "auth enabled with issuer",
+			name:    "auth enabled with issuer over TLS required",
 			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com"},
+			tlsMode: TLSModeRequired,
 			wantErr: "",
 		},
 		{
-			name:    "auth enabled with ed25519 keys file",
+			name:    "auth enabled with issuer over TLS optional",
+			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com"},
+			tlsMode: TLSModeOptional,
+			wantErr: "",
+		},
+		{
+			name:    "auth enabled with ed25519 keys file over TLS",
 			auth:    AuthFlagConfig{Enabled: true, Ed25519KeysFile: "/path/to/keys"},
+			tlsMode: TLSModeRequired,
 			wantErr: "",
 		},
 		{
-			name:    "auth enabled with both issuer and ed25519",
+			name:    "auth enabled with both issuer and ed25519 over TLS",
 			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com", Ed25519KeysFile: "/path/to/keys"},
+			tlsMode: TLSModeRequired,
 			wantErr: "",
+		},
+		{
+			name:    "auth enabled with credentials but TLS disabled",
+			auth:    AuthFlagConfig{Enabled: true, Issuer: "https://issuer.example.com"},
+			tlsMode: TLSModeDisabled,
+			wantErr: "--auth-enabled requires TLS",
 		},
 		{
 			name:    "auth enabled without credentials",
 			auth:    AuthFlagConfig{Enabled: true},
-			wantErr: "--auth-enabled requires",
+			tlsMode: TLSModeRequired,
+			wantErr: "--auth-enabled requires either",
 		},
 		{
 			name:    "auth disabled no flags",
 			auth:    AuthFlagConfig{},
+			tlsMode: TLSModeDisabled,
 			wantErr: "",
 		},
 		{
 			name:    "auth disabled with issuer set",
 			auth:    AuthFlagConfig{Enabled: false, Issuer: "https://issuer.example.com"},
+			tlsMode: TLSModeDisabled,
 			wantErr: "--auth-issuer",
 		},
 	}
@@ -244,6 +263,12 @@ func TestValidateAuthConfig(t *testing.T) {
 
 			cfg := validBaseConfig()
 			cfg.AuthConfig = tt.auth
+			cfg.TLSConfig.Mode = tt.tlsMode
+			if tt.tlsMode.AllowsTLS() {
+				// Provide cert/key so the TLS-config validation doesn't trip first.
+				cfg.TLSConfig.CertFile = "/tmp/fake.crt"
+				cfg.TLSConfig.KeyFile = "/tmp/fake.key"
+			}
 
 			err := cfg.Validate()
 			if tt.wantErr == "" {

--- a/misc/operator/internal/controller/build_command_test.go
+++ b/misc/operator/internal/controller/build_command_test.go
@@ -153,7 +153,7 @@ func TestBuildEnvVars_AuthEd25519Keys(t *testing.T) {
 			if tt.authEnabled != nil {
 				ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{Enabled: tt.authEnabled}
 			}
-			envs := buildEnvVars(ls, "disabled", tt.credentials)
+			envs := buildEnvVars(ls, "required", tt.credentials)
 			if tt.wantEnv {
 				assertEnv(t, envs, "AUTH_ED25519_KEYS", "/auth-keys/auth-keys.json")
 			} else {

--- a/misc/operator/internal/controller/cluster_controller.go
+++ b/misc/operator/internal/controller/cluster_controller.go
@@ -614,6 +614,21 @@ func validateSpec(ledger *ledgerv1alpha1.Cluster) error {
 // this only rejects values that would either be silently ignored or that the
 // server would refuse.
 func validateClusterConfig(spec *ledgerv1alpha1.ClusterSpec) error {
+	// Auth requires TLS. The ledger server rejects --auth-enabled unless
+	// --tls-mode=required, and buildEnvVars defers auth env until TLS converges
+	// to `required`. Without this guard a CR with auth.enabled=true but
+	// tls.enabled=false would reconcile into a silently-unauthenticated cluster
+	// (auth env deferred forever because the target mode never reaches
+	// `required`). Reject that contradiction loudly here instead. During a valid
+	// TLS-enable migration tls.enabled is already true, so this passes and the
+	// deferral only bridges the transient `optional` rollout window.
+	if spec.Auth != nil && spec.Auth.Enabled != nil && *spec.Auth.Enabled &&
+		(spec.TLS == nil || !spec.TLS.Enabled) {
+		return errors.New("auth.enabled requires tls.enabled: authentication needs TLS " +
+			"(the ledger server rejects --auth-enabled without --tls-mode=required); " +
+			"enable TLS before enabling auth")
+	}
+
 	if spec.Cache != nil && spec.Cache.RotationThreshold != nil && *spec.Cache.RotationThreshold <= 0 {
 		return fmt.Errorf("cache.rotationThreshold must be > 0, got %d", *spec.Cache.RotationThreshold)
 	}

--- a/misc/operator/internal/controller/envvars.go
+++ b/misc/operator/internal/controller/envvars.go
@@ -280,8 +280,23 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 		}
 	}
 
-	// Auth
-	if spec.Auth != nil {
+	// Auth — deferred until TLS has fully converged to `required`.
+	//
+	// The ledger server rejects `--auth-enabled` (and the auto-enabling
+	// AUTH_ED25519_KEYS) unless `--tls-mode=required`, so bearer tokens can
+	// never travel in plaintext (see internal/bootstrap/config.go
+	// validateAuthConfig). But `computeTargetTLSMode` drives a TLS *enable*
+	// toggle through the transitional `optional` mode: emitting auth env during
+	// that phase would boot every pod into a config the server refuses, so the
+	// rolling update never becomes Ready, never converges, and the migration
+	// deadlocks at `optional`. We therefore hold ALL auth env off until the
+	// target mode reaches `required`; a subsequent reconcile then enables auth
+	// on top of the converged TLS. The API is briefly unauthenticated during
+	// the `optional` window — no worse than the plaintext state the cluster is
+	// migrating away from. When TLS is `disabled`/`optional` no auth env is
+	// emitted at all (auth defaults off), which also avoids the server's
+	// "auth flags set without --auth-enabled" rejection.
+	if targetTLSMode == tlsModeRequired && spec.Auth != nil {
 		envs = appendIfBool(envs, "AUTH_ENABLED", spec.Auth.Enabled)
 		envs = appendIfStr(envs, "AUTH_ISSUER", spec.Auth.Issuer)
 		if len(spec.Auth.Issuers) > 0 {
@@ -304,9 +319,12 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 
 	// AUTH_ED25519_KEYS points at the configmap-mounted JSON file when
 	// credentials are registered and auth is not explicitly disabled. The path
-	// is fixed by the volume mount declared in reconcileStatefulSet.
+	// is fixed by the volume mount declared in reconcileStatefulSet. Gated on
+	// `required` for the same reason as the block above — AUTH_ED25519_KEYS
+	// auto-enables auth on the server, so emitting it under `optional` would
+	// deadlock the migration.
 	authExplicitlyDisabled := spec.Auth != nil && spec.Auth.Enabled != nil && !*spec.Auth.Enabled
-	if len(credentials) > 0 && !authExplicitlyDisabled {
+	if targetTLSMode == tlsModeRequired && len(credentials) > 0 && !authExplicitlyDisabled {
 		envs = append(envs, strEnv("AUTH_ED25519_KEYS", "/auth-keys/auth-keys.json"))
 	}
 

--- a/misc/operator/internal/controller/envvars.go
+++ b/misc/operator/internal/controller/envvars.go
@@ -296,6 +296,13 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 	// migrating away from. When TLS is `disabled`/`optional` no auth env is
 	// emitted at all (auth defaults off), which also avoids the server's
 	// "auth flags set without --auth-enabled" rejection.
+	//
+	// This deferral is safe — never a silent auth drop — because
+	// validateClusterConfig (cluster_controller.go) rejects the invalid steady
+	// state auth.enabled=true + tls.enabled=false up front (ValidationFailed
+	// condition, Phase=Error, no reconcile). The only reachable non-`required`
+	// auth case that gets here is therefore the transient `optional` window of a
+	// `disabled`->`required` migration, where tls.enabled is already true.
 	if targetTLSMode == tlsModeRequired && spec.Auth != nil {
 		envs = appendIfBool(envs, "AUTH_ENABLED", spec.Auth.Enabled)
 		envs = appendIfStr(envs, "AUTH_ISSUER", spec.Auth.Issuer)

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -401,7 +401,7 @@ func TestBuildEnvVars_AuthIssuers(t *testing.T) {
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 			Issuers: []string{"https://issuer1.example.com", "https://issuer2.example.com"},
 		}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		assertEnv(t, envs, "AUTH_ISSUERS", "https://issuer1.example.com,https://issuer2.example.com")
 	})
 
@@ -411,7 +411,7 @@ func TestBuildEnvVars_AuthIssuers(t *testing.T) {
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 			Issuers: []string{"https://auth.example.com"},
 		}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		assertEnv(t, envs, "AUTH_ISSUERS", "https://auth.example.com")
 	})
 
@@ -419,7 +419,7 @@ func TestBuildEnvVars_AuthIssuers(t *testing.T) {
 		t.Parallel()
 		ls := newMinimalCluster()
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		assertNoEnv(t, envs, "AUTH_ISSUERS")
 	})
 }
@@ -432,7 +432,7 @@ func TestBuildEnvVars_AuthCheckScopes(t *testing.T) {
 	ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 		CheckScopes: &b,
 	}
-	envs := buildEnvVars(ls, "disabled", nil)
+	envs := buildEnvVars(ls, "required", nil)
 	assertEnv(t, envs, "AUTH_CHECK_SCOPES", "true")
 }
 
@@ -444,7 +444,7 @@ func TestBuildEnvVars_AuthReadKeySetMaxRetries(t *testing.T) {
 	ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 		ReadKeySetMaxRetries: &v,
 	}
-	envs := buildEnvVars(ls, "disabled", nil)
+	envs := buildEnvVars(ls, "required", nil)
 	assertEnv(t, envs, "AUTH_READ_KEY_SET_MAX_RETRIES", "5")
 }
 
@@ -773,7 +773,7 @@ func TestBuildEnvVars_AuthScopeMapping(t *testing.T) {
 				"ledger:write": {"ledger:TransactionWrite"},
 			},
 		}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		e := findEnv(envs, "AUTH_SCOPE_MAPPING")
 		require.NotNil(t, e, "AUTH_SCOPE_MAPPING should be present")
 		assert.Contains(t, e.Value, "ledger:read")
@@ -784,7 +784,7 @@ func TestBuildEnvVars_AuthScopeMapping(t *testing.T) {
 		t.Parallel()
 		ls := newMinimalCluster()
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		assertNoEnv(t, envs, "AUTH_SCOPE_MAPPING")
 	})
 }
@@ -802,7 +802,7 @@ func TestBuildEnvVars_AuthAnonymousScopes(t *testing.T) {
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 			AnonymousScopes: []string{"*:read"},
 		}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		e := findEnv(envs, "AUTH_ANONYMOUS_SCOPES")
 		require.NotNil(t, e, "AUTH_ANONYMOUS_SCOPES should be present")
 		assert.Equal(t, "*:read", e.Value)
@@ -814,7 +814,7 @@ func TestBuildEnvVars_AuthAnonymousScopes(t *testing.T) {
 		ls.Spec.Auth = &ledgerv1alpha1.AuthorizationConfig{
 			AnonymousScopes: []string{"ledger:LedgerRead", "ledger:AccountRead"},
 		}
-		envs := buildEnvVars(ls, "disabled", nil)
+		envs := buildEnvVars(ls, "required", nil)
 		e := findEnv(envs, "AUTH_ANONYMOUS_SCOPES")
 		require.NotNil(t, e)
 		assert.Equal(t, "ledger:LedgerRead,ledger:AccountRead", e.Value)
@@ -989,7 +989,7 @@ func TestBuildEnvVars_AllNewFields(t *testing.T) {
 		},
 	}
 
-	envs := buildEnvVars(ls, "disabled", nil)
+	envs := buildEnvVars(ls, "required", nil)
 
 	// Sentinel mode
 	assertEnv(t, envs, "SENTINEL_MODE", "true")

--- a/misc/operator/internal/controller/reconcile_auth_keys_test.go
+++ b/misc/operator/internal/controller/reconcile_auth_keys_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -67,6 +68,12 @@ func TestReconcile_AuthKeysStatefulSet(t *testing.T) {
 	// Create Cluster first so the credentials has a namespace to distribute into.
 	ls := newCluster("authsts-cluster", ns)
 	ls.Labels = map[string]string{"tier": "authsts"}
+	// Auth env (incl. AUTH_ED25519_KEYS) is only emitted once TLS has converged
+	// to `required` (see buildEnvVars' auth deferral). A fresh cluster with no
+	// prior StatefulSet targets the desired mode directly (computeTargetTLSMode
+	// bootstrap branch), so enabling TLS here makes the reconcile reach
+	// `required` immediately and the AUTH_ED25519_KEYS assertion below holds.
+	ls.Spec.TLS = &ledgerv1alpha1.TLSConfig{Enabled: true, SecretName: "authsts-tls"}
 	require.NoError(t, k8sClient.Create(ctx, ls))
 
 	// Create credentials with matching selector.

--- a/misc/operator/internal/controller/validate_cluster_config_test.go
+++ b/misc/operator/internal/controller/validate_cluster_config_test.go
@@ -42,6 +42,64 @@ func TestValidateClusterConfig_AcceptsNilAndEmpty(t *testing.T) {
 	}))
 }
 
+func TestValidateClusterConfig_AuthRequiresTLS(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name    string
+		auth    *ledgerv1alpha1.AuthorizationConfig
+		tls     *ledgerv1alpha1.TLSConfig
+		wantErr bool
+	}{
+		{
+			name:    "auth enabled + tls enabled is accepted",
+			auth:    &ledgerv1alpha1.AuthorizationConfig{Enabled: &enabled},
+			tls:     &ledgerv1alpha1.TLSConfig{Enabled: true},
+			wantErr: false,
+		},
+		{
+			name:    "auth enabled + tls disabled is rejected",
+			auth:    &ledgerv1alpha1.AuthorizationConfig{Enabled: &enabled},
+			tls:     &ledgerv1alpha1.TLSConfig{Enabled: false},
+			wantErr: true,
+		},
+		{
+			name:    "auth enabled + tls nil is rejected",
+			auth:    &ledgerv1alpha1.AuthorizationConfig{Enabled: &enabled},
+			tls:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "auth explicitly disabled + tls disabled is accepted",
+			auth:    &ledgerv1alpha1.AuthorizationConfig{Enabled: &disabled},
+			tls:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "auth nil + tls disabled is accepted",
+			auth:    nil,
+			tls:     nil,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateClusterConfig(&ledgerv1alpha1.ClusterSpec{Auth: tt.auth, TLS: tt.tls})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "auth.enabled requires tls.enabled")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateClusterConfig_RejectsNonPositiveRotation(t *testing.T) {
 	t.Parallel()
 	zero := int32(0)

--- a/tests/e2e/cluster/auth_test.go
+++ b/tests/e2e/cluster/auth_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -149,6 +147,12 @@ var _ = Describe("Auth", Ordered, func() {
 			Expect(os.RemoveAll(dataTmpDir)).To(Succeed())
 		})
 
+		// Auth requires TLS (bearer tokens must not travel in plaintext), so
+		// generate a throwaway CA + server cert for the fixture.
+		certDir := GinkgoT().TempDir()
+		certs, err := testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
 		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 			NodeID:    1,
 			ClusterID: "test-cluster",
@@ -165,6 +169,9 @@ var _ = Describe("Auth", Ordered, func() {
 			testserver.WithAuthEnabled(),
 			testserver.WithAuthIssuer(oidcServer.URL),
 			testserver.WithAuthService("ledger"),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
 		)
 
 		server := testservice.New(cmdserver.NewRunCommand,
@@ -178,17 +185,10 @@ var _ = Describe("Auth", Ordered, func() {
 			Expect(server.Stop(stopCtx)).To(Succeed())
 		})
 
-		// Create insecure gRPC client (no TLS needed for this test)
-		grpcConn, err = grpc.NewClient(
-			fmt.Sprintf("localhost:%d", authTestGRPCPort),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
-		)
+		// Auth requires TLS: dial the server over TLS trusting the fixture CA.
+		client, clusterClient, grpcConn, err = newTLSGRPCClient(authTestGRPCPort, certs.CACertFile)
 		Expect(err).To(Succeed())
 		DeferCleanup(func() { _ = grpcConn.Close() })
-
-		client = servicepb.NewBucketServiceClient(grpcConn)
-		clusterClient = clusterpb.NewClusterServiceClient(grpcConn)
 
 		// Wait for leader election
 		Eventually(func(g Gomega) bool {

--- a/tests/e2e/cluster/auth_writes_only_test.go
+++ b/tests/e2e/cluster/auth_writes_only_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -68,6 +67,12 @@ var _ = Describe("Auth writes-only mode", Ordered, func() {
 			Expect(os.RemoveAll(dataTmpDir)).To(Succeed())
 		})
 
+		// Auth requires TLS (bearer tokens must not travel in plaintext), so
+		// generate a throwaway CA + server cert for the fixture.
+		certDir := GinkgoT().TempDir()
+		certs, err := testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
 		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 			NodeID:    1,
 			ClusterID: "test-cluster",
@@ -84,6 +89,9 @@ var _ = Describe("Auth writes-only mode", Ordered, func() {
 			testserver.WithAuthEnabled(),
 			testserver.WithAuthIssuer(oidcServer.URL),
 			testserver.WithAuthService("ledger"),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
 			// Writes-only: every read scope is granted to anonymous callers.
 			testserver.WithAuthAnonymousScopes("*:read"),
 		)
@@ -99,16 +107,10 @@ var _ = Describe("Auth writes-only mode", Ordered, func() {
 			Expect(server.Stop(stopCtx)).To(Succeed())
 		})
 
-		grpcConn, err = grpc.NewClient(
-			fmt.Sprintf("localhost:%d", writesOnlyGRPCPort),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
-		)
+		// Auth requires TLS: dial the server over TLS trusting the fixture CA.
+		client, clusterCli, grpcConn, err = newTLSGRPCClient(writesOnlyGRPCPort, certs.CACertFile)
 		Expect(err).To(Succeed())
 		DeferCleanup(func() { _ = grpcConn.Close() })
-
-		client = servicepb.NewBucketServiceClient(grpcConn)
-		clusterCli = clusterpb.NewClusterServiceClient(grpcConn)
 		httpAddr = fmt.Sprintf("http://localhost:%d", writesOnlyHTTPPort)
 
 		// Wait for leader election (use a write-scoped token).

--- a/tests/e2e/cluster/ed25519_auth_test.go
+++ b/tests/e2e/cluster/ed25519_auth_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -145,6 +144,12 @@ var _ = Describe("Ed25519 Auth", Ordered, func() {
 			Expect(os.RemoveAll(dataTmpDir)).To(Succeed())
 		})
 
+		// Auth requires TLS (bearer tokens must not travel in plaintext), so
+		// generate a throwaway CA + server cert for the fixture.
+		certDir := GinkgoT().TempDir()
+		certs, err := testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
 		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 			NodeID:    1,
 			ClusterID: "test-cluster",
@@ -161,6 +166,9 @@ var _ = Describe("Ed25519 Auth", Ordered, func() {
 			testserver.WithAuthEnabled(),
 			testserver.WithAuthEd25519Keys(configPath),
 			testserver.WithAuthService("ledger"),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
 		)
 
 		server := testservice.New(cmdserver.NewRunCommand,
@@ -174,17 +182,10 @@ var _ = Describe("Ed25519 Auth", Ordered, func() {
 			Expect(server.Stop(stopCtx)).To(Succeed())
 		})
 
-		// Create gRPC client
-		grpcConn, err = grpc.NewClient(
-			fmt.Sprintf("localhost:%d", ed25519AuthTestGRPCPort),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
-		)
+		// Auth requires TLS: dial the server over TLS trusting the fixture CA.
+		client, clusterClient, grpcConn, err = newTLSGRPCClient(ed25519AuthTestGRPCPort, certs.CACertFile)
 		Expect(err).To(Succeed())
 		DeferCleanup(func() { _ = grpcConn.Close() })
-
-		client = servicepb.NewBucketServiceClient(grpcConn)
-		clusterClient = clusterpb.NewClusterServiceClient(grpcConn)
 
 		// Wait for leader election
 		Eventually(func(g Gomega) bool {
@@ -351,6 +352,12 @@ var _ = Describe("Ed25519 Auth Scope Restrictions", Ordered, func() {
 			Expect(os.RemoveAll(dataTmpDir)).To(Succeed())
 		})
 
+		// Auth requires TLS (bearer tokens must not travel in plaintext), so
+		// generate a throwaway CA + server cert for the fixture.
+		certDir := GinkgoT().TempDir()
+		certs, err := testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
 		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 			NodeID:    1,
 			ClusterID: "test-cluster",
@@ -367,6 +374,9 @@ var _ = Describe("Ed25519 Auth Scope Restrictions", Ordered, func() {
 			testserver.WithAuthEnabled(),
 			testserver.WithAuthEd25519Keys(configPath),
 			testserver.WithAuthService("ledger"),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
 		)
 
 		server := testservice.New(cmdserver.NewRunCommand,
@@ -380,16 +390,10 @@ var _ = Describe("Ed25519 Auth Scope Restrictions", Ordered, func() {
 			Expect(server.Stop(stopCtx)).To(Succeed())
 		})
 
-		grpcConn, err = grpc.NewClient(
-			fmt.Sprintf("localhost:%d", ed25519ScopeTestGRPCPort),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
-		)
+		// Auth requires TLS: dial the server over TLS trusting the fixture CA.
+		client, clusterClient, grpcConn, err = newTLSGRPCClient(ed25519ScopeTestGRPCPort, certs.CACertFile)
 		Expect(err).To(Succeed())
 		DeferCleanup(func() { _ = grpcConn.Close() })
-
-		client = servicepb.NewBucketServiceClient(grpcConn)
-		clusterClient = clusterpb.NewClusterServiceClient(grpcConn)
 
 		// Wait for leader election using a read that goes through Raft.
 		// GetLedger calls ReadIndexAndWait, which returns ErrNoLeader (Unavailable)
@@ -541,6 +545,12 @@ var _ = Describe("Ed25519 Auth God Mode", Ordered, func() {
 			Expect(os.RemoveAll(dataTmpDir)).To(Succeed())
 		})
 
+		// Auth requires TLS (bearer tokens must not travel in plaintext), so
+		// generate a throwaway CA + server cert for the fixture.
+		certDir := GinkgoT().TempDir()
+		certs, err := testserver.GenerateTestCerts(certDir)
+		Expect(err).To(Succeed())
+
 		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 			NodeID:    1,
 			ClusterID: "test-cluster",
@@ -557,6 +567,9 @@ var _ = Describe("Ed25519 Auth God Mode", Ordered, func() {
 			testserver.WithAuthEnabled(),
 			testserver.WithAuthEd25519Keys(configPath),
 			testserver.WithAuthService("ledger"),
+			testserver.WithTLSMode("required"),
+			testserver.WithTLSCertFile(certs.ServerCertFile),
+			testserver.WithTLSKeyFile(certs.ServerKeyFile),
 		)
 
 		server := testservice.New(cmdserver.NewRunCommand,
@@ -570,16 +583,10 @@ var _ = Describe("Ed25519 Auth God Mode", Ordered, func() {
 			Expect(server.Stop(stopCtx)).To(Succeed())
 		})
 
-		grpcConn, err = grpc.NewClient(
-			fmt.Sprintf("localhost:%d", ed25519GodTestGRPCPort),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
-		)
+		// Auth requires TLS: dial the server over TLS trusting the fixture CA.
+		client, clusterClient, grpcConn, err = newTLSGRPCClient(ed25519GodTestGRPCPort, certs.CACertFile)
 		Expect(err).To(Succeed())
 		DeferCleanup(func() { _ = grpcConn.Close() })
-
-		client = servicepb.NewBucketServiceClient(grpcConn)
-		clusterClient = clusterpb.NewClusterServiceClient(grpcConn)
 
 		// Wait for leader election
 		Eventually(func(g Gomega) bool {


### PR DESCRIPTION
## Summary

Enabling external-client authentication (`--auth-enabled`, OIDC JWT / Ed25519) over a plaintext transport sends bearer tokens in the clear — an on-path attacker can intercept and replay them. The `--cluster-secret` (inter-node) credential already requires TLS at startup; `--auth-enabled` (external client) did not. This makes the protection symmetric.

`validateAuthConfig()` now rejects the `--auth-enabled` + `--tls-mode=disabled` combination at boot, with a message styled after the existing `--cluster-secret` rule.

## Decision

**Hard error, no opt-out** — mirroring `--cluster-secret` exactly (which has no escape hatch either). Same predicate: only `TLSModeDisabled` is rejected; `optional` and `required` both pass. TLS must be terminated on the ledger process itself, even behind an ingress/mesh that also terminates TLS upstream.

## Changes

- `internal/bootstrap/config.go` — TLS check in `validateAuthConfig()`.
- `internal/bootstrap/config_test.go` — added a `tlsMode` dimension: TLS-disabled rejection, `optional`/`required` acceptance.
- `docs/ops/authentication.md`, `docs/ops/cli.md`, `docs/ops/deployment.md` — documented the invariant; made runnable examples TLS-correct.

## Testing

- `just pre-commit` — 0 lint issues, no generated-file drift.
- `just test` (full `-race` suite) — green.

## Ticket

https://formance-team.atlassian.net/browse/EN-1553
