### PR TITLE
fix(EN-1564): avoid backfill for indexes declared on an empty ledger

### DIFF
--- a/docs/technical/architecture/subsystems/indexer/indexes.md
+++ b/docs/technical/architecture/subsystems/indexer/indexes.md
@@ -84,6 +84,15 @@ stateDiagram-v2
     Steady --> [*]: DropIndex
 ```
 
+### Initial indexes vs. later indexes
+
+An index gets a fast path when it is declared in the **same atomic apply batch** as the `CreateLedger` that creates its ledger, before any indexable data log for that ledger. The FSM classifies this per-proposal — a ledger is treated as "born empty" until it emits its first indexable data log — and stamps the result on a new `CreatedIndexLog.initial` boolean.
+
+- **Initial index** (`CreatedIndexLog.initial == true`): there is no history to replay, so the indexbuilder promotes the index straight to live on applying the log — it seeds `IndexVersionState{CurrentVersion: 1, PendingVersion: 0}` and schedules **no** historical backfill. `GetIndexStatus` immediately reports `current_version > 0` and carries no backfill cursor.
+- **Later index** (`CreatedIndexLog.initial == false`): the unchanged path described above. This covers an index added to a ledger that already holds data, **and** an index created in a separate apply batch even if the ledger is still empty. It is seeded `IndexVersionState{CurrentVersion: 0, PendingVersion: 1}`, backfilled from cursor `0`, and gated by `current_version == 0` (queries get `ErrIndexBuilding`) until the backfill completes and the atomic switch flips the served version.
+
+The classification is deliberately conservative: only the same-atomic-batch-before-any-data case qualifies as initial. A separate-batch index on a still-empty ledger backfills exactly as before — safe (it replays an empty history and completes immediately), just not routed through the zero-cost promotion.
+
 ## Statistics (computed on demand)
 
 There is **no persisted statistics structure**. The figures returned by `InspectIndex` are recomputed by scanning the live Pebble keyspace at the version the caller asks for.

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -402,10 +402,11 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // declared on a born-empty ledger), there is no local history to replay — the
 // index is promoted straight to live (current=1) and NO backfill is scheduled.
 //
-// Idempotency: when the same CreateIndex is replayed against an index that
-// is already cached as READY (the processor short-circuited a duplicate
-// create on an already-built index), we skip the backfill scheduling so the
-// builder does not redo work that has already completed.
+// Idempotency: when the same CreateIndex is replayed (or re-submitted) against
+// an index this replica has already promoted to live, we skip the reset and
+// backfill scheduling so the builder does not redo work that has already
+// completed — and, more importantly, does not knock a live index back into
+// ErrIndexBuilding.
 func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.CreatedIndexLog) {
 	id := log.GetId()
 	if id == nil {
@@ -414,8 +415,17 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 
 	cfg := b.getOrCreateLedgerConfig(ledgerName)
 
-	if existing := cfg.byCanonical[indexes.Canonical(id)]; existing != nil &&
-		existing.GetBuildStatus() == commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_READY {
+	// Post-EN-1323 the per-replica readiness signal is
+	// IndexVersionState.CurrentVersion, not the (now purely informational)
+	// registry BuildStatus — nothing ever flips BuildStatus back to READY, so a
+	// BuildStatus-based short-circuit here is dead. If this replica has already
+	// promoted the index to live (current != 0), a repeated CreatedIndexLog —
+	// a duplicate CreateIndex re-emitted by the processor, or an apply replay —
+	// must be a no-op: re-seeding {current:0, pending:1} and rescheduling a
+	// backfill would flip an already-live index back to ErrIndexBuilding. This
+	// mirrors the loadIndexRegistry boot guard and covers both the EN-1564
+	// initial fast path and the normal post-backfill live state.
+	if current, _ := b.versionFor(ledgerName, indexes.Canonical(id)); current != 0 {
 		return
 	}
 

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -398,6 +398,10 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // The index starts in BUILDING state — it is NOT marked as ready here.
 // A backfill task is created to replay historical logs for the new index.
 //
+// Initial fast path (EN-1564): when the log carries the initial flag (index
+// declared on a born-empty ledger), there is no local history to replay — the
+// index is promoted straight to live (current=1) and NO backfill is scheduled.
+//
 // Idempotency: when the same CreateIndex is replayed against an index that
 // is already cached as READY (the processor short-circuited a duplicate
 // create on an already-built index), we skip the backfill scheduling so the
@@ -419,6 +423,33 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 		Id:                     id,
 		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
 		ForwardEncodingVersion: 1,
+	}
+
+	// EN-1564: an index declared on a born-empty ledger has no local history to
+	// replay. Promote it straight to live (current=1) and skip the backfill;
+	// the live indexing path maintains it from ledger birth. Persist so a reboot
+	// sees current!=0 and loadIndexRegistry skips scheduling a backfill.
+	if log.GetInitial() {
+		state := readstore.IndexVersionState{
+			CurrentVersion: 1,
+			PendingVersion: 0,
+		}
+
+		if b.wb != nil && b.readStore != nil {
+			if batch := b.wb.Batch(); batch != nil {
+				if err := b.readStore.WriteIndexVersionState(batch, ledgerName, indexes.Canonical(id), state); err != nil {
+					b.logger.WithFields(map[string]any{
+						"ledger": ledgerName,
+						"index":  indexes.Canonical(id),
+						"error":  err,
+					}).Errorf("Persisting IndexVersionState on initial CreateIndex")
+				}
+			}
+		}
+
+		b.putVersionState(ledgerName, indexes.Canonical(id), state)
+
+		return
 	}
 
 	// First time this replica sees the index: target v=1 via the

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -1064,3 +1064,49 @@ func TestInitIndexConfig_IdempotentAcrossRetries(t *testing.T) {
 	assert.Equal(t, firstBackfills, len(b.backfillTasks), "retry must not double-schedule backfills")
 	assert.Equal(t, firstRewrites, len(b.schemaRewriteTasks), "retry must not double-schedule rewrites")
 }
+
+// TestHandleCreatedIndexLog_InitialSkipsBackfill verifies an initial index is
+// promoted straight to live (current=1) with no backfill task (EN-1564).
+func TestHandleCreatedIndexLog_InitialSkipsBackfill(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const ledger = "test"
+	id := indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
+	canonical := indexes.Canonical(id)
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true})
+	require.NoError(t, b.wb.Flush())
+
+	require.Empty(t, b.backfillTasks, "initial index must not schedule a backfill")
+
+	current, pending := b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(1), current, "initial index is live immediately")
+	require.Equal(t, uint32(0), pending)
+}
+
+// TestHandleCreatedIndexLog_NonInitialSchedulesBackfill pins the unchanged path:
+// a normal CreateIndex still schedules a backfill and stays gated at current=0.
+func TestHandleCreatedIndexLog_NonInitialSchedulesBackfill(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const ledger = "test"
+	id := indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
+	canonical := indexes.Canonical(id)
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.wb.Flush())
+
+	require.Len(t, b.backfillTasks, 1, "non-initial index must schedule a backfill")
+
+	current, pending := b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(0), current, "non-initial index stays gated until backfill catches up")
+	require.Equal(t, uint32(1), pending)
+}

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -1110,3 +1110,42 @@ func TestHandleCreatedIndexLog_NonInitialSchedulesBackfill(t *testing.T) {
 	require.Equal(t, uint32(0), current, "non-initial index stays gated until backfill catches up")
 	require.Equal(t, uint32(1), pending)
 }
+
+// TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent pins the fix for the
+// duplicate-CreateIndex reschedule: once a replica has promoted an index to live
+// (current != 0), a second CreatedIndexLog for the same index must NOT reset the
+// version state to {0,1} or schedule a backfill — doing so would flip an
+// already-live index back to ErrIndexBuilding. Covers both EN-1564 (initial fast
+// path) and the pre-existing normal post-backfill live state.
+func TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const ledger = "test"
+	id := indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
+	canonical := indexes.Canonical(id)
+
+	// First create promotes the index straight to live (current=1, no backfill).
+	first := b.readStore.NewBatch()
+	b.initBatch(first)
+	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true})
+	require.NoError(t, b.wb.Flush())
+
+	require.Empty(t, b.backfillTasks)
+	current, pending := b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(1), current)
+	require.Equal(t, uint32(0), pending)
+
+	// A duplicate CreateIndex — re-emitted by the processor as initial=false once
+	// the ledger is no longer born-empty — must be a no-op on this live replica.
+	second := b.readStore.NewBatch()
+	b.initBatch(second)
+	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.wb.Flush())
+
+	require.Empty(t, b.backfillTasks, "duplicate create must not reschedule a backfill")
+	current, pending = b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(1), current, "index stays live after a duplicate create")
+	require.Equal(t, uint32(0), pending, "no pending backfill after a duplicate create")
+}

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -1149,3 +1149,66 @@ func TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent(t *testing.T) {
 	require.Equal(t, uint32(1), current, "index stays live after a duplicate create")
 	require.Equal(t, uint32(0), pending, "no pending backfill after a duplicate create")
 }
+
+// TestDropLedgerVersionState_EvictsOnlyThatLedger pins the eviction the live
+// DeleteLedger apply path performs (via dropLedgerVersionState): every in-memory
+// version state for the deleted ledger is dropped, and other ledgers are left
+// untouched. Without this a same-name recreate would read a stale
+// CurrentVersion != 0 (see TestHandleCreatedIndexLog_RecreateAfterDelete).
+func TestDropLedgerVersionState_EvictsOnlyThatLedger(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	idA := indexes.Canonical(indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET))
+	idB := indexes.Canonical(indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE))
+
+	b.putVersionState("gone", idA, readstore.IndexVersionState{CurrentVersion: 1})
+	b.putVersionState("gone", idB, readstore.IndexVersionState{CurrentVersion: 2})
+	b.putVersionState("kept", idA, readstore.IndexVersionState{CurrentVersion: 3})
+
+	b.dropLedgerVersionState("gone")
+
+	c, _ := b.versionFor("gone", idA)
+	require.Equal(t, uint32(0), c, "deleted ledger index A must be evicted")
+	c, _ = b.versionFor("gone", idB)
+	require.Equal(t, uint32(0), c, "deleted ledger index B must be evicted")
+	c, _ = b.versionFor("kept", idA)
+	require.Equal(t, uint32(3), c, "other ledgers must be untouched")
+}
+
+// TestHandleCreatedIndexLog_RecreateAfterDelete_ReseedsBackfill guards the
+// name-reuse corner of the readiness guard: once the DeleteLedger apply path has
+// evicted the in-memory version state (dropLedgerVersionState), a same-name
+// recreate must be treated as genuinely new — re-seed {current:0, pending:1} and
+// schedule a backfill — rather than short-circuited as a live duplicate and
+// stranded behind ErrIndexBuilding.
+func TestHandleCreatedIndexLog_RecreateAfterDelete_ReseedsBackfill(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const ledger = "reused"
+	id := indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
+	canonical := indexes.Canonical(id)
+
+	// A live index left over in memory from the ledger's prior life, then the
+	// DeleteLedger apply path evicts it (as processLogs does live).
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{CurrentVersion: 1})
+	b.dropLedgerVersionState(ledger)
+	current, pending := b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(0), current, "delete must evict the in-memory version state")
+	require.Equal(t, uint32(0), pending)
+
+	// A CreateIndex for the recreated ledger must be treated as genuinely new:
+	// re-seed {current:0, pending:1} and schedule a backfill, not short-circuit.
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.wb.Flush())
+
+	require.Len(t, b.backfillTasks, 1, "recreated ledger index must schedule a backfill")
+	current, pending = b.versionFor(ledger, canonical)
+	require.Equal(t, uint32(0), current)
+	require.Equal(t, uint32(1), pending)
+}

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -134,6 +134,11 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 					}
 
 					b.markLedgerDeletedInBatch(name)
+					// Live delete: evict the in-memory version state too so a
+					// same-name recreate is treated as genuinely new. (The
+					// backfill replay path deliberately does NOT do this — see
+					// dropLedgerVersionState.)
+					b.dropLedgerVersionState(name)
 				}
 
 				continue
@@ -903,6 +908,23 @@ func (b *Builder) writeAccountByAssetDedup(kb *dal.KeyBuilder, ledger, account, 
 func (b *Builder) markLedgerDeletedInBatch(name string) {
 	b.deletedThisBatch[name] = struct{}{}
 	b.seenAcctAsset = make(map[string]struct{})
+}
+
+// dropLedgerVersionState evicts every in-memory per-index version state for a
+// ledger — the whole-ledger counterpart of dropVersionState. It mirrors the
+// persisted wipe DeleteLedgerIndexes performs on the SubInternalIndexVersion
+// prefix, so a same-name recreate in the same process starts from a clean
+// CurrentVersion == 0: otherwise the handleCreatedIndexLog readiness guard would
+// read the dead generation's CurrentVersion != 0, skip seeding fresh state and
+// scheduling the backfill, and strand the new index behind ErrIndexBuilding.
+//
+// This lives on the LIVE DeleteLedger apply path only (processLogs), NOT in
+// markLedgerDeletedInBatch: the backfill replay path also calls that helper for
+// a historical delete of the task ledger, where the in-progress version state
+// tracks the RECREATED generation the backfill is building and must survive so
+// completeBackfill can promote it.
+func (b *Builder) dropLedgerVersionState(name string) {
+	delete(b.indexVersions, name)
 }
 
 // readstoreKeyExists reports whether key is present in committed read-store

--- a/internal/domain/processing/processor.go
+++ b/internal/domain/processing/processor.go
@@ -58,6 +58,67 @@ type Context struct {
 	NumscriptCache *numscript.NumscriptCache
 	CompiledTypes  map[string][]accounttype.CompiledType
 	AssetCache     map[string]cachedAssetPrecision
+
+	// BornEmptyLedgers tracks ledgers created in THIS proposal that have not
+	// yet emitted any indexable data log. An index declared while its ledger
+	// is in this set is "initial" (EN-1564): the indexbuilder marks it live
+	// immediately instead of scheduling a historical backfill. Transient,
+	// per-ProcessOrders-call bookkeeping — never persisted.
+	BornEmptyLedgers map[string]struct{}
+}
+
+// markBornEmpty records a freshly-created ledger as having no indexable data
+// yet. Lazy-inits the map so callers holding a bare Context (ProcessOrder and
+// unit tests) work without a constructor change.
+func (c *Context) markBornEmpty(ledger string) {
+	if c.BornEmptyLedgers == nil {
+		c.BornEmptyLedgers = make(map[string]struct{})
+	}
+
+	c.BornEmptyLedgers[ledger] = struct{}{}
+}
+
+// isBornEmpty reports whether the ledger was created earlier in this proposal
+// and has emitted no indexable data log since. Nil-safe.
+func (c *Context) isBornEmpty(ledger string) bool {
+	_, ok := c.BornEmptyLedgers[ledger]
+
+	return ok
+}
+
+// updateBornEmpty folds a just-produced log into the born-empty set: a
+// CreatedLedger marks the ledger empty; the first indexable data log clears it.
+// Driven off the emitted top-level log so the apply, mirror-ingest and
+// order-skip paths (all wrapped as LogPayload_Apply) are covered from one call
+// site. delete on a nil map is a no-op.
+func (c *Context) updateBornEmpty(payload *commonpb.LogPayload) {
+	if cl := payload.GetCreateLedger(); cl != nil {
+		c.markBornEmpty(cl.GetName())
+
+		return
+	}
+
+	if apply := payload.GetApply(); apply != nil {
+		if isIndexableDataPayload(apply.GetLog().GetData()) {
+			delete(c.BornEmptyLedgers, apply.GetLedgerName())
+		}
+	}
+}
+
+// isIndexableDataPayload reports whether a ledger log payload carries data the
+// read-side indexbuilder backfills (mirrors indexbuilder.isDataLog). A ledger
+// that has emitted one of these is no longer "born empty" for EN-1564. Nil-safe.
+func isIndexableDataPayload(p *commonpb.LedgerLogPayload) bool {
+	switch p.GetPayload().(type) {
+	case *commonpb.LedgerLogPayload_CreatedTransaction,
+		*commonpb.LedgerLogPayload_RevertedTransaction,
+		*commonpb.LedgerLogPayload_SavedMetadata,
+		*commonpb.LedgerLogPayload_DeletedMetadata,
+		*commonpb.LedgerLogPayload_OrderSkipped:
+		return true
+	default:
+		return false
+	}
 }
 
 // NewRequestProcessor creates a new RequestProcessor with the given meter.
@@ -243,6 +304,7 @@ func (p *RequestProcessor) ProcessOrders(orders []*raftcmdpb.Order, scopeFactory
 				}
 
 				sink.Absorb(order, skipLog)
+				ctx.updateBornEmpty(skippedPayload)
 
 				result.CreatedLogs = append(result.CreatedLogs, skipLog)
 				if result.MinLogSequence == 0 || nextSequenceID < result.MinLogSequence {
@@ -305,6 +367,7 @@ func (p *RequestProcessor) ProcessOrders(orders []*raftcmdpb.Order, scopeFactory
 		// log payload and updates whatever cross-order accumulator
 		// the framework needs.
 		sink.Absorb(order, log)
+		ctx.updateBornEmpty(payload)
 
 		// Accumulate the derivations applyProposal previously rebuilt
 		// by walking the log slice again (createdLogs filter +

--- a/internal/domain/processing/processor_born_empty_test.go
+++ b/internal/domain/processing/processor_born_empty_test.go
@@ -1,0 +1,58 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func TestBornEmpty_MarkAndClearViaUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := &Context{}
+
+	// A CreatedLedger log marks the ledger born-empty.
+	ctx.updateBornEmpty(&commonpb.LogPayload{
+		Type: &commonpb.LogPayload_CreateLedger{
+			CreateLedger: &commonpb.CreatedLedgerLog{Name: "l1"},
+		},
+	})
+	require.True(t, ctx.isBornEmpty("l1"))
+	require.False(t, ctx.isBornEmpty("other"))
+
+	// A config log (CreateIndex) does NOT clear it.
+	ctx.updateBornEmpty(applyLog("l1", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{CreateIndex: &commonpb.CreatedIndexLog{}},
+	}))
+	require.True(t, ctx.isBornEmpty("l1"))
+
+	// The first indexable data log clears it.
+	ctx.updateBornEmpty(applyLog("l1", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{}},
+	}))
+	require.False(t, ctx.isBornEmpty("l1"))
+}
+
+func TestBornEmpty_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	ctx := &Context{}
+	require.False(t, ctx.isBornEmpty("x")) // read on nil map
+	ctx.updateBornEmpty(applyLog("x", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{}},
+	})) // delete on nil map, must not panic
+	require.False(t, ctx.isBornEmpty("x"))
+}
+
+func applyLog(ledger string, data *commonpb.LedgerLogPayload) *commonpb.LogPayload {
+	return &commonpb.LogPayload{
+		Type: &commonpb.LogPayload_Apply{
+			Apply: &commonpb.ApplyLedgerLog{
+				LedgerName: ledger,
+				Log:        &commonpb.LedgerLog{Data: data},
+			},
+		},
+	}
+}

--- a/internal/domain/processing/processor_index.go
+++ b/internal/domain/processing/processor_index.go
@@ -31,7 +31,7 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 	}
 
 	if existing != nil && existing.GetBuildStatus() == commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_READY {
-		return buildCreatedIndexLogPayload(id), nil
+		return buildCreatedIndexLogPayload(id, false), nil
 	}
 
 	indexes.Put(ctx.Scope.Indexes(), info.GetName(), &commonpb.Index{
@@ -44,7 +44,7 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 		ForwardEncodingVersion: 1,
 	})
 
-	return buildCreatedIndexLogPayload(id), nil
+	return buildCreatedIndexLogPayload(id, ctx.isBornEmpty(ledger)), nil
 }
 
 func processDropIndex(ledger string, order *raftcmdpb.DropIndexOrder, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
@@ -90,10 +90,10 @@ func validateIndexTarget(info *commonpb.LedgerInfo, id *commonpb.IndexID) domain
 	return nil
 }
 
-func buildCreatedIndexLogPayload(id *commonpb.IndexID) *commonpb.LedgerLogPayload {
+func buildCreatedIndexLogPayload(id *commonpb.IndexID, initial bool) *commonpb.LedgerLogPayload {
 	return &commonpb.LedgerLogPayload{
 		Payload: &commonpb.LedgerLogPayload_CreateIndex{
-			CreateIndex: &commonpb.CreatedIndexLog{Id: id},
+			CreateIndex: &commonpb.CreatedIndexLog{Id: id, Initial: initial},
 		},
 	}
 }

--- a/internal/domain/processing/processor_index_test.go
+++ b/internal/domain/processing/processor_index_test.go
@@ -134,3 +134,58 @@ func TestProcessDeleteLedger_DoesNotTouchIndexRegistry(t *testing.T) {
 	require.Nil(t, derr)
 	require.NotNil(t, payload)
 }
+
+// TestProcessCreateIndex_StampsInitialWhenBornEmpty verifies an index declared
+// while its ledger is still born-empty is stamped initial=true on the log.
+func TestProcessCreateIndex_StampsInitialWhenBornEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+
+	ledgerInfo := &commonpb.LedgerInfo{Name: "test-ledger", Id: 7}
+	indexID := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	now := &commonpb.Timestamp{Data: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, ledgerInfo.AsReader(), nil)
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+
+	idxStub := setupIndexesStub(mockStore)
+	idxStub.expectGet(domain.IndexKey{LedgerName: "test-ledger", Canonical: indexes.Canonical(indexID)}, nil, domain.ErrNotFound)
+	idxStub.putHook = func(domain.IndexKey, *commonpb.Index) {}
+
+	ctx := &Context{Scope: mockStore}
+	ctx.markBornEmpty("test-ledger")
+
+	payload, derr := processCreateIndex("test-ledger", &raftcmdpb.CreateIndexOrder{Id: indexID}, ctx)
+	require.Nil(t, derr)
+	require.True(t, payload.GetCreateIndex().GetInitial())
+}
+
+// TestProcessCreateIndex_NotInitialWithoutBornEmpty verifies the default: an
+// index on a ledger not tracked as born-empty is stamped initial=false.
+func TestProcessCreateIndex_NotInitialWithoutBornEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+
+	ledgerInfo := &commonpb.LedgerInfo{Name: "test-ledger", Id: 7}
+	indexID := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	now := &commonpb.Timestamp{Data: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, ledgerInfo.AsReader(), nil)
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+
+	idxStub := setupIndexesStub(mockStore)
+	idxStub.expectGet(domain.IndexKey{LedgerName: "test-ledger", Canonical: indexes.Canonical(indexID)}, nil, domain.ErrNotFound)
+	idxStub.putHook = func(domain.IndexKey, *commonpb.Index) {}
+
+	payload, derr := processCreateIndex("test-ledger", &raftcmdpb.CreateIndexOrder{Id: indexID}, &Context{Scope: mockStore})
+	require.Nil(t, derr)
+	require.False(t, payload.GetCreateIndex().GetInitial())
+}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -6422,8 +6422,13 @@ func (x *OrderSkippedLog) GetContext() map[string]string {
 
 // CreatedIndexLog records the creation of an index.
 type CreatedIndexLog struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            *IndexID               `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    *IndexID               `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
+	// initial marks an index declared on a ledger that had no local history yet
+	// (same atomic apply batch as CreateLedger, before any indexable data log).
+	// The read-side indexbuilder promotes such indexes straight to live with no
+	// historical backfill; later indexes (initial=false) keep backfilling. EN-1564.
+	Initial       bool `protobuf:"varint,5,opt,name=initial,proto3" json:"initial,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6463,6 +6468,13 @@ func (x *CreatedIndexLog) GetId() *IndexID {
 		return x.Id
 	}
 	return nil
+}
+
+func (x *CreatedIndexLog) GetInitial() bool {
+	if x != nil {
+		return x.Initial
+	}
+	return false
 }
 
 // DroppedIndexLog records the removal of an index.
@@ -13261,9 +13273,10 @@ const file_common_proto_rawDesc = "" +
 	"\acontext\x18\x02 \x03(\v2$.common.OrderSkippedLog.ContextEntryR\acontext\x1a:\n" +
 	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"g\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x01\n" +
 	"\x0fCreatedIndexLog\x12\x1f\n" +
-	"\x02id\x18\x04 \x01(\v2\x0f.common.IndexIDR\x02idJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vlog_builtinR\vtransactionR\aaccount\"g\n" +
+	"\x02id\x18\x04 \x01(\v2\x0f.common.IndexIDR\x02id\x12\x18\n" +
+	"\ainitial\x18\x05 \x01(\bR\ainitialJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vlog_builtinR\vtransactionR\aaccount\"g\n" +
 	"\x0fDroppedIndexLog\x12\x1f\n" +
 	"\x02id\x18\x04 \x01(\v2\x0f.common.IndexIDR\x02idJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vlog_builtinR\vtransactionR\aaccount\"/\n" +
 	"\fFilledGapLog\x12\x1f\n" +

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -5786,6 +5786,7 @@ func (m orderSkippedLog_contextMapReadonly) Range(yield func(string, string) boo
 // Call Mutate() to obtain a mutable clone.
 type CreatedIndexLogReader interface {
 	GetId() IndexIDReader
+	GetInitial() bool
 	Mutate() *CreatedIndexLog
 }
 
@@ -5797,6 +5798,10 @@ func (r *createdIndexLogReadonly) GetId() IndexIDReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *createdIndexLogReadonly) GetInitial() bool {
+	return (*CreatedIndexLog)(r).GetInitial()
 }
 
 func (r *createdIndexLogReadonly) Mutate() *CreatedIndexLog {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -2045,6 +2045,7 @@ func (m *CreatedIndexLog) CloneVT() *CreatedIndexLog {
 	}
 	r := new(CreatedIndexLog)
 	r.Id = m.Id.CloneVT()
+	r.Initial = m.Initial
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -8016,6 +8017,9 @@ func (this *CreatedIndexLog) EqualVT(that *CreatedIndexLog) bool {
 		return false
 	}
 	if !this.Id.EqualVT(that.Id) {
+		return false
+	}
+	if this.Initial != that.Initial {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -17286,6 +17290,16 @@ func (m *CreatedIndexLog) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Initial {
+		i--
+		if m.Initial {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
 	if m.Id != nil {
 		size, err := m.Id.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -25496,6 +25510,9 @@ func (m *CreatedIndexLog) SizeVT() (n int) {
 	if m.Id != nil {
 		l = m.Id.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Initial {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -40409,6 +40426,26 @@ func (m *CreatedIndexLog) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Initial", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Initial = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -750,6 +750,11 @@ message CreatedIndexLog {
   reserved 1, 2, 3;
   reserved "log_builtin", "transaction", "account";
   IndexID id = 4;
+  // initial marks an index declared on a ledger that had no local history yet
+  // (same atomic apply batch as CreateLedger, before any indexable data log).
+  // The read-side indexbuilder promotes such indexes straight to live with no
+  // historical backfill; later indexes (initial=false) keep backfilling. EN-1564.
+  bool initial = 5;
 }
 
 // DroppedIndexLog records the removal of an index.

--- a/tests/e2e/business/indexes_test.go
+++ b/tests/e2e/business/indexes_test.go
@@ -584,6 +584,81 @@ var _ = Describe("UserConfigurableIndexes", Ordered, func() {
 			Expect(result.GetCursor().TransactionData).To(BeEmpty())
 		})
 	})
+
+	// ========================================================================
+	// Initial index declared atomically with CreateLedger (EN-1564):
+	// an index created in the same batch as the ledger, before any data log,
+	// is stamped CreatedIndexLog.initial and promoted straight to live by the
+	// indexbuilder (current_version > 0, no backfill cursor). Contrast with the
+	// "Reference index lifecycle" context above, where an index added after the
+	// ledger already holds transactions goes through a backfill pass.
+	// ========================================================================
+	Context("Initial index on an empty ledger", Ordered, func() {
+		const ledgerName = "idx-initial"
+
+		BeforeAll(func() {
+			// Create the ledger AND its reference index in ONE atomic Apply,
+			// before any transaction is ingested.
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+				actions.CreateLedgerAction(ledgerName, nil),
+				actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE),
+			))
+			Expect(err).To(Succeed())
+		})
+
+		It("Should promote the initial index straight to live with no backfill", func() {
+			Eventually(func(g Gomega) {
+				resp, err := sharedClient.GetIndexStatus(sharedCtx, &servicepb.GetIndexStatusRequest{Ledger: ledgerName})
+				g.Expect(err).To(Succeed())
+
+				var entry *servicepb.IndexEntry
+				for _, e := range resp.GetIndexes() {
+					b, ok := e.GetIndex().GetId().GetKind().(*commonpb.IndexID_TxBuiltin)
+					if e.GetLedger() == ledgerName && ok && b.TxBuiltin == commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE {
+						entry = e
+
+						break
+					}
+				}
+				g.Expect(entry).NotTo(BeNil())
+				// Live immediately on the local replica: current_version has
+				// advanced past 0 without ever running a backfill pass.
+				g.Expect(entry.GetCurrentVersion()).To(BeNumerically(">", 0))
+				// No backfill cursor was ever set (0 == not backfilling / done).
+				g.Expect(entry.GetCursor()).To(Equal(uint64(0)))
+			}).Within(10 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+		})
+
+		It("Should resolve a reference-backed query immediately after ingest, with no ErrIndexBuilding", func() {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+				actions.WithReference(actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+					actions.NewPosting("world", "alice", big.NewInt(100), "USD/2"),
+				}, nil), "init-pay-001"),
+			))
+			Expect(err).To(Succeed())
+
+			_, err = sharedClient.CreatePreparedQuery(sharedCtx, &servicepb.CreatePreparedQueryRequest{
+				Ledger: ledgerName,
+
+				Query: &commonpb.PreparedQuery{
+					Name:   "by-reference",
+					Target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+					Filter: actions.ReferenceFilter("init-pay-001"),
+				},
+			})
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				result, err := sharedClient.ExecutePreparedQuery(sharedCtx, &servicepb.ExecutePreparedQueryRequest{
+					Ledger:    ledgerName,
+					QueryName: "by-reference",
+					Mode:      commonpb.QueryMode_QUERY_MODE_LIST,
+				})
+				g.Expect(err).To(Succeed())
+				g.Expect(result.GetCursor().TransactionData).To(HaveLen(1))
+			}).Within(10 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+		})
+	})
 })
 
 // listLedgerIndexes streams BucketService.ListIndexes scoped to ledgerName and


### PR DESCRIPTION
## Summary

Avoids the unnecessary historical backfill (and the readiness gap) for an index declared in the **same atomic apply batch** as its `CreateLedger`, before any ledger-local data exists — the Bitcoin-ingestion pattern.

Jira: https://formance-team.atlassian.net/browse/EN-1564

## Problem

When a ledger is created empty and its indexes are declared atomically, each `CreateIndex` was still treated as an index added to a historical ledger: the indexbuilder seeded `IndexVersionState{Current:0, Pending:1}`, scheduled a backfill from `cursor=0`, and gated indexed reads with `ErrIndexBuilding` until the backfill caught the moving global cursor. For a ledger born empty there is nothing to backfill, so this is pure wasted work plus an availability gap on the hot path.

## Approach

The FSM tracks, per proposal, ledgers created in the batch that have not yet emitted any indexable data log (transient, non-persisted, deterministic). When `CreateIndex` applies for such a ledger it stamps a new `CreatedIndexLog.initial` flag. The read-side indexbuilder promotes an `initial` index straight to live (`IndexVersionState{Current:1, Pending:0}`) and schedules **no** backfill; the live indexing path maintains it from ledger birth. Later indexes (added to a ledger with data, or created in a separate batch) are unchanged — they still backfill and stay gated until `current_version > 0`.

The classification is conservative: only same-atomic-batch-before-any-data qualifies. A false positive would silently skip indexing real history, so anything else keeps the existing backfill behavior.

## Changes

- `misc/proto/common.proto`: add `bool initial = 5` to `CreatedIndexLog` (regenerated).
- `internal/domain/processing`: per-proposal born-empty tracking on `Context`; stamp `initial` in `processCreateIndex`.
- `internal/application/indexbuilder`: `handleCreatedIndexLog` promotes initial indexes to live with no backfill.
- Tests: processing unit tests (born-empty + stamping), indexbuilder unit tests (initial vs non-initial), and an e2e scenario (atomic create+index → live immediately, immediate ingestion resolves with no `ErrIndexBuilding`).
- Docs: initial-vs-later index semantics.

## Invariants

- **#2 determinism:** born-empty tracking is a pure function of the deterministically-ordered batch.
- **#8 checker:** no new persisted projection; `compareIndexes` keys on `IndexID` identity and excludes `BuildStatus`, so the flag needs no compare pass.
- **#9 coverage gate:** no new cache-attribute reads on the hot path.
- **#10 order immutability:** only the FSM-produced log is stamped; the accepted `Order` is untouched.
- **Boot safety:** an initial index persists `Current:1`, and `loadIndexRegistry` skips backfill scheduling when `current != 0`.

## Testing

- `just pre-commit`: 0 lint issues (both modules).
- `just test` (root module unit tests): pass.
- New unit tests pass; e2e compiles under the `e2e` tag (runs in CI).

## Acceptance criteria

- [x] Atomic create + index creates no backfill task.
- [x] `GetIndexStatus` reports `current_version > 0` and no backfill cursor for initial indexes.
- [x] Immediately-ingested transactions are indexed by the live path.
- [x] A later index on a ledger with data still backfills and stays gated until complete.
- [x] Covered by tests (unit + e2e).
- [x] Docs clarify initial vs later index semantics.
