### PR TITLE
fix(EN-1508): align gRPC ListLogs scope with HTTP on ledger:LedgerRead

### DIFF
--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -754,7 +754,7 @@ Read endpoints comparison with the original ledger:
 | `GET /v3/{ledgerName}/accounts/{address}/balances` | ❌ | ✅ | Get account balances |
 | `GET /v3/{ledgerName}/accounts/{address}/volumes` | ❌ | ✅ | Get account volumes |
 | `GET /v3/{ledgerName}/volumes` | ✅ | ✅ | Aggregate volumes (per-asset, generic account `filter`) |
-| `GET /v3/{ledgerName}/logs` | ✅ | ✅ | List per-ledger logs. Supports `?after=` for pagination |
+| `GET /v3/{ledgerName}/logs` | ✅ | ✅ | List per-ledger logs. Supports `?after=` for pagination. Ledger-scoped read → requires `ledger:read` (granular `ledger:LedgerRead`) on both transports |
 | `GET /v3/{ledgerName}/stats` | ✅ | ✅ | Ledger usage statistics (transaction, volume, reference, posting, log, revert, Numscript-execution, ephemeral-evicted and transient-used counts) |
 | `GET /v3/{ledgerName}` | ✅ | ✅ | Get ledger info |
 | `POST /v3/{ledgerName}/promote` | ✅ | ❌ | Promote mirror ledger to normal mode |
@@ -780,7 +780,7 @@ Read endpoints comparison with the original ledger:
 | `DELETE /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Remove account type |
 | `PUT /v3/{ledgerName}/account-types/default-enforcement-mode` | ✅ | ❌ | Set default enforcement mode (STRICT/AUDIT) |
 | `GET /v3/{ledgerName}/transactions` | ✅ | ❌ | List transactions: cursor pagination, `startDate`/`endDate` range, and the generic `filter` (reference selection via `filter={"$match":{"reference":"..."}}`) |
-| `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence |
+| `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence. No ledger identity → requires `ledger` ops-read (granular `ledger:OpsRead`) |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
 | `GET /v3/_/chapter-schedule` | ✅ | ❌ | Get the auto-rotation cron for chapters |
 | `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`) |
@@ -867,8 +867,8 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `ListChapters` | Stream all chapters | ✅ |
 | `ListAuditEntries` | Stream audit log entries (success + failure). Request is `{ options }` only — no dedicated filter fields. Follows the shared `ListOptions` contract: cursor/page_size/reverse/checkpoint_id plus a bare-audit-field `QueryFilter` (outcome, ledger, caller_subject, order_type, seq, proposal_id, timestamp, log_seq — bare fields resolved against the audit query target, EN-1549 replacing the old `audit[...]` syntax) resolved through the audit secondary index. Ledger scope and outcome selection are expressed as filter conditions | ✅ |
 | `GetAuditEntry` | Get a single audit entry by sequence number | ✅ |
-| `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination) | ✅ |
-| `GetLog` | Get a single system log by sequence number | ✅ |
+| `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination). Ledger-scoped read → requires `ledger:read` (granular `ledger:LedgerRead`), same as the HTTP `GET /v3/{ledgerName}/logs` route | ✅ |
+| `GetLog` | Get a single system log by bucket-wide sequence number. No ledger identity in the request → requires `ledger` ops-read (granular `ledger:OpsRead`), like the HTTP `GET /v3/_/logs/{sequence}` route | ✅ |
 | `ListSigningKeys` | Stream all registered signing keys | ✅ |
 | `Discovery` | Return server capabilities (response signing config) and build info (`ServerInfo`: version, commit, build date, Go version) | ✅ |
 | `AnalyzeAccounts` | Analyze accounts and suggest Chart of Accounts | ✅ |

--- a/internal/adapter/auth/http_middleware_test.go
+++ b/internal/adapter/auth/http_middleware_test.go
@@ -366,6 +366,51 @@ func TestRequireScope_WriteScope(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+// TestRequireScope_LedgersRead_GatesLogListing pins the HTTP side of EN-1508:
+// GET /{ledgerName}/logs sits behind requireLedgersRead, i.e.
+// RequireScope(cfg, ScopeLedgersRead). It asserts the gate with GRANULAR scopes
+// (identity pass-through) rather than the aggregate "ledger:read" — the
+// aggregate expands to both ScopeLedgersRead and ScopeOpsRead and would mask a
+// scope drift between transports.
+func TestRequireScope_LedgersRead_GatesLogListing(t *testing.T) {
+	t.Parallel()
+
+	privKey, keySet := testKeyPair(t)
+	cfg := AuthConfig{
+		Enabled:      true,
+		KeySet:       keySet,
+		Issuer:       testIssuer,
+		Service:      "ledger",
+		ScopeMapping: DefaultMapping("ledger"),
+	}
+
+	handler := HTTPAuthMiddleware(cfg)(RequireScope(cfg, ScopeLedgersRead)(ok200))
+
+	t.Run("granular ledger-read token passes the gate", func(t *testing.T) {
+		t.Parallel()
+
+		token := signToken(t, privKey, newTestClaims(string(ScopeLedgersRead)))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/main/logs", nil)
+		r.Header.Set("Authorization", "Bearer "+token)
+		handler.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("granular ops-read-only token is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression guard: an OpsRead-only token (the scope the old code
+		// required) must NOT list a ledger's logs over HTTP.
+		token := signToken(t, privKey, newTestClaims(string(ScopeOpsRead)))
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/main/logs", nil)
+		r.Header.Set("Authorization", "Bearer "+token)
+		handler.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}
+
 // --- EdDSA (Ed25519) HTTP middleware tests ---
 
 func TestHTTPAuthMiddleware_EdDSA_ValidToken(t *testing.T) {

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -1064,7 +1064,7 @@ func (impl *BucketServiceServerImpl) ListLogs(req *servicepb.ListLogsRequest, st
 	ctx, span := bucketTracer.Start(stream.Context(), "grpc.ListLogs")
 	defer span.End()
 
-	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeOpsRead); err != nil {
+	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeLedgersRead); err != nil {
 		return err
 	}
 

--- a/internal/adapter/grpc/server_bucket_auth_test.go
+++ b/internal/adapter/grpc/server_bucket_auth_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -95,5 +96,129 @@ func TestBarrier_RequiresOpsReadScope(t *testing.T) {
 
 		_, err := impl.Barrier(context.Background(), &servicepb.BarrierRequest{})
 		require.NoError(t, err)
+	})
+}
+
+// TestListLogs_RequiresLedgersReadScope guards EN-1508: listing a ledger's logs
+// is a ledger-scoped read and must require ledger:LedgerRead across transports,
+// matching the HTTP route (which already sits behind requireLedgersRead). The
+// MockController carries no expectations on the deny paths, so any controller
+// call would fail gomock — proving the scope gate short-circuits before the
+// controller is reached.
+func TestListLogs_RequiresLedgersReadScope(t *testing.T) {
+	t.Parallel()
+
+	// anonCfg enables auth and grants the given scopes to unauthenticated
+	// callers via the anonymous mapping (see TestBarrier for the rationale).
+	anonCfg := func(scopes ...internalauth.Scope) internalauth.AuthConfig {
+		return internalauth.AuthConfig{
+			Enabled: true,
+			ScopeMapping: internalauth.ScopeMapping{
+				internalauth.ScopeMappingAnonymousKey: scopes,
+			},
+		}
+	}
+
+	// newImpl wires a MockController. expectList=true expects ListLogs once
+	// (the authorized path); expectList=false leaves the controller with no
+	// expectations so any call fails gomock, proving auth denied before it.
+	newImpl := func(cfg internalauth.AuthConfig, expectList bool) *BucketServiceServerImpl {
+		controller := NewMockController(gomock.NewController(t))
+		if expectList {
+			controller.EXPECT().
+				ListLogs(gomock.Any(), "main", gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(page[commonpb.Log](), nil)
+		}
+
+		return &BucketServiceServerImpl{logger: noopLogger{}, ctrl: controller, authCfg: cfg}
+	}
+
+	// A minimal valid request: with no options the checkpoint id is 0 (live
+	// read) and min_log_sequence is 0, so the authorized path reaches the
+	// controller without touching the read store.
+	newReq := func() *servicepb.ListLogsRequest { return &servicepb.ListLogsRequest{Ledger: "main"} }
+
+	t.Run("allows caller with ScopeLedgersRead", func(t *testing.T) {
+		t.Parallel()
+
+		impl := newImpl(anonCfg(internalauth.ScopeLedgersRead), true)
+
+		require.NoError(t, impl.ListLogs(newReq(), newFakeServerStream[commonpb.Log](t)))
+	})
+
+	t.Run("rejects caller whose scopes omit ledger-read", func(t *testing.T) {
+		t.Parallel()
+
+		// Effective scopes carry no ledger/log read scope at all.
+		impl := newImpl(anonCfg(internalauth.ScopeAccountsRead, internalauth.ScopeTransactionsRead), false)
+
+		require.Error(t, impl.ListLogs(newReq(), newFakeServerStream[commonpb.Log](t)))
+	})
+
+	t.Run("rejects ScopeOpsRead-only caller", func(t *testing.T) {
+		t.Parallel()
+
+		// Regression guard: the scope moved off OpsRead, so an OpsRead-only
+		// token is now denied for ListLogs.
+		impl := newImpl(anonCfg(internalauth.ScopeOpsRead), false)
+
+		require.Error(t, impl.ListLogs(newReq(), newFakeServerStream[commonpb.Log](t)))
+	})
+
+	t.Run("rejects unauthenticated caller", func(t *testing.T) {
+		t.Parallel()
+
+		impl := newImpl(anonCfg(), false) // anonymous gets no scopes
+
+		err := impl.ListLogs(newReq(), newFakeServerStream[commonpb.Log](t))
+		require.Error(t, err)
+		require.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+}
+
+// TestGetLog_RequiresOpsReadScope pins the other half of the EN-1508 split:
+// the global GetLog(sequence) addresses a bucket-wide raft sequence with no
+// ledger identity, so it stays on ledger:OpsRead and must NOT accept a
+// ledger-read-only token. This proves the two operations did not collapse onto
+// the same scope.
+func TestGetLog_RequiresOpsReadScope(t *testing.T) {
+	t.Parallel()
+
+	anonCfg := func(scopes ...internalauth.Scope) internalauth.AuthConfig {
+		return internalauth.AuthConfig{
+			Enabled: true,
+			ScopeMapping: internalauth.ScopeMapping{
+				internalauth.ScopeMappingAnonymousKey: scopes,
+			},
+		}
+	}
+
+	newImpl := func(cfg internalauth.AuthConfig, expectGet bool) *BucketServiceServerImpl {
+		controller := NewMockController(gomock.NewController(t))
+		if expectGet {
+			// checkpoint id 0 → readController returns the live controller, so
+			// the authorized path reaches this expectation directly.
+			controller.EXPECT().GetLog(gomock.Any(), uint64(1)).Return(&commonpb.Log{}, nil)
+		}
+
+		return &BucketServiceServerImpl{logger: noopLogger{}, ctrl: controller, authCfg: cfg}
+	}
+
+	t.Run("allows caller with ScopeOpsRead", func(t *testing.T) {
+		t.Parallel()
+
+		impl := newImpl(anonCfg(internalauth.ScopeOpsRead), true)
+
+		_, err := impl.GetLog(context.Background(), &servicepb.GetLogRequest{Sequence: 1})
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects ScopeLedgersRead-only caller", func(t *testing.T) {
+		t.Parallel()
+
+		impl := newImpl(anonCfg(internalauth.ScopeLedgersRead), false)
+
+		_, err := impl.GetLog(context.Background(), &servicepb.GetLogRequest{Sequence: 1})
+		require.Error(t, err)
 	})
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -334,7 +334,7 @@ paths:
       description: |
         Lists log entries for a specific ledger, ordered by ledger-local log ID ascending.
         Requires the builtin `LOG` index to be enabled on the ledger via `CreateIndex`.
-        Supports cursor pagination via the `after` query parameter. Requires `ledger:OpsRead` scope.
+        Supports cursor pagination via the `after` query parameter. Requires `ledger:read` scope.
       operationId: listLedgerLogs
       tags:
         - Logs


### PR DESCRIPTION
## Summary

Listing a ledger's logs is a **ledger-scoped read** (the request carries a `ledger` field), but the two transports required different granular scopes:

| Operation | Transport | Before | After |
|-----------|-----------|--------|-------|
| List ledger logs | HTTP `GET /v3/{ledgerName}/logs` | `ledger:LedgerRead` | `ledger:LedgerRead` (unchanged) |
| List ledger logs | gRPC `ListLogs` | `ledger:OpsRead` ❌ | `ledger:LedgerRead` ✅ |
| Get global log by seq | gRPC `GetLog` / HTTP `GET /v3/_/logs/{sequence}` | `ledger:OpsRead` | `ledger:OpsRead` (unchanged) |

The divergence was masked by the aggregate `ledger:read` scope, which expands to **both** `ledger:LedgerRead` and `ledger:OpsRead`, so only callers using granular scopes hit it.

Global `GetLog(sequence)` deliberately **stays** on `ledger:OpsRead`: it addresses a bucket-wide raft sequence with no ledger identity, so it cannot safely be authorized as a ledger-scoped read.

## Changes

- **gRPC** `ListLogs`: `ScopeOpsRead` → `ScopeLedgersRead` (`internal/adapter/grpc/server_bucket.go`) — the only production-code line.
- **OpenAPI** (`openapi.yml`): corrected the `GET /v3/{ledgerName}/logs` prose from `ledger:OpsRead` to `ledger:read`.
- **Docs** (`docs/technical/contributing/api-comparison.md`): documented the ledger-scoped-listing vs global-by-sequence scope distinction on both the HTTP and gRPC tables.
- **Tests** (granular scopes only — the aggregate `ledger:read` would mask the difference):
  - gRPC `TestListLogs_RequiresLedgersReadScope`: allows `LedgerRead`; denies scopes-without-ledger-read, `OpsRead`-only (regression guard), and unauthenticated — **asserting the controller is never invoked** on denial (MockController with no expectations).
  - gRPC `TestGetLog_RequiresOpsReadScope`: `GetLog` still requires `OpsRead`; a `LedgerRead`-only token is denied — proving the two operations did not collapse onto one scope.
  - HTTP `TestRequireScope_LedgersRead_GatesLogListing`: `LedgerRead` token passes the `/{ledgerName}/logs` gate; an `OpsRead`-only token gets `403`.

## Out of scope

`GetLog` behavior, protobuf messages, FSM, storage, preload, checker — none change. Authorization alignment + docs + tests only.

## Verification

- `just pre-commit` — 0 lint issues, no regenerated files.
- `just test` — full unit suite passes.
- New tests pass uncached on all sub-cases.

Ticket: https://formance-team.atlassian.net/browse/EN-1508