### PR TITLE
fix(security): redact historical credentials

### DIFF
--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -10,6 +10,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, and error handling. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
+| [secret-redaction.md](secret-redaction.md) | Secret-safe projections for historical audit and system-log read responses. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/api/secret-redaction.md
+++ b/docs/technical/architecture/subsystems/api/secret-redaction.md
@@ -1,0 +1,54 @@
+# Secret Redaction on Historical Reads
+
+The audit chain and system log store accepted business intent. Some accepted
+orders necessarily contain credentials used to configure event sinks or mirror
+sources. Those persisted records remain authoritative and unchanged: mutating
+them would invalidate the audit hash chain, idempotency evidence, or signed
+client payloads.
+
+Public read APIs therefore return a deep-cloned, secret-safe projection from
+the controller boundary. This boundary is shared by gRPC and the HTTP
+compatibility API, including local-leader reads, follower-routed reads,
+checkpoint reads, and cold-storage log reads.
+
+## Covered fields
+
+The projection replaces non-empty credentials with `***REDACTED***` in:
+
+- NATS sink URLs (the URL may contain user/password or token userinfo);
+- ClickHouse sink DSNs;
+- Kafka SASL passwords;
+- HTTP sink HMAC secrets;
+- Databricks PATs and OAuth client secrets;
+- PostgreSQL mirror DSNs;
+- HTTP mirror OAuth client secrets.
+
+The same transformation is applied inside:
+
+- `AddedEventsSinkLog.config` and `CreatedLedgerLog.mirror_source`;
+- `AuditItem.serialized_order` for `AddEventsSink` and `CreateLedger` orders;
+- the `SignedApplyBatch.payload` retained on an audit entry.
+
+Projection always operates on deep clones. Stored records and objects owned by
+the controller are never mutated.
+
+## Integrity semantics
+
+`AuditEntry.hash` continues to identify and protect the authoritative persisted
+entry. A redacted response is deliberately not the original hash preimage.
+Likewise, an Ed25519 signature covers the original unredacted `ApplyBatch`, not
+the projected payload. The read projection keeps the signer key ID and a
+parseable redacted payload, but omits the signature bytes so clients cannot
+mistake the projection for independently verifiable signed evidence.
+
+Integrity checking and rebuild paths read the authoritative store directly and
+are not projected. Operators who need offline verification of raw audit
+evidence must use a separately controlled administrative export rather than a
+read-scoped API.
+
+## Failure behavior
+
+If a stored order or signed batch cannot be decoded, the read fails loudly. It
+must never fall back to returning opaque bytes that might contain a secret.
+This fail-closed behavior also surfaces corrupted or schema-incompatible audit
+data instead of silently weakening redaction.

--- a/docs/technical/architecture/subsystems/api/secret-redaction.md
+++ b/docs/technical/architecture/subsystems/api/secret-redaction.md
@@ -6,10 +6,12 @@ sources. Those persisted records remain authoritative and unchanged: mutating
 them would invalidate the audit hash chain, idempotency evidence, or signed
 client payloads.
 
-Public read APIs therefore return a deep-cloned, secret-safe projection from
-the controller boundary. This boundary is shared by gRPC and the HTTP
-compatibility API, including local-leader reads, follower-routed reads,
-checkpoint reads, and cold-storage log reads.
+The historical audit and system-log APIs therefore return a deep-cloned,
+secret-safe projection from the controller boundary. The projected controller
+methods are `GetAuditEntry`, `ListAuditEntriesFrom`, `GetLog`, and `ListLogs`.
+This covers HTTP and gRPC reads served locally, checkpoint audit reads, and
+cold-storage log reads. For a follower-routed request, the serving node applies
+the projection before its gRPC response leaves that node.
 
 ## Covered fields
 
@@ -35,11 +37,13 @@ the controller are never mutated.
 ## Integrity semantics
 
 `AuditEntry.hash` continues to identify and protect the authoritative persisted
-entry. A redacted response is deliberately not the original hash preimage.
-Likewise, an Ed25519 signature covers the original unredacted `ApplyBatch`, not
-the projected payload. The read projection keeps the signer key ID and a
-parseable redacted payload, but omits the signature bytes so clients cannot
-mistake the projection for independently verifiable signed evidence.
+entry. When credentials are replaced, the response is deliberately not the
+original hash preimage. Likewise, when a signed `ApplyBatch` contains replaced
+credentials, the read projection keeps the signer key ID and a parseable
+redacted payload but omits the Ed25519 signature bytes so clients cannot mistake
+the projection for independently verifiable signed evidence. Entries without
+credentials retain their exact serialized order bytes, signed payload, and
+signature, so their evidence remains independently verifiable.
 
 Integrity checking and rebuild paths read the authoritative store directly and
 are not projected. Operators who need offline verification of raw audit
@@ -52,3 +56,13 @@ If a stored order or signed batch cannot be decoded, the read fails loudly. It
 must never fall back to returning opaque bytes that might contain a secret.
 This fail-closed behavior also surfaces corrupted or schema-incompatible audit
 data instead of silently weakening redaction.
+
+## Related live read boundaries
+
+This mechanism is intentionally limited to historical audit and system-log
+records. Live event-sink configuration reads are protected separately by
+[PR #1651](https://github.com/formancehq/ledger/pull/1651), and live
+`LedgerInfo.mirror_source` reads by
+[PR #1653](https://github.com/formancehq/ledger/pull/1653). Those adapter-level
+projections cover both HTTP and gRPC without coupling their live response
+models to the historical audit projection in this package.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -58,7 +58,7 @@ This document compares the POC's API with the original Formance ledger API and d
 | Analyze accounts | ✅ | ❌ | Suggest Chart of Accounts from address patterns |
 | Aggregate volumes | ✅ | ✅ | Per-asset aggregated volumes for filtered accounts (direct RPC, no prepared query needed) |
 | **Logs** |
-| List logs | ✅ | ✅ | gRPC stream, supports `--filter 'ledger == "foo"'` for per-ledger listing (opt-in index) |
+| List logs | ✅ | ✅ | gRPC stream, supports `--filter 'ledger == "foo"'` for per-ledger listing (opt-in index). Historical sink/mirror credentials are redacted from read responses. |
 | **Import/Export** |
 | Import logs | ⚠️ | ✅ | Interface defined but not implemented |
 | Export logs | ⚠️ | ✅ | Interface defined but not implemented |
@@ -74,8 +74,8 @@ This document compares the POC's API with the original Formance ledger API and d
 | List numscript versions | ✅ | ❌ | Per-ledger, `GET .../numscripts/{name}/versions`, current latest + every stored version |
 | **Audit Log** |
 | Audit log (success + failure) | ✅ | ❌ | Replicated via Raft, stored in Pebble |
-| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + a bare-audit-field filter expression (`outcome`, `ledger`, `seq`, `proposal_id`, `timestamp`, `log_seq`, `caller_subject`, `order_type`, resolved against the audit query target — EN-1549 replaced the old `audit[...]` namespaced syntax; textual form only, audit has no structured JSON form — see [Filter input formats](#filter-input-formats-dual-format-contract-en-1511)) |
-| Get audit entry by sequence | ✅ | ❌ | `GET /v3/_/audit-entries/{sequence}` (HTTP) + gRPC. Populates per-order `items` |
+| List audit entries | ✅ | ❌ | `GET /v3/_/audit-entries` (HTTP) + gRPC stream. Bucket-wide; `pageSize`/`after`/`reverse` + a bare-audit-field filter expression (`outcome`, `ledger`, `seq`, `proposal_id`, `timestamp`, `log_seq`, `caller_subject`, `order_type`, resolved against the audit query target — EN-1549 replaced the old `audit[...]` namespaced syntax; textual form only, audit has no structured JSON form — see [Filter input formats](#filter-input-formats-dual-format-contract-en-1511)). Secret-bearing signed batch payloads are returned as redacted projections. |
+| Get audit entry by sequence | ✅ | ❌ | `GET /v3/_/audit-entries/{sequence}` (HTTP) + gRPC. Populates per-order `items`; secret-bearing order and signed-batch bytes are projected with credentials redacted. |
 | Audit log disable/enable | ❌ | ❌ | Not implemented |
 | **Error Handling** |
 | Structured gRPC error codes | ✅ | ✅ | BusinessError with ErrorInfo details |
@@ -716,7 +716,7 @@ Read endpoints comparison with the original ledger:
 | `DELETE /v3/{ledgerName}/account-types/{typeName}` | ✅ | ❌ | Remove account type |
 | `PUT /v3/{ledgerName}/account-types/default-enforcement-mode` | ✅ | ❌ | Set default enforcement mode (STRICT/AUDIT) |
 | `GET /v3/{ledgerName}/transactions` | ✅ | ❌ | List transactions: cursor pagination, `startDate`/`endDate` range, and the generic `filter` (reference selection via `filter={"$match":{"reference":"..."}}`) |
-| `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence |
+| `GET /v3/_/logs/{sequence}` | ✅ | ❌ | Fetch a single system log by bucket-wide sequence; historical sink/mirror credentials are redacted |
 | `GET /v3/_/chapters` | ✅ | ❌ | Stream chapters (audit-chain segments) |
 | `GET /v3/_/chapter-schedule` | ✅ | ❌ | Get the auto-rotation cron for chapters |
 | `GET /v3/_/events-sinks` | ✅ | ❌ | List configured event sinks with per-sink status (`{sinks, sinkStatuses}`, parity with gRPC `GetEventsSinks`) |
@@ -801,10 +801,10 @@ The POC provides a gRPC API for internal service communication (Raft node forwar
 | `ListNumscriptVersions` | List the latest pointer and every stored version | ✅ |
 | `Apply(CloseChapter)` | Close the current open chapter | ✅ |
 | `ListChapters` | Stream all chapters | ✅ |
-| `ListAuditEntries` | Stream audit log entries (success + failure). Request is `{ options }` only — no dedicated filter fields. Follows the shared `ListOptions` contract: cursor/page_size/reverse/checkpoint_id plus a bare-audit-field `QueryFilter` (outcome, ledger, caller_subject, order_type, seq, proposal_id, timestamp, log_seq — bare fields resolved against the audit query target, EN-1549 replacing the old `audit[...]` syntax) resolved through the audit secondary index. Ledger scope and outcome selection are expressed as filter conditions | ✅ |
-| `GetAuditEntry` | Get a single audit entry by sequence number | ✅ |
-| `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination) | ✅ |
-| `GetLog` | Get a single system log by sequence number | ✅ |
+| `ListAuditEntries` | Stream audit log entries (success + failure). Request is `{ options }` only — no dedicated filter fields. Follows the shared `ListOptions` contract: cursor/page_size/reverse/checkpoint_id plus a bare-audit-field `QueryFilter` (outcome, ledger, caller_subject, order_type, seq, proposal_id, timestamp, log_seq — bare fields resolved against the audit query target, EN-1549 replacing the old `audit[...]` syntax) resolved through the audit secondary index. Ledger scope and outcome selection are expressed as filter conditions. Secret-bearing signed payloads are redacted on read. | ✅ |
+| `GetAuditEntry` | Get a single audit entry by sequence number. Secret-bearing order and signed-batch bytes are redacted on read. | ✅ |
+| `ListLogs` | Stream system logs for a ledger (requires `ledger` field; supports `log_id` and date filters for pagination). Historical credentials are redacted on read. | ✅ |
+| `GetLog` | Get a single system log by sequence number. Historical credentials are redacted on read. | ✅ |
 | `ListSigningKeys` | Stream all registered signing keys | ✅ |
 | `Discovery` | Return server capabilities (response signing config) and build info (`ServerInfo`: version, commit, build date, Go version) | ✅ |
 | `AnalyzeAccounts` | Analyze accounts and suggest Chart of Accounts | ✅ |

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1691,7 +1691,7 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 		return nil, fmt.Errorf("reading ledger logs: %w", err)
 	}
 
-	return cursor.NewClosingCursor(c, handle), nil
+	return newProjectingCursor(cursor.NewClosingCursor(c, handle), projectLogForRead), nil
 }
 
 // ListAuditEntries returns a cursor over audit entries against the live store,
@@ -1745,7 +1745,7 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 		return nil, fmt.Errorf("listing audit entries: %w", err)
 	}
 
-	return cursor.NewClosingCursor(c, handle), nil
+	return newProjectingCursor(cursor.NewClosingCursor(c, handle), projectAuditEntryForRead), nil
 }
 
 // GetLog returns a single system log by sequence number.
@@ -1767,7 +1767,7 @@ func (ctrl *DefaultController) GetLog(ctx context.Context, sequence uint64) (*co
 		return nil, commonpb.NewNotFoundError("log %d not found", sequence)
 	}
 
-	return log, nil
+	return projectLogForRead(log)
 }
 
 // GetAuditEntry returns a single audit entry by sequence number, with items populated.
@@ -1795,7 +1795,7 @@ func (ctrl *DefaultController) GetAuditEntry(ctx context.Context, sequence uint6
 
 	entry.Items = items
 
-	return entry, nil
+	return projectAuditEntryForRead(entry)
 }
 
 // ListChapters returns a cursor over all non-purged chapters from the store.

--- a/internal/application/ctrl/secret_read_projection.go
+++ b/internal/application/ctrl/secret_read_projection.go
@@ -1,0 +1,209 @@
+package ctrl
+
+import (
+	"fmt"
+
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+const redactedSecret = "***REDACTED***"
+
+// projectingCursor applies a read-only projection to each item while preserving
+// the underlying cursor's lifecycle and routed pagination trailer.
+type projectingCursor[T any] struct {
+	inner   cursor.Cursor[T]
+	project func(T) (T, error)
+}
+
+func (c *projectingCursor[T]) Next() (T, error) {
+	item, err := c.inner.Next()
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	return c.project(item)
+}
+
+func (c *projectingCursor[T]) Close() error {
+	return c.inner.Close()
+}
+
+// NextCursor forwards routed gRPC pagination metadata when the wrapped cursor
+// provides it. Local cursors return an empty token.
+func (c *projectingCursor[T]) NextCursor() string {
+	if upstream, ok := c.inner.(interface{ NextCursor() string }); ok {
+		return upstream.NextCursor()
+	}
+
+	return ""
+}
+
+func newProjectingCursor[T any](inner cursor.Cursor[T], project func(T) (T, error)) cursor.Cursor[T] {
+	return &projectingCursor[T]{inner: inner, project: project}
+}
+
+// projectAuditEntryForRead returns a deep-cloned, secret-safe representation
+// for public audit reads. The persisted entry remains the authoritative,
+// hash-chain-verifiable source; projected order and signed-batch bytes are not
+// themselves signature/hash preimages after credentials are replaced.
+func projectAuditEntryForRead(entry *auditpb.AuditEntry) (*auditpb.AuditEntry, error) {
+	if entry == nil {
+		return nil, nil
+	}
+
+	projected := entry.CloneVT()
+
+	for _, item := range projected.GetItems() {
+		serialized, err := projectSerializedOrderForRead(item.GetSerializedOrder())
+		if err != nil {
+			return nil, fmt.Errorf("projecting audit item %d: %w", item.GetOrderIndex(), err)
+		}
+
+		item.SerializedOrder = serialized
+	}
+
+	if signature := projected.GetSignature(); signature != nil && len(signature.GetPayload()) > 0 {
+		payload, err := projectSignedBatchPayloadForRead(signature.GetPayload())
+		if err != nil {
+			return nil, fmt.Errorf("projecting signed audit payload: %w", err)
+		}
+
+		// The original Ed25519 signature covers the unredacted payload. Keeping
+		// it beside projected bytes would falsely imply that those bytes verify.
+		signature.Signature = nil
+		signature.Payload = payload
+	}
+
+	return projected, nil
+}
+
+func projectSerializedOrderForRead(serialized []byte) ([]byte, error) {
+	if len(serialized) == 0 {
+		return nil, nil
+	}
+
+	order := &raftcmdpb.Order{}
+	if err := order.UnmarshalVT(serialized); err != nil {
+		return nil, fmt.Errorf("unmarshaling serialized order: %w", err)
+	}
+
+	redactOrderSecrets(order)
+
+	// Use the same business-intent projection as current audit capture. This
+	// also safely handles pre-EN-1558 entries that embedded OrderTechnical.
+	return processing.MarshalOrderBusinessIntent(order, nil), nil
+}
+
+func projectSignedBatchPayloadForRead(payload []byte) ([]byte, error) {
+	batch := &servicepb.ApplyBatch{}
+	if err := batch.UnmarshalVT(payload); err != nil {
+		return nil, fmt.Errorf("unmarshaling ApplyBatch: %w", err)
+	}
+
+	for _, request := range batch.GetRequests() {
+		if addSink := request.GetAddEventsSink(); addSink != nil {
+			redactSinkConfigSecrets(addSink.GetConfig())
+		}
+
+		if createLedger := request.GetCreateLedger(); createLedger != nil {
+			redactMirrorSourceSecrets(createLedger.GetMirrorSource())
+		}
+	}
+
+	projected, err := batch.MarshalVT()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling projected ApplyBatch: %w", err)
+	}
+
+	return projected, nil
+}
+
+func redactOrderSecrets(order *raftcmdpb.Order) {
+	if addSink := order.GetSystemScoped().GetAddEventsSink(); addSink != nil {
+		redactSinkConfigSecrets(addSink.GetConfig())
+	}
+
+	if createLedger := order.GetLedgerScoped().GetCreateLedger(); createLedger != nil {
+		redactMirrorSourceSecrets(createLedger.GetMirrorSource())
+	}
+}
+
+func projectLogForRead(log *commonpb.Log) (*commonpb.Log, error) {
+	if log == nil {
+		return nil, nil
+	}
+
+	projected := log.CloneVT()
+	payload := projected.GetPayload()
+
+	if addedSink := payload.GetAddedEventsSink(); addedSink != nil {
+		redactSinkConfigSecrets(addedSink.GetConfig())
+	}
+
+	if createdLedger := payload.GetCreateLedger(); createdLedger != nil {
+		redactMirrorSourceSecrets(createdLedger.GetMirrorSource())
+	}
+
+	return projected, nil
+}
+
+func redactSinkConfigSecrets(config *commonpb.SinkConfig) {
+	if config == nil {
+		return
+	}
+
+	if nats := config.GetNats(); nats != nil && nats.GetUrl() != "" {
+		// A NATS URL may use either user:password or token userinfo. The URL
+		// is a single opaque field, so redact it as a unit to cover both forms.
+		nats.Url = redactedSecret
+	}
+
+	if clickhouse := config.GetClickhouse(); clickhouse != nil && clickhouse.GetDsn() != "" {
+		clickhouse.Dsn = redactedSecret
+	}
+
+	if kafka := config.GetKafka(); kafka != nil && kafka.GetSaslPassword() != "" {
+		kafka.SaslPassword = redactedSecret
+	}
+
+	if httpConfig := config.GetHttp(); httpConfig != nil && httpConfig.GetSecret() != "" {
+		httpConfig.Secret = redactedSecret
+	}
+
+	if databricks := config.GetDatabricks(); databricks != nil {
+		switch auth := databricks.GetAuth().(type) {
+		case *commonpb.DatabricksSinkConfig_Token:
+			if auth.Token != "" {
+				auth.Token = redactedSecret
+			}
+		case *commonpb.DatabricksSinkConfig_OauthM2M:
+			if auth.OauthM2M != nil && auth.OauthM2M.GetClientSecret() != "" {
+				auth.OauthM2M.ClientSecret = redactedSecret
+			}
+		}
+	}
+}
+
+func redactMirrorSourceSecrets(source *commonpb.MirrorSourceConfig) {
+	if source == nil {
+		return
+	}
+
+	if httpSource := source.GetHttp(); httpSource != nil {
+		credentials := httpSource.GetOauth2ClientCredentials()
+		if credentials != nil && credentials.GetClientSecret() != "" {
+			credentials.ClientSecret = redactedSecret
+		}
+	}
+
+	if postgres := source.GetPostgres(); postgres != nil && postgres.GetDsn() != "" {
+		postgres.Dsn = redactedSecret
+	}
+}

--- a/internal/application/ctrl/secret_read_projection.go
+++ b/internal/application/ctrl/secret_read_projection.go
@@ -14,7 +14,7 @@ import (
 const redactedSecret = "***REDACTED***"
 
 // projectingCursor applies a read-only projection to each item while preserving
-// the underlying cursor's lifecycle and routed pagination trailer.
+// the underlying cursor's lifecycle.
 type projectingCursor[T any] struct {
 	inner   cursor.Cursor[T]
 	project func(T) (T, error)
@@ -33,16 +33,6 @@ func (c *projectingCursor[T]) Next() (T, error) {
 
 func (c *projectingCursor[T]) Close() error {
 	return c.inner.Close()
-}
-
-// NextCursor forwards routed gRPC pagination metadata when the wrapped cursor
-// provides it. Local cursors return an empty token.
-func (c *projectingCursor[T]) NextCursor() string {
-	if upstream, ok := c.inner.(interface{ NextCursor() string }); ok {
-		return upstream.NextCursor()
-	}
-
-	return ""
 }
 
 func newProjectingCursor[T any](inner cursor.Cursor[T], project func(T) (T, error)) cursor.Cursor[T] {
@@ -70,15 +60,17 @@ func projectAuditEntryForRead(entry *auditpb.AuditEntry) (*auditpb.AuditEntry, e
 	}
 
 	if signature := projected.GetSignature(); signature != nil && len(signature.GetPayload()) > 0 {
-		payload, err := projectSignedBatchPayloadForRead(signature.GetPayload())
+		payload, changed, err := projectSignedBatchPayloadForRead(signature.GetPayload())
 		if err != nil {
 			return nil, fmt.Errorf("projecting signed audit payload: %w", err)
 		}
 
-		// The original Ed25519 signature covers the unredacted payload. Keeping
-		// it beside projected bytes would falsely imply that those bytes verify.
-		signature.Signature = nil
-		signature.Payload = payload
+		if changed {
+			// The original Ed25519 signature covers the unredacted payload. Keeping
+			// it beside projected bytes would falsely imply that those bytes verify.
+			signature.Signature = nil
+			signature.Payload = payload
+		}
 	}
 
 	return projected, nil
@@ -94,45 +86,61 @@ func projectSerializedOrderForRead(serialized []byte) ([]byte, error) {
 		return nil, fmt.Errorf("unmarshaling serialized order: %w", err)
 	}
 
-	redactOrderSecrets(order)
+	if !redactOrderSecrets(order) {
+		// Preserve the exact hash-chain preimage whenever the order contains no
+		// credential. This includes legacy bytes whose representation may differ
+		// from the current business-intent marshaller.
+		return serialized, nil
+	}
 
-	// Use the same business-intent projection as current audit capture. This
-	// also safely handles pre-EN-1558 entries that embedded OrderTechnical.
+	// A credential-bearing response is deliberately a projection rather than
+	// the authoritative hash preimage. Use the current business-intent encoding
+	// so technical execution metadata is not reintroduced into projected bytes.
 	return processing.MarshalOrderBusinessIntent(order, nil), nil
 }
 
-func projectSignedBatchPayloadForRead(payload []byte) ([]byte, error) {
+func projectSignedBatchPayloadForRead(payload []byte) ([]byte, bool, error) {
 	batch := &servicepb.ApplyBatch{}
 	if err := batch.UnmarshalVT(payload); err != nil {
-		return nil, fmt.Errorf("unmarshaling ApplyBatch: %w", err)
+		return nil, false, fmt.Errorf("unmarshaling ApplyBatch: %w", err)
 	}
+
+	changed := false
 
 	for _, request := range batch.GetRequests() {
 		if addSink := request.GetAddEventsSink(); addSink != nil {
-			redactSinkConfigSecrets(addSink.GetConfig())
+			changed = redactSinkConfigSecrets(addSink.GetConfig()) || changed
 		}
 
 		if createLedger := request.GetCreateLedger(); createLedger != nil {
-			redactMirrorSourceSecrets(createLedger.GetMirrorSource())
+			changed = redactMirrorSourceSecrets(createLedger.GetMirrorSource()) || changed
 		}
+	}
+
+	if !changed {
+		return payload, false, nil
 	}
 
 	projected, err := batch.MarshalVT()
 	if err != nil {
-		return nil, fmt.Errorf("marshaling projected ApplyBatch: %w", err)
+		return nil, false, fmt.Errorf("marshaling projected ApplyBatch: %w", err)
 	}
 
-	return projected, nil
+	return projected, true, nil
 }
 
-func redactOrderSecrets(order *raftcmdpb.Order) {
+func redactOrderSecrets(order *raftcmdpb.Order) bool {
+	changed := false
+
 	if addSink := order.GetSystemScoped().GetAddEventsSink(); addSink != nil {
-		redactSinkConfigSecrets(addSink.GetConfig())
+		changed = redactSinkConfigSecrets(addSink.GetConfig()) || changed
 	}
 
 	if createLedger := order.GetLedgerScoped().GetCreateLedger(); createLedger != nil {
-		redactMirrorSourceSecrets(createLedger.GetMirrorSource())
+		changed = redactMirrorSourceSecrets(createLedger.GetMirrorSource()) || changed
 	}
+
+	return changed
 }
 
 func projectLogForRead(log *commonpb.Log) (*commonpb.Log, error) {
@@ -154,27 +162,33 @@ func projectLogForRead(log *commonpb.Log) (*commonpb.Log, error) {
 	return projected, nil
 }
 
-func redactSinkConfigSecrets(config *commonpb.SinkConfig) {
+func redactSinkConfigSecrets(config *commonpb.SinkConfig) bool {
 	if config == nil {
-		return
+		return false
 	}
+
+	changed := false
 
 	if nats := config.GetNats(); nats != nil && nats.GetUrl() != "" {
 		// A NATS URL may use either user:password or token userinfo. The URL
 		// is a single opaque field, so redact it as a unit to cover both forms.
 		nats.Url = redactedSecret
+		changed = true
 	}
 
 	if clickhouse := config.GetClickhouse(); clickhouse != nil && clickhouse.GetDsn() != "" {
 		clickhouse.Dsn = redactedSecret
+		changed = true
 	}
 
 	if kafka := config.GetKafka(); kafka != nil && kafka.GetSaslPassword() != "" {
 		kafka.SaslPassword = redactedSecret
+		changed = true
 	}
 
 	if httpConfig := config.GetHttp(); httpConfig != nil && httpConfig.GetSecret() != "" {
 		httpConfig.Secret = redactedSecret
+		changed = true
 	}
 
 	if databricks := config.GetDatabricks(); databricks != nil {
@@ -182,28 +196,38 @@ func redactSinkConfigSecrets(config *commonpb.SinkConfig) {
 		case *commonpb.DatabricksSinkConfig_Token:
 			if auth.Token != "" {
 				auth.Token = redactedSecret
+				changed = true
 			}
 		case *commonpb.DatabricksSinkConfig_OauthM2M:
 			if auth.OauthM2M != nil && auth.OauthM2M.GetClientSecret() != "" {
 				auth.OauthM2M.ClientSecret = redactedSecret
+				changed = true
 			}
 		}
 	}
+
+	return changed
 }
 
-func redactMirrorSourceSecrets(source *commonpb.MirrorSourceConfig) {
+func redactMirrorSourceSecrets(source *commonpb.MirrorSourceConfig) bool {
 	if source == nil {
-		return
+		return false
 	}
+
+	changed := false
 
 	if httpSource := source.GetHttp(); httpSource != nil {
 		credentials := httpSource.GetOauth2ClientCredentials()
 		if credentials != nil && credentials.GetClientSecret() != "" {
 			credentials.ClientSecret = redactedSecret
+			changed = true
 		}
 	}
 
 	if postgres := source.GetPostgres(); postgres != nil && postgres.GetDsn() != "" {
 		postgres.Dsn = redactedSecret
+		changed = true
 	}
+
+	return changed
 }

--- a/internal/application/ctrl/secret_read_projection_test.go
+++ b/internal/application/ctrl/secret_read_projection_test.go
@@ -181,6 +181,39 @@ func TestProjectAuditEntryForReadRedactsOrdersAndSignedPayload(t *testing.T) {
 	}
 }
 
+func TestProjectAuditEntryForReadPreservesVerifiableEvidenceWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_SystemScoped{SystemScoped: &raftcmdpb.SystemScopedOrder{
+		Payload: &raftcmdpb.SystemScopedOrder_RemoveEventsSink{RemoveEventsSink: &raftcmdpb.RemoveEventsSinkOrder{Name: "sink"}},
+	}}, Technical: &raftcmdpb.OrderTechnical{CoverageBits: []byte{0x01}}}
+	// Model a legacy audit item that still contains OrderTechnical. A no-op
+	// secret projection must preserve these exact historical bytes rather than
+	// normalizing them through the current business-intent marshaller.
+	serializedOrder := order.MarshalDeterministicVT(nil)
+	batchPayload, err := (&servicepb.ApplyBatch{Requests: []*servicepb.Request{{
+		Type: &servicepb.Request_RemoveEventsSink{RemoveEventsSink: &servicepb.RemoveEventsSinkRequest{Name: "sink"}},
+	}}}).MarshalVT()
+	require.NoError(t, err)
+
+	entry := &auditpb.AuditEntry{
+		Sequence: 43,
+		Items:    []*auditpb.AuditItem{{SerializedOrder: serializedOrder}},
+		Signature: &signaturepb.SignedApplyBatch{
+			KeyId:     "signer-key",
+			Signature: []byte("original-signature"),
+			Payload:   batchPayload,
+		},
+	}
+
+	projected, err := projectAuditEntryForRead(entry)
+	require.NoError(t, err)
+	require.Equal(t, entry, projected)
+	require.Equal(t, serializedOrder, projected.GetItems()[0].GetSerializedOrder())
+	require.Equal(t, batchPayload, projected.GetSignature().GetPayload())
+	require.Equal(t, []byte("original-signature"), projected.GetSignature().GetSignature())
+}
+
 func TestProjectAuditEntryForReadRejectsUnparseableSecretContainers(t *testing.T) {
 	t.Parallel()
 
@@ -227,10 +260,10 @@ func TestProjectLogForReadRedactsEveryCredentialVariant(t *testing.T) {
 	}
 }
 
-func TestProjectingCursorPreservesItemsErrorsAndPagination(t *testing.T) {
+func TestProjectingCursorPreservesItemsAndClose(t *testing.T) {
 	t.Parallel()
 
-	upstream := &projectionTestCursor{items: []*commonpb.Log{{Sequence: 1}}, nextCursor: "next-page"}
+	upstream := &projectionTestCursor{items: []*commonpb.Log{{Sequence: 1}}}
 	projected := newProjectingCursor[*commonpb.Log](upstream, projectLogForRead)
 
 	item, err := projected.Next()
@@ -239,15 +272,13 @@ func TestProjectingCursorPreservesItemsErrorsAndPagination(t *testing.T) {
 
 	_, err = projected.Next()
 	require.ErrorIs(t, err, io.EOF)
-	require.Equal(t, "next-page", projected.(interface{ NextCursor() string }).NextCursor())
 	require.NoError(t, projected.Close())
 	require.True(t, upstream.closed)
 }
 
 type projectionTestCursor struct {
-	items      []*commonpb.Log
-	nextCursor string
-	closed     bool
+	items  []*commonpb.Log
+	closed bool
 }
 
 func (c *projectionTestCursor) Next() (*commonpb.Log, error) {
@@ -265,10 +296,6 @@ func (c *projectionTestCursor) Close() error {
 	c.closed = true
 
 	return nil
-}
-
-func (c *projectionTestCursor) NextCursor() string {
-	return c.nextCursor
 }
 
 var _ cursor.Cursor[*commonpb.Log] = (*projectionTestCursor)(nil)

--- a/internal/application/ctrl/secret_read_projection_test.go
+++ b/internal/application/ctrl/secret_read_projection_test.go
@@ -1,0 +1,331 @@
+package ctrl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestDefaultControllerGetLogReturnsProjectionWithoutMutatingStore(t *testing.T) {
+	t.Parallel()
+
+	store := newReceiptTestStore(t)
+	config, secrets := secretBearingSinkConfigs()
+	stored := &commonpb.Log{
+		Sequence: 7,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_AddedEventsSink{
+			AddedEventsSink: &commonpb.AddedEventsSinkLog{Config: config[1]},
+		}},
+	}
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{stored}))
+	require.NoError(t, batch.Commit())
+
+	projected, err := newSecretProjectionTestController(store).GetLog(context.Background(), stored.GetSequence())
+	require.NoError(t, err)
+	require.NotContains(t, projected.String(), secrets[1])
+	require.Contains(t, projected.String(), redactedSecret)
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	authoritative, err := query.ReadLogBySequence(context.Background(), handle, stored.GetSequence())
+	require.NoError(t, err)
+	require.Contains(t, authoritative.String(), secrets[1])
+}
+
+func TestDefaultControllerGetAuditEntryReturnsProjectionWithoutMutatingStore(t *testing.T) {
+	t.Parallel()
+
+	store := newReceiptTestStore(t)
+	config, secrets := secretBearingSinkConfigs()
+	order := addSinkOrder(config[2])
+	serializedOrder := processing.MarshalOrderBusinessIntent(order, nil)
+	publicBatch, err := (&servicepb.ApplyBatch{Requests: []*servicepb.Request{{
+		Type: &servicepb.Request_AddEventsSink{AddEventsSink: &servicepb.AddEventsSinkRequest{Config: config[2].CloneVT()}},
+	}}}).MarshalVT()
+	require.NoError(t, err)
+
+	entry := &auditpb.AuditEntry{
+		Sequence: 9,
+		Signature: &signaturepb.SignedApplyBatch{
+			KeyId: "key", Signature: []byte("signature"), Payload: publicBatch,
+		},
+	}
+	item := &auditpb.AuditItem{OrderIndex: 0, SerializedOrder: serializedOrder}
+
+	batch := store.OpenWriteSession()
+	batch.KeyBuilder.PutZonePrefix(dal.ZoneCold, dal.SubColdAudit).PutUint64(entry.GetSequence())
+	require.NoError(t, batch.SetProtoDeterministic(batch.KeyBuilder.Consume(), entry))
+	batch.KeyBuilder.PutZonePrefix(dal.ZoneCold, dal.SubColdAuditItem).PutUint64(entry.GetSequence()).PutUint32(0)
+	require.NoError(t, batch.SetProto(batch.KeyBuilder.Consume(), item))
+	require.NoError(t, batch.Commit())
+
+	projected, err := newSecretProjectionTestController(store).GetAuditEntry(context.Background(), entry.GetSequence())
+	require.NoError(t, err)
+	require.NotContains(t, string(projected.GetItems()[0].GetSerializedOrder()), secrets[2])
+	require.NotContains(t, string(projected.GetSignature().GetPayload()), secrets[2])
+	require.Empty(t, projected.GetSignature().GetSignature())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	authoritativeItems, err := query.ReadAuditItems(context.Background(), handle, entry.GetSequence())
+	require.NoError(t, err)
+	require.Contains(t, string(authoritativeItems[0].GetSerializedOrder()), secrets[2])
+	authoritativeEntry, err := query.ReadAuditEntry(context.Background(), handle, entry.GetSequence())
+	require.NoError(t, err)
+	require.Contains(t, string(authoritativeEntry.GetSignature().GetPayload()), secrets[2])
+}
+
+func newSecretProjectionTestController(store *dal.Store) *DefaultController {
+	logger := logging.FromContext(logging.TestingContext())
+	meter := noop.NewMeterProvider().Meter("test")
+
+	return NewDefaultController(nil, store, logger, attributes.New(), nil, nil, nil, nil, meter)
+}
+
+func TestProjectAuditEntryForReadRedactsOrdersAndSignedPayload(t *testing.T) {
+	t.Parallel()
+
+	sinkConfigs, sinkSecrets := secretBearingSinkConfigs()
+	mirrorSources, mirrorSecrets := secretBearingMirrorSources()
+
+	var (
+		items    []*auditpb.AuditItem
+		requests []*servicepb.Request
+	)
+
+	for _, config := range sinkConfigs {
+		order := addSinkOrder(config.CloneVT())
+		items = append(items, &auditpb.AuditItem{
+			OrderIndex:      uint32(len(items)),
+			SerializedOrder: processing.MarshalOrderBusinessIntent(order, nil),
+		})
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_AddEventsSink{
+			AddEventsSink: &servicepb.AddEventsSinkRequest{Config: config.CloneVT()},
+		}})
+	}
+
+	for _, source := range mirrorSources {
+		order := createLedgerOrder(source.CloneVT())
+		items = append(items, &auditpb.AuditItem{
+			OrderIndex:      uint32(len(items)),
+			SerializedOrder: processing.MarshalOrderBusinessIntent(order, nil),
+		})
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_CreateLedger{
+			CreateLedger: &servicepb.CreateLedgerRequest{MirrorSource: source.CloneVT()},
+		}})
+	}
+
+	batchPayload, err := (&servicepb.ApplyBatch{Requests: requests}).MarshalVT()
+	require.NoError(t, err)
+
+	entry := &auditpb.AuditEntry{
+		Sequence: 42,
+		Items:    items,
+		Signature: &signaturepb.SignedApplyBatch{
+			KeyId:     "signer-key",
+			Signature: []byte("original-signature"),
+			Payload:   batchPayload,
+		},
+	}
+	original := entry.CloneVT()
+
+	projected, err := projectAuditEntryForRead(entry)
+	require.NoError(t, err)
+	require.Equal(t, original, entry, "read projection must not mutate authoritative audit data")
+	require.Empty(t, projected.GetSignature().GetSignature(), "signature does not cover projected bytes")
+	require.Equal(t, "signer-key", projected.GetSignature().GetKeyId())
+
+	projectedBatch := &servicepb.ApplyBatch{}
+	require.NoError(t, projectedBatch.UnmarshalVT(projected.GetSignature().GetPayload()))
+	require.Len(t, projectedBatch.GetRequests(), len(requests))
+
+	for _, item := range projected.GetItems() {
+		order := &raftcmdpb.Order{}
+		require.NoError(t, order.UnmarshalVT(item.GetSerializedOrder()))
+	}
+
+	rendered, err := json.Marshal(projected)
+	require.NoError(t, err)
+
+	for _, secret := range append(sinkSecrets, mirrorSecrets...) {
+		require.NotContains(t, string(rendered), secret)
+		require.NotContains(t, string(projected.GetSignature().GetPayload()), secret)
+		for _, item := range projected.GetItems() {
+			require.NotContains(t, string(item.GetSerializedOrder()), secret)
+		}
+	}
+}
+
+func TestProjectAuditEntryForReadRejectsUnparseableSecretContainers(t *testing.T) {
+	t.Parallel()
+
+	_, err := projectAuditEntryForRead(&auditpb.AuditEntry{
+		Items: []*auditpb.AuditItem{{SerializedOrder: []byte{0xff}}},
+	})
+	require.ErrorContains(t, err, "unmarshaling serialized order")
+
+	_, err = projectAuditEntryForRead(&auditpb.AuditEntry{
+		Signature: &signaturepb.SignedApplyBatch{Payload: []byte{0xff}},
+	})
+	require.ErrorContains(t, err, "unmarshaling ApplyBatch")
+}
+
+func TestProjectLogForReadRedactsEveryCredentialVariant(t *testing.T) {
+	t.Parallel()
+
+	sinkConfigs, sinkSecrets := secretBearingSinkConfigs()
+	for i, config := range sinkConfigs {
+		log := &commonpb.Log{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_AddedEventsSink{
+			AddedEventsSink: &commonpb.AddedEventsSinkLog{Config: config},
+		}}}
+		original := log.CloneVT()
+
+		projected, err := projectLogForRead(log)
+		require.NoError(t, err)
+		require.Equal(t, original, log)
+		require.NotContains(t, projected.String(), sinkSecrets[i])
+		require.Contains(t, projected.String(), redactedSecret)
+	}
+
+	mirrorSources, mirrorSecrets := secretBearingMirrorSources()
+	for i, source := range mirrorSources {
+		log := &commonpb.Log{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{
+			CreateLedger: &commonpb.CreatedLedgerLog{MirrorSource: source},
+		}}}
+		original := log.CloneVT()
+
+		projected, err := projectLogForRead(log)
+		require.NoError(t, err)
+		require.Equal(t, original, log)
+		require.NotContains(t, projected.String(), mirrorSecrets[i])
+		require.Contains(t, projected.String(), redactedSecret)
+	}
+}
+
+func TestProjectingCursorPreservesItemsErrorsAndPagination(t *testing.T) {
+	t.Parallel()
+
+	upstream := &projectionTestCursor{items: []*commonpb.Log{{Sequence: 1}}, nextCursor: "next-page"}
+	projected := newProjectingCursor[*commonpb.Log](upstream, projectLogForRead)
+
+	item, err := projected.Next()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), item.GetSequence())
+
+	_, err = projected.Next()
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, "next-page", projected.(interface{ NextCursor() string }).NextCursor())
+	require.NoError(t, projected.Close())
+	require.True(t, upstream.closed)
+}
+
+type projectionTestCursor struct {
+	items      []*commonpb.Log
+	nextCursor string
+	closed     bool
+}
+
+func (c *projectionTestCursor) Next() (*commonpb.Log, error) {
+	if len(c.items) == 0 {
+		return nil, io.EOF
+	}
+
+	item := c.items[0]
+	c.items = c.items[1:]
+
+	return item, nil
+}
+
+func (c *projectionTestCursor) Close() error {
+	c.closed = true
+
+	return nil
+}
+
+func (c *projectionTestCursor) NextCursor() string {
+	return c.nextCursor
+}
+
+var _ cursor.Cursor[*commonpb.Log] = (*projectionTestCursor)(nil)
+
+func TestProjectingCursorReturnsProjectionErrors(t *testing.T) {
+	t.Parallel()
+
+	expected := errors.New("projection failed")
+	projected := newProjectingCursor(
+		cursor.NewSliceCursor([]*commonpb.Log{{Sequence: 1}}),
+		func(*commonpb.Log) (*commonpb.Log, error) { return nil, expected },
+	)
+
+	_, err := projected.Next()
+	require.ErrorIs(t, err, expected)
+}
+
+func secretBearingSinkConfigs() ([]*commonpb.SinkConfig, []string) {
+	return []*commonpb.SinkConfig{
+			{Name: "nats", Type: &commonpb.SinkConfig_Nats{Nats: &commonpb.NatsSinkConfig{Url: "nats://token-secret@nats.example:4222", Topic: "ledger"}}},
+			{Name: "clickhouse", Type: &commonpb.SinkConfig_Clickhouse{Clickhouse: &commonpb.ClickHouseSinkConfig{Dsn: "clickhouse://user:clickhouse-secret@db.example/ledger", Table: "events"}}},
+			{Name: "kafka", Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{Brokers: []string{"broker:9092"}, SaslUsername: "ledger", SaslPassword: "kafka-secret"}}},
+			{Name: "http", Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://hooks.example/ledger", Secret: "webhook-secret"}}},
+			{Name: "databricks-token", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{ServerHostname: "db.example", Auth: &commonpb.DatabricksSinkConfig_Token{Token: "databricks-token-secret"}}}},
+			{Name: "databricks-oauth", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{ServerHostname: "db.example", Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{ClientId: "client", ClientSecret: "databricks-oauth-secret"}}}}},
+		}, []string{
+			"nats://token-secret@nats.example:4222",
+			"clickhouse://user:clickhouse-secret@db.example/ledger",
+			"kafka-secret",
+			"webhook-secret",
+			"databricks-token-secret",
+			"databricks-oauth-secret",
+		}
+}
+
+func secretBearingMirrorSources() ([]*commonpb.MirrorSourceConfig, []string) {
+	return []*commonpb.MirrorSourceConfig{
+		{LedgerName: "source-http", Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
+			BaseUrl: "https://ledger.example",
+			Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{
+				ClientId: "client", ClientSecret: "mirror-oauth-secret", TokenEndpoint: "https://auth.example/token",
+			},
+		}}},
+		{LedgerName: "source-postgres", Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{
+			Dsn: "postgres://ledger:mirror-postgres-secret@db.example/ledger",
+		}}},
+	}, []string{"mirror-oauth-secret", "postgres://ledger:mirror-postgres-secret@db.example/ledger"}
+}
+
+func addSinkOrder(config *commonpb.SinkConfig) *raftcmdpb.Order {
+	return &raftcmdpb.Order{Type: &raftcmdpb.Order_SystemScoped{SystemScoped: &raftcmdpb.SystemScopedOrder{
+		Payload: &raftcmdpb.SystemScopedOrder_AddEventsSink{AddEventsSink: &raftcmdpb.AddEventsSinkOrder{Config: config}},
+	}}}
+}
+
+func createLedgerOrder(source *commonpb.MirrorSourceConfig) *raftcmdpb.Order {
+	return &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: "mirror", Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{CreateLedger: &raftcmdpb.CreateLedgerOrder{MirrorSource: source}},
+	}}}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -523,7 +523,9 @@ paths:
         `items` populated (the list endpoint omits `items` for compactness).
         Credentials inside serialized orders and signed batch payloads are
         replaced with `***REDACTED***`. Projected bytes are not the original
-        audit-hash or Ed25519-signature preimage; the signature bytes are omitted.
+        audit-hash or Ed25519-signature preimage; signature bytes are omitted
+        only when the signed payload was redacted. Entries without credentials
+        retain their original payload and signature.
         Requires `ledger:AuditRead` scope.
       operationId: getAuditEntry
       tags:
@@ -5491,8 +5493,9 @@ components:
           type: object
           description: |
             Signed-batch metadata (protobuf JSON); absent for unsigned batches.
-            On public reads the payload is redacted and the signature bytes are
-            omitted because they cover the original unredacted payload.
+            When credentials are present, public reads redact the payload and
+            omit the signature bytes because they cover the original unredacted
+            payload. Otherwise the exact payload and signature are preserved.
 
     AuditItem:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -335,6 +335,8 @@ paths:
         Lists log entries for a specific ledger, ordered by ledger-local log ID ascending.
         Requires the builtin `LOG` index to be enabled on the ledger via `CreateIndex`.
         Supports cursor pagination via the `after` query parameter. Requires `ledger:OpsRead` scope.
+        Secret-bearing sink and mirror fields in historical records are replaced with
+        `***REDACTED***`; the authoritative stored log is not mutated.
       operationId: listLedgerLogs
       tags:
         - Logs
@@ -427,6 +429,9 @@ paths:
         indexed. A client that needs a pinned or consistency-bounded audit read
         must use the gRPC surface.
 
+        Secret-bearing signed batch payloads are returned as redacted read
+        projections. The authoritative stored entry and hash chain are unchanged.
+
         Requires `ledger:AuditRead` scope.
       operationId: listAuditEntries
       tags:
@@ -516,6 +521,9 @@ paths:
       description: |
         Returns a single audit entry by its global sequence, with per-order
         `items` populated (the list endpoint omits `items` for compactness).
+        Credentials inside serialized orders and signed batch payloads are
+        replaced with `***REDACTED***`. Projected bytes are not the original
+        audit-hash or Ed25519-signature preimage; the signature bytes are omitted.
         Requires `ledger:AuditRead` scope.
       operationId: getAuditEntry
       tags:
@@ -2229,8 +2237,9 @@ paths:
       summary: Get a single system log by bucket-wide sequence
       description: |
         Returns the system log entry with the given bucket-wide sequence number.
-        Falls back to cold storage when the log has been archived. Requires
-        `ledger:OpsRead` scope.
+        Falls back to cold storage when the log has been archived. Secret-bearing
+        sink and mirror fields are replaced with `***REDACTED***`; the authoritative
+        stored log is not mutated. Requires `ledger:OpsRead` scope.
       operationId: getLog
       tags:
         - Logs
@@ -5431,7 +5440,9 @@ components:
       description: |
         A single audit trail entry for a proposal (success or failure). Exactly
         one of `success` / `failure` is set. `items` is populated only by the
-        single-entry lookup, not by the list endpoint.
+        single-entry lookup, not by the list endpoint. Public reads return a
+        secret-safe projection; the stored hash remains the identifier of the
+        unprojected authoritative entry.
       properties:
         sequence:
           type: integer
@@ -5478,7 +5489,10 @@ components:
           description: Batch identity / idempotency information (protobuf JSON)
         signature:
           type: object
-          description: Client signature over the ApplyBatch (protobuf JSON); absent for unsigned batches
+          description: |
+            Signed-batch metadata (protobuf JSON); absent for unsigned batches.
+            On public reads the payload is redacted and the signature bytes are
+            omitted because they cover the original unredacted payload.
 
     AuditItem:
       type: object
@@ -5490,7 +5504,10 @@ components:
           description: Zero-based position of this order within the proposal
         serializedOrder:
           type: string
-          description: Hex-encoded deterministic serialized bytes of the order at apply time
+          description: |
+            Hex-encoded deterministic serialized business-intent bytes projected
+            for public reads. Credential fields are `***REDACTED***`, so these
+            bytes are not the authoritative audit-hash preimage.
         logSequence:
           type: integer
           format: uint64


### PR DESCRIPTION
## What changed

- project sink and mirror credentials out of historical audit and system-log read responses
- redact credentials inside serialized audit orders and signed batch payloads without mutating authoritative stored records
- preserve exact historical bytes and Ed25519 signatures when an audit entry contains no redacted credential
- document the historical boundary and conditional hash/signature verification semantics

## Root cause

Accepted `AddEventsSink` and `CreateLedger` orders contain reusable credentials. The audit chain and system logs persist those exact values, then `GetAuditEntry`, `ListAuditEntries`, `GetLog`, and `ListLogs` returned the stored records directly to read-scoped callers. The default `ledger:read` bundle includes both `AuditRead` and `OpsRead`.

The fix is intentionally placed at the shared `DefaultController` historical read boundary so HTTP, gRPC, local, routed, checkpoint, and cold-storage reads all receive deep-cloned secret-safe projections. FSM processing, accepted orders, audit hashes, idempotency hashes, checker inputs, and persisted bytes remain unchanged.

## Security details

Covered credentials include NATS URL userinfo/tokens, ClickHouse DSNs, Kafka SASL passwords, HTTP webhook HMAC secrets, Databricks PAT/OAuth secrets, PostgreSQL mirror DSNs, and mirror OAuth client secrets.

When a credential is replaced, the projected audit response is not the original hash/signature preimage. The signer key ID and redacted signed payload remain available, while the Ed25519 signature bytes are omitted to avoid implying that the projected payload verifies. Entries without credentials retain their exact serialized order, signed payload, and signature bytes.

Live event-sink configuration responses are handled separately by [PR #1651](https://github.com/formancehq/ledger/pull/1651), and live `LedgerInfo.mirror_source` responses by [PR #1653](https://github.com/formancehq/ledger/pull/1653). Both companion changes cover HTTP and gRPC, so this PR does not duplicate their adapter boundaries.

Jira: [EN-1634](https://formance-team.atlassian.net/browse/EN-1634)

## Validation

- `nix develop --command bash -c "GOROOT= go test ./internal/application/ctrl ./internal/adapter/grpc ./internal/adapter/http -count=1"`
- `nix develop --command bash -c "GOROOT= go build ./..."`
- `nix develop --command bash -c "just pre-commit"`
- GitNexus `detect_changes(scope=compare, base_ref=release/v3.0)`: HIGH aggregate graph risk from six `ListLogs` storage-read traces; reviewed individually, with the change confined to the returned cursor projection after existing reads/indexing

Regression tests prove every sink/mirror credential variant is absent from projected audit orders, signed payloads, JSON output, and system logs, while authoritative controller/store objects remain unchanged. They also prove that entries without credentials preserve exact legacy order bytes, signed payload bytes, and signatures.


[EN-1634]: https://formance-team.atlassian.net/browse/EN-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ