### PR TITLE
feat(operator): support multiple DNSEndpoints per Cluster

### DIFF
--- a/misc/operator/api/v1alpha1/cluster_types.go
+++ b/misc/operator/api/v1alpha1/cluster_types.go
@@ -312,9 +312,14 @@ type ClusterSpec struct {
 	// +optional
 	NetworkPolicy *NetworkPolicySpec `json:"networkPolicy,omitempty"`
 
-	// DNSEndpoint configuration for ExternalDNS.
+	// DNSEndpoints configures one or more ExternalDNS DNSEndpoint resources.
+	// Each entry is reconciled into its own DNSEndpoint object, so distinct
+	// endpoints (e.g. a public and a private one) can carry different
+	// annotations. Entries are keyed by their unique name.
 	// +optional
-	DNSEndpoint *DNSEndpointSpec `json:"dnsEndpoint,omitempty"`
+	// +listType=map
+	// +listMapKey=name
+	DNSEndpoints []DNSEndpointSpec `json:"dnsEndpoints,omitempty"`
 
 	// LivenessProbe overrides the default liveness probe for the ledger container.
 	// +optional
@@ -1219,9 +1224,18 @@ type NetworkPolicySpec struct {
 	AdditionalEgress []networkingv1.NetworkPolicyEgressRule `json:"additionalEgress,omitempty"`
 }
 
-// DNSEndpointSpec defines ExternalDNS DNSEndpoint configuration.
-// +kubebuilder:validation:XValidation:rule="!self.enabled || size(self.endpoints) > 0",message="endpoints are required when dnsEndpoint is enabled"
+// DNSEndpointSpec defines a single ExternalDNS DNSEndpoint configuration.
+// +kubebuilder:validation:XValidation:rule="!self.enabled || size(self.endpoints) > 0",message="endpoints are required when the DNSEndpoint is enabled"
 type DNSEndpointSpec struct {
+	// Name is a unique, stable identifier for this DNSEndpoint within the
+	// Cluster. It is used as the suffix of the generated DNSEndpoint object's
+	// name (e.g. "public", "private"), so it must be unique across entries and
+	// a valid DNS-1123 label (it is concatenated into the object's metadata.name).
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	Name string `json:"name"`
+
 	// Enabled enables the DNSEndpoint resource.
 	// +optional
 	Enabled bool `json:"enabled,omitempty"`

--- a/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -779,10 +779,12 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(NetworkPolicySpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DNSEndpoint != nil {
-		in, out := &in.DNSEndpoint, &out.DNSEndpoint
-		*out = new(DNSEndpointSpec)
-		(*in).DeepCopyInto(*out)
+	if in.DNSEndpoints != nil {
+		in, out := &in.DNSEndpoints, &out.DNSEndpoints
+		*out = make([]DNSEndpointSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.LivenessProbe != nil {
 		in, out := &in.LivenessProbe, &out.LivenessProbe

--- a/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
@@ -1231,66 +1231,90 @@ spec:
                   LogLevel takes precedence when both are set; prefer LogLevel for new
                   manifests since it also unlocks the trace level.
                 type: boolean
-              dnsEndpoint:
-                description: DNSEndpoint configuration for ExternalDNS.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to add to the DNSEndpoint resource.
-                    type: object
-                  enabled:
-                    description: Enabled enables the DNSEndpoint resource.
-                    type: boolean
-                  endpoints:
-                    description: Endpoints is the list of DNS endpoint entries.
-                    items:
-                      description: DNSEndpointEntry defines a single DNS endpoint.
-                      properties:
-                        dnsName:
-                          description: DNSName is the hostname for the DNS record.
-                          type: string
-                        providerSpecific:
-                          description: ProviderSpecific holds provider-specific properties.
-                          items:
-                            description: ProviderSpecificProperty defines a provider-specific
-                              key-value pair.
-                            properties:
-                              name:
-                                description: Name is the property name.
-                                type: string
-                              value:
-                                description: Value is the property value.
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        recordTTL:
-                          description: RecordTTL is the TTL in seconds for the DNS
-                            record.
-                          format: int64
-                          type: integer
-                        recordType:
-                          description: RecordType is the DNS record type (e.g., CNAME,
-                            A). Defaults to CNAME.
-                          type: string
-                        targets:
-                          description: Targets is the list of target hostnames or
-                            IPs.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - dnsName
-                      - targets
+              dnsEndpoints:
+                description: |-
+                  DNSEndpoints configures one or more ExternalDNS DNSEndpoint resources.
+                  Each entry is reconciled into its own DNSEndpoint object, so distinct
+                  endpoints (e.g. a public and a private one) can carry different
+                  annotations. Entries are keyed by their unique name.
+                items:
+                  description: DNSEndpointSpec defines a single ExternalDNS DNSEndpoint
+                    configuration.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to add to the DNSEndpoint resource.
                       type: object
-                    type: array
-                type: object
-                x-kubernetes-validations:
-                - message: endpoints are required when dnsEndpoint is enabled
-                  rule: '!self.enabled || size(self.endpoints) > 0'
+                    enabled:
+                      description: Enabled enables the DNSEndpoint resource.
+                      type: boolean
+                    endpoints:
+                      description: Endpoints is the list of DNS endpoint entries.
+                      items:
+                        description: DNSEndpointEntry defines a single DNS endpoint.
+                        properties:
+                          dnsName:
+                            description: DNSName is the hostname for the DNS record.
+                            type: string
+                          providerSpecific:
+                            description: ProviderSpecific holds provider-specific
+                              properties.
+                            items:
+                              description: ProviderSpecificProperty defines a provider-specific
+                                key-value pair.
+                              properties:
+                                name:
+                                  description: Name is the property name.
+                                  type: string
+                                value:
+                                  description: Value is the property value.
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          recordTTL:
+                            description: RecordTTL is the TTL in seconds for the DNS
+                              record.
+                            format: int64
+                            type: integer
+                          recordType:
+                            description: RecordType is the DNS record type (e.g.,
+                              CNAME, A). Defaults to CNAME.
+                            type: string
+                          targets:
+                            description: Targets is the list of target hostnames or
+                              IPs.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - dnsName
+                        - targets
+                        type: object
+                      type: array
+                    name:
+                      description: |-
+                        Name is a unique, stable identifier for this DNSEndpoint within the
+                        Cluster. It is used as the suffix of the generated DNSEndpoint object's
+                        name (e.g. "public", "private"), so it must be unique across entries and
+                        a valid DNS-1123 label (it is concatenated into the object's metadata.name).
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: endpoints are required when the DNSEndpoint is enabled
+                    rule: '!self.enabled || size(self.endpoints) > 0'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               extraEnv:
                 description: ExtraEnv is a list of additional environment variables
                   to inject into ledger containers.

--- a/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
@@ -1231,66 +1231,90 @@ spec:
                   LogLevel takes precedence when both are set; prefer LogLevel for new
                   manifests since it also unlocks the trace level.
                 type: boolean
-              dnsEndpoint:
-                description: DNSEndpoint configuration for ExternalDNS.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to add to the DNSEndpoint resource.
-                    type: object
-                  enabled:
-                    description: Enabled enables the DNSEndpoint resource.
-                    type: boolean
-                  endpoints:
-                    description: Endpoints is the list of DNS endpoint entries.
-                    items:
-                      description: DNSEndpointEntry defines a single DNS endpoint.
-                      properties:
-                        dnsName:
-                          description: DNSName is the hostname for the DNS record.
-                          type: string
-                        providerSpecific:
-                          description: ProviderSpecific holds provider-specific properties.
-                          items:
-                            description: ProviderSpecificProperty defines a provider-specific
-                              key-value pair.
-                            properties:
-                              name:
-                                description: Name is the property name.
-                                type: string
-                              value:
-                                description: Value is the property value.
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                        recordTTL:
-                          description: RecordTTL is the TTL in seconds for the DNS
-                            record.
-                          format: int64
-                          type: integer
-                        recordType:
-                          description: RecordType is the DNS record type (e.g., CNAME,
-                            A). Defaults to CNAME.
-                          type: string
-                        targets:
-                          description: Targets is the list of target hostnames or
-                            IPs.
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - dnsName
-                      - targets
+              dnsEndpoints:
+                description: |-
+                  DNSEndpoints configures one or more ExternalDNS DNSEndpoint resources.
+                  Each entry is reconciled into its own DNSEndpoint object, so distinct
+                  endpoints (e.g. a public and a private one) can carry different
+                  annotations. Entries are keyed by their unique name.
+                items:
+                  description: DNSEndpointSpec defines a single ExternalDNS DNSEndpoint
+                    configuration.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to add to the DNSEndpoint resource.
                       type: object
-                    type: array
-                type: object
-                x-kubernetes-validations:
-                - message: endpoints are required when dnsEndpoint is enabled
-                  rule: '!self.enabled || size(self.endpoints) > 0'
+                    enabled:
+                      description: Enabled enables the DNSEndpoint resource.
+                      type: boolean
+                    endpoints:
+                      description: Endpoints is the list of DNS endpoint entries.
+                      items:
+                        description: DNSEndpointEntry defines a single DNS endpoint.
+                        properties:
+                          dnsName:
+                            description: DNSName is the hostname for the DNS record.
+                            type: string
+                          providerSpecific:
+                            description: ProviderSpecific holds provider-specific
+                              properties.
+                            items:
+                              description: ProviderSpecificProperty defines a provider-specific
+                                key-value pair.
+                              properties:
+                                name:
+                                  description: Name is the property name.
+                                  type: string
+                                value:
+                                  description: Value is the property value.
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          recordTTL:
+                            description: RecordTTL is the TTL in seconds for the DNS
+                              record.
+                            format: int64
+                            type: integer
+                          recordType:
+                            description: RecordType is the DNS record type (e.g.,
+                              CNAME, A). Defaults to CNAME.
+                            type: string
+                          targets:
+                            description: Targets is the list of target hostnames or
+                              IPs.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - dnsName
+                        - targets
+                        type: object
+                      type: array
+                    name:
+                      description: |-
+                        Name is a unique, stable identifier for this DNSEndpoint within the
+                        Cluster. It is used as the suffix of the generated DNSEndpoint object's
+                        name (e.g. "public", "private"), so it must be unique across entries and
+                        a valid DNS-1123 label (it is concatenated into the object's metadata.name).
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: endpoints are required when the DNSEndpoint is enabled
+                    rule: '!self.enabled || size(self.endpoints) > 0'
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               extraEnv:
                 description: ExtraEnv is a list of additional environment variables
                   to inject into ledger containers.

--- a/misc/operator/internal/controller/hash.go
+++ b/misc/operator/internal/controller/hash.go
@@ -27,7 +27,7 @@ func computeSpecHash(spec *ledgerv1alpha1.ClusterSpec) string {
 	cp.Ingress = nil
 	cp.IngressGrpc = nil
 	cp.NetworkPolicy = nil
-	cp.DNSEndpoint = nil
+	cp.DNSEndpoints = nil
 
 	// DeletionProtection only drives PVC/PV label patches (reconcileVolumeProtection);
 	// it has no pod-template effect, so toggling it must not roll the StatefulSet.

--- a/misc/operator/internal/controller/hash_test.go
+++ b/misc/operator/internal/controller/hash_test.go
@@ -31,10 +31,10 @@ func TestComputeSpecHash_ExcludesNonPodFields(t *testing.T) {
 	withGrpcIngress.IngressGrpc = &ledgerv1alpha1.IngressGrpcSpec{Enabled: true}
 	assert.Equal(t, baseHash, computeSpecHash(withGrpcIngress), "IngressGrpc change should not affect hash")
 
-	// Changing DNSEndpoint should NOT change the hash.
+	// Changing DNSEndpoints should NOT change the hash.
 	withDNS := base.DeepCopy()
-	withDNS.DNSEndpoint = &ledgerv1alpha1.DNSEndpointSpec{Enabled: true}
-	assert.Equal(t, baseHash, computeSpecHash(withDNS), "DNSEndpoint change should not affect hash")
+	withDNS.DNSEndpoints = []ledgerv1alpha1.DNSEndpointSpec{{Name: "public", Enabled: true}}
+	assert.Equal(t, baseHash, computeSpecHash(withDNS), "DNSEndpoints change should not affect hash")
 
 	// Changing Replicas should NOT change the hash.
 	withReplicas := base.DeepCopy()

--- a/misc/operator/internal/controller/names.go
+++ b/misc/operator/internal/controller/names.go
@@ -24,9 +24,18 @@ func prefixedName(crName string) string {
 }
 
 // resourceName is the base name for the primary objects of a Cluster:
-// the StatefulSet, ClusterIP Service, Ingress, NetworkPolicy and DNSEndpoint.
+// the StatefulSet, ClusterIP Service, Ingress and NetworkPolicy. DNSEndpoint
+// objects derive their names from it via dnsEndpointName.
 func resourceName(crName string) string {
 	return prefixedName(crName)
+}
+
+// dnsEndpointName returns the DNSEndpoint object name for the entry identified
+// by epName within a Cluster. Each spec.dnsEndpoints entry is reconciled into
+// its own DNSEndpoint object, so its name is suffixed with the entry's unique
+// name to keep the objects distinct.
+func dnsEndpointName(crName, epName string) string {
+	return resourceName(crName) + "-" + epName
 }
 
 // headlessServiceName returns the headless Service name for a Cluster.

--- a/misc/operator/internal/controller/reconcile_dnsendpoint.go
+++ b/misc/operator/internal/controller/reconcile_dnsendpoint.go
@@ -4,55 +4,74 @@ import (
 	"context"
 	"maps"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
 )
 
+var dnsEndpointGVK = schema.GroupVersionKind{
+	Group:   "externaldns.k8s.io",
+	Version: "v1alpha1",
+	Kind:    "DNSEndpoint",
+}
+
+// reconcileDNSEndpoint reconciles the set of ExternalDNS DNSEndpoint objects for
+// a Cluster. Each spec.dnsEndpoints entry becomes its own DNSEndpoint object so
+// that, for example, a public and a private endpoint can carry different
+// annotations. Entries that are disabled or carry no endpoints are not created,
+// and any previously-created DNSEndpoint object no longer desired is deleted.
 func (r *ClusterReconciler) reconcileDNSEndpoint(ctx context.Context, ledger *ledgerv1alpha1.Cluster) error {
-	gvk := schema.GroupVersionKind{
-		Group:   "externaldns.k8s.io",
-		Version: "v1alpha1",
-		Kind:    "DNSEndpoint",
+	desired := make(map[string]struct{}, len(ledger.Spec.DNSEndpoints))
+
+	for i := range ledger.Spec.DNSEndpoints {
+		spec := &ledger.Spec.DNSEndpoints[i]
+		if !spec.Enabled {
+			continue
+		}
+
+		endpoints := make([]any, 0, len(spec.Endpoints))
+		for _, ep := range spec.Endpoints {
+			endpoints = append(endpoints, buildEndpointEntry(ep))
+		}
+		if len(endpoints) == 0 {
+			continue
+		}
+
+		name := dnsEndpointName(ledger.Name, spec.Name)
+		desired[name] = struct{}{}
+
+		if err := r.applyDNSEndpoint(ctx, ledger, name, spec.Annotations, endpoints); err != nil {
+			return err
+		}
 	}
 
-	if ledger.Spec.DNSEndpoint == nil || !ledger.Spec.DNSEndpoint.Enabled {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(gvk)
-		obj.SetName(resourceName(ledger.Name))
-		obj.SetNamespace(ledger.Namespace)
+	return r.pruneDNSEndpoints(ctx, ledger, desired)
+}
 
-		return r.deleteUnstructuredIfExists(ctx, obj)
-	}
-
-	var endpoints []any
+// applyDNSEndpoint creates or updates a single DNSEndpoint object.
+func (r *ClusterReconciler) applyDNSEndpoint(
+	ctx context.Context,
+	ledger *ledgerv1alpha1.Cluster,
+	name string,
+	specAnnotations map[string]string,
+	endpoints []any,
+) error {
 	annotations := make(map[string]string)
-	maps.Copy(annotations, ledger.Spec.DNSEndpoint.Annotations)
-
-	for _, ep := range ledger.Spec.DNSEndpoint.Endpoints {
-		endpoints = append(endpoints, buildEndpointEntry(ep))
-	}
-
-	if len(endpoints) == 0 {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(gvk)
-		obj.SetName(resourceName(ledger.Name))
-		obj.SetNamespace(ledger.Namespace)
-
-		return r.deleteUnstructuredIfExists(ctx, obj)
-	}
+	maps.Copy(annotations, specAnnotations)
 
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(gvk)
-	obj.SetName(resourceName(ledger.Name))
+	obj.SetGroupVersionKind(dnsEndpointGVK)
+	obj.SetName(name)
 	obj.SetNamespace(ledger.Namespace)
 
-	// Fetch existing to merge.
-	_ = r.Get(ctx, types.NamespacedName{Name: resourceName(ledger.Name), Namespace: ledger.Namespace}, obj)
-
+	// CreateOrUpdate fetches the current object internally before invoking the
+	// mutate function, so no explicit pre-Get is needed. Labels and annotations
+	// are authoritatively (re)set: the operator owns the full metadata surface
+	// of the DNSEndpoint objects it creates.
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, obj, func() error {
 		obj.SetLabels(commonLabels(ledger))
 		obj.SetAnnotations(annotations)
@@ -65,6 +84,44 @@ func (r *ClusterReconciler) reconcileDNSEndpoint(ctx context.Context, ledger *le
 	})
 
 	return err
+}
+
+// pruneDNSEndpoints deletes DNSEndpoint objects owned by the Cluster that are no
+// longer in the desired set (an entry was removed, renamed, disabled, or left
+// with no endpoints).
+//
+// Discovery lists by the non-overridable managed-by label only: the instance
+// label is user-overridable via spec.additionalLabels (see selectorLabels), so
+// it cannot be trusted to find every object this reconciler created. Ownership
+// is then established authoritatively via the controller owner reference stamped
+// by SetControllerReference — a label match alone is never sufficient to delete,
+// so a manually-labeled DNSEndpoint the operator does not control is left alone.
+func (r *ClusterReconciler) pruneDNSEndpoints(ctx context.Context, ledger *ledgerv1alpha1.Cluster, desired map[string]struct{}) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(dnsEndpointGVK)
+
+	if err := r.List(ctx, list,
+		client.InNamespace(ledger.Namespace),
+		client.MatchingLabels{labelManagedBy: "ledger-operator"},
+	); err != nil {
+		// The DNSEndpoint CRD may not be installed (NoKindMatch); nothing to prune.
+		return ignoreNotFound(err)
+	}
+
+	for i := range list.Items {
+		obj := &list.Items[i]
+		if _, ok := desired[obj.GetName()]; ok {
+			continue
+		}
+		if !metav1.IsControlledBy(obj, ledger) {
+			continue
+		}
+		if err := r.deleteUnstructuredIfExists(ctx, obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func buildEndpointEntry(ep ledgerv1alpha1.DNSEndpointEntry) map[string]any {


### PR DESCRIPTION
## What

Changes the Cluster CRD field `dnsEndpoint` (a single `*DNSEndpointSpec`) into `dnsEndpoints` (a slice), so distinct ExternalDNS endpoints — e.g. a **public** and a **private** one — can each carry their own annotations.

```yaml
dnsEndpoints:
  - name: private
    enabled: true
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
    endpoints: [...]
  - name: public
    enabled: true
    annotations: { ... }   # different annotations
    endpoints: [...]
```

## How

- **API** (`cluster_types.go`): `DNSEndpoint *DNSEndpointSpec` → `DNSEndpoints []DNSEndpointSpec`, annotated `+listType=map` / `+listMapKey=name` (K8s-enforced name uniqueness). New required `name` field, validated as a DNS-1123 label (`MinLength=1`, `MaxLength=63`, pattern) since it becomes the suffix of the generated object's `metadata.name`.
- **Naming** (`names.go`): new `dnsEndpointName(crName, epName)` → `ledger-<cr>-<name>` (e.g. `ledger-foo-public`).
- **Reconcile** (`reconcile_dnsendpoint.go`): creates one `DNSEndpoint` object per enabled entry that has endpoints. New `pruneDNSEndpoints` lists objects by the **non-overridable** `managed-by` label and deletes only those this Cluster **controls** (owner reference) and no longer desires — never on a label match alone (the `instance` label is user-overridable via `spec.additionalLabels`).
- `hash.go` unchanged in intent: `dnsEndpoints` stays excluded from the pod-template spec hash (does not roll the StatefulSet).
- Regenerated `zz_generated.deepcopy.go` + CRD (`config/crd/bases` and synced `helm/crds`).

## Review

Reviewed by Codex; addressed the owner-reference prune safety, the DNS-1123 name validation, and removed a redundant pre-`Get`.

## ⚠️ Breaking change / migration

This is a **hard field rename** with no back-compat shim. On upgrade, an existing Cluster still carrying the old `spec.dnsEndpoint` deserializes with an empty slice, so its previously-created `ledger-<cr>` DNSEndpoint object is **pruned**. Existing CRs must be migrated to `dnsEndpoints` (and the object is renamed to `ledger-<cr>-<name>`). Say the word if a deprecation shim is preferred instead.

## Verification

- `just generate` ✅
- `go build ./...` ✅
- `go test ./internal/controller/ ./api/...` ✅

## Not tested

No dedicated `reconcile_dnsendpoint` tests yet (multi-entry create, annotation retention, disable/rename prune, owner-reference deletion guard).