### PR TITLE
fix(backup): rebuild idempotency keys on restore

### DIFF
--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -4237,61 +4237,32 @@ type expectedIdempotency struct {
 }
 
 // expectedIdempotencyOutcome re-derives the frozen idempotency value a keyed
-// proposal would have written, from its audit entry + items. ok is false when
-// the proposal froze nothing under its key: an all-replay success (no log
-// produced) or a non-freezable failure (retryable/internal) — neither writes
-// SubIdempKeys.
+// proposal would have written, from its audit entry + items, as the comparison
+// target for the stored SubIdempKeys projection. ok is false when the proposal
+// froze nothing under its key: an all-replay success (no log produced) or a
+// non-freezable failure (retryable/internal) — neither writes SubIdempKeys. The
+// derivation itself lives in state.IdempotencyValueFromAudit, shared with the
+// backup restore path so the two never diverge.
 func expectedIdempotencyOutcome(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) (expectedIdempotency, bool) {
-	switch out := entry.GetOutcome().(type) {
-	case *auditpb.AuditEntry_Failure:
-		reason := out.Failure.GetReason()
-		if !domain.IsFreezableFailure(domain.KindForReason(reason)) {
-			return expectedIdempotency{}, false
-		}
-
-		return expectedIdempotency{
-			proposalHash: recomputeProposalHash(items),
-			failure:      true,
-			reason:       reason,
-			message:      out.Failure.GetMessage(),
-			metadata:     out.Failure.GetContext(),
-		}, true
-	case *auditpb.AuditEntry_Success:
-		maxSeq := out.Success.GetMaxLogSequence()
-		if maxSeq == 0 {
-			return expectedIdempotency{}, false
-		}
-
-		minSeq := out.Success.GetMinLogSequence()
-
-		return expectedIdempotency{
-			proposalHash: recomputeProposalHash(items),
-			firstLog:     minSeq,
-			logCount:     uint32(maxSeq - minSeq + 1),
-		}, true
-	default:
+	value, ok := state.IdempotencyValueFromAudit(entry, items)
+	if !ok {
 		return expectedIdempotency{}, false
 	}
-}
 
-// recomputeProposalHash re-derives a proposal's idempotency hash from its
-// persisted audit orders, reusing the FSM's hashing so the result is
-// byte-identical to what was frozen. The orders round-trip from the chain-bound
-// serialized_order bytes; a corrupt order would already have broken the audit
-// chain above, so a nil here only forces a loud hash mismatch.
-func recomputeProposalHash(items []*auditpb.AuditItem) []byte {
-	orders := make([]*raftcmdpb.Order, 0, len(items))
-
-	for _, item := range items {
-		order := &raftcmdpb.Order{}
-		if err := order.UnmarshalVT(item.GetSerializedOrder()); err != nil {
-			return nil
-		}
-
-		orders = append(orders, order)
+	exp := expectedIdempotency{
+		proposalHash: value.GetHash(),
+		firstLog:     value.GetFirstLogSequence(),
+		logCount:     value.GetLogCount(),
 	}
 
-	return processing.HashOrders(orders)
+	if f := value.GetFailure(); f != nil {
+		exp.failure = true
+		exp.reason = f.GetReason()
+		exp.message = f.GetMessage()
+		exp.metadata = f.GetMetadata()
+	}
+
+	return exp, true
 }
 
 // reDeriveArchivedIdempotency extends `expected` with the frozen idempotency

--- a/internal/application/check/checker_tamper_test.go
+++ b/internal/application/check/checker_tamper_test.go
@@ -382,7 +382,7 @@ func TestVerifyAuditHashChain_DetectsIdempotencyOutcomeTampering(t *testing.T) {
 }
 
 // writeIdempotencyEntry persists a frozen idempotency value at its canonical
-// SubIdempKeys location (the layout state.saveIdempotencyKey uses).
+// SubIdempKeys location (the layout state.SaveIdempotencyKey uses).
 func writeIdempotencyEntry(t *testing.T, store *dal.Store, key string, value *commonpb.IdempotencyKeyValue) {
 	t.Helper()
 

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -448,6 +448,15 @@ func RebuildDelta(
 		return fmt.Errorf("flushing rebuilt reversion bitsets: %w", err)
 	}
 
+	// Re-materialize idempotency keys frozen in the delta range (pre-checkpoint
+	// keys ride along in the raw checkpoint SSTs; post-checkpoint ones live only
+	// in the audit). Reads the delta audit entries seeded by ApplyExports.
+	if err := writer.rebuildIdempotency(ctx, readHandle, fromAuditSeq); err != nil {
+		_ = writer.batch.Cancel()
+
+		return fmt.Errorf("rebuilding idempotency keys: %w", err)
+	}
+
 	if err := writer.batch.Commit(); err != nil {
 		return fmt.Errorf("committing boundaries batch: %w", err)
 	}
@@ -798,6 +807,60 @@ func (w *attributeReplayWriter) applyAuditOrderEffects(reader dal.PebbleReader, 
 	}
 
 	return iter.Error()
+}
+
+// rebuildIdempotency re-materializes the idempotency-key projection for the
+// delta range. The full checkpoint carries pre-checkpoint keys as raw SSTs, but
+// keys frozen after it live only in the audit — so RebuildDelta re-derives each
+// keyed proposal's frozen outcome (committed-log range or definitive failure)
+// and persists it, letting a restored node dedup a retried key instead of
+// re-executing it. A key produced no frozen outcome (all-replay success or a
+// non-freezable failure) is skipped, matching the apply path. Expired entries
+// are re-materialized too: the read-path TTL gate ignores them and the leader's
+// eviction scheduler reclaims them, exactly as on a live node.
+func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader dal.PebbleReader, fromAuditSeq uint64) error {
+	var after *uint64
+	if fromAuditSeq > 0 {
+		after = &fromAuditSeq
+	}
+
+	auditCursor, err := query.ReadAuditEntries(ctx, reader, after)
+	if err != nil {
+		return fmt.Errorf("reading audit entries for idempotency rebuild: %w", err)
+	}
+
+	defer func() { _ = auditCursor.Close() }()
+
+	for {
+		entry, err := auditCursor.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading audit entry for idempotency rebuild: %w", err)
+		}
+
+		key := entry.GetIdempotency().GetKey()
+		if key == "" {
+			continue
+		}
+
+		items, err := query.ReadAuditItems(ctx, reader, entry.GetSequence())
+		if err != nil {
+			return fmt.Errorf("reading audit items for idempotency rebuild (seq %d): %w", entry.GetSequence(), err)
+		}
+
+		value, ok := state.IdempotencyValueFromAudit(entry, items)
+		if !ok {
+			continue
+		}
+
+		if err := state.SaveIdempotencyKey(w.batch, key, value); err != nil {
+			return fmt.Errorf("persisting rebuilt idempotency key (seq %d): %w", entry.GetSequence(), err)
+		}
+	}
+
+	return nil
 }
 
 // deleteLedger reproduces the live DeleteLedger apply state: the LedgerInfo

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -831,6 +831,10 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 
 	defer func() { _ = auditCursor.Close() }()
 
+	// Keys already given an outcome in this pass; a later failure entry (e.g. a
+	// same-key/different-body conflict) must not overwrite one — see below.
+	seen := make(map[string]struct{})
+
 	for {
 		entry, err := auditCursor.Next()
 		if errors.Is(err, io.EOF) {
@@ -855,9 +859,42 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 			continue
 		}
 
+		// A failure must not overwrite a key that already holds an outcome, just
+		// as the live path's recordIdempotencyFailure never overwrites a real
+		// result ("a conflict holds the real outcome"): a reused key with a
+		// different body is audited as a freezable (AlreadyExists) failure, so
+		// without this guard it would clobber the original success/failure. The
+		// prior outcome is either an earlier delta entry (seen) or a checkpoint
+		// SST (reader — its snapshot predates this pass's writes). A SUCCESS
+		// always writes: it only reaches the FSM when the gate found no live
+		// outcome, so any prior had expired — a legitimate re-freeze.
+		//
+		// Expiry is not re-evaluated here (unlike the live guard's !IsExpired):
+		// an outcome expiring within the exported delta would let the live path
+		// record a later failure this keeps as the earlier outcome — benign and
+		// unreachable at the default 24h TTL; matching it would need the TTL
+		// threaded through RebuildDelta.
+		if value.GetFailure() != nil {
+			_, dup := seen[key]
+			if !dup {
+				existing, err := state.LoadIdempotencyKey(reader, key)
+				if err != nil {
+					return fmt.Errorf("checking existing idempotency outcome for rebuild (seq %d): %w", entry.GetSequence(), err)
+				}
+
+				dup = existing != nil
+			}
+
+			if dup {
+				continue
+			}
+		}
+
 		if err := state.SaveIdempotencyKey(w.batch, key, value); err != nil {
 			return fmt.Errorf("persisting rebuilt idempotency key (seq %d): %w", entry.GetSequence(), err)
 		}
+
+		seen[key] = struct{}{}
 	}
 
 	return nil

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -831,9 +831,26 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 
 	defer func() { _ = auditCursor.Close() }()
 
-	// Keys already given an outcome in this pass; a later failure entry (e.g. a
-	// same-key/different-body conflict) must not overwrite one — see below.
-	seen := make(map[string]struct{})
+	// The overwrite guard below mirrors the live recordIdempotencyFailure, which
+	// only protects a NON-expired outcome, so read the persisted TTL and apply
+	// the same expiry test. An absent config (exports-only restore, no
+	// checkpoint) yields ttl 0 = never expire — the conservative "never overwrite
+	// a prior" behaviour. (Threading TTL config changes through Raft so expiry is
+	// fully deterministic across nodes is future work; here it is the persisted
+	// value the checkpoint carried.)
+	cfg, err := query.ReadPersistedConfig(reader)
+	if err != nil {
+		return fmt.Errorf("reading persisted config for idempotency TTL: %w", err)
+	}
+
+	var ttlMicros uint64
+	if cfg != nil {
+		ttlMicros = cfg.GetIdempotencyTtlSeconds() * 1_000_000
+	}
+
+	// seen maps a key to the created_at of the outcome currently rebuilt for it,
+	// so a later failure can tell whether that prior is still live.
+	seen := make(map[string]uint64)
 
 	for {
 		entry, err := auditCursor.Next()
@@ -859,33 +876,31 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 			continue
 		}
 
-		// A failure must not overwrite a key that already holds an outcome, just
-		// as the live path's recordIdempotencyFailure never overwrites a real
-		// result ("a conflict holds the real outcome"): a reused key with a
-		// different body is audited as a freezable (AlreadyExists) failure, so
-		// without this guard it would clobber the original success/failure. The
-		// prior outcome is either an earlier delta entry (seen) or a checkpoint
-		// SST (reader — its snapshot predates this pass's writes). A SUCCESS
-		// always writes: it only reaches the FSM when the gate found no live
-		// outcome, so any prior had expired — a legitimate re-freeze.
-		//
-		// Expiry is not re-evaluated here (unlike the live guard's !IsExpired):
-		// an outcome expiring within the exported delta would let the live path
-		// record a later failure this keeps as the earlier outcome — benign and
-		// unreachable at the default 24h TTL; matching it would need the TTL
-		// threaded through RebuildDelta.
+		// A failure must not overwrite a key that already holds a LIVE outcome,
+		// mirroring the live recordIdempotencyFailure ("a conflict holds the real
+		// outcome"): a reused key with a different body is audited as a freezable
+		// (AlreadyExists) failure, so without this guard it would clobber the
+		// original success/failure. The prior outcome is an earlier delta entry
+		// (seen) or a checkpoint SST (reader — its snapshot predates this pass's
+		// writes). A SUCCESS always writes: it only reaches the FSM when the gate
+		// found no live outcome, so any prior had expired — a legitimate re-freeze.
 		if value.GetFailure() != nil {
-			_, dup := seen[key]
-			if !dup {
+			priorTs, have := seen[key]
+			if !have {
 				existing, err := state.LoadIdempotencyKey(reader, key)
 				if err != nil {
 					return fmt.Errorf("checking existing idempotency outcome for rebuild (seq %d): %w", entry.GetSequence(), err)
 				}
 
-				dup = existing != nil
+				if existing != nil {
+					priorTs, have = existing.GetCreatedAt(), true
+					seen[key] = priorTs
+				}
 			}
 
-			if dup {
+			// Skip only while the prior is still live at this entry's time —
+			// exactly the FSM's !IsExpired guard; an expired prior is overwritten.
+			if have && !state.IdempotencyExpired(priorTs, value.GetCreatedAt(), ttlMicros) {
 				continue
 			}
 		}
@@ -894,7 +909,7 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 			return fmt.Errorf("persisting rebuilt idempotency key (seq %d): %w", entry.GetSequence(), err)
 		}
 
-		seen[key] = struct{}{}
+		seen[key] = value.GetCreatedAt()
 	}
 
 	return nil

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -852,6 +852,8 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 	// so a later failure can tell whether that prior is still live.
 	seen := make(map[string]uint64)
 
+	var written uint64
+
 	for {
 		entry, err := auditCursor.Next()
 		if errors.Is(err, io.EOF) {
@@ -910,6 +912,19 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 		}
 
 		seen[key] = value.GetCreatedAt()
+
+		// Flush in bounded chunks so restore memory does not grow with the whole
+		// delta, mirroring the log-replay pass above. The read snapshot is
+		// unaffected (committed keys stay invisible to it), and prior-outcome
+		// tracking lives in `seen`, so the guard above is unchanged across a flush.
+		written++
+		if written%5000 == 0 {
+			if err := w.batch.Commit(); err != nil {
+				return fmt.Errorf("committing idempotency batch at audit %d: %w", entry.GetSequence(), err)
+			}
+
+			w.batch = w.store.OpenWriteSession()
+		}
 	}
 
 	return nil

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -812,12 +812,18 @@ func (w *attributeReplayWriter) applyAuditOrderEffects(reader dal.PebbleReader, 
 // rebuildIdempotency re-materializes the idempotency-key projection for the
 // delta range. The full checkpoint carries pre-checkpoint keys as raw SSTs, but
 // keys frozen after it live only in the audit — so RebuildDelta re-derives each
-// keyed proposal's frozen outcome (committed-log range or definitive failure)
-// and persists it, letting a restored node dedup a retried key instead of
-// re-executing it. A key produced no frozen outcome (all-replay success or a
-// non-freezable failure) is skipped, matching the apply path. Expired entries
-// are re-materialized too: the read-path TTL gate ignores them and the leader's
-// eviction scheduler reclaims them, exactly as on a live node.
+// keyed proposal's frozen outcome and persists it, letting a restored node dedup
+// a retried key instead of re-executing it.
+//
+// Entries are folded in ascending order, last write wins. No overwrite guard is
+// needed: IdempotencyValueFromAudit returns ok=false for the only rejection that
+// must NOT overwrite a prior — an IDEMPOTENCY_KEY_CONFLICT, which the FSM's gate
+// only produces against a still-live prior. Every other keyed outcome (a fresh
+// success, or a non-conflict failure from a reuse the gate executed because the
+// prior had expired) is a genuine freeze that overwrites, matching the FSM. This
+// reads the FSM's own live/expired decision straight off the hash-chain-bound
+// audit reason, so no persisted TTL — and no ambiguous zero-value sentinel — is
+// consulted here.
 func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader dal.PebbleReader, fromAuditSeq uint64) error {
 	var after *uint64
 	if fromAuditSeq > 0 {
@@ -830,27 +836,6 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 	}
 
 	defer func() { _ = auditCursor.Close() }()
-
-	// The overwrite guard below mirrors the live recordIdempotencyFailure, which
-	// only protects a NON-expired outcome, so read the persisted TTL and apply
-	// the same expiry test. An absent config (exports-only restore, no
-	// checkpoint) yields ttl 0 = never expire — the conservative "never overwrite
-	// a prior" behaviour. (Threading TTL config changes through Raft so expiry is
-	// fully deterministic across nodes is future work; here it is the persisted
-	// value the checkpoint carried.)
-	cfg, err := query.ReadPersistedConfig(reader)
-	if err != nil {
-		return fmt.Errorf("reading persisted config for idempotency TTL: %w", err)
-	}
-
-	var ttlMicros uint64
-	if cfg != nil {
-		ttlMicros = cfg.GetIdempotencyTtlSeconds() * 1_000_000
-	}
-
-	// seen maps a key to the created_at of the outcome currently rebuilt for it,
-	// so a later failure can tell whether that prior is still live.
-	seen := make(map[string]uint64)
 
 	var written uint64
 
@@ -878,45 +863,13 @@ func (w *attributeReplayWriter) rebuildIdempotency(ctx context.Context, reader d
 			continue
 		}
 
-		// A failure must not overwrite a key that already holds a LIVE outcome,
-		// mirroring the live recordIdempotencyFailure ("a conflict holds the real
-		// outcome"): a reused key with a different body is audited as a freezable
-		// (AlreadyExists) failure, so without this guard it would clobber the
-		// original success/failure. The prior outcome is an earlier delta entry
-		// (seen) or a checkpoint SST (reader — its snapshot predates this pass's
-		// writes). A SUCCESS always writes: it only reaches the FSM when the gate
-		// found no live outcome, so any prior had expired — a legitimate re-freeze.
-		if value.GetFailure() != nil {
-			priorTs, have := seen[key]
-			if !have {
-				existing, err := state.LoadIdempotencyKey(reader, key)
-				if err != nil {
-					return fmt.Errorf("checking existing idempotency outcome for rebuild (seq %d): %w", entry.GetSequence(), err)
-				}
-
-				if existing != nil {
-					priorTs, have = existing.GetCreatedAt(), true
-					seen[key] = priorTs
-				}
-			}
-
-			// Skip only while the prior is still live at this entry's time —
-			// exactly the FSM's !IsExpired guard; an expired prior is overwritten.
-			if have && !state.IdempotencyExpired(priorTs, value.GetCreatedAt(), ttlMicros) {
-				continue
-			}
-		}
-
 		if err := state.SaveIdempotencyKey(w.batch, key, value); err != nil {
 			return fmt.Errorf("persisting rebuilt idempotency key (seq %d): %w", entry.GetSequence(), err)
 		}
 
-		seen[key] = value.GetCreatedAt()
-
 		// Flush in bounded chunks so restore memory does not grow with the whole
 		// delta, mirroring the log-replay pass above. The read snapshot is
-		// unaffected (committed keys stay invisible to it), and prior-outcome
-		// tracking lives in `seen`, so the guard above is unchanged across a flush.
+		// unaffected — committed keys stay invisible to it.
 		written++
 		if written%5000 == 0 {
 			if err := w.batch.Commit(); err != nil {

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -887,35 +887,27 @@ func keyedAuditFailure(seq uint64, key string, tsMicros uint64, reason commonpb.
 	}
 }
 
-func writeIdempotencyTTL(t *testing.T, batch *dal.WriteSession, ttlSeconds uint64) {
-	t.Helper()
-	require.NoError(t, batch.SetProto([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig},
-		&commonpb.PersistedConfig{IdempotencyTtlSeconds: ttlSeconds}))
-}
+const (
+	idemConflict     = commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT
+	idemFreshFailure = commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS
+)
 
-const idemConflict = commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT
-
-// A same-key/different-body conflict later in the delta is audited as a
-// freezable failure. While the original outcome is still live, the rebuild must
-// keep it — mirroring the live recordIdempotencyFailure — not clobber it with
-// the conflict (which would make the original body conflict after restore).
-func TestRebuildDelta_IdempotencyConflictKeepsLiveDeltaOutcome(t *testing.T) {
+// A same-key/different-body reuse is audited as an IDEMPOTENCY_KEY_CONFLICT
+// failure. The FSM only produces it against a live prior and never overwrites
+// that prior, so the rebuild must skip it — keeping the original, not clobbering
+// it with the conflict (which would make the original body conflict after
+// restore).
+func TestRebuildDelta_IdempotencyConflictKeepsDeltaOutcome(t *testing.T) {
 	t.Parallel()
 
 	store := newRebuildTestStore(t)
 
-	const (
-		key     = "idem-key"
-		ttlSecs = 100
-	)
-	t0 := uint64(1_000_000)
-	t1 := t0 + 50*1_000_000 // within the 100s TTL: the original is still live
+	const key = "idem-key"
 
 	batch := store.OpenWriteSession()
-	writeIdempotencyTTL(t, batch, ttlSecs)
-	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, t0, 1, 1)))
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, 1_000_000, 1, 1)))
 	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 1))))
-	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, 2_000_000, idemConflict)))
 	require.NoError(t, batch.SetProto(coldAuditItemKey(2, 0), auditItem(t, 0, fillGapOrder("l", 2))))
 	require.NoError(t, batch.Commit())
 
@@ -928,32 +920,27 @@ func TestRebuildDelta_IdempotencyConflictKeepsLiveDeltaOutcome(t *testing.T) {
 	v, err := state.LoadIdempotencyKey(handle, key)
 	require.NoError(t, err)
 	require.NotNil(t, v, "the committed keyed outcome must be rebuilt")
-	require.Nil(t, v.GetFailure(), "a live original must not be overwritten by the conflict")
-	require.Equal(t, uint64(1), v.GetFirstLogSequence(), "the original success must survive")
+	require.Nil(t, v.GetFailure(), "the conflict must not overwrite the original")
+	require.Equal(t, uint64(1), v.GetFirstLogSequence(), "the original success survives")
 }
 
-// Same guard, but the original outcome lives in the checkpoint SSTs (present in
-// the store before the rebuild) rather than an earlier delta entry.
+// Same, but the original outcome lives in the checkpoint SSTs (present in the
+// store before the rebuild) rather than an earlier delta entry — the rebuild
+// skips the delta conflict, so nothing overwrites it.
 func TestRebuildDelta_IdempotencyConflictKeepsCheckpointOutcome(t *testing.T) {
 	t.Parallel()
 
 	store := newRebuildTestStore(t)
 
-	const (
-		key     = "idem-key"
-		ttlSecs = 100
-	)
-	t0 := uint64(1_000_000)
-	t1 := t0 + 50*1_000_000 // within the 100s TTL
+	const key = "idem-key"
 
 	batch := store.OpenWriteSession()
-	writeIdempotencyTTL(t, batch, ttlSecs)
 	// Original success frozen in the "checkpoint" (already in the store).
 	require.NoError(t, state.SaveIdempotencyKey(batch, key, &commonpb.IdempotencyKeyValue{
-		FirstLogSequence: 1, LogCount: 1, CreatedAt: t0,
+		FirstLogSequence: 1, LogCount: 1, CreatedAt: 1_000_000,
 	}))
 	// Only the later conflict is in the exported delta.
-	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditFailure(1, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditFailure(1, key, 2_000_000, idemConflict)))
 	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 2))))
 	require.NoError(t, batch.Commit())
 
@@ -966,30 +953,25 @@ func TestRebuildDelta_IdempotencyConflictKeepsCheckpointOutcome(t *testing.T) {
 	v, err := state.LoadIdempotencyKey(handle, key)
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	require.Nil(t, v.GetFailure(), "a live checkpoint outcome must not be overwritten by a delta conflict")
+	require.Nil(t, v.GetFailure(), "a delta conflict must not overwrite the checkpoint outcome")
 	require.Equal(t, uint64(1), v.GetFirstLogSequence())
 }
 
-// Once the original outcome has expired (a short/custom TTL and a delta that
-// spans it), the guard must NOT protect it: the later freezable failure is
-// materialized, exactly as the live recordIdempotencyFailure would.
-func TestRebuildDelta_IdempotencyExpiredOutcomeOverwritten(t *testing.T) {
+// A genuine (non-conflict) failure DOES overwrite an earlier outcome: it is a
+// reuse the FSM's gate executed fresh because the prior had expired, so the new
+// freeze is real. Unlike a conflict it carries a normal business reason and must
+// materialize.
+func TestRebuildDelta_IdempotencyFreshFailureOverwrites(t *testing.T) {
 	t.Parallel()
 
 	store := newRebuildTestStore(t)
 
-	const (
-		key     = "idem-key"
-		ttlSecs = 100
-	)
-	t0 := uint64(1_000_000)
-	t1 := t0 + 200*1_000_000 // past the 100s TTL: the original has expired
+	const key = "idem-key"
 
 	batch := store.OpenWriteSession()
-	writeIdempotencyTTL(t, batch, ttlSecs)
-	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, t0, 1, 1)))
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, 1_000_000, 1, 1)))
 	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 1))))
-	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, 2_000_000, idemFreshFailure)))
 	require.NoError(t, batch.SetProto(coldAuditItemKey(2, 0), auditItem(t, 0, fillGapOrder("l", 2))))
 	require.NoError(t, batch.Commit())
 
@@ -1002,5 +984,5 @@ func TestRebuildDelta_IdempotencyExpiredOutcomeOverwritten(t *testing.T) {
 	v, err := state.LoadIdempotencyKey(handle, key)
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	require.NotNil(t, v.GetFailure(), "once the original expired, the later freezable failure is materialized")
+	require.NotNil(t, v.GetFailure(), "a fresh non-conflict failure overwrites the earlier outcome")
 }

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -861,3 +861,146 @@ func TestAttributeReplayWriter_DeleteLedgerRemovesReversionRows(t *testing.T) {
 	require.Empty(t, bs.Words(), "deleted ledger's reversion rows must not survive the replay")
 	require.Empty(t, writer.reversions["doomed"])
 }
+
+// keyedAuditSuccess / keyedAuditFailure build audit entries carrying an
+// idempotency key and timestamp, as the rebuild reads them to reconstruct the
+// SubIdempKeys projection.
+func keyedAuditSuccess(seq uint64, key string, tsMicros, minLog, maxLog uint64) *auditpb.AuditEntry {
+	return &auditpb.AuditEntry{
+		Sequence:    seq,
+		Timestamp:   &commonpb.Timestamp{Data: tsMicros},
+		Idempotency: &commonpb.Idempotency{Key: key},
+		Outcome: &auditpb.AuditEntry_Success{
+			Success: &auditpb.AuditSuccess{MinLogSequence: minLog, MaxLogSequence: maxLog},
+		},
+	}
+}
+
+func keyedAuditFailure(seq uint64, key string, tsMicros uint64, reason commonpb.ErrorReason) *auditpb.AuditEntry {
+	return &auditpb.AuditEntry{
+		Sequence:    seq,
+		Timestamp:   &commonpb.Timestamp{Data: tsMicros},
+		Idempotency: &commonpb.Idempotency{Key: key},
+		Outcome: &auditpb.AuditEntry_Failure{
+			Failure: &auditpb.AuditFailure{Reason: reason},
+		},
+	}
+}
+
+func writeIdempotencyTTL(t *testing.T, batch *dal.WriteSession, ttlSeconds uint64) {
+	t.Helper()
+	require.NoError(t, batch.SetProto([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig},
+		&commonpb.PersistedConfig{IdempotencyTtlSeconds: ttlSeconds}))
+}
+
+const idemConflict = commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT
+
+// A same-key/different-body conflict later in the delta is audited as a
+// freezable failure. While the original outcome is still live, the rebuild must
+// keep it — mirroring the live recordIdempotencyFailure — not clobber it with
+// the conflict (which would make the original body conflict after restore).
+func TestRebuildDelta_IdempotencyConflictKeepsLiveDeltaOutcome(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	const (
+		key     = "idem-key"
+		ttlSecs = 100
+	)
+	t0 := uint64(1_000_000)
+	t1 := t0 + 50*1_000_000 // within the 100s TTL: the original is still live
+
+	batch := store.OpenWriteSession()
+	writeIdempotencyTTL(t, batch, ttlSecs)
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, t0, 1, 1)))
+	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 1))))
+	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditItemKey(2, 0), auditItem(t, 0, fillGapOrder("l", 2))))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	v, err := state.LoadIdempotencyKey(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, v, "the committed keyed outcome must be rebuilt")
+	require.Nil(t, v.GetFailure(), "a live original must not be overwritten by the conflict")
+	require.Equal(t, uint64(1), v.GetFirstLogSequence(), "the original success must survive")
+}
+
+// Same guard, but the original outcome lives in the checkpoint SSTs (present in
+// the store before the rebuild) rather than an earlier delta entry.
+func TestRebuildDelta_IdempotencyConflictKeepsCheckpointOutcome(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	const (
+		key     = "idem-key"
+		ttlSecs = 100
+	)
+	t0 := uint64(1_000_000)
+	t1 := t0 + 50*1_000_000 // within the 100s TTL
+
+	batch := store.OpenWriteSession()
+	writeIdempotencyTTL(t, batch, ttlSecs)
+	// Original success frozen in the "checkpoint" (already in the store).
+	require.NoError(t, state.SaveIdempotencyKey(batch, key, &commonpb.IdempotencyKeyValue{
+		FirstLogSequence: 1, LogCount: 1, CreatedAt: t0,
+	}))
+	// Only the later conflict is in the exported delta.
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditFailure(1, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 2))))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	v, err := state.LoadIdempotencyKey(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.Nil(t, v.GetFailure(), "a live checkpoint outcome must not be overwritten by a delta conflict")
+	require.Equal(t, uint64(1), v.GetFirstLogSequence())
+}
+
+// Once the original outcome has expired (a short/custom TTL and a delta that
+// spans it), the guard must NOT protect it: the later freezable failure is
+// materialized, exactly as the live recordIdempotencyFailure would.
+func TestRebuildDelta_IdempotencyExpiredOutcomeOverwritten(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	const (
+		key     = "idem-key"
+		ttlSecs = 100
+	)
+	t0 := uint64(1_000_000)
+	t1 := t0 + 200*1_000_000 // past the 100s TTL: the original has expired
+
+	batch := store.OpenWriteSession()
+	writeIdempotencyTTL(t, batch, ttlSecs)
+	require.NoError(t, batch.SetProto(coldAuditKey(1), keyedAuditSuccess(1, key, t0, 1, 1)))
+	require.NoError(t, batch.SetProto(coldAuditItemKey(1, 0), auditItem(t, 0, fillGapOrder("l", 1))))
+	require.NoError(t, batch.SetProto(coldAuditKey(2), keyedAuditFailure(2, key, t1, idemConflict)))
+	require.NoError(t, batch.SetProto(coldAuditItemKey(2, 0), auditItem(t, 0, fillGapOrder("l", 2))))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	v, err := state.LoadIdempotencyKey(handle, key)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.NotNil(t, v.GetFailure(), "once the original expired, the later freezable failure is materialized")
+}

--- a/internal/infra/state/idempotency_derived.go
+++ b/internal/infra/state/idempotency_derived.go
@@ -49,7 +49,7 @@ func (d *DerivedIdempotencyStore) Reset() {
 // updates the parent in-memory map.
 func (d *DerivedIdempotencyStore) Merge(batch *dal.WriteSession) error {
 	for key, value := range d.pending {
-		if err := saveIdempotencyKey(batch, key, value); err != nil {
+		if err := SaveIdempotencyKey(batch, key, value); err != nil {
 			return err
 		}
 

--- a/internal/infra/state/idempotency_eviction_test.go
+++ b/internal/infra/state/idempotency_eviction_test.go
@@ -64,7 +64,7 @@ func TestIdempotencyEviction_SameTimestampSiblingsNeverOrphaned(t *testing.T) {
 		}
 
 		value := &commonpb.IdempotencyKeyValue{CreatedAt: ts}
-		require.NoError(t, saveIdempotencyKey(batch, k, value))
+		require.NoError(t, SaveIdempotencyKey(batch, k, value))
 		// Mirror the in-memory map: production paths always Put alongside
 		// the Pebble write, and RestoreFromStore rebuilds the map from
 		// Pebble at boot. Evict's step-2 dedup uses the map as the source
@@ -158,7 +158,7 @@ func TestIdempotencyEviction_LastScannedKeyExcludesSiblingsLexically(t *testing.
 	for i := range 4 {
 		key := []byte{byte('a' + i)}
 		value := &commonpb.IdempotencyKeyValue{CreatedAt: ts}
-		require.NoError(t, saveIdempotencyKey(batch, string(key), value))
+		require.NoError(t, SaveIdempotencyKey(batch, string(key), value))
 		idemp.Put(string(key), value)
 	}
 
@@ -223,7 +223,7 @@ func TestIdempotencyEviction_DoubleApplyIsNoOp(t *testing.T) {
 	batch := store.OpenWriteSession()
 	for _, k := range keys {
 		value := &commonpb.IdempotencyKeyValue{CreatedAt: ts}
-		require.NoError(t, saveIdempotencyKey(batch, k, value))
+		require.NoError(t, SaveIdempotencyKey(batch, k, value))
 		idemp.Put(k, value)
 	}
 
@@ -285,7 +285,7 @@ func TestIdempotencyEviction_MultiBatchConvergence(t *testing.T) {
 	for i := range 4 {
 		key := []byte{byte('a' + i)}
 		value := &commonpb.IdempotencyKeyValue{CreatedAt: ts + uint64(i)}
-		require.NoError(t, saveIdempotencyKey(batch, string(key), value))
+		require.NoError(t, SaveIdempotencyKey(batch, string(key), value))
 		idemp.Put(string(key), value)
 	}
 
@@ -391,7 +391,7 @@ func TestIdempotencyEvictionScheduler_StopCancelsProposeFn(t *testing.T) {
 	idemp := NewIdempotencyStore(0)
 	batch := store.OpenWriteSession()
 	value := &commonpb.IdempotencyKeyValue{CreatedAt: expiredTs}
-	require.NoError(t, saveIdempotencyKey(batch, "stop-test", value))
+	require.NoError(t, SaveIdempotencyKey(batch, "stop-test", value))
 	idemp.Put("stop-test", value)
 	require.NoError(t, batch.Commit())
 

--- a/internal/infra/state/idempotency_rebuild.go
+++ b/internal/infra/state/idempotency_rebuild.go
@@ -1,0 +1,77 @@
+package state
+
+import (
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// IdempotencyValueFromAudit re-derives the frozen idempotency value a keyed
+// proposal wrote, from its (chain-verified) audit entry and items. ok is false
+// when the proposal froze nothing under its key: an all-replay success (no log
+// produced) or a non-freezable (retryable/internal) failure — neither writes
+// SubIdempKeys. The proposal hash is recomputed from the audit orders, reusing
+// the FSM's hashing so it is byte-identical to what was frozen at apply time.
+//
+// Shared by the integrity checker (which compares it against the stored
+// projection) and the backup restore path (which persists it via
+// SaveIdempotencyKey), so the two never diverge.
+func IdempotencyValueFromAudit(entry *auditpb.AuditEntry, items []*auditpb.AuditItem) (*commonpb.IdempotencyKeyValue, bool) {
+	switch out := entry.GetOutcome().(type) {
+	case *auditpb.AuditEntry_Failure:
+		reason := out.Failure.GetReason()
+		if !domain.IsFreezableFailure(domain.KindForReason(reason)) {
+			return nil, false
+		}
+
+		return &commonpb.IdempotencyKeyValue{
+			Hash:      recomputeProposalHash(items),
+			CreatedAt: entry.GetTimestamp().GetData(),
+			Failure: &commonpb.IdempotencyFailure{
+				Reason:   reason,
+				Message:  out.Failure.GetMessage(),
+				Metadata: out.Failure.GetContext(),
+			},
+		}, true
+
+	case *auditpb.AuditEntry_Success:
+		maxSeq := out.Success.GetMaxLogSequence()
+		if maxSeq == 0 {
+			return nil, false
+		}
+
+		minSeq := out.Success.GetMinLogSequence()
+
+		return &commonpb.IdempotencyKeyValue{
+			Hash:             recomputeProposalHash(items),
+			FirstLogSequence: minSeq,
+			LogCount:         uint32(maxSeq - minSeq + 1),
+			CreatedAt:        entry.GetTimestamp().GetData(),
+		}, true
+
+	default:
+		return nil, false
+	}
+}
+
+// recomputeProposalHash re-derives a proposal's idempotency hash from its
+// persisted audit orders, reusing the FSM's hashing so the result is
+// byte-identical to what was frozen. The orders round-trip from the chain-bound
+// serialized_order bytes; a corrupt order would already have broken the audit
+// chain during verification, so a nil here only forces a loud hash mismatch.
+func recomputeProposalHash(items []*auditpb.AuditItem) []byte {
+	orders := make([]*raftcmdpb.Order, 0, len(items))
+
+	for _, item := range items {
+		order := &raftcmdpb.Order{}
+		if err := order.UnmarshalVT(item.GetSerializedOrder()); err != nil {
+			return nil
+		}
+
+		orders = append(orders, order)
+	}
+
+	return processing.HashOrders(orders)
+}

--- a/internal/infra/state/idempotency_rebuild.go
+++ b/internal/infra/state/idempotency_rebuild.go
@@ -11,9 +11,11 @@ import (
 // IdempotencyValueFromAudit re-derives the frozen idempotency value a keyed
 // proposal wrote, from its (chain-verified) audit entry and items. ok is false
 // when the proposal froze nothing under its key: an all-replay success (no log
-// produced) or a non-freezable (retryable/internal) failure — neither writes
-// SubIdempKeys. The proposal hash is recomputed from the audit orders, reusing
-// the FSM's hashing so it is byte-identical to what was frozen at apply time.
+// produced), a non-freezable (retryable/internal) failure, or an
+// IDEMPOTENCY_KEY_CONFLICT (a rejection of a reuse, which never overwrites the
+// existing outcome) — none of these write SubIdempKeys. The proposal hash is
+// recomputed from the audit orders, reusing the FSM's hashing so it is
+// byte-identical to what was frozen at apply time.
 //
 // Shared by the integrity checker (which compares it against the stored
 // projection) and the backup restore path (which persists it via
@@ -22,6 +24,18 @@ func IdempotencyValueFromAudit(entry *auditpb.AuditEntry, items []*auditpb.Audit
 	switch out := entry.GetOutcome().(type) {
 	case *auditpb.AuditEntry_Failure:
 		reason := out.Failure.GetReason()
+
+		// A conflict (reused key + different body) freezes nothing: the FSM's gate
+		// only produces it when a LIVE prior outcome exists, and
+		// recordIdempotencyFailure never overwrites that prior. So it is never a
+		// stored outcome — skip it. The hash-chain-bound audit reason already
+		// records whether a reuse hit a live prior (conflict) or executed fresh
+		// (a normal reason), so no expiry re-derivation is needed to tell them
+		// apart.
+		if reason == commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT {
+			return nil, false
+		}
+
 		if !domain.IsFreezableFailure(domain.KindForReason(reason)) {
 			return nil, false
 		}

--- a/internal/infra/state/idempotency_recovery_test.go
+++ b/internal/infra/state/idempotency_recovery_test.go
@@ -29,7 +29,7 @@ func TestIdempotencyStore_RestoreFromStore_RebuildsMapFromPebble(t *testing.T) {
 	}
 
 	for key, value := range values {
-		require.NoError(t, saveIdempotencyKey(batch, key, value))
+		require.NoError(t, SaveIdempotencyKey(batch, key, value))
 	}
 
 	require.NoError(t, batch.Commit())
@@ -78,12 +78,12 @@ func TestIdempotencyStore_RestoreFromStore_LoadsAllEntriesRegardlessOfAge(t *tes
 
 	batch := store.OpenWriteSession()
 
-	require.NoError(t, saveIdempotencyKey(batch, "ancient", &commonpb.IdempotencyKeyValue{
+	require.NoError(t, SaveIdempotencyKey(batch, "ancient", &commonpb.IdempotencyKeyValue{
 		FirstLogSequence: 1,
 		LogCount:         1,
 		CreatedAt:        ancientCreatedAt,
 	}))
-	require.NoError(t, saveIdempotencyKey(batch, "fresh", &commonpb.IdempotencyKeyValue{
+	require.NoError(t, SaveIdempotencyKey(batch, "fresh", &commonpb.IdempotencyKeyValue{
 		FirstLogSequence: 2,
 		LogCount:         1,
 		CreatedAt:        freshCreatedAt,
@@ -141,7 +141,7 @@ func TestIdempotencyStore_RestoreFromStore_OverwritesPriorEntries(t *testing.T) 
 	store := newTestStore(t)
 
 	batch := store.OpenWriteSession()
-	require.NoError(t, saveIdempotencyKey(batch, "persisted", &commonpb.IdempotencyKeyValue{
+	require.NoError(t, SaveIdempotencyKey(batch, "persisted", &commonpb.IdempotencyKeyValue{
 		FirstLogSequence: 42,
 		LogCount:         1,
 		CreatedAt:        1_000,

--- a/internal/infra/state/idempotency_store.go
+++ b/internal/infra/state/idempotency_store.go
@@ -298,9 +298,9 @@ func (s *IdempotencyStore) Evict(batch *dal.WriteSession, cutoffMicros uint64, l
 	return evicted, nil
 }
 
-// SaveIdempotencyKey writes an idempotency key-value pair to Pebble under prefix 0x03,
-// and creates a time index entry under prefix 0x04 for efficient eviction.
-func saveIdempotencyKey(batch *dal.WriteSession, key string, value *commonpb.IdempotencyKeyValue) error {
+// SaveIdempotencyKey writes an idempotency key-value pair under [0x05][0x01] and
+// a time-index entry under [0x05][0x02] for efficient eviction.
+func SaveIdempotencyKey(batch *dal.WriteSession, key string, value *commonpb.IdempotencyKeyValue) error {
 	keyHash := HashIdempotencyKey(key)
 
 	// Main entry: [0x05][0x01][key_hash 16 bytes] -> marshaled IdempotencyKeyValue

--- a/internal/infra/state/idempotency_store.go
+++ b/internal/infra/state/idempotency_store.go
@@ -60,11 +60,14 @@ func (s *IdempotencyStore) Put(key string, value *commonpb.IdempotencyKeyValue) 
 // IsExpired returns true if the value's created_at is older than TTL relative to nowMicros.
 // Returns false if TTL is 0 (no expiration).
 func (s *IdempotencyStore) IsExpired(value *commonpb.IdempotencyKeyValue, nowMicros uint64) bool {
-	if s.ttlMicros == 0 {
-		return false
-	}
+	return IdempotencyExpired(value.GetCreatedAt(), nowMicros, s.ttlMicros)
+}
 
-	return nowMicros-value.GetCreatedAt() > s.ttlMicros
+// IdempotencyExpired reports whether an outcome frozen at createdAt has outlived
+// ttlMicros as of nowMicros. ttlMicros == 0 means never expire. Shared with the
+// backup restore path so its overwrite guard uses the same rule as the FSM.
+func IdempotencyExpired(createdAt, nowMicros, ttlMicros uint64) bool {
+	return ttlMicros != 0 && nowMicros-createdAt > ttlMicros
 }
 
 // Reset clears the in-memory map (used during snapshot restore).

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1591,7 +1591,7 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 			CreatedAt:        effectiveDate.GetData(),
 		}
 
-		if saveErr := saveIdempotencyKey(batch, idempotencyKey, value); saveErr != nil {
+		if saveErr := SaveIdempotencyKey(batch, idempotencyKey, value); saveErr != nil {
 			return nil, fmt.Errorf("storing idempotency outcome: %w", saveErr)
 		}
 
@@ -1756,7 +1756,7 @@ func (fsm *Machine) recordIdempotencyFailure(batch *dal.WriteSession, key string
 		},
 	}
 
-	if err := saveIdempotencyKey(batch, key, value); err != nil {
+	if err := SaveIdempotencyKey(batch, key, value); err != nil {
 		return err
 	}
 

--- a/tests/e2e/cluster/restore_idempotency_test.go
+++ b/tests/e2e/cluster/restore_idempotency_test.go
@@ -1,0 +1,338 @@
+//go:build e2e && s3
+
+package cluster
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// This suite pins the idempotency-key loss the model test surfaced: keys frozen
+// after the last full checkpoint live only in the audit, and the raw-SST
+// checkpoint copy can't carry them, so unless RebuildDelta re-derives them a
+// restored node forgets every key in the exported delta. Forgotten, a retried
+// key is re-executed instead of replayed (a duplicate), and a reused key with a
+// different body is executed instead of rejected IDEMPOTENCY_KEY_CONFLICT — the
+// same shape as the reversion-bitset loss (see restore_reversion_test.go).
+var _ = Describe("Restore idempotency keys", Ordered, func() {
+	const (
+		httpPort   = testutil.TestSingleHTTPPort
+		grpcPort   = testutil.TestSingleGRPCPort
+		raftPort   = grpcPort - 1000
+		ledgerName = "idem-restore-ledger"
+		s3Bucket   = "restore-idempotency-keys"
+		clusterID  = "idem-restore-cluster"
+
+		account     = "acc:1"
+		replayKey   = "idem-replay-key"
+		conflictKey = "idem-conflict-key"
+	)
+
+	var (
+		ctx            context.Context
+		restoreWalDir  string
+		restoreDataDir string
+		minioEndpoint  string
+	)
+
+	// replayTx is the keyed commit re-sent to check the replay path: world -> acc
+	// for 100 USD. conflictSeed freezes conflictKey with a 50 USD body;
+	// conflictBody reuses that key with a different amount, which must conflict.
+	replayTx := func() *servicepb.ApplyRequest {
+		return actions.WithIdempotencyKey(replayKey,
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", account, big.NewInt(100), "USD"),
+			}, nil, nil),
+		)
+	}
+	conflictSeed := func() *servicepb.ApplyRequest {
+		return actions.WithIdempotencyKey(conflictKey,
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", account, big.NewInt(50), "USD"),
+			}, nil, nil),
+		)
+	}
+	conflictBody := func() *servicepb.ApplyRequest {
+		return actions.WithIdempotencyKey(conflictKey,
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", account, big.NewInt(999), "USD"),
+			}, nil, nil),
+		)
+	}
+
+	// expectIdempotency asserts both dedup directions against a node, then pins
+	// the account volume. A forgotten key would re-execute the replay (input
+	// climbs past 150) or execute the conflicting body (no error, input climbs),
+	// so either divergence is caught.
+	expectIdempotency := func(client servicepb.BucketServiceClient, phase string) {
+		// Same key + same body: replays the committed success, no re-execution.
+		_, err := client.Apply(ctx, replayTx())
+		Expect(err).To(Succeed(), "%s: replaying a committed key must succeed", phase)
+
+		// Same key + different body: rejected, not executed.
+		_, err = client.Apply(ctx, conflictBody())
+		Expect(err).To(HaveOccurred(), "%s: reusing a key with a different body must conflict", phase)
+		Expect(status.Code(err)).To(Equal(codes.AlreadyExists), "%s: conflict must surface as AlreadyExists", phase)
+
+		// Each key moved funds exactly once: 100 + 50 = 150.
+		acct, err := actions.GetAccount(ctx, client, ledgerName, account)
+		Expect(err).To(Succeed())
+
+		vol := acct.FindVolume("USD", "")
+		Expect(vol).ToNot(BeNil(), "%s: %s USD volumes missing", phase, account)
+		Expect(vol.GetInput()).To(Equal("150"), "%s: %s USD input (keys must dedup, no double-apply)", phase, account)
+	}
+
+	storage := func() *commonpb.BackupStorage {
+		return testutil.S3BackupStorage(&commonpb.S3StorageConfig{
+			Bucket:   s3Bucket,
+			Region:   restoreS3Region,
+			Endpoint: minioEndpoint,
+		})
+	}
+
+	BeforeAll(func() {
+		ctx = logging.TestingContext()
+
+		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+			testcontainers.WithEnv(map[string]string{
+				"MINIO_ROOT_USER":     restoreMinioAccessKey,
+				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,
+			}),
+			testcontainers.WithCmd("server", "/data"),
+			testcontainers.WithExposedPorts("9000/tcp"),
+			testcontainers.WithWaitStrategy(
+				wait.ForHTTP("/minio/health/live").WithPort("9000/tcp").WithStartupTimeout(30*time.Second),
+			),
+		)
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { _ = container.Terminate(context.Background()) })
+
+		minioEndpoint, err = container.Endpoint(context.Background(), "http")
+		Expect(err).To(Succeed())
+
+		cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(restoreS3Region),
+			awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				restoreMinioAccessKey, restoreMinioSecretKey, "",
+			)),
+		)
+		Expect(err).To(Succeed())
+
+		s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(minioEndpoint)
+			o.UsePathStyle = true
+		})
+		_, err = s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(s3Bucket)})
+		Expect(err).To(Succeed())
+
+		GinkgoT().Setenv("AWS_ACCESS_KEY_ID", restoreMinioAccessKey)
+		GinkgoT().Setenv("AWS_SECRET_ACCESS_KEY", restoreMinioSecretKey)
+
+		restoreWalDir, err = os.MkdirTemp("", "idem-restore-wal-*")
+		Expect(err).To(Succeed())
+		restoreDataDir, err = os.MkdirTemp("", "idem-restore-data-*")
+		Expect(err).To(Succeed())
+	})
+
+	Describe("Phase 1: keyed commits in the exported delta", Ordered, func() {
+		var (
+			sourceServer  *testservice.Service
+			client        servicepb.BucketServiceClient
+			clusterClient clusterpb.ClusterServiceClient
+			grpcConn      *grpc.ClientConn
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				HTTPPort:  httpPort,
+				RaftPort:  raftPort,
+				GRPCPort:  grpcPort,
+				WalDir:    GinkgoT().TempDir(),
+				DataDir:   GinkgoT().TempDir(),
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			sourceServer = testservice.New(cmdserver.NewRunCommand, testservice.WithInstruments(instruments...))
+			Expect(sourceServer.Start(ctx)).To(Succeed())
+
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+
+			// Full checkpoint on the EMPTY store: every keyed commit below lands in
+			// the incremental delta, so the restore must reconstruct the idempotency
+			// keys by replaying the exported audit rather than copying SST files.
+			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(sourceServer.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("commits two keyed transactions", func() {
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateLedgerAction(ledgerName, nil),
+			))
+			Expect(err).To(Succeed())
+
+			_, err = client.Apply(ctx, replayTx())
+			Expect(err).To(Succeed())
+
+			_, err = client.Apply(ctx, conflictSeed())
+			Expect(err).To(Succeed())
+		})
+
+		It("dedups on the live node", func() {
+			// Premise guard: if the live gate did not hold, the post-restore
+			// assertions would be vacuous.
+			expectIdempotency(client, "live")
+		})
+
+		It("exports the delta", func() {
+			incResp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(incResp.GetLogEntriesExported()).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("Phase 2: restore", Ordered, func() {
+		var (
+			restoreClient restorepb.RestoreServiceClient
+			grpcConn      *grpc.ClientConn
+			server        *testservice.Service
+		)
+
+		BeforeAll(func() {
+			server = testservice.New(cmdserver.NewRunCommand,
+				testservice.WithInstruments(
+					testservice.DebugInstrumentation(testutil.Debug),
+					testservice.OutputInstrumentation(GinkgoWriter),
+					testserver.WithNodeID(1),
+					testserver.WithClusterID(clusterID),
+					testserver.WithHTTPPort(httpPort),
+					testserver.WithWalDir(restoreWalDir),
+					testserver.WithDataDir(restoreDataDir),
+					testserver.WithRaftPort(raftPort),
+					testserver.WithGRPCPort(grpcPort),
+					testserver.WithRestore(),
+				),
+			)
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var err error
+			restoreClient, grpcConn, err = newRestoreGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("downloads and finalizes the backup", func() {
+			startResp, err := restoreClient.StartDownloadBackup(ctx, &restorepb.StartDownloadBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+
+			Eventually(func() restorepb.DownloadState {
+				resp, statusErr := restoreClient.GetDownloadStatus(ctx, &restorepb.GetDownloadStatusRequest{JobId: startResp.GetJobId()})
+				Expect(statusErr).To(Succeed())
+				return resp.GetState()
+			}, 2*time.Minute, 500*time.Millisecond).Should(Equal(restorepb.DownloadState_DOWNLOAD_STATE_SUCCEEDED))
+
+			_, err = restoreClient.FinalizeRestore(ctx, &restorepb.FinalizeRestoreRequest{})
+			Expect(err).To(Succeed())
+		})
+	})
+
+	Describe("Phase 3: verify the restored idempotency keys", Ordered, func() {
+		var (
+			client   servicepb.BucketServiceClient
+			grpcConn *grpc.ClientConn
+			server   *testservice.Service
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				HTTPPort:  httpPort,
+				RaftPort:  raftPort,
+				GRPCPort:  grpcPort,
+				WalDir:    restoreWalDir,
+				DataDir:   restoreDataDir,
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			server = testservice.New(cmdserver.NewRunCommand, testservice.WithInstruments(instruments...))
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var clusterClient clusterpb.ClusterServiceClient
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(grpcPort)
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+			_ = os.RemoveAll(restoreWalDir)
+			_ = os.RemoveAll(restoreDataDir)
+		})
+
+		It("still dedups after the rebuild", func() {
+			expectIdempotency(client, "restored")
+		})
+	})
+})

--- a/tests/e2e/cluster/restore_idempotency_test.go
+++ b/tests/e2e/cluster/restore_idempotency_test.go
@@ -98,6 +98,13 @@ var _ = Describe("Restore idempotency keys", Ordered, func() {
 		Expect(err).To(HaveOccurred(), "%s: reusing a key with a different body must conflict", phase)
 		Expect(status.Code(err)).To(Equal(codes.AlreadyExists), "%s: conflict must surface as AlreadyExists", phase)
 
+		// The conflict must NOT have clobbered the committed outcome: re-sending the
+		// ORIGINAL body under conflictKey still replays its committed success. A
+		// restore that froze the conflict entry over the original (no overwrite
+		// guard in the rebuild) would hash-mismatch here and conflict instead.
+		_, err = client.Apply(ctx, conflictSeed())
+		Expect(err).To(Succeed(), "%s: the original body must still replay after a conflict, not conflict itself", phase)
+
 		// Each key moved funds exactly once: 100 + 50 = 150.
 		acct, err := actions.GetAccount(ctx, client, ledgerName, account)
 		Expect(err).To(Succeed())


### PR DESCRIPTION
## Problem

`RebuildDelta` (`internal/infra/backup/rebuild.go`) reconstructs every derived
projection from the exported audit delta — ledgers, txns, volumes, metadata,
references, boundaries, reversions (#1592) — but **not the idempotency keys**.

A backup is a full Pebble checkpoint (raw SSTs) plus incremental audit exports.
The raw checkpoint drags the idempotency zone (`0x05`) along incidentally, so
keys frozen **before** the last full checkpoint survive a restore. But keys
frozen **after** it live only in the audit, and nothing re-materialized them —
so on restore a node silently forgot every idempotency key in the delta window:

- a retried key **re-executed** instead of replaying (a duplicate), and
- a reused key with a **different** body **executed** instead of returning
  `IDEMPOTENCY_KEY_CONFLICT`.

This is the same shape as the #1592 reversion-bitset loss. The main-store
integrity checker did not catch it: `compareIdempotencyOutcomes` is
one-directional (it flags stored-but-unaudited / tampered entries, never
audited-but-missing ones).

Surfaced by the model-driver restore cycle (two findings, both post-restore: a
`removeType` reused-key bulk executed to `NotFound` and a `delMeta` reused-key
bulk committed, where the model expected `IDEMPOTENCY_KEY_CONFLICT`).

## Fix

`RebuildDelta` now iterates the delta-range audit entries and, for each keyed
proposal, re-derives its frozen outcome (committed-log range or definitive
failure) and persists it via `state.SaveIdempotencyKey` (main key + time index).

- The `(auditEntry, items) → IdempotencyKeyValue` derivation is extracted to
  `state.IdempotencyValueFromAudit`, **shared** with the checker's
  `expectedIdempotencyOutcome` so the two can't drift (the proposal hash is
  recomputed via `processing.HashOrders`, byte-identical to what was frozen).
- Expired entries are re-materialized like a live node's: the read-path TTL gate
  ignores them and the eviction scheduler reclaims them — no wall-clock read is
  introduced into the deterministic restore path.
- `saveIdempotencyKey` is exported as `state.SaveIdempotencyKey` (callable from
  the backup package); all callers updated.

## Testing

`tests/e2e/cluster/restore_idempotency_test.go` (`e2e && s3`), modeled on
`restore_reversion_test.go`: empty full checkpoint → keyed commits land in the
incremental delta → restore into a fresh store → assert both directions still
hold post-restore (same key+body replays with no duplicate; same key + different
body → `AlreadyExists`), pinned by the account volume.

Verified the test **catches the bug**:

- fix enabled → `5 Passed | 0 Failed`
- fix disabled → `4 Passed | 1 Failed`, failing exactly at the Phase-3 assertion
  `restored: reusing a key with a different body must conflict`.

Lint clean on the changed packages; unit tests green; main module builds.

## Out of scope

Making `compareIdempotencyOutcomes` bidirectional (so `Check()` itself flags an
audited-but-missing key) would close the checker's blind spot, but needs to be
TTL-window-aware to avoid flagging legitimately-expired keys — left as a
follow-up. The e2e test is the regression guard here.
