### PR TITLE
fix(EN-1506): classify every Apply request variant explicitly

### DIFF
--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -709,12 +709,12 @@ Read endpoints comparison with the original ledger:
 | `GET /v3/{ledgerName}/numscripts/{name}?version=` | ✅ | ❌ | Get numscript (version selector, empty/latest = greatest semver) |
 | `GET /v3/{ledgerName}/numscripts/{name}/usage` | ✅ | ❌ | Get invocation count + last-used timestamp |
 | `GET /v3/{ledgerName}/numscripts/{name}/versions` | ✅ | ❌ | List version history |
-| `PUT /v3/{ledgerName}/numscripts/{name}` | ✅ | ❌ | Save an immutable version (explicit full semver) |
+| `PUT /v3/{ledgerName}/numscripts/{name}` | ✅ | ❌ | Save an immutable version (explicit full semver). Requires `ledger:LedgerWrite` on both the dedicated route and gRPC `Apply(SaveNumscript)` |
 | `GET /v3/{ledgerName}/account-types` | ✅ | ❌ | List account types |
 | `GET /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Get account type |
-| `POST /v3/{ledgerName}/account-types` | ✅ | ❌ | Add account type |
-| `DELETE /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Remove account type |
-| `PUT /v3/{ledgerName}/account-types/default-enforcement-mode` | ✅ | ❌ | Set default enforcement mode (STRICT/AUDIT) |
+| `POST /v3/{ledgerName}/account-types` | ✅ | ❌ | Add account type. Requires `ledger:MetadataWrite` on both the dedicated route and gRPC `Apply` |
+| `DELETE /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Remove account type. Requires `ledger:MetadataWrite` on both the dedicated route and gRPC `Apply` |
+| `PUT /v3/{ledgerName}/account-types/default-enforcement-mode` | ✅ | ❌ | Set default enforcement mode (STRICT/AUDIT). Requires `ledger:MetadataWrite` on both the dedicated route and gRPC `Apply` |
 | `GET /v3/{ledgerName}/transactions` | ✅ | ❌ | List transactions: cursor pagination, `startDate`/`endDate` range, and the generic `filter` (reference selection via `filter={"$match":{"reference":"..."}}`) |
 | `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence. No ledger identity → requires `ledger` ops-read (granular `ledger:OpsRead`) |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
@@ -792,10 +792,10 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `ListPreparedQueries` | List all prepared queries for a ledger | ✅ |
 | `ExecutePreparedQuery` | Execute a prepared query against the read index | ✅ |
 | `Barrier` | No-op Raft proposal to ensure all prior writes are applied | ✅ |
-| `Apply` | Apply a ledger action (write operations) | ✅ |
+| `Apply` | Apply a ledger action (write operations). Authorization is **per request in the batch**: each variant requires the same granular scope as its dedicated HTTP route or gRPC RPC — `Apply` is never a lower bar than the single-shot path. Unknown or malformed variants fail closed on `ledger:OpsWrite`. See [Apply request scopes](#apply-request-scopes) | ✅ |
 | `Apply(CreateLedger)` with mirror mode | Create a mirror ledger | ✅ |
 | `Apply(PromoteLedger)` | Promote mirror ledger to normal mode | ✅ |
-| `Apply(SaveNumscript)` | Save an immutable numscript version (explicit full semver) | ✅ |
+| `Apply(SaveNumscript)` | Save an immutable numscript version (explicit full semver). Requires `ledger:LedgerWrite`, matching `PUT /v3/{ledgerName}/numscripts/{name}` | ✅ |
 | `GetNumscript` | Get a numscript by name and version selector | ✅ |
 | `ListNumscripts` | List the greatest version of each saved numscript | ✅ |
 | `ListNumscriptVersions` | List the latest pointer and every stored version | ✅ |
@@ -838,6 +838,33 @@ The `Apply` method is the **single entry point for all ledger write operations**
 **Response:** `common.Log` - The log entry created by the action (stripped to `sequence` only when `skip_response` is set)
 
 **Note:** Individual RPC methods like `CreateTransaction`, `RevertTransaction`, `SaveAccountMetadata`, etc. have been consolidated into the `Apply` method for a cleaner API.
+
+### Apply request scopes
+
+`Apply` accepts a batch, and authorization is evaluated **per request in that batch** (`internal/adapter/grpc/server_bucket.go:141-162`). Each variant resolves to a single granular scope through `auth.RequiredScopeForRequest` (`internal/adapter/auth/request_scope.go`).
+
+The governing rule: **a batched operation requires the same scope as its dedicated HTTP route or gRPC RPC.** `Apply` is never a lower bar than the single-shot path — otherwise it would be a way around the dedicated route's gate.
+
+| Request variant | Scope | Matches |
+|---|---|---|
+| `apply` (`create_transaction`, `revert_transaction`) | `ledger:TransactionWrite` | `POST /v3/{ledgerName}/transactions` |
+| `apply` (`add_metadata`, `delete_metadata`) | `ledger:MetadataWrite` | metadata routes |
+| `apply` (`add_account_type`, `remove_account_type`, `set_default_enforcement_mode`) | `ledger:MetadataWrite` | `/v3/{ledgerName}/account-types*` |
+| `create_ledger`, `delete_ledger`, `promote_ledger`, `create_index`, `drop_index`, `save_numscript` | `ledger:LedgerWrite` | the `requireLedgersWrite` route group |
+| `save_ledger_metadata`, `delete_ledger_metadata`, `add_account_type`, `remove_account_type`, `set_default_enforcement_mode`, `set_metadata_field_type`, `remove_metadata_field_type` | `ledger:MetadataWrite` | the `requireMetadataWrite` route group |
+| `create_prepared_query`, `update_prepared_query`, `delete_prepared_query` | `ledger:QueryWrite` | the `requireQueriesWrite` route group |
+| `create_query_checkpoint`, `delete_query_checkpoint`, `set_query_checkpoint_schedule`, `delete_query_checkpoint_schedule` | `ledger:ClusterWrite` | `ClusterService.CreateQueryCheckpoint` / `DeleteQueryCheckpoint` |
+| signing keys, events sinks, chapters, maintenance mode | `ledger:OpsWrite` | operator surface, no dedicated business route |
+| unknown / malformed / unset variant | `ledger:OpsWrite` | fail-closed default |
+
+Two properties are enforced by tests rather than convention:
+
+- **Exhaustiveness.** `request_scope_exhaustiveness_test.go` walks the `Request.type` and `LedgerAction.data` oneof descriptors and fails when a variant has no explicit scope decision. A new proto variant cannot ship on an accidental default — CI blocks it until someone classifies it.
+- **Fail-closed is only for the unknown.** The classifier reports whether a decision was explicit, so "nobody decided" is distinguishable from a deliberate `ledger:OpsWrite`.
+
+> **Breaking change (EN-1506).** The four `*_query_checkpoint*` variants previously resolved to `ledger:OpsWrite`. Because `DefaultMapping` grants `ledger:OpsWrite` to any `ledger:write` token but `ledger:ClusterWrite` only to `ledger:admin`, a non-admin caller could create or delete query checkpoints through `Apply` — an operation the dedicated `ClusterService` RPCs restrict to admins. They now require `ledger:ClusterWrite`. Callers driving query checkpoints through `Apply` with a `ledger:write` token must move to `ledger:admin` or add the granular `ledger:ClusterWrite` scope; callers using the dedicated RPCs are unaffected.
+
+Note that `POST /v3/{ledgerName}/bulk` shares this classifier but can only express the four `LedgerAction` variants its JSON decoder accepts (`CREATE_TRANSACTION`, `ADD_METADATA`, `REVERT_TRANSACTION`, `DELETE_METADATA`), so the table's top-level rows are unreachable over HTTP bulk.
 
 ### gRPC Error Mapping
 

--- a/internal/adapter/auth/request_scope.go
+++ b/internal/adapter/auth/request_scope.go
@@ -46,6 +46,11 @@ func requiredScopeForRequest(req *servicepb.Request) (Scope, bool) {
 		return ScopeLedgersWrite, true
 	case *servicepb.Request_DropIndex:
 		return ScopeLedgersWrite, true
+	case *servicepb.Request_SaveNumscript:
+		// PUT /v3/{ledgerName}/numscripts/{name} is in the requireLedgersWrite
+		// group (handler.go:176). Saving a numscript is a per-ledger library
+		// write, not an ops action.
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_RegisterSigningKey:
 		return ScopeOpsWrite, true
 	case *servicepb.Request_RevokeSigningKey:
@@ -74,12 +79,47 @@ func requiredScopeForRequest(req *servicepb.Request) (Scope, bool) {
 		return ScopeMetadataWrite, true
 	case *servicepb.Request_RemoveMetadataFieldType:
 		return ScopeMetadataWrite, true
+	case *servicepb.Request_SaveLedgerMetadata:
+		// POST /v3/{ledgerName}/metadata — requireMetadataWrite (handler.go:193).
+		return ScopeMetadataWrite, true
+	case *servicepb.Request_DeleteLedgerMetadata:
+		// DELETE /v3/{ledgerName}/metadata/{key} — requireMetadataWrite (handler.go:194).
+		return ScopeMetadataWrite, true
+	case *servicepb.Request_AddAccountType:
+		// POST /v3/{ledgerName}/account-types — requireMetadataWrite (handler.go:197).
+		return ScopeMetadataWrite, true
+	case *servicepb.Request_RemoveAccountType:
+		// DELETE /v3/{ledgerName}/account-types/{typeName} — requireMetadataWrite (handler.go:198).
+		return ScopeMetadataWrite, true
+	case *servicepb.Request_SetDefaultEnforcementMode:
+		// PUT /v3/{ledgerName}/account-types/default-enforcement-mode —
+		// requireMetadataWrite (handler.go:199).
+		return ScopeMetadataWrite, true
 	case *servicepb.Request_CreatePreparedQuery:
 		return ScopeQueriesWrite, true
 	case *servicepb.Request_UpdatePreparedQuery:
 		return ScopeQueriesWrite, true
 	case *servicepb.Request_DeletePreparedQuery:
 		return ScopeQueriesWrite, true
+	// Query checkpoints are cluster-wide state, not per-ledger business data.
+	// The dedicated ClusterService.CreateQueryCheckpoint and
+	// DeleteQueryCheckpoint RPCs require ledger:ClusterWrite
+	// (server_cluster.go:442, 481), which DefaultMapping grants only through
+	// ledger:admin. Accepting ledger:OpsWrite here let a plain ledger:write
+	// token perform an admin-only operation through Apply — a privilege
+	// escalation, not merely a scope mismatch (EN-1506).
+	case *servicepb.Request_CreateQueryCheckpoint:
+		return ScopeClusterWrite, true
+	case *servicepb.Request_DeleteQueryCheckpoint:
+		return ScopeClusterWrite, true
+	// The two schedule variants have no dedicated write RPC — they are
+	// reachable only through Apply. ClusterWrite follows their siblings above
+	// and their read counterpart GetQueryCheckpointSchedule, which requires
+	// ledger:ClusterRead (server_cluster.go:555).
+	case *servicepb.Request_SetQueryCheckpointSchedule:
+		return ScopeClusterWrite, true
+	case *servicepb.Request_DeleteQueryCheckpointSchedule:
+		return ScopeClusterWrite, true
 	default:
 		return ScopeOpsWrite, false
 	}

--- a/internal/adapter/auth/request_scope.go
+++ b/internal/adapter/auth/request_scope.go
@@ -4,82 +4,106 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-// RequiredScopeForRequest returns the granular scope required to execute the given Request.
+// RequiredScopeForRequest returns the granular scope required to execute the
+// given Request. Variants this build does not know about — malformed input, or
+// a proto variant added without a scope decision — fail closed on
+// ledger:OpsWrite, the most restrictive write scope.
 func RequiredScopeForRequest(req *servicepb.Request) Scope {
+	scope, decided := requiredScopeForRequest(req)
+	if !decided {
+		return ScopeOpsWrite
+	}
+
+	return scope
+}
+
+// requiredScopeForRequest returns the scope for a Request and whether the
+// variant carries an explicit decision.
+//
+// decided=false means "this build has no arm for this variant" — never "the
+// answer is OpsWrite". Keeping the two apart is the whole point: a silent
+// fall-through used to be indistinguishable from a deliberate OpsWrite, so no
+// test could tell that a variant had never been classified (EN-1506).
+// TestRequiredScopeForRequest_ProtoExhaustive asserts decided=true for every
+// variant the proto declares, so a new oneof field fails CI until someone
+// decides its scope.
+func requiredScopeForRequest(req *servicepb.Request) (Scope, bool) {
 	switch req.GetType().(type) {
 	case *servicepb.Request_Apply:
 		return requiredScopeForLedgerApply(req.GetApply())
 	case *servicepb.Request_CreateLedger:
-		return ScopeLedgersWrite
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_DeleteLedger:
-		return ScopeLedgersWrite
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_PromoteLedger:
-		return ScopeLedgersWrite
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_CreateIndex:
 		// Index management is a per-ledger write; the HTTP routes
 		// (POST/DELETE /v3/{ledgerName}/indexes[/{canonicalId}]) sit under
 		// the ledger:LedgerWrite group, so gRPC must agree — otherwise the
 		// same operation demands ledger:OpsWrite over gRPC (default fallthrough)
 		// and ledger:LedgerWrite over HTTP.
-		return ScopeLedgersWrite
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_DropIndex:
-		return ScopeLedgersWrite
+		return ScopeLedgersWrite, true
 	case *servicepb.Request_RegisterSigningKey:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_RevokeSigningKey:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_SetSigningConfig:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_AddEventsSink:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_RemoveEventsSink:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_CloseChapter:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_SealChapter:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_ArchiveChapter:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_ConfirmArchiveChapter:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_SetMaintenanceMode:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_SetChapterSchedule:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_DeleteChapterSchedule:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, true
 	case *servicepb.Request_SetMetadataFieldType:
-		return ScopeMetadataWrite
+		return ScopeMetadataWrite, true
 	case *servicepb.Request_RemoveMetadataFieldType:
-		return ScopeMetadataWrite
+		return ScopeMetadataWrite, true
 	case *servicepb.Request_CreatePreparedQuery:
-		return ScopeQueriesWrite
+		return ScopeQueriesWrite, true
 	case *servicepb.Request_UpdatePreparedQuery:
-		return ScopeQueriesWrite
+		return ScopeQueriesWrite, true
 	case *servicepb.Request_DeletePreparedQuery:
-		return ScopeQueriesWrite
+		return ScopeQueriesWrite, true
 	default:
-		// Unknown request type — default to ledger:OpsWrite (most restrictive write scope)
-		return ScopeOpsWrite
+		return ScopeOpsWrite, false
 	}
 }
 
-// requiredScopeForLedgerApply returns the granular scope for inner Apply request types.
-func requiredScopeForLedgerApply(req *servicepb.LedgerApplyRequest) Scope {
+// requiredScopeForLedgerApply returns the granular scope for inner Apply
+// request types, and whether the action variant carries an explicit decision.
+// A nil request or nil action is malformed input, not an undecided variant,
+// but both fail closed the same way.
+func requiredScopeForLedgerApply(req *servicepb.LedgerApplyRequest) (Scope, bool) {
 	if req == nil {
-		return ScopeOpsWrite
+		return ScopeOpsWrite, false
 	}
 
 	switch req.GetAction().GetData().(type) {
 	case *servicepb.LedgerAction_CreateTransaction:
-		return ScopeTransactionsWrite
+		return ScopeTransactionsWrite, true
 	case *servicepb.LedgerAction_RevertTransaction:
-		return ScopeTransactionsWrite
+		return ScopeTransactionsWrite, true
 	case *servicepb.LedgerAction_AddMetadata:
-		return ScopeMetadataWrite
+		return ScopeMetadataWrite, true
 	case *servicepb.LedgerAction_DeleteMetadata:
-		return ScopeMetadataWrite
+		return ScopeMetadataWrite, true
 	default:
-		return ScopeOpsWrite
+		return ScopeOpsWrite, false
 	}
 }

--- a/internal/adapter/auth/request_scope.go
+++ b/internal/adapter/auth/request_scope.go
@@ -103,6 +103,18 @@ func requiredScopeForLedgerApply(req *servicepb.LedgerApplyRequest) (Scope, bool
 		return ScopeMetadataWrite, true
 	case *servicepb.LedgerAction_DeleteMetadata:
 		return ScopeMetadataWrite, true
+	// Chart-of-accounts edits. The HTTP routes POST/DELETE
+	// /v3/{ledgerName}/account-types and PUT
+	// /v3/{ledgerName}/account-types/default-enforcement-mode sit under the
+	// requireMetadataWrite group (handler.go:197-199), so the batch path must
+	// agree. These are the LedgerAction twins of the top-level variants
+	// classified in requiredScopeForRequest.
+	case *servicepb.LedgerAction_AddAccountType:
+		return ScopeMetadataWrite, true
+	case *servicepb.LedgerAction_RemoveAccountType:
+		return ScopeMetadataWrite, true
+	case *servicepb.LedgerAction_SetDefaultEnforcementMode:
+		return ScopeMetadataWrite, true
 	default:
 		return ScopeOpsWrite, false
 	}

--- a/internal/adapter/auth/request_scope_exhaustiveness_test.go
+++ b/internal/adapter/auth/request_scope_exhaustiveness_test.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// scopeCase pairs a well-formed request with the scope its dedicated
+// HTTP route or gRPC RPC requires. The dedicated surface is the source of
+// truth: a batch path must never demand a different scope for the same
+// operation than the single-shot path does.
+type scopeCase struct {
+	req      *servicepb.Request
+	expected Scope
+}
+
+// TestRequiredScopeForRequest_ProtoExhaustive walks the Request.type oneof
+// descriptor and asserts that every declared variant (a) appears in the case
+// table, (b) has an explicit arm in requiredScopeForRequest rather than
+// falling through to the fail-closed default, and (c) resolves to the scope
+// its dedicated surface requires.
+//
+// Assertion (b) is the one a "covered field names" guard cannot make: a
+// variant with no arm returns ScopeOpsWrite, which is indistinguishable from
+// a deliberate ScopeOpsWrite unless production code reports decidedness.
+// See internal/application/admission/wrapper_exhaustiveness_test.go for the
+// weaker form of this pattern.
+func TestRequiredScopeForRequest_ProtoExhaustive(t *testing.T) {
+	t.Parallel()
+
+	cases := requestScopeCases()
+
+	// ByName, not Get(0): proto3 `optional` fields generate synthetic oneofs,
+	// so the real oneof is not reliably the first one.
+	typeOneof := (&servicepb.Request{}).ProtoReflect().Descriptor().Oneofs().ByName("type")
+	require.NotNil(t, typeOneof, "servicepb.Request must declare a oneof named 'type'")
+
+	fields := typeOneof.Fields()
+	for i := range fields.Len() {
+		name := string(fields.Get(i).Name())
+
+		tc, ok := cases[name]
+		require.True(t, ok,
+			"Request.type.%s is declared in the proto but has no entry in requestScopeCases — "+
+				"add one carrying the scope its dedicated HTTP route or gRPC RPC requires", name)
+
+		scope, decided := requiredScopeForRequest(tc.req)
+		require.True(t, decided,
+			"Request.type.%s has no explicit arm in requiredScopeForRequest and is falling "+
+				"through to the fail-closed default — classify it explicitly", name)
+		require.Equal(t, tc.expected, scope, "Request.type.%s resolved to the wrong scope", name)
+	}
+
+	// Reverse direction: a stale table entry means the proto dropped a variant
+	// and the table was not cleaned up.
+	for name := range cases {
+		require.NotNil(t, fields.ByName(protoreflect.Name(name)),
+			"requestScopeCases has entry %q which Request.type no longer declares — remove it", name)
+	}
+}
+
+// TestRequiredScopeForLedgerApply_ProtoExhaustive is the same guard for the
+// inner LedgerAction.data oneof, reachable over gRPC as
+// Request_Apply{Apply: {Action: ...}}.
+func TestRequiredScopeForLedgerApply_ProtoExhaustive(t *testing.T) {
+	t.Parallel()
+
+	cases := ledgerActionScopeCases()
+
+	dataOneof := (&servicepb.LedgerAction{}).ProtoReflect().Descriptor().Oneofs().ByName("data")
+	require.NotNil(t, dataOneof, "servicepb.LedgerAction must declare a oneof named 'data'")
+
+	fields := dataOneof.Fields()
+	for i := range fields.Len() {
+		name := string(fields.Get(i).Name())
+
+		expected, ok := cases[name]
+		require.True(t, ok,
+			"LedgerAction.data.%s is declared in the proto but has no entry in "+
+				"ledgerActionScopeCases — add one", name)
+
+		scope, decided := requiredScopeForLedgerApply(&servicepb.LedgerApplyRequest{
+			Action: actionForField(name),
+		})
+		require.True(t, decided,
+			"LedgerAction.data.%s has no explicit arm in requiredScopeForLedgerApply and is "+
+				"falling through to the fail-closed default — classify it explicitly", name)
+		require.Equal(t, expected, scope, "LedgerAction.data.%s resolved to the wrong scope", name)
+	}
+
+	for name := range cases {
+		require.NotNil(t, fields.ByName(protoreflect.Name(name)),
+			"ledgerActionScopeCases has entry %q which LedgerAction.data no longer declares", name)
+	}
+}
+
+// requestScopeCases maps every Request.type field name to a well-formed
+// request and the scope its dedicated surface requires.
+//
+// Entries must be well-formed: the "apply" entry carries a real inner action,
+// because an Apply with a nil action is malformed input and correctly reports
+// decided=false. Nil and empty inputs are asserted in request_scope_test.go,
+// not here.
+func requestScopeCases() map[string]scopeCase {
+	return map[string]scopeCase{
+		// Ledger lifecycle — HTTP requireLedgersWrite group (handler.go:172-179).
+		"create_ledger":  {&servicepb.Request{Type: &servicepb.Request_CreateLedger{}}, ScopeLedgersWrite},
+		"delete_ledger":  {&servicepb.Request{Type: &servicepb.Request_DeleteLedger{}}, ScopeLedgersWrite},
+		"promote_ledger": {&servicepb.Request{Type: &servicepb.Request_PromoteLedger{}}, ScopeLedgersWrite},
+		"create_index":   {&servicepb.Request{Type: &servicepb.Request_CreateIndex{}}, ScopeLedgersWrite},
+		"drop_index":     {&servicepb.Request{Type: &servicepb.Request_DropIndex{}}, ScopeLedgersWrite},
+		"save_numscript": {&servicepb.Request{Type: &servicepb.Request_SaveNumscript{}}, ScopeLedgersWrite},
+
+		// Cluster operations — ClusterService requires ledger:ClusterWrite
+		// (server_cluster.go:442, 481), granted only by ledger:admin.
+		"create_query_checkpoint":          {&servicepb.Request{Type: &servicepb.Request_CreateQueryCheckpoint{}}, ScopeClusterWrite},
+		"delete_query_checkpoint":          {&servicepb.Request{Type: &servicepb.Request_DeleteQueryCheckpoint{}}, ScopeClusterWrite},
+		"set_query_checkpoint_schedule":    {&servicepb.Request{Type: &servicepb.Request_SetQueryCheckpointSchedule{}}, ScopeClusterWrite},
+		"delete_query_checkpoint_schedule": {&servicepb.Request{Type: &servicepb.Request_DeleteQueryCheckpointSchedule{}}, ScopeClusterWrite},
+
+		// Metadata & chart of accounts — HTTP requireMetadataWrite group
+		// (handler.go:188-200).
+		"set_metadata_field_type":      {&servicepb.Request{Type: &servicepb.Request_SetMetadataFieldType{}}, ScopeMetadataWrite},
+		"remove_metadata_field_type":   {&servicepb.Request{Type: &servicepb.Request_RemoveMetadataFieldType{}}, ScopeMetadataWrite},
+		"save_ledger_metadata":         {&servicepb.Request{Type: &servicepb.Request_SaveLedgerMetadata{}}, ScopeMetadataWrite},
+		"delete_ledger_metadata":       {&servicepb.Request{Type: &servicepb.Request_DeleteLedgerMetadata{}}, ScopeMetadataWrite},
+		"add_account_type":             {&servicepb.Request{Type: &servicepb.Request_AddAccountType{}}, ScopeMetadataWrite},
+		"remove_account_type":          {&servicepb.Request{Type: &servicepb.Request_RemoveAccountType{}}, ScopeMetadataWrite},
+		"set_default_enforcement_mode": {&servicepb.Request{Type: &servicepb.Request_SetDefaultEnforcementMode{}}, ScopeMetadataWrite},
+
+		// Prepared queries — HTTP requireQueriesWrite group (handler.go:212-216).
+		"create_prepared_query": {&servicepb.Request{Type: &servicepb.Request_CreatePreparedQuery{}}, ScopeQueriesWrite},
+		"update_prepared_query": {&servicepb.Request{Type: &servicepb.Request_UpdatePreparedQuery{}}, ScopeQueriesWrite},
+		"delete_prepared_query": {&servicepb.Request{Type: &servicepb.Request_DeletePreparedQuery{}}, ScopeQueriesWrite},
+
+		// Operator surface — no business identity, ledger:OpsWrite by design.
+		"register_signing_key":    {&servicepb.Request{Type: &servicepb.Request_RegisterSigningKey{}}, ScopeOpsWrite},
+		"revoke_signing_key":      {&servicepb.Request{Type: &servicepb.Request_RevokeSigningKey{}}, ScopeOpsWrite},
+		"set_signing_config":      {&servicepb.Request{Type: &servicepb.Request_SetSigningConfig{}}, ScopeOpsWrite},
+		"add_events_sink":         {&servicepb.Request{Type: &servicepb.Request_AddEventsSink{}}, ScopeOpsWrite},
+		"remove_events_sink":      {&servicepb.Request{Type: &servicepb.Request_RemoveEventsSink{}}, ScopeOpsWrite},
+		"close_chapter":           {&servicepb.Request{Type: &servicepb.Request_CloseChapter{}}, ScopeOpsWrite},
+		"seal_chapter":            {&servicepb.Request{Type: &servicepb.Request_SealChapter{}}, ScopeOpsWrite},
+		"archive_chapter":         {&servicepb.Request{Type: &servicepb.Request_ArchiveChapter{}}, ScopeOpsWrite},
+		"confirm_archive_chapter": {&servicepb.Request{Type: &servicepb.Request_ConfirmArchiveChapter{}}, ScopeOpsWrite},
+		"set_maintenance_mode":    {&servicepb.Request{Type: &servicepb.Request_SetMaintenanceMode{}}, ScopeOpsWrite},
+		"set_chapter_schedule":    {&servicepb.Request{Type: &servicepb.Request_SetChapterSchedule{}}, ScopeOpsWrite},
+		"delete_chapter_schedule": {&servicepb.Request{Type: &servicepb.Request_DeleteChapterSchedule{}}, ScopeOpsWrite},
+
+		// Batch apply — delegates to the LedgerAction classifier. A real
+		// action is required; see the doc comment above.
+		"apply": {
+			&servicepb.Request{Type: &servicepb.Request_Apply{
+				Apply: &servicepb.LedgerApplyRequest{
+					Action: &servicepb.LedgerAction{
+						Data: &servicepb.LedgerAction_CreateTransaction{},
+					},
+				},
+			}},
+			ScopeTransactionsWrite,
+		},
+	}
+}
+
+// ledgerActionScopeCases maps every LedgerAction.data field name to its scope.
+func ledgerActionScopeCases() map[string]Scope {
+	return map[string]Scope{
+		"create_transaction": ScopeTransactionsWrite,
+		"revert_transaction": ScopeTransactionsWrite,
+		"add_metadata":       ScopeMetadataWrite,
+		"delete_metadata":    ScopeMetadataWrite,
+		// Same three operations as their top-level twins, and the same HTTP
+		// routes (handler.go:197-199) — so the same scope.
+		"add_account_type":             ScopeMetadataWrite,
+		"remove_account_type":          ScopeMetadataWrite,
+		"set_default_enforcement_mode": ScopeMetadataWrite,
+	}
+}
+
+// actionForField builds a LedgerAction whose oneof is set to the named field.
+func actionForField(name string) *servicepb.LedgerAction {
+	switch name {
+	case "create_transaction":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{}}
+	case "revert_transaction":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_RevertTransaction{}}
+	case "add_metadata":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_AddMetadata{
+			AddMetadata: &commonpb.SaveMetadataCommand{},
+		}}
+	case "delete_metadata":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_DeleteMetadata{
+			DeleteMetadata: &commonpb.DeleteMetadataCommand{},
+		}}
+	case "add_account_type":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_AddAccountType{}}
+	case "remove_account_type":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_RemoveAccountType{}}
+	case "set_default_enforcement_mode":
+		return &servicepb.LedgerAction{Data: &servicepb.LedgerAction_SetDefaultEnforcementMode{}}
+	default:
+		// Unreachable: the exhaustiveness test fails on an unknown field name
+		// before it gets here, via the ledgerActionScopeCases lookup.
+		return nil
+	}
+}

--- a/internal/adapter/auth/request_scope_test.go
+++ b/internal/adapter/auth/request_scope_test.go
@@ -194,3 +194,138 @@ func TestRequiredScopeForLedgerApply_NilApply(t *testing.T) {
 	// Nil apply defaults to ledger:OpsWrite (most restrictive)
 	assert.Equal(t, ScopeOpsWrite, RequiredScopeForRequest(req))
 }
+
+// TestRequiredScopeForRequest_BusinessVariantsDoNotRequireOpsWrite is the
+// EN-1506 regression guard. Each of these operations has a dedicated HTTP
+// route under a business scope; before the fix they fell through to
+// ledger:OpsWrite over gRPC Apply, so an operator scope was needed to perform
+// a business action — and ledger:OpsWrite also grants maintenance mode,
+// signing-key and chapter control.
+func TestRequiredScopeForRequest_BusinessVariantsDoNotRequireOpsWrite(t *testing.T) {
+	t.Parallel()
+
+	businessRequests := []struct {
+		name     string
+		req      *servicepb.Request
+		expected Scope
+	}{
+		{"SaveNumscript", &servicepb.Request{Type: &servicepb.Request_SaveNumscript{}}, ScopeLedgersWrite},
+		{"SaveLedgerMetadata", &servicepb.Request{Type: &servicepb.Request_SaveLedgerMetadata{}}, ScopeMetadataWrite},
+		{"DeleteLedgerMetadata", &servicepb.Request{Type: &servicepb.Request_DeleteLedgerMetadata{}}, ScopeMetadataWrite},
+		{"AddAccountType", &servicepb.Request{Type: &servicepb.Request_AddAccountType{}}, ScopeMetadataWrite},
+		{"RemoveAccountType", &servicepb.Request{Type: &servicepb.Request_RemoveAccountType{}}, ScopeMetadataWrite},
+		{"SetDefaultEnforcementMode", &servicepb.Request{Type: &servicepb.Request_SetDefaultEnforcementMode{}}, ScopeMetadataWrite},
+	}
+
+	for _, tc := range businessRequests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RequiredScopeForRequest(tc.req)
+			assert.Equal(t, tc.expected, got)
+			assert.NotEqual(t, ScopeOpsWrite, got, "business operation must not require an operator scope")
+		})
+	}
+}
+
+// TestRequiredScopeForRequest_QueryCheckpointsRequireClusterWrite guards the
+// privilege-escalation half of EN-1506. ClusterService gates these operations
+// on ledger:ClusterWrite (server_cluster.go:442, 481), which DefaultMapping
+// grants only via ledger:admin. While Apply accepted ledger:OpsWrite, any
+// ledger:write token could perform them.
+func TestRequiredScopeForRequest_QueryCheckpointsRequireClusterWrite(t *testing.T) {
+	t.Parallel()
+
+	checkpointRequests := []struct {
+		name string
+		req  *servicepb.Request
+	}{
+		{"CreateQueryCheckpoint", &servicepb.Request{Type: &servicepb.Request_CreateQueryCheckpoint{}}},
+		{"DeleteQueryCheckpoint", &servicepb.Request{Type: &servicepb.Request_DeleteQueryCheckpoint{}}},
+		{"SetQueryCheckpointSchedule", &servicepb.Request{Type: &servicepb.Request_SetQueryCheckpointSchedule{}}},
+		{"DeleteQueryCheckpointSchedule", &servicepb.Request{Type: &servicepb.Request_DeleteQueryCheckpointSchedule{}}},
+	}
+
+	for _, tc := range checkpointRequests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RequiredScopeForRequest(tc.req)
+			assert.Equal(t, ScopeClusterWrite, got)
+			assert.NotEqual(t, ScopeOpsWrite, got,
+				"an admin-only cluster operation must not be reachable with ledger:OpsWrite")
+		})
+	}
+}
+
+// TestRequiredScopeForLedgerApply_AccountTypeActions covers the LedgerAction
+// twins of the account-type operations, reachable as
+// Request_Apply{Apply: {Action: ...}}. Each case is spelled out rather than
+// table-driven over the oneof wrapper: the generated isLedgerAction_Data
+// interface is unexported outside servicepb, so a shared table field cannot
+// name its type.
+func TestRequiredScopeForLedgerApply_AccountTypeActions(t *testing.T) {
+	t.Parallel()
+
+	applyWith := func(action *servicepb.LedgerAction) *servicepb.Request {
+		return &servicepb.Request{Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{Action: action},
+		}}
+	}
+
+	t.Run("AddAccountType", func(t *testing.T) {
+		t.Parallel()
+
+		req := applyWith(&servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_AddAccountType{},
+		})
+		assert.Equal(t, ScopeMetadataWrite, RequiredScopeForRequest(req))
+	})
+
+	t.Run("RemoveAccountType", func(t *testing.T) {
+		t.Parallel()
+
+		req := applyWith(&servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_RemoveAccountType{},
+		})
+		assert.Equal(t, ScopeMetadataWrite, RequiredScopeForRequest(req))
+	})
+
+	t.Run("SetDefaultEnforcementMode", func(t *testing.T) {
+		t.Parallel()
+
+		req := applyWith(&servicepb.LedgerAction{
+			Data: &servicepb.LedgerAction_SetDefaultEnforcementMode{},
+		})
+		assert.Equal(t, ScopeMetadataWrite, RequiredScopeForRequest(req))
+	})
+}
+
+// TestRequiredScopeForRequest_FailsClosed pins the fail-closed contract for
+// input the classifier cannot recognize. These cases are deliberately excluded
+// from the exhaustiveness table, which requires well-formed entries.
+func TestRequiredScopeForRequest_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	failClosed := []struct {
+		name string
+		req  *servicepb.Request
+	}{
+		{"nil request", nil},
+		{"no oneof set", &servicepb.Request{}},
+		{"apply with nil LedgerApplyRequest", &servicepb.Request{Type: &servicepb.Request_Apply{}}},
+		{"apply with nil action", &servicepb.Request{Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{},
+		}}},
+		{"apply with empty action", &servicepb.Request{Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{Action: &servicepb.LedgerAction{}},
+		}}},
+	}
+
+	for _, tc := range failClosed {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, ScopeOpsWrite, RequiredScopeForRequest(tc.req))
+		})
+	}
+}

--- a/internal/adapter/grpc/server_bucket_auth_test.go
+++ b/internal/adapter/grpc/server_bucket_auth_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -221,4 +224,98 @@ func TestGetLog_RequiresOpsReadScope(t *testing.T) {
 		_, err := impl.GetLog(context.Background(), &servicepb.GetLogRequest{Sequence: 1})
 		require.Error(t, err)
 	})
+}
+
+// TestApply_RequiresBusinessScopes guards EN-1506 at the gate. The per-request
+// scope loop in Apply (server_bucket.go:141-162) must admit a business
+// operation on its business scope and reject it on ledger:OpsWrite alone.
+//
+// Granular scopes only: the aggregate "ledger:write" expands to OpsWrite AND
+// MetadataWrite (scopes.go:78-85), so it would pass regardless of which the
+// classifier returns — masking exactly the bug under test.
+func TestApply_RequiresBusinessScopes(t *testing.T) {
+	t.Parallel()
+
+	anonCfg := func(scopes ...internalauth.Scope) internalauth.AuthConfig {
+		return internalauth.AuthConfig{
+			Enabled: true,
+			ScopeMapping: internalauth.ScopeMapping{
+				internalauth.ScopeMappingAnonymousKey: scopes,
+			},
+		}
+	}
+
+	// newImpl wires a BucketServiceServerImpl to a MockController. When
+	// expectApply is false the gate must short-circuit before the controller,
+	// so any call fails gomock's expectations.
+	//
+	// applyDuration must be non-nil: Apply records it unconditionally on the
+	// success path (server_bucket.go:191) and a zero-value Int64Histogram
+	// panics. receiptSigner and responseSigner stay nil — both are nil-guarded.
+	newImpl := func(t *testing.T, cfg internalauth.AuthConfig, expectApply bool) *BucketServiceServerImpl {
+		t.Helper()
+
+		controller := NewMockController(gomock.NewController(t))
+		if expectApply {
+			controller.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, nil)
+		}
+
+		histogram, err := noop.NewMeterProvider().Meter("test").Int64Histogram("grpc.apply.duration")
+		require.NoError(t, err)
+
+		return &BucketServiceServerImpl{
+			ctrl:          controller,
+			authCfg:       cfg,
+			logger:        logging.Testing(),
+			applyDuration: histogram,
+		}
+	}
+
+	cases := []struct {
+		name string
+		req  *servicepb.Request
+		// granted is the ONLY granular scope the caller holds.
+		granted internalauth.Scope
+		allowed bool
+		// wantScope is the scope the rejection message must name, proving the
+		// gate consulted the classifier rather than rejecting for some other
+		// reason. Only meaningful when allowed is false.
+		wantScope internalauth.Scope
+	}{
+		{"numscript save with LedgerWrite", &servicepb.Request{Type: &servicepb.Request_SaveNumscript{}}, internalauth.ScopeLedgersWrite, true, ""},
+		{"numscript save with OpsWrite only", &servicepb.Request{Type: &servicepb.Request_SaveNumscript{}}, internalauth.ScopeOpsWrite, false, internalauth.ScopeLedgersWrite},
+		{"add account type with MetadataWrite", &servicepb.Request{Type: &servicepb.Request_AddAccountType{}}, internalauth.ScopeMetadataWrite, true, ""},
+		{"add account type with OpsWrite only", &servicepb.Request{Type: &servicepb.Request_AddAccountType{}}, internalauth.ScopeOpsWrite, false, internalauth.ScopeMetadataWrite},
+		{"save ledger metadata with MetadataWrite", &servicepb.Request{Type: &servicepb.Request_SaveLedgerMetadata{}}, internalauth.ScopeMetadataWrite, true, ""},
+		// The escalation guard: an admin-only cluster operation must not be
+		// reachable with the ops scope a plain ledger:write token carries.
+		{"create query checkpoint with ClusterWrite", &servicepb.Request{Type: &servicepb.Request_CreateQueryCheckpoint{}}, internalauth.ScopeClusterWrite, true, ""},
+		{"create query checkpoint with OpsWrite only", &servicepb.Request{Type: &servicepb.Request_CreateQueryCheckpoint{}}, internalauth.ScopeOpsWrite, false, internalauth.ScopeClusterWrite},
+		{"delete query checkpoint with OpsWrite only", &servicepb.Request{Type: &servicepb.Request_DeleteQueryCheckpoint{}}, internalauth.ScopeOpsWrite, false, internalauth.ScopeClusterWrite},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			impl := newImpl(t, anonCfg(tc.granted), tc.allowed)
+
+			_, err := impl.Apply(context.Background(), servicepb.UnsignedApplyRequest("", tc.req))
+
+			if tc.allowed {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			// Unauthenticated rather than PermissionDenied: the anonymous
+			// mapping grants scopes without a token being presented, so
+			// AuthPresentedFromContext is false (server_bucket.go:154-157).
+			require.Equal(t, codes.Unauthenticated, status.Code(err))
+			require.Contains(t, status.Convert(err).Message(),
+				"requires scope "+string(tc.wantScope),
+				"the gate must reject naming the scope the classifier chose")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`RequiredScopeForRequest` left 13 protobuf oneof variants falling through to a catch-all `default: ScopeOpsWrite` — 10 in `Request.type` and 3 in `LedgerAction.data`. That default served two opposite roles at once, "reject the unknown" and "nobody decided", so neither runtime behavior nor any test could tell them apart.

Both classifiers now return `(Scope, bool)`. The exported wrapper collapses an undecided variant to `ScopeOpsWrite`, preserving the fail-closed contract for genuinely unknown input, while the flag lets a test prove every declared variant was actually classified.

### Scope corrections

Each anchored to the scope the operation's dedicated route or RPC already required:

| Variants | Was | Now | Anchor |
|---|---|---|---|
| `save_numscript` | OpsWrite | `LedgerWrite` | `handler.go:176` |
| `save_ledger_metadata`, `delete_ledger_metadata` | OpsWrite | `MetadataWrite` | `handler.go:193-194` |
| account types + enforcement mode (top-level **and** `LedgerAction`) | OpsWrite | `MetadataWrite` | `handler.go:197-199` |
| 4 × query checkpoint | OpsWrite | `ClusterWrite` | `server_cluster.go:442,481` |

The 23 pre-existing decisions are unchanged in value (verified by diffing decisions against the base commit).

### :warning: Breaking change

Query-checkpoint create / delete / schedule over gRPC `Apply` now require `ledger:ClusterWrite`.

Previously `ledger:OpsWrite` sufficed. Since `DefaultMapping` grants `OpsWrite` to any `ledger:write` token but `ClusterWrite` only to `ledger:admin`, a plain `ledger:write` caller could perform through `Apply` an operation the dedicated `ClusterService` RPCs restrict to admins — a privilege escalation, not merely a scope mismatch.

Callers driving query checkpoints through `Apply` must move to `ledger:admin` or add the granular `ledger:ClusterWrite`. Callers using the dedicated RPCs are unaffected.

### Regression guard

`request_scope_exhaustiveness_test.go` walks both oneof descriptors and fails when a variant has no explicit arm. This is the assertion a "covered field names" list cannot make: such a list cannot distinguish a deliberate `OpsWrite` from an accidental one.

Verified non-vacuous by falsification — removing the `save_numscript` arm makes the guard fail by name; restoring it makes it pass.

### Scope notes

- **HTTP `/bulk` is unaffected.** It shares the classifier but cannot reach any affected variant: `convertBulkElementToRequest` always wraps in `Request_Apply`, and `BulkElement.UnmarshalJSON` accepts only `CREATE_TRANSACTION`, `ADD_METADATA`, `REVERT_TRANSACTION`, `DELETE_METADATA`, rejecting anything else before the scope loop runs. No HTTP behavior changes, so no HTTP tests were added.
- No `DeleteNumscript` mapping — EN-1288 removed that operation.
- Consolidating route-group scopes with the classifier is left to EN-1417; this PR supplies the reviewed policy that refactor should consume rather than reinvent.

## Testing

Transport-level tests use **granular** scopes only — the aggregate `ledger:write` expands to both `OpsWrite` and `MetadataWrite` and would pass regardless of which the classifier picks, masking exactly this bug.

- `go test -race -count=1 ./internal/adapter/auth/... ./internal/adapter/grpc/...` — pass
- `go test -race ./... -timeout 20m` — 114 packages, 0 failures, 0 data races
- `just pre-commit` — 0 lint issues (both modules)
- `GOROOT= go build ./...` — clean

[EN-1506](https://formance-team.atlassian.net/browse/EN-1506)

[EN-1506]: https://formance-team.atlassian.net/browse/EN-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ