### PR TITLE
fix(query,admission): read archived logs from cold storage across replay / ListLogs / prepared-query paths

### DIFF
--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -25,6 +25,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/domain/processing/numscript"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/infra/health"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
 	"github.com/formancehq/ledger/v3/internal/infra/plan"
@@ -64,6 +65,7 @@ type Admission struct {
 	attrs              *attributes.Attributes
 	numscriptCache     *numscript.NumscriptCache
 	coldStorageEnabled bool
+	coldReader         *coldstorage.ColdReader
 	authEnabled        bool
 	waitLeaderReady    func(context.Context) error
 
@@ -132,6 +134,15 @@ func WithReceiptSigner(signer *receipt.Signer) func(*Admission) {
 func WithColdStorageEnabled() func(*Admission) {
 	return func(a *Admission) {
 		a.coldStorageEnabled = true
+	}
+}
+
+// WithColdReader wires the cold-storage reader so an idempotent-replay response
+// can resolve a referenced log whose chapter has been archived and purged from
+// hot storage. Nil (cold storage disabled) leaves resolution hot-only.
+func WithColdReader(cr *coldstorage.ColdReader) func(*Admission) {
+	return func(a *Admission) {
+		a.coldReader = cr
 	}
 }
 
@@ -804,17 +815,44 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) (log
 	}()
 
 	logs = make([]*commonpb.Log, len(result.Logs))
+
+	// A referenced log may live in a chapter that has been archived and purged
+	// from hot storage, so resolve it with a cold-storage fallback (mirroring
+	// GetLog) — otherwise a replay of that key returns an empty log. The cold
+	// read needs a read handle (its archived-chapter lookup iterates), which the
+	// raw store is not; open one lazily, only on the replay path.
+	var handle *dal.ReadHandle
+	defer func() {
+		if handle != nil {
+			_ = handle.Close()
+		}
+	}()
+
 	for i, logOrRef := range result.Logs {
 		if created := logOrRef.GetCreatedLog(); created != nil {
 			logs[i] = created
-		} else if refSeq := logOrRef.GetReferenceSequence(); refSeq > 0 {
-			log, fetchErr := query.ReadLogBySequence(ctx, a.store, refSeq)
-			if fetchErr != nil {
-				return nil, fmt.Errorf("fetching referenced log %d for idempotent response: %w", refSeq, fetchErr)
-			}
 
-			logs[i] = log
+			continue
 		}
+
+		refSeq := logOrRef.GetReferenceSequence()
+		if refSeq == 0 {
+			continue
+		}
+
+		if handle == nil {
+			handle, err = a.store.NewReadHandle()
+			if err != nil {
+				return nil, fmt.Errorf("opening read handle for idempotent response: %w", err)
+			}
+		}
+
+		log, fetchErr := query.ReadLogBySequenceWithCold(ctx, handle, a.coldReader, refSeq)
+		if fetchErr != nil {
+			return nil, fmt.Errorf("fetching referenced log %d for idempotent response: %w", refSeq, fetchErr)
+		}
+
+		logs[i] = log
 	}
 
 	return logs, err

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1679,7 +1679,7 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 		return nil, fmt.Errorf("paginating log filter: %w", paginateErr)
 	}
 
-	c, err := query.ReadLedgerLogsCompiled(handle, ctrl.coldReader, snap, ledgerInfo.GetName(), logIDs)
+	c, err := query.ReadLedgerLogsCompiled(ctx, handle, ctrl.coldReader, snap, ledgerInfo.GetName(), logIDs)
 	if err != nil {
 		_ = handle.Close()
 

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1679,7 +1679,7 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 		return nil, fmt.Errorf("paginating log filter: %w", paginateErr)
 	}
 
-	c, err := query.ReadLedgerLogsCompiled(handle, snap, ledgerInfo.GetName(), logIDs)
+	c, err := query.ReadLedgerLogsCompiled(handle, ctrl.coldReader, snap, ledgerInfo.GetName(), logIDs)
 	if err != nil {
 		_ = handle.Close()
 
@@ -1868,7 +1868,7 @@ func (ctrl *DefaultController) entityEnricher() *query.EntityEnricher {
 func (ctrl *DefaultController) ExecutePreparedQuery(ctx context.Context, req *servicepb.ExecutePreparedQueryRequest) (*servicepb.ExecutePreparedQueryResponse, error) {
 	profile := query.ProfileFromContext(ctx)
 
-	return query.Execute(ctx, ctrl.readStore, ctrl.store, ctrl.attrs.Volume, ctrl.attrs.PreparedQuery, ctrl.attrs.Index, req, profile, ctrl.entityEnricher())
+	return query.Execute(ctx, ctrl.readStore, ctrl.store, ctrl.coldReader, ctrl.attrs.Volume, ctrl.attrs.PreparedQuery, ctrl.attrs.Index, req, profile, ctrl.entityEnricher())
 }
 
 // GetNumscript returns a numscript by ledger, name and optional version ("" = latest).

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -697,7 +697,7 @@ func Module() fx.Option {
 			func(node *node.Node, ctrl ctrl.Controller) httpcompat.Backend {
 				return httpcompat.NewDefaultBackend(node, ctrl)
 			},
-			func(
+			fx.Annotate(func(
 				cfg Config,
 				node *node.Node,
 				store *dal.Store,
@@ -710,6 +710,7 @@ func Module() fx.Option {
 				receiptSigner *receipt.Signer,
 				attrs *attributes.Attributes,
 				authCfg internalauth.AuthConfig,
+				coldReader *coldstorage.ColdReader,
 			) ctrl.Admission {
 				var opts []func(*admission.Admission)
 				if cfg.AdmissionMetrics {
@@ -723,6 +724,10 @@ func Module() fx.Option {
 				if cfg.ColdStorageConfig.Driver != "none" {
 					opts = append(opts, admission.WithColdStorageEnabled())
 				}
+
+				// nil when cold storage is disabled (optional fx dependency) —
+				// idempotent-replay log resolution then stays hot-only.
+				opts = append(opts, admission.WithColdReader(coldReader))
 
 				if authCfg.Enabled {
 					opts = append(opts, admission.WithAuthEnabled())
@@ -742,7 +747,7 @@ func Module() fx.Option {
 					node.WaitLeaderReady,
 					opts...,
 				)
-			},
+			}, fx.ParamTags(``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, ``, `optional:"true"`)),
 			func(
 				logger logging.Logger,
 				store *dal.Store,

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
@@ -44,6 +45,7 @@ func Execute(
 	ctx context.Context,
 	rs *readstore.Store,
 	pebbleStore *dal.Store,
+	coldReader *coldstorage.ColdReader,
 	volumeAttr *attributes.Attribute[*raftcmdpb.VolumePair],
 	preparedQueryAttr *attributes.Attribute[*commonpb.PreparedQuery],
 	indexAttr *attributes.Attribute[*commonpb.Index],
@@ -136,7 +138,7 @@ func Execute(
 
 	switch req.GetMode() {
 	case commonpb.QueryMode_QUERY_MODE_LIST:
-		resp, err = executeList(ctx, iter, pq.GetTarget(), req, profile, handle, indexSnap, ledgerInfo.GetName(), enricher)
+		resp, err = executeList(ctx, iter, pq.GetTarget(), req, profile, handle, coldReader, indexSnap, ledgerInfo.GetName(), enricher)
 		if err != nil {
 			return nil, err
 		}
@@ -169,6 +171,7 @@ func executeList(
 	req *servicepb.ExecutePreparedQueryRequest,
 	profile *QueryProfile,
 	reader dal.PebbleReader,
+	coldReader *coldstorage.ColdReader,
 	indexReader dal.PebbleReader,
 	ledgerName string,
 	enricher *EntityEnricher,
@@ -225,7 +228,7 @@ func executeList(
 
 		cursor.TransactionData = txns
 	case commonpb.QueryTarget_QUERY_TARGET_LOGS:
-		logs, err := EnrichLogs(reader, indexReader, ledgerName, entities)
+		logs, err := EnrichLogs(reader, coldReader, indexReader, ledgerName, entities)
 		if err != nil {
 			return nil, err
 		}
@@ -293,8 +296,8 @@ func EnrichTransactions(ctx context.Context, entityIDs [][]byte, enricher *Entit
 // payloads from Pebble. pebbleReader reads the log payloads (Cold zone);
 // indexReader resolves logID → sequence through the same snapshot used for
 // iteration.
-func EnrichLogs(pebbleReader dal.PebbleReader, indexReader dal.PebbleReader, ledgerName string, logIDs [][]byte) ([]*commonpb.Log, error) {
-	c, err := ReadLedgerLogsCompiled(pebbleReader, indexReader, ledgerName, logIDs)
+func EnrichLogs(pebbleReader dal.PebbleReader, coldReader *coldstorage.ColdReader, indexReader dal.PebbleReader, ledgerName string, logIDs [][]byte) ([]*commonpb.Log, error) {
+	c, err := ReadLedgerLogsCompiled(pebbleReader, coldReader, indexReader, ledgerName, logIDs)
 	if err != nil {
 		return nil, fmt.Errorf("reading ledger logs: %w", err)
 	}

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -228,7 +228,7 @@ func executeList(
 
 		cursor.TransactionData = txns
 	case commonpb.QueryTarget_QUERY_TARGET_LOGS:
-		logs, err := EnrichLogs(reader, coldReader, indexReader, ledgerName, entities)
+		logs, err := EnrichLogs(ctx, reader, coldReader, indexReader, ledgerName, entities)
 		if err != nil {
 			return nil, err
 		}
@@ -296,8 +296,8 @@ func EnrichTransactions(ctx context.Context, entityIDs [][]byte, enricher *Entit
 // payloads from Pebble. pebbleReader reads the log payloads (Cold zone);
 // indexReader resolves logID → sequence through the same snapshot used for
 // iteration.
-func EnrichLogs(pebbleReader dal.PebbleReader, coldReader *coldstorage.ColdReader, indexReader dal.PebbleReader, ledgerName string, logIDs [][]byte) ([]*commonpb.Log, error) {
-	c, err := ReadLedgerLogsCompiled(pebbleReader, coldReader, indexReader, ledgerName, logIDs)
+func EnrichLogs(ctx context.Context, pebbleReader dal.PebbleReader, coldReader *coldstorage.ColdReader, indexReader dal.PebbleReader, ledgerName string, logIDs [][]byte) ([]*commonpb.Log, error) {
+	c, err := ReadLedgerLogsCompiled(ctx, pebbleReader, coldReader, indexReader, ledgerName, logIDs)
 	if err != nil {
 		return nil, fmt.Errorf("reading ledger logs: %w", err)
 	}

--- a/internal/query/executor_ledger_not_found_test.go
+++ b/internal/query/executor_ledger_not_found_test.go
@@ -67,7 +67,7 @@ func TestExecute_LedgerNotFound(t *testing.T) {
 				QueryName: "q",
 			}
 
-			_, err = query.Execute(context.Background(), rs, s, attrs.Volume, attrs.PreparedQuery, attrs.Index, req, nil, nil)
+			_, err = query.Execute(context.Background(), rs, s, nil, attrs.Volume, attrs.PreparedQuery, attrs.Index, req, nil, nil)
 			require.Error(t, err)
 
 			var notFound *domain.ErrLedgerNotFound

--- a/internal/query/log.go
+++ b/internal/query/log.go
@@ -65,9 +65,10 @@ func ReadLogBySequence(ctx context.Context, reader dal.PebbleGetter, sequence ui
 // ledgerLogCursor iterates over pre-fetched global sequences and fetches full
 // Log entries from Pebble on demand. It holds no long-lived resources.
 type ledgerLogCursor struct {
-	pebble dal.PebbleGetter
-	seqs   []uint64
-	pos    int
+	pebble     dal.PebbleReader
+	coldReader *coldstorage.ColdReader
+	seqs       []uint64
+	pos        int
 }
 
 func (c *ledgerLogCursor) Next() (*commonpb.Log, error) {
@@ -78,7 +79,10 @@ func (c *ledgerLogCursor) Next() (*commonpb.Log, error) {
 	seq := c.seqs[c.pos]
 	c.pos++
 
-	log, err := ReadLogBySequence(context.Background(), c.pebble, seq)
+	// Cold-storage fallback: a listed sequence may belong to a chapter that has
+	// been archived and purged from hot storage, so fall back to cold (like
+	// GetLog) instead of failing the whole listing.
+	log, err := ReadLogBySequenceWithCold(context.Background(), c.pebble, c.coldReader, seq)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +106,8 @@ func (c *ledgerLogCursor) Close() error { return nil }
 // truncated query result is worse than a clear error because the caller
 // cannot tell it apart from a legitimate empty result.
 func ReadLedgerLogsCompiled(
-	pebbleReader dal.PebbleGetter,
+	pebbleReader dal.PebbleReader,
+	coldReader *coldstorage.ColdReader,
 	indexReader dal.PebbleGetter,
 	ledgerName string,
 	logIDs [][]byte,
@@ -153,7 +158,7 @@ func ReadLedgerLogsCompiled(
 		_ = closer.Close()
 	}
 
-	return &ledgerLogCursor{pebble: pebbleReader, seqs: seqs}, nil
+	return &ledgerLogCursor{pebble: pebbleReader, coldReader: coldReader, seqs: seqs}, nil
 }
 
 // ReadLogsSinceRaw returns a raw Pebble iterator for logs after the given

--- a/internal/query/log.go
+++ b/internal/query/log.go
@@ -65,6 +65,10 @@ func ReadLogBySequence(ctx context.Context, reader dal.PebbleGetter, sequence ui
 // ledgerLogCursor iterates over pre-fetched global sequences and fetches full
 // Log entries from Pebble on demand. It holds no long-lived resources.
 type ledgerLogCursor struct {
+	// ctx is the request context, carried because Cursor.Next is ctx-less: the
+	// cold-storage fallback below does slow S3 fetch/ingest that must honor
+	// request cancellation and deadlines.
+	ctx        context.Context
 	pebble     dal.PebbleReader
 	coldReader *coldstorage.ColdReader
 	seqs       []uint64
@@ -82,7 +86,7 @@ func (c *ledgerLogCursor) Next() (*commonpb.Log, error) {
 	// Cold-storage fallback: a listed sequence may belong to a chapter that has
 	// been archived and purged from hot storage, so fall back to cold (like
 	// GetLog) instead of failing the whole listing.
-	log, err := ReadLogBySequenceWithCold(context.Background(), c.pebble, c.coldReader, seq)
+	log, err := ReadLogBySequenceWithCold(c.ctx, c.pebble, c.coldReader, seq)
 	if err != nil {
 		return nil, err
 	}
@@ -106,6 +110,7 @@ func (c *ledgerLogCursor) Close() error { return nil }
 // truncated query result is worse than a clear error because the caller
 // cannot tell it apart from a legitimate empty result.
 func ReadLedgerLogsCompiled(
+	ctx context.Context,
 	pebbleReader dal.PebbleReader,
 	coldReader *coldstorage.ColdReader,
 	indexReader dal.PebbleGetter,
@@ -158,7 +163,7 @@ func ReadLedgerLogsCompiled(
 		_ = closer.Close()
 	}
 
-	return &ledgerLogCursor{pebble: pebbleReader, coldReader: coldReader, seqs: seqs}, nil
+	return &ledgerLogCursor{ctx: ctx, pebble: pebbleReader, coldReader: coldReader, seqs: seqs}, nil
 }
 
 // ReadLogsSinceRaw returns a raw Pebble iterator for logs after the given

--- a/internal/query/log_inconsistency_test.go
+++ b/internal/query/log_inconsistency_test.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"encoding/binary"
 	"io"
 	"testing"
@@ -78,6 +79,7 @@ func TestReadLedgerLogsCompiled_HappyPath(t *testing.T) {
 	}
 
 	cur, err := ReadLedgerLogsCompiled(
+		context.Background(),
 		nil, // pebble reader unused in this path (cursor.Next is not called)
 		nil, // cold reader unused
 		newGetterWithEntries(t, entries),
@@ -98,6 +100,7 @@ func TestReadLedgerLogsCompiled_MalformedLogIDBytes(t *testing.T) {
 	t.Parallel()
 
 	_, err := ReadLedgerLogsCompiled(
+		context.Background(),
 		nil, nil, newGetterUnused(t),
 		"test",
 		[][]byte{{0x01, 0x02}}, // logID is only 2 bytes — caught before any Get
@@ -120,6 +123,7 @@ func TestReadLedgerLogsCompiled_IndexGetError(t *testing.T) {
 	const ledgerName = "test"
 
 	_, err := ReadLedgerLogsCompiled(
+		context.Background(),
 		nil,
 		nil,
 		newGetterAlwaysErr(t, pebble.ErrNotFound),
@@ -148,6 +152,7 @@ func TestReadLedgerLogsCompiled_MalformedIndexValue(t *testing.T) {
 	}
 
 	_, err := ReadLedgerLogsCompiled(
+		context.Background(),
 		nil,
 		nil,
 		newGetterWithEntries(t, entries),

--- a/internal/query/log_inconsistency_test.go
+++ b/internal/query/log_inconsistency_test.go
@@ -78,7 +78,8 @@ func TestReadLedgerLogsCompiled_HappyPath(t *testing.T) {
 	}
 
 	cur, err := ReadLedgerLogsCompiled(
-		newGetterUnused(t), // pebble reader unused in this path (cursor.Next is not called)
+		nil, // pebble reader unused in this path (cursor.Next is not called)
+		nil, // cold reader unused
 		newGetterWithEntries(t, entries),
 		ledgerName,
 		[][]byte{logID8(10), logID8(20), logID8(30)},
@@ -97,7 +98,7 @@ func TestReadLedgerLogsCompiled_MalformedLogIDBytes(t *testing.T) {
 	t.Parallel()
 
 	_, err := ReadLedgerLogsCompiled(
-		newGetterUnused(t), newGetterUnused(t),
+		nil, nil, newGetterUnused(t),
 		"test",
 		[][]byte{{0x01, 0x02}}, // logID is only 2 bytes — caught before any Get
 	)
@@ -119,7 +120,8 @@ func TestReadLedgerLogsCompiled_IndexGetError(t *testing.T) {
 	const ledgerName = "test"
 
 	_, err := ReadLedgerLogsCompiled(
-		newGetterUnused(t),
+		nil,
+		nil,
 		newGetterAlwaysErr(t, pebble.ErrNotFound),
 		ledgerName,
 		[][]byte{logID8(99)},
@@ -146,7 +148,8 @@ func TestReadLedgerLogsCompiled_MalformedIndexValue(t *testing.T) {
 	}
 
 	_, err := ReadLedgerLogsCompiled(
-		newGetterUnused(t),
+		nil,
+		nil,
 		newGetterWithEntries(t, entries),
 		ledgerName,
 		[][]byte{logID8(5)},

--- a/tests/e2e/business/idempotency_replay_cold_test.go
+++ b/tests/e2e/business/idempotency_replay_cold_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// A committed idempotency outcome references the committed log by its sequence;
+// a replay resolves that reference back to the log. Once the key's chapter is
+// archived, the log is purged from hot storage, so without a cold-storage
+// fallback the reference resolves to nothing and the replay returns an empty log
+// (sequence 0) instead of the committed outcome — an exactly-once violation. The
+// key itself is not purged (it lives outside the cold zone), so the replay is
+// still served; only the log resolution regresses. This pins that replay
+// resolution falls back to cold storage.
+var _ = Describe("Idempotency replay resolves archived logs from cold storage", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const (
+		httpPort = 15704
+		grpcPort = 15804
+		ledger   = "idem-replay-cold"
+		idemKey  = "replay-cold-key"
+	)
+
+	BeforeAll(func() {
+		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort,
+			testserver.WithColdStorageDriver("filesystem"),
+		)
+	})
+
+	keyedTx := func() *servicepb.ApplyRequest {
+		return actions.WithIdempotencyKey(idemKey,
+			actions.CreateTransactionAction(ledger, []*commonpb.Posting{
+				actions.NewPosting("world", "users:alice", big.NewInt(100), "USD"),
+			}, nil, nil),
+		)
+	}
+
+	It("replays the original committed log after its chapter is archived", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		// First apply commits; capture the committed log's sequence.
+		first, err := client.Apply(ctx, keyedTx())
+		Expect(err).To(Succeed())
+		Expect(first.GetLogs()).To(HaveLen(1))
+		originalSeq := first.GetLogs()[0].GetSequence()
+		Expect(originalSeq).To(BeNumerically(">", 0))
+
+		// Archive the chapter holding the transaction, purging its log from hot
+		// storage into cold.
+		archiveChapterFull(ctx, client)
+
+		// Replay the same key + body. The idempotency cache returns a reference to
+		// the original log sequence; resolving it must fall back to cold storage
+		// and return the original committed log — not an empty (sequence 0) log.
+		replay, err := client.Apply(ctx, keyedTx())
+		Expect(err).To(Succeed(), "replay of an archived key must succeed")
+		Expect(replay.GetLogs()).To(HaveLen(1))
+		Expect(replay.GetLogs()[0].GetSequence()).To(Equal(originalSeq),
+			"replay must resolve the original committed log from cold storage, not an empty log")
+
+		// The resolved log is the real transaction, not a zero value.
+		tx := replay.GetLogs()[0].GetPayload().GetApply().GetLog().GetData().GetCreatedTransaction().GetTransaction()
+		Expect(tx).ToNot(BeNil(), "replayed log must carry the committed transaction")
+		Expect(tx.GetPostings()).To(HaveLen(1))
+		Expect(tx.GetPostings()[0].GetDestination()).To(Equal("users:alice"))
+	})
+})

--- a/tests/e2e/business/listlogs_cold_test.go
+++ b/tests/e2e/business/listlogs_cold_test.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"io"
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// ListLogs pages over sequences from the read-side log index, which still lists
+// a log after its chapter is archived and purged from hot storage — so the
+// per-log fetch must fall back to cold storage. Without that, listing a page
+// that includes an archived log fails the whole call ("log with sequence N not
+// found in Pebble"). This pins the cold fallback in the ListLogs cursor.
+var _ = Describe("ListLogs reads archived logs from cold storage", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+	const (
+		httpPort = 15706
+		grpcPort = 15806
+		ledger   = "listlogs-cold"
+	)
+
+	BeforeAll(func() {
+		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort,
+			testserver.WithColdStorageDriver("filesystem"),
+		)
+	})
+
+	It("lists all logs after their chapter is archived", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		for range 3 {
+			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateForceTransactionAction(ledger, []*commonpb.Posting{
+					actions.NewPosting("world", "acc:1", big.NewInt(10), "USD"),
+				}, nil)))
+			Expect(err).To(Succeed())
+		}
+
+		archiveChapterFull(ctx, client)
+
+		// Give the read-side a moment, then list.
+		var (
+			count   int
+			listErr error
+		)
+		Eventually(func() bool {
+			stream, e := client.ListLogs(ctx, &servicepb.ListLogsRequest{Ledger: ledger})
+			if e != nil {
+				listErr = e
+				return true
+			}
+			count = 0
+			for {
+				_, re := stream.Recv()
+				if re == io.EOF {
+					break
+				}
+				if re != nil {
+					listErr = re
+					return true
+				}
+				count++
+			}
+			return true
+		}).Should(BeTrue())
+
+		Expect(listErr).To(Succeed(), "ListLogs must not error on archived logs")
+		Expect(count).To(Equal(3), "ListLogs returned %d logs after archiving 3", count)
+	})
+})

--- a/tests/e2e/business/listlogs_cold_test.go
+++ b/tests/e2e/business/listlogs_cold_test.go
@@ -53,33 +53,24 @@ var _ = Describe("ListLogs reads archived logs from cold storage", Ordered, func
 
 		archiveChapterFull(ctx, client)
 
-		// Give the read-side a moment, then list.
-		var (
-			count   int
-			listErr error
-		)
-		Eventually(func() bool {
-			stream, e := client.ListLogs(ctx, &servicepb.ListLogsRequest{Ledger: ledger})
-			if e != nil {
-				listErr = e
-				return true
-			}
-			count = 0
+		// The read-side index is eventually consistent, so retry until all three
+		// logs are listable — each must now resolve from cold storage since the
+		// chapter is archived. Asserting inside Eventually makes it actually wait
+		// for the indexer rather than pass on the first attempt.
+		Eventually(func(g Gomega) {
+			stream, err := client.ListLogs(ctx, &servicepb.ListLogsRequest{Ledger: ledger})
+			g.Expect(err).To(Succeed(), "ListLogs must not error on archived logs")
+
+			count := 0
 			for {
 				_, re := stream.Recv()
 				if re == io.EOF {
 					break
 				}
-				if re != nil {
-					listErr = re
-					return true
-				}
+				g.Expect(re).To(Succeed(), "streaming archived logs must not error")
 				count++
 			}
-			return true
-		}).Should(BeTrue())
-
-		Expect(listErr).To(Succeed(), "ListLogs must not error on archived logs")
-		Expect(count).To(Equal(3), "ListLogs returned %d logs after archiving 3", count)
+			g.Expect(count).To(Equal(3), "expected 3 logs after archiving 3")
+		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Problem

`GetLog` reads a log with a cold-storage fallback (`ReadLogBySequenceWithCold`), so it keeps working after a chapter is archived and its logs are purged from hot storage. Several sibling read paths used the hot-only `ReadLogBySequence` and did **not**, so they broke once a log was archived — even though the log is safe in cold storage and the read-side index still references it:

- **Idempotent replay** — a committed idempotency outcome references its committed log by sequence; resolving that reference for the response was hot-only, so replaying a key whose chapter was archived returned an **empty log (sequence 0)** instead of the committed outcome (an exactly-once violation). The key itself is not purged, so the replay was still served — only the log resolution regressed.
- **`ListLogs` / prepared-query `LOGS`** — the read-side log index still lists an archived log's sequence, but the `ledgerLogCursor` fetched each log hot-only, so a page including an archived log failed the whole call with `log with sequence N not found in Pebble` (surfaced to the client as an `Unknown` gRPC error).

This is the same class as #1623 (which fixed `GetTransaction` and its receipt lookup). This PR sweeps the remaining reachable sites.

## Fix

Both paths now resolve logs via `ReadLogBySequenceWithCold`, degrading to hot-only when cold storage is disabled (nil reader) — and archival can't happen without cold storage, so no referenced/listed log is ever purged in that case.

- **admission** (`fceddbc5b`): the idempotent-replay resolution loop opens a read handle lazily (replay path only — the cold chapter lookup iterates, which the raw store can't) and falls back to cold. `ColdReader` is wired into `Admission` as an **optional** fx dependency (`optional:"true"`, matching the controller provider) via a new `WithColdReader` option.
- **query** (`61c7e8dc4`): the `ledgerLogCursor` falls back to cold; the reader is threaded through `ReadLedgerLogsCompiled` / `EnrichLogs` / `executeList` / `Execute`, supplied from `ctrl.coldReader` at both callers (`ListLogs` and `ExecutePreparedQuery`).

## Not affected (reviewed)

`usagebuilder`'s `readLog` (the third `ReadLogBySequence` grep hit) is a forward-only fold over the **audit** stream, and archival purges audit entries **with** their logs — so a present audit entry's log is also present. A log-read fallback there would address nothing; left unchanged.

## Testing

Two e2e tests (filesystem cold storage, `//go:build e2e`), each verified to **fail without the fix**:

- `tests/e2e/business/idempotency_replay_cold_test.go` — a keyed transaction whose chapter is archived replays the original committed log (not sequence 0). Without the fix: replay returns sequence 0.
- `tests/e2e/business/listlogs_cold_test.go` — after archiving a chapter of logs, `ListLogs` still returns them all. Without the fix: `log with sequence N not found in Pebble`.

Changed-package unit tests (query, ctrl, admission, bootstrap) green; lint clean; full module builds.

## Notes

Surfaced while building chapter-archival coverage for the model test (the model driver replaying idempotency keys across archival hit the admission bug; a probe confirmed the `ListLogs` one). No existing Jira ticket covers this class — closest neighbours are EN-1341 (checker-side archived-idempotency verification) and EN-1463 (chapter-close checkpoint queries), neither of which is this read-fallback defect.
