### PR TITLE
test(antithesis): model-driver idempotency replay + conflict coverage

### DIFF
--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -17,13 +17,44 @@ import (
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
-// applyRequest renders a bulk into a sendable ApplyRequest. One fresh
-// idempotency key for the whole batch (idempotency is per ApplyBatch),
-// generated once per Apply call and reused across the client's internal
-// retries, so an ambiguous UNAVAILABLE replays the committed batch instead of
-// re-applying it.
+// applyRequest renders a bulk into a sendable ApplyRequest. Idempotency is per
+// ApplyBatch, so the whole batch carries one key. A replayable original (and its
+// later replay) carries a tracked key the model froze; every other bulk gets a
+// fresh ephemeral key — untracked by the model, but still making the client's
+// internal retries safe (an ambiguous UNAVAILABLE replays the committed batch
+// instead of re-applying it).
 func applyRequest(b oracle.Bulk) *servicepb.ApplyRequest {
-	return servicepb.UnsignedApplyRequest(idempotencyKey(), b.Requests...)
+	key := b.IdempotencyKey
+	if key == "" {
+		key = idempotencyKey()
+	}
+
+	return servicepb.UnsignedApplyRequest(key, b.Requests...)
+}
+
+// indexPool builds a 0..n-1 index slice for a 1-in-n RandomChoice roll, derived
+// from the const so the odds and the pool stay in lockstep (see typePool).
+func indexPool(n int) []uint8 {
+	out := make([]uint8, n)
+	for i := range out {
+		out[i] = uint8(i)
+	}
+	return out
+}
+
+var (
+	replayTrackPool    = indexPool(replayTrackOneIn)
+	replayConflictPool = indexPool(replayConflictOneIn)
+)
+
+// rollReplayTrack reports whether to stamp a bulk as a replayable original.
+func rollReplayTrack() bool {
+	return random.RandomChoice(replayTrackPool) == 0
+}
+
+// rollConflict reports whether to reuse a committed key on a different body.
+func rollConflict() bool {
+	return random.RandomChoice(replayConflictPool) == 0
 }
 
 // Pool: every type name and every tx address uses a "t-N" prefix where

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
@@ -57,6 +57,12 @@ type Checker struct {
 	// during generation, both under mu.
 	receiptByRef map[string]string
 
+	// replayable holds committed bulks that carried a tracked idempotency key —
+	// the originals runReplay re-sends to exercise the server's idempotency
+	// replay. Populated at commit (rememberReplayable), capped at
+	// replayRegistryCap. Guarded by mu.
+	replayable []replayEntry
+
 	// paused gates worker dispatch during a restore cycle; resumeCh is closed on
 	// resume so parked workers wake. Both guarded by mu (see restore.go).
 	paused   bool

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
@@ -118,6 +118,27 @@ const (
 	txEmitStop  = 4000 // below this: ~1-in-8; at or above: stop creating new ones
 )
 
+// --- Idempotency replay -------------------------------------------------
+
+// A generated bulk becomes a replayable original — stamped with a tracked
+// idempotency key so runReplay can re-send it — with probability
+// 1/replayTrackOneIn, but only while the registry has room. Capping the count
+// of tracked keys bounds the model's frozen idempotency map, which is never
+// evicted (the model assumes an infinite TTL).
+const replayTrackOneIn = 4
+
+// Max remembered replayable bulks. The server's idempotency TTL (24h default,
+// unset in the antithesis cluster) dwarfs any run, so keys frozen early stay
+// replayable throughout — including across a restore cycle, which is the point.
+// Bounds the model's never-evicted frozen map; kept well under the transaction
+// log the search already clones/hashes each fold, so it is not the cost driver.
+const replayRegistryCap = 2048
+
+// Once the registry is non-empty, a generated bulk reuses a committed key with
+// its own (different) body — forcing an IDEMPOTENCY_KEY_CONFLICT — with
+// probability 1/replayConflictOneIn.
+const replayConflictOneIn = 6
+
 // --- Worker pacing ------------------------------------------------------
 
 // Sleep per worker iteration — CPU/server breathing room.

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -175,13 +175,15 @@ func runWorker(
 		// (declared field types). Reads validate against the in-flight bulk set,
 		// exercising cross-node freshness without needing quiescence.
 		if random.RandomChoice([]uint8{0, 1, 2, 3, 4}) == 0 {
-			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4}) {
+			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5}) {
 			case 0:
 				runLedgerRead(ctx, client, c)
 			case 1:
 				runTransactionRead(ctx, client, c)
 			case 2:
 				runSchemaRead(ctx, client, c)
+			case 3:
+				runReplay(ctx, client, c)
 			default:
 				runRead(ctx, client, c)
 			}
@@ -201,6 +203,10 @@ func runWorker(
 			c.mu.Unlock()
 			continue
 		}
+		// Occasionally tag this bulk with an idempotency key — reusing a committed
+		// key on a different body (conflict) or minting a fresh tracked one (a
+		// replayable original) — to exercise the server's dedup.
+		c.stampIdempotency(&bulk)
 		ticket := c.registerInflight(bulk)
 		c.mu.Unlock()
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/replay.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/replay.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/antithesishq/antithesis-sdk-go/random"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+// replayEntry is a committed keyed bulk the driver can re-send to exercise the
+// server's idempotency replay: the idempotency key, the exact body that froze
+// under it, and the log sequences its commit was assigned. Re-sending the same
+// body reproduces the recorded outcome (a differing body would conflict); the
+// sequences distinguish a replay from a re-execution — a true replay echoes them
+// verbatim, a re-execution commits fresh, higher ones.
+type replayEntry struct {
+	key     string
+	bulk    oracle.Bulk
+	logSeqs []uint64
+}
+
+// stampIdempotency may tag a freshly generated bulk with an idempotency key to
+// exercise the server's per-batch dedup. With committed keys on hand it
+// sometimes reuses one carrying a DIFFERENT body, which the server must reject
+// IDEMPOTENCY_KEY_CONFLICT; otherwise, while the registry has room, it sometimes
+// mints a fresh tracked key so the bulk becomes a replayable original. Most bulks
+// stay untracked. Caller holds c.mu.
+func (c *Checker) stampIdempotency(bulk *oracle.Bulk) {
+	if len(c.replayable) > 0 && rollConflict() {
+		entry := random.RandomChoice(c.replayable)
+		// A differing body is guaranteed to conflict, not replay (RequestsEqual is
+		// a faithful proxy for the server's idempotency hash). Skip the rare exact
+		// match, which would replay and misroute through the commit path.
+		if !oracle.RequestsEqual(entry.bulk.Requests, bulk.Requests) {
+			bulk.IdempotencyKey = entry.key
+
+			return
+		}
+	}
+
+	if len(c.replayable) < replayRegistryCap && rollReplayTrack() {
+		bulk.IdempotencyKey = idempotencyKey()
+	}
+}
+
+// rememberReplayable records a committed keyed bulk so runReplay can later
+// re-send it. Only keyed bulks are eligible, and only until the registry is
+// full — the cap bounds the model's frozen idempotency map, which the model
+// never evicts (infinite TTL). Caller holds c.mu.
+func (c *Checker) rememberReplayable(bulk oracle.Bulk, logs []*commonpb.Log) {
+	if bulk.IdempotencyKey == "" || len(c.replayable) >= replayRegistryCap {
+		return
+	}
+
+	c.replayable = append(c.replayable, replayEntry{
+		key:     bulk.IdempotencyKey,
+		bulk:    bulk,
+		logSeqs: logSequences(logs),
+	})
+}
+
+// runReplay re-sends a previously committed keyed bulk and checks the server
+// replays the recorded outcome and commits no new log. It is read-like: a replay
+// echoes the original's log references (which the server resolves to the original
+// sequences) and produces no fresh log, so it must NOT flow through the
+// log-sequence re-order buffer — it registers as a read and validates against
+// the candidate states, exactly like GetAccount/GetTransaction.
+func runReplay(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	c.mu.Lock()
+	if len(c.replayable) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	entry := random.RandomChoice(c.replayable)
+	readID := c.registerRead()
+	c.mu.Unlock()
+	defer c.finishRead(readID)
+
+	resp, err := client.Apply(ctx, applyRequest(entry.bulk))
+	// High-water at the replay's response: only bulks dispatched by now could be
+	// folded into the states this replay is validated against.
+	maxTicket := c.ticketSeq.Load()
+	if err != nil {
+		if internal.IsTransient(err) || isShutdownError(err) {
+			return
+		}
+		// The original committed and the server's TTL dwarfs any run, so a replay
+		// must not surface a definitive error (a re-execution that now conflicts,
+		// or an eviction) — that is a finding.
+		assert.Unreachable("singleton_driver_model: idempotency replay returned unexpected error", internal.Details{
+			"ledgers": bulkLedgers(entry.bulk),
+			"key":     entry.key,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.validateReplay(maxTicket, entry, resp)
+}
+
+// validateReplay checks a replay's response two ways: it must echo the original
+// commit's log sequences verbatim (a fresh sequence means the key was
+// re-executed, not replayed — an exactly-once violation), and its content must
+// match the model's frozen outcome under some candidate base (Apply replays the
+// bulk because the base holds the key, folded from modelState).
+func (c *Checker) validateReplay(maxTicket uint64, entry replayEntry, resp *servicepb.ApplyResponse) {
+	if !sequencesEqual(logSequences(resp.GetLogs()), entry.logSeqs) {
+		assert.Unreachable("singleton_driver_model: idempotency replay produced new log sequences", internal.Details{
+			"ledgers":  bulkLedgers(entry.bulk),
+			"key":      entry.key,
+			"original": entry.logSeqs,
+			"replayed": logSeqs(resp.GetLogs()),
+		})
+
+		return
+	}
+
+	if c.matchesModel(maxTicket, "REPLAY", func(base oracle.GlobalState) bool {
+		res := base.Apply(entry.bulk)
+		return res.OK && replayOrdersMatch(entry.bulk, res.Orders, resp.GetLogs())
+	}) {
+		// Coverage: prove the replay path is actually exercised — if this stops
+		// firing, the driver has stopped tracking or re-sending keyed bulks.
+		assert.Reachable("singleton_driver_model: idempotency replay exercised", internal.Details{})
+
+		return
+	}
+
+	assert.Unreachable("singleton_driver_model: idempotency replay outside model", internal.Details{
+		"ledgers": bulkLedgers(entry.bulk),
+		"key":     entry.key,
+		"kinds":   requestKinds(entry.bulk),
+		"logSeqs": logSeqs(resp.GetLogs()),
+	})
+}
+
+// logSequences extracts the log sequences from a response, in order.
+func logSequences(logs []*commonpb.Log) []uint64 {
+	out := make([]uint64, len(logs))
+	for i, l := range logs {
+		out[i] = l.GetSequence()
+	}
+
+	return out
+}
+
+// sequencesEqual reports whether two sequence slices are identical in order.
+func sequencesEqual(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// replayOrdersMatch reports whether the server's response logs echo the frozen
+// orders — the transaction identity that defines "same result": assigned ids,
+// echoed references and postings, per-cell post-commit volumes, and stored
+// metadata. It reuses the leaf predicates crossCheckCommit asserts on; the two
+// stay separate because crossCheckCommit needs a distinct assert callsite per
+// field (Antithesis catalogues by callsite) while a replay diverges as a whole.
+func replayOrdersMatch(bulk oracle.Bulk, orders []oracle.OrderResult, logs []*commonpb.Log) bool {
+	for i, order := range orders {
+		if i >= len(logs) {
+			return false
+		}
+
+		req := bulk.Requests[i]
+		data := logs[i].GetPayload().GetApply().GetLog().GetData()
+
+		switch {
+		case order.Revert != nil:
+			rt := data.GetRevertedTransaction()
+			revTx := rt.GetRevertTransaction()
+			if revTx.GetId() != order.TxID ||
+				rt.GetRevertedTransactionId() != order.Revert.RevertedID() ||
+				!postingsEqual(order.Revert.Postings(), revTx.GetPostings()) {
+				return false
+			}
+
+		case order.TxID != 0:
+			tx := data.GetCreatedTransaction().GetTransaction()
+			ct := req.GetApply().GetAction().GetCreateTransaction()
+			if tx.GetId() != order.TxID ||
+				tx.GetReference() != ct.GetReference() ||
+				!postingsEqual(ct.GetPostings(), tx.GetPostings()) ||
+				!accountMetaMapEqual(ct.GetAccountMetadata(), data.GetCreatedTransaction().GetAccountMetadata()) {
+				return false
+			}
+		}
+
+		if order.PCV != nil {
+			if !pcvMatches(order.PCV, serverPCV(data)) {
+				return false
+			}
+		}
+
+		if order.Meta != nil {
+			if !metaMapEqual(order.Meta.Saved(), responseMetaEffect(req, logs[i])) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// pcvMatches reports whether every model cell equals the server's post-commit
+// volume for that cell.
+func pcvMatches(model map[oracle.VolumeKey]oracle.VolumePair, server *commonpb.PostCommitVolumes) bool {
+	for key, vp := range model {
+		gotIn, gotOut, ok := postCommitVolume(server, key)
+		if !ok || vp.Input.Cmp(&gotIn) != 0 || vp.Output.Cmp(&gotOut) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// serverPCV pulls the post-commit volumes off a create or revert response log.
+// PCV rides on the transaction itself (CreatedTransaction.Transaction /
+// RevertedTransaction.RevertTransaction) and is present on every committed
+// transaction.
+func serverPCV(data *commonpb.LedgerLogPayload) *commonpb.PostCommitVolumes {
+	switch {
+	case data.GetCreatedTransaction() != nil:
+		return data.GetCreatedTransaction().GetTransaction().GetPostCommitVolumes()
+	case data.GetRevertedTransaction() != nil:
+		return data.GetRevertedTransaction().GetRevertTransaction().GetPostCommitVolumes()
+	default:
+		return nil
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -326,6 +326,11 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 	}
 
 	c.modelState = res.State
+
+	// A committed keyed bulk is frozen in modelState; remember it (with the
+	// sequences it committed at) so runReplay can re-send it and check the server
+	// replays this same outcome.
+	c.rememberReplayable(bulk, resp.GetLogs())
 }
 
 // validateFailure accepts the observed failure of failedBulk iff some
@@ -363,6 +368,8 @@ func (c *Checker) validateFailure(maxTicket uint64, failedBulk oracle.Bulk, reqE
 			assert.Reachable("singleton_driver_model: volume-overflow rejection exercised", internal.Details{})
 		case domain.ErrReasonValidation:
 			assert.Reachable("singleton_driver_model: validation rejection exercised", internal.Details{})
+		case domain.ErrReasonIdempotencyKeyConflict:
+			assert.Reachable("singleton_driver_model: idempotency-conflict rejection exercised", internal.Details{})
 		}
 
 		dbg("MODEL FAIL OK: ledgers=%s kinds=%s explained by %s", bulkLedgers(failedBulk), requestKinds(failedBulk), reason)

--- a/tests/oracle/bulk.go
+++ b/tests/oracle/bulk.go
@@ -4,6 +4,13 @@ import "github.com/formancehq/ledger/v3/internal/proto/servicepb"
 
 // Bulk is one Apply call's worth of requests — the unit the model folds in one
 // atomic step, mirroring the server's per-ApplyBatch atomicity.
+//
+// IdempotencyKey is the batch's idempotency key (idempotency is per ApplyBatch,
+// not per request). When empty the model applies the bulk with no idempotency
+// bookkeeping. When set, Apply freezes the committed outcome under the key and
+// replays it verbatim for any later bulk carrying the same key (same body), or
+// rejects a same-key/different-body bulk as a conflict — see GlobalState.Apply.
 type Bulk struct {
-	Requests []*servicepb.Request
+	Requests       []*servicepb.Request
+	IdempotencyKey string
 }

--- a/tests/oracle/cmd/replay/main.go
+++ b/tests/oracle/cmd/replay/main.go
@@ -85,7 +85,7 @@ func replaySubmits(submits []batch, target string) {
 			fmt.Fprintf(os.Stderr, "seq=%d PeekBatch: %v\n", b.seq, err)
 			os.Exit(1)
 		}
-		bulk := oracle.Bulk{Requests: ab.GetRequests()}
+		bulk := oracle.Bulk{Requests: ab.GetRequests(), IdempotencyKey: ab.GetIdempotencyKey()}
 
 		touchesTarget := false
 		for _, r := range bulk.Requests {
@@ -154,7 +154,7 @@ func replayCommitted(batches []batch, target string) {
 			fmt.Fprintf(os.Stderr, "seq=%d PeekBatch: %v\n", b.seq, err)
 			os.Exit(1)
 		}
-		bulk := oracle.Bulk{Requests: ab.GetRequests()}
+		bulk := oracle.Bulk{Requests: ab.GetRequests(), IdempotencyKey: ab.GetIdempotencyKey()}
 
 		hitsTarget := false
 		for _, r := range bulk.Requests {

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -332,20 +332,41 @@ func (s *LedgerState) AccountMetadata(addr string) map[string]*commonpb.Metadata
 // observations) so it can be unit-tested and forked.
 type GlobalState struct {
 	ledgers map[string]LedgerState
+	// idempotency freezes the committed outcome of every keyed bulk, so a later
+	// bulk carrying the same key replays it (Apply). It spans ledgers because a
+	// bulk's key covers the whole atomic batch, whatever ledgers it touched.
+	// Entries are immutable once frozen (infinite TTL — the model never evicts),
+	// so forks share the pointers; only the map itself is copied.
+	idempotency map[string]*frozenOutcome
+}
+
+// frozenOutcome is a keyed bulk's recorded outcome: the exact requests it
+// committed (to tell a genuine replay from a same-key/different-body conflict)
+// and the per-order results the server will echo on every replay.
+type frozenOutcome struct {
+	requests []*servicepb.Request
+	orders   []OrderResult
 }
 
 func NewGlobalState() GlobalState {
-	return GlobalState{ledgers: map[string]LedgerState{}}
+	return GlobalState{
+		ledgers:     map[string]LedgerState{},
+		idempotency: map[string]*frozenOutcome{},
+	}
 }
 
-// clone deep-copies each ledger so forks never share mutable state.
+// clone deep-copies each ledger so forks never share mutable state. The
+// idempotency map is copied shallowly — its entries are immutable once frozen.
 func (g GlobalState) clone() GlobalState {
 	m := make(map[string]LedgerState, len(g.ledgers))
 	for name, ls := range g.ledgers {
 		m[name] = ls.clone()
 	}
 
-	return GlobalState{ledgers: m}
+	idem := make(map[string]*frozenOutcome, len(g.idempotency))
+	maps.Copy(idem, g.idempotency)
+
+	return GlobalState{ledgers: m, idempotency: idem}
 }
 
 // ledger returns the named ledger's state, or an empty one if untouched.
@@ -381,6 +402,29 @@ func (g GlobalState) Hash(h io.Writer) {
 		}
 		_, _ = fmt.Fprintf(h, "L|%s\n", n)
 		_, _ = h.Write(buf.Bytes())
+	}
+
+	// Frozen idempotency outcomes are observable through a replay, so bases that
+	// differ only in which id a key froze must stay distinct — otherwise
+	// candidateBases collapses two commuting keyed transactions (identical
+	// business state, opposite id assignments) and a replay can no longer resolve
+	// to the id the server actually returned. Only the outcome identity a replay
+	// reveals (per-order id) needs hashing, not the whole result.
+	ikeys := make([]string, 0, len(g.idempotency))
+	for k := range g.idempotency {
+		ikeys = append(ikeys, k)
+	}
+	sort.Strings(ikeys)
+	for _, k := range ikeys {
+		fo := g.idempotency[k]
+		_, _ = fmt.Fprintf(h, "IK|%s|%d\n", k, len(fo.orders))
+		for i, o := range fo.orders {
+			revertedID := uint64(0)
+			if o.Revert != nil {
+				revertedID = o.Revert.revertedID
+			}
+			_, _ = fmt.Fprintf(h, "IO|%d|%d|%d\n", i, o.TxID, revertedID)
+		}
 	}
 }
 
@@ -501,6 +545,22 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 		}
 	}
 
+	// Per-batch idempotency, checked after admission's structural gate (the
+	// empty-create above) and before any FSM outcome — mirroring the server,
+	// where the dedup runs in the apply path ahead of ProcessOrders. Only
+	// successes are frozen (see the commit return below), so a hit is always a
+	// committed outcome: same body replays it verbatim with no new state; a
+	// different body under the same key is a conflict.
+	if bulk.IdempotencyKey != "" {
+		if fo, ok := g.idempotency[bulk.IdempotencyKey]; ok {
+			if !RequestsEqual(fo.requests, bulk.Requests) {
+				return ApplyResult{OK: false, Reason: domain.ErrReasonIdempotencyKeyConflict, State: g}
+			}
+
+			return ApplyResult{OK: true, State: g, Orders: fo.orders}
+		}
+	}
+
 	next := g.clone()
 	orders := make([]OrderResult, 0, len(bulk.Requests))
 	touched := map[string]map[VolumeKey]bool{}
@@ -547,7 +607,36 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 		ls.purgeZeroBalance(cells)
 	}
 
+	// Freeze the committed outcome so a later bulk with this key replays it. Only
+	// the success path records an entry; a rejected keyed bulk leaves no frozen
+	// outcome (the driver never replays a key whose bulk did not commit).
+	if bulk.IdempotencyKey != "" {
+		next.idempotency[bulk.IdempotencyKey] = &frozenOutcome{
+			requests: bulk.Requests,
+			orders:   orders,
+		}
+	}
+
 	return ApplyResult{OK: true, State: next, Orders: orders}
+}
+
+// RequestsEqual reports whether two request slices are element-wise equal,
+// telling a genuine replay (same body) from a same-key/different-body conflict.
+// It is a faithful proxy for the server's idempotency hash: every request field
+// rides on the hashed order, and only admission's OrderTechnical is excluded —
+// so equal requests hash identically (replay) and any difference conflicts.
+func RequestsEqual(a, b []*servicepb.Request) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if !a[i].EqualVT(b[i]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // applyOne mutates the (already-forked) working state for one request and

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -1,6 +1,7 @@
 package oracle
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
@@ -12,6 +13,17 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
 )
+
+func hashState(g GlobalState) string {
+	var buf bytes.Buffer
+	g.Hash(&buf)
+
+	return buf.String()
+}
+
+func keyedBulk(key string, reqs ...*servicepb.Request) Bulk {
+	return Bulk{Requests: reqs, IdempotencyKey: key}
+}
 
 // dec renders a uint256 volume value (Dec has a pointer receiver, so this
 // takes an addressable copy for call sites on non-addressable map/return values).
@@ -41,6 +53,78 @@ func TestGlobalState_Apply_ChartOps(t *testing.T) {
 	gone := removed.State.Apply(bulkOf(oracletest.RemoveTypeReq("T")))
 	require.False(t, gone.OK)
 	require.Equal(t, domain.ErrReasonAccountTypeNotFound, gone.Reason)
+}
+
+func TestGlobalState_Apply_IdempotencyReplay(t *testing.T) {
+	t.Parallel()
+
+	// First apply of a keyed bulk commits and assigns id 1.
+	first := NewGlobalState().Apply(keyedBulk("k1", oracletest.TxReq("world", "a:1", "USD", 5)))
+	require.True(t, first.OK)
+	require.Equal(t, uint64(1), first.Orders[0].TxID)
+	require.Len(t, first.State.Ledger("L").txs, 1)
+
+	// Replay: same key, same body -> the recorded outcome, no new transaction.
+	replay := first.State.Apply(keyedBulk("k1", oracletest.TxReq("world", "a:1", "USD", 5)))
+	require.True(t, replay.OK)
+	require.Equal(t, uint64(1), replay.Orders[0].TxID)
+	require.Len(t, replay.State.Ledger("L").txs, 1, "replay must not append a second transaction")
+	replayed := replay.State.Ledger("L")
+	require.Equal(t, "5", dec(replayed.vol(VolumeKey{"a:1", "USD"}).Input),
+		"replay must not move volumes again")
+
+	// A fresh key with the same body applies for real (id 2).
+	fresh := first.State.Apply(keyedBulk("k2", oracletest.TxReq("world", "a:1", "USD", 5)))
+	require.True(t, fresh.OK)
+	require.Equal(t, uint64(2), fresh.Orders[0].TxID)
+	require.Len(t, fresh.State.Ledger("L").txs, 2)
+}
+
+func TestGlobalState_Apply_IdempotencyConflict(t *testing.T) {
+	t.Parallel()
+
+	first := NewGlobalState().Apply(keyedBulk("k1", oracletest.TxReq("world", "a:1", "USD", 5)))
+	require.True(t, first.OK)
+
+	// Same key, different body -> conflict, no state change.
+	conflict := first.State.Apply(keyedBulk("k1", oracletest.TxReq("world", "a:1", "USD", 6)))
+	require.False(t, conflict.OK)
+	require.Equal(t, domain.ErrReasonIdempotencyKeyConflict, conflict.Reason)
+	require.Len(t, conflict.State.Ledger("L").txs, 1)
+}
+
+func TestGlobalState_Apply_IdempotencyFailureNotFrozen(t *testing.T) {
+	t.Parallel()
+
+	// A keyed bulk that the FSM rejects freezes nothing, so the key stays free:
+	// a later bulk reusing it is neither a replay nor a conflict.
+	failed := NewGlobalState().Apply(keyedBulk("k1", oracletest.RemoveTypeReq("missing")))
+	require.False(t, failed.OK)
+
+	reuse := failed.State.Apply(keyedBulk("k1", oracletest.TxReq("world", "a:1", "USD", 5)))
+	require.True(t, reuse.OK, "a key whose first bulk failed must not be frozen")
+	require.Equal(t, uint64(1), reuse.Orders[0].TxID)
+}
+
+func TestGlobalState_Hash_DistinguishesFrozenKeyAssignments(t *testing.T) {
+	t.Parallel()
+
+	// Two keyed bulks with IDENTICAL postings reach the same business state under
+	// either order (a's volume, both tx records), so LedgerState.Hash alone can't
+	// tell the orders apart. Idempotency makes the key->id assignment observable
+	// via replay, so the frozen map must push the two orders to distinct hashes —
+	// else candidateBases collapses them and a replay can't resolve to the id the
+	// server actually returned.
+	ab := NewGlobalState().
+		Apply(keyedBulk("ka", oracletest.TxReq("world", "a:1", "USD", 5))).State.
+		Apply(keyedBulk("kb", oracletest.TxReq("world", "a:1", "USD", 5))).State
+
+	ba := NewGlobalState().
+		Apply(keyedBulk("kb", oracletest.TxReq("world", "a:1", "USD", 5))).State.
+		Apply(keyedBulk("ka", oracletest.TxReq("world", "a:1", "USD", 5))).State
+
+	require.NotEqual(t, hashState(ab), hashState(ba),
+		"frozen key->id assignment must be part of the state fingerprint")
 }
 
 func TestGlobalState_Apply_AtomicRejection(t *testing.T) {


### PR DESCRIPTION
Extends the forward-model linearizability driver (`singleton_driver_model`) with idempotency coverage:

- Keyed bulks: a configurable fraction of driver bulks carry an idempotency key.
- Replay: accepted keyed bulks are re-submitted and must return the frozen original result — validated read-style against the original sequences, so a replay that re-executes (instead of replaying) is caught.
- Conflicts: re-using a key with a different payload must fail with `IDEMPOTENCY_KEY_CONFLICT`.
- Oracle: models keyed replay for successful bulks; frozen outcomes are also checked across a restore cycle (guards the RebuildDelta idempotency restore, #1607).

Known follow-up (deliberately out of scope here): failure-freezing — replaying a keyed bulk whose original outcome was a business failure is not yet modeled.