### PR TITLE
fix(revert): keep original postings out of the audit-bound order

### DIFF
--- a/docs/technical/architecture/audit-vs-technical-state.md
+++ b/docs/technical/architecture/audit-vs-technical-state.md
@@ -78,6 +78,38 @@ adding a variant, classify it with the table above and answer:
 If any answer is yes, the variant needs either an audited order or an explicit
 checker pass that verifies the stored value against audit-bound data.
 
+## Accepted Order Enrichment
+
+An accepted order is audit-bound: its serialized bytes feed the hash chain
+(`AuditItem.SerializedOrder`, via `state.BuildPerItemPayload`). The order must
+therefore carry only **caller intent** — the fields the caller submitted.
+Admission must not enrich it with state-derived execution data, even when that
+data is deterministic given the request. Doing so binds admission-time state into
+the audit chain and makes the serialized order depend on which node admitted it
+and what that node could read.
+
+State-derived execution inputs the FSM needs at apply time flow through a
+different channel: the **coverage-gated preloaded state**. Admission declares the
+`preload.Needs` for every key the apply path reads (invariant #6), and the FSM
+reads the value through `Scope.GetX(...)` under the coverage gate (invariant #9).
+Because the apply path cannot read Pebble (invariant #3), the value comes from the
+cache the preload seeded — never from the order.
+
+**Revert is the canonical example.** `RevertTransactionOrder` carries only
+`transaction_id`, `force`, `at_effective_date`, `metadata`, and `expand_volumes`.
+The original postings the FSM reverses are **not** on the order: admission
+preloads the target `TransactionState` (`addTransactionTargetNeeds`) and
+`processRevertTransaction` reads `origState.GetPostings()` through the coverage
+gate. Admission still resolves the postings at order-build time — from the signed
+receipt or the `Transaction` attribute — to declare the volume-preload coverage
+the reversed postings touch (invariant #9), but it holds them in an
+admission-local sidecar (`bulkOverlay.revertOriginalPostings`), never on the wire
+order. Chapter archival does not evict `TransactionState` (`executePurge` removes
+only the cold log/audit ranges), so a revert of a pre-archival transaction reads
+its postings from the surviving projection; a missing state for an *allocated* id
+is an inconsistency surfaced loudly (invariant #7), not a routine not-found —
+that case is caught earlier by the `txID >= NextTransactionId` boundary check.
+
 ## Mirror Cursor
 
 Mirror ingestion is the highest-risk boundary because the mirror cursor is an

--- a/docs/technical/architecture/subsystems/chapters/receipts.md
+++ b/docs/technical/architecture/subsystems/chapters/receipts.md
@@ -2,28 +2,29 @@
 
 ## Overview
 
-A **receipt** is a short JWT that lets a client revert an **archived** transaction without anyone reading cold storage. The client gets the receipt at the time the transaction is archived (or already has it from when the transaction was created); on revert, it presents the receipt to the server; the server verifies the receipt and applies the reversal directly, with no round-trip to S3.
+A **receipt** is a short JWT, issued when a transaction is created, that carries a signed copy of the transaction's postings. A client can present it when reverting so that admission does not have to read the transaction's postings itself.
 
-Receipts are how the cold-storage layer stays write-only: the system never needs to thaw an archived chapter just to revert a single transaction inside it.
+The reversal is always applied by the FSM from the transaction's own state (`TransactionState`), which lives in the coverage-gated cache and **survives chapter archival** — archival purges only the cold `Log` / `Audit` / `AppliedProposal` ranges, never `TransactionState` (see `WriteSet.executePurge`). No revert path — receipt or not — reads cold storage. The receipt's role is purely admission-side: it is one source (versus admission's own store read) for the postings admission uses to declare the volume-preload coverage the reversed postings touch (invariant #9).
+
+> **Open question.** Because `TransactionState` survives archival and the FSM reverts from it, admission can normally read the postings directly, so the receipt's distinct value is now thin. Whether the receipt feature is still needed is under review (tracked in the Ledger v3.0 backlog).
 
 Source: `internal/infra/receipt/receipt.go`.
 
 ## Claim shape
 
-`receipt.go:32-40` — the JWT carries everything the FSM needs to construct the reversal:
+`receipt.go` — the JWT carries the signed postings admission uses to declare the revert's coverage:
 
 ```go
 type Claims struct {
-    Ledger    string             // ledger name
-    TxID      uint64             // archived transaction ID
-    Postings  []*commonpb.Posting// the original transaction's postings
-    Asset     string
-    ChapterID uint64             // which chapter holds the original
-    jwt.RegisteredClaims         // iss, iat
+    jwt.RegisteredClaims            // iss, iat
+    Ledger    string                // ledger name
+    TxID      uint64                // original transaction ID
+    Postings  []PostingClaim        // the original transaction's postings
+    ChapterID uint64                // chapter that held the original
 }
 ```
 
-The `Postings` field is the load-bearing one: the receipt is essentially **a frozen copy of the postings to invert**. The FSM consumes them at revert time without ever consulting the chapter's archived log.
+The `Postings` field is a signed, frozen copy of the original transaction's postings. **Admission** consumes it at propose time — to declare the volume-preload coverage the reversed postings will touch — as an alternative to reading the postings from the transaction's own state. It is not consumed by the FSM: the FSM reverts from the coverage-gated `TransactionState` (see [The revert path](#the-revert-path)).
 
 ## Signing
 
@@ -48,7 +49,7 @@ Receipts are deliberately the simpler primitive: the only consumer is the cluste
 3. HMAC check.
 4. Standard `exp` / `nbf` handling (claims expose `IssuedAt`; expiration is a deployment-policy choice).
 
-If verification passes, the FSM has a trusted `Claims` struct and can apply the revert deterministically.
+Verification runs in **admission** (`convertApplyRequest`), which also checks that the receipt's `Ledger` and `TxID` match the resolved request. If verification passes, admission has a trusted `Claims` struct and uses its `Postings` to declare the revert's volume coverage.
 
 ## Lifecycle
 
@@ -66,24 +67,28 @@ sequenceDiagram
     Note over S,Cold: Chapter sealed → archived
     ...
     C->>S: RevertTransaction(receipt)
-    S->>S: receipt.Verify(token)
-    S->>S: apply reversal from receipt.Postings
+    S->>S: admission: receipt.Verify(token) → declare volume coverage from receipt.Postings
+    S->>S: FSM: revert from coverage-gated TransactionState
     S-->>C: revert log
 ```
 
-The receipt is issued **once**, at the time of the transaction's archival (or directly when the transaction is created, for forward-compatibility — the client gets the receipt regardless of whether the chapter has been archived yet). The client is responsible for storing it; the server does not keep a copy. From the cluster's point of view, the receipt's content is recoverable from the chapter even after archival — the receipt just saves the round-trip.
+The receipt is issued **once**, when the transaction is created; the client is responsible for storing it and the server keeps no copy. It is only ever an admission-side convenience: the postings are also recoverable from the transaction's own state (which the FSM reads on revert regardless), so the receipt just saves admission a store read.
 
 ## The revert path
 
-`RevertTransactionOrder` (`raft_cmd.proto:337-344`) carries an optional `original_postings` field. Under normal conditions (transaction still in a hot chapter), the field is left empty and the FSM reads the postings from Pebble. For an archived transaction, the field is populated **from the verified receipt's `Postings`**, and the FSM applies the inverse without touching cold storage.
+`RevertTransactionOrder` carries only caller intent — `transaction_id`, `force`, `at_effective_date`, `metadata`. It does **not** carry the original postings: that would be state-derived execution data on an audit-bound order (see [audit-vs-technical-state.md](../../audit-vs-technical-state.md#accepted-order-enrichment)).
 
-The resulting `RevertedTransaction` log is hash-bound by the audit chain exactly like any other revert — the fact that the original was archived has no effect on the chain integrity.
+At apply time the FSM sources the original postings from the target's `TransactionState`, read through the coverage-gated scope — admission preloads that entry (`addTransactionTargetNeeds`), so the read never touches Pebble (invariant #3). It builds the reversed postings from `origState.GetPostings()`; a missing state for an allocated id is a loud inconsistency, and a non-existent id is caught earlier by the `txID >= NextTransactionId` boundary check.
+
+The receipt (when present) never reaches the FSM. Admission verifies it and uses its `Postings` only to declare the volume-preload coverage the reversed postings touch — the same coverage it would otherwise derive from its own read of `TransactionState`.
+
+The resulting `RevertedTransaction` log is hash-bound by the audit chain exactly like any other revert — the fact that the original chapter was archived has no effect on chain integrity.
 
 ## What a receipt does not authorise
 
 - **It does not authenticate the caller.** Receipt verification proves "this content was signed by the cluster" — it says nothing about who is allowed to invoke it. The standard [auth](../api/auth.md) flow (JWT bearer + scopes) still runs in front. A valid receipt without a valid `ledger:TransactionWrite` scope is rejected at admission.
 - **It is not idempotency.** Re-submitting the same receipt twice produces two revert attempts; the second one is rejected by the FSM because the original is already reverted (`checkReversionInvariants` enforces no-double-revert). If the client needs idempotent retries, it uses the standard idempotency key on the request — receipts and idempotency keys are orthogonal.
-- **It is not arbitrary forging power.** The receipt's `Postings` are fixed at issuance time; they cannot be edited and re-signed. A receipt revert produces a revert log that is, byte-for-byte, the revert the cluster would have produced from cold-storage replay.
+- **It is not arbitrary forging power.** The receipt's `Postings` are fixed at issuance time and can't be edited without the HMAC key. And even a validly-signed receipt can't determine the reversal: the FSM builds the revert from the target's `TransactionState`, not from the receipt. A receipt whose postings disagreed with the stored state would only mis-declare coverage — at worst a coverage-miss error, never a wrong revert.
 
 ## Security envelope
 
@@ -95,7 +100,7 @@ Three things keep the scheme honest:
 
 ## Audit binding
 
-Receipts themselves are **not** stored in the audit chain — they are external artefacts. The **revert log** that uses a receipt is bound by the chain like every other log, carrying the original-postings field in the order's `SerializedOrder`. The audit chain therefore records "the cluster reverted txID X with these postings", which is exactly what an independent auditor needs to verify.
+Receipts themselves are **not** stored in the audit chain — they are external artefacts. The audit-bound order (`AuditItem.SerializedOrder`) carries only the caller's revert intent (`transaction_id`, `force`, `at_effective_date`, `metadata`), not the postings. The reversed postings appear in the produced `RevertedTransaction` log — a checker-verified projection, re-derivable by replaying the target's `TransactionState` — so an independent auditor can still confirm "the cluster reverted txID X with these postings" from the chain-bound log.
 
 A receipt that is signed but never used leaves no trace anywhere — there is no audit row for "receipt issued but never redeemed".
 
@@ -104,7 +109,8 @@ A receipt that is signed but never used leaves no trace anywhere — there is no
 | Concern | File |
 |---------|------|
 | Signer / Verifier | `internal/infra/receipt/receipt.go` |
-| Claims shape | `internal/infra/receipt/receipt.go:32-40` |
-| `RevertTransactionOrder` proto | `misc/proto/raft_cmd.proto:337-344` |
-| Revert FSM processor | `internal/domain/processing/processor_revert_transaction.go` |
-| Double-revert invariant | `internal/application/check/checker.go:1959-2006` |
+| Claims shape | `internal/infra/receipt/receipt.go` |
+| Receipt verification + coverage declaration (admission) | `internal/application/admission/admission.go` (`convertApplyRequest`) |
+| `RevertTransactionOrder` proto | `misc/proto/raft_cmd.proto` |
+| Revert FSM processor (postings from `TransactionState`) | `internal/domain/processing/processor_revert_transaction.go` |
+| Double-revert invariant | `internal/application/check/checker.go` |

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -515,7 +515,7 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 	}
 
 	// Step 1: Extract preload needs from orders (excludes script-dependent needs)
-	needs, perOrder, err := a.extractPreloadNeeds(ctx, orders)
+	needs, perOrder, err := a.extractPreloadNeeds(ctx, orders, overlay)
 	if err != nil {
 		return nil, err
 	}
@@ -1053,7 +1053,7 @@ func addTransactionTargetNeeds(p *plan.Coverage, ledgerName string, txID uint64)
 // extractLedgerScopedNeeds populates the preload Coverage for a ledger-scoped
 // order. The ledger lives once on the wrapper; every payload variant reads it
 // from there instead of carrying its own field.
-func extractLedgerScopedNeeds(p *plan.Coverage, ls *raftcmdpb.LedgerScopedOrder) {
+func extractLedgerScopedNeeds(p *plan.Coverage, ls *raftcmdpb.LedgerScopedOrder, overlay *bulkOverlay) {
 	ledgerName := ls.GetLedger()
 	ledgerKey := domain.LedgerKey{Name: ledgerName}
 
@@ -1222,7 +1222,13 @@ func extractLedgerScopedNeeds(p *plan.Coverage, ls *raftcmdpb.LedgerScopedOrder)
 		case *raftcmdpb.LedgerApplyOrder_RevertTransaction:
 			addTransactionTargetNeeds(p, ledgerName, applyData.RevertTransaction.GetTransactionId())
 
-			for _, posting := range applyData.RevertTransaction.GetOriginalPostings() {
+			// The reversed postings touch the same accounts as the original;
+			// admission resolved them at order-build time into the overlay
+			// sidecar (the order itself carries only caller intent).
+			originalPostings := overlay.revertOriginalPostingsFor(
+				domain.TransactionKey{LedgerName: ledgerName, ID: applyData.RevertTransaction.GetTransactionId()},
+			)
+			for _, posting := range originalPostings {
 				addVolumeNeed(p, ledgerName, posting.GetDestination(), posting.GetAsset(), posting.GetColor())
 				addVolumeNeed(p, ledgerName, posting.GetSource(), posting.GetAsset(), posting.GetColor())
 			}
@@ -1369,7 +1375,7 @@ func extractSystemScopedNeeds(p *plan.Coverage, ss *raftcmdpb.SystemScopedOrder)
 // extractPreloadNeeds extracts all preload keys from orders in a single pass.
 // Returns the proposal-wide aggregate Coverage and a parallel slice with one
 // Coverage per order (used to compute Order.coverage_bits after Build).
-func (a *Admission) extractPreloadNeeds(ctx context.Context, orders []*raftcmdpb.Order) (*plan.Coverage, []*plan.Coverage, error) {
+func (a *Admission) extractPreloadNeeds(ctx context.Context, orders []*raftcmdpb.Order, overlay *bulkOverlay) (*plan.Coverage, []*plan.Coverage, error) {
 	aggregate := plan.NewCoverage()
 	perOrder := make([]*plan.Coverage, len(orders))
 
@@ -1378,7 +1384,7 @@ func (a *Admission) extractPreloadNeeds(ctx context.Context, orders []*raftcmdpb
 
 		switch orderType := order.GetType().(type) {
 		case *raftcmdpb.Order_LedgerScoped:
-			extractLedgerScopedNeeds(p, orderType.LedgerScoped)
+			extractLedgerScopedNeeds(p, orderType.LedgerScoped, overlay)
 		case *raftcmdpb.Order_SystemScoped:
 			extractSystemScopedNeeds(p, orderType.SystemScoped)
 		}
@@ -1509,8 +1515,12 @@ func (a *Admission) resolveScriptsAndEnrichNeeds(ctx context.Context, orders []*
 			// destination becomes source, original source becomes
 			// destination — see processRevertTransaction), so the net balance
 			// delta is the inverse of the original: source +amount, dest
-			// −amount relative to the original posting.
-			for _, posting := range applyData.RevertTransaction.GetOriginalPostings() {
+			// −amount relative to the original posting. The postings come from
+			// the sidecar admission filled at order-build time, not the order.
+			originalPostings := overlay.revertOriginalPostingsFor(
+				domain.TransactionKey{LedgerName: ledgerName, ID: applyData.RevertTransaction.GetTransactionId()},
+			)
+			for _, posting := range originalPostings {
 				amount := posting.GetAmount().ToBigInt()
 				effects.addBalanceDelta(
 					domain.NewVolumeKey(ledgerName, posting.GetSource(), posting.GetAsset(), posting.GetColor()),
@@ -1808,7 +1818,7 @@ func (a *Admission) requestToOrder(ctx context.Context, req *servicepb.Request, 
 			return nil, err
 		}
 
-		applyOrder, err := a.convertApplyRequest(ctx, reqType.Apply)
+		applyOrder, err := a.convertApplyRequest(ctx, reqType.Apply, overlay)
 		if err != nil {
 			return nil, err
 		}
@@ -2135,7 +2145,7 @@ func (a *Admission) requestToOrder(ctx context.Context, req *servicepb.Request, 
 // convertApplyRequest converts a servicepb.LedgerApplyRequest to a
 // raftcmdpb.LedgerApplyOrder payload. The ledger name lives on the
 // surrounding LedgerScopedOrder wrapper; callers must set it there.
-func (a *Admission) convertApplyRequest(ctx context.Context, apply *servicepb.LedgerApplyRequest) (*raftcmdpb.LedgerApplyOrder, error) {
+func (a *Admission) convertApplyRequest(ctx context.Context, apply *servicepb.LedgerApplyRequest, overlay *bulkOverlay) (*raftcmdpb.LedgerApplyOrder, error) {
 	order := &raftcmdpb.LedgerApplyOrder{}
 
 	switch data := apply.GetAction().GetData().(type) {
@@ -2220,19 +2230,21 @@ func (a *Admission) convertApplyRequest(ctx context.Context, apply *servicepb.Le
 			return nil, err
 		}
 
-		// Fetch the original postings so admission can (a) declare volume
+		// Resolve the original postings so admission can declare volume
 		// coverage for each posting account (invariant #9 — the FSM's
-		// applyPosting call reads Volumes().Get through the coverage gate)
-		// and (b) attach them to the order as a migration bridge for
-		// pre-EN-1242 TxStates that don't yet carry Postings.
+		// applyPosting call reads Volumes().Get through the coverage gate).
+		// They are recorded in the overlay sidecar for the preload and
+		// intra-bulk effect passes, NOT attached to the order: the FSM
+		// re-derives them from the coverage-gated TransactionState, so the
+		// audit-bound order carries only caller intent.
 		//
-		// A receipt-signed revert bypasses the store fetch: admission trusts
-		// the signed claims. On the non-receipt path a fetch miss (missing
-		// ledger, missing tx, or persistence lag racing a just-applied create)
-		// yields nil postings and the proposal still enters Raft; the FSM
-		// apply is the audit authority for the resulting business rejection
-		// (invariant #8) — processApply.loadBoundaries audits missing ledgers,
-		// processRevertTransaction's boundary check audits missing txs.
+		// A receipt-signed revert trusts the signed claims and skips the
+		// store fetch. On the non-receipt path a fetch miss (missing ledger
+		// or missing tx) yields nil postings and the proposal still enters
+		// Raft; the FSM apply is the audit authority for the resulting
+		// business rejection (invariant #8) — processApply.loadBoundaries
+		// audits missing ledgers, processRevertTransaction's boundary check
+		// audits missing txs.
 		var originalPostings []*commonpb.Posting
 
 		if data.RevertTransaction.GetReceipt() != "" && a.receiptSigner != nil {
@@ -2257,13 +2269,17 @@ func (a *Admission) convertApplyRequest(ctx context.Context, apply *servicepb.Le
 			}
 		}
 
+		overlay.recordRevertOriginalPostings(
+			domain.TransactionKey{LedgerName: apply.GetLedger(), ID: txID},
+			originalPostings,
+		)
+
 		order.Data = &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 			RevertTransaction: &raftcmdpb.RevertTransactionOrder{
-				TransactionId:    txID,
-				Force:            data.RevertTransaction.GetForce(),
-				AtEffectiveDate:  data.RevertTransaction.GetAtEffectiveDate(),
-				Metadata:         data.RevertTransaction.GetMetadata(),
-				OriginalPostings: originalPostings,
+				TransactionId:   txID,
+				Force:           data.RevertTransaction.GetForce(),
+				AtEffectiveDate: data.RevertTransaction.GetAtEffectiveDate(),
+				Metadata:        data.RevertTransaction.GetMetadata(),
 			},
 		}
 	default:

--- a/internal/application/admission/admission_test.go
+++ b/internal/application/admission/admission_test.go
@@ -123,7 +123,7 @@ func TestExtractNeededVolumes(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// Should have 2 volume keys: both source (world) and destination (user:alice) are preloaded
@@ -149,7 +149,22 @@ func TestExtractNeededVolumes(t *testing.T) {
 
 		// For a revert, original postings are reversed:
 		// Original: world -> alice
-		// Revert: alice -> world (alice needs balance check, world receives credit)
+		// Revert: alice -> world (alice needs balance check, world receives credit).
+		// The postings live in the overlay sidecar (admission resolves them at
+		// order-build time), not on the wire order.
+		overlay := newBulkOverlay()
+		overlay.recordRevertOriginalPostings(
+			domain.TransactionKey{LedgerName: testLedgerName, ID: 1},
+			[]*commonpb.Posting{
+				{
+					Source:      "world",
+					Destination: "user:alice",
+					Amount:      commonpb.NewUint256FromUint64(100),
+					Asset:       "USD",
+				},
+			},
+		)
+
 		orders := []*raftcmdpb.Order{
 			{
 				Type: &raftcmdpb.Order_LedgerScoped{
@@ -159,14 +174,6 @@ func TestExtractNeededVolumes(t *testing.T) {
 							Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 								RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 									TransactionId: 1,
-									OriginalPostings: []*commonpb.Posting{
-										{
-											Source:      "world",
-											Destination: "user:alice",
-											Amount:      commonpb.NewUint256FromUint64(100),
-											Asset:       "USD",
-										},
-									},
 								},
 							},
 							},
@@ -176,7 +183,7 @@ func TestExtractNeededVolumes(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, overlay)
 		require.NoError(t, err)
 
 		// Should have 2 volume keys: both the new source (alice) and new destination (world) are preloaded
@@ -200,6 +207,25 @@ func TestExtractNeededVolumes(t *testing.T) {
 		store := createTestStore(t)
 		admission, _ := createTestAdmission(t, store)
 
+		overlay := newBulkOverlay()
+		overlay.recordRevertOriginalPostings(
+			domain.TransactionKey{LedgerName: testLedgerName, ID: 1},
+			[]*commonpb.Posting{
+				{
+					Source:      "world",
+					Destination: "user:alice",
+					Amount:      commonpb.NewUint256FromUint64(100),
+					Asset:       "USD",
+				},
+				{
+					Source:      "user:alice",
+					Destination: "user:bob",
+					Amount:      commonpb.NewUint256FromUint64(50),
+					Asset:       "USD",
+				},
+			},
+		)
+
 		orders := []*raftcmdpb.Order{
 			{
 				Type: &raftcmdpb.Order_LedgerScoped{
@@ -209,20 +235,6 @@ func TestExtractNeededVolumes(t *testing.T) {
 							Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 								RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 									TransactionId: 1,
-									OriginalPostings: []*commonpb.Posting{
-										{
-											Source:      "world",
-											Destination: "user:alice",
-											Amount:      commonpb.NewUint256FromUint64(100),
-											Asset:       "USD",
-										},
-										{
-											Source:      "user:alice",
-											Destination: "user:bob",
-											Amount:      commonpb.NewUint256FromUint64(50),
-											Asset:       "USD",
-										},
-									},
 								},
 							},
 							},
@@ -232,7 +244,7 @@ func TestExtractNeededVolumes(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, overlay)
 		require.NoError(t, err)
 
 		// Should have 3 volume keys: alice, bob (original destinations become sources in revert)
@@ -285,7 +297,7 @@ func TestExtractNeededVolumes(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		require.True(t, needs.Has(dal.SubAttrTransaction, domain.TransactionKey{LedgerName: "test-ledger", ID: 7}.Bytes()), "transaction key should be preloaded when id is used")
@@ -296,7 +308,7 @@ func TestExtractNeededVolumes(t *testing.T) {
 func TestConvertApplyRequest_RevertTransaction(t *testing.T) {
 	t.Parallel()
 
-	t.Run("attaches original postings for volume coverage", func(t *testing.T) {
+	t.Run("records original postings in sidecar for volume coverage", func(t *testing.T) {
 		t.Parallel()
 		store := createTestStore(t)
 		admission, attrs := createTestAdmission(t, store)
@@ -333,17 +345,22 @@ func TestConvertApplyRequest_RevertTransaction(t *testing.T) {
 			},
 		}
 
-		order, err := admission.convertApplyRequest(t.Context(), applyRequest)
+		overlay := newBulkOverlay()
+		order, err := admission.convertApplyRequest(t.Context(), applyRequest, overlay)
 		require.NoError(t, err)
 		require.NotNil(t, order)
 
 		revertOrder := order.GetData().(*raftcmdpb.LedgerApplyOrder_RevertTransaction).RevertTransaction
 		require.NotNil(t, revertOrder)
 		require.Equal(t, uint64(1), revertOrder.GetTransactionId())
-		require.Len(t, revertOrder.GetOriginalPostings(), 1,
-			"admission reads TxState.Postings directly and attaches them to declare volume coverage (invariant #9)")
-		require.Equal(t, "world", revertOrder.GetOriginalPostings()[0].GetSource())
-		require.Equal(t, "user:alice", revertOrder.GetOriginalPostings()[0].GetDestination())
+
+		// The audit-bound order carries only caller intent; the resolved
+		// postings live in the sidecar for the preload pass (invariant #9).
+		sidecar := overlay.revertOriginalPostingsFor(domain.TransactionKey{LedgerName: testLedgerName, ID: 1})
+		require.Len(t, sidecar, 1,
+			"admission reads TxState.Postings into the sidecar to declare volume coverage")
+		require.Equal(t, "world", sidecar[0].GetSource())
+		require.Equal(t, "user:alice", sidecar[0].GetDestination())
 	})
 
 	t.Run("passes revert of non-existent transaction through to FSM (audited)", func(t *testing.T) {
@@ -365,17 +382,18 @@ func TestConvertApplyRequest_RevertTransaction(t *testing.T) {
 		// A revert on a non-existent transaction must NOT fail-fast at
 		// admission: invariant #8 requires business decisions to be
 		// hash-chained in the audit, and only the FSM apply writes audit
-		// entries. Admission emits an order with OriginalPostings=nil;
-		// the FSM's processRevertTransaction returns ErrTransactionNotFound
-		// (via `txID >= boundaries.GetNextTransactionId()`) BEFORE touching
-		// volumes — that error lands in the audit chain.
-		order, err := admission.convertApplyRequest(t.Context(), applyRequest)
+		// entries. Admission emits the order and records nil postings in the
+		// sidecar; the FSM's processRevertTransaction returns
+		// ErrTransactionNotFound (via `txID >= boundaries.GetNextTransactionId()`)
+		// BEFORE touching volumes — that error lands in the audit chain.
+		overlay := newBulkOverlay()
+		order, err := admission.convertApplyRequest(t.Context(), applyRequest, overlay)
 		require.NoError(t, err)
 		require.NotNil(t, order)
 
-		revert, ok := order.GetData().(*raftcmdpb.LedgerApplyOrder_RevertTransaction)
+		_, ok := order.GetData().(*raftcmdpb.LedgerApplyOrder_RevertTransaction)
 		require.True(t, ok)
-		require.Empty(t, revert.RevertTransaction.GetOriginalPostings(),
+		require.Empty(t, overlay.revertOriginalPostingsFor(domain.TransactionKey{LedgerName: testLedgerName, ID: 999}),
 			"admission must pass through with nil postings when the source tx is absent")
 	})
 
@@ -393,7 +411,7 @@ func TestConvertApplyRequest_RevertTransaction(t *testing.T) {
 			},
 		}
 
-		_, err := admission.convertApplyRequest(t.Context(), applyRequest)
+		_, err := admission.convertApplyRequest(t.Context(), applyRequest, newBulkOverlay())
 		require.ErrorIs(t, err, domain.ErrTransactionTargetMissing)
 	})
 }
@@ -432,7 +450,7 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// Should have 2 volume keys: both source and destination are always preloaded
@@ -482,7 +500,7 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// Should have 2 volume keys: both source and destination are always preloaded
@@ -557,7 +575,7 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// Should have 4 volume keys: source+dest from both orders
@@ -594,6 +612,19 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 		admission, _ := createTestAdmission(t, store)
 
 		// force=true on revert still preloads all volumes
+		overlay := newBulkOverlay()
+		overlay.recordRevertOriginalPostings(
+			domain.TransactionKey{LedgerName: testLedgerName, ID: 1},
+			[]*commonpb.Posting{
+				{
+					Source:      "world",
+					Destination: "user:alice",
+					Amount:      commonpb.NewUint256FromUint64(100),
+					Asset:       "USD",
+				},
+			},
+		)
+
 		orders := []*raftcmdpb.Order{
 			{
 				Type: &raftcmdpb.Order_LedgerScoped{
@@ -604,14 +635,6 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 								RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 									TransactionId: 1,
 									Force:         true,
-									OriginalPostings: []*commonpb.Posting{
-										{
-											Source:      "world",
-											Destination: "user:alice",
-											Amount:      commonpb.NewUint256FromUint64(100),
-											Asset:       "USD",
-										},
-									},
 								},
 							},
 							},
@@ -621,7 +644,7 @@ func TestExtractNeededVolumes_Force(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, overlay)
 		require.NoError(t, err)
 
 		// Revert reverses postings: alice->world. Both source (alice) and destination (world) preloaded.
@@ -716,7 +739,7 @@ func TestExtractPreloadNeeds_AccountMetadata_ScriptBacked(t *testing.T) {
 				},
 			}
 
-			needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+			needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 			require.NoError(t, err)
 
 			key := domain.MetadataKey{
@@ -757,7 +780,7 @@ func TestConvertApplyRequest_CreateTransaction_Force(t *testing.T) {
 			},
 		}
 
-		order, err := admission.convertApplyRequest(t.Context(), applyRequest)
+		order, err := admission.convertApplyRequest(t.Context(), applyRequest, newBulkOverlay())
 		require.NoError(t, err)
 		require.NotNil(t, order)
 
@@ -769,13 +792,13 @@ func TestConvertApplyRequest_CreateTransaction_Force(t *testing.T) {
 func TestRequestToOrder_RevertTransaction(t *testing.T) {
 	t.Parallel()
 
-	t.Run("converts revert request with empty OriginalPostings", func(t *testing.T) {
+	t.Run("converts revert request to a caller-intent-only order", func(t *testing.T) {
 		t.Parallel()
 		store := createTestStore(t)
 		admission, _ := createTestAdmission(t, store)
 
-		// Non-receipt reverts leave OriginalPostings nil on the wire; the FSM
-		// reads TxState.Postings authoritatively at apply time.
+		// The wire order carries only caller intent; the FSM reads
+		// TxState.Postings authoritatively at apply time.
 		request := &servicepb.Request{
 			Type: &servicepb.Request_Apply{
 				Apply: &servicepb.LedgerApplyRequest{
@@ -804,7 +827,6 @@ func TestRequestToOrder_RevertTransaction(t *testing.T) {
 		revertOrder := applyOrder.GetData().(*raftcmdpb.LedgerApplyOrder_RevertTransaction).RevertTransaction
 		require.Equal(t, uint64(42), revertOrder.GetTransactionId())
 		require.True(t, revertOrder.GetForce())
-		require.Empty(t, revertOrder.GetOriginalPostings())
 	})
 }
 
@@ -843,7 +865,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 		require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrderNeeds, false))
 
@@ -895,7 +917,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 		require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrderNeeds, false))
 
@@ -957,7 +979,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 				)
 			`)
 
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 		require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrderNeeds, false))
 
@@ -999,7 +1021,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		err = admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrderNeeds, false)
@@ -1054,7 +1076,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		err = admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrderNeeds, false)
@@ -1109,7 +1131,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// hasIdempotencyKey = true → forward instead of fail-fast.
@@ -1150,7 +1172,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 		}
 
 		overlay := newBulkOverlay()
-		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, perOrderNeeds, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// hasIdempotencyKey = true, but the cause is definitive → terminal.
@@ -1197,7 +1219,7 @@ func TestExtractNeededVolumes_Numscript(t *testing.T) {
 			},
 		}
 
-		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders)
+		needs, _, err := admission.extractPreloadNeeds(context.Background(), orders, newBulkOverlay())
 		require.NoError(t, err)
 
 		// Should use explicit postings, not numscript emulation; both source and destination preloaded

--- a/internal/application/admission/numscript_intrabatch_test.go
+++ b/internal/application/admission/numscript_intrabatch_test.go
@@ -52,15 +52,17 @@ func applyOrder(ledger string, data *raftcmdpb.LedgerApplyOrder) *raftcmdpb.Orde
 	}
 }
 
-// revertOrder builds a revert whose original postings are supplied directly
-// (admission normally reads them from the store; here we set them so the FSM's
-// reversed-posting balance effect is deterministic).
-func revertOrder(ledger string, txID uint64, original ...*commonpb.Posting) *raftcmdpb.Order {
+// revertOrder builds a caller-intent revert order and records its original
+// postings in the overlay sidecar (admission normally resolves them from the
+// store/receipt at order-build time), so the FSM's reversed-posting balance
+// effect is deterministic in tests.
+func revertOrder(overlay *bulkOverlay, ledger string, txID uint64, original ...*commonpb.Posting) *raftcmdpb.Order {
+	overlay.recordRevertOriginalPostings(domain.TransactionKey{LedgerName: ledger, ID: txID}, original)
+
 	return applyOrder(ledger, &raftcmdpb.LedgerApplyOrder{
 		Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 			RevertTransaction: &raftcmdpb.RevertTransactionOrder{
-				TransactionId:    txID,
-				OriginalPostings: original,
+				TransactionId: txID,
 			},
 		},
 	})
@@ -118,12 +120,12 @@ func writeVolume(t *testing.T, admission *Admission, ledger, account, asset stri
 	require.NoError(t, batch.Commit())
 }
 
-func resolveHashFor(t *testing.T, admission *Admission, orders []*raftcmdpb.Order, idx int) []byte {
+func resolveHashFor(t *testing.T, admission *Admission, overlay *bulkOverlay, orders []*raftcmdpb.Order, idx int) []byte {
 	t.Helper()
 
-	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), orders)
+	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), orders, overlay)
 	require.NoError(t, err)
-	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, newBulkOverlay(), needs, perOrder, false))
+	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), orders, overlay, needs, perOrder, false))
 
 	return orders[idx].GetTechnical().GetInputsResolutionHash()
 }
@@ -153,7 +155,7 @@ send $all (source = @bulk:source destination = @bulk:dest)
 
 	storeBatch := createTestStore(t)
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 1)
+	batchHash := resolveHashFor(t, admissionBatch, newBulkOverlay(), batch, 1)
 	require.NotEmpty(t, batchHash, "order 1 reads a balance, so it must carry a resolution hash")
 
 	// Reference: the same order 1 resolved standalone against a store where
@@ -163,7 +165,7 @@ send $all (source = @bulk:source destination = @bulk:dest)
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "bulk:source", "USD/2", 100, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, `
 vars {
   monetary $all = balance(@bulk:source, USD/2)
@@ -180,7 +182,7 @@ send $all (source = @bulk:source destination = @bulk:dest)
 	// the resolved balance.
 	storeEmpty := createTestStore(t)
 	admissionEmpty, _ := createTestAdmission(t, storeEmpty)
-	emptyHash := resolveHashFor(t, admissionEmpty, []*raftcmdpb.Order{
+	emptyHash := resolveHashFor(t, admissionEmpty, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, `
 vars {
   monetary $all = balance(@bulk:source, USD/2)
@@ -213,9 +215,10 @@ send [USD/2 5] (source = @world destination = $dst)
 	store := createTestStore(t)
 	admission, _ := createTestAdmission(t, store)
 
-	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), batch)
+	overlay := newBulkOverlay()
+	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), batch, overlay)
 	require.NoError(t, err)
-	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), batch, newBulkOverlay(), needs, perOrder, false))
+	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), batch, overlay, needs, perOrder, false))
 
 	// The dependent order's meta() resolved to ib:resolved, so that destination
 	// volume must have been preloaded — proving admission saw order 0's write.
@@ -237,8 +240,9 @@ func TestResolveScripts_IntraBatchRevertBalanceDependency(t *testing.T) {
 	// whose original posting sent 100 world->rev:acct; the reversed posting
 	// sends 100 rev:acct->world, so rev:acct ends at 150. Order 1 sends
 	// balance(@rev:acct) onward and must resolve against 150.
+	overlay := newBulkOverlay()
 	batch := []*raftcmdpb.Order{
-		revertOrder(testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
+		revertOrder(overlay, testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
 		scriptOrder(testLedgerName, `
 vars {
   monetary $all = balance(@rev:acct, USD/2)
@@ -250,7 +254,7 @@ send $all (source = @rev:acct destination = @rev:dest)
 	storeBatch := createTestStore(t)
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
 	writeVolume(t, admissionBatch, testLedgerName, "rev:acct", "USD/2", 250, 0)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 1)
+	batchHash := resolveHashFor(t, admissionBatch, overlay, batch, 1)
 	require.NotEmpty(t, batchHash, "order 1 reads a balance, so it must carry a resolution hash")
 
 	// Reference: order 1 resolved standalone against a store where rev:acct
@@ -259,7 +263,7 @@ send $all (source = @rev:acct destination = @rev:dest)
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "rev:acct", "USD/2", 150, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, `
 vars {
   monetary $all = balance(@rev:acct, USD/2)
@@ -275,7 +279,7 @@ send $all (source = @rev:acct destination = @rev:dest)
 	storePre := createTestStore(t)
 	admissionPre, _ := createTestAdmission(t, storePre)
 	writeVolume(t, admissionPre, testLedgerName, "rev:acct", "USD/2", 250, 0)
-	preHash := resolveHashFor(t, admissionPre, []*raftcmdpb.Order{
+	preHash := resolveHashFor(t, admissionPre, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, `
 vars {
   monetary $all = balance(@rev:acct, USD/2)
@@ -306,9 +310,10 @@ send [USD/2 5] (source = @world destination = $dst)
 	store := createTestStore(t)
 	admission, _ := createTestAdmission(t, store)
 
-	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), batch)
+	overlay := newBulkOverlay()
+	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), batch, overlay)
 	require.NoError(t, err)
-	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), batch, newBulkOverlay(), needs, perOrder, false))
+	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), batch, overlay, needs, perOrder, false))
 
 	// meta() resolved to am:resolved, so that destination volume must have been
 	// discovered — proving admission saw the preceding AddMetadata write.
@@ -343,9 +348,10 @@ vars {
 send [USD/2 1] (source = @world destination = $dst)
 `),
 	}
-	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), okBatch)
+	okOverlay := newBulkOverlay()
+	needs, perOrder, err := admission.extractPreloadNeeds(context.Background(), okBatch, okOverlay)
 	require.NoError(t, err)
-	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), okBatch, newBulkOverlay(), needs, perOrder, false))
+	require.NoError(t, admission.resolveScriptsAndEnrichNeeds(context.Background(), okBatch, okOverlay, needs, perOrder, false))
 
 	// A preceding DeleteMetadata tombstones the key: the dependent meta() now
 	// resolves absent and discovery fails.
@@ -358,10 +364,11 @@ vars {
 send [USD/2 1] (source = @world destination = $dst)
 `),
 	}
-	needs, perOrder, err = admission.extractPreloadNeeds(context.Background(), delBatch)
+	delOverlay := newBulkOverlay()
+	needs, perOrder, err = admission.extractPreloadNeeds(context.Background(), delBatch, delOverlay)
 	require.NoError(t, err)
 
-	err = admission.resolveScriptsAndEnrichNeeds(context.Background(), delBatch, newBulkOverlay(), needs, perOrder, false)
+	err = admission.resolveScriptsAndEnrichNeeds(context.Background(), delBatch, delOverlay, needs, perOrder, false)
 	require.Error(t, err, "a preceding same-batch delete must make the dependent meta() resolve absent and fail discovery")
 
 	var businessErr *domain.BusinessError

--- a/internal/application/admission/numscript_skip_parity_test.go
+++ b/internal/application/admission/numscript_skip_parity_test.go
@@ -62,8 +62,8 @@ func postingsOrderWithReference(ledger, source, destination, asset string, amoun
 
 // revertOrderSkippable builds a revert order opting into the
 // TRANSACTION_ALREADY_REVERTED skippable reason.
-func revertOrderSkippable(ledger string, txID uint64, original ...*commonpb.Posting) *raftcmdpb.Order {
-	order := revertOrder(ledger, txID, original...)
+func revertOrderSkippable(overlay *bulkOverlay, ledger string, txID uint64, original ...*commonpb.Posting) *raftcmdpb.Order {
+	order := revertOrder(overlay, ledger, txID, original...)
 	order.GetLedgerScoped().GetApply().SkippableReasons = []commonpb.ErrorReason{
 		commonpb.ErrorReason_ERROR_REASON_TRANSACTION_ALREADY_REVERTED,
 	}
@@ -134,14 +134,14 @@ func TestResolveScripts_SkippedReferenceConflictNotFolded(t *testing.T) {
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
 	// The reference already exists → order 0 will be skipped by the FSM.
 	writeReference(t, admissionBatch, testLedgerName, "dup-ref", 42)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 1)
+	batchHash := resolveHashFor(t, admissionBatch, newBulkOverlay(), batch, 1)
 	require.NotEmpty(t, batchHash, "order 1 reads a balance, so it must carry a resolution hash")
 
 	// Reference: order 1 resolved standalone against an EMPTY store — the state
 	// the FSM sees once order 0 has been dropped (skip:src still at 0).
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("skip:src")),
 	}, 0)
 
@@ -153,7 +153,7 @@ func TestResolveScripts_SkippedReferenceConflictNotFolded(t *testing.T) {
 	// same deposit via a NON-skippable predecessor and confirming a different hash.
 	storeFolded := createTestStore(t)
 	admissionFolded, _ := createTestAdmission(t, storeFolded)
-	foldedHash := resolveHashFor(t, admissionFolded, []*raftcmdpb.Order{
+	foldedHash := resolveHashFor(t, admissionFolded, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, `send [USD/2 100] (source = @world destination = @skip:src)`),
 		scriptOrder(testLedgerName, dependentBalanceScript("skip:src")),
 	}, 1)
@@ -179,7 +179,7 @@ func TestResolveScripts_NonConflictingReferenceStillFolded(t *testing.T) {
 
 	storeBatch := createTestStore(t)
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 1)
+	batchHash := resolveHashFor(t, admissionBatch, newBulkOverlay(), batch, 1)
 	require.NotEmpty(t, batchHash)
 
 	// Reference: order 1 resolved standalone against a store where fresh:src
@@ -188,7 +188,7 @@ func TestResolveScripts_NonConflictingReferenceStillFolded(t *testing.T) {
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "fresh:src", "USD/2", 100, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("fresh:src")),
 	}, 0)
 
@@ -207,8 +207,9 @@ func TestResolveScripts_SkippedAlreadyRevertedNotFolded(t *testing.T) {
 	// Pre-batch: rev:acct holds 250. Order 0 reverts tx 1 (original world->rev:acct
 	// 100) with skip opt-in, but tx 1 is ALREADY reverted → the FSM drops it, so
 	// rev:acct stays at 250. Order 1 reads balance(@rev:acct).
+	overlay := newBulkOverlay()
 	batch := []*raftcmdpb.Order{
-		revertOrderSkippable(testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
+		revertOrderSkippable(overlay, testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
 		scriptOrder(testLedgerName, dependentBalanceScript("rev:acct")),
 	}
 
@@ -216,7 +217,7 @@ func TestResolveScripts_SkippedAlreadyRevertedNotFolded(t *testing.T) {
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
 	writeVolume(t, admissionBatch, testLedgerName, "rev:acct", "USD/2", 250, 0)
 	writeReverted(t, admissionBatch, testLedgerName, 1) // tx 1 already reverted
-	batchHash := resolveHashFor(t, admissionBatch, batch, 1)
+	batchHash := resolveHashFor(t, admissionBatch, overlay, batch, 1)
 	require.NotEmpty(t, batchHash)
 
 	// Reference: order 1 resolved standalone against rev:acct = 250 — the state
@@ -224,7 +225,7 @@ func TestResolveScripts_SkippedAlreadyRevertedNotFolded(t *testing.T) {
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "rev:acct", "USD/2", 250, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("rev:acct")),
 	}, 0)
 
@@ -236,8 +237,9 @@ func TestResolveScripts_SkippedAlreadyRevertedNotFolded(t *testing.T) {
 	storeApplied := createTestStore(t)
 	admissionApplied, _ := createTestAdmission(t, storeApplied)
 	writeVolume(t, admissionApplied, testLedgerName, "rev:acct", "USD/2", 250, 0)
-	appliedHash := resolveHashFor(t, admissionApplied, []*raftcmdpb.Order{
-		revertOrderSkippable(testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
+	appliedOverlay := newBulkOverlay()
+	appliedHash := resolveHashFor(t, admissionApplied, appliedOverlay, []*raftcmdpb.Order{
+		revertOrderSkippable(appliedOverlay, testLedgerName, 1, posting("world", "rev:acct", "USD/2", 100)),
 		scriptOrder(testLedgerName, dependentBalanceScript("rev:acct")),
 	}, 1)
 	require.NotEqual(t, appliedHash, batchHash,
@@ -265,14 +267,14 @@ func TestResolveScripts_IntraBatchDuplicateReferenceSkipped(t *testing.T) {
 
 	storeBatch := createTestStore(t)
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 2)
+	batchHash := resolveHashFor(t, admissionBatch, newBulkOverlay(), batch, 2)
 	require.NotEmpty(t, batchHash)
 
 	// Reference: order 2 resolved against ib:src = 100 (only the first deposit).
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "ib:src", "USD/2", 100, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("ib:src")),
 	}, 0)
 
@@ -283,7 +285,7 @@ func TestResolveScripts_IntraBatchDuplicateReferenceSkipped(t *testing.T) {
 	storeBoth := createTestStore(t)
 	admissionBoth, _ := createTestAdmission(t, storeBoth)
 	writeVolume(t, admissionBoth, testLedgerName, "ib:src", "USD/2", 200, 0)
-	bothHash := resolveHashFor(t, admissionBoth, []*raftcmdpb.Order{
+	bothHash := resolveHashFor(t, admissionBoth, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("ib:src")),
 	}, 0)
 	require.NotEqual(t, bothHash, batchHash,
@@ -314,14 +316,14 @@ func TestResolveScripts_PostingsOnlyReferenceRecordedForIntraBatchSkip(t *testin
 
 	storeBatch := createTestStore(t)
 	admissionBatch, _ := createTestAdmission(t, storeBatch)
-	batchHash := resolveHashFor(t, admissionBatch, batch, 2)
+	batchHash := resolveHashFor(t, admissionBatch, newBulkOverlay(), batch, 2)
 	require.NotEmpty(t, batchHash)
 
 	// Reference: order 2 resolved against ib:src = 100 (only the first deposit).
 	storeRef := createTestStore(t)
 	admissionRef, _ := createTestAdmission(t, storeRef)
 	writeVolume(t, admissionRef, testLedgerName, "ib:src", "USD/2", 100, 0)
-	refHash := resolveHashFor(t, admissionRef, []*raftcmdpb.Order{
+	refHash := resolveHashFor(t, admissionRef, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("ib:src")),
 	}, 0)
 
@@ -333,7 +335,7 @@ func TestResolveScripts_PostingsOnlyReferenceRecordedForIntraBatchSkip(t *testin
 	storeBoth := createTestStore(t)
 	admissionBoth, _ := createTestAdmission(t, storeBoth)
 	writeVolume(t, admissionBoth, testLedgerName, "ib:src", "USD/2", 200, 0)
-	bothHash := resolveHashFor(t, admissionBoth, []*raftcmdpb.Order{
+	bothHash := resolveHashFor(t, admissionBoth, newBulkOverlay(), []*raftcmdpb.Order{
 		scriptOrder(testLedgerName, dependentBalanceScript("ib:src")),
 	}, 0)
 	require.NotEqual(t, bothHash, batchHash,

--- a/internal/application/admission/overlay.go
+++ b/internal/application/admission/overlay.go
@@ -1,6 +1,7 @@
 package admission
 
 import (
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/pkg/semver"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -74,14 +75,34 @@ type bulkOverlay struct {
 	numscriptEntries *overlay[numscriptEntryKey, string]
 	numscriptLatest  *overlay[numscriptNameKey, string]
 	sinks            *overlay[string, *commonpb.SinkConfig]
+	// Original postings of each revert target, resolved once at order-build
+	// time (from the signed receipt or the transaction attribute) and reused
+	// by the preload and intra-bulk effect passes. They stay off the wire
+	// order: the FSM re-derives them from the coverage-gated TransactionState,
+	// and only caller intent is bound into the audit chain.
+	revertOriginalPostings map[domain.TransactionKey][]*commonpb.Posting
 }
 
 func newBulkOverlay() *bulkOverlay {
 	return &bulkOverlay{
-		numscriptEntries: newOverlay[numscriptEntryKey, string](),
-		numscriptLatest:  newOverlay[numscriptNameKey, string](),
-		sinks:            newOverlay[string, *commonpb.SinkConfig](),
+		numscriptEntries:       newOverlay[numscriptEntryKey, string](),
+		numscriptLatest:        newOverlay[numscriptNameKey, string](),
+		sinks:                  newOverlay[string, *commonpb.SinkConfig](),
+		revertOriginalPostings: make(map[domain.TransactionKey][]*commonpb.Posting),
 	}
+}
+
+// recordRevertOriginalPostings stores the postings admission resolved for a
+// revert target so later passes read them without re-fetching (and without a
+// second fetch missing on the receipt path, where the store read is skipped).
+func (o *bulkOverlay) recordRevertOriginalPostings(key domain.TransactionKey, postings []*commonpb.Posting) {
+	o.revertOriginalPostings[key] = postings
+}
+
+// revertOriginalPostingsFor returns the postings recorded for a revert target,
+// or nil if none were resolved (missing tx — the FSM audits the rejection).
+func (o *bulkOverlay) revertOriginalPostingsFor(key domain.TransactionKey) []*commonpb.Posting {
+	return o.revertOriginalPostings[key]
 }
 
 // recordNumscriptSave records an immutable save in the overlay and advances the

--- a/internal/application/admission/validate_order.go
+++ b/internal/application/admission/validate_order.go
@@ -53,13 +53,17 @@ func validateOrder(order *raftcmdpb.Order) error {
 }
 
 // validateOrderPostingColors validates Color on every direct Posting attached
-// to a CreateTransaction or RevertTransaction order, BEFORE admission extracts
-// preload needs from those postings.
+// to a CreateTransaction order, BEFORE admission extracts preload needs from
+// those postings.
 //
 // Color flows directly from the request into the volume-key tuple admission
 // uses for preload extraction, so a malformed value (e.g. `Color="A\x00B"`)
 // would otherwise materialize a corrupted cache key before the FSM's own
 // ValidateColor rejected the order. Validating here closes that window.
+//
+// Revert orders need no check here: their reversed postings inherit colors
+// from the original transaction (via the coverage-gated TransactionState),
+// already validated when that transaction was created.
 //
 // Postings produced by Numscript still get their second-pass validation in
 // the FSM (`validatePostings` in processor_transaction.go); the FSM stays the
@@ -71,15 +75,8 @@ func validateOrderPostingColors(order *raftcmdpb.Order) domain.Describable {
 		return nil
 	}
 
-	switch d := apply.Apply.GetData().(type) {
-	case *raftcmdpb.LedgerApplyOrder_CreateTransaction:
+	if d, ok := apply.Apply.GetData().(*raftcmdpb.LedgerApplyOrder_CreateTransaction); ok {
 		for _, p := range d.CreateTransaction.GetPostings() {
-			if err := domain.ValidateColor(p.GetColor()); err != nil {
-				return err
-			}
-		}
-	case *raftcmdpb.LedgerApplyOrder_RevertTransaction:
-		for _, p := range d.RevertTransaction.GetOriginalPostings() {
 			if err := domain.ValidateColor(p.GetColor()); err != nil {
 				return err
 			}

--- a/internal/application/admission/validate_order_test.go
+++ b/internal/application/admission/validate_order_test.go
@@ -1216,29 +1216,3 @@ func TestValidateOrder_MirrorIAMRejectsPGSSLMODEBypass(t *testing.T) {
 	require.ErrorIs(t, err, ErrMirrorIAMRequiresTLS,
 		"PGSSLMODE=require in the pod env must not satisfy the admission TLS gate — the persisted DSN must carry sslmode= itself")
 }
-
-func TestValidateOrder_RejectsInvalidColorInRevert(t *testing.T) {
-	t.Parallel()
-
-	order := &raftcmdpb.Order{
-		Type: &raftcmdpb.Order_LedgerScoped{
-			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
-				Ledger: "default",
-				Payload: &raftcmdpb.LedgerScopedOrder_Apply{
-					Apply: &raftcmdpb.LedgerApplyOrder{
-						Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
-							RevertTransaction: &raftcmdpb.RevertTransactionOrder{
-								TransactionId: 42,
-								OriginalPostings: []*commonpb.Posting{
-									commonpb.NewColoredPosting("users:alice", "world", "USD/2", "lowercase", big.NewInt(100)),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	require.Error(t, validateOrder(order))
-}

--- a/internal/application/admission/wrapper_dispatch_test.go
+++ b/internal/application/admission/wrapper_dispatch_test.go
@@ -25,9 +25,17 @@ func TestExtractLedgerScopedNeeds_CoversEveryPayloadVariant(t *testing.T) {
 
 	ledgerKey := domain.LedgerKey{Name: wrapperTestLedger}
 
+	// Revert original postings live in the overlay sidecar, not on the order.
+	revertOverlay := newBulkOverlay()
+	revertOverlay.recordRevertOriginalPostings(
+		domain.TransactionKey{LedgerName: wrapperTestLedger, ID: 13},
+		[]*commonpb.Posting{{Source: "world", Destination: "user:eve", Asset: "USD"}},
+	)
+
 	cases := []struct {
 		name    string
 		payload *raftcmdpb.LedgerScopedOrder
+		overlay *bulkOverlay
 		assert  func(t *testing.T, n *plan.Coverage)
 	}{
 		{
@@ -329,14 +337,12 @@ func TestExtractLedgerScopedNeeds_CoversEveryPayloadVariant(t *testing.T) {
 						Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 							RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 								TransactionId: 13,
-								OriginalPostings: []*commonpb.Posting{
-									{Source: "world", Destination: "user:eve", Asset: "USD"},
-								},
 							},
 						},
 					},
 				},
 			},
+			overlay: revertOverlay,
 			assert: func(t *testing.T, n *plan.Coverage) {
 				require.True(t, n.Has(dal.SubAttrTransaction, domain.TransactionKey{LedgerName: wrapperTestLedger, ID: 13}.Bytes()))
 				require.True(t, n.Has(dal.SubAttrVolume, domain.VolumeKey{
@@ -438,8 +444,13 @@ func TestExtractLedgerScopedNeeds_CoversEveryPayloadVariant(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			overlay := tc.overlay
+			if overlay == nil {
+				overlay = newBulkOverlay()
+			}
+
 			needs := plan.NewCoverage()
-			extractLedgerScopedNeeds(needs, tc.payload)
+			extractLedgerScopedNeeds(needs, tc.payload, overlay)
 			tc.assert(t, needs)
 		})
 	}

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -864,7 +864,10 @@ func createTransactionWithMetadataOrder(ledger string, force bool, metadata map[
 	}
 }
 
-func revertTransactionOrder(ledger string, txID uint64, originalPostings []*commonpb.Posting) *raftcmdpb.Order {
+// revertTransactionOrder builds a revert order carrying only caller intent.
+// The FSM sources the original postings from the target's stored
+// TransactionState, so the transaction must have been created earlier.
+func revertTransactionOrder(ledger string, txID uint64) *raftcmdpb.Order {
 	return &raftcmdpb.Order{
 		Type: &raftcmdpb.Order_LedgerScoped{
 			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
@@ -872,8 +875,7 @@ func revertTransactionOrder(ledger string, txID uint64, originalPostings []*comm
 				Payload: &raftcmdpb.LedgerScopedOrder_Apply{
 					Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 						RevertTransaction: &raftcmdpb.RevertTransactionOrder{
-							TransactionId:    txID,
-							OriginalPostings: originalPostings,
+							TransactionId: txID,
 						},
 					},
 					},
@@ -1068,11 +1070,7 @@ func TestCheckerComprehensive(t *testing.T) {
 	// --- Step 8: Revert a transaction ---
 	// Revert the first user:alice USD transfer (tx ID 4 in trading ledger, 0-indexed tx=3 -> 4th tx)
 	// The postings were: bank -> user:alice 1000 USD
-	engine.processAndCommit(revertTransactionOrder("trading", 4,
-		[]*commonpb.Posting{
-			newPosting("bank", "user:alice", "USD", 1000),
-		},
-	))
+	engine.processAndCommit(revertTransactionOrder("trading", 4))
 
 	// --- Step 9: More transactions after revert ---
 	engine.processAndCommit(createTransactionOrder("trading", false,
@@ -1308,18 +1306,10 @@ func TestCheckerManyOperationTypes(t *testing.T) {
 	}))
 
 	// Revert the user:alpha -> user:beta transfer (tx ID 11: 4 funding + 5 distribution + 1 multi + 1 alpha->beta)
-	engine.processAndCommit(revertTransactionOrder("main", 11,
-		[]*commonpb.Posting{
-			newPosting("user:alpha", "user:beta", "USD", 100),
-		},
-	))
+	engine.processAndCommit(revertTransactionOrder("main", 11))
 
 	// Revert the escrow -> beneficiary:1 transfer
-	engine.processAndCommit(revertTransactionOrder("secondary", 2,
-		[]*commonpb.Posting{
-			newPosting("escrow", "beneficiary:1", "USD", 10000),
-		},
-	))
+	engine.processAndCommit(revertTransactionOrder("secondary", 2))
 
 	// More transactions after reverts
 	engine.processAndCommit(createTransactionOrder("main", false,

--- a/internal/domain/processing/processor_revert_transaction.go
+++ b/internal/domain/processing/processor_revert_transaction.go
@@ -33,23 +33,16 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 		return nil, &domain.ErrTransactionAlreadyReverted{TransactionID: order.GetTransactionId()}
 	}
 
-	// Admission attaches OriginalPostings from either the signed receipt or
-	// its own read of TxState.Postings (via attrs.Transaction.Get). A revert
-	// order that reaches the FSM with an empty OriginalPostings means the
-	// tx was not visible to admission at propose time — a business
-	// rejection that must appear in the audit chain (invariant #8).
-	originalPostings := order.GetOriginalPostings()
-	if len(originalPostings) == 0 {
-		return nil, &domain.ErrTransactionNotFound{TransactionID: order.GetTransactionId()}
-	}
-
+	// The original postings live on the transaction's own state, which
+	// admission preloaded (addTransactionTargetNeeds) and the FSM reads
+	// through the coverage gate — never off the order, which carries only
+	// caller intent (invariant #8). A genuinely non-existent tx is already
+	// rejected by the boundary check above; a miss here means an allocated
+	// tx with no state (chapter archival does not evict TransactionState,
+	// and IDs have no gaps), i.e. a cache/Pebble desync — surface loudly
+	// with the invariant-violation error class (invariant #7).
 	origStateReader, err := s.TransactionStates().Get(txKey)
 	if errors.Is(err, domain.ErrNotFound) {
-		// Impossible by design under invariants #1/#6: the len(originalPostings)
-		// check above already established the tx was visible to admission at
-		// propose time (so admission preloaded TxState). A miss here implies
-		// a cache/Pebble desync, not a routine business "not found" — surface
-		// loudly with the invariant-violation error class.
 		return nil, &domain.ErrTransactionStateInconsistent{TransactionID: order.GetTransactionId(), Operation: "revert"}
 	}
 
@@ -58,6 +51,14 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	}
 
 	origState := origStateReader.Mutate()
+
+	originalPostings := origState.GetPostings()
+	if len(originalPostings) == 0 {
+		// Create rejects empty transactions, so a stored state always carries
+		// at least one posting; an empty set here is an inconsistent projection
+		// (invariant #7), not a revertable transaction.
+		return nil, &domain.ErrTransactionStateInconsistent{TransactionID: order.GetTransactionId(), Operation: "revert"}
+	}
 
 	// Create reversed postings and update volumes
 	// For a revert: original destination becomes source, original source becomes destination.

--- a/internal/domain/processing/processor_revert_transaction_test.go
+++ b/internal/domain/processing/processor_revert_transaction_test.go
@@ -51,10 +51,19 @@ func TestProcessRevertTransaction_Success(t *testing.T) {
 
 	mockStore.EXPECT().PutReverted(txKey, true)
 
-	// Processor reads original transaction state, then records the reversion on it:
-	// the compensating transaction id and the effective time it was reverted.
+	// Processor reads the original transaction state (postings included), builds
+	// the reversed postings from it, then records the reversion on it: the
+	// compensating transaction id and the effective time it was reverted.
 	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{
 		CreatedByLog: 42,
+		Postings: []*commonpb.Posting{
+			{
+				Source:      "bank",
+				Destination: "users:123",
+				Amount:      commonpb.NewUint256FromUint64(100),
+				Asset:       "USD",
+			},
+		},
 	}).AsReader(), nil)
 	expectPutTransactionState(t, mockStore, txKey, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
 		require.Equal(t, uint64(5), st.GetRevertedByTransaction())
@@ -76,14 +85,6 @@ func TestProcessRevertTransaction_Success(t *testing.T) {
 					Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
 						RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 							TransactionId: 3,
-							OriginalPostings: []*commonpb.Posting{
-								{
-									Source:      "bank",
-									Destination: "users:123",
-									Amount:      commonpb.NewUint256FromUint64(100),
-									Asset:       "USD",
-								},
-							},
 						},
 					},
 					},
@@ -148,10 +149,19 @@ func TestProcessRevertTransaction_AtEffectiveDate(t *testing.T) {
 
 	mockStore.EXPECT().PutReverted(txKey, true)
 
-	// Original transaction state carries the effective timestamp populated at create time.
+	// Original transaction state carries the postings and the effective
+	// timestamp populated at create time.
 	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{
 		CreatedByLog: 42,
 		Timestamp:    originalTimestamp,
+		Postings: []*commonpb.Posting{
+			{
+				Source:      "bank",
+				Destination: "users:123",
+				Amount:      commonpb.NewUint256FromUint64(100),
+				Asset:       "USD",
+			},
+		},
 	}).AsReader(), nil)
 	expectPutTransactionState(t, mockStore, txKey, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
 		require.Equal(t, uint64(5), st.GetRevertedByTransaction())
@@ -174,14 +184,6 @@ func TestProcessRevertTransaction_AtEffectiveDate(t *testing.T) {
 							RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 								TransactionId:   3,
 								AtEffectiveDate: true,
-								OriginalPostings: []*commonpb.Posting{
-									{
-										Source:      "bank",
-										Destination: "users:123",
-										Amount:      commonpb.NewUint256FromUint64(100),
-										Asset:       "USD",
-									},
-								},
 							},
 						},
 					},
@@ -231,13 +233,21 @@ func TestProcessRevertTransaction_AtEffectiveDate_MissingOriginalTimestamp(t *te
 
 	mockStore.EXPECT().PutReverted(txKey, true)
 
-	// Simulate a TransactionState written before the Timestamp field existed (or
-	// otherwise inconsistent state). With at_effective_date=true this must surface
-	// loudly rather than silently falling back to s.GetDate(). The timestamp is
-	// resolved before the reverted markers are written, so no transaction state is
-	// persisted on this path.
+	// State carries postings (so the revert proceeds past posting resolution)
+	// but no Timestamp. With at_effective_date=true this must surface loudly
+	// rather than silently falling back to s.GetDate(). The timestamp is
+	// resolved before the reverted markers are written, so no transaction state
+	// is persisted on this path.
 	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{
 		CreatedByLog: 42,
+		Postings: []*commonpb.Posting{
+			{
+				Source:      "bank",
+				Destination: "users:123",
+				Amount:      commonpb.NewUint256FromUint64(100),
+				Asset:       "USD",
+			},
+		},
 	}).AsReader(), nil)
 
 	order := &raftcmdpb.Order{
@@ -250,14 +260,6 @@ func TestProcessRevertTransaction_AtEffectiveDate_MissingOriginalTimestamp(t *te
 							RevertTransaction: &raftcmdpb.RevertTransactionOrder{
 								TransactionId:   3,
 								AtEffectiveDate: true,
-								OriginalPostings: []*commonpb.Posting{
-									{
-										Source:      "bank",
-										Destination: "users:123",
-										Amount:      commonpb.NewUint256FromUint64(100),
-										Asset:       "USD",
-									},
-								},
 							},
 						},
 					},
@@ -314,6 +316,54 @@ func TestProcessRevertTransaction_NotFound(t *testing.T) {
 	var txNotFound *domain.ErrTransactionNotFound
 	require.ErrorAs(t, err, &txNotFound)
 	require.Equal(t, uint64(99), txNotFound.TransactionID)
+}
+
+// An allocated tx id (below NextTransactionId, so it passes the boundary
+// check) whose TransactionState is absent is an inconsistent projection, not a
+// routine "not found": chapter archival never evicts TransactionState and tx
+// ids have no gaps. It must surface loudly (invariant #7), never silently.
+func TestProcessRevertTransaction_StateMissingIsInconsistent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 5, NextLogId: 10}
+	txKey := domain.TransactionKey{LedgerName: "test-ledger", ID: 3}
+
+	expectGetBoundaries(mockStore, domain.LedgerKey{Name: "test-ledger"}, boundaries.AsReader(), nil)
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, (&commonpb.LedgerInfo{Name: "test-ledger", Id: 1}).AsReader(), nil).AnyTimes()
+	mockStore.EXPECT().GetReverted(txKey).Return(false, nil)
+	expectGetTransactionState(mockStore, txKey, nil, domain.ErrNotFound)
+
+	order := &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: "test-ledger",
+				Payload: &raftcmdpb.LedgerScopedOrder_Apply{
+					Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
+						RevertTransaction: &raftcmdpb.RevertTransactionOrder{
+							TransactionId: 3,
+						},
+					},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := processor.ProcessOrder(order, mockStore)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	var inconsistent *domain.ErrTransactionStateInconsistent
+	require.ErrorAs(t, err, &inconsistent)
+	require.Equal(t, uint64(3), inconsistent.TransactionID)
+	require.Equal(t, "revert", inconsistent.Operation)
 }
 
 func TestProcessRevertTransaction_AlreadyReverted(t *testing.T) {

--- a/internal/proto/raftcmdpb/raft_cmd.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd.pb.go
@@ -3306,14 +3306,13 @@ func (x *SaveMetadataOrder) GetMetadata() map[string]*commonpb.MetadataValue {
 }
 
 type RevertTransactionOrder struct {
-	state            protoimpl.MessageState             `protogen:"open.v1"`
-	TransactionId    uint64                             `protobuf:"fixed64,1,opt,name=transaction_id,json=transactionId,proto3" json:"transaction_id,omitempty"`
-	Force            bool                               `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
-	AtEffectiveDate  bool                               `protobuf:"varint,3,opt,name=at_effective_date,json=atEffectiveDate,proto3" json:"at_effective_date,omitempty"`
-	Metadata         map[string]*commonpb.MetadataValue `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	OriginalPostings []*commonpb.Posting                `protobuf:"bytes,5,rep,name=original_postings,json=originalPostings,proto3" json:"original_postings,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state           protoimpl.MessageState             `protogen:"open.v1"`
+	TransactionId   uint64                             `protobuf:"fixed64,1,opt,name=transaction_id,json=transactionId,proto3" json:"transaction_id,omitempty"`
+	Force           bool                               `protobuf:"varint,2,opt,name=force,proto3" json:"force,omitempty"`
+	AtEffectiveDate bool                               `protobuf:"varint,3,opt,name=at_effective_date,json=atEffectiveDate,proto3" json:"at_effective_date,omitempty"`
+	Metadata        map[string]*commonpb.MetadataValue `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *RevertTransactionOrder) Reset() {
@@ -3370,13 +3369,6 @@ func (x *RevertTransactionOrder) GetAtEffectiveDate() bool {
 func (x *RevertTransactionOrder) GetMetadata() map[string]*commonpb.MetadataValue {
 	if x != nil {
 		return x.Metadata
-	}
-	return nil
-}
-
-func (x *RevertTransactionOrder) GetOriginalPostings() []*commonpb.Posting {
-	if x != nil {
-		return x.OriginalPostings
 	}
 	return nil
 }
@@ -6293,13 +6285,12 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\bmetadata\x18\x02 \x03(\v2%.raft.SaveMetadataOrder.MetadataEntryR\bmetadata\x1aR\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
-	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"\xdb\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"\x9d\x02\n" +
 	"\x16RevertTransactionOrder\x12%\n" +
 	"\x0etransaction_id\x18\x01 \x01(\x06R\rtransactionId\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\x12*\n" +
 	"\x11at_effective_date\x18\x03 \x01(\bR\x0fatEffectiveDate\x12F\n" +
-	"\bmetadata\x18\x04 \x03(\v2*.raft.RevertTransactionOrder.MetadataEntryR\bmetadata\x12<\n" +
-	"\x11original_postings\x18\x05 \x03(\v2\x0f.common.PostingR\x10originalPostings\x1aR\n" +
+	"\bmetadata\x18\x04 \x03(\v2*.raft.RevertTransactionOrder.MetadataEntryR\bmetadata\x1aR\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x05value\x18\x02 \x01(\v2\x15.common.MetadataValueR\x05value:\x028\x01\"O\n" +
@@ -6740,81 +6731,80 @@ var file_raft_cmd_proto_depIdxs = []int32{
 	106, // 81: raft.SaveMetadataOrder.target:type_name -> common.Target
 	94,  // 82: raft.SaveMetadataOrder.metadata:type_name -> raft.SaveMetadataOrder.MetadataEntry
 	95,  // 83: raft.RevertTransactionOrder.metadata:type_name -> raft.RevertTransactionOrder.MetadataEntry
-	105, // 84: raft.RevertTransactionOrder.original_postings:type_name -> common.Posting
-	106, // 85: raft.DeleteMetadataOrder.target:type_name -> common.Target
-	96,  // 86: raft.SaveLedgerMetadataOrder.metadata:type_name -> raft.SaveLedgerMetadataOrder.MetadataEntry
-	2,   // 87: raft.Proposal.orders:type_name -> raft.Order
-	100, // 88: raft.Proposal.date:type_name -> common.Timestamp
-	69,  // 89: raft.Proposal.execution_plan:type_name -> raft.ExecutionPlan
-	113, // 90: raft.Proposal.caller_snapshot:type_name -> common.CallerSnapshot
-	114, // 91: raft.Proposal.idempotency:type_name -> common.Idempotency
-	115, // 92: raft.Proposal.signature:type_name -> signature.SignedApplyBatch
-	53,  // 93: raft.Proposal.technical_updates:type_name -> raft.TechnicalUpdate
-	64,  // 94: raft.TechnicalUpdate.mirror_sync:type_name -> raft.MirrorSyncUpdate
-	65,  // 95: raft.TechnicalUpdate.events_sink:type_name -> raft.EventsSinkUpdate
-	63,  // 96: raft.TechnicalUpdate.idempotency_eviction:type_name -> raft.IdempotencyEviction
-	116, // 97: raft.TechnicalUpdate.cluster_config:type_name -> common.ClusterConfig
-	58,  // 98: raft.TechnicalUpdate.backup_order:type_name -> raft.BackupOrder
-	59,  // 99: raft.TechnicalUpdate.incremental_backup_order:type_name -> raft.IncrementalBackupOrder
-	55,  // 100: raft.BackupDestination.s3:type_name -> raft.S3BackupTarget
-	56,  // 101: raft.BackupDestination.azure:type_name -> raft.AzureBackupTarget
-	0,   // 102: raft.BackupJob.kind:type_name -> raft.BackupKind
-	1,   // 103: raft.BackupJob.status:type_name -> raft.BackupJobStatus
-	54,  // 104: raft.BackupJob.destination:type_name -> raft.BackupDestination
-	60,  // 105: raft.BackupOrder.start:type_name -> raft.BackupOrderStart
-	61,  // 106: raft.BackupOrder.complete:type_name -> raft.BackupOrderComplete
-	62,  // 107: raft.BackupOrder.fail:type_name -> raft.BackupOrderFail
-	60,  // 108: raft.IncrementalBackupOrder.start:type_name -> raft.BackupOrderStart
-	61,  // 109: raft.IncrementalBackupOrder.complete:type_name -> raft.BackupOrderComplete
-	62,  // 110: raft.IncrementalBackupOrder.fail:type_name -> raft.BackupOrderFail
-	54,  // 111: raft.BackupOrderStart.destination:type_name -> raft.BackupDestination
-	117, // 112: raft.MirrorSyncUpdate.error:type_name -> common.MirrorSyncError
-	118, // 113: raft.EventsSinkUpdate.error:type_name -> common.SinkError
-	119, // 114: raft.CreatedLogOrReference.created_log:type_name -> common.Log
-	120, // 115: raft.VolumePair.input:type_name -> common.Uint256
-	120, // 116: raft.VolumePair.output:type_name -> common.Uint256
-	70,  // 117: raft.ExecutionPlan.attributes:type_name -> raft.AttributeCoverage
-	72,  // 118: raft.ExecutionPlan.idempotency_keys:type_name -> raft.ReloadIdempotencyKey
-	85,  // 119: raft.AttributeCoverage.id:type_name -> raft.AttributeID
-	71,  // 120: raft.AttributeCoverage.value:type_name -> raft.AttributeValue
-	121, // 121: raft.ReloadIdempotencyKey.value:type_name -> common.IdempotencyKeyValue
-	78,  // 122: raft.GenerationSnapshot.volumes:type_name -> raft.VolumeAttributeSnapshotEntry
-	79,  // 123: raft.GenerationSnapshot.metadata:type_name -> raft.MetadataAttributeEntry
-	79,  // 124: raft.GenerationSnapshot.ledger_metadata:type_name -> raft.MetadataAttributeEntry
-	80,  // 125: raft.GenerationSnapshot.ledgers:type_name -> raft.LedgerAttributeEntry
-	81,  // 126: raft.GenerationSnapshot.boundaries:type_name -> raft.BoundaryAttributeEntry
-	82,  // 127: raft.GenerationSnapshot.references:type_name -> raft.TransactionReferenceAttributeEntry
-	83,  // 128: raft.GenerationSnapshot.transactions:type_name -> raft.TransactionStateAttributeEntry
-	85,  // 129: raft.VolumeAttributeSnapshotEntry.id:type_name -> raft.AttributeID
-	120, // 130: raft.VolumeAttributeSnapshotEntry.input:type_name -> common.Uint256
-	120, // 131: raft.VolumeAttributeSnapshotEntry.output:type_name -> common.Uint256
-	85,  // 132: raft.MetadataAttributeEntry.id:type_name -> raft.AttributeID
-	122, // 133: raft.MetadataAttributeEntry.value:type_name -> common.MetadataValue
-	85,  // 134: raft.LedgerAttributeEntry.id:type_name -> raft.AttributeID
-	123, // 135: raft.LedgerAttributeEntry.info:type_name -> common.LedgerInfo
-	85,  // 136: raft.BoundaryAttributeEntry.id:type_name -> raft.AttributeID
-	67,  // 137: raft.BoundaryAttributeEntry.boundaries:type_name -> raft.LedgerBoundaries
-	85,  // 138: raft.TransactionReferenceAttributeEntry.id:type_name -> raft.AttributeID
-	124, // 139: raft.TransactionReferenceAttributeEntry.value:type_name -> common.TransactionReferenceValue
-	85,  // 140: raft.TransactionStateAttributeEntry.id:type_name -> raft.AttributeID
-	125, // 141: raft.TransactionStateAttributeEntry.state:type_name -> common.TransactionState
-	85,  // 142: raft.IdempotencyKeyAttributeEntry.id:type_name -> raft.AttributeID
-	121, // 143: raft.IdempotencyKeyAttributeEntry.value:type_name -> common.IdempotencyKeyValue
-	109, // 144: raft.CreateLedgerOrder.AccountTypesEntry.value:type_name -> common.AccountType
-	122, // 145: raft.MirrorCreatedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
-	126, // 146: raft.MirrorCreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	122, // 147: raft.MirrorSavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	122, // 148: raft.MirrorRevertedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
-	122, // 149: raft.CreateTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	126, // 150: raft.CreateTransactionOrder.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	122, // 151: raft.SaveMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	122, // 152: raft.RevertTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	122, // 153: raft.SaveLedgerMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	154, // [154:154] is the sub-list for method output_type
-	154, // [154:154] is the sub-list for method input_type
-	154, // [154:154] is the sub-list for extension type_name
-	154, // [154:154] is the sub-list for extension extendee
-	0,   // [0:154] is the sub-list for field type_name
+	106, // 84: raft.DeleteMetadataOrder.target:type_name -> common.Target
+	96,  // 85: raft.SaveLedgerMetadataOrder.metadata:type_name -> raft.SaveLedgerMetadataOrder.MetadataEntry
+	2,   // 86: raft.Proposal.orders:type_name -> raft.Order
+	100, // 87: raft.Proposal.date:type_name -> common.Timestamp
+	69,  // 88: raft.Proposal.execution_plan:type_name -> raft.ExecutionPlan
+	113, // 89: raft.Proposal.caller_snapshot:type_name -> common.CallerSnapshot
+	114, // 90: raft.Proposal.idempotency:type_name -> common.Idempotency
+	115, // 91: raft.Proposal.signature:type_name -> signature.SignedApplyBatch
+	53,  // 92: raft.Proposal.technical_updates:type_name -> raft.TechnicalUpdate
+	64,  // 93: raft.TechnicalUpdate.mirror_sync:type_name -> raft.MirrorSyncUpdate
+	65,  // 94: raft.TechnicalUpdate.events_sink:type_name -> raft.EventsSinkUpdate
+	63,  // 95: raft.TechnicalUpdate.idempotency_eviction:type_name -> raft.IdempotencyEviction
+	116, // 96: raft.TechnicalUpdate.cluster_config:type_name -> common.ClusterConfig
+	58,  // 97: raft.TechnicalUpdate.backup_order:type_name -> raft.BackupOrder
+	59,  // 98: raft.TechnicalUpdate.incremental_backup_order:type_name -> raft.IncrementalBackupOrder
+	55,  // 99: raft.BackupDestination.s3:type_name -> raft.S3BackupTarget
+	56,  // 100: raft.BackupDestination.azure:type_name -> raft.AzureBackupTarget
+	0,   // 101: raft.BackupJob.kind:type_name -> raft.BackupKind
+	1,   // 102: raft.BackupJob.status:type_name -> raft.BackupJobStatus
+	54,  // 103: raft.BackupJob.destination:type_name -> raft.BackupDestination
+	60,  // 104: raft.BackupOrder.start:type_name -> raft.BackupOrderStart
+	61,  // 105: raft.BackupOrder.complete:type_name -> raft.BackupOrderComplete
+	62,  // 106: raft.BackupOrder.fail:type_name -> raft.BackupOrderFail
+	60,  // 107: raft.IncrementalBackupOrder.start:type_name -> raft.BackupOrderStart
+	61,  // 108: raft.IncrementalBackupOrder.complete:type_name -> raft.BackupOrderComplete
+	62,  // 109: raft.IncrementalBackupOrder.fail:type_name -> raft.BackupOrderFail
+	54,  // 110: raft.BackupOrderStart.destination:type_name -> raft.BackupDestination
+	117, // 111: raft.MirrorSyncUpdate.error:type_name -> common.MirrorSyncError
+	118, // 112: raft.EventsSinkUpdate.error:type_name -> common.SinkError
+	119, // 113: raft.CreatedLogOrReference.created_log:type_name -> common.Log
+	120, // 114: raft.VolumePair.input:type_name -> common.Uint256
+	120, // 115: raft.VolumePair.output:type_name -> common.Uint256
+	70,  // 116: raft.ExecutionPlan.attributes:type_name -> raft.AttributeCoverage
+	72,  // 117: raft.ExecutionPlan.idempotency_keys:type_name -> raft.ReloadIdempotencyKey
+	85,  // 118: raft.AttributeCoverage.id:type_name -> raft.AttributeID
+	71,  // 119: raft.AttributeCoverage.value:type_name -> raft.AttributeValue
+	121, // 120: raft.ReloadIdempotencyKey.value:type_name -> common.IdempotencyKeyValue
+	78,  // 121: raft.GenerationSnapshot.volumes:type_name -> raft.VolumeAttributeSnapshotEntry
+	79,  // 122: raft.GenerationSnapshot.metadata:type_name -> raft.MetadataAttributeEntry
+	79,  // 123: raft.GenerationSnapshot.ledger_metadata:type_name -> raft.MetadataAttributeEntry
+	80,  // 124: raft.GenerationSnapshot.ledgers:type_name -> raft.LedgerAttributeEntry
+	81,  // 125: raft.GenerationSnapshot.boundaries:type_name -> raft.BoundaryAttributeEntry
+	82,  // 126: raft.GenerationSnapshot.references:type_name -> raft.TransactionReferenceAttributeEntry
+	83,  // 127: raft.GenerationSnapshot.transactions:type_name -> raft.TransactionStateAttributeEntry
+	85,  // 128: raft.VolumeAttributeSnapshotEntry.id:type_name -> raft.AttributeID
+	120, // 129: raft.VolumeAttributeSnapshotEntry.input:type_name -> common.Uint256
+	120, // 130: raft.VolumeAttributeSnapshotEntry.output:type_name -> common.Uint256
+	85,  // 131: raft.MetadataAttributeEntry.id:type_name -> raft.AttributeID
+	122, // 132: raft.MetadataAttributeEntry.value:type_name -> common.MetadataValue
+	85,  // 133: raft.LedgerAttributeEntry.id:type_name -> raft.AttributeID
+	123, // 134: raft.LedgerAttributeEntry.info:type_name -> common.LedgerInfo
+	85,  // 135: raft.BoundaryAttributeEntry.id:type_name -> raft.AttributeID
+	67,  // 136: raft.BoundaryAttributeEntry.boundaries:type_name -> raft.LedgerBoundaries
+	85,  // 137: raft.TransactionReferenceAttributeEntry.id:type_name -> raft.AttributeID
+	124, // 138: raft.TransactionReferenceAttributeEntry.value:type_name -> common.TransactionReferenceValue
+	85,  // 139: raft.TransactionStateAttributeEntry.id:type_name -> raft.AttributeID
+	125, // 140: raft.TransactionStateAttributeEntry.state:type_name -> common.TransactionState
+	85,  // 141: raft.IdempotencyKeyAttributeEntry.id:type_name -> raft.AttributeID
+	121, // 142: raft.IdempotencyKeyAttributeEntry.value:type_name -> common.IdempotencyKeyValue
+	109, // 143: raft.CreateLedgerOrder.AccountTypesEntry.value:type_name -> common.AccountType
+	122, // 144: raft.MirrorCreatedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
+	126, // 145: raft.MirrorCreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	122, // 146: raft.MirrorSavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	122, // 147: raft.MirrorRevertedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
+	122, // 148: raft.CreateTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	126, // 149: raft.CreateTransactionOrder.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	122, // 150: raft.SaveMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	122, // 151: raft.RevertTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	122, // 152: raft.SaveLedgerMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	153, // [153:153] is the sub-list for method output_type
+	153, // [153:153] is the sub-list for method input_type
+	153, // [153:153] is the sub-list for extension type_name
+	153, // [153:153] is the sub-list for extension extendee
+	0,   // [0:153] is the sub-list for field type_name
 }
 
 func init() { file_raft_cmd_proto_init() }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -1386,15 +1386,6 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferDeterministicVT(dAtA []byte
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.OriginalPostings) > 0 {
-		for iNdEx := len(m.OriginalPostings) - 1; iNdEx >= 0; iNdEx-- {
-			size, _ := m.OriginalPostings[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
-			i -= size
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-			i--
-			dAtA[i] = 0x2a
-		}
-	}
 	if len(m.Metadata) > 0 {
 		keysPtr := _dethashKeyPoolGithubComFormancehqLedgerV3InternalProtoRaftcmdpbRaftCmdString.Get().(*[]string)
 		keys := (*keysPtr)[:0]

--- a/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
@@ -3631,7 +3631,6 @@ type RevertTransactionOrderReader interface {
 	GetForce() bool
 	GetAtEffectiveDate() bool
 	GetMetadata() RevertTransactionOrder_MetadataMapReader
-	GetOriginalPostings() commonpb.PostingListReader
 	Mutate() *RevertTransactionOrder
 }
 
@@ -3651,10 +3650,6 @@ func (r *revertTransactionOrderReadonly) GetAtEffectiveDate() bool {
 
 func (r *revertTransactionOrderReadonly) GetMetadata() RevertTransactionOrder_MetadataMapReader {
 	return revertTransactionOrder_metadataMapReadonly((*RevertTransactionOrder)(r).GetMetadata())
-}
-
-func (r *revertTransactionOrderReadonly) GetOriginalPostings() commonpb.PostingListReader {
-	return commonpb.NewPostingListReader((*RevertTransactionOrder)(r).GetOriginalPostings())
 }
 
 func (r *revertTransactionOrderReadonly) Mutate() *RevertTransactionOrder {

--- a/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
@@ -1385,13 +1385,6 @@ func (m *RevertTransactionOrder) CloneVT() *RevertTransactionOrder {
 		}
 		r.Metadata = tmpContainer
 	}
-	if rhs := m.OriginalPostings; rhs != nil {
-		tmpContainer := make([]*commonpb.Posting, len(rhs))
-		for k, v := range rhs {
-			tmpContainer[k] = v.CloneVT()
-		}
-		r.OriginalPostings = tmpContainer
-	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -4775,23 +4768,6 @@ func (this *RevertTransactionOrder) EqualVT(that *RevertTransactionOrder) bool {
 			}
 			if q == nil {
 				q = &commonpb.MetadataValue{}
-			}
-			if !p.EqualVT(q) {
-				return false
-			}
-		}
-	}
-	if len(this.OriginalPostings) != len(that.OriginalPostings) {
-		return false
-	}
-	for i, vx := range this.OriginalPostings {
-		vy := that.OriginalPostings[i]
-		if p, q := vx, vy; p != q {
-			if p == nil {
-				p = &commonpb.Posting{}
-			}
-			if q == nil {
-				q = &commonpb.Posting{}
 			}
 			if !p.EqualVT(q) {
 				return false
@@ -9572,18 +9548,6 @@ func (m *RevertTransactionOrder) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.OriginalPostings) > 0 {
-		for iNdEx := len(m.OriginalPostings) - 1; iNdEx >= 0; iNdEx-- {
-			size, err := m.OriginalPostings[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-			i--
-			dAtA[i] = 0x2a
-		}
-	}
 	if len(m.Metadata) > 0 {
 		for k := range m.Metadata {
 			v := m.Metadata[k]
@@ -13674,12 +13638,6 @@ func (m *RevertTransactionOrder) SizeVT() (n int) {
 			l += 1 + protohelpers.SizeOfVarint(uint64(l))
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
-		}
-	}
-	if len(m.OriginalPostings) > 0 {
-		for _, e := range m.OriginalPostings {
-			l = e.SizeVT()
-			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -22274,40 +22232,6 @@ func (m *RevertTransactionOrder) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Metadata[mapkey] = mapvalue
-			iNdEx = postIndex
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field OriginalPostings", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.OriginalPostings = append(m.OriginalPostings, &commonpb.Posting{})
-			if err := m.OriginalPostings[len(m.OriginalPostings)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/misc/proto/raft_cmd.proto
+++ b/misc/proto/raft_cmd.proto
@@ -402,7 +402,6 @@ message RevertTransactionOrder {
   bool force = 2;
   bool at_effective_date = 3;
   map<string, common.MetadataValue> metadata = 4;
-  repeated common.Posting original_postings = 5;
 }
 
 message DeleteMetadataOrder {


### PR DESCRIPTION
## Problem

Admission enriched `RevertTransactionOrder` with `OriginalPostings` read from the target transaction's state at propose time. That order is serialized into `AuditItem.SerializedOrder` and bound into the audit hash chain — so the chain proved an *enriched* order rather than the request the caller submitted: data the caller never provided, and whose presence/absence depended on which node admitted the request and what it could read. This violates accepted-order immutability and contributes to audit/idempotency hash pollution.

## Fix

- `RevertTransactionOrder` now carries only caller intent: `transaction_id`, `force`, `at_effective_date`, `metadata`.
- The FSM sources the original postings from the coverage-gated `TransactionState` it already reads (preloaded via `addTransactionTargetNeeds`) — no order field, no new read, invariant #3 (no Pebble reads on the hot path) untouched.
- Admission still resolves the postings at order-build time (signed receipt or `Transaction` attribute) to declare the volume-preload coverage the reversed postings touch (invariant #9), but holds them in an admission-local overlay sidecar rather than on the wire order.
- A missing `TransactionState` for an *allocated* id is now a loud inconsistency (invariant #7): chapter archival does not evict `TransactionState`, and a genuinely non-existent id is already rejected by the `txID >= NextTransactionId` boundary check.
- Revert color validation dropped — reversed postings inherit colors already validated at create time.

## Acceptance criteria

- [x] Audit-serialized revert order contains only caller-provided intent.
- [x] `OriginalPostings` no longer lives on the accepted/audit-bound order.
- [x] FSM execution stays deterministic, uses only covered/preloaded data, no Pebble reads.
- [x] Idempotency for the same revert request is unaffected by admission-time enrichment.
- [x] Tests cover successful revert, missing original transaction, and the receipt/store path.
- [x] Docs describe where state-derived revert execution data lives.

## Testing

- Unit suites green: `admission`, `processing`, `check`, `state`, `usagebuilder`, `adapter/http`, `adapter/v2`, `raftcmdpb`.
- New FSM test for the allocated-but-missing-state inconsistency path; updated success / at-effective-date / not-found / receipt / intra-batch-fold tests.
- `just pre-commit` clean — 0 lint issues, no codegen/`go mod tidy` drift.

## Docs

New "Accepted Order Enrichment" section in `docs/technical/architecture/audit-vs-technical-state.md`.
