### PR TITLE
feat(release): build ledgerctl for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,6 +201,11 @@ jobs:
         uses: ./.github/actions/default
       - run: >
           nix develop --command go build ./...
+      - name: Cross-compile ledgerctl for Windows
+        run: >
+          nix develop --command bash -c "mkdir -p build &&
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o build/ledgerctl-windows-amd64.exe ./cmd/ledgerctl &&
+          CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o build/ledgerctl-windows-arm64.exe ./cmd/ledgerctl"
       - name: Build operator
         run: >
           nix develop --command bash -c "cd misc/operator && go build ./..."

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 ---
 version: 2
-project_name: ledger-v3
+project_name: ledger
 
 # IMAGE_REPOSITORY controls where Docker images are pushed. Override the env
 # var to publish to a different GHCR location. Default targets the canonical

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,7 @@ archives:
   ids:
   - ledger-server
   - ledgerctl
+  allow_different_binary_count: true
   formats:
   - tar.gz
   format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,7 @@ builds:
   goos:
   - linux
   - darwin
+  - windows
   goarch:
   - amd64
   - arm64
@@ -67,6 +68,10 @@ archives:
   - ledgerctl
   formats:
   - tar.gz
+  format_overrides:
+  - goos: windows
+    formats:
+    - zip
   name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}"
   wrap_in_directory: true
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,6 +46,21 @@ builds:
   goos:
   - linux
   - darwin
+  goarch:
+  - amd64
+  - arm64
+
+- binary: ledgerctl
+  id: ledgerctl-windows
+  main: ./cmd/ledgerctl
+  ldflags:
+  - -X github.com/formancehq/ledger/v3/internal/pkg/version.Version={{ .Version }}
+  - -X github.com/formancehq/ledger/v3/internal/pkg/version.Commit={{ .ShortCommit }}
+  - -X github.com/formancehq/ledger/v3/internal/pkg/version.BuildDate={{ .Date }}
+  - -extldflags=-static
+  env:
+  - CGO_ENABLED=0
+  goos:
   - windows
   goarch:
   - amd64
@@ -62,17 +77,19 @@ release:
   - glob: openapi.yml
 
 archives:
-- id: "{{ .ProjectName }}"
+- id: ledger-unix
   ids:
   - ledger-server
   - ledgerctl
-  allow_different_binary_count: true
   formats:
   - tar.gz
-  format_overrides:
-  - goos: windows
-    formats:
-    - zip
+  name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}"
+  wrap_in_directory: true
+- id: ledger-windows
+  ids:
+  - ledgerctl-windows
+  formats:
+  - zip
   name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}"
   wrap_in_directory: true
 

--- a/cmd/ledgerctl/upgrade/command.go
+++ b/cmd/ledgerctl/upgrade/command.go
@@ -46,7 +46,7 @@ func runUpgrade(currentVersion, channel string, force, dryRun bool) error {
 	spinner, _ := pterm.DefaultSpinner.Start(
 		fmt.Sprintf("Checking for updates (channel: %s)...", channel))
 
-	release, err := fetchRelease(channel)
+	release, err := fetchRelease(channel, currentVersion)
 	if err != nil {
 		spinner.Fail("Failed to check for updates")
 

--- a/cmd/ledgerctl/upgrade/download.go
+++ b/cmd/ledgerctl/upgrade/download.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bufio"
 	"compress/gzip"
 	"crypto/sha256"
@@ -9,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -74,7 +76,7 @@ func downloadAndVerify(archiveAsset, checksumsAsset *assetInfo, spinner *pterm.S
 
 	defer func() { _ = archiveResp.Body.Close() }()
 
-	tmpArchive, err := os.CreateTemp("", "ledgerctl-upgrade-*.tar.gz")
+	tmpArchive, err := os.CreateTemp("", "ledgerctl-upgrade-*")
 	if err != nil {
 		return "", fmt.Errorf("creating temp file: %w", err)
 	}
@@ -119,19 +121,39 @@ func downloadAndVerify(archiveAsset, checksumsAsset *assetInfo, spinner *pterm.S
 		return "", fmt.Errorf("checksum verification failed: expected %s, got %s", expectedHash, actualHash)
 	}
 
-	// 4. Extract ledgerctl binary from tar.gz.
+	// 4. Extract the ledgerctl binary from the platform archive.
 	spinner.UpdateText("Extracting ledgerctl...")
 
 	if _, err := tmpArchive.Seek(0, io.SeekStart); err != nil {
 		return "", fmt.Errorf("seeking archive: %w", err)
 	}
 
-	return extractBinary(tmpArchive, "ledgerctl")
+	archiveInfo, err := tmpArchive.Stat()
+	if err != nil {
+		return "", fmt.Errorf("reading archive metadata: %w", err)
+	}
+
+	return extractBinary(
+		tmpArchive,
+		archiveInfo.Size(),
+		archiveAsset.Name,
+		executableName(runtime.GOOS),
+	)
 }
 
-// extractBinary extracts a named file from a tar.gz archive and writes it to a temp file.
-// Returns the path to the temp file.
-func extractBinary(archive io.Reader, name string) (string, error) {
+// extractBinary extracts a named file from a supported release archive and writes it to a temp file.
+func extractBinary(archive io.ReaderAt, archiveSize int64, archiveName, binaryName string) (string, error) {
+	switch {
+	case strings.HasSuffix(archiveName, ".tar.gz"):
+		return extractTarGzBinary(io.NewSectionReader(archive, 0, archiveSize), binaryName)
+	case strings.HasSuffix(archiveName, ".zip"):
+		return extractZipBinary(archive, archiveSize, binaryName)
+	default:
+		return "", fmt.Errorf("unsupported archive format %q", archiveName)
+	}
+}
+
+func extractTarGzBinary(archive io.Reader, binaryName string) (string, error) {
 	gz, err := gzip.NewReader(archive)
 	if err != nil {
 		return "", fmt.Errorf("opening gzip reader: %w", err)
@@ -150,28 +172,71 @@ func extractBinary(archive io.Reader, name string) (string, error) {
 			return "", fmt.Errorf("reading tar: %w", err)
 		}
 
-		if hdr.Name == name || strings.HasSuffix(hdr.Name, "/"+name) {
-			tmpBinary, err := os.CreateTemp("", "ledgerctl-new-*")
-			if err != nil {
-				return "", fmt.Errorf("creating temp binary: %w", err)
-			}
-
-			if _, err := io.Copy(tmpBinary, tr); err != nil {
-				_ = tmpBinary.Close()
-				_ = os.Remove(tmpBinary.Name())
-
-				return "", fmt.Errorf("extracting binary: %w", err)
-			}
-
-			if err := tmpBinary.Close(); err != nil {
-				_ = os.Remove(tmpBinary.Name())
-
-				return "", fmt.Errorf("closing temp binary: %w", err)
-			}
-
-			return tmpBinary.Name(), nil
+		if isBinaryEntry(hdr.Name, binaryName) {
+			return writeExtractedBinary(tr)
 		}
 	}
 
-	return "", fmt.Errorf("binary %q not found in archive", name)
+	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func extractZipBinary(archive io.ReaderAt, archiveSize int64, binaryName string) (string, error) {
+	zr, err := zip.NewReader(archive, archiveSize)
+	if err != nil {
+		return "", fmt.Errorf("opening zip reader: %w", err)
+	}
+
+	for _, file := range zr.File {
+		if !isBinaryEntry(file.Name, binaryName) {
+			continue
+		}
+
+		binary, err := file.Open()
+		if err != nil {
+			return "", fmt.Errorf("opening binary in zip: %w", err)
+		}
+
+		path, extractErr := writeExtractedBinary(binary)
+		closeErr := binary.Close()
+
+		if extractErr != nil {
+			return "", extractErr
+		}
+
+		if closeErr != nil {
+			_ = os.Remove(path)
+
+			return "", fmt.Errorf("closing binary in zip: %w", closeErr)
+		}
+
+		return path, nil
+	}
+
+	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func isBinaryEntry(entryName, binaryName string) bool {
+	return entryName == binaryName || strings.HasSuffix(entryName, "/"+binaryName)
+}
+
+func writeExtractedBinary(binary io.Reader) (string, error) {
+	tmpBinary, err := os.CreateTemp("", "ledgerctl-new-*")
+	if err != nil {
+		return "", fmt.Errorf("creating temp binary: %w", err)
+	}
+
+	if _, err := io.Copy(tmpBinary, binary); err != nil {
+		_ = tmpBinary.Close()
+		_ = os.Remove(tmpBinary.Name())
+
+		return "", fmt.Errorf("extracting binary: %w", err)
+	}
+
+	if err := tmpBinary.Close(); err != nil {
+		_ = os.Remove(tmpBinary.Name())
+
+		return "", fmt.Errorf("closing temp binary: %w", err)
+	}
+
+	return tmpBinary.Name(), nil
 }

--- a/cmd/ledgerctl/upgrade/download_test.go
+++ b/cmd/ledgerctl/upgrade/download_test.go
@@ -1,0 +1,106 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractBinary(t *testing.T) {
+	t.Parallel()
+
+	const binaryContents = "ledgerctl binary"
+
+	tests := []struct {
+		name        string
+		archiveName string
+		binaryName  string
+		archive     func(*testing.T, string, string) []byte
+	}{
+		{
+			name:        "tar.gz",
+			archiveName: "ledger-v3_linux-amd64.tar.gz",
+			binaryName:  "ledgerctl",
+			archive:     tarGzArchive,
+		},
+		{
+			name:        "zip",
+			archiveName: "ledger-v3_windows-amd64.zip",
+			binaryName:  "ledgerctl.exe",
+			archive:     zipArchive,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			archive := test.archive(t, "ledger-v3/"+test.binaryName, binaryContents)
+			archiveReader := bytes.NewReader(archive)
+
+			extractedPath, err := extractBinary(
+				archiveReader,
+				int64(len(archive)),
+				test.archiveName,
+				test.binaryName,
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, os.Remove(extractedPath))
+			})
+
+			extracted, err := os.ReadFile(extractedPath)
+			require.NoError(t, err)
+			require.Equal(t, binaryContents, string(extracted))
+		})
+	}
+}
+
+func TestExtractBinaryRejectsUnknownArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := bytes.NewReader(nil)
+	_, err := extractBinary(archive, 0, "ledger-v3_windows-amd64.rar", "ledgerctl.exe")
+	require.EqualError(t, err, `unsupported archive format "ledger-v3_windows-amd64.rar"`)
+}
+
+func tarGzArchive(t *testing.T, binaryName, contents string) []byte {
+	t.Helper()
+
+	var archive bytes.Buffer
+
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: binaryName,
+		Mode: 0o755,
+		Size: int64(len(contents)),
+	}))
+	_, err := tw.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	return archive.Bytes()
+}
+
+func zipArchive(t *testing.T, binaryName, contents string) []byte {
+	t.Helper()
+
+	var archive bytes.Buffer
+
+	zw := zip.NewWriter(&archive)
+	binary, err := zw.Create(binaryName)
+	require.NoError(t, err)
+	_, err = binary.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	return archive.Bytes()
+}

--- a/cmd/ledgerctl/upgrade/download_test.go
+++ b/cmd/ledgerctl/upgrade/download_test.go
@@ -24,13 +24,13 @@ func TestExtractBinary(t *testing.T) {
 	}{
 		{
 			name:        "tar.gz",
-			archiveName: "ledger-v3_linux-amd64.tar.gz",
+			archiveName: archiveAssetName("linux", "amd64"),
 			binaryName:  "ledgerctl",
 			archive:     tarGzArchive,
 		},
 		{
 			name:        "zip",
-			archiveName: "ledger-v3_windows-amd64.zip",
+			archiveName: archiveAssetName("windows", "amd64"),
 			binaryName:  "ledgerctl.exe",
 			archive:     zipArchive,
 		},
@@ -40,7 +40,7 @@ func TestExtractBinary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			archive := test.archive(t, "ledger-v3/"+test.binaryName, binaryContents)
+			archive := test.archive(t, projectName+"/"+test.binaryName, binaryContents)
 			archiveReader := bytes.NewReader(archive)
 
 			extractedPath, err := extractBinary(
@@ -65,8 +65,9 @@ func TestExtractBinaryRejectsUnknownArchive(t *testing.T) {
 	t.Parallel()
 
 	archive := bytes.NewReader(nil)
-	_, err := extractBinary(archive, 0, "ledger-v3_windows-amd64.rar", "ledgerctl.exe")
-	require.EqualError(t, err, `unsupported archive format "ledger-v3_windows-amd64.rar"`)
+	archiveName := projectName + "_windows-amd64.rar"
+	_, err := extractBinary(archive, 0, archiveName, "ledgerctl.exe")
+	require.EqualError(t, err, `unsupported archive format "ledger_windows-amd64.rar"`)
 }
 
 func tarGzArchive(t *testing.T, binaryName, contents string) []byte {

--- a/cmd/ledgerctl/upgrade/github.go
+++ b/cmd/ledgerctl/upgrade/github.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	githubRepo  = "formancehq/ledger"
-	projectName = "ledger"
+	projectName = "ledger-v3"
 )
 
 type releaseInfo struct {
@@ -173,21 +173,38 @@ func githubDownload(url string) (*http.Response, error) {
 	return resp, nil
 }
 
-// archiveAssetName returns the expected archive filename for the current OS/arch.
-func archiveAssetName() string {
-	return fmt.Sprintf("%s_%s-%s.tar.gz", projectName, runtime.GOOS, runtime.GOARCH)
+// archiveAssetName returns the expected archive filename for an OS/arch pair.
+func archiveAssetName(goos, goarch string) string {
+	extension := ".tar.gz"
+	if goos == "windows" {
+		extension = ".zip"
+	}
+
+	return fmt.Sprintf("%s_%s-%s%s", projectName, goos, goarch, extension)
+}
+
+func executableName(goos string) string {
+	if goos == "windows" {
+		return "ledgerctl.exe"
+	}
+
+	return "ledgerctl"
 }
 
 // findAsset finds the archive asset matching the current OS/arch in the release.
 func findAsset(release *releaseInfo) (*assetInfo, error) {
-	want := archiveAssetName()
+	return findAssetForPlatform(release, runtime.GOOS, runtime.GOARCH)
+}
+
+func findAssetForPlatform(release *releaseInfo, goos, goarch string) (*assetInfo, error) {
+	want := archiveAssetName(goos, goarch)
 	for i := range release.Assets {
 		if release.Assets[i].Name == want {
 			return &release.Assets[i], nil
 		}
 	}
 
-	return nil, fmt.Errorf("no binary available for %s/%s (expected asset %q)", runtime.GOOS, runtime.GOARCH, want)
+	return nil, fmt.Errorf("no binary available for %s/%s (expected asset %q)", goos, goarch, want)
 }
 
 // findChecksumsAsset finds the checksums.txt asset in the release.

--- a/cmd/ledgerctl/upgrade/github.go
+++ b/cmd/ledgerctl/upgrade/github.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 const (
@@ -22,6 +23,8 @@ type releaseInfo struct {
 	TagName         string      `json:"tag_name"`
 	Name            string      `json:"name"`
 	TargetCommitish string      `json:"target_commitish"`
+	Draft           bool        `json:"draft"`
+	Prerelease      bool        `json:"prerelease"`
 	Assets          []assetInfo `json:"assets"`
 }
 
@@ -32,13 +35,14 @@ type assetInfo struct {
 
 // fetchRelease fetches the release info for the given channel.
 // For "nightly", it fetches the release tagged "nightly".
-// For "stable", it fetches the most recent release matching a semver tag.
-func fetchRelease(channel string) (*releaseInfo, error) {
+// For "stable", it fetches the most recent final release matching the running
+// binary's major version.
+func fetchRelease(channel, currentVersion string) (*releaseInfo, error) {
 	switch channel {
 	case "nightly":
 		return fetchNightlyRelease()
 	case "stable":
-		return fetchStableRelease()
+		return fetchStableRelease(currentVersion)
 	default:
 		return nil, fmt.Errorf("unknown channel %q; use \"nightly\" or \"stable\"", channel)
 	}
@@ -57,29 +61,65 @@ func fetchNightlyRelease() (*releaseInfo, error) {
 	return &release, nil
 }
 
-var semverTagRe = regexp.MustCompile(`^v3\.\d+\.\d+$`)
+func fetchStableRelease(currentVersion string) (*releaseInfo, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", githubRepo)
 
-func fetchStableRelease() (*releaseInfo, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=20", githubRepo)
-
-	var releases []releaseInfo
-
-	err := githubGet(url, &releases)
-	if err != nil {
-		return nil, err
-	}
-
-	return findStableRelease(releases)
+	return fetchStableReleaseFromURL(currentVersion, url)
 }
 
-func findStableRelease(releases []releaseInfo) (*releaseInfo, error) {
-	for i := range releases {
-		if semverTagRe.MatchString(releases[i].TagName) {
-			return &releases[i], nil
+func fetchStableReleaseFromURL(currentVersion, releasesURL string) (*releaseInfo, error) {
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot select a stable release for current version %q: %w; use --channel nightly",
+			currentVersion,
+			err,
+		)
+	}
+
+	const releasesPerPage = 100
+
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s?per_page=%d&page=%d", releasesURL, releasesPerPage, page)
+
+		var releases []releaseInfo
+		if err := githubGet(url, &releases); err != nil {
+			return nil, err
+		}
+
+		if release := findStableRelease(releases, current.Major()); release != nil {
+			return release, nil
+		}
+
+		if len(releases) < releasesPerPage {
+			break
 		}
 	}
 
-	return nil, errors.New("no stable v3 release found; use --channel nightly")
+	return nil, fmt.Errorf(
+		"no final release found for major v%d; use --channel nightly",
+		current.Major(),
+	)
+}
+
+func findStableRelease(releases []releaseInfo, currentMajor uint64) *releaseInfo {
+	for i := range releases {
+		release := &releases[i]
+		if release.Draft || release.Prerelease {
+			continue
+		}
+
+		releaseVersion, err := semver.StrictNewVersion(strings.TrimPrefix(release.TagName, "v"))
+		if err != nil || releaseVersion.Prerelease() != "" {
+			continue
+		}
+
+		if releaseVersion.Major() == currentMajor {
+			return release
+		}
+	}
+
+	return nil
 }
 
 var (

--- a/cmd/ledgerctl/upgrade/github.go
+++ b/cmd/ledgerctl/upgrade/github.go
@@ -8,10 +8,13 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
+	"golang.org/x/mod/module"
 )
 
 const (
@@ -63,12 +66,16 @@ func fetchNightlyRelease() (*releaseInfo, error) {
 
 func fetchStableRelease(currentVersion string) (*releaseInfo, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", githubRepo)
+	modulePath := ""
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		modulePath = buildInfo.Main.Path
+	}
 
-	return fetchStableReleaseFromURL(currentVersion, url)
+	return fetchStableReleaseFromURL(currentVersion, modulePath, url)
 }
 
-func fetchStableReleaseFromURL(currentVersion, releasesURL string) (*releaseInfo, error) {
-	current, err := semver.NewVersion(currentVersion)
+func fetchStableReleaseFromURL(currentVersion, modulePath, releasesURL string) (*releaseInfo, error) {
+	currentMajor, err := versionMajor(currentVersion, modulePath)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"cannot select a stable release for current version %q: %w; use --channel nightly",
@@ -87,7 +94,7 @@ func fetchStableReleaseFromURL(currentVersion, releasesURL string) (*releaseInfo
 			return nil, err
 		}
 
-		if release := findStableRelease(releases, current.Major()); release != nil {
+		if release := findStableRelease(releases, currentMajor); release != nil {
 			return release, nil
 		}
 
@@ -98,8 +105,31 @@ func fetchStableReleaseFromURL(currentVersion, releasesURL string) (*releaseInfo
 
 	return nil, fmt.Errorf(
 		"no final release found for major v%d; use --channel nightly",
-		current.Major(),
+		currentMajor,
 	)
+}
+
+func versionMajor(currentVersion, modulePath string) (uint64, error) {
+	current, versionErr := semver.NewVersion(currentVersion)
+	if versionErr == nil {
+		return current.Major(), nil
+	}
+
+	_, pathMajor, ok := module.SplitPathVersion(modulePath)
+	if !ok || pathMajor == "" {
+		return 0, fmt.Errorf(
+			"version is not semantic and module path %q has no major suffix: %w",
+			modulePath,
+			versionErr,
+		)
+	}
+
+	major, err := strconv.ParseUint(strings.TrimPrefix(pathMajor, "/v"), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing module major %q: %w", pathMajor, err)
+	}
+
+	return major, nil
 }
 
 func findStableRelease(releases []releaseInfo, currentMajor uint64) *releaseInfo {

--- a/cmd/ledgerctl/upgrade/github.go
+++ b/cmd/ledgerctl/upgrade/github.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	githubRepo  = "formancehq/ledger"
-	projectName = "ledger-v3"
+	projectName = "ledger"
 )
 
 type releaseInfo struct {

--- a/cmd/ledgerctl/upgrade/github.go
+++ b/cmd/ledgerctl/upgrade/github.go
@@ -57,7 +57,7 @@ func fetchNightlyRelease() (*releaseInfo, error) {
 	return &release, nil
 }
 
-var semverTagRe = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+var semverTagRe = regexp.MustCompile(`^v3\.\d+\.\d+$`)
 
 func fetchStableRelease() (*releaseInfo, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=20", githubRepo)
@@ -69,13 +69,17 @@ func fetchStableRelease() (*releaseInfo, error) {
 		return nil, err
 	}
 
+	return findStableRelease(releases)
+}
+
+func findStableRelease(releases []releaseInfo) (*releaseInfo, error) {
 	for i := range releases {
 		if semverTagRe.MatchString(releases[i].TagName) {
 			return &releases[i], nil
 		}
 	}
 
-	return nil, errors.New("no stable release found; use --channel nightly")
+	return nil, errors.New("no stable v3 release found; use --channel nightly")
 }
 
 var (

--- a/cmd/ledgerctl/upgrade/github_test.go
+++ b/cmd/ledgerctl/upgrade/github_test.go
@@ -67,3 +67,29 @@ func TestFindAssetForPlatform(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, archiveAssetName("windows", "amd64"), asset.Name)
 }
+
+func TestFindStableRelease(t *testing.T) {
+	t.Parallel()
+
+	releases := []releaseInfo{
+		{TagName: "v2.4.12"},
+		{TagName: "v3.0.0-alpha.13"},
+		{TagName: "v3.0.0"},
+	}
+
+	release, err := findStableRelease(releases)
+	require.NoError(t, err)
+	require.Equal(t, "v3.0.0", release.TagName)
+}
+
+func TestFindStableReleaseRejectsOtherMajorsAndPrereleases(t *testing.T) {
+	t.Parallel()
+
+	releases := []releaseInfo{
+		{TagName: "v2.4.12"},
+		{TagName: "v3.0.0-alpha.13"},
+	}
+
+	_, err := findStableRelease(releases)
+	require.EqualError(t, err, "no stable v3 release found; use --channel nightly")
+}

--- a/cmd/ledgerctl/upgrade/github_test.go
+++ b/cmd/ledgerctl/upgrade/github_test.go
@@ -1,6 +1,11 @@
 package upgrade
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,12 +78,14 @@ func TestFindStableRelease(t *testing.T) {
 
 	releases := []releaseInfo{
 		{TagName: "v2.4.12"},
-		{TagName: "v3.0.0-alpha.13"},
+		{TagName: "v3.0.0-alpha.13", Prerelease: true},
+		{TagName: "v3.0.0-rc.1"},
+		{TagName: "v3.0.0", Draft: true},
 		{TagName: "v3.0.0"},
 	}
 
-	release, err := findStableRelease(releases)
-	require.NoError(t, err)
+	release := findStableRelease(releases, 3)
+	require.NotNil(t, release)
 	require.Equal(t, "v3.0.0", release.TagName)
 }
 
@@ -87,9 +94,47 @@ func TestFindStableReleaseRejectsOtherMajorsAndPrereleases(t *testing.T) {
 
 	releases := []releaseInfo{
 		{TagName: "v2.4.12"},
-		{TagName: "v3.0.0-alpha.13"},
+		{TagName: "v3.0.0-alpha.13", Prerelease: true},
 	}
 
-	_, err := findStableRelease(releases)
-	require.EqualError(t, err, "no stable v3 release found; use --channel nightly")
+	require.Nil(t, findStableRelease(releases, 3))
+}
+
+func TestFetchStableReleaseFromURLPaginates(t *testing.T) {
+	t.Parallel()
+
+	firstPage := make([]releaseInfo, 100)
+	for i := range firstPage {
+		firstPage[i] = releaseInfo{TagName: fmt.Sprintf("v2.4.%d", i)}
+	}
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+
+		var releases []releaseInfo
+		switch r.URL.Query().Get("page") {
+		case "1":
+			releases = firstPage
+		case "2":
+			releases = []releaseInfo{{TagName: "v3.0.0"}}
+		default:
+			require.Fail(t, "unexpected releases page", r.URL.String())
+		}
+
+		require.NoError(t, json.NewEncoder(w).Encode(releases))
+	}))
+	t.Cleanup(server.Close)
+
+	release, err := fetchStableReleaseFromURL("v3.0.0-alpha.13", server.URL)
+	require.NoError(t, err)
+	require.Equal(t, "v3.0.0", release.TagName)
+	require.EqualValues(t, 2, requests.Load())
+}
+
+func TestFetchStableReleaseFromURLRejectsUnversionedBinary(t *testing.T) {
+	t.Parallel()
+
+	_, err := fetchStableReleaseFromURL("nightly-deadbeef", "unused")
+	require.ErrorContains(t, err, `cannot select a stable release for current version "nightly-deadbeef"`)
 }

--- a/cmd/ledgerctl/upgrade/github_test.go
+++ b/cmd/ledgerctl/upgrade/github_test.go
@@ -19,19 +19,19 @@ func TestArchiveAssetName(t *testing.T) {
 			name:   "linux amd64",
 			goos:   "linux",
 			goarch: "amd64",
-			want:   "ledger-v3_linux-amd64.tar.gz",
+			want:   "ledger_linux-amd64.tar.gz",
 		},
 		{
 			name:   "darwin arm64",
 			goos:   "darwin",
 			goarch: "arm64",
-			want:   "ledger-v3_darwin-arm64.tar.gz",
+			want:   "ledger_darwin-arm64.tar.gz",
 		},
 		{
 			name:   "windows amd64",
 			goos:   "windows",
 			goarch: "amd64",
-			want:   "ledger-v3_windows-amd64.zip",
+			want:   "ledger_windows-amd64.zip",
 		},
 	}
 
@@ -58,12 +58,12 @@ func TestFindAssetForPlatform(t *testing.T) {
 	release := &releaseInfo{
 		Assets: []assetInfo{
 			{Name: "checksums.txt"},
-			{Name: "ledger-v3_linux-amd64.tar.gz"},
-			{Name: "ledger-v3_windows-amd64.zip"},
+			{Name: archiveAssetName("linux", "amd64")},
+			{Name: archiveAssetName("windows", "amd64")},
 		},
 	}
 
 	asset, err := findAssetForPlatform(release, "windows", "amd64")
 	require.NoError(t, err)
-	require.Equal(t, "ledger-v3_windows-amd64.zip", asset.Name)
+	require.Equal(t, archiveAssetName("windows", "amd64"), asset.Name)
 }

--- a/cmd/ledgerctl/upgrade/github_test.go
+++ b/cmd/ledgerctl/upgrade/github_test.go
@@ -1,0 +1,69 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveAssetName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+		want   string
+	}{
+		{
+			name:   "linux amd64",
+			goos:   "linux",
+			goarch: "amd64",
+			want:   "ledger-v3_linux-amd64.tar.gz",
+		},
+		{
+			name:   "darwin arm64",
+			goos:   "darwin",
+			goarch: "arm64",
+			want:   "ledger-v3_darwin-arm64.tar.gz",
+		},
+		{
+			name:   "windows amd64",
+			goos:   "windows",
+			goarch: "amd64",
+			want:   "ledger-v3_windows-amd64.zip",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.want, archiveAssetName(test.goos, test.goarch))
+		})
+	}
+}
+
+func TestExecutableName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "ledgerctl", executableName("linux"))
+	require.Equal(t, "ledgerctl", executableName("darwin"))
+	require.Equal(t, "ledgerctl.exe", executableName("windows"))
+}
+
+func TestFindAssetForPlatform(t *testing.T) {
+	t.Parallel()
+
+	release := &releaseInfo{
+		Assets: []assetInfo{
+			{Name: "checksums.txt"},
+			{Name: "ledger-v3_linux-amd64.tar.gz"},
+			{Name: "ledger-v3_windows-amd64.zip"},
+		},
+	}
+
+	asset, err := findAssetForPlatform(release, "windows", "amd64")
+	require.NoError(t, err)
+	require.Equal(t, "ledger-v3_windows-amd64.zip", asset.Name)
+}

--- a/cmd/ledgerctl/upgrade/github_test.go
+++ b/cmd/ledgerctl/upgrade/github_test.go
@@ -126,15 +126,59 @@ func TestFetchStableReleaseFromURLPaginates(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	release, err := fetchStableReleaseFromURL("v3.0.0-alpha.13", server.URL)
+	release, err := fetchStableReleaseFromURL(
+		"nightly-deadbeef",
+		"github.com/formancehq/ledger/v3",
+		server.URL,
+	)
 	require.NoError(t, err)
 	require.Equal(t, "v3.0.0", release.TagName)
 	require.EqualValues(t, 2, requests.Load())
 }
 
-func TestFetchStableReleaseFromURLRejectsUnversionedBinary(t *testing.T) {
+func TestVersionMajor(t *testing.T) {
 	t.Parallel()
 
-	_, err := fetchStableReleaseFromURL("nightly-deadbeef", "unused")
-	require.ErrorContains(t, err, `cannot select a stable release for current version "nightly-deadbeef"`)
+	tests := []struct {
+		name           string
+		currentVersion string
+		modulePath     string
+		want           uint64
+		wantErr        string
+	}{
+		{
+			name:           "semantic prerelease",
+			currentVersion: "v4.0.0-alpha.1",
+			modulePath:     "github.com/formancehq/ledger/v3",
+			want:           4,
+		},
+		{
+			name:           "nightly module fallback",
+			currentVersion: "nightly-deadbeef",
+			modulePath:     "github.com/formancehq/ledger/v3",
+			want:           3,
+		},
+		{
+			name:           "missing module major",
+			currentVersion: "nightly-deadbeef",
+			modulePath:     "github.com/formancehq/ledger",
+			wantErr:        "has no major suffix",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			major, err := versionMajor(test.currentVersion, test.modulePath)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, major)
+		})
+	}
 }

--- a/cmd/ledgerctl/upgrade/replace.go
+++ b/cmd/ledgerctl/upgrade/replace.go
@@ -100,7 +100,14 @@ func replaceExecutable(currentPath, replacementPath, goos string) error {
 
 	if err := os.Rename(replacementPath, currentPath); err != nil {
 		if rollbackErr := os.Rename(backupPath, currentPath); rollbackErr != nil {
-			return fmt.Errorf("installing replacement: %w; restoring current executable: %w", err, rollbackErr)
+			return fmt.Errorf(
+				"installing replacement: %w; restoring current executable from backup %q: %w; recover manually by renaming %q to %q",
+				err,
+				backupPath,
+				rollbackErr,
+				backupPath,
+				currentPath,
+			)
 		}
 
 		return fmt.Errorf("installing replacement: %w", err)

--- a/cmd/ledgerctl/upgrade/replace.go
+++ b/cmd/ledgerctl/upgrade/replace.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
-// replaceBinary atomically replaces the current binary with the new one at srcPath.
-// It resolves symlinks to find the actual binary path, preserves permissions,
-// and uses rename for atomicity (requires same filesystem).
+// replaceBinary replaces the current binary with the new one at srcPath.
+// It resolves symlinks to find the actual binary path and preserves permissions.
 func replaceBinary(srcPath string) (string, error) {
 	currentPath, err := os.Executable()
 	if err != nil {
@@ -67,12 +67,38 @@ func replaceBinary(srcPath string) (string, error) {
 		return "", fmt.Errorf("closing temp file: %w", err)
 	}
 
-	// Atomic rename.
-	if err := os.Rename(tmpPath, currentPath); err != nil {
+	if err := replaceExecutable(currentPath, tmpPath, runtime.GOOS); err != nil {
 		_ = os.Remove(tmpPath)
 
 		return "", fmt.Errorf("replacing binary: %w (you may need elevated permissions)", err)
 	}
 
 	return currentPath, nil
+}
+
+func replaceExecutable(currentPath, replacementPath, goos string) error {
+	if goos != "windows" {
+		return os.Rename(replacementPath, currentPath)
+	}
+
+	backupPath := currentPath + ".old"
+	if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing previous backup: %w", err)
+	}
+
+	// Windows cannot replace a running executable in place. Renaming it keeps the
+	// current process alive while freeing the original path for the new binary.
+	if err := os.Rename(currentPath, backupPath); err != nil {
+		return fmt.Errorf("backing up current executable: %w", err)
+	}
+
+	if err := os.Rename(replacementPath, currentPath); err != nil {
+		if rollbackErr := os.Rename(backupPath, currentPath); rollbackErr != nil {
+			return fmt.Errorf("installing replacement: %w; restoring current executable: %w", err, rollbackErr)
+		}
+
+		return fmt.Errorf("installing replacement: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/ledgerctl/upgrade/replace.go
+++ b/cmd/ledgerctl/upgrade/replace.go
@@ -37,34 +37,10 @@ func replaceBinary(srcPath string) (string, error) {
 	tmpPath := tmpFile.Name()
 	_ = tmpFile.Close()
 
-	// Copy new binary to the temp file.
-	src, err := os.Open(srcPath)
-	if err != nil {
+	if err := copyReplacement(srcPath, tmpPath, info.Mode()); err != nil {
 		_ = os.Remove(tmpPath)
 
-		return "", fmt.Errorf("opening new binary: %w", err)
-	}
-
-	defer func() { _ = src.Close() }()
-
-	dst, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_TRUNC, info.Mode())
-	if err != nil {
-		_ = os.Remove(tmpPath)
-
-		return "", fmt.Errorf("opening temp file: %w", err)
-	}
-
-	if _, err := dst.ReadFrom(src); err != nil {
-		_ = dst.Close()
-		_ = os.Remove(tmpPath)
-
-		return "", fmt.Errorf("writing new binary: %w", err)
-	}
-
-	if err := dst.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-
-		return "", fmt.Errorf("closing temp file: %w", err)
+		return "", err
 	}
 
 	if err := replaceExecutable(currentPath, tmpPath, runtime.GOOS); err != nil {
@@ -74,6 +50,36 @@ func replaceBinary(srcPath string) (string, error) {
 	}
 
 	return currentPath, nil
+}
+
+func copyReplacement(srcPath, dstPath string, mode os.FileMode) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("opening new binary: %w", err)
+	}
+
+	defer func() { _ = src.Close() }()
+
+	dst, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return fmt.Errorf("opening temp file: %w", err)
+	}
+
+	if _, err := dst.ReadFrom(src); err != nil {
+		_ = dst.Close()
+
+		return fmt.Errorf("writing new binary: %w", err)
+	}
+
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Chmod(dstPath, mode); err != nil {
+		return fmt.Errorf("preserving binary permissions: %w", err)
+	}
+
+	return nil
 }
 
 func replaceExecutable(currentPath, replacementPath, goos string) error {

--- a/cmd/ledgerctl/upgrade/replace_test.go
+++ b/cmd/ledgerctl/upgrade/replace_test.go
@@ -3,7 +3,6 @@ package upgrade
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,10 +17,6 @@ func TestReplaceExecutable(t *testing.T) {
 		wantBackup bool
 	}{
 		{
-			name: "unix",
-			goos: "linux",
-		},
-		{
 			name:       "windows",
 			goos:       "windows",
 			wantBackup: true,
@@ -31,9 +26,6 @@ func TestReplaceExecutable(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			if runtime.GOOS == "windows" && test.goos != "windows" {
-				t.Skip("Windows cannot exercise Unix overwrite semantics")
-			}
 
 			dir := t.TempDir()
 			currentPath := filepath.Join(dir, "ledgerctl")

--- a/cmd/ledgerctl/upgrade/replace_test.go
+++ b/cmd/ledgerctl/upgrade/replace_test.go
@@ -8,46 +8,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReplaceExecutable(t *testing.T) {
+func TestReplaceExecutableWindows(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		goos       string
-		wantBackup bool
-	}{
-		{
-			name:       "windows",
-			goos:       "windows",
-			wantBackup: true,
-		},
-	}
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "ledgerctl.exe")
+	replacementPath := filepath.Join(dir, "ledgerctl-new.exe")
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	require.NoError(t, os.WriteFile(currentPath, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(replacementPath, []byte("new"), 0o755))
+	require.NoError(t, replaceExecutable(currentPath, replacementPath, "windows"))
 
-			dir := t.TempDir()
-			currentPath := filepath.Join(dir, "ledgerctl")
-			replacementPath := filepath.Join(dir, "ledgerctl-new")
+	current, err := os.ReadFile(currentPath)
+	require.NoError(t, err)
+	require.Equal(t, "new", string(current))
 
-			require.NoError(t, os.WriteFile(currentPath, []byte("old"), 0o755))
-			require.NoError(t, os.WriteFile(replacementPath, []byte("new"), 0o755))
-			require.NoError(t, replaceExecutable(currentPath, replacementPath, test.goos))
-
-			current, err := os.ReadFile(currentPath)
-			require.NoError(t, err)
-			require.Equal(t, "new", string(current))
-
-			backup, err := os.ReadFile(currentPath + ".old")
-			if test.wantBackup {
-				require.NoError(t, err)
-				require.Equal(t, "old", string(backup))
-			} else {
-				require.ErrorIs(t, err, os.ErrNotExist)
-			}
-		})
-	}
+	backup, err := os.ReadFile(currentPath + ".old")
+	require.NoError(t, err)
+	require.Equal(t, "old", string(backup))
 }
 
 func TestReplaceExecutableWindowsRemovesPreviousBackup(t *testing.T) {

--- a/cmd/ledgerctl/upgrade/replace_test.go
+++ b/cmd/ledgerctl/upgrade/replace_test.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,9 @@ func TestReplaceExecutable(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			if runtime.GOOS == "windows" && test.goos != "windows" {
+				t.Skip("Windows cannot exercise Unix overwrite semantics")
+			}
 
 			dir := t.TempDir()
 			currentPath := filepath.Join(dir, "ledgerctl")

--- a/cmd/ledgerctl/upgrade/replace_test.go
+++ b/cmd/ledgerctl/upgrade/replace_test.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceExecutable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		goos       string
+		wantBackup bool
+	}{
+		{
+			name: "unix",
+			goos: "linux",
+		},
+		{
+			name:       "windows",
+			goos:       "windows",
+			wantBackup: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			currentPath := filepath.Join(dir, "ledgerctl")
+			replacementPath := filepath.Join(dir, "ledgerctl-new")
+
+			require.NoError(t, os.WriteFile(currentPath, []byte("old"), 0o755))
+			require.NoError(t, os.WriteFile(replacementPath, []byte("new"), 0o755))
+			require.NoError(t, replaceExecutable(currentPath, replacementPath, test.goos))
+
+			current, err := os.ReadFile(currentPath)
+			require.NoError(t, err)
+			require.Equal(t, "new", string(current))
+
+			backup, err := os.ReadFile(currentPath + ".old")
+			if test.wantBackup {
+				require.NoError(t, err)
+				require.Equal(t, "old", string(backup))
+			} else {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+func TestReplaceExecutableWindowsRemovesPreviousBackup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "ledgerctl.exe")
+	replacementPath := filepath.Join(dir, "ledgerctl-new.exe")
+
+	require.NoError(t, os.WriteFile(currentPath, []byte("current"), 0o755))
+	require.NoError(t, os.WriteFile(currentPath+".old", []byte("previous backup"), 0o755))
+	require.NoError(t, os.WriteFile(replacementPath, []byte("replacement"), 0o755))
+	require.NoError(t, replaceExecutable(currentPath, replacementPath, "windows"))
+
+	backup, err := os.ReadFile(currentPath + ".old")
+	require.NoError(t, err)
+	require.Equal(t, "current", string(backup))
+}
+
+func TestReplaceExecutableWindowsRollsBack(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "ledgerctl.exe")
+	replacementPath := filepath.Join(dir, "missing.exe")
+
+	require.NoError(t, os.WriteFile(currentPath, []byte("current"), 0o755))
+	require.Error(t, replaceExecutable(currentPath, replacementPath, "windows"))
+
+	current, err := os.ReadFile(currentPath)
+	require.NoError(t, err)
+	require.Equal(t, "current", string(current))
+	_, err = os.Stat(currentPath + ".old")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/cmd/ledgerctl/upgrade/replace_unix_test.go
+++ b/cmd/ledgerctl/upgrade/replace_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceExecutableUnix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "ledgerctl")
+	replacementPath := filepath.Join(dir, "ledgerctl-new")
+
+	require.NoError(t, os.WriteFile(currentPath, []byte("old"), 0o755))
+	require.NoError(t, os.WriteFile(replacementPath, []byte("new"), 0o755))
+	require.NoError(t, replaceExecutable(currentPath, replacementPath, "linux"))
+
+	current, err := os.ReadFile(currentPath)
+	require.NoError(t, err)
+	require.Equal(t, "new", string(current))
+	_, err = os.Stat(currentPath + ".old")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/cmd/ledgerctl/upgrade/replace_unix_test.go
+++ b/cmd/ledgerctl/upgrade/replace_unix_test.go
@@ -27,3 +27,23 @@ func TestReplaceExecutableUnix(t *testing.T) {
 	_, err = os.Stat(currentPath + ".old")
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
+
+func TestCopyReplacementPreservesMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "downloaded-ledgerctl")
+	dstPath := filepath.Join(dir, "staged-ledgerctl")
+
+	require.NoError(t, os.WriteFile(srcPath, []byte("new binary"), 0o600))
+	require.NoError(t, os.WriteFile(dstPath, nil, 0o600))
+	require.NoError(t, copyReplacement(srcPath, dstPath, 0o755))
+
+	contents, err := os.ReadFile(dstPath)
+	require.NoError(t, err)
+	require.Equal(t, "new binary", string(contents))
+
+	info, err := os.Stat(dstPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -8,8 +8,19 @@
 
 ## Installation
 
+### Download a prebuilt binary
+
+Releases publish platform archives on
+[GitHub](https://github.com/formancehq/ledger/releases):
+
+- Linux/macOS: `ledger_linux-amd64.tar.gz`, `ledger_darwin-arm64.tar.gz`, and the corresponding architectures. These archives contain `ledger-server` and `ledgerctl`.
+- Windows: `ledger_windows-amd64.zip` and `ledger_windows-arm64.zip`. These archives contain `ledgerctl.exe` only.
+
+Extract the archive and put `ledgerctl` or `ledgerctl.exe` on your `PATH`. Once installed, `ledgerctl upgrade` keeps the CLI current.
+
+### Build from source
+
 ```bash
-# Build from source
 just build-client
 
 # Or directly with Go
@@ -4927,7 +4938,7 @@ See [Event System Architecture](../technical/architecture/subsystems/events-mirr
 
 ### upgrade
 
-Self-update `ledgerctl` to the latest version from GitHub releases. Downloads the archive, verifies the SHA256 checksum, and replaces the binary in-place.
+Self-update `ledgerctl` to the latest version from GitHub releases. Downloads the archive, verifies the SHA256 checksum, and replaces the installed binary.
 
 ```bash
 ledgerctl upgrade [flags]
@@ -4950,7 +4961,7 @@ ledgerctl upgrade [flags]
 
 **Channels:**
 - **`nightly`** (default): The rolling nightly build, tagged `nightly` on GitHub. Version format: `nightly-<shortcommit>`.
-- **`stable`**: The latest tagged release matching `v*.*.*` semver format.
+- **`stable`**: The latest final Ledger v3 release matching `v3.*.*` (prereleases excluded).
 
 **Example:**
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4956,12 +4956,12 @@ ledgerctl upgrade [flags]
 - Downloads the latest release from `formancehq/ledger` GitHub releases
 - Verifies the archive's SHA256 checksum against `checksums.txt`
 - Extracts `ledgerctl` from the Linux/macOS tarball or `ledgerctl.exe` from the Windows ZIP archive, then replaces the current binary
-- On Windows, keeps the previous executable as `ledgerctl.exe.old` because the running executable cannot be replaced in place
+- On Windows, keeps the previous executable as `ledgerctl.exe.old` because the running executable cannot be replaced in place. If an upgrade is interrupted and `ledgerctl.exe` is missing, rename `ledgerctl.exe.old` back to `ledgerctl.exe`.
 - If the current version is `dev` (built without ldflags), warns and requires `--force`
 
 **Channels:**
 - **`nightly`** (default): The rolling nightly build, tagged `nightly` on GitHub. Version format: `nightly-<shortcommit>`.
-- **`stable`**: The latest final Ledger v3 release matching `v3.*.*` (prereleases excluded).
+- **`stable`**: The latest final release matching the running binary's major version. Drafts and prereleases are excluded. Until the first final release for that major exists, the command returns an error and `nightly` must be used.
 
 **Example:**
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4945,6 +4945,7 @@ ledgerctl upgrade [flags]
 - Downloads the latest release from `formancehq/ledger` GitHub releases
 - Verifies the archive's SHA256 checksum against `checksums.txt`
 - Extracts `ledgerctl` from the Linux/macOS tarball or `ledgerctl.exe` from the Windows ZIP archive, then replaces the current binary
+- On Windows, keeps the previous executable as `ledgerctl.exe.old` because the running executable cannot be replaced in place
 - If the current version is `dev` (built without ldflags), warns and requires `--force`
 
 **Channels:**

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4944,7 +4944,7 @@ ledgerctl upgrade [flags]
 **Behavior:**
 - Downloads the latest release from `formancehq/ledger` GitHub releases
 - Verifies the archive's SHA256 checksum against `checksums.txt`
-- Extracts the `ledgerctl` binary and atomically replaces the current binary
+- Extracts `ledgerctl` from the Linux/macOS tarball or `ledgerctl.exe` from the Windows ZIP archive, then replaces the current binary
 - If the current version is `dev` (built without ldflags), warns and requires `--force`
 
 **Channels:**

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.7.0
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
 	github.com/IBM/sarama v1.46.3
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/antithesishq/antithesis-sdk-go v0.7.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
@@ -95,7 +96,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/RaduBerinde/axisds v0.1.0 // indirect
 	github.com/RaduBerinde/btreemap v0.0.0-20250419174037-3d62b7205d54 // indirect

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/mod v0.35.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
@@ -304,7 +305,6 @@ require (
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect


### PR DESCRIPTION
## What changed

- build `ledgerctl` for Windows on `amd64` and `arm64`
- package Windows artifacts as ZIP archives
- align the GoReleaser project and artifact names with `main` (`ledger_<os>-<arch>`)
- teach `ledgerctl upgrade` to select and extract Windows ZIP artifacts and `ledgerctl.exe`
- select stable releases by the running binary's semver major, excluding GitHub drafts and prereleases across paginated results
- preserve executable permissions when staging an upgrade
- replace the running Windows executable through a rollback-safe `.old` backup and document manual recovery after an interrupted swap
- keep separate Unix and Windows GoReleaser builds/archives so platform consistency checks remain enabled
- cross-compile both Windows architectures in the regular Build CI job
- document prebuilt installation and platform-specific self-upgrade behavior

## Why

Windows users currently have no prebuilt `ledgerctl` artifact in GitHub releases. Adding the binaries also requires the release and self-upgrade paths to handle the Windows archive format, executable name, replacement constraints, and v2/v3 release coexistence deliberately.

## Impact

Future v3 releases will include `ledger_windows-amd64.zip` and `ledger_windows-arm64.zip`. Linux and macOS keep their existing `tar.gz` archives. `ledger-server` remains unchanged. On Windows, the previous executable remains available as `ledgerctl.exe.old`; if a swap is interrupted, it can be renamed back to `ledgerctl.exe`.

The artifact rename from `ledger-v3_*` to `ledger_*` is intentional to align v3 with `main`. Existing v3 alpha asset consumers must update their filenames. `ledgerctl upgrade --channel stable` selects only final releases matching the running binary's major, preventing selection of the active v2 line. Until the first final v3 release exists, the command reports that `nightly` must be used.

## Validation

- `nix develop --command go test ./cmd/ledgerctl/upgrade -count=1`
- `GOLANGCI_LINT_CACHE=<isolated-cache> nix develop --command bash -c "just pre-commit"`
- `nix develop --command bash -c "GOROOT= go build ./..."`
- cross-compiled `ledgerctl` for Windows `amd64` and `arm64`
- tested draft/prerelease rejection, semver-major matching, and release pagination
- verified the live GitHub release list currently has no final v3 release
- `nix develop --command goreleaser check`
- full `nix develop --command goreleaser release --snapshot --clean --skip=docker`
- verified all six archives and `ledger_windows-amd64/ledgerctl.exe`