### PR TITLE
fix(EN-1379): surface coverage misses instead of wrapping them as storage faults

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -139,6 +139,15 @@ linters:
           violation (coverage miss / invalid execution plan) verbatim so the audit chain
           records COVERAGE_MISS, and wraps everything else as a storage fault. See
           docs/technical/architecture/subsystems/fsm/coverage-gate.md.
+
+          analyze-types is on, so this rule fires on ANY reference whose type resolves
+          to ErrStorageOperation outside domain.StoreFailure — not only a composite
+          literal. An errors.As target declaration, a field read off such a target and
+          a type-switch case are all flagged. A construction-only pattern is not
+          expressible here: forbidigo renders the type expression and never the brace.
+          If you are legitimately CONSUMING a storage fault (reading Operation for a
+          log line, distinguishing an IO fault from a business outcome), the rule has
+          no alternative to offer — add //nolint:forbidigo with a justification.
   exclusions:
     rules:
     # I2 exceptions for OpenWriteSession / NewWriteSessionFromDB.
@@ -183,9 +192,12 @@ linters:
       linters: [forbidigo]
     # coverage.go owns the single legitimate ErrStorageOperation construction:
     # domain.StoreFailure is the wrapper every other site must go through, and
-    # it is the one place allowed to build the fallback. (EN-1379)
+    # it is the one place allowed to build the fallback. Pinned by source to that
+    # one construction — symmetric with the errors.go rule below — so a second,
+    # unintended reference in this file is still caught. (EN-1379)
     - path: internal/domain/coverage\.go
       linters: [forbidigo]
+      source: 'ErrStorageOperation\{'
     # ErrStorageOperation's own methods read its fields; with analyze-types the
     # receiver resolves to the forbidden type, so e.Operation / e.Cause are
     # flagged inside the declaration itself. Pinned to those field reads via

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -126,6 +126,19 @@ linters:
           OpenWriteSession check. It is reserved for subsystems that manage their own
           Pebble instance (currently: internal/storage/readstore). New call sites must
           be added to the .golangci.yaml exclusions block with a justification.
+      # EN-1379: a bare ErrStorageOperation swallows the reason of an
+      # admission-contract violation. buildAuditFailure reads Reason()/Metadata()
+      # off the OUTERMOST Describable and never unwraps, so wrapping a
+      # *ErrCoverageMiss permanently records an admission bug in the
+      # hash-chained audit as STORAGE_OPERATION_FAILED with the identifying key
+      # stripped. domain.StoreFailure propagates the violation verbatim.
+      - pattern: '\bErrStorageOperation\b'
+        msg: |
+          Do not construct domain.ErrStorageOperation directly. Use
+          domain.StoreFailure(operation, err), which propagates an admission-contract
+          violation (coverage miss / invalid execution plan) verbatim so the audit chain
+          records COVERAGE_MISS, and wraps everything else as a storage fault. See
+          docs/technical/architecture/subsystems/fsm/coverage-gate.md.
   exclusions:
     rules:
     # I2 exceptions for OpenWriteSession / NewWriteSessionFromDB.
@@ -168,6 +181,19 @@ linters:
     # NewWriteSessionFromDB by the same rationale.
     - path: internal/storage/usagestore/
       linters: [forbidigo]
+    # coverage.go owns the single legitimate ErrStorageOperation construction:
+    # domain.StoreFailure is the wrapper every other site must go through, and
+    # it is the one place allowed to build the fallback. (EN-1379)
+    - path: internal/domain/coverage\.go
+      linters: [forbidigo]
+    # ErrStorageOperation's own methods read its fields; with analyze-types the
+    # receiver resolves to the forbidden type, so e.Operation / e.Cause are
+    # flagged inside the declaration itself. Pinned to those field reads via
+    # source so a bare &ErrStorageOperation{...} in errors.go is still caught.
+    # (EN-1379)
+    - path: internal/domain/errors\.go
+      linters: [forbidigo]
+      source: 'e\.(Operation|Cause)'
     # Tests use OpenWriteSession to seed data; the structural guarantee is on
     # production paths.
     - path: _test\.go$

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -660,6 +660,21 @@ Trying to keep existing Pebble data and upgrade in-place is **unsafe**:
 
 Mixed-binary rolling upgrades are **not supported** across this change. Stop all nodes before deploying the new binary.
 
+### Upgrading across EN-1379 (coverage-miss reclassification)
+
+EN-1379 changes how the FSM labels one failure class. A preload coverage miss used to be flattened into `ERROR_REASON_STORAGE_OPERATION_FAILED`; it now surfaces under its own `ERROR_REASON_COVERAGE_MISS` with the identifying context (`attribute`, `canonicalHex`, `idHex`, `raftIndex`) intact.
+
+That relabelling is **not hash-neutral**. `buildAuditFailurePayload` folds the failure reason, its message and every sorted context key *and value* into the audit hash pre-image, so for one and the same Raft entry an old binary and a new binary compute different `AuditEntry.Hash` values. `HashVersion` identifies the hash *algorithm* only and carries no notion of failure-projection semantics, so nothing lets a node recognise an entry written under the old classification.
+
+Mixed-binary rolling upgrades are **not supported** across this change. Restart every node onto the new binary; a coverage miss applied while the cluster straddles the two builds diverges the audit chain at that index, and `ledgerctl check` then reports `HASH_MISMATCH` on whichever node disagrees with the persisted chain.
+
+Unlike the pre-#400 upgrade above, **no data wipe is required**:
+
+- No persisted key layout or value encoding changed, so `storage-schema-version` is unaffected and existing entries stay verifiable byte-for-byte.
+- The exposure is confined to entries written *inside* the mixed-binary window, and only to this one failure class. A coverage miss is itself an admission-contract violation that should never fire (invariant #7), so in a healthy cluster the window is empty.
+
+The hazard generalises: **any** change to an FSM-emitted error's reason, message or metadata is observable in the hash chain, and should carry an upgrade note like this one. Making it structurally safe would require a failure-projection semantics version carried alongside `HashVersion`, so old entries keep reproducing their original bytes — a deliberate design change that EN-1379 does not take on. See [coverage-gate.md](../technical/architecture/subsystems/fsm/coverage-gate.md#upgrade-note-the-reason-is-hash-bound) for the mechanism in detail.
+
 ### Audit hash keying — threat model
 
 The audit hash chain (`processing.HashGenerator`) is keyed by a value derived from the immutable `cluster-id`. This is **defense in depth against offline grinding from outside the cluster boundary**, not a tamper-evidence guarantee against an attacker with persisted-store access.

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -660,20 +660,24 @@ Trying to keep existing Pebble data and upgrade in-place is **unsafe**:
 
 Mixed-binary rolling upgrades are **not supported** across this change. Stop all nodes before deploying the new binary.
 
-### Upgrading across EN-1379 (coverage-miss reclassification)
+### Upgrading across an FSM error-identity change
 
-EN-1379 changes how the FSM labels one failure class. A preload coverage miss used to be flattened into `ERROR_REASON_STORAGE_OPERATION_FAILED`; it now surfaces under its own `ERROR_REASON_COVERAGE_MISS` with the identifying context (`attribute`, `canonicalHex`, `idHex`, `raftIndex`) intact.
+`buildAuditFailurePayload` folds a failure's reason, its message and every sorted context key *and value* into the audit hash pre-image. So **any** change to how the FSM identifies an error — its reason, its message text, or its metadata keys and values — makes an old binary and a new binary compute different `AuditEntry.Hash` values for one and the same Raft entry. `HashVersion` identifies the hash *algorithm* only and carries no notion of failure-projection semantics, so nothing lets a node recognise an entry written under an older classification.
 
-That relabelling is **not hash-neutral**. `buildAuditFailurePayload` folds the failure reason, its message and every sorted context key *and value* into the audit hash pre-image, so for one and the same Raft entry an old binary and a new binary compute different `AuditEntry.Hash` values. `HashVersion` identifies the hash *algorithm* only and carries no notion of failure-projection semantics, so nothing lets a node recognise an entry written under the old classification.
+This is a standing rule rather than a per-change note. Whenever a release changes an FSM-emitted error's identity:
 
-Mixed-binary rolling upgrades are **not supported** across this change. Restart every node onto the new binary; a coverage miss applied while the cluster straddles the two builds diverges the audit chain at that index, and `ledgerctl check` then reports `HASH_MISMATCH` on whichever node disagrees with the persisted chain.
+- **Mixed-binary rolling upgrades are not supported across that change.** Restart every node onto the new binary. Note that the Kubernetes operator performs a *rolling* update by default (a pod-template spec-hash annotation drives it), so this constraint has to be applied deliberately — it is not the default behaviour. A failure of the affected class applied while the cluster straddles two builds diverges the audit chain at that index, and `ledgerctl check` then reports `HASH_MISMATCH` on whichever node disagrees with the persisted chain.
+- **No data wipe is required**, unlike the pre-#400 upgrade above. No persisted key layout or value encoding changes, `storage-schema-version` is unaffected, and existing entries stay verifiable byte-for-byte. The exposure is confined to entries written *inside* the mixed-binary window, and only to the affected failure class.
 
-Unlike the pre-#400 upgrade above, **no data wipe is required**:
+Changes in this release line that fall under the rule:
 
-- No persisted key layout or value encoding changed, so `storage-schema-version` is unaffected and existing entries stay verifiable byte-for-byte.
-- The exposure is confined to entries written *inside* the mixed-binary window, and only to this one failure class. A coverage miss is itself an admission-contract violation that should never fire (invariant #7), so in a healthy cluster the window is empty.
+| Change | What shifts in the hash pre-image | Exposure |
+|--------|-----------------------------------|----------|
+| EN-1558 (`e43016439`) | `marshalOrdersForAudit` hashes business-intent bytes instead of the whole order | every order |
+| EN-1536 (`8b24ee535`) | `buildAuditFailure` resolves the outermost `Describable` instead of `errors.As`-unwrapping, and takes `Message` from `d.Error()` — reason, message and context can all shift for a wrapped failure | any wrapped FSM failure |
+| EN-1379 | a preload coverage miss stops being flattened into `ERROR_REASON_STORAGE_OPERATION_FAILED` and surfaces as `ERROR_REASON_COVERAGE_MISS`, with `attribute`, `canonicalHex`, `idHex`, `raftIndex` intact | coverage misses only — themselves admission-contract violations that must never fire (invariant #7), so in a healthy cluster the window is empty |
 
-The hazard generalises: **any** change to an FSM-emitted error's reason, message or metadata is observable in the hash chain, and should carry an upgrade note like this one. Making it structurally safe would require a failure-projection semantics version carried alongside `HashVersion`, so old entries keep reproducing their original bytes — a deliberate design change that EN-1379 does not take on. See [coverage-gate.md](../technical/architecture/subsystems/fsm/coverage-gate.md#upgrade-note-the-reason-is-hash-bound) for the mechanism in detail.
+Making this structurally safe would require a failure-projection semantics version carried alongside `HashVersion`, so old entries keep reproducing their original bytes. That is a deliberate design change, tracked as EN-1661; until it lands, the rule above is the mitigation. See [coverage-gate.md](../technical/architecture/subsystems/fsm/coverage-gate.md#upgrade-note-the-reason-is-hash-bound) for the mechanism in detail.
 
 ### Audit hash keying — threat model
 

--- a/docs/technical/architecture/subsystems/fsm/coverage-gate.md
+++ b/docs/technical/architecture/subsystems/fsm/coverage-gate.md
@@ -83,11 +83,28 @@ A coverage miss is an admission bug, not an infrastructure fault, and it is labe
 |---------|-------|
 | Hash-chained `AuditFailure.Reason` | `ERROR_REASON_COVERAGE_MISS` |
 | `AuditFailure.Context` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
-| Frozen idempotency outcome | the same reason and metadata |
+| Frozen idempotency outcome | **not applicable** — `KindInternal` failures are deliberately never frozen (`IsFreezableFailure`, `internal/domain/errors.go:152-158`), so a coverage miss leaves no idempotency record and the request stays retryable |
 | gRPC / HTTP `ErrorInfo.reason` | `COVERAGE_MISS` (status `INTERNAL` — both reasons are `KindInternal`) |
 | Node-local log + OTel counter | `scope.go:374-378` (see [Metrics](#metrics)) |
 
 The `Metadata()` keys are camelCase, matching every other `Describable` and the repo-wide wire convention. The structured log emitted alongside keeps snake_case field names — that is a log, not a wire payload.
+
+The idempotency row is worth stating explicitly because the non-freezing is a design point, not an oversight: `recordIdempotencyFailure` returns early (`machine.go:1729`) for any non-freezable kind, and `KindForReason` classifies `ERROR_REASON_COVERAGE_MISS` as `KindInternal` (`internal/domain/reason.go:124`). Freezing would pin a server bug against the caller's key for the whole TTL. This was equally true before EN-1379 — `ERROR_REASON_STORAGE_OPERATION_FAILED` sits in the same `KindInternal` arm — so the idempotency outcome is not one of the surfaces the fix repairs.
+
+### Upgrade note: the reason is hash-bound
+
+`buildAuditFailurePayload` (`internal/infra/state/audit_envelope.go:176-198`) folds the reason, the message and every sorted context key **and value** into the audit hash pre-image. Relabelling an FSM-emitted failure is therefore *not* hash-neutral: for one and the same Raft entry, a node on the old build hashes `{STORAGE_OPERATION_FAILED, "storage operation failed: loading ledger", {operation}}` while a node on the new build hashes `{COVERAGE_MISS, "preload coverage miss (…)", {attribute, canonicalHex, idHex, raftIndex}}`.
+
+During a rolling upgrade both builds apply the same replicated log, so a coverage miss landing inside the mixed-version window writes **different hashes for the same index** — invariant #2 across the version boundary, after which `checker.verifyAuditHashChain` fails on whichever node disagrees with the persisted chain. Nothing absorbs this: `HashVersion` comes from `HashGenerator.Algorithm()` (`machine.go:1427`) and identifies the hash *algorithm* only, carrying no notion of failure-projection semantics, so a node cannot recognise "this entry was produced under the old classification".
+
+Consequences to hold in mind:
+
+- Coverage misses are correctly and consistently classified only once **every** node runs the new build. A miss inside the window can diverge the chain.
+- The window is narrow in practice: the trigger is itself an admission bug that should never fire. This is a low-probability path, not a routine one.
+- Only the read sites EN-1379 **converted** are affected. The numscript re-resolution path already returned the bare miss, so its reason and context are unchanged; only its message shifts, and only because `Error()` was aligned to the camelCase `raftIndex` spelling.
+- **This hazard is general.** It attaches to any change to an FSM-emitted error's reason, message or metadata — not to EN-1379 specifically. Treat "relabelling an FSM error is observable in the hash chain" as the standing rule when reviewing such a change.
+
+Making this structurally safe would mean carrying a failure-projection semantics version alongside `HashVersion` so old entries keep reproducing their original bytes. That is a deliberate design decision, not something EN-1379 took on.
 
 This holds because FSM read sites build their failure through `domain.StoreFailure(operation, err)` instead of constructing a `domain.ErrStorageOperation` directly:
 
@@ -109,9 +126,9 @@ failure.Reason = domain.ReasonCode(d.Reason())
 maps.Copy(failure.GetContext(), d.Metadata())
 ```
 
-So wrapping a `*ErrCoverageMiss` would permanently record an admission bug as `STORAGE_OPERATION_FAILED`, with the context stripped to `{operation: "..."}` — in a chain that is immutable by construction. The same outermost-only read happens in `recordIdempotencyFailure` (`machine.go:1746-1748`), which freezes the outcome for the idempotency TTL, and in `businessErrorToGRPCStatus` (`internal/adapter/grpc/errors.go:86`).
+So wrapping a `*ErrCoverageMiss` would permanently record an admission bug as `STORAGE_OPERATION_FAILED`, with the context stripped to `{operation: "..."}` — in a chain that is immutable by construction. `businessErrorToGRPCStatus` (`internal/adapter/grpc/errors.go:86`) performs the same outermost-only read, so the client sees the relabelled reason too. (`recordIdempotencyFailure` reads the outermost `Describable` the same way, but never reaches a coverage miss at all — see the idempotency row above.)
 
-`CoverageContractViolation` matches on the stable domain `Reason()` string rather than the concrete type, because `internal/domain/processing` cannot import `internal/infra/state` — `state` imports `processing`, so a type-based `errors.As` would be an import cycle. It recognises both `COVERAGE_MISS` and `INVALID_EXECUTION_PLAN`, walking the `Unwrap` chain so a violation nested behind a numscript `QueryBalanceError` is still found. (It follows single-error `Unwrap` only; an `errors.Join` hides its members.)
+`CoverageContractViolation` matches on the stable domain `Reason()` string rather than the concrete type, because `internal/domain/processing` cannot import `internal/infra/state` — `state` imports `processing`, so a type-based `errors.As` would be an import cycle. It recognises both `COVERAGE_MISS` and `INVALID_EXECUTION_PLAN`, walking the `Unwrap` chain so a violation nested behind a numscript `QueryBalanceError` is still found. It also descends into multi-error nodes (`errors.Join`, or `fmt.Errorf` with several `%w`), which `errors.Unwrap` cannot follow, visiting members in slice order so the result stays deterministic as the apply path requires. The `forbidigo` rule below cannot see a future `Join` — it is a plain call, not a forbidden type reference — so handling it in the walk is what keeps the guard whole.
 
 A `forbidigo` rule in `.golangci.yaml` forbids bare `ErrStorageOperation` construction, so a new read site cannot silently reintroduce the flattening.
 

--- a/docs/technical/architecture/subsystems/fsm/coverage-gate.md
+++ b/docs/technical/architecture/subsystems/fsm/coverage-gate.md
@@ -75,6 +75,50 @@ The result is a value the apply path was never authorized to consult. Two failur
 
 Both are catastrophic for an FSM that is supposed to be a pure function of its declared inputs.
 
+## How a violation surfaces
+
+A coverage miss is an admission bug, not an infrastructure fault, and it is labelled that way on every surface it reaches:
+
+| Surface | Value |
+|---------|-------|
+| Hash-chained `AuditFailure.Reason` | `ERROR_REASON_COVERAGE_MISS` |
+| `AuditFailure.Context` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
+| Frozen idempotency outcome | the same reason and metadata |
+| gRPC / HTTP `ErrorInfo.reason` | `COVERAGE_MISS` (status `INTERNAL` — both reasons are `KindInternal`) |
+| Node-local log + OTel counter | `scope.go:374-378` (see [Metrics](#metrics)) |
+
+The `Metadata()` keys are camelCase, matching every other `Describable` and the repo-wide wire convention. The structured log emitted alongside keeps snake_case field names — that is a log, not a wire payload.
+
+This holds because FSM read sites build their failure through `domain.StoreFailure(operation, err)` instead of constructing a `domain.ErrStorageOperation` directly:
+
+```go
+// internal/domain/coverage.go
+func StoreFailure(operation string, err error) Describable {
+	if violation := CoverageContractViolation(err); violation != nil {
+		return violation // propagated verbatim — reason and metadata intact
+	}
+
+	return &ErrStorageOperation{Operation: operation, Cause: err}
+}
+```
+
+The distinction is load-bearing. `buildAuditFailure` (`internal/infra/state/audit.go:19-29`) reads `Reason()` and `Metadata()` off the **outermost** `Describable` and never unwraps:
+
+```go
+failure.Reason = domain.ReasonCode(d.Reason())
+maps.Copy(failure.GetContext(), d.Metadata())
+```
+
+So wrapping a `*ErrCoverageMiss` would permanently record an admission bug as `STORAGE_OPERATION_FAILED`, with the context stripped to `{operation: "..."}` — in a chain that is immutable by construction. The same outermost-only read happens in `recordIdempotencyFailure` (`machine.go:1746-1748`), which freezes the outcome for the idempotency TTL, and in `businessErrorToGRPCStatus` (`internal/adapter/grpc/errors.go:86`).
+
+`CoverageContractViolation` matches on the stable domain `Reason()` string rather than the concrete type, because `internal/domain/processing` cannot import `internal/infra/state` — `state` imports `processing`, so a type-based `errors.As` would be an import cycle. It recognises both `COVERAGE_MISS` and `INVALID_EXECUTION_PLAN`, walking the `Unwrap` chain so a violation nested behind a numscript `QueryBalanceError` is still found. (It follows single-error `Unwrap` only; an `errors.Join` hides its members.)
+
+A `forbidigo` rule in `.golangci.yaml` forbids bare `ErrStorageOperation` construction, so a new read site cannot silently reintroduce the flattening.
+
+Technical-update handlers take a different route to the same place: they return plain `fmt.Errorf("...: %w", err)` and `applyTechnicalUpdates` extracts the violation via `planInvariantDescribable` (`machine.go:1133`), which uses `errors.As` because the `state` package *can* name the concrete type. Both routes end at the same reason code.
+
+Note that a violation is not only produced by reads. `gatedAccessor.Delete` (`internal/infra/state/accessor.go:113-118`) also calls `CheckCoverage`, so a staged tombstone flushed by `orderOverlayScope.Commit()` surfaces a coverage miss too — which is why `ProcessOrders` routes that error through `StoreFailure` rather than dropping it (`internal/domain/processing/processor.go:341-350`).
+
 ## The cascade-on-delete edge case
 
 Some operations naturally want to scan: "delete every metadata row attached to this account", "purge every volume belonging to a deleted ledger", etc. These are the cases where a naive implementation reaches for `Registry.X.KeyStore().M` — and where the rule has historically been challenged.

--- a/docs/technical/architecture/subsystems/fsm/coverage-gate.md
+++ b/docs/technical/architecture/subsystems/fsm/coverage-gate.md
@@ -106,7 +106,7 @@ Consequences to hold in mind:
 
 Making this structurally safe would mean carrying a failure-projection semantics version alongside `HashVersion` so old entries keep reproducing their original bytes. That is a deliberate design decision, not something EN-1379 took on.
 
-The operational consequence is declared where operators look for supported upgrade paths: [deployment.md — Upgrading across EN-1379](../../../../ops/deployment.md#upgrading-across-en-1379-coverage-miss-reclassification) states that mixed-binary rolling upgrades are not supported across this change, and that no data wipe is required because no persisted layout changed.
+The operational consequence is declared where operators look for supported upgrade paths: [deployment.md — Upgrading across an FSM error-identity change](../../../../ops/deployment.md#upgrading-across-an-fsm-error-identity-change) states the standing rule — mixed-binary rolling upgrades are not supported across any such change, and no data wipe is required because no persisted layout changes — and lists EN-1379 alongside the earlier changes it covers.
 
 This holds because FSM read sites build their failure through `domain.StoreFailure(operation, err)` instead of constructing a `domain.ErrStorageOperation` directly:
 

--- a/docs/technical/architecture/subsystems/fsm/coverage-gate.md
+++ b/docs/technical/architecture/subsystems/fsm/coverage-gate.md
@@ -106,6 +106,8 @@ Consequences to hold in mind:
 
 Making this structurally safe would mean carrying a failure-projection semantics version alongside `HashVersion` so old entries keep reproducing their original bytes. That is a deliberate design decision, not something EN-1379 took on.
 
+The operational consequence is declared where operators look for supported upgrade paths: [deployment.md — Upgrading across EN-1379](../../../../ops/deployment.md#upgrading-across-en-1379-coverage-miss-reclassification) states that mixed-binary rolling upgrades are not supported across this change, and that no data wipe is required because no persisted layout changed.
+
 This holds because FSM read sites build their failure through `domain.StoreFailure(operation, err)` instead of constructing a `domain.ErrStorageOperation` directly:
 
 ```go

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -937,6 +937,7 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Invalid order type (protocol mismatch) | `INTERNAL` | `INVALID_ORDER_TYPE` | `typeName` |
 | Invalid apply type (protocol mismatch) | `INTERNAL` | `INVALID_APPLY_TYPE` | `typeName` |
 | Storage operation failed | `INTERNAL` | `STORAGE_OPERATION_FAILED` | `operation` |
+| Preload coverage miss (admission contract violation) | `INTERNAL` | `COVERAGE_MISS` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
 | Checkpoint ID required | `INVALID_ARGUMENT` | `CHECKPOINT_ID_REQUIRED` | *(none)* |
 
 ### REST/HTTP Error Mapping

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -1122,8 +1122,9 @@ func wrapSystemScoped(order *raftcmdpb.Order, ss *raftcmdpb.SystemScopedOrder) {
 // `Scope.GetVolume` returns `domain.ErrNotFound` and callers treat it
 // as a fresh zero balance (see `processing.readVolumeOrZero`). A
 // `*state.ErrCoverageMiss` (admission contract violation — need never
-// declared) stays distinct and propagates loud through
-// `ErrStorageOperation{Cause: covErr}`.
+// declared) stays distinct and propagates verbatim through
+// `domain.StoreFailure`, so the audit chain records `COVERAGE_MISS`
+// rather than a storage fault (EN-1379).
 func addVolumeNeed(p *plan.Coverage, ledgerName, account, asset, color string) {
 	p.Add(dal.SubAttrVolume, domain.VolumeKey{
 		AccountKey: domain.AccountKey{LedgerName: ledgerName, Account: account},

--- a/internal/domain/coverage.go
+++ b/internal/domain/coverage.go
@@ -8,8 +8,11 @@ import "errors"
 //
 // Both mean the FSM apply path read a key the proposer never declared, or was
 // handed a plan that cannot be applied: "should not happen" bugs (invariant #7)
-// that must reach the audit chain, the frozen idempotency outcome and the client
-// under their own reason, never relabelled as a storage fault.
+// that must reach the audit chain and the client under their own reason, never
+// relabelled as a storage fault. They never reach a frozen idempotency outcome:
+// KindForReason maps both reasons to KindInternal, which IsFreezableFailure
+// excludes, so recordIdempotencyFailure returns early — see
+// docs/technical/architecture/subsystems/fsm/coverage-gate.md.
 //
 // It matches on the stable domain Reason string rather than the concrete type so
 // callers need not import internal/infra/state, which owns *ErrCoverageMiss and

--- a/internal/domain/coverage.go
+++ b/internal/domain/coverage.go
@@ -18,18 +18,33 @@ import "errors"
 // wrappers — ErrStorageOperation, or the numscript library's QueryBalanceError /
 // QueryMetadataError — implement Unwrap.
 //
-// Limitation: the walk follows single-error Unwrap only. An error joined with
-// errors.Join hides its members from this check.
+// The walk also descends into multi-error nodes (errors.Join, or fmt.Errorf with
+// several %w verbs), which errors.Unwrap cannot follow. Members are visited in
+// slice order, so the Describable returned for a given tree is deterministic —
+// a requirement on the FSM apply path (invariant #2). Without this the forbidigo
+// rule guarding StoreFailure would not help: a future Join is a plain call the
+// linter cannot see, and it would silently relabel the violation as a storage
+// fault in the immutable audit chain.
 func CoverageContractViolation(err error) Describable {
 	for e := err; e != nil; e = errors.Unwrap(e) {
-		describable, ok := e.(Describable) //nolint:errorlint // deliberate per-node check; the loop unwraps the chain itself
+		if describable, ok := e.(Describable); ok { //nolint:errorlint // deliberate per-node check; the loop walks the chain itself
+			switch describable.Reason() {
+			case ErrReasonCoverageMiss, ErrReasonInvalidExecutionPlan:
+				return describable
+			}
+		}
+
+		// A multi-error node reports no single cause, so errors.Unwrap returns
+		// nil and this iteration is the last: recurse before the loop ends.
+		joined, ok := e.(interface{ Unwrap() []error })
 		if !ok {
 			continue
 		}
 
-		switch describable.Reason() {
-		case ErrReasonCoverageMiss, ErrReasonInvalidExecutionPlan:
-			return describable
+		for _, member := range joined.Unwrap() {
+			if violation := CoverageContractViolation(member); violation != nil {
+				return violation
+			}
 		}
 	}
 

--- a/internal/domain/coverage.go
+++ b/internal/domain/coverage.go
@@ -1,0 +1,57 @@
+package domain
+
+import "errors"
+
+// CoverageContractViolation returns the admission-contract violation carried by
+// err — a coverage miss (ErrReasonCoverageMiss) or a structurally inconsistent
+// execution plan (ErrReasonInvalidExecutionPlan) — or nil when err is neither.
+//
+// Both mean the FSM apply path read a key the proposer never declared, or was
+// handed a plan that cannot be applied: "should not happen" bugs (invariant #7)
+// that must reach the audit chain, the frozen idempotency outcome and the client
+// under their own reason, never relabelled as a storage fault.
+//
+// It matches on the stable domain Reason string rather than the concrete type so
+// callers need not import internal/infra/state, which owns *ErrCoverageMiss and
+// itself imports internal/domain/processing (an import cycle in the other
+// direction). Every Describable in the chain is inspected because intermediate
+// wrappers — ErrStorageOperation, or the numscript library's QueryBalanceError /
+// QueryMetadataError — implement Unwrap.
+//
+// Limitation: the walk follows single-error Unwrap only. An error joined with
+// errors.Join hides its members from this check.
+func CoverageContractViolation(err error) Describable {
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		describable, ok := e.(Describable) //nolint:errorlint // deliberate per-node check; the loop unwraps the chain itself
+		if !ok {
+			continue
+		}
+
+		switch describable.Reason() {
+		case ErrReasonCoverageMiss, ErrReasonInvalidExecutionPlan:
+			return describable
+		}
+	}
+
+	return nil
+}
+
+// StoreFailure returns the Describable for a failed store operation.
+//
+// An admission-contract violation is propagated verbatim so its reason and
+// metadata survive to the audit chain; anything else is wrapped as
+// ErrStorageOperation under the given operation label. Every FSM read site must
+// build its failure through this function rather than constructing an
+// ErrStorageOperation directly — a bare construction swallows the coverage
+// reason, which is enforced by a forbidigo rule in .golangci.yaml.
+//
+// operation is the short identifier ErrStorageOperation surfaces ("loading
+// ledger", "checking transaction reference"). err is expected to be non-nil;
+// calling with nil yields an ErrStorageOperation with a nil cause.
+func StoreFailure(operation string, err error) Describable {
+	if violation := CoverageContractViolation(err); violation != nil {
+		return violation
+	}
+
+	return &ErrStorageOperation{Operation: operation, Cause: err}
+}

--- a/internal/domain/coverage_test.go
+++ b/internal/domain/coverage_test.go
@@ -34,6 +34,18 @@ func TestCoverageContractViolation(t *testing.T) {
 		{name: "nil", err: nil, want: nil},
 		{name: "plain error", err: errors.New("disk on fire"), want: nil},
 		{name: "unrelated describable", err: other, want: nil},
+		{
+			// A genuine stale-inputs error is retryable, not an admission bug —
+			// the numscript re-resolution triage depends on the two staying apart.
+			name: "stale inputs resolution sentinel",
+			err:  ErrStaleInputsResolution,
+			want: nil,
+		},
+		{
+			name: "invalid execution plan sentinel type",
+			err:  &ErrInvalidExecutionPlan{Reason_: "undeclared key"},
+			want: &ErrInvalidExecutionPlan{Reason_: "undeclared key"},
+		},
 		{name: "bare coverage miss", err: miss, want: miss},
 		{name: "bare invalid plan", err: plan, want: plan},
 		{

--- a/internal/domain/coverage_test.go
+++ b/internal/domain/coverage_test.go
@@ -63,6 +63,50 @@ func TestCoverageContractViolation(t *testing.T) {
 			err:  &ErrStorageOperation{Operation: "loading ledger", Cause: errors.New("pebble: closed")},
 			want: nil,
 		},
+		// The multi-error cases below are the branch the forbidigo rule cannot
+		// guard: a future errors.Join is a plain call the linter cannot see, so
+		// only these rows stand between a regressed descent and a contract
+		// violation silently relabelled as a storage fault in the audit chain.
+		{
+			name: "coverage miss joined with an unrelated error",
+			err:  errors.Join(errors.New("pebble: closed"), miss),
+			want: miss,
+		},
+		{
+			name: "coverage miss joined behind a wrap",
+			err:  fmt.Errorf("commit: %w", errors.Join(miss, errors.New("flush failed"))),
+			want: miss,
+		},
+		{
+			name: "multi-%w wrap carrying a coverage miss",
+			err:  fmt.Errorf("%w: %w", errors.New("outer"), miss),
+			want: miss,
+		},
+		{
+			name: "join with no violation",
+			err:  errors.Join(errors.New("pebble: closed"), other),
+			want: nil,
+		},
+		{
+			name: "violation nested in a joined subtree",
+			err:  errors.Join(errors.New("pebble: closed"), fmt.Errorf("wrap: %w", errors.Join(errors.New("flush failed"), plan))),
+			want: plan,
+		},
+		// This pair pins the slice-order visit CoverageContractViolation
+		// documents: the same member set in the opposite order must yield the
+		// other violation. A map-based or otherwise unordered traversal would
+		// satisfy every row above but not both of these, and a non-deterministic
+		// pick on the FSM apply path breaks invariant #2.
+		{
+			name: "two violations joined, first in slice order wins",
+			err:  errors.Join(miss, plan),
+			want: miss,
+		},
+		{
+			name: "two violations joined, reversed slice order",
+			err:  errors.Join(plan, miss),
+			want: plan,
+		},
 	}
 
 	for _, tt := range tests {
@@ -94,6 +138,16 @@ func TestStoreFailure(t *testing.T) {
 		miss := &stubDescribable{reason: ErrReasonCoverageMiss, msg: "coverage miss"}
 
 		got := StoreFailure("loading ledger", fmt.Errorf("numscript: %w", miss))
+
+		require.Same(t, miss, got)
+	})
+
+	t.Run("propagates a joined coverage miss verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		miss := &stubDescribable{reason: ErrReasonCoverageMiss, msg: "coverage miss"}
+
+		got := StoreFailure("loading ledger", errors.Join(errors.New("pebble: closed"), miss))
 
 		require.Same(t, miss, got)
 	})

--- a/internal/domain/coverage_test.go
+++ b/internal/domain/coverage_test.go
@@ -1,0 +1,100 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubDescribable is a minimal Describable used to build error chains without
+// importing internal/infra/state (which imports this package's dependents).
+type stubDescribable struct {
+	reason string
+	msg    string
+}
+
+func (s *stubDescribable) Error() string               { return s.msg }
+func (s *stubDescribable) Reason() string              { return s.reason }
+func (s *stubDescribable) Metadata() map[string]string { return map[string]string{"stub": s.reason} }
+
+func TestCoverageContractViolation(t *testing.T) {
+	t.Parallel()
+
+	miss := &stubDescribable{reason: ErrReasonCoverageMiss, msg: "coverage miss"}
+	plan := &stubDescribable{reason: ErrReasonInvalidExecutionPlan, msg: "bad plan"}
+	other := &stubDescribable{reason: ErrReasonNumscriptRuntime, msg: "boom"}
+
+	tests := []struct {
+		name string
+		err  error
+		want Describable
+	}{
+		{name: "nil", err: nil, want: nil},
+		{name: "plain error", err: errors.New("disk on fire"), want: nil},
+		{name: "unrelated describable", err: other, want: nil},
+		{name: "bare coverage miss", err: miss, want: miss},
+		{name: "bare invalid plan", err: plan, want: plan},
+		{
+			name: "coverage miss wrapped once",
+			err:  &ErrStorageOperation{Operation: "loading ledger", Cause: miss},
+			want: miss,
+		},
+		{
+			name: "coverage miss wrapped twice",
+			err:  fmt.Errorf("outer: %w", &ErrStorageOperation{Operation: "loading ledger", Cause: miss}),
+			want: miss,
+		},
+		{
+			name: "genuine store fault",
+			err:  &ErrStorageOperation{Operation: "loading ledger", Cause: errors.New("pebble: closed")},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, CoverageContractViolation(tt.err))
+		})
+	}
+}
+
+func TestStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("propagates a coverage miss verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		miss := &stubDescribable{reason: ErrReasonCoverageMiss, msg: "coverage miss"}
+
+		got := StoreFailure("loading ledger", miss)
+
+		require.Same(t, miss, got)
+		require.Equal(t, ErrReasonCoverageMiss, got.Reason())
+		require.Equal(t, map[string]string{"stub": ErrReasonCoverageMiss}, got.Metadata())
+	})
+
+	t.Run("propagates a wrapped coverage miss verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		miss := &stubDescribable{reason: ErrReasonCoverageMiss, msg: "coverage miss"}
+
+		got := StoreFailure("loading ledger", fmt.Errorf("numscript: %w", miss))
+
+		require.Same(t, miss, got)
+	})
+
+	t.Run("wraps a genuine store fault", func(t *testing.T) {
+		t.Parallel()
+
+		cause := errors.New("pebble: closed")
+
+		got := StoreFailure("loading ledger", cause)
+
+		require.Equal(t, ErrReasonStorageOperation, got.Reason())
+		require.Equal(t, map[string]string{"operation": "loading ledger"}, got.Metadata())
+		require.ErrorIs(t, got, cause)
+	})
+}

--- a/internal/domain/processing/coverage_propagation_test.go
+++ b/internal/domain/processing/coverage_propagation_test.go
@@ -1,0 +1,70 @@
+package processing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+)
+
+// TestLoadLedgerPropagatesCoverageMiss pins the EN-1379 contract on the highest
+// leverage read site of the apply path: a coverage miss is an admission-contract
+// violation and must reach the audit chain under COVERAGE_MISS, carrying the very
+// Describable the Scope produced.
+func TestLoadLedgerPropagatesCoverageMiss(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	miss := coverageMissDescribable{}
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "l-a"}, nil, miss)
+
+	info, err := loadLedger(mockStore, "l-a")
+	require.Nil(t, info)
+	require.NotNil(t, err)
+	require.Equal(t, domain.ErrReasonCoverageMiss, err.Reason(),
+		"a coverage miss must not be relabelled as a storage fault")
+	require.Equal(t, miss, err, "the violation must propagate verbatim, not re-wrapped")
+}
+
+// TestLoadLedgerWrapsGenuineStoreFault guards against over-correcting: anything
+// that is not an admission-contract violation still becomes ErrStorageOperation.
+func TestLoadLedgerWrapsGenuineStoreFault(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "l-a"}, nil, errors.New("pebble: db closed"))
+
+	info, err := loadLedger(mockStore, "l-a")
+	require.Nil(t, info)
+	require.NotNil(t, err)
+	require.Equal(t, domain.ErrReasonStorageOperation, err.Reason())
+}
+
+// TestLoadBoundariesPropagatesCoverageMiss mirrors
+// TestLoadLedgerPropagatesCoverageMiss for the LedgerBoundaries channel.
+func TestLoadBoundariesPropagatesCoverageMiss(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	miss := coverageMissDescribable{}
+	expectGetBoundaries(mockStore, domain.LedgerKey{Name: "l-a"}, nil, miss)
+
+	boundaries, err := loadBoundaries(mockStore, "l-a")
+	require.Nil(t, boundaries)
+	require.NotNil(t, err)
+	require.Equal(t, domain.ErrReasonCoverageMiss, err.Reason(),
+		"a coverage miss must not be relabelled as a storage fault")
+	require.Equal(t, miss, err, "the violation must propagate verbatim, not re-wrapped")
+}

--- a/internal/domain/processing/coverage_propagation_test.go
+++ b/internal/domain/processing/coverage_propagation_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // TestLoadLedgerPropagatesCoverageMiss pins the EN-1379 contract on the highest
@@ -66,5 +67,35 @@ func TestLoadBoundariesPropagatesCoverageMiss(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, domain.ErrReasonCoverageMiss, err.Reason(),
 		"a coverage miss must not be relabelled as a storage fault")
+	require.Equal(t, miss, err, "the violation must propagate verbatim, not re-wrapped")
+}
+
+// TestBuildPostCommitVolumesPropagatesCoverageMiss extends the EN-1379 contract
+// to the volume read path. EN-1440 already established that a non-NotFound read
+// here must reject the order rather than truncate the PCV payload; the reason
+// carried by that rejection must still be COVERAGE_MISS when the cause is an
+// admission-contract violation.
+func TestBuildPostCommitVolumesPropagatesCoverageMiss(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	miss := coverageMissDescribable{}
+	expectGetVolume(mockStore, domain.NewVolumeKey("l-a", "alice", "USD", ""), nil, miss)
+
+	postings := []*commonpb.Posting{{
+		Source:      "alice",
+		Destination: "bob",
+		Asset:       "USD",
+		Amount:      commonpb.NewUint256FromUint64(10),
+	}}
+
+	volumes, err := buildPostCommitVolumes(mockStore, "l-a", postings)
+	require.Nil(t, volumes)
+	require.NotNil(t, err)
+	require.Equal(t, domain.ErrReasonCoverageMiss, err.Reason(),
+		"a coverage miss on the post-commit volume read must not be relabelled as a storage fault (EN-1440)")
 	require.Equal(t, miss, err, "the violation must propagate verbatim, not re-wrapped")
 }

--- a/internal/domain/processing/processor.go
+++ b/internal/domain/processing/processor.go
@@ -342,9 +342,11 @@ func (p *RequestProcessor) ProcessOrders(orders []*raftcmdpb.Order, scopeFactory
 			if err := overlay.Commit(); err != nil {
 				// Coverage-miss surfaced by a staged Delete (invariant #6):
 				// the FSM apply path must not silently drop tombstones —
-				// wrap as ErrStorageOperation so the order fails loudly
-				// (mirrors buildPostCommitVolumes / applyPosting).
-				return nil, &domain.ErrStorageOperation{Operation: "committing order overlay", Cause: err}
+				// route through StoreFailure so a coverage miss reaches the
+				// audit chain under its own reason and anything else fails
+				// loudly as a storage fault (mirrors buildPostCommitVolumes
+				// / applyPosting).
+				return nil, domain.StoreFailure("committing order overlay", err)
 			}
 		}
 

--- a/internal/domain/processing/processor_apply.go
+++ b/internal/domain/processing/processor_apply.go
@@ -21,7 +21,7 @@ func processApply(ledger string, apply *raftcmdpb.LedgerApplyOrder, ctx *Context
 	// even though the ledger is just deleted.
 	ledgerInfoReader, infoErr := s.Ledgers().Get(domain.LedgerKey{Name: ledger})
 	if infoErr != nil && !errors.Is(infoErr, domain.ErrNotFound) {
-		return nil, &domain.ErrStorageOperation{Operation: "loading ledger", Cause: infoErr}
+		return nil, domain.StoreFailure("loading ledger", infoErr)
 	}
 
 	infoOk := infoErr == nil

--- a/internal/domain/processing/processor_events_sink.go
+++ b/internal/domain/processing/processor_events_sink.go
@@ -19,7 +19,7 @@ func processAddEventsSink(order *raftcmdpb.AddEventsSinkOrder, ctx *Context) (*c
 
 	existing, err := ctx.Scope.GetSinkConfig(cfg.GetName())
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "checking existing sink " + cfg.GetName(), Cause: err}
+		return nil, domain.StoreFailure("checking existing sink "+cfg.GetName(), err)
 	}
 
 	if existing != nil {
@@ -38,7 +38,7 @@ func processAddEventsSink(order *raftcmdpb.AddEventsSinkOrder, ctx *Context) (*c
 func processRemoveEventsSink(order *raftcmdpb.RemoveEventsSinkOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
 	existing, err := ctx.Scope.GetSinkConfig(order.GetName())
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "checking existing sink " + order.GetName(), Cause: err}
+		return nil, domain.StoreFailure("checking existing sink "+order.GetName(), err)
 	}
 
 	if existing == nil {

--- a/internal/domain/processing/processor_index.go
+++ b/internal/domain/processing/processor_index.go
@@ -33,7 +33,7 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 	// payload consistent.
 	existing, findErr := indexes.Find(ctx.Scope.Indexes(), ledger, id)
 	if findErr != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "looking up existing index", Cause: findErr}
+		return nil, domain.StoreFailure("looking up existing index", findErr)
 	}
 
 	if existing != nil && existing.GetBuildStatus() == commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_READY {
@@ -64,7 +64,7 @@ func processDropIndex(ledger string, order *raftcmdpb.DropIndexOrder, ctx *Conte
 	// Key off the command envelope, never the loaded projection's mutable
 	// name field (see processCreateIndex).
 	if err := indexes.Remove(ctx.Scope.Indexes(), ledger, id); err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "dropping index", Cause: err}
+		return nil, domain.StoreFailure("dropping index", err)
 	}
 
 	return &commonpb.LedgerLogPayload{

--- a/internal/domain/processing/processor_ledger.go
+++ b/internal/domain/processing/processor_ledger.go
@@ -129,7 +129,7 @@ func processDeleteLedger(ledger string, ctx *Context) (*commonpb.LogPayload, dom
 	// ungated delete. Future GetBoundaries calls — in this proposal and,
 	// after Merge, in later ones — return domain.ErrNotFound as before.
 	if err := s.Boundaries().Delete(domain.LedgerKey{Name: ledger}); err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "deleting ledger boundary", Cause: err}
+		return nil, domain.StoreFailure("deleting ledger boundary", err)
 	}
 	// The LedgerCleanup signal (cleanup queue + deferred data purge) is
 	// derived from DeletedLedgerLog by deriveSignals / WriteSet.Absorb.

--- a/internal/domain/processing/processor_ledger.go
+++ b/internal/domain/processing/processor_ledger.go
@@ -15,7 +15,7 @@ func processCreateLedger(ledger string, order *raftcmdpb.CreateLedgerOrder, ctx 
 	s := ctx.Scope
 	existing, err := s.Ledgers().Get(domain.LedgerKey{Name: ledger})
 	if err != nil && !errors.Is(err, domain.ErrNotFound) {
-		return nil, &domain.ErrStorageOperation{Operation: "loading ledger", Cause: err}
+		return nil, domain.StoreFailure("loading ledger", err)
 	}
 
 	if err == nil {

--- a/internal/domain/processing/processor_ledger_metadata.go
+++ b/internal/domain/processing/processor_ledger_metadata.go
@@ -78,11 +78,11 @@ func processDeleteLedgerMetadata(ledger string, order *raftcmdpb.DeleteLedgerMet
 			}
 		}
 
-		return nil, &domain.ErrStorageOperation{Operation: "checking ledger metadata", Cause: err}
+		return nil, domain.StoreFailure("checking ledger metadata", err)
 	}
 
 	if err := s.LedgerMetadata().Delete(metaKey); err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "deleting ledger metadata", Cause: err}
+		return nil, domain.StoreFailure("deleting ledger metadata", err)
 	}
 
 	return &commonpb.LogPayload{

--- a/internal/domain/processing/processor_metadata.go
+++ b/internal/domain/processing/processor_metadata.go
@@ -77,7 +77,7 @@ func processAddMetadata(ledger string, order *raftcmdpb.SaveMetadataOrder, ctx *
 		}
 
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{Operation: "getting transaction state", Cause: err}
+			return nil, domain.StoreFailure("getting transaction state", err)
 		}
 
 		// Mutate() yields a fresh clone — handlers may freely modify the
@@ -139,11 +139,11 @@ func processDeleteMetadata(ledger string, order *raftcmdpb.DeleteMetadataOrder, 
 				}
 			}
 
-			return nil, &domain.ErrStorageOperation{Operation: "checking account metadata", Cause: err}
+			return nil, domain.StoreFailure("checking account metadata", err)
 		}
 
 		if err := s.AccountMetadata().Delete(metaKey); err != nil {
-			return nil, &domain.ErrStorageOperation{Operation: "deleting account metadata", Cause: err}
+			return nil, domain.StoreFailure("deleting account metadata", err)
 		}
 	case *commonpb.Target_TransactionId:
 		txID := target.TransactionId
@@ -159,7 +159,7 @@ func processDeleteMetadata(ledger string, order *raftcmdpb.DeleteMetadataOrder, 
 		}
 
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{Operation: "getting transaction state for delete", Cause: err}
+			return nil, domain.StoreFailure("getting transaction state for delete", err)
 		}
 
 		state := stateReader.Mutate()

--- a/internal/domain/processing/processor_metadata_schema.go
+++ b/internal/domain/processing/processor_metadata_schema.go
@@ -74,7 +74,7 @@ func processSetMetadataFieldType(ledger string, order *raftcmdpb.SetMetadataFiel
 	id := indexes.MetadataID(order.GetTargetType(), order.GetKey())
 	existing, findErr := indexes.Find(s.Indexes(), ledger, id)
 	if findErr != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "looking up index for schema change", Cause: findErr}
+		return nil, domain.StoreFailure("looking up index for schema change", findErr)
 	}
 
 	if existing != nil {
@@ -136,12 +136,12 @@ func processRemoveMetadataFieldType(ledger string, order *raftcmdpb.RemoveMetada
 	id := indexes.MetadataID(order.GetTargetType(), order.GetKey())
 	existing, findErr := indexes.Find(s.Indexes(), ledger, id)
 	if findErr != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "looking up index for schema removal", Cause: findErr}
+		return nil, domain.StoreFailure("looking up index for schema removal", findErr)
 	}
 
 	if existing != nil {
 		if err := indexes.Remove(s.Indexes(), ledger, id); err != nil {
-			return nil, &domain.ErrStorageOperation{Operation: "removing metadata field index", Cause: err}
+			return nil, domain.StoreFailure("removing metadata field index", err)
 		}
 		droppedIndex = id
 	}

--- a/internal/domain/processing/processor_mirror.go
+++ b/internal/domain/processing/processor_mirror.go
@@ -313,7 +313,7 @@ func processMirrorSavedMetadata(ledger string, sm *raftcmdpb.MirrorSavedMetadata
 
 				stateReader, err := s.TransactionStates().Get(txKey)
 				if err != nil && !errors.Is(err, domain.ErrNotFound) {
-					return nil, &domain.ErrStorageOperation{Operation: "reading transaction state", Cause: err}
+					return nil, domain.StoreFailure("reading transaction state", err)
 				}
 
 				if stateReader != nil {
@@ -356,14 +356,14 @@ func processMirrorDeletedMetadata(ledger string, dm *raftcmdpb.MirrorDeletedMeta
 				Key:        dm.GetKey(),
 			}
 			if err := s.AccountMetadata().Delete(metaKey); err != nil {
-				return nil, &domain.ErrStorageOperation{Operation: "deleting account metadata", Cause: err}
+				return nil, domain.StoreFailure("deleting account metadata", err)
 			}
 		case *commonpb.Target_TransactionId:
 			txKey := domain.TransactionKey{LedgerName: ledger, ID: target.TransactionId}
 
 			stateReader, err := s.TransactionStates().Get(txKey)
 			if err != nil && !errors.Is(err, domain.ErrNotFound) {
-				return nil, &domain.ErrStorageOperation{Operation: "reading transaction state", Cause: err}
+				return nil, domain.StoreFailure("reading transaction state", err)
 			}
 
 			if stateReader != nil && stateReader.GetMetadata() != nil {
@@ -423,7 +423,7 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 
 	origReader, err := s.TransactionStates().Get(origKey)
 	if err != nil && !errors.Is(err, domain.ErrNotFound) {
-		return nil, &domain.ErrStorageOperation{Operation: "reading original transaction state", Cause: err}
+		return nil, domain.StoreFailure("reading original transaction state", err)
 	}
 
 	if origReader != nil {

--- a/internal/domain/processing/processor_numscript_library.go
+++ b/internal/domain/processing/processor_numscript_library.go
@@ -40,7 +40,7 @@ func processSaveNumscript(ledger string, order *raftcmdpb.SaveNumscriptOrder, ct
 	// Immutable: a stored version can never be overwritten.
 	exists, existsErr := s.NumscriptVersionExists(ledger, order.GetName(), order.GetVersion())
 	if existsErr != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "checking numscript version existence", Cause: existsErr}
+		return nil, domain.StoreFailure("checking numscript version existence", existsErr)
 	}
 
 	if exists {
@@ -52,7 +52,7 @@ func processSaveNumscript(ledger string, order *raftcmdpb.SaveNumscriptOrder, ct
 	// are about to write.
 	current, curErr := s.GetNumscriptLatestVersion(ledger, order.GetName())
 	if curErr != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "getting numscript latest version", Cause: curErr}
+		return nil, domain.StoreFailure("getting numscript latest version", curErr)
 	}
 
 	info := &commonpb.NumscriptInfo{

--- a/internal/domain/processing/processor_posting.go
+++ b/internal/domain/processing/processor_posting.go
@@ -100,12 +100,12 @@ func applyPosting(s Scope, ledgerName string, posting *commonpb.Posting, skipBal
 	// GetOutput return the underlying *Uint256 directly, zero allocation.
 	//
 	// readVolumeOrZero treats a declared-but-absent key as a fresh zero
-	// balance (EN-1378); a coverage miss (admission contract violation)
-	// propagates unchanged through the ErrStorageOperation wrap,
-	// preserving the cause for downstream errors.As.
+	// balance (EN-1378); a coverage miss (admission contract violation) is
+	// returned verbatim by domain.StoreFailure — not wrapped at all — so its
+	// COVERAGE_MISS reason reaches the audit chain (EN-1379).
 	sourceReader, err := readVolumeOrZero(s, sourceKey)
 	if err != nil {
-		return &domain.ErrStorageOperation{Operation: "loading source volume", Cause: err}
+		return domain.StoreFailure("loading source volume", err)
 	}
 	if sourceReader == nil {
 		return &domain.ErrBalanceNotPreloaded{Account: posting.GetSource(), Asset: posting.GetAsset(), Color: color}
@@ -171,7 +171,7 @@ func applyPosting(s Scope, ledgerName string, posting *commonpb.Posting, skipBal
 
 	destReader, err := readVolumeOrZero(s, destKey)
 	if err != nil {
-		return &domain.ErrStorageOperation{Operation: "loading destination volume", Cause: err}
+		return domain.StoreFailure("loading destination volume", err)
 	}
 	if destReader == nil {
 		return &domain.ErrBalanceNotPreloaded{Account: posting.GetDestination(), Asset: posting.GetAsset(), Color: color}

--- a/internal/domain/processing/processor_prepared_query.go
+++ b/internal/domain/processing/processor_prepared_query.go
@@ -10,8 +10,10 @@ import (
 
 // lookupPreparedQuery centralises the (nil, ErrNotFound) vs (nil, otherErr)
 // discrimination on the Accessor contract: a tombstone / absent-key returns
-// (nil, nil) so callers see "doesn't exist"; any other error wraps into
-// ErrStorageOperation. Mirrors the loadLedger pattern.
+// (nil, nil) so callers see "doesn't exist"; an admission-contract violation
+// (notably *state.ErrCoverageMiss) propagates verbatim so the audit chain
+// records COVERAGE_MISS rather than a storage fault (EN-1379); any other
+// error wraps into ErrStorageOperation. Mirrors the loadLedger pattern.
 func lookupPreparedQuery(s Scope, ledger, name string) (commonpb.PreparedQueryReader, domain.Describable) {
 	pq, err := s.PreparedQueries().Get(domain.PreparedQueryKey{LedgerName: ledger, Name: name})
 	if errors.Is(err, domain.ErrNotFound) {
@@ -19,7 +21,7 @@ func lookupPreparedQuery(s Scope, ledger, name string) (commonpb.PreparedQueryRe
 	}
 
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "getting prepared query", Cause: err}
+		return nil, domain.StoreFailure("getting prepared query", err)
 	}
 
 	return pq, nil
@@ -176,7 +178,7 @@ func processDeletePreparedQuery(ledger string, order *raftcmdpb.DeletePreparedQu
 	}
 
 	if err := s.PreparedQueries().Delete(domain.PreparedQueryKey{LedgerName: ledger, Name: order.GetName()}); err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "deleting prepared query", Cause: err}
+		return nil, domain.StoreFailure("deleting prepared query", err)
 	}
 
 	return &commonpb.LogPayload{

--- a/internal/domain/processing/processor_revert_transaction.go
+++ b/internal/domain/processing/processor_revert_transaction.go
@@ -26,7 +26,7 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	// Check if the transaction is already reverted (bitset lookup, never errors)
 	reverted, err := s.GetReverted(txKey)
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "checking reverted status", Cause: err}
+		return nil, domain.StoreFailure("checking reverted status", err)
 	}
 
 	if reverted {
@@ -47,7 +47,7 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	}
 
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "getting original transaction state", Cause: err}
+		return nil, domain.StoreFailure("getting original transaction state", err)
 	}
 
 	origState := origStateReader.Mutate()

--- a/internal/domain/processing/processor_skippable.go
+++ b/internal/domain/processing/processor_skippable.go
@@ -146,7 +146,7 @@ func assignSkipLogIDAndDate(parent Scope, order *raftcmdpb.Order, payload *commo
 			return &domain.ErrInvalidExecutionPlan{Reason_: fmt.Sprintf("skip allocated for unknown ledger %q", ledger)}
 		}
 
-		return &domain.ErrStorageOperation{Operation: fmt.Sprintf("loading boundaries for skip log on ledger %q", ledger), Cause: err}
+		return domain.StoreFailure(fmt.Sprintf("loading boundaries for skip log on ledger %q", ledger), err)
 	}
 
 	boundaries := boundariesReader.Mutate()

--- a/internal/domain/processing/processor_transaction.go
+++ b/internal/domain/processing/processor_transaction.go
@@ -27,7 +27,7 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 
 		existingRef, err := s.TransactionReferences().Get(refKey)
 		if err != nil && !errors.Is(err, domain.ErrNotFound) {
-			return nil, &domain.ErrStorageOperation{Operation: "checking transaction reference", Cause: err}
+			return nil, domain.StoreFailure("checking transaction reference", err)
 		}
 
 		if existingRef != nil {
@@ -50,7 +50,7 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 		if version == "" || version == "latest" {
 			greatest, gErr := s.GetNumscriptLatestVersion(ledger, name)
 			if gErr != nil {
-				return nil, &domain.ErrStorageOperation{Operation: fmt.Sprintf("resolving latest numscript %q", name), Cause: gErr}
+				return nil, domain.StoreFailure(fmt.Sprintf("resolving latest numscript %q", name), gErr)
 			}
 
 			if greatest == "" {
@@ -70,10 +70,7 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 
 		info, err := s.ResolveNumscriptContent(ledger, name, version)
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{
-				Operation: fmt.Sprintf("resolving numscript %q v%s", name, version),
-				Cause:     err,
-			}
+			return nil, domain.StoreFailure(fmt.Sprintf("resolving numscript %q v%s", name, version), err)
 		}
 
 		if info == nil {

--- a/internal/domain/processing/processor_transaction_numscript.go
+++ b/internal/domain/processing/processor_transaction_numscript.go
@@ -78,8 +78,9 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 			// returns the Describable as-is). Softening this to retryable stale
 			// would hide the bug and spin the client in an infinite re-admit loop
 			// against the same missing declaration — surface it loudly (invariant
-			// #7). Matched by domain Reason so this file need not import
-			// internal/infra/state (which imports processing — import cycle).
+			// #7). Matched by domain Reason via domain.CoverageContractViolation
+			// so this file need not import internal/infra/state (which imports
+			// processing — import cycle).
 			//
 			// Accepted limitation (EN-1406): when the resolved dependency set is a
 			// function of mutable metadata (e.g. `account $src = meta(@cfg,"acct")`)
@@ -94,7 +95,7 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 			// missing declaration). Downgrading only ErrCoverageMiss to stale would
 			// close the value-shift case but risks masking the latter as an infinite
 			// retry loop, so that refinement is deferred to an explicit design call.
-			if isCoverageContractViolation(resolveErr) {
+			if domain.CoverageContractViolation(resolveErr) != nil {
 				return nil, resolveErr
 			}
 
@@ -315,34 +316,6 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 		TransactionMetadata: txMeta,
 		AccountsMetadata:    accountsMeta,
 	}, nil
-}
-
-// isCoverageContractViolation reports whether err is an admission-contract
-// violation surfaced by the coverage-gated Scope during apply-time re-resolution
-// — a *state.ErrCoverageMiss (a key admission never declared) or a
-// *domain.ErrInvalidExecutionPlan (a structurally inconsistent plan). Both are
-// "should not happen" bugs (invariant #7) that must surface loudly rather than
-// be softened to the retryable ErrStaleInputsResolution.
-//
-// It matches on the stable domain Reason string rather than the concrete type so
-// this package need not import internal/infra/state (state imports processing —
-// an import cycle). Every Describable in the chain is inspected because the
-// numscript library wraps the store error (QueryBalanceError / QueryMetadataError
-// both implement Unwrap), so errors.As can reach the underlying typed error.
-func isCoverageContractViolation(err error) bool {
-	for e := err; e != nil; e = errors.Unwrap(e) {
-		describable, ok := e.(domain.Describable) //nolint:errorlint // deliberate per-node check; the loop unwraps the chain itself
-		if !ok {
-			continue
-		}
-
-		switch describable.Reason() {
-		case domain.ErrReasonCoverageMiss, domain.ErrReasonInvalidExecutionPlan:
-			return true
-		}
-	}
-
-	return false
 }
 
 // scopeValueSource reads balances and metadata through the FSM apply Scope.

--- a/internal/domain/processing/processor_transaction_numscript.go
+++ b/internal/domain/processing/processor_transaction_numscript.go
@@ -95,8 +95,13 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 			// missing declaration). Downgrading only ErrCoverageMiss to stale would
 			// close the value-shift case but risks masking the latter as an infinite
 			// retry loop, so that refinement is deferred to an explicit design call.
-			if domain.CoverageContractViolation(resolveErr) != nil {
-				return nil, resolveErr
+			// Return the extracted violation rather than resolveErr: today
+			// convertNumscriptError has already flattened the chain to the bare
+			// Describable, so the two are the same value — but that flattening
+			// lives two packages away and nothing pins it here. Returning what
+			// the discriminator found keeps the reason intact regardless.
+			if violation := domain.CoverageContractViolation(resolveErr); violation != nil {
+				return nil, violation
 			}
 
 			// (3) Otherwise it is a genuine input-shift (a var origin now points

--- a/internal/domain/processing/processor_transaction_numscript.go
+++ b/internal/domain/processing/processor_transaction_numscript.go
@@ -168,10 +168,8 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 
 		sourceReader, err := readVolumeOrZero(s, sourceKey)
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{
-				Operation: fmt.Sprintf("source volume %s/%s color=%q", posting.Source, posting.Asset, posting.Color),
-				Cause:     err,
-			}
+			return nil, domain.StoreFailure(
+				fmt.Sprintf("source volume %s/%s color=%q", posting.Source, posting.Asset, posting.Color), err)
 		}
 		if sourceReader == nil || sourceReader.GetInput() == nil || sourceReader.GetOutput() == nil {
 			return nil, &domain.ErrVolumeNotMaterialized{
@@ -206,10 +204,8 @@ func (p *numscriptPostingProducer) produce(s Scope, ledgerName string, order *ra
 
 		destReader, err := readVolumeOrZero(s, destKey)
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{
-				Operation: fmt.Sprintf("destination volume %s/%s color=%q", posting.Destination, posting.Asset, posting.Color),
-				Cause:     err,
-			}
+			return nil, domain.StoreFailure(
+				fmt.Sprintf("destination volume %s/%s color=%q", posting.Destination, posting.Asset, posting.Color), err)
 		}
 		if destReader == nil || destReader.GetInput() == nil || destReader.GetOutput() == nil {
 			return nil, &domain.ErrVolumeNotMaterialized{

--- a/internal/domain/processing/processor_transaction_numscript_stale_test.go
+++ b/internal/domain/processing/processor_transaction_numscript_stale_test.go
@@ -1,8 +1,6 @@
 package processing
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -144,20 +142,9 @@ func TestProduce_InvalidExecutionPlanDuringResolutionIsLoudNotStale(t *testing.T
 	require.ErrorAs(t, err, &invalid, "the invalid-execution-plan violation must surface loudly")
 }
 
-// TestIsCoverageContractViolation is a focused unit test for the discriminator
-// the apply path uses, including the wrapped-in-chain case.
-func TestIsCoverageContractViolation(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, isCoverageContractViolation(coverageMissDescribable{}))
-	require.True(t, isCoverageContractViolation(&domain.ErrInvalidExecutionPlan{Reason_: "x"}))
-	// A coverage violation nested behind an fmt-wrapped error is still found via
-	// the Unwrap chain.
-	require.True(t, isCoverageContractViolation(
-		fmt.Errorf("wrapped: %w", &domain.ErrInvalidExecutionPlan{Reason_: "x"})))
-
-	require.False(t, isCoverageContractViolation(nil))
-	require.False(t, isCoverageContractViolation(errors.New("some resolution error")))
-	require.False(t, isCoverageContractViolation(domain.ErrStaleInputsResolution),
-		"a genuine stale-inputs error is not a coverage violation")
-}
+// The focused unit test for the discriminator itself now lives with the
+// discriminator: TestCoverageContractViolation in internal/domain/coverage_test.go
+// (EN-1379 promoted the private isCoverageContractViolation to the shared
+// domain.CoverageContractViolation). The tests above keep exercising this
+// package's use of it through produce(), which is the behaviour that matters
+// here.

--- a/internal/domain/processing/processor_volumes.go
+++ b/internal/domain/processing/processor_volumes.go
@@ -17,14 +17,15 @@ import (
 // the response is deterministic across reads.
 //
 // Reads go through readVolumeOrZero: a declared-but-absent key (domain.ErrNotFound)
-// is reported as a zero balance, while any other error — notably
-// *state.ErrCoverageMiss, an admission-contract violation (invariants #6/#9) that
-// is impossible by design under a correct preload — is propagated as an
-// ErrStorageOperation so the order is rejected loudly (invariant #7) rather than
-// returned to the client as a silently truncated volume map (EN-1440). Two
-// nodes must not emit divergent PCV payloads for the same applied index, so a
-// non-NotFound store error is always surfaced. This mirrors applyPosting, which
-// reads the same source+destination keys.
+// is reported as a zero balance, while an admission-contract violation — notably
+// *state.ErrCoverageMiss (invariants #6/#9), impossible by design under a correct
+// preload — propagates verbatim so the audit chain records COVERAGE_MISS rather
+// than a storage fault (EN-1379). Any other error is wrapped as ErrStorageOperation.
+// Either way the order is rejected loudly (invariant #7) rather than returned to
+// the client as a silently truncated volume map (EN-1440). Two nodes must not emit
+// divergent PCV payloads for the same applied index, so a non-NotFound store error
+// is always surfaced. This mirrors applyPosting, which reads the same
+// source+destination keys.
 func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Posting) (*commonpb.PostCommitVolumes, domain.Describable) {
 	type tuple struct {
 		account string
@@ -57,7 +58,7 @@ func buildPostCommitVolumes(s Scope, ledgerName string, postings []*commonpb.Pos
 	for _, t := range tuples {
 		vol, err := readVolumeOrZero(s, domain.NewVolumeKey(ledgerName, t.account, t.asset, t.color))
 		if err != nil {
-			return nil, &domain.ErrStorageOperation{Operation: "loading post-commit volume", Cause: err}
+			return nil, domain.StoreFailure("loading post-commit volume", err)
 		}
 
 		vol.GetInput().IntoUint256(&scratch)

--- a/internal/domain/processing/scope_helpers.go
+++ b/internal/domain/processing/scope_helpers.go
@@ -10,9 +10,10 @@ import (
 
 // loadLedger reads a ledger through the Scope and translates Scope-level
 // errors into business errors handlers can return directly. ErrNotFound
-// becomes ErrLedgerNotFound; any other error (notably *ErrCoverageMiss)
-// is wrapped in ErrStorageOperation so the FSM emits a failure audit
-// entry rather than misreporting the cause.
+// becomes ErrLedgerNotFound; an admission-contract violation (notably
+// *state.ErrCoverageMiss) propagates verbatim so the audit chain records
+// COVERAGE_MISS rather than a storage fault (EN-1379); any other error is
+// wrapped in ErrStorageOperation so the FSM emits a failure audit entry.
 //
 // Returns a Mutate()-clone so handlers can freely modify the result and
 // write it back through s.PutLedger without mutating the cached pointer
@@ -24,7 +25,7 @@ func loadLedger(s Scope, name string) (*commonpb.LedgerInfo, domain.Describable)
 	}
 
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "loading ledger", Cause: err}
+		return nil, domain.StoreFailure("loading ledger", err)
 	}
 
 	return info.Mutate(), nil
@@ -38,7 +39,7 @@ func loadBoundaries(s Scope, name string) (raftcmdpb.LedgerBoundariesReader, dom
 	}
 
 	if err != nil {
-		return nil, &domain.ErrStorageOperation{Operation: "loading boundaries", Cause: err}
+		return nil, domain.StoreFailure("loading boundaries", err)
 	}
 
 	return boundaries, nil

--- a/internal/infra/state/audit_test.go
+++ b/internal/infra/state/audit_test.go
@@ -376,6 +376,61 @@ func TestBuildAuditFailure(t *testing.T) {
 		require.Equal(t, domain.ErrReasonChapterNotClosed, domain.ReasonString(failure.GetReason()))
 		require.Equal(t, "3", failure.GetContext()["chapterId"])
 	})
+
+	// CoverageMiss pins the EN-1379 contract on the surface that matters most:
+	// the hash-chained AuditFailure. buildAuditFailure reads Reason()/Metadata()
+	// off the OUTERMOST Describable and never unwraps, so an admission-contract
+	// violation that reached here wrapped would be recorded permanently as
+	// STORAGE_OPERATION_FAILED with the identifying key stripped.
+	//
+	// The exact key SET is asserted, not just the values: buildAuditFailurePayload
+	// folds every sorted Context key AND value into the audit hash pre-image, so a
+	// renamed or added key changes bytes that are immutable once written. Asserting
+	// the keys only on Metadata() (scope_unit_test.go) leaves that free to drift —
+	// which is how the EN-1379 snake_case -> camelCase rename shipped green.
+	t.Run("CoverageMiss", func(t *testing.T) {
+		t.Parallel()
+
+		err := &ErrCoverageMiss{
+			Attribute:    "volumes",
+			CanonicalHex: "deadbeef",
+			IDHex:        "0102",
+			RaftIndex:    42,
+		}
+		failure := buildAuditFailure(err)
+
+		require.Equal(t, domain.ErrReasonCoverageMiss, domain.ReasonString(failure.GetReason()),
+			"an undeclared key is an admission bug, never a storage fault (EN-1379)")
+		require.Equal(t, err.Error(), failure.GetMessage())
+
+		require.Equal(t, map[string]string{
+			"attribute":    "volumes",
+			"canonicalHex": "deadbeef",
+			"idHex":        "0102",
+			"raftIndex":    "42",
+		}, failure.GetContext())
+	})
+
+	// CoverageMissWrappedStaysStorageFault is the negative control for the
+	// subtest above: buildAuditFailure genuinely does NOT unwrap, so the no-wrap
+	// contract has to be upheld by every FSM read site going through
+	// domain.StoreFailure. If someone reintroduces a bare wrap, this is the shape
+	// the audit chain would record forever.
+	t.Run("CoverageMissWrappedStaysStorageFault", func(t *testing.T) {
+		t.Parallel()
+
+		miss := &ErrCoverageMiss{Attribute: "volumes", IDHex: "0102", RaftIndex: 42}
+
+		failure := buildAuditFailure(&domain.ErrStorageOperation{Operation: "loading volume", Cause: miss})
+
+		require.Equal(t, domain.ErrReasonStorageOperation, domain.ReasonString(failure.GetReason()))
+		require.Equal(t, map[string]string{"operation": "loading volume"}, failure.GetContext(),
+			"the wrap strips the identifying key — this is what EN-1379 prevents")
+
+		// And the supported path avoids exactly that.
+		require.Equal(t, domain.ErrReasonCoverageMiss,
+			domain.ReasonString(buildAuditFailure(domain.StoreFailure("loading volume", miss)).GetReason()))
+	})
 }
 
 // TestExtractLedgers_WrapperCoversAllLedgerScopedPayloads guards the

--- a/internal/infra/state/scope.go
+++ b/internal/infra/state/scope.go
@@ -44,12 +44,18 @@ func (e *ErrCoverageMiss) Error() string {
 }
 
 func (*ErrCoverageMiss) Reason() string { return domain.ErrReasonCoverageMiss }
+
+// Metadata keys are camelCase, matching every other Describable and the
+// repo-wide wire convention: since EN-1379 this map is no longer swallowed by
+// an ErrStorageOperation wrap, so it reaches the gRPC/HTTP ErrorInfo and the
+// AuditFailure context verbatim. The structured log emitted by coverageMiss
+// keeps its own snake_case field names — that is a log, not a wire payload.
 func (e *ErrCoverageMiss) Metadata() map[string]string {
 	return map[string]string{
-		"attribute":     e.Attribute,
-		"canonical_hex": e.CanonicalHex,
-		"id_hex":        e.IDHex,
-		"raft_index":    strconv.FormatUint(e.RaftIndex, 10),
+		"attribute":    e.Attribute,
+		"canonicalHex": e.CanonicalHex,
+		"idHex":        e.IDHex,
+		"raftIndex":    strconv.FormatUint(e.RaftIndex, 10),
 	}
 }
 

--- a/internal/infra/state/scope.go
+++ b/internal/infra/state/scope.go
@@ -39,17 +39,36 @@ type ErrCoverageMiss struct {
 }
 
 func (e *ErrCoverageMiss) Error() string {
-	return fmt.Sprintf("preload coverage miss (kind=%s id=%s raft_index=%d)",
+	return fmt.Sprintf("preload coverage miss (kind=%s id=%s raftIndex=%d)",
 		e.Attribute, e.IDHex, e.RaftIndex)
 }
 
 func (*ErrCoverageMiss) Reason() string { return domain.ErrReasonCoverageMiss }
 
 // Metadata keys are camelCase, matching every other Describable and the
-// repo-wide wire convention: since EN-1379 this map is no longer swallowed by
-// an ErrStorageOperation wrap, so it reaches the gRPC/HTTP ErrorInfo and the
-// AuditFailure context verbatim. The structured log emitted by coverageMiss
-// keeps its own snake_case field names — that is a log, not a wire payload.
+// repo-wide wire convention (CLAUDE.md). This map was NOT unreachable before
+// EN-1379: two paths already surfaced the bare miss, so the EN-1379 rename from
+// snake_case is a deliberate breaking change, not an incidental cleanup —
+//
+//   - numscript re-resolution returns the bare miss (convertNumscriptError
+//     flattens the chain via errors.As), and a ProcessOrders failure feeds
+//     buildAuditFailure, which copies Metadata() into the hash-chained
+//     AuditFailure.Context. The snake_case keys were already in the audit.
+//   - planInvariantDescribable returns the bare miss to applyProposal, which
+//     surfaces it as a domain.BusinessError whose Metadata() delegates through
+//     to the gRPC/HTTP ErrorInfo.
+//
+// So operator tooling keyed on canonical_hex / id_hex / raft_index stops
+// matching at this deploy, and audit entries for this failure class carry
+// different key names either side of it. That cost is paid once, deliberately:
+// this was the last snake_case Describable in the repo, and leaving the only
+// outlier on the error that most needs to be greppable would just defer the
+// same seam. Error() above uses the same raftIndex spelling so a single audit
+// record does not carry both (kind= / id= are prose labels, not payload keys).
+// See docs/technical/architecture/subsystems/fsm/coverage-gate.md.
+//
+// The structured log emitted by coverageMiss keeps its own snake_case field
+// names — that is a log, not a wire payload.
 func (e *ErrCoverageMiss) Metadata() map[string]string {
 	return map[string]string{
 		"attribute":    e.Attribute,

--- a/internal/infra/state/scope_unit_test.go
+++ b/internal/infra/state/scope_unit_test.go
@@ -69,6 +69,10 @@ func TestErrCoverageMissSurvivesStoreFailure(t *testing.T) {
 		{name: "bare", err: miss},
 		{name: "wrapped once", err: fmt.Errorf("numscript: %w", miss)},
 		{name: "wrapped in a storage operation", err: &domain.ErrStorageOperation{Operation: "loading volume", Cause: miss}},
+		// A multi-error node reports no single cause, so errors.Unwrap stops
+		// there: the discriminator has to descend into the members explicitly.
+		{name: "joined with an unrelated error", err: errors.Join(errors.New("pebble: db closed"), miss)},
+		{name: "joined behind a wrap", err: fmt.Errorf("commit: %w", errors.Join(miss, errors.New("flush failed")))},
 	}
 
 	for _, tt := range tests {

--- a/internal/infra/state/scope_unit_test.go
+++ b/internal/infra/state/scope_unit_test.go
@@ -33,9 +33,9 @@ func TestErrCoverageMiss_Describable(t *testing.T) {
 
 	md := miss.Metadata()
 	require.Equal(t, "ledgers", md["attribute"])
-	require.Equal(t, "deadbeef", md["canonical_hex"])
-	require.Equal(t, "0102", md["id_hex"])
-	require.Equal(t, strconv.FormatUint(42, 10), md["raft_index"])
+	require.Equal(t, "deadbeef", md["canonicalHex"])
+	require.Equal(t, "0102", md["idHex"])
+	require.Equal(t, strconv.FormatUint(42, 10), md["raftIndex"])
 
 	require.Contains(t, miss.Error(), "ledgers")
 	require.Contains(t, miss.Error(), "0102")
@@ -82,9 +82,9 @@ func TestErrCoverageMissSurvivesStoreFailure(t *testing.T) {
 
 			md := got.Metadata()
 			require.Equal(t, "volumes", md["attribute"])
-			require.Equal(t, "deadbeef", md["canonical_hex"])
-			require.Equal(t, "0102", md["id_hex"])
-			require.Equal(t, "42", md["raft_index"])
+			require.Equal(t, "deadbeef", md["canonicalHex"])
+			require.Equal(t, "0102", md["idHex"])
+			require.Equal(t, "42", md["raftIndex"])
 		})
 	}
 }

--- a/internal/infra/state/scope_unit_test.go
+++ b/internal/infra/state/scope_unit_test.go
@@ -42,6 +42,67 @@ func TestErrCoverageMiss_Describable(t *testing.T) {
 	require.Contains(t, miss.Error(), "42")
 }
 
+// TestErrCoverageMissSurvivesStoreFailure pins the EN-1379 propagation
+// contract against the REAL *ErrCoverageMiss type. domain.StoreFailure matches
+// on the Reason string (internal/domain/processing cannot import this package
+// — import cycle), so this is the test that proves the string contract and the
+// concrete type actually agree.
+//
+// It matters because buildAuditFailure reads Reason()/Metadata() off the
+// OUTERMOST Describable and never unwraps: if StoreFailure wrapped the miss,
+// the hash-chained audit entry would permanently record
+// STORAGE_OPERATION_FAILED with the identifying key stripped.
+func TestErrCoverageMissSurvivesStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	miss := &ErrCoverageMiss{
+		Attribute:    "volumes",
+		CanonicalHex: "deadbeef",
+		IDHex:        "0102",
+		RaftIndex:    42,
+	}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "bare", err: miss},
+		{name: "wrapped once", err: fmt.Errorf("numscript: %w", miss)},
+		{name: "wrapped in a storage operation", err: &domain.ErrStorageOperation{Operation: "loading volume", Cause: miss}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := domain.StoreFailure("loading volume", tt.err)
+
+			require.Same(t, miss, got)
+			require.Equal(t, domain.ErrReasonCoverageMiss, got.Reason())
+
+			md := got.Metadata()
+			require.Equal(t, "volumes", md["attribute"])
+			require.Equal(t, "deadbeef", md["canonical_hex"])
+			require.Equal(t, "0102", md["id_hex"])
+			require.Equal(t, "42", md["raft_index"])
+		})
+	}
+}
+
+// TestGenuineStoreFaultStillWraps guards the other direction: a real IO failure
+// must keep the storage label, so the EN-1379 branch cannot silently
+// reclassify infrastructure faults as admission bugs.
+func TestGenuineStoreFaultStillWraps(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("pebble: db closed")
+
+	got := domain.StoreFailure("loading volume", cause)
+
+	require.Equal(t, domain.ErrReasonStorageOperation, got.Reason())
+	require.ErrorIs(t, got, cause)
+}
+
 // TestKindLabel exhaustively pins the (sub-attribute byte → label)
 // mapping the gatedScope counter + structured log rely on. A new
 // SubAttrXxx that forgets to land here would surface as

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1265,7 +1265,7 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 			// zero-balance assertion below would run on an unread base and
 			// mis-decide the proposal. Surface it loudly rather than
 			// silently treating the base as absent (invariant #7).
-			storageFaults = append(storageFaults, storageFault{key, &domain.ErrStorageOperation{Operation: "reading transient base volume", Cause: baseErr}})
+			storageFaults = append(storageFaults, storageFault{key, domain.StoreFailure("reading transient base volume", baseErr)})
 
 			continue
 		}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1223,7 +1223,7 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 			}
 
 			if err != nil {
-				storageFaults = append(storageFaults, storageFault{key, &domain.ErrStorageOperation{Operation: "loading ledger for transient volume validation", Cause: err}})
+				storageFaults = append(storageFaults, storageFault{key, domain.StoreFailure("loading ledger for transient volume validation", err)})
 
 				continue
 			}
@@ -1254,7 +1254,7 @@ func (b *WriteSet) ValidateTransientVolumes(scope processing.Scope) domain.Descr
 		// preserve the coverage invariant on this otherwise-engine-
 		// internal read.
 		if err := scope.CheckCoverage(dal.SubAttrVolume, key); err != nil {
-			storageFaults = append(storageFaults, storageFault{key, &domain.ErrStorageOperation{Operation: "coverage check on transient base volume", Cause: err}})
+			storageFaults = append(storageFaults, storageFault{key, domain.StoreFailure("coverage check on transient base volume", err)})
 
 			continue
 		}

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -961,3 +961,65 @@ func TestValidateTransientVolumesStorageFaultTakesPrecedence(t *testing.T) {
 			"iteration %d: an undeclared key is an admission bug, not a storage fault (EN-1379)", i)
 	}
 }
+
+// TestValidateTransientVolumesLedgerCoverageMissPropagates covers the OTHER
+// StoreFailure site in ValidateTransientVolumes: the ledger load, not the
+// per-volume CheckCoverage that
+// TestValidateTransientVolumesStorageFaultTakesPrecedence drives.
+//
+// Here the volume coverage IS declared but the ledger is not, so
+// scope.Ledgers().Get returns *ErrCoverageMiss. That is neither
+// domain.ErrNotFound (which is the legitimate "ledger absent, skip" branch) nor
+// an IO fault, so it must reach the audit chain as COVERAGE_MISS with the
+// identifying key rather than as a relabelled storage fault (EN-1379).
+func TestValidateTransientVolumesLedgerCoverageMissPropagates(t *testing.T) {
+	t.Parallel()
+
+	buf, machine, _ := newTestBuffer(t)
+
+	ledger := &commonpb.LedgerInfo{
+		Name: "l-a",
+		Id:   1,
+		AccountTypes: map[string]*commonpb.AccountType{
+			"staging": {
+				Name:        "staging",
+				Pattern:     "staging:{id}",
+				Persistence: commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT,
+			},
+		},
+	}
+	_, _, err := machine.Registry.Ledgers.KeyStore().Put(
+		(&domain.LedgerKey{Name: ledger.GetName()}).Bytes(),
+		ledger,
+	)
+	require.NoError(t, err)
+
+	offender := domain.NewVolumeKey("l-a", "staging:a", "USD", "")
+	buf.Derived.Volumes.Put(offender, &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(200),
+		Output: commonpb.NewUint256FromUint64(50),
+	})
+
+	// Declare ONLY the volume coverage. The ledger plan is deliberately absent,
+	// so the ledger read inside ValidateTransientVolumes misses the gate.
+	vid, _ := attributes.MakeKey(offender.Bytes())
+	scope, err := NewScopeFactory(
+		buf,
+		&raftcmdpb.ExecutionPlan{Attributes: []*raftcmdpb.AttributeCoverage{
+			declareTestPlan(vid, dal.SubAttrVolume),
+		}},
+		machine.logger,
+		machine.preloadMissCounter,
+		1,
+	).NewProposalScope()
+	require.NoError(t, err)
+
+	describ := buf.ValidateTransientVolumes(scope)
+	require.NotNil(t, describ)
+
+	miss, ok := describ.(*ErrCoverageMiss)
+	require.True(t, ok, "the ledger-load site must propagate the miss verbatim, got %T", describ)
+	require.Equal(t, domain.ErrReasonCoverageMiss, miss.Reason())
+	require.Equal(t, "ledgers", miss.Metadata()["attribute"],
+		"the identifying key must survive to the audit context")
+}

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -895,8 +895,11 @@ func TestValidateTransientVolumesListsAllOffendersSorted(t *testing.T) {
 // should-not-happen storage/coverage fault surfaces ahead of any business
 // offender: the check could not run correctly for that key, so the aggregated
 // ErrTransientAccountNonZero must not mask it. Here one transient volume has no
-// declared volume coverage (CheckCoverage fails => ErrStorageOperation) while
-// another is a plain non-zero business offender.
+// declared volume coverage (CheckCoverage fails => *ErrCoverageMiss) while
+// another is a plain non-zero business offender. Since EN-1379 that miss
+// propagates verbatim through domain.StoreFailure instead of being relabelled
+// as an ErrStorageOperation, so the audit chain records COVERAGE_MISS with the
+// identifying key.
 func TestValidateTransientVolumesStorageFaultTakesPrecedence(t *testing.T) {
 	t.Parallel()
 
@@ -952,7 +955,9 @@ func TestValidateTransientVolumesStorageFaultTakesPrecedence(t *testing.T) {
 		describ := buf.ValidateTransientVolumes(scope)
 		require.NotNil(t, describ, "iteration %d: expected a fault", i)
 
-		_, ok := describ.(*domain.ErrStorageOperation)
-		require.True(t, ok, "iteration %d: storage fault must win over business offender, got %T", i, describ)
+		_, ok := describ.(*ErrCoverageMiss)
+		require.True(t, ok, "iteration %d: coverage fault must win over business offender, got %T", i, describ)
+		require.Equal(t, domain.ErrReasonCoverageMiss, describ.Reason(),
+			"iteration %d: an undeclared key is an admission bug, not a storage fault (EN-1379)", i)
 	}
 }


### PR DESCRIPTION
## Summary

An FSM coverage-gate violation (`*state.ErrCoverageMiss` — an admission bug, reason `COVERAGE_MISS`) was wrapped in `domain.ErrStorageOperation` at every read site. `buildAuditFailure` (`internal/infra/state/audit.go:25-26`) reads `Reason()`/`Metadata()` off the **outermost** `Describable` and never unwraps, so the admission bug was permanently recorded in the **hash-chained, immutable** audit as `STORAGE_OPERATION_FAILED`, with the context stripped to `{operation: "..."}` — losing the very fields that identify *which* declaration was missing. `businessErrorToGRPCStatus` (`grpc/errors.go:86`) performs the same outermost-only read, so the client saw the relabelled reason too.

This adds two functions to `internal/domain`, routes all 39 `ErrStorageOperation` construction sites through the second, and locks the convention in with a `forbidigo` rule:

```go
func CoverageContractViolation(err error) Describable       // innermost COVERAGE_MISS / INVALID_EXECUTION_PLAN, else nil
func StoreFailure(operation string, err error) Describable  // propagates a violation verbatim, wraps everything else
```

The reason is now `COVERAGE_MISS` on both affected surfaces with the identifying metadata intact. The gRPC status code is unchanged — both reasons map to `KindInternal`. (See the upgrade note below: the status code is unchanged, but the audit **hash** is not.)

Pass-through rather than a new sentinel, per the 2026-07-17 planning note. No proto change, no `KindForReason` change, no new import edge (`internal/domain` is already imported by both `state` and `processing`).

## Not a surface: the frozen idempotency outcome

An earlier revision of this description claimed the wrap also froze the wrong reason into the idempotency outcome. That was wrong, in both directions — **a coverage miss is never frozen at all**:

- `recordIdempotencyFailure` returns early at `machine.go:1729`: `if !errors.As(bizErr, &d) || !domain.IsFreezableFailure(domain.Kind(d)) { return nil }`
- `IsFreezableFailure` (`internal/domain/errors.go:152-158`) admits only `KindValidation`, `KindNotFound`, `KindAlreadyExists`, `KindConflict`, `KindPrecondition`.
- `KindForReason` (`internal/domain/reason.go:124`) classifies `ERROR_REASON_COVERAGE_MISS` as `KindInternal`.

`ERROR_REASON_STORAGE_OPERATION_FAILED` sits in the same `KindInternal` arm, so nothing was frozen on this path before either. An internal-kind failure is deliberately left unfrozen so the request stays retryable — freezing would pin a server bug against the caller's key for the whole TTL. `coverage-gate.md` now states this positively rather than listing a surface that does not exist.

## Upgrade note: the reason is hash-bound

`buildAuditFailurePayload` (`internal/infra/state/audit_envelope.go:176-198`) folds the reason, the message and every sorted context key **and value** into the audit hash pre-image. Relabelling an FSM-emitted failure is therefore **not hash-neutral**: for the same Raft entry, a node on the old build hashes `{STORAGE_OPERATION_FAILED, "storage operation failed: loading ledger", {operation}}` while a node on the new build hashes `{COVERAGE_MISS, "preload coverage miss (…)", {attribute, canonicalHex, idHex, raftIndex}}`.

During a rolling upgrade both builds apply the same replicated log, so **a coverage miss landing inside the mixed-version window writes different hashes for the same index**, and `checker.verifyAuditHashChain` then fails on whichever node disagrees with the persisted chain. Nothing absorbs this: `HashVersion` comes from `HashGenerator.Algorithm()` and identifies the hash *algorithm* only, carrying no notion of failure-projection semantics.

Taken as a documented upgrade constraint rather than a code change, because:

- the trigger is itself an admission bug that should never fire, so the path is low-probability;
- only the read sites this PR **converts** are affected — the numscript re-resolution path already returned the bare miss, so only its message shifts;
- the hazard is **general** to any change to an FSM-emitted error's reason, message or metadata, not specific to this PR.

Making it structurally safe would mean carrying a failure-projection semantics version alongside `HashVersion` so old entries keep reproducing their original bytes. That is a deliberate design decision this PR does not take on. Recorded in `coverage-gate.md` under "Upgrade note: the reason is hash-bound".

## Why a Reason-string match rather than `errors.As`

`internal/infra/state` imports `internal/domain/processing`, so `processing` can never import `state` to name `*ErrCoverageMiss`. This is the same workaround PR #1560 introduced privately for the numscript re-resolution triage; that helper is deleted here in favour of the shared one — same `Unwrap` walk, one implementation.

The walk also descends into multi-error nodes (`errors.Join`, or `fmt.Errorf` with several `%w`), which `errors.Unwrap` cannot follow, visiting members in slice order so the result stays deterministic on the apply path. This is not covered by the `forbidigo` rule — a `Join` is a plain call, not a forbidden type reference — so handling it in the walk is what keeps the guard whole.

## Notes for review

- **`processor.go:347` is a substantive fix, not a cosmetic conversion.** `gatedAccessor.Delete` (`accessor.go:113-118`) also calls `CheckCoverage`, so a staged tombstone flushed by `orderOverlayScope.Commit()` produces a genuine coverage miss. That path was mislabelling too.
- **`ValidateTransientVolumes` is included.** Its `Describable` reaches `buildAuditFailure` directly (`machine.go:1543`), bypassing `planInvariantDescribable`. This is the post-handler path from the EN-1520 comment.
- **Technical-update handlers need no change** — they return `fmt.Errorf("...%w")` and `applyTechnicalUpdates` already extracts the violation via `planInvariantDescribable` (defined at `machine.go:1133`; the TU call site is `machine.go:1214`), which can use `errors.As` because `state` can name the type.
- **`ErrCoverageMiss.Metadata()` keys moved to camelCase** (`canonical_hex` → `canonicalHex`, etc.) — **a deliberate breaking change, not an incidental cleanup.** This map was *not* previously unreachable; two paths already surfaced the bare miss on `release/v3.0`:
  - numscript re-resolution returns the bare miss (`convertNumscriptError` flattens the chain via `errors.As`), and a `ProcessOrders` failure feeds `buildAuditFailure` — so the snake_case keys were **already landing in the hash-chained audit**;
  - `planInvariantDescribable` already returned the bare miss to the client through `BusinessError.Metadata()` and the gRPC `ErrorInfo`.

  So operator tooling, alerts or dashboards keyed on `canonical_hex` / `id_hex` / `raft_index` stop matching at this deploy, and audit entries for this failure class carry different key names either side of it. The change is kept because this was the **last snake_case `Describable` in the repo** (~90 metadata keys in `internal/domain/errors.go`, zero snake_case; the only multi-word one is `existingTransactionId`) and CLAUDE.md mandates camelCase on the wire — deferring it would pay the same forensic seam later. `Error()` is aligned to the same `raftIndex` spelling so one audit record does not carry both. The structured log keeps snake_case field names (a log, not a wire payload). Old audit entries keep their stored bytes and re-verify against them, and `compareIdempotencyOutcomes` does not diverge.

## Regression guard

`forbidigo` forbids bare `ErrStorageOperation` construction, following the existing `OpenWriteSession` precedent. Verified in both directions: clean on the converted tree, and it fires with the intended message on a deliberately-bad line.

Because `analyze-types` is on, the rule matches **any** reference resolving to the type — an `errors.As` target declaration, a field read off it, a type-switch case — not only a composite literal (a construction-only pattern is not expressible: forbidigo renders the type expression, never the brace). The message says so and points legitimate consumers at `//nolint:forbidigo` with a justification. Two scoped exclusions, both `source:`-pinned: `coverage.go` (the one legitimate construction) and `errors.go` (where the type's own method receivers resolve).

## Testing

Three layers: a hermetic table test on the discriminator (`internal/domain/coverage_test.go`), a binding proof against the real `*ErrCoverageMiss` (`internal/infra/state/scope_unit_test.go`, including two `errors.Join` cases), and handler-level tests via the generated `MockScope` covering Ledger, Boundaries and post-commit volumes. Each new test was verified to fail without its fix (`expected COVERAGE_MISS, actual STORAGE_OPERATION_FAILED`), and each conversion has an over-correction guard asserting a genuine IO fault still yields `STORAGE_OPERATION_FAILED`.

Added on review:

- `TestBuildAuditFailure/CoverageMiss` — drives an `*ErrCoverageMiss` through `buildAuditFailure` and asserts the reason, the message and the **exact** `Context` key set. This is the assertion that was missing: the key names were pinned on `Metadata()` directly but nowhere they are consumed, which is how a rename could ship green while every context key feeds the immutable hash pre-image. A sibling negative control pins what the wrapped shape would have recorded instead.
- `TestValidateTransientVolumesLedgerCoverageMissPropagates` — covers the ledger-load `StoreFailure` site, which had no coverage-miss test; the existing one only drives the `CheckCoverage` site.

`TestValidateTransientVolumesStorageFaultTakesPrecedence` was updated — it pinned the old wrapping. Its precedence assertion (fault beats business offender) is unchanged.

## Question for @gfyrag re: the EN-1520 comment

Two of that comment's three bullets appear already resolved on `release/v3.0`, and I did not act on them:

- `updateBoundaryCounters` no longer exists — the per-ledger usage counters moved to the `usagestore` peer store under EN-1334 / EN-1420, leaving only a stale reference in a comment at `write_set.go:211`.
- I found no counter-underflow clamp in `internal/infra/state` or `internal/domain/processing`.

The third — post-handler coverage errors — is addressed here via `ValidateTransientVolumes`. Please confirm nothing was missed before EN-1522 rebases on this.

## Ticket

https://formance-team.atlassian.net/browse/EN-1379
