### PR TITLE
fix(backup): drop hardcoded "backups/" segment from S3 keys

### DIFF
--- a/cmd/ledgerctl/store/bootstrap.go
+++ b/cmd/ledgerctl/store/bootstrap.go
@@ -90,7 +90,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 		bucketID = "default"
 	}
 
-	manifestKey := bucketID + "/backups/manifest.json"
+	manifestKey := backup.ManifestKey(bucketID)
 
 	// Read manifest
 	spinner, _ := pterm.DefaultSpinner.Start("Reading backup manifest...")

--- a/cmd/ledgerctl/store/bootstrap.go
+++ b/cmd/ledgerctl/store/bootstrap.go
@@ -90,7 +90,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 		bucketID = "default"
 	}
 
-	manifestKey := bucketID + "/backups/manifest.json"
+	manifestKey := backup.ManifestKey(bucketID)
 
 	// Read manifest
 	spinner := cmdutil.StartSpinner("Reading backup manifest...")

--- a/internal/adapter/grpc/server_restore_download.go
+++ b/internal/adapter/grpc/server_restore_download.go
@@ -216,7 +216,7 @@ func (s *RestoreServiceServerImpl) prepareDownload(
 		bucketID = s.clusterID
 	}
 
-	manifestKey := bucketID + "/backups/manifest.json"
+	manifestKey := backup.ManifestKey(bucketID)
 
 	manifestReader, err := storage.GetFile(ctx, manifestKey)
 	if err != nil {

--- a/internal/infra/backup/manifest.go
+++ b/internal/infra/backup/manifest.go
@@ -187,7 +187,7 @@ func WriteManifest(ctx context.Context, storage Storage, key string, manifest *M
 
 // ManifestKey returns the S3 key for the manifest file.
 func ManifestKey(bucketID string) string {
-	return bucketID + "/backups/manifest.json"
+	return bucketID + "/manifest.json"
 }
 
 // ReadManifestOrEmpty reads a manifest from storage, returning an empty

--- a/internal/infra/backup/manifest_test.go
+++ b/internal/infra/backup/manifest_test.go
@@ -43,14 +43,14 @@ func TestReadManifest_CurrentFormatDecodes(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage := NewMockStorage(ctrl)
 
-	current := `{"checkpoint":{"timestamp":"t","lastAppliedIndex":1,"lastLogSequence":1,"lastAuditSequence":1,"files":{"000001.sst":{"size":123,"key":"b/backups/data/000001.sst.abc"}}},"exports":null}`
+	current := `{"checkpoint":{"timestamp":"t","lastAppliedIndex":1,"lastLogSequence":1,"lastAuditSequence":1,"files":{"000001.sst":{"size":123,"key":"b/data/000001.sst.abc"}}},"exports":null}`
 	storage.EXPECT().GetFile(gomock.Any(), "k").
 		Return(io.NopCloser(bytes.NewReader([]byte(current))), nil)
 
 	m, err := ReadManifest(context.Background(), storage, "k")
 	require.NoError(t, err)
 	require.NotNil(t, m.Checkpoint)
-	require.Equal(t, "b/backups/data/000001.sst.abc", m.Checkpoint.Files["000001.sst"].Key)
+	require.Equal(t, "b/data/000001.sst.abc", m.Checkpoint.Files["000001.sst"].Key)
 	require.EqualValues(t, 123, m.Checkpoint.Files["000001.sst"].Size)
 }
 

--- a/internal/infra/backup/segment.go
+++ b/internal/infra/backup/segment.go
@@ -10,12 +10,12 @@ import "fmt"
 
 // ExportLogSegmentKey returns the S3 key for part `part` of a log export.
 func ExportLogSegmentKey(bucketID string, startSeq, endSeq uint64, part int) string {
-	return fmt.Sprintf("%s/backups/exports/logs-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
+	return fmt.Sprintf("%s/exports/logs-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
 }
 
 // ExportAuditSegmentKey returns the S3 key for part `part` of an audit-entry export.
 func ExportAuditSegmentKey(bucketID string, startSeq, endSeq uint64, part int) string {
-	return fmt.Sprintf("%s/backups/exports/audit-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
+	return fmt.Sprintf("%s/exports/audit-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
 }
 
 // ExportAuditItemSegmentKey returns the S3 key for part `part` of an audit-item
@@ -23,7 +23,7 @@ func ExportAuditSegmentKey(bucketID string, startSeq, endSeq uint64, part int) s
 // live in a separate subzone from audit entries and must be exported alongside
 // them, or a restored incremental backup cannot reconstruct the hash chain.
 func ExportAuditItemSegmentKey(bucketID string, startSeq, endSeq uint64, part int) string {
-	return fmt.Sprintf("%s/backups/exports/audit-items-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
+	return fmt.Sprintf("%s/exports/audit-items-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
 }
 
 // ExportAppliedProposalSegmentKey returns the S3 key for part `part` of an
@@ -32,7 +32,7 @@ func ExportAuditItemSegmentKey(bucketID string, startSeq, endSeq uint64, part in
 // without this segment would leave the index builder unable to learn the
 // transient-account exclusion set for replayed logs.
 func ExportAppliedProposalSegmentKey(bucketID string, startSeq, endSeq uint64, part int) string {
-	return fmt.Sprintf("%s/backups/exports/applied-proposals-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
+	return fmt.Sprintf("%s/exports/applied-proposals-%020d-%020d-%05d.bin", bucketID, startSeq, endSeq, part)
 }
 
 // CheckpointFileKey returns the content-addressed S3 key for a checkpoint file.
@@ -52,10 +52,10 @@ func CheckpointFileKey(bucketID, filename, contentHash string) string {
 
 // CheckpointPrefix returns the key prefix shared by every checkpoint file.
 func CheckpointPrefix(bucketID string) string {
-	return bucketID + "/backups/data/"
+	return bucketID + "/data/"
 }
 
 // ExportPrefix returns the key prefix shared by every export segment.
 func ExportPrefix(bucketID string) string {
-	return bucketID + "/backups/exports/"
+	return bucketID + "/exports/"
 }

--- a/tests/e2e/business/backup_azure_test.go
+++ b/tests/e2e/business/backup_azure_test.go
@@ -30,8 +30,8 @@ const (
 	azuriteAccountKey  = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 
 	backupAzureContainer = "backup-e2e"
-	azureManifestKey     = "test-cluster/backups/manifest.json"
-	azureBackupDataPfx   = "test-cluster/backups/data/"
+	azureManifestKey     = "test-cluster/manifest.json"
+	azureBackupDataPfx   = "test-cluster/data/"
 )
 
 // readAzureBackupManifest fetches and parses the backup manifest from Azure Blob.

--- a/tests/e2e/business/backup_s3_test.go
+++ b/tests/e2e/business/backup_s3_test.go
@@ -33,8 +33,8 @@ const (
 	backupMinioSecretKey = "minioadmin"
 	backupS3Bucket       = "backup-e2e"
 	backupS3Region       = "us-east-1"
-	backupManifestKey    = "test-cluster/backups/manifest.json"
-	backupS3DataPrefix   = "test-cluster/backups/data/"
+	backupManifestKey    = "test-cluster/manifest.json"
+	backupS3DataPrefix   = "test-cluster/data/"
 )
 
 // readS3BackupManifest fetches and parses the backup manifest from S3.
@@ -247,7 +247,7 @@ var _ = Describe("S3 Backup", Ordered, func() {
 		// manifest nor any export segment.
 		_, getErr := s3Client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: aws.String(backupS3Bucket),
-			Key:    aws.String("no-prior/backups/manifest.json"),
+			Key:    aws.String("no-prior/manifest.json"),
 		})
 		Expect(getErr).To(HaveOccurred(),
 			"no manifest must be published for a rejected checkpoint-less incremental backup")

--- a/tests/e2e/cluster/restore_test.go
+++ b/tests/e2e/cluster/restore_test.go
@@ -48,7 +48,7 @@ const (
 func readS3Manifest(ctx context.Context, client *s3.Client) (*backup.Manifest, error) {
 	out, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(restoreS3Bucket),
-		Key:    aws.String("test-cluster/backups/manifest.json"),
+		Key:    aws.String("test-cluster/manifest.json"),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Removes the redundant hardcoded `backups/` path segment from backup S3 object keys.

Since `bucketID` already namespaces every object under the destination S3 bucket, the extra `backups/` middle segment added nothing. Keys are now flat under the `bucketID` prefix:

| Object | Before | After |
|---|---|---|
| Manifest | `<bucketID>/backups/manifest.json` | `<bucketID>/manifest.json` |
| Checkpoints | `<bucketID>/backups/data/…` | `<bucketID>/data/…` |
| Exports | `<bucketID>/backups/exports/…` | `<bucketID>/exports/…` |

Also routes `bootstrap.go` through `backup.ManifestKey()` instead of re-deriving the manifest key inline (DRY).

## Files

- `internal/infra/backup/segment.go` — 6 key builders (`ExportLogSegmentKey`, `ExportAuditSegmentKey`, `ExportAuditItemSegmentKey`, `ExportAppliedProposalSegmentKey`, `CheckpointPrefix`, `ExportPrefix`)
- `internal/infra/backup/manifest.go` — `ManifestKey`
- `cmd/ledgerctl/store/bootstrap.go` — use `backup.ManifestKey()` helper
- `internal/infra/backup/manifest_test.go` — updated round-trip literal to new layout

## ⚠️ Breaking layout change

Backups already written under the old `.../backups/...` keys are **not** found by this code. Fine for greenfield; needs a migration story if pre-existing backups must be read.

## Not touched

Cold storage shares the same `bucketID` root but keeps its own `chapters/` segment (`<bucketID>/chapters/<chapterID>/archive.sst`). Left as-is — no collision since the sub-prefixes differ. Can follow up for symmetry if desired.

## Test plan

- [x] `go build ./internal/infra/backup/... ./cmd/ledgerctl/...`
- [x] `go test ./internal/infra/backup/...` (green)
- [ ] Reading a backup written by a pre-change client (intentionally not covered — breaking change)