### PR TITLE
fix: correct trailing ':' / '...' account-address matching semantics (backport #1618)

### DIFF
--- a/internal/storage/ledger/accounts_test.go
+++ b/internal/storage/ledger/accounts_test.go
@@ -524,3 +524,50 @@ func TestAccountsUpsert(t *testing.T) {
 	err = store.UpsertAccounts(ctx, &account1)
 	require.NoError(t, err)
 }
+
+// TestAccountsListAddressSegmentMatching pins the trailing-segment matching
+// semantics: "foo:" matches exactly one level deeper, "foo::" matches exactly
+// two levels deeper, and "foo:..." matches the whole subtree. All address-filtered
+// endpoints (accounts / volumes / aggregate-balances) share filterAccountAddress,
+// so covering accounts is enough to guard the behavior.
+func TestAccountsListAddressSegmentMatching(t *testing.T) {
+	t.Parallel()
+	store := newLedgerStore(t)
+	ctx := logging.TestingContext()
+
+	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
+		"foo:a":     {"seg": "1"},
+		"foo:d":     {"seg": "1"},
+		"foo:a:b":   {"seg": "1"},
+		"foo:a:b:c": {"seg": "1"},
+	}, time.Time{}))
+
+	addresses := func(t *testing.T, address string) []string {
+		accounts, err := store.Accounts().Paginate(ctx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.Match("address", address),
+			},
+		})
+		require.NoError(t, err)
+		result := make([]string, len(accounts.Data))
+		for i, account := range accounts.Data {
+			result[i] = account.Address
+		}
+		return result
+	}
+
+	t.Run("trailing colon matches one level deeper only", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a", "foo:d"}, addresses(t, "foo:"))
+	})
+
+	t.Run("double trailing colon matches two levels deeper only", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a:b"}, addresses(t, "foo::"))
+	})
+
+	t.Run("trailing ellipsis matches the whole subtree", func(t *testing.T) {
+		t.Parallel()
+		require.ElementsMatch(t, []string{"foo:a", "foo:d", "foo:a:b", "foo:a:b:c"}, addresses(t, "foo:..."))
+	})
+}

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -441,7 +441,7 @@ func TestBalancesAggregatesPITWithMetadataHistoryDisabled(t *testing.T) {
 		ret, err := store.AggregatedVolumes().GetOne(ctx, common.ResourceQuery[ledgerstore.GetAggregatedVolumesOptions]{
 			PIT: pointer.For(now.Add(time.Minute)),
 			Builder: query.And(
-				query.Match("address", "merchant:"),
+				query.Match("address", "merchant:..."),
 				query.Match("metadata[trust]", "true"),
 			),
 		})

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -28,7 +28,7 @@ func filterAccountAddress(address, key string) string {
 
 	if isPartialAddress(address) {
 		src := strings.Split(address, ":")
-		if src[len(src)-1] != "" {
+		if src[len(src)-1] != "..." {
 			parts = append(parts, fmt.Sprintf("jsonb_array_length(%s_array) = %d", key, len(src)))
 		}
 


### PR DESCRIPTION
Backport of #1618 to `release/v2.3`.

## Problem

`filterAccountAddress` (accounts / volumes / aggregate-balances) inverted the trailing-`:` and trailing-`...` matchers relative to the transactions path (`filterAccountAddressOnTransactions`): `foo:` matched the whole subtree and `foo:...` matched only one level — the reverse of the intended behavior.

## Fix

Add the `jsonb_array_length` constraint when the address does **not** end in `...` (was: does not end in `""`), mirroring the null-terminator logic in the transactions path. Now `foo:` matches exactly one level deeper and `foo:...` matches the whole subtree.

## Backport notes

The escaping helpers / `TestFilterAccountAddress_*` unit tests from `main` do not exist on this branch, so the diff is the minimal semantic change:
- `utils.go`: the one-line fix.
- `accounts_test.go`: new `TestAccountsListAddressSegmentMatching` proving one-level / two-level / subtree on nested data.
- `balances_test.go`: `TestBalancesAggregatesPITWithMetadataHistoryDisabled` filtered a 3-segment account with `merchant:` expecting a subtree match (relied on the bug) → updated to `merchant:...`.

Affected `it` tests pass locally against Postgres.

Closes #1612