### PR TITLE
fix(EN-1536): enforce typed audit failures and fatal post-Preload scope invariant

### DIFF
--- a/internal/infra/state/audit.go
+++ b/internal/infra/state/audit.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"errors"
 	"maps"
 	"slices"
 
@@ -11,30 +10,21 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
-// buildAuditFailure extracts the error type and context from a processing error
-// to build an AuditFailure proto. Previously this was a 30-case hand-maintained
-// type-switch that would fall to "UNKNOWN" on every new typed error; it now
-// consumes the Describable contract directly so adding a new domain error type
-// automatically extends audit coverage with no edit here.
-func buildAuditFailure(err error) *auditpb.AuditFailure {
+// buildAuditFailure projects a typed domain error into an AuditFailure proto.
+// It accepts domain.Describable — not a bare error — so the compiler
+// guarantees only typed, deterministic outcomes reach the audit chain. There
+// is no ERROR_REASON_UNSPECIFIED fallback: a non-Describable failure is an FSM
+// invariant violation that must fail loudly at its origin, never be downgraded
+// to an unspecified business outcome in the authoritative chain.
+func buildAuditFailure(d domain.Describable) *auditpb.AuditFailure {
 	failure := &auditpb.AuditFailure{
-		Message: err.Error(),
+		Message: d.Error(),
 		Context: make(map[string]string),
 	}
 
-	var d domain.Describable
-	if errors.As(err, &d) {
-		failure.Reason = domain.ReasonCode(d.Reason())
+	failure.Reason = domain.ReasonCode(d.Reason())
+	maps.Copy(failure.GetContext(), d.Metadata())
 
-		maps.Copy(failure.GetContext(), d.Metadata())
-
-		return failure
-	}
-
-	// Reaching here means a non-Describable error escaped the typed
-	// processing pipeline. After #431 this branch is structurally
-	// unreachable in production; kept as a safety net for tests that
-	// fabricate raw errors. Reason stays ERROR_REASON_UNSPECIFIED.
 	return failure
 }
 

--- a/internal/infra/state/audit_test.go
+++ b/internal/infra/state/audit_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
-	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -376,14 +375,6 @@ func TestBuildAuditFailure(t *testing.T) {
 		failure := buildAuditFailure(err)
 		require.Equal(t, domain.ErrReasonChapterNotClosed, domain.ReasonString(failure.GetReason()))
 		require.Equal(t, "3", failure.GetContext()["chapterId"])
-	})
-
-	t.Run("Unknown", func(t *testing.T) {
-		t.Parallel()
-
-		err := errors.New("some unknown error")
-		failure := buildAuditFailure(err)
-		require.Equal(t, commonpb.ErrorReason_ERROR_REASON_UNSPECIFIED, failure.GetReason())
 	})
 }
 

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1518,29 +1518,22 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 	// checked before Commit.
 	validateScope, scopeErr := scopeFactory.NewProposalScope()
 	if scopeErr != nil {
-		// Building the proposal-wide scope failed only when the
-		// ExecutionPlan is malformed (unknown attr_code). Treat as
-		// business rejection — same model as orders/TU coverage misses.
-		// NewScope's contract guarantees the error is
-		// *domain.ErrInvalidExecutionPlan.
-		invariant := planInvariantDescribable(scopeErr)
-		if invariant == nil {
-			invariant = &domain.ErrInvalidExecutionPlan{Reason_: scopeErr.Error()}
-		}
+		// Impossible after a successful Preload. Preload already ran
+		// validatePlan over every AttributeCoverage in this immutable
+		// ExecutionPlan (machine.go Preload), and applyAllPlans re-runs the
+		// SAME check on the SAME plan. A failure here means pre-validation
+		// and scope construction have diverged — an FSM invariant violation,
+		// never a business outcome. Fail loudly: write no audit failure,
+		// freeze no idempotency outcome, return no soft ApplyResult. The
+		// caller cancels the Pebble batch and propagates, so nothing commits.
+		assert.Unreachable("proposal scope construction failed after successful Preload", map[string]any{
+			"raftIndex":  raftIndex,
+			"proposalID": proposal.GetId(),
+			"error":      scopeErr.Error(),
+		})
 
-		scopeFailureEntry := auditpb.AuditEntryFromVTPool()
-		scopeFailureEntry.Outcome = &auditpb.AuditEntry_Failure{Failure: buildAuditFailure(scopeErr)}
-		appendErr := writeAuditEntry(scopeFailureEntry, nil, "validate-scope construction failure")
-		scopeFailureEntry.ReturnToVTPool()
-		if appendErr != nil {
-			return nil, appendErr
-		}
-
-		return &ApplyResult{
-			ProposalID:        proposal.GetId(),
-			Error:             &domain.BusinessError{Err: invariant},
-			AuditEntryWritten: true,
-		}, nil
+		return nil, fmt.Errorf("invariant: proposal scope construction failed after Preload (raft index %d, proposal %d): %w",
+			raftIndex, proposal.GetId(), scopeErr)
 	}
 
 	transientErr := buffer.ValidateTransientVolumes(validateScope)

--- a/internal/infra/state/scope_unit_test.go
+++ b/internal/infra/state/scope_unit_test.go
@@ -162,6 +162,43 @@ func TestApplyPlans_Errors(t *testing.T) {
 	})
 }
 
+// TestApplyAllPlans_AcceptsValidPlans pins the contract that makes the
+// post-Preload NewProposalScope branch in applyProposal unreachable: any
+// AttributeCoverage set that passes validatePlan (16-byte AttributeID +
+// an attr_code the FSM handles) is accepted by applyAllPlans without error.
+// Preload runs the SAME validatePlan over the SAME immutable plan before
+// order processing, so a NewProposalScope failure after a successful
+// Preload can only mean the two checks diverged — an FSM invariant, not a
+// business outcome.
+func TestApplyAllPlans_AcceptsValidPlans(t *testing.T) {
+	t.Parallel()
+
+	var coverage coverageSlots
+
+	ledgerU128, _ := attributes.MakeKey(domain.LedgerKey{Name: "L"}.Bytes())
+	volumeU128, _ := attributes.MakeKey(domain.LedgerKey{Name: "L2"}.Bytes())
+
+	plans := []*raftcmdpb.AttributeCoverage{
+		{
+			Id:       &raftcmdpb.AttributeID{Id: ledgerU128[:]},
+			AttrCode: uint32(dal.SubAttrLedger),
+		},
+		{
+			Id:       &raftcmdpb.AttributeID{Id: volumeU128[:]},
+			AttrCode: uint32(dal.SubAttrVolume),
+		},
+	}
+
+	// Each plan must first pass the shared envelope check.
+	for i, p := range plans {
+		require.Nil(t, validatePlan(p, i))
+	}
+
+	// applyAllPlans (the proposal-wide path NewProposalScope uses) accepts
+	// every validatePlan-passing plan.
+	require.Nil(t, applyAllPlans(&coverage, plans))
+}
+
 // TestPlanInvariantDescribable pins the predicate that decides whether
 // an error coming out of applyTechnicalUpdates / NewScope should be
 // surfaced as a business-level ApplyResult.Error (admission bug) or


### PR DESCRIPTION
## Summary

Enforces two compile- and runtime-level guarantees so an impossible internal state can never be recorded into the cryptographically-bound FSM audit chain as an ordinary business outcome:

1. **`buildAuditFailure` accepts only `domain.Describable`** (was `error`). The `errors.As` fallback and the `ERROR_REASON_UNSPECIFIED` path are removed — the compiler now guarantees only typed, deterministic outcomes reach the audit chain. Both surviving call sites already pass `domain.Describable` statically, so they compile unchanged.
2. **A post-Preload `NewProposalScope` failure is now a fatal FSM invariant.** This branch is structurally unreachable — `Preload` already runs the shared `validatePlan` over the same immutable `ExecutionPlan`, and `applyAllPlans` re-runs the identical check on the identical plan. It previously downgraded the impossible case to a soft business rejection that appended an `AuditFailure` and audited the raw error while returning a differently-normalized one. It now calls `assert.Unreachable(...)` and returns `fmt.Errorf("invariant: …: %w", scopeErr)`; the caller cancels the Pebble batch and propagates, so nothing commits — no audit failure, no idempotency freeze, no soft `ApplyResult`.

The shared `validatePlan` boundary and the `NewProposalScope` interface signature are unchanged; `planInvariantDescribable` remains (still used by the `Preload` and `applyTechnicalUpdates` error paths).

## Changes

- `internal/infra/state/audit.go` — `buildAuditFailure(err error)` → `buildAuditFailure(d domain.Describable)`; drop fallback + unused `errors` import.
- `internal/infra/state/machine.go` — `applyProposal` post-Preload scope branch made FSM-fatal.
- `internal/infra/state/scope_unit_test.go` — add `TestApplyAllPlans_AcceptsValidPlans` pinning the contract that makes the fatal branch unreachable.
- `internal/infra/state/audit_test.go` — remove the `"Unknown"` subtest (raw error → `UNSPECIFIED` is now a compile error).

## Invariants preserved

FSM determinism; audit as sole authority recording only typed outcomes (CLAUDE.md #8); no Pebble read added to the hot path; accepted order not mutated (#10); the impossible branch fails loudly rather than being downgraded to a soft business outcome (#7).

## Verification

- `GOROOT= go build ./...` — pass
- `go test ./internal/infra/state/... ./internal/domain/...` — pass
- `just pre-commit` (nix) — golangci-lint `0 issues`, no regen diff
- GitNexus `detect_changes(compare, release/v3.0)` — low risk, changes confined to `buildAuditFailure` + `applyProposal` + tests, zero affected execution flows

## Jira

https://formance-team.atlassian.net/browse/EN-1536
