### PR TITLE
fix(operator): apply persistence volume size increases online

### DIFF
--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -99,6 +99,25 @@ spec:
 | `pvcProtection.allowDeletionAnnotation` | `formance.com/allow-deletion` | Annotation key whose value `true` opts a volume out of deletion protection |
 | `pvcProtection.additionalExemptServiceAccounts` | `[]` | Extra ServiceAccount usernames (`system:serviceaccount:<ns>:<name>`) exempt from the policies — sibling operator releases managing protected ledgers, or managed workload/GitOps controllers |
 
+## Volume Resizing
+
+Increasing a volume size in the Cluster spec (`spec.persistence.wal|data|coldCache.size`)
+is applied online. Because a StatefulSet's `volumeClaimTemplates` are **immutable**,
+the operator does not (and cannot) edit them in place; instead it:
+
+1. Patches every existing PVC's `spec.resources.requests.storage` upward, which
+   triggers CSI online expansion of the live disks. This requires the volume's
+   `StorageClass` to have `allowVolumeExpansion: true` and a driver that supports it.
+2. Recreates the StatefulSet with orphan propagation (pods and PVCs are retained and
+   re-adopted, so there is no pod restart) so the refreshed template carries the new
+   size — future scale-out ordinals are then born at the new size.
+
+Resizing is **grow-only**. A smaller size is rejected with a `VolumeShrinkRejected`
+warning event and the PVC is left untouched (Kubernetes does not support shrinking a
+PVC). Each successful expansion emits a `VolumeExpanded` event. The StatefulSet's
+`volumeClaimTemplates` will keep reporting the previous size until the recreate lands;
+the authoritative size is on the PVCs.
+
 ## Volume Deletion Protection
 
 Protection is **on by default**: a freshly deployed ledger is protected without

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -112,11 +112,14 @@ the operator does not (and cannot) edit them in place; instead it:
    re-adopted, so there is no pod restart) so the refreshed template carries the new
    size — future scale-out ordinals are then born at the new size.
 
-Resizing is **grow-only**. A smaller size is rejected with a `VolumeShrinkRejected`
-warning event and the PVC is left untouched (Kubernetes does not support shrinking a
-PVC). Each successful expansion emits a `VolumeExpanded` event. The StatefulSet's
-`volumeClaimTemplates` will keep reporting the previous size until the recreate lands;
-the authoritative size is on the PVCs.
+Resizing is **grow-only**. A requested size below the largest live PVC for a volume
+is rejected with a `VolumeShrinkRejected` warning event, and that volume's template is
+clamped back up to the current size (Kubernetes does not support shrinking a PVC). The
+floor is taken from the live PVCs, not the StatefulSet template, so a rejected shrink
+never leaks into a rebuilt template across the recreate — including when the same
+update grows one volume and shrinks another. Each successful expansion emits a
+`VolumeExpanded` event. The StatefulSet's `volumeClaimTemplates` keep reporting the
+previous size until the recreate lands; the authoritative size is on the PVCs.
 
 ## Volume Deletion Protection
 

--- a/misc/operator/internal/controller/hash.go
+++ b/misc/operator/internal/controller/hash.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
 )
 
@@ -33,6 +35,22 @@ func computeSpecHash(spec *ledgerv1alpha1.ClusterSpec) string {
 	// it has no pod-template effect, so toggling it must not roll the StatefulSet.
 	// Persistence is a value field, so zeroing it on the shallow copy is safe.
 	cp.Persistence.DeletionProtection = nil
+
+	// The PVC-only VolumeSpec fields (size, storageClass, accessMode,
+	// volumeAttributesClassName) map to the VolumeClaimTemplates / live PVCs, not
+	// the pod template — they never appear in buildPodTemplate. A volume resize is
+	// applied online by reconcilePVCExpansion (PVC patch + orphan StatefulSet
+	// recreate); it MUST NOT bump the pod-template hash, or the recreated
+	// StatefulSet would compute a different ControllerRevision from the adopted
+	// pods and (with Partition 0) roll them — defeating the no-restart expansion.
+	// HostPath is deliberately kept: switching a volume between PVC and hostPath
+	// mode DOES change the pod template (inline hostPath volume vs PVC mount).
+	for _, v := range []*ledgerv1alpha1.VolumeSpec{&cp.Persistence.WAL, &cp.Persistence.Data, &cp.Persistence.ColdCache} {
+		v.Size = resource.Quantity{}
+		v.StorageClass = ""
+		v.AccessMode = ""
+		v.VolumeAttributesClassName = ""
+	}
 
 	data, _ := json.Marshal(&cp) //nolint:errchkjson // spec is always serializable
 

--- a/misc/operator/internal/controller/hash_test.go
+++ b/misc/operator/internal/controller/hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
 )
@@ -48,6 +49,20 @@ func TestComputeSpecHash_ExcludesNonPodFields(t *testing.T) {
 	optOut := false
 	withDeletionProtection.Persistence.DeletionProtection = &optOut
 	assert.Equal(t, baseHash, computeSpecHash(withDeletionProtection), "DeletionProtection change should not affect hash")
+
+	// Changing a volume SIZE must NOT change the hash: size maps to the
+	// VolumeClaimTemplate / PVC, not the pod template. Online expansion recreates
+	// the StatefulSet, and a changed hash would roll the adopted pods.
+	withSize := base.DeepCopy()
+	withSize.Persistence.Data.Size = resource.MustParse("100Gi")
+	assert.Equal(t, baseHash, computeSpecHash(withSize), "volume size change should not affect hash")
+
+	// The other PVC-only VolumeSpec fields must not affect the hash either.
+	withPVCFields := base.DeepCopy()
+	withPVCFields.Persistence.Data.StorageClass = "fast"
+	withPVCFields.Persistence.Data.AccessMode = "ReadWriteOncePod"
+	withPVCFields.Persistence.Data.VolumeAttributesClassName = "gold"
+	assert.Equal(t, baseHash, computeSpecHash(withPVCFields), "PVC-only VolumeSpec fields should not affect hash")
 }
 
 func TestComputeSpecHash_IncludesPodFields(t *testing.T) {
@@ -103,4 +118,11 @@ func TestComputeSpecHash_IncludesPodFields(t *testing.T) {
 		LedgerMetadata: &ledgerv1alpha1.BloomFilterConfig{FPRate: "0.001"},
 	}
 	assert.NotEqual(t, baseHash, computeSpecHash(withBloomLedgerMetadata), "Bloom.LedgerMetadata change should affect hash")
+
+	// Switching a volume to hostPath DOES change the pod template (inline hostPath
+	// volume vs PVC mount), so it must still affect the hash even though the other
+	// VolumeSpec fields are excluded.
+	withHostPath := base.DeepCopy()
+	withHostPath.Persistence.Data.HostPath = &ledgerv1alpha1.HostPathVolumeSpec{Path: "/mnt/nvme0/data"}
+	assert.NotEqual(t, baseHash, computeSpecHash(withHostPath), "hostPath switch should affect hash")
 }

--- a/misc/operator/internal/controller/reconcile_pvc_expansion.go
+++ b/misc/operator/internal/controller/reconcile_pvc_expansion.go
@@ -16,29 +16,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// reconcilePVCExpansion grows this Cluster's existing PersistentVolumeClaims to
-// match the desired volumeClaimTemplate sizes.
+// reconcilePVCExpansion reconciles this Cluster's PersistentVolumeClaim sizes
+// toward the desired volumeClaimTemplates, in a single pass over the live PVCs.
+// It does three things:
 //
-// StatefulSet volumeClaimTemplates are immutable, so a size bump in the Cluster
-// spec never reaches the running volumes on its own: the normal update path
-// leaves the template untouched (see reconcileStatefulSet), and even
-// delete-recreating the StatefulSet only re-adopts the existing PVCs — the
-// StatefulSet controller never resizes a PVC it already owns. The live disks are
-// grown by patching each PVC's spec.resources.requests.storage upward, which
-// triggers CSI online expansion (the StorageClass must have
-// allowVolumeExpansion: true and the driver must support it).
+//   - Clamps each desired template size UP to the largest existing PVC for that
+//     volume, mutating `desired` in place. Volume resizing is grow-only, so a
+//     spec size below a live disk is rejected: a VolumeShrinkRejected warning is
+//     emitted once for the volume and the template keeps (at least) the current
+//     size. Flooring against the *live PVCs* — not the StatefulSet template — is
+//     load-bearing: the template is destroyed by the orphan delete-recreate used
+//     to refresh a grown template, and on the following reconcile the template is
+//     rebuilt straight from the (possibly shrunk) spec. The PVCs survive that
+//     delete, so they are the only durable record of the current size. Without
+//     this floor, a spec that grows one volume and shrinks another leaks the
+//     shrunken size into the recreated template and every future scale-out
+//     ordinal (the mixed grow/shrink case). In all operator-managed states the
+//     largest PVC equals the template size, so the floor only diverges when a PVC
+//     was resized out of band.
+//   - Grows each existing PVC whose request is below the clamped desired size via
+//     a spec.resources.requests.storage patch, triggering CSI online expansion
+//     (the StorageClass must have allowVolumeExpansion: true). A PVC already at or
+//     above the desired size is left untouched.
+//   - Returns templateGrew=true when the clamped desired template exceeds the
+//     existing StatefulSet template for any volume, signalling the caller to
+//     recreate the StatefulSet (orphan propagation) so future scale-out ordinals
+//     inherit the new size.
 //
-// It is grow-only. A desired size smaller than a PVC's current request is
-// rejected with a Warning event and the PVC is left untouched: Kubernetes does
-// not support shrinking a PVC and would reject the patch anyway. A missing PVC
-// (an ordinal not yet scaled out) is skipped; it is created from the refreshed
-// template at the new size once it appears.
-//
-// It returns templateGrew=true when the desired template size exceeds the
-// existing StatefulSet template size for any volume, signalling the caller to
-// recreate the StatefulSet (with orphan propagation) so future scale-out
-// ordinals inherit the new template size. A nil recorder/object skips eventing
-// (unit tests without a recorder).
+// existingTemplates is the current StatefulSet's volumeClaimTemplates, or nil
+// when the StatefulSet does not exist yet (e.g. the create pass right after a
+// recreate) — in which case templateGrew is always false but the clamp and the
+// PVC grow still run. A missing PVC (an ordinal not yet scaled out) is skipped;
+// it is created from the template at the clamped size. A nil recorder/object
+// skips eventing (unit tests without a recorder).
 func reconcilePVCExpansion(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -46,14 +56,19 @@ func reconcilePVCExpansion(
 	object runtime.Object,
 	namespace, stsName string,
 	replicas int32,
-	existing, desired []corev1.PersistentVolumeClaim,
+	existingTemplates, desired []corev1.PersistentVolumeClaim,
 ) (bool, error) {
 	logger := log.FromContext(ctx)
 	pvcClient := clientset.CoreV1().PersistentVolumeClaims(namespace)
 
-	existingSizeByName := make(map[string]resource.Quantity, len(existing))
-	for i := range existing {
-		existingSizeByName[existing[i].Name] = *existing[i].Spec.Resources.Requests.Storage()
+	existingSizeByName := make(map[string]resource.Quantity, len(existingTemplates))
+	for i := range existingTemplates {
+		existingSizeByName[existingTemplates[i].Name] = *existingTemplates[i].Spec.Resources.Requests.Storage()
+	}
+
+	type livePVC struct {
+		name string
+		size resource.Quantity
 	}
 
 	templateGrew := false
@@ -64,55 +79,50 @@ func reconcilePVCExpansion(
 			continue
 		}
 
-		// Decide grow vs shrink from the *template* delta — the user's declared
-		// intent for this volume — not from any individual PVC's current request.
-		// A PVC manually expanded past the new template size is NOT a shrink
-		// request: it must be left alone by the grow-only patch below, never
-		// warned about. Comparing per-PVC would (wrongly) flag such a PVC as a
-		// shrink on every reconcile. A size increase also needs a StatefulSet
-		// recreate (templateGrew): the immutable VCT can only be re-emitted by
-		// delete-recreate, and without it a later scale-out ordinal would be born
-		// at the old size.
-		if oldSize, ok := existingSizeByName[vct.Name]; ok {
-			switch cmp := desiredSize.Cmp(oldSize); {
-			case cmp < 0:
-				// Spec-driven shrink intent: unsupported. Warn once for the volume
-				// and leave its PVCs untouched rather than issuing a patch the API
-				// server would reject.
-				msg := fmt.Sprintf("refusing to shrink volume %q from %s to %s: "+
-					"Kubernetes does not support shrinking a PersistentVolumeClaim",
-					vct.Name, oldSize.String(), desiredSize.String())
-				logger.Info(msg)
-				if recorder != nil && object != nil {
-					recorder.Event(object, corev1.EventTypeWarning, "VolumeShrinkRejected", msg)
-				}
-
-				continue
-			case cmp > 0:
-				templateGrew = true
-			}
-			// cmp == 0 falls through: the grow loop is a no-op for matching PVCs
-			// but self-heals any PVC that lags the (unchanged) template size.
-		}
-
-		// Grow-only: patch each existing PVC strictly below the desired size. A PVC
-		// already at or above it (equal, or manually over-expanded) is skipped
-		// silently — never shrunk, never warned about.
+		// Read this volume's live PVCs once: track the largest request (the
+		// grow-only floor) and keep the list so we can grow the laggards below.
+		var floor resource.Quantity
+		var pvcs []livePVC
 		for ordinal := range replicas {
 			pvcName := fmt.Sprintf("%s-%s-%d", vct.Name, stsName, ordinal)
 			pvc, err := pvcClient.Get(ctx, pvcName, metav1.GetOptions{})
 			if err != nil {
 				if kerrors.IsNotFound(err) {
-					// Not yet scaled out; the StatefulSet controller creates it from
-					// the refreshed template at the new size.
-					continue
+					continue // not yet scaled out; born from the template at the clamped size
 				}
 
 				return false, fmt.Errorf("getting PVC %s: %w", pvcName, err)
 			}
 
-			current := pvc.Spec.Resources.Requests.Storage()
-			if desiredSize.Cmp(*current) <= 0 {
+			size := *pvc.Spec.Resources.Requests.Storage()
+			if size.Cmp(floor) > 0 {
+				floor = size
+			}
+			pvcs = append(pvcs, livePVC{name: pvcName, size: size})
+		}
+
+		// Grow-only: never let the template drop below the largest live disk.
+		if !floor.IsZero() && desiredSize.Cmp(floor) < 0 {
+			msg := fmt.Sprintf("refusing to shrink volume %q from %s to %s: Kubernetes does "+
+				"not support shrinking a PersistentVolumeClaim; keeping the current size",
+				vct.Name, floor.String(), desiredSize.String())
+			logger.Info(msg)
+			if recorder != nil && object != nil {
+				recorder.Event(object, corev1.EventTypeWarning, "VolumeShrinkRejected", msg)
+			}
+			vct.Spec.Resources.Requests[corev1.ResourceStorage] = floor
+			desiredSize = vct.Spec.Resources.Requests.Storage() // re-read: the map now holds `floor`
+		}
+
+		// A size increase must be re-emitted into the immutable template, which
+		// only a delete-recreate can do — otherwise a later scale-out ordinal is
+		// born at the old size.
+		if oldSize, ok := existingSizeByName[vct.Name]; ok && desiredSize.Cmp(oldSize) > 0 {
+			templateGrew = true
+		}
+
+		for _, p := range pvcs {
+			if desiredSize.Cmp(p.size) <= 0 {
 				continue // already at or above the desired size
 			}
 
@@ -126,15 +136,15 @@ func reconcilePVCExpansion(
 				},
 			})
 			if err != nil {
-				return false, fmt.Errorf("marshaling storage expansion patch for PVC %s: %w", pvcName, err)
+				return false, fmt.Errorf("marshaling storage expansion patch for PVC %s: %w", p.name, err)
 			}
-			if _, err := pvcClient.Patch(ctx, pvcName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
-				return false, fmt.Errorf("patching storage request on PVC %s: %w", pvcName, err)
+			if _, err := pvcClient.Patch(ctx, p.name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+				return false, fmt.Errorf("patching storage request on PVC %s: %w", p.name, err)
 			}
-			logger.Info("expanded PVC storage request", "pvc", pvcName, "from", current.String(), "to", desiredSize.String())
+			logger.Info("expanded PVC storage request", "pvc", p.name, "from", p.size.String(), "to", desiredSize.String())
 			if recorder != nil && object != nil {
 				recorder.Eventf(object, corev1.EventTypeNormal, "VolumeExpanded",
-					"expanded PVC %s from %s to %s", pvcName, current.String(), desiredSize.String())
+					"expanded PVC %s from %s to %s", p.name, p.size.String(), desiredSize.String())
 			}
 		}
 	}

--- a/misc/operator/internal/controller/reconcile_pvc_expansion.go
+++ b/misc/operator/internal/controller/reconcile_pvc_expansion.go
@@ -1,0 +1,143 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// reconcilePVCExpansion grows this Cluster's existing PersistentVolumeClaims to
+// match the desired volumeClaimTemplate sizes.
+//
+// StatefulSet volumeClaimTemplates are immutable, so a size bump in the Cluster
+// spec never reaches the running volumes on its own: the normal update path
+// leaves the template untouched (see reconcileStatefulSet), and even
+// delete-recreating the StatefulSet only re-adopts the existing PVCs — the
+// StatefulSet controller never resizes a PVC it already owns. The live disks are
+// grown by patching each PVC's spec.resources.requests.storage upward, which
+// triggers CSI online expansion (the StorageClass must have
+// allowVolumeExpansion: true and the driver must support it).
+//
+// It is grow-only. A desired size smaller than a PVC's current request is
+// rejected with a Warning event and the PVC is left untouched: Kubernetes does
+// not support shrinking a PVC and would reject the patch anyway. A missing PVC
+// (an ordinal not yet scaled out) is skipped; it is created from the refreshed
+// template at the new size once it appears.
+//
+// It returns templateGrew=true when the desired template size exceeds the
+// existing StatefulSet template size for any volume, signalling the caller to
+// recreate the StatefulSet (with orphan propagation) so future scale-out
+// ordinals inherit the new template size. A nil recorder/object skips eventing
+// (unit tests without a recorder).
+func reconcilePVCExpansion(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	recorder record.EventRecorder,
+	object runtime.Object,
+	namespace, stsName string,
+	replicas int32,
+	existing, desired []corev1.PersistentVolumeClaim,
+) (bool, error) {
+	logger := log.FromContext(ctx)
+	pvcClient := clientset.CoreV1().PersistentVolumeClaims(namespace)
+
+	existingSizeByName := make(map[string]resource.Quantity, len(existing))
+	for i := range existing {
+		existingSizeByName[existing[i].Name] = *existing[i].Spec.Resources.Requests.Storage()
+	}
+
+	templateGrew := false
+	for i := range desired {
+		vct := &desired[i]
+		desiredSize := vct.Spec.Resources.Requests.Storage()
+		if desiredSize.IsZero() {
+			continue
+		}
+
+		// Decide grow vs shrink from the *template* delta — the user's declared
+		// intent for this volume — not from any individual PVC's current request.
+		// A PVC manually expanded past the new template size is NOT a shrink
+		// request: it must be left alone by the grow-only patch below, never
+		// warned about. Comparing per-PVC would (wrongly) flag such a PVC as a
+		// shrink on every reconcile. A size increase also needs a StatefulSet
+		// recreate (templateGrew): the immutable VCT can only be re-emitted by
+		// delete-recreate, and without it a later scale-out ordinal would be born
+		// at the old size.
+		if oldSize, ok := existingSizeByName[vct.Name]; ok {
+			switch cmp := desiredSize.Cmp(oldSize); {
+			case cmp < 0:
+				// Spec-driven shrink intent: unsupported. Warn once for the volume
+				// and leave its PVCs untouched rather than issuing a patch the API
+				// server would reject.
+				msg := fmt.Sprintf("refusing to shrink volume %q from %s to %s: "+
+					"Kubernetes does not support shrinking a PersistentVolumeClaim",
+					vct.Name, oldSize.String(), desiredSize.String())
+				logger.Info(msg)
+				if recorder != nil && object != nil {
+					recorder.Event(object, corev1.EventTypeWarning, "VolumeShrinkRejected", msg)
+				}
+
+				continue
+			case cmp > 0:
+				templateGrew = true
+			}
+			// cmp == 0 falls through: the grow loop is a no-op for matching PVCs
+			// but self-heals any PVC that lags the (unchanged) template size.
+		}
+
+		// Grow-only: patch each existing PVC strictly below the desired size. A PVC
+		// already at or above it (equal, or manually over-expanded) is skipped
+		// silently — never shrunk, never warned about.
+		for ordinal := range replicas {
+			pvcName := fmt.Sprintf("%s-%s-%d", vct.Name, stsName, ordinal)
+			pvc, err := pvcClient.Get(ctx, pvcName, metav1.GetOptions{})
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					// Not yet scaled out; the StatefulSet controller creates it from
+					// the refreshed template at the new size.
+					continue
+				}
+
+				return false, fmt.Errorf("getting PVC %s: %w", pvcName, err)
+			}
+
+			current := pvc.Spec.Resources.Requests.Storage()
+			if desiredSize.Cmp(*current) <= 0 {
+				continue // already at or above the desired size
+			}
+
+			patch, err := json.Marshal(map[string]any{
+				"spec": map[string]any{
+					"resources": map[string]any{
+						"requests": map[string]any{
+							string(corev1.ResourceStorage): desiredSize.String(),
+						},
+					},
+				},
+			})
+			if err != nil {
+				return false, fmt.Errorf("marshaling storage expansion patch for PVC %s: %w", pvcName, err)
+			}
+			if _, err := pvcClient.Patch(ctx, pvcName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+				return false, fmt.Errorf("patching storage request on PVC %s: %w", pvcName, err)
+			}
+			logger.Info("expanded PVC storage request", "pvc", pvcName, "from", current.String(), "to", desiredSize.String())
+			if recorder != nil && object != nil {
+				recorder.Eventf(object, corev1.EventTypeNormal, "VolumeExpanded",
+					"expanded PVC %s from %s to %s", pvcName, current.String(), desiredSize.String())
+			}
+		}
+	}
+
+	return templateGrew, nil
+}

--- a/misc/operator/internal/controller/reconcile_pvc_expansion_test.go
+++ b/misc/operator/internal/controller/reconcile_pvc_expansion_test.go
@@ -25,12 +25,15 @@ func vct(name, size string) corev1.PersistentVolumeClaim {
 	}
 }
 
-// dataPVC builds a bound-looking data PVC for the given ordinal at a size.
-func dataPVC(ordinal int, namespace, size string) *corev1.PersistentVolumeClaim {
-	pvc := dataPVCName(ordinal)
+func volPVCName(vol string, ordinal int) string {
+	return vol + "-" + testStsName + "-" + string(rune('0'+ordinal))
+}
 
+// volPVC builds a PVC for the given volume/ordinal at a size, mirroring the
+// StatefulSet naming convention <volume>-<stsName>-<ordinal>.
+func volPVC(vol string, ordinal int, namespace, size string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: pvc, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: volPVCName(vol, ordinal), Namespace: namespace},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
@@ -39,16 +42,23 @@ func dataPVC(ordinal int, namespace, size string) *corev1.PersistentVolumeClaim 
 	}
 }
 
-func dataPVCName(ordinal int) string {
-	return "data-" + testStsName + "-" + string(rune('0'+ordinal))
+func dataPVC(ordinal int, namespace, size string) *corev1.PersistentVolumeClaim {
+	return volPVC("data", ordinal, namespace, size)
 }
 
-func pvcStorage(t *testing.T, cs *fake.Clientset, ordinal int) *resource.Quantity {
+func volStorage(t *testing.T, cs *fake.Clientset, vol string, ordinal int) *resource.Quantity {
 	t.Helper()
-	got, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), dataPVCName(ordinal), metav1.GetOptions{})
+	got, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), volPVCName(vol, ordinal), metav1.GetOptions{})
 	require.NoError(t, err)
 
 	return got.Spec.Resources.Requests.Storage()
+}
+
+// requireQuantity asserts a quantity equals the parsed want string.
+func requireQuantity(t *testing.T, got *resource.Quantity, want string) {
+	t.Helper()
+	w := resource.MustParse(want)
+	require.Equal(t, 0, got.Cmp(w), "got %s, want %s", got.String(), want)
 }
 
 func TestReconcilePVCExpansion_GrowsAllPVCsAndSignalsRecreate(t *testing.T) {
@@ -63,10 +73,8 @@ func TestReconcilePVCExpansion_GrowsAllPVCsAndSignalsRecreate(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, grew, "a template size increase must signal a StatefulSet recreate")
 
-	want := resource.MustParse("3Ti")
 	for ordinal := range 3 {
-		require.Equal(t, 0, pvcStorage(t, cs, ordinal).Cmp(want),
-			"PVC ordinal %d must be grown to 3Ti", ordinal)
+		requireQuantity(t, volStorage(t, cs, "data", ordinal), "3Ti")
 	}
 }
 
@@ -85,7 +93,7 @@ func TestReconcilePVCExpansion_NoChangeIsNoop(t *testing.T) {
 	require.Zero(t, *patches, "equal sizes must not patch any PVC")
 }
 
-func TestReconcilePVCExpansion_ShrinkIsRejectedAndPVCUntouched(t *testing.T) {
+func TestReconcilePVCExpansion_ShrinkIsRejectedAndClampedToLiveSize(t *testing.T) {
 	t.Parallel()
 
 	cs := fake.NewClientset(dataPVC(0, "ns", "3Ti"))
@@ -93,16 +101,16 @@ func TestReconcilePVCExpansion_ShrinkIsRejectedAndPVCUntouched(t *testing.T) {
 	rec := record.NewFakeRecorder(4)
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
 
+	desired := []corev1.PersistentVolumeClaim{vct("data", "2Ti")}
 	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
-		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
-		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
-	)
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")}, desired)
 	require.NoError(t, err)
 	require.False(t, grew, "a shrink must not trigger a recreate")
 	require.Zero(t, *patches, "a shrink must never patch the PVC")
 
-	want := resource.MustParse("3Ti")
-	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want), "PVC must be left at its original size")
+	// The desired template is clamped back up to the live disk size in place.
+	requireQuantity(t, desired[0].Spec.Resources.Requests.Storage(), "3Ti")
+	requireQuantity(t, volStorage(t, cs, "data", 0), "3Ti")
 
 	select {
 	case ev := <-rec.Events:
@@ -125,40 +133,34 @@ func TestReconcilePVCExpansion_MissingPVCSkipped(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, grew)
 
-	want := resource.MustParse("3Ti")
-	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want), "existing PVC is grown")
+	requireQuantity(t, volStorage(t, cs, "data", 0), "3Ti")
 	// Missing ordinals must not error and must not be created by this pass.
-	_, err = cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), dataPVCName(1), metav1.GetOptions{})
+	_, err = cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), volPVCName("data", 1), metav1.GetOptions{})
 	require.Error(t, err, "the expansion pass must not create absent PVCs")
 }
 
-func TestReconcilePVCExpansion_GrowOnlyPVCAlreadyLargerLeftAlone(t *testing.T) {
+func TestReconcilePVCExpansion_SpecBelowLargestLiveDiskClampsUp(t *testing.T) {
 	t.Parallel()
 
-	// PVC already manually grown past the template — must never be shrunk to it,
-	// and (crucially) must not be misread as a shrink request: template grew
-	// 2Ti->3Ti but the live PVC sits at 4Ti, above the new desired size.
+	// A PVC sits at 4Ti (e.g. resized out of band) while the template was 2Ti and
+	// the new spec asks for 3Ti. 3Ti is below the live disk, so it is a shrink
+	// relative to what exists: clamp the template up to 4Ti, warn, never patch the
+	// 4Ti PVC down. templateGrew because 4Ti > the old 2Ti template.
 	cs := fake.NewClientset(dataPVC(0, "ns", "4Ti"))
 	patches := countPatches(cs, "persistentvolumeclaims")
 	rec := record.NewFakeRecorder(4)
 	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
 
+	desired := []corev1.PersistentVolumeClaim{vct("data", "3Ti")}
 	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
-		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
-		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
-	)
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")}, desired)
 	require.NoError(t, err)
-	require.True(t, grew, "template still grew 2Ti->3Ti so the template must refresh")
-	require.Zero(t, *patches, "a PVC already larger than desired must not be patched")
+	require.True(t, grew, "clamped template 4Ti exceeds the old 2Ti template")
+	require.Zero(t, *patches, "a PVC already at/above the desired size must not be patched")
 
-	want := resource.MustParse("4Ti")
-	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want))
-
-	select {
-	case ev := <-rec.Events:
-		t.Fatalf("an over-expanded PVC must not emit any event, got %q", ev)
-	default:
-	}
+	requireQuantity(t, desired[0].Spec.Resources.Requests.Storage(), "4Ti")
+	requireQuantity(t, volStorage(t, cs, "data", 0), "4Ti")
+	require.Len(t, rec.Events, 1, "clamping below a live disk warns once")
 }
 
 func TestReconcilePVCExpansion_ShrinkWarnsOncePerVolume(t *testing.T) {
@@ -177,4 +179,50 @@ func TestReconcilePVCExpansion_ShrinkWarnsOncePerVolume(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, grew)
 	require.Len(t, rec.Events, 1, "shrink must warn exactly once per volume, not per PVC")
+}
+
+// TestReconcilePVCExpansion_MixedGrowShrinkDoesNotLeakShrink is the regression
+// for the mixed grow/shrink case: growing one volume forces a StatefulSet
+// recreate that rebuilds every template from spec, so the rejected shrink on the
+// other volume must be clamped back to its live size and must not leak.
+func TestReconcilePVCExpansion_MixedGrowShrinkDoesNotLeakShrink(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset(dataPVC(0, "ns", "2Ti"), volPVC("wal", 0, "ns", "5Gi"))
+	rec := record.NewFakeRecorder(8)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
+
+	desired := []corev1.PersistentVolumeClaim{vct("data", "3Ti"), vct("wal", "4Gi")}
+	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti"), vct("wal", "5Gi")}, desired)
+	require.NoError(t, err)
+	require.True(t, grew, "the data grow must still signal a recreate")
+
+	// data grows; wal is clamped back to its live 5Gi and must NOT carry the
+	// requested 4Gi into the (about to be recreated) template.
+	requireQuantity(t, desired[0].Spec.Resources.Requests.Storage(), "3Ti")
+	requireQuantity(t, desired[1].Spec.Resources.Requests.Storage(), "5Gi")
+	requireQuantity(t, volStorage(t, cs, "data", 0), "3Ti")
+	requireQuantity(t, volStorage(t, cs, "wal", 0), "5Gi")
+	require.Len(t, rec.Events, 2, "one VolumeExpanded for data, one VolumeShrinkRejected for wal")
+}
+
+// TestReconcilePVCExpansion_ClampSurvivesRecreatePath models the reconcile right
+// after the orphan delete: the StatefulSet is gone (existingTemplates nil) but
+// the live PVC persists, so the clamp still floors the rebuilt template.
+func TestReconcilePVCExpansion_ClampSurvivesRecreatePath(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset(volPVC("wal", 0, "ns", "5Gi"))
+	rec := record.NewFakeRecorder(4)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
+
+	desired := []corev1.PersistentVolumeClaim{vct("wal", "4Gi")}
+	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
+		nil, desired)
+	require.NoError(t, err)
+	require.False(t, grew, "no existing template to compare against on the create path")
+
+	requireQuantity(t, desired[0].Spec.Resources.Requests.Storage(), "5Gi")
+	require.Len(t, rec.Events, 1, "clamp still warns on the recreate path")
 }

--- a/misc/operator/internal/controller/reconcile_pvc_expansion_test.go
+++ b/misc/operator/internal/controller/reconcile_pvc_expansion_test.go
@@ -1,0 +1,180 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+)
+
+// vct builds a volumeClaimTemplate carrying only the storage request the
+// expansion pass compares on.
+func vct(name, size string) corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+			},
+		},
+	}
+}
+
+// dataPVC builds a bound-looking data PVC for the given ordinal at a size.
+func dataPVC(ordinal int, namespace, size string) *corev1.PersistentVolumeClaim {
+	pvc := dataPVCName(ordinal)
+
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvc, Namespace: namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+			},
+		},
+	}
+}
+
+func dataPVCName(ordinal int) string {
+	return "data-" + testStsName + "-" + string(rune('0'+ordinal))
+}
+
+func pvcStorage(t *testing.T, cs *fake.Clientset, ordinal int) *resource.Quantity {
+	t.Helper()
+	got, err := cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), dataPVCName(ordinal), metav1.GetOptions{})
+	require.NoError(t, err)
+
+	return got.Spec.Resources.Requests.Storage()
+}
+
+func TestReconcilePVCExpansion_GrowsAllPVCsAndSignalsRecreate(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset(dataPVC(0, "ns", "2Ti"), dataPVC(1, "ns", "2Ti"), dataPVC(2, "ns", "2Ti"))
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, nil, nil, "ns", testStsName, 3,
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
+	)
+	require.NoError(t, err)
+	require.True(t, grew, "a template size increase must signal a StatefulSet recreate")
+
+	want := resource.MustParse("3Ti")
+	for ordinal := range 3 {
+		require.Equal(t, 0, pvcStorage(t, cs, ordinal).Cmp(want),
+			"PVC ordinal %d must be grown to 3Ti", ordinal)
+	}
+}
+
+func TestReconcilePVCExpansion_NoChangeIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset(dataPVC(0, "ns", "2Ti"))
+	patches := countPatches(cs, "persistentvolumeclaims")
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, nil, nil, "ns", testStsName, 1,
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+	)
+	require.NoError(t, err)
+	require.False(t, grew)
+	require.Zero(t, *patches, "equal sizes must not patch any PVC")
+}
+
+func TestReconcilePVCExpansion_ShrinkIsRejectedAndPVCUntouched(t *testing.T) {
+	t.Parallel()
+
+	cs := fake.NewClientset(dataPVC(0, "ns", "3Ti"))
+	patches := countPatches(cs, "persistentvolumeclaims")
+	rec := record.NewFakeRecorder(4)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+	)
+	require.NoError(t, err)
+	require.False(t, grew, "a shrink must not trigger a recreate")
+	require.Zero(t, *patches, "a shrink must never patch the PVC")
+
+	want := resource.MustParse("3Ti")
+	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want), "PVC must be left at its original size")
+
+	select {
+	case ev := <-rec.Events:
+		require.Contains(t, ev, "VolumeShrinkRejected")
+	default:
+		t.Fatal("expected a VolumeShrinkRejected event")
+	}
+}
+
+func TestReconcilePVCExpansion_MissingPVCSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Only ordinal 0 exists; ordinals 1 and 2 are not yet scaled out.
+	cs := fake.NewClientset(dataPVC(0, "ns", "2Ti"))
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, nil, nil, "ns", testStsName, 3,
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
+	)
+	require.NoError(t, err)
+	require.True(t, grew)
+
+	want := resource.MustParse("3Ti")
+	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want), "existing PVC is grown")
+	// Missing ordinals must not error and must not be created by this pass.
+	_, err = cs.CoreV1().PersistentVolumeClaims("ns").Get(context.Background(), dataPVCName(1), metav1.GetOptions{})
+	require.Error(t, err, "the expansion pass must not create absent PVCs")
+}
+
+func TestReconcilePVCExpansion_GrowOnlyPVCAlreadyLargerLeftAlone(t *testing.T) {
+	t.Parallel()
+
+	// PVC already manually grown past the template — must never be shrunk to it,
+	// and (crucially) must not be misread as a shrink request: template grew
+	// 2Ti->3Ti but the live PVC sits at 4Ti, above the new desired size.
+	cs := fake.NewClientset(dataPVC(0, "ns", "4Ti"))
+	patches := countPatches(cs, "persistentvolumeclaims")
+	rec := record.NewFakeRecorder(4)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 1,
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
+	)
+	require.NoError(t, err)
+	require.True(t, grew, "template still grew 2Ti->3Ti so the template must refresh")
+	require.Zero(t, *patches, "a PVC already larger than desired must not be patched")
+
+	want := resource.MustParse("4Ti")
+	require.Equal(t, 0, pvcStorage(t, cs, 0).Cmp(want))
+
+	select {
+	case ev := <-rec.Events:
+		t.Fatalf("an over-expanded PVC must not emit any event, got %q", ev)
+	default:
+	}
+}
+
+func TestReconcilePVCExpansion_ShrinkWarnsOncePerVolume(t *testing.T) {
+	t.Parallel()
+
+	// A spec shrink across all three ordinals must warn exactly once for the
+	// volume, not once per PVC.
+	cs := fake.NewClientset(dataPVC(0, "ns", "3Ti"), dataPVC(1, "ns", "3Ti"), dataPVC(2, "ns", "3Ti"))
+	rec := record.NewFakeRecorder(8)
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "ns"}}
+
+	grew, err := reconcilePVCExpansion(context.Background(), cs, rec, obj, "ns", testStsName, 3,
+		[]corev1.PersistentVolumeClaim{vct("data", "3Ti")},
+		[]corev1.PersistentVolumeClaim{vct("data", "2Ti")},
+	)
+	require.NoError(t, err)
+	require.False(t, grew)
+	require.Len(t, rec.Events, 1, "shrink must warn exactly once per volume, not per PVC")
+}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -181,6 +181,11 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 			}
 			// Returning here requeues via the owned-StatefulSet delete event — the next
 			// reconciliation creates the new StatefulSet and the orphaned pods are adopted.
+			// This branch only DELETES; it never builds the replacement template. The
+			// new StatefulSet is created on the next reconcile, which re-runs
+			// reconcilePVCExpansion above and re-clamps `desired` against the live PVCs
+			// (which survive the orphan delete) — so a rejected shrink cannot reach the
+			// recreated template even though this delete carries the grown volume.
 			return ctrl.Result{}, nil
 		}
 	}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -126,36 +126,47 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 
 	desired := buildStatefulSetSpec(ledger, specHash, credentials, targetTLSMode)
 
-	// Check if VolumeClaimTemplates changed on an existing StatefulSet.
-	// VCTs are immutable, so any change that must land in the template requires a
-	// delete-recreate with orphan propagation:
-	//   - a name-set change (a volume switching between PVC and hostPath mode), and
-	//   - a size increase, so future scale-out ordinals are born at the new size.
-	// A size increase additionally requires patching the *existing* PVCs directly:
-	// recreating the StatefulSet re-adopts them without resizing, so the live
-	// disks only grow via reconcilePVCExpansion's CSI online expansion.
-	//
-	// This is deliberately skipped while a scale-down is in progress: the
-	// delete-recreate returns early, which would bypass the deleteScaledDownPVCs
-	// cleanup below and orphan the removed ordinals' PVCs. Two disruptive
-	// StatefulSet operations must not interleave in one pass — the scale-down
-	// completes this reconcile (including PVC cleanup) and the template change is
-	// picked up on the next one, once scalingDown is false.
 	existing := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: ledger.Namespace}, existing); err == nil && !scalingDown {
-		namesChanged := volumeClaimTemplatesChanged(existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
+	stsFound := r.Get(ctx, types.NamespacedName{Name: name, Namespace: ledger.Namespace}, existing) == nil
 
-		templateGrew := false
-		if r.Clientset != nil {
-			grew, err := reconcilePVCExpansion(ctx, r.Clientset, r.Recorder, ledger,
-				ledger.Namespace, name, desiredReplicas,
-				existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("expanding PVCs for volume size change: %w", err)
-			}
-			templateGrew = grew
+	var existingVCTs []corev1.PersistentVolumeClaim
+	if stsFound {
+		existingVCTs = existing.Spec.VolumeClaimTemplates
+	}
+
+	// Reconcile PVC sizes: clamp the desired templates up to the largest live PVC
+	// (grow-only — a spec shrink is rejected and the current size kept), grow any
+	// lagging PVCs via CSI online expansion, and learn whether the template grew.
+	//
+	// This runs on EVERY path, not only when the StatefulSet exists: the create
+	// path right after a recreate (below) rebuilds the template straight from the
+	// spec, so the clamp must re-apply there too, or a rejected shrink would leak
+	// back into the rebuilt template. Because the clamp floors against the live
+	// PVCs (which survive the orphan delete), it is stable across the recreate.
+	templateGrew := false
+	if r.Clientset != nil {
+		grew, err := reconcilePVCExpansion(ctx, r.Clientset, r.Recorder, ledger,
+			ledger.Namespace, name, desiredReplicas, existingVCTs, desired.VolumeClaimTemplates)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("reconciling PVC sizes for volume change: %w", err)
 		}
+		templateGrew = grew
+	}
 
+	// VolumeClaimTemplates are immutable, so a change that must land in the
+	// template requires a delete-recreate with orphan propagation:
+	//   - a name-set change (a volume switching between PVC and hostPath mode), or
+	//   - a size increase, so future scale-out ordinals are born at the new size.
+	// The pods and PVCs are retained and re-adopted by the recreated StatefulSet.
+	//
+	// Deliberately skipped while a scale-down is in progress: the delete-recreate
+	// returns early, which would bypass the deleteScaledDownPVCs cleanup below and
+	// orphan the removed ordinals' PVCs. Two disruptive StatefulSet operations
+	// must not interleave in one pass — the scale-down completes this reconcile
+	// (including PVC cleanup), and the template change is picked up on the next
+	// one, once scalingDown is false.
+	if stsFound && !scalingDown {
+		namesChanged := volumeClaimTemplatesChanged(existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
 		if namesChanged || templateGrew {
 			reason := "VolumeClaimTemplates changed"
 			if templateGrew {

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -127,11 +127,41 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 	desired := buildStatefulSetSpec(ledger, specHash, credentials, targetTLSMode)
 
 	// Check if VolumeClaimTemplates changed on an existing StatefulSet.
-	// VCTs are immutable — we must delete-recreate with orphan propagation.
+	// VCTs are immutable, so any change that must land in the template requires a
+	// delete-recreate with orphan propagation:
+	//   - a name-set change (a volume switching between PVC and hostPath mode), and
+	//   - a size increase, so future scale-out ordinals are born at the new size.
+	// A size increase additionally requires patching the *existing* PVCs directly:
+	// recreating the StatefulSet re-adopts them without resizing, so the live
+	// disks only grow via reconcilePVCExpansion's CSI online expansion.
+	//
+	// This is deliberately skipped while a scale-down is in progress: the
+	// delete-recreate returns early, which would bypass the deleteScaledDownPVCs
+	// cleanup below and orphan the removed ordinals' PVCs. Two disruptive
+	// StatefulSet operations must not interleave in one pass — the scale-down
+	// completes this reconcile (including PVC cleanup) and the template change is
+	// picked up on the next one, once scalingDown is false.
 	existing := &appsv1.StatefulSet{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: ledger.Namespace}, existing); err == nil {
-		if volumeClaimTemplatesChanged(existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates) {
-			logger.Info("VolumeClaimTemplates changed, recreating StatefulSet with orphan propagation")
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: ledger.Namespace}, existing); err == nil && !scalingDown {
+		namesChanged := volumeClaimTemplatesChanged(existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
+
+		templateGrew := false
+		if r.Clientset != nil {
+			grew, err := reconcilePVCExpansion(ctx, r.Clientset, r.Recorder, ledger,
+				ledger.Namespace, name, desiredReplicas,
+				existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("expanding PVCs for volume size change: %w", err)
+			}
+			templateGrew = grew
+		}
+
+		if namesChanged || templateGrew {
+			reason := "VolumeClaimTemplates changed"
+			if templateGrew {
+				reason = "volume size increased"
+			}
+			logger.Info("recreating StatefulSet with orphan propagation", "reason", reason)
 			orphan := metav1.DeletePropagationOrphan
 			if err := r.Delete(ctx, existing, &client.DeleteOptions{
 				PropagationPolicy: &orphan,


### PR DESCRIPTION
## Problem

Editing `spec.persistence.<vol>.size` on a `Cluster` (e.g. `data: 2Ti → 3Ti`) did nothing to the disks. The StatefulSet reconcile only detected volumeClaimTemplate **name** changes (`volumeClaimTemplatesChanged` compares the name set), and the normal update path deliberately skips the immutable VCT. The size bump *did* change the pod-template spec-hash — so pods rolled — while the volumes stayed at the old size. The STS `volumeClaimTemplates` kept reporting the old size.

## Change

- **New `reconcilePVCExpansion`** (`internal/controller/reconcile_pvc_expansion.go`): patches each existing PVC's `spec.resources.requests.storage` upward, triggering CSI online expansion. Grow-only.
- **Wired into `reconcileStatefulSet`**: after the expansion pass, delete-recreate the StatefulSet with `DeletePropagationOrphan` (pods/PVCs retained and re-adopted, no restart) whenever VCT names changed **or** a size grew, so future scale-out ordinals inherit the new template size.
- **README**: new "Volume Resizing" section documenting the online-grow flow, the `allowVolumeExpansion: true` prerequisite, and grow-only semantics.

### Behavior notes
- **Grow-only.** A smaller desired size emits a `VolumeShrinkRejected` warning event and leaves the PVC untouched (K8s cannot shrink a PVC). Each successful expansion emits `VolumeExpanded`.
- **Shrink is decided from the template delta, not per-PVC size** — a PVC manually expanded past the new template size is left alone rather than falsely warned every reconcile. Warns once per volume, not per PVC.
- **Skipped during scale-down** so the recreate's early return does not bypass `deleteScaledDownPVCs` and orphan the removed ordinals' PVCs (also closes the same latent issue in the pre-existing name-change branch). The template change is picked up on the next reconcile once the scale-down settles.

## Why not operator-owned PVCs?
Keeping `volumeClaimTemplates` preserves per-ordinal RWO identity for the Raft nodes for free. Owning PVCs directly means either shared storage (broken) or reimplementing StatefulSet (unacceptable risk). The gap was only the missing grow path — same pattern as Prometheus Operator / CloudNativePG.

## Review
Reviewed by Codex (gpt-5.5): confirmed the `resource.Quantity.Cmp` approach, the `requests.storage` patch API, and orphan re-adoption. It found two Medium issues — false shrink warnings for over-expanded PVCs, and the resize+scale-down cleanup bypass — both fixed in this branch and covered by tests.

## Tests
- 6 unit tests in `reconcile_pvc_expansion_test.go` (grow-all + recreate signal, no-op, shrink rejected, missing ordinal skipped, over-expanded left alone with no event, shrink-warns-once-per-volume).
- Full `internal/controller` package passes; `golangci-lint` 0 issues; `go build ./...` clean.

## Not covered (needs e2e follow-up)
The full delete-recreate + pod re-adoption cycle and the resize+scale-down deferral are not unit-testable with a fake clientset (`raftScaleDown` execs into pods).