### PR TITLE
fix(ledgerctl): rename --ch-* sink flags to --clickhouse-*

### DIFF
--- a/cmd/ledgerctl/events/add_sink.go
+++ b/cmd/ledgerctl/events/add_sink.go
@@ -37,7 +37,7 @@ Examples:
     --format protobuf --batch-size 128 --batch-delay-ms 50
 
   # Add a ClickHouse sink
-  ledgerctl events add-sink --name analytics --ch-dsn clickhouse://user:pass@localhost:9000/db --ch-table ledger_events
+  ledgerctl events add-sink --name analytics --clickhouse-dsn clickhouse://user:pass@localhost:9000/db --clickhouse-table ledger_events
 
   # Add a Kafka sink
   ledgerctl events add-sink --name streaming --kafka-brokers localhost:9092 --kafka-topic ledger-events
@@ -74,8 +74,8 @@ Examples:
 	cmd.Flags().String("name", "", "Unique name for this sink (required)")
 	cmd.Flags().String("nats-url", "", "NATS server URL")
 	cmd.Flags().String("nats-topic", "", "NATS topic/subject for events")
-	cmd.Flags().String("ch-dsn", "", "ClickHouse DSN (e.g. clickhouse://user:pass@host:9000/db)")
-	cmd.Flags().String("ch-table", "ledger_events", "ClickHouse table name")
+	cmd.Flags().String("clickhouse-dsn", "", "ClickHouse DSN (e.g. clickhouse://user:pass@host:9000/db)")
+	cmd.Flags().String("clickhouse-table", "ledger_events", "ClickHouse table name")
 	cmd.Flags().String("kafka-brokers", "", "Kafka broker addresses (comma-separated, e.g. localhost:9092)")
 	cmd.Flags().String("kafka-topic", "", "Kafka topic name")
 	cmd.Flags().Bool("kafka-tls", false, "Enable TLS for Kafka connection")
@@ -115,8 +115,8 @@ func runAddSink(cmd *cobra.Command, _ []string) error {
 	var (
 		natsURL, _         = cmd.Flags().GetString("nats-url")
 		natsTopic, _       = cmd.Flags().GetString("nats-topic")
-		chDSN, _           = cmd.Flags().GetString("ch-dsn")
-		chTable, _         = cmd.Flags().GetString("ch-table")
+		chDSN, _           = cmd.Flags().GetString("clickhouse-dsn")
+		chTable, _         = cmd.Flags().GetString("clickhouse-table")
 		kafkaBrokersStr, _ = cmd.Flags().GetString("kafka-brokers")
 		kafkaTopic, _      = cmd.Flags().GetString("kafka-topic")
 		kafkaTLS, _        = cmd.Flags().GetBool("kafka-tls")
@@ -183,11 +183,11 @@ func runAddSink(cmd *cobra.Command, _ []string) error {
 	}
 
 	if sinkCount > 1 {
-		return errors.New("cannot specify multiple sink types; choose one of: NATS (--nats-url), ClickHouse (--ch-dsn), Kafka (--kafka-brokers), HTTP (--http-endpoint), or Databricks (--databricks-host)")
+		return errors.New("cannot specify multiple sink types; choose one of: NATS (--nats-url), ClickHouse (--clickhouse-dsn), Kafka (--kafka-brokers), HTTP (--http-endpoint), or Databricks (--databricks-host)")
 	}
 
 	if sinkCount == 0 {
-		return errors.New("must specify a sink type: NATS (--nats-url and --nats-topic), ClickHouse (--ch-dsn), Kafka (--kafka-brokers and --kafka-topic), HTTP (--http-endpoint), or Databricks (--databricks-host)")
+		return errors.New("must specify a sink type: NATS (--nats-url and --nats-topic), ClickHouse (--clickhouse-dsn), Kafka (--kafka-brokers and --kafka-topic), HTTP (--http-endpoint), or Databricks (--databricks-host)")
 	}
 
 	var (

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4846,10 +4846,10 @@ ledgerctl events add-sink --name primary --nats-url nats://localhost:4222 --nats
   --format protobuf --batch-size 128 --batch-delay-ms 50
 
 # Add a ClickHouse sink for analytics
-ledgerctl events add-sink --name analytics --ch-dsn clickhouse://user:pass@localhost:9000/db
+ledgerctl events add-sink --name analytics --clickhouse-dsn clickhouse://user:pass@localhost:9000/db
 
 # Add a ClickHouse sink with custom table name
-ledgerctl events add-sink --name analytics --ch-dsn clickhouse://user:pass@localhost:9000/db --ch-table my_events
+ledgerctl events add-sink --name analytics --clickhouse-dsn clickhouse://user:pass@localhost:9000/db --clickhouse-table my_events
 
 # Add a Kafka sink
 ledgerctl events add-sink --name streaming --kafka-brokers localhost:9092 --kafka-topic ledger-events
@@ -4872,8 +4872,8 @@ ledgerctl events add-sink --name webhook --http-endpoint https://example.com/web
 | `--name` | *(required)* | Unique name for this sink |
 | `--nats-url` | | NATS server URL (required for NATS sinks) |
 | `--nats-topic` | | NATS topic/subject for events (required for NATS sinks) |
-| `--ch-dsn` | | ClickHouse DSN (required for ClickHouse sinks, e.g. `clickhouse://user:pass@host:9000/db`) |
-| `--ch-table` | `ledger_events` | ClickHouse table name |
+| `--clickhouse-dsn` | | ClickHouse DSN (required for ClickHouse sinks, e.g. `clickhouse://user:pass@host:9000/db`) |
+| `--clickhouse-table` | `ledger_events` | ClickHouse table name |
 | `--kafka-brokers` | | Kafka broker addresses (comma-separated, required for Kafka sinks) |
 | `--kafka-topic` | | Kafka topic name (required for Kafka sinks) |
 | `--kafka-tls` | `false` | Enable TLS for Kafka connection |
@@ -4897,7 +4897,7 @@ ledgerctl events add-sink --name webhook --http-endpoint https://example.com/web
 | `--event-types` | | Comma-separated list of event types to forward (empty = all) |
 | `--timeout` | `10s` | Request timeout |
 
-You must specify exactly one sink type: NATS (`--nats-url` + `--nats-topic`), ClickHouse (`--ch-dsn`), Kafka (`--kafka-brokers` + `--kafka-topic`), HTTP (`--http-endpoint`), or Databricks (`--databricks-host` + `--databricks-http-path` + `--databricks-catalog` + `--databricks-schema` + one of `--databricks-token` for PAT or `--databricks-client-id`/`--databricks-client-secret` for OAuth M2M).
+You must specify exactly one sink type: NATS (`--nats-url` + `--nats-topic`), ClickHouse (`--clickhouse-dsn`), Kafka (`--kafka-brokers` + `--kafka-topic`), HTTP (`--http-endpoint`), or Databricks (`--databricks-host` + `--databricks-http-path` + `--databricks-catalog` + `--databricks-schema` + one of `--databricks-token` for PAT or `--databricks-client-id`/`--databricks-client-secret` for OAuth M2M).
 
 The HTTP sink sends each event as an individual POST request with headers:
 - `Content-Type`: `application/json` or `application/protobuf`

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -367,10 +367,10 @@ ledgerctl events add-sink --name primary --nats-url nats://localhost:4222 --nats
   --format protobuf --batch-size 128 --batch-delay-ms 50
 
 # Add a ClickHouse sink for analytics
-ledgerctl events add-sink --name analytics --ch-dsn clickhouse://user:pass@localhost:9000/db
+ledgerctl events add-sink --name analytics --clickhouse-dsn clickhouse://user:pass@localhost:9000/db
 
 # Add a ClickHouse sink with custom table name
-ledgerctl events add-sink --name analytics --ch-dsn clickhouse://user:pass@localhost:9000/db --ch-table my_events
+ledgerctl events add-sink --name analytics --clickhouse-dsn clickhouse://user:pass@localhost:9000/db --clickhouse-table my_events
 
 # Add a Kafka sink
 ledgerctl events add-sink --name streaming --kafka-brokers localhost:9092 --kafka-topic ledger-events


### PR DESCRIPTION
## What

Renames the ClickHouse event-sink flags on `ledgerctl events add-sink`:

| Old | New |
|-----|-----|
| `--ch-dsn` | `--clickhouse-dsn` |
| `--ch-table` | `--clickhouse-table` |

## Why

Consistency with the other spelled-out sink prefixes (`--nats-*`, `--kafka-*`, `--databricks-*`). `--ch-*` was the only abbreviated one.

## Changes

- `cmd/ledgerctl/events/add_sink.go` — flag registrations, `GetString` lookups, long-help example, and both sink-type error messages
- `docs/ops/cli.md` — examples, flag table, sink-type note
- `docs/technical/architecture/subsystems/events-mirror/events.md` — ClickHouse examples

## ⚠️ Breaking change

The old `--ch-*` names are **removed, not aliased**. Any external scripts using them will break. If backward compatibility is desired, cobra deprecated flag aliases can be added — happy to follow up.

## Verification

- `GOROOT= go build ./cmd/ledgerctl/...` passes
- No remaining `--ch-dsn` / `--ch-table` references in `.go` / `.md`