### PR TITLE
fix(bulk): map business errors to their API codes instead of INTERNAL

### DIFF
--- a/internal/api/bulking/handler_json.go
+++ b/internal/api/bulking/handler_json.go
@@ -110,6 +110,8 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 				errorCode = common.ErrInterpreterParse
 			case errors.Is(result.Error, ledgercontroller.ErrRuntime{}):
 				errorCode = common.ErrInterpreterRuntime
+			case errors.Is(result.Error, ledgercontroller.ErrAlreadyReverted{}):
+				errorCode = common.ErrAlreadyRevert
 			default:
 				errorCode = api.ErrorInternal
 			}

--- a/internal/api/bulking/handler_json.go
+++ b/internal/api/bulking/handler_json.go
@@ -4,14 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"slices"
+
 	"github.com/formancehq/go-libs/v3/api"
 	"github.com/formancehq/go-libs/v3/collectionutils"
 	"github.com/formancehq/go-libs/v3/pointer"
+	"github.com/formancehq/numscript"
+
 	"github.com/formancehq/ledger/internal/api/common"
 	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
 	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
-	"net/http"
-	"slices"
 )
 
 type JsonBulkHandler struct {
@@ -95,26 +98,7 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 		)
 
 		if result.Error != nil {
-			switch {
-			case errors.Is(result.Error, &ledgercontroller.ErrInsufficientFunds{}):
-				errorCode = common.ErrInsufficientFund
-			case errors.Is(result.Error, &ledgercontroller.ErrInvalidVars{}) || errors.Is(result.Error, ledgercontroller.ErrCompilationFailed{}):
-				errorCode = common.ErrCompilationFailed
-			case errors.Is(result.Error, &ledgercontroller.ErrMetadataOverride{}):
-				errorCode = common.ErrMetadataOverride
-			case errors.Is(result.Error, ledgercontroller.ErrNoPostings):
-				errorCode = common.ErrNoPostings
-			case errors.Is(result.Error, ledgerstore.ErrTransactionReferenceConflict{}):
-				errorCode = common.ErrConflict
-			case errors.Is(result.Error, ledgercontroller.ErrParsing{}):
-				errorCode = common.ErrInterpreterParse
-			case errors.Is(result.Error, ledgercontroller.ErrRuntime{}):
-				errorCode = common.ErrInterpreterRuntime
-			case errors.Is(result.Error, ledgercontroller.ErrAlreadyReverted{}):
-				errorCode = common.ErrAlreadyRevert
-			default:
-				errorCode = api.ErrorInternal
-			}
+			errorCode = mapBulkElementError(result.Error)
 			errorDescription = result.Error.Error()
 			responseType = "ERROR"
 		}
@@ -148,4 +132,36 @@ func writeJSONResponse(w http.ResponseWriter, actions []string, results []BulkEl
 type ComposedErrorResponse struct {
 	api.BaseResponse[[]APIResult]
 	api.ErrorResponse
+}
+
+// mapBulkElementError maps a controller error for a bulk element to the same API
+// error code the individual (non-bulk) endpoints return, so a business error in a
+// bulk is not reported as a generic INTERNAL. It must stay consistent with the
+// per-endpoint mappings in internal/api/v2 and common.HandleCommon*Errors.
+func mapBulkElementError(err error) string {
+	switch {
+	case errors.Is(err, &ledgercontroller.ErrInsufficientFunds{}), errors.Is(err, numscript.MissingFundsErr{}):
+		return common.ErrInsufficientFund
+	case errors.Is(err, &ledgercontroller.ErrInvalidVars{}) || errors.Is(err, ledgercontroller.ErrCompilationFailed{}):
+		return common.ErrCompilationFailed
+	case errors.Is(err, &ledgercontroller.ErrMetadataOverride{}):
+		return common.ErrMetadataOverride
+	case errors.Is(err, ledgercontroller.ErrNoPostings):
+		return common.ErrNoPostings
+	case errors.Is(err, ledgerstore.ErrTransactionReferenceConflict{}), errors.Is(err, ledgercontroller.ErrIdempotencyKeyConflict{}):
+		return common.ErrConflict
+	case errors.Is(err, ledgercontroller.ErrParsing{}):
+		return common.ErrInterpreterParse
+	case errors.Is(err, ledgercontroller.ErrRuntime{}):
+		return common.ErrInterpreterRuntime
+	case errors.Is(err, ledgercontroller.ErrAlreadyReverted{}):
+		return common.ErrAlreadyRevert
+	case errors.Is(err, ledgercontroller.ErrInvalidIdempotencyInput{}):
+		return common.ErrValidation
+	case errors.Is(err, ledgercontroller.ErrNotFound):
+		// go-libs/v3's api package has no exported NOT_FOUND constant.
+		return "NOT_FOUND"
+	default:
+		return api.ErrorInternal
+	}
 }

--- a/internal/api/bulking/handler_json_error_test.go
+++ b/internal/api/bulking/handler_json_error_test.go
@@ -1,0 +1,44 @@
+package bulking
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v3/api"
+	"github.com/formancehq/numscript"
+
+	"github.com/formancehq/ledger/internal/api/common"
+	ledgercontroller "github.com/formancehq/ledger/internal/controller/ledger"
+	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
+)
+
+// A bulk element's business error must map to the same code the individual
+// endpoints return, never the generic INTERNAL fallback.
+func TestMapBulkElementError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"insufficient funds", &ledgercontroller.ErrInsufficientFunds{}, common.ErrInsufficientFund},
+		{"numscript missing funds", numscript.MissingFundsErr{}, common.ErrInsufficientFund},
+		{"invalid vars", &ledgercontroller.ErrInvalidVars{}, common.ErrCompilationFailed},
+		{"compilation failed", ledgercontroller.ErrCompilationFailed{}, common.ErrCompilationFailed},
+		{"metadata override", &ledgercontroller.ErrMetadataOverride{}, common.ErrMetadataOverride},
+		{"no postings", ledgercontroller.ErrNoPostings, common.ErrNoPostings},
+		{"reference conflict", ledgerstore.ErrTransactionReferenceConflict{}, common.ErrConflict},
+		{"idempotency key conflict", ledgercontroller.ErrIdempotencyKeyConflict{}, common.ErrConflict},
+		{"parsing", ledgercontroller.ErrParsing{}, common.ErrInterpreterParse},
+		{"runtime", ledgercontroller.ErrRuntime{}, common.ErrInterpreterRuntime},
+		{"already reverted", ledgercontroller.ErrAlreadyReverted{}, common.ErrAlreadyRevert},
+		{"invalid idempotency input", ledgercontroller.ErrInvalidIdempotencyInput{}, common.ErrValidation},
+		{"not found", ledgercontroller.ErrNotFound, "NOT_FOUND"},
+		{"unknown", errors.New("boom"), api.ErrorInternal},
+	} {
+		require.Equal(t, tc.want, mapBulkElementError(tc.err), tc.name)
+	}
+}

--- a/test/e2e/api_bulk_test.go
+++ b/test/e2e/api_bulk_test.go
@@ -434,4 +434,24 @@ var _ = Context("Ledger engine tests", func() {
 			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("ALREADY_REVERT"))
 		})
 	})
+	When("targeting a non-existent transaction inside a bulk", func() {
+		// Regression: a bulk element targeting a missing transaction must report
+		// NOT_FOUND, like the standalone endpoints — not INTERNAL.
+		var err error
+		It("should report NOT_FOUND for that element", func(specContext SpecContext) {
+			bulkResponse, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+				Ledger: "default",
+				RequestBody: []components.V2BulkElement{
+					components.CreateV2BulkElementRevertTransaction(components.V2BulkElementRevertTransaction{
+						Data: &components.V2BulkElementRevertTransactionData{
+							ID: big.NewInt(42),
+						},
+					}),
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(bulkResponse.V2BulkResponse.Data[0].Type).To(Equal(components.V2BulkElementResultType("ERROR")))
+			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("NOT_FOUND"))
+		})
+	})
 })

--- a/test/e2e/api_bulk_test.go
+++ b/test/e2e/api_bulk_test.go
@@ -387,4 +387,51 @@ var _ = Context("Ledger engine tests", func() {
 			})
 		})
 	})
+	When("reverting an already-reverted transaction inside a bulk", func() {
+		// Regression: a revert of an already-reverted transaction inside a bulk
+		// must report ALREADY_REVERT, like the standalone revert endpoint — not
+		// INTERNAL, which the bulk error mapping used to fall back to.
+		var (
+			err  error
+			txID *big.Int
+		)
+		BeforeEach(func(specContext SpecContext) {
+			client := Wait(specContext, DeferClient(testServer))
+			createResponse, createErr := client.Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				V2PostTransaction: components.V2PostTransaction{
+					Metadata: map[string]string{},
+					Postings: []components.V2Posting{{
+						Amount:      big.NewInt(100),
+						Asset:       "USD/2",
+						Destination: "bank",
+						Source:      "world",
+					}},
+				},
+			})
+			Expect(createErr).To(Succeed())
+			txID = createResponse.V2CreateTransactionResponse.Data.ID
+
+			_, err = client.Ledger.V2.RevertTransaction(ctx, operations.V2RevertTransactionRequest{
+				Ledger: "default",
+				ID:     txID,
+			})
+			Expect(err).To(Succeed())
+		})
+		It("should report ALREADY_REVERT for that element", func(specContext SpecContext) {
+			bulkResponse, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+				Ledger: "default",
+				RequestBody: []components.V2BulkElement{
+					components.CreateV2BulkElementRevertTransaction(components.V2BulkElementRevertTransaction{
+						Data: &components.V2BulkElementRevertTransactionData{
+							ID: txID,
+						},
+					}),
+				},
+			})
+			Expect(err).To(Succeed())
+			Expect(bulkResponse.V2BulkResponse.Data[0].Type).To(Equal(components.V2BulkElementResultType("ERROR")))
+			Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultError.ErrorCode).To(Equal("ALREADY_REVERT"))
+		})
+	})
 })


### PR DESCRIPTION
Backport of #1600 to `release/v2.3`. **Adapted** (not a clean cherry-pick): v2.3 uses go-libs/v3, so imports differ, `api.ErrorCodeNotFound` is unavailable (literal `"NOT_FOUND"` used), and the schema-metadata error cases (`ErrSchemaValidationError`/`ErrSchemaNotSpecified`/`ErrSchemaNotFound`) don't exist on v2.3 and were dropped. The remaining mappings (ALREADY_REVERT, NOT_FOUND, numscript missing funds, idempotency conflict/invalid input) are backported. See #1600.

Validated: `mapBulkElementError` unit test + both bulk e2e regressions pass locally.