### PR TITLE
fix(snapshot): prevent FetchFile path traversal

### DIFF
--- a/docs/technical/architecture/subsystems/consensus/README.md
+++ b/docs/technical/architecture/subsystems/consensus/README.md
@@ -7,6 +7,7 @@ The replication and ordering layer (`internal/infra/node`, `internal/infra/trans
 | Document | Description |
 |----------|-------------|
 | [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, leader election, log replication, and snapshot transfer. |
+| [snapshot-file-transfer.md](snapshot-file-transfer.md) | Snapshot checkpoint file serving and its filesystem containment boundary. |
 | [global-log.md](global-log.md) | Two-level log architecture enabling system-level atomic bulk operations. |
 | [hybrid-logical-clock.md](hybrid-logical-clock.md) | Monotonic HLC timestamps across leader changes and clock skew. |
 | [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted. |

--- a/docs/technical/architecture/subsystems/consensus/snapshot-file-transfer.md
+++ b/docs/technical/architecture/subsystems/consensus/snapshot-file-transfer.md
@@ -1,0 +1,37 @@
+# Snapshot File Transfer
+
+Follower synchronization uses the internal `SnapshotService` gRPC API to copy
+a temporary Pebble checkpoint from a donor node. `PrepareSnapshot` creates the
+checkpoint and returns a manifest. Concurrent `FetchFile` calls then stream the
+manifest's relative paths before `CloseSession` removes the checkpoint.
+
+## Filesystem containment
+
+`FetchFileRequest.path` crosses an internal network boundary and must never
+grant filesystem authority beyond the prepared checkpoint. The server applies
+two complementary controls:
+
+1. `filepath.IsLocal` rejects empty, absolute, reserved, and parent-escaping
+   paths before streaming starts.
+2. `streamOneFile` opens the final file through `os.Root`, rooted at the session
+   checkpoint. The rooted open prevents a path from escaping through a symbolic
+   link or through a concurrent rename between validation and open.
+
+The rooted open is the authoritative containment control. Lexical validation is
+kept at the RPC boundary so malformed paths receive `InvalidArgument` instead
+of being interpreted as missing files. Valid nested regular files remain
+supported, and symlinks are followed only when their target remains beneath the
+checkpoint root.
+
+These checks do not turn the checkpoint into a general sandbox: `os.Root` does
+not block bind mounts, device files, or filesystem boundaries. Snapshot
+checkpoints are created by the ledger process from Pebble data and must not be
+populated from caller-controlled filesystem trees.
+
+## Owning code
+
+| Responsibility | Location |
+| --- | --- |
+| Snapshot session and lexical path validation | `internal/adapter/grpc/server_snapshot.go` |
+| Rooted file open and chunk streaming | `internal/adapter/grpc/file_streaming.go` |
+| Snapshot protocol | `misc/proto/snapshot.proto` |

--- a/docs/technical/architecture/subsystems/consensus/snapshot-file-transfer.md
+++ b/docs/technical/architecture/subsystems/consensus/snapshot-file-transfer.md
@@ -11,8 +11,8 @@ manifest's relative paths before `CloseSession` removes the checkpoint.
 grant filesystem authority beyond the prepared checkpoint. The server applies
 two complementary controls:
 
-1. `filepath.IsLocal` rejects empty, absolute, reserved, and parent-escaping
-   paths before streaming starts.
+1. `filepath.IsLocal` rejects empty, absolute, and parent-escaping paths before
+   streaming starts. It also rejects reserved device names on Windows.
 2. `streamOneFile` opens the final file through `os.Root`, rooted at the session
    checkpoint. The rooted open prevents a path from escaping through a symbolic
    link or through a concurrent rename between validation and open.
@@ -20,8 +20,25 @@ two complementary controls:
 The rooted open is the authoritative containment control. Lexical validation is
 kept at the RPC boundary so malformed paths receive `InvalidArgument` instead
 of being interpreted as missing files. Valid nested regular files remain
-supported, and symlinks are followed only when their target remains beneath the
-checkpoint root.
+supported. A symlink is followed only when its target is expressed relatively
+and remains beneath the checkpoint root; an absolute symlink target is rejected
+even when it points inside the root. Pebble checkpoints contain hard links or
+copied files rather than symlinks, so this distinction does not arise in normal
+checkpoint data.
+
+## Follower-side receiving
+
+The manifest returned by a donor is network-supplied input. The follower
+validates every manifest path with `filepath.IsLocal` immediately after
+`PrepareSnapshot`, before scanning resume state or requesting a file. A second
+validation in the file fetcher protects direct callers.
+
+Resume scans, temporary-file creation, hashing, and the final rename all use an
+`os.Root` opened on the follower's staging directory. This is the mirror of the
+serving-side containment boundary: neither a manifest traversal nor a symlink
+already present in the staging directory can redirect a read or write outside
+that directory. Temporary files are removed on stream, hash, close, or rename
+failure.
 
 These checks do not turn the checkpoint into a general sandbox: `os.Root` does
 not block bind mounts, device files, or filesystem boundaries. Snapshot
@@ -34,4 +51,5 @@ populated from caller-controlled filesystem trees.
 | --- | --- |
 | Snapshot session and lexical path validation | `internal/adapter/grpc/server_snapshot.go` |
 | Rooted file open and chunk streaming | `internal/adapter/grpc/file_streaming.go` |
+| Manifest validation and rooted receive-side writes | `internal/application/ctrl/file_receiver.go`, `internal/application/ctrl/file_fetcher.go` |
 | Snapshot protocol | `misc/proto/snapshot.proto` |

--- a/internal/adapter/grpc/file_streaming.go
+++ b/internal/adapter/grpc/file_streaming.go
@@ -55,14 +55,25 @@ func buildManifest(dirPath string) (*snapshotpb.SnapshotManifest, error) {
 	return &snapshotpb.SnapshotManifest{Files: files}, nil
 }
 
-// streamOneFile reads a single file in chunks and sends them via send.
+// streamOneFile reads a single file beneath dirPath in chunks and sends them via send.
+// The rooted open is load-bearing: a caller-controlled path or symlink must not
+// escape the prepared snapshot checkpoint.
 func streamOneFile(
 	dirPath string,
 	relPath string,
 	buf []byte,
 	send func(*snapshotpb.FetchFileResponse) error,
 ) error {
-	f, err := os.Open(filepath.Join(dirPath, relPath))
+	root, err := os.OpenRoot(dirPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = root.Close()
+	}()
+
+	f, err := root.Open(relPath)
 	if err != nil {
 		return err
 	}

--- a/internal/adapter/grpc/file_streaming_test.go
+++ b/internal/adapter/grpc/file_streaming_test.go
@@ -115,3 +115,56 @@ func TestStreamOneFile_Empty(t *testing.T) {
 	require.Len(t, chunks, 1)
 	require.True(t, chunks[0].GetEof())
 }
+
+func TestStreamOneFile_PathConfinement(t *testing.T) {
+	t.Parallel()
+
+	checkpointDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("secret"), 0644))
+
+	nestedDir := filepath.Join(checkpointDir, "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedDir, "data.txt"), []byte("nested data"), 0644))
+
+	symlinkPath := filepath.Join(checkpointDir, "outside-link")
+	require.NoError(t, os.Symlink(outsidePath, symlinkPath))
+
+	traversalPath, err := filepath.Rel(checkpointDir, outsidePath)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "nested file", path: filepath.Join("nested", "data.txt")},
+		{name: "parent traversal", path: traversalPath, wantErr: true},
+		{name: "absolute path", path: outsidePath, wantErr: true},
+		{name: "symlink escape", path: filepath.Base(symlinkPath), wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var content []byte
+			err := streamOneFile(checkpointDir, test.path, make([]byte, defaultChunkSize), func(resp *snapshotpb.FetchFileResponse) error {
+				content = append(content, resp.GetData()...)
+
+				return nil
+			})
+
+			if test.wantErr {
+				require.Error(t, err)
+				require.Empty(t, content)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, "nested data", string(content))
+		})
+	}
+}

--- a/internal/adapter/grpc/file_streaming_test.go
+++ b/internal/adapter/grpc/file_streaming_test.go
@@ -168,3 +168,13 @@ func TestStreamOneFile_PathConfinement(t *testing.T) {
 		})
 	}
 }
+
+func TestStreamOneFile_MissingRoot(t *testing.T) {
+	t.Parallel()
+
+	err := streamOneFile(filepath.Join(t.TempDir(), "missing"), "data.txt", make([]byte, defaultChunkSize), func(*snapshotpb.FetchFileResponse) error {
+		return nil
+	})
+
+	require.Error(t, err)
+}

--- a/internal/adapter/grpc/file_streaming_test.go
+++ b/internal/adapter/grpc/file_streaming_test.go
@@ -135,14 +135,14 @@ func TestStreamOneFile_PathConfinement(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name    string
-		path    string
-		wantErr bool
+		name       string
+		path       string
+		wantErr    bool
+		errorCause string
 	}{
 		{name: "nested file", path: filepath.Join("nested", "data.txt")},
-		{name: "parent traversal", path: traversalPath, wantErr: true},
-		{name: "absolute path", path: outsidePath, wantErr: true},
-		{name: "symlink escape", path: filepath.Base(symlinkPath), wantErr: true},
+		{name: "parent traversal", path: traversalPath, wantErr: true, errorCause: "path escapes from parent"},
+		{name: "symlink escape", path: filepath.Base(symlinkPath), wantErr: true, errorCause: "path escapes from parent"},
 	}
 
 	for _, test := range tests {
@@ -157,7 +157,7 @@ func TestStreamOneFile_PathConfinement(t *testing.T) {
 			})
 
 			if test.wantErr {
-				require.Error(t, err)
+				require.ErrorContains(t, err, test.errorCause)
 				require.Empty(t, content)
 
 				return

--- a/internal/adapter/grpc/server_snapshot.go
+++ b/internal/adapter/grpc/server_snapshot.go
@@ -138,10 +138,7 @@ func (s *SnapshotServiceServerImpl) FetchFile(req *snapshotpb.FetchFileRequest, 
 
 	// Validate the path stays within the checkpoint directory.
 	relPath := req.GetPath()
-	fullPath := filepath.Join(session.checkpointPath, relPath)
-
-	resolved, err := filepath.Rel(session.checkpointPath, fullPath)
-	if err != nil || resolved != relPath {
+	if !filepath.IsLocal(relPath) {
 		return status.Errorf(codes.InvalidArgument, "invalid file path: %s", relPath)
 	}
 

--- a/internal/adapter/grpc/server_snapshot_test.go
+++ b/internal/adapter/grpc/server_snapshot_test.go
@@ -271,6 +271,26 @@ func TestSnapshotService_InvalidSessionID(t *testing.T) {
 	require.Equal(t, codes.NotFound, s.Code())
 }
 
+func TestSnapshotService_FetchFileRejectsNonLocalPath(t *testing.T) {
+	t.Parallel()
+
+	sessions := newSnapshotSessionStore(nil, noopLogger{}, defaultSessionTTL)
+	t.Cleanup(sessions.stop)
+
+	sessionID, err := sessions.create("test-sync", t.TempDir())
+	require.NoError(t, err)
+
+	server := &SnapshotServiceServerImpl{sessions: sessions}
+	stream := newFakeServerStream[snapshotpb.FetchFileResponse](t)
+	err = server.FetchFile(&snapshotpb.FetchFileRequest{
+		SessionId: sessionID,
+		Path:      "../outside",
+	}, stream)
+
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, stream.sent)
+}
+
 func TestSnapshotService_EmptyCheckpoint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/grpc/server_snapshot_test.go
+++ b/internal/adapter/grpc/server_snapshot_test.go
@@ -274,21 +274,27 @@ func TestSnapshotService_InvalidSessionID(t *testing.T) {
 func TestSnapshotService_FetchFileRejectsNonLocalPath(t *testing.T) {
 	t.Parallel()
 
-	sessions := newSnapshotSessionStore(nil, noopLogger{}, defaultSessionTTL)
-	t.Cleanup(sessions.stop)
+	for _, path := range []string{"../outside", filepath.Join(string(filepath.Separator), "outside")} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
 
-	sessionID, err := sessions.create("test-sync", t.TempDir())
-	require.NoError(t, err)
+			sessions := newSnapshotSessionStore(nil, noopLogger{}, defaultSessionTTL)
+			t.Cleanup(sessions.stop)
 
-	server := &SnapshotServiceServerImpl{sessions: sessions}
-	stream := newFakeServerStream[snapshotpb.FetchFileResponse](t)
-	err = server.FetchFile(&snapshotpb.FetchFileRequest{
-		SessionId: sessionID,
-		Path:      "../outside",
-	}, stream)
+			sessionID, err := sessions.create("test-sync", t.TempDir())
+			require.NoError(t, err)
 
-	require.Equal(t, codes.InvalidArgument, status.Code(err))
-	require.Empty(t, stream.sent)
+			server := &SnapshotServiceServerImpl{sessions: sessions}
+			stream := newFakeServerStream[snapshotpb.FetchFileResponse](t)
+			err = server.FetchFile(&snapshotpb.FetchFileRequest{
+				SessionId: sessionID,
+				Path:      path,
+			}, stream)
+
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Empty(t, stream.sent)
+		})
+	}
 }
 
 func TestSnapshotService_EmptyCheckpoint(t *testing.T) {

--- a/internal/application/ctrl/file_fetcher.go
+++ b/internal/application/ctrl/file_fetcher.go
@@ -59,6 +59,19 @@ func (f *fileFetcher) fetchFile(ctx context.Context, entry *snapshotpb.FileEntry
 }
 
 func (f *fileFetcher) fetchFileOnce(ctx context.Context, entry *snapshotpb.FileEntry, targetDir string, progress *state.SyncProgress) error {
+	if !filepath.IsLocal(entry.GetPath()) {
+		return fmt.Errorf("invalid snapshot path: %q", entry.GetPath())
+	}
+
+	root, err := os.OpenRoot(targetDir)
+	if err != nil {
+		return fmt.Errorf("opening snapshot target directory: %w", err)
+	}
+
+	defer func() {
+		_ = root.Close()
+	}()
+
 	stream, err := f.client.FetchFile(ctx, &snapshotpb.FetchFileRequest{
 		SessionId: f.sessionID,
 		Path:      entry.GetPath(),
@@ -67,12 +80,12 @@ func (f *fileFetcher) fetchFileOnce(ctx context.Context, entry *snapshotpb.FileE
 		return fmt.Errorf("opening stream for %s: %w", entry.GetPath(), err)
 	}
 
-	tmpPath := filepath.Join(targetDir, entry.GetPath()+".tmp")
-	if err := os.MkdirAll(filepath.Dir(tmpPath), 0755); err != nil {
+	tmpPath := entry.GetPath() + ".tmp"
+	if err := root.MkdirAll(filepath.Dir(tmpPath), 0755); err != nil {
 		return fmt.Errorf("creating parent directory for %s: %w", entry.GetPath(), err)
 	}
 
-	tmpFile, err := os.Create(tmpPath)
+	tmpFile, err := root.Create(tmpPath)
 	if err != nil {
 		return fmt.Errorf("creating temp file for %s: %w", entry.GetPath(), err)
 	}
@@ -81,6 +94,7 @@ func (f *fileFetcher) fetchFileOnce(ctx context.Context, entry *snapshotpb.FileE
 
 	defer func() {
 		_ = tmpFile.Close()
+		_ = root.Remove(tmpPath)
 	}()
 
 	for {
@@ -117,8 +131,7 @@ func (f *fileFetcher) fetchFileOnce(ctx context.Context, entry *snapshotpb.FileE
 		return fmt.Errorf("hash mismatch for %s: expected %s, got %s", entry.GetPath(), entry.GetSha256(), gotHash)
 	}
 
-	finalPath := filepath.Join(targetDir, entry.GetPath())
-	if err := os.Rename(tmpPath, finalPath); err != nil {
+	if err := root.Rename(tmpPath, entry.GetPath()); err != nil {
 		return fmt.Errorf("renaming %s: %w", entry.GetPath(), err)
 	}
 

--- a/internal/application/ctrl/file_fetcher_test.go
+++ b/internal/application/ctrl/file_fetcher_test.go
@@ -1,0 +1,79 @@
+package ctrl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/snapshotpb"
+)
+
+func TestFileFetcher_FetchFileOnceRejectsNonLocalPath(t *testing.T) {
+	t.Parallel()
+
+	client, csState := newMockSnapshotClient(t, nil, nil, nil)
+	fetcher := &fileFetcher{client: client, sessionID: "test-session"}
+
+	err := fetcher.fetchFileOnce(t.Context(), &snapshotpb.FileEntry{Path: "../outside"}, t.TempDir(), nil)
+	require.ErrorContains(t, err, "invalid snapshot path")
+	require.Equal(t, int32(0), csState.fetchFileCalls.Load())
+}
+
+func TestFileFetcher_FetchFileOnceRejectsMissingTargetRoot(t *testing.T) {
+	t.Parallel()
+
+	client, csState := newMockSnapshotClient(t, nil, nil, nil)
+	fetcher := &fileFetcher{client: client, sessionID: "test-session"}
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+
+	err := fetcher.fetchFileOnce(t.Context(), &snapshotpb.FileEntry{Path: "data.txt"}, missingRoot, nil)
+	require.ErrorContains(t, err, "opening snapshot target directory")
+	require.Equal(t, int32(0), csState.fetchFileCalls.Load())
+}
+
+func TestFileFetcher_FetchFileOnceReportsTempCreateFailure(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(targetDir, "data.txt.tmp"), 0755))
+
+	content := []byte("data")
+	client, _ := newMockSnapshotClient(t, nil, nil, map[string]*MockServerStreamingClient[snapshotpb.FetchFileResponse]{
+		"data.txt": newFileStream(t, fileStreamScript{
+			responses: []*snapshotpb.FetchFileResponse{{Data: content, Eof: true}},
+			failAt:    -1,
+		}),
+	})
+	fetcher := &fileFetcher{client: client, sessionID: "test-session"}
+
+	err := fetcher.fetchFileOnce(t.Context(), &snapshotpb.FileEntry{
+		Path:   "data.txt",
+		Sha256: fileSHA256(content),
+	}, targetDir, nil)
+	require.ErrorContains(t, err, "creating temp file")
+}
+
+func TestFileFetcher_FetchFileOnceRemovesTempAfterRenameFailure(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(targetDir, "data.txt"), 0755))
+
+	content := []byte("data")
+	client, _ := newMockSnapshotClient(t, nil, nil, map[string]*MockServerStreamingClient[snapshotpb.FetchFileResponse]{
+		"data.txt": newFileStream(t, fileStreamScript{
+			responses: []*snapshotpb.FetchFileResponse{{Data: content, Eof: true}},
+			failAt:    -1,
+		}),
+	})
+	fetcher := &fileFetcher{client: client, sessionID: "test-session"}
+
+	err := fetcher.fetchFileOnce(t.Context(), &snapshotpb.FileEntry{
+		Path:   "data.txt",
+		Sha256: fileSHA256(content),
+	}, targetDir, nil)
+	require.ErrorContains(t, err, "renaming data.txt")
+	require.NoFileExists(t, filepath.Join(targetDir, "data.txt.tmp"))
+}

--- a/internal/application/ctrl/file_receiver.go
+++ b/internal/application/ctrl/file_receiver.go
@@ -3,6 +3,7 @@ package ctrl
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -18,12 +19,23 @@ func scanCompletedFiles(targetDir string, manifest *snapshotpb.SnapshotManifest)
 		return nil, nil
 	}
 
+	if err := validateSnapshotManifest(manifest); err != nil {
+		return nil, err
+	}
+
+	root, err := os.OpenRoot(targetDir)
+	if err != nil {
+		return nil, fmt.Errorf("opening snapshot target directory: %w", err)
+	}
+
+	defer func() {
+		_ = root.Close()
+	}()
+
 	var completed []string
 
 	for _, entry := range manifest.GetFiles() {
-		fullPath := filepath.Join(targetDir, entry.GetPath())
-
-		info, err := os.Stat(fullPath)
+		info, err := root.Stat(entry.GetPath())
 		if err != nil {
 			continue // file not present or not accessible
 		}
@@ -32,7 +44,7 @@ func scanCompletedFiles(targetDir string, manifest *snapshotpb.SnapshotManifest)
 			continue // size mismatch — incomplete or different file
 		}
 
-		hash, err := hashFileSHA256(fullPath)
+		hash, err := hashFileSHA256(root, entry.GetPath())
 		if err != nil {
 			continue // can't hash — treat as incomplete
 		}
@@ -47,6 +59,22 @@ func scanCompletedFiles(targetDir string, manifest *snapshotpb.SnapshotManifest)
 	return completed, nil
 }
 
+// validateSnapshotManifest rejects paths that would escape the follower's
+// staging root before any file is requested or written.
+func validateSnapshotManifest(manifest *snapshotpb.SnapshotManifest) error {
+	if manifest == nil {
+		return nil
+	}
+
+	for i, entry := range manifest.GetFiles() {
+		if !filepath.IsLocal(entry.GetPath()) {
+			return fmt.Errorf("invalid snapshot path at manifest entry %d: %q", i, entry.GetPath())
+		}
+	}
+
+	return nil
+}
+
 // manifestTotalSize returns the sum of all file sizes in the manifest.
 func manifestTotalSize(manifest *snapshotpb.SnapshotManifest) uint64 {
 	var total uint64
@@ -57,9 +85,9 @@ func manifestTotalSize(manifest *snapshotpb.SnapshotManifest) uint64 {
 	return total
 }
 
-// hashFileSHA256 computes the SHA256 hex digest of a file.
-func hashFileSHA256(path string) (string, error) {
-	f, err := os.Open(path)
+// hashFileSHA256 computes the SHA256 hex digest of a file beneath root.
+func hashFileSHA256(root *os.Root, path string) (string, error) {
+	f, err := root.Open(path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/application/ctrl/file_receiver_test.go
+++ b/internal/application/ctrl/file_receiver_test.go
@@ -100,6 +100,29 @@ func TestScanCompletedFiles_IgnoresTmpFiles(t *testing.T) {
 	require.Empty(t, completed)
 }
 
+func TestScanCompletedFiles_RejectsNonLocalManifestPath(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	outsideDir := t.TempDir()
+	content := []byte("outside")
+	outsidePath := filepath.Join(outsideDir, "outside.txt")
+	require.NoError(t, os.WriteFile(outsidePath, content, 0644))
+
+	traversalPath, err := filepath.Rel(targetDir, outsidePath)
+	require.NoError(t, err)
+
+	manifest := &snapshotpb.SnapshotManifest{
+		Files: []*snapshotpb.FileEntry{
+			{Path: traversalPath, Size: uint64(len(content)), Sha256: sha256Hex(content)},
+		},
+	}
+
+	completed, err := scanCompletedFiles(targetDir, manifest)
+	require.ErrorContains(t, err, "invalid snapshot path")
+	require.Empty(t, completed)
+}
+
 func TestManifestTotalSize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/ctrl/file_receiver_test.go
+++ b/internal/application/ctrl/file_receiver_test.go
@@ -123,6 +123,30 @@ func TestScanCompletedFiles_RejectsNonLocalManifestPath(t *testing.T) {
 	require.Empty(t, completed)
 }
 
+func TestScanCompletedFiles_ReportsMissingTargetRoot(t *testing.T) {
+	t.Parallel()
+
+	manifest := &snapshotpb.SnapshotManifest{Files: []*snapshotpb.FileEntry{{Path: "data.txt"}}}
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+
+	completed, err := scanCompletedFiles(missingRoot, manifest)
+	require.ErrorContains(t, err, "opening snapshot target directory")
+	require.Empty(t, completed)
+}
+
+func TestHashFileSHA256_ReportsConfinedOpenError(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, root.Close())
+	})
+
+	_, err = hashFileSHA256(root, "missing.txt")
+	require.Error(t, err)
+}
+
 func TestManifestTotalSize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/ctrl/snapshot_fetcher.go
+++ b/internal/application/ctrl/snapshot_fetcher.go
@@ -184,6 +184,10 @@ func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir st
 
 	sessionID := resp.GetSessionId()
 	manifest := resp.GetManifest()
+	if err := validateSnapshotManifest(manifest); err != nil {
+		return 0, fmt.Errorf("validating snapshot manifest: %w", err)
+	}
+
 	totalSize := manifestTotalSize(manifest)
 
 	logger.WithFields(map[string]any{

--- a/internal/application/ctrl/snapshot_fetcher_test.go
+++ b/internal/application/ctrl/snapshot_fetcher_test.go
@@ -217,6 +217,74 @@ func TestGRPCSnapshotFetcher_HashMismatch(t *testing.T) {
 	_, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "hash mismatch")
+	require.NoFileExists(t, filepath.Join(dir, "data.bin.tmp"))
+}
+
+func TestGRPCSnapshotFetcher_RejectsNonLocalManifestPath(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "written-outside.txt")
+	traversalPath, err := filepath.Rel(targetDir, outsidePath)
+	require.NoError(t, err)
+
+	content := []byte("attacker-controlled")
+	streams := map[string]*MockServerStreamingClient[snapshotpb.FetchFileResponse]{
+		traversalPath: newFileStream(t, fileStreamScript{
+			responses: []*snapshotpb.FetchFileResponse{{Data: content, Eof: true}},
+			failAt:    -1,
+		}),
+	}
+	client, csState := newMockSnapshotClient(t,
+		&snapshotpb.PrepareSnapshotResponse{
+			SessionId: "test-session",
+			Manifest: &snapshotpb.SnapshotManifest{Files: []*snapshotpb.FileEntry{
+				{Path: traversalPath, Size: uint64(len(content)), Sha256: fileSHA256(content)},
+			}},
+		},
+		nil,
+		streams,
+	)
+
+	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	_, err = fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
+	require.ErrorContains(t, err, "invalid snapshot path")
+	require.Equal(t, int32(0), csState.fetchFileCalls.Load())
+	require.NoFileExists(t, outsidePath)
+}
+
+func TestGRPCSnapshotFetcher_RejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	outsideDir := t.TempDir()
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(targetDir, "outside-link")))
+
+	entryPath := filepath.Join("outside-link", "written-outside.txt")
+	content := []byte("attacker-controlled")
+	streams := map[string]*MockServerStreamingClient[snapshotpb.FetchFileResponse]{
+		entryPath: newFileStream(t, fileStreamScript{
+			responses: []*snapshotpb.FetchFileResponse{{Data: content, Eof: true}},
+			failAt:    -1,
+		}),
+	}
+	client, csState := newMockSnapshotClient(t,
+		&snapshotpb.PrepareSnapshotResponse{
+			SessionId: "test-session",
+			Manifest: &snapshotpb.SnapshotManifest{Files: []*snapshotpb.FileEntry{
+				{Path: entryPath, Size: uint64(len(content)), Sha256: fileSHA256(content)},
+			}},
+		},
+		nil,
+		streams,
+	)
+
+	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
+	require.ErrorContains(t, err, "creating parent directory")
+	require.Equal(t, int32(1), csState.fetchFileCalls.Load())
+	require.NoFileExists(t, filepath.Join(outsideDir, "written-outside.txt"))
 }
 
 func TestGRPCSnapshotFetcher_UnavailableWrapsErrNotAvailable(t *testing.T) {

--- a/internal/application/ctrl/snapshot_fetcher_test.go
+++ b/internal/application/ctrl/snapshot_fetcher_test.go
@@ -287,6 +287,22 @@ func TestGRPCSnapshotFetcher_RejectsSymlinkEscape(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(outsideDir, "written-outside.txt"))
 }
 
+func TestGRPCSnapshotFetcher_AcceptsNilManifestAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	client, csState := newMockSnapshotClient(t,
+		&snapshotpb.PrepareSnapshotResponse{SessionId: "test-session"},
+		nil,
+		nil,
+	)
+	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+
+	size, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
+	require.NoError(t, err)
+	require.Zero(t, size)
+	require.Equal(t, int32(0), csState.fetchFileCalls.Load())
+}
+
 func TestGRPCSnapshotFetcher_UnavailableWrapsErrNotAvailable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- reject non-local snapshot file paths at the `FetchFile` RPC boundary
- open snapshot files through an `os.Root` confined to the prepared checkpoint
- cover parent traversal, absolute paths, symlink escape, and legitimate nested files
- document the snapshot filesystem-containment invariant

## Root cause

The previous guard compared the caller's path with `filepath.Rel(checkpoint, filepath.Join(checkpoint, path))`. A clean parent traversal such as `../secret` survives that round trip unchanged, so the guard accepted it. The final `os.Open(filepath.Join(...))` also followed a symlink outside the checkpoint.

The lexical guard now uses `filepath.IsLocal`, while the authoritative final open uses `os.Root` so a caller-controlled path or symlink cannot escape the session checkpoint.

## Security impact

This closes Codex Security finding `csf_28a6468cfb15e1235fc5480c` / occurrence `occ_fc7550ae99fcd8c15ad3b04a` (High, CWE-22/CWE-200).

Jira: [EN-1633](https://formance-team.atlassian.net/browse/EN-1633)

## Validation

- `GOROOT= go test ./internal/adapter/grpc -run '^(TestStreamOneFile_PathConfinement|TestStreamOneFile_Content|TestStreamOneFile_Empty|TestSnapshotService_FullRoundTrip)$' -count=1`
- `GOROOT= go test ./internal/adapter/grpc -count=1`
- `GOROOT= go build ./...`
- `nix develop --command bash -c "just pre-commit"`
- `git diff --check`
- GitNexus `detect_changes` against `release/v3.0`: low risk, no affected execution flows

The new regression test failed before the patch because parent traversal and symlink escape streamed the external file. It passes after the patch, and the nested-file control remains readable.

[EN-1633]: https://formance-team.atlassian.net/browse/EN-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ