### PR TITLE
test(antithesis): negative-space read probes for the model driver

### DIFF
--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -258,6 +258,17 @@ func renderMetaMap(m map[string]*commonpb.MetadataValue) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
+// renderVolumeSet renders a returned volume set as {asset=(in,out),...}, sorted.
+func renderVolumeSet(vols map[string]oracle.VolumePair) string {
+	parts := make([]string, 0, len(vols))
+	for asset, vp := range vols {
+		parts = append(parts, fmt.Sprintf("%s=(%s,%s)", asset, vp.Input.Dec(), vp.Output.Dec()))
+	}
+	sort.Strings(parts)
+
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
 // modelAccountMetaDump renders the committed model's metadata for addr as
 // {k=value[ft],...} — for diagnosing read mismatches. Acquires c.mu.
 func (c *Checker) modelAccountMetaDump(ledger, addr string) string {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -18,12 +18,13 @@ import (
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
 
-// runRead picks a known account, issues a linearizable GetAccount, and validates
-// the result — the picked asset's volumes and the account's whole metadata map —
-// against the model (see validateAccountRead).
+// runRead picks a read target — usually a known account, sometimes one the model
+// holds no state for — issues a linearizable GetAccount, and validates the result
+// (the picked asset's volumes and the account's whole metadata map) against the
+// model (see validateAccountRead).
 func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	c.mu.Lock()
-	ledger, addr, asset, ok := pickCell(c.modelState)
+	ledger, addr, asset, absent, ok := pickReadTarget(c.modelState, c.ledgerNames)
 	if !ok {
 		c.mu.Unlock()
 		return
@@ -31,6 +32,14 @@ func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Check
 	readID := c.registerRead()
 	c.mu.Unlock()
 	defer c.finishRead(readID)
+
+	if absent {
+		// Coverage: GetAccount is probing the negative space pickCell can't reach —
+		// an account the model holds no state for. The server must report it empty;
+		// a returned cell or metadata no candidate base explains is how this path
+		// catches server state the model lacks (validateAccountRead).
+		assert.Reachable("singleton_driver_model: GetAccount probing a model-absent account", internal.Details{"ledger": ledger})
+	}
 
 	// Be explicit about consistency so the test still validates the
 	// property it cares about if the server-side default ever changes.
@@ -77,6 +86,64 @@ func isShutdownError(err error) bool {
 	default:
 		return false
 	}
+}
+
+// pickReadTarget chooses what GetAccount reads back. Most reads hit a known
+// account (pickCell); ~1-in-4 probe an account the model has no state for
+// (pickAbsentAccount, absent=true). Without the absent probe pickCell can only
+// ever target accounts the model already holds, so GetAccount is structurally
+// blind to server state the model lacks — e.g. an account or cell the server
+// retained but the model doesn't have. Falls back to pickCell when no absent
+// address is found. Caller holds c.mu.
+func pickReadTarget(g oracle.GlobalState, ledgers []string) (ledger, addr, asset string, absent, ok bool) {
+	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
+		if ledger, addr, asset, ok = pickAbsentAccount(g, ledgers); ok {
+			return ledger, addr, asset, true, true
+		}
+	}
+
+	ledger, addr, asset, ok = pickCell(g)
+
+	return ledger, addr, asset, false, ok
+}
+
+// pickAbsentAccount returns a (ledger, address, asset) the model holds no volume
+// cell or metadata for — a pool-space address (t-N:M) the workload could create
+// but has not touched. It reads a random workload asset so a server cell in any
+// asset can be caught. ok=false when no ledger exists or no absent address turned
+// up in a few tries (the pool space is far larger than what is touched, so this is
+// rare). Caller holds c.mu.
+func pickAbsentAccount(g oracle.GlobalState, ledgers []string) (ledger, addr, asset string, ok bool) {
+	if len(ledgers) == 0 {
+		return "", "", "", false
+	}
+
+	ledger = random.RandomChoice(ledgers)
+	ls := g.Ledger(ledger)
+	for tries := 0; tries < 8; tries++ {
+		cand := poolAddress()
+		if !modelKnowsAccount(ls, cand) {
+			return ledger, cand, random.RandomChoice(assets), true
+		}
+	}
+
+	return "", "", "", false
+}
+
+// modelKnowsAccount reports whether ls holds any volume cell or metadata for addr.
+func modelKnowsAccount(ls oracle.LedgerState, addr string) bool {
+	for k := range ls.Volumes() {
+		if k.Address == addr {
+			return true
+		}
+	}
+	for k := range ls.Metadata() {
+		if k.Address == addr {
+			return true
+		}
+	}
+
+	return false
 }
 
 // pickCell returns a random readable account across all ledgers as

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -25,7 +25,7 @@ import (
 // model (see validateAccountRead).
 func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	c.mu.Lock()
-	ledger, addr, asset, absent, ok := pickReadTarget(c.modelState, c.ledgerNames)
+	ledger, addr, asset, absentAccount, absentLedger, ok := pickReadTarget(c.modelState, c.ledgerNames)
 	if !ok {
 		c.mu.Unlock()
 		return
@@ -34,11 +34,17 @@ func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Check
 	c.mu.Unlock()
 	defer c.finishRead(readID)
 
-	if absent {
-		// Coverage: GetAccount is probing the negative space pickCell can't reach —
-		// an account the model holds no state for. The server must report it empty;
-		// a returned cell or metadata no candidate base explains is how this path
-		// catches server state the model lacks (validateAccountRead).
+	// Both probes flow through the same validateAccountRead: the model models an
+	// absent ledger as an empty ledger and an absent account as an empty account,
+	// so the server must report empty (NotFound), and any cell or metadata no
+	// candidate base explains is a finding.
+	switch {
+	case absentLedger:
+		// Coverage: probing a ledger outside the fleet — the account cannot exist.
+		assert.Reachable("singleton_driver_model: GetAccount probing an absent ledger", internal.Details{"ledger": ledger})
+	case absentAccount:
+		// Coverage: probing the negative space pickCell can't reach — an account the
+		// model holds no state for, in a known ledger.
 		assert.Reachable("singleton_driver_model: GetAccount probing a model-absent account", internal.Details{"ledger": ledger})
 	}
 
@@ -96,22 +102,27 @@ func percentChance(pct uint64) bool {
 }
 
 // pickReadTarget chooses what GetAccount reads back. Most reads hit a known
-// account (pickCell); ~5% probe an account the model has no state for
-// (pickAbsentAccount, absent=true). Without the absent probe pickCell can only
-// ever target accounts the model already holds, so GetAccount is structurally
-// blind to server state the model lacks — e.g. an account or cell the server
-// retained but the model doesn't have. Falls back to pickCell when no absent
-// address is found. Caller holds c.mu.
-func pickReadTarget(g oracle.GlobalState, ledgers []string) (ledger, addr, asset string, absent, ok bool) {
+// account (pickCell); ~5% probe an account the model has no state for in a known
+// ledger (pickAbsentAccount, absentAccount=true); ~2% probe any account in a
+// ledger outside the fleet (absentLedger=true). Both probes close blind spots
+// pickCell can't reach — it only ever targets accounts the model already holds,
+// so GetAccount is otherwise structurally blind to server state the model lacks
+// (a retained cell, or an account in a ledger the model never created). Falls
+// back to pickCell when no absent account is found. Caller holds c.mu.
+func pickReadTarget(g oracle.GlobalState, ledgers []string) (ledger, addr, asset string, absentAccount, absentLedger, ok bool) {
+	if len(ledgers) > 0 && percentChance(2) {
+		return absentLedgerName(ledgers), poolAddress(), random.RandomChoice(assets), false, true, true
+	}
+
 	if percentChance(5) {
 		if ledger, addr, asset, ok = pickAbsentAccount(g, ledgers); ok {
-			return ledger, addr, asset, true, true
+			return ledger, addr, asset, true, false, true
 		}
 	}
 
 	ledger, addr, asset, ok = pickCell(g)
 
-	return ledger, addr, asset, false, ok
+	return ledger, addr, asset, false, false, ok
 }
 
 // pickAbsentAccount returns a (ledger, address, asset) the model holds no volume
@@ -301,13 +312,19 @@ func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c 
 	c.validateLedgerRead(maxTicket, ledger, info.GetAccountTypes(), info.GetMetadata())
 }
 
-// pickTransactionID picks a ledger and a transaction id to read back, probing up
-// to a small slack past the committed frontier so the id may land on a committed
-// transaction, an in-flight one, or an unassigned id (a legal NotFound).
-// ok=false only before any ledger exists.
-func pickTransactionID(g oracle.GlobalState, ledgers []string) (ledger string, id uint64, ok bool) {
+// pickTransactionID picks a ledger and a transaction id to read back. Usually a
+// fleet ledger, probing up to a small slack past the committed frontier so the id
+// may land on a committed transaction, an in-flight one, or an unassigned id (a
+// legal NotFound). ~2% target a ledger outside the fleet (absentLedger=true),
+// where no transaction can exist and any id must resolve NotFound. ok=false only
+// before any ledger exists.
+func pickTransactionID(g oracle.GlobalState, ledgers []string) (ledger string, id uint64, absentLedger, ok bool) {
 	if len(ledgers) == 0 {
-		return "", 0, false
+		return "", 0, false, false
+	}
+
+	if percentChance(2) {
+		return absentLedgerName(ledgers), 1 + internal.Rand().Uint64()%64, true, true
 	}
 
 	ledger = random.RandomChoice(ledgers)
@@ -315,7 +332,7 @@ func pickTransactionID(g oracle.GlobalState, ledgers []string) (ledger string, i
 	frontier := uint64(len(g.Ledger(ledger).Txs()))
 	id = 1 + internal.Rand().Uint64()%(frontier+slack)
 
-	return ledger, id, true
+	return ledger, id, false, true
 }
 
 // runTransactionRead issues a linearizable GetTransaction on a probed id and
@@ -324,7 +341,7 @@ func pickTransactionID(g oracle.GlobalState, ledgers []string) (ledger string, i
 // accumulated transaction metadata back.
 func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	c.mu.Lock()
-	ledger, id, ok := pickTransactionID(c.modelState, c.ledgerNames)
+	ledger, id, absentLedger, ok := pickTransactionID(c.modelState, c.ledgerNames)
 	if !ok {
 		c.mu.Unlock()
 		return
@@ -332,6 +349,13 @@ func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClien
 	readID := c.registerRead()
 	c.mu.Unlock()
 	defer c.finishRead(readID)
+
+	if absentLedger {
+		// Coverage: probing a ledger outside the fleet — no transaction can exist,
+		// so the server must answer NotFound (validateTransactionRead treats the
+		// absent ledger as empty); a returned transaction is a finding.
+		assert.Reachable("singleton_driver_model: GetTransaction probing an absent ledger", internal.Details{"ledger": ledger})
+	}
 
 	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
 	resp, err := client.GetTransaction(readCtx, &servicepb.GetTransactionRequest{Ledger: ledger, TransactionId: id})

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
@@ -216,11 +217,43 @@ func accountAssetVolumes(acct *commonpb.Account, asset string) (in, out uint256.
 	return in, out, true
 }
 
-// runLedgerRead issues a linearizable GetLedger and checks the server's whole
-// ledger snapshot — account types and ledger metadata — against the model (see
-// validateLedgerRead).
+// absentLedgerName returns a ledger name outside the fixed fleet — the
+// negative-space target for a ledger-scoped read. The fleet is created at setup
+// and never grows, so any name not in ledgers is guaranteed absent; the server
+// answers NotFound for it, a pure read that creates nothing.
+func absentLedgerName(ledgers []string) string {
+	known := make(map[string]bool, len(ledgers))
+	for _, l := range ledgers {
+		known[l] = true
+	}
+
+	for {
+		cand := internal.PrefixModel.WithSuffix(fmt.Sprintf("absent-%016x%016x", internal.Rand().Uint64(), internal.Rand().Uint64()))
+		if !known[cand] {
+			return cand
+		}
+	}
+}
+
+// pickLedgerReadTarget chooses a ledger for a ledger-scoped read: usually a known
+// fleet ledger, ~1-in-4 an absent one (absent=true). The absent probe closes the
+// blind spot a known-only pick leaves — a ledger-scoped read can never otherwise
+// detect the server serving a ledger the model never created. An absent ledger
+// must answer NotFound; a served snapshot is a finding.
+func pickLedgerReadTarget(ledgers []string) (ledger string, absent bool) {
+	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
+		return absentLedgerName(ledgers), true
+	}
+
+	return random.RandomChoice(ledgers), false
+}
+
+// runLedgerRead issues a linearizable GetLedger — usually on a fleet ledger,
+// sometimes on an absent one — and checks the result against the model: a fleet
+// ledger's whole snapshot (account types and ledger metadata, see
+// validateLedgerRead), or an absent ledger's mandatory NotFound.
 func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
-	ledger := random.RandomChoice(c.ledgerNames)
+	ledger, absent := pickLedgerReadTarget(c.ledgerNames)
 
 	c.mu.Lock()
 	readID := c.registerRead()
@@ -236,12 +269,26 @@ func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c 
 		if internal.IsTransient(err) || isShutdownError(err) {
 			return
 		}
-		// The fleet is created at setup and never deleted, so a definitive error
-		// on a linearizable read — NotFound, Internal — is a real finding.
+		if absent && status.Code(err) == codes.NotFound {
+			// Coverage: a ledger outside the fleet must resolve NotFound.
+			assert.Reachable("singleton_driver_model: GetLedger on an absent ledger returned NotFound", internal.Details{"ledger": ledger})
+			return
+		}
+		// A fleet ledger is created at setup and never deleted, so a definitive
+		// error on it — NotFound, Internal — is a real finding; so is any
+		// non-NotFound definitive error on an absent ledger.
 		assert.Unreachable("singleton_driver_model: GetLedger returned unexpected error", internal.Details{
 			"ledger": ledger,
+			"absent": absent,
 			"error":  err.Error(),
 		})
+		return
+	}
+
+	if absent {
+		// The fleet never grows, so a snapshot for a name outside it is a ledger the
+		// server holds but the model never created.
+		assert.Unreachable("singleton_driver_model: GetLedger served a ledger outside the fleet", internal.Details{"ledger": ledger})
 		return
 	}
 
@@ -311,7 +358,7 @@ func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClien
 // validateSchemaRead) — the read-back that verifies the declared-schema
 // projection, not just the per-op SetMetadataFieldType echo.
 func runSchemaRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
-	ledger := random.RandomChoice(c.ledgerNames)
+	ledger, absent := pickLedgerReadTarget(c.ledgerNames)
 
 	c.mu.Lock()
 	readID := c.registerRead()
@@ -327,12 +374,26 @@ func runSchemaRead(ctx context.Context, client servicepb.BucketServiceClient, c 
 		if internal.IsTransient(err) || isShutdownError(err) {
 			return
 		}
-		// The fleet is created at setup and never deleted, so a definitive error
-		// on a linearizable schema read is a real finding.
+		if absent && status.Code(err) == codes.NotFound {
+			// Coverage: a schema read of a ledger outside the fleet must resolve NotFound.
+			assert.Reachable("singleton_driver_model: GetMetadataSchemaStatus on an absent ledger returned NotFound", internal.Details{"ledger": ledger})
+			return
+		}
+		// A fleet ledger is created at setup and never deleted, so a definitive
+		// error on it is a real finding; so is any non-NotFound definitive error on
+		// an absent ledger.
 		assert.Unreachable("singleton_driver_model: GetMetadataSchemaStatus returned unexpected error", internal.Details{
 			"ledger": ledger,
+			"absent": absent,
 			"error":  err.Error(),
 		})
+		return
+	}
+
+	if absent {
+		// The fleet never grows, so a schema for a name outside it is a ledger the
+		// server holds but the model never created.
+		assert.Unreachable("singleton_driver_model: GetMetadataSchemaStatus served a ledger outside the fleet", internal.Details{"ledger": ledger})
 		return
 	}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/random"
-	"github.com/holiman/uint256"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -64,9 +63,9 @@ func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Check
 		if internal.IsTransient(err) || isShutdownError(err) {
 			return
 		}
-		// NotFound = no entries server-side; validate as zero volumes / no metadata.
+		// NotFound = no entries server-side; validate as no volumes / no metadata.
 		if status.Code(err) == codes.NotFound {
-			c.validateAccountRead(maxTicket, ledger, addr, asset, uint256.Int{}, uint256.Int{}, false, nil)
+			c.validateAccountRead(maxTicket, ledger, addr, asset, nil, true, nil)
 			return
 		}
 		assert.Unreachable("singleton_driver_model: GetAccount returned unexpected error", internal.Details{
@@ -78,8 +77,8 @@ func runRead(ctx context.Context, client servicepb.BucketServiceClient, c *Check
 		return
 	}
 
-	gotIn, gotOut, found := accountAssetVolumes(acct, asset)
-	c.validateAccountRead(maxTicket, ledger, addr, asset, gotIn, gotOut, found, acct.GetMetadata())
+	gotVols, wellFormed := accountVolumeSet(acct)
+	c.validateAccountRead(maxTicket, ledger, addr, asset, gotVols, wellFormed, acct.GetMetadata())
 }
 
 // isShutdownError reports whether err is a context cancellation/deadline — what
@@ -209,29 +208,33 @@ func pickCell(g oracle.GlobalState) (ledger, addr, asset string, ok bool) {
 	return c.ledger, c.key.Address, c.key.Asset, true
 }
 
-// accountAssetVolumes extracts (input, output) for one asset from a GetAccount
-// response. The workload only ever exercises uncolored postings, so we look
-// up the uncolored bucket (color="") explicitly — colored buckets are out of
-// scope for this driver model. found=false when the bucket is missing.
-func accountAssetVolumes(acct *commonpb.Account, asset string) (in, out uint256.Int, found bool) {
+// accountVolumeSet extracts the account's full volume set as asset -> volumes,
+// so validation covers every returned cell — a ghost row under any asset is
+// caught, not just the probed one. The workload only ever exercises uncolored
+// postings, so ok=false marks a response shape no model state explains — a
+// colored bucket, or an unparseable amount — and the caller's validation fails
+// it outright rather than mistaking it for an empty reading.
+func accountVolumeSet(acct *commonpb.Account) (map[string]oracle.VolumePair, bool) {
 	if acct == nil {
-		return in, out, false
+		return nil, true
 	}
 
-	v := acct.FindVolume(asset, "")
-	if v == nil {
-		return in, out, false
+	out := make(map[string]oracle.VolumePair, len(acct.GetVolumes()))
+	for _, entry := range acct.GetVolumes() {
+		if entry.GetColor() != "" {
+			return nil, false
+		}
+
+		var vp oracle.VolumePair
+		if vp.Input.SetFromDecimal(entry.GetVolumes().GetInput()) != nil ||
+			vp.Output.SetFromDecimal(entry.GetVolumes().GetOutput()) != nil {
+			return nil, false
+		}
+
+		out[entry.GetAsset()] = vp
 	}
 
-	if err := in.SetFromDecimal(v.GetInput()); err != nil {
-		in.Clear()
-	}
-
-	if err := out.SetFromDecimal(v.GetOutput()); err != nil {
-		out.Clear()
-	}
-
-	return in, out, true
+	return out, true
 }
 
 // absentLedgerName returns a ledger name outside the fixed fleet — the

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads.go
@@ -89,15 +89,21 @@ func isShutdownError(err error) bool {
 	}
 }
 
+// percentChance reports true with probability pct/100, drawing from the
+// Antithesis-controlled source so the fuzzer steers how often the branch is taken.
+func percentChance(pct uint64) bool {
+	return internal.Rand().Uint64()%100 < pct
+}
+
 // pickReadTarget chooses what GetAccount reads back. Most reads hit a known
-// account (pickCell); ~1-in-4 probe an account the model has no state for
+// account (pickCell); ~5% probe an account the model has no state for
 // (pickAbsentAccount, absent=true). Without the absent probe pickCell can only
 // ever target accounts the model already holds, so GetAccount is structurally
 // blind to server state the model lacks — e.g. an account or cell the server
 // retained but the model doesn't have. Falls back to pickCell when no absent
 // address is found. Caller holds c.mu.
 func pickReadTarget(g oracle.GlobalState, ledgers []string) (ledger, addr, asset string, absent, ok bool) {
-	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
+	if percentChance(5) {
 		if ledger, addr, asset, ok = pickAbsentAccount(g, ledgers); ok {
 			return ledger, addr, asset, true, true
 		}
@@ -236,12 +242,12 @@ func absentLedgerName(ledgers []string) string {
 }
 
 // pickLedgerReadTarget chooses a ledger for a ledger-scoped read: usually a known
-// fleet ledger, ~1-in-4 an absent one (absent=true). The absent probe closes the
-// blind spot a known-only pick leaves — a ledger-scoped read can never otherwise
-// detect the server serving a ledger the model never created. An absent ledger
-// must answer NotFound; a served snapshot is a finding.
-func pickLedgerReadTarget(ledgers []string) (ledger string, absent bool) {
-	if random.RandomChoice([]uint8{0, 1, 2, 3}) == 0 {
+// fleet ledger, else an absent one (absent=true) with probability absentPct. The
+// absent probe closes the blind spot a known-only pick leaves — a ledger-scoped
+// read can never otherwise detect the server serving a ledger the model never
+// created. An absent ledger must answer NotFound; a served snapshot is a finding.
+func pickLedgerReadTarget(ledgers []string, absentPct uint64) (ledger string, absent bool) {
+	if percentChance(absentPct) {
 		return absentLedgerName(ledgers), true
 	}
 
@@ -253,7 +259,7 @@ func pickLedgerReadTarget(ledgers []string) (ledger string, absent bool) {
 // ledger's whole snapshot (account types and ledger metadata, see
 // validateLedgerRead), or an absent ledger's mandatory NotFound.
 func runLedgerRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
-	ledger, absent := pickLedgerReadTarget(c.ledgerNames)
+	ledger, absent := pickLedgerReadTarget(c.ledgerNames, 2)
 
 	c.mu.Lock()
 	readID := c.registerRead()
@@ -358,7 +364,7 @@ func runTransactionRead(ctx context.Context, client servicepb.BucketServiceClien
 // validateSchemaRead) — the read-back that verifies the declared-schema
 // projection, not just the per-op SetMetadataFieldType echo.
 func runSchemaRead(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
-	ledger, absent := pickLedgerReadTarget(c.ledgerNames)
+	ledger, absent := pickLedgerReadTarget(c.ledgerNames, 3)
 
 	c.mu.Lock()
 	readID := c.registerRead()

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
@@ -56,7 +56,8 @@ func TestPickLedgerReadTarget(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		require.False(t, known[absentLedgerName(fleet)], "absent name collided with fleet")
 
-		ledger, absent := pickLedgerReadTarget(fleet)
+		// 50% here just to exercise both branches; runLedgerRead/runSchemaRead use 2%/3%.
+		ledger, absent := pickLedgerReadTarget(fleet, 50)
 		if absent {
 			require.False(t, known[ledger], "absent target is a fleet ledger: %s", ledger)
 		} else {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
@@ -44,3 +44,23 @@ func TestPickAbsentAccount(t *testing.T) {
 	_, _, _, ok := pickAbsentAccount(c.modelState, nil)
 	require.False(t, ok)
 }
+
+// absentLedgerName must never collide with the fleet, and pickLedgerReadTarget's
+// absent branch must hand back exactly those absent names.
+func TestPickLedgerReadTarget(t *testing.T) {
+	t.Parallel()
+
+	fleet := []string{"L", "L2", "L3"}
+	known := map[string]bool{"L": true, "L2": true, "L3": true}
+
+	for i := 0; i < 200; i++ {
+		require.False(t, known[absentLedgerName(fleet)], "absent name collided with fleet")
+
+		ledger, absent := pickLedgerReadTarget(fleet)
+		if absent {
+			require.False(t, known[ledger], "absent target is a fleet ledger: %s", ledger)
+		} else {
+			require.True(t, known[ledger], "known target is not a fleet ledger: %s", ledger)
+		}
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/reads_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+)
+
+func TestModelKnowsAccount(t *testing.T) {
+	t.Parallel()
+
+	c := NewChecker([]string{"L"}, nil)
+	// world -> t-0:5 gives t-0:5 a volume cell; world keeps one too.
+	c.modelState = c.modelState.Apply(bulkOf(oracletest.TxReq("world", "t-0:5", "USD/2", 10))).State
+	ls := c.modelState.Ledger("L")
+
+	require.True(t, modelKnowsAccount(ls, "t-0:5"))
+	require.True(t, modelKnowsAccount(ls, "world"))
+	require.False(t, modelKnowsAccount(ls, "t-0:6"))
+	require.False(t, modelKnowsAccount(ls, "t-99:1"))
+}
+
+// pickAbsentAccount must always hand back an address the model has no state for,
+// carrying a workload asset, on a known ledger — the negative-space target runRead
+// probes.
+func TestPickAbsentAccount(t *testing.T) {
+	t.Parallel()
+
+	c := NewChecker([]string{"L"}, nil)
+	c.modelState = c.modelState.Apply(bulkOf(oracletest.TxReq("world", "t-0:5", "USD/2", 10))).State
+	ls := c.modelState.Ledger("L")
+
+	for i := 0; i < 100; i++ {
+		ledger, addr, asset, ok := pickAbsentAccount(c.modelState, []string{"L"})
+		require.True(t, ok)
+		require.Equal(t, "L", ledger)
+		require.False(t, modelKnowsAccount(ls, addr), "returned a known account: %s", addr)
+		require.Contains(t, assets, asset)
+	}
+
+	// No ledgers -> nothing to probe.
+	_, _, _, ok := pickAbsentAccount(c.modelState, nil)
+	require.False(t, ok)
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -448,43 +448,46 @@ func (c *Checker) matchesModel(maxTicket uint64, label string, matcher func(orac
 // is legal iff some candidate base holds both the picked (gotIn, gotOut, found)
 // volume cell and exactly the server's metadata for the address. Both must hold
 // on the SAME base — the read is one atomic snapshot.
-func (c *Checker) validateAccountRead(maxTicket uint64, ledger, addr, asset string, gotIn, gotOut uint256.Int, found bool, serverMeta map[string]*commonpb.MetadataValue) {
-	key := oracle.VolumeKey{Address: addr, Asset: asset}
-
-	if c.matchesModel(maxTicket, "READ", func(base oracle.GlobalState) bool {
+func (c *Checker) validateAccountRead(maxTicket uint64, ledger, addr, asset string, serverVols map[string]oracle.VolumePair, wellFormed bool, serverMeta map[string]*commonpb.MetadataValue) {
+	if wellFormed && c.matchesModel(maxTicket, "READ", func(base oracle.GlobalState) bool {
 		ls := base.Ledger(ledger)
-		return volumeCellMatches(ls, key, gotIn, gotOut, found) && metadataMatches(ls, addr, serverMeta)
+		return accountVolumesMatch(ls, addr, serverVols) && metadataMatches(ls, addr, serverMeta)
 	}) {
 		return
 	}
 
 	assert.Unreachable("singleton_driver_model: account read outside model", internal.Details{
-		"ledger":         ledger,
-		"address":        addr,
-		"asset":          asset,
-		"serverIn":       gotIn.Dec(),
-		"serverOut":      gotOut.Dec(),
-		"serverHadAsset": found,
-		"serverMeta":     renderMetaMap(serverMeta),
-		"modelMeta":      c.modelAccountMetaDump(ledger, addr),
+		"ledger":     ledger,
+		"address":    addr,
+		"asset":      asset,
+		"serverVols": renderVolumeSet(serverVols),
+		"wellFormed": wellFormed,
+		"serverMeta": renderMetaMap(serverMeta),
+		"modelMeta":  c.modelAccountMetaDump(ledger, addr),
 	})
 }
 
-// volumeCellMatches reports whether ls holds exactly the (gotIn, gotOut, found)
-// reading for cell key: present with matching volumes, or absent when the server
-// returned no row (the base's purge sweep already removed zero-balance
-// EPHEMERAL/TRANSIENT cells). An empty asset — a metadata-only pick — is never a
-// present cell, so it imposes no volume constraint.
-func volumeCellMatches(ls oracle.LedgerState, key oracle.VolumeKey, gotIn, gotOut uint256.Int, found bool) bool {
-	vp, present := ls.Volumes()[key]
-	switch {
-	case found && present && vp.Input.Cmp(&gotIn) == 0 && vp.Output.Cmp(&gotOut) == 0:
-		return true
-	case !found && !present:
-		return true
+// accountVolumesMatch reports whether ls holds exactly the returned volume set
+// for addr — same assets, same cumulative volumes. GetAccount returns the
+// account's whole volume set in one linearizable snapshot, so a returned cell
+// the base lacks (a ghost row under ANY asset, e.g. a stranded zero-balance
+// row the base's purge sweep removed) and a base cell the server omitted are
+// both mismatches.
+func accountVolumesMatch(ls oracle.LedgerState, addr string, got map[string]oracle.VolumePair) bool {
+	cells := 0
+	for k, vp := range ls.Volumes() {
+		if k.Address != addr {
+			continue
+		}
+
+		g, ok := got[k.Asset]
+		if !ok || g.Input.Cmp(&vp.Input) != 0 || g.Output.Cmp(&vp.Output) != 0 {
+			return false
+		}
+		cells++
 	}
 
-	return false
+	return cells == len(got)
 }
 
 // metadataMatches reports whether ls holds exactly serverMeta for addr — same

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/tests/oracle"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+)
+
+// A returned volume set must match the base exactly: a ghost cell under ANY
+// asset (not just the probed one — the stranded-row class), an omitted cell,
+// and a divergent value are all mismatches.
+func TestAccountVolumesMatch(t *testing.T) {
+	t.Parallel()
+
+	c := NewChecker([]string{"L"}, nil)
+	c.modelState = c.modelState.Apply(bulkOf(
+		oracletest.TxReq("world", "t-0:5", "USD/2", 10),
+		oracletest.TxReq("world", "t-0:5", "COIN", 3),
+	)).State
+	ls := c.modelState.Ledger("L")
+
+	exact := map[string]oracle.VolumePair{}
+	for k, vp := range ls.Volumes() {
+		if k.Address == "t-0:5" {
+			exact[k.Asset] = vp
+		}
+	}
+	require.Len(t, exact, 2)
+	require.True(t, accountVolumesMatch(ls, "t-0:5", exact))
+
+	ghost := maps.Clone(exact)
+	var g oracle.VolumePair
+	g.Input.SetUint64(7)
+	g.Output.SetUint64(7)
+	ghost["EUR/2"] = g
+	require.False(t, accountVolumesMatch(ls, "t-0:5", ghost), "ghost cell under an unprobed asset must mismatch")
+
+	omitted := maps.Clone(exact)
+	delete(omitted, "USD/2")
+	require.False(t, accountVolumesMatch(ls, "t-0:5", omitted), "omitted cell must mismatch")
+
+	divergent := maps.Clone(exact)
+	d := divergent["USD/2"]
+	d.Input.AddUint64(&d.Input, 1)
+	divergent["USD/2"] = d
+	require.False(t, accountVolumesMatch(ls, "t-0:5", divergent))
+
+	// An account the base doesn't hold: only the empty reading matches.
+	require.True(t, accountVolumesMatch(ls, "t-9:9", nil))
+	require.False(t, accountVolumesMatch(ls, "t-9:9", map[string]oracle.VolumePair{"USD/2": {}}))
+}


### PR DESCRIPTION
## What

The model driver's reads only ever targeted state the model already holds, so every read RPC was structurally blind to server state the model lacks (a stranded row, a ghost account, a ledger the model never created). This adds negative-space probes to all four read RPCs, validated through the existing candidate-base-aware validators (absent = empty, so the server must answer NotFound/empty and anything served is a finding):

| Read RPC | negative-space axes |
|---|---|
| `GetAccount` | model-absent account (5%) + absent ledger (2%) |
| `GetTransaction` | absent ledger (2%) — unassigned-id slack already existed |
| `GetLedger` | absent ledger (2%) |
| `GetMetadataSchemaStatus` | absent ledger (3%) |

Rates draw from the Antithesis-controlled source (`percentChance`), so the fuzzer can steer them.

## Why it matters

The point probe is the only detector for the stranded-row bug class that hides from list validation (point and list reads take different server code paths). Validated end-to-end: against a server with the #1645 fix reverted, the model-absent GetAccount probe finds the ghost account (`serverIn == serverOut`, model holds nothing) and fail-fast stops the run — see `scratch/model_test_distributions.md` for the detection-time analysis.

## Verification

- Unit tests for the pickers (`reads_test.go`).
- 30-min single-node run: PASS, all five coverage reachables fired, zero unreachability hits.
- Pre-#1645 A/B: finding surfaced in 18.4 min, exact expected signature.