### PR TITLE
fix(security): redact event sink read credentials

### DIFF
--- a/cmd/ledgerctl/cmdutil/format.go
+++ b/cmd/ledgerctl/cmdutil/format.go
@@ -3,6 +3,8 @@ package cmdutil
 import (
 	"fmt"
 	"strings"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/redact"
 )
 
 // FormatBytes formats a byte count as a human-readable string.
@@ -69,27 +71,5 @@ func WrapText(text string, maxWidth int, separator string) []string {
 // Works with postgres://, postgresql://, clickhouse:// and similar URL-format DSNs.
 // If the DSN is not URL-formatted or has no password, it is returned unchanged.
 func ObfuscateDSN(dsn string) string {
-	schemeEnd := strings.Index(dsn, "://")
-	if schemeEnd == -1 {
-		return dsn
-	}
-
-	rest := dsn[schemeEnd+3:]
-
-	lastAt := strings.LastIndex(rest, "@")
-	if lastAt == -1 {
-		return dsn
-	}
-
-	creds := rest[:lastAt]
-
-	before, _, ok := strings.Cut(creds, ":")
-	if !ok {
-		return dsn
-	}
-
-	user := before
-	hostPart := rest[lastAt:]
-
-	return dsn[:schemeEnd+3] + user + ":****" + hostPart
+	return redact.DSN(dsn)
 }

--- a/cmd/ledgerctl/cmdutil/format_test.go
+++ b/cmd/ledgerctl/cmdutil/format_test.go
@@ -106,9 +106,9 @@ func TestObfuscateDSN(t *testing.T) {
 			expected: "clickhouse://default:****@ch-host:9000/events",
 		},
 		{
-			name:     "password with special chars",
+			name:     "malformed URL with password fails closed",
 			input:    "postgres://formance:YCA[sRR-~X]Pqdv|Ms3?hzc0u#f_@host:5432/db",
-			expected: "postgres://formance:****@host:5432/db",
+			expected: "(set)",
 		},
 		{
 			name:     "no password",

--- a/cmd/ledgerctl/events/list.go
+++ b/cmd/ledgerctl/events/list.go
@@ -57,8 +57,9 @@ func runList(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return cmdutil.FormatGRPCError("failed to get event sinks", err)
 	}
+	resp = redactGetEventsSinksResponse(resp)
 
-	if handled, err := cmdutil.EncodeStructured(cmd, redactGetEventsSinksResponse(resp)); handled || err != nil {
+	if handled, err := cmdutil.EncodeStructured(cmd, resp); handled || err != nil {
 		return err
 	}
 

--- a/cmd/ledgerctl/events/redact.go
+++ b/cmd/ledgerctl/events/redact.go
@@ -1,9 +1,8 @@
 package events
 
 import (
-	"google.golang.org/protobuf/proto"
-
-	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
+	"github.com/formancehq/ledger/v3/internal/adapter/eventsink"
+	"github.com/formancehq/ledger/v3/internal/pkg/redact"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -13,65 +12,15 @@ import (
 // from any plausible secret value so downstream readers cannot confuse them
 // with real data.
 const (
-	secretSet  = "(set)"
-	secretNone = "(none)"
+	secretSet  = redact.SecretSet
+	secretNone = redact.SecretNone
 )
 
 // redactSecret returns secretSet if s is non-empty, secretNone otherwise.
 // Use for opaque secrets where preserving any byte of the original value would
 // be a leak (PATs, OAuth client secrets, SASL passwords, HMAC keys).
 func redactSecret(s string) string {
-	if s == "" {
-		return secretNone
-	}
-
-	return secretSet
-}
-
-// redactSinkConfigInPlace mutates cfg, replacing every secret-bearing field
-// with a sentinel. URL-shaped DSNs go through ObfuscateDSN so the host and
-// user remain visible for operator troubleshooting.
-//
-// Call redactSinkConfig (which clones first) when handing the result to an
-// encoder; this in-place variant is for callers that already own a deep copy.
-func redactSinkConfigInPlace(cfg *commonpb.SinkConfig) {
-	if cfg == nil {
-		return
-	}
-
-	switch t := cfg.GetType().(type) {
-	case *commonpb.SinkConfig_Kafka:
-		if t.Kafka != nil {
-			t.Kafka.SaslPassword = redactSecret(t.Kafka.GetSaslPassword())
-		}
-	case *commonpb.SinkConfig_Http:
-		if t.Http != nil {
-			t.Http.Secret = redactSecret(t.Http.GetSecret())
-		}
-	case *commonpb.SinkConfig_Clickhouse:
-		if t.Clickhouse != nil {
-			t.Clickhouse.Dsn = cmdutil.ObfuscateDSN(t.Clickhouse.GetDsn())
-		}
-	case *commonpb.SinkConfig_Databricks:
-		if t.Databricks != nil {
-			redactDatabricksAuthInPlace(t.Databricks)
-		}
-	}
-}
-
-// redactDatabricksAuthInPlace mutates d.Auth, masking the PAT or OAuth M2M
-// client secret depending on which auth variant is set. Public fields
-// (server hostname, HTTP path, catalog, schema, table, OAuth client_id) are
-// left visible.
-func redactDatabricksAuthInPlace(d *commonpb.DatabricksSinkConfig) {
-	switch a := d.GetAuth().(type) {
-	case *commonpb.DatabricksSinkConfig_Token:
-		a.Token = redactSecret(a.Token)
-	case *commonpb.DatabricksSinkConfig_OauthM2M:
-		if a.OauthM2M != nil {
-			a.OauthM2M.ClientSecret = redactSecret(a.OauthM2M.GetClientSecret())
-		}
-	}
+	return redact.Secret(s)
 }
 
 // redactSinkConfig returns a deep clone of cfg with every secret-bearing
@@ -79,28 +28,12 @@ func redactDatabricksAuthInPlace(d *commonpb.DatabricksSinkConfig) {
 // without leaking PATs, OAuth client secrets, SASL passwords, HMAC keys, or
 // DSN passwords.
 func redactSinkConfig(cfg *commonpb.SinkConfig) *commonpb.SinkConfig {
-	if cfg == nil {
-		return nil
-	}
-
-	cloned, _ := proto.Clone(cfg).(*commonpb.SinkConfig)
-	redactSinkConfigInPlace(cloned)
-
-	return cloned
+	return eventsink.RedactConfig(cfg)
 }
 
 // redactGetEventsSinksResponse returns a deep clone of resp with every sink
 // config redacted. Sink statuses are cloned but otherwise untouched (they do
 // not carry secrets).
 func redactGetEventsSinksResponse(resp *servicepb.GetEventsSinksResponse) *servicepb.GetEventsSinksResponse {
-	if resp == nil {
-		return nil
-	}
-
-	cloned, _ := proto.Clone(resp).(*servicepb.GetEventsSinksResponse)
-	for _, s := range cloned.GetSinks() {
-		redactSinkConfigInPlace(s)
-	}
-
-	return cloned
+	return eventsink.RedactGetResponse(resp)
 }

--- a/cmd/ledgerctl/events/redact_test.go
+++ b/cmd/ledgerctl/events/redact_test.go
@@ -171,7 +171,7 @@ func TestRedactSinkConfig_NilSafe(t *testing.T) {
 // check: it serializes the whole response through protojson (what
 // EncodeStructured uses for --json and --yaml) and asserts that no plaintext
 // secret survives. Any future field added to a SinkConfig that carries a
-// secret must be added to redactSinkConfigInPlace, or this test will catch the
+// secret must be added to eventsink.RedactConfig, or this test will catch the
 // regression.
 func TestRedactGetEventsSinksResponse_NoSecretInJSON(t *testing.T) {
 	t.Parallel()

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4789,7 +4789,7 @@ Manage event sinks (NATS, ClickHouse, Kafka, HTTP, Databricks) that receive doma
 
 ### `events list`
 
-List all configured event sinks and their current status (cursor position, errors). Credential-bearing fields are redacted by the server and again by `ledgerctl` for compatibility with older servers. Opaque secrets display `(set)` or `(none)`, and DSN passwords display `****`.
+List all configured event sinks and their current status (cursor position, errors). The server redacts configured credential fields, and `ledgerctl` applies the same projection for compatibility with older servers. Kafka SASL passwords, HTTP HMAC secrets, and Databricks PAT/OAuth secrets display `(set)` or `(none)`. ClickHouse DSN credentials and NATS/HTTP URL userinfo display `****`; usernames, hosts, paths, topics, and other operational fields remain visible.
 
 ```bash
 ledgerctl events list

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4789,7 +4789,7 @@ Manage event sinks (NATS, ClickHouse, Kafka, HTTP, Databricks) that receive doma
 
 ### `events list`
 
-List all configured event sinks and their current status (cursor position, errors).
+List all configured event sinks and their current status (cursor position, errors). Credential-bearing fields are redacted by the server and again by `ledgerctl` for compatibility with older servers. Opaque secrets display `(set)` or `(none)`, and DSN passwords display `****`.
 
 ```bash
 ledgerctl events list

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -160,7 +160,7 @@ Key formats:
 
 When a sink publish fails, the emitter reports the error via Raft by proposing an `EventsSinkUpdate` with the error details. The FSM stores a `SinkStatus` protobuf under `[0x06][0x0A][sink_name]` (`ZoneGlobal` + `SubGlobSinkStatus`). On subsequent successful publish, the emitter proposes an update with `clear_error = true`, which deletes the status entry.
 
-The `GetEventsSinks` gRPC endpoint returns all sink configs and their statuses, allowing operators to monitor sink health cluster-wide:
+The `GetEventsSinks` gRPC endpoint returns all sink configs and their statuses, allowing operators to monitor sink health cluster-wide. The read projection is cloned before serialization and replaces all reusable credentials with non-reusable markers: opaque secrets use `(set)` or `(none)`, while URL-shaped DSN passwords use `****`. The runtime configuration remains unchanged. HTTP `GET /v3/_/events-sinks` uses the same projection, so callers must not reuse either read response as a sink mutation payload.
 
 ```protobuf
 message SinkStatus {

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -160,7 +160,9 @@ Key formats:
 
 When a sink publish fails, the emitter reports the error via Raft by proposing an `EventsSinkUpdate` with the error details. The FSM stores a `SinkStatus` protobuf under `[0x06][0x0A][sink_name]` (`ZoneGlobal` + `SubGlobSinkStatus`). On subsequent successful publish, the emitter proposes an update with `clear_error = true`, which deletes the status entry.
 
-The `GetEventsSinks` gRPC endpoint returns all sink configs and their statuses, allowing operators to monitor sink health cluster-wide. The read projection is cloned before serialization and replaces all reusable credentials with non-reusable markers: opaque secrets use `(set)` or `(none)`, while URL-shaped DSN passwords use `****`. The runtime configuration remains unchanged. HTTP `GET /v3/_/events-sinks` uses the same projection, so callers must not reuse either read response as a sink mutation payload.
+The `GetEventsSinks` gRPC endpoint returns all sink configs and their statuses, allowing operators to monitor sink health cluster-wide. The read projection is cloned before serialization. Kafka SASL passwords, HTTP HMAC secrets, Databricks PATs, and Databricks OAuth client secrets use `(set)` or `(none)`. ClickHouse userinfo passwords and credential-bearing DSN query values use `****`; NATS and HTTP URL userinfo passwords or tokens also use `****`. Usernames, client IDs, hosts, paths, topics, and other operational fields remain visible, while sink statuses are cloned unchanged. The runtime configuration remains unchanged. HTTP `GET /v3/_/events-sinks` and `ledgerctl events list` use the same projection, so callers must not reuse a read response as a sink mutation payload.
+
+Historical copies of sink configuration in system logs and audit records require a separate read projection because persisted audit bytes remain authoritative and hash-chain-bound. That projection is implemented independently by EN-1634 / PR #1654; this endpoint projection does not mutate or reinterpret historical records.
 
 ```protobuf
 message SinkStatus {

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -719,7 +719,7 @@ Read endpoints comparison with the original ledger:
 | `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
 | `GET /v3/_/chapter-schedule` | ✅ | ❌ | Get the auto-rotation cron for chapters |
-| `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`; credentials redacted) |
+| `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`; configured secret fields and URL userinfo redacted) |
 | `GET /v3/_/signing-keys` | ✅ | ❌ | List registered Ed25519 signing keys |
 | `GET /v3/{ledgerName}/indexes` | ✅ | ❌ | List indexes registered on a ledger |
 | `GET /v3/{ledgerName}/indexes/{canonicalId}` | ✅ | ❌ | Get a single Index registry entry |

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -719,7 +719,7 @@ Read endpoints comparison with the original ledger:
 | `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
 | `GET /v3/_/chapter-schedule` | ✅ | ❌ | Get the auto-rotation cron for chapters |
-| `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`) |
+| `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`; credentials redacted) |
 | `GET /v3/_/signing-keys` | ✅ | ❌ | List registered Ed25519 signing keys |
 | `GET /v3/{ledgerName}/indexes` | ✅ | ❌ | List indexes registered on a ledger |
 | `GET /v3/{ledgerName}/indexes/{canonicalId}` | ✅ | ❌ | Get a single Index registry entry |
@@ -782,7 +782,7 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `GetPrimaryMetrics` | Get primary Pebble store metrics | ✅ |
 | `GetSecondaryMetrics` | Get secondary (read index) Pebble store metrics | ✅ |
 | `CheckStore` | Verify store integrity (hash chain + derived data) | ✅ |
-| `GetEventsSinks` | Get per-sink configurations and statuses | ✅ |
+| `GetEventsSinks` | Get redacted per-sink configurations and statuses | ✅ |
 | `GetChapterSchedule` | Get current chapter rotation schedule | ✅ |
 | `GetMetadataSchemaStatus` | Get the declared metadata schema for a ledger | ✅ |
 | `AnalyzeTransactions` | Discover transaction flow patterns | ✅ |

--- a/internal/adapter/eventsink/redact.go
+++ b/internal/adapter/eventsink/redact.go
@@ -62,6 +62,7 @@ func redactConfigInPlace(cfg *commonpb.SinkConfig) {
 		}
 	case *commonpb.SinkConfig_Http:
 		if sink.Http != nil {
+			sink.Http.Endpoint = redact.URLUserinfo(sink.Http.GetEndpoint())
 			sink.Http.Secret = redact.Secret(sink.Http.GetSecret())
 		}
 	case *commonpb.SinkConfig_Databricks:
@@ -77,31 +78,9 @@ func redactNATSURLs(value string) string {
 	servers := strings.Split(value, ",")
 	for index, server := range servers {
 		trimmed := strings.TrimSpace(server)
-		schemeEnd := strings.Index(trimmed, "://")
-		if schemeEnd == -1 {
-			continue
-		}
-
-		rest := trimmed[schemeEnd+3:]
-		userinfoEnd := strings.LastIndex(rest, "@")
-		if userinfoEnd == -1 {
-			continue
-		}
-
-		userinfo := rest[:userinfoEnd]
-		if userinfo == "" {
-			continue
-		}
-
-		if username, _, hasPassword := strings.Cut(userinfo, ":"); hasPassword {
-			userinfo = username + ":" + redact.SecretSet
-		} else {
-			userinfo = redact.SecretSet
-		}
-
 		leadingSpace := server[:len(server)-len(strings.TrimLeft(server, " \t"))]
 		trailingSpace := server[len(strings.TrimRight(server, " \t")):]
-		servers[index] = leadingSpace + trimmed[:schemeEnd+3] + userinfo + rest[userinfoEnd:] + trailingSpace
+		servers[index] = leadingSpace + redact.URLUserinfo(trimmed) + trailingSpace
 	}
 
 	return strings.Join(servers, ",")

--- a/internal/adapter/eventsink/redact.go
+++ b/internal/adapter/eventsink/redact.go
@@ -1,0 +1,77 @@
+// Package eventsink provides the read-side projection of event-sink
+// configuration. Runtime configuration retains the original credentials;
+// externally serialized read models expose only redaction markers.
+package eventsink
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/redact"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// RedactConfig returns a deep clone of cfg with every credential-bearing field
+// replaced by a non-reusable marker. The supplied runtime configuration is not
+// mutated.
+func RedactConfig(cfg *commonpb.SinkConfig) *commonpb.SinkConfig {
+	if cfg == nil {
+		return nil
+	}
+
+	cloned, _ := proto.Clone(cfg).(*commonpb.SinkConfig)
+	redactConfigInPlace(cloned)
+
+	return cloned
+}
+
+// RedactGetResponse returns a deep clone of resp whose sink configurations are
+// safe to return through read-scoped APIs. Status records are cloned unchanged.
+func RedactGetResponse(resp *servicepb.GetEventsSinksResponse) *servicepb.GetEventsSinksResponse {
+	if resp == nil {
+		return nil
+	}
+
+	cloned, _ := proto.Clone(resp).(*servicepb.GetEventsSinksResponse)
+	for _, sink := range cloned.GetSinks() {
+		redactConfigInPlace(sink)
+	}
+
+	return cloned
+}
+
+func redactConfigInPlace(cfg *commonpb.SinkConfig) {
+	if cfg == nil {
+		return
+	}
+
+	switch sink := cfg.GetType().(type) {
+	case *commonpb.SinkConfig_Clickhouse:
+		if sink.Clickhouse != nil {
+			sink.Clickhouse.Dsn = redact.DSN(sink.Clickhouse.GetDsn())
+		}
+	case *commonpb.SinkConfig_Kafka:
+		if sink.Kafka != nil {
+			sink.Kafka.SaslPassword = redact.Secret(sink.Kafka.GetSaslPassword())
+		}
+	case *commonpb.SinkConfig_Http:
+		if sink.Http != nil {
+			sink.Http.Secret = redact.Secret(sink.Http.GetSecret())
+		}
+	case *commonpb.SinkConfig_Databricks:
+		if sink.Databricks != nil {
+			redactDatabricksAuthInPlace(sink.Databricks)
+		}
+	}
+}
+
+func redactDatabricksAuthInPlace(cfg *commonpb.DatabricksSinkConfig) {
+	switch auth := cfg.GetAuth().(type) {
+	case *commonpb.DatabricksSinkConfig_Token:
+		auth.Token = redact.Secret(auth.Token)
+	case *commonpb.DatabricksSinkConfig_OauthM2M:
+		if auth.OauthM2M != nil {
+			auth.OauthM2M.ClientSecret = redact.Secret(auth.OauthM2M.GetClientSecret())
+		}
+	}
+}

--- a/internal/adapter/eventsink/redact.go
+++ b/internal/adapter/eventsink/redact.go
@@ -4,6 +4,8 @@
 package eventsink
 
 import (
+	"strings"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/redact"
@@ -54,6 +56,10 @@ func redactConfigInPlace(cfg *commonpb.SinkConfig) {
 		if sink.Kafka != nil {
 			sink.Kafka.SaslPassword = redact.Secret(sink.Kafka.GetSaslPassword())
 		}
+	case *commonpb.SinkConfig_Nats:
+		if sink.Nats != nil {
+			sink.Nats.Url = redactNATSURLs(sink.Nats.GetUrl())
+		}
 	case *commonpb.SinkConfig_Http:
 		if sink.Http != nil {
 			sink.Http.Secret = redact.Secret(sink.Http.GetSecret())
@@ -63,6 +69,42 @@ func redactConfigInPlace(cfg *commonpb.SinkConfig) {
 			redactDatabricksAuthInPlace(sink.Databricks)
 		}
 	}
+}
+
+// redactNATSURLs removes password and token userinfo from the comma-separated
+// server list accepted by the NATS client while preserving server addresses.
+func redactNATSURLs(value string) string {
+	servers := strings.Split(value, ",")
+	for index, server := range servers {
+		trimmed := strings.TrimSpace(server)
+		schemeEnd := strings.Index(trimmed, "://")
+		if schemeEnd == -1 {
+			continue
+		}
+
+		rest := trimmed[schemeEnd+3:]
+		userinfoEnd := strings.LastIndex(rest, "@")
+		if userinfoEnd == -1 {
+			continue
+		}
+
+		userinfo := rest[:userinfoEnd]
+		if userinfo == "" {
+			continue
+		}
+
+		if username, _, hasPassword := strings.Cut(userinfo, ":"); hasPassword {
+			userinfo = username + ":" + redact.SecretSet
+		} else {
+			userinfo = redact.SecretSet
+		}
+
+		leadingSpace := server[:len(server)-len(strings.TrimLeft(server, " \t"))]
+		trailingSpace := server[len(strings.TrimRight(server, " \t")):]
+		servers[index] = leadingSpace + trimmed[:schemeEnd+3] + userinfo + rest[userinfoEnd:] + trailingSpace
+	}
+
+	return strings.Join(servers, ",")
 }
 
 func redactDatabricksAuthInPlace(cfg *commonpb.DatabricksSinkConfig) {

--- a/internal/adapter/eventsink/redact_test.go
+++ b/internal/adapter/eventsink/redact_test.go
@@ -21,6 +21,8 @@ func TestRedactGetResponse_RemovesEverySinkCredential(t *testing.T) {
 		"webhook-secret",
 		"dapi-pat-plaintext",
 		"oauth-secret-plaintext",
+		"nats-password",
+		"nats-token",
 	}
 	response := &servicepb.GetEventsSinksResponse{
 		Sinks: []*commonpb.SinkConfig{
@@ -43,6 +45,12 @@ func TestRedactGetResponse_RemovesEverySinkCredential(t *testing.T) {
 				Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{
 					Endpoint: "https://example.com/events",
 					Secret:   secrets[2],
+				}},
+			},
+			{
+				Name: "nats",
+				Type: &commonpb.SinkConfig_Nats{Nats: &commonpb.NatsSinkConfig{
+					Url: "nats://operator:" + secrets[5] + "@one.example:4222, nats://" + secrets[6] + "@two.example:4222,nats://three.example:4222",
 				}},
 			},
 			{
@@ -76,17 +84,20 @@ func TestRedactGetResponse_RemovesEverySinkCredential(t *testing.T) {
 	assert.Equal(t, "clickhouse://operator:****@example.com:9000/ledger", redacted.GetSinks()[0].GetClickhouse().GetDsn())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[1].GetKafka().GetSaslPassword())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[2].GetHttp().GetSecret())
-	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[3].GetDatabricks().GetToken())
-	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientSecret())
-	assert.Equal(t, "operator-client", redacted.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientId())
+	assert.Equal(t, "nats://operator:(set)@one.example:4222, nats://(set)@two.example:4222,nats://three.example:4222", redacted.GetSinks()[3].GetNats().GetUrl())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[4].GetDatabricks().GetToken())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[5].GetDatabricks().GetOauthM2M().GetClientSecret())
+	assert.Equal(t, "operator-client", redacted.GetSinks()[5].GetDatabricks().GetOauthM2M().GetClientId())
 	assert.Equal(t, uint64(42), redacted.GetSinkStatuses()[0].GetCursor())
 
 	// Read-side projection must not corrupt the controller-owned runtime config.
 	assert.Contains(t, response.GetSinks()[0].GetClickhouse().GetDsn(), secrets[0])
 	assert.Equal(t, secrets[1], response.GetSinks()[1].GetKafka().GetSaslPassword())
 	assert.Equal(t, secrets[2], response.GetSinks()[2].GetHttp().GetSecret())
-	assert.Equal(t, secrets[3], response.GetSinks()[3].GetDatabricks().GetToken())
-	assert.Equal(t, secrets[4], response.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientSecret())
+	assert.Contains(t, response.GetSinks()[3].GetNats().GetUrl(), secrets[5])
+	assert.Contains(t, response.GetSinks()[3].GetNats().GetUrl(), secrets[6])
+	assert.Equal(t, secrets[3], response.GetSinks()[4].GetDatabricks().GetToken())
+	assert.Equal(t, secrets[4], response.GetSinks()[5].GetDatabricks().GetOauthM2M().GetClientSecret())
 }
 
 func TestRedactConfig_ReportsAbsentSecretWithoutMutatingInput(t *testing.T) {

--- a/internal/adapter/eventsink/redact_test.go
+++ b/internal/adapter/eventsink/redact_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/redact"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -84,7 +85,7 @@ func TestRedactGetResponse_RemovesEverySinkCredential(t *testing.T) {
 	assert.Equal(t, "clickhouse://operator:****@example.com:9000/ledger", redacted.GetSinks()[0].GetClickhouse().GetDsn())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[1].GetKafka().GetSaslPassword())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[2].GetHttp().GetSecret())
-	assert.Equal(t, "nats://operator:(set)@one.example:4222, nats://(set)@two.example:4222,nats://three.example:4222", redacted.GetSinks()[3].GetNats().GetUrl())
+	assert.Equal(t, "nats://operator:****@one.example:4222, nats://****@two.example:4222,nats://three.example:4222", redacted.GetSinks()[3].GetNats().GetUrl())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[4].GetDatabricks().GetToken())
 	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[5].GetDatabricks().GetOauthM2M().GetClientSecret())
 	assert.Equal(t, "operator-client", redacted.GetSinks()[5].GetDatabricks().GetOauthM2M().GetClientId())
@@ -115,4 +116,65 @@ func TestRedactConfig_ReportsAbsentSecretWithoutMutatingInput(t *testing.T) {
 	assert.Empty(t, config.GetHttp().GetSecret())
 	assert.Nil(t, RedactConfig(nil))
 	assert.Nil(t, RedactGetResponse(nil))
+}
+
+func TestRedactConfig_RedactsURLCredentialShapesAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   *commonpb.SinkConfig
+		secrets  []string
+		expected string
+	}{
+		{
+			name: "ClickHouse query password",
+			config: &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Clickhouse{
+				Clickhouse: &commonpb.ClickHouseSinkConfig{Dsn: "clickhouse://host:9000/ledger?username=operator&password=query-secret"},
+			}},
+			secrets:  []string{"query-secret"},
+			expected: "clickhouse://host:9000/ledger?password=****&username=operator",
+		},
+		{
+			name: "NATS password and token server list",
+			config: &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Nats{
+				Nats: &commonpb.NatsSinkConfig{Url: "nats://operator:nats-password@one:4222, nats://nats-token@two:4222"},
+			}},
+			secrets:  []string{"nats-password", "nats-token"},
+			expected: "nats://operator:****@one:4222, nats://****@two:4222",
+		},
+		{
+			name: "HTTP endpoint basic auth",
+			config: &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Http{
+				Http: &commonpb.HttpSinkConfig{Endpoint: "https://operator:http-password@example.com/hooks@v2"},
+			}},
+			secrets:  []string{"http-password"},
+			expected: "https://operator:****@example.com/hooks@v2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			original := test.config.CloneVT()
+			redacted := RedactConfig(test.config)
+			repeated := RedactConfig(redacted)
+
+			assert.True(t, proto.Equal(original, test.config))
+			assert.True(t, proto.Equal(redacted, repeated))
+			for _, secret := range test.secrets {
+				assert.NotContains(t, redacted.String(), secret)
+			}
+
+			switch sink := redacted.GetType().(type) {
+			case *commonpb.SinkConfig_Clickhouse:
+				assert.Equal(t, test.expected, sink.Clickhouse.GetDsn())
+			case *commonpb.SinkConfig_Nats:
+				assert.Equal(t, test.expected, sink.Nats.GetUrl())
+			case *commonpb.SinkConfig_Http:
+				assert.Equal(t, test.expected, sink.Http.GetEndpoint())
+			}
+		})
+	}
 }

--- a/internal/adapter/eventsink/redact_test.go
+++ b/internal/adapter/eventsink/redact_test.go
@@ -1,0 +1,107 @@
+package eventsink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/redact"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestRedactGetResponse_RemovesEverySinkCredential(t *testing.T) {
+	t.Parallel()
+
+	secrets := []string{
+		"clickhouse-password",
+		"kafka-password",
+		"webhook-secret",
+		"dapi-pat-plaintext",
+		"oauth-secret-plaintext",
+	}
+	response := &servicepb.GetEventsSinksResponse{
+		Sinks: []*commonpb.SinkConfig{
+			{
+				Name: "clickhouse",
+				Type: &commonpb.SinkConfig_Clickhouse{Clickhouse: &commonpb.ClickHouseSinkConfig{
+					Dsn: "clickhouse://operator:" + secrets[0] + "@example.com:9000/ledger",
+				}},
+			},
+			{
+				Name: "kafka",
+				Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{
+					Brokers:      []string{"broker:9092"},
+					SaslUsername: "operator",
+					SaslPassword: secrets[1],
+				}},
+			},
+			{
+				Name: "webhook",
+				Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{
+					Endpoint: "https://example.com/events",
+					Secret:   secrets[2],
+				}},
+			},
+			{
+				Name: "databricks-pat",
+				Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{
+					ServerHostname: "adb.example.com",
+					Auth:           &commonpb.DatabricksSinkConfig_Token{Token: secrets[3]},
+				}},
+			},
+			{
+				Name: "databricks-oauth",
+				Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{
+					ServerHostname: "adb.example.com",
+					Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{
+						ClientId:     "operator-client",
+						ClientSecret: secrets[4],
+					}},
+				}},
+			},
+		},
+		SinkStatuses: []*commonpb.SinkStatus{{SinkName: "kafka", Cursor: 42}},
+	}
+
+	redacted := RedactGetResponse(response)
+	rendered, err := protojson.Marshal(redacted)
+	require.NoError(t, err)
+
+	for _, secret := range secrets {
+		assert.NotContains(t, string(rendered), secret)
+	}
+	assert.Equal(t, "clickhouse://operator:****@example.com:9000/ledger", redacted.GetSinks()[0].GetClickhouse().GetDsn())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[1].GetKafka().GetSaslPassword())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[2].GetHttp().GetSecret())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[3].GetDatabricks().GetToken())
+	assert.Equal(t, redact.SecretSet, redacted.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientSecret())
+	assert.Equal(t, "operator-client", redacted.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientId())
+	assert.Equal(t, uint64(42), redacted.GetSinkStatuses()[0].GetCursor())
+
+	// Read-side projection must not corrupt the controller-owned runtime config.
+	assert.Contains(t, response.GetSinks()[0].GetClickhouse().GetDsn(), secrets[0])
+	assert.Equal(t, secrets[1], response.GetSinks()[1].GetKafka().GetSaslPassword())
+	assert.Equal(t, secrets[2], response.GetSinks()[2].GetHttp().GetSecret())
+	assert.Equal(t, secrets[3], response.GetSinks()[3].GetDatabricks().GetToken())
+	assert.Equal(t, secrets[4], response.GetSinks()[4].GetDatabricks().GetOauthM2M().GetClientSecret())
+}
+
+func TestRedactConfig_ReportsAbsentSecretWithoutMutatingInput(t *testing.T) {
+	t.Parallel()
+
+	config := &commonpb.SinkConfig{
+		Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{
+			Endpoint: "https://example.com/events",
+		}},
+	}
+
+	redacted := RedactConfig(config)
+
+	assert.Equal(t, redact.SecretNone, redacted.GetHttp().GetSecret())
+	assert.Empty(t, config.GetHttp().GetSecret())
+	assert.Nil(t, RedactConfig(nil))
+	assert.Nil(t, RedactGetResponse(nil))
+}

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -22,6 +22,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/adapter/eventsink"
 	"github.com/formancehq/ledger/v3/internal/application/check"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/domain"
@@ -1149,10 +1150,10 @@ func (impl *BucketServiceServerImpl) GetEventsSinks(ctx context.Context, _ *serv
 		return nil, fmt.Errorf("loading events sinks: %w", err)
 	}
 
-	return &servicepb.GetEventsSinksResponse{
+	return eventsink.RedactGetResponse(&servicepb.GetEventsSinksResponse{
 		Sinks:        sinks,
 		SinkStatuses: statuses,
-	}, nil
+	}), nil
 }
 
 func (impl *BucketServiceServerImpl) GetChapterSchedule(ctx context.Context, _ *servicepb.GetChapterScheduleRequest) (*servicepb.GetChapterScheduleResponse, error) {

--- a/internal/adapter/grpc/server_bucket_events_sinks_test.go
+++ b/internal/adapter/grpc/server_bucket_events_sinks_test.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/eventsink"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestGetEventsSinks_RedactsCredentialsAtGRPCBoundary(t *testing.T) {
+	t.Parallel()
+
+	config := &commonpb.SinkConfig{
+		Name: "webhook",
+		Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{
+			Endpoint: "https://example.com/events",
+			Secret:   "grpc-plaintext-secret",
+		}},
+	}
+	controller := NewMockController(gomock.NewController(t))
+	controller.EXPECT().GetEventsSinks(gomock.Any()).Return(
+		[]*commonpb.SinkConfig{config},
+		[]*commonpb.SinkStatus{{SinkName: "webhook", Cursor: 12}},
+		nil,
+	)
+	server := &BucketServiceServerImpl{ctrl: controller}
+
+	response, err := server.GetEventsSinks(context.Background(), &servicepb.GetEventsSinksRequest{})
+	require.NoError(t, err)
+	require.Len(t, response.GetSinks(), 1)
+	assert.Equal(t, eventsink.RedactConfig(config).GetHttp().GetSecret(), response.GetSinks()[0].GetHttp().GetSecret())
+	assert.NotEqual(t, "grpc-plaintext-secret", response.GetSinks()[0].GetHttp().GetSecret())
+	assert.Equal(t, "grpc-plaintext-secret", config.GetHttp().GetSecret())
+	assert.Equal(t, uint64(12), response.GetSinkStatuses()[0].GetCursor())
+}

--- a/internal/adapter/http/handlers_get_events_sinks.go
+++ b/internal/adapter/http/handlers_get_events_sinks.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/eventsink"
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -25,10 +26,10 @@ func (s *Server) handleGetEventsSinks(w http.ResponseWriter, r *http.Request) {
 	// configs) serialize in camelCase — the sonic default would leak snake_case
 	// proto tags (sink_name) and the untagged oneof wrapper field. Reusing the
 	// gRPC GetEventsSinksResponse gives both transports an identical shape.
-	raw, err := protojson.Marshal(&servicepb.GetEventsSinksResponse{
+	raw, err := protojson.Marshal(eventsink.RedactGetResponse(&servicepb.GetEventsSinksResponse{
 		Sinks:        sinks,
 		SinkStatuses: statuses,
-	})
+	}))
 	if err != nil {
 		handleError(w, r, err)
 

--- a/internal/adapter/http/handlers_get_events_sinks_test.go
+++ b/internal/adapter/http/handlers_get_events_sinks_test.go
@@ -63,3 +63,33 @@ func TestHandleGetEventsSinks_BackendError(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+func TestHandleGetEventsSinks_RedactsCredentialsAtHTTPBoundary(t *testing.T) {
+	t.Parallel()
+
+	config := &commonpb.SinkConfig{
+		Name: "kafka",
+		Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{
+			Brokers:      []string{"broker:9092"},
+			SaslUsername: "operator",
+			SaslPassword: "http-plaintext-password",
+		}},
+	}
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetEventsSinks(gomock.Any()).Return(
+		[]*commonpb.SinkConfig{config},
+		[]*commonpb.SinkStatus{{SinkName: "kafka", Cursor: 42}},
+		nil,
+	)
+	srv := newTestServer(t, backend)
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/_/events-sinks", nil, nil)
+
+	srv.handleGetEventsSinks(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), "http-plaintext-password")
+	require.Contains(t, w.Body.String(), `"saslPassword":"(set)"`)
+	require.Contains(t, w.Body.String(), `"saslUsername":"operator"`)
+	require.Equal(t, "http-plaintext-password", config.GetKafka().GetSaslPassword())
+}

--- a/internal/pkg/redact/redact.go
+++ b/internal/pkg/redact/redact.go
@@ -1,0 +1,42 @@
+package redact
+
+import "strings"
+
+const (
+	SecretSet  = "(set)"
+	SecretNone = "(none)"
+)
+
+// Secret replaces an opaque secret with a marker that only exposes whether a
+// value is configured.
+func Secret(value string) string {
+	if value == "" {
+		return SecretNone
+	}
+
+	return SecretSet
+}
+
+// DSN replaces the password in a URL-shaped DSN with "****" while preserving
+// the username and host for operator diagnostics. Non-URL DSNs and DSNs without
+// a password are returned unchanged.
+func DSN(dsn string) string {
+	schemeEnd := strings.Index(dsn, "://")
+	if schemeEnd == -1 {
+		return dsn
+	}
+
+	rest := dsn[schemeEnd+3:]
+	lastAt := strings.LastIndex(rest, "@")
+	if lastAt == -1 {
+		return dsn
+	}
+
+	creds := rest[:lastAt]
+	user, _, ok := strings.Cut(creds, ":")
+	if !ok {
+		return dsn
+	}
+
+	return dsn[:schemeEnd+3] + user + ":****" + rest[lastAt:]
+}

--- a/internal/pkg/redact/redact.go
+++ b/internal/pkg/redact/redact.go
@@ -1,42 +1,117 @@
+// Package redact provides deterministic, idempotent projections for values
+// that may contain reusable credentials.
 package redact
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 const (
 	SecretSet  = "(set)"
 	SecretNone = "(none)"
+	urlMask    = "****"
 )
 
 // Secret replaces an opaque secret with a marker that only exposes whether a
 // value is configured.
 func Secret(value string) string {
-	if value == "" {
+	switch value {
+	case "":
 		return SecretNone
+	case SecretSet, SecretNone:
+		return value
+	default:
+		return SecretSet
 	}
-
-	return SecretSet
 }
 
-// DSN replaces the password in a URL-shaped DSN with "****" while preserving
-// the username and host for operator diagnostics. Non-URL DSNs and DSNs without
-// a password are returned unchanged.
+// DSN replaces credentials in a URL-shaped DSN while preserving non-secret
+// connection details for operator diagnostics. Userinfo passwords and
+// credential-bearing query parameters use "****". Invalid URL-shaped values
+// fail closed to SecretSet; non-URL DSNs are returned unchanged.
 func DSN(dsn string) string {
-	schemeEnd := strings.Index(dsn, "://")
-	if schemeEnd == -1 {
+	if dsn == "" || !strings.Contains(dsn, "://") {
 		return dsn
 	}
 
-	rest := dsn[schemeEnd+3:]
-	lastAt := strings.LastIndex(rest, "@")
-	if lastAt == -1 {
-		return dsn
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.Scheme == "" {
+		return SecretSet
 	}
 
-	creds := rest[:lastAt]
-	user, _, ok := strings.Cut(creds, ":")
-	if !ok {
-		return dsn
+	if parsed.User != nil {
+		username := parsed.User.Username()
+		password, hasPassword := parsed.User.Password()
+		if hasPassword {
+			if password == "" {
+				parsed.User = url.UserPassword(username, "")
+			} else {
+				parsed.User = url.UserPassword(username, urlMask)
+			}
+		}
 	}
 
-	return dsn[:schemeEnd+3] + user + ":****" + rest[lastAt:]
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return SecretSet
+	}
+	for key, values := range query {
+		if !isCredentialQueryKey(key) {
+			continue
+		}
+
+		for index, value := range values {
+			if value != "" {
+				values[index] = urlMask
+			}
+		}
+	}
+	parsed.RawQuery = query.Encode()
+
+	return restoreURLMask(parsed.String())
+}
+
+// URLUserinfo replaces password or token userinfo in a URL with "****" while
+// preserving its scheme, host, path, query and fragment. Invalid URLs fail
+// closed to SecretSet.
+func URLUserinfo(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return SecretSet
+	}
+	if parsed.User == nil {
+		return value
+	}
+
+	username := parsed.User.Username()
+	password, hasPassword := parsed.User.Password()
+	switch {
+	case hasPassword && password == "":
+		parsed.User = url.UserPassword(username, "")
+	case hasPassword:
+		parsed.User = url.UserPassword(username, urlMask)
+	default:
+		parsed.User = url.User(urlMask)
+	}
+
+	return restoreURLMask(parsed.String())
+}
+
+func isCredentialQueryKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(key, "-", "_"))
+	switch normalized {
+	case "password", "passwd", "pass", "token", "access_token", "api_key", "secret", "client_secret":
+		return true
+	default:
+		return false
+	}
+}
+
+func restoreURLMask(value string) string {
+	return strings.ReplaceAll(value, "%2A%2A%2A%2A", urlMask)
 }

--- a/internal/pkg/redact/redact_test.go
+++ b/internal/pkg/redact/redact_test.go
@@ -1,0 +1,151 @@
+package redact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecretIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "plaintext-secret", SecretSet, SecretNone} {
+		t.Run(value, func(t *testing.T) {
+			t.Parallel()
+
+			once := Secret(value)
+			assert.Equal(t, once, Secret(once))
+		})
+	}
+}
+
+func TestDSNRedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		secrets  []string
+		expected string
+	}{
+		{
+			name:     "userinfo password",
+			input:    "clickhouse://operator:supersecret@host:9000/ledger",
+			secrets:  []string{"supersecret"},
+			expected: "clickhouse://operator:****@host:9000/ledger",
+		},
+		{
+			name:     "query password",
+			input:    "clickhouse://host:9000/ledger?username=operator&password=supersecret",
+			secrets:  []string{"supersecret"},
+			expected: "clickhouse://host:9000/ledger?password=****&username=operator",
+		},
+		{
+			name:     "userinfo username and query password",
+			input:    "clickhouse://operator@host:9000/ledger?password=supersecret",
+			secrets:  []string{"supersecret"},
+			expected: "clickhouse://operator@host:9000/ledger?password=****",
+		},
+		{
+			name:     "userinfo and query passwords",
+			input:    "clickhouse://operator:userinfo-secret@host:9000/ledger?password=query-secret",
+			secrets:  []string{"userinfo-secret", "query-secret"},
+			expected: "clickhouse://operator:****@host:9000/ledger?password=****",
+		},
+		{
+			name:     "at sign inside query password",
+			input:    "clickhouse://host:9000/ledger?password=p%40ss",
+			secrets:  []string{"p%40ss", "p@ss"},
+			expected: "clickhouse://host:9000/ledger?password=****",
+		},
+		{
+			name:     "explicit empty password",
+			input:    "clickhouse://operator:@host:9000/ledger?password=",
+			expected: "clickhouse://operator:@host:9000/ledger?password=",
+		},
+		{
+			name:     "other credential query keys",
+			input:    "clickhouse://host:9000/ledger?access-token=a&api_key=b&client-secret=c&token=d",
+			secrets:  []string{"=a", "=b", "=c", "=d"},
+			expected: "clickhouse://host:9000/ledger?access-token=****&api_key=****&client-secret=****&token=****",
+		},
+		{
+			name:     "malformed URL fails closed",
+			input:    "clickhouse://operator:secret%zz@host:9000/ledger",
+			secrets:  []string{"secret"},
+			expected: SecretSet,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DSN(test.input)
+			assert.Equal(t, test.expected, got)
+			for _, secret := range test.secrets {
+				assert.NotContains(t, got, secret)
+			}
+			assert.Equal(t, got, DSN(got))
+		})
+	}
+}
+
+func TestURLUserinfoRedactsPasswordsAndTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		secret   string
+		expected string
+	}{
+		{
+			name:     "username and password",
+			input:    "nats://operator:password-secret@host:4222",
+			secret:   "password-secret",
+			expected: "nats://operator:****@host:4222",
+		},
+		{
+			name:     "token",
+			input:    "nats://token-secret@host:4222",
+			secret:   "token-secret",
+			expected: "nats://****@host:4222",
+		},
+		{
+			name:     "HTTP basic auth",
+			input:    "https://operator:http-secret@example.com/hooks",
+			secret:   "http-secret",
+			expected: "https://operator:****@example.com/hooks",
+		},
+		{
+			name:     "at sign in path is not userinfo",
+			input:    "https://example.com/hooks@v2",
+			expected: "https://example.com/hooks@v2",
+		},
+		{
+			name:     "explicit empty password",
+			input:    "nats://operator:@host:4222",
+			expected: "nats://operator:@host:4222",
+		},
+		{
+			name:     "malformed URL fails closed",
+			input:    "nats://token%zz@host:4222",
+			secret:   "token",
+			expected: SecretSet,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := URLUserinfo(test.input)
+			assert.Equal(t, test.expected, got)
+			if test.secret != "" {
+				assert.NotContains(t, got, test.secret)
+			}
+			assert.Equal(t, got, URLUserinfo(got))
+		})
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -2348,9 +2348,18 @@ paths:
       summary: List configured event sinks
       description: |
         Returns every event sink configured on the cluster. Requires
-        `ledger:OpsRead` scope. Credential-bearing fields are redacted: opaque
-        secrets use `(set)` or `(none)`, and URL-shaped DSN passwords use
-        `****`. Read responses must not be reused as sink mutation payloads.
+        `ledger:OpsRead` scope. The response applies these field-level
+        projections:
+
+        - `kafka.saslPassword`, `http.secret`, `databricks.token`, and
+          `databricks.oauthM2m.clientSecret` use `(set)` or `(none)`;
+        - password and credential-query values in `clickhouse.dsn` use `****`;
+        - password or token userinfo in `nats.url` and `http.endpoint` uses
+          `****`.
+
+        Usernames, client IDs, hosts, paths, topics, and other operational
+        fields remain visible. `sinkStatuses` are returned unchanged. Read
+        responses must not be reused as sink mutation payloads.
       operationId: getEventsSinks
       tags:
         - Ops
@@ -2379,7 +2388,8 @@ paths:
                           type: object
                           description: >
                             Redacted SinkConfig (protobuf JSON representation).
-                            Non-secret operational fields remain visible.
+                            The endpoint description defines the projected
+                            credential fields; operational fields remain visible.
                       sinkStatuses:
                         type: array
                         items:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2348,7 +2348,9 @@ paths:
       summary: List configured event sinks
       description: |
         Returns every event sink configured on the cluster. Requires
-        `ledger:OpsRead` scope.
+        `ledger:OpsRead` scope. Credential-bearing fields are redacted: opaque
+        secrets use `(set)` or `(none)`, and URL-shaped DSN passwords use
+        `****`. Read responses must not be reused as sink mutation payloads.
       operationId: getEventsSinks
       tags:
         - Ops
@@ -2375,7 +2377,9 @@ paths:
                         type: array
                         items:
                           type: object
-                          description: SinkConfig (protobuf JSON representation)
+                          description: >
+                            Redacted SinkConfig (protobuf JSON representation).
+                            Non-secret operational fields remain visible.
                       sinkStatuses:
                         type: array
                         items:


### PR DESCRIPTION
## What changed

- redact reusable event-sink credentials before gRPC and HTTP read responses are serialized
- deep-clone the read projection so runtime sink configuration remains unchanged
- handle ClickHouse userinfo and credential query parameters with URL-aware parsing
- redact NATS password/token userinfo, including comma-separated server lists, and HTTP endpoint userinfo
- make opaque and URL redaction idempotent across leader forwarding and CLI compatibility passes
- share the implementation with `ledgerctl` and document the field-level API contract
- add direct primitive, projection, transport, and CLI regression coverage

## Root cause

`GetEventsSinks` returned the controller's full `SinkConfig` under `ledger:OpsRead`. Because the default `ledger:read` mapping includes that scope, ordinary read callers could retrieve reusable credentials. CLI masking happened only after the server response.

The original redaction pass also relied on string slicing for DSNs and NATS URLs. It missed ClickHouse query-string passwords, could misparse `@` outside userinfo, did not cover HTTP endpoint userinfo, and was not a fixed point when routed or CLI paths redacted a response twice.

## Security behavior

- Kafka SASL passwords, HTTP HMAC secrets, Databricks PATs, and Databricks OAuth client secrets become `(set)` or `(none)`.
- ClickHouse userinfo passwords and credential-bearing DSN query values become `****`.
- NATS and HTTP URL userinfo passwords or tokens become `****`.
- Usernames, client IDs, hosts, paths, topics, and sink statuses remain visible.
- Runtime/controller-owned configuration is not mutated.

Historical copies in system logs and audit records are a distinct persistence/read boundary and are handled independently by draft PR [#1654](https://github.com/formancehq/ledger/pull/1654); this PR deliberately does not duplicate that projection.

## Validation

- `nix develop --command bash -c "GOROOT= go test ./internal/pkg/redact ./internal/adapter/eventsink ./internal/adapter/grpc ./internal/adapter/http ./cmd/ledgerctl/cmdutil ./cmd/ledgerctl/events"`
- `nix develop --command bash -c "GOROOT= go build ./..."`
- `nix develop --command bash -c "just pre-commit"`
- GitNexus index refreshed on the PR head
- GitNexus `detect_changes(scope: compare, base_ref: release/v3.0)`: LOW aggregate, expected files, no affected execution flows

## Tracking

- [EN-1632](https://formance-team.atlassian.net/browse/EN-1632)
- Historical-read companion: [EN-1634](https://formance-team.atlassian.net/browse/EN-1634) / [#1654](https://github.com/formancehq/ledger/pull/1654)


[EN-1632]: https://formance-team.atlassian.net/browse/EN-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ