### PR TITLE
fix: update CODEOWNERS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @formancehq/backend
+* @formancehq/transactions


### PR DESCRIPTION
## Summary

- replace the removed `@formancehq/backend` team with `@formancehq/transactions`
- keep the existing catch-all ownership scope unchanged

## Rationale

Ledger is owned by the Transactions domain. The Transactions team exists in the organization and has organization-wide write access.

## Validation

- `git diff --check`
- verified the repository has no additional local contribution instructions
- verified `@formancehq/transactions` exists and has active members