### PR TITLE
fix(EN-1597): honor absolute SeekGE/SeekLE reposition-after-exhaustion in read-store iterators

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -7,6 +7,7 @@ The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `intern
 | Document | Description |
 |----------|-------------|
 | [query-pipeline.md](query-pipeline.md) | End-to-end read flow: ReadIndex barrier, min_log_sequence, Pebble snapshot, iterator algebra, pagination, streaming. |
+| [iterator-seek-contract.md](iterator-seek-contract.md) | Absolute SeekGE/SeekLE semantics across the iterator algebra, and the seekFloor/seekCeil exhaustion-proof cache. |
 | [read-snapshot-consistency.md](read-snapshot-consistency.md) | Single-snapshot rule for controller reads that stitch LedgerInfo with attribute data. |
 | [prepared-queries.md](prepared-queries.md) | Named pre-validated query templates: lifecycle, filter DSL, execution, bloom acceleration. |
 | [query-checkpoints.md](query-checkpoints.md) | Point-in-time snapshots of main store and read index for historical queries. |

--- a/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
+++ b/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
@@ -1,0 +1,64 @@
+# Iterator Seek Contract
+
+How `SeekGE`/`SeekLE` behave across the read-store iterator algebra
+(`internal/storage/readstore/iterator_*.go`), and the exhaustion-proof cache
+(`seekFloor`/`seekCeil`) that keeps re-seeks cheap. Introduced by EN-1597,
+where iterators that latched on exhaustion silently dropped rows under nested
+boolean filters.
+
+## The absolute-seek contract
+
+`EntityIterator.SeekGE(target)` (and its descending mirror,
+`ReverseIterator.SeekLE`) is an **absolute reposition**:
+
+1. **Computed from `target` alone.** The result never depends on the
+   iterator's current position, direction of travel, or exhaustion state.
+2. **Idempotent and non-consuming.** Repeating the seek with the same target
+   yields the same entity; a seek must not consume `Current()` (a destructive
+   consume makes a repeated seek return the *next* row, silently dropping an
+   intersection — the `AddressTxIterator` bug class).
+3. **Well-defined after exhaustion.** A false `Next`/`SeekGE` does not latch
+   the iterator; a later seek to a smaller (forward) or larger (reverse)
+   target repositions normally.
+4. **A failed seek leaves the iterator un-positioned but re-seekable.**
+   `Next` returns false until the next successful seek.
+
+Composite iterators rely on this freely: `AndIterator.SeekGE` seeks **every**
+child to the target (a child left at a stale position past the target would
+become the convergence candidate and skip valid intersections below it), then
+`converge` leapfrogs children forward; `OrIterator`/`ReverseOrIterator`
+re-seek all children per seek; `NotIterator` re-seeks its excluded child to
+the universe's position on every step. Any latch or consuming seek in a leaf
+turns these algebra steps into silent row drops.
+
+The contract is enforced by unit tests per leaf (`iterator_floor_test.go`,
+`iterator_address_test.go`, `iterator_and_seek_test.go`) and end-to-end by the
+contradiction specs in
+`tests/e2e/business/filter_nested_not_reposition_test.go`.
+
+## The exhaustion-proof cache (`seekFloor`/`seekCeil`)
+
+`iterator_floor.go`. Without the latch, an exhausted child would be re-seeked
+by its composite parent once per merge step — a fresh Pebble seek plus
+allocations, O(rows) times per query. The floor restores the O(1) fast path
+without reintroducing the latch:
+
+- a **cleanly** failed `SeekGE(t)` proves *no entity >= t exists in the view*;
+  the floor records `t` and every later seek at or above it returns false in
+  one comparison. `seekCeil` mirrors this for `SeekLE` (*no entity <= t*).
+- a seek below the floor (above the ceil) is not covered and repositions
+  normally — the contract above is preserved.
+
+Two preconditions make the proof permanent, and both are load-bearing:
+
+1. **The view is snapshot-fixed.** Every leaf holds a `pebble.Iterator`, whose
+   view is fixed at creation; iterators are created per query. A proof can
+   therefore never go stale, and the bound is never cleared. Handing these
+   iterators a live, mutating view would silently violate this.
+2. **Only clean exhaustion proves anything.** `SeekGE` also returns false on
+   I/O error (`Err()`), and an I/O-failed seek proves nothing about the view's
+   contents. `seekFloor.fail`/`seekCeil.fail` take the iterator's storage
+   error and drop the proof when it is non-nil. (Pebble's error is sticky and
+   pagination propagates `Err()` unconditionally, so the query still fails
+   loudly either way — the guard keeps the cache sound on its own terms
+   rather than by leaning on that second-order property.)

--- a/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
+++ b/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
@@ -27,9 +27,17 @@ Composite iterators rely on this freely: `AndIterator.SeekGE` seeks **every**
 child to the target (a child left at a stale position past the target would
 become the convergence candidate and skip valid intersections below it), then
 `converge` leapfrogs children forward; `OrIterator`/`ReverseOrIterator`
-re-seek all children per seek; `NotIterator` re-seeks its excluded child to
-the universe's position on every step. Any latch or consuming seek in a leaf
+re-seek all children per seek; `NotIterator` re-seeks its excluded child on
+every `SeekGE` — including after the child reported done — and catches it up
+with `Next()` as the universe advances. Any latch or consuming seek in a leaf
 turns these algebra steps into silent row drops.
+
+One leaf is exempt by construction: `RangeIterator` emits rows in
+`(value, entity)` order across index-value buckets, so an entity-space
+`SeekGE` is undefined on the raw scan. It only supports forward draining;
+every construction site materializes it into a sorted `SliceIterator` before
+composing, and a direct `SeekGE` call fails the query with an invariant
+error.
 
 The contract is enforced by unit tests per leaf (`iterator_floor_test.go`,
 `iterator_address_test.go`, `iterator_and_seek_test.go`) and end-to-end by the

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -81,7 +81,7 @@ Source: `internal/query/executor.go`.
 
 Commit `c1f79db80` (EN-1321) wired prepared-query keys into the standard bloom-filter infrastructure (see [attributes / bloom.md](../attributes/bloom.md)). A `MayContain` lookup on the prepared-query bloom now short-circuits the "query doesn't exist" path at preload time, putting prepared queries on the same footing as every other attribute kind.
 
-Commit `7662d2bae` (`optimized-prepared-queries`) added monotonic-skip and probe-based optimisations to the `AndIterator` used by the filter compiler, which the prepared-query execution path benefits from directly.
+Commit `7662d2bae` (`optimized-prepared-queries`) added monotonic-skip and probe-based optimisations to the `AndIterator` used by the filter compiler, which the prepared-query execution path benefits from directly. EN-1597 later reshaped the seek semantics — `AndIterator.SeekGE` now force-seeks every child, and the ahead-child skip lives in the converge loop with `seekFloor`/`seekCeil` covering re-seeks of exhausted children; see [iterator-seek-contract.md](iterator-seek-contract.md) for the current behavior.
 
 These accelerators are correctness-neutral: turning them off (e.g. by a saturated bloom) only slows execution.
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -161,7 +161,7 @@ Multiple concurrent readers share snapshots cheaply (Pebble's snapshot is a vers
 | `NotIterator` | Difference against the entity-existence index (`0x02`). |
 | address-prefix iterator | Leaf scan with a chart-of-accounts prefix predicate. |
 
-The filter compiler turns a `QueryFilter` proto into a tree of these. Recent work (commit `7662d2bae`) added monotonic-skip and probe-based optimisations to the `AndIterator` to short-circuit when one child runs ahead of the others.
+The filter compiler turns a `QueryFilter` proto into a tree of these. `SeekGE`/`SeekLE` are **absolute** repositions — `AndIterator.SeekGE` force-seeks *every* child to the target (EN-1597; a child left ahead would skip valid intersections), and the ahead-child leapfrog survives only inside `converge`'s merge loop. Exhausted leaves stay re-seekable; the `seekFloor`/`seekCeil` cache keeps repeated re-seeks of a proven-empty child O(1). See [iterator-seek-contract.md](iterator-seek-contract.md).
 
 ## Pagination
 

--- a/internal/storage/readstore/iterator_address.go
+++ b/internal/storage/readstore/iterator_address.go
@@ -3,6 +3,7 @@ package readstore
 import (
 	"bytes"
 	"encoding/binary"
+	"sort"
 
 	"github.com/cockroachdb/pebble/v2"
 
@@ -14,17 +15,23 @@ import (
 //  1. Scanning the existence index for matching account addresses
 //  2. For each matching account, scanning the account→tx mapping
 //  3. Merge-unioning all transaction ID sets into a single sorted output
+//
+// The union is materialized in full on first use and kept for the iterator's
+// lifetime; Next and SeekGE are cursor moves over the stable sorted slice, so
+// SeekGE is a true absolute reposition — seekable backwards, repeatable, and
+// well-defined after exhaustion — as the EntityIterator contract requires.
 type AddressTxIterator struct {
-	reader      dal.PebbleReader
-	kb          *dal.KeyBuilder
-	ledgerName  string
-	prefix      byte           // which account→tx prefix to scan
-	addrIter    EntityIterator // iterates over matching account addresses
-	current     []byte         // current txID (8 bytes)
-	exhausted   bool
-	err         error    // first I/O error from materialize / addrIter
-	pendingTxns [][]byte // merge-union buffer for deduplication
-	txSeen      map[uint64]struct{}
+	reader     dal.PebbleReader
+	kb         *dal.KeyBuilder
+	ledgerName string
+	prefix     byte           // which account→tx prefix to scan
+	addrIter   EntityIterator // iterates over matching account addresses
+	current    []byte         // current txID (8 bytes)
+	err        error          // first I/O error from materialize / addrIter
+
+	materialized bool
+	txns         [][]byte // all matching txIDs, sorted and deduplicated
+	pos          int      // index into txns of the entry the next Next() yields
 }
 
 // NewAddressTxIterator creates an iterator that, for each address matching
@@ -43,39 +50,20 @@ func NewAddressTxIterator(
 		ledgerName: ledgerName,
 		prefix:     prefix,
 		addrIter:   addrIter,
-		txSeen:     make(map[uint64]struct{}),
 	}
 }
 
 func (it *AddressTxIterator) Next() bool {
-	if it.exhausted {
+	if !it.ensureMaterialized() {
 		return false
 	}
 
-	// Try to get next tx from pending buffer
-	if len(it.pendingTxns) > 0 {
-		it.current = it.pendingTxns[0]
-		it.pendingTxns = it.pendingTxns[1:]
-
-		return true
-	}
-
-	// Materialize all txIDs for remaining accounts and merge-union
-	if err := it.materialize(); err != nil {
-		it.err = err
-		it.exhausted = true
-
+	if it.pos >= len(it.txns) {
 		return false
 	}
 
-	if len(it.pendingTxns) == 0 {
-		it.exhausted = true
-
-		return false
-	}
-
-	it.current = it.pendingTxns[0]
-	it.pendingTxns = it.pendingTxns[1:]
+	it.current = it.txns[it.pos]
+	it.pos++
 
 	return true
 }
@@ -85,44 +73,21 @@ func (it *AddressTxIterator) Current() []byte {
 }
 
 func (it *AddressTxIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
+	if !it.ensureMaterialized() {
 		return false
 	}
 
-	// Re-materialize with filter
-	if len(it.pendingTxns) == 0 {
-		if err := it.materialize(); err != nil {
-			it.err = err
-			it.exhausted = true
-
-			return false
-		}
-
-		if len(it.pendingTxns) == 0 {
-			it.exhausted = true
-
-			return false
-		}
-	}
-
-	// Binary search in sorted pendingTxns
-	idx := 0
-	for idx < len(it.pendingTxns) {
-		if bytes.Compare(it.pendingTxns[idx], target) >= 0 {
-			break
-		}
-
-		idx++
-	}
-
-	if idx >= len(it.pendingTxns) {
-		it.exhausted = true
+	idx := sort.Search(len(it.txns), func(i int) bool {
+		return bytes.Compare(it.txns[i], target) >= 0
+	})
+	if idx >= len(it.txns) {
+		it.pos = len(it.txns)
 
 		return false
 	}
 
-	it.current = it.pendingTxns[idx]
-	it.pendingTxns = it.pendingTxns[idx+1:]
+	it.current = it.txns[idx]
+	it.pos = idx + 1
 
 	return true
 }
@@ -139,11 +104,34 @@ func (it *AddressTxIterator) Close() {
 	it.addrIter.Close()
 }
 
+// ensureMaterialized runs the one-time materialization, latching any I/O error
+// (an error is permanent — positioning calls after it always return false).
+func (it *AddressTxIterator) ensureMaterialized() bool {
+	if it.err != nil {
+		return false
+	}
+
+	if it.materialized {
+		return true
+	}
+
+	it.materialized = true
+	if err := it.materialize(); err != nil {
+		it.err = err
+
+		return false
+	}
+
+	return true
+}
+
 // materialize collects all transaction IDs from all matching accounts,
 // deduplicates, and sorts them. Surfaces I/O errors from the underlying
 // Pebble iterators and from the addrIter through addrIter.Err()
 // (checked by the caller via it.Err()).
 func (it *AddressTxIterator) materialize() error {
+	txSeen := make(map[uint64]struct{})
+
 	for it.addrIter.Next() {
 		account := string(it.addrIter.Current())
 		prefix := AccountTxPrefix(it.kb, it.prefix, it.ledgerName, account)
@@ -167,15 +155,15 @@ func (it *AddressTxIterator) materialize() error {
 			txIDBytes := k[len(k)-8:]
 			txID := binary.BigEndian.Uint64(txIDBytes)
 
-			if _, seen := it.txSeen[txID]; seen {
+			if _, seen := txSeen[txID]; seen {
 				continue
 			}
 
-			it.txSeen[txID] = struct{}{}
+			txSeen[txID] = struct{}{}
 
 			txCopy := make([]byte, 8)
 			copy(txCopy, txIDBytes)
-			it.pendingTxns = insertSorted(it.pendingTxns, txCopy)
+			it.txns = insertSorted(it.txns, txCopy)
 		}
 
 		iterErr := iter.Error()

--- a/internal/storage/readstore/iterator_address_test.go
+++ b/internal/storage/readstore/iterator_address_test.go
@@ -1,0 +1,155 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func txIDBytes(id uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, id)
+
+	return b
+}
+
+// newAddressTxFixture writes account→tx rows and returns an AddressTxIterator
+// over the given addresses.
+func newAddressTxFixture(t *testing.T, txsByAccount map[string][]uint64, addrs ...string) *AddressTxIterator {
+	t.Helper()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	for account, txs := range txsByAccount {
+		for _, id := range txs {
+			require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", account, id), nil, pebble.NoSync))
+		}
+	}
+
+	return NewAddressTxIterator(s.DB(), dal.NewKeyBuilder(), "l", newAliasingIter(addrs...), PrefixAccountTx)
+}
+
+// SeekGE on AddressTxIterator must be an absolute reposition over the
+// materialized union: repeatable at the same target, seekable backwards, and
+// well-defined after exhaustion (EN-1597, paul-nicolas review of PR #1635).
+// The prior implementation consumed the matched entry (`pendingTxns[idx+1:]`)
+// and latched on exhaustion, so a repeated or backward seek dropped rows.
+func TestAddressTxIterator_SeekGEIsAbsolute(t *testing.T) {
+	t.Parallel()
+
+	it := newAddressTxFixture(t, map[string][]uint64{
+		"acc:1": {1, 3},
+		"acc:2": {2, 3}, // tx 3 shared — union must deduplicate
+	}, "acc:1", "acc:2")
+	defer it.Close()
+
+	// Full forward pass: the deduplicated union in order.
+	var got []uint64
+	for it.Next() {
+		got = append(got, binary.BigEndian.Uint64(it.Current()))
+	}
+	require.Equal(t, []uint64{1, 2, 3}, got)
+	require.NoError(t, it.Err())
+
+	// Reposition after exhaustion.
+	require.True(t, it.SeekGE(txIDBytes(2)))
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+
+	// Same target again: same row (a conforming seek does not consume).
+	require.True(t, it.SeekGE(txIDBytes(2)))
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+
+	// Next continues from the seeked position.
+	require.True(t, it.Next())
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+
+	// Backward seek below everything.
+	require.True(t, it.SeekGE(txIDBytes(0)))
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+
+	// Seek past the end fails, then a lower seek succeeds again.
+	require.False(t, it.SeekGE(txIDBytes(99)))
+	require.False(t, it.Next())
+	require.True(t, it.SeekGE(txIDBytes(3)))
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+// An AND over an AddressTxIterator must not drop intersections when converge
+// re-seeks the child onto its own current position (the destructive-consume
+// regression from the unconditional all-children re-seek in AndIterator.SeekGE).
+func TestAndIterator_AddressTxChildKeepsIntersection(t *testing.T) {
+	t.Parallel()
+
+	addrTx := newAddressTxFixture(t, map[string][]uint64{
+		"acc:1": {1, 2, 3},
+	}, "acc:1")
+
+	other := newAliasingIter(
+		string(txIDBytes(1)), string(txIDBytes(2)), string(txIDBytes(3)),
+	)
+
+	it := NewAndIterator(addrTx, other)
+	defer it.Close()
+
+	require.True(t, it.SeekGE(txIDBytes(1)))
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+
+	// Re-seek to the same target: the intersection must still start at 1.
+	require.True(t, it.SeekGE(txIDBytes(1)))
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+
+	var rest []uint64
+	for it.Next() {
+		rest = append(rest, binary.BigEndian.Uint64(it.Current()))
+	}
+	require.Equal(t, []uint64{2, 3}, rest)
+	require.NoError(t, it.Err())
+}
+
+// A NOT whose child is an AddressTxIterator must keep excluding after the
+// child was driven to exhaustion by a forward pass — the child's SeekGE must
+// reposition, not latch. Pre-fix, the exhausted (and consumed) child stopped
+// excluding, leaking every excluded row into the difference.
+func TestNotIterator_AddressTxChildExcludesAfterExhaustion(t *testing.T) {
+	t.Parallel()
+
+	addrTx := newAddressTxFixture(t, map[string][]uint64{
+		"acc:1": {1, 2, 3},
+	}, "acc:1")
+
+	universe := newAliasingIter(
+		string(txIDBytes(1)), string(txIDBytes(2)), string(txIDBytes(3)), string(txIDBytes(4)),
+	)
+
+	it := NewNotIterator(universe, addrTx)
+	defer it.Close()
+
+	// Forward pass: 1-3 are excluded; reaching 4 drives the child past its
+	// last entry, exhausting it.
+	require.True(t, it.Next())
+	require.Equal(t, uint64(4), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	// The absolute re-seek back to 1 must still exclude 1-3 and land on 4.
+	require.True(t, it.SeekGE(txIDBytes(1)))
+	require.Equal(t, uint64(4), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+func TestAddressTxIterator_EmptyUnion(t *testing.T) {
+	t.Parallel()
+
+	it := newAddressTxFixture(t, nil, "acc:1")
+	defer it.Close()
+
+	require.False(t, it.Next())
+	require.False(t, it.SeekGE(txIDBytes(0)))
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_and.go
+++ b/internal/storage/readstore/iterator_and.go
@@ -47,9 +47,13 @@ func (it *AndIterator) Current() []byte {
 }
 
 func (it *AndIterator) SeekGE(target []byte) bool {
-	if it.exhausted || len(it.children) == 0 {
+	if len(it.children) == 0 {
 		return false
 	}
+
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion re-establishes the intersection (converge re-seeks children).
+	it.exhausted = false
 
 	// Seek all children to target
 	if !it.children[0].SeekGE(target) {

--- a/internal/storage/readstore/iterator_and.go
+++ b/internal/storage/readstore/iterator_and.go
@@ -51,15 +51,19 @@ func (it *AndIterator) SeekGE(target []byte) bool {
 		return false
 	}
 
-	// Absolute reposition: clear the exhausted latch so a re-seek after
-	// exhaustion re-establishes the intersection (converge re-seeks children).
+	// Absolute reposition: seek EVERY child to target, not just children[0].
+	// converge uses each child's Current() as a candidate, so a child left at a
+	// stale position past target would become the candidate and skip valid
+	// intersections below it. Clearing exhausted lets a re-seek after exhaustion
+	// re-establish the intersection.
 	it.exhausted = false
 
-	// Seek all children to target
-	if !it.children[0].SeekGE(target) {
-		it.exhausted = true
+	for i := range it.children {
+		if !it.children[i].SeekGE(target) {
+			it.exhausted = true
 
-		return false
+			return false
+		}
 	}
 
 	return it.converge()

--- a/internal/storage/readstore/iterator_and.go
+++ b/internal/storage/readstore/iterator_and.go
@@ -51,10 +51,10 @@ func (it *AndIterator) SeekGE(target []byte) bool {
 		return false
 	}
 
-	// Absolute reposition: seek EVERY child to target, not just children[0].
-	// converge uses each child's Current() as a candidate, so a child left at a
-	// stale position past target would become the candidate and skip valid
-	// intersections below it. Clearing exhausted lets a re-seek after exhaustion
+	// Absolute reposition: seek EVERY child to target. converge uses each
+	// child's Current() as a candidate, so a child left at a stale position
+	// past target would become the candidate and skip valid intersections
+	// below it. Clearing exhausted lets a re-seek after exhaustion
 	// re-establish the intersection.
 	it.exhausted = false
 

--- a/internal/storage/readstore/iterator_and_seek_test.go
+++ b/internal/storage/readstore/iterator_and_seek_test.go
@@ -1,0 +1,34 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AndIterator.SeekGE must reposition EVERY child, not just the first. After a
+// forward pass advances/exhausts a non-first child, an absolute SeekGE back to a
+// smaller target must not let that child's stale (higher) Current() become the
+// convergence candidate — doing so skips valid intersections below it (EN-1597,
+// NumaryBot review of PR #1635).
+func TestAndIterator_SeekGERepositionsAllChildren(t *testing.T) {
+	t.Parallel()
+
+	left := newAliasingIter("a", "b", "c", "z")
+	right := newAliasingIter("a", "b", "c")
+
+	it := NewAndIterator(left, right)
+	defer it.Close()
+
+	// Forward pass: intersection is {a,b,c}; the merge then exhausts (left at z,
+	// right run out), leaving right's Current() stale at "c".
+	var got []string
+	for it.Next() {
+		got = append(got, string(it.Current()))
+	}
+	require.Equal(t, []string{"a", "b", "c"}, got)
+
+	// Absolute re-seek back to "a" must yield "a" — both children hold it.
+	require.True(t, it.SeekGE([]byte("a")))
+	require.Equal(t, "a", string(it.Current()))
+}

--- a/internal/storage/readstore/iterator_bitset.go
+++ b/internal/storage/readstore/iterator_bitset.go
@@ -68,11 +68,16 @@ func (it *BitsetIterator) Current() []byte {
 }
 
 func (it *BitsetIterator) SeekGE(target []byte) bool {
-	if it.done || it.bs == nil {
+	if it.bs == nil {
 		return false
 	}
 
+	// SeekGE is absolute repositioning: recompute the position from target even
+	// after a prior walk exhausted the iterator. A latched `done` would make a
+	// re-seek to an earlier target (as the NOT/AND merge iterators issue once
+	// forward iteration has consumed the bitset) wrongly report no match.
 	it.started = true
+	it.done = false
 
 	var from uint64
 	if len(target) >= 8 {

--- a/internal/storage/readstore/iterator_floor.go
+++ b/internal/storage/readstore/iterator_floor.go
@@ -3,12 +3,15 @@ package readstore
 import "bytes"
 
 // seekFloor caches an exhaustion proof for a forward iterator: a failed
-// SeekGE(t) proves no entity >= t exists in the iterator's view. The view is
-// fixed at pebble.Iterator creation, so the proof never goes stale and the
-// floor is never cleared. Composite iterators re-seek exhausted children once
-// per merge step (AND converge, OR findMin, the NOT child catch-up); the floor
-// turns every such re-seek at or above the proven bound into an O(1)
-// comparison instead of a Pebble seek.
+// SeekGE(t) proves no entity >= t exists in the iterator's view. The proof is
+// valid only for a CLEAN exhaustion of a snapshot-fixed view: the Pebble view
+// is fixed at pebble.Iterator creation (so a proof never goes stale and the
+// floor is never cleared), and a seek that failed because of an I/O error
+// proves nothing about the view's contents (fail drops it — see #320 for the
+// error class). Composite iterators re-seek exhausted children once per merge
+// step (AND converge, OR findMin, the NOT child catch-up); the floor turns
+// every such re-seek at or above the proven bound into an O(1) comparison
+// instead of a Pebble seek.
 type seekFloor struct {
 	bound []byte
 	set   bool
@@ -19,17 +22,24 @@ func (f *seekFloor) covers(target []byte) bool {
 	return f.set && bytes.Compare(target, f.bound) >= 0
 }
 
-// fail records a failed SeekGE(target): no entity >= target exists. The bound
-// is copied — target may alias a sibling iterator's Pebble key buffer. Callers
-// only reach a real (uncovered) seek with target below the current bound, so
+// fail records a failed SeekGE(target): no entity >= target exists. err is the
+// iterator's storage error: a non-nil err means the seek failed for I/O
+// reasons, which proves nothing, so no bound is recorded. The bound is copied
+// — target may alias a sibling iterator's Pebble key buffer. Callers only
+// reach a real (uncovered) seek with target below the current bound, so
 // overwriting always tightens it.
-func (f *seekFloor) fail(target []byte) {
+func (f *seekFloor) fail(target []byte, err error) {
+	if err != nil {
+		return
+	}
+
 	f.bound = append(f.bound[:0], target...)
 	f.set = true
 }
 
 // seekCeil is the reverse-iteration analog of seekFloor: a failed SeekLE(t)
-// proves no entity <= t exists.
+// proves no entity <= t exists. Same clean-exhaustion / snapshot-fixed-view
+// precondition.
 type seekCeil struct {
 	bound []byte
 	set   bool
@@ -40,8 +50,13 @@ func (c *seekCeil) covers(target []byte) bool {
 	return c.set && bytes.Compare(target, c.bound) <= 0
 }
 
-// fail records a failed SeekLE(target): no entity <= target exists.
-func (c *seekCeil) fail(target []byte) {
+// fail records a failed SeekLE(target): no entity <= target exists. A non-nil
+// err drops the proof, like seekFloor.fail.
+func (c *seekCeil) fail(target []byte, err error) {
+	if err != nil {
+		return
+	}
+
 	c.bound = append(c.bound[:0], target...)
 	c.set = true
 }

--- a/internal/storage/readstore/iterator_floor.go
+++ b/internal/storage/readstore/iterator_floor.go
@@ -1,0 +1,47 @@
+package readstore
+
+import "bytes"
+
+// seekFloor caches an exhaustion proof for a forward iterator: a failed
+// SeekGE(t) proves no entity >= t exists in the iterator's view. The view is
+// fixed at pebble.Iterator creation, so the proof never goes stale and the
+// floor is never cleared. Composite iterators re-seek exhausted children once
+// per merge step (AND converge, OR findMin, the NOT child catch-up); the floor
+// turns every such re-seek at or above the proven bound into an O(1)
+// comparison instead of a Pebble seek.
+type seekFloor struct {
+	bound []byte
+	set   bool
+}
+
+// covers reports whether SeekGE(target) is proven empty by a prior failure.
+func (f *seekFloor) covers(target []byte) bool {
+	return f.set && bytes.Compare(target, f.bound) >= 0
+}
+
+// fail records a failed SeekGE(target): no entity >= target exists. The bound
+// is copied — target may alias a sibling iterator's Pebble key buffer. Callers
+// only reach a real (uncovered) seek with target below the current bound, so
+// overwriting always tightens it.
+func (f *seekFloor) fail(target []byte) {
+	f.bound = append(f.bound[:0], target...)
+	f.set = true
+}
+
+// seekCeil is the reverse-iteration analog of seekFloor: a failed SeekLE(t)
+// proves no entity <= t exists.
+type seekCeil struct {
+	bound []byte
+	set   bool
+}
+
+// covers reports whether SeekLE(target) is proven empty by a prior failure.
+func (c *seekCeil) covers(target []byte) bool {
+	return c.set && bytes.Compare(target, c.bound) <= 0
+}
+
+// fail records a failed SeekLE(target): no entity <= target exists.
+func (c *seekCeil) fail(target []byte) {
+	c.bound = append(c.bound[:0], target...)
+	c.set = true
+}

--- a/internal/storage/readstore/iterator_floor.go
+++ b/internal/storage/readstore/iterator_floor.go
@@ -8,10 +8,11 @@ import "bytes"
 // is fixed at pebble.Iterator creation (so a proof never goes stale and the
 // floor is never cleared), and a seek that failed because of an I/O error
 // proves nothing about the view's contents (fail drops it — see #320 for the
-// error class). Composite iterators re-seek exhausted children once per merge
-// step (AND converge, OR findMin, the NOT child catch-up); the floor turns
-// every such re-seek at or above the proven bound into an O(1) comparison
-// instead of a Pebble seek.
+// error class). Exhausted children still get re-seeked: AndIterator.converge
+// seeks per merge step, and the composite SeekGE/SeekLE child loops (AND, OR,
+// NOT, ReverseOr) seek unconditionally — once per parent merge step when
+// nested. The floor turns each such re-seek at or above the proven bound into
+// an O(1) comparison instead of a Pebble seek.
 type seekFloor struct {
 	bound []byte
 	set   bool

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -1,0 +1,79 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestSeekFloor(t *testing.T) {
+	t.Parallel()
+
+	var f seekFloor
+
+	require.False(t, f.covers([]byte("a")), "unset floor covers nothing")
+
+	f.fail([]byte("m"))
+	require.True(t, f.covers([]byte("m")), "failure bound is inclusive")
+	require.True(t, f.covers([]byte("z")))
+	require.False(t, f.covers([]byte("a")), "targets below the bound must re-seek")
+
+	f.fail([]byte("d"))
+	require.True(t, f.covers([]byte("d")), "a lower failure tightens the bound")
+	require.False(t, f.covers([]byte("c")))
+}
+
+func TestSeekCeil(t *testing.T) {
+	t.Parallel()
+
+	var c seekCeil
+
+	require.False(t, c.covers([]byte("a")), "unset ceil covers nothing")
+
+	c.fail([]byte("m"))
+	require.True(t, c.covers([]byte("m")), "failure bound is inclusive")
+	require.True(t, c.covers([]byte("a")))
+	require.False(t, c.covers([]byte("z")), "targets above the bound must re-seek")
+
+	c.fail([]byte("t"))
+	require.True(t, c.covers([]byte("t")), "a higher failure tightens the bound")
+	require.False(t, c.covers([]byte("u")))
+}
+
+// A floored leaf must still honor the absolute-seek contract: failed seeks at
+// or above the proven bound return false (without re-seeking Pebble), while a
+// seek below it repositions normally — including after exhaustion.
+func TestPrefixIterator_SeekFloorKeepsRepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	for _, id := range []uint64{1, 2, 3} {
+		require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", "acc:1", id), nil, pebble.NoSync))
+	}
+
+	prefix := AccountTxPrefix(dal.NewKeyBuilder(), PrefixAccountTx, "l", "acc:1")
+
+	it, err := NewPrefixIterator(s.DB(), prefix, len(prefix), 8)
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.False(t, it.SeekGE(txIDBytes(5)), "no entity >= 5")
+	require.False(t, it.Next(), "failed seek leaves the iterator exhausted")
+	require.False(t, it.SeekGE(txIDBytes(7)), "covered by the floor")
+
+	require.True(t, it.SeekGE(txIDBytes(2)), "below the floor: real reposition")
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE(txIDBytes(0)), "reposition after Next-exhaustion")
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -253,3 +253,49 @@ func TestPebbleAccountIterator_SeekFloorKeepsRepositioning(t *testing.T) {
 	require.Equal(t, "a:1", string(it.Current()))
 	require.NoError(t, it.Err())
 }
+
+// The account mirror of TestPebbleReverseTxIterator_SeekLERepositioning:
+// same seek-then-step-back shape over address extraction, covering the
+// Prev()-fails and Last()-fails branches plus reposition after exhaustion.
+func TestPebbleReverseAccountIterator_SeekLERepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	prefix := make([]byte, 2+dal.LedgerNameFixedSize)
+	prefix[0] = dal.ZoneAttributes
+	prefix[1] = dal.SubAttrVolume
+	copy(prefix[2:], "l")
+
+	for _, addr := range []string{"a:2", "a:3"} {
+		key := append(append(append([]byte{}, prefix...), addr...), dal.CanonicalKeySepVolume)
+		require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
+	}
+
+	it, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "l")
+	require.NoError(t, err)
+	defer it.Close()
+
+	// Prev()-fails branch: the seek lands on a:2's key, stepping back leaves
+	// the bounded range.
+	require.False(t, it.SeekLE([]byte("a:1")), "no address <= a:1")
+	require.False(t, it.SeekLE([]byte("a:0")), "covered by the ceil")
+
+	require.True(t, it.SeekLE([]byte("a:2")), "above the ceil: real reposition")
+	require.Equal(t, "a:2", string(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekLE([]byte("a:9")), "reposition after Next-exhaustion")
+	require.Equal(t, "a:3", string(it.Current()))
+	require.NoError(t, it.Err())
+
+	// Last()-fails branch: an empty view records the ceil on the first seek,
+	// covering every later target below it.
+	empty, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "empty")
+	require.NoError(t, err)
+	defer empty.Close()
+
+	require.False(t, empty.SeekLE([]byte("z")), "empty view")
+	require.False(t, empty.SeekLE([]byte("a")), "covered by the ceil")
+	require.NoError(t, empty.Err())
+}

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -3,6 +3,7 @@ package readstore
 import (
 	"encoding/binary"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -298,4 +299,28 @@ func TestPebbleReverseAccountIterator_SeekLERepositioning(t *testing.T) {
 	require.False(t, empty.SeekLE([]byte("z")), "empty view")
 	require.False(t, empty.SeekLE([]byte("a")), "covered by the ceil")
 	require.NoError(t, empty.Err())
+}
+
+// SeekLE at the all-0xff cursor must return the last transaction: the
+// incremented probe key wraps to zero, and mistaking that for an empty range
+// would also poison the ceil for every later seek.
+func TestPebbleReverseTxIterator_SeekLEMaxUint64(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	for _, id := range []uint64{5, 7} {
+		require.NoError(t, s.DB().Set(append(txAttributeCode("l"), txIDBytes(id)...), nil, pebble.NoSync))
+	}
+
+	it, err := NewPebbleReverseTxIterator(s.DB(), "l")
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.True(t, it.SeekLE(txIDBytes(math.MaxUint64)), "everything is <= MaxUint64")
+	require.Equal(t, uint64(7), binary.BigEndian.Uint64(it.Current()))
+
+	require.True(t, it.SeekLE(txIDBytes(6)), "ceil must not be poisoned by the wrap")
+	require.Equal(t, uint64(5), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
 }

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -2,6 +2,7 @@ package readstore
 
 import (
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -17,12 +18,15 @@ func TestSeekFloor(t *testing.T) {
 
 	require.False(t, f.covers([]byte("a")), "unset floor covers nothing")
 
-	f.fail([]byte("m"))
+	f.fail([]byte("x"), errors.New("checksum mismatch"))
+	require.False(t, f.covers([]byte("x")), "an I/O-failed seek proves nothing")
+
+	f.fail([]byte("m"), nil)
 	require.True(t, f.covers([]byte("m")), "failure bound is inclusive")
 	require.True(t, f.covers([]byte("z")))
 	require.False(t, f.covers([]byte("a")), "targets below the bound must re-seek")
 
-	f.fail([]byte("d"))
+	f.fail([]byte("d"), nil)
 	require.True(t, f.covers([]byte("d")), "a lower failure tightens the bound")
 	require.False(t, f.covers([]byte("c")))
 }
@@ -34,12 +38,15 @@ func TestSeekCeil(t *testing.T) {
 
 	require.False(t, c.covers([]byte("a")), "unset ceil covers nothing")
 
-	c.fail([]byte("m"))
+	c.fail([]byte("b"), errors.New("checksum mismatch"))
+	require.False(t, c.covers([]byte("b")), "an I/O-failed seek proves nothing")
+
+	c.fail([]byte("m"), nil)
 	require.True(t, c.covers([]byte("m")), "failure bound is inclusive")
 	require.True(t, c.covers([]byte("a")))
 	require.False(t, c.covers([]byte("z")), "targets above the bound must re-seek")
 
-	c.fail([]byte("t"))
+	c.fail([]byte("t"), nil)
 	require.True(t, c.covers([]byte("t")), "a higher failure tightens the bound")
 	require.False(t, c.covers([]byte("u")))
 }
@@ -76,4 +83,78 @@ func TestPrefixIterator_SeekFloorKeepsRepositioning(t *testing.T) {
 	require.True(t, it.SeekGE(txIDBytes(0)), "reposition after Next-exhaustion")
 	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
 	require.NoError(t, it.Err())
+}
+
+// The descending mirror: failed SeekLEs at or below the proven ceil return
+// false without a Pebble seek, while a seek above it repositions normally —
+// including after exhaustion.
+func TestReversePrefixIterator_SeekCeilKeepsRepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	for _, id := range []uint64{2, 3, 4} {
+		require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", "acc:1", id), nil, pebble.NoSync))
+	}
+
+	prefix := AccountTxPrefix(dal.NewKeyBuilder(), PrefixAccountTx, "l", "acc:1")
+
+	it, err := NewReversePrefixIterator(s.DB(), prefix, len(prefix), 8)
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.False(t, it.SeekLE(txIDBytes(1)), "no entity <= 1")
+	require.False(t, it.Next(), "failed seek leaves the iterator exhausted")
+	require.False(t, it.SeekLE(txIDBytes(0)), "covered by the ceil")
+
+	require.True(t, it.SeekLE(txIDBytes(3)), "above the ceil: real reposition")
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekLE(txIDBytes(9)), "reposition after Next-exhaustion")
+	require.Equal(t, uint64(4), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+// PebbleReverseTxIterator.SeekLE has three exhaustion branches (Prev fails
+// after a positioned SeekGE, Last fails on an empty view, and the scan-back
+// loop running out); the first two must record the ceil and stay re-seekable.
+func TestPebbleReverseTxIterator_SeekLERepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	for _, id := range []uint64{5, 7} {
+		require.NoError(t, s.DB().Set(append(txAttributeCode("l"), txIDBytes(id)...), nil, pebble.NoSync))
+	}
+
+	it, err := NewPebbleReverseTxIterator(s.DB(), "l")
+	require.NoError(t, err)
+	defer it.Close()
+
+	// Prev()-fails branch: SeekGE lands on tx 5's key, stepping back leaves the
+	// bounded range.
+	require.False(t, it.SeekLE(txIDBytes(4)), "no entity <= 4")
+	require.False(t, it.SeekLE(txIDBytes(4)), "covered by the ceil")
+
+	require.True(t, it.SeekLE(txIDBytes(6)), "above the ceil: real reposition")
+	require.Equal(t, uint64(5), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekLE(txIDBytes(7)), "reposition after Next-exhaustion")
+	require.Equal(t, uint64(7), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+
+	// Last()-fails branch: an empty view records the ceil on the first seek,
+	// covering every later target below it.
+	empty, err := NewPebbleReverseTxIterator(s.DB(), "empty")
+	require.NoError(t, err)
+	defer empty.Close()
+
+	require.False(t, empty.SeekLE(txIDBytes(9)), "empty view")
+	require.False(t, empty.SeekLE(txIDBytes(3)), "covered by the ceil")
+	require.NoError(t, empty.Err())
 }

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -158,3 +158,98 @@ func TestPebbleReverseTxIterator_SeekLERepositioning(t *testing.T) {
 	require.False(t, empty.SeekLE(txIDBytes(3)), "covered by the ceil")
 	require.NoError(t, empty.Err())
 }
+
+// The floor short-circuit and reposition-after-exhaustion behavior is
+// mechanically identical across the forward Pebble leaves; the three tests
+// below mirror TestPrefixIterator_SeekFloorKeepsRepositioning for the
+// remaining leaves.
+
+func TestPebbleTxIterator_SeekFloorKeepsRepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	for _, id := range []uint64{1, 2, 3} {
+		require.NoError(t, s.DB().Set(append(txAttributeCode("l"), txIDBytes(id)...), nil, pebble.NoSync))
+	}
+
+	it, err := NewPebbleTxIterator(s.DB(), "l")
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.False(t, it.SeekGE(txIDBytes(5)), "no entity >= 5")
+	require.False(t, it.Next(), "failed seek leaves the iterator exhausted")
+	require.False(t, it.SeekGE(txIDBytes(7)), "covered by the floor")
+
+	require.True(t, it.SeekGE(txIDBytes(2)), "below the floor: real reposition")
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE(txIDBytes(1)), "reposition after Next-exhaustion")
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+func TestPebbleTxRangeIterator_SeekFloorKeepsRepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	for _, id := range []uint64{1, 2, 3} {
+		require.NoError(t, s.DB().Set(append(txAttributeCode("l"), txIDBytes(id)...), nil, pebble.NoSync))
+	}
+
+	it, err := NewPebbleTxRangeIterator(s.DB(), "l", txIDBytes(1), txIDBytes(4))
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.False(t, it.SeekGE(txIDBytes(5)), "past the upper bound")
+	require.False(t, it.Next(), "failed seek leaves the iterator exhausted")
+	require.False(t, it.SeekGE(txIDBytes(9)), "covered by the floor")
+
+	require.True(t, it.SeekGE(txIDBytes(2)), "below the floor: real reposition")
+	require.Equal(t, uint64(2), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(3), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE(txIDBytes(1)), "reposition after Next-exhaustion")
+	require.Equal(t, uint64(1), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+func TestPebbleAccountIterator_SeekFloorKeepsRepositioning(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+
+	prefix := make([]byte, 2+dal.LedgerNameFixedSize)
+	prefix[0] = dal.ZoneAttributes
+	prefix[1] = dal.SubAttrVolume
+	copy(prefix[2:], "l")
+
+	for _, addr := range []string{"a:1", "a:2", "a:3"} {
+		key := append(append(append([]byte{}, prefix...), addr...), dal.CanonicalKeySepVolume)
+		require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
+	}
+
+	it, err := newSingleTypeAccountIterator(s.DB(), dal.SubAttrVolume, "l", "")
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.False(t, it.SeekGE([]byte("b")), "no address >= b")
+	require.False(t, it.Next(), "failed seek leaves the iterator exhausted")
+	require.False(t, it.SeekGE([]byte("c")), "covered by the floor")
+
+	require.True(t, it.SeekGE([]byte("a:2")), "below the floor: real reposition")
+	require.Equal(t, "a:2", string(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, "a:3", string(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE([]byte("a:1")), "reposition after Next-exhaustion")
+	require.Equal(t, "a:1", string(it.Current()))
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_leaf.go
+++ b/internal/storage/readstore/iterator_leaf.go
@@ -90,9 +90,9 @@ func (it *PrefixIterator) Current() []byte {
 }
 
 func (it *PrefixIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	// Build a seek key: prefix base + target entity.
 	seekKey := make([]byte, 0, it.entityOffset+len(target))
@@ -232,9 +232,9 @@ func (it *RangeIterator) Current() []byte {
 }
 
 func (it *RangeIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	seekKey := make([]byte, 0, it.entityOffset+len(target))
 	// Use the stored lower bound prefix for seek key construction.

--- a/internal/storage/readstore/iterator_leaf.go
+++ b/internal/storage/readstore/iterator_leaf.go
@@ -16,6 +16,7 @@ type PrefixIterator struct {
 	current      []byte
 	started      bool
 	exhausted    bool
+	floor        seekFloor
 }
 
 // NewPrefixIterator creates an iterator that scans all keys with the given
@@ -90,6 +91,13 @@ func (it *PrefixIterator) Current() []byte {
 }
 
 func (it *PrefixIterator) SeekGE(target []byte) bool {
+	// A prior failed seek at or below target proves this one empty too.
+	if it.floor.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -103,6 +111,7 @@ func (it *PrefixIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekPrefixGE(seekKey) {
 		it.exhausted = true
+		it.floor.fail(target)
 
 		return false
 	}
@@ -122,6 +131,7 @@ func (it *PrefixIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.floor.fail(target)
 
 	return false
 }
@@ -167,6 +177,7 @@ type RangeIterator struct {
 	current      []byte
 	started      bool
 	exhausted    bool
+	floor        seekFloor
 }
 
 // NewRangeIterator creates an iterator that scans keys in [lower, upper).
@@ -232,6 +243,13 @@ func (it *RangeIterator) Current() []byte {
 }
 
 func (it *RangeIterator) SeekGE(target []byte) bool {
+	// A prior failed seek at or below target proves this one empty too.
+	if it.floor.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -248,6 +266,7 @@ func (it *RangeIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekPrefixGE(seekKey) {
 		it.exhausted = true
+		it.floor.fail(target)
 
 		return false
 	}
@@ -266,6 +285,7 @@ func (it *RangeIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.floor.fail(target)
 
 	return false
 }

--- a/internal/storage/readstore/iterator_leaf.go
+++ b/internal/storage/readstore/iterator_leaf.go
@@ -111,7 +111,7 @@ func (it *PrefixIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekPrefixGE(seekKey) {
 		it.exhausted = true
-		it.floor.fail(target)
+		it.floor.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -131,7 +131,7 @@ func (it *PrefixIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.floor.fail(target)
+	it.floor.fail(target, it.iter.Error())
 
 	return false
 }
@@ -266,7 +266,7 @@ func (it *RangeIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekPrefixGE(seekKey) {
 		it.exhausted = true
-		it.floor.fail(target)
+		it.floor.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -285,7 +285,7 @@ func (it *RangeIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.floor.fail(target)
+	it.floor.fail(target, it.iter.Error())
 
 	return false
 }

--- a/internal/storage/readstore/iterator_leaf.go
+++ b/internal/storage/readstore/iterator_leaf.go
@@ -1,6 +1,8 @@
 package readstore
 
 import (
+	"errors"
+
 	"github.com/cockroachdb/pebble/v2"
 
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -168,7 +170,10 @@ func (it *PrefixIterator) extractEntity(key []byte) []byte {
 }
 
 // RangeIterator scans keys between lower and upper bounds in the read index,
-// extracting entity IDs from each key.
+// extracting entity IDs from each key. When the range spans several
+// index-value buckets the emitted entities are NOT globally sorted — they
+// surface in (value, entity) order — so this iterator only supports forward
+// draining; see SeekGE.
 type RangeIterator struct {
 	iter         *pebble.Iterator
 	lowerBound   []byte // stored for SeekPrefixGE initial positioning
@@ -177,8 +182,12 @@ type RangeIterator struct {
 	current      []byte
 	started      bool
 	exhausted    bool
-	floor        seekFloor
+	seekErr      error
 }
+
+// errInvariantRangeIteratorSeek fails a query that composed a RangeIterator
+// without materializing it first — see RangeIterator.SeekGE.
+var errInvariantRangeIteratorSeek = errors.New("invariant: RangeIterator.SeekGE called; materialize into a SliceIterator before composing")
 
 // NewRangeIterator creates an iterator that scans keys in [lower, upper).
 func NewRangeIterator(
@@ -242,55 +251,26 @@ func (it *RangeIterator) Current() []byte {
 	return it.current
 }
 
-func (it *RangeIterator) SeekGE(target []byte) bool {
-	// A prior failed seek at or below target proves this one empty too.
-	if it.floor.covers(target) {
-		it.exhausted = true
-
-		return false
-	}
-
-	// Absolute reposition: clear the exhausted latch so a re-seek after
-	// exhaustion still finds entities (the body re-seeks from target).
-	it.exhausted = false
-
-	seekKey := make([]byte, 0, it.entityOffset+len(target))
-	// Use the stored lower bound prefix for seek key construction.
-	if len(it.lowerBound) >= it.entityOffset {
-		seekKey = append(seekKey, it.lowerBound[:it.entityOffset]...)
-	}
-
-	seekKey = append(seekKey[:min(len(seekKey), it.entityOffset)], target...)
-
-	it.started = true
-
-	if !it.iter.SeekPrefixGE(seekKey) {
-		it.exhausted = true
-		it.floor.fail(target, it.iter.Error())
-
-		return false
-	}
-
-	for it.iter.Valid() {
-		entity := it.extractEntity(it.iter.Key())
-		if entity != nil && compareEntities(entity, target) >= 0 {
-			it.current = entity
-
-			return true
-		}
-
-		if !it.iter.Next() {
-			break
-		}
-	}
-
+// SeekGE cannot be implemented on a raw range scan: the [lower, upper) range
+// may span several index-value buckets, so rows surface in (value, entity)
+// order and "the first entity >= target" is undefined without draining the
+// whole range. Every construction site materializes this iterator into a
+// sorted SliceIterator before composing (internal/query.materializeIterator),
+// which serves seeks over the sorted result; a call here is an invariant
+// violation and fails the query loudly instead of returning
+// plausible-looking wrong rows.
+func (it *RangeIterator) SeekGE([]byte) bool {
+	it.seekErr = errInvariantRangeIteratorSeek
 	it.exhausted = true
-	it.floor.fail(target, it.iter.Error())
 
 	return false
 }
 
 func (it *RangeIterator) Err() error {
+	if it.seekErr != nil {
+		return it.seekErr
+	}
+
 	if it.iter == nil {
 		return nil
 	}

--- a/internal/storage/readstore/iterator_leaf_test.go
+++ b/internal/storage/readstore/iterator_leaf_test.go
@@ -1,0 +1,43 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// RangeIterator drains [lower, upper) forward; SeekGE is unimplementable on
+// the raw scan (rows surface in (value, entity) order across buckets) and
+// must fail the query loudly instead of mis-seeking.
+func TestRangeIterator_DrainsForwardAndRefusesSeek(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	for _, id := range []uint64{1, 2, 3} {
+		require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", "acc:1", id), nil, pebble.NoSync))
+	}
+
+	prefix := AccountTxPrefix(dal.NewKeyBuilder(), PrefixAccountTx, "l", "acc:1")
+	lower := append(append([]byte{}, prefix...), txIDBytes(1)...)
+	upper := append(append([]byte{}, prefix...), txIDBytes(3)...)
+
+	it, err := NewRangeIterator(s.DB(), lower, upper, len(prefix), 8)
+	require.NoError(t, err)
+	defer it.Close()
+
+	var got []uint64
+	for it.Next() {
+		got = append(got, binary.BigEndian.Uint64(it.Current()))
+	}
+	require.Equal(t, []uint64{1, 2}, got, "upper bound is exclusive")
+	require.NoError(t, it.Err())
+
+	require.False(t, it.SeekGE(txIDBytes(1)))
+	require.ErrorIs(t, it.Err(), errInvariantRangeIteratorSeek)
+}

--- a/internal/storage/readstore/iterator_not.go
+++ b/internal/storage/readstore/iterator_not.go
@@ -71,9 +71,9 @@ func (it *NotIterator) Current() []byte {
 }
 
 func (it *NotIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the universe is re-seeked below).
+	it.exhausted = false
 
 	it.started = true
 

--- a/internal/storage/readstore/iterator_not.go
+++ b/internal/storage/readstore/iterator_not.go
@@ -75,19 +75,21 @@ func (it *NotIterator) SeekGE(target []byte) bool {
 		return false
 	}
 
-	if !it.started {
-		it.started = true
-		if it.child.SeekGE(target) {
-			it.childVal = it.child.Current()
-		} else {
-			it.childDone = true
-		}
-	} else if !it.childDone {
-		if it.child.SeekGE(target) {
-			it.childVal = it.child.Current()
-		} else {
-			it.childDone = true
-		}
+	it.started = true
+
+	// Re-position the child on every SeekGE, including after it has reported
+	// done. Forward Next() iteration can consume the child past a later,
+	// smaller seek target (nested NOTs reach this: the outer NOT advances the
+	// inner one to emit its first row, exhausting a finite child such as the
+	// reversion bitset). A latched childDone would then leave the child unable
+	// to report that the entity at target is excluded, leaking it into the
+	// difference. SeekGE is absolute repositioning (>= target), so re-seeking
+	// is always well-defined.
+	if it.child.SeekGE(target) {
+		it.childVal = it.child.Current()
+		it.childDone = false
+	} else {
+		it.childDone = true
 	}
 
 	if !it.universe.SeekGE(target) {

--- a/internal/storage/readstore/iterator_or.go
+++ b/internal/storage/readstore/iterator_or.go
@@ -51,9 +51,13 @@ func (it *OrIterator) Current() []byte {
 }
 
 func (it *OrIterator) SeekGE(target []byte) bool {
-	if it.exhausted || len(it.children) == 0 {
+	if len(it.children) == 0 {
 		return false
 	}
+
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion re-establishes the union (all children are re-seeked below).
+	it.exhausted = false
 
 	for i := range it.children {
 		it.valid[i] = it.children[i].SeekGE(target)

--- a/internal/storage/readstore/iterator_or_seek_test.go
+++ b/internal/storage/readstore/iterator_or_seek_test.go
@@ -1,0 +1,32 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// OrIterator.SeekGE must re-establish the union after exhaustion — the union
+// mirror of TestAndIterator_SeekGERepositionsAllChildren.
+func TestOrIterator_SeekGERepositionsAfterExhaustion(t *testing.T) {
+	t.Parallel()
+
+	it := NewOrIterator(newAliasingIter("a", "c"), newAliasingIter("b"))
+	defer it.Close()
+
+	var got []string
+	for it.Next() {
+		got = append(got, string(it.Current()))
+	}
+	require.Equal(t, []string{"a", "b", "c"}, got)
+
+	require.True(t, it.SeekGE([]byte("b")), "reposition after exhaustion")
+	require.Equal(t, "b", string(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, "c", string(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE([]byte("a")), "backward absolute seek")
+	require.Equal(t, "a", string(it.Current()))
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_or_seek_test.go
+++ b/internal/storage/readstore/iterator_or_seek_test.go
@@ -30,3 +30,28 @@ func TestOrIterator_SeekGERepositionsAfterExhaustion(t *testing.T) {
 	require.Equal(t, "a", string(it.Current()))
 	require.NoError(t, it.Err())
 }
+
+// ReverseOrIterator.SeekLE must re-establish the union after exhaustion —
+// the descending mirror of the OR test above.
+func TestReverseOrIterator_SeekLERepositionsAfterExhaustion(t *testing.T) {
+	t.Parallel()
+
+	it := NewReverseOrIterator(newReverseAliasingIter("a", "c"), newReverseAliasingIter("b"))
+	defer it.Close()
+
+	var got []string
+	for it.Next() {
+		got = append(got, string(it.Current()))
+	}
+	require.Equal(t, []string{"c", "b", "a"}, got)
+
+	require.True(t, it.SeekLE([]byte("b")), "reposition after exhaustion")
+	require.Equal(t, "b", string(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, "a", string(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekLE([]byte("c")), "forward absolute seek")
+	require.Equal(t, "c", string(it.Current()))
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -188,9 +188,9 @@ func (it *PebbleAccountIterator) Current() []byte {
 }
 
 func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	it.started = true
 
@@ -355,9 +355,9 @@ func (it *PebbleReverseAccountIterator) Current() []byte {
 }
 
 func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	it.started = true
 
@@ -519,9 +519,9 @@ func (it *PebbleTxIterator) Current() []byte {
 }
 
 func (it *PebbleTxIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	it.started = true
 
@@ -656,9 +656,9 @@ func (it *PebbleReverseTxIterator) Current() []byte {
 }
 
 func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	it.started = true
 
@@ -843,9 +843,9 @@ func (it *PebbleTxRangeIterator) Next() bool {
 func (it *PebbleTxRangeIterator) Current() []byte { return it.current }
 
 func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	it.started = true
 

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -58,6 +58,7 @@ type PebbleAccountIterator struct {
 	current   []byte
 	started   bool
 	exhausted bool
+	floor     seekFloor
 }
 
 // newSingleTypeAccountIterator creates a forward account iterator for one attribute type.
@@ -188,6 +189,13 @@ func (it *PebbleAccountIterator) Current() []byte {
 }
 
 func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
+	// A prior failed seek at or below target proves this one empty too.
+	if it.floor.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -200,6 +208,7 @@ func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
+		it.floor.fail(target)
 
 		return false
 	}
@@ -218,6 +227,7 @@ func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.floor.fail(target)
 
 	return false
 }
@@ -250,6 +260,7 @@ type PebbleReverseAccountIterator struct {
 	current   []byte
 	started   bool
 	exhausted bool
+	ceil      seekCeil
 }
 
 // newSingleTypeReverseAccountIterator creates a reverse account iterator for one attribute type.
@@ -355,6 +366,13 @@ func (it *PebbleReverseAccountIterator) Current() []byte {
 }
 
 func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
+	// A prior failed seek at or above target proves this one empty too.
+	if it.ceil.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -382,12 +400,14 @@ func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
 		// Past target, step back
 		if !it.iter.Prev() {
 			it.exhausted = true
+			it.ceil.fail(target)
 
 			return false
 		}
 	} else if !it.iter.Last() {
 		// Past end, go to last
 		it.exhausted = true
+		it.ceil.fail(target)
 
 		return false
 	}
@@ -406,6 +426,7 @@ func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.ceil.fail(target)
 
 	return false
 }
@@ -442,6 +463,7 @@ type PebbleTxIterator struct {
 	current   []byte
 	started   bool
 	exhausted bool
+	floor     seekFloor
 }
 
 // NewPebbleTxIterator creates an iterator over all transactions in a ledger.
@@ -519,6 +541,13 @@ func (it *PebbleTxIterator) Current() []byte {
 }
 
 func (it *PebbleTxIterator) SeekGE(target []byte) bool {
+	// A prior failed seek at or below target proves this one empty too.
+	if it.floor.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -531,6 +560,7 @@ func (it *PebbleTxIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
+		it.floor.fail(target)
 
 		return false
 	}
@@ -543,6 +573,7 @@ func (it *PebbleTxIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.floor.fail(target)
 
 	return false
 }
@@ -578,6 +609,7 @@ type PebbleReverseTxIterator struct {
 	current   []byte
 	started   bool
 	exhausted bool
+	ceil      seekCeil
 }
 
 // NewPebbleReverseTxIterator creates a reverse transaction iterator.
@@ -656,6 +688,13 @@ func (it *PebbleReverseTxIterator) Current() []byte {
 }
 
 func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
+	// A prior failed seek at or above target proves this one empty too.
+	if it.ceil.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -672,12 +711,14 @@ func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
 	if it.iter.SeekGE(seekKey) {
 		if !it.iter.Prev() {
 			it.exhausted = true
+			it.ceil.fail(target)
 
 			return false
 		}
 	} else {
 		if !it.iter.Last() {
 			it.exhausted = true
+			it.ceil.fail(target)
 
 			return false
 		}
@@ -697,6 +738,7 @@ func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.ceil.fail(target)
 
 	return false
 }
@@ -757,6 +799,7 @@ type PebbleTxRangeIterator struct {
 	current   []byte
 	started   bool
 	exhausted bool
+	floor     seekFloor
 }
 
 // NewPebbleTxRangeIterator creates a bounded transaction iterator for range queries.
@@ -843,6 +886,13 @@ func (it *PebbleTxRangeIterator) Next() bool {
 func (it *PebbleTxRangeIterator) Current() []byte { return it.current }
 
 func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
+	// A prior failed seek at or below target proves this one empty too.
+	if it.floor.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -856,6 +906,7 @@ func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
+		it.floor.fail(target)
 
 		return false
 	}
@@ -868,6 +919,7 @@ func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.floor.fail(target)
 
 	return false
 }

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -3,6 +3,7 @@ package readstore
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 
 	"github.com/cockroachdb/pebble/v2"
 
@@ -715,26 +716,31 @@ func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
 	it.started = true
 
 	// Seek to the last byLog entry for target txID:
-	// SeekGE([prefix][target+1]) then Prev(), or Last() if past end
-	nextTarget := incrementUint64Bytes(target)
-	seekKey := make([]byte, len(it.prefix)+8)
-	copy(seekKey, it.prefix)
-	copy(seekKey[len(it.prefix):], nextTarget)
-
-	if it.iter.SeekGE(seekKey) {
-		if !it.iter.Prev() {
-			it.exhausted = true
-			it.ceil.fail(target, it.iter.Error())
-
-			return false
-		}
+	// SeekGE([prefix][target+1]) then Prev(), or Last() if past end.
+	// An all-0xff target wraps the increment to zero, which would land the
+	// probe on the FIRST key and mis-record an emptiness proof; every key
+	// qualifies for that target, so position at the end of the range directly.
+	var positioned bool
+	if isMaxUint64Bytes(target) {
+		positioned = it.iter.Last()
 	} else {
-		if !it.iter.Last() {
-			it.exhausted = true
-			it.ceil.fail(target, it.iter.Error())
+		nextTarget := incrementUint64Bytes(target)
+		seekKey := make([]byte, len(it.prefix)+8)
+		copy(seekKey, it.prefix)
+		copy(seekKey[len(it.prefix):], nextTarget)
 
-			return false
+		if it.iter.SeekGE(seekKey) {
+			positioned = it.iter.Prev()
+		} else {
+			positioned = it.iter.Last()
 		}
+	}
+
+	if !positioned {
+		it.exhausted = true
+		it.ceil.fail(target, it.iter.Error())
+
+		return false
 	}
 
 	for it.iter.Valid() {
@@ -1016,6 +1022,12 @@ func copyBytes(b []byte) []byte {
 	copy(cp, b)
 
 	return cp
+}
+
+// isMaxUint64Bytes reports whether b is the 8-byte encoding of MaxUint64 —
+// the one value incrementUint64Bytes wraps to zero on.
+func isMaxUint64Bytes(b []byte) bool {
+	return len(b) == 8 && binary.BigEndian.Uint64(b) == math.MaxUint64
 }
 
 func incrementUint64Bytes(b []byte) []byte {

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -27,6 +27,19 @@ type EntityIterator interface {
 
 	// SeekGE positions the iterator at the first entity >= target.
 	// Returns false if no such entity exists OR on I/O error — see Err().
+	//
+	// SeekGE is an ABSOLUTE reposition (see
+	// docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md):
+	//   - the result is computed from target alone, never from the iterator's
+	//     position, direction of travel, or exhaustion state;
+	//   - it is idempotent: repeating SeekGE with the same target yields the
+	//     same entity, and must not consume it;
+	//   - it is well-defined after exhaustion (a false Next/SeekGE) — a later
+	//     seek to a smaller target repositions normally;
+	//   - a failed seek leaves the iterator un-positioned (Next returns false)
+	//     but still re-seekable.
+	// Composite iterators (AND/OR/NOT) re-seek children freely under this
+	// contract; a latch or a consuming seek silently drops rows (EN-1597).
 	SeekGE(target []byte) bool
 
 	// Err returns the first storage error encountered during iteration, or
@@ -208,7 +221,7 @@ func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
-		it.floor.fail(target)
+		it.floor.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -227,7 +240,7 @@ func (it *PebbleAccountIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.floor.fail(target)
+	it.floor.fail(target, it.iter.Error())
 
 	return false
 }
@@ -400,14 +413,14 @@ func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
 		// Past target, step back
 		if !it.iter.Prev() {
 			it.exhausted = true
-			it.ceil.fail(target)
+			it.ceil.fail(target, it.iter.Error())
 
 			return false
 		}
 	} else if !it.iter.Last() {
 		// Past end, go to last
 		it.exhausted = true
-		it.ceil.fail(target)
+		it.ceil.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -426,7 +439,7 @@ func (it *PebbleReverseAccountIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.ceil.fail(target)
+	it.ceil.fail(target, it.iter.Error())
 
 	return false
 }
@@ -560,7 +573,7 @@ func (it *PebbleTxIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
-		it.floor.fail(target)
+		it.floor.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -573,7 +586,7 @@ func (it *PebbleTxIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.floor.fail(target)
+	it.floor.fail(target, it.iter.Error())
 
 	return false
 }
@@ -711,14 +724,14 @@ func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
 	if it.iter.SeekGE(seekKey) {
 		if !it.iter.Prev() {
 			it.exhausted = true
-			it.ceil.fail(target)
+			it.ceil.fail(target, it.iter.Error())
 
 			return false
 		}
 	} else {
 		if !it.iter.Last() {
 			it.exhausted = true
-			it.ceil.fail(target)
+			it.ceil.fail(target, it.iter.Error())
 
 			return false
 		}
@@ -738,7 +751,7 @@ func (it *PebbleReverseTxIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.ceil.fail(target)
+	it.ceil.fail(target, it.iter.Error())
 
 	return false
 }
@@ -906,7 +919,7 @@ func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
 
 	if !it.iter.SeekGE(seekKey) {
 		it.exhausted = true
-		it.floor.fail(target)
+		it.floor.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -919,7 +932,7 @@ func (it *PebbleTxRangeIterator) SeekGE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.floor.fail(target)
+	it.floor.fail(target, it.iter.Error())
 
 	return false
 }

--- a/internal/storage/readstore/iterator_reverse.go
+++ b/internal/storage/readstore/iterator_reverse.go
@@ -88,9 +88,9 @@ func (it *ReversePrefixIterator) Current() []byte {
 
 // SeekLE positions the iterator at the first entity whose key is <= target.
 func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
-	if it.exhausted {
-		return false
-	}
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds entities (the body re-seeks from target).
+	it.exhausted = false
 
 	// Build seek key: prefix base + target entity
 	seekKey := make([]byte, 0, it.entityOffset+len(target))

--- a/internal/storage/readstore/iterator_reverse.go
+++ b/internal/storage/readstore/iterator_reverse.go
@@ -18,6 +18,7 @@ type ReversePrefixIterator struct {
 	current      []byte
 	started      bool
 	exhausted    bool
+	ceil         seekCeil
 }
 
 // NewReversePrefixIterator creates an iterator that scans all keys with the
@@ -88,6 +89,13 @@ func (it *ReversePrefixIterator) Current() []byte {
 
 // SeekLE positions the iterator at the first entity whose key is <= target.
 func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
+	// A prior failed seek at or above target proves this one empty too.
+	if it.ceil.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
 	// Absolute reposition: clear the exhausted latch so a re-seek after
 	// exhaustion still finds entities (the body re-seeks from target).
 	it.exhausted = false
@@ -111,12 +119,14 @@ func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
 		// Key is > target, step back
 		if !it.iter.Prev() {
 			it.exhausted = true
+			it.ceil.fail(target)
 
 			return false
 		}
 	} else if !it.iter.Last() {
 		// Past the end — go to last key
 		it.exhausted = true
+		it.ceil.fail(target)
 
 		return false
 	}
@@ -135,6 +145,7 @@ func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
+	it.ceil.fail(target)
 
 	return false
 }

--- a/internal/storage/readstore/iterator_reverse.go
+++ b/internal/storage/readstore/iterator_reverse.go
@@ -119,14 +119,14 @@ func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
 		// Key is > target, step back
 		if !it.iter.Prev() {
 			it.exhausted = true
-			it.ceil.fail(target)
+			it.ceil.fail(target, it.iter.Error())
 
 			return false
 		}
 	} else if !it.iter.Last() {
 		// Past the end — go to last key
 		it.exhausted = true
-		it.ceil.fail(target)
+		it.ceil.fail(target, it.iter.Error())
 
 		return false
 	}
@@ -145,7 +145,7 @@ func (it *ReversePrefixIterator) SeekLE(target []byte) bool {
 	}
 
 	it.exhausted = true
-	it.ceil.fail(target)
+	it.ceil.fail(target, it.iter.Error())
 
 	return false
 }

--- a/internal/storage/readstore/iterator_reverse_or.go
+++ b/internal/storage/readstore/iterator_reverse_or.go
@@ -63,9 +63,13 @@ func (it *ReverseOrIterator) Current() []byte {
 }
 
 func (it *ReverseOrIterator) SeekLE(target []byte) bool {
-	if it.done || len(it.children) == 0 {
+	if len(it.children) == 0 {
 		return false
 	}
+
+	// Absolute reposition: clear the done latch so a re-seek after exhaustion
+	// re-establishes the union (all children are re-seeked below).
+	it.done = false
 
 	for i := range it.children {
 		it.children[i].valid = it.children[i].iter.SeekLE(target)

--- a/internal/storage/readstore/paginate.go
+++ b/internal/storage/readstore/paginate.go
@@ -37,6 +37,15 @@ func PaginateForward(iter EntityIterator, pageSize uint32, after []byte) (items 
 type ReverseIterator interface {
 	Next() bool
 	Current() []byte
+	// SeekLE positions the iterator at the first (largest) entity <= target.
+	// Returns false if no such entity exists OR on I/O error — see Err().
+	//
+	// SeekLE is an ABSOLUTE reposition, the descending mirror of
+	// EntityIterator.SeekGE (see iterator_pebble.go and
+	// docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md):
+	// computed from target alone, idempotent and non-consuming at the same
+	// target, well-defined after exhaustion, and a failed seek leaves the
+	// iterator un-positioned but still re-seekable.
 	SeekLE(target []byte) bool
 	Err() error
 }

--- a/tests/e2e/business/filter_nested_not_reposition_test.go
+++ b/tests/e2e/business/filter_nested_not_reposition_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package business
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Nested-NOT filters over index-free leaves (tx-id range, account address).
+// A NOT drives its child forward — exhausting a finite leaf — before the AND
+// merge seeks the tree back to a smaller key; the leaf must reposition on that
+// backward SeekGE rather than latch on exhaustion (EN-1597). Each filter here
+// is a contradiction (`and(not(F), F)`, spelled with an extra NOT to force the
+// exhaust-then-seek-back path) and must return nothing.
+var _ = Describe("Nested-NOT filter reposition", Ordered, ContinueOnFailure, func() {
+	const ledgerName = "nested-not-reposition-ledger"
+
+	tripleNot := func(f *commonpb.QueryFilter) *commonpb.QueryFilter {
+		return actions.NotFilter(actions.NotFilter(actions.NotFilter(f)))
+	}
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		for i := 0; i < 8; i++ {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", fmt.Sprintf("acc:%d", i), big.NewInt(100), "USD"),
+			}, nil, nil)))
+			Expect(err).To(Succeed())
+		}
+	})
+
+	It("tx-id range: and(not(not(not(id[3,5]))), id[3,5]) is empty", func() {
+		f := actions.AndFilter(tripleNot(actions.TxIDRangeFilter(3, 5)), actions.TxIDRangeFilter(3, 5))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+
+	It("tx-id range: and(not(not(id[3,5])), not(id[3,5])) is empty", func() {
+		f := actions.AndFilter(actions.NotFilter(actions.NotFilter(actions.TxIDRangeFilter(3, 5))), actions.NotFilter(actions.TxIDRangeFilter(3, 5)))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+
+	It("address: and(not(not(not(addr^acc:))), addr^acc:) is empty", func() {
+		f := actions.AndFilter(tripleNot(actions.AddressPrefixFilter("acc:")), actions.AddressPrefixFilter("acc:"))
+		accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", f)
+		Expect(err).To(Succeed())
+		Expect(accts).To(BeEmpty())
+	})
+
+	It("address: and(not(not(addr^acc:)), not(addr^acc:)) is empty", func() {
+		f := actions.AndFilter(actions.NotFilter(actions.NotFilter(actions.AddressPrefixFilter("acc:"))), actions.NotFilter(actions.AddressPrefixFilter("acc:")))
+		accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", f)
+		Expect(err).To(Succeed())
+		Expect(accts).To(BeEmpty())
+	})
+})

--- a/tests/e2e/business/filter_nested_not_reposition_test.go
+++ b/tests/e2e/business/filter_nested_not_reposition_test.go
@@ -5,6 +5,7 @@ package business
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -36,6 +37,22 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, ContinueOnFailure, fun
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 		}
+	})
+
+	// Guard against vacuous passes: an empty result is only meaningful once the
+	// bare leaves see the data. The Pebble read index is populated
+	// asynchronously by the index builder, so wait for both leaf shapes to
+	// return the seeded rows before testing the contradictions.
+	It("baseline: the bare leaves return the seeded data", func() {
+		Eventually(func(g Gomega) {
+			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, actions.TxIDRangeFilter(3, 5))
+			g.Expect(err).To(Succeed())
+			g.Expect(txs).To(HaveLen(3))
+
+			accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", actions.AddressPrefixFilter("acc:"))
+			g.Expect(err).To(Succeed())
+			g.Expect(accts).To(HaveLen(8))
+		}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 	})
 
 	It("tx-id range: and(not(not(not(id[3,5]))), id[3,5]) is empty", func() {

--- a/tests/e2e/business/filter_nested_not_reposition_test.go
+++ b/tests/e2e/business/filter_nested_not_reposition_test.go
@@ -14,11 +14,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Nested-NOT filters over index-free leaves (tx-id range, account address).
-// A NOT drives its child forward — exhausting a finite leaf — before the AND
-// merge seeks the tree back to a smaller key; the leaf must reposition on that
-// backward SeekGE rather than latch on exhaustion (EN-1597). Each filter here
-// is a contradiction (`and(not(F), F)`, spelled with an extra NOT to force the
+// Nested-NOT filters over three leaf shapes: tx-id range and account address
+// (index-free, main-store scans), and address-on-transactions (through the
+// tx-address index and AddressTxIterator). A NOT drives its child forward —
+// exhausting a finite leaf — before the AND merge seeks the tree back to a
+// smaller key; the leaf must reposition on that backward SeekGE rather than
+// latch on exhaustion (EN-1597). Each filter here is a contradiction
+// (`and(not(F), F)`, spelled with an extra NOT to force the
 // exhaust-then-seek-back path) and must return nothing.
 var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 	const ledgerName = "nested-not-reposition-ledger"
@@ -29,12 +31,17 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 
 	// The trailing guard aborts the container on failure (a BeforeAll failure
 	// skips every spec), so the BeEmpty contradictions below can never pass
-	// vacuously against a view that lost the seeded data. Both bare leaves read
-	// the main store's attributes zone, written synchronously by the FSM before
-	// Apply returns — neither touches the asynchronously-built read index — so
-	// the Eventually is a freshness backstop, not an indexing wait.
+	// vacuously against a view that lost the seeded data. The tx-id and
+	// account-address leaves read the main store's attributes zone, written
+	// synchronously by the FSM before Apply returns — for those the Eventually
+	// is a freshness backstop. The address-on-transactions leaf compiles only
+	// once the tx-address index is READY on this replica, which the explicit
+	// wait guarantees.
 	BeforeAll(func() {
 		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateAddressIndexAction(ledgerName, commonpb.AddressRole_ADDRESS_ROLE_ANY)))
 		Expect(err).To(Succeed())
 
 		for i := 0; i < 8; i++ {
@@ -44,6 +51,8 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 			Expect(err).To(Succeed())
 		}
 
+		Expect(actions.WaitForAddressIndexReady(sharedCtx, sharedClient, ledgerName, commonpb.AddressRole_ADDRESS_ROLE_ANY)).To(Succeed())
+
 		Eventually(func(g Gomega) {
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, actions.TxIDRangeFilter(3, 5))
 			g.Expect(err).To(Succeed())
@@ -52,6 +61,10 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 			accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", actions.AddressPrefixFilter("acc:"))
 			g.Expect(err).To(Succeed())
 			g.Expect(accts).To(HaveLen(8))
+
+			txsByAddr, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, actions.AddressPrefixFilter("acc:"))
+			g.Expect(err).To(Succeed())
+			g.Expect(txsByAddr).To(HaveLen(8))
 		}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 	})
 
@@ -81,5 +94,25 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 		accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", f)
 		Expect(err).To(Succeed())
 		Expect(accts).To(BeEmpty())
+	})
+
+	// On the TRANSACTIONS target an address leaf compiles to
+	// NotIterator{universe: PebbleTxIterator, child: AddressTxIterator} — the
+	// materialized-union iterator whose SeekGE must be an absolute reposition.
+	// These two specs pin the compile-path reachability (no other e2e builds an
+	// AddressTxIterator); the absolute-seek conformance itself is pinned by the
+	// unit tests in readstore/iterator_address_test.go.
+	It("tx-address: and(not(not(not(addr^acc:))), addr^acc:) is empty on transactions", func() {
+		f := actions.AndFilter(tripleNot(actions.AddressPrefixFilter("acc:")), actions.AddressPrefixFilter("acc:"))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+
+	It("tx-address: and(not(not(addr^acc:)), not(addr^acc:)) is empty on transactions", func() {
+		f := actions.AndFilter(actions.NotFilter(actions.NotFilter(actions.AddressPrefixFilter("acc:"))), actions.NotFilter(actions.AddressPrefixFilter("acc:")))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
 	})
 })

--- a/tests/e2e/business/filter_nested_not_reposition_test.go
+++ b/tests/e2e/business/filter_nested_not_reposition_test.go
@@ -20,13 +20,19 @@ import (
 // backward SeekGE rather than latch on exhaustion (EN-1597). Each filter here
 // is a contradiction (`and(not(F), F)`, spelled with an extra NOT to force the
 // exhaust-then-seek-back path) and must return nothing.
-var _ = Describe("Nested-NOT filter reposition", Ordered, ContinueOnFailure, func() {
+var _ = Describe("Nested-NOT filter reposition", Ordered, func() {
 	const ledgerName = "nested-not-reposition-ledger"
 
 	tripleNot := func(f *commonpb.QueryFilter) *commonpb.QueryFilter {
 		return actions.NotFilter(actions.NotFilter(actions.NotFilter(f)))
 	}
 
+	// The trailing guard aborts the container on failure (a BeforeAll failure
+	// skips every spec), so the BeEmpty contradictions below can never pass
+	// vacuously against a view that lost the seeded data. Both bare leaves read
+	// the main store's attributes zone, written synchronously by the FSM before
+	// Apply returns — neither touches the asynchronously-built read index — so
+	// the Eventually is a freshness backstop, not an indexing wait.
 	BeforeAll(func() {
 		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
 		Expect(err).To(Succeed())
@@ -37,13 +43,7 @@ var _ = Describe("Nested-NOT filter reposition", Ordered, ContinueOnFailure, fun
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 		}
-	})
 
-	// Guard against vacuous passes: an empty result is only meaningful once the
-	// bare leaves see the data. The Pebble read index is populated
-	// asynchronously by the index builder, so wait for both leaf shapes to
-	// return the seeded rows before testing the contradictions.
-	It("baseline: the bare leaves return the seeded data", func() {
 		Eventually(func(g Gomega) {
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, actions.TxIDRangeFilter(3, 5))
 			g.Expect(err).To(Succeed())

--- a/tests/e2e/business/reverted_filter_contradiction_test.go
+++ b/tests/e2e/business/reverted_filter_contradiction_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package business
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Reverted-filter set logic. The reverted condition is served from the reversion
+// bitset (no index), composed with And/Or/Not via the merge iterators. A filter
+// that is logically unsatisfiable — reverted=false AND reverted=true — must
+// return no transactions, on its own and under boolean rewrites that reduce to
+// the same contradiction. Reproduces a case the model-based antithesis driver
+// flagged: and(not(not(reverted=false)), reverted=true) returned a row (EN-1597).
+var _ = Describe("Reverted filter set logic", Ordered, func() {
+	const ledgerName = "reverted-contradiction-ledger"
+
+	var revertedIDs []uint64
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		// Six funding transactions to distinct accounts (ids assigned in order).
+		var ids []uint64
+		for i := 0; i < 6; i++ {
+			resp, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", fmt.Sprintf("acc:%d", i), big.NewInt(100), "USD"),
+			}, nil, nil)))
+			Expect(err).To(Succeed())
+			ids = append(ids, resp.GetLogs()[0].GetPayload().GetApply().GetLog().GetData().GetCreatedTransaction().GetTransaction().GetId())
+		}
+
+		// Revert two originals so the reversion bitset is non-empty (each revert
+		// also commits a compensating transaction, which is itself not reverted).
+		for _, idx := range []int{1, 3} {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.RevertTransactionAction(ledgerName, ids[idx], true, false, nil)))
+			Expect(err).To(Succeed())
+			revertedIDs = append(revertedIDs, ids[idx])
+		}
+	})
+
+	It("reverted=true returns exactly the reverted originals", func() {
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, actions.RevertedFilter(true))
+		Expect(err).To(Succeed())
+		Expect(idsOf(txs)).To(ConsistOf(revertedIDs))
+	})
+
+	It("and(reverted=false, reverted=true) is unsatisfiable and returns nothing", func() {
+		f := actions.AndFilter(actions.RevertedFilter(false), actions.RevertedFilter(true))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+
+	It("and(reverted=true, reverted=false) is unsatisfiable and returns nothing", func() {
+		f := actions.AndFilter(actions.RevertedFilter(true), actions.RevertedFilter(false))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+
+	It("and(not(not(reverted=false)), reverted=true) reduces to the same contradiction", func() {
+		f := actions.AndFilter(actions.NotFilter(actions.NotFilter(actions.RevertedFilter(false))), actions.RevertedFilter(true))
+		txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, f)
+		Expect(err).To(Succeed())
+		Expect(txs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
## Problem

A `ListTransactions`/`ListAccounts` filter composing `NOT` (especially nested `NOT`) with other conditions could return entities it must exclude. Reduced case: `and(not(not(reverted=false)), reverted=true)` — a logical contradiction — returned a transaction instead of nothing.

## Root cause

`SeekGE`/`SeekLE` are contractually *absolute* repositioning ("position at the first entity ≥/≤ target"), but the read-store iterators latched on exhaustion: once exhausted they early-returned `false` and refused to reposition, even though their bodies already recompute position from `target`.

A `NOT` drives a child forward to exhaustion while emitting an early row; an `AND`/`OR` merge then seeks the tree back to a smaller key; the latch turns that backward seek into a no-op, so the `NOT` stops excluding and an excluded entity leaks through `universe \ child`.

## Changes

1. **`NotIterator` + `BitsetIterator`** — re-seek the child unconditionally / reposition from target instead of latching (the confirmed root cause).
2. **Uniform pass** — clear the exhausted/done latch in every leaf and merge iterator so `SeekGE`/`SeekLE` reposition after exhaustion: `PebbleTxIterator`, `PebbleAccountIterator`, `PebbleTxRangeIterator`, `PebbleReverseTxIterator`, `PebbleReverseAccountIterator`, `PrefixIterator`, `ReversePrefixIterator`, `AndIterator`, `OrIterator`, `NotIterator`, `ReverseOrIterator`. `RangeIterator` is the deliberate exception: a raw range scan surfaces rows in `(value, entity)` order across index-value buckets, so an entity-space `SeekGE` is unimplementable without draining the range. Every construction site already materializes it into a sorted `SliceIterator`; its `SeekGE` now fails the query with an invariant error instead of mis-seeking plausibly.
3. **`AndIterator.SeekGE`** — re-seek **all** children, not just `children[0]`; a stale non-first child could otherwise become the `converge` candidate and skip valid intersections below it (reported by NumaryBot).
4. **`AddressTxIterator` restructured into a conforming absolute repositioner** — the old implementation destructively consumed a materialized slice (`pendingTxns[idx+1:]`) behind an exhaustion latch, so `SeekGE` on it dropped rows once the `AndIterator` change re-seeked children unconditionally. It now materializes the account→tx union once into a stable slice and seeks with a `sort.Search` cursor — repeatable, backward-seekable, well-defined after exhaustion.
5. **`seekFloor`/`seekCeil` exhaustion-proof cache** (`iterator_floor.go`) — removing the latches made composite parents re-seek exhausted children once per merge step (O(rows) Pebble seeks). A *cleanly* failed `SeekGE(t)` proves no entity ≥ t exists in the iterator's snapshot-fixed view, so the leaf records the bound and answers later covered seeks in O(1). Preconditions: the Pebble view is fixed at iterator creation (proofs never expire), and an I/O-failed seek proves nothing — `fail()` takes the iterator's storage error and drops the proof when non-nil.
6. **Contract made normative** — `EntityIterator.SeekGE` / `ReverseIterator.SeekLE` doc blocks now state the absolute-reposition guarantees (computed from target alone, idempotent/non-consuming, valid after exhaustion, failed seek leaves the iterator re-seekable), with a dedicated docs page: `docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md`. `query-pipeline.md`/`prepared-queries.md` updated — `AndIterator.SeekGE` now force-seeks every child, so the old "monotonic-skip on seek" description no longer holds.

## Tests

- e2e regressions: `reverted_filter_contradiction_test.go` and `filter_nested_not_reposition_test.go` (tx-id-range + account-address leaves) — fail pre-fix, pass after. The nested-NOT suite guards against vacuous passes with a `BeforeAll` baseline (aborts the container if the seeded rows are not visible); those leaves read the FSM-synchronous attributes zone.
- e2e coverage: two tx-address contradictions in the nested-NOT suite (`ListTransactionsFiltered` + `AddressPrefixFilter` behind a READY tx-address index) — the only e2e path that compiles an `AddressTxIterator`. These pin reachability, not the pre-fix bug: with the `NotIterator`/`AndIterator` fixes in place, `converge` only seeks strictly-behind children, so no single-page query re-seeks the same target twice and the old destructive consume has no e2e repro (verified: the specs pass against the pre-fix `AddressTxIterator`). The conformance itself is pinned at unit level.
- readstore unit suites: `iterator_and_seek_test.go` (AndIterator re-seeks all children), `iterator_address_test.go` (AddressTxIterator absolute-seek conformance), `iterator_floor_test.go` (floor/ceil algebra incl. the I/O-error carve-out, forward + reverse leaf repositioning through the cache, `PebbleReverseTxIterator` exhaust-then-seek-back branches), `iterator_leaf_test.go` (RangeIterator forward drain + loud invariant error on `SeekGE`).
- `internal/storage/readstore` + `internal/query` unit suites green.

Found by the model-based antithesis driver (`singleton_driver_model`); confirmed on a single node and on a 3-node cluster with rolling restarts.
