### PR TITLE
fix(backup): skip re-hashing unchanged files and retry transient uploads

### DIFF
--- a/internal/infra/backup/manager.go
+++ b/internal/infra/backup/manager.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -10,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -74,30 +76,22 @@ func RunBackup(
 		_ = store.RemoveTemporaryCheckpoint(checkpointName)
 	}()
 
-	// 2. List files in the checkpoint, hashing each so its stored key is
-	// content-addressed (see CheckpointFile / CheckpointFileKey). The hash both
-	// makes the object immutable per content and lets us skip re-uploading files
-	// already present under the same key.
-	checkpointFiles, err := listCheckpointFiles(bucketID, checkpointPath)
-	if err != nil {
-		return nil, fmt.Errorf("listing checkpoint files: %w", err)
-	}
-
-	// 3. Read existing manifest. It is used for two things: logging the upload
-	// delta, and classifying which objects the post-manifest prune (step 8)
-	// removes — objects the previous manifest referenced are stale checkpoint
-	// files this run superseded (normal churn, counted as FilesDeleted), objects
-	// it did not are true orphans leaked by a crashed run (OrphansDeleted).
-	// Correctness of the upload no longer depends on diffing sizes — the
-	// content-addressed key is the diff.
+	// 2. Read the existing manifest FIRST. It is used for three things: reusing
+	// prior per-file hashes so unchanged immutable files are not re-hashed
+	// (step 4), logging the upload delta, and classifying which objects the
+	// post-manifest prune (step 8) removes — objects the previous manifest
+	// referenced are stale checkpoint files this run superseded (normal churn,
+	// counted as FilesDeleted), objects it did not are true orphans leaked by a
+	// crashed run (OrphansDeleted). Correctness of the upload no longer depends
+	// on diffing sizes — the content-addressed key is the diff.
 	// A legacy pre-content-addressing manifest is NOT fatal here: a full backup
 	// overwrites the manifest wholesale and never diffs against it, so retaking a
 	// full backup with the current binary is exactly the documented recovery path
 	// out of a legacy manifest. Treat it as a warning and proceed with no
 	// previous-manifest keys (so its objects, which live under bare data/<name>
-	// keys, all classify as orphans on prune). (The incremental path, which does
-	// depend on the existing manifest, keeps the error fatal — see
-	// RunIncrementalBackup.)
+	// keys, all classify as orphans on prune, and no hash reuse triggers). (The
+	// incremental path, which depends on the existing manifest, keeps the error
+	// fatal — see RunIncrementalBackup.)
 	prevManifest, err := ReadManifestOrEmpty(ctx, logger, storage, manifestKey)
 	if err != nil {
 		if errors.Is(err, ErrLegacyManifestFormat) {
@@ -113,23 +107,32 @@ func RunBackup(
 	prevCheckpointKeys := checkpointKeySet(prevManifest)
 	prevExportKeys := exportKeySet(prevManifest)
 
-	// 4. Determine which files still need uploading. A file whose
-	// content-addressed key already exists on storage is byte-identical to what
-	// is already there (that is what content-addressing guarantees), so it is
-	// skipped — this is the incremental dedup, now keyed by content rather than
-	// by name+size. Objects the new manifest will NOT reference are left in
-	// place and removed by the post-manifest orphan prune (step 8).
-	//
-	// Existence is resolved with a single List of the checkpoint prefix rather
-	// than one GetObject/HEAD per file: a full backup hashes hundreds/thousands
-	// of SSTs and a per-file remote round trip would dominate the wall clock.
-	// The List is done once and every computed content-addressed key is compared
-	// against the returned set locally.
+	// 3. List the objects already present under the checkpoint prefix with a
+	// single List (not a HEAD per file: a full backup has thousands of SSTs and
+	// a per-file round trip would dominate wall clock). This set is used twice:
+	// as the guard that lets a prior file's hash be reused (a reused key must
+	// still be present remotely — see listCheckpointFiles), and as the upload
+	// dedup (a file whose content-addressed key already exists is byte-identical
+	// and skipped).
 	existingKeys, err := listKeySet(ctx, storage, CheckpointPrefix(bucketID))
 	if err != nil {
 		return nil, fmt.Errorf("listing existing checkpoint objects: %w", err)
 	}
 
+	// 4. Enumerate the checkpoint files, computing each file's content-addressed
+	// key. Unchanged immutable files (.sst/.blob still present remotely under
+	// the prior manifest's key with the same size+mtime) reuse that key instead
+	// of being re-hashed — the dominant cost on a large store where almost every
+	// SST is unchanged between runs.
+	checkpointFiles, err := listCheckpointFiles(ctx, bucketID, checkpointPath, prevManifest, existingKeys)
+	if err != nil {
+		return nil, fmt.Errorf("listing checkpoint files: %w", err)
+	}
+
+	// 5. Determine which files still need uploading — those whose
+	// content-addressed key is not already on storage. Objects the new manifest
+	// will NOT reference are left in place and removed by the post-manifest
+	// orphan prune (step 8).
 	var toUpload []string
 
 	for filename, cf := range checkpointFiles {
@@ -157,7 +160,7 @@ func RunBackup(
 	// restorable — there is never a window where the current manifest points at
 	// a half-written or deleted object.
 	for _, filename := range toUpload {
-		if err := uploadFile(ctx, storage, checkpointPath, checkpointFiles[filename].Key, filename); err != nil {
+		if err := uploadFile(ctx, logger, storage, checkpointPath, checkpointFiles[filename].Key, filename); err != nil {
 			return nil, err
 		}
 	}
@@ -209,7 +212,7 @@ func RunBackup(
 		Exports: nil,
 	}
 
-	if err := WriteManifest(ctx, storage, manifestKey, newManifest); err != nil {
+	if err := writeManifestWithRetry(ctx, storage, manifestKey, newManifest, logger); err != nil {
 		return nil, fmt.Errorf("writing manifest: %w", err)
 	}
 
@@ -494,7 +497,7 @@ func RunIncrementalBackup(
 	// 6. Export new log entries
 	if currentLogSeq > afterLogSeq {
 		segs, count, err := exportEntries(
-			ctx, storage, readHandle,
+			ctx, logger, storage, readHandle,
 			dal.ZoneCold, dal.SubColdLog, afterLogSeq, currentLogSeq, "log",
 			func(part int) string { return ExportLogSegmentKey(bucketID, afterLogSeq+1, currentLogSeq, part) },
 			maxSegmentBytes,
@@ -511,7 +514,7 @@ func RunIncrementalBackup(
 	// 7. Export new audit entries
 	if currentAuditSeq > afterAuditSeq {
 		segs, count, err := exportEntries(
-			ctx, storage, readHandle,
+			ctx, logger, storage, readHandle,
 			dal.ZoneCold, dal.SubColdAudit, afterAuditSeq, currentAuditSeq, "audit",
 			func(part int) string { return ExportAuditSegmentKey(bucketID, afterAuditSeq+1, currentAuditSeq, part) },
 			maxSegmentBytes,
@@ -537,7 +540,7 @@ func RunIncrementalBackup(
 		// storage (subsequent ApplyExports would fail on GetFile). Same
 		// guard as the appliedProposal branch below.
 		itemSegs, _, err := exportEntries(
-			ctx, storage, readHandle,
+			ctx, logger, storage, readHandle,
 			dal.ZoneCold, dal.SubColdAuditItem, afterAuditSeq, currentAuditSeq, "auditItem",
 			func(part int) string {
 				return ExportAuditItemSegmentKey(bucketID, afterAuditSeq+1, currentAuditSeq, part)
@@ -558,7 +561,7 @@ func RunIncrementalBackup(
 		// referencing a key that does not exist on storage, or a subsequent
 		// ApplyExports will fail on GetFile.
 		appliedSegs, _, err := exportEntries(
-			ctx, storage, readHandle,
+			ctx, logger, storage, readHandle,
 			dal.ZoneCold, dal.SubColdAppliedProposal, afterAuditSeq, currentAuditSeq, "appliedProposal",
 			func(part int) string {
 				return ExportAppliedProposalSegmentKey(bucketID, afterAuditSeq+1, currentAuditSeq, part)
@@ -574,7 +577,7 @@ func RunIncrementalBackup(
 	}
 
 	// 8. Write updated manifest
-	if err := WriteManifest(ctx, storage, manifestKey, manifest); err != nil {
+	if err := writeManifestWithRetry(ctx, storage, manifestKey, manifest, logger); err != nil {
 		return nil, fmt.Errorf("writing manifest: %w", err)
 	}
 
@@ -623,6 +626,7 @@ const maxExportSegmentBytes = 4 << 30 // 4 GiB
 // memory stays bounded regardless of range size.
 func exportEntries(
 	ctx context.Context,
+	logger logging.Logger,
 	storage Storage,
 	reader dal.PebbleReader,
 	zone, sub byte,
@@ -666,7 +670,7 @@ func exportEntries(
 		startSeq := seqFromKey(iter.Key())
 		key := keyFn(part)
 
-		endSeqPart, count, size, err := uploadSegmentPart(ctx, storage, key, iter, maxSegmentBytes)
+		endSeqPart, count, size, err := uploadSegmentPart(ctx, logger, storage, key, iter, maxSegmentBytes)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -693,12 +697,60 @@ func exportEntries(
 }
 
 // uploadSegmentPart streams one KV segment from the iterator's current position
-// through an io.Pipe into storage.PutFile. It writes entries until the segment
-// reaches maxSegmentBytes at a sequence boundary or the iterator is exhausted,
-// leaving the iterator positioned at the first entry of the next segment (or
-// invalid). It returns the last sequence written, the entry count, and the
-// segment's on-storage byte size.
+// through an io.Pipe into storage.PutFile, with bounded upload retry. It writes
+// entries until the segment reaches maxSegmentBytes at a sequence boundary or
+// the iterator is exhausted, leaving the iterator positioned at the first entry
+// of the next segment (or invalid). It returns the last sequence written, the
+// entry count, and the segment's on-storage byte size.
+//
+// Retry replays the segment from its start key: a pipe body is single-use, so a
+// failed upload must re-stream. The iterator is re-seeked at the top of each
+// attempt, which is safe because streamSegment joins its writer goroutine before
+// returning — Pebble iterators are not safe for concurrent use.
 func uploadSegmentPart(
+	ctx context.Context,
+	logger logging.Logger,
+	storage Storage,
+	key string,
+	iter *pebble.Iterator,
+	maxSegmentBytes int64,
+) (endSeq, count uint64, size int64, err error) {
+	// iter is Valid here (exportEntries guarantees it). Capture the segment's
+	// first key so each retry attempt can replay the same range.
+	startKey := bytes.Clone(iter.Key())
+
+	var (
+		endSeqOut, countOut uint64
+		sizeOut             int64
+	)
+
+	retryErr := retryUpload(ctx, key, logger, func() error {
+		iter.SeekGE(startKey)
+		if err := iter.Error(); err != nil {
+			return fmt.Errorf("seeking segment start: %w", err)
+		}
+
+		if !iter.Valid() || !bytes.Equal(iter.Key(), startKey) {
+			return fmt.Errorf("invariant: iterator lost segment start on retry of %s", key)
+		}
+
+		e, c, s, streamErr := streamSegment(ctx, storage, key, iter, maxSegmentBytes)
+		endSeqOut, countOut, sizeOut = e, c, s
+
+		return streamErr
+	})
+	if retryErr != nil {
+		return 0, 0, 0, retryErr
+	}
+
+	return endSeqOut, countOut, sizeOut, nil
+}
+
+// streamSegment performs one attempt of uploadSegmentPart: it streams KV
+// entries from the iterator's current position through an io.Pipe into
+// storage.PutFile, and joins the writer goroutine before returning so the
+// iterator is safe to re-seek and reuse afterwards.
+func streamSegment(
 	ctx context.Context,
 	storage Storage,
 	key string,
@@ -802,24 +854,25 @@ func (c *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func uploadFile(ctx context.Context, storage Storage, checkpointPath, key, filename string) error {
+func uploadFile(ctx context.Context, logger logging.Logger, storage Storage, checkpointPath, key, filename string) error {
 	localPath := filepath.Join(checkpointPath, filepath.FromSlash(filename))
 
-	file, err := os.Open(localPath)
+	// Stat once for the size hint. The body itself is (re-)opened per attempt
+	// by putWithRetry so a retried upload always streams from the start of the
+	// file — an *os.File consumed by a failed multipart upload is single-use.
+	info, err := os.Stat(localPath)
 	if err != nil {
-		return fmt.Errorf("opening %s for upload: %w", filename, err)
-	}
-
-	info, err := file.Stat()
-	if err != nil {
-		_ = file.Close()
-
 		return fmt.Errorf("stat %s: %w", filename, err)
 	}
 
-	err = storage.PutFile(ctx, key, file, info.Size())
-	_ = file.Close()
+	err = putWithRetry(ctx, storage, key, info.Size(), logger, func() (io.Reader, func(), error) {
+		f, openErr := os.Open(localPath)
+		if openErr != nil {
+			return nil, func() {}, fmt.Errorf("opening %s for upload: %w", filename, openErr)
+		}
 
+		return f, func() { _ = f.Close() }, nil
+	})
 	if err != nil {
 		return fmt.Errorf("uploading %s: %w", filename, err)
 	}
@@ -828,16 +881,28 @@ func uploadFile(ctx context.Context, storage Storage, checkpointPath, key, filen
 }
 
 // listCheckpointFiles walks the checkpoint directory and returns, per local
-// filename, its size and content-addressed storage key. Each file is hashed
-// (sha256 over its bytes) so its key embeds the content: a file whose bytes
-// change between checkpoints — notably Pebble's same-named MANIFEST-NNNNNN that
-// grows in place — maps to a different key and is uploaded as a new object
+// filename, its size, mtime, and content-addressed storage key. A file's key
+// embeds a sha256 of its bytes so it is immutable per content: a file whose
+// bytes change between checkpoints — notably Pebble's same-named MANIFEST-NNNNNN
+// that grows in place — maps to a different key and is uploaded as a new object
 // instead of overwriting the one the currently published manifest references.
-func listCheckpointFiles(bucketID, dir string) (map[string]CheckpointFile, error) {
+//
+// Hashing every file is the dominant cost on a large store, so an unchanged
+// immutable file (.sst/.blob still present remotely under the prior manifest's
+// key with the same size+mtime) reuses that key instead of being re-hashed —
+// see reusePriorKey. prev/existingKeys may be empty (first backup, legacy
+// manifest), in which case every file is hashed.
+func listCheckpointFiles(ctx context.Context, bucketID, dir string, prev *Manifest, existingKeys map[string]struct{}) (map[string]CheckpointFile, error) {
 	files := make(map[string]CheckpointFile)
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			return err
+		}
+
+		// Abort promptly on cancellation: hashing a multi-TiB store is an
+		// otherwise-uninterruptible phase that holds the destination lock.
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -850,16 +915,28 @@ func listCheckpointFiles(bucketID, dir string) (map[string]CheckpointFile, error
 			return err
 		}
 
-		hash, err := hashFile(path)
+		// Normalize to forward slashes for consistent keys across platforms.
+		name := filepath.ToSlash(relPath)
+
+		if key, ok := reusePriorKey(name, info, prev, existingKeys); ok {
+			files[name] = CheckpointFile{
+				Size:            info.Size(),
+				Key:             key,
+				ModTimeUnixNano: info.ModTime().UnixNano(),
+			}
+
+			return nil
+		}
+
+		hash, err := hashFileFn(ctx, path)
 		if err != nil {
 			return fmt.Errorf("hashing %s: %w", relPath, err)
 		}
 
-		// Normalize to forward slashes for consistent keys across platforms.
-		name := filepath.ToSlash(relPath)
 		files[name] = CheckpointFile{
-			Size: info.Size(),
-			Key:  CheckpointFileKey(bucketID, name, hash),
+			Size:            info.Size(),
+			Key:             CheckpointFileKey(bucketID, name, hash),
+			ModTimeUnixNano: info.ModTime().UnixNano(),
 		}
 
 		return nil
@@ -868,9 +945,61 @@ func listCheckpointFiles(bucketID, dir string) (map[string]CheckpointFile, error
 	return files, err
 }
 
+// reusePriorKey reports whether name's prior content-addressed key can be
+// reused (skipping the sha256 re-hash), returning it when so. Reuse is sound
+// only for a file byte-identical to the previous backup, which requires ALL of:
+//
+//   - immutable-by-name: a Pebble .sst or .blob, never rewritten in place and
+//     whose file number is never reused within a store lineage. Metadata files
+//     (MANIFEST-*, OPTIONS-*, CURRENT, marker.*) change under a stable name and
+//     are always re-hashed;
+//   - the previous manifest recorded the same name with the same size AND the
+//     same mtime. mtime is the lineage discriminator: RestoreCheckpoint swaps in
+//     freshly-written files, so a restored file with a colliding number+size
+//     gets a new mtime and is re-hashed rather than falsely reused;
+//   - the reused key is still present on storage. Otherwise a missing object
+//     would be re-uploaded under a stale hash-bearing key that no longer matches
+//     current bytes, corrupting content-addressing — fall through to a re-hash.
+func reusePriorKey(name string, info os.FileInfo, prev *Manifest, existingKeys map[string]struct{}) (string, bool) {
+	if prev == nil || prev.Checkpoint == nil {
+		return "", false
+	}
+
+	if !isImmutableCheckpointFile(name) {
+		return "", false
+	}
+
+	pf, ok := prev.Checkpoint.Files[name]
+	if !ok {
+		return "", false
+	}
+
+	if pf.Size != info.Size() || pf.ModTimeUnixNano != info.ModTime().UnixNano() {
+		return "", false
+	}
+
+	if _, present := existingKeys[pf.Key]; !present {
+		return "", false
+	}
+
+	return pf.Key, true
+}
+
+// isImmutableCheckpointFile reports whether a checkpoint file is one Pebble
+// never mutates in place (an SST or a value-separation blob), and is therefore
+// safe to identify by name+size+mtime for hash reuse.
+func isImmutableCheckpointFile(name string) bool {
+	return strings.HasSuffix(name, ".sst") || strings.HasSuffix(name, ".blob")
+}
+
+// hashFileFn is the hasher listCheckpointFiles uses, indirected through a
+// package variable so tests can count invocations to assert re-hash skipping.
+var hashFileFn = hashFile
+
 // hashFile returns the hex-encoded sha256 of a file's contents, streamed so
-// memory stays bounded regardless of file size.
-func hashFile(path string) (string, error) {
+// memory stays bounded regardless of file size. The read is wrapped so a long
+// hash of a multi-GB file aborts promptly on context cancellation.
+func hashFile(ctx context.Context, path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -879,9 +1008,24 @@ func hashFile(path string) (string, error) {
 	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
+	if _, err := io.Copy(h, &ctxReader{ctx: ctx, r: f}); err != nil {
 		return "", err
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// ctxReader aborts a streaming read when ctx is cancelled: io.Copy would
+// otherwise run a multi-GB hash to completion, ignoring a cancelled backup.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	return c.r.Read(p)
 }

--- a/internal/infra/backup/manager_test.go
+++ b/internal/infra/backup/manager_test.go
@@ -831,7 +831,7 @@ func TestExportEntries_SplitsLargeRangeAndRoundTrips(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = readHandle.Close() })
 
-	segs, count, err := exportEntries(ctx, storage, readHandle,
+	segs, count, err := exportEntries(ctx, logging.Testing(), storage, readHandle,
 		dal.ZoneCold, dal.SubColdLog, 0, n, "log",
 		func(part int) string { return ExportLogSegmentKey("bucket", 1, n, part) },
 		capBytes,
@@ -907,7 +907,7 @@ func TestExportEntries_SplitsOnlyAtSequenceBoundaries(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = readHandle.Close() })
 
-	segs, count, err := exportEntries(ctx, storage, readHandle,
+	segs, count, err := exportEntries(ctx, logging.Testing(), storage, readHandle,
 		dal.ZoneCold, dal.SubColdAuditItem, 0, seqs, "auditItem",
 		func(part int) string { return ExportAuditItemSegmentKey("bucket", 1, seqs, part) },
 		capBytes,
@@ -964,7 +964,7 @@ func TestExportEntries_EmptyRangeUploadsNothing(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = readHandle.Close() })
 
-	segs, count, err := exportEntries(ctx, storage, readHandle,
+	segs, count, err := exportEntries(ctx, logging.Testing(), storage, readHandle,
 		dal.ZoneCold, dal.SubColdAppliedProposal, 0, 100, "appliedProposal",
 		func(part int) string { return ExportAppliedProposalSegmentKey("bucket", 1, 100, part) },
 		maxExportSegmentBytes,

--- a/internal/infra/backup/manifest.go
+++ b/internal/infra/backup/manifest.go
@@ -39,6 +39,16 @@ type CheckpointManifest struct {
 type CheckpointFile struct {
 	Size int64  `json:"size"`
 	Key  string `json:"key"`
+	// ModTimeUnixNano is the checkpoint file's modification time (unix nanos).
+	// It lets a later backup skip re-hashing an unchanged immutable file
+	// (.sst/.blob): if the same local name still has the same size and mtime,
+	// the content is byte-identical within the store lineage, so the prior
+	// content-addressed Key is reused as-is. mtime doubles as the lineage
+	// discriminator — RestoreCheckpoint writes fresh files, so a restored file
+	// with a colliding number+size gets a new mtime and is correctly re-hashed.
+	// Zero on manifests written before this field existed (reuse then never
+	// triggers → one full re-hash, then steady state).
+	ModTimeUnixNano int64 `json:"modTimeUnixNano"`
 }
 
 // ExportSegment describes a single incremental export segment stored on S3.

--- a/internal/infra/backup/rehash_retry_test.go
+++ b/internal/infra/backup/rehash_retry_test.go
@@ -1,0 +1,315 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// stubHashCounter swaps hashFileFn for one that records the base name of every
+// file it hashes (then delegates to the real hasher), returning a restore func.
+// Tests using it must NOT run in parallel: hashFileFn is a package global.
+func stubHashCounter(hashed *[]string) func() {
+	orig := hashFileFn
+	hashFileFn = func(ctx context.Context, path string) (string, error) {
+		*hashed = append(*hashed, filepath.Base(path))
+
+		return orig(ctx, path)
+	}
+
+	return func() { hashFileFn = orig }
+}
+
+func writeCheckpointFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+}
+
+// TestListCheckpointFiles_ReusesUnchangedImmutableFiles verifies that an
+// unchanged .sst/.blob (same name+size+mtime, key still present remotely) is
+// NOT re-hashed on a subsequent run, while metadata files are always hashed.
+func TestListCheckpointFiles_ReusesUnchangedImmutableFiles(t *testing.T) {
+	// No t.Parallel(): mutates the hashFileFn global.
+	dir := t.TempDir()
+	writeCheckpointFile(t, dir, "100.sst", "sst-contents")
+	writeCheckpointFile(t, dir, "200.blob", "blob-contents")
+	writeCheckpointFile(t, dir, "MANIFEST-000001", "manifest-contents")
+	writeCheckpointFile(t, dir, "CURRENT", "MANIFEST-000001\n")
+
+	ctx := logging.TestingContext()
+
+	// First pass: no prior manifest → every file is hashed.
+	var firstHashed []string
+	restore := stubHashCounter(&firstHashed)
+	files1, err := listCheckpointFiles(ctx, "bucket", dir, &Manifest{}, nil)
+	restore()
+	require.NoError(t, err)
+	require.Len(t, files1, 4)
+	require.ElementsMatch(t, []string{"100.sst", "200.blob", "MANIFEST-000001", "CURRENT"}, firstHashed)
+
+	// Prior manifest = the first pass output; mark the immutable keys present remotely.
+	prev := &Manifest{Checkpoint: &CheckpointManifest{Files: files1}}
+	existing := map[string]struct{}{
+		files1["100.sst"].Key:  {},
+		files1["200.blob"].Key: {},
+	}
+
+	// Second pass: .sst/.blob reused (not hashed); metadata files re-hashed.
+	var secondHashed []string
+	restore = stubHashCounter(&secondHashed)
+	files2, err := listCheckpointFiles(ctx, "bucket", dir, prev, existing)
+	restore()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"MANIFEST-000001", "CURRENT"}, secondHashed,
+		"only mutable-name metadata files should be re-hashed")
+	require.Equal(t, files1["100.sst"].Key, files2["100.sst"].Key, "reused key must be identical")
+	require.Equal(t, files1["200.blob"].Key, files2["200.blob"].Key)
+}
+
+// TestListCheckpointFiles_ReHashesWhenRemoteObjectMissing is the critical
+// correctness guard: a prior key whose object is NOT present remotely must be
+// re-hashed, never reused (reuse would record a stale hash for current bytes).
+func TestListCheckpointFiles_ReHashesWhenRemoteObjectMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeCheckpointFile(t, dir, "100.sst", "sst-contents")
+
+	ctx := logging.TestingContext()
+
+	files1, err := listCheckpointFiles(ctx, "bucket", dir, &Manifest{}, nil)
+	require.NoError(t, err)
+
+	prev := &Manifest{Checkpoint: &CheckpointManifest{Files: files1}}
+
+	// existingKeys is empty → object missing remotely → must re-hash.
+	var hashed []string
+	restore := stubHashCounter(&hashed)
+	_, err = listCheckpointFiles(ctx, "bucket", dir, prev, map[string]struct{}{})
+	restore()
+	require.NoError(t, err)
+	require.Contains(t, hashed, "100.sst", "must re-hash when the prior key is absent remotely")
+}
+
+// TestListCheckpointFiles_ReHashesOnSizeChange verifies a size change defeats reuse.
+func TestListCheckpointFiles_ReHashesOnSizeChange(t *testing.T) {
+	dir := t.TempDir()
+	writeCheckpointFile(t, dir, "100.sst", "sst-contents")
+
+	ctx := logging.TestingContext()
+	files1, err := listCheckpointFiles(ctx, "bucket", dir, &Manifest{}, nil)
+	require.NoError(t, err)
+
+	// Prior manifest records a different size for the same name.
+	stale := files1["100.sst"]
+	stale.Size += 1
+	prev := &Manifest{Checkpoint: &CheckpointManifest{Files: map[string]CheckpointFile{"100.sst": stale}}}
+	existing := map[string]struct{}{stale.Key: {}}
+
+	var hashed []string
+	restore := stubHashCounter(&hashed)
+	_, err = listCheckpointFiles(ctx, "bucket", dir, prev, existing)
+	restore()
+	require.NoError(t, err)
+	require.Contains(t, hashed, "100.sst", "size mismatch must force a re-hash")
+}
+
+// flakyStorage fails PutFile a fixed number of times, then succeeds. Only
+// PutFile is exercised by the retry helpers; the rest satisfy the interface.
+type flakyStorage struct {
+	failsLeft int
+	calls     int
+}
+
+func (f *flakyStorage) PutFile(_ context.Context, _ string, data io.Reader, _ int64) error {
+	f.calls++
+	_, _ = io.Copy(io.Discard, data) // drain so a pipe body unblocks
+
+	if f.failsLeft > 0 {
+		f.failsLeft--
+
+		return errors.New("transient upload error")
+	}
+
+	return nil
+}
+
+func (f *flakyStorage) GetFile(context.Context, string) (io.ReadCloser, error) {
+	return nil, ErrFileNotFound
+}
+func (f *flakyStorage) DeleteFile(context.Context, string) error            { return nil }
+func (f *flakyStorage) ListFiles(context.Context, string) ([]string, error) { return nil, nil }
+
+// withFastBackoff shrinks the retry backoff so retry tests run quickly.
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+	origInit, origMax := uploadInitialBackoff, uploadMaxBackoff
+	uploadInitialBackoff = time.Millisecond
+	uploadMaxBackoff = 2 * time.Millisecond
+	t.Cleanup(func() {
+		uploadInitialBackoff = origInit
+		uploadMaxBackoff = origMax
+	})
+}
+
+func TestPutWithRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	withFastBackoff(t)
+
+	storage := &flakyStorage{failsLeft: 2}
+
+	var cleanups int
+	err := putWithRetry(context.Background(), storage, "k", 3, logging.Testing(), func() (io.Reader, func(), error) {
+		return bytes.NewReader([]byte("abc")), func() { cleanups++ }, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, storage.calls, "should retry twice then succeed")
+	require.Equal(t, 3, cleanups, "cleanup must run once per attempt")
+}
+
+func TestPutWithRetry_ExhaustsAttempts(t *testing.T) {
+	withFastBackoff(t)
+
+	storage := &flakyStorage{failsLeft: 100}
+	err := putWithRetry(context.Background(), storage, "k", 0, logging.Testing(), func() (io.Reader, func(), error) {
+		return bytes.NewReader([]byte("abc")), func() {}, nil
+	})
+	require.Error(t, err)
+	require.Equal(t, uploadMaxAttempts, storage.calls)
+}
+
+func TestPutWithRetry_NoRetryOnCanceledContext(t *testing.T) {
+	withFastBackoff(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	storage := &flakyStorage{failsLeft: 100}
+	err := putWithRetry(ctx, storage, "k", 0, logging.Testing(), func() (io.Reader, func(), error) {
+		return bytes.NewReader([]byte("abc")), func() {}, nil
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, storage.calls, "a cancelled context must not be retried")
+}
+
+// TestListCheckpointFiles_ReHashesOnMtimeChange verifies that a size-identical
+// file whose mtime differs from the prior manifest is re-hashed — mtime alone
+// must defeat reuse (it is the store-lineage discriminator).
+func TestListCheckpointFiles_ReHashesOnMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+	writeCheckpointFile(t, dir, "100.sst", "sst-contents")
+
+	ctx := logging.TestingContext()
+	files1, err := listCheckpointFiles(ctx, "bucket", dir, &Manifest{}, nil)
+	require.NoError(t, err)
+
+	// Same name, same size, but the prior manifest recorded an older mtime.
+	stale := files1["100.sst"]
+	stale.ModTimeUnixNano -= int64(time.Second)
+	require.Equal(t, files1["100.sst"].Size, stale.Size, "guard: size must be identical for this test")
+
+	prev := &Manifest{Checkpoint: &CheckpointManifest{Files: map[string]CheckpointFile{"100.sst": stale}}}
+	existing := map[string]struct{}{stale.Key: {}}
+
+	var hashed []string
+	restore := stubHashCounter(&hashed)
+	_, err = listCheckpointFiles(ctx, "bucket", dir, prev, existing)
+	restore()
+	require.NoError(t, err)
+	require.Contains(t, hashed, "100.sst", "mtime mismatch with identical size must force a re-hash")
+}
+
+// partialFailOnceStorage wraps a working in-memory storage but, the first time
+// each key is uploaded, reads a few bytes off the body then returns an error —
+// simulating a transient failure after a partial pipe read. The retry must
+// re-seek the iterator and re-stream the segment from scratch.
+type partialFailOnceStorage struct {
+	*inMemoryBackupStorage
+
+	failed map[string]bool
+	calls  int
+}
+
+func (s *partialFailOnceStorage) PutFile(ctx context.Context, key string, data io.Reader, size int64) error {
+	s.calls++
+
+	if !s.failed[key] {
+		s.failed[key] = true
+
+		buf := make([]byte, 4)
+		_, _ = data.Read(buf) // partial read, then abandon
+
+		return errors.New("simulated transient upload failure after partial read")
+	}
+
+	return s.inMemoryBackupStorage.PutFile(ctx, key, data, size)
+}
+
+// TestExportEntries_RetriesStreamedSegmentAndRoundTrips exercises the streaming
+// (io.Pipe) retry path: the first PutFile for the segment fails after a partial
+// read, the retry re-seeks the Pebble iterator to the segment start and
+// re-streams, and applying the result reconstructs every entry — proving the
+// re-seek replays the exact same bytes.
+func TestExportEntries_RetriesStreamedSegmentAndRoundTrips(t *testing.T) {
+	withFastBackoff(t)
+
+	ctx := logging.TestingContext()
+	src := newBackupTestStore(t)
+
+	const n = 5
+
+	want := make(map[uint64][]byte, n)
+
+	batch := src.OpenWriteSession()
+	for seq := uint64(1); seq <= n; seq++ {
+		val := bytes.Repeat([]byte{byte(seq)}, 256)
+		require.NoError(t, batch.SetBytes(coldLogKey(seq), val))
+		want[seq] = val
+	}
+
+	require.NoError(t, batch.Commit())
+
+	storage := &partialFailOnceStorage{
+		inMemoryBackupStorage: newInMemoryBackupStorage(),
+		failed:                map[string]bool{},
+	}
+
+	readHandle, err := src.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = readHandle.Close() })
+
+	// Large cap → a single segment, so exactly one key is uploaded (fail + retry).
+	segs, count, err := exportEntries(ctx, logging.Testing(), storage, readHandle,
+		dal.ZoneCold, dal.SubColdLog, 0, n, "log",
+		func(part int) string { return ExportLogSegmentKey("bucket", 1, n, part) },
+		1<<30,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(n), count)
+	require.Len(t, segs, 1)
+	require.Equal(t, 2, storage.calls, "segment upload must fail once then succeed on retry")
+
+	// Round-trip: applying the retried segment reconstructs every entry, proving
+	// the iterator re-seek replayed the identical range.
+	dst := newBackupTestStore(t)
+	require.NoError(t, ApplyExports(ctx, logging.Testing(), storage, dst, segs))
+
+	dstHandle, err := dst.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dstHandle.Close() })
+
+	for seq := uint64(1); seq <= n; seq++ {
+		got, closer, err := dstHandle.Get(coldLogKey(seq))
+		require.NoError(t, err, "seq %d", seq)
+		require.Equal(t, want[seq], got, "seq %d", seq)
+		_ = closer.Close()
+	}
+}

--- a/internal/infra/backup/rehash_retry_test.go
+++ b/internal/infra/backup/rehash_retry_test.go
@@ -313,3 +313,75 @@ func TestExportEntries_RetriesStreamedSegmentAndRoundTrips(t *testing.T) {
 		_ = closer.Close()
 	}
 }
+
+func TestCtxReader_Read(t *testing.T) {
+	t.Parallel()
+
+	// Live context: reads pass through.
+	live := &ctxReader{ctx: context.Background(), r: bytes.NewReader([]byte("abc"))}
+	buf := make([]byte, 3)
+	n, err := live.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	// Cancelled context: reads short-circuit with the context error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	dead := &ctxReader{ctx: ctx, r: bytes.NewReader([]byte("abc"))}
+	_, err = dead.Read(buf)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestHashFile_OpenError(t *testing.T) {
+	t.Parallel()
+
+	_, err := hashFile(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestPutWithRetry_BodyFactoryError(t *testing.T) {
+	withFastBackoff(t)
+
+	storage := &flakyStorage{}
+	err := putWithRetry(context.Background(), storage, "k", 0, logging.Testing(), func() (io.Reader, func(), error) {
+		return nil, func() {}, errors.New("cannot open body")
+	})
+	require.Error(t, err)
+	require.Equal(t, 0, storage.calls, "PutFile must not be called when the body cannot be prepared")
+}
+
+func TestWriteManifestWithRetry_RetriesThenSucceeds(t *testing.T) {
+	withFastBackoff(t)
+
+	storage := &flakyStorage{failsLeft: 1}
+	m := &Manifest{Checkpoint: &CheckpointManifest{Files: map[string]CheckpointFile{}}}
+	err := writeManifestWithRetry(context.Background(), storage, "backups/manifest.json", m, logging.Testing())
+	require.NoError(t, err)
+	require.Equal(t, 2, storage.calls, "manifest write must retry the transient failure")
+}
+
+func TestUploadFile_StatError(t *testing.T) {
+	t.Parallel()
+
+	storage := &flakyStorage{}
+	err := uploadFile(context.Background(), logging.Testing(), storage, t.TempDir(), "some/key", "missing.sst")
+	require.Error(t, err)
+	require.Equal(t, 0, storage.calls, "a missing local file must fail before any upload")
+}
+
+func TestListCheckpointFiles_ContextCancelledAbortsWalk(t *testing.T) {
+	// No t.Parallel(): mutates the hashFileFn global.
+	dir := t.TempDir()
+	writeCheckpointFile(t, dir, "100.sst", "sst-contents")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var hashed []string
+	restore := stubHashCounter(&hashed)
+	_, err := listCheckpointFiles(ctx, "bucket", dir, &Manifest{}, nil)
+	restore()
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, hashed, "a cancelled walk must not hash any file")
+}

--- a/internal/infra/backup/retry.go
+++ b/internal/infra/backup/retry.go
@@ -1,0 +1,111 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// Upload retry bounds. The aws-sdk-go-v2 manager already retries transient
+// individual part PUTs internally; this layer adds a bounded whole-object
+// retry the SDK will NOT do for a non-retryable 400 such as the
+// CompleteMultipartUpload InvalidPart we observed. Fixed (no config knob): a
+// backup is worth a handful of retries, and the bound caps wasted time on a
+// genuinely permanent error (auth/config).
+const uploadMaxAttempts = 5
+
+// Backoff bounds are vars (not consts) solely so tests can shrink them; they
+// are never reconfigured at runtime.
+var (
+	uploadInitialBackoff = 500 * time.Millisecond
+	uploadMaxBackoff     = 30 * time.Second
+)
+
+// bodyFactory produces a fresh reader for one upload attempt plus a cleanup to
+// release it. A streamed body (an *os.File, an io.Pipe) is single-use, so a
+// retried attempt MUST obtain a fresh one. cleanup runs after every attempt —
+// success or failure — so no reader leaks across a retry.
+type bodyFactory func() (io.Reader, func(), error)
+
+// retryUpload runs attempt with bounded exponential backoff. It retries every
+// error EXCEPT context cancellation, which is terminal (leadership loss,
+// shutdown, or caller abort). Cancellation is detected via both ctx.Err() and
+// the context sentinels because storage SDKs frequently wrap cancellation in
+// an opaque error where errors.Is alone would miss it.
+func retryUpload(ctx context.Context, key string, logger logging.Logger, attempt func() error) error {
+	backoff := uploadInitialBackoff
+
+	var lastErr error
+
+	for i := 1; i <= uploadMaxAttempts; i++ {
+		err := attempt()
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+
+		if i == uploadMaxAttempts {
+			break
+		}
+
+		logger.WithFields(map[string]any{
+			"key":     key,
+			"attempt": i,
+			"backoff": backoff.String(),
+			"error":   err,
+		}).Infof("Backup upload attempt failed; retrying")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff = min(backoff*2, uploadMaxBackoff)
+	}
+
+	return fmt.Errorf("upload %s failed after %d attempts: %w", key, uploadMaxAttempts, lastErr)
+}
+
+// putWithRetry uploads key through storage.PutFile with retryUpload's bounded
+// backoff, obtaining a fresh body from newBody for each attempt and always
+// releasing it via the returned cleanup.
+func putWithRetry(ctx context.Context, storage Storage, key string, size int64, logger logging.Logger, newBody bodyFactory) error {
+	return retryUpload(ctx, key, logger, func() error {
+		body, cleanup, err := newBody()
+		if err != nil {
+			return fmt.Errorf("preparing upload body for %s: %w", key, err)
+		}
+
+		defer cleanup()
+
+		return storage.PutFile(ctx, key, body, size)
+	})
+}
+
+// writeManifestWithRetry marshals and writes the manifest with upload retry.
+// A transient failure writing the tiny manifest AFTER a multi-hour data upload
+// would otherwise discard the whole run, so the manifest write is retried just
+// like the data objects. WriteManifest is left untouched for non-backup
+// callers that manage their own error handling.
+func writeManifestWithRetry(ctx context.Context, storage Storage, key string, manifest *Manifest, logger logging.Logger) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling manifest: %w", err)
+	}
+
+	return putWithRetry(ctx, storage, key, int64(len(data)), logger, func() (io.Reader, func(), error) {
+		return bytes.NewReader(data), func() {}, nil
+	})
+}


### PR DESCRIPTION
## Problem

A full backup of a large store (~2 TiB) (1) re-hashed **every** checkpoint file on **every** run — a ~30–70 min silent, non-cancellable prelude before any upload — and (2) failed the whole run on any single transient upload error (no application-level retry around `PutFile`).

Independent of #1631 (disjoint files); both are needed to get a 2 TiB backup through.

## Change (`internal/infra/backup/`)

**Skip re-hashing unchanged files.** `RunBackup` now reads the previous manifest and lists existing objects *before* enumerating files, and reuses a prior file's content-addressed key instead of re-hashing when ALL hold:
- immutable-by-name (`.sst`/`.blob`) — metadata files (MANIFEST/OPTIONS/CURRENT/marker) are always re-hashed;
- same name + size + **mtime** as the previous manifest — mtime is the store-lineage discriminator (`RestoreCheckpoint` writes fresh files → fresh mtime, so a restored colliding file is correctly re-hashed);
- **the reused key is still present remotely** — otherwise a missing object would be re-uploaded under a stale content hash. This guard is load-bearing.

`CheckpointFile` gains `ModTimeUnixNano` (backward compatible: old manifests → zero → one full re-hash after upgrade, then steady state). Hashing is now context-aware (walk + `hashFile`) so a cancelled backup exits the hashing phase promptly instead of holding the destination lock.

**Bounded upload retry** (`retry.go`). `uploadFile`, the export-segment path, and the manifest write retry with bounded exponential backoff (5 attempts, 500 ms→30 s). A fresh body per attempt via a factory (re-`os.Open` the file / re-seek the Pebble iterator; the segment path joins its writer goroutine before re-seeking since iterators aren't concurrency-safe). All errors retried except context cancellation (checked via `ctx.Err()` and the sentinels).

## Verification

- 8 unit tests (reuse-skip, re-hash on missing-remote / size-change / **mtime-change**, retry succeeds/exhausts/no-retry-on-cancel, **streamed-segment retry round-trip**) + all existing backup tests pass.
- `go build ./...` / `-tags s3 ./...`, `go vet`, `golangci-lint` clean.
- ⚠️ No live multi-TiB run yet; s3 integration tests need Docker (CI).

## Residual risk (accepted)

Reusing a prior hash means the backup no longer *incidentally* re-hashes each `.sst`/`.blob` every run, so it wouldn't catch out-of-band corruption preserving name+size+mtime. Pebble's immutable-file contract precludes this in normal operation; object integrity is covered by content-addressing, the audit hash chain, and the checker (invariant #8). Documented on `reusePriorKey`.