### PR TITLE
fix(state): purge stranded pre-transient volume rows at zero balance

### DIFF
--- a/docs/technical/architecture/subsystems/usage/counters.md
+++ b/docs/technical/architecture/subsystems/usage/counters.md
@@ -79,7 +79,7 @@ The disjoint encoding pays exactly `len(ephemeral)` per log instead of `2 × len
 1. `partitionVolumes(volumeUpdates)` (existing) yields `partResult.{kept, purged, transient}`.
 2. `splitPurged(partResult.purged)` (new, in `write_set_new_volumes.go`) partitions `purged` further into:
    - **ephemeral**: `!Old.IsDefined() || isVolumePreloadZero(Old.Value())` — the key had no prior state, was touched, immediately purged.
-   - **draining**: `Old.IsDefined() && !isVolumePreloadZero(Old.Value())` — had a prior non-zero balance, drained to zero, evicted.
+   - **draining**: `Old.IsDefined() && !isVolumePreloadZero(Old.Value())` — had a prior persisted value, at zero balance now, evicted.
 3. `makeNewKeptKeySet(partResult.kept)` (new) yields the subset of `kept` where `Old` was undefined / zero-placeholder — i.e. new persistent volumes.
 4. `buildTouchedByLog(volumes.Slots(), setX)` (new, generalised from the previous `buildPurgedByLog`) intersects the per-order touched-volume tracking with each of the three sets to produce the per-log annotation lists. Deduplication + deterministic sort by (account, asset) keeps the log payload byte-identical across nodes.
 

--- a/internal/infra/state/write_set_ephemeral_purge.go
+++ b/internal/infra/state/write_set_ephemeral_purge.go
@@ -40,11 +40,11 @@ type volumePartitionResult struct {
 //   - NORMAL accounts: always kept
 //   - EPHEMERAL accounts with zero balance: purged (deleted from Pebble)
 //   - EPHEMERAL accounts with non-zero balance: kept
-//   - TRANSIENT accounts with a pre-existing non-zero balance (from before the
+//   - TRANSIENT accounts with a persisted row (non-zero Old, from before the
 //     transient pattern started matching them): mirror EPHEMERAL — kept while
-//     the running cumulative is still unbalanced, purged once it returns to
-//     zero balance. Steady-state TRANSIENT (no pre-existing balance, or already
-//     purged): never written to Pebble.
+//     the running cumulative is still unbalanced, purged once it is at zero
+//     balance. Steady-state TRANSIENT (all-zero Old: never persisted, or
+//     already purged): never written to Pebble.
 func (b *WriteSet) partitionVolumes(
 	updates []attributes.Update[domain.VolumeKey, *raftcmdpb.VolumePair],
 ) volumePartitionResult {
@@ -84,13 +84,16 @@ func (b *WriteSet) partitionVolumes(
 
 		switch matched.GetPersistence() {
 		case commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT:
-			// Pre-existing non-zero balance (e.g., account was funded under a
-			// default-normal policy before the transient pattern started matching
-			// it): mirror the ephemeral lifecycle. Keep the running cumulative in
-			// 0xF1 while it's still unbalanced; purge once it returns to zero
-			// balance. Once purged, KS.M is zeroed and the account behaves as
-			// steady-state transient (Old.IsZero) from then on.
-			if update.Old.IsDefined() && !isVolumeZeroBalance(update.Old.Value()) {
+			// A defined Old with non-zero limbs means a persisted row exists
+			// from before the transient pattern started matching the account
+			// (funded under a default-normal policy — its balance may already
+			// sit at zero, e.g. after a revert). Mirror the ephemeral
+			// lifecycle: keep the running cumulative in 0xF1 while it's still
+			// unbalanced; purge once it is at zero balance, deleting the row.
+			// An all-zero Old (post-purge zeroed cache entry, or the
+			// preloader's zero seed for a fresh key) is steady-state
+			// transient: nothing persisted, nothing to delete.
+			if update.Old.IsDefined() && !isVolumePreloadZero(update.Old.Value()) {
 				if isVolumeZeroBalance(update.New) {
 					result.purged = append(result.purged, update)
 				} else {

--- a/internal/infra/state/write_set_ephemeral_purge_test.go
+++ b/internal/infra/state/write_set_ephemeral_purge_test.go
@@ -305,7 +305,8 @@ func TestPartitionVolumesTransient_PreExistingBalance(t *testing.T) {
 			},
 		},
 		{
-			// TRANSIENT + Old already zero-balance → steady-state transient.
+			// TRANSIENT + Old all-zero (post-purge placeholder / preload seed)
+			// → steady-state transient.
 			Key:          domain.VolumeKey{AccountKey: domain.AccountKey{LedgerName: "test", Account: "staging:steady"}, Asset: "USD"},
 			CanonicalKey: (&domain.VolumeKey{AccountKey: domain.AccountKey{LedgerName: "test", Account: "staging:steady"}, Asset: "USD"}).Bytes(),
 			Old: kv.Some(&raftcmdpb.VolumePair{
@@ -317,6 +318,22 @@ func TestPartitionVolumesTransient_PreExistingBalance(t *testing.T) {
 				Output: commonpb.NewUint256FromUint64(42),
 			},
 		},
+		{
+			// TRANSIENT + Old zero-balance but non-zero limbs: a row persisted
+			// while the account was normal that already sits at input == output
+			// (e.g. after a revert). The row exists in Pebble, so the update
+			// must be purged — steady-state classification would strand it.
+			Key:          domain.VolumeKey{AccountKey: domain.AccountKey{LedgerName: "test", Account: "staging:stranded"}, Asset: "USD"},
+			CanonicalKey: (&domain.VolumeKey{AccountKey: domain.AccountKey{LedgerName: "test", Account: "staging:stranded"}, Asset: "USD"}).Bytes(),
+			Old: kv.Some(&raftcmdpb.VolumePair{
+				Input:  commonpb.NewUint256FromUint64(100),
+				Output: commonpb.NewUint256FromUint64(100),
+			}),
+			New: &raftcmdpb.VolumePair{
+				Input:  commonpb.NewUint256FromUint64(150),
+				Output: commonpb.NewUint256FromUint64(150),
+			},
+		},
 	}
 
 	result := buf.partitionVolumes(updates)
@@ -324,8 +341,9 @@ func TestPartitionVolumesTransient_PreExistingBalance(t *testing.T) {
 	require.Len(t, result.kept, 1)
 	require.Equal(t, "staging:draining", result.kept[0].Key.Account)
 
-	require.Len(t, result.purged, 1)
+	require.Len(t, result.purged, 2)
 	require.Equal(t, "staging:rebalanced", result.purged[0].Key.Account)
+	require.Equal(t, "staging:stranded", result.purged[1].Key.Account)
 
 	require.Len(t, result.transient, 1)
 	require.Equal(t, "staging:steady", result.transient[0].Key.Account)

--- a/internal/infra/state/write_set_new_volumes.go
+++ b/internal/infra/state/write_set_new_volumes.go
@@ -15,15 +15,7 @@ import (
 // — the exact seed the preloader emits so admission's `Needs` can be planned
 // deterministically.
 func isVolumePreloadZero(v *raftcmdpb.VolumePair) bool {
-	if v == nil {
-		return true
-	}
-
-	in := v.GetInput()
-	out := v.GetOutput()
-
-	return (in == nil || (in.GetV0() == 0 && in.GetV1() == 0 && in.GetV2() == 0 && in.GetV3() == 0)) &&
-		(out == nil || (out.GetV0() == 0 && out.GetV1() == 0 && out.GetV2() == 0 && out.GetV3() == 0))
+	return v.GetInput().IsZero() && v.GetOutput().IsZero()
 }
 
 // isNewVolumeUpdate reports whether a volume update represents a

--- a/tests/e2e/business/transient_accounts_test.go
+++ b/tests/e2e/business/transient_accounts_test.go
@@ -405,6 +405,87 @@ var _ = Describe("TransientAccounts", Ordered, func() {
 		})
 	})
 
+	// An account funded and then reverted to zero balance while NORMAL keeps its
+	// persisted volume row (input == output != 0). When a transient pattern later
+	// starts matching the account, the next batch that touches it must purge that
+	// row: the checker replay (SimulateEphemeralPurge) and the backup rebuild both
+	// delete it at zero balance, so a row left behind diverges from every
+	// re-derivation of the store — and resurfaces as a ghost account in listings.
+	Context("When a zero-balance row persisted before the transient pattern matched", Ordered, func() {
+		const ledgerName = "transient-stranded-row"
+
+		BeforeAll(func() {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+			Expect(err).To(Succeed())
+
+			// Fund staging:s with 100 USD (no account type yet → normal persistence).
+			resp, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "staging:s", big.NewInt(100), "USD"),
+			}, nil)))
+			Expect(err).To(Succeed())
+			txID := resp.Logs[0].Payload.GetApply().Log.Data.GetCreatedTransaction().GetTransaction().GetId()
+
+			// Revert the funding: staging:s lands at input=100, output=100 — zero
+			// balance, still normal → the row is legitimately kept.
+			_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.RevertTransactionAction(ledgerName, txID, false, false, nil)))
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				account, err := sharedClient.GetAccount(sharedCtx, &servicepb.GetAccountRequest{
+					Ledger:  ledgerName,
+					Address: "staging:s",
+				})
+				g.Expect(err).To(Succeed())
+				usdVol := account.FindVolume("USD", "")
+				g.Expect(usdVol).NotTo(BeNil())
+				g.Expect(usdVol.GetInput()).To(Equal("100"))
+				g.Expect(usdVol.GetBalance()).To(Equal("0"))
+			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+
+			// Now mark staging:{id} as transient.
+			_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.AddAccountTypeWithPersistenceAction(ledgerName, "staging", "staging:{id}",
+				commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+				actions.AddAccountTypeAction(ledgerName, "wallet", "wallet:{id}")))
+			Expect(err).To(Succeed())
+
+			// Zero-balance wash on staging:s under the transient type.
+			_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "staging:s", big.NewInt(50), "USD"),
+			}, nil),
+				actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+					actions.NewPosting("staging:s", "wallet:c", big.NewInt(50), "USD"),
+				}, nil, nil)))
+			Expect(err).To(Succeed())
+		})
+
+		It("Should purge the stranded row once a transient batch touches the account", func() {
+			Eventually(func(g Gomega) {
+				account, err := sharedClient.GetAccount(sharedCtx, &servicepb.GetAccountRequest{
+					Ledger:  ledgerName,
+					Address: "staging:s",
+				})
+				g.Expect(err).To(Succeed())
+				g.Expect(account.GetVolumes()).To(BeEmpty(),
+					"staging:s should have no persisted volumes after the transient wash")
+			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+		})
+
+		It("Should not list the account anymore", func() {
+			Eventually(func(g Gomega) {
+				accounts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", nil)
+				g.Expect(err).To(Succeed())
+
+				addrs := make([]string, 0, len(accounts))
+				for _, a := range accounts {
+					addrs = append(addrs, a.GetAddress())
+				}
+				g.Expect(addrs).To(ContainElement("wallet:c"))
+				g.Expect(addrs).NotTo(ContainElement("staging:s"),
+					"purged transient account must not linger in account listings")
+			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+		})
+	})
+
 	// Re-touching the same transient address in a later batch must not accumulate.
 	// The transient slot must read {0, 0} into the second batch's PCV — anything
 	// else means the prior cumulative value leaked through the cache.


### PR DESCRIPTION
## Bug

`partitionVolumes` classified a TRANSIENT-matched volume as steady-state (never written, **never deleted**) whenever `Old`'s balance was zero. But a row persisted while the account was NORMAL can already sit at `input == output` — e.g. funded then **reverted**. The next transient touch then strands that Pebble row forever:

1. `world → staging:s 100` (no type yet → NORMAL, row persisted)
2. revert → `{in:100, out:100}`, zero balance, row legitimately kept
3. `staging:{id}` becomes TRANSIENT
4. wash batch on `staging:s` → `Old.IsDefined() && !isVolumeZeroBalance(Old)` is false → steady-state → no write, no delete

Effects:
- stale `SubAttrVolume` row → **ghost account** in ListAccounts/GetAccount (never purgeable again — every later touch reclassifies as steady-state);
- FSM cache holds `{0,0}` while Pebble holds `{100,100}` for the same applied index — resurfaces via cache rotation + preload Pebble fallback;
- diverges from every re-derivation of the store: the checker's `SimulateEphemeralPurge` (deletes at `input == output`, no prior-balance precondition), the backup rebuild, and the antithesis model oracle — so a restored store would silently differ from the live one, and `Check()` flags `VOLUME_MISMATCH`.

Found by the model-based antithesis driver's account-query validation: the server's ListAccounts window contained an account the oracle had purged (verified on disk with a read-only Pebble scan of the failing run's data dir).

## Fix

Route the transient branch on "`Old` has non-zero **limbs**" (`isVolumePreloadZero`, the same test `splitPurged` already uses) instead of non-zero **balance**. Draining behavior is unchanged (non-zero balance ⊂ non-zero limbs); the stranded case now lands in `purged` → Pebble row deleted, listed as a draining eviction in `LedgerLog.PurgedVolumes`. The post-purge `{0,0}` cache placeholder and the preloader's zero seed still classify as steady-state, so no extra writes for genuine steady-state transients.

`New` is guaranteed zero-balance in the newly-purged case: the transient end-zero gate only exempts pre-batch non-zero-balance accounts.

## Tests

- e2e (`transient_accounts_test.go`, new Context "When a zero-balance row persisted before the transient pattern matched"): fund → revert → mark transient → wash; asserts `GetAccount` has no volumes and the account no longer appears in `ListAccounts`. Red before the fix (returned the stranded `{100,100}` row), green after.
- unit (`TestPartitionVolumesTransient_PreExistingBalance`): new `staging:stranded` case — `Old {100,100}` → purged.
- Full business e2e suite green; `state`, `check`, `indexbuilder`, `usagebuilder` unit tests green.