### PR TITLE
fix(query): read archived transactions from cold storage in GetTransaction

### DIFF
--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -349,8 +349,16 @@ func (impl *BucketServiceServerImpl) GetTransaction(ctx context.Context, req *se
 		if impl.receiptSigner != nil {
 			// Checkpoint read: sign from the checkpoint's fixed store so the
 			// receipt's ledger + creation-log reads stay self-consistent with the
-			// transaction, which was read from that same store.
-			receiptToken, cErr := impl.localCtrl.ComputeTransactionReceipt(ctx, mainStore, req.GetLedger(), req.GetTransactionId(), tx)
+			// transaction, which was read from that same store. A read handle (not
+			// the raw store) so the creation-log lookup's cold-storage fallback can
+			// scan chapters.
+			receiptHandle, hErr := mainStore.NewReadHandle()
+			if hErr != nil {
+				return nil, fmt.Errorf("opening checkpoint receipt read handle: %w", hErr)
+			}
+
+			receiptToken, cErr := impl.localCtrl.ComputeTransactionReceipt(ctx, receiptHandle, req.GetLedger(), req.GetTransactionId(), tx)
+			_ = receiptHandle.Close()
 			if cErr != nil {
 				return nil, fmt.Errorf("computing transaction receipt: %w", cErr)
 			}

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -231,17 +231,18 @@ func (ctrl *DefaultController) GetTransaction(ctx context.Context, ledgerName st
 // no receipt: no creation log in this store (archived/purged), or a
 // non-created creation log (e.g. a reversal). The caller must have verified the
 // signer is non-nil.
-func (ctrl *DefaultController) ComputeTransactionReceipt(ctx context.Context, reader dal.PebbleGetter, ledger string, txID uint64, tx *commonpb.Transaction) (string, error) {
+func (ctrl *DefaultController) ComputeTransactionReceipt(ctx context.Context, reader dal.PebbleReader, ledger string, txID uint64, tx *commonpb.Transaction) (string, error) {
 	ledgerInfo, err := query.GetLedgerByName(ctx, reader, ledger)
 	if err != nil {
 		return "", err
 	}
 
-	log, err := query.FindTransactionCreationLog(ctx, reader, ctrl.attrs.Transaction, ledgerInfo.GetName(), txID)
+	log, err := query.FindTransactionCreationLog(ctx, reader, ctrl.coldReader, ctrl.attrs.Transaction, ledgerInfo.GetName(), txID)
 	if errors.Is(err, domain.ErrNotFound) {
-		// No creation log for this transaction in this store (e.g. its log was
-		// archived/purged). The transaction is still readable; it just has no
-		// receipt. Not an error.
+		// No creation log found in hot or cold storage — cold storage disabled,
+		// or the log genuinely absent. The transaction is still readable from its
+		// state; it just has no receipt. Not an error. (An archived transaction's
+		// log IS found via the cold fallback, so it keeps its receipt.)
 		return "", nil
 	}
 
@@ -315,14 +316,18 @@ func (ctrl *DefaultController) buildTransaction(ctx context.Context, reader dal.
 		return nil, commonpb.NewNotFoundError("transaction %d not found", transactionID)
 	}
 
-	return assembleTransactionFromState(ctx, reader, transactionID, state)
+	return assembleTransactionFromState(ctx, reader, ctrl.coldReader, transactionID, state)
 }
 
 // assembleTransactionFromState builds a transaction from its TransactionState and the creation log.
 // Metadata values are returned verbatim — declared_type is an index hint, not
 // an API contract, so reads do not coerce.
-func assembleTransactionFromState(ctx context.Context, reader dal.PebbleReader, transactionID uint64, state *commonpb.TransactionState) (*commonpb.Transaction, error) {
-	log, err := query.ReadLogBySequence(ctx, reader, state.GetCreatedByLog())
+func assembleTransactionFromState(ctx context.Context, reader dal.PebbleReader, coldReader *coldstorage.ColdReader, transactionID uint64, state *commonpb.TransactionState) (*commonpb.Transaction, error) {
+	// Cold-storage fallback so a transaction whose creation log lives in an
+	// archived-and-purged chapter is still assembled from the cold-stored log
+	// (which carries the reference / post-commit volumes the attribute-zone
+	// state does not), rather than reported NotFound.
+	log, err := query.ReadLogBySequenceWithCold(ctx, reader, coldReader, state.GetCreatedByLog())
 	if err != nil {
 		return nil, fmt.Errorf("getting system log %d: %w", state.GetCreatedByLog(), err)
 	}

--- a/internal/infra/state/batch_extended_test.go
+++ b/internal/infra/state/batch_extended_test.go
@@ -339,18 +339,22 @@ func TestFindTransactionCreationLog(t *testing.T) {
 	}}
 	appendLogs(t, s, 1, logs...)
 
-	// Find the creation log
-	log, err := query.FindTransactionCreationLog(context.Background(), s, txAttr, "test", 1)
+	reader, err := s.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reader.Close() })
+
+	// Find the creation log. Nil cold reader: hot-only lookup.
+	log, err := query.FindTransactionCreationLog(context.Background(), reader, nil, txAttr, "test", 1)
 	require.NoError(t, err)
 	require.NotNil(t, log)
 	require.Equal(t, uint64(5), log.GetSequence())
 
 	// Non-existent transaction should return ErrNotFound
-	_, err = query.FindTransactionCreationLog(context.Background(), s, txAttr, "test", 999)
+	_, err = query.FindTransactionCreationLog(context.Background(), reader, nil, txAttr, "test", 999)
 	require.ErrorIs(t, err, domain.ErrNotFound)
 
 	// Non-existent ledger should return error
-	_, err = query.FindTransactionCreationLog(context.Background(), s, txAttr, "other", 1)
+	_, err = query.FindTransactionCreationLog(context.Background(), reader, nil, txAttr, "other", 1)
 	require.Error(t, err)
 }
 

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
@@ -33,8 +34,10 @@ func ReadTransactionState(ctx context.Context, reader dal.PebbleGetter, attrs *a
 }
 
 // FindTransactionCreationLog returns the system log that created a transaction.
-// It reads the TransactionState to find the creation log sequence.
-func FindTransactionCreationLog(ctx context.Context, reader dal.PebbleGetter, attrs *attributes.Attribute[*commonpb.TransactionState], ledgerName string, txID uint64) (*commonpb.Log, error) {
+// It reads the TransactionState to find the creation log sequence, then reads
+// that log with a cold-storage fallback so the creation log of a transaction
+// whose chapter has been archived (and purged from hot storage) is still found.
+func FindTransactionCreationLog(ctx context.Context, reader dal.PebbleReader, coldReader *coldstorage.ColdReader, attrs *attributes.Attribute[*commonpb.TransactionState], ledgerName string, txID uint64) (*commonpb.Log, error) {
 	state, err := ReadTransactionState(ctx, reader, attrs, ledgerName, txID)
 	if err != nil {
 		return nil, fmt.Errorf("reading transaction state for %d: %w", txID, err)
@@ -44,7 +47,7 @@ func FindTransactionCreationLog(ctx context.Context, reader dal.PebbleGetter, at
 		return nil, domain.ErrNotFound
 	}
 
-	log, err := ReadLogBySequence(ctx, reader, state.GetCreatedByLog())
+	log, err := ReadLogBySequenceWithCold(ctx, reader, coldReader, state.GetCreatedByLog())
 	if err != nil {
 		return nil, fmt.Errorf("getting system log %d: %w", state.GetCreatedByLog(), err)
 	}

--- a/tests/e2e/business/get_transaction_cold_test.go
+++ b/tests/e2e/business/get_transaction_cold_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// Once a transaction's chapter is archived, its creation log is purged from hot
+// storage. GetTransaction rebuilds the transaction from that log (the
+// attribute-zone state carries no reference / post-commit volumes), so without a
+// cold-storage fallback it returns NotFound for an archived transaction — even
+// though the log is safe in cold storage and GetLog can still read it. This
+// pins that GetTransaction (and its receipt) fall back to cold storage, so an
+// archived transaction stays fully readable.
+var _ = Describe("GetTransaction reads archived transactions from cold storage", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const (
+		httpPort = 15702
+		grpcPort = 15802
+		ledger   = "get-tx-cold"
+		txRef    = "cold-tx-ref"
+		txID     = 1 // first transaction in a fresh ledger
+	)
+
+	BeforeAll(func() {
+		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort,
+			testserver.WithColdStorageDriver("filesystem"),
+			testserver.WithReceiptSigningKey("get-tx-cold-receipt-key"),
+		)
+	})
+
+	It("returns the full transaction and its receipt after its chapter is archived", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		// A referenced transaction: reference lives only in the creation log, so
+		// it is the field a state-only rebuild would lose.
+		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.WithReference(
+				actions.CreateTransactionAction(ledger, []*commonpb.Posting{
+					actions.NewPosting("world", "users:alice", big.NewInt(100), "USD"),
+				}, nil, nil),
+				txRef,
+			),
+		))
+		Expect(err).To(Succeed())
+
+		// Baseline read while the chapter is still hot.
+		hot, err := client.GetTransaction(ctx, &servicepb.GetTransactionRequest{Ledger: ledger, TransactionId: txID})
+		Expect(err).To(Succeed())
+		Expect(hot.GetTransaction().GetReference()).To(Equal(txRef))
+		Expect(hot.GetTransaction().GetPostCommitVolumes()).ToNot(BeNil(), "post-commit volumes present while hot")
+		Expect(hot.GetReceipt()).ToNot(BeEmpty(), "receipt present while hot")
+
+		// Close + seal + archive + confirm the chapter holding the transaction,
+		// purging its creation log from hot storage into cold.
+		archiveChapterFull(ctx, client)
+
+		// The read that regresses without the cold fallback: NotFound before the
+		// fix. With it, the transaction comes back whole from cold storage.
+		got, err := client.GetTransaction(ctx, &servicepb.GetTransactionRequest{Ledger: ledger, TransactionId: txID})
+		Expect(err).To(Succeed(), "archived transaction must still be readable from cold storage")
+
+		tx := got.GetTransaction()
+		Expect(tx.GetId()).To(Equal(uint64(txID)))
+		Expect(tx.GetReference()).To(Equal(txRef), "reference must survive archival (log-only field)")
+		Expect(tx.GetPostings()).To(HaveLen(1))
+		Expect(tx.GetPostings()[0].GetSource()).To(Equal("world"))
+		Expect(tx.GetPostings()[0].GetDestination()).To(Equal("users:alice"))
+		Expect(tx.GetPostCommitVolumes()).ToNot(BeNil(), "post-commit volumes must survive archival (log-only field)")
+
+		// The receipt lookup shares the cold fallback, so an archived transaction
+		// keeps its receipt (the chapter id it signs over is immutable).
+		Expect(got.GetReceipt()).ToNot(BeEmpty(), "receipt must survive archival via the cold fallback")
+	})
+})


### PR DESCRIPTION
## Problem

After a chapter is archived and its logs are purged from hot storage,
`GetTransaction` returned `NotFound` for any transaction in that chapter — even
though the log is safe in cold storage and `GetLog` can still read it.

`GetTransaction` rebuilds a transaction from its **creation log**
(`assembleTransactionFromState`): the attribute-zone `TransactionState` survives
purge, but it carries no `reference` and no `post_commit_volumes` (added by
EN-1546), so those fields come only from the log. The read used hot-only
`query.ReadLogBySequence`, so once the log was purged the whole read failed.

This was a latent inconsistency, not intended behavior:
- `GetLog` already falls back to cold storage (`ReadLogBySequenceWithCold`).
- `TransactionState.postings` is retained specifically to avoid needing the log.
- `ComputeTransactionReceipt`'s own comment asserts *"the transaction is still
  readable; it just has no receipt"* after archival — but the code returned
  NotFound from the transaction read **before** that branch was ever reached, so
  the branch was dead.

## Fix

`assembleTransactionFromState` and `query.FindTransactionCreationLog` now use
`ReadLogBySequenceWithCold`, so an archived transaction is assembled from the
cold-stored log.

- `buildTransaction` (the single assembly choke point — serves both
  `GetTransaction` and `ListTransactions`) passes `ctrl.coldReader`.
- The **receipt** shares the fallback too: an archived transaction keeps its
  receipt. The only log-derived input to the signature is the creation log's
  chapter id, which is immutable, so the token is byte-identical to the one
  issued while the transaction was hot. (This is why the receipt lookup also
  moved to the cold-aware read rather than staying hot-only.)
- Degrades to hot-only when cold storage is disabled (nil cold reader), so
  checkpoint / restore-mode reads are unaffected.
- `FindTransactionCreationLog` / `ComputeTransactionReceipt` reader params
  widened `dal.PebbleGetter` → `dal.PebbleReader` (the cold chapter lookup
  iterates); the checkpoint receipt path now passes a read handle instead of the
  raw `*dal.Store`.

## Testing

`tests/e2e/business/get_transaction_cold_test.go` (`e2e`, filesystem cold
storage, modeled on `audit_purge_test.go`'s `archiveChapterFull`): a referenced
transaction whose chapter is archived+purged is still returned whole (reference,
postings, post-commit volumes) with its receipt.

Verified it **catches the bug**:
- fix reverted → `FAIL` at "archived transaction must still be readable from
  cold storage" (`NotFound: transaction 1 not found`)
- fix in place → `1 Passed`

Changed-package unit tests (query, ctrl, state, grpc) green; lint clean.

## Notes

Surfaced while planning a chapter-archival model test — this is the server-side
read regression that planning uncovered, split out as its own fix.
