### PR TITLE
fix(indexbuilder): clear LedgerLog volume-annotation lists on cursor reuse

### DIFF
--- a/internal/application/indexbuilder/proto_reset.go
+++ b/internal/application/indexbuilder/proto_reset.go
@@ -68,6 +68,13 @@ func resetLogPayload(p *commonpb.LogPayload) {
 
 func resetLedgerLog(ll *commonpb.LedgerLog) {
 	ll.Id = 0
+	// The volume-annotation lists are absent from the wire on most logs, so a
+	// leftover would survive the next unmarshal and poison excludedForLog —
+	// the exclusion set that gates every posting-index write. Truncate to keep
+	// the backing arrays (same idiom as Transaction.Postings).
+	ll.PurgedVolumes = ll.GetPurgedVolumes()[:0]
+	ll.NewKeptVolumes = ll.GetNewKeptVolumes()[:0]
+	ll.EphemeralVolumes = ll.GetEphemeralVolumes()[:0]
 	// Preserve ll.Date (always present in apply logs).
 	// Preserve ll.Data (always present).
 

--- a/internal/application/indexbuilder/proto_reset_test.go
+++ b/internal/application/indexbuilder/proto_reset_test.go
@@ -286,3 +286,28 @@ func buildTestLog() *commonpb.Log {
 		},
 	}
 }
+
+// The LedgerLog volume-annotation lists feed the exclusion projection the
+// posting-index writes consult (excludedForLog). Proto3 unmarshal leaves a
+// repeated field untouched when the wire carries no entries for it, so a
+// reused message whose lists survive the reset makes the NEXT log inherit the
+// PREVIOUS log's purged/ephemeral tuples — the index builder then silently
+// skips that log's posting-index writes for the stale-excluded cells,
+// permanently losing account→tx, role, and has-asset rows (EN-1625 finding:
+// a drain purging (t-20:99, EUR/2) at log N excluded the same account's
+// force-drain at log N+1).
+func TestResetLogForReuse_ClearsVolumeAnnotationLists(t *testing.T) {
+	t.Parallel()
+
+	log := buildTestLog()
+	ll := log.GetPayload().GetType().(*commonpb.LogPayload_Apply).Apply.GetLog()
+	ll.PurgedVolumes = []*commonpb.TouchedVolume{{Account: "t-20:99", Asset: "EUR/2"}}
+	ll.EphemeralVolumes = []*commonpb.TouchedVolume{{Account: "e:1", Asset: "USD"}}
+	ll.NewKeptVolumes = []*commonpb.TouchedVolume{{Account: "a:1", Asset: "USD"}}
+
+	resetLogForReuse(log)
+
+	assert.Empty(t, ll.GetPurgedVolumes())
+	assert.Empty(t, ll.GetEphemeralVolumes())
+	assert.Empty(t, ll.GetNewKeptVolumes())
+}

--- a/tests/e2e/business/index_cursor_reuse_leak_test.go
+++ b/tests/e2e/business/index_cursor_reuse_leak_test.go
@@ -1,0 +1,92 @@
+//go:build e2e
+
+package business
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The index builder's live log cursor reuses one proto message per scan
+// (dal.WithReuse + resetLogForReuse). A log whose wire bytes carry no volume
+// annotations must not inherit the PREVIOUS log's purged/ephemeral lists:
+// those feed excludedForLog, whose (account, asset, color) exclusion keys
+// carry no ledger dimension, so a stale entry silently skips the posting-index
+// writes of whatever log the cursor reads next.
+//
+// The trigger here is deterministic: one cross-ledger bulk commits an
+// ephemeral wash on ledger A (its log carries purged=[e:1 USD]) and a plain
+// funding of the same-named account on ledger B (its log carries no purged
+// list). The two logs are adjacent in the same proposal, hence always read
+// back-to-back through one reused cursor message; with a leaky reset, B's
+// funding inherits A's purged entry and loses its destination-address row —
+// permanently, since nothing later repairs index rows.
+var _ = Describe("Address index across a cross-ledger purge bulk", Ordered, func() {
+	const (
+		ledgerA = "idx-reuse-leak-a"
+		ledgerB = "idx-reuse-leak-b"
+	)
+
+	roleFilter := func(addr string, role commonpb.AddressRole) *commonpb.QueryFilter {
+		f := actions.AddressExactFilter(addr)
+		f.GetAddress().Role = role
+
+		return f
+	}
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateLedgerAction(ledgerA, nil),
+			actions.CreateLedgerAction(ledgerB, nil),
+			actions.AddEphemeralAccountTypeAction(ledgerA, "e", "e:{id}"),
+			actions.CreateAddressIndexAction(ledgerB, commonpb.AddressRole_ADDRESS_ROLE_DESTINATION),
+			actions.CreateAddressIndexAction(ledgerB, commonpb.AddressRole_ADDRESS_ROLE_ANY),
+		))
+		Expect(err).To(Succeed())
+
+		// Wait for ledger B's indexes so the bulk below is indexed by the LIVE
+		// path (the backfill parses raw wire bytes with its own reset and is
+		// not subject to the reuse leak).
+		Eventually(func(g Gomega) {
+			indexes, err := listLedgerIndexes(sharedCtx, sharedClient, ledgerB)
+			g.Expect(err).To(Succeed())
+			g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS)).To(BeTrue())
+			g.Expect(hasTxBuiltinIndex(indexes, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS)).To(BeTrue())
+		}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+
+		// One bulk, two orders, two adjacent logs: the ledger-A wash ends its
+		// (e:1, USD) cell at zero — purged, so its log carries the annotation —
+		// while the ledger-B funding leaves its own (e:1, USD) cell non-zero
+		// and must be indexed.
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateTransactionAction(ledgerA, []*commonpb.Posting{
+				actions.NewPosting("world", "e:1", big.NewInt(5), "USD"),
+				actions.NewPosting("e:1", "world", big.NewInt(5), "USD"),
+			}, nil, nil),
+			actions.CreateTransactionAction(ledgerB, []*commonpb.Posting{
+				actions.NewPosting("world", "e:1", big.NewInt(5), "USD"),
+			}, nil, nil),
+		))
+		Expect(err).To(Succeed())
+	})
+
+	It("indexes the sibling ledger's funding despite the adjacent purge log", func() {
+		Eventually(func(g Gomega) {
+			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerB, 0, 0,
+				roleFilter("e:1", commonpb.AddressRole_ADDRESS_ROLE_DESTINATION))
+			g.Expect(err).To(Succeed())
+
+			ids := make([]uint64, len(txs))
+			for i, tx := range txs {
+				ids[i] = tx.GetId()
+			}
+			g.Expect(ids).To(ConsistOf(uint64(1)))
+		}).Within(10 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Summary

The index builder's live log cursor runs with `dal.WithReuse()` — one proto message, reset (`resetLogForReuse`) and re-unmarshalled per log. The reset truncates `Transaction.Postings` but was never extended for the `LedgerLog` volume-annotation lists (`purged_volumes` / `new_kept_volumes` / `ephemeral_volumes`). Proto3 unmarshal leaves a repeated field untouched when the wire carries no entries for it, so every log inherited — and accumulated — the eviction lists of every preceding log in the same cursor window.

`excludedForLog` consumes exactly those lists (keyed by (account, asset, color), no ledger dimension), so a log touching a cell that any earlier log in the window had purged got its posting-index writes silently skipped: the account→tx role mappings, the any-role mapping, and the has-asset row were never written. Nothing repairs them short of a full read-store rebuild.

Only the live path is affected: the posting backfill parses raw wire bytes into its own `parsedLog`, which truncates the lists correctly on every parse.

## Reproduction

Found by the model-based antithesis driver's address-window validation (singleton_driver_model, EN-1625): a force-drain re-touching a just-purged ephemeral cell in the next log lost its source-address row, while the FSM's on-disk `LedgerLog` lists and a boot-time read-store rebuild were both provably correct.

**Deterministic e2e regression** (`index_cursor_reuse_leak_test.go`): one cross-ledger bulk pairs an ephemeral wash on ledger A (log annotated `purged=[e:1 USD]`) with a plain funding of the same-named account on ledger B (clean log). The two logs are adjacent in one proposal, hence always read back-to-back through the reused cursor message — pre-fix, B's funding deterministically inherits A's purged entry and loses its destination-address row (test times out red); post-fix it passes.

## Fix

Truncate the three lists in `resetLedgerLog`, same idiom as `Postings[:0]`. Red→green at both levels: `TestResetLogForReuse_ClearsVolumeAnnotationLists` (unit) and the e2e above.
