### PR TITLE
fix: correct trailing ':' / '...' account-address matching semantics

### DIFF
--- a/internal/storage/ledger/accounts_test.go
+++ b/internal/storage/ledger/accounts_test.go
@@ -548,3 +548,50 @@ func TestAccountsUpsert(t *testing.T) {
 	err = store.UpsertAccounts(ctx, ledger.AccountWithDefaultMetadata{Account: &account1})
 	require.NoError(t, err)
 }
+
+// TestAccountsListAddressSegmentMatching pins the trailing-segment matching
+// semantics: "foo:" matches exactly one level deeper, "foo::" matches exactly
+// two levels deeper, and "foo:..." matches the whole subtree. All address-filtered
+// endpoints (accounts / volumes / aggregate-balances) share filterAccountAddress,
+// so covering accounts is enough to guard the behavior.
+func TestAccountsListAddressSegmentMatching(t *testing.T) {
+	t.Parallel()
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+
+	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
+		"foo:a":     {"seg": "1"},
+		"foo:d":     {"seg": "1"},
+		"foo:a:b":   {"seg": "1"},
+		"foo:a:b:c": {"seg": "1"},
+	}, time.Time{}))
+
+	addresses := func(t *testing.T, address string) []string {
+		accounts, err := store.Accounts().Paginate(ctx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.Match("address", address),
+			},
+		})
+		require.NoError(t, err)
+		result := make([]string, len(accounts.Data))
+		for i, account := range accounts.Data {
+			result[i] = account.Address
+		}
+		return result
+	}
+
+	t.Run("trailing colon matches one level deeper only", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a", "foo:d"}, addresses(t, "foo:"))
+	})
+
+	t.Run("double trailing colon matches two levels deeper only", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a:b"}, addresses(t, "foo::"))
+	})
+
+	t.Run("trailing ellipsis matches the whole subtree", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a", "foo:d", "foo:a:b", "foo:a:b:c"}, addresses(t, "foo:..."))
+	})
+}

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -457,7 +457,7 @@ func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
 		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledger.GetAggregatedVolumesOptions]{
 			PIT: pointer.For(now.Add(time.Minute)),
 			Builder: query.And(
-				query.Match("address", "merchant:"),
+				query.Match("address", "merchant:..."),
 				query.Match("metadata[trust]", "true"),
 			),
 		})

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -43,7 +43,7 @@ func filterAccountAddress(address, key string) string {
 
 	if isPartialAddress(address) {
 		src := strings.Split(address, ":")
-		if src[len(src)-1] != "" {
+		if src[len(src)-1] != "..." {
 			parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, len(src)))
 		}
 

--- a/internal/storage/ledger/utils_test.go
+++ b/internal/storage/ledger/utils_test.go
@@ -244,25 +244,27 @@ func TestFilterAccountAddress_NormalCases(t *testing.T) {
 		assert.Equal(t, "address = 'users:alice'", result)
 	})
 
-	t.Run("partial address with trailing colon matches on segment", func(t *testing.T) {
+	t.Run("partial address with trailing colon matches one level deeper", func(t *testing.T) {
 		t.Parallel()
+		// "users:" means exactly 2 segments with "users" at position 0
 		result := filterAccountAddress("users:", "address")
-		assert.Equal(t, `address_array @@ ('$[0] == "users"')::jsonpath`, result)
+		assert.Equal(t, `jsonb_array_length(address_array) = 2 and address_array @@ ('$[0] == "users"')::jsonpath`, result)
 	})
 
 	t.Run("partial address with two fixed segments", func(t *testing.T) {
 		t.Parallel()
 		result := filterAccountAddress("users:alice:", "address")
+		assert.Contains(t, result, "jsonb_array_length(address_array) = 3")
 		assert.Contains(t, result, `$[0] == "users"`)
 		assert.Contains(t, result, `$[1] == "alice"`)
 	})
 
-	t.Run("wildcard suffix constrains length and segment", func(t *testing.T) {
+	t.Run("wildcard suffix matches the whole subtree", func(t *testing.T) {
 		t.Parallel()
-		// "users:..." means exactly 2 segments with "users" at position 0
+		// "users:..." means "users" at position 0 with any number of segments
 		result := filterAccountAddress("users:...", "address")
-		assert.Contains(t, result, "jsonb_array_length(address_array) = 2")
-		assert.Contains(t, result, `$[0] == "users"`)
+		assert.Equal(t, `address_array @@ ('$[0] == "users"')::jsonpath`, result)
+		assert.NotContains(t, result, "jsonb_array_length")
 	})
 
 	t.Run("key prefix is applied correctly", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Account-address segment matching was **inverted** between endpoints. `filterAccountAddress` (accounts / volumes / aggregate-balances) treated the trailing matchers as the reverse of `filterAccountAddressOnTransactions` (transactions):

|                          | trailing `:` | trailing `...` |
|--------------------------|--------------|----------------|
| transactions             | one level (correct) | full subtree (correct) |
| accounts/volumes/agg-bal | full subtree (**wrong**) | one level (**wrong**) |

Intended semantics: `foo:` matches only `foo:xxx` (exactly one level deeper); `foo:...` matches the whole `foo:` subtree.

## Root cause

In `filterAccountAddress`, a trailing `:` leaves an empty final split segment, so the `jsonb_array_length = len(src)` constraint was skipped → unbounded subtree; a trailing `...` is a non-empty segment, so the length constraint was added → pinned to one level. Exactly backwards from the null-terminator logic in `filterAccountAddressOnTransactions`.

## Fix

Add the length constraint when the address does **not** end in `...` (was: does not end in `""`), mirroring the transactions path. Now `foo:` → one level, `foo::` → two levels, `foo:...` → whole subtree, consistently across all endpoints.

## Tests

- Updated the `utils_test.go` unit assertions that encoded the inverted behavior.
- Added `TestAccountsListAddressSegmentMatching` (integration) asserting `foo:`→one level, `foo::`→two levels, `foo:...`→subtree on nested data — the coverage gap that let this through.
- `TestBalancesAggregatesPITWithMetadataHistoryDisabled` depended on the old behavior (filtered a 3-segment account with `merchant:` expecting a subtree match) → updated to `merchant:...`.
- Full `internal/storage/ledger` `it` suite passes; e2e partial-address cases verified unaffected (all use one-level-deep accounts).

## Note

This changes behavior on a released v2 endpoint (`:` on accounts/volumes/aggregate-balances changes from subtree → one level) and should ship with a changelog callout. The [filtering-queries docs](https://docs.formance.com/modules/ledger/working-with/filtering-queries) also describe both matchers identically and need correcting (separate repo).

Closes #1612