### PR TITLE
fix(security): redact mirror credentials from ledger reads

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -128,6 +128,11 @@ message MirrorSourceConfig {
 
 A ledger created with `mirror_source` set has `LedgerInfo.mode = MIRROR`, which is what the manager looks at to decide whether to spin up a worker.
 
+The stored mirror source retains the credentials required by that worker. Public
+ledger get/list responses are deep-cloned projections: OAuth client secrets and
+PostgreSQL password material are removed at the HTTP/gRPC adapter boundary,
+while non-secret source metadata and mirror progress remain visible.
+
 ## Declaring indexes on a mirror ledger (operator)
 
 A mirror ledger is read-only to clients, but index create/drop is explicitly allowed on it (`isMirrorSafeApply` whitelists `CreateIndex`/`DropIndex`), so a mirror can carry the same query indexes as its source. Because mirror ledgers are typically provisioned entirely through the Kubernetes operator's `Ledger` CRD, the CRD exposes a declarative `spec.indexes` block so the index set is part of the same GitOps manifest:

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -338,6 +338,11 @@ Request body includes `mode` (`"MIRROR"`) and a `mirrorSource` object specifying
 
 If `type` is omitted, defaults to `"http"`.
 
+**Read responses:** `GET /v3/{ledgerName}` and `GET /v3/ledgers` return the
+mirror source as a read-only projection. OAuth client secrets and PostgreSQL
+password material are removed. A DSN whose form cannot be parsed safely is
+returned as `[redacted]`; the stored runtime configuration is unchanged.
+
 **Write guard:** All direct write operations (create transaction, save metadata, delete metadata, revert transaction) are rejected on mirror-mode ledgers with HTTP 409 (`LEDGER_IN_MIRROR_MODE`) or gRPC `FailedPrecondition`.
 
 **Sync progress:** `GET /v3/{ledgerName}` returns a `mirrorSyncProgress` object for mirror ledgers with:

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -22,6 +22,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	adapterledgerinfo "github.com/formancehq/ledger/v3/internal/adapter/ledgerinfo"
 	"github.com/formancehq/ledger/v3/internal/application/check"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/domain"
@@ -713,6 +714,8 @@ func (impl *BucketServiceServerImpl) ListLedgers(req *servicepb.ListLedgersReque
 		return fmt.Errorf("paginating ledgers: %w", err)
 	}
 
+	c = adapterledgerinfo.NewRedactingCursor(c)
+
 	return sendPagedToStream(ctx, c, stream, "ledger", pageSize, func(l *commonpb.LedgerInfo) string {
 		return l.GetName()
 	})
@@ -744,7 +747,12 @@ func (impl *BucketServiceServerImpl) GetLedger(ctx context.Context, req *service
 	}
 	defer cleanup()
 
-	return c.GetLedgerByName(ctx, req.GetLedger())
+	ledgerInfo, err := c.GetLedgerByName(ctx, req.GetLedger())
+	if err != nil {
+		return nil, err
+	}
+
+	return adapterledgerinfo.RedactSecrets(ledgerInfo), nil
 }
 
 func (impl *BucketServiceServerImpl) GetAccount(ctx context.Context, req *servicepb.GetAccountRequest) (*commonpb.Account, error) {

--- a/internal/adapter/grpc/server_bucket_list_test.go
+++ b/internal/adapter/grpc/server_bucket_list_test.go
@@ -93,6 +93,52 @@ func TestListLedgers(t *testing.T) {
 	})
 }
 
+func TestListLedgers_RedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl := newListHandlerHarness(t)
+	original := &commonpb.LedgerInfo{
+		Name: "mirror",
+		MirrorSource: &commonpb.MirrorSourceConfig{
+			Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
+				Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{
+					ClientId:     "client-id",
+					ClientSecret: "list-secret",
+				},
+			}},
+		},
+	}
+	mockCtrl.EXPECT().ListLedgers(gomock.Any()).Return(page(original), nil)
+
+	stream := newFakeServerStream[commonpb.LedgerInfo](t)
+	require.NoError(t, impl.ListLedgers(&servicepb.ListLedgersRequest{}, stream))
+	require.Len(t, stream.sent, 1)
+	require.Empty(t, stream.sent[0].GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+	require.Equal(t, "client-id", stream.sent[0].GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientId())
+	require.Equal(t, "list-secret", original.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+}
+
+func TestGetLedger_RedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl := newListHandlerHarness(t)
+	original := &commonpb.LedgerInfo{
+		Name: "mirror",
+		MirrorSource: &commonpb.MirrorSourceConfig{
+			Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{
+				Dsn: "postgres://user:get-secret@db.example/ledger?sslmode=require",
+			}},
+		},
+	}
+	mockCtrl.EXPECT().GetLedgerByName(gomock.Any(), "mirror").Return(original, nil)
+
+	redacted, err := impl.GetLedger(context.Background(), &servicepb.GetLedgerRequest{Ledger: "mirror"})
+	require.NoError(t, err)
+	require.NotContains(t, redacted.GetMirrorSource().GetPostgres().GetDsn(), "get-secret")
+	require.Contains(t, redacted.GetMirrorSource().GetPostgres().GetDsn(), "db.example/ledger")
+	require.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "get-secret")
+}
+
 // TestListTransactions covers the new plumbing for transactions: peek-ahead
 // uses txCursorOf (id as decimal), ledger-name required, cursor parsing,
 // page-size clamping.

--- a/internal/adapter/grpc/server_bucket_list_test.go
+++ b/internal/adapter/grpc/server_bucket_list_test.go
@@ -80,6 +80,26 @@ func TestListLedgers(t *testing.T) {
 		require.Empty(t, stream.trailerCursor())
 	})
 
+	t.Run("routed exact page forwards upstream trailer", func(t *testing.T) {
+		t.Parallel()
+
+		impl, mockCtrl := newListHandlerHarness(t)
+		mockCtrl.EXPECT().ListLedgers(gomock.Any()).Return(
+			&upstreamCursor[commonpb.LedgerInfo]{
+				items:      []*commonpb.LedgerInfo{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+				nextCursor: "leader-next-page",
+			},
+			nil,
+		)
+
+		stream := newFakeServerStream[commonpb.LedgerInfo](t)
+		req := &servicepb.ListLedgersRequest{Options: &commonpb.ListOptions{PageSize: 3}}
+
+		require.NoError(t, impl.ListLedgers(req, stream))
+		require.Equal(t, []string{"a", "b", "c"}, sentLedgerNames(stream))
+		require.Equal(t, "leader-next-page", stream.trailerCursor())
+	})
+
 	t.Run("controller error wrapped", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/adapter/http/handlers_get_ledger.go
+++ b/internal/adapter/http/handlers_get_ledger.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"net/http"
+
+	adapterledgerinfo "github.com/formancehq/ledger/v3/internal/adapter/ledgerinfo"
 )
 
 // handleGetLedger handles GET /{ledgerName} to get a ledger.
@@ -19,5 +21,5 @@ func (s *Server) handleGetLedger(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return ledger info wrapped in BaseResponse
-	writeOK(w, ledgerInfo)
+	writeOK(w, adapterledgerinfo.RedactSecrets(ledgerInfo))
 }

--- a/internal/adapter/http/handlers_get_ledger_test.go
+++ b/internal/adapter/http/handlers_get_ledger_test.go
@@ -33,6 +33,34 @@ func TestHandleGetLedger_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestHandleGetLedger_RedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	original := &commonpb.LedgerInfo{
+		Name: "mirror",
+		MirrorSource: &commonpb.MirrorSourceConfig{
+			Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
+				Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{
+					ClientId:     "client-id",
+					ClientSecret: "http-get-secret",
+				},
+			}},
+		},
+	}
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetLedgerByName(gomock.Any(), "mirror").Return(original, nil)
+	srv := newTestServer(t, backend)
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/mirror", nil, map[string]string{"ledgerName": "mirror"})
+
+	srv.handleGetLedger(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), "http-get-secret")
+	require.Contains(t, w.Body.String(), "client-id")
+	require.Equal(t, "http-get-secret", original.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+}
+
 func TestHandleGetLedger_MissingName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_list_all_ledgers.go
+++ b/internal/adapter/http/handlers_list_all_ledgers.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"net/http"
+
+	adapterledgerinfo "github.com/formancehq/ledger/v3/internal/adapter/ledgerinfo"
 )
 
 // handleListAllLedgers handles GET / to list all ledgers.
@@ -19,6 +21,10 @@ func (s *Server) handleListAllLedgers(w http.ResponseWriter, r *http.Request) {
 	ret, ok := drainCursor(w, r, cursor)
 	if !ok {
 		return
+	}
+
+	for i, ledgerInfo := range ret {
+		ret[i] = adapterledgerinfo.RedactSecrets(ledgerInfo)
 	}
 
 	// Return ledgers list wrapped in BaseResponse

--- a/internal/adapter/http/handlers_list_all_ledgers_test.go
+++ b/internal/adapter/http/handlers_list_all_ledgers_test.go
@@ -34,6 +34,31 @@ func TestHandleListAllLedgers_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestHandleListAllLedgers_RedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	original := &commonpb.LedgerInfo{
+		Name: "mirror",
+		MirrorSource: &commonpb.MirrorSourceConfig{
+			Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{
+				Dsn: "postgres://user:http-list-secret@db.example/ledger?sslmode=require",
+			}},
+		},
+	}
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().ListLedgers(gomock.Any()).Return(cursor.NewSliceCursor([]*commonpb.LedgerInfo{original}), nil)
+	srv := newTestServer(t, backend)
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/", nil, nil)
+
+	srv.handleListAllLedgers(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), "http-list-secret")
+	require.Contains(t, w.Body.String(), "db.example/ledger")
+	require.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "http-list-secret")
+}
+
 func TestHandleListAllLedgers_Empty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/ledgerinfo/redact.go
+++ b/internal/adapter/ledgerinfo/redact.go
@@ -1,0 +1,102 @@
+package ledgerinfo
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// RedactSecrets returns a deep-cloned LedgerInfo safe for external read
+// responses. The stored value must retain the credentials used by mirror
+// workers, so redaction belongs at the adapter boundary and never mutates the
+// caller-owned message.
+func RedactSecrets(info *commonpb.LedgerInfo) *commonpb.LedgerInfo {
+	if info == nil {
+		return nil
+	}
+
+	redacted := info.CloneVT()
+	source := redacted.GetMirrorSource()
+
+	if source == nil {
+		return redacted
+	}
+
+	switch typed := source.GetType().(type) {
+	case *commonpb.MirrorSourceConfig_Http:
+		if credentials := typed.Http.GetOauth2ClientCredentials(); credentials != nil {
+			credentials.ClientSecret = ""
+		}
+	case *commonpb.MirrorSourceConfig_Postgres:
+		if typed.Postgres != nil {
+			typed.Postgres.Dsn = redactPostgresDSN(typed.Postgres.GetDsn())
+		}
+	}
+
+	return redacted
+}
+
+// NewRedactingCursor applies RedactSecrets lazily while preserving the wrapped
+// cursor's streaming and close semantics.
+func NewRedactingCursor(inner cursor.Cursor[*commonpb.LedgerInfo]) cursor.Cursor[*commonpb.LedgerInfo] {
+	return &redactingCursor{inner: inner}
+}
+
+type redactingCursor struct {
+	inner cursor.Cursor[*commonpb.LedgerInfo]
+}
+
+func (c *redactingCursor) Next() (*commonpb.LedgerInfo, error) {
+	info, err := c.inner.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	return RedactSecrets(info), nil
+}
+
+func (c *redactingCursor) Close() error {
+	return c.inner.Close()
+}
+
+// redactPostgresDSN removes password-bearing URI components while retaining
+// non-secret connection metadata. Unknown/non-URI forms are blanked so a
+// legacy value cannot bypass the response boundary through parser ambiguity.
+func redactPostgresDSN(dsn string) string {
+	if dsn == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil || (parsed.Scheme != "postgres" && parsed.Scheme != "postgresql") || parsed.Host == "" {
+		return ""
+	}
+
+	changed := false
+
+	if parsed.User != nil {
+		if _, hasPassword := parsed.User.Password(); hasPassword {
+			parsed.User = url.User(parsed.User.Username())
+			changed = true
+		}
+	}
+
+	query := parsed.Query()
+
+	for key := range query {
+		if strings.Contains(strings.ToLower(key), "password") {
+			query.Del(key)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return dsn
+	}
+
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
+}

--- a/internal/adapter/ledgerinfo/redact.go
+++ b/internal/adapter/ledgerinfo/redact.go
@@ -8,6 +8,8 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
+const redactedDSNPlaceholder = "[redacted]"
+
 // RedactSecrets returns a deep-cloned LedgerInfo safe for external read
 // responses. The stored value must retain the credentials used by mirror
 // workers, so redaction belongs at the adapter boundary and never mutates the
@@ -61,9 +63,21 @@ func (c *redactingCursor) Close() error {
 	return c.inner.Close()
 }
 
+// NextCursor preserves the optional routed-cursor trailer capability used by
+// the gRPC pagination layer. A local cursor has no upstream token.
+func (c *redactingCursor) NextCursor() string {
+	if provider, ok := c.inner.(interface{ NextCursor() string }); ok {
+		return provider.NextCursor()
+	}
+
+	return ""
+}
+
 // redactPostgresDSN removes password-bearing URI components while retaining
-// non-secret connection metadata. Unknown/non-URI forms are blanked so a
-// legacy value cannot bypass the response boundary through parser ambiguity.
+// non-secret connection metadata. Unknown/non-URI forms are replaced in full
+// so a legacy value cannot bypass the response boundary through parser
+// ambiguity. The returned value is a display projection, not a connectable
+// DSN; url.URL normalizes query ordering while removing secrets.
 func redactPostgresDSN(dsn string) string {
 	if dsn == "" {
 		return ""
@@ -71,7 +85,7 @@ func redactPostgresDSN(dsn string) string {
 
 	parsed, err := url.Parse(dsn)
 	if err != nil || (parsed.Scheme != "postgres" && parsed.Scheme != "postgresql") || parsed.Host == "" {
-		return ""
+		return redactedDSNPlaceholder
 	}
 
 	changed := false

--- a/internal/adapter/ledgerinfo/redact_test.go
+++ b/internal/adapter/ledgerinfo/redact_test.go
@@ -1,25 +1,28 @@
 package ledgerinfo
 
 import (
+	"errors"
+	"io"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 func TestRedactSecrets(t *testing.T) {
 	t.Parallel()
 
-	t.Run("HTTP OAuth credentials", func(t *testing.T) {
-		t.Parallel()
-
-		original := &commonpb.LedgerInfo{
-			Name: "mirror",
-			MirrorSource: &commonpb.MirrorSourceConfig{
+	tests := []struct {
+		name     string
+		original *commonpb.LedgerInfo
+		check    func(*testing.T, *commonpb.LedgerInfo, *commonpb.LedgerInfo)
+	}{
+		{
+			name: "HTTP OAuth credentials",
+			original: &commonpb.LedgerInfo{Name: "mirror", MirrorSource: &commonpb.MirrorSourceConfig{
 				LedgerName: "source",
 				Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
 					BaseUrl: "https://source.example",
@@ -30,75 +33,155 @@ func TestRedactSecrets(t *testing.T) {
 						Scopes:        []string{"ledger:read"},
 					},
 				}},
+			}},
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				require.NotSame(t, original, redacted)
+				assert.Empty(t, redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+				assert.Equal(t, "client-id", redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientId())
+				assert.Equal(t, "oauth-secret", original.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
 			},
-		}
+		},
+		{
+			name: "HTTP without OAuth credentials",
+			original: &commonpb.LedgerInfo{Name: "mirror", MirrorSource: &commonpb.MirrorSourceConfig{
+				Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "https://source.example"}},
+			}},
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Nil(t, redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials())
+				assert.Equal(t, original.GetMirrorSource().GetHttp().GetBaseUrl(), redacted.GetMirrorSource().GetHttp().GetBaseUrl())
+			},
+		},
+		{
+			name:     "mirror source without type",
+			original: &commonpb.LedgerInfo{Name: "mirror", MirrorSource: &commonpb.MirrorSourceConfig{LedgerName: "source"}},
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Equal(t, original, redacted)
+				require.NotSame(t, original, redacted)
+			},
+		},
+		{
+			name:     "PostgreSQL URI",
+			original: postgresLedger("postgres://user:p%40ss@db.example:5432/ledger?application_name=mirror&password=query-secret&sslmode=require"),
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				redactedDSN := redacted.GetMirrorSource().GetPostgres().GetDsn()
+				assert.NotContains(t, redactedDSN, "p%40ss")
+				assert.NotContains(t, redactedDSN, "query-secret")
+				assert.Contains(t, redactedDSN, "db.example:5432/ledger")
+				assert.Contains(t, redactedDSN, "application_name=mirror")
+				assert.Contains(t, redactedDSN, "sslmode=require")
 
-		redacted := RedactSecrets(original)
+				parsed, err := url.Parse(redactedDSN)
+				require.NoError(t, err)
+				_, hasPassword := parsed.User.Password()
+				assert.False(t, hasPassword)
+				assert.False(t, parsed.Query().Has("password"))
+				assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "query-secret")
+			},
+		},
+		{
+			name:     "unknown DSN form uses explicit marker",
+			original: postgresLedger("host=db.example user=mirror password=keyword-secret"),
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Equal(t, redactedDSNPlaceholder, redacted.GetMirrorSource().GetPostgres().GetDsn())
+				assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "keyword-secret")
+			},
+		},
+		{
+			name:     "Unix socket URI uses explicit marker",
+			original: postgresLedger("postgres:///ledger?host=/var/run/postgresql&password=socket-secret"),
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Equal(t, redactedDSNPlaceholder, redacted.GetMirrorSource().GetPostgres().GetDsn())
+				assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "socket-secret")
+			},
+		},
+		{
+			name:     "passwordless PostgreSQL URI is preserved",
+			original: postgresLedger("postgres://iam-user@db.example/ledger?sslmode=require"),
+			check: func(t *testing.T, original, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Equal(t, original.GetMirrorSource().GetPostgres().GetDsn(), redacted.GetMirrorSource().GetPostgres().GetDsn())
+			},
+		},
+		{
+			name:     "nil",
+			original: nil,
+			check: func(t *testing.T, _, redacted *commonpb.LedgerInfo) {
+				t.Helper()
+				assert.Nil(t, redacted)
+			},
+		},
+	}
 
-		require.NotSame(t, original, redacted)
-		assert.Empty(t, redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
-		assert.Equal(t, "client-id", redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientId())
-		assert.Equal(t, "oauth-secret", original.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
-	})
-
-	t.Run("PostgreSQL URI", func(t *testing.T) {
-		t.Parallel()
-
-		original := postgresLedger("postgres://user:p%40ss@db.example:5432/ledger?application_name=mirror&password=query-secret&sslmode=require")
-		redacted := RedactSecrets(original)
-		redactedDSN := redacted.GetMirrorSource().GetPostgres().GetDsn()
-
-		assert.NotContains(t, redactedDSN, "p%40ss")
-		assert.NotContains(t, redactedDSN, "query-secret")
-		assert.Contains(t, redactedDSN, "db.example:5432/ledger")
-		assert.Contains(t, redactedDSN, "application_name=mirror")
-		assert.Contains(t, redactedDSN, "sslmode=require")
-
-		parsed, err := url.Parse(redactedDSN)
-		require.NoError(t, err)
-		_, hasPassword := parsed.User.Password()
-		assert.False(t, hasPassword)
-		assert.False(t, parsed.Query().Has("password"))
-		assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "query-secret")
-	})
-
-	t.Run("unknown DSN form fails closed", func(t *testing.T) {
-		t.Parallel()
-
-		original := postgresLedger("host=db.example user=mirror password=keyword-secret")
-		redacted := RedactSecrets(original)
-
-		assert.Empty(t, redacted.GetMirrorSource().GetPostgres().GetDsn())
-		assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "keyword-secret")
-	})
-
-	t.Run("passwordless PostgreSQL URI is preserved", func(t *testing.T) {
-		t.Parallel()
-
-		dsn := "postgres://iam-user@db.example/ledger?sslmode=require"
-		redacted := RedactSecrets(postgresLedger(dsn))
-
-		assert.Equal(t, dsn, redacted.GetMirrorSource().GetPostgres().GetDsn())
-	})
-
-	t.Run("nil", func(t *testing.T) {
-		t.Parallel()
-
-		assert.Nil(t, RedactSecrets(nil))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.check(t, tt.original, RedactSecrets(tt.original))
+		})
+	}
 }
 
 func TestNewRedactingCursor(t *testing.T) {
 	t.Parallel()
 
 	original := postgresLedger("postgres://user:cursor-secret@db.example/ledger")
-	redactedCursor := NewRedactingCursor(cursor.NewSliceCursor([]*commonpb.LedgerInfo{original}))
+	inner := &redactingCursorTestSource{
+		items:      []*commonpb.LedgerInfo{original},
+		nextCursor: "leader-next-page",
+	}
+	redactedCursor := NewRedactingCursor(inner)
 
 	redacted, err := redactedCursor.Next()
 	require.NoError(t, err)
 	assert.NotContains(t, redacted.GetMirrorSource().GetPostgres().GetDsn(), "cursor-secret")
 	assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "cursor-secret")
+	provider, ok := redactedCursor.(interface{ NextCursor() string })
+	require.True(t, ok)
+	assert.Equal(t, "leader-next-page", provider.NextCursor())
 	require.NoError(t, redactedCursor.Close())
+	assert.True(t, inner.closed)
+
+	boom := errors.New("cursor failed")
+	failing := NewRedactingCursor(&redactingCursorTestSource{nextErr: boom})
+	_, err = failing.Next()
+	require.ErrorIs(t, err, boom)
+}
+
+type redactingCursorTestSource struct {
+	items      []*commonpb.LedgerInfo
+	index      int
+	nextCursor string
+	nextErr    error
+	closed     bool
+}
+
+func (c *redactingCursorTestSource) Next() (*commonpb.LedgerInfo, error) {
+	if c.index < len(c.items) {
+		item := c.items[c.index]
+		c.index++
+
+		return item, nil
+	}
+	if c.nextErr != nil {
+		return nil, c.nextErr
+	}
+
+	return nil, io.EOF
+}
+
+func (c *redactingCursorTestSource) NextCursor() string {
+	return c.nextCursor
+}
+
+func (c *redactingCursorTestSource) Close() error {
+	c.closed = true
+
+	return nil
 }
 
 func postgresLedger(dsn string) *commonpb.LedgerInfo {

--- a/internal/adapter/ledgerinfo/redact_test.go
+++ b/internal/adapter/ledgerinfo/redact_test.go
@@ -1,0 +1,114 @@
+package ledgerinfo
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func TestRedactSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HTTP OAuth credentials", func(t *testing.T) {
+		t.Parallel()
+
+		original := &commonpb.LedgerInfo{
+			Name: "mirror",
+			MirrorSource: &commonpb.MirrorSourceConfig{
+				LedgerName: "source",
+				Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
+					BaseUrl: "https://source.example",
+					Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{
+						ClientId:      "client-id",
+						ClientSecret:  "oauth-secret",
+						TokenEndpoint: "https://source.example/oauth/token",
+						Scopes:        []string{"ledger:read"},
+					},
+				}},
+			},
+		}
+
+		redacted := RedactSecrets(original)
+
+		require.NotSame(t, original, redacted)
+		assert.Empty(t, redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+		assert.Equal(t, "client-id", redacted.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientId())
+		assert.Equal(t, "oauth-secret", original.GetMirrorSource().GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+	})
+
+	t.Run("PostgreSQL URI", func(t *testing.T) {
+		t.Parallel()
+
+		original := postgresLedger("postgres://user:p%40ss@db.example:5432/ledger?application_name=mirror&password=query-secret&sslmode=require")
+		redacted := RedactSecrets(original)
+		redactedDSN := redacted.GetMirrorSource().GetPostgres().GetDsn()
+
+		assert.NotContains(t, redactedDSN, "p%40ss")
+		assert.NotContains(t, redactedDSN, "query-secret")
+		assert.Contains(t, redactedDSN, "db.example:5432/ledger")
+		assert.Contains(t, redactedDSN, "application_name=mirror")
+		assert.Contains(t, redactedDSN, "sslmode=require")
+
+		parsed, err := url.Parse(redactedDSN)
+		require.NoError(t, err)
+		_, hasPassword := parsed.User.Password()
+		assert.False(t, hasPassword)
+		assert.False(t, parsed.Query().Has("password"))
+		assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "query-secret")
+	})
+
+	t.Run("unknown DSN form fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		original := postgresLedger("host=db.example user=mirror password=keyword-secret")
+		redacted := RedactSecrets(original)
+
+		assert.Empty(t, redacted.GetMirrorSource().GetPostgres().GetDsn())
+		assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "keyword-secret")
+	})
+
+	t.Run("passwordless PostgreSQL URI is preserved", func(t *testing.T) {
+		t.Parallel()
+
+		dsn := "postgres://iam-user@db.example/ledger?sslmode=require"
+		redacted := RedactSecrets(postgresLedger(dsn))
+
+		assert.Equal(t, dsn, redacted.GetMirrorSource().GetPostgres().GetDsn())
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, RedactSecrets(nil))
+	})
+}
+
+func TestNewRedactingCursor(t *testing.T) {
+	t.Parallel()
+
+	original := postgresLedger("postgres://user:cursor-secret@db.example/ledger")
+	redactedCursor := NewRedactingCursor(cursor.NewSliceCursor([]*commonpb.LedgerInfo{original}))
+
+	redacted, err := redactedCursor.Next()
+	require.NoError(t, err)
+	assert.NotContains(t, redacted.GetMirrorSource().GetPostgres().GetDsn(), "cursor-secret")
+	assert.Contains(t, original.GetMirrorSource().GetPostgres().GetDsn(), "cursor-secret")
+	require.NoError(t, redactedCursor.Close())
+}
+
+func postgresLedger(dsn string) *commonpb.LedgerInfo {
+	return &commonpb.LedgerInfo{
+		Name: "mirror",
+		MirrorSource: &commonpb.MirrorSourceConfig{
+			LedgerName: "source",
+			Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{
+				Dsn: dsn,
+			}},
+		},
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -3192,7 +3192,8 @@ components:
             - MIRROR
           description: Ledger mode (NORMAL or MIRROR)
         mirror_source:
-          $ref: '#/components/schemas/MirrorSourceConfig'
+          allOf:
+            - $ref: '#/components/schemas/MirrorSourceConfig'
           description: Mirror source configuration with reusable credentials removed from read responses.
         mirror_sync_progress:
           $ref: '#/components/schemas/MirrorSyncProgress'
@@ -4378,7 +4379,8 @@ components:
       description: >
         Configuration for the mirror source (required when mode is MIRROR).
         Ledger read responses preserve non-secret connection metadata but omit
-        OAuth client secrets and PostgreSQL password material.
+        OAuth client secrets and PostgreSQL password material. DSNs whose form
+        cannot be safely parsed are replaced in full with `[redacted]`.
       required:
         - ledgerName
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3193,6 +3193,7 @@ components:
           description: Ledger mode (NORMAL or MIRROR)
         mirror_source:
           $ref: '#/components/schemas/MirrorSourceConfig'
+          description: Mirror source configuration with reusable credentials removed from read responses.
         mirror_sync_progress:
           $ref: '#/components/schemas/MirrorSyncProgress'
         account_types:
@@ -4374,7 +4375,10 @@ components:
 
     MirrorSourceConfig:
       type: object
-      description: Configuration for the mirror source (required when mode is MIRROR)
+      description: >
+        Configuration for the mirror source (required when mode is MIRROR).
+        Ledger read responses preserve non-secret connection metadata but omit
+        OAuth client secrets and PostgreSQL password material.
       required:
         - ledgerName
       properties:


### PR DESCRIPTION
## What changed

- add a shared LedgerInfo response projection that deep-clones before redaction
- remove OAuth client secrets from HTTP mirror configuration
- strip PostgreSQL URI passwords and password query parameters, failing closed for ambiguous non-URI DSNs
- apply the projection to gRPC and HTTP GetLedger/ListLedgers responses
- document the read-response contract in OpenAPI and mirror architecture docs
- add regression coverage for both mirror variants, both transports, list/get paths, and non-mutation

## Why

A caller with ordinary `ledger:LedgerRead` authority could retrieve reusable mirror database passwords or OAuth client secrets because `LedgerInfo` embedded the stored `MirrorSourceConfig` unchanged.

The response boundary now returns a secret-safe clone while internal mirror workers continue to receive the original credentials.

Jira: [EN-1635](https://formance-team.atlassian.net/browse/EN-1635)
Codex Security: `csf_77e237f70693cb54836d4c80` / `occ_5acf221f891c2da6179d9da6`

## Validation

- `GOROOT= go test ./internal/adapter/ledgerinfo ./internal/adapter/grpc ./internal/adapter/http`
- `GOROOT= go build ./...`
- `nix develop --command bash -c "just pre-commit"`
- GitNexus `detect_changes` against `origin/release/v3.0`: low risk, no affected execution flow

## Coordination

EN-1632 introduces generic DSN redaction for a separate config surface. This PR stays independently mergeable with an adapter-local LedgerInfo projection; after EN-1632 lands, the small DSN helper overlap can be consolidated during rebase without coupling the two security fixes.

[EN-1635]: https://formance-team.atlassian.net/browse/EN-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ