### PR TITLE
feat(EN-1582): add per-action admission counters

### DIFF
--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -286,6 +286,27 @@ When a value is not guaranteed to be in cache (based on the cache generation), t
 | `admission.propose.duration` | Histogram | µs | Time waiting for Raft to accept and replicate a proposal (Propose + Wait). |
 | `admission.command.size` | Histogram | By | Size of marshalled Raft commands in bytes. Large commands may indicate many postings or metadata. |
 
+### Action Metrics
+
+An `Admit` call carries one batch = one Raft command, and a batch can hold multiple, mixed orders (actions). `command.duration` observes once per batch, so it cannot break work down by action. These two counters do, keyed by action type.
+
+| Metric | Type | Unit | Description |
+|--------|------|------|-------------|
+| `admission.action.total` | Counter | 1 | Number of orders (actions) admission processed, by `order_type`. Counts **every order attempted** in the batch, regardless of outcome — it is not gated on the FSM apply result. |
+| `admission.action.errors.total` | Counter | 1 | Number of orders whose admission batch ended in error, by `order_type`. A **strict subset** of `admission.action.total`. |
+
+**Attributes**:
+- `order_type`: The action kind, e.g. `create_transaction`, `revert_transaction`, `add_metadata`, `create_ledger`, `delete_ledger`, `save_numscript`, `create_index`, `register_signing_key`, `seal_chapter`, … This is the same stable vocabulary used by the audit filter DSL (`domain.AuditOrderType`); it is extended additively and tokens are never renamed.
+
+**Per-action error rate**: `admission.action.errors.total / admission.action.total` — a ratio in `[0, 1]` because errors is a strict subset of total.
+
+**Semantics and attribution**:
+- **Attempted, not performed**: `action.total` increments for every order in the batch even when the batch ultimately fails. This is deliberate — it is what makes the error rate a clean ratio.
+- **Atomic batch**: a batch is one Raft command with a single outcome. On failure, **every order in the batch is counted as errored** under its own `order_type` — none of them applied. For the common single-order batch this is exact; for a mixed batch the failure is attributed to each action type present.
+- **All admission-observed errors**: both admission-side rejections raised after orders are built (numscript resolution, preload, per-order validation) and FSM business rejections (insufficient funds, conflicts) surfaced when the command resolves.
+- **Carve-out**: failures *before* orders are built — write gate, leader readiness, bad batch signature, maintenance mode, request-to-order conversion — have no `order_type` to attribute to and are **not** counted here. They are batch-level/structural failures, not per-action business outcomes.
+- **Leader-local**: like `command.duration`, recording happens on the admission path on the leader only. Recording never touches the FSM apply path, preserving FSM determinism.
+
 ### Propose Queue Metrics
 
 | Metric | Type | Unit | Description |

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -84,6 +84,8 @@ type Admission struct {
 	preloadCacheHitsCounter        metric.Int64Counter
 	missingCallerCounter           metric.Int64Counter
 	callerSubjectEmptyCounter      metric.Int64Counter
+	actionCounter                  metric.Int64Counter
+	actionErrorsCounter            metric.Int64Counter
 
 	// Per-phase histograms — decompose command.duration into
 	// resolve_batch (signature verify) + orders_prep (orders + coverage
@@ -307,6 +309,24 @@ func NewAdmission(
 		panic(err)
 	}
 
+	actionCounter, err := meter.Int64Counter(
+		"admission.action.total",
+		metric.WithDescription("Total number of orders (actions) admission processed, tagged by order_type. Counts every order attempted in the batch; not gated on the FSM apply outcome."),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	actionErrorsCounter, err := meter.Int64Counter(
+		"admission.action.errors.total",
+		metric.WithDescription("Number of orders (actions) whose admission batch ended in error, tagged by order_type. A strict subset of admission.action.total."),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
 	missingCallerCounter, err := meter.Int64Counter(
 		"admission.audit.missing_caller",
 		metric.WithDescription("Committed user writes with no caller snapshot while auth is enabled"),
@@ -379,6 +399,8 @@ func NewAdmission(
 	a.preloadCacheHitsCounter = preloadCacheHitsCounter
 	a.missingCallerCounter = missingCallerCounter
 	a.callerSubjectEmptyCounter = callerSubjectEmptyCounter
+	a.actionCounter = actionCounter
+	a.actionErrorsCounter = actionErrorsCounter
 	a.resolveBatchDurationHistogram = resolveBatchDurationHistogram
 	a.ordersPreparationDurationHistogram = ordersPreparationDurationHistogram
 	a.scriptsDurationHistogram = scriptsDurationHistogram
@@ -411,6 +433,31 @@ func (a *Admission) observeCallerSnapshot(ctx context.Context, snap *commonpb.Ca
 		if id.GetSubject() == "" {
 			a.logger.Infof("committed write caller has a source but an empty subject: audit entry identifies the caller only by source")
 			a.callerSubjectEmptyCounter.Add(ctx, 1)
+		}
+	}
+}
+
+// recordActionOutcome tallies the per-order admission counters at the single
+// Admit exit. It runs as a deferred call registered only once the batch's orders
+// have been built, so pre-order (structural) failures — bad signature,
+// maintenance mode, request-to-order conversion — carry no order_type and are
+// intentionally excluded.
+//
+// admission.action.total counts every order attempted, regardless of outcome.
+// A batch is one atomic Raft command with a single outcome, so on failure
+// (*errp != nil) every order in the batch is counted as errored under its own
+// order_type: none of them applied. That keeps admission.action.errors.total a
+// strict subset of admission.action.total (error rate ∈ [0, 1]). order_type
+// reuses domain.AuditOrderType so the labels stay consistent with the audit
+// filter DSL (EN-1305 / EN-1582). Recording stays on the admission path; the FSM
+// apply path is never touched.
+func (a *Admission) recordActionOutcome(ctx context.Context, orders []*raftcmdpb.Order, errp *error) {
+	failed := *errp != nil
+	for _, order := range orders {
+		attrs := metric.WithAttributes(attribute.String("order_type", domain.AuditOrderType(order)))
+		a.actionCounter.Add(ctx, 1, attrs)
+		if failed {
+			a.actionErrorsCounter.Add(ctx, 1, attrs)
 		}
 	}
 }
@@ -455,7 +502,7 @@ func (a *Admission) recordPhaseOnExit(ctx context.Context, hist metric.Int64Hist
 // 3. When not guaranteed, load base value from store at boundary B(nextIndex)
 // 4. For volumes not guaranteed in cache, load base values from store at B(nextIndex)
 // 5. Propose command with Preload containing base values.
-func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) (logs []*commonpb.Log, err error) {
 	if err := a.writeGate.CheckWritesAllowed(); err != nil {
 		return nil, err
 	}
@@ -513,6 +560,12 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 	if err != nil {
 		return nil, fmt.Errorf("converting requests to orders: %w", err)
 	}
+
+	// Tally per-order action counters at whichever exit Admit returns through.
+	// Registered here — after orders exist — so pre-order failures (signature,
+	// maintenance mode, conversion) fall outside per-action attribution. Reads the
+	// named return err to classify the batch outcome. See recordActionOutcome.
+	defer a.recordActionOutcome(ctx, orders, &err)
 
 	// Step 1: Extract preload needs from orders (excludes script-dependent needs)
 	needs, perOrder, err := a.extractPreloadNeeds(ctx, orders)
@@ -750,7 +803,7 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) ([]*
 		a.responseResolutionDurationHistogram.Record(ctx, time.Since(responseResolutionStart).Microseconds())
 	}()
 
-	logs := make([]*commonpb.Log, len(result.Logs))
+	logs = make([]*commonpb.Log, len(result.Logs))
 	for i, logOrRef := range result.Logs {
 		if created := logOrRef.GetCreatedLog(); created != nil {
 			logs[i] = created

--- a/internal/application/admission/admission_action_metrics_test.go
+++ b/internal/application/admission/admission_action_metrics_test.go
@@ -1,0 +1,285 @@
+package admission
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+const (
+	mActionTotal  = "admission.action.total"
+	mActionErrors = "admission.action.errors.total"
+)
+
+// recordedActionCounts collects, from the manual reader, the value of each
+// action counter broken down by its order_type attribute. The shape is
+// metric name -> order_type -> summed value. Absent instruments / series map to
+// a missing key (the SDK never created the series), which callers treat as zero.
+func recordedActionCounts(t *testing.T, reader *sdkmetric.ManualReader) map[string]map[string]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	counts := make(map[string]map[string]int64)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			if m.Name != mActionTotal && m.Name != mActionErrors {
+				continue
+			}
+
+			byType := make(map[string]int64)
+			for _, dp := range sum.DataPoints {
+				v, ok := dp.Attributes.Value(attribute.Key("order_type"))
+				require.True(t, ok, "action counter data point missing order_type attribute")
+				byType[v.AsString()] += dp.Value
+			}
+			counts[m.Name] = byType
+		}
+	}
+
+	return counts
+}
+
+func createLedgerOrder() *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{
+					CreateLedger: &raftcmdpb.CreateLedgerOrder{},
+				},
+			},
+		},
+	}
+}
+
+func createTransactionOrder() *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Payload: &raftcmdpb.LedgerScopedOrder_Apply{
+					Apply: &raftcmdpb.LedgerApplyOrder{
+						Data: &raftcmdpb.LedgerApplyOrder_CreateTransaction{
+							CreateTransaction: &raftcmdpb.CreateTransactionOrder{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func registerSigningKeyOrder() *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_RegisterSigningKey{
+					RegisterSigningKey: &raftcmdpb.RegisterSigningKeyOrder{},
+				},
+			},
+		},
+	}
+}
+
+// TestRecordActionOutcome exercises the counting logic directly: total counts
+// every order attempted, errors is the strict subset counted only when the
+// batch failed, and both break down by order_type via domain.AuditOrderType.
+// Driving it directly avoids faking the full green Admit path (plan.Builder.Run
+// + resolved FSM future), which no unit test can cheaply synthesize.
+func TestRecordActionOutcome(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success increments total only, per order_type", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+		a, reader := createTestAdmissionWithReader(t, store, nil)
+
+		var err error // nil == batch succeeded
+		a.recordActionOutcome(context.Background(), []*raftcmdpb.Order{createTransactionOrder()}, &err)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(1), counts[mActionTotal]["create_transaction"])
+		require.Zero(t, counts[mActionErrors]["create_transaction"], "errors must not increment on success")
+	})
+
+	t.Run("failure increments total and errors, per order_type", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+		a, reader := createTestAdmissionWithReader(t, store, nil)
+
+		err := errors.New("batch failed")
+		a.recordActionOutcome(context.Background(), []*raftcmdpb.Order{createTransactionOrder()}, &err)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(1), counts[mActionTotal]["create_transaction"])
+		require.Equal(t, int64(1), counts[mActionErrors]["create_transaction"])
+	})
+
+	t.Run("mixed multi-order batch breaks down by order_type", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+		a, reader := createTestAdmissionWithReader(t, store, nil)
+
+		// A failed atomic batch: total AND errors count every order under its own
+		// order_type — two create_ledger, one create_transaction, one
+		// register_signing_key.
+		orders := []*raftcmdpb.Order{
+			createLedgerOrder(),
+			createLedgerOrder(),
+			createTransactionOrder(),
+			registerSigningKeyOrder(),
+		}
+		err := errors.New("batch failed")
+		a.recordActionOutcome(context.Background(), orders, &err)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(2), counts[mActionTotal]["create_ledger"])
+		require.Equal(t, int64(1), counts[mActionTotal]["create_transaction"])
+		require.Equal(t, int64(1), counts[mActionTotal]["register_signing_key"])
+		require.Equal(t, int64(2), counts[mActionErrors]["create_ledger"])
+		require.Equal(t, int64(1), counts[mActionErrors]["create_transaction"])
+		require.Equal(t, int64(1), counts[mActionErrors]["register_signing_key"])
+	})
+}
+
+// TestAdmitActionCounters exercises the wiring: the deferred recorder is
+// registered right after orders are built, so real failure paths past that point
+// increment both counters under the order's type, while a failure before orders
+// exist (the carve-out) records nothing.
+func TestAdmitActionCounters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("failure after orders built increments total and errors", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+		a, reader := createTestAdmissionWithReader(t, store, nil)
+
+		// A CreateTransaction referencing a missing numscript fails in the scripts
+		// phase — after orders are built and the recorder defer is registered.
+		_, err := a.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+			Type: &servicepb.Request_Apply{
+				Apply: &servicepb.LedgerApplyRequest{
+					Ledger: testLedgerName,
+					Action: &servicepb.LedgerAction{
+						Data: &servicepb.LedgerAction_CreateTransaction{
+							CreateTransaction: &servicepb.CreateTransactionPayload{
+								ScriptReference: &servicepb.ScriptReference{Name: "does-not-exist"},
+							},
+						},
+					},
+				},
+			},
+		}))
+		require.Error(t, err)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(1), counts[mActionTotal]["create_transaction"])
+		require.Equal(t, int64(1), counts[mActionErrors]["create_transaction"])
+	})
+
+	t.Run("propose failure increments total and errors", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+
+		ctrl := gomock.NewController(t)
+		proposer := NewMockProposer(ctrl)
+		proposer.EXPECT().InitialIndex().Return(uint64(0)).AnyTimes()
+		proposer.EXPECT().
+			Propose(gomock.Any(), gomock.Any()).
+			Return(nil, commonpb.ErrNoLeader).
+			AnyTimes()
+
+		a, reader := createTestAdmissionWithReader(t, store, proposer)
+
+		_, err := a.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+			Type: &servicepb.Request_CreateLedger{
+				CreateLedger: &servicepb.CreateLedgerRequest{Name: "ledger-propose-fail"},
+			},
+		}))
+		require.ErrorIs(t, err, commonpb.ErrNoLeader)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(1), counts[mActionTotal]["create_ledger"])
+		require.Equal(t, int64(1), counts[mActionErrors]["create_ledger"])
+	})
+
+	t.Run("multi-order propose failure counts each order", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+
+		ctrl := gomock.NewController(t)
+		proposer := NewMockProposer(ctrl)
+		proposer.EXPECT().InitialIndex().Return(uint64(0)).AnyTimes()
+		proposer.EXPECT().
+			Propose(gomock.Any(), gomock.Any()).
+			Return(nil, commonpb.ErrNoLeader).
+			AnyTimes()
+
+		a, reader := createTestAdmissionWithReader(t, store, proposer)
+
+		// Two CreateLedger orders in one atomic batch: both are built, the batch
+		// fails at propose, so each is counted once under create_ledger.
+		_, err := a.Admit(context.Background(), servicepb.UnsignedApplyRequest("",
+			&servicepb.Request{Type: &servicepb.Request_CreateLedger{
+				CreateLedger: &servicepb.CreateLedgerRequest{Name: "ledger-a"},
+			}},
+			&servicepb.Request{Type: &servicepb.Request_CreateLedger{
+				CreateLedger: &servicepb.CreateLedgerRequest{Name: "ledger-b"},
+			}},
+		))
+		require.ErrorIs(t, err, commonpb.ErrNoLeader)
+
+		counts := recordedActionCounts(t, reader)
+		require.Equal(t, int64(2), counts[mActionTotal]["create_ledger"])
+		require.Equal(t, int64(2), counts[mActionErrors]["create_ledger"])
+	})
+
+	t.Run("pre-order failure records nothing (carve-out)", func(t *testing.T) {
+		t.Parallel()
+
+		store := createTestStore(t)
+		a, reader := createTestAdmissionWithReader(t, store, nil)
+
+		// A revert with transaction id 0 is rejected inside requestsToOrders, before
+		// orders exist and before the recorder defer is registered — so no action
+		// counter is touched.
+		_, err := a.Admit(context.Background(), servicepb.UnsignedApplyRequest("", &servicepb.Request{
+			Type: &servicepb.Request_Apply{
+				Apply: &servicepb.LedgerApplyRequest{
+					Ledger: testLedgerName,
+					Action: &servicepb.LedgerAction{
+						Data: &servicepb.LedgerAction_RevertTransaction{
+							RevertTransaction: &servicepb.RevertTransactionPayload{TransactionId: 0},
+						},
+					},
+				},
+			},
+		}))
+		require.ErrorIs(t, err, domain.ErrTransactionTargetMissing)
+
+		counts := recordedActionCounts(t, reader)
+		require.Empty(t, counts[mActionTotal], "no action.total series expected for a pre-order failure")
+		require.Empty(t, counts[mActionErrors], "no action.errors series expected for a pre-order failure")
+	})
+}

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/metrics.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/metrics.libsonnet
@@ -31,6 +31,8 @@
     orders_preparation_duration: 'admission.orders_preparation.duration',
     scripts_duration: 'admission.scripts.duration',
     response_resolution_duration: 'admission.response_resolution.duration',
+    action_total: 'admission.action.total',
+    action_errors_total: 'admission.action.errors.total',
   },
 
   // bloom — internal/infra/bloom/bloom.go


### PR DESCRIPTION
## Summary

Adds two leader-local counters on the admission path, both labelled by `order_type` (`domain.AuditOrderType` — the stable vocabulary shared with the audit filter DSL, EN-1305):

- **`admission.action.total`** `{order_type}` — every order (action) admission processes, counted per order in the batch **regardless of outcome** (attempted actions).
- **`admission.action.errors.total`** `{order_type}` — the **strict subset** whose batch ended in error.

Per-action error rate is then `errors.total / action.total ∈ [0, 1]`.

`admission.command.duration` observes once per batch, so it can't break work down by action. These counters close that gap without adding a histogram.

## Design

- **Counting** is done by a single deferred recorder (`recordActionOutcome`) registered right after the batch's orders are built. `total` increments for every order; `errors` for every order too when `Admit` returns an error.
- **Atomic-batch attribution**: a batch is one Raft command with a single outcome — on failure, every order in it counts as errored under its own `order_type`.
- **Error scope**: all admission-observed errors — admission-side rejections (numscript, preload, validation) *and* FSM business rejections (insufficient funds, conflicts).
- **Carve-out**: failures *before* orders exist (write gate, bad signature, maintenance mode, request→order conversion) have no `order_type` and are not counted.
- **Invariant #2 preserved**: recording lives entirely in `Admit` on the leader; the FSM apply path is untouched.

## Changes

- `internal/application/admission/admission.go` — two `Int64Counter` fields, construction, and the deferred recorder; `Admit` uses named returns so the recorder observes the outcome.
- `internal/application/admission/admission_action_metrics_test.go` — unit tests for the counting logic (success / failure / mixed multi-order) and the `Admit` wiring (real failure paths + carve-out).
- `misc/devenv/monitoring-dashboards/jsonnet/lib/metrics.libsonnet` — registry entries (enforced by `TestMetricsRegistry`).
- `docs/ops/monitoring.md` — new "Action Metrics" subsection.

## Testing

- `just pre-commit` — clean (0 lint issues).
- `just test` — full root-module unit suite green (incl. `TestMetricsRegistry`).

## Ticket

https://formance-team.atlassian.net/browse/EN-1582