### PR TITLE
fix: harden S3 multipart uploads against CompleteMultipartUpload InvalidPart

### DIFF
--- a/internal/infra/backup/s3.go
+++ b/internal/infra/backup/s3.go
@@ -34,10 +34,19 @@ type S3Storage struct {
 
 // NewS3Storage creates a new S3Storage backed by the given S3 client and bucket.
 func NewS3Storage(client *s3.Client, bucket string) *S3Storage {
+	return newS3StorageWithPartSize(client, bucket, s3UploadPartSize)
+}
+
+// newS3StorageWithPartSize is NewS3Storage with an explicit multipart part
+// size. Production always uses s3UploadPartSize; tests use it to force a small
+// part size so a modest payload still exercises the multipart path
+// (CreateMultipartUpload / UploadPart / CompleteMultipartUpload) rather than a
+// single PutObject, independent of the production default.
+func newS3StorageWithPartSize(client *s3.Client, bucket string, partSize int64) *S3Storage {
 	return &S3Storage{
 		client: client,
 		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
-			u.PartSize = s3UploadPartSize
+			u.PartSize = partSize
 		}),
 		bucket: bucket,
 	}

--- a/internal/infra/backup/s3.go
+++ b/internal/infra/backup/s3.go
@@ -16,6 +16,15 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 )
 
+// s3UploadPartSize is the multipart part size for backup object uploads.
+// The aws-sdk-go-v2 default is 5 MiB; at the 10,000-part ceiling that caps a
+// single object at ~48.8 GiB and produces thousands of parts for a multi-GB
+// checkpoint blob, widening the window for a single part failure to fail the
+// whole CompleteMultipartUpload. 32 MiB cuts the part count ~6.4x (lifting the
+// single-object ceiling to ~312 GiB) while keeping per-part memory bounded
+// (partSize x concurrency).
+const s3UploadPartSize = 32 << 20 // 32 MiB
+
 // S3Storage implements Storage using Amazon S3 (or S3-compatible stores like MinIO).
 type S3Storage struct {
 	client   *s3.Client
@@ -26,9 +35,11 @@ type S3Storage struct {
 // NewS3Storage creates a new S3Storage backed by the given S3 client and bucket.
 func NewS3Storage(client *s3.Client, bucket string) *S3Storage {
 	return &S3Storage{
-		client:   client,
-		uploader: manager.NewUploader(client),
-		bucket:   bucket,
+		client: client,
+		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
+			u.PartSize = s3UploadPartSize
+		}),
+		bucket: bucket,
 	}
 }
 

--- a/internal/infra/backup/s3_test.go
+++ b/internal/infra/backup/s3_test.go
@@ -79,10 +79,13 @@ func TestS3Storage_PutFileMultipartLargeObject(t *testing.T) {
 	t.Parallel()
 
 	client := setupMinIOBackup(t)
-	storage := NewS3Storage(client, backupTestBucket)
+	// Force a 5 MiB part size so the 12 MiB payload takes the multipart path
+	// (this PR raised the production default to 32 MiB, which would otherwise
+	// route a 12 MiB object through a single PutObject).
+	storage := newS3StorageWithPartSize(client, backupTestBucket, 5<<20)
 	ctx := context.Background()
 
-	// 12 MiB > the 5 MiB default part size → at least 3 parts.
+	// 12 MiB > the 5 MiB part size set above → at least 3 parts.
 	const size = 12 << 20
 
 	payload := make([]byte, size)
@@ -110,7 +113,10 @@ func TestS3Storage_PutFileStreamsUnknownLengthReader(t *testing.T) {
 	t.Parallel()
 
 	client := setupMinIOBackup(t)
-	storage := NewS3Storage(client, backupTestBucket)
+	// Force a 5 MiB part size so the 12 MiB payload takes the multipart path
+	// (this PR raised the production default to 32 MiB, which would otherwise
+	// route a 12 MiB object through a single PutObject).
+	storage := newS3StorageWithPartSize(client, backupTestBucket, 5<<20)
 	ctx := context.Background()
 
 	const size = 12 << 20

--- a/internal/infra/coldstorage/s3.go
+++ b/internal/infra/coldstorage/s3.go
@@ -27,7 +27,17 @@ const s3ChecksumMetadataKey = "sha256"
 // Otherwise the default AWS credential chain is used (env vars, ~/.aws/credentials, IAM role).
 // If endpoint is non-empty, it is used as a custom S3 endpoint (e.g. for MinIO).
 func NewS3Client(region, endpoint, accessKeyID, secretAccessKey string) (*s3.Client, error) {
-	var opts []func(*awsconfig.LoadOptions) error
+	// Disable the SDK-default request checksums (WhenSupported adds a trailing
+	// CRC via aws-chunked encoding on every PutObject/UploadPart). That default
+	// shipped with recent aws-sdk-go-v2 and is the suspected cause of multipart
+	// CompleteMultipartUpload failing with InvalidPart against this deployment's
+	// S3 path (EN backup incident) — the older binary that predates the default
+	// uploaded fine. Object integrity is still covered end to end: checkpoint
+	// keys are content-addressed by sha256 and cold-storage archives carry a
+	// sha256 metadata checksum verified on read.
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
+	}
 	if region != "" {
 		opts = append(opts, awsconfig.WithRegion(region))
 	}
@@ -61,9 +71,22 @@ type S3Storage struct {
 	bucket   string
 }
 
+// s3UploadPartSize is the multipart part size for cold-storage archive uploads.
+// It matches the backup uploader (see internal/infra/backup/s3.go): 32 MiB
+// instead of the aws-sdk-go-v2 default 5 MiB, so multi-GB chapter archives
+// upload in far fewer parts (smaller failure surface, higher single-object
+// ceiling) with per-part memory still bounded by partSize x concurrency.
+const s3UploadPartSize = 32 << 20 // 32 MiB
+
 // NewS3Storage creates a new S3Storage backed by the given S3 client and bucket.
 func NewS3Storage(client *s3.Client, bucket string) *S3Storage {
-	return &S3Storage{client: client, uploader: manager.NewUploader(client), bucket: bucket}
+	return &S3Storage{
+		client: client,
+		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
+			u.PartSize = s3UploadPartSize
+		}),
+		bucket: bucket,
+	}
 }
 
 func (s *S3Storage) archiveKey(bucketID string, chapterID uint64) string {

--- a/internal/infra/coldstorage/s3.go
+++ b/internal/infra/coldstorage/s3.go
@@ -80,10 +80,19 @@ const s3UploadPartSize = 32 << 20 // 32 MiB
 
 // NewS3Storage creates a new S3Storage backed by the given S3 client and bucket.
 func NewS3Storage(client *s3.Client, bucket string) *S3Storage {
+	return newS3StorageWithPartSize(client, bucket, s3UploadPartSize)
+}
+
+// newS3StorageWithPartSize is NewS3Storage with an explicit multipart part
+// size. Production always uses s3UploadPartSize; tests use it to force a small
+// part size so a modest payload still exercises the multipart path
+// (CreateMultipartUpload / UploadPart / CompleteMultipartUpload) rather than a
+// single PutObject, independent of the production default.
+func newS3StorageWithPartSize(client *s3.Client, bucket string, partSize int64) *S3Storage {
 	return &S3Storage{
 		client: client,
 		uploader: manager.NewUploader(client, func(u *manager.Uploader) {
-			u.PartSize = s3UploadPartSize
+			u.PartSize = partSize
 		}),
 		bucket: bucket,
 	}

--- a/internal/infra/coldstorage/s3_test.go
+++ b/internal/infra/coldstorage/s3_test.go
@@ -316,10 +316,13 @@ func TestS3Storage_ArchiveMultipartLargeObject(t *testing.T) {
 	t.Parallel()
 
 	client, _ := setupMinIO(t)
-	storage := NewS3Storage(client, minioBucket)
+	// Force a 5 MiB part size so the 12 MiB payload takes the multipart path
+	// (the production default is 32 MiB, which would otherwise route a 12 MiB
+	// object through a single PutObject).
+	storage := newS3StorageWithPartSize(client, minioBucket, 5<<20)
 	ctx := context.Background()
 
-	// 12 MiB > the 5 MiB default part size → at least 3 parts.
+	// 12 MiB > the 5 MiB part size set above → at least 3 parts.
 	const size = 12 << 20
 
 	payload := make([]byte, size)


### PR DESCRIPTION
## Problem

Full S3 backups of a large ledger fail with `CompleteMultipartUpload … InvalidPart: One or more of the specified parts could not be found`. Investigation against the customer's dev bucket showed the bucket/KMS/S3 are healthy for multipart from a clean path — the failure is specific to the client's multipart execution, on files large enough to go multipart.

## Change

- **32 MiB multipart part size** on both the backup (`internal/infra/backup/s3.go`) and cold-storage (`internal/infra/coldstorage/s3.go`) uploaders (SDK default is 5 MiB). Cuts part count ~6.4× for multi-GB objects (smaller failure surface) and lifts the 10,000-part single-object ceiling from ~48.8 GiB to ~312 GiB.
- **`RequestChecksumCalculation=WhenRequired`** on the shared S3 client (`coldstorage.NewS3Client`, reused by the backup client). Recent `aws-sdk-go-v2` defaults to `WhenSupported`, which attaches a trailing CRC via `aws-chunked` encoding on every part — the leading suspect for the `InvalidPart` at Complete, and the older binary that predates the default uploaded fine.

Object integrity is preserved end-to-end without the SDK checksums: checkpoint keys are content-addressed by sha256, and cold-storage archives carry a verified sha256 metadata checksum.

## Verification

- `go build -tags s3 ./...` and `go vet` clean.
- Multipart + trailing-CRC upload verified working against the exact bucket from a clean network path (bucket/KMS are not the problem).
- ⚠️ s3 integration tests (MinIO testcontainer) require Docker → CI.
- ⚠️ Confidence on the checksum lever is medium (hypothesis, not reproduced from a clean path); the part-size change is unambiguously beneficial.

## Notes

- Operational: with 32 MiB parts, a non-seekable upload can buffer ~160 MiB (concurrency × part size), up from ~25 MiB.