### PR TITLE
test(antithesis): model-driver query coverage — filters, indexes, typed metadata (EN-1625)

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -515,6 +515,8 @@ default. A successful run also requires at least one
 `singleton_driver_model: model outcome verified` assertion hit, emitted only
 after a definitive server outcome reaches model validation. Driver liveness,
 assertion registration, and ledger-setup assertions do not satisfy that gate.
+
+It also requires every coverage sonde to have been satisfied (see below).
 Common tunables (full list in the script header):
 
 | Variable | Meaning |
@@ -526,6 +528,35 @@ Common tunables (full list in the script header):
 | `RESTART_INTERVAL` / `DEAD_TIME` | Cluster restart cadence and how long a killed node stays down. |
 | `COMPACTION_MARGIN` | Raft entries between snapshots; low values force snapshot recovery. |
 | `RESTORE_INTERVAL` | Seconds between backup/restore cycles with `--restore`. |
+
+#### Coverage sondes
+
+A green run proves nothing about a query path it never took. `coverage.go`
+registers one `Sometimes` per index the oracle models — the nine the generator
+churns, plus one per entity target for the metadata-field indexes and one for
+the retype window — and the runner fails when any of them was never satisfied.
+A sonde is satisfied only by a page that the index was needed for AND that the
+oracle verified; a refusal the model predicted proves the lifecycle gate, not
+that the index can answer.
+
+They are `Sometimes` rather than `Reachable` because a `Reachable` hard-wires
+its condition to true and so never produces a failing evaluation for
+Antithesis to steer on. On the platform this gate is redundant: the run
+branches and biases toward unsatisfied sondes, so a reachable path is reached.
+Locally there is one linear trajectory and no guidance, which is what the gate
+covers. A full 300s three-node run satisfies all twelve.
+
+Sonde names are data-driven, so the instrumentor cannot catalogue them; they
+are registered through `assert.AssertRaw`, as `internal/block/block.go` does.
+
+Because these sondes are false by design on most queries, the runner treats
+assertion classes differently: a false `Always` / `AlwaysOrUnreachable` /
+`Unreachable` is a finding, a false `Sometimes` is not. The exception is
+`STRICT_SOMETIMES`, the shared helpers whose `assert.Sometimes(IsTolerated(err),
+...)` probes are invariants wearing the wrong primitive; locally there is no
+fault injection and transients are retried to a definitive outcome, so those
+must hold on every call. `check-repo-invariants` pins that list against its
+call sites.
 
 #### Restore cycles (`--restore`, single node)
 

--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -450,10 +450,12 @@ restart. It catches:
   set.
 
 It exercises the chart of accounts, transactions and reverts (with post-commit
-volumes), account/transaction/ledger metadata, the typed-metadata schema, and
+volumes), account/transaction/ledger metadata, the typed-metadata schema and
+its index lifecycle (create, retype with serving-window closure, remove), and
 the transient/ephemeral persistence classes — and reads them back: account,
-whole-ledger, transaction-by-id, and declared-schema reads are all validated
-against the model.
+whole-ledger, transaction-by-id, and declared-schema reads, plus the filtered,
+paginated list surface (ListAccounts, ListTransactions, ListLogs, indexed
+metadata-range queries) are all validated against the model.
 
 #### How it works
 
@@ -476,6 +478,9 @@ the harness around it:
 | `search.go` (driver) | `candidateBases` — enumerates the states the server could legitimately be in. |
 | `validate.go` (driver) | The conformance checks for committed bulks, failures, and reads. |
 | `actions.go` / `reads.go` (driver) | Random bulk generation; account, whole-ledger, transaction-by-id, and metadata-schema read execution. |
+| `queries.go` / `queries_logs.go` (driver) | Filtered, paginated list reads (ListAccounts, ListTransactions, ListLogs) generated against the model's committed state and validated window-by-window. |
+| `indexes.go` (driver) | Metadata-index lifecycle: create/retype/remove generation, readiness polling, retype-window bookkeeping, and indexed range-query validation. |
+| `metadata_filters.go` (driver) | Typed metadata filter generation shared by the query validators. |
 
 The key primitive is **`candidateBases`**: a committed bulk drains in
 log-sequence order, so the committed model state is its exact predecessor and
@@ -557,7 +562,7 @@ Where to make the matching change:
 | Changed business/validation rule (new rejection condition, enforcement change, volume math) | Update the matching `apply*` predictor in `tests/oracle/model.go`. |
 | New or changed response field the test should check | Update the validator in `validate.go` and the predicted effect it compares against. |
 | New rejection reason | Return the matching `domain.ErrReason*` from the right model branch so `validateFailure` can explain it. |
-| New persisted projection or read surface | Add the read in `reads.go` and a validator in `validate.go`, mirroring the account/ledger reads. |
+| New persisted projection or read surface | Point reads: add the read in `reads.go` and a validator in `validate.go`, mirroring the account/ledger reads. Filtered/paginated list surfaces: follow the `queries.go` / `queries_logs.go` pattern (generate against committed model state, validate the returned window). Index-backed reads: `indexes.go`. |
 
 To diagnose a finding deterministically, capture the run with
 `MODEL_DUMP_BATCHES=1` and feed the dump back through the model offline:

--- a/scripts/check-repo-invariants.go
+++ b/scripts/check-repo-invariants.go
@@ -53,6 +53,19 @@ func main() {
 		}
 	}
 
+	if !fuzzInventoryOnly {
+		strictFindings, err := checkStrictSometimes(files)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "check-repo-invariants: checking STRICT_SOMETIMES: %v\n", err)
+			failed = true
+		}
+
+		for _, item := range strictFindings {
+			printFinding(item)
+			failed = true
+		}
+	}
+
 	fuzzFindings, err := checkFuzzInventory(files)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "check-repo-invariants: checking fuzz inventory: %v\n", err)

--- a/scripts/check_strict_sometimes.go
+++ b/scripts/check_strict_sometimes.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// run_model_test.sh treats a false `Sometimes` as normal, because a Sometimes
+// is existential. Three assertions in the shared workload helpers are the
+// exception: they are invariants written with the wrong primitive
+// (`assert.Sometimes(IsTolerated(err), ...)` claims every call succeeds or
+// fails transiently), and locally, with no fault injection and transients
+// retried to a definitive outcome, they must hold on every call. The script
+// keeps universal treatment for exactly those, listed in STRICT_SOMETIMES.
+//
+// A new tolerated-error probe added to the helpers and not to that list would
+// silently lose its local strictness, so the two are pinned to each other.
+const (
+	strictSometimesScript = "tests/antithesis/run_model_test.sh"
+	strictSometimesDir    = "tests/antithesis/workload/internal"
+)
+
+var strictSometimesDecl = regexp.MustCompile(`(?m)^STRICT_SOMETIMES='(\[.*\])'$`)
+
+// checkStrictSometimes reports drift between the script's allowlist and the
+// tolerated-error probes it is meant to name.
+func checkStrictSometimes(files []string) ([]finding, error) {
+	declared, err := strictSometimesAllowlist()
+	if err != nil {
+		return nil, err
+	}
+
+	actual, err := toleratedSometimesMessages(files)
+	if err != nil {
+		return nil, err
+	}
+
+	var findings []finding
+
+	for _, msg := range missingFrom(actual, declared) {
+		findings = append(findings, finding{
+			path: strictSometimesScript, line: 1, column: 1,
+			message: fmt.Sprintf("STRICT_SOMETIMES does not list the tolerated-error probe %q; "+
+				"a false evaluation of it would not fail a local run", msg),
+		})
+	}
+
+	for _, msg := range missingFrom(declared, actual) {
+		findings = append(findings, finding{
+			path: strictSometimesScript, line: 1, column: 1,
+			message: fmt.Sprintf("STRICT_SOMETIMES lists %q, which no longer matches an "+
+				"assert.Sometimes(IsTolerated(...)) call in "+strictSometimesDir, msg),
+		})
+	}
+
+	return findings, nil
+}
+
+func missingFrom(want, have []string) []string {
+	index := make(map[string]struct{}, len(have))
+	for _, msg := range have {
+		index[msg] = struct{}{}
+	}
+
+	var out []string
+
+	for _, msg := range want {
+		if _, ok := index[msg]; !ok {
+			out = append(out, msg)
+		}
+	}
+
+	return out
+}
+
+// strictSometimesAllowlist reads the JSON array the script declares.
+func strictSometimesAllowlist() ([]string, error) {
+	source, err := os.ReadFile(strictSometimesScript)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", strictSometimesScript, err)
+	}
+
+	return parseStrictSometimes(source)
+}
+
+// parseStrictSometimes extracts the allowlist from the script's source.
+func parseStrictSometimes(source []byte) ([]string, error) {
+	match := strictSometimesDecl.FindSubmatch(source)
+	if match == nil {
+		return nil, fmt.Errorf("%s: no STRICT_SOMETIMES declaration found", strictSometimesScript)
+	}
+
+	return parseJSONStringArray(string(match[1]))
+}
+
+// parseJSONStringArray decodes the flat ["a","b"] literal the script carries,
+// without pulling encoding/json in for one line.
+func parseJSONStringArray(literal string) ([]string, error) {
+	trimmed := strings.TrimSpace(literal)
+	if !strings.HasPrefix(trimmed, "[") || !strings.HasSuffix(trimmed, "]") {
+		return nil, fmt.Errorf("STRICT_SOMETIMES is not a JSON array: %s", literal)
+	}
+
+	trimmed = strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var out []string
+
+	for part := range strings.SplitSeq(trimmed, ",") {
+		value, err := strconv.Unquote(strings.TrimSpace(part))
+		if err != nil {
+			return nil, fmt.Errorf("STRICT_SOMETIMES entry %s: %w", part, err)
+		}
+
+		out = append(out, value)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// toleratedSometimesMessages collects the literal message of every
+// assert.Sometimes whose condition is an IsTolerated(...) call.
+func toleratedSometimesMessages(files []string) ([]string, error) {
+	var out []string
+
+	for _, path := range files {
+		if !strings.HasPrefix(path, strictSometimesDir+"/") ||
+			!strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		messages, err := toleratedSometimesInSource(path, source)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, messages...)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}
+
+func toleratedSometimesInSource(path string, source []byte) ([]string, error) {
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, source, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	var out []string
+
+	ast.Inspect(parsed, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || !isSelector(call.Fun, "assert", "Sometimes") || len(call.Args) < 2 {
+			return true
+		}
+
+		cond, ok := call.Args[0].(*ast.CallExpr)
+		if !ok || !isIdent(cond.Fun, "IsTolerated") {
+			return true
+		}
+
+		if msg, ok := call.Args[1].(*ast.BasicLit); ok && msg.Kind == token.STRING {
+			if value, err := strconv.Unquote(msg.Value); err == nil {
+				out = append(out, value)
+			}
+		}
+
+		return true
+	})
+
+	return out, nil
+}
+
+func isSelector(expr ast.Expr, pkg, name string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+
+	return ok && sel.Sel.Name == name && isIdent(sel.X, pkg)
+}
+
+func isIdent(expr ast.Expr, name string) bool {
+	ident, ok := expr.(*ast.Ident)
+
+	return ok && ident.Name == name
+}

--- a/scripts/check_strict_sometimes_test.go
+++ b/scripts/check_strict_sometimes_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Only assert.Sometimes calls whose condition is IsTolerated(...) are
+// invariants in disguise; a Sometimes over any other condition is a genuine
+// existential and must not be pulled into the strict list.
+func TestToleratedSometimesInSource_MatchesOnlyToleratedConditions(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`package sample
+
+func Sample(err error, converged bool) {
+	assert.Sometimes(IsTolerated(err), "should be able to create ledger", nil)
+	assert.Sometimes(converged, "scaling converges within timeout", nil)
+	assert.Sometimes(true, "a pure reachability probe", nil)
+	assert.Reachable("not a sometimes at all", nil)
+	other.Sometimes(IsTolerated(err), "a different package", nil)
+}
+`)
+
+	got, err := toleratedSometimesInSource("sample.go", source)
+	require.NoError(t, err)
+	require.Equal(t, []string{"should be able to create ledger"}, got)
+}
+
+// A non-literal message cannot be pinned, so it is skipped rather than
+// half-recorded; the assertion-name rule already forbids them.
+func TestToleratedSometimesInSource_SkipsNonLiteralMessages(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`package sample
+
+func Sample(err error, name string) {
+	assert.Sometimes(IsTolerated(err), name, nil)
+}
+`)
+
+	got, err := toleratedSometimesInSource("sample.go", source)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestParseJSONStringArray(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseJSONStringArray(`["b thing","a thing"]`)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a thing", "b thing"}, got, "sorted, so comparison is order-free")
+
+	empty, err := parseJSONStringArray(`[]`)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	_, err = parseJSONStringArray(`not an array`)
+	require.Error(t, err)
+}
+
+// The declaration the live script carries must stay machine-readable: the
+// whole invariant rests on finding and parsing it.
+func TestParseStrictSometimes_ReadsTheLiveScript(t *testing.T) {
+	t.Parallel()
+
+	source, err := os.ReadFile(filepath.Join("..", strictSometimesScript))
+	require.NoError(t, err)
+
+	got, err := parseStrictSometimes(source)
+	require.NoError(t, err)
+	require.Contains(t, got, "should be able to create ledger")
+}
+
+func TestParseStrictSometimes_RejectsAMissingDeclaration(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseStrictSometimes([]byte("#!/bin/sh\necho hi\n"))
+	require.Error(t, err)
+}
+
+func TestMissingFrom(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"b"}, missingFrom([]string{"a", "b"}, []string{"a"}))
+	require.Empty(t, missingFrom([]string{"a"}, []string{"a", "b"}))
+}

--- a/tests/antithesis/Justfile
+++ b/tests/antithesis/Justfile
@@ -22,9 +22,10 @@ ledger_image_name := env_var_or_default("LEDGER_IMAGE_NAME", "ledger")
 # on a specific subset (e.g. "main/parallel_driver_bulk,main/first_default_ledger").
 run duration description='ledger-v3 manual run' include='' *ARGS:
     just tag={{tag}} push-images {{quote(include)}} {{ARGS}}
-    curl --fail \
-        --user "formance:$ANTITHESIS_PASSWORD" \
-        -X POST https://formance.antithesis.com/api/v1/launch/basic_test -d '{ \
+    curl --fail --silent --show-error \
+        --header "Authorization: Bearer $ANTITHESIS_API_KEY" \
+        --header "Content-Type: application/json" \
+        -X POST "https://$ANTITHESIS_TENANT.antithesis.com/api/v1/launch/basic_test" -d '{ \
             "params": { \
                 "custom.duration": "{{duration}}", \
                 "custom.containers_to_exclude_from_network_faults":"etcd-0 etcd-1 etcd-2 workload", \
@@ -41,7 +42,7 @@ build-images:
     docker tag quay.io/coreos/etcd:v3.5.9 "$ANTITHESIS_REPOSITORY/etcd:v3.5.9"
 
     # ledger (instrumented for Antithesis)
-    docker build \
+    env -u SOURCE_DATE_EPOCH docker build \
         --platform linux/amd64 \
         -f ../../Dockerfile.antithesis \
         --progress=plain \
@@ -77,22 +78,56 @@ deploy-local: build-images
 # "main/parallel_driver_bulk,main/first_default_ledger").
 k8s-run duration_hours description='ledger-v3 k8s run' include='' *ARGS:
     just tag={{tag}} k8s-push-images {{quote(include)}} {{ARGS}}
-    curl --fail \
-        --user "formance:$ANTITHESIS_PASSWORD" \
-        -X POST https://formance.antithesis.com/api/v1/launch/basic_k8s_test -d '{ \
-            "params": { \
-                "antithesis.duration": "'"$(echo "{{duration_hours}} * 60" | bc | cut -d. -f1)"'", \
-                "antithesis.report.recipients": "'"$ANTITHESIS_REPORT_RECIPIENT"'", \
-                "antithesis.config_image": "'"antithesis-config-ledger-v3-k8s:{{tag}}"'", \
-                "antithesis.description": "{{description}}", \
-                "antithesis.images": "'"workload-ledger-v3:{{tag}};{{ledger_image_name}}:{{tag}};ledger-operator:{{tag}}"'" \
-            } \
-        }'
+    just tag={{tag}} check-k8s-image-freshness
+    just tag={{tag}} k8s-launch-minutes "$(echo "{{duration_hours}} * 60" | bc | cut -d. -f1)" {{quote(description)}}
+
+# Launch an already-built k8s suite with a duration expressed in minutes.
+# This is the convenient entrypoint for short validation runs such as 20m.
+k8s-run-minutes duration_minutes description='ledger-v3 k8s run' include='' *ARGS:
+    just tag={{tag}} k8s-push-images {{quote(include)}} {{ARGS}}
+    just tag={{tag}} check-k8s-image-freshness
+    just tag={{tag}} k8s-launch-minutes {{quote(duration_minutes)}} {{quote(description)}}
+
+# Launch an already-published k8s suite. The request returns as soon as
+# Antithesis accepts it; the platform run continues independently.
+k8s-launch-minutes duration_minutes description:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    : "${ANTITHESIS_API_KEY:?ANTITHESIS_API_KEY is required}"
+    : "${ANTITHESIS_TENANT:?ANTITHESIS_TENANT is required}"
+    : "${ANTITHESIS_REPORT_RECIPIENT:?ANTITHESIS_REPORT_RECIPIENT is required}"
+
+    if ! [[ {{quote(duration_minutes)}} =~ ^[1-9][0-9]*$ ]]; then
+        printf 'duration_minutes must be a positive integer, got: %s\n' {{quote(duration_minutes)}} >&2
+        exit 1
+    fi
+
+    payload="$(jq -n \
+        --arg duration {{quote(duration_minutes)}} \
+        --arg recipients "$ANTITHESIS_REPORT_RECIPIENT" \
+        --arg config_image "antithesis-config-ledger-v3-k8s:{{tag}}" \
+        --arg description {{quote(description)}} \
+        --arg images "workload-ledger-v3:{{tag}};{{ledger_image_name}}:{{tag}};ledger-operator:{{tag}}" \
+        '{params: {
+            "antithesis.duration": $duration,
+            "antithesis.report.recipients": $recipients,
+            "antithesis.config_image": $config_image,
+            "antithesis.description": $description,
+            "antithesis.images": $images
+        }}')"
+
+    curl --fail --silent --show-error \
+        --header "Authorization: Bearer $ANTITHESIS_API_KEY" \
+        --header "Content-Type: application/json" \
+        --request POST \
+        --data "$payload" \
+        "https://$ANTITHESIS_TENANT.antithesis.com/api/v1/launch/basic_k8s_test"
 
 # Build all images needed for k8s mode.
 k8s-build-images:
     # ledger (instrumented for Antithesis)
-    docker build \
+    env -u SOURCE_DATE_EPOCH docker build \
         --platform linux/amd64 \
         -f ../../Dockerfile.antithesis \
         --progress=plain \
@@ -100,7 +135,7 @@ k8s-build-images:
         ../../
 
     # operator
-    docker build \
+    env -u SOURCE_DATE_EPOCH docker build \
         --platform linux/amd64 \
         -t "$ANTITHESIS_REPOSITORY/ledger-operator:{{tag}}" \
         ../../misc/operator
@@ -112,3 +147,58 @@ k8s-push-images include='' *ARGS:
     just --justfile workload/Justfile -d workload tag={{tag}} push {{quote(include)}}
     docker push $ANTITHESIS_REPOSITORY/{{ledger_image_name}}:{{tag}}
     docker push $ANTITHESIS_REPOSITORY/ledger-operator:{{tag}}
+
+# Exit non-zero while a completed run still contains failing properties.
+check-run run_id:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    : "${ANTITHESIS_API_KEY:?ANTITHESIS_API_KEY is required}"
+    : "${ANTITHESIS_TENANT:?ANTITHESIS_TENANT is required}"
+
+    response="$({ curl --fail --silent --show-error --get \
+        --header "Authorization: Bearer $ANTITHESIS_API_KEY" \
+        --data-urlencode 'limit=100' \
+        --data-urlencode 'status=Failing' \
+        "https://$ANTITHESIS_TENANT.antithesis.com/api/v0/runs/{{run_id}}/properties"; } 2>&1)" || {
+        printf '%s\n' "$response" >&2
+        exit 1
+    }
+
+    count="$(jq '.data | length' <<<"$response")"
+    if (( count > 0 )); then
+        printf 'Antithesis run {{run_id}} has %d failing properties:\n' "$count" >&2
+        jq -r '.data[].name | "- \(.)"' <<<"$response" >&2
+        exit 1
+    fi
+
+    printf 'Antithesis run {{run_id}} has no failing properties.\n'
+
+# Ensure the locally built k8s images carry a creation time Antithesis accepts.
+check-k8s-image-freshness:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    : "${ANTITHESIS_REPOSITORY:?ANTITHESIS_REPOSITORY is required}"
+
+    now="$(date +%s)"
+    max_age_seconds="$((72 * 60 * 60))"
+    images=(
+        "antithesis-config-ledger-v3-k8s"
+        "{{ledger_image_name}}"
+        "ledger-operator"
+        "workload-ledger-v3"
+        "workload-ledger-v3-sidecar"
+    )
+
+    for name in "${images[@]}"; do
+        image="$ANTITHESIS_REPOSITORY/$name:{{tag}}"
+        created="$(docker image inspect "$image" | jq -r '.[0].Created')"
+        created_epoch="$(date -d "$created" +%s)"
+        age="$((now - created_epoch))"
+        if (( age < 0 || age > max_age_seconds )); then
+            printf '%s is not fresh: created=%s age=%ss\n' "$image" "$created" "$age" >&2
+            exit 1
+        fi
+        printf '%s is fresh: created=%s\n' "$image" "$created"
+    done

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -159,7 +159,10 @@ prefer `internal.CheckCreatedTransaction(resp, details)` over the manual
   the fuzzer "this branch matters."
 - A `Reachable("X")` with no upstream `Sometimes` that fires when X is true
   is passive: Antithesis cannot bias toward making X happen. Prefer pairing
-  them when the path is fragile.
+  them when the path is fragile. When the sonde and the `Reachable` would
+  carry the same predicate, drop the `Reachable` — both are `mustHit`, so the
+  `Sometimes` alone enforces it and additionally gives the fuzzer a gradient.
+  `singleton_driver_model/coverage.go` is the worked example.
 - Never use `panic` / `log.Fatal` / `os.Exit` to signal a finding from a
   driver — they kill the worker without producing a structured signal.
   `setup` programs (`first_default_ledger` etc.) may use `log.Fatalf` for

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -52,7 +52,10 @@ swallows a stream truncation will silently report "all green" on a real bug.
 The workload uses a layered predicate set (`internal/client.go`):
 
 - `IsTransient(err)` — retry-safe set, what the retry interceptor handles.
-  Covers `Unavailable | DeadlineExceeded | ExternalServiceError`.
+  Covers `Unavailable | DeadlineExceeded | ExternalServiceError |
+  WritesBlockedDiskFull` (the write gate's
+  `ResourceExhausted / WRITES_BLOCKED_DISK_FULL` refusal: rejected before
+  consensus, so the bulk did not commit and a retry is sound).
 - `IsCanceled(err)` — local ctx is dead (driver shutting down). Not a
   finding; the driver just exits.
 - `IsTolerated(err)` — `nil | IsTransient | IsCanceled | errors.Is(context.DeadlineExceeded) | errors.Is(context.Canceled)`.

--- a/tests/antithesis/config/Justfile
+++ b/tests/antithesis/config/Justfile
@@ -13,5 +13,5 @@ push *ARGS:
 
 	just build-config "$tmpdir/docker-compose.yaml"
 
-	docker build --platform linux/amd64 -f Dockerfile.config -t $ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3:{{tag}} $tmpdir
+	env -u SOURCE_DATE_EPOCH docker build --platform linux/amd64 -f Dockerfile.config -t $ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3:{{tag}} $tmpdir
 	docker push $ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3:{{tag}}

--- a/tests/antithesis/k8s/Justfile
+++ b/tests/antithesis/k8s/Justfile
@@ -6,7 +6,7 @@ generate-manifests:
 
 # Build the config image containing all k8s manifests.
 build-config: generate-manifests
-    docker build --platform linux/amd64 -f Dockerfile.config -t "$ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3-k8s:{{tag}}" .
+    env -u SOURCE_DATE_EPOCH docker build --platform linux/amd64 -f Dockerfile.config -t "$ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3-k8s:{{tag}}" .
 
 push: build-config
     docker push "$ANTITHESIS_REPOSITORY/antithesis-config-ledger-v3-k8s:{{tag}}"

--- a/tests/antithesis/k8s/workload.yaml
+++ b/tests/antithesis/k8s/workload.yaml
@@ -99,6 +99,11 @@ spec:
           value: "ledger-ledger-0.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-1.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-2.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-3.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-4.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-5.ledger-ledger-headless.default.svc.cluster.local:8888,ledger-ledger-6.ledger-ledger-headless.default.svc.cluster.local:8888"
         - name: EXPECTED_VOTERS
           value: "3"
+        # Per-bulk driver decisions (dispatch, outcome, model verdict) in the
+        # container log, so a divergence finding carries the driver's view of
+        # every observation in the moment logs.
+        - name: MODEL_DEBUG
+          value: "1"
         # Dumps every committed ApplyRequest (base64) for exact deterministic
         # replay through the oracle (see tests/oracle/cmd/replay). Empty
         # disables; substituted by generate-manifests.sh from the

--- a/tests/antithesis/run_model_test.sh
+++ b/tests/antithesis/run_model_test.sh
@@ -391,8 +391,15 @@ has_verified_model_outcome() {
 # ---------------------------------------------------------------------------
 # --restore drives S3 backups (to MinIO), so the server and ledgerctl need the
 # s3 build tag; the light default build stubs S3 out.
-server_tags=""
-[ "$RESTORE" = 1 ] && server_tags="-tags s3"
+#
+# Pebble's internal invariant checks (iterator bound violations, key ordering,
+# ...) ride the `invariants` build tag — the Antithesis image gets them
+# through -race, and a misuse they catch panics loudly there while an
+# untagged build silently tolerates it. The local server is always built with
+# the tag so both environments police the same store invariants; the cost is
+# a few percent, not race-detector overhead.
+server_tags="-tags invariants"
+[ "$RESTORE" = 1 ] && server_tags="-tags invariants,s3"
 build_cmd="go build $server_tags -o '$SERVER_BIN' . && "
 if [ "$NODES" -gt 1 ] || [ "$RESTORE" = 1 ]; then
 	build_cmd="${build_cmd}go build $server_tags -o '$LEDGERCTL_BIN' ./cmd/ledgerctl && "
@@ -476,6 +483,7 @@ fi
 LEDGER_GRPC_ADDR="$ADDR_LIST" \
 ANTITHESIS_SDK_LOCAL_OUTPUT="$ASSERTIONS" \
 MODEL_DEBUG="${MODEL_DEBUG:-}" \
+MODEL_DUMP_BATCHES="${MODEL_DUMP_BATCHES:-}" \
 MODEL_LEDGERS="${MODEL_LEDGERS:-}" \
 MODEL_WORKERS="${MODEL_WORKERS:-}" \
 MODEL_MAX_SECONDS="$(( DURATION + 15 ))" \

--- a/tests/antithesis/run_model_test.sh
+++ b/tests/antithesis/run_model_test.sh
@@ -355,13 +355,54 @@ wait_healthy() {
 	return 1
 }
 
-# True (0) when MODEL_FAIL_FAST is set and a finding (condition:false + hit:true,
-# optionally matching the MODEL_FAIL_FAST substring) is present in the output.
+# The assertions that count as findings, by assertion class. Shared by the
+# in-run fail-fast poll and the end-of-run report so the two cannot disagree.
+#
+# Always / AlwaysOrUnreachable / Unreachable are universal: one false
+# evaluation is a failure, here and on the platform alike.
+#
+# Sometimes is existential -- satisfied by a single true evaluation anywhere in
+# the run -- so an individual false is normal and is NOT a finding. Its failure
+# mode is the opposite one, never satisfied at all, which the report checks
+# separately over the coverage sondes.
+#
+# The exception is the shared internal helpers, whose Sometimes assertions are
+# invariants wearing the wrong primitive: `assert.Sometimes(IsTolerated(err),
+# ...)` in internal/ledger.go claims every call either succeeds or fails
+# transiently. On the platform, fault injection can legitimately break a single
+# attempt; locally there is none and the gRPC interceptors retry transients to
+# a definitive outcome, so the condition must hold on every call and a false is
+# a genuine non-transient failure. They keep universal treatment until they are
+# retyped to AlwaysOrUnreachable, which is what they actually assert.
+# scripts/check-repo-invariants pins this list against those call sites.
+STRICT_SOMETIMES='["should be able to create ledger","should always be able to get created ledger","should be able to get a random ledger"]'
+
+failed_assertions() {
+	[ -s "$ASSERTIONS" ] || return 0
+	if command -v jq >/dev/null 2>&1; then
+		jq -c --argjson strict "$STRICT_SOMETIMES" '
+			select(.antithesis_assert.hit == true and .antithesis_assert.condition == false)
+			| .antithesis_assert
+			| select(.display_type != "Sometimes" or (.message as $m | $strict | index($m)))
+			| {display_type, message, details}' "$ASSERTIONS" 2>/dev/null
+		return 0
+	fi
+
+	# Without jq the class split is unavailable. Drop the coverage sondes,
+	# which are false by design, and treat every other false as a finding --
+	# over-reporting a rare Sometimes beats missing a real invariant.
+	grep -E '"hit":[[:space:]]*true' "$ASSERTIONS" 2>/dev/null \
+		| grep -E '"condition":[[:space:]]*false' \
+		| grep -v 'singleton_driver_model: coverage '
+}
+
+# True (0) when MODEL_FAIL_FAST is set and a finding is present in the output,
+# optionally matching the MODEL_FAIL_FAST substring.
 check_fail_fast() {
 	case "$MODEL_FAIL_FAST" in ''|0|off|false|no) return 1 ;; esac
 	[ -s "$ASSERTIONS" ] || return 1
 	local ff
-	ff="$(grep -E '"condition":[[:space:]]*false' "$ASSERTIONS" 2>/dev/null | grep -E '"hit":[[:space:]]*true')"
+	ff="$(failed_assertions)"
 	[ -n "$ff" ] || return 1
 	if [ "$MODEL_FAIL_FAST" != "1" ]; then
 		ff="$(printf '%s\n' "$ff" | grep -F "$MODEL_FAIL_FAST")"
@@ -553,24 +594,10 @@ log "topology: $NODES node(s)"
 
 findings=0
 
-# 1. Failed assertions (condition:false AND hit:true) from the driver model. We
-# deliberately do NOT exclude "Sometimes" here, unlike a platform run. On the
-# antithesis platform an individual Sometimes:false is expected noise (it fails
-# only if never true across the whole campaign, and fault injection can
-# legitimately make a single attempt fail). singleton_driver_model's only
-# Sometimes assertions are the "success-or-transient" idiom from the
-# CreateLedger/GetLedger helpers (cond = `err == nil || IsTransient(err)`); with
-# transients retried to a definitive outcome that condition must hold on every
-# call, so a Sometimes:false here is a genuine non-transient failure worth
-# surfacing. (This would over-report a pure reachability Sometimes such as
-# `Sometimes(commitIndex > 0)`; this script only runs singleton_driver_model,
-# which has none of those.)
+# 1. Failed assertions from the driver model (see failed_assertions for how
+# each assertion class is treated).
 if [ -s "$ASSERTIONS" ]; then
-	if command -v jq >/dev/null 2>&1; then
-		failed="$(jq -c 'select(.antithesis_assert.hit == true and .antithesis_assert.condition == false) | .antithesis_assert | {display_type, message, details}' "$ASSERTIONS" 2>/dev/null)"
-	else
-		failed="$(grep -E '"hit":true' "$ASSERTIONS" 2>/dev/null | grep -E '"condition":false')"
-	fi
+	failed="$(failed_assertions)"
 	if [ -n "$failed" ]; then
 		echo "MODEL FINDINGS (failed assertions):"
 		echo "$failed"
@@ -651,6 +678,45 @@ if [ "$RESTORE" = 1 ] && [ "$RESTORE_FAILED_CYCLES" -gt 0 ]; then
 	echo
 	echo "RESTORE CYCLE FAILURES: $RESTORE_FAILED_CYCLES cycle(s) failed (see 'restore:' lines above)"
 	findings=$((findings + 1))
+fi
+
+# 9. Coverage sondes that were registered but never satisfied. A Sometimes is
+# existential, so its failure mode is "never true anywhere in the run" -- which
+# is exactly the claim the query oracle needs: an index that never served a
+# page the model verified was not tested, however green the run looks. The
+# required set is the registrations themselves (the driver emits every sonde
+# with hit:false before the first query), so nothing is duplicated here and the
+# two cannot drift.
+#
+# Antithesis needs no equivalent: it explores a branching tree and steers
+# toward unsatisfied sondes, so it enforces this itself. This gate exists
+# because a local run is one short linear trajectory with no guidance.
+unsatisfied_coverage() {
+	[ -s "$ASSERTIONS" ] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+
+	# The output carries non-assertion lines (the SDK version block), so the
+	# message is matched only where one exists: an unguarded startswith aborts
+	# jq, and with stderr silenced the gate would then pass vacuously.
+	jq -r -s '
+		[.[] | .antithesis_assert
+		 | select(type == "object" and (.message | type) == "string")
+		 | select(.message | startswith("singleton_driver_model: coverage "))] as $c
+		| ([$c[] | select(.hit == false) | .message] | unique) as $registered
+		| ([$c[] | select(.hit == true and .condition == true) | .message] | unique) as $satisfied
+		| $registered - $satisfied
+		| .[]' "$ASSERTIONS" 2>/dev/null
+}
+
+if [ "$findings" -eq 0 ]; then
+	missing="$(unsatisfied_coverage)"
+	if [ -n "$missing" ]; then
+		echo
+		echo "COVERAGE SONDES NEVER SATISFIED: the oracle predicted no served page for"
+		printf '  %s\n' "$missing"
+		echo "  (the run proves nothing about these; lengthen it or fix the generator's weighting)"
+		findings=$((findings + $(printf '%s\n' "$missing" | grep -c .)))
+	fi
 fi
 
 echo "-----------------------------------------------------"

--- a/tests/antithesis/workload/.gitignore
+++ b/tests/antithesis/workload/.gitignore
@@ -1,0 +1,1 @@
+bin/cmds/model/singleton_driver_model/singleton_driver_model

--- a/tests/antithesis/workload/Justfile
+++ b/tests/antithesis/workload/Justfile
@@ -5,8 +5,8 @@ tag := 'antithesis'
 # Empty (default) ships every driver. Use the filtered mode for dev-loop runs
 # where the Antithesis composer should focus on a specific subset.
 build include='':
-	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
-	docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --target sidecar --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3-sidecar:{{tag}}" ../../../
+	env -u SOURCE_DATE_EPOCH docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}" ../../../
+	env -u SOURCE_DATE_EPOCH docker build --platform linux/amd64 --build-arg GOARCH=amd64 --build-arg GOOS=linux --build-arg INCLUDED_DRIVERS={{quote(include)}} -f Dockerfile --target sidecar --progress=plain -t "$ANTITHESIS_REPOSITORY/workload-ledger-v3-sidecar:{{tag}}" ../../../
 
 push include='': (build include)
 	docker push "$ANTITHESIS_REPOSITORY/workload-ledger-v3:{{tag}}"

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/actions.go
@@ -131,6 +131,15 @@ func generateBulk(g oracle.GlobalState, ledgers []string) oracle.Bulk {
 		}
 	}
 
+	// An index create/drop is its own single-request bulk (single-ledger, since
+	// the index is ledger-scoped). Emitting it alone keeps the model's index
+	// lifecycle a clean sequence of committed CreateIndex/DropIndex orders.
+	if len(picks) == 1 && rollIndexOp() {
+		if req := generateIndexOp(g, picks[0]); req != nil {
+			return oracle.Bulk{Requests: []*servicepb.Request{req}}
+		}
+	}
+
 	size := bulkSize()
 	requests := make([]*servicepb.Request, 0, size)
 
@@ -901,19 +910,28 @@ func generateSchemaOp(ledger string, ls oracle.LedgerState) *servicepb.Request {
 		}
 	}
 
-	return generateSetMetadataFieldType(ledger)
+	return generateSetMetadataFieldType(ledger, ls)
 }
 
 // SetMetadataFieldType for an account- or ledger-target key, with a type from the
 // pool. Declared on the same small key pool as metadata values, so writes and
 // reads of those keys coerce.
-func generateSetMetadataFieldType(ledger string) *servicepb.Request {
+//
+// A retype of a key that currently has a metadata index triggers a background
+// index REWRITE (version bump + re-encode). The model tracks its serving
+// window (oracle.RetypeWindow): until the driver observes every replica's
+// atomic switch, queries on the key are legal under the old type or the new,
+// each as a whole window — so indexed keys are retyped like any other.
+func generateSetMetadataFieldType(ledger string, ls oracle.LedgerState) *servicepb.Request {
+	target := random.RandomChoice(metaTargetPool)
+	key := metaKey()
+
 	return &servicepb.Request{
 		Type: &servicepb.Request_SetMetadataFieldType{
 			SetMetadataFieldType: &servicepb.SetMetadataFieldTypeRequest{
 				Ledger:     ledger,
-				TargetType: random.RandomChoice(metaTargetPool),
-				Key:        metaKey(),
+				TargetType: target,
+				Key:        key,
 				Type:       random.RandomChoice(metaTypePool),
 			},
 		},

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/checker.go
@@ -51,6 +51,19 @@ type Checker struct {
 	// in-flight set onto.
 	modelState oracle.GlobalState
 
+	// retypeObs tracks each open retype window's per-node closure progress —
+	// see retypeObservation. Keyed by retypeObsKey. Guarded by mu.
+	retypeObs map[string]*retypeObservation
+
+	// indexCreateSeq is each tracked index's create frontier: the committed log
+	// sequence of the latest CreateIndex folded for (ledger → canonical). A
+	// drop+recreate reuses the canonical but moves the frontier, so it is the
+	// index's lifecycle generation. The readiness poller snapshots it before
+	// polling, discards any per-node report whose indexer has not folded past
+	// it (the report describes the prior incarnation), and refuses to apply a
+	// verdict once the frontier moved under it. Guarded by mu.
+	indexCreateSeq map[string]map[string]uint64
+
 	// replayable holds committed bulks that carried a tracked idempotency key —
 	// the originals runReplay re-sends to exercise the server's idempotency
 	// replay. Populated at commit (rememberReplayable), capped at
@@ -85,7 +98,8 @@ type pendingObservation struct {
 // (declared at creation, see setupLedgers); caller spawns the processor
 // goroutine. The schema is replayed as SetMetadataFieldType orders — the server
 // records the identical declared types at creation (populateInitialSchema), so
-// the model's schema state matches the server's from the first bulk.
+// the model's schema state matches the server's from the first bulk. They are
+// seeded rather than applied: at creation they produce no ledger log.
 func NewChecker(ledgerNames []string, schemas map[string][]*commonpb.SetMetadataFieldTypeCommand) *Checker {
 	modelState := oracle.NewGlobalState()
 	for _, ledger := range ledgerNames {
@@ -108,7 +122,9 @@ func NewChecker(ledgerNames []string, schemas map[string][]*commonpb.SetMetadata
 			})
 		}
 
-		modelState = modelState.Apply(oracle.Bulk{Requests: reqs}).State
+		// Seeded, not applied: the server declares these at creation, so they
+		// emit no ledger log (see SeedInitialSchema).
+		modelState = modelState.SeedInitialSchema(reqs)
 	}
 
 	return &Checker{
@@ -117,5 +133,70 @@ func NewChecker(ledgerNames []string, schemas map[string][]*commonpb.SetMetadata
 		reads:       map[uint64]struct{}{},
 		incoming:    make(chan observation, incomingBuffer),
 		modelState:  modelState,
+		retypeObs:   map[string]*retypeObservation{},
+
+		indexCreateSeq: map[string]map[string]uint64{},
 	}
+}
+
+// retypeObservation drives one retype window's closure, two-phase per node so
+// the close can never race the fold: a poll proving the retype's own log
+// folded (last_indexed_sequence >= openSeq) arms the node, and only a LATER
+// poll showing pending_version == 0 confirms its switch — the two fields need
+// not be sampled atomically within one response, but pending cannot return to
+// zero before the switch once the bump is known applied. The window closes
+// when every node confirmed. openSeq extends and phases reset on a chained
+// retype, whose new rewrite must be observed afresh. Guarded by c.mu.
+type retypeObservation struct {
+	ledger    string
+	canonical string
+	openSeq   uint64
+	foldSeen  map[int]bool
+	pendClear map[int]bool
+
+	// confirmedAt is the dispatch-ticket frontier at the moment every node
+	// confirmed its switch; zero until then. The window itself closes only
+	// once every read ticketed at or before it has finished: a read served
+	// from a pre-switch snapshot is validated against the model AFTER its
+	// response arrives, and closing under it would judge a legitimately
+	// old-typed answer by post-switch rules.
+	confirmedAt uint64
+}
+
+// closeAllRetypeWindows ends every open retype window, for the restore cycle:
+// rebuilt read-stores encode under the live schema, so no replica serves an
+// old-typed index after a restore.
+func (c *Checker) closeAllRetypeWindows() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, obs := range c.retypeObs {
+		c.modelState.CloseRetypeWindow(obs.ledger, obs.canonical)
+		delete(c.retypeObs, key)
+	}
+}
+
+func retypeObsKey(ledger, canonical string) string {
+	return ledger + "\x00" + canonical
+}
+
+// noteRetypeCommit registers (or re-arms) the closure observation for a
+// committed retype whose window the fold just opened or extended. Caller
+// holds c.mu.
+func (c *Checker) noteRetypeCommit(ledger, canonical string, seq uint64) {
+	key := retypeObsKey(ledger, canonical)
+
+	obs, ok := c.retypeObs[key]
+	if !ok {
+		obs = &retypeObservation{ledger: ledger, canonical: canonical}
+		c.retypeObs[key] = obs
+	}
+
+	if seq > obs.openSeq {
+		obs.openSeq = seq
+	}
+
+	obs.foldSeen = map[int]bool{}
+	obs.pendClear = map[int]bool{}
+	obs.confirmedAt = 0
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/config.go
@@ -147,6 +147,13 @@ const replayConflictOneIn = 6
 // Worker → processor channel cap, well above steady-state inflight.
 const incomingBuffer = 256
 
+// --- Index readiness poller ---------------------------------------------
+
+// Base interval between per-replica index-readiness reconciliations. Short so a
+// freshly created (or restore-rebuilt) index is promoted to active — where the
+// model then requires its queries to return results — soon after it goes live.
+const indexPollInterval = 2 * time.Second
+
 // --- Restore cycle ------------------------------------------------------
 
 // Poll cadence while waiting for the driver to fully drain before a backup.

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage.go
@@ -101,33 +101,47 @@ func emitCoverage(cond bool, msg string, details internal.Details, hit bool) {
 		hit, true, "sometimes", "Sometimes", msg)
 }
 
-// noteQueryCoverage records what one validated query outcome proves. served is
-// true only when the oracle accepted the outcome AND the server returned rows:
-// a refusal the model predicted shows the lifecycle gate works, not that the
-// index can answer. needed is the filter's index requirement, so a sonde can
-// only be satisfied by a query that genuinely depended on that index.
-//
-// Every sonde is evaluated on every call, not only the satisfied one — the
-// false evaluations are what let Antithesis bias toward a starved index. The
-// caller must not hold c.mu.
-func (c *Checker) noteQueryCoverage(ledger string, target commonpb.QueryTarget, filter *commonpb.QueryFilter, needed map[string]struct{}, served bool) {
+// noteQueryCoverage records what one validated query outcome proves. Every
+// sonde is evaluated on every call, not only the satisfied one — the false
+// evaluations are what let Antithesis bias toward a starved index. The caller
+// must not hold c.mu.
+func (c *Checker) noteQueryCoverage(ledger string, target commonpb.QueryTarget, filter *commonpb.QueryFilter, needed map[string]struct{}, verified bool, rows int) {
 	details := internal.Details{"ledger": ledger}
+
+	for msg, cond := range coverageHits(target, filter, needed, verified, rows,
+		c.retypeWindowOpenFor(ledger, needed)) {
+		emitCoverage(cond, msg, details, coverageHit)
+	}
+}
+
+// coverageHits is the per-sonde verdict for one query outcome: message to
+// whether this outcome satisfies it.
+//
+// A sonde needs three things at once. The oracle must have ACCEPTED the
+// outcome; the server must have returned at least one ROW, because a verified
+// empty page proves the index was consulted but never that it can produce a
+// matching record — and the generator emits deliberately unmatchable filters,
+// so empty pages are the common case; and the filter must have NEEDED that
+// index, so a page served through one index cannot vouch for another.
+func coverageHits(target commonpb.QueryTarget, filter *commonpb.QueryFilter, needed map[string]struct{}, verified bool, rows int, retypeOpen bool) map[string]bool {
+	served := verified && rows > 0
+	out := make(map[string]bool, len(coverageIndexes)+2)
 
 	for _, wi := range coverageIndexes {
 		_, want := needed[wi.canonical]
-		emitCoverage(served && want, coverageIndexMessage(wi.canonical), details, coverageHit)
+		out[coverageIndexMessage(wi.canonical)] = served && want
 	}
 
 	// Only the entity targets have metadata fields; a LOGS filter cannot need a
 	// metadata index, so folding it in would report against an entity sonde it
 	// can never satisfy.
 	if target != commonpb.QueryTarget_QUERY_TARGET_LOGS {
-		emitCoverage(served && filterNeedsMetadataIndex(filter),
-			coverageMetadataMessage(target), details, coverageHit)
+		out[coverageMetadataMessage(target)] = served && filterNeedsMetadataIndex(filter)
 	}
 
-	emitCoverage(served && c.retypeWindowOpenFor(ledger, needed),
-		coverageRetypeMessage, details, coverageHit)
+	out[coverageRetypeMessage] = served && retypeOpen
+
+	return out
 }
 
 // filterNeedsMetadataIndex reports whether any leaf is a metadata-field

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+// Coverage sondes prove the query oracle actually predicted a served response
+// for each index it models, rather than merely compiling code that could have.
+// A run in which an index never served a page the oracle checked says nothing
+// about that index, so each sonde is a must-hit `Sometimes`: satisfied the
+// first time that index serves a verified page, and evaluated false on every
+// other query so Antithesis has a gradient to steer along. `Reachable` cannot
+// do this — its condition is hard-wired true, so it never produces the failing
+// evaluations the platform's guidance biases on.
+//
+// The names are data-driven (one per index), so the antithesis-go-instrumentor
+// cannot catalogue them: it only resolves literal message arguments. They are
+// registered at run time through assert.AssertRaw instead — the same not-hit
+// emission the generated catalog performs for literal assertions — and the
+// hit-time emissions reuse the identical message/ID so they land on the
+// registered property. This mirrors internal/block/block.go, and AssertRaw is
+// invisible to the scanner, so no anonymous catalog entries are produced.
+const (
+	coverageClass = "github.com/formancehq/ledger/v3/tests/antithesis/workload/bin/cmds/model/singleton_driver_model"
+	coverageFile  = "tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage.go"
+
+	coverageHit    = true
+	coverageNotHit = false
+)
+
+// coveragePrefix marks every sonde below. run_model_test.sh keys its
+// "registered but never satisfied" gate on it, and TestCoverageMessages pins
+// that no sonde escapes the prefix.
+const coveragePrefix = "singleton_driver_model: coverage "
+
+// coverageIndexes is the static index set the sondes are keyed on, resolved
+// once: noteQueryCoverage runs on every query.
+var coverageIndexes = workloadIndexes()
+
+// coverageIndexMessage names the per-index sonde. The canonical IndexID is the
+// oracle's own index-map key, so the sonde and the lifecycle it proves are
+// keyed identically.
+func coverageIndexMessage(canonical string) string {
+	return coveragePrefix + "index " + canonical + " served a model-verified page"
+}
+
+// coverageMetadataMessage names the per-target metadata-index sonde. Metadata
+// indexes are one per declared field, a set that churns as the schema changes,
+// so they are covered by shape rather than by identity: an unbounded, unstable
+// family of names cannot be registered up front.
+func coverageMetadataMessage(target commonpb.QueryTarget) string {
+	return coveragePrefix + "a metadata-field index served a model-verified page on " + coverageTargetName(target)
+}
+
+// coverageTargetName names one of the two entity targets; metadata sondes exist
+// for no others.
+func coverageTargetName(target commonpb.QueryTarget) string {
+	if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		return "transactions"
+	}
+
+	return "accounts"
+}
+
+// coverageRetypeMessage names the sonde for the retype exception: a page served
+// while one of its indexes still had an open retype window. That window is the
+// subtlest state the oracle models — the served version may still be bound to a
+// superseded declared type — and nothing else proves the exception was
+// exercised rather than merely compiled.
+const coverageRetypeMessage = coveragePrefix + "a query was served while a retype window was open"
+
+// coverageMessages is every sonde this driver registers, in registration order.
+func coverageMessages() []string {
+	out := make([]string, 0, len(coverageIndexes)+3)
+	for _, wi := range coverageIndexes {
+		out = append(out, coverageIndexMessage(wi.canonical))
+	}
+
+	return append(out,
+		coverageMetadataMessage(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS),
+		coverageMetadataMessage(commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS),
+		coverageRetypeMessage,
+	)
+}
+
+// registerCoverage declares every sonde before the run loop starts, so one that
+// is never evaluated is still visible as an unsatisfied property instead of
+// being absent from the output altogether.
+func registerCoverage() {
+	for _, msg := range coverageMessages() {
+		emitCoverage(false, msg, nil, coverageNotHit)
+	}
+}
+
+func emitCoverage(cond bool, msg string, details internal.Details, hit bool) {
+	assert.AssertRaw(cond, msg, details, coverageClass, "noteQueryCoverage", coverageFile, 0,
+		hit, true, "sometimes", "Sometimes", msg)
+}
+
+// noteQueryCoverage records what one validated query outcome proves. served is
+// true only when the oracle accepted the outcome AND the server returned rows:
+// a refusal the model predicted shows the lifecycle gate works, not that the
+// index can answer. needed is the filter's index requirement, so a sonde can
+// only be satisfied by a query that genuinely depended on that index.
+//
+// Every sonde is evaluated on every call, not only the satisfied one — the
+// false evaluations are what let Antithesis bias toward a starved index. The
+// caller must not hold c.mu.
+func (c *Checker) noteQueryCoverage(ledger string, target commonpb.QueryTarget, filter *commonpb.QueryFilter, needed map[string]struct{}, served bool) {
+	details := internal.Details{"ledger": ledger}
+
+	for _, wi := range coverageIndexes {
+		_, want := needed[wi.canonical]
+		emitCoverage(served && want, coverageIndexMessage(wi.canonical), details, coverageHit)
+	}
+
+	// Only the entity targets have metadata fields; a LOGS filter cannot need a
+	// metadata index, so folding it in would report against an entity sonde it
+	// can never satisfy.
+	if target != commonpb.QueryTarget_QUERY_TARGET_LOGS {
+		emitCoverage(served && filterNeedsMetadataIndex(filter),
+			coverageMetadataMessage(target), details, coverageHit)
+	}
+
+	emitCoverage(served && c.retypeWindowOpenFor(ledger, needed),
+		coverageRetypeMessage, details, coverageHit)
+}
+
+// filterNeedsMetadataIndex reports whether any leaf is a metadata-field
+// condition — the leaves neededIndexCanonicals maps to a per-(target, key)
+// metadata index. Read off the filter rather than sniffed out of the canonical
+// strings, so it stays exact as the IndexID encoding changes.
+func filterNeedsMetadataIndex(f *commonpb.QueryFilter) bool {
+	found := false
+
+	visitLeaves(f, func(leaf *commonpb.QueryFilter) {
+		if _, ok := leaf.GetFilter().(*commonpb.QueryFilter_Field); ok {
+			found = true
+		}
+	})
+
+	return found
+}
+
+// retypeWindowOpenFor reports whether any of the query's indexes still had an
+// open retype window on the committed state. The window is read there rather
+// than from the candidate base the match came from, which matchesModel does not
+// report; the committed state is the same source the finding diagnostics use.
+func (c *Checker) retypeWindowOpenFor(ledger string, needed map[string]struct{}) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ls := c.modelState.Ledger(ledger)
+	for canon := range needed {
+		if _, open := ls.RetypeWindow(canon); open {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage_test.go
@@ -119,3 +119,53 @@ func TestRetypeWindowOpenFor(t *testing.T) {
 	require.False(t, c.retypeWindowOpenFor("L", map[string]struct{}{assetIndexCanonical: {}}),
 		"a query that did not need the retyped index proves nothing about the window")
 }
+
+// A sonde needs an accepted outcome, a returned row, and the filter to have
+// needed that index. Any one missing and it stays unsatisfied — an empty page
+// in particular proves the index was consulted, never that it can produce a
+// matching record, and the generator emits unmatchable filters on purpose.
+func TestCoverageHits_NeedsAcceptedNonEmptyAndNeeded(t *testing.T) {
+	t.Parallel()
+
+	accounts := commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS
+	assetSonde := coverageIndexMessage(assetIndexCanonical)
+	needed := map[string]struct{}{assetIndexCanonical: {}}
+	filter := filterMetaExists("k1")
+
+	hits := coverageHits(accounts, filter, needed, true, 3, true)
+	require.True(t, hits[assetSonde], "accepted, non-empty, and needed")
+	require.True(t, hits[coverageMetadataMessage(accounts)])
+	require.True(t, hits[coverageRetypeMessage])
+
+	require.False(t, coverageHits(accounts, filter, needed, true, 0, true)[assetSonde],
+		"a verified but empty page must not satisfy a sonde")
+	require.False(t, coverageHits(accounts, filter, needed, false, 3, true)[assetSonde],
+		"an outcome the oracle rejected proves nothing")
+
+	other := map[string]struct{}{logDateIndexCanonical: {}}
+	require.False(t, coverageHits(accounts, filter, other, true, 3, true)[assetSonde],
+		"a page served through another index cannot vouch for this one")
+
+	require.False(t, coverageHits(accounts, filter, needed, true, 3, false)[coverageRetypeMessage],
+		"no open window, nothing to prove")
+	require.False(t, coverageHits(accounts, filterReverted(true), needed, true, 3, true)[coverageMetadataMessage(accounts)],
+		"no metadata leaf, no metadata-index claim")
+}
+
+// Every registered sonde must be decided on every call, or one could never be
+// evaluated false and Antithesis would get no gradient for it.
+func TestCoverageHits_DecidesEveryEntitySonde(t *testing.T) {
+	t.Parallel()
+
+	accounts := commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS
+
+	hits := coverageHits(accounts, filterMetaExists("k1"), nil, true, 1, false)
+	for _, msg := range coverageMessages() {
+		if msg == coverageMetadataMessage(commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS) {
+			continue // the other target's sonde is decided by its own queries
+		}
+
+		_, decided := hits[msg]
+		require.True(t, decided, "%q was not evaluated", msg)
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/coverage_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+)
+
+// Every index the generator churns needs its own sonde, or a run can serve
+// pages from some of them and still look fully covered.
+func TestCoverageMessages_OneSondePerWorkloadIndex(t *testing.T) {
+	t.Parallel()
+
+	msgs := coverageMessages()
+
+	for _, wi := range workloadIndexes() {
+		require.Contains(t, msgs, coverageIndexMessage(wi.canonical),
+			"index %s is churned but has no coverage sonde", wi.canonical)
+	}
+
+	require.Len(t, msgs, len(workloadIndexes())+3,
+		"the two metadata sondes and the retype sonde, and nothing else")
+}
+
+// Antithesis keys properties by message, so two sondes sharing a name collapse
+// into one signal and a starved index hides behind a covered one.
+func TestCoverageMessages_AreUniqueAndPrefixed(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]struct{}{}
+
+	for _, msg := range coverageMessages() {
+		require.True(t, strings.HasPrefix(msg, coveragePrefix),
+			"%q escapes the prefix run_model_test.sh keys its gate on", msg)
+
+		_, dup := seen[msg]
+		require.False(t, dup, "duplicate sonde name %q", msg)
+		seen[msg] = struct{}{}
+	}
+}
+
+// The two entity targets must not collapse onto one another's sonde.
+func TestCoverageMetadataMessage_DistinguishesTargets(t *testing.T) {
+	t.Parallel()
+
+	require.NotEqual(t,
+		coverageMetadataMessage(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS),
+		coverageMetadataMessage(commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS))
+}
+
+// The metadata sonde is satisfied by a metadata-field leaf and nothing else: a
+// builtin-index leaf is served by a sonde of its own, and an index-free one by
+// none.
+func TestFilterNeedsMetadataIndex(t *testing.T) {
+	t.Parallel()
+
+	meta := filterMetaExists("k1")
+	require.True(t, filterNeedsMetadataIndex(meta))
+	require.True(t, filterNeedsMetadataIndex(filterAnd(meta, filterReverted(true))),
+		"a metadata leaf anywhere in the tree counts")
+
+	require.False(t, filterNeedsMetadataIndex(filterReverted(true)))
+	require.False(t, filterNeedsMetadataIndex(filterReference("ref-1")),
+		"a builtin index is not a metadata-field index")
+	require.False(t, filterNeedsMetadataIndex(nil))
+}
+
+// The retype sonde reads the committed model, so it must see a window the fold
+// opened — and only for an index the query actually needed.
+func TestRetypeWindowOpenFor(t *testing.T) {
+	t.Parallel()
+
+	const key = "k1"
+
+	target := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	canon := metadataCanonical(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, key)
+	needed := map[string]struct{}{canon: {}}
+
+	c := NewChecker([]string{"L"}, nil)
+	require.False(t, c.retypeWindowOpenFor("L", needed), "no window on a fresh state")
+
+	// A window opens only once the index exists over a declared field and the
+	// declaration then changes: the served version may still be bound to the
+	// superseded type.
+	apply := func(reqs ...*servicepb.Request) {
+		t.Helper()
+
+		res := c.modelState.Apply(oracle.Bulk{Requests: reqs})
+		require.True(t, res.OK, "setup bulk rejected: %s", res.Reason)
+		c.modelState = res.State
+	}
+
+	apply(oracletest.SetFieldTypeReq(target, key, commonpb.MetadataType_METADATA_TYPE_STRING))
+	apply(oracletest.CreateIndexReq(indexes.MetadataID(target, key)))
+	require.False(t, c.retypeWindowOpenFor("L", needed), "declaring and indexing opens no window")
+
+	apply(oracletest.SetFieldTypeReq(target, key, commonpb.MetadataType_METADATA_TYPE_INT64))
+	require.True(t, c.retypeWindowOpenFor("L", needed), "the retype opens it")
+
+	// A window open somewhere in the ledger is not the claim: only a query that
+	// needed THAT index observed the superseded binding. A second indexed field
+	// that was never retyped must read as closed.
+	const other = "k2"
+
+	apply(oracletest.SetFieldTypeReq(target, other, commonpb.MetadataType_METADATA_TYPE_STRING))
+	apply(oracletest.CreateIndexReq(indexes.MetadataID(target, other)))
+
+	require.False(t, c.retypeWindowOpenFor("L", map[string]struct{}{
+		metadataCanonical(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, other): {},
+	}), "another field's open window says nothing about this one")
+
+	require.False(t, c.retypeWindowOpenFor("L", map[string]struct{}{assetIndexCanonical: {}}),
+		"a query that did not need the retyped index proves nothing about the window")
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/debug.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/grpc/status"
 
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
@@ -110,6 +111,10 @@ func requestKinds(b oracle.Bulk) string {
 			parts[i] = "setFieldType"
 		case *servicepb.Request_RemoveMetadataFieldType:
 			parts[i] = "removeFieldType"
+		case *servicepb.Request_CreateIndex:
+			parts[i] = "createIndex"
+		case *servicepb.Request_DropIndex:
+			parts[i] = "dropIndex"
 		default:
 			parts[i] = "other"
 		}
@@ -155,6 +160,12 @@ func bulkMeta(b oracle.Bulk) string {
 		case *servicepb.Request_RemoveMetadataFieldType:
 			ft := t.RemoveMetadataFieldType
 			parts = append(parts, fmt.Sprintf("rmFT %s/tgt%d/%s", ft.GetLedger(), ft.GetTargetType(), ft.GetKey()))
+		case *servicepb.Request_CreateIndex:
+			ci := t.CreateIndex
+			parts = append(parts, fmt.Sprintf("crIdx %s/%s", ci.GetLedger(), indexes.Canonical(ci.GetId())))
+		case *servicepb.Request_DropIndex:
+			di := t.DropIndex
+			parts = append(parts, fmt.Sprintf("drIdx %s/%s", di.GetLedger(), indexes.Canonical(di.GetId())))
 		}
 	}
 
@@ -269,6 +280,23 @@ func renderVolumeSet(vols map[string]oracle.VolumePair) string {
 	return "{" + strings.Join(parts, ",") + "}"
 }
 
+// modelIndexDump renders a ledger's model index set as canonical[state], sorted
+// — "a" for active (READY confirmed by the poller), "?" for ambiguous. Takes a
+// LedgerState so callsites already holding c.mu can use it.
+func modelIndexDump(ls oracle.LedgerState) string {
+	var parts []string
+	for canon, active := range ls.Indexes().All() {
+		state := "?"
+		if active {
+			state = "a"
+		}
+		parts = append(parts, fmt.Sprintf("%s[%s]", canon, state))
+	}
+	sort.Strings(parts)
+
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
 // modelAccountMetaDump renders the committed model's metadata for addr as
 // {k=value[ft],...} — for diagnosing read mismatches. Acquires c.mu.
 func (c *Checker) modelAccountMetaDump(ledger, addr string) string {
@@ -308,6 +336,35 @@ func (c *Checker) modelLedgerMetaDump(ledger string) string {
 	sort.Strings(parts)
 
 	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// modelChartDump renders the committed model's account-type chart as sorted
+// "name=pattern|persistence" entries, for a chart-divergence finding. Acquires c.mu.
+func (c *Checker) modelChartDump(ledger string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ls := c.modelState.Ledger(ledger)
+
+	var parts []string
+	for name, t := range ls.Types().All() {
+		parts = append(parts, fmt.Sprintf("%s=%s|%d", name, t.Pattern, t.Persistence))
+	}
+	sort.Strings(parts)
+
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+// renderChart renders a server account-type map the same way as modelChartDump,
+// so the two can be diffed directly in a finding.
+func renderChart(types map[string]*commonpb.AccountType) string {
+	var parts []string
+	for name, t := range types {
+		parts = append(parts, fmt.Sprintf("%s=%s|%d", name, t.GetPattern(), t.GetPersistence()))
+	}
+	sort.Strings(parts)
+
+	return "[" + strings.Join(parts, ",") + "]"
 }
 
 // modelTxDump renders the committed model's transaction at id (reference,
@@ -361,4 +418,42 @@ func logSeqs(logs []*commonpb.Log) string {
 		ids[i] = fmt.Sprintf("%d", l.GetSequence())
 	}
 	return "[" + strings.Join(ids, ",") + "]"
+}
+
+// modelTxMetaDump renders the model's metadata for a transaction, so a row the
+// server returned but the model excluded can be classified: a DIFFERENT value
+// for the filtered key means a stale index entry, no value means a phantom.
+func (c *Checker) modelTxMetaDump(ledger string, id uint64) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	txs := c.modelState.Ledger(ledger).Txs()
+	if id == 0 || id > uint64(txs.Len()) {
+		return "<no such tx in model>"
+	}
+
+	meta := txs.Get(int(id - 1)).Metadata()
+	if len(meta) == 0 {
+		return "<no metadata>"
+	}
+
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	ls := c.modelState.Ledger(ledger)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		ft := "none"
+		if t, ok := ls.FieldTypeFor(commonpb.TargetType_TARGET_TYPE_TRANSACTION, k); ok {
+			ft = fmt.Sprintf("%d", t)
+		}
+		parts = append(parts, fmt.Sprintf("%s=%s[ft=%s]", k, oracle.MetaValueString(meta[k]), ft))
+	}
+
+	return strings.Join(parts, ",")
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/filter_fold.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/filter_fold.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// filterFold reduces a QueryFilter tree bottom-up. foldFilter owns the
+// And/Or/Not traversal, so every walk over a filter — index needs, validity,
+// matching, rendering — shares one combinator step and differs only in how it
+// judges a leaf. leaf receives every non-combinator node, the nil filter
+// included, so each walk decides in one place what "no condition" means.
+type filterFold[T any] struct {
+	and  func(children []T) T
+	or   func(children []T) T
+	not  func(child T) T
+	leaf func(f *commonpb.QueryFilter) T
+}
+
+func foldFilter[T any](f *commonpb.QueryFilter, fold filterFold[T]) T {
+	switch x := f.GetFilter().(type) {
+	case *commonpb.QueryFilter_And:
+		return fold.and(foldChildren(x.And.GetFilters(), fold))
+	case *commonpb.QueryFilter_Or:
+		return fold.or(foldChildren(x.Or.GetFilters(), fold))
+	case *commonpb.QueryFilter_Not:
+		return fold.not(foldFilter(x.Not.GetFilter(), fold))
+	default:
+		return fold.leaf(f)
+	}
+}
+
+func foldChildren[T any](children []*commonpb.QueryFilter, fold filterFold[T]) []T {
+	out := make([]T, 0, len(children))
+	for _, child := range children {
+		out = append(out, foldFilter(child, fold))
+	}
+
+	return out
+}
+
+// anyLeaf reports whether pred holds for some leaf of f; combinators only
+// propagate their children's verdicts.
+func anyLeaf(f *commonpb.QueryFilter, pred func(*commonpb.QueryFilter) bool) bool {
+	return foldFilter(f, filterFold[bool]{and: anyOf, or: anyOf, not: identity[bool], leaf: pred})
+}
+
+// visitLeaves calls visit on every leaf of f in tree order.
+func visitLeaves(f *commonpb.QueryFilter, visit func(*commonpb.QueryFilter)) {
+	foldFilter(f, filterFold[struct{}]{
+		and: func([]struct{}) struct{} { return struct{}{} },
+		or:  func([]struct{}) struct{} { return struct{}{} },
+		not: identity[struct{}],
+		leaf: func(leaf *commonpb.QueryFilter) struct{} {
+			visit(leaf)
+
+			return struct{}{}
+		},
+	})
+}
+
+func anyOf(vs []bool) bool {
+	for _, v := range vs {
+		if v {
+			return true
+		}
+	}
+
+	return false
+}
+
+func allOf(vs []bool) bool {
+	for _, v := range vs {
+		if !v {
+			return false
+		}
+	}
+
+	return true
+}
+
+func negate(v bool) bool { return !v }
+
+func identity[T any](v T) T { return v }
+
+// kleene is a three-valued verdict: known=false means the answer hinges on a
+// server stamp the model has not learned yet. Booleans propagate unknowns
+// Kleene-style — a decided AND/OR short-circuits, an undecided one stays
+// unknown.
+type kleene struct {
+	match, known bool
+}
+
+func kleeneAnd(children []kleene) kleene {
+	known := true
+	for _, c := range children {
+		if c.known && !c.match {
+			return kleene{match: false, known: true}
+		}
+
+		known = known && c.known
+	}
+
+	return kleene{match: true, known: known}
+}
+
+func kleeneOr(children []kleene) kleene {
+	known := true
+	for _, c := range children {
+		if c.known && c.match {
+			return kleene{match: true, known: true}
+		}
+
+		known = known && c.known
+	}
+
+	return kleene{match: false, known: known}
+}
+
+func kleeneNot(c kleene) kleene { return kleene{match: !c.match, known: c.known} }
+
+// withinBounds reports whether v lies within the bounds an Int/UintCondition
+// carries — mirroring resolveUintBounds: each side honors its exclusive flag
+// and an absent bound is open on that side.
+func withinBounds[T cmp.Ordered](v T, lo *T, loExclusive bool, hi *T, hiExclusive bool) bool {
+	if lo != nil && (v < *lo || (loExclusive && v == *lo)) {
+		return false
+	}
+
+	if hi != nil && (v > *hi || (hiExclusive && v == *hi)) {
+		return false
+	}
+
+	return true
+}
+
+func matchUintBounds(cond *commonpb.UintCondition, v uint64) bool {
+	return withinBounds(v, cond.Min, cond.GetMinExclusive(), cond.Max, cond.GetMaxExclusive())
+}
+
+func matchIntBounds(cond *commonpb.IntCondition, v int64) bool {
+	return withinBounds(v, cond.Min, cond.GetMinExclusive(), cond.Max, cond.GetMaxExclusive())
+}
+
+// renderBound renders one side of a bound for filter descriptions: "_" when
+// open, the value otherwise, an exclusive bound parenthesized on its outer
+// side — "(3" for a lower bound, "7)" for an upper one.
+func renderBound[T cmp.Ordered](v *T, exclusive, upper bool) string {
+	if v == nil {
+		return "_"
+	}
+
+	s := fmt.Sprint(*v)
+
+	switch {
+	case exclusive && upper:
+		return s + ")"
+	case exclusive:
+		return "(" + s
+	default:
+		return s
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
@@ -1,0 +1,1206 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/antithesishq/antithesis-sdk-go/random"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+// Index lifecycle. The query surface has index-backed conditions the compiler
+// serves only from created indexes: AccountHasAsset (account-by-asset builtin)
+// on accounts, and reference / date builtins on transactions. To exercise those
+// paths with validated results (not just the not-found rejection), the
+// generator emits CreateIndex / DropIndex bulks for each (workloadIndexes) and
+// the model tracks each index's lifecycle:
+//
+//   - absent — no index. A has-asset query must be rejected (FailedPrecondition).
+//   - ambiguous — created, but not yet confirmed READY on every replica. A query
+//     may return a validated window OR be rejected not-ready, both legal (a
+//     replica whose initial backfill hasn't flipped CurrentVersion>0 rejects it).
+//   - active — the readiness poller confirmed CurrentVersion>0 on every reachable
+//     replica. A query must return a validated window; a not-ready rejection is
+//     now a finding.
+//
+// CreateIndex adds the index ambiguous; the poller promotes it to active once
+// every replica reports it live, and demotes it back to ambiguous whenever a
+// replica reports it not-ready again (a restored node rebuilding its read-store).
+// DropIndex removes it instantly — the drop order sits in the committed prefix a
+// linearizable read issued after its response must observe.
+
+// assetIndexID is the account-by-asset builtin index the has-asset condition is
+// served from. assetIndexCanonical is its stable map key.
+func assetIndexID() *commonpb.IndexID {
+	return indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET)
+}
+
+var assetIndexCanonical = indexes.Canonical(assetIndexID())
+
+// workloadTxBuiltins are the transaction builtin indexes the generator churns:
+// the index-backed leaves of the transactions filter grammar (reference, the
+// three date fields, and the three address-role account→tx mappings).
+var workloadTxBuiltins = []commonpb.TransactionBuiltinIndex{
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS,
+	commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS,
+}
+
+// addressRoleBuiltin maps an address role to the tx builtin index serving it —
+// the model's copy of the compiler's txAddressIndexID.
+func addressRoleBuiltin(role commonpb.AddressRole) commonpb.TransactionBuiltinIndex {
+	switch role {
+	case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
+		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS
+	case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
+		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS
+	default:
+		return commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS
+	}
+}
+
+// txBuiltinCanonical returns the canonical IndexID string of a tx builtin — the
+// model's index-map key the filter classifier and the lifecycle validation
+// share.
+func txBuiltinCanonical(field commonpb.TransactionBuiltinIndex) string {
+	return indexes.Canonical(indexes.TxBuiltinID(field))
+}
+
+// workloadIndex is one index the generator churns: its wire ID and canonical key.
+type workloadIndex struct {
+	id        *commonpb.IndexID
+	canonical string
+}
+
+// workloadIndexes is every index the workload creates and drops: the
+// account-by-asset builtin, the tx builtins, and the log-date builtin the LOGS
+// date filters are served from.
+func workloadIndexes() []workloadIndex {
+	out := []workloadIndex{
+		{assetIndexID(), assetIndexCanonical},
+		{logDateIndexID(), logDateIndexCanonical},
+	}
+	for _, field := range workloadTxBuiltins {
+		out = append(out, workloadIndex{indexes.TxBuiltinID(field), txBuiltinCanonical(field)})
+	}
+
+	return out
+}
+
+// indexStateLabel renders an index's model lifecycle state for finding details.
+// indexStateLabelFull renders one canonical's model state, retype window
+// included, for finding diagnostics.
+func indexStateLabelFull(ls oracle.LedgerState, canon string) string {
+	exists, active := ls.IndexState(canon)
+	label := indexStateLabel(exists, active)
+	if oldTypes, open := ls.RetypeWindow(canon); open {
+		parts := make([]string, len(oldTypes))
+		for i, t := range oldTypes {
+			parts[i] = fmt.Sprintf("%d", t)
+		}
+		label += fmt.Sprintf("+window(old=%s)", strings.Join(parts, ","))
+	}
+
+	return label
+}
+
+func indexStateLabel(exists, active bool) string {
+	switch {
+	case !exists:
+		return "absent"
+	case active:
+		return "active"
+	default:
+		return "ambiguous"
+	}
+}
+
+// --- has-asset evaluation ------------------------------------------------
+
+// workloadAsset is a (base, precision) pair matching one of the workload's asset
+// strings (config.go assets), so a has-asset filter built from it can match the
+// accounts those postings touched.
+type workloadAsset struct {
+	base      string
+	precision uint32
+}
+
+// workloadAssets mirrors config.go assets {"USD/2","EUR/2","COIN"} split into
+// (base, precision) via the server's asset-string convention (no "/N" suffix
+// means precision 0).
+var workloadAssets = []workloadAsset{{"USD", 2}, {"EUR", 2}, {"COIN", 0}}
+
+// accountHasAsset reports whether addr is in the account-by-asset index for
+// (assetBase, precision): whether it has EVER touched that asset via a committed,
+// non-excluded posting. This is a monotonic history the oracle tracks (see
+// LedgerState.everAsset / recordAssetTouches), NOT the current volume set — an
+// account drained to zero and purged from the volume table still matches.
+func accountHasAsset(ls oracle.LedgerState, addr, assetBase string, precision uint32) bool {
+	return ls.HasEverAsset(addr, assetBase, precision)
+}
+
+// assetWindow is the model's prediction of a bare has-asset ListAccounts page:
+// the accounts that ever touched (base, precision), in address order (reversed
+// when reverse), with the exclusive cursor applied and capped at pageSize —
+// mirroring accountWindow's pagination over the ever-touched set instead of the
+// current-volume universe.
+func assetWindow(ls oracle.LedgerState, base string, precision uint32, cursor string, pageSize int, reverse bool) []string {
+	window := ls.EverAssetAccounts(base, precision)
+
+	if reverse {
+		reverseStrings(window)
+	}
+
+	if cursor != "" {
+		kept := window[:0]
+		for _, addr := range window {
+			if reverse && addr >= cursor || !reverse && addr <= cursor {
+				continue
+			}
+
+			kept = append(kept, addr)
+		}
+		window = kept
+	}
+
+	if len(window) > pageSize {
+		window = window[:pageSize]
+	}
+
+	return window
+}
+
+// hasAssetTarget extracts the (base, precision) of a bare AccountHasAsset filter.
+// genAccountAssetFilter only produces bare has-asset leaves, so this is total for
+// the asset-index path.
+func hasAssetTarget(f *commonpb.QueryFilter) (base string, precision uint32, ok bool) {
+	if ha, isHA := f.GetFilter().(*commonpb.QueryFilter_AccountHasAsset); isHA {
+		return ha.AccountHasAsset.GetAssetBase(), ha.AccountHasAsset.GetPrecision(), true
+	}
+
+	return "", 0, false
+}
+
+// --- asset-filter generation ---------------------------------------------
+
+// genAccountAssetFilter rolls a bare AccountHasAsset leaf on a random workload
+// asset — the account-by-asset lifecycle path. It is deliberately NOT composed
+// with other leaves: the has-asset index returns accounts that may have been
+// purged from the volume table ("ever touched"), while an index-free address leaf
+// scans only current accounts, so a boolean of the two matches the server's
+// iterator intersection/union — set semantics the model would have to reproduce
+// the read-store to predict. A bare leaf's result set is exactly
+// EverAssetAccounts(base, precision), which the model tracks directly.
+func genAccountAssetFilter() *commonpb.QueryFilter {
+	a := workloadAssets[int(random.RandomChoice([]uint8{0, 1, 2}))]
+
+	return filterHasAsset(a.base, a.precision)
+}
+
+// --- asset-index query validation ----------------------------------------
+
+// validateAssetAccountQuery validates a ListAccounts query whose only index need
+// is the account-by-asset builtin. The legal outcomes depend on that index's
+// lifecycle in each candidate base:
+//
+//   - a result set is legal iff some base holds the index (ambiguous or active)
+//     and its ordered window equals the streamed accounts position-for-position;
+//   - a not-ready rejection (ErrIndexNotFound as FailedPrecondition + reason
+//     INDEX_NOT_FOUND, or ErrIndexBuilding as Unavailable + reason
+//     INDEX_BUILDING) is legal iff some base does not hold the index active
+//     (absent or ambiguous).
+//
+// Any other error code is a finding. So is a result set no base can produce
+// (spurious rows without the index) and a rejection when every base has the index
+// active (ready everywhere, yet rejected).
+func (c *Checker) validateAssetAccountQuery(maxTicket uint64, ledger string, filter *commonpb.QueryFilter, cursor string, pageSize int, reverse bool, serverAccts []*commonpb.Account, err error) {
+	if err != nil && !isIndexNotFound(err) && !isIndexNotReady(err) {
+		assert.Unreachable("singleton_driver_model: asset-index account query returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	base, precision, ok := hasAssetTarget(filter)
+	if !ok {
+		assert.Unreachable("singleton_driver_model: asset-index query filter is not a bare has-asset leaf", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+		})
+
+		return
+	}
+
+	gotResults := err == nil
+
+	if c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
+		ls := cand.Ledger(ledger)
+		exists, active := ls.IndexState(assetIndexCanonical)
+
+		if !gotResults {
+			// A not-ready rejection is legal unless the index is active here.
+			return !exists || !active
+		}
+
+		if !exists {
+			return false // rows require the index present
+		}
+
+		want := assetWindow(ls, base, precision, cursor, pageSize, reverse)
+		if len(want) != len(serverAccts) {
+			return false
+		}
+
+		for i, addr := range want {
+			if serverAccts[i].GetAddress() != addr || !accountMatches(ls, addr, serverAccts[i]) {
+				return false
+			}
+		}
+
+		return true
+	}) {
+		if gotResults {
+			assert.Reachable("singleton_driver_model: asset-index account query served results", internal.Details{"ledger": ledger})
+		} else {
+			assert.Reachable("singleton_driver_model: asset-index account query gated", internal.Details{"ledger": ledger})
+		}
+
+		return
+	}
+
+	c.mu.Lock()
+	modelLS := c.modelState.Ledger(ledger)
+	exists, active := modelLS.IndexState(assetIndexCanonical)
+	modelWindow := assetWindow(modelLS, base, precision, cursor, pageSize, reverse)
+	c.mu.Unlock()
+
+	details := internal.Details{
+		"ledger":     ledger,
+		"filter":     describeFilter(filter),
+		"cursor":     cursor,
+		"pageSize":   pageSize,
+		"reverse":    reverse,
+		"modelIdx":   indexStateLabel(exists, active),
+		"modelAddrs": strings.Join(modelWindow, ","),
+		"bases": c.describeCandidateVerdicts(maxTicket, ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, map[string]struct{}{assetIndexCanonical: {}}, func(ls oracle.LedgerState) []string {
+			return assetWindow(ls, base, precision, cursor, pageSize, reverse)
+		}),
+	}
+	if gotResults {
+		serverAddrs := make([]string, len(serverAccts))
+		for i, a := range serverAccts {
+			serverAddrs[i] = a.GetAddress()
+		}
+		details["rows"] = len(serverAccts)
+		details["serverAddrs"] = strings.Join(serverAddrs, ",")
+		details["contentDiag"] = c.assetContentDiags(maxTicket, ledger, base, precision, cursor, pageSize, reverse, serverAccts)
+	} else {
+		details["error"] = err.Error()
+	}
+
+	details["foldDiag"] = c.foldDiag(maxTicket)
+
+	assert.Unreachable("singleton_driver_model: asset-index account query outside model", details)
+}
+
+// describeAccountContentDiff renders the first content divergence between a
+// base's view of addr and the server's enriched row — the diagnostic for a
+// finding whose page ADDRESSES match a candidate base while a row's content
+// does not. Empty when the row matches.
+func describeAccountContentDiff(ls oracle.LedgerState, addr string, serverAcct *commonpb.Account) string {
+	modelMeta := ls.AccountMetadata(addr)
+	serverMeta := serverAcct.GetMetadata()
+
+	for k, v := range modelMeta {
+		sv, ok := serverMeta[k]
+		if !ok {
+			return fmt.Sprintf("%s meta[%s] model=%s server=<absent>", addr, k, oracle.MetaValueString(v))
+		}
+
+		if oracle.MetaValueString(sv) != oracle.MetaValueString(v) {
+			return fmt.Sprintf("%s meta[%s] model=%s server=%s", addr, k, oracle.MetaValueString(v), oracle.MetaValueString(sv))
+		}
+	}
+
+	for k, sv := range serverMeta {
+		if _, ok := modelMeta[k]; !ok {
+			return fmt.Sprintf("%s meta[%s] model=<absent> server=%s", addr, k, oracle.MetaValueString(sv))
+		}
+	}
+
+	model := map[string]oracle.VolumePair{}
+	for k, vp := range ls.Volumes().All() {
+		if k.Address == addr {
+			model[k.Asset] = vp
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, av := range serverAcct.GetVolumes() {
+		if av.GetColor() != "" {
+			continue
+		}
+
+		seen[av.GetAsset()] = true
+
+		vp, ok := model[av.GetAsset()]
+		if !ok {
+			return fmt.Sprintf("%s volumes[%s] model=<absent> server=in:%s,out:%s", addr, av.GetAsset(), av.GetVolumes().GetInput(), av.GetVolumes().GetOutput())
+		}
+
+		if vp.Input.Dec() != av.GetVolumes().GetInput() || vp.Output.Dec() != av.GetVolumes().GetOutput() {
+			return fmt.Sprintf("%s volumes[%s] model=in:%s,out:%s server=in:%s,out:%s", addr, av.GetAsset(), vp.Input.Dec(), vp.Output.Dec(), av.GetVolumes().GetInput(), av.GetVolumes().GetOutput())
+		}
+	}
+
+	for asset, vp := range model {
+		if !seen[asset] {
+			return fmt.Sprintf("%s volumes[%s] model=in:%s,out:%s server=<absent>", addr, asset, vp.Input.Dec(), vp.Output.Dec())
+		}
+	}
+
+	return ""
+}
+
+// assetContentDiags collects, across the candidate bases whose asset window
+// equals the server page address-for-address, the distinct first content
+// divergences (capped) — pinpointing WHICH row and field failed a page whose
+// membership was explainable. Empty when no base reproduces the addresses. Acquires c.mu.
+func (c *Checker) assetContentDiags(maxTicket uint64, ledger, assetBase string, precision uint32, cursor string, pageSize int, reverse bool, serverAccts []*commonpb.Account) string {
+	var diags []string
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.candidateBases(maxTicket, func(cand oracle.GlobalState) bool {
+		ls := cand.Ledger(ledger)
+
+		w := assetWindow(ls, assetBase, precision, cursor, pageSize, reverse)
+		if len(w) != len(serverAccts) {
+			return false
+		}
+
+		for i := range w {
+			if w[i] != serverAccts[i].GetAddress() {
+				return false
+			}
+		}
+
+		for i, a := range serverAccts {
+			if d := describeAccountContentDiff(ls, w[i], a); d != "" {
+				if len(diags) < 3 && !slices.Contains(diags, d) {
+					diags = append(diags, d)
+				}
+
+				break
+			}
+		}
+
+		return false
+	})
+
+	return strings.Join(diags, " ; ")
+}
+
+// foldDiag walks the enumeration's raw material — the ordered pending prefix
+// from modelState, then each in-flight bulk on the fully-folded state — and
+// reports every bulk the model REFUSES to apply. A refused pending bulk blocks
+// the whole prefix behind it (candidateBases only advances pending through a
+// successful Apply), so one such refusal explains a server effect no candidate
+// base contains. Empty when everything folds. Acquires c.mu.
+func (c *Checker) foldDiag(maxTicket uint64) string {
+	var parts []string
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	base := c.modelState
+	blocked := false
+
+	for i, pe := range c.pending {
+		if pe.obs.ticket > maxTicket {
+			break
+		}
+
+		res := base.Apply(pe.obs.bulk)
+		if !res.OK {
+			parts = append(parts, fmt.Sprintf("pending[%d] minSeq=%d kinds=%s meta=%s refused=%q",
+				i, pe.minSeq, requestKinds(pe.obs.bulk), bulkMeta(pe.obs.bulk), res.Reason))
+			blocked = true
+
+			break
+		}
+
+		base = res.State
+	}
+
+	if !blocked {
+		for t, b := range c.inflight {
+			if t > maxTicket {
+				continue
+			}
+
+			if res := base.Apply(b); !res.OK {
+				parts = append(parts, fmt.Sprintf("inflight[t=%d] kinds=%s meta=%s refused=%q",
+					t, requestKinds(b), bulkMeta(b), res.Reason))
+				if len(parts) >= 4 {
+					break
+				}
+			}
+		}
+	}
+
+	return strings.Join(parts, " ; ")
+}
+
+// --- index-op generation -------------------------------------------------
+
+// createIndexReq / dropIndexReq wrap an IndexID as a CreateIndex / DropIndex
+// Apply request. Both are idempotent on the server (a duplicate create on a
+// present index is a no-op, a drop of an absent index a no-op — no
+// AlreadyExists / NotFound), so the model applies them as always-OK.
+func createIndexReq(ledger string, id *commonpb.IndexID) *servicepb.Request {
+	return &servicepb.Request{Type: &servicepb.Request_CreateIndex{
+		CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledger, Id: id},
+	}}
+}
+
+func dropIndexReq(ledger string, id *commonpb.IndexID) *servicepb.Request {
+	return &servicepb.Request{Type: &servicepb.Request_DropIndex{
+		DropIndex: &servicepb.DropIndexRequest{Ledger: ledger, Id: id},
+	}}
+}
+
+// rollIndexOp: ~1-in-16 a bulk is an index create/drop rather than ledger
+// traffic, churning the index lifecycles the indexed queries probe.
+func rollIndexOp() bool {
+	return oneIn(16)
+}
+
+// generateIndexOp picks one workload index; creates it when the ledger lacks
+// it, else occasionally drops it (so the lifecycle keeps cycling) and otherwise
+// leaves it in place for queries to validate against. One-in-16 it instead
+// probes CreateIndex on an UNDECLARED metadata field — rejected with
+// METADATA_FIELD_NOT_IN_SCHEMA, which the model predicts identically. Reads
+// committed state only.
+func generateIndexOp(g oracle.GlobalState, ledger string) *servicepb.Request {
+	if oneIn(16) {
+		return createIndexReq(ledger, indexes.MetadataID(
+			commonpb.TargetType_TARGET_TYPE_ACCOUNT, "undeclared-"+metaKey()))
+	}
+
+	ls := g.Ledger(ledger)
+	all := workloadIndexes()
+
+	// The declared metadata fields of both indexable targets join the pool, so
+	// metadata index lifecycles churn alongside the builtins.
+	for _, target := range []commonpb.TargetType{
+		commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+		commonpb.TargetType_TARGET_TYPE_TRANSACTION,
+	} {
+		for key := range ls.FieldTypesFor(target).All() {
+			id := indexes.MetadataID(target, key)
+			all = append(all, workloadIndex{id, indexes.Canonical(id)})
+		}
+	}
+
+	pick := all[internal.Rand().Intn(len(all))]
+
+	exists, _ := ls.IndexState(pick.canonical)
+	if !exists {
+		return createIndexReq(ledger, pick.id)
+	}
+
+	if oneIn(3) {
+		return dropIndexReq(ledger, pick.id)
+	}
+
+	return nil
+}
+
+// --- readiness poller ----------------------------------------------------
+
+// trackedIndexes snapshots the (ledger → canonical → create frontier) set the
+// model currently holds, so the poller can query each one's per-replica
+// readiness without holding mu across the network round-trips. The frontier is
+// part of the snapshot: it names the incarnation the poll is about, and the
+// apply step refuses the verdict if it moved (a drop+recreate reused the
+// canonical while the RPCs were in flight).
+func (c *Checker) trackedIndexes() map[string]map[string]uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := map[string]map[string]uint64{}
+	for _, ledger := range c.ledgerNames {
+		for canon := range c.modelState.Ledger(ledger).Indexes().All() {
+			if out[ledger] == nil {
+				out[ledger] = map[string]uint64{}
+			}
+
+			out[ledger][canon] = c.indexCreateSeq[ledger][canon]
+		}
+	}
+
+	return out
+}
+
+// applyIndexReadiness folds one poll's per-canonical verdicts into the model.
+// canons is the poll's snapshot (canonical → create frontier), readyAll the
+// all-replicas verdict gathered against it. Each verdict is bound to the
+// incarnation it sampled: a moved create frontier means a drop+recreate reused
+// the canonical while the RPCs were in flight, and an all-replicas-ready
+// snapshot of the dead incarnation must not promote its successor — skip both
+// directions, the poll says nothing about the current entry. Caller holds c.mu.
+func (c *Checker) applyIndexReadiness(ledger string, canons map[string]uint64, readyAll map[string]bool) {
+	for canon, createSeq := range canons {
+		exists, wasActive := c.modelState.Ledger(ledger).IndexState(canon)
+		if !exists {
+			continue // dropped between the snapshot and now
+		}
+
+		if c.indexCreateSeq[ledger][canon] != createSeq {
+			continue // recreated between the snapshot and now
+		}
+
+		if readyAll[canon] {
+			c.modelState.SetIndexActive(ledger, canon)
+			if !wasActive {
+				// Coverage: the poller confirmed the index READY on every replica
+				// and promoted it — after which its queries must return results.
+				assert.Reachable("singleton_driver_model: index promoted to active", internal.Details{"ledger": ledger, "index": canon})
+			}
+		} else {
+			c.modelState.SetIndexAmbiguous(ledger, canon)
+			if wasActive {
+				// Coverage: a replica reported the index not-ready again (node
+				// down / restored node rebuilding), demoting it back to ambiguous.
+				assert.Reachable("singleton_driver_model: index demoted to ambiguous", internal.Details{"ledger": ledger, "index": canon})
+			}
+		}
+	}
+}
+
+// demoteAllIndexes flips every tracked index back to ambiguous. Called around a
+// restore cycle: the restored node rebuilds its read-store from the log, so its
+// indexes re-enter BUILDING (CurrentVersion 0) until the backfill catches up —
+// the model must tolerate a not-ready rejection again until the poller reconfirms
+// readiness. Demotion only widens tolerance, so it can never cause a finding.
+func (c *Checker) demoteAllIndexes() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, ledger := range c.ledgerNames {
+		for canon := range c.modelState.Ledger(ledger).Indexes().All() {
+			c.modelState.SetIndexAmbiguous(ledger, canon)
+		}
+	}
+}
+
+// runIndexReadinessPoller reconciles each tracked index's active flag against the
+// cluster on a jittered interval until ctx ends. Because queries hit any replica
+// through the round-robin client, an index is active only when every reachable
+// replica reports CurrentVersion>0 for it; a single not-ready (or unreachable)
+// replica demotes it to ambiguous, where a not-ready rejection is tolerated.
+func runIndexReadinessPoller(ctx context.Context, c *Checker, conns internal.PerNodeConns, interval time.Duration) {
+	for {
+		jitter := time.Duration(internal.Rand().Int63n(int64(interval/2) + 1))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval + jitter):
+		}
+
+		reconcileIndexes(ctx, c, conns)
+	}
+}
+
+// reconcileIndexes polls every replica's GetIndexStatus for each ledger holding a
+// tracked index and promotes/demotes each index by whether every replica reports
+// it live. A replica that is unreachable this tick counts as not-ready, so a
+// transient node down demotes rather than freezing a stale active flag.
+func reconcileIndexes(ctx context.Context, c *Checker, conns internal.PerNodeConns) {
+	for ledger, canons := range c.trackedIndexes() {
+		// readyAll starts true and is cleared for any canonical a replica reports
+		// missing, not-yet-live, or that we could not read at all.
+		readyAll := make(map[string]bool, len(canons))
+		for canon := range canons {
+			readyAll[canon] = true
+		}
+
+		// Per-node observations for retype-window closure: the node's fold
+		// cursor and each index's in-flight rewrite target. nodeOK marks the
+		// nodes actually sampled this tick — an unreachable node makes no
+		// progress, in either phase.
+		nodeOK := make([]bool, len(conns))
+		nodeLastIndexed := make([]uint64, len(conns))
+		nodePending := make([]map[string]uint32, len(conns))
+
+		for i, pc := range conns {
+			// Stale consistency: the question is "is THIS replica's index
+			// ready", so the answer must be locally attributable. The default
+			// linearizable read forwards exactly when the node is syncing —
+			// crediting a rebuilding follower with the leader's ready state.
+			resp, err := pc.Bucket.GetIndexStatus(internal.WithStaleConsistency(ctx), &servicepb.GetIndexStatusRequest{Ledger: ledger})
+			if err != nil {
+				for canon := range canons {
+					readyAll[canon] = false
+				}
+
+				continue
+			}
+
+			nodeOK[i] = true
+			nodeLastIndexed[i] = resp.GetLastIndexedSequence()
+			nodePending[i] = make(map[string]uint32, len(resp.GetIndexes()))
+
+			version := make(map[string]uint32, len(resp.GetIndexes()))
+			for _, e := range resp.GetIndexes() {
+				canon := indexes.Canonical(e.GetIndex().GetId())
+				version[canon] = e.GetCurrentVersion()
+				nodePending[i][canon] = e.GetPendingVersion()
+			}
+
+			for canon, createSeq := range canons {
+				// A node proves it is reporting on THIS incarnation only once
+				// its indexer folded past the create: below that, a non-zero
+				// version describes the previous same-canonical incarnation
+				// (dropped and recreated), whose readiness must not transfer.
+				if version[canon] == 0 || resp.GetLastIndexedSequence() < createSeq {
+					readyAll[canon] = false
+				}
+			}
+		}
+
+		c.mu.Lock()
+		c.applyIndexReadiness(ledger, canons, readyAll)
+
+		// Retype-window closure, two-phase per node (see retypeObservation):
+		// a node is armed once a poll proves this retype's log folded, and
+		// confirmed only by a LATER poll with no rewrite pending. Closing on a
+		// single poll would race the fold — pending may read 0 before the
+		// bump this retype is about to apply.
+		for key, obs := range c.retypeObs {
+			if obs.ledger != ledger {
+				continue
+			}
+
+			if _, open := c.modelState.Ledger(ledger).RetypeWindow(obs.canonical); !open {
+				delete(c.retypeObs, key) // window died with its index
+
+				continue
+			}
+
+			confirmed := 0
+			for i := range conns {
+				switch {
+				case obs.pendClear[i]:
+					confirmed++
+				case !nodeOK[i]:
+				case !obs.foldSeen[i]:
+					if nodeLastIndexed[i] >= obs.openSeq {
+						obs.foldSeen[i] = true
+					}
+				default:
+					// Presence is part of the proof: an index this node's
+					// response does not list at all (e.g. temporarily hidden
+					// while its config rebuilds) reads as pending==0 through
+					// the map's zero value, and closing on that would end the
+					// window with the replica still serving the old encoding.
+					if p, listed := nodePending[i][obs.canonical]; listed && p == 0 {
+						obs.pendClear[i] = true
+						confirmed++
+					}
+				}
+			}
+
+			if confirmed == len(conns) && obs.confirmedAt == 0 {
+				obs.confirmedAt = c.ticketSeq.Load()
+			}
+
+			// The switch is proven everywhere, but reads dispatched before the
+			// confirmation may still hold pre-switch snapshots; the window
+			// outlives them so their old-typed answers stay legal.
+			if obs.confirmedAt != 0 {
+				if minTicket, empty := c.earliestOutstanding(); empty || minTicket > obs.confirmedAt {
+					c.modelState.CloseRetypeWindow(ledger, obs.canonical)
+					delete(c.retypeObs, key)
+					assert.Reachable("singleton_driver_model: retype window closed", internal.Details{
+						"ledger": ledger, "index": obs.canonical,
+					})
+				}
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+// --- indexed transaction-query validation ----------------------------------
+
+// validateIndexedTransactionQuery validates a ListTransactions query whose
+// filter carries index-backed tx leaves. needed holds the canonical IndexIDs
+// the compiler must find READY. The legal outcomes per candidate base:
+//
+//   - a result set is legal iff the base holds every needed index (ambiguous or
+//     active) and the page is a legal window over the base's rows
+//     (txWindowMatches);
+//   - a not-ready rejection (FailedPrecondition) is legal iff some needed index
+//     is not active on the base (absent, ambiguous, or never built).
+//
+// Any other error code is a finding, as are rows without every needed index and
+// a rejection when every needed index is active on every base.
+func (c *Checker) validateIndexedTransactionQuery(maxTicket uint64, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, afterID uint64, pageSize int, reverse bool, serverTxs []*commonpb.Transaction, err error) {
+	errKind, ok := classifyIndexedQueryError(err)
+	if !ok {
+		assert.Unreachable("singleton_driver_model: indexed transaction query returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	if c.matchesModel(maxTicket, "TXQUERY-IDX", func(cand oracle.GlobalState) bool {
+		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed, errKind, func(ls oracle.LedgerState) bool {
+			return txWindowMatches(ls, filter, afterID, pageSize, reverse, serverTxs)
+		})
+	}) {
+		switch errKind {
+		case indexedErrNone:
+			assert.Reachable("singleton_driver_model: indexed transaction query served results", internal.Details{"ledger": ledger})
+		case indexedErrCompilation:
+			assert.Reachable("singleton_driver_model: kind-mismatched field query rejected on transactions", internal.Details{"ledger": ledger})
+		default:
+			assert.Reachable("singleton_driver_model: indexed transaction query gated", internal.Details{"ledger": ledger})
+		}
+
+		return
+	}
+
+	c.mu.Lock()
+	modelLS := c.modelState.Ledger(ledger)
+	idxStates := make([]string, 0, len(needed))
+	for canon := range needed {
+		idxStates = append(idxStates, canon+"="+indexStateLabelFull(modelLS, canon))
+	}
+	modelWindow := transactionWindow(modelLS, filter, afterID, pageSize, reverse)
+	c.mu.Unlock()
+
+	details := internal.Details{
+		"ledger":   ledger,
+		"filter":   describeFilter(filter),
+		"afterId":  afterID,
+		"pageSize": pageSize,
+		"reverse":  reverse,
+		"modelIdx": strings.Join(idxStates, " "),
+		"modelIds": joinUint64(modelWindow),
+		"bases": c.describeCandidateVerdicts(maxTicket, ledger, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed, func(ls oracle.LedgerState) []string {
+			ids := transactionWindow(ls, filter, afterID, pageSize, reverse)
+			out := make([]string, len(ids))
+			for i, id := range ids {
+				out[i] = strconv.FormatUint(id, 10)
+			}
+
+			return out
+		}),
+	}
+	if err == nil {
+		serverIds := make([]uint64, len(serverTxs))
+		for i, t := range serverTxs {
+			serverIds[i] = t.GetId()
+		}
+		details["rows"] = len(serverTxs)
+		details["serverIds"] = joinUint64(serverIds)
+	} else {
+		details["error"] = err.Error()
+	}
+
+	if err == nil {
+		inModel := map[uint64]bool{}
+		for _, id := range modelWindow {
+			inModel[id] = true
+		}
+
+		var surplus []string
+		for _, t := range serverTxs {
+			if id := t.GetId(); !inModel[id] {
+				surplus = append(surplus, strconv.FormatUint(id, 10)+"{"+c.modelTxMetaDump(ledger, id)+"}")
+			}
+		}
+
+		details["surplusModelMeta"] = strings.Join(surplus, " ; ")
+	}
+
+	assert.Unreachable("singleton_driver_model: indexed transaction query outside model", details)
+}
+
+// describeCandidateVerdicts re-enumerates a failed observation's candidate
+// bases and renders the DISTINCT verdicts (capped): the needed-index states,
+// each open retype window's type views, and the model window head under each
+// view — the context a finding needs to distinguish a server-side divergence
+// (no base explains the response) from an envelope gap (the explaining base
+// was never enumerated). Deduped on the rendered verdict, because enumeration
+// order front-loads near-identical bases and a first-N cap would hide the
+// interesting ones. Acquires c.mu.
+func (c *Checker) describeCandidateVerdicts(maxTicket uint64, ledger string, target commonpb.QueryTarget, filter *commonpb.QueryFilter, needed map[string]struct{}, window func(oracle.LedgerState) []string) string {
+	const maxDistinct = 8
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	tt := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		tt = commonpb.TargetType_TARGET_TYPE_TRANSACTION
+	}
+
+	head := func(w []string) string {
+		if len(w) > 6 {
+			w = append(w[:6:6], "…")
+		}
+
+		return strings.Join(w, ",")
+	}
+
+	var parts []string
+
+	seen := map[string]bool{}
+	n := 0
+	c.candidateBases(maxTicket, func(cand oracle.GlobalState) bool {
+		n++
+
+		ls := cand.Ledger(ledger)
+		idx := make([]string, 0, len(needed))
+		for canon := range needed {
+			idx = append(idx, canon+"="+indexStateLabelFull(ls, canon))
+		}
+		sort.Strings(idx)
+
+		views := []string{"w=" + head(window(ls))}
+		for _, r := range windowedFieldRefs(ls, target, filter) {
+			for _, ot := range r.types {
+				old := ls.WithDeclaredType(tt, r.key, ot)
+				views = append(views, fmt.Sprintf("w[%s@%d]=%s", r.key, ot, head(window(old))))
+			}
+		}
+
+		verdict := fmt.Sprintf("{%s|%s}", strings.Join(idx, " "), strings.Join(views, " "))
+		if !seen[verdict] && len(seen) < maxDistinct {
+			seen[verdict] = true
+			parts = append(parts, verdict)
+		}
+
+		return false
+	})
+
+	return fmt.Sprintf("%d bases, %d distinct: %s", n, len(parts), strings.Join(parts, " ; "))
+}
+
+// metadataCanonical is the canonical IndexID of the per-(target, key) metadata
+// index serving Field conditions on the given query target.
+func metadataCanonical(target commonpb.QueryTarget, key string) string {
+	tt := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		tt = commonpb.TargetType_TARGET_TYPE_TRANSACTION
+	}
+
+	return indexes.Canonical(indexes.MetadataID(tt, key))
+}
+
+// indexedQueryOutcomeLegal is the shared per-candidate verdict for a query
+// whose filter needs indexes. Per Field leaf the compiler checks
+// schema → requireIndexReady → kind coercion, but across a multi-leaf tree
+// the surfaced error follows the compiler's walk order, which the model does
+// not pin down. So:
+//
+//   - a FailedPrecondition (index not found / not ready) is legal iff some
+//     needed index is not active on the base;
+//   - a FILTER_COMPILATION rejection (InvalidArgument) is legal iff the filter
+//     carries a kind-mismatched Field leaf under the base's declared types —
+//     regardless of the other leaves' index states: when a mismatched leaf and
+//     an absent index coexist (e.g. or(field:absent, field:mismatched)),
+//     whichever leaf the walk reaches first decides which honest rejection
+//     surfaces, and both are legal;
+//   - results are legal iff there is no kind mismatch, every needed index
+//     exists, and the window matches (windowMatches).
+//
+// A retype of an indexed key opens a serving window (EN-1724): the schema
+// flips at commit, but each replica keeps serving the index under its current
+// version's bound type until that rewrite's atomic switch — and a CHAIN of
+// retypes walks the replica through every intermediate binding, so the window
+// accumulates a SET of possible serving types. A query during the window is
+// legal under the current declared type or any accumulated one — each as a
+// WHOLE window, since one query is served from one snapshot of one replica —
+// and the flip is per-index, so a filter touching several windowed keys may
+// see any combination. The verdict enumerates those assignments over the
+// existing single-view legality and accepts any.
+func indexedQueryOutcomeLegal(
+	ls oracle.LedgerState,
+	target commonpb.QueryTarget,
+	filter *commonpb.QueryFilter,
+	needed map[string]struct{},
+	errKind indexedErrKind,
+	windowMatches func(oracle.LedgerState) bool,
+) bool {
+	refs := windowedFieldRefs(ls, target, filter)
+
+	// While any referenced key's window is open, a switch may just have
+	// landed above the query's pin, in which case the server honestly
+	// refuses the read (pin below the promoted version's activation
+	// sequence) instead of serving it — the same not-ready class a building
+	// index produces.
+	if errKind == indexedErrNotReady && len(refs) > 0 {
+		return true
+	}
+
+	tt := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		tt = commonpb.TargetType_TARGET_TYPE_TRANSACTION
+	}
+
+	// Cross-product over the per-key choices: the current declared type
+	// (choice 0) or any type the window accumulated. Capped: a filter
+	// referencing this many windowed keys and chained types is beyond anything
+	// the generator produces; enumerating further would only burn the checker.
+	const maxViews = 256
+
+	views := 0
+
+	var enumerate func(view oracle.LedgerState, i int) bool
+	enumerate = func(view oracle.LedgerState, i int) bool {
+		if i == len(refs) {
+			views++
+
+			return indexedQueryOutcomeLegalUnder(view, target, filter, needed, errKind, windowMatches)
+		}
+
+		if enumerate(view, i+1) {
+			return true
+		}
+
+		for _, t := range refs[i].types {
+			if views >= maxViews {
+				return false
+			}
+
+			if enumerate(view.WithDeclaredType(tt, refs[i].key, t), i+1) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	return enumerate(ls, 0)
+}
+
+// windowedFieldRefs collects the filter's distinct metadata keys whose index
+// has an open retype window on this base, with the accumulated types each
+// window may still serve.
+func windowedFieldRefs(ls oracle.LedgerState, target commonpb.QueryTarget, f *commonpb.QueryFilter) []windowedRef {
+	seen := map[string]bool{}
+
+	var out []windowedRef
+
+	visitLeaves(f, func(leaf *commonpb.QueryFilter) {
+		x, ok := leaf.GetFilter().(*commonpb.QueryFilter_Field)
+		if !ok {
+			return
+		}
+
+		key := x.Field.GetField().GetMetadata()
+		if seen[key] {
+			return
+		}
+
+		seen[key] = true
+		if oldTypes, open := ls.RetypeWindow(metadataCanonical(target, key)); open {
+			out = append(out, windowedRef{key: key, types: oldTypes})
+		}
+	})
+
+	return out
+}
+
+type windowedRef struct {
+	key   string
+	types []commonpb.MetadataType
+}
+
+func indexedQueryOutcomeLegalUnder(
+	ls oracle.LedgerState,
+	target commonpb.QueryTarget,
+	filter *commonpb.QueryFilter,
+	needed map[string]struct{},
+	errKind indexedErrKind,
+	windowMatches func(oracle.LedgerState) bool,
+) bool {
+	switch errKind {
+	case indexedErrNotReady:
+		for canon := range needed {
+			if exists, active := ls.IndexState(canon); !exists || !active {
+				return true
+			}
+		}
+
+		return false
+	case indexedErrCompilation:
+		return fieldKindMismatch(ls, filter, target)
+	default: // results
+		if fieldKindMismatch(ls, filter, target) {
+			return false
+		}
+		for canon := range needed {
+			if exists, _ := ls.IndexState(canon); !exists {
+				return false
+			}
+		}
+
+		return windowMatches(ls)
+	}
+}
+
+// indexedErrKind classifies the observed outcome of an index-backed query.
+type indexedErrKind int
+
+const (
+	indexedErrNone indexedErrKind = iota
+	indexedErrNotReady
+	indexedErrCompilation
+)
+
+// classifyIndexedQueryError buckets err for indexedQueryOutcomeLegal; ok=false
+// means the code is not part of the indexed-query surface at all (a finding).
+func classifyIndexedQueryError(err error) (indexedErrKind, bool) {
+	switch {
+	case err == nil:
+		return indexedErrNone, true
+	case isIndexNotFound(err):
+		// ErrIndexNotFound: the filter needs an index no replica holds. The
+		// reason is required — an unrelated FailedPrecondition explained away
+		// as a missing index would hide a server regression.
+		return indexedErrNotReady, true
+	case isIndexNotReady(err):
+		// ErrIndexBuilding rides codes.Unavailable so SDK retry predicates
+		// retry it; the reason is what identifies it as the not-ready class.
+		return indexedErrNotReady, true
+	case status.Code(err) == codes.InvalidArgument && internal.HasErrorReason(err, "FILTER_COMPILATION_ERROR"):
+		return indexedErrCompilation, true
+	default:
+		return indexedErrNone, false
+	}
+}
+
+// validateIndexedAccountQuery is the accounts twin of
+// validateIndexedTransactionQuery: same needed-set lifecycle gating, with the
+// ordered account window (accountWindow + accountMatches) as the result check.
+func (c *Checker) validateIndexedAccountQuery(maxTicket uint64, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, cursor string, pageSize int, reverse bool, serverAccts []*commonpb.Account, err error) {
+	errKind, ok := classifyIndexedQueryError(err)
+	if !ok {
+		assert.Unreachable("singleton_driver_model: indexed account query returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	if c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
+		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed, errKind, func(ls oracle.LedgerState) bool {
+			want := accountWindow(ls, filter, cursor, pageSize, reverse)
+			if len(want) != len(serverAccts) {
+				return false
+			}
+
+			for i, addr := range want {
+				if serverAccts[i].GetAddress() != addr || !accountMatches(ls, addr, serverAccts[i]) {
+					return false
+				}
+			}
+
+			return true
+		})
+	}) {
+		switch errKind {
+		case indexedErrNone:
+			assert.Reachable("singleton_driver_model: indexed account query served results", internal.Details{"ledger": ledger})
+		case indexedErrCompilation:
+			assert.Reachable("singleton_driver_model: kind-mismatched field query rejected on accounts", internal.Details{"ledger": ledger})
+		default:
+			assert.Reachable("singleton_driver_model: indexed account query gated", internal.Details{"ledger": ledger})
+		}
+
+		return
+	}
+
+	c.mu.Lock()
+	modelLS := c.modelState.Ledger(ledger)
+	idxStates := make([]string, 0, len(needed))
+	for canon := range needed {
+		idxStates = append(idxStates, canon+"="+indexStateLabelFull(modelLS, canon))
+	}
+	modelWindow := accountWindow(modelLS, filter, cursor, pageSize, reverse)
+	c.mu.Unlock()
+
+	details := internal.Details{
+		"ledger":     ledger,
+		"filter":     describeFilter(filter),
+		"cursor":     cursor,
+		"pageSize":   pageSize,
+		"reverse":    reverse,
+		"modelIdx":   strings.Join(idxStates, " "),
+		"modelAddrs": strings.Join(modelWindow, ","),
+		"bases": c.describeCandidateVerdicts(maxTicket, ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed, func(ls oracle.LedgerState) []string {
+			return accountWindow(ls, filter, cursor, pageSize, reverse)
+		}),
+	}
+	if err == nil {
+		serverAddrs := make([]string, len(serverAccts))
+		for i, a := range serverAccts {
+			serverAddrs[i] = a.GetAddress()
+		}
+		details["rows"] = len(serverAccts)
+		details["serverAddrs"] = strings.Join(serverAddrs, ",")
+	} else {
+		details["error"] = err.Error()
+	}
+
+	if err == nil {
+		inModel := map[string]bool{}
+		for _, a := range modelWindow {
+			inModel[a] = true
+		}
+
+		var surplus []string
+		for _, a := range serverAccts {
+			if addr := a.GetAddress(); !inModel[addr] {
+				surplus = append(surplus, addr+"{"+c.modelAccountMetaDump(ledger, addr)+"}")
+			}
+		}
+
+		details["surplusModelMeta"] = strings.Join(surplus, " ; ")
+	}
+
+	assert.Unreachable("singleton_driver_model: indexed account query outside model", details)
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
@@ -283,7 +283,7 @@ func (c *Checker) validateAssetAccountQuery(maxTicket uint64, ledger string, fil
 	})
 
 	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter,
-		map[string]struct{}{assetIndexCanonical: {}}, matched && gotResults)
+		map[string]struct{}{assetIndexCanonical: {}}, matched && gotResults, len(serverAccts))
 
 	if matched {
 		if gotResults {
@@ -798,7 +798,7 @@ func (c *Checker) validateIndexedTransactionQuery(maxTicket uint64, ledger strin
 	})
 
 	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed,
-		matched && errKind == indexedErrNone)
+		matched && errKind == indexedErrNone, len(serverTxs))
 
 	if matched {
 		switch errKind {
@@ -1185,7 +1185,7 @@ func (c *Checker) validateIndexedAccountQuery(maxTicket uint64, ledger string, f
 	})
 
 	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed,
-		matched && errKind == indexedErrNone)
+		matched && errKind == indexedErrNone, len(serverAccts))
 
 	if matched {
 		switch errKind {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
@@ -255,7 +255,7 @@ func (c *Checker) validateAssetAccountQuery(maxTicket uint64, ledger string, fil
 
 	gotResults := err == nil
 
-	if c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
+	matched := c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
 		ls := cand.Ledger(ledger)
 		exists, active := ls.IndexState(assetIndexCanonical)
 
@@ -280,7 +280,12 @@ func (c *Checker) validateAssetAccountQuery(maxTicket uint64, ledger string, fil
 		}
 
 		return true
-	}) {
+	})
+
+	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter,
+		map[string]struct{}{assetIndexCanonical: {}}, matched && gotResults)
+
+	if matched {
 		if gotResults {
 			assert.Reachable("singleton_driver_model: asset-index account query served results", internal.Details{"ledger": ledger})
 		} else {
@@ -786,11 +791,16 @@ func (c *Checker) validateIndexedTransactionQuery(maxTicket uint64, ledger strin
 	}
 
 	rejectedIndex := rejectedIndexLabel(err)
-	if c.matchesModel(maxTicket, "TXQUERY-IDX", func(cand oracle.GlobalState) bool {
+	matched := c.matchesModel(maxTicket, "TXQUERY-IDX", func(cand oracle.GlobalState) bool {
 		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed, errKind, rejectedIndex, func(ls oracle.LedgerState) bool {
 			return txWindowMatches(ls, filter, afterID, pageSize, reverse, serverTxs)
 		})
-	}) {
+	})
+
+	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed,
+		matched && errKind == indexedErrNone)
+
+	if matched {
 		switch errKind {
 		case indexedErrNone:
 			assert.Reachable("singleton_driver_model: indexed transaction query served results", internal.Details{"ledger": ledger})
@@ -1157,7 +1167,7 @@ func (c *Checker) validateIndexedAccountQuery(maxTicket uint64, ledger string, f
 	}
 
 	rejectedIndex := rejectedIndexLabel(err)
-	if c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
+	matched := c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
 		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed, errKind, rejectedIndex, func(ls oracle.LedgerState) bool {
 			want := accountWindow(ls, filter, cursor, pageSize, reverse)
 			if len(want) != len(serverAccts) {
@@ -1172,7 +1182,12 @@ func (c *Checker) validateIndexedAccountQuery(maxTicket uint64, ledger string, f
 
 			return true
 		})
-	}) {
+	})
+
+	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed,
+		matched && errKind == indexedErrNone)
+
+	if matched {
 		switch errKind {
 		case indexedErrNone:
 			assert.Reachable("singleton_driver_model: indexed account query served results", internal.Details{"ledger": ledger})

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/antithesishq/antithesis-sdk-go/random"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -507,7 +508,10 @@ func rollIndexOp() bool {
 func generateIndexOp(g oracle.GlobalState, ledger string) *servicepb.Request {
 	if oneIn(16) {
 		return createIndexReq(ledger, indexes.MetadataID(
-			commonpb.TargetType_TARGET_TYPE_ACCOUNT, "undeclared-"+metaKey()))
+			random.RandomChoice([]commonpb.TargetType{
+				commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
+			}), "undeclared-"+metaKey()))
 	}
 
 	ls := g.Ledger(ledger)
@@ -781,8 +785,9 @@ func (c *Checker) validateIndexedTransactionQuery(maxTicket uint64, ledger strin
 		return
 	}
 
+	rejectedIndex := rejectedIndexLabel(err)
 	if c.matchesModel(maxTicket, "TXQUERY-IDX", func(cand oracle.GlobalState) bool {
-		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed, errKind, func(ls oracle.LedgerState) bool {
+		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter, needed, errKind, rejectedIndex, func(ls oracle.LedgerState) bool {
 			return txWindowMatches(ls, filter, afterID, pageSize, reverse, serverTxs)
 		})
 	}) {
@@ -916,6 +921,22 @@ func (c *Checker) describeCandidateVerdicts(maxTicket uint64, ledger string, tar
 	return fmt.Sprintf("%d bases, %d distinct: %s", n, len(parts), strings.Join(parts, " ; "))
 }
 
+// rejectedIndexLabel preserves the index identity carried by a documented
+// readiness refusal. The reason match prevents an unrelated detail from
+// granting the retype-window exception.
+func rejectedIndexLabel(err error) string {
+	if !isIndexNotFound(err) && !isIndexNotReady(err) {
+		return ""
+	}
+	for _, detail := range status.Convert(err).Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok &&
+			(info.GetReason() == "INDEX_NOT_FOUND" || info.GetReason() == "INDEX_BUILDING") {
+			return info.GetMetadata()["index"]
+		}
+	}
+	return ""
+}
+
 // metadataCanonical is the canonical IndexID of the per-(target, key) metadata
 // index serving Field conditions on the given query target.
 func metadataCanonical(target commonpb.QueryTarget, key string) string {
@@ -960,6 +981,7 @@ func indexedQueryOutcomeLegal(
 	filter *commonpb.QueryFilter,
 	needed map[string]struct{},
 	errKind indexedErrKind,
+	rejectedIndex string,
 	windowMatches func(oracle.LedgerState) bool,
 ) bool {
 	refs := windowedFieldRefs(ls, target, filter)
@@ -969,8 +991,16 @@ func indexedQueryOutcomeLegal(
 	// refuses the read (pin below the promoted version's activation
 	// sequence) instead of serving it — the same not-ready class a building
 	// index produces.
-	if errKind == indexedErrNotReady && len(refs) > 0 {
-		return true
+	// Attribute the refusal to the windowed index through the server's
+	// ErrorInfo metadata. A sibling index being active must still make its
+	// own refusal a finding, even when this filter also touches a retype.
+	if errKind == indexedErrNotReady {
+		targetName := commonpb.TargetHumanName(target)
+		for _, ref := range refs {
+			if rejectedIndex == fmt.Sprintf("metadata[%q] on %s", ref.key, targetName) {
+				return true
+			}
+		}
 	}
 
 	tt := commonpb.TargetType_TARGET_TYPE_ACCOUNT
@@ -1126,8 +1156,9 @@ func (c *Checker) validateIndexedAccountQuery(maxTicket uint64, ledger string, f
 		return
 	}
 
+	rejectedIndex := rejectedIndexLabel(err)
 	if c.matchesModel(maxTicket, "AQUERY-IDX", func(cand oracle.GlobalState) bool {
-		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed, errKind, func(ls oracle.LedgerState) bool {
+		return indexedQueryOutcomeLegal(cand.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter, needed, errKind, rejectedIndex, func(ls oracle.LedgerState) bool {
 			want := accountWindow(ls, filter, cursor, pageSize, reverse)
 			if len(want) != len(serverAccts) {
 				return false

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+func TestIndexNeeds(t *testing.T) {
+	t.Parallel()
+
+	assertNeeds := func(asset, other bool, gotAsset, gotOther bool) {
+		t.Helper()
+		require.Equal(t, asset, gotAsset, "asset need")
+		require.Equal(t, other, gotOther, "other need")
+	}
+
+	// nil / universe: no index.
+	a, o := indexNeeds(nil, accounts)
+	assertNeeds(false, false, a, o)
+
+	// has-asset → asset index only.
+	a, o = indexNeeds(filterHasAsset("USD", 2), accounts)
+	assertNeeds(true, false, a, o)
+
+	// metadata field → a non-asset index on either target.
+	a, o = indexNeeds(filterMetaExists("k"), accounts)
+	assertNeeds(false, true, a, o)
+	a, o = indexNeeds(filterMetaExists("k"), txns)
+	assertNeeds(false, true, a, o)
+
+	// index-free leaves.
+	a, o = indexNeeds(filterReverted(true), txns)
+	assertNeeds(false, false, a, o)
+	a, o = indexNeeds(filterTxIDRange(1, 5), txns)
+	assertNeeds(false, false, a, o)
+	a, o = indexNeeds(filterAddrPrefix("acc:"), accounts)
+	assertNeeds(false, false, a, o)
+
+	// address is index-backed (non-asset) on transactions.
+	a, o = indexNeeds(filterAddrPrefix("acc:"), txns)
+	assertNeeds(false, true, a, o)
+
+	// Combinators OR their children's needs.
+	a, o = indexNeeds(filterAnd(filterHasAsset("USD", 2), filterAddrPrefix("acc:")), accounts)
+	assertNeeds(true, false, a, o) // asset-only: the other operand is index-free
+	a, o = indexNeeds(filterAnd(filterHasAsset("USD", 2), filterMetaExists("k")), accounts)
+	assertNeeds(true, true, a, o) // needs both → not asset-only
+	a, o = indexNeeds(filterNot(filterHasAsset("USD", 2)), accounts)
+	assertNeeds(true, false, a, o)
+}
+
+func TestAccountHasAsset(t *testing.T) {
+	t.Parallel()
+
+	// world → acc:1 in USD/2 and world → acc:2 in COIN (precision 0).
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:1", "USD/2", 5),
+		oracletest.TxReq("world", "acc:2", "COIN", 5),
+	)
+
+	require.True(t, accountHasAsset(ls, "acc:1", "USD", 2))
+	require.False(t, accountHasAsset(ls, "acc:1", "USD", 4)) // precision must match
+	require.False(t, accountHasAsset(ls, "acc:1", "EUR", 2))
+	require.True(t, accountHasAsset(ls, "acc:2", "COIN", 0))
+	require.False(t, accountHasAsset(ls, "acc:2", "COIN", 2))
+	// A source is credited on the output side, so it holds the asset too.
+	require.True(t, accountHasAsset(ls, "world", "USD", 2))
+	require.True(t, accountHasAsset(ls, "world", "COIN", 0))
+	require.False(t, accountHasAsset(ls, "acc:absent", "USD", 2))
+}
+
+// TestGenAccountAssetFilterAssetOnly asserts every filter the asset generator
+// produces is a bare has-asset leaf that is asset-only (needs the account-by-asset
+// index and no other) and valid on the accounts target — the properties the
+// lifecycle path relies on.
+func TestGenAccountAssetFilterAssetOnly(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i < 500; i++ {
+		f := genAccountAssetFilter()
+		a, o := indexNeeds(f, accounts)
+		require.True(t, a, "must need the asset index: %s", describeFilter(f))
+		require.False(t, o, "must not need any other index: %s", describeFilter(f))
+		require.False(t, filterInvalidForTarget(f, accounts), "must be valid on accounts: %s", describeFilter(f))
+
+		_, _, ok := hasAssetTarget(f)
+		require.True(t, ok, "must be a bare has-asset leaf: %s", describeFilter(f))
+	}
+}
+
+// TestAssetWindow checks the ever-touched account set and the has-asset page
+// window: every account a USD/2 posting touched (both sides, including the
+// source world) appears, ordered by address, with the exclusive cursor and
+// reverse applied — and an account that only touched a different asset does not.
+func TestAssetWindow(t *testing.T) {
+	t.Parallel()
+
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:1", "USD/2", 5),
+		oracletest.TxReq("world", "acc:2", "USD/2", 5),
+		oracletest.TxReq("world", "acc:3", "EUR/2", 5),
+	)
+
+	// Ever-touched USD/2: acc:1, acc:2, world (source of both). acc:3 only EUR.
+	require.Equal(t, []string{"acc:1", "acc:2", "world"}, ls.EverAssetAccounts("USD", 2))
+	require.Equal(t, []string{"acc:3", "world"}, ls.EverAssetAccounts("EUR", 2))
+	require.Empty(t, ls.EverAssetAccounts("USD", 4)) // precision must match
+
+	// Full window, forward.
+	require.Equal(t, []string{"acc:1", "acc:2", "world"},
+		assetWindow(ls, "USD", 2, "", 10, false))
+
+	// pageSize cap.
+	require.Equal(t, []string{"acc:1", "acc:2"},
+		assetWindow(ls, "USD", 2, "", 2, false))
+
+	// Forward cursor is exclusive (drops <= cursor).
+	require.Equal(t, []string{"acc:2", "world"},
+		assetWindow(ls, "USD", 2, "acc:1", 10, false))
+
+	// Reverse order + exclusive cursor (drops >= cursor).
+	require.Equal(t, []string{"acc:2", "acc:1"},
+		assetWindow(ls, "USD", 2, "world", 10, true))
+}
+
+// A multi-leaf filter can carry both an absent needed index and a
+// kind-mismatched leaf; the surfaced rejection follows the compiler's walk
+// order, so both honest error classes must be legal — but never results, and
+// never a rejection class the filter cannot produce.
+func TestIndexedQueryOutcomeLegal_MismatchAndAbsentCoexist(t *testing.T) {
+	t.Parallel()
+
+	acct := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+
+	// k0 declared UINT64 with an active index; k3 never declared, no index.
+	gs := buildGlobal(t,
+		oracletest.SetFieldTypeReq(acct, "k0", commonpb.MetadataType_METADATA_TYPE_UINT64),
+		oracletest.CreateIndexReq(indexes.MetadataID(acct, "k0")),
+	)
+	gs.SetIndexActive("L", indexes.Canonical(indexes.MetadataID(acct, "k0")))
+	ls := gs.Ledger("L")
+
+	neg := int64(-5)
+	mismatched := filterFieldInt("k0", &neg, nil) // negative bound on unsigned: kind mismatch
+	absent := filterFieldExists("k3", false)
+
+	both := filterOr(mismatched, absent)
+	needed := map[string]struct{}{}
+	neededIndexCanonicals(both, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, needed)
+
+	noWindow := func(oracle.LedgerState) bool { return false }
+
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrCompilation, noWindow),
+		"the mismatched leaf makes a compilation rejection legal even with an absent sibling index")
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNotReady, noWindow),
+		"the absent index keeps a not-ready rejection legal too")
+	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNone, noWindow),
+		"results are never legal while a leaf mismatches")
+
+	// Mismatch alone (all needed indexes active): compilation legal, not-ready illegal.
+	alone := filterOr(mismatched, mismatched)
+	neededAlone := map[string]struct{}{}
+	neededIndexCanonicals(alone, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, neededAlone)
+
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrCompilation, noWindow))
+	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrNotReady, noWindow),
+		"with every needed index active, a not-ready rejection is unexplained")
+}
+
+// fakeStatusClient serves a canned GetIndexStatus response, standing in for one
+// node of PerNodeConns. Every other client method panics via the embedded nil
+// interface — the poller must not call anything else.
+type fakeStatusClient struct {
+	servicepb.BucketServiceClient
+	resp *servicepb.GetIndexStatusResponse
+}
+
+func (f fakeStatusClient) GetIndexStatus(context.Context, *servicepb.GetIndexStatusRequest, ...grpc.CallOption) (*servicepb.GetIndexStatusResponse, error) {
+	return f.resp, nil
+}
+
+// TestReconcileIndexes_IncarnationGuard pins the readiness poll's binding to
+// the sampled incarnation: a node's report counts toward promotion only once
+// its indexer has folded past the index's create frontier, and a verdict is
+// discarded when the frontier moved while the RPCs were in flight (a
+// drop+recreate reused the canonical). Without either gate, a report about a
+// dead incarnation promotes its still-building successor and manufactures a
+// false "rejected while active" finding.
+func TestReconcileIndexes_IncarnationGuard(t *testing.T) {
+	t.Parallel()
+
+	id := assetIndexID()
+	canon := assetIndexCanonical
+
+	newTracked := func(createSeq uint64) *Checker {
+		c := NewChecker([]string{"L"}, nil)
+		res := c.modelState.Apply(oracle.Bulk{Requests: []*servicepb.Request{oracletest.CreateIndexReq(id)}})
+		require.True(t, res.OK)
+		c.modelState = res.State
+		c.recordIndexCreates(
+			oracle.Bulk{Requests: []*servicepb.Request{oracletest.CreateIndexReq(id)}},
+			&servicepb.ApplyResponse{Logs: []*commonpb.Log{{Sequence: createSeq}}},
+		)
+
+		return c
+	}
+
+	statusConns := func(lastIndexed uint64, version uint32) internal.PerNodeConns {
+		return internal.PerNodeConns{{Bucket: fakeStatusClient{resp: &servicepb.GetIndexStatusResponse{
+			LastIndexedSequence: lastIndexed,
+			Indexes:             []*servicepb.IndexEntry{{Ledger: "L", Index: &commonpb.Index{Id: id}, CurrentVersion: version}},
+		}}}}
+	}
+
+	active := func(c *Checker) bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		_, a := c.modelState.Ledger("L").IndexState(canon)
+
+		return a
+	}
+
+	// Node folded past the create and serves the index live: promote.
+	c := newTracked(10)
+	reconcileIndexes(context.Background(), c, statusConns(12, 1))
+	require.True(t, active(c), "a report about this incarnation promotes")
+
+	// Node still folding toward the create: its live version describes the
+	// previous same-canonical incarnation and must not promote this one.
+	c = newTracked(10)
+	reconcileIndexes(context.Background(), c, statusConns(9, 1))
+	require.False(t, active(c), "a pre-create fold cursor must not promote")
+
+	// Frontier moved while the poll was in flight (drop+recreate): the
+	// all-ready verdict was gathered against frontier 10, the recreate moved
+	// it to 20 before the apply — the verdict belongs to the dead incarnation
+	// and is discarded. Drives the apply step directly, since the window sits
+	// between reconcileIndexes' own snapshot and its apply.
+	c = newTracked(10)
+	c.mu.Lock()
+	c.indexCreateSeq["L"][canon] = 20 // recreate committed mid-poll
+	c.applyIndexReadiness("L", map[string]uint64{canon: 10}, map[string]bool{canon: true})
+	c.mu.Unlock()
+	require.False(t, active(c), "a moved create frontier discards the verdict")
+}
+
+// TestIndexBuildingErrorReachesValidators pins the not-ready plumbing for
+// ErrIndexBuilding, which rides codes.Unavailable and therefore sits inside
+// internal.IsTransient: the query paths must peel it off the generic transient
+// bail (isIndexNotReady) and the classifier must bucket it as not-ready —
+// otherwise a server wrongly rejecting an active index is silently skipped and
+// the lifecycle coverage never fires.
+func TestIndexBuildingErrorReachesValidators(t *testing.T) {
+	t.Parallel()
+
+	st, err := status.New(codes.Unavailable, "index is building").WithDetails(&errdetails.ErrorInfo{
+		Domain: "ledger",
+		Reason: "INDEX_BUILDING",
+	})
+	require.NoError(t, err)
+
+	building := st.Err()
+
+	require.True(t, internal.IsTransient(building),
+		"the trap this test guards: INDEX_BUILDING is inside the transient set")
+	require.True(t, isIndexNotReady(building))
+
+	kind, ok := classifyIndexedQueryError(building)
+	require.True(t, ok)
+	require.Equal(t, indexedErrNotReady, kind)
+
+	// A plain Unavailable (node down) stays a skippable transient.
+	plain := status.Error(codes.Unavailable, "connection refused")
+	require.True(t, internal.IsTransient(plain))
+	require.False(t, isIndexNotReady(plain))
+}
+
+// TestIndexNotFoundMatchedByReason pins the reason requirement on the
+// index-absent rejection: a FailedPrecondition carrying an unrelated reason
+// (or none) must stay a finding, never be explained away as a missing index.
+func TestIndexNotFoundMatchedByReason(t *testing.T) {
+	t.Parallel()
+
+	st, err := status.New(codes.FailedPrecondition, "index not found").WithDetails(&errdetails.ErrorInfo{
+		Domain: "ledger",
+		Reason: "INDEX_NOT_FOUND",
+	})
+	require.NoError(t, err)
+
+	kind, ok := classifyIndexedQueryError(st.Err())
+	require.True(t, ok)
+	require.Equal(t, indexedErrNotReady, kind)
+	require.True(t, isIndexNotFound(st.Err()))
+
+	// Bare FailedPrecondition: not part of the indexed-query surface.
+	_, ok = classifyIndexedQueryError(status.Error(codes.FailedPrecondition, "boom"))
+	require.False(t, ok, "a reasonless precondition error must stay a finding")
+
+	// Unrelated reason on the same code: also a finding.
+	other, err := status.New(codes.FailedPrecondition, "transient account non-zero").WithDetails(&errdetails.ErrorInfo{
+		Domain: "ledger",
+		Reason: "TRANSIENT_ACCOUNT_NON_ZERO",
+	})
+	require.NoError(t, err)
+	_, ok = classifyIndexedQueryError(other.Err())
+	require.False(t, ok)
+	require.False(t, isIndexNotFound(other.Err()))
+}
+
+// TestIndexNotReadyRequiresDocumentedCode pins isIndexNotReady to the
+// documented wire shape: the INDEX_BUILDING reason on any other status code is
+// an API error-code regression and must surface as a finding, not be accepted
+// as the expected not-ready response.
+func TestIndexNotReadyRequiresDocumentedCode(t *testing.T) {
+	t.Parallel()
+
+	wrongCode, err := status.New(codes.FailedPrecondition, "index is building").WithDetails(&errdetails.ErrorInfo{
+		Domain: "ledger",
+		Reason: "INDEX_BUILDING",
+	})
+	require.NoError(t, err)
+
+	require.False(t, isIndexNotReady(wrongCode.Err()),
+		"INDEX_BUILDING on a non-Unavailable code is a regression, not a not-ready response")
+	require.False(t, isIndexNotFound(wrongCode.Err()))
+
+	_, ok := classifyIndexedQueryError(wrongCode.Err())
+	require.False(t, ok, "the wrong-code shape must stay a finding")
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/indexes_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -164,11 +166,11 @@ func TestIndexedQueryOutcomeLegal_MismatchAndAbsentCoexist(t *testing.T) {
 
 	noWindow := func(oracle.LedgerState) bool { return false }
 
-	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrCompilation, noWindow),
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrCompilation, "", noWindow),
 		"the mismatched leaf makes a compilation rejection legal even with an absent sibling index")
-	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNotReady, noWindow),
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNotReady, "", noWindow),
 		"the absent index keeps a not-ready rejection legal too")
-	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNone, noWindow),
+	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, both, needed, indexedErrNone, "", noWindow),
 		"results are never legal while a leaf mismatches")
 
 	// Mismatch alone (all needed indexes active): compilation legal, not-ready illegal.
@@ -176,8 +178,8 @@ func TestIndexedQueryOutcomeLegal_MismatchAndAbsentCoexist(t *testing.T) {
 	neededAlone := map[string]struct{}{}
 	neededIndexCanonicals(alone, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, neededAlone)
 
-	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrCompilation, noWindow))
-	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrNotReady, noWindow),
+	require.True(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrCompilation, "", noWindow))
+	require.False(t, indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, alone, neededAlone, indexedErrNotReady, "", noWindow),
 		"with every needed index active, a not-ready rejection is unexplained")
 }
 
@@ -340,4 +342,94 @@ func TestIndexNotReadyRequiresDocumentedCode(t *testing.T) {
 
 	_, ok := classifyIndexedQueryError(wrongCode.Err())
 	require.False(t, ok, "the wrong-code shape must stay a finding")
+}
+
+// An open window for one filter leaf cannot explain a refusal attributed to
+// its active sibling. Both codes carry the server's index identity, so keep
+// that identity through classification and candidate validation.
+func TestIndexedQueryOutcomeLegal_RetypeRefusalAttribution(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []struct {
+		name   string
+		typeID commonpb.TargetType
+		query  commonpb.QueryTarget
+	}{
+		{"accounts", commonpb.TargetType_TARGET_TYPE_ACCOUNT, accounts},
+		{"transactions", commonpb.TargetType_TARGET_TYPE_TRANSACTION, txns},
+	} {
+		t.Run(target.name, func(t *testing.T) {
+			t.Parallel()
+			gs := buildGlobal(t,
+				oracletest.SetFieldTypeReq(target.typeID, "changing", commonpb.MetadataType_METADATA_TYPE_STRING),
+				oracletest.CreateIndexReq(indexes.MetadataID(target.typeID, "changing")),
+				oracletest.SetFieldTypeReq(target.typeID, "sibling", commonpb.MetadataType_METADATA_TYPE_STRING),
+				oracletest.CreateIndexReq(indexes.MetadataID(target.typeID, "sibling")),
+				oracletest.SetFieldTypeReq(target.typeID, "changing", commonpb.MetadataType_METADATA_TYPE_INT64),
+			)
+			for _, key := range []string{"changing", "sibling"} {
+				gs.SetIndexActive("L", indexes.Canonical(indexes.MetadataID(target.typeID, key)))
+			}
+			filter := filterAnd(filterMetaExists("changing"), filterMetaExists("sibling"))
+			needed := map[string]struct{}{}
+			neededIndexCanonicals(filter, target.query, needed)
+			_, open := gs.Ledger("L").RetypeWindow(metadataCanonical(target.query, "changing"))
+			require.True(t, open, "the setup must actually exercise an open window")
+
+			for _, refusal := range []struct {
+				code   codes.Code
+				reason string
+			}{
+				{codes.Unavailable, "INDEX_BUILDING"},
+				{codes.FailedPrecondition, "INDEX_NOT_FOUND"},
+			} {
+				for _, key := range []string{"changing", "sibling", "unreferenced", ""} {
+					label := ""
+					if key != "" {
+						label = fmt.Sprintf("metadata[%q] on %s", key, target.name)
+					}
+					st, err := status.New(refusal.code, "index refusal").WithDetails(&errdetails.ErrorInfo{
+						Domain: "ledger", Reason: refusal.reason, Metadata: map[string]string{"index": label},
+					})
+					require.NoError(t, err)
+					errKind, ok := classifyIndexedQueryError(st.Err())
+					require.True(t, ok)
+					legal := indexedQueryOutcomeLegal(gs.Ledger("L"), target.query, filter, needed, errKind, rejectedIndexLabel(st.Err()), func(oracle.LedgerState) bool {
+						t.Fatal("a refusal must not use the result-window branch")
+						return false
+					})
+					require.Equal(t, key == "changing", legal, "%s attributed to %q", refusal.reason, label)
+				}
+			}
+			gs.CloseRetypeWindow("L", metadataCanonical(target.query, "changing"))
+			require.False(t, indexedQueryOutcomeLegal(gs.Ledger("L"), target.query, filter, needed, indexedErrNotReady,
+				fmt.Sprintf("metadata[%q] on %s", "changing", target.name), func(oracle.LedgerState) bool { return false }),
+				"once the window closes, its active index must serve results again")
+		})
+	}
+}
+
+// This probabilistic generator check exercises the actual probe selection,
+// following the existing generator tests. At 4096 rolls the expected count is
+// 128 for each target; an account-only generator deterministically fails.
+func TestGenerateIndexOp_UndeclaredFieldsOnBothTargets(t *testing.T) {
+	t.Parallel()
+
+	gs := oracle.NewGlobalState()
+	seen := map[commonpb.TargetType]bool{}
+	for range 4096 {
+		req := generateIndexOp(gs, "L")
+		field := req.GetCreateIndex().GetId().GetMetadata()
+		if field == nil || !strings.HasPrefix(field.GetKey(), "undeclared-") {
+			continue
+		}
+		seen[field.GetTarget()] = true
+		res := gs.Apply(oracle.Bulk{Requests: []*servicepb.Request{req}})
+		require.False(t, res.OK)
+		require.Equal(t, "METADATA_FIELD_NOT_IN_SCHEMA", res.Reason)
+	}
+	require.Equal(t, map[commonpb.TargetType]bool{
+		commonpb.TargetType_TARGET_TYPE_ACCOUNT:     true,
+		commonpb.TargetType_TARGET_TYPE_TRANSACTION: true,
+	}, seen)
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -142,10 +142,28 @@ func main() {
 		log.Printf("restore cycle enabled (interval ~%s)", restoreInterval())
 	}
 
-	// Workers stop on ctx.Done. Wait for the restore cycle too before closing the
-	// processor's channel, so no cycle touches the checker during teardown.
+	// Index readiness poller: reconciles each created index's active flag against
+	// per-replica CurrentVersion, so has-asset queries validate results once the
+	// index is live everywhere. Per-node conns are lazy, so dialing never fails on
+	// a down node; it is skipped only when no addresses resolve.
+	var pollers sync.WaitGroup
+	if conns, err := internal.DialPerNode(ctx); err != nil {
+		log.Printf("index readiness poller disabled: per-node dial failed: %s", err)
+	} else {
+		pollers.Add(1)
+		go func() {
+			defer pollers.Done()
+			defer conns.Close()
+			runIndexReadinessPoller(ctx, checker, conns, indexPollInterval)
+		}()
+	}
+
+	// Workers stop on ctx.Done. Wait for the restore cycle and poller too before
+	// closing the processor's channel, so nothing touches the checker during
+	// teardown.
 	workers.Wait()
 	restore.Wait()
+	pollers.Wait()
 	close(checker.incoming)
 	processors.Wait()
 }
@@ -171,11 +189,13 @@ func runWorker(
 
 		// 1-in-5: a read this iteration, split across the whole-ledger read
 		// (chart + ledger metadata), a single-account read, a transaction read
-		// (id + postings + reverted + metadata), and a metadata-schema read
-		// (declared field types). Reads validate against the in-flight bulk set,
-		// exercising cross-node freshness without needing quiescence.
+		// (id + postings + reverted + metadata), a metadata-schema read (declared
+		// field types), and the two list queries (filtered, paginated, ordered
+		// windows over accounts and transactions). Reads validate against the
+		// in-flight bulk set, exercising cross-node freshness without needing
+		// quiescence.
 		if random.RandomChoice([]uint8{0, 1, 2, 3, 4}) == 0 {
-			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5}) {
+			switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5, 6, 7}) {
 			case 0:
 				runLedgerRead(ctx, client, c)
 			case 1:
@@ -183,7 +203,13 @@ func runWorker(
 			case 2:
 				runSchemaRead(ctx, client, c)
 			case 3:
+				runAccountQuery(ctx, client, c)
+			case 4:
+				runTransactionQuery(ctx, client, c)
+			case 5:
 				runReplay(ctx, client, c)
+			case 6:
+				runLogQuery(ctx, client, c)
 			default:
 				runRead(ctx, client, c)
 			}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -111,6 +111,10 @@ func main() {
 
 	checker := NewChecker(names, schemas)
 
+	// Declared before the first query so an index the run never exercises shows
+	// up as an unsatisfied property rather than as no output at all.
+	registerCoverage()
+
 	// No seed type — workers fill the chart organically; early txs at
 	// untyped prefixes fail ACCOUNT_NOT_MATCHING_TYPE and validate fine.
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/metadata_filters.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/metadata_filters.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+// Metadata Field filters. The compiler serves a Field condition from the
+// per-(target, key) metadata index: the key must be DECLARED in the target's
+// schema (else index-not-found), the index must be READY, and the condition
+// kind must be compatible with the declared type (validateAndCoerceCondition —
+// else FILTER_COMPILATION_ERROR). The index holds each entity's CURRENT value
+// coerced to the declared type (CoerceToDeclaredType at write, replace
+// semantics, deletes remove rows), so evaluation coerces the stored value the
+// same way and compares under the condition kind.
+
+// --- constructors ----------------------------------------------------------
+
+func fieldRef(key string) *commonpb.FieldRef {
+	return &commonpb.FieldRef{Metadata: key}
+}
+
+func filterFieldString(key, value string) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field: fieldRef(key),
+		Condition: &commonpb.FieldCondition_StringCond{StringCond: &commonpb.StringCondition{
+			Value: &commonpb.StringCondition_Hardcoded{Hardcoded: value},
+		}},
+	}}}
+}
+
+// filterFieldInt matches key values in [lo, hi], both bounds inclusive; nil
+// leaves a side open.
+func filterFieldInt(key string, lo, hi *int64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field:     fieldRef(key),
+		Condition: &commonpb.FieldCondition_IntCond{IntCond: &commonpb.IntCondition{Min: lo, Max: hi}},
+	}}}
+}
+
+// filterFieldUint matches key values in [lo, hi], both bounds inclusive; nil
+// leaves a side open.
+func filterFieldUint(key string, lo, hi *uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field:     fieldRef(key),
+		Condition: &commonpb.FieldCondition_UintCond{UintCond: &commonpb.UintCondition{Min: lo, Max: hi}},
+	}}}
+}
+
+func filterFieldBool(key string, value bool) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field: fieldRef(key),
+		Condition: &commonpb.FieldCondition_BoolCond{BoolCond: &commonpb.BoolCondition{
+			Value: &commonpb.BoolCondition_Hardcoded{Hardcoded: value},
+		}},
+	}}}
+}
+
+func filterFieldExists(key string, includeNull bool) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field:     fieldRef(key),
+		Condition: &commonpb.FieldCondition_ExistsCond{ExistsCond: &commonpb.ExistsCondition{IncludeNull: includeNull}},
+	}}}
+}
+
+// --- evaluation ------------------------------------------------------------
+
+// matchFieldCondition evaluates a Field leaf against an entity's stored
+// metadata under the declared types. The index stores the value coerced to the
+// declared type, so the model coerces identically (the server's own
+// ConvertMetadataValue) before comparing. An undeclared key or a missing value
+// has no index row and never matches.
+func matchFieldCondition(declared oracle.Map[string, commonpb.MetadataType], lookup func(string) (*commonpb.MetadataValue, bool), fc *commonpb.FieldCondition) bool {
+	key := fc.GetField().GetMetadata()
+
+	declaredType, ok := declared.Get(key)
+	if !ok {
+		return false
+	}
+
+	stored, present := lookup(key)
+	if !present {
+		return false
+	}
+
+	coerced := stored
+	if !commonpb.TypeMatches(stored, declaredType) {
+		coerced = commonpb.ConvertMetadataValue(stored, declaredType)
+	}
+
+	switch c := fc.GetCondition().(type) {
+	case *commonpb.FieldCondition_ExistsCond:
+		if c.ExistsCond.GetIncludeNull() {
+			return true
+		}
+		_, isNull := coerced.GetType().(*commonpb.MetadataValue_NullValue)
+
+		return !isNull
+	case *commonpb.FieldCondition_StringCond:
+		sv, isStr := coerced.GetType().(*commonpb.MetadataValue_StringValue)
+
+		return isStr && sv.StringValue == c.StringCond.GetHardcoded()
+	case *commonpb.FieldCondition_BoolCond:
+		bv, isBool := coerced.GetType().(*commonpb.MetadataValue_BoolValue)
+
+		return isBool && bv.BoolValue == c.BoolCond.GetHardcoded()
+	case *commonpb.FieldCondition_IntCond:
+		// Datetime shares the order-preserving int64 index encoding, so an int
+		// range scans datetime rows too (validateAndCoerceCondition admits it).
+		// On an unsigned-declared field the compiler coerces the int bounds
+		// into a uint condition (coerceIntToUint), so a UintValue matches by
+		// the same numeric bounds; negative bounds never reach here — they are
+		// a compilation rejection (fieldKindMismatch).
+		switch t := coerced.GetType().(type) {
+		case *commonpb.MetadataValue_IntValue:
+			return matchIntBounds(c.IntCond, t.IntValue)
+		case *commonpb.MetadataValue_DatetimeValue:
+			return matchIntBounds(c.IntCond, t.DatetimeValue)
+		case *commonpb.MetadataValue_UintValue:
+			uc, ok := intCondAsUint(c.IntCond)
+
+			return ok && matchUintBounds(uc, t.UintValue)
+		default:
+			return false
+		}
+	case *commonpb.FieldCondition_UintCond:
+		uv, isUint := coerced.GetType().(*commonpb.MetadataValue_UintValue)
+
+		return isUint && matchUintBounds(c.UintCond, uv.UintValue)
+	default:
+		return false
+	}
+}
+
+// intCondAsUint mirrors the compiler's coerceIntToUint: the int bounds carried
+// into the unsigned domain, ok=false on a negative bound (the compiler rejects
+// those, so a match verdict is never reached).
+func intCondAsUint(cond *commonpb.IntCondition) (*commonpb.UintCondition, bool) {
+	uc := &commonpb.UintCondition{
+		MinExclusive: cond.GetMinExclusive(),
+		MaxExclusive: cond.GetMaxExclusive(),
+	}
+
+	if cond.Min != nil {
+		if cond.GetMin() < 0 {
+			return nil, false
+		}
+
+		v := uint64(cond.GetMin())
+		uc.Min = &v
+	}
+
+	if cond.Max != nil {
+		if cond.GetMax() < 0 {
+			return nil, false
+		}
+
+		v := uint64(cond.GetMax())
+		uc.Max = &v
+	}
+
+	return uc, true
+}
+
+// fieldKindMismatch reports whether f contains a Field leaf whose condition
+// kind is incompatible with the key's declared type — the shapes
+// validateAndCoerceCondition rejects with FILTER_COMPILATION_ERROR
+// (InvalidArgument). Undeclared keys are NOT mismatches: the compiler rejects
+// them earlier as index-not-found. The compiler only reaches the coercion
+// check after requireIndexReady, so a mismatch verdict competes with the
+// not-ready rejection — validateFieldMismatchProbe accepts either.
+func fieldKindMismatch(ls oracle.LedgerState, f *commonpb.QueryFilter, target commonpb.QueryTarget) bool {
+	return anyLeaf(f, func(leaf *commonpb.QueryFilter) bool {
+		x, ok := leaf.GetFilter().(*commonpb.QueryFilter_Field)
+		if !ok {
+			return false
+		}
+
+		declaredType, ok := declaredFieldTypes(ls, target).Get(x.Field.GetField().GetMetadata())
+		if !ok {
+			return false
+		}
+
+		switch cond := x.Field.GetCondition().(type) {
+		case *commonpb.FieldCondition_ExistsCond:
+			return false
+		case *commonpb.FieldCondition_IntCond:
+			// Signed and datetime verbatim; unsigned via coerceIntToUint,
+			// which rejects negative bounds.
+			if commonpb.IsSignedType(declaredType) || commonpb.IsDatetimeType(declaredType) {
+				return false
+			}
+
+			if commonpb.IsUnsignedType(declaredType) {
+				return (cond.IntCond.Min != nil && cond.IntCond.GetMin() < 0) ||
+					(cond.IntCond.Max != nil && cond.IntCond.GetMax() < 0)
+			}
+
+			return true
+		case *commonpb.FieldCondition_UintCond:
+			return !commonpb.IsUnsignedType(declaredType)
+		case *commonpb.FieldCondition_StringCond:
+			return declaredType != commonpb.MetadataType_METADATA_TYPE_STRING
+		case *commonpb.FieldCondition_BoolCond:
+			return declaredType != commonpb.MetadataType_METADATA_TYPE_BOOL
+		default:
+			return false
+		}
+	})
+}
+
+// declaredFieldTypes returns the declared-type map matching a query target.
+func declaredFieldTypes(ls oracle.LedgerState, target commonpb.QueryTarget) oracle.Map[string, commonpb.MetadataType] {
+	if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+		return ls.TransactionFieldTypes()
+	}
+
+	return ls.AccountFieldTypes()
+}
+
+// --- generation ------------------------------------------------------------
+
+// fieldSeed is one declared (key, type) with an optional committed value the
+// generator can aim a hit at.
+type fieldSeed struct {
+	key          string
+	declaredType commonpb.MetadataType
+	sample       *commonpb.MetadataValue
+}
+
+// sampleFieldSeeds snapshots the declared fields of the target plus one stored
+// value per key (coerced-comparable as-is; the generator coerces itself).
+// Caller holds c.mu (like the other committed-state samplers).
+func sampleFieldSeeds(ls oracle.LedgerState, target commonpb.QueryTarget) []fieldSeed {
+	var seeds []fieldSeed
+	for key, dt := range declaredFieldTypes(ls, target).All() {
+		seed := fieldSeed{key: key, declaredType: dt}
+
+		if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+			for _, rec := range ls.Txs().All() {
+				if v, ok := rec.Metadata()[key]; ok {
+					seed.sample = v
+
+					break
+				}
+			}
+		} else {
+			for mk, v := range ls.Metadata().All() {
+				if mk.Key == key {
+					seed.sample = v
+
+					break
+				}
+			}
+		}
+
+		seeds = append(seeds, seed)
+	}
+
+	return seeds
+}
+
+// genFieldLeaf rolls a kind-compatible Field leaf on a declared key, aiming
+// bounds/values at a committed sample when one exists so the filter actually
+// straddles live rows. One-in-eight it deliberately rolls a kind-MISMATCHED
+// leaf (the FILTER_COMPILATION_ERROR probe). Returns nil when the target has
+// no declared fields.
+func genFieldLeaf(seeds []fieldSeed) *commonpb.QueryFilter {
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	seed := seeds[internal.Rand().Intn(len(seeds))]
+
+	// Coerce the sample to the declared type — the value space the index holds.
+	var coerced *commonpb.MetadataValue
+	if seed.sample != nil {
+		coerced = seed.sample
+		if !commonpb.TypeMatches(coerced, seed.declaredType) {
+			coerced = commonpb.ConvertMetadataValue(coerced, seed.declaredType)
+		}
+	}
+
+	if oneIn(6) {
+		return filterFieldExists(seed.key, oneIn(2))
+	}
+
+	switch {
+	case seed.declaredType == commonpb.MetadataType_METADATA_TYPE_STRING:
+		if sv, ok := coerced.GetType().(*commonpb.MetadataValue_StringValue); ok && !oneIn(4) {
+			return filterFieldString(seed.key, sv.StringValue)
+		}
+
+		return filterFieldString(seed.key, "absent-value")
+	case seed.declaredType == commonpb.MetadataType_METADATA_TYPE_BOOL:
+		return filterFieldBool(seed.key, oneIn(2))
+	case commonpb.IsUnsignedType(seed.declaredType):
+		center := internal.Rand().Uint64() % 1024
+		if uv, ok := coerced.GetType().(*commonpb.MetadataValue_UintValue); ok && !oneIn(4) {
+			center = uv.UintValue
+		}
+
+		return filterFieldUint(seed.key, uintBound(center, true), uintBound(center, false))
+	default:
+		// Signed and datetime both take int bounds.
+		var center int64
+		switch t := coerced.GetType().(type) {
+		case *commonpb.MetadataValue_IntValue:
+			center = t.IntValue
+		case *commonpb.MetadataValue_DatetimeValue:
+			center = t.DatetimeValue
+		default:
+			center = internal.Rand().Int63n(1024)
+		}
+
+		return filterFieldInt(seed.key, intBound(center, true), intBound(center, false))
+	}
+}
+
+// genMismatchedFieldLeaf rolls a bare Field leaf whose condition kind the
+// declared type rejects — the FILTER_COMPILATION_ERROR probe. Emitted only at
+// the top level so the rejection attribution stays unambiguous. Returns nil
+// when the target declares no fields.
+func genMismatchedFieldLeaf(seeds []fieldSeed) *commonpb.QueryFilter {
+	if len(seeds) == 0 {
+		return nil
+	}
+
+	seed := seeds[internal.Rand().Intn(len(seeds))]
+
+	switch {
+	case seed.declaredType == commonpb.MetadataType_METADATA_TYPE_STRING:
+		return filterFieldBool(seed.key, true)
+	case seed.declaredType == commonpb.MetadataType_METADATA_TYPE_BOOL:
+		lo := int64(0)
+
+		return filterFieldInt(seed.key, &lo, nil)
+	case commonpb.IsUnsignedType(seed.declaredType):
+		return filterFieldString(seed.key, "x")
+	default:
+		return filterFieldString(seed.key, "x")
+	}
+}
+
+// intBound rolls an inclusive bound around center: lower ≤ center for lo,
+// ≥ center for hi, occasionally open (nil).
+func intBound(center int64, lo bool) *int64 {
+	if oneIn(4) {
+		return nil
+	}
+
+	delta := internal.Rand().Int63n(64)
+	v := center + delta
+	if lo {
+		v = center - delta
+	}
+
+	return &v
+}
+
+func uintBound(center uint64, lo bool) *uint64 {
+	if oneIn(4) {
+		return nil
+	}
+
+	delta := internal.Rand().Uint64() % 64
+	v := center + delta
+	if lo {
+		if delta > center {
+			delta = center
+		}
+		v = center - delta
+	}
+
+	return &v
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
@@ -172,3 +172,14 @@ func minLogSequence(logs []*commonpb.Log) uint64 {
 	}
 	return min
 }
+
+// Largest Log.Sequence in logs, or 0 if none.
+func maxLogSequence(logs []*commonpb.Log) uint64 {
+	var max uint64
+	for _, l := range logs {
+		if s := l.GetSequence(); s > max {
+			max = s
+		}
+	}
+	return max
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
@@ -585,6 +585,9 @@ func accountMatches(ls oracle.LedgerState, addr string, serverAcct *commonpb.Acc
 		}
 	}
 
+	// One entry per asset, per the list's contract. A repeat would collapse
+	// into this map and be counted once, so the exact comparison below would
+	// never see it.
 	server := map[string]struct{ in, out uint256.Int }{}
 	for _, av := range serverAcct.GetVolumes() {
 		// No generated posting carries a colour, so a coloured bucket is a row
@@ -599,6 +602,10 @@ func accountMatches(ls oracle.LedgerState, addr string, serverAcct *commonpb.Acc
 			return false
 		}
 		if err := out.SetFromDecimal(av.GetVolumes().GetOutput()); err != nil {
+			return false
+		}
+
+		if _, dup := server[av.GetAsset()]; dup {
 			return false
 		}
 
@@ -687,7 +694,8 @@ func txRecordMatches(rec txRecordView, serverTx *commonpb.Transaction) bool {
 
 // pcvSnapshotMatches compares a served post-commit snapshot against the
 // model's cell for cell, in both directions: an absent cell and a fabricated
-// one are equally wrong. A coloured entry fails outright — no generated
+// one are equally wrong, and so is a repeated one — only the first copy of a
+// cell is ever read, so a duplicate would hide whatever the second carries. A coloured entry fails outright — no generated
 // posting carries a colour, so the model's colourless key addresses every cell
 // the run can produce.
 func pcvSnapshotMatches(model map[oracle.VolumeKey]oracle.VolumePair, server *commonpb.PostCommitVolumes) bool {
@@ -699,7 +707,12 @@ func pcvSnapshotMatches(model map[oracle.VolumeKey]oracle.VolumePair, server *co
 				return false
 			}
 
-			served[oracle.VolumeKey{Address: account, Asset: entry.GetAsset()}] = struct{}{}
+			key := oracle.VolumeKey{Address: account, Asset: entry.GetAsset()}
+			if _, dup := served[key]; dup {
+				return false
+			}
+
+			served[key] = struct{}{}
 		}
 	}
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
@@ -53,8 +53,8 @@ func queryPageSize() int {
 }
 
 // runAccountQuery issues a linearizable ListAccounts and checks the streamed
-// page against the model's ordered window (see validateAccountQuery). One-in-six
-// queries carry an index-backed filter to exercise the NotFound rejection path.
+// page against the model's ordered window (see validateAccountQuery). Filters
+// cover indexed and index-free reads plus missing-index and invalid-kind probes.
 func runAccountQuery(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	ledger := random.RandomChoice(c.ledgerNames)
 	filter := genAccountFilter(c.sampleAccountFieldSeeds(ledger))
@@ -166,7 +166,7 @@ func (c *Checker) sampleAccountFieldSeeds(ledger string) []fieldSeed {
 
 // runTransactionQuery issues a linearizable ListTransactions and checks the
 // streamed page against the model's ordered window (see validateTransactionQuery).
-// One-in-six queries carry an index-backed filter to exercise the NotFound path.
+// Filters cover indexed and index-free reads plus missing-index and invalid-kind probes.
 func runTransactionQuery(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
 	ledger := random.RandomChoice(c.ledgerNames)
 	filter := genTransactionFilter(c.sampleTxFilterSeeds(ledger))
@@ -691,13 +691,11 @@ func oneIn(n int) bool {
 	return random.RandomChoice(choices) == 0
 }
 
-// genAccountFilter rolls a query filter for ListAccounts. One-in-six is an
-// index-backed metadata condition the driver never creates (the gated / NotFound
-// path); one-in-six is an account-by-asset filter whose outcome the index
-// lifecycle governs (see genAccountAssetFilter); ~1-in-16 is a transactions-only
-// condition invalid on this target (the InvalidArgument path); then one-in-four
-// is the no-filter universe (a nil top-level filter); the rest are index-free
-// address filters and boolean compositions.
+// genAccountFilter rolls a query filter for ListAccounts. The sequential rolls
+// try an undeclared-field probe (1/8), a kind-mismatch probe (1/12), has-asset
+// (1/6), a target-invalid condition (1/16), then the no-filter universe (1/4).
+// These odds are conditional on earlier rolls missing. The remaining choices
+// mix declared metadata filters with address leaves or use index-free filters.
 func genAccountFilter(seeds []fieldSeed) *commonpb.QueryFilter {
 	switch {
 	case oneIn(8):
@@ -806,12 +804,11 @@ func (c *Checker) sampleTxFilterSeeds(ledger string) txFilterSeeds {
 	return seeds
 }
 
-// genTransactionFilter rolls a query filter for ListTransactions. One-in-six is
-// an index-backed metadata condition (a never-built index — the NotFound path);
-// ~1-in-16 is an accounts-only condition invalid on this target (the
-// InvalidArgument path); then one-in-four is the no-filter universe; the rest
-// split between the index-backed tx-builtin grammar (reference / date leaves,
-// freely composed with index-free ones) and the pure index-free grammar.
+// genTransactionFilter rolls a query filter for ListTransactions. Sequential
+// rolls try an undeclared-field probe (1/8), a kind-mismatch probe (1/12), a
+// target-invalid condition (1/16), then the no-filter universe (1/4). These
+// odds are conditional on earlier rolls missing. The remaining choices split
+// between indexed metadata/tx-builtin filters and the index-free grammar.
 func genTransactionFilter(seeds txFilterSeeds) *commonpb.QueryFilter {
 	switch {
 	case oneIn(8):

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
@@ -587,8 +587,11 @@ func accountMatches(ls oracle.LedgerState, addr string, serverAcct *commonpb.Acc
 
 	server := map[string]struct{ in, out uint256.Int }{}
 	for _, av := range serverAcct.GetVolumes() {
+		// No generated posting carries a colour, so a coloured bucket is a row
+		// nothing in this run could have produced. Dropping it here would let a
+		// fabricated one through untouched.
 		if av.GetColor() != "" {
-			continue
+			return false
 		}
 
 		var in, out uint256.Int
@@ -684,15 +687,16 @@ func txRecordMatches(rec txRecordView, serverTx *commonpb.Transaction) bool {
 
 // pcvSnapshotMatches compares a served post-commit snapshot against the
 // model's cell for cell, in both directions: an absent cell and a fabricated
-// one are equally wrong. A coloured entry is a cell the model's volume key
-// cannot address, so the whole snapshot is left uncompared for that row.
+// one are equally wrong. A coloured entry fails outright — no generated
+// posting carries a colour, so the model's colourless key addresses every cell
+// the run can produce.
 func pcvSnapshotMatches(model map[oracle.VolumeKey]oracle.VolumePair, server *commonpb.PostCommitVolumes) bool {
 	served := map[oracle.VolumeKey]struct{}{}
 
 	for account, byAssets := range server.GetVolumesByAccount() {
 		for _, entry := range byAssets.GetVolumes() {
 			if entry.GetColor() != "" {
-				return true
+				return false
 			}
 
 			served[oracle.VolumeKey{Address: account, Asset: entry.GetAsset()}] = struct{}{}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
@@ -1,0 +1,1498 @@
+package main
+
+import (
+	"context"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/antithesishq/antithesis-sdk-go/random"
+	"github.com/holiman/uint256"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+// Query reads exercise ListAccounts / ListTransactions — the filtered,
+// paginated, ordered read surface. A list page is a deterministic ordered
+// window: given the filter, the sort order, the cursor, the page size, and the
+// reverse flag, exactly one slice of the matching entities is correct. The
+// model reproduces that slice over a candidate base and checks the streamed
+// page element-for-element, so both membership and order are validated.
+//
+// Ordering (server): accounts by address bytes, transactions by id, ascending;
+// reverse flips it. The cursor is exclusive in both directions — forward drops
+// keys <= cursor, reverse drops keys >= cursor (PaginateForward / listDescFiltered).
+//
+// Index gating: the server's filter compiler serves most conditions from a
+// created index and rejects the query when the index is absent or not yet
+// ready. The generator churns the full index lifecycle (indexes.go), so every
+// index-backed filter routes through the per-filter needed-set validation
+// (neededIndexCanonicals + validateIndexedAccountQuery /
+// validateIndexedTransactionQuery): results require every needed index and an
+// exact window, a not-ready rejection is legal only while some needed index is
+// not active, and a kind-mismatched Field leaf must be rejected as a
+// compilation error. The index-free conditions — universe,
+// address-on-accounts, reverted, the tx-id builtin, and boolean compositions
+// of these — always return the window the model computes.
+
+// queryPageSize is the page size a query read requests. Kept well under
+// MaxPageSize (1000) so the server never clamps it — the model uses the same
+// value to size its window, and a clamp would desync the two.
+func queryPageSize() int {
+	return int(random.RandomChoice([]uint8{1, 2, 3, 5, 10, 50}))
+}
+
+// runAccountQuery issues a linearizable ListAccounts and checks the streamed
+// page against the model's ordered window (see validateAccountQuery). One-in-six
+// queries carry an index-backed filter to exercise the NotFound rejection path.
+func runAccountQuery(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	ledger := random.RandomChoice(c.ledgerNames)
+	filter := genAccountFilter(c.sampleAccountFieldSeeds(ledger))
+	needed := map[string]struct{}{}
+	neededIndexCanonicals(filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, needed)
+	_, _, bareAsset := hasAssetTarget(filter)
+	invalidTarget := filterInvalidForTarget(filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+	pageSize := queryPageSize()
+	reverse := random.RandomChoice([]uint8{0, 1}) == 1
+
+	var cursor string
+	if random.RandomChoice([]uint8{0, 1}) == 0 {
+		cursor = poolAddress()
+	}
+
+	c.mu.Lock()
+	readID := c.registerRead()
+	c.mu.Unlock()
+	defer c.finishRead(readID)
+
+	// A linearizable read is served from a main-store snapshot at a fixed Raft
+	// horizon at or past every bulk whose response this driver has observed;
+	// when the filter consults an index, the read projection is certified up
+	// to that horizon too (EN-1946). The snapshot therefore holds at least
+	// every state the drain gate may fold into modelState while the read is
+	// in flight, and the ordered window stays representable by a candidate
+	// base.
+	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
+	stream, err := client.ListAccounts(readCtx, &servicepb.ListAccountsRequest{
+		Ledger: ledger,
+		Options: &commonpb.ListOptions{
+			PageSize: uint32(pageSize),
+			Cursor:   cursor,
+			Reverse:  reverse,
+			Filter:   filter,
+		},
+	})
+
+	var accounts []*commonpb.Account
+	if err == nil {
+		accounts, err = drainStream(stream)
+	}
+
+	// High-water at the read's completion: only bulks dispatched by now could be
+	// reflected in the page. Captured before validation so later dispatches
+	// aren't folded into this read's candidate states.
+	maxTicket := c.ticketSeq.Load()
+
+	if err != nil {
+		if (internal.IsTransient(err) && !isIndexNotReady(err)) || isShutdownError(err) {
+			return
+		}
+		if handleInvalidTargetError(invalidTarget, "account", ledger, filter, err) {
+			return
+		}
+		if bareAsset {
+			// The account-by-asset index governs this filter's outcome; a not-ready
+			// error is legal while the index is absent or ambiguous.
+			c.validateAssetAccountQuery(maxTicket, ledger, filter, cursor, pageSize, reverse, nil, err)
+			return
+		}
+		if len(needed) > 0 {
+			c.validateIndexedAccountQuery(maxTicket, ledger, filter, needed, cursor, pageSize, reverse, nil, err)
+			return
+		}
+
+		assert.Unreachable("singleton_driver_model: ListAccounts returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	if invalidTarget {
+		// The filter carries a condition invalid on this target; the server must
+		// reject it, not stream rows.
+		assert.Unreachable("singleton_driver_model: target-invalid account query returned results", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"rows":   len(accounts),
+		})
+
+		return
+	}
+
+	if bareAsset {
+		c.validateAssetAccountQuery(maxTicket, ledger, filter, cursor, pageSize, reverse, accounts, nil)
+		return
+	}
+
+	if len(needed) > 0 {
+		c.validateIndexedAccountQuery(maxTicket, ledger, filter, needed, cursor, pageSize, reverse, accounts, nil)
+		return
+	}
+
+	c.validateAccountQuery(maxTicket, ledger, filter, cursor, pageSize, reverse, accounts)
+}
+
+// sampleAccountFieldSeeds snapshots the ledger's declared account fields plus
+// value samples for the filter generator. Acquires c.mu.
+func (c *Checker) sampleAccountFieldSeeds(ledger string) []fieldSeed {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return sampleFieldSeeds(c.modelState.Ledger(ledger), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
+}
+
+// runTransactionQuery issues a linearizable ListTransactions and checks the
+// streamed page against the model's ordered window (see validateTransactionQuery).
+// One-in-six queries carry an index-backed filter to exercise the NotFound path.
+func runTransactionQuery(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	ledger := random.RandomChoice(c.ledgerNames)
+	filter := genTransactionFilter(c.sampleTxFilterSeeds(ledger))
+	needed := map[string]struct{}{}
+	neededIndexCanonicals(filter, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, needed)
+	invalidTarget := filterInvalidForTarget(filter, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+	pageSize := queryPageSize()
+	reverse := random.RandomChoice([]uint8{0, 1}) == 1
+
+	var (
+		cursor  string
+		afterID uint64
+	)
+	if random.RandomChoice([]uint8{0, 1}) == 0 {
+		afterID = 1 + internal.Rand().Uint64()%256
+		cursor = strconv.FormatUint(afterID, 10)
+	}
+
+	c.mu.Lock()
+	readID := c.registerRead()
+	c.mu.Unlock()
+	defer c.finishRead(readID)
+
+	// A linearizable read is served from a main-store snapshot at a fixed Raft
+	// horizon at or past every bulk whose response this driver has observed;
+	// when the filter consults an index, the read projection is certified up
+	// to that horizon too (EN-1946). The snapshot therefore holds at least
+	// every state the drain gate may fold into modelState while the read is
+	// in flight, and the ordered window stays representable by a candidate
+	// base.
+	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
+	stream, err := client.ListTransactions(readCtx, &servicepb.ListTransactionsRequest{
+		Ledger: ledger,
+		Options: &commonpb.ListOptions{
+			PageSize: uint32(pageSize),
+			Cursor:   cursor,
+			Reverse:  reverse,
+			Filter:   filter,
+		},
+	})
+
+	var txs []*commonpb.Transaction
+	if err == nil {
+		txs, err = drainStream(stream)
+	}
+
+	maxTicket := c.ticketSeq.Load()
+
+	if err != nil {
+		if (internal.IsTransient(err) && !isIndexNotReady(err)) || isShutdownError(err) {
+			return
+		}
+		if handleInvalidTargetError(invalidTarget, "transaction", ledger, filter, err) {
+			return
+		}
+		if len(needed) > 0 {
+			c.validateIndexedTransactionQuery(maxTicket, ledger, filter, needed, afterID, pageSize, reverse, nil, err)
+			return
+		}
+
+		assert.Unreachable("singleton_driver_model: ListTransactions returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	if invalidTarget {
+		assert.Unreachable("singleton_driver_model: target-invalid transaction query returned results", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"rows":   len(txs),
+		})
+
+		return
+	}
+
+	if len(needed) > 0 {
+		c.validateIndexedTransactionQuery(maxTicket, ledger, filter, needed, afterID, pageSize, reverse, txs, nil)
+		return
+	}
+
+	c.validateTransactionQuery(maxTicket, ledger, filter, afterID, pageSize, reverse, txs)
+}
+
+// handleInvalidTargetError validates the error of a filter carrying a condition
+// invalid on its target (e.g. reverted on accounts, account-has-asset on
+// transactions). The server's rejectInvalidCondition runs before index checks,
+// so this must be consulted before handleIndexGatedError; the expected outcome
+// is InvalidArgument. Returns true when it has fully handled err.
+func handleInvalidTargetError(invalidTarget bool, kind, ledger string, filter *commonpb.QueryFilter, err error) bool {
+	if !invalidTarget {
+		return false
+	}
+
+	if status.Code(err) == codes.InvalidArgument {
+		// Coverage: the per-target validity rejection is actually exercised.
+		// One literal per target — Antithesis catalogues assertions by literal,
+		// and the two targets have disjoint invalid-condition sets.
+		switch kind {
+		case "account":
+			assert.Reachable("singleton_driver_model: target-invalid query rejected on accounts", internal.Details{"ledger": ledger})
+		default:
+			assert.Reachable("singleton_driver_model: target-invalid query rejected on transactions", internal.Details{"ledger": ledger})
+		}
+
+		return true
+	}
+
+	assert.Unreachable("singleton_driver_model: target-invalid query returned unexpected error", internal.Details{
+		"kind":   kind,
+		"ledger": ledger,
+		"filter": describeFilter(filter),
+		"error":  err.Error(),
+	})
+
+	return true
+}
+
+// drainStream reads a server stream to exhaustion, returning every item in
+// stream order. io.EOF is clean end-of-stream; any other error (a compile
+// rejection surfaces on the first Recv) is returned alongside what was read.
+func drainStream[T any](stream grpc.ServerStreamingClient[T]) ([]*T, error) {
+	var out []*T
+	for {
+		item, err := stream.Recv()
+		if err == io.EOF {
+			return out, nil
+		}
+		if err != nil {
+			return out, err
+		}
+
+		out = append(out, item)
+	}
+}
+
+// validateAccountQuery checks a ListAccounts page against the model: legal iff
+// some candidate base's ordered window — filtered, sorted, cursor-skipped,
+// page-capped — equals the streamed accounts position-for-position, each row's
+// address AND its whole volumes/metadata snapshot matching on that same base.
+func (c *Checker) validateAccountQuery(maxTicket uint64, ledger string, filter *commonpb.QueryFilter, cursor string, pageSize int, reverse bool, serverAccts []*commonpb.Account) {
+	if c.matchesModel(maxTicket, "AQUERY", func(base oracle.GlobalState) bool {
+		ls := base.Ledger(ledger)
+		want := accountWindow(ls, filter, cursor, pageSize, reverse)
+		if len(want) != len(serverAccts) {
+			return false
+		}
+
+		for i, addr := range want {
+			if serverAccts[i].GetAddress() != addr || !accountMatches(ls, addr, serverAccts[i]) {
+				return false
+			}
+		}
+
+		return true
+	}) {
+		return
+	}
+
+	serverAddrs := make([]string, len(serverAccts))
+	for i, a := range serverAccts {
+		serverAddrs[i] = a.GetAddress()
+	}
+
+	assert.Unreachable("singleton_driver_model: account query outside model", internal.Details{
+		"ledger":      ledger,
+		"filter":      describeFilter(filter),
+		"cursor":      cursor,
+		"pageSize":    pageSize,
+		"reverse":     reverse,
+		"rows":        len(serverAccts),
+		"serverAddrs": strings.Join(serverAddrs, ","),
+		"modelAddrs":  strings.Join(c.modelAccountWindow(ledger, filter, cursor, pageSize, reverse), ","),
+	})
+}
+
+// modelAccountWindow returns the account window on the committed modelState — the
+// base with no in-flight bulks folded — for a finding's diagnostics. Acquires c.mu.
+func (c *Checker) modelAccountWindow(ledger string, filter *commonpb.QueryFilter, cursor string, pageSize int, reverse bool) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return accountWindow(c.modelState.Ledger(ledger), filter, cursor, pageSize, reverse)
+}
+
+// validateTransactionQuery checks a ListTransactions page against the model:
+// legal iff some candidate base's ordered window equals the streamed
+// transactions position-for-position, each row matching the model record at its
+// id (see txRecordMatches) on that same base.
+func (c *Checker) validateTransactionQuery(maxTicket uint64, ledger string, filter *commonpb.QueryFilter, afterID uint64, pageSize int, reverse bool, serverTxs []*commonpb.Transaction) {
+	if c.matchesModel(maxTicket, "TXQUERY", func(base oracle.GlobalState) bool {
+		return txWindowMatches(base.Ledger(ledger), filter, afterID, pageSize, reverse, serverTxs)
+	}) {
+		return
+	}
+
+	serverIds := make([]uint64, len(serverTxs))
+	for i, t := range serverTxs {
+		serverIds[i] = t.GetId()
+	}
+
+	assert.Unreachable("singleton_driver_model: transaction query outside model", internal.Details{
+		"ledger":    ledger,
+		"filter":    describeFilter(filter),
+		"afterId":   afterID,
+		"pageSize":  pageSize,
+		"reverse":   reverse,
+		"rows":      len(serverTxs),
+		"serverIds": joinUint64(serverIds),
+		"modelIds":  joinUint64(c.modelTransactionWindow(ledger, filter, afterID, pageSize, reverse)),
+	})
+}
+
+// modelTransactionWindow returns the transaction window on the committed
+// modelState — the base with no in-flight bulks folded — for a finding's
+// diagnostics. Acquires c.mu.
+func (c *Checker) modelTransactionWindow(ledger string, filter *commonpb.QueryFilter, afterID uint64, pageSize int, reverse bool) []uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return transactionWindow(c.modelState.Ledger(ledger), filter, afterID, pageSize, reverse)
+}
+
+// accountWindow is the model's prediction of a ListAccounts page: the ledger's
+// accounts matching filter, in address order (reversed when reverse), with the
+// exclusive cursor applied and capped at pageSize. Because the list is sorted,
+// dropping every key past the cursor equals the server's contiguous prefix skip.
+func accountWindow(ls oracle.LedgerState, filter *commonpb.QueryFilter, cursor string, pageSize int, reverse bool) []string {
+	var window []string
+	for _, addr := range accountUniverse(ls) {
+		if matchAccountFilter(ls, filter, addr) {
+			window = append(window, addr)
+		}
+	}
+
+	if reverse {
+		reverseStrings(window)
+	}
+
+	if cursor != "" {
+		kept := window[:0]
+		for _, addr := range window {
+			if reverse && addr >= cursor || !reverse && addr <= cursor {
+				continue
+			}
+
+			kept = append(kept, addr)
+		}
+		window = kept
+	}
+
+	if len(window) > pageSize {
+		window = window[:pageSize]
+	}
+
+	return window
+}
+
+// transactionWindow is the required-row window — the ids a page must show when
+// every filter verdict is known — capped at pageSize. Used for a finding's
+// diagnostics; validation goes through txWindowMatches, which also handles
+// optional rows.
+func transactionWindow(ls oracle.LedgerState, filter *commonpb.QueryFilter, afterID uint64, pageSize int, reverse bool) []uint64 {
+	var window []uint64
+	for _, row := range transactionWindowRows(ls, filter, afterID, reverse) {
+		if row.required {
+			window = append(window, row.id)
+		}
+	}
+
+	if len(window) > pageSize {
+		window = window[:pageSize]
+	}
+
+	return window
+}
+
+// txWindowRow is one ordered candidate row of a predicted transaction page:
+// required rows must appear in the server page, optional ones (a filter verdict
+// hinging on a not-yet-learned server stamp) may.
+type txWindowRow struct {
+	id       uint64
+	required bool
+}
+
+// transactionWindowRows is the ordered, cursor-filtered, UNTRUNCATED row
+// sequence a ListTransactions page draws from. Truncation is the matcher's job
+// (txWindowMatches) — optional rows may or may not consume page slots, so a
+// fixed prefix cut would be wrong.
+//
+// The transactions endpoint INVERTS the API reverse flag (controller
+// ListTransactionsFrom passes reverse=!reverse to listEntities): reverse=false
+// yields newest-first (descending id), reverse=true yields oldest-first
+// (ascending). This is the opposite of accounts, which follow reverse literally.
+// Descending pages drop ids >= afterID (older-than cursor); ascending pages drop
+// ids <= afterID (newer-than cursor) — mirroring PaginateReverse / PaginateForward.
+func transactionWindowRows(ls oracle.LedgerState, filter *commonpb.QueryFilter, afterID uint64, reverse bool) []txWindowRow {
+	descending := !reverse
+
+	var rows []txWindowRow
+	for _, rec := range ls.Txs().All() {
+		match, known := matchTxFilter(ls, filter, rec)
+		if known && !match {
+			continue
+		}
+
+		rows = append(rows, txWindowRow{id: rec.Id(), required: known})
+	}
+
+	if descending {
+		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+			rows[i], rows[j] = rows[j], rows[i]
+		}
+	}
+
+	if afterID != 0 {
+		kept := rows[:0]
+		for _, row := range rows {
+			if descending && row.id >= afterID || !descending && row.id <= afterID {
+				continue
+			}
+
+			kept = append(kept, row)
+		}
+		rows = kept
+	}
+
+	return rows
+}
+
+// txWindowMatches reports whether the server page is exactly a legal window
+// over the candidate's row sequence: required rows appear in order (each
+// content-matching its model record), optional rows may, nothing else does, and
+// a required row may only be missing past a full (truncated) page.
+func txWindowMatches(ls oracle.LedgerState, filter *commonpb.QueryFilter, afterID uint64, pageSize int, reverse bool, serverTxs []*commonpb.Transaction) bool {
+	if len(serverTxs) > pageSize {
+		return false
+	}
+
+	txs := ls.Txs()
+	j := 0
+
+	for _, row := range transactionWindowRows(ls, filter, afterID, reverse) {
+		if j == len(serverTxs) {
+			if len(serverTxs) == pageSize {
+				return true // full page — the remaining rows were truncated
+			}
+			if row.required {
+				return false // page had room, yet a required row is missing
+			}
+
+			continue
+		}
+
+		if serverTxs[j].GetId() == row.id {
+			if !txRecordMatches(txs.Get(int(row.id-1)), serverTxs[j]) {
+				return false
+			}
+			j++
+		} else if row.required {
+			return false
+		}
+	}
+
+	return j == len(serverTxs)
+}
+
+// accountUniverse returns ls's account addresses — every address carrying a
+// volume cell or a metadata entry — in ascending byte order, matching the
+// server's merged V+M attribute scan (readstore.NewPebbleAccountIterator).
+func accountUniverse(ls oracle.LedgerState) []string {
+	seen := map[string]struct{}{}
+	for k := range ls.Volumes().All() {
+		seen[k.Address] = struct{}{}
+	}
+	for k := range ls.Metadata().All() {
+		seen[k.Address] = struct{}{}
+	}
+
+	out := make([]string, 0, len(seen))
+	for addr := range seen {
+		out = append(out, addr)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+// accountMatches reports whether the server account is exactly what the model
+// holds for addr: the same uncolored volume cells (per asset, input and output)
+// and the same metadata. The workload only exercises uncolored postings, so
+// colored buckets are out of scope. metadataMatches is shared with the single
+// GetAccount read.
+func accountMatches(ls oracle.LedgerState, addr string, serverAcct *commonpb.Account) bool {
+	if !metadataMatches(ls, addr, serverAcct.GetMetadata()) {
+		return false
+	}
+
+	model := map[string]oracle.VolumePair{}
+	for k, vp := range ls.Volumes().All() {
+		if k.Address == addr {
+			model[k.Asset] = vp
+		}
+	}
+
+	server := map[string]struct{ in, out uint256.Int }{}
+	for _, av := range serverAcct.GetVolumes() {
+		if av.GetColor() != "" {
+			continue
+		}
+
+		var in, out uint256.Int
+		if err := in.SetFromDecimal(av.GetVolumes().GetInput()); err != nil {
+			return false
+		}
+		if err := out.SetFromDecimal(av.GetVolumes().GetOutput()); err != nil {
+			return false
+		}
+
+		server[av.GetAsset()] = struct{ in, out uint256.Int }{in, out}
+	}
+
+	if len(model) != len(server) {
+		return false
+	}
+
+	for asset, vp := range model {
+		sv, ok := server[asset]
+		if !ok || vp.Input.Cmp(&sv.in) != 0 || vp.Output.Cmp(&sv.out) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// txRecordView is the subset of oracle's (unexported) transaction record that
+// the query and single-read validators compare against. Declaring the interface
+// here lets both share txRecordMatches without oracle exporting the concrete type.
+type txRecordView interface {
+	Id() uint64
+	Reference() string
+	Postings() []*commonpb.Posting
+	Metadata() map[string]*commonpb.MetadataValue
+	Reverted() bool
+	Timestamp() *commonpb.Timestamp
+	InsertedAt() *commonpb.Timestamp
+	RevertedBy() uint64
+	RevertedAt() *commonpb.Timestamp
+	RevertsTransaction() uint64
+	IndexedAddrs() map[string]uint8
+}
+
+// txRecordMatches reports whether the model record rec is consistent with the
+// server transaction: same id, reference, revert relationships, postings, and
+// metadata. Timestamps follow the model's nil-means-server-dated convention — a
+// nil model timestamp is unpredictable, so it is not checked; inserted_at and
+// reverted_at are the same, and only a reverted record may carry the latter at
+// all.
+func txRecordMatches(rec txRecordView, serverTx *commonpb.Transaction) bool {
+	tsOK := rec.Timestamp() == nil || rec.Timestamp().GetData() == serverTx.GetTimestamp().GetData()
+
+	// inserted_at follows the same convention: server-assigned, so it is
+	// checked only once learned — and once learned it also drives inserted_at
+	// filter evaluation, so a row serving a different value must not pass.
+	insOK := rec.InsertedAt() == nil || rec.InsertedAt().GetData() == serverTx.GetInsertedAt().GetData()
+
+	var raOK bool
+	switch {
+	case rec.RevertedAt() != nil:
+		raOK = serverTx.GetRevertedAt() != nil && rec.RevertedAt().GetData() == serverTx.GetRevertedAt().GetData()
+	case rec.Reverted():
+		raOK = true
+	default:
+		raOK = serverTx.GetRevertedAt() == nil
+	}
+
+	return rec.Id() == serverTx.GetId() &&
+		rec.Reference() == serverTx.GetReference() &&
+		rec.Reverted() == serverTx.GetReverted() &&
+		rec.RevertedBy() == serverTx.GetRevertedByTransaction() &&
+		rec.RevertsTransaction() == serverTx.GetRevertsTransaction() &&
+		tsOK && insOK && raOK &&
+		postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
+		metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
+}
+
+// --- Filter generation --------------------------------------------------
+
+// maxQueryGenDepth bounds generated boolean nesting. It must stay well under
+// domain.MaxFilterDepth (100), the depth the compiler rejects.
+const maxQueryGenDepth = 3
+
+// isIndexNotReady matches the server's index-building rejection. The reason
+// rides codes.Unavailable (SDK retry predicates retry it), which puts it
+// inside internal.IsTransient — so the generic transient bail must peel it
+// off first: an index the model holds active answering INDEX_BUILDING is the
+// exact finding the lifecycle coverage exists to catch, not a skippable blip.
+func isIndexNotReady(err error) bool {
+	return status.Code(err) == codes.Unavailable && internal.HasErrorReason(err, "INDEX_BUILDING")
+}
+
+// isIndexNotFound matches the server's index-absent rejection by its reason,
+// not by the bare FailedPrecondition code — an unrelated precondition error
+// must stay a finding instead of being explained away as a missing index.
+func isIndexNotFound(err error) bool {
+	return status.Code(err) == codes.FailedPrecondition && internal.HasErrorReason(err, "INDEX_NOT_FOUND")
+}
+
+// oneIn reports a 1-in-n chance through the Antithesis chooser, so the platform
+// can steer toward the (rare) branch it gates. n must be in [1, 256].
+func oneIn(n int) bool {
+	choices := make([]uint8, n)
+	for i := range choices {
+		choices[i] = uint8(i)
+	}
+
+	return random.RandomChoice(choices) == 0
+}
+
+// genAccountFilter rolls a query filter for ListAccounts. One-in-six is an
+// index-backed metadata condition the driver never creates (the gated / NotFound
+// path); one-in-six is an account-by-asset filter whose outcome the index
+// lifecycle governs (see genAccountAssetFilter); ~1-in-16 is a transactions-only
+// condition invalid on this target (the InvalidArgument path); then one-in-four
+// is the no-filter universe (a nil top-level filter); the rest are index-free
+// address filters and boolean compositions.
+func genAccountFilter(seeds []fieldSeed) *commonpb.QueryFilter {
+	switch {
+	case oneIn(8):
+		// A Field leaf on an UNDECLARED key: the index-not-found probe.
+		return filterMetaExists("undeclared-" + metaKey())
+	case oneIn(12):
+		// A bare kind-mismatched Field leaf: the FILTER_COMPILATION probe.
+		if f := genMismatchedFieldLeaf(seeds); f != nil {
+			return f
+		}
+
+		return filterMetaExists(metaKey())
+	case oneIn(6):
+		return genAccountAssetFilter()
+	case oneIn(16):
+		// Target-invalid probe: a transactions-only condition, rejected on accounts.
+		if random.RandomChoice([]uint8{0, 1}) == 0 {
+			return filterReverted(true)
+		}
+
+		return filterTxIDRange(0, 255)
+	case oneIn(4):
+		return nil // top-level universe (no filter)
+	case random.RandomChoice([]uint8{0, 1}) == 0:
+		return genAccountFilterIndexed(seeds, 0)
+	default:
+		return genAccountFilterFree(0)
+	}
+}
+
+// genAccountFilterIndexed rolls an accounts filter mixing metadata Field
+// leaves (on declared keys) with the index-free address leaves. Field results
+// select from the same current V+M universe address leaves scan — an account
+// carrying metadata always has an attributes row — so booleans compose without
+// the ever-touched-universe caveat that keeps has-asset bare.
+func genAccountFilterIndexed(seeds []fieldSeed, depth int) *commonpb.QueryFilter {
+	if depth >= maxQueryGenDepth || random.RandomChoice([]uint8{0, 1}) == 0 {
+		if f := genFieldLeaf(seeds); f != nil && random.RandomChoice([]uint8{0, 1, 2}) != 0 {
+			return f
+		}
+
+		return genAccountFilterFree(depth)
+	}
+
+	return genBoolean(depth, func(d int) *commonpb.QueryFilter { return genAccountFilterIndexed(seeds, d) })
+}
+
+// genAccountFilterFree rolls a non-nil index-free accounts filter: an address
+// prefix/exact leaf, or a boolean composition of the same. It never returns nil
+// — universe is expressible only as the absent top-level filter (a nil child in
+// a repeated And/Or field marshals as an empty condition the compiler rejects).
+func genAccountFilterFree(depth int) *commonpb.QueryFilter {
+	if depth >= maxQueryGenDepth || random.RandomChoice([]uint8{0, 1}) == 0 {
+		if random.RandomChoice([]uint8{0, 1}) == 0 {
+			return filterAddrPrefix(poolName() + ":")
+		}
+
+		return filterAddrExact(poolAddress())
+	}
+
+	return genBoolean(depth, genAccountFilterFree)
+}
+
+// txFilterSeeds carries committed-state samples the transaction filter
+// generator aims at, so index-backed leaves hit live data instead of always
+// missing: committed references and learned date stamps. Sampled under the
+// checker's lock (sampleTxFilterSeeds) — the generator itself runs outside it.
+type txFilterSeeds struct {
+	refs   []string
+	stamps []uint64
+	fields []fieldSeed
+}
+
+// sampleTxFilterSeeds snapshots up to a handful of committed references and
+// known date stamps of the ledger. Acquires c.mu.
+func (c *Checker) sampleTxFilterSeeds(ledger string) txFilterSeeds {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var seeds txFilterSeeds
+
+	ls := c.modelState.Ledger(ledger)
+	for ref := range ls.TxByRef().All() {
+		seeds.refs = append(seeds.refs, ref)
+		if len(seeds.refs) == 4 {
+			break
+		}
+	}
+
+	txs := ls.Txs()
+	for range 4 {
+		if txs.Len() == 0 {
+			break
+		}
+
+		rec := txs.Get(internal.Rand().Intn(txs.Len()))
+		for _, ts := range []*commonpb.Timestamp{rec.Timestamp(), rec.InsertedAt(), rec.RevertedAt()} {
+			if ts != nil {
+				seeds.stamps = append(seeds.stamps, ts.GetData())
+			}
+		}
+	}
+
+	seeds.fields = sampleFieldSeeds(ls, commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS)
+
+	return seeds
+}
+
+// genTransactionFilter rolls a query filter for ListTransactions. One-in-six is
+// an index-backed metadata condition (a never-built index — the NotFound path);
+// ~1-in-16 is an accounts-only condition invalid on this target (the
+// InvalidArgument path); then one-in-four is the no-filter universe; the rest
+// split between the index-backed tx-builtin grammar (reference / date leaves,
+// freely composed with index-free ones) and the pure index-free grammar.
+func genTransactionFilter(seeds txFilterSeeds) *commonpb.QueryFilter {
+	switch {
+	case oneIn(8):
+		// A Field leaf on an UNDECLARED key: the index-not-found probe.
+		return filterMetaExists("undeclared-" + metaKey())
+	case oneIn(12):
+		// A bare kind-mismatched Field leaf: the FILTER_COMPILATION probe.
+		if f := genMismatchedFieldLeaf(seeds.fields); f != nil {
+			return f
+		}
+
+		return filterMetaExists(metaKey())
+	case oneIn(16):
+		// Target-invalid probe: an accounts-only condition, rejected on transactions.
+		return filterHasAsset("USD", 2)
+	case random.RandomChoice([]uint8{0, 1, 2, 3}) == 0:
+		return nil // top-level universe (no filter)
+	case random.RandomChoice([]uint8{0, 1}) == 0:
+		return genTransactionFilterIndexed(seeds, 0)
+	default:
+		return genTransactionFilterFree(0)
+	}
+}
+
+// genTransactionFilterIndexed rolls a transactions filter whose leaves include
+// the index-backed tx builtins — reference and the three date fields — mixed
+// with the index-free leaves. Unlike has-asset on accounts, every tx leaf
+// selects from the same transaction-log universe, so composition needs no
+// special casing: the window evaluator handles any boolean of these.
+func genTransactionFilterIndexed(seeds txFilterSeeds, depth int) *commonpb.QueryFilter {
+	if depth >= maxQueryGenDepth || random.RandomChoice([]uint8{0, 1}) == 0 {
+		switch random.RandomChoice([]uint8{0, 1, 2, 3, 4, 5}) {
+		case 0:
+			return filterReference(seedReference(seeds))
+		case 1, 2:
+			return genDateLeaf(seeds)
+		case 3:
+			return genTxAddressLeaf()
+		case 4:
+			if f := genFieldLeaf(seeds.fields); f != nil {
+				return f
+			}
+
+			return genTransactionFilterFree(depth)
+		default:
+			return genTransactionFilterFree(depth)
+		}
+	}
+
+	return genBoolean(depth, func(d int) *commonpb.QueryFilter { return genTransactionFilterIndexed(seeds, d) })
+}
+
+// genTxAddressLeaf rolls an address leaf for the transactions target: a pool
+// address (exact or cut to a prefix), or an unmatchable prefix, under a random
+// role. Pool addresses re-target heavily, so exact and prefix variants both
+// straddle live account→tx rows.
+func genTxAddressLeaf() *commonpb.QueryFilter {
+	roles := []commonpb.AddressRole{
+		commonpb.AddressRole_ADDRESS_ROLE_ANY,
+		commonpb.AddressRole_ADDRESS_ROLE_SOURCE,
+		commonpb.AddressRole_ADDRESS_ROLE_DESTINATION,
+	}
+	role := roles[int(random.RandomChoice([]uint8{0, 1, 2}))]
+
+	addr := poolAddress()
+	switch random.RandomChoice([]uint8{0, 1, 2, 3}) {
+	case 0:
+		return filterAddrExactRole(addr, role)
+	case 1:
+		return filterAddrExactRole("world", role)
+	case 2:
+		// The "t-N:" one-type prefix; ":"-terminated so it cannot over-match.
+		return filterAddrPrefixRole(addr[:strings.IndexByte(addr, ':')+1], role)
+	default:
+		if oneIn(8) {
+			return filterAddrPrefixRole("absent:", role)
+		}
+
+		return filterAddrPrefixRole("t-", role)
+	}
+}
+
+// seedReference picks a committed reference most of the time, a miss otherwise
+// (an unknown reference, or the empty string — never indexed, matches nothing).
+func seedReference(seeds txFilterSeeds) string {
+	switch {
+	case len(seeds.refs) > 0 && !oneIn(4):
+		return seeds.refs[internal.Rand().Intn(len(seeds.refs))]
+	case oneIn(8):
+		return ""
+	default:
+		return "t-ref:absent"
+	}
+}
+
+// genDateLeaf rolls a range condition on one of the three date builtins,
+// bounded by committed stamps so it actually straddles live records: two seed
+// stamps as [min, max] (single-sided or exclusive variants occasionally), or
+// unconstrained bounds when the ledger has no known stamps yet.
+func genDateLeaf(seeds txFilterSeeds) *commonpb.QueryFilter {
+	fields := []commonpb.TransactionBuiltinIndex{
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT,
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT,
+	}
+	field := fields[int(random.RandomChoice([]uint8{0, 1, 2}))]
+
+	pick := func() uint64 {
+		if len(seeds.stamps) == 0 {
+			return internal.Rand().Uint64() % 1024
+		}
+
+		return seeds.stamps[internal.Rand().Intn(len(seeds.stamps))]
+	}
+
+	a, b := pick(), pick()
+	if a > b {
+		a, b = b, a
+	}
+
+	f := filterDateRange(field, a, b)
+	cond := f.GetBuiltinUint().GetCond()
+	if oneIn(4) {
+		cond.Min = nil
+	} else {
+		cond.MinExclusive = oneIn(4)
+	}
+	if oneIn(4) {
+		cond.Max = nil
+	} else {
+		cond.MaxExclusive = oneIn(4)
+	}
+
+	return f
+}
+
+// genTransactionFilterFree rolls a non-nil index-free transactions filter: a
+// reverted or tx-id-range leaf, or a boolean composition of the same. Like the
+// accounts variant it never returns nil.
+func genTransactionFilterFree(depth int) *commonpb.QueryFilter {
+	if depth >= maxQueryGenDepth || random.RandomChoice([]uint8{0, 1}) == 0 {
+		switch random.RandomChoice([]uint8{0, 1, 2}) {
+		case 0:
+			return filterReverted(true)
+		case 1:
+			return filterReverted(false)
+		default:
+			lo := internal.Rand().Uint64() % 256
+			return filterTxIDRange(lo, lo+internal.Rand().Uint64()%256)
+		}
+	}
+
+	return genBoolean(depth, genTransactionFilterFree)
+}
+
+// genBoolean wraps two (And/Or) or one (Not) recursively-generated children in a
+// boolean combinator. gen never returns nil, so no combinator carries a nil
+// child (which would marshal as an empty condition the compiler rejects).
+func genBoolean(depth int, gen func(int) *commonpb.QueryFilter) *commonpb.QueryFilter {
+	switch random.RandomChoice([]uint8{0, 1, 2}) {
+	case 0:
+		return filterAnd(gen(depth+1), gen(depth+1))
+	case 1:
+		return filterOr(gen(depth+1), gen(depth+1))
+	default:
+		return filterNot(gen(depth + 1))
+	}
+}
+
+// --- Filter constructors ------------------------------------------------
+
+func filterAddrPrefix(prefix string) *commonpb.QueryFilter {
+	return filterAddrPrefixRole(prefix, commonpb.AddressRole_ADDRESS_ROLE_ANY)
+}
+
+func filterAddrPrefixRole(prefix string, role commonpb.AddressRole) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Address{Address: &commonpb.AddressMatch{
+		Match: &commonpb.AddressMatch_HardcodedPrefix{HardcodedPrefix: prefix},
+		Role:  role,
+	}}}
+}
+
+func filterAddrExact(addr string) *commonpb.QueryFilter {
+	return filterAddrExactRole(addr, commonpb.AddressRole_ADDRESS_ROLE_ANY)
+}
+
+func filterAddrExactRole(addr string, role commonpb.AddressRole) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Address{Address: &commonpb.AddressMatch{
+		Match: &commonpb.AddressMatch_HardcodedExact{HardcodedExact: addr},
+		Role:  role,
+	}}}
+}
+
+func filterReference(value string) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Reference{Reference: &commonpb.ReferenceCondition{
+		Cond: &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: value}},
+	}}}
+}
+
+func filterReverted(value bool) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Reverted{
+		Reverted: &commonpb.RevertedCondition{Value: value},
+	}}
+}
+
+// filterTxIDRange matches transactions with lo <= id <= hi. Both bounds are
+// inclusive (no exclusive flags), mirroring resolveUintBounds' [min, max+1).
+func filterTxIDRange(lo, hi uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{BuiltinUint: &commonpb.BuiltinUintCondition{
+		Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID,
+		Cond:  &commonpb.UintCondition{Min: &lo, Max: &hi},
+	}}}
+}
+
+// filterDateRange matches transactions whose `field` date lies in [lo, hi],
+// both bounds inclusive (like filterTxIDRange).
+func filterDateRange(field commonpb.TransactionBuiltinIndex, lo, hi uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{BuiltinUint: &commonpb.BuiltinUintCondition{
+		Field: field,
+		Cond:  &commonpb.UintCondition{Min: &lo, Max: &hi},
+	}}}
+}
+
+func filterAnd(children ...*commonpb.QueryFilter) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: children}}}
+}
+
+func filterOr(children ...*commonpb.QueryFilter) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: children}}}
+}
+
+func filterNot(child *commonpb.QueryFilter) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{Filter: child}}}
+}
+
+// filterMetaExists matches entities that carry metadata key — an existence
+// condition, index-backed on both targets. On a declared, indexed key it is a
+// result-returning filter; on an undeclared key it is the index-not-found
+// probe.
+func filterMetaExists(key string) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{
+		Field:     &commonpb.FieldRef{Metadata: key},
+		Condition: &commonpb.FieldCondition_ExistsCond{ExistsCond: &commonpb.ExistsCondition{}},
+	}}}
+}
+
+// filterHasAsset matches accounts holding (assetBase, precision). Valid only on
+// the ACCOUNTS target, so on transactions it is the target-invalid probe
+// (rejected with InvalidArgument before any index check). The values are
+// immaterial — rejection happens on target validity, before evaluation.
+func filterHasAsset(assetBase string, precision uint32) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_AccountHasAsset{
+		AccountHasAsset: &commonpb.AccountHasAssetCondition{AssetBase: assetBase, Precision: precision},
+	}}
+}
+
+// --- Filter evaluation --------------------------------------------------
+
+// filterNeedsIndex reports whether f contains any condition the server's
+// compiler serves from a created index (query.Compile → requireIndexReady): the
+// account-by-asset builtin, or any other index-backed leaf (metadata Field,
+// Reference, timestamp builtins, address-on-transactions). The index-free
+// conditions are universe (nil), address on accounts, reverted, and the tx-id
+// builtin. See indexNeeds for the asset/other split the account-query lifecycle
+// path keys on.
+func filterNeedsIndex(f *commonpb.QueryFilter, target commonpb.QueryTarget) bool {
+	asset, other := indexNeeds(f, target)
+
+	return asset || other
+}
+
+// neededIndexCanonicals collects the canonical ids of every index the filter
+// needs on target — the builtin transaction indexes, the account-by-asset index,
+// per-(target, key) metadata indexes — plus a sentinel for any index-backed
+// leaf whose index the workload never creates. The sentinel is never in the
+// model's index set, so those filters always predict rejection. The set drives
+// the per-index lifecycle validation (validateIndexedTransactionQuery /
+// validateIndexedAccountQuery); empty means the filter is index-free and
+// validates exactly. Target-invalid leaves classify like their home target —
+// callers consult filterInvalidForTarget first, mirroring the compiler's
+// check order.
+func neededIndexCanonicals(f *commonpb.QueryFilter, target commonpb.QueryTarget, out map[string]struct{}) {
+	visitLeaves(f, func(leaf *commonpb.QueryFilter) {
+		switch x := leaf.GetFilter().(type) {
+		case nil:
+			// No condition, no index.
+		case *commonpb.QueryFilter_Field:
+			out[metadataCanonical(target, x.Field.GetField().GetMetadata())] = struct{}{}
+		case *commonpb.QueryFilter_AccountHasAsset:
+			out[assetIndexCanonical] = struct{}{}
+		case *commonpb.QueryFilter_Reference:
+			out[txBuiltinCanonical(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)] = struct{}{}
+		case *commonpb.QueryFilter_Address:
+			// Index-free on accounts (existence scan); the account→tx mapping
+			// index on transactions.
+			if target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS {
+				out[txBuiltinCanonical(addressRoleBuiltin(x.Address.GetRole()))] = struct{}{}
+			}
+		case *commonpb.QueryFilter_BuiltinUint:
+			if x.BuiltinUint.GetField() != commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID {
+				out[txBuiltinCanonical(x.BuiltinUint.GetField())] = struct{}{}
+			}
+		case *commonpb.QueryFilter_Reverted:
+			// index-free
+		default:
+			// Log conditions and future leaves: index-backed, never built here.
+			out[neverBuiltIndexCanonical] = struct{}{}
+		}
+	})
+}
+
+// neverBuiltIndexCanonical is the sentinel canonical for index-backed leaves
+// the workload never builds an index for. It never appears in the model's index
+// set, so IndexState reports it absent — a rejection is always legal, results
+// never are.
+const neverBuiltIndexCanonical = "workload:never-built"
+
+// indexNeeds classifies f's index requirements into two buckets: `asset` is set
+// if any leaf needs the account-by-asset builtin (an AccountHasAsset condition),
+// `other` if any leaf needs a different index (metadata Field, Reference, a
+// timestamp builtin, address-on-transactions). A filter is asset-only — its
+// outcome governed by the account-by-asset lifecycle — iff asset && !other; the
+// driver creates only that index, so any `other` need means a missing index and
+// a rejected compile regardless. Combinators OR their children's needs; the
+// compiler fails the whole query on the first missing index, so a single
+// index-backed leaf anywhere sets the whole tree's need.
+func indexNeeds(f *commonpb.QueryFilter, target commonpb.QueryTarget) (asset, other bool) {
+	n := foldFilter(f, filterFold[indexNeed]{
+		and: unionNeeds,
+		or:  unionNeeds,
+		not: identity[indexNeed],
+		leaf: func(leaf *commonpb.QueryFilter) indexNeed {
+			switch x := leaf.GetFilter().(type) {
+			case nil:
+				return indexNeed{}
+			case *commonpb.QueryFilter_AccountHasAsset:
+				return indexNeed{asset: true}
+			case *commonpb.QueryFilter_Reverted:
+				return indexNeed{}
+			case *commonpb.QueryFilter_Address:
+				// Index-free on accounts; on transactions it needs the account→tx index.
+				return indexNeed{other: target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS}
+			case *commonpb.QueryFilter_BuiltinUint:
+				// Only the id builtin scans the always-present Pebble tx keyspace; the
+				// timestamp/inserted_at/reverted_at builtins need an index.
+				return indexNeed{other: x.BuiltinUint.GetField() != commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID}
+			default:
+				// Field, Reference, log conditions — index-backed, non-asset.
+				return indexNeed{other: true}
+			}
+		},
+	})
+
+	return n.asset, n.other
+}
+
+type indexNeed struct {
+	asset, other bool
+}
+
+func unionNeeds(children []indexNeed) indexNeed {
+	var n indexNeed
+	for _, c := range children {
+		n.asset, n.other = n.asset || c.asset, n.other || c.other
+	}
+
+	return n
+}
+
+// filterInvalidForTarget reports whether f carries any condition the server's
+// per-target validity table rejects (rejectInvalidCondition → InvalidArgument) —
+// e.g. reverted / tx-id on accounts, or account-has-asset on transactions. It
+// reuses the exact commonpb functions the compiler consults, so the model's
+// verdict cannot drift from the server's; every node is checked, combinators
+// included (mirroring the compiler's per-node check). The server checks
+// validity before index availability, so callers must consult this before
+// filterNeedsIndex.
+func filterInvalidForTarget(f *commonpb.QueryFilter, target commonpb.QueryTarget) bool {
+	invalidKind := func(kind commonpb.ConditionKind) bool {
+		return !commonpb.ConditionValidForTarget(target, kind)
+	}
+
+	return foldFilter(f, filterFold[bool]{
+		and: func(children []bool) bool { return invalidKind(commonpb.ConditionKindAnd) || anyOf(children) },
+		or:  func(children []bool) bool { return invalidKind(commonpb.ConditionKindOr) || anyOf(children) },
+		not: func(child bool) bool { return invalidKind(commonpb.ConditionKindNot) || child },
+		leaf: func(leaf *commonpb.QueryFilter) bool {
+			return leaf.GetFilter() != nil && invalidKind(commonpb.ConditionKindOf(leaf))
+		},
+	})
+}
+
+// matchAccountFilter evaluates an accounts filter against one address in ls.
+// Empty And/Or match nothing, mirroring the compiler's empty-iterator treatment;
+// a nil node is the universe (always matches). The AccountHasAsset arm needs the
+// account's volumes, so ls is threaded through even though the index-free arms
+// depend only on the address.
+func matchAccountFilter(ls oracle.LedgerState, f *commonpb.QueryFilter, addr string) bool {
+	return foldFilter(f, filterFold[bool]{
+		and: func(children []bool) bool { return len(children) > 0 && allOf(children) },
+		or:  anyOf,
+		not: negate,
+		leaf: func(leaf *commonpb.QueryFilter) bool {
+			switch x := leaf.GetFilter().(type) {
+			case nil:
+				return true
+			case *commonpb.QueryFilter_Address:
+				switch m := x.Address.GetMatch().(type) {
+				case *commonpb.AddressMatch_HardcodedPrefix:
+					return strings.HasPrefix(addr, m.HardcodedPrefix)
+				case *commonpb.AddressMatch_HardcodedExact:
+					return addr == m.HardcodedExact
+				}
+
+				return false
+			case *commonpb.QueryFilter_AccountHasAsset:
+				return accountHasAsset(ls, addr, x.AccountHasAsset.GetAssetBase(), x.AccountHasAsset.GetPrecision())
+			case *commonpb.QueryFilter_Field:
+				return matchFieldCondition(ls.AccountFieldTypes(), func(key string) (*commonpb.MetadataValue, bool) {
+					v, ok := ls.Metadata().Get(oracle.MetaKey{Address: addr, Key: key})
+
+					return v, ok
+				}, x.Field)
+			default:
+				return false
+			}
+		},
+	})
+}
+
+// matchTxFilter evaluates f on rec three-valued: known=false means the leaf
+// verdict hinges on a server stamp the model has not learned yet (a date field
+// of a bulk still in flight — see oracle.LearnTxStamps). Booleans propagate
+// unknowns Kleene-style: a decided AND/OR short-circuits, an undecided one
+// stays unknown. Window construction turns unknown rows into optional ones.
+func matchTxFilter(ls oracle.LedgerState, f *commonpb.QueryFilter, rec txRecordView) (match, known bool) {
+	v := foldFilter(f, filterFold[kleene]{
+		and: kleeneAnd,
+		or:  kleeneOr,
+		not: kleeneNot,
+		leaf: func(leaf *commonpb.QueryFilter) kleene {
+			switch x := leaf.GetFilter().(type) {
+			case nil:
+				return kleene{match: true, known: true}
+			case *commonpb.QueryFilter_Reverted:
+				return kleene{match: rec.Reverted() == x.Reverted.GetValue(), known: true}
+			case *commonpb.QueryFilter_Reference:
+				// Exact match on the null-terminated txref key; empty references are
+				// never written to the index, so they can never match.
+				return kleene{match: rec.Reference() != "" && rec.Reference() == x.Reference.GetCond().GetHardcoded(), known: true}
+			case *commonpb.QueryFilter_Address:
+				return kleene{match: matchTxAddress(ls, x.Address, rec), known: true}
+			case *commonpb.QueryFilter_Field:
+				return kleene{match: matchFieldCondition(ls.TransactionFieldTypes(), func(key string) (*commonpb.MetadataValue, bool) {
+					v, ok := rec.Metadata()[key]
+
+					return v, ok
+				}, x.Field), known: true}
+			case *commonpb.QueryFilter_BuiltinUint:
+				m, k := matchTxBuiltinUint(x.BuiltinUint, rec)
+
+				return kleene{match: m, known: k}
+			default:
+				return kleene{match: false, known: true}
+			}
+		},
+	})
+
+	return v.match, v.known
+}
+
+// matchTxAddress evaluates an address leaf on the TRANSACTIONS target: the
+// transaction matches iff some account in its account→tx index membership
+// (IndexedAddrs, role-filtered) matches the prefix/exact pattern AND is still
+// in the merged V+M account universe — the server resolves matching accounts
+// through the attributes zone (pebbleAccountExists / the account prefix
+// iterator), so a purged account with no metadata stops reaching its
+// transactions even though the index rows remain.
+func matchTxAddress(ls oracle.LedgerState, am *commonpb.AddressMatch, rec txRecordView) bool {
+	var roleMask uint8
+	switch am.GetRole() {
+	case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
+		roleMask = oracle.AddrIndexedSource
+	case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
+		roleMask = oracle.AddrIndexedDestination
+	default:
+		roleMask = oracle.AddrIndexedSource | oracle.AddrIndexedDestination
+	}
+
+	for addr, bits := range rec.IndexedAddrs() {
+		if bits&roleMask == 0 {
+			continue
+		}
+
+		switch m := am.GetMatch().(type) {
+		case *commonpb.AddressMatch_HardcodedPrefix:
+			if !strings.HasPrefix(addr, m.HardcodedPrefix) {
+				continue
+			}
+		case *commonpb.AddressMatch_HardcodedExact:
+			if addr != m.HardcodedExact {
+				continue
+			}
+		default:
+			continue // param matches are not generated
+		}
+
+		if ls.HasAccount(addr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchTxBuiltinUint evaluates a transaction builtin-uint leaf. The date
+// builtins read the record's (possibly learned) server stamps; a still-unknown
+// stamp is an unknown verdict, not a miss — the record may well be in the
+// server's index.
+func matchTxBuiltinUint(cond *commonpb.BuiltinUintCondition, rec txRecordView) (match, known bool) {
+	switch cond.GetField() {
+	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:
+		return matchUintBounds(cond.GetCond(), rec.Id()), true
+	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:
+		if rec.Timestamp() == nil {
+			return false, false
+		}
+
+		return matchUintBounds(cond.GetCond(), rec.Timestamp().GetData()), true
+	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT:
+		if rec.InsertedAt() == nil {
+			return false, false
+		}
+
+		return matchUintBounds(cond.GetCond(), rec.InsertedAt().GetData()), true
+	case commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT:
+		// Only reverted originals carry an rvat row. An un-reverted record is a
+		// known miss; a reverted one with an unlearned revert stamp is unknown.
+		if !rec.Reverted() {
+			return false, true
+		}
+		if rec.RevertedAt() == nil {
+			return false, false
+		}
+
+		return matchUintBounds(cond.GetCond(), rec.RevertedAt().GetData()), true
+	default:
+		return false, true
+	}
+}
+
+// --- helpers ------------------------------------------------------------
+
+func reverseStrings(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}
+
+func joinUint64(s []uint64) string {
+	parts := make([]string, len(s))
+	for i, v := range s {
+		parts[i] = strconv.FormatUint(v, 10)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// describeFilter renders a filter as a compact prefix expression for assertion
+// details and debug logs.
+func describeFilter(f *commonpb.QueryFilter) string {
+	return foldFilter(f, filterFold[string]{
+		and: func(children []string) string { return "and(" + strings.Join(children, ",") + ")" },
+		or:  func(children []string) string { return "or(" + strings.Join(children, ",") + ")" },
+		not: func(child string) string { return "not(" + child + ")" },
+		leaf: func(leaf *commonpb.QueryFilter) string {
+			switch x := leaf.GetFilter().(type) {
+			case nil:
+				return "*"
+			case *commonpb.QueryFilter_Address:
+				role := ""
+				switch x.Address.GetRole() {
+				case commonpb.AddressRole_ADDRESS_ROLE_SOURCE:
+					role = "/src"
+				case commonpb.AddressRole_ADDRESS_ROLE_DESTINATION:
+					role = "/dst"
+				}
+
+				switch m := x.Address.GetMatch().(type) {
+				case *commonpb.AddressMatch_HardcodedPrefix:
+					return "addr^" + m.HardcodedPrefix + role
+				case *commonpb.AddressMatch_HardcodedExact:
+					return "addr=" + m.HardcodedExact + role
+				}
+
+				return "addr?"
+			case *commonpb.QueryFilter_Reverted:
+				return "reverted=" + strconv.FormatBool(x.Reverted.GetValue())
+			case *commonpb.QueryFilter_Reference:
+				return "ref=" + x.Reference.GetCond().GetHardcoded()
+			case *commonpb.QueryFilter_BuiltinUint:
+				return describeBuiltinUint(x.BuiltinUint)
+			case *commonpb.QueryFilter_Field:
+				return "field:" + x.Field.GetField().GetMetadata() + describeFieldCondition(x.Field)
+			case *commonpb.QueryFilter_AccountHasAsset:
+				return "hasAsset:" + x.AccountHasAsset.GetAssetBase()
+			case *commonpb.QueryFilter_Ledger:
+				return "ledger=" + x.Ledger.GetCond().GetHardcoded()
+			case *commonpb.QueryFilter_LogId:
+				return "logId" + describeUintBounds(x.LogId.GetCond())
+			case *commonpb.QueryFilter_LogBuiltinUint:
+				return "logDate" + describeUintBounds(x.LogBuiltinUint.GetCond())
+			default:
+				return "?"
+			}
+		},
+	})
+}
+
+// describeBuiltinUint renders a builtin-uint leaf: the field's short name and
+// its bounds, exclusive bounds parenthesized, absent ones as "_".
+func describeBuiltinUint(c *commonpb.BuiltinUintCondition) string {
+	name := map[commonpb.TransactionBuiltinIndex]string{
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID:          "id",
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP:   "ts",
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT: "iat",
+		commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT: "rvat",
+	}[c.GetField()]
+	if name == "" {
+		name = c.GetField().String()
+	}
+
+	return name + describeUintBounds(c.GetCond())
+}
+
+// describeUintBounds renders a uint range, exclusive bounds parenthesized and
+// absent ones as "_". A finding must be diagnosable from its details alone, so
+// every generated leaf renders its bounds.
+func describeUintBounds(cond *commonpb.UintCondition) string {
+	lo, hi := "_", "_"
+	if cond.Min != nil {
+		lo = strconv.FormatUint(cond.GetMin(), 10)
+		if cond.GetMinExclusive() {
+			lo = "(" + lo
+		}
+	}
+
+	if cond.Max != nil {
+		hi = strconv.FormatUint(cond.GetMax(), 10)
+		if cond.GetMaxExclusive() {
+			hi += ")"
+		}
+	}
+
+	return "[" + lo + "," + hi + "]"
+}
+
+// describeFieldCondition renders a Field leaf's condition — the bounds are
+// what a retype-window finding needs to be diagnosable from its details alone
+// (which coercions the serving types apply to them decides the verdict).
+func describeFieldCondition(fc *commonpb.FieldCondition) string {
+	switch c := fc.GetCondition().(type) {
+	case *commonpb.FieldCondition_ExistsCond:
+		if c.ExistsCond.GetIncludeNull() {
+			return "?exists+null"
+		}
+
+		return "?exists"
+	case *commonpb.FieldCondition_StringCond:
+		return "=" + strconv.Quote(c.StringCond.GetHardcoded())
+	case *commonpb.FieldCondition_BoolCond:
+		return "=" + strconv.FormatBool(c.BoolCond.GetHardcoded())
+	case *commonpb.FieldCondition_IntCond:
+		ic := c.IntCond
+
+		return "[" + renderBound(ic.Min, ic.GetMinExclusive(), false) + "," + renderBound(ic.Max, ic.GetMaxExclusive(), true) + "]"
+	case *commonpb.FieldCondition_UintCond:
+		uc := c.UintCond
+
+		return "u[" + renderBound(uc.Min, uc.GetMinExclusive(), false) + "," + renderBound(uc.Max, uc.GetMaxExclusive(), true) + "]"
+	default:
+		return "?"
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries.go
@@ -569,6 +569,15 @@ func accountMatches(ls oracle.LedgerState, addr string, serverAcct *commonpb.Acc
 		return false
 	}
 
+	// assembleAccount fills address, metadata and volumes and nothing else, so
+	// these three carry no value the model could be held to. Pinned as absent:
+	// once the server starts stamping them, the oracle must learn to predict
+	// them rather than keep waving whatever arrives through.
+	if serverAcct.GetFirstUsage() != nil || serverAcct.GetInsertionDate() != nil ||
+		serverAcct.GetUpdatedAt() != nil {
+		return false
+	}
+
 	model := map[string]oracle.VolumePair{}
 	for k, vp := range ls.Volumes().All() {
 		if k.Address == addr {
@@ -622,6 +631,7 @@ type txRecordView interface {
 	RevertedAt() *commonpb.Timestamp
 	RevertsTransaction() uint64
 	IndexedAddrs() map[string]uint8
+	PostCommitVolumes() map[oracle.VolumeKey]oracle.VolumePair
 }
 
 // txRecordMatches reports whether the model record rec is consistent with the
@@ -648,6 +658,20 @@ func txRecordMatches(rec txRecordView, serverTx *commonpb.Transaction) bool {
 		raOK = serverTx.GetRevertedAt() == nil
 	}
 
+	// updated_at is stamped once, from the same proposal date as inserted_at
+	// (processor_transaction.go, processor_revert_transaction.go), and nothing
+	// bumps it afterwards — not a metadata save, not being reverted. So the
+	// two must agree on every served row, whether or not the model learned the
+	// value.
+	if serverTx.GetUpdatedAt().GetData() != serverTx.GetInsertedAt().GetData() ||
+		(serverTx.GetUpdatedAt() == nil) != (serverTx.GetInsertedAt() == nil) {
+		return false
+	}
+
+	if !pcvSnapshotMatches(rec.PostCommitVolumes(), serverTx.GetPostCommitVolumes()) {
+		return false
+	}
+
 	return rec.Id() == serverTx.GetId() &&
 		rec.Reference() == serverTx.GetReference() &&
 		rec.Reverted() == serverTx.GetReverted() &&
@@ -656,6 +680,37 @@ func txRecordMatches(rec txRecordView, serverTx *commonpb.Transaction) bool {
 		tsOK && insOK && raOK &&
 		postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
 		metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
+}
+
+// pcvSnapshotMatches compares a served post-commit snapshot against the
+// model's cell for cell, in both directions: an absent cell and a fabricated
+// one are equally wrong. A coloured entry is a cell the model's volume key
+// cannot address, so the whole snapshot is left uncompared for that row.
+func pcvSnapshotMatches(model map[oracle.VolumeKey]oracle.VolumePair, server *commonpb.PostCommitVolumes) bool {
+	served := map[oracle.VolumeKey]struct{}{}
+
+	for account, byAssets := range server.GetVolumesByAccount() {
+		for _, entry := range byAssets.GetVolumes() {
+			if entry.GetColor() != "" {
+				return true
+			}
+
+			served[oracle.VolumeKey{Address: account, Asset: entry.GetAsset()}] = struct{}{}
+		}
+	}
+
+	if len(served) != len(model) {
+		return false
+	}
+
+	for key, vp := range model {
+		gotIn, gotOut, ok := postCommitVolume(server, key)
+		if !ok || vp.Input.Cmp(&gotIn) != 0 || vp.Output.Cmp(&gotOut) != 0 {
+			return false
+		}
+	}
+
+	return true
 }
 
 // --- Filter generation --------------------------------------------------

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -1,0 +1,585 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/antithesishq/antithesis-sdk-go/random"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+)
+
+// LOGS is the only target whose universe comes from the read index rather than
+// the main store, so it is the one shape that is always owed cross-store
+// alignment (query.AlignmentOwed). Nothing else in the driver reaches it.
+//
+// Two of the three LOGS-valid leaves need no index: the ledger name and the
+// ledger-local log id. The third, the log date, is served from an opt-in
+// builtin index, so a filter carrying one is owed whatever that index's
+// lifecycle in the model allows — a page or a not-ready refusal
+// (neededLogIndexes, validateLogQuery).
+
+// genLogFilter builds a filter over the conditions valid on LOGS: ledger name,
+// log id range, and the boolean combinators. Returns nil for the unfiltered
+// case, which exercises the universe scan itself.
+func genLogFilter(ledger string, depth int) *commonpb.QueryFilter {
+	if depth >= 2 || oneIn(3) {
+		return genLogLeaf(ledger)
+	}
+
+	switch random.RandomChoice([]uint8{0, 1, 2}) {
+	case 0:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{
+			And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
+				genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1),
+			}},
+		}}
+	case 1:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{
+			Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
+				genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1),
+			}},
+		}}
+	default:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{
+			Not: &commonpb.NotFilter{Filter: genLogFilter(ledger, depth+1)},
+		}}
+	}
+}
+
+// genLogLeaf picks one LOGS-valid leaf. Bounds straddle the populated range so
+// empty, partial and total windows all occur.
+func genLogLeaf(ledger string) *commonpb.QueryFilter {
+	switch random.RandomChoice([]uint8{0, 1, 2}) {
+	case 0:
+		name := ledger
+		if oneIn(4) {
+			name = "no-such-ledger"
+		}
+
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Ledger{
+			Ledger: &commonpb.LedgerCondition{
+				Cond: &commonpb.StringCondition{Value: &commonpb.StringCondition_Hardcoded{Hardcoded: name}},
+			},
+		}}
+	case 1:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogId{
+			LogId: &commonpb.LogIdCondition{Cond: genLogUintCond()},
+		}}
+	default:
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogBuiltinUint{
+			LogBuiltinUint: &commonpb.LogBuiltinUintCondition{
+				Field: commonpb.LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE,
+				Cond:  genLogUintCond(),
+			},
+		}}
+	}
+}
+
+func genLogUintCond() *commonpb.UintCondition {
+	cond := &commonpb.UintCondition{}
+
+	if oneIn(2) {
+		min := internal.Rand().Uint64() % 32
+		cond.Min = &min
+		cond.MinExclusive = oneIn(2)
+	}
+
+	if oneIn(2) {
+		max := 8 + internal.Rand().Uint64()%64
+		cond.Max = &max
+		cond.MaxExclusive = oneIn(2)
+	}
+
+	return cond
+}
+
+// hasDateLeaf reports whether the filter reads the log date, which is served
+// only when the log-date builtin index exists.
+func hasDateLeaf(f *commonpb.QueryFilter) bool {
+	return anyLeaf(f, func(leaf *commonpb.QueryFilter) bool {
+		_, ok := leaf.GetFilter().(*commonpb.QueryFilter_LogBuiltinUint)
+
+		return ok
+	})
+}
+
+// logDateIndexID is the opt-in builtin index the log date is served from.
+// logDateIndexCanonical is its stable map key in the model's index set.
+func logDateIndexID() *commonpb.IndexID {
+	return indexes.LogBuiltinID(commonpb.LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE)
+}
+
+var logDateIndexCanonical = indexes.Canonical(logDateIndexID())
+
+// neededLogIndexes returns the canonical IDs of the indexes a LOGS filter
+// needs the compiler to find ready. The model owns whether each one exists:
+// the outcome the server owes — a page or a not-ready refusal — follows from
+// the index's lifecycle in every candidate base, exactly as on the accounts
+// and transactions paths.
+func neededLogIndexes(f *commonpb.QueryFilter) map[string]struct{} {
+	if !hasDateLeaf(f) {
+		return nil
+	}
+
+	return map[string]struct{}{logDateIndexCanonical: {}}
+}
+
+// matchLogFilter evaluates a LOGS filter against one modelled log, three-valued
+// (see kleene). date is the server-assigned value learned at commit; it is nil
+// for a log whose response this base has not folded yet — a candidate base that
+// applied an observed-but-undrained bulk holds exactly such logs — so a date
+// leaf reading it is undecided, and the row becomes optional in the predicted
+// window rather than absent from it.
+func matchLogFilter(ledger string, id uint64, date *commonpb.Timestamp, f *commonpb.QueryFilter) (match, known bool) {
+	v := foldFilter(f, filterFold[kleene]{
+		and: kleeneAnd,
+		or:  kleeneOr,
+		not: kleeneNot,
+		leaf: func(leaf *commonpb.QueryFilter) kleene {
+			switch t := leaf.GetFilter().(type) {
+			case nil:
+				return kleene{match: true, known: true}
+			case *commonpb.QueryFilter_Ledger:
+				return kleene{match: ledger == t.Ledger.GetCond().GetHardcoded(), known: true}
+			case *commonpb.QueryFilter_LogId:
+				return kleene{match: matchUintBounds(t.LogId.GetCond(), id), known: true}
+			case *commonpb.QueryFilter_LogBuiltinUint:
+				if date == nil {
+					return kleene{known: false}
+				}
+
+				return kleene{match: matchUintBounds(t.LogBuiltinUint.GetCond(), date.GetData()), known: true}
+			default:
+				// Every LOGS-valid condition is handled above; anything else means
+				// the generator and the matcher have drifted apart.
+				panic("model: unmatched LOGS condition")
+			}
+		},
+	})
+
+	return v.match, v.known
+}
+
+// logWindowRow is one row a ListLogs page may draw. required=false marks a log
+// whose date this base has not learned, so a date leaf cannot be decided for
+// it: the page may or may not carry it.
+type logWindowRow struct {
+	id       uint64
+	required bool
+}
+
+// logWindowRows is the ordered, cursor-filtered, UNTRUNCATED row sequence a
+// ListLogs page draws from. The endpoint has no reverse mode
+// (ValidateListOptions rejects it) and paginates forward only, so rows are
+// ascending by id with the cursor as an exclusive lower bound — exactly how
+// the controller translates afterSequence into a LogId condition. Truncation is
+// logWindowMatches' job: optional rows may or may not consume page slots, so a
+// fixed prefix cut would be wrong.
+func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64) []logWindowRow {
+	var rows []logWindowRow
+
+	for _, row := range ls.LogDates() {
+		if row.ID <= afterSeq {
+			continue
+		}
+
+		match, known := matchLogFilter(ledger, row.ID, row.Date, filter)
+		if known && !match {
+			continue
+		}
+
+		rows = append(rows, logWindowRow{id: row.ID, required: known})
+	}
+
+	return rows
+}
+
+// logWindowMatches reports whether the page is exactly a legal window over the
+// candidate's row sequence: required rows appear in order, optional rows may,
+// nothing else does, and a required row may only be missing past a full
+// (truncated) page.
+func logWindowMatches(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int, ids []uint64) bool {
+	if len(ids) > pageSize {
+		return false
+	}
+
+	j := 0
+
+	for _, row := range logWindowRows(ls, ledger, filter, afterSeq) {
+		if j == len(ids) {
+			if len(ids) == pageSize {
+				return true // full page — the remaining rows were truncated
+			}
+
+			if row.required {
+				return false // page had room, yet a required row is missing
+			}
+
+			continue
+		}
+
+		if ids[j] == row.id {
+			j++
+		} else if row.required {
+			return false
+		}
+	}
+
+	return j == len(ids)
+}
+
+// logWindow is the page the model predicts when every row is decided: the
+// required rows, truncated to pageSize. Optional rows are left out, so it is a
+// diagnostic rendering only — legality is logWindowMatches, which admits them.
+func logWindow(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int) []uint64 {
+	var window []uint64
+
+	for _, row := range logWindowRows(ls, ledger, filter, afterSeq) {
+		if !row.required {
+			continue
+		}
+
+		window = append(window, row.id)
+		if len(window) == pageSize {
+			break
+		}
+	}
+
+	return window
+}
+
+// runLogQuery drives one ListLogs page and checks it against the model.
+func runLogQuery(ctx context.Context, client servicepb.BucketServiceClient, c *Checker) {
+	ledger := random.RandomChoice(c.ledgerNames)
+
+	var filter *commonpb.QueryFilter
+	if !oneIn(4) {
+		filter = genLogFilter(ledger, 0)
+	}
+
+	pageSize := queryPageSize()
+
+	var (
+		cursor   string
+		afterSeq uint64
+	)
+
+	if oneIn(2) {
+		afterSeq = internal.Rand().Uint64() % 16
+		cursor = strconv.FormatUint(afterSeq, 10)
+	}
+
+	c.mu.Lock()
+	readID := c.registerRead()
+	c.mu.Unlock()
+
+	defer c.finishRead(readID)
+
+	// A linearizable read is served at a fixed Raft horizon at or past every
+	// bulk whose response this driver has observed, with the read projection
+	// certified up to it (EN-1946), so the window stays representable by a
+	// candidate base.
+	readCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "linearizable")
+	stream, err := client.ListLogs(readCtx, &servicepb.ListLogsRequest{
+		Ledger: ledger,
+		Options: &commonpb.ListOptions{
+			PageSize: uint32(pageSize),
+			Cursor:   cursor,
+			Filter:   filter,
+		},
+	})
+
+	var logs []*commonpb.Log
+	if err == nil {
+		logs, err = drainStream(stream)
+	}
+
+	maxTicket := c.ticketSeq.Load()
+
+	errKind, gated := classifyLogQueryError(err)
+	if !gated {
+		if internal.IsTransient(err) || isShutdownError(err) {
+			return
+		}
+
+		assert.Unreachable("singleton_driver_model: ListLogs returned unexpected error", internal.Details{
+			"ledger": ledger,
+			"filter": describeFilter(filter),
+			"error":  err.Error(),
+		})
+
+		return
+	}
+
+	c.validateLogQuery(ctx, client, maxTicket, ledger, filter, afterSeq, pageSize, logs, neededLogIndexes(filter), errKind, err)
+}
+
+// classifyLogQueryError maps a ListLogs outcome to its class. ok=false means
+// the error is not one the index gate produces, so the caller decides whether
+// it is environmental. The not-ready rejection rides codes.Unavailable, which
+// sits inside internal.IsTransient, so classifying must happen before any
+// transient bail: an index gate refusing a filter the model can serve — or
+// refusing one that needs no index — is a finding, not a blip.
+func classifyLogQueryError(err error) (indexedErrKind, bool) {
+	switch {
+	case err == nil:
+		return indexedErrNone, true
+	case isIndexNotFound(err), isIndexNotReady(err):
+		return indexedErrNotReady, true
+	default:
+		return indexedErrNone, false
+	}
+}
+
+// serverLogIDs pulls the ledger-local ids out of a page.
+func serverLogIDs(logs []*commonpb.Log) []uint64 {
+	out := make([]uint64, 0, len(logs))
+	for _, l := range logs {
+		out = append(out, l.GetPayload().GetApply().GetLog().GetId())
+	}
+
+	return out
+}
+
+// validateLogQuery checks one ListLogs outcome against the model. needed holds
+// the canonical IDs of the indexes the filter reads (see neededLogIndexes) and
+// errKind the observed outcome class, so the legal outcomes per candidate base
+// are the ones every index-backed target shares (indexedQueryOutcomeLegal):
+//
+//   - a page is legal iff the base holds every needed index and the page is
+//     that base's ordered window;
+//   - a not-ready refusal is legal iff some needed index is not active on the
+//     base — so a refusal of a filter needing no index is a finding, and so is
+//     a page served for an index no base holds.
+func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketServiceClient, maxTicket uint64, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int, serverLogs []*commonpb.Log, needed map[string]struct{}, errKind indexedErrKind, err error) {
+	ids := serverLogIDs(serverLogs)
+
+	// A page must always be ascending, within the cursor, and no longer than
+	// requested — properties that hold whatever the filter reads.
+	for i, id := range ids {
+		if id <= afterSeq || (i > 0 && id <= ids[i-1]) || len(ids) > pageSize {
+			assert.Unreachable("singleton_driver_model: log page violates its own ordering", internal.Details{
+				"ledger":    ledger,
+				"filter":    describeFilter(filter),
+				"afterSeq":  afterSeq,
+				"pageSize":  pageSize,
+				"serverIds": joinUint64(ids),
+			})
+
+			return
+		}
+	}
+
+	if c.matchesModel(maxTicket, "LOGQUERY", func(base oracle.GlobalState) bool {
+		return logOutcomeLegal(base.Ledger(ledger), ledger, filter, needed, errKind, ids, afterSeq, pageSize)
+	}) {
+		if errKind == indexedErrNotReady {
+			assert.Reachable("singleton_driver_model: log query gated on a missing index", internal.Details{"ledger": ledger})
+		} else {
+			assert.Reachable("singleton_driver_model: log query served results", internal.Details{"ledger": ledger})
+		}
+
+		return
+	}
+
+	recheckIDs, recheckErr := recheckLogIDs(ctx, client, ledger)
+	serverKinds, kindsErr := recheckLogKinds(ctx, client, ledger)
+
+	details := internal.Details{
+		"ledger":      ledger,
+		"filter":      describeFilter(filter),
+		"afterSeq":    afterSeq,
+		"pageSize":    pageSize,
+		"rows":        len(ids),
+		"serverIds":   joinUint64(ids),
+		"modelIds":    joinUint64(c.modelLogWindow(ledger, filter, afterSeq, pageSize)),
+		"modelIdx":    c.describeLogIndexStates(ledger, needed),
+		"modelDates":  c.describeLogDates(ledger),
+		"recheck":     diagnosticDetail(joinUint64(recheckIDs), recheckErr),
+		"modelKinds":  strings.Join(c.modelLogKinds(ledger), ","),
+		"serverKinds": diagnosticDetail(strings.Join(serverKinds, ","), kindsErr),
+	}
+	if err != nil {
+		details["error"] = err.Error()
+	}
+
+	assert.Unreachable("singleton_driver_model: log query outside model", details)
+}
+
+// logOutcomeLegal is the per-candidate verdict for one ListLogs outcome: the
+// shared index-lifecycle legality, with the base's ordered log window as the
+// result check.
+func logOutcomeLegal(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, errKind indexedErrKind, ids []uint64, afterSeq uint64, pageSize int) bool {
+	return indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed, errKind, func(view oracle.LedgerState) bool {
+		return logWindowMatches(view, ledger, filter, afterSeq, pageSize, ids)
+	})
+}
+
+// describeLogDates renders the committed model's (log id, learned date) pairs,
+// an unlearned date as "?" — what a date-filter finding is decided by, so it
+// must be readable from the finding's details alone. Capped: a long ledger's
+// tail says nothing the head does not. Acquires c.mu.
+func (c *Checker) describeLogDates(ledger string) string {
+	const maxRendered = 24
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	rows := c.modelState.Ledger(ledger).LogDates()
+
+	parts := make([]string, 0, min(len(rows), maxRendered))
+	for _, row := range rows {
+		if len(parts) == maxRendered {
+			parts = append(parts, "…")
+
+			break
+		}
+
+		date := "?"
+		if row.Date != nil {
+			date = strconv.FormatUint(row.Date.GetData(), 10)
+		}
+
+		parts = append(parts, strconv.FormatUint(row.ID, 10)+"="+date)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// describeLogIndexStates renders the committed model's lifecycle state for each
+// needed index, for a finding's diagnostics. Acquires c.mu.
+func (c *Checker) describeLogIndexStates(ledger string, needed map[string]struct{}) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ls := c.modelState.Ledger(ledger)
+
+	states := make([]string, 0, len(needed))
+	for canon := range needed {
+		states = append(states, canon+"="+indexStateLabelFull(ls, canon))
+	}
+	slices.Sort(states)
+
+	return strings.Join(states, " ")
+}
+
+// modelLogWindow returns the log window on the committed modelState for a
+// finding's diagnostics. Acquires c.mu.
+func (c *Checker) modelLogWindow(ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int) []uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return logWindow(c.modelState.Ledger(ledger), ledger, filter, afterSeq, pageSize)
+}
+
+// equalUint64 compares two id sequences elementwise; a nil and an empty slice
+// are the same empty page.
+func equalUint64(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// recheckLogIDs re-reads the ledger's logs unfiltered after the finding, at a
+// later horizon. It separates "not yet visible at the first read's horizon"
+// from "never visible": if the ids the model expected show up here, the page
+// was a visibility question; if they never appear, the logs are absent.
+func recheckLogIDs(ctx context.Context, client servicepb.BucketServiceClient, ledger string) ([]uint64, error) {
+	stream, err := client.ListLogs(ctx, &servicepb.ListLogsRequest{
+		Ledger:  ledger,
+		Options: &commonpb.ListOptions{PageSize: 200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logs, err := drainStream(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	return serverLogIDs(logs), nil
+}
+
+func (c *Checker) modelLogKinds(ledger string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.modelState.Ledger(ledger).LogKinds()
+}
+
+// recheckLogKinds names the payload arm of each log the server actually holds,
+// so a surplus in the model can be attributed to a request kind.
+func recheckLogKinds(ctx context.Context, client servicepb.BucketServiceClient, ledger string) ([]string, error) {
+	stream, err := client.ListLogs(ctx, &servicepb.ListLogsRequest{
+		Ledger:  ledger,
+		Options: &commonpb.ListOptions{PageSize: 200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logs, err := drainStream(stream)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(logs))
+	for _, l := range logs {
+		switch d := l.GetPayload().GetApply().GetLog().GetData(); {
+		case d.GetCreatedTransaction() != nil:
+			out = append(out, "created_transaction")
+		case d.GetRevertedTransaction() != nil:
+			out = append(out, "reverted_transaction")
+		case d.GetSavedMetadata() != nil:
+			out = append(out, "saved_metadata")
+		case d.GetDeletedMetadata() != nil:
+			out = append(out, "deleted_metadata")
+		case d.GetSetMetadataFieldType() != nil:
+			out = append(out, "set_metadata_field_type")
+		case d.GetRemovedMetadataFieldType() != nil:
+			out = append(out, "removed_metadata_field_type")
+		case d.GetCreateIndex() != nil:
+			out = append(out, "create_index")
+		case d.GetDropIndex() != nil:
+			out = append(out, "drop_index")
+		case d.GetAddedAccountType() != nil:
+			out = append(out, "added_account_type")
+		case d.GetRemovedAccountType() != nil:
+			out = append(out, "removed_account_type")
+		default:
+			out = append(out, "other")
+		}
+	}
+
+	return out, nil
+}
+
+// diagnosticDetail renders a best-effort recheck into a finding detail. A
+// failed diagnostic RPC must be distinguishable from a genuinely empty server
+// view — an empty recheck otherwise corrupts the triage of a real finding.
+func diagnosticDetail(value string, err error) string {
+	if err != nil {
+		return "recheck failed: " + err.Error()
+	}
+
+	return value
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -38,21 +38,11 @@ func genLogFilter(ledger string, depth int) *commonpb.QueryFilter {
 
 	switch random.RandomChoice([]uint8{0, 1, 2}) {
 	case 0:
-		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{
-			And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
-				genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1),
-			}},
-		}}
+		return filterAnd(genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1))
 	case 1:
-		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{
-			Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
-				genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1),
-			}},
-		}}
+		return filterOr(genLogFilter(ledger, depth+1), genLogFilter(ledger, depth+1))
 	default:
-		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{
-			Not: &commonpb.NotFilter{Filter: genLogFilter(ledger, depth+1)},
-		}}
+		return filterNot(genLogFilter(ledger, depth+1))
 	}
 }
 
@@ -420,7 +410,7 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 // shared index-lifecycle legality, with the base's ordered log window as the
 // result check.
 func logOutcomeLegal(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, errKind indexedErrKind, ids []uint64, afterSeq uint64, pageSize int) bool {
-	return indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed, errKind, func(view oracle.LedgerState) bool {
+	return indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed, errKind, "", func(view oracle.LedgerState) bool {
 		return logWindowMatches(view, ledger, filter, afterSeq, pageSize, ids)
 	})
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -537,9 +537,14 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 		}
 	}
 
-	if c.matchesModel(maxTicket, "LOGQUERY", func(base oracle.GlobalState) bool {
+	matched := c.matchesModel(maxTicket, "LOGQUERY", func(base oracle.GlobalState) bool {
 		return logOutcomeLegal(base.Ledger(ledger), ledger, filter, needed, errKind, page, afterSeq, pageSize)
-	}) {
+	})
+
+	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed,
+		matched && errKind == indexedErrNone)
+
+	if matched {
 		if errKind == indexedErrNotReady {
 			assert.Reachable("singleton_driver_model: log query gated on a missing index", internal.Details{"ledger": ledger})
 		} else {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -167,6 +167,8 @@ type logWindowRow struct {
 	id        uint64
 	kind      string
 	payload   string
+	tx        txRecordView
+	revertsID uint64
 	date      *commonpb.Timestamp
 	sequence  uint64
 	purged    string
@@ -178,13 +180,15 @@ type logWindowRow struct {
 // serverLogRow is one log of a page, reduced to what the model can pin: the
 // ledger it belongs to, its per-ledger id, its payload kind, the date the
 // server assigned it, its end-of-bulk volume annotations, and whether it
-// arrived signed. volumesKnown is false when an annotation names a colour, a
-// dimension the model's volume key does not carry.
+// arrived signed. volumesKnown is false when an annotation names a colour,
+// which no generated posting produces.
 type serverLogRow struct {
 	ledger       string
 	id           uint64
 	kind         string
 	payload      string
+	tx           *commonpb.Transaction
+	revertsID    uint64
 	date         uint64
 	hasDate      bool
 	sequence     uint64
@@ -202,6 +206,8 @@ func serverLogRows(logs []*commonpb.Log) []serverLogRow {
 	for _, l := range logs {
 		entry := l.GetPayload().GetApply().GetLog()
 
+		tx, revertsID := servedLogTransaction(entry.GetData())
+
 		purged, purgedOK := renderServedVolumes(entry.GetPurgedVolumes())
 		newKept, newKeptOK := renderServedVolumes(entry.GetNewKeptVolumes())
 		ephemeral, ephemeralOK := renderServedVolumes(entry.GetEphemeralVolumes())
@@ -211,6 +217,8 @@ func serverLogRows(logs []*commonpb.Log) []serverLogRow {
 			id:           entry.GetId(),
 			kind:         serverLogKind(l),
 			payload:      oracle.CanonicalServedLogPayload(entry.GetData()),
+			tx:           tx,
+			revertsID:    revertsID,
 			date:         entry.GetDate().GetData(),
 			hasDate:      entry.GetDate() != nil,
 			sequence:     l.GetSequence(),
@@ -225,10 +233,27 @@ func serverLogRows(logs []*commonpb.Log) []serverLogRow {
 	return out
 }
 
+// servedLogTransaction pulls the transaction a log announces off its payload,
+// with the id of the transaction a revert compensates. Nil for the kinds that
+// announce none.
+func servedLogTransaction(data *commonpb.LedgerLogPayload) (*commonpb.Transaction, uint64) {
+	switch {
+	case data.GetCreatedTransaction() != nil:
+		return data.GetCreatedTransaction().GetTransaction(), 0
+	case data.GetRevertedTransaction() != nil:
+		rt := data.GetRevertedTransaction()
+
+		return rt.GetRevertTransaction(), rt.GetRevertedTransactionId()
+	default:
+		return nil, 0
+	}
+}
+
 // renderServedVolumes names a served annotation list the way the oracle names
 // its own: "account:asset" entries joined by commas, verbatim in the order the
 // server sent them, so a mis-sorted or duplicated list is a mismatch. The
-// second result is false when an entry carries a colour.
+// second result is false when an entry carries a colour — no generated posting
+// does, so such a cell is a row nothing in this run could have produced.
 func renderServedVolumes(vols []*commonpb.TouchedVolume) (string, bool) {
 	if len(vols) == 0 {
 		return "", true
@@ -297,6 +322,7 @@ func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryF
 
 		rows = append(rows, logWindowRow{
 			id: row.ID, kind: row.Kind, payload: row.Payload,
+			tx: modelTxForLog(ls, row.TxID), revertsID: revertedIDForLog(ls, row),
 			date: row.Date, sequence: row.Sequence,
 			purged: row.PurgedVolumes, newKept: row.NewKeptVolumes, ephemeral: row.EphemeralVolumes,
 			required: known,
@@ -304,6 +330,27 @@ func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryF
 	}
 
 	return rows
+}
+
+// modelTxForLog resolves the transaction a log announces, nil when the log
+// announces none or the id is past this base's frontier.
+func modelTxForLog(ls oracle.LedgerState, txID uint64) txRecordView {
+	if txID == 0 || txID > uint64(ls.Txs().Len()) {
+		return nil
+	}
+
+	return ls.Txs().Get(int(txID - 1))
+}
+
+// revertedIDForLog names the transaction a revert log compensates, which the
+// model holds on the revert's own record.
+func revertedIDForLog(ls oracle.LedgerState, row oracle.LogRow) uint64 {
+	tx := modelTxForLog(ls, row.TxID)
+	if tx == nil {
+		return 0
+	}
+
+	return tx.RevertsTransaction()
 }
 
 // logWindowMatches reports whether the page is exactly a legal window over the
@@ -353,9 +400,18 @@ func logRowMatches(ledger string, row logWindowRow, got serverLogRow) bool {
 		return false
 	}
 
-	// The payload rendering is empty for a transaction log, whose content the
-	// ListTransactions path validates against the model's own records.
 	if row.payload != "" && got.payload != row.payload {
+		return false
+	}
+
+	// A transaction log carries the whole transaction, and it is the log's own
+	// copy: ListTransactions agreeing with the model says nothing about what
+	// this payload holds.
+	if row.tx != nil {
+		if got.tx == nil || !logTxMatches(row.tx, got.tx) || got.revertsID != row.revertsID {
+			return false
+		}
+	} else if got.tx != nil {
 		return false
 	}
 
@@ -369,8 +425,8 @@ func logRowMatches(ledger string, row logWindowRow, got serverLogRow) bool {
 	// The three volume annotations are derived, never learned: the model runs
 	// the same end-of-bulk partition, so all three are pinned exactly — an
 	// empty list included.
-	if got.volumesKnown &&
-		(got.purged != row.purged || got.newKept != row.newKept || got.ephemeral != row.ephemeral) {
+	if !got.volumesKnown ||
+		got.purged != row.purged || got.newKept != row.newKept || got.ephemeral != row.ephemeral {
 		return false
 	}
 
@@ -379,6 +435,37 @@ func logRowMatches(ledger string, row logWindowRow, got serverLogRow) bool {
 	}
 
 	return got.hasDate && got.date == row.date.GetData()
+}
+
+// logTxMatches compares the transaction embedded in a log against the model's
+// record of it, over the fields the payload freezes at creation.
+//
+// The record keeps moving after its log is written — a later revert sets
+// reverted, reverted_by and reverted_at, and a metadata save rewrites the
+// metadata map — while the log keeps the values it was written with. Only the
+// fields that cannot move are compared here; the mutable ones are the
+// transaction table's to answer for, through txRecordMatches.
+func logTxMatches(rec txRecordView, got *commonpb.Transaction) bool {
+	if rec.Id() != got.GetId() || rec.Reference() != got.GetReference() ||
+		rec.RevertsTransaction() != got.GetRevertsTransaction() {
+		return false
+	}
+
+	if rec.Timestamp() != nil && rec.Timestamp().GetData() != got.GetTimestamp().GetData() {
+		return false
+	}
+
+	if rec.InsertedAt() != nil && rec.InsertedAt().GetData() != got.GetInsertedAt().GetData() {
+		return false
+	}
+
+	if got.GetUpdatedAt().GetData() != got.GetInsertedAt().GetData() ||
+		(got.GetUpdatedAt() == nil) != (got.GetInsertedAt() == nil) {
+		return false
+	}
+
+	return postingsEqual(rec.Postings(), got.GetPostings()) &&
+		pcvSnapshotMatches(rec.PostCommitVolumes(), got.GetPostCommitVolumes())
 }
 
 // logWindow is the page the model predicts when every row is decided: the

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -160,12 +160,119 @@ func matchLogFilter(ledger string, id uint64, date *commonpb.Timestamp, f *commo
 	return v.match, v.known
 }
 
-// logWindowRow is one row a ListLogs page may draw. required=false marks a log
-// whose date this base has not learned, so a date leaf cannot be decided for
-// it: the page may or may not carry it.
+// logWindowRow is one row a ListLogs page may draw, with the fields the model
+// pins on it. required=false marks a log whose date this base has not learned,
+// so a date leaf cannot be decided for it: the page may or may not carry it.
 type logWindowRow struct {
-	id       uint64
-	required bool
+	id        uint64
+	kind      string
+	payload   string
+	date      *commonpb.Timestamp
+	sequence  uint64
+	purged    string
+	newKept   string
+	ephemeral string
+	required  bool
+}
+
+// serverLogRow is one log of a page, reduced to what the model can pin: the
+// ledger it belongs to, its per-ledger id, its payload kind, the date the
+// server assigned it, its end-of-bulk volume annotations, and whether it
+// arrived signed. volumesKnown is false when an annotation names a colour, a
+// dimension the model's volume key does not carry.
+type serverLogRow struct {
+	ledger       string
+	id           uint64
+	kind         string
+	payload      string
+	date         uint64
+	hasDate      bool
+	sequence     uint64
+	purged       string
+	newKept      string
+	ephemeral    string
+	volumesKnown bool
+	signed       bool
+}
+
+// serverLogRows reads a page into comparable rows.
+func serverLogRows(logs []*commonpb.Log) []serverLogRow {
+	out := make([]serverLogRow, 0, len(logs))
+
+	for _, l := range logs {
+		entry := l.GetPayload().GetApply().GetLog()
+
+		purged, purgedOK := renderServedVolumes(entry.GetPurgedVolumes())
+		newKept, newKeptOK := renderServedVolumes(entry.GetNewKeptVolumes())
+		ephemeral, ephemeralOK := renderServedVolumes(entry.GetEphemeralVolumes())
+
+		out = append(out, serverLogRow{
+			ledger:       l.GetPayload().GetApply().GetLedgerName(),
+			id:           entry.GetId(),
+			kind:         serverLogKind(l),
+			payload:      oracle.CanonicalServedLogPayload(entry.GetData()),
+			date:         entry.GetDate().GetData(),
+			hasDate:      entry.GetDate() != nil,
+			sequence:     l.GetSequence(),
+			purged:       purged,
+			newKept:      newKept,
+			ephemeral:    ephemeral,
+			volumesKnown: purgedOK && newKeptOK && ephemeralOK,
+			signed:       l.GetResponseSignature() != nil,
+		})
+	}
+
+	return out
+}
+
+// renderServedVolumes names a served annotation list the way the oracle names
+// its own: "account:asset" entries joined by commas, verbatim in the order the
+// server sent them, so a mis-sorted or duplicated list is a mismatch. The
+// second result is false when an entry carries a colour.
+func renderServedVolumes(vols []*commonpb.TouchedVolume) (string, bool) {
+	if len(vols) == 0 {
+		return "", true
+	}
+
+	parts := make([]string, 0, len(vols))
+	for _, v := range vols {
+		if v.GetColor() != "" {
+			return "", false
+		}
+
+		parts = append(parts, v.GetAccount()+":"+v.GetAsset())
+	}
+
+	return strings.Join(parts, ","), true
+}
+
+// serverLogKind names a log's payload the way the model names it from the
+// request that produced it (oracle logKindOf), so the two are comparable.
+func serverLogKind(l *commonpb.Log) string {
+	switch d := l.GetPayload().GetApply().GetLog().GetData(); {
+	case d.GetCreatedTransaction() != nil:
+		return "created_transaction"
+	case d.GetRevertedTransaction() != nil:
+		return "reverted_transaction"
+	case d.GetSavedMetadata() != nil:
+		return "saved_metadata"
+	case d.GetDeletedMetadata() != nil:
+		return "deleted_metadata"
+	case d.GetSetMetadataFieldType() != nil:
+		return "set_metadata_field_type"
+	case d.GetRemovedMetadataFieldType() != nil:
+		return "removed_metadata_field_type"
+	case d.GetCreateIndex() != nil:
+		return "create_index"
+	case d.GetDropIndex() != nil:
+		return "drop_index"
+	case d.GetAddedAccountType() != nil:
+		return "added_account_type"
+	case d.GetRemovedAccountType() != nil:
+		return "removed_account_type"
+	default:
+		return "other"
+	}
 }
 
 // logWindowRows is the ordered, cursor-filtered, UNTRUNCATED row sequence a
@@ -178,7 +285,7 @@ type logWindowRow struct {
 func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64) []logWindowRow {
 	var rows []logWindowRow
 
-	for _, row := range ls.LogDates() {
+	for _, row := range ls.LogRows() {
 		if row.ID <= afterSeq {
 			continue
 		}
@@ -188,7 +295,12 @@ func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryF
 			continue
 		}
 
-		rows = append(rows, logWindowRow{id: row.ID, required: known})
+		rows = append(rows, logWindowRow{
+			id: row.ID, kind: row.Kind, payload: row.Payload,
+			date: row.Date, sequence: row.Sequence,
+			purged: row.PurgedVolumes, newKept: row.NewKeptVolumes, ephemeral: row.EphemeralVolumes,
+			required: known,
+		})
 	}
 
 	return rows
@@ -198,16 +310,16 @@ func logWindowRows(ls oracle.LedgerState, ledger string, filter *commonpb.QueryF
 // candidate's row sequence: required rows appear in order, optional rows may,
 // nothing else does, and a required row may only be missing past a full
 // (truncated) page.
-func logWindowMatches(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int, ids []uint64) bool {
-	if len(ids) > pageSize {
+func logWindowMatches(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int, page []serverLogRow) bool {
+	if len(page) > pageSize {
 		return false
 	}
 
 	j := 0
 
 	for _, row := range logWindowRows(ls, ledger, filter, afterSeq) {
-		if j == len(ids) {
-			if len(ids) == pageSize {
+		if j == len(page) {
+			if len(page) == pageSize {
 				return true // full page — the remaining rows were truncated
 			}
 
@@ -218,14 +330,55 @@ func logWindowMatches(ls oracle.LedgerState, ledger string, filter *commonpb.Que
 			continue
 		}
 
-		if ids[j] == row.id {
+		if page[j].id == row.id {
+			if !logRowMatches(ledger, row, page[j]) {
+				return false
+			}
+
 			j++
 		} else if row.required {
 			return false
 		}
 	}
 
-	return j == len(ids)
+	return j == len(page)
+}
+
+// logRowMatches compares a served log against the model's record of it, field
+// by field. The date is compared once the model has learned it from the commit
+// response; before that the row is optional and its date says nothing. Every
+// other field the model derives itself, so a mismatch is the server's.
+func logRowMatches(ledger string, row logWindowRow, got serverLogRow) bool {
+	if got.ledger != ledger || got.kind != row.kind {
+		return false
+	}
+
+	// The payload rendering is empty for a transaction log, whose content the
+	// ListTransactions path validates against the model's own records.
+	if row.payload != "" && got.payload != row.payload {
+		return false
+	}
+
+	// The global sequence counts every ledger's logs and the technical entries
+	// between them, so the model holds it only for a bulk whose response it
+	// folded; before that it says nothing.
+	if row.sequence != 0 && got.sequence != row.sequence {
+		return false
+	}
+
+	// The three volume annotations are derived, never learned: the model runs
+	// the same end-of-bulk partition, so all three are pinned exactly — an
+	// empty list included.
+	if got.volumesKnown &&
+		(got.purged != row.purged || got.newKept != row.newKept || got.ephemeral != row.ephemeral) {
+		return false
+	}
+
+	if row.date == nil {
+		return true
+	}
+
+	return got.hasDate && got.date == row.date.GetData()
 }
 
 // logWindow is the page the model predicts when every row is decided: the
@@ -352,6 +505,7 @@ func serverLogIDs(logs []*commonpb.Log) []uint64 {
 //     base — so a refusal of a filter needing no index is a finding, and so is
 //     a page served for an index no base holds.
 func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketServiceClient, maxTicket uint64, ledger string, filter *commonpb.QueryFilter, afterSeq uint64, pageSize int, serverLogs []*commonpb.Log, needed map[string]struct{}, errKind indexedErrKind, err error) {
+	page := serverLogRows(serverLogs)
 	ids := serverLogIDs(serverLogs)
 
 	// A page must always be ascending, within the cursor, and no longer than
@@ -370,8 +524,21 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 		}
 	}
 
+	// Nothing in this workload configures a signing key, so a signed log on a
+	// read means the server signed something this driver cannot account for.
+	for _, row := range page {
+		if row.signed {
+			assert.Unreachable("singleton_driver_model: log page carries a response signature", internal.Details{
+				"ledger": ledger,
+				"logId":  row.id,
+			})
+
+			return
+		}
+	}
+
 	if c.matchesModel(maxTicket, "LOGQUERY", func(base oracle.GlobalState) bool {
-		return logOutcomeLegal(base.Ledger(ledger), ledger, filter, needed, errKind, ids, afterSeq, pageSize)
+		return logOutcomeLegal(base.Ledger(ledger), ledger, filter, needed, errKind, page, afterSeq, pageSize)
 	}) {
 		if errKind == indexedErrNotReady {
 			assert.Reachable("singleton_driver_model: log query gated on a missing index", internal.Details{"ledger": ledger})
@@ -392,6 +559,7 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 		"pageSize":    pageSize,
 		"rows":        len(ids),
 		"serverIds":   joinUint64(ids),
+		"serverRows":  describeServerLogRows(page),
 		"modelIds":    joinUint64(c.modelLogWindow(ledger, filter, afterSeq, pageSize)),
 		"modelIdx":    c.describeLogIndexStates(ledger, needed),
 		"modelDates":  c.describeLogDates(ledger),
@@ -406,12 +574,31 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 	assert.Unreachable("singleton_driver_model: log query outside model", details)
 }
 
+// describeServerLogRows renders every pinned field of a served page, the shape
+// a field mismatch is read from: id:kind@date/seq[payload]{volume annotations}.
+func describeServerLogRows(page []serverLogRow) string {
+	parts := make([]string, 0, len(page))
+
+	for _, row := range page {
+		date := "?"
+		if row.hasDate {
+			date = strconv.FormatUint(row.date, 10)
+		}
+
+		parts = append(parts, strconv.FormatUint(row.id, 10)+":"+row.kind+"@"+date+
+			"/seq"+strconv.FormatUint(row.sequence, 10)+"["+row.payload+"]"+
+			"{purged="+row.purged+";newKept="+row.newKept+";ephemeral="+row.ephemeral+"}")
+	}
+
+	return strings.Join(parts, ",")
+}
+
 // logOutcomeLegal is the per-candidate verdict for one ListLogs outcome: the
 // shared index-lifecycle legality, with the base's ordered log window as the
 // result check.
-func logOutcomeLegal(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, errKind indexedErrKind, ids []uint64, afterSeq uint64, pageSize int) bool {
+func logOutcomeLegal(ls oracle.LedgerState, ledger string, filter *commonpb.QueryFilter, needed map[string]struct{}, errKind indexedErrKind, page []serverLogRow, afterSeq uint64, pageSize int) bool {
 	return indexedQueryOutcomeLegal(ls, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed, errKind, "", func(view oracle.LedgerState) bool {
-		return logWindowMatches(view, ledger, filter, afterSeq, pageSize, ids)
+		return logWindowMatches(view, ledger, filter, afterSeq, pageSize, page)
 	})
 }
 

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs.go
@@ -542,7 +542,7 @@ func (c *Checker) validateLogQuery(ctx context.Context, client servicepb.BucketS
 	})
 
 	c.noteQueryCoverage(ledger, commonpb.QueryTarget_QUERY_TARGET_LOGS, filter, needed,
-		matched && errKind == indexedErrNone)
+		matched && errKind == indexedErrNone, len(page))
 
 	if matched {
 		if errKind == indexedErrNotReady {

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -10,10 +11,41 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+	"github.com/formancehq/ledger/v3/tests/oracle"
 	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
 )
 
 const logTestPageSize = 8
+
+// servedRows renders the model's own view of the given ids as a served page,
+// so a test can then vary one field at a time.
+func servedRows(ls oracle.LedgerState, ledger string, ids ...uint64) []serverLogRow {
+	byID := map[uint64]oracle.LogRow{}
+	for _, row := range ls.LogRows() {
+		byID[row.ID] = row
+	}
+
+	out := make([]serverLogRow, 0, len(ids))
+
+	for _, id := range ids {
+		row := byID[id]
+		out = append(out, serverLogRow{
+			ledger:       ledger,
+			id:           id,
+			kind:         row.Kind,
+			payload:      row.Payload,
+			date:         row.Date.GetData(),
+			hasDate:      row.Date != nil,
+			sequence:     row.Sequence,
+			purged:       row.PurgedVolumes,
+			newKept:      row.NewKeptVolumes,
+			ephemeral:    row.EphemeralVolumes,
+			volumesKnown: true,
+		})
+	}
+
+	return out
+}
 
 func filterLogDateLeaf() *commonpb.QueryFilter {
 	min := uint64(1)
@@ -97,7 +129,7 @@ func TestLogOutcome_AbsentDateIndexRequiresTheRefusal(t *testing.T) {
 	needed := neededLogIndexes(filter)
 	window := logWindow(ls, "L", filter, 0, logTestPageSize)
 
-	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize),
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, servedRows(ls, "L", window...), 0, logTestPageSize),
 		"a page served from an index no base holds is a finding, matching rows or not")
 	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
 		"the not-ready refusal is the legal outcome while the index is absent")
@@ -116,8 +148,8 @@ func TestLogOutcome_ActiveDateIndexRequiresThePage(t *testing.T) {
 	needed := neededLogIndexes(filter)
 	window := logWindow(ls, "L", filter, 0, logTestPageSize)
 
-	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize))
-	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, append(window, 999), 0, logTestPageSize),
+	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, servedRows(ls, "L", window...), 0, logTestPageSize))
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, servedRows(ls, "L", append(window, 999)...), 0, logTestPageSize),
 		"a page whose rows are not the base's window is a finding")
 	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
 		"refusing an index every base holds active is a finding")
@@ -140,9 +172,9 @@ func TestLogWindowMatches_UnlearnedDateIsOptional(t *testing.T) {
 
 	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, nil),
 		"an undecided row may be absent from the page")
-	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id}),
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id)),
 		"and it may be present")
-	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id + 7}),
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id+7)),
 		"a row the base does not hold at all is never legal")
 }
 
@@ -160,9 +192,192 @@ func TestLogWindowMatches_LearnedDateIsRequired(t *testing.T) {
 	filter := filterLogDateLeaf() // date >= 1
 
 	require.Equal(t, []uint64{id}, logWindow(ls, "L", filter, 0, logTestPageSize))
-	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id}))
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id)))
 	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, nil),
 		"a page with room may not omit a required row")
+}
+
+// A page is compared field by field, not by id: the id can be right while the
+// ledger, the payload kind or the server-assigned date is not. Each of those
+// is a value the model derives or learned, so a mismatch is the server's.
+func TestLogWindowMatches_ComparesEveryPinnedField(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5))
+
+	id := gs.Ledger("L").LogRows()[0].ID
+	gs.LearnLogDate("L", id, &commonpb.Timestamp{Data: 5})
+	gs.LearnLogSequence("L", id, 12)
+
+	ls := gs.Ledger("L")
+	filter := filterLogIDLeaf()
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id)),
+		"the model's own view of the row is what the server owes")
+
+	for _, tc := range []struct {
+		name   string
+		break_ func(*serverLogRow)
+	}{
+		{"another ledger's name", func(r *serverLogRow) { r.ledger = "other" }},
+		{"another payload kind", func(r *serverLogRow) { r.kind = "deleted_metadata" }},
+		{"a date the server never assigned", func(r *serverLogRow) { r.date = 6 }},
+		{"no date at all", func(r *serverLogRow) { r.hasDate = false }},
+		{"another global sequence", func(r *serverLogRow) { r.sequence = 77 }},
+		{"a purged volume the bulk never drained", func(r *serverLogRow) { r.purged = "acc:1:USD/2" }},
+		{"a new-kept volume the log did not touch", func(r *serverLogRow) { r.newKept = "acc:9:USD/2" }},
+		{"no new-kept volumes at all", func(r *serverLogRow) { r.newKept = "" }},
+		{"an ephemeral volume that outlived the bulk", func(r *serverLogRow) { r.ephemeral = "acc:1:USD/2" }},
+		{"new-kept volumes out of order", func(r *serverLogRow) { r.newKept = "world:USD/2,acc:1:USD/2" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			page := servedRows(ls, "L", id)
+			tc.break_(&page[0])
+
+			require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+		})
+	}
+}
+
+// Before the model learns a date it cannot hold the server to one, so the row
+// stays optional and its date is not compared — but its kind still is.
+func TestLogWindowMatches_UnlearnedDateSkipsOnlyTheDate(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
+
+	rows := ls.LogRows()
+	require.Len(t, rows, 1)
+	require.Nil(t, rows[0].Date)
+
+	filter := filterLogIDLeaf()
+
+	page := servedRows(ls, "L", rows[0].ID)
+	page[0].date, page[0].hasDate = 999, true
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page),
+		"an unlearned date says nothing about the served one")
+
+	page[0].kind = "drop_index"
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page),
+		"the kind is derived from the request and is compared regardless")
+}
+
+// A config-mutation log's payload is compared canonically: the model renders
+// what the request implies and the served log must render the same. A right id
+// and kind with the wrong key, type or value is a finding.
+func TestLogWindowMatches_ComparesCanonicalPayload(t *testing.T) {
+	t.Parallel()
+
+	acct := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+
+	gs := buildGlobal(t, oracletest.SetFieldTypeReq(acct, "tier", commonpb.MetadataType_METADATA_TYPE_STRING))
+	ls := gs.Ledger("L")
+
+	rows := ls.LogRows()
+	require.Len(t, rows, 1)
+	require.Equal(t, "set_metadata_field_type", rows[0].Kind)
+	require.NotEmpty(t, rows[0].Payload, "a schema log's payload is pinned")
+
+	filter := filterLogIDLeaf()
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", rows[0].ID)))
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{"another key", "target=1|key=grade|type=1"},
+		{"another declared type", "target=1|key=tier|type=2"},
+		{"another target", "target=2|key=tier|type=1"},
+		{"no payload at all", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			page := servedRows(ls, "L", rows[0].ID)
+			page[0].payload = tc.payload
+
+			require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+		})
+	}
+}
+
+// A metadata log renders its target and its key-sorted, type-tagged values, so
+// a value served under the wrong type or a key the request never carried is a
+// finding.
+func TestCanonicalServedLogPayload_MetadataValuesAreTypeTagged(t *testing.T) {
+	t.Parallel()
+
+	served := oracle.CanonicalServedLogPayload(&commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_SavedMetadata{SavedMetadata: &commonpb.SavedMetadata{
+			Target: &commonpb.Target{Target: &commonpb.Target_Account{Account: &commonpb.TargetAccount{Addr: "acc:1"}}},
+			Metadata: map[string]*commonpb.MetadataValue{
+				"b": {Type: &commonpb.MetadataValue_StringValue{StringValue: "5"}},
+				"a": {Type: &commonpb.MetadataValue_IntValue{IntValue: 5}},
+			},
+		}},
+	})
+
+	require.Equal(t, "target=acct:acc:1|a=i:5,b=s:5", served,
+		"keys sorted, values type-tagged, so a string 5 and an int 5 never compare equal")
+}
+
+// The commit fold is where both server-assigned fields enter the model: a
+// response's log carries the date and the global sequence, and learnTxStamps
+// is what records them. Without this the read comparison has nothing to hold
+// the server to.
+func TestLearnTxStamps_RecordsLogDateAndSequence(t *testing.T) {
+	t.Parallel()
+
+	bulk := bulkOf(oracletest.TxReq("world", "acc:1", "USD/2", 5))
+
+	res := oracle.NewGlobalState().Apply(bulk)
+	require.True(t, res.OK, "setup bulk rejected: %s", res.Reason)
+
+	gs := res.State
+	row := gs.Ledger("L").LogRows()[0]
+	require.Nil(t, row.Date)
+	require.Zero(t, row.Sequence)
+
+	learnTxStamps(gs, bulk, []*commonpb.Log{{
+		Sequence: 17,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{
+			LedgerName: "L",
+			Log:        &commonpb.LedgerLog{Id: row.ID, Date: &commonpb.Timestamp{Data: 99}},
+		}}},
+	}})
+
+	learned := gs.Ledger("L").LogRows()[0]
+	assert.Equal(t, uint64(99), learned.Date.GetData(), "the date comes from the commit response")
+	assert.Equal(t, uint64(17), learned.Sequence, "so does the global sequence")
+}
+
+// The global sequence spans every ledger and the technical entries between
+// them, so the model holds it only for a bulk whose response it folded. Until
+// then the served value is not compared; once learned it is.
+func TestLogWindowMatches_GlobalSequenceComparedOnceLearned(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5))
+	id := gs.Ledger("L").LogRows()[0].ID
+
+	ls := gs.Ledger("L")
+	filter := filterLogIDLeaf()
+	require.Zero(t, ls.LogRows()[0].Sequence, "the fixture must leave the sequence unlearned")
+
+	page := servedRows(ls, "L", id)
+	page[0].sequence = 4242
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page),
+		"an unlearned sequence says nothing about the served one")
+
+	gs.LearnLogSequence("L", id, 12)
+	ls = gs.Ledger("L")
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id)))
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page),
+		"a served sequence other than the learned one is a finding")
 }
 
 // A page may be truncated but never gap-toothed: carrying a later required row
@@ -186,12 +401,12 @@ func TestLogWindowMatches_RequiredRowMayNotBeSkipped(t *testing.T) {
 	ls := gs.Ledger("L")
 	filter := filterLogDateLeaf() // date >= 1: both rows required
 
-	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{rows[0].ID, rows[1].ID}))
-	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{rows[1].ID}),
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", rows[0].ID, rows[1].ID)))
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", rows[1].ID)),
 		"skipping an earlier required row is a finding")
-	require.True(t, logWindowMatches(ls, "L", filter, 0, 1, []uint64{rows[0].ID}),
+	require.True(t, logWindowMatches(ls, "L", filter, 0, 1, servedRows(ls, "L", rows[0].ID)),
 		"a full page of one legitimately truncates the rest")
-	require.False(t, logWindowMatches(ls, "L", filter, 0, 1, []uint64{rows[1].ID}),
+	require.False(t, logWindowMatches(ls, "L", filter, 0, 1, servedRows(ls, "L", rows[1].ID)),
 		"a full page must still start at the first required row")
 }
 
@@ -220,9 +435,62 @@ func TestLogOutcome_IndexFreeFilterMayNotBeGated(t *testing.T) {
 	window := logWindow(ls, "L", filter, 0, logTestPageSize)
 
 	require.NotEmpty(t, window, "the id filter must select the committed log, or this pins nothing")
-	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize))
+	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, servedRows(ls, "L", window...), 0, logTestPageSize))
 	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, nil, 0, logTestPageSize),
 		"an empty page where the model holds rows is a finding")
 	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
 		"a not-ready refusal of an index-free filter is a finding")
+}
+
+// serverLogRows must read the three volume annotations off the wire in the
+// order the FSM wrote them, and a colour — a dimension the model's volume key
+// does not carry — must take the whole comparison off rather than fail it.
+func TestServerLogRows_ReadsVolumeAnnotations(t *testing.T) {
+	t.Parallel()
+
+	logOf := func(l *commonpb.LedgerLog) *commonpb.Log {
+		return &commonpb.Log{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{
+			Apply: &commonpb.ApplyLedgerLog{LedgerName: "L", Log: l},
+		}}}
+	}
+
+	rows := serverLogRows([]*commonpb.Log{logOf(&commonpb.LedgerLog{
+		Id:               1,
+		PurgedVolumes:    []*commonpb.TouchedVolume{{Account: "e:1", Asset: "USD"}},
+		NewKeptVolumes:   []*commonpb.TouchedVolume{{Account: "world", Asset: "EUR"}, {Account: "n:1", Asset: "EUR"}},
+		EphemeralVolumes: []*commonpb.TouchedVolume{{Account: "e:2", Asset: "USD"}},
+	})})
+
+	require.Len(t, rows, 1)
+	require.True(t, rows[0].volumesKnown)
+	require.Equal(t, "e:1:USD", rows[0].purged)
+	require.Equal(t, "world:EUR,n:1:EUR", rows[0].newKept,
+		"read verbatim: the model renders its own list sorted, so a mis-sorted served list must not be repaired here")
+	require.Equal(t, "e:2:USD", rows[0].ephemeral)
+
+	coloured := serverLogRows([]*commonpb.Log{logOf(&commonpb.LedgerLog{
+		Id:             1,
+		NewKeptVolumes: []*commonpb.TouchedVolume{{Account: "n:1", Asset: "EUR", Color: "red"}},
+	})})
+
+	require.Len(t, coloured, 1)
+	require.False(t, coloured[0].volumesKnown, "a colour splits a cell the model holds as one")
+}
+
+// With a colour on the wire the three annotations say nothing, so a page that
+// disagrees on them is still legal — every other field is still compared.
+func TestLogWindowMatches_ColouredVolumesAreNotCompared(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
+	filter := filterLogIDLeaf()
+	id := ls.LogRows()[0].ID
+
+	page := servedRows(ls, "L", id)
+	page[0].newKept, page[0].volumesKnown = "", false
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+
+	page[0].kind = "drop_index"
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
@@ -29,10 +29,22 @@ func servedRows(ls oracle.LedgerState, ledger string, ids ...uint64) []serverLog
 
 	for _, id := range ids {
 		row := byID[id]
+
+		var (
+			tx        *commonpb.Transaction
+			revertsID uint64
+		)
+
+		if rec := modelTxForLog(ls, row.TxID); rec != nil {
+			tx, revertsID = serverTxFromRec(rec), rec.RevertsTransaction()
+		}
+
 		out = append(out, serverLogRow{
 			ledger:       ledger,
 			id:           id,
 			kind:         row.Kind,
+			tx:           tx,
+			revertsID:    revertsID,
 			payload:      row.Payload,
 			date:         row.Date.GetData(),
 			hasDate:      row.Date != nil,
@@ -477,20 +489,101 @@ func TestServerLogRows_ReadsVolumeAnnotations(t *testing.T) {
 	require.False(t, coloured[0].volumesKnown, "a colour splits a cell the model holds as one")
 }
 
-// With a colour on the wire the three annotations say nothing, so a page that
-// disagrees on them is still legal — every other field is still compared.
-func TestLogWindowMatches_ColouredVolumesAreNotCompared(t *testing.T) {
+// No generated posting carries a colour, so a coloured annotation is a cell
+// nothing in the run could have produced — a finding, not a reason to stop
+// comparing.
+func TestLogWindowMatches_ColouredVolumesAreRejected(t *testing.T) {
 	t.Parallel()
 
 	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
 	filter := filterLogIDLeaf()
 	id := ls.LogRows()[0].ID
 
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", id)))
+
 	page := servedRows(ls, "L", id)
-	page[0].newKept, page[0].volumesKnown = "", false
-
-	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
-
-	page[0].kind = "drop_index"
+	page[0].volumesKnown = false
 	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+}
+
+// A transaction log carries its own copy of the transaction. ListTransactions
+// agreeing with the model says nothing about that copy, so it is held to the
+// same record: a corrupted embedded transaction is a finding even when the
+// transaction table is right.
+func TestLogWindowMatches_ComparesTheEmbeddedTransaction(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t,
+		oracletest.TxReqRefL("L", "r1", "world", "acc:1", "USD/2", 5),
+		oracletest.RevertReqL("L", 1, true),
+	)
+
+	ls := gs.Ledger("L")
+	filter := filterLogIDLeaf()
+
+	rows := ls.LogRows()
+	require.Len(t, rows, 2)
+	require.Equal(t, uint64(1), rows[0].TxID, "the create log names its transaction")
+	require.Equal(t, uint64(2), rows[1].TxID, "the revert log names the compensating one")
+
+	ids := []uint64{rows[0].ID, rows[1].ID}
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, servedRows(ls, "L", ids...)))
+
+	for name, corrupt := range map[string]func(*serverLogRow){
+		"a different transaction id": func(r *serverLogRow) { r.tx.Id = 99 },
+		"a different reference":      func(r *serverLogRow) { r.tx.Reference = "elsewhere" },
+		"a dropped posting":          func(r *serverLogRow) { r.tx.Postings = nil },
+		"an invented revert link":    func(r *serverLogRow) { r.tx.RevertsTransaction = 7 },
+		"no transaction at all":      func(r *serverLogRow) { r.tx = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			page := servedRows(ls, "L", ids...)
+			corrupt(&page[0])
+			require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+		})
+	}
+
+	// The revert log's reverted_transaction_id is part of the payload too.
+	page := servedRows(ls, "L", ids...)
+	page[1].revertsID = 42
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, page))
+
+	// A config-mutation log announces no transaction; one appearing is a finding.
+	cfg := buildGlobal(t, oracletest.AddTypeReq("T")).Ledger("L")
+	cfgPage := servedRows(cfg, "L", cfg.LogRows()[0].ID)
+	cfgPage[0].tx = &commonpb.Transaction{Id: 1}
+	require.False(t, logWindowMatches(cfg, "L", filter, 0, logTestPageSize, cfgPage))
+}
+
+// The payload is frozen at creation while the record keeps moving, so a
+// transaction reverted or re-tagged after its log was written must not make
+// that log's own copy look wrong.
+func TestLogTxMatches_IgnoresPostCreationMutation(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t,
+		oracletest.TxReqL("L", "world", "acc:1", "USD/2", 5),
+		oracletest.RevertReqL("L", 1, true),
+		oracletest.AddTxMetaReq(1, map[string]*commonpb.MetadataValue{"k1": commonpb.NewStringValue("late")}),
+	)
+
+	ls := gs.Ledger("L")
+	rec := ls.Txs().Get(0)
+	require.True(t, rec.Reverted(), "the record moved after its log was written")
+	require.NotEmpty(t, rec.Metadata())
+
+	// The log's copy still carries the creation-time values.
+	frozen := &commonpb.Transaction{Id: rec.Id(), Postings: rec.Postings()}
+	frozen.PostCommitVolumes = serverPCVFromRec(rec)
+	require.True(t, logTxMatches(rec, frozen))
+
+	var ids []uint64
+	for _, row := range ls.LogRows() {
+		ids = append(ids, row.ID)
+	}
+
+	require.True(t, logWindowMatches(ls, "L", filterLogIDLeaf(), 0, logTestPageSize,
+		servedRows(ls, "L", ids...)))
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_logs_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+)
+
+const logTestPageSize = 8
+
+func filterLogDateLeaf() *commonpb.QueryFilter {
+	min := uint64(1)
+
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogBuiltinUint{
+		LogBuiltinUint: &commonpb.LogBuiltinUintCondition{
+			Field: commonpb.LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE,
+			Cond:  &commonpb.UintCondition{Min: &min},
+		},
+	}}
+}
+
+func filterLogIDLeaf() *commonpb.QueryFilter {
+	min := uint64(1)
+
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogId{
+		LogId: &commonpb.LogIdCondition{Cond: &commonpb.UintCondition{Min: &min}},
+	}}
+}
+
+func reasonErr(t *testing.T, code codes.Code, reason string) error {
+	t.Helper()
+
+	st, err := status.New(code, reason).WithDetails(&errdetails.ErrorInfo{Domain: "ledger", Reason: reason})
+	require.NoError(t, err)
+
+	return st.Err()
+}
+
+// The date leaf is the only LOGS leaf served from an index, wherever it sits in
+// the tree; every other shape needs none.
+func TestNeededLogIndexes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, map[string]struct{}{logDateIndexCanonical: {}}, neededLogIndexes(filterLogDateLeaf()))
+	require.Equal(t, map[string]struct{}{logDateIndexCanonical: {}},
+		neededLogIndexes(filterOr(filterLogIDLeaf(), filterLogDateLeaf())), "a nested date leaf still needs the index")
+	require.Nil(t, neededLogIndexes(filterLogIDLeaf()))
+	require.Nil(t, neededLogIndexes(nil), "the unfiltered universe scan needs no index")
+}
+
+// Both index-gate rejections must reach the validator. INDEX_BUILDING rides
+// codes.Unavailable and therefore sits inside internal.IsTransient: classifying
+// it before the transient bail is what keeps a wrongly gated read a finding
+// instead of a skipped blip.
+func TestClassifyLogQueryError(t *testing.T) {
+	t.Parallel()
+
+	kind, gated := classifyLogQueryError(nil)
+	require.True(t, gated)
+	require.Equal(t, indexedErrNone, kind)
+
+	notFound := reasonErr(t, codes.FailedPrecondition, "INDEX_NOT_FOUND")
+	kind, gated = classifyLogQueryError(notFound)
+	require.True(t, gated)
+	require.Equal(t, indexedErrNotReady, kind)
+
+	building := reasonErr(t, codes.Unavailable, "INDEX_BUILDING")
+	require.True(t, internal.IsTransient(building), "the trap: INDEX_BUILDING is inside the transient set")
+
+	kind, gated = classifyLogQueryError(building)
+	require.True(t, gated, "an index-building refusal must reach the validator, not the transient bail")
+	require.Equal(t, indexedErrNotReady, kind)
+
+	_, gated = classifyLogQueryError(status.Error(codes.Unavailable, "connection refused"))
+	require.False(t, gated, "a plain Unavailable stays environmental")
+
+	_, gated = classifyLogQueryError(status.Error(codes.FailedPrecondition, "boom"))
+	require.False(t, gated, "a reasonless precondition error is not an index-gate outcome")
+}
+
+// With the log-date index absent from the model, the refusal is REQUIRED, not
+// merely tolerated: a page is a finding even when its rows are exactly the
+// predicted window, which is what a server that stopped gating date filters
+// would return.
+func TestLogOutcome_AbsentDateIndexRequiresTheRefusal(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
+	filter := filterLogDateLeaf()
+	needed := neededLogIndexes(filter)
+	window := logWindow(ls, "L", filter, 0, logTestPageSize)
+
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize),
+		"a page served from an index no base holds is a finding, matching rows or not")
+	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
+		"the not-ready refusal is the legal outcome while the index is absent")
+}
+
+// Once the model holds the index active the obligation flips: the page is owed,
+// its rows are checked, and a refusal is a finding.
+func TestLogOutcome_ActiveDateIndexRequiresThePage(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5), oracletest.CreateIndexReq(logDateIndexID()))
+	gs.SetIndexActive("L", logDateIndexCanonical)
+
+	ls := gs.Ledger("L")
+	filter := filterLogDateLeaf()
+	needed := neededLogIndexes(filter)
+	window := logWindow(ls, "L", filter, 0, logTestPageSize)
+
+	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize))
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, append(window, 999), 0, logTestPageSize),
+		"a page whose rows are not the base's window is a finding")
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
+		"refusing an index every base holds active is a finding")
+}
+
+// A log whose date this base has not learned cannot be decided against a date
+// leaf — the shape a candidate base holds after folding an observed-but-
+// undrained bulk — so the page may carry it or not, but nothing else.
+func TestLogWindowMatches_UnlearnedDateIsOptional(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
+	filter := filterLogDateLeaf()
+
+	rows := ls.LogDates()
+	require.Len(t, rows, 1)
+	require.Nil(t, rows[0].Date, "the fixture must leave the date unlearned")
+
+	id := rows[0].ID
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, nil),
+		"an undecided row may be absent from the page")
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id}),
+		"and it may be present")
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id + 7}),
+		"a row the base does not hold at all is never legal")
+}
+
+// Once the date is learned the row is decided: a matching log is required, so a
+// page with room that omits it is a finding.
+func TestLogWindowMatches_LearnedDateIsRequired(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5))
+
+	id := gs.Ledger("L").LogDates()[0].ID
+	gs.LearnLogDate("L", id, &commonpb.Timestamp{Data: 5})
+
+	ls := gs.Ledger("L")
+	filter := filterLogDateLeaf() // date >= 1
+
+	require.Equal(t, []uint64{id}, logWindow(ls, "L", filter, 0, logTestPageSize))
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{id}))
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, nil),
+		"a page with room may not omit a required row")
+}
+
+// A page may be truncated but never gap-toothed: carrying a later required row
+// while skipping an earlier one is a finding, which is what a server serving
+// the wrong version's keyspace would return.
+func TestLogWindowMatches_RequiredRowMayNotBeSkipped(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t,
+		oracletest.TxReq("world", "acc:1", "USD/2", 5),
+		oracletest.TxReq("world", "acc:2", "USD/2", 7),
+	)
+
+	rows := gs.Ledger("L").LogDates()
+	require.Len(t, rows, 2)
+
+	for _, row := range rows {
+		gs.LearnLogDate("L", row.ID, &commonpb.Timestamp{Data: 5})
+	}
+
+	ls := gs.Ledger("L")
+	filter := filterLogDateLeaf() // date >= 1: both rows required
+
+	require.True(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{rows[0].ID, rows[1].ID}))
+	require.False(t, logWindowMatches(ls, "L", filter, 0, logTestPageSize, []uint64{rows[1].ID}),
+		"skipping an earlier required row is a finding")
+	require.True(t, logWindowMatches(ls, "L", filter, 0, 1, []uint64{rows[0].ID}),
+		"a full page of one legitimately truncates the rest")
+	require.False(t, logWindowMatches(ls, "L", filter, 0, 1, []uint64{rows[1].ID}),
+		"a full page must still start at the first required row")
+}
+
+// The generator churns the log-date index, so the LOGS date filters cycle
+// through absent, ambiguous and active instead of only ever being refused.
+func TestWorkloadIndexes_IncludesTheLogDateIndex(t *testing.T) {
+	t.Parallel()
+
+	var found bool
+	for _, wi := range workloadIndexes() {
+		if wi.canonical == logDateIndexCanonical {
+			found = true
+		}
+	}
+
+	require.True(t, found, "the log-date index must be in the create/drop pool")
+}
+
+// A filter needing no index may never be gated.
+func TestLogOutcome_IndexFreeFilterMayNotBeGated(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReq("world", "acc:1", "USD/2", 5)).Ledger("L")
+	filter := filterLogIDLeaf()
+	needed := neededLogIndexes(filter)
+	window := logWindow(ls, "L", filter, 0, logTestPageSize)
+
+	require.NotEmpty(t, window, "the id filter must select the committed log, or this pins nothing")
+	require.True(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, window, 0, logTestPageSize))
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNone, nil, 0, logTestPageSize),
+		"an empty page where the model holds rows is a finding")
+	require.False(t, logOutcomeLegal(ls, "L", filter, needed, indexedErrNotReady, nil, 0, logTestPageSize),
+		"a not-ready refusal of an index-free filter is a finding")
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
@@ -688,8 +688,8 @@ func TestTxRecordMatches_ComparesPostCommitVolumes(t *testing.T) {
 
 	coloured := serverTxFromRec(rec)
 	coloured.PostCommitVolumes.GetVolumesByAccount()["acc:1"].Volumes[0].Color = "red"
-	require.True(t, txRecordMatches(rec, coloured),
-		"colour is a dimension the model's key cannot address, so the snapshot is not compared")
+	require.False(t, txRecordMatches(rec, coloured),
+		"no generated posting is coloured, so a coloured cell is unexplained data")
 }
 
 // assembleAccount never stamps these, so the oracle pins them absent rather
@@ -723,4 +723,27 @@ func TestAccountMatches_RejectsUnmodelledTimestamps(t *testing.T) {
 			require.False(t, accountMatches(ls, "acc:1", acct))
 		})
 	}
+}
+
+// No generated posting carries a colour, so a coloured bucket is a row nothing
+// in the run could have produced — dropping it would let a fabricated one
+// through the exact volume comparison untouched.
+func TestAccountMatches_RejectsColouredVolumes(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5)).Ledger("L")
+
+	acct := &commonpb.Account{
+		Address: "acc:1",
+		Volumes: []*commonpb.AccountVolume{
+			{Asset: "USD", Volumes: &commonpb.VolumesWithBalance{Input: "5", Output: "0", Balance: "5"}},
+		},
+	}
+	require.True(t, accountMatches(ls, "acc:1", acct))
+
+	acct.Volumes = append(acct.Volumes, &commonpb.AccountVolume{
+		Asset: "USD", Color: "red",
+		Volumes: &commonpb.VolumesWithBalance{Input: "1", Output: "0", Balance: "1"},
+	})
+	require.False(t, accountMatches(ls, "acc:1", acct))
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
@@ -747,3 +747,37 @@ func TestAccountMatches_RejectsColouredVolumes(t *testing.T) {
 	})
 	require.False(t, accountMatches(ls, "acc:1", acct))
 }
+
+// The volume lists carry one entry per asset. A repeat collapses into the
+// comparison's map and is counted once, so without an explicit check it would
+// pass — and only the first copy is ever read, hiding whatever the second one
+// carries.
+func TestVolumeComparisons_RejectDuplicateRows(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5)).Ledger("L")
+
+	usd := func(in, out, bal string) *commonpb.AccountVolume {
+		return &commonpb.AccountVolume{
+			Asset:   "USD",
+			Volumes: &commonpb.VolumesWithBalance{Input: in, Output: out, Balance: bal},
+		}
+	}
+
+	acct := &commonpb.Account{Address: "acc:1", Volumes: []*commonpb.AccountVolume{usd("5", "0", "5")}}
+	require.True(t, accountMatches(ls, "acc:1", acct))
+
+	acct.Volumes = append(acct.Volumes, usd("5", "0", "5"))
+	require.False(t, accountMatches(ls, "acc:1", acct), "an exact repeat is still malformed")
+
+	rec := ls.Txs().Get(0)
+	snapshot := serverPCVFromRec(rec)
+	require.True(t, pcvSnapshotMatches(rec.PostCommitVolumes(), snapshot))
+
+	byAccount := snapshot.GetVolumesByAccount()["acc:1"]
+	byAccount.Volumes = append(byAccount.Volumes, &commonpb.VolumeEntry{
+		Asset: "USD", Volumes: &commonpb.Volumes{Input: "999", Output: "0"},
+	})
+	require.False(t, pcvSnapshotMatches(rec.PostCommitVolumes(), snapshot),
+		"the second copy is never read, so it must not be tolerated")
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
@@ -268,10 +268,42 @@ func serverTxFromRec(rec txRecordView) *commonpb.Transaction {
 		RevertsTransaction:    rec.RevertsTransaction(),
 		Timestamp:             rec.Timestamp(),
 		InsertedAt:            rec.InsertedAt(),
-		RevertedAt:            rec.RevertedAt(),
-		Postings:              rec.Postings(),
-		Metadata:              rec.Metadata(),
+		// Stamped from the same proposal date as inserted_at and never bumped.
+		UpdatedAt:         rec.InsertedAt(),
+		RevertedAt:        rec.RevertedAt(),
+		Postings:          rec.Postings(),
+		Metadata:          rec.Metadata(),
+		PostCommitVolumes: serverPCVFromRec(rec),
 	}
+}
+
+// serverPCVFromRec renders the model's frozen snapshot the way the server
+// sends it, so a row built from the record is the row the server owes.
+func serverPCVFromRec(rec txRecordView) *commonpb.PostCommitVolumes {
+	model := rec.PostCommitVolumes()
+	if len(model) == 0 {
+		return nil
+	}
+
+	byAccount := map[string]*commonpb.VolumesByAssets{}
+
+	for key, vp := range model {
+		entry := byAccount[key.Address]
+		if entry == nil {
+			entry = &commonpb.VolumesByAssets{}
+			byAccount[key.Address] = entry
+		}
+
+		entry.Volumes = append(entry.Volumes, &commonpb.VolumeEntry{
+			Asset:   key.Asset,
+			Volumes: &commonpb.Volumes{Input: vp.Input.Dec(), Output: vp.Output.Dec()},
+		})
+	}
+
+	out := &commonpb.PostCommitVolumes{VolumesByAccount: byAccount}
+	out.SortVolumes()
+
+	return out
 }
 
 func TestMatchTxFilter_TxBuiltinLeaves(t *testing.T) {
@@ -590,13 +622,105 @@ func TestTxRecordMatches_LearnedInsertedAt(t *testing.T) {
 	require.True(t, txRecordMatches(rec, serverTxFromRec(rec)))
 
 	mismatched := serverTxFromRec(rec)
-	mismatched.InsertedAt = stamp(999)
+	mismatched.InsertedAt, mismatched.UpdatedAt = stamp(999), stamp(999)
 	require.False(t, txRecordMatches(rec, mismatched),
 		"a learned inserted_at must reject a row serving a different value")
 
 	unlearned := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5)).Ledger("L").Txs().Get(0)
 	anyStamp := serverTxFromRec(unlearned)
-	anyStamp.InsertedAt = stamp(123)
+	anyStamp.InsertedAt, anyStamp.UpdatedAt = stamp(123), stamp(123)
 	require.True(t, txRecordMatches(unlearned, anyStamp),
 		"an unlearned inserted_at stays server-dated and unchecked")
+}
+
+// updated_at is stamped from the same proposal date as inserted_at and nothing
+// bumps it afterwards, so a row where the two disagree is corrupt regardless of
+// what the model learned.
+func TestTxRecordMatches_UpdatedAtTracksInsertedAt(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5))
+	gs.LearnTxStamps("L", 1, stamp(100), stamp(110), nil)
+
+	rec := gs.Ledger("L").Txs().Get(0)
+	require.True(t, txRecordMatches(rec, serverTxFromRec(rec)))
+
+	drifted := serverTxFromRec(rec)
+	drifted.UpdatedAt = stamp(111)
+	require.False(t, txRecordMatches(rec, drifted), "a bumped updated_at is a finding")
+
+	missing := serverTxFromRec(rec)
+	missing.UpdatedAt = nil
+	require.False(t, txRecordMatches(rec, missing), "so is dropping it")
+}
+
+// The post-commit snapshot is frozen at the transaction's own sequence, so a
+// read must echo it whatever the balances have done since. It is compared in
+// both directions: a missing cell and an invented one are equally wrong.
+func TestTxRecordMatches_ComparesPostCommitVolumes(t *testing.T) {
+	t.Parallel()
+
+	// The second transaction moves acc:1 again, so the first one's snapshot no
+	// longer equals any current balance.
+	gs := buildGlobal(t,
+		oracletest.TxReqL("L", "world", "acc:1", "USD", 5),
+		oracletest.TxReqL("L", "world", "acc:1", "USD", 7),
+	)
+
+	rec := gs.Ledger("L").Txs().Get(0)
+	require.NotEmpty(t, rec.PostCommitVolumes(), "the model froze a snapshot")
+	require.True(t, txRecordMatches(rec, serverTxFromRec(rec)))
+
+	current := serverTxFromRec(rec)
+	current.PostCommitVolumes.GetVolumesByAccount()["acc:1"].Volumes[0].Volumes.Input = "12"
+	require.False(t, txRecordMatches(rec, current),
+		"serving the current balance instead of the snapshot is a finding")
+
+	dropped := serverTxFromRec(rec)
+	delete(dropped.PostCommitVolumes.GetVolumesByAccount(), "acc:1")
+	require.False(t, txRecordMatches(rec, dropped), "a missing cell is a finding")
+
+	invented := serverTxFromRec(rec)
+	invented.PostCommitVolumes.GetVolumesByAccount()["ghost:1"] = &commonpb.VolumesByAssets{
+		Volumes: []*commonpb.VolumeEntry{{Asset: "USD", Volumes: &commonpb.Volumes{Input: "1", Output: "0"}}},
+	}
+	require.False(t, txRecordMatches(rec, invented), "an invented cell is a finding")
+
+	coloured := serverTxFromRec(rec)
+	coloured.PostCommitVolumes.GetVolumesByAccount()["acc:1"].Volumes[0].Color = "red"
+	require.True(t, txRecordMatches(rec, coloured),
+		"colour is a dimension the model's key cannot address, so the snapshot is not compared")
+}
+
+// assembleAccount never stamps these, so the oracle pins them absent rather
+// than waving through whatever a future change starts sending.
+func TestAccountMatches_RejectsUnmodelledTimestamps(t *testing.T) {
+	t.Parallel()
+
+	ls := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5)).Ledger("L")
+
+	base := func() *commonpb.Account {
+		return &commonpb.Account{
+			Address: "acc:1",
+			Volumes: []*commonpb.AccountVolume{
+				{Asset: "USD", Volumes: &commonpb.VolumesWithBalance{Input: "5", Output: "0", Balance: "5"}},
+			},
+		}
+	}
+
+	require.True(t, accountMatches(ls, "acc:1", base()))
+
+	for name, mutate := range map[string]func(*commonpb.Account){
+		"first_usage":    func(a *commonpb.Account) { a.FirstUsage = stamp(1) },
+		"insertion_date": func(a *commonpb.Account) { a.InsertionDate = stamp(1) },
+		"updated_at":     func(a *commonpb.Account) { a.UpdatedAt = stamp(1) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			acct := base()
+			mutate(acct)
+			require.False(t, accountMatches(ls, "acc:1", acct))
+		})
+	}
 }

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/queries_test.go
@@ -1,0 +1,602 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/tests/oracle"
+	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
+)
+
+// buildLedger applies reqs as one committed bulk on an empty-chart ledger "L"
+// and returns its state. An empty chart disables account-type enforcement, so
+// transactions to arbitrary addresses commit and populate volumes.
+func buildLedger(t *testing.T, reqs ...*servicepb.Request) oracle.LedgerState {
+	t.Helper()
+
+	res := oracle.NewGlobalState().Apply(oracle.Bulk{Requests: reqs})
+	require.True(t, res.OK, "setup bulk rejected: %s", res.Reason)
+
+	return res.State.Ledger("L")
+}
+
+const (
+	accounts = commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS
+	txns     = commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS
+)
+
+func TestFilterNeedsIndex(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, filterNeedsIndex(nil, accounts))
+	require.False(t, filterNeedsIndex(nil, txns))
+
+	// Address is index-free on accounts, index-backed on transactions.
+	require.False(t, filterNeedsIndex(filterAddrPrefix("acc:"), accounts))
+	require.True(t, filterNeedsIndex(filterAddrPrefix("acc:"), txns))
+
+	require.False(t, filterNeedsIndex(filterReverted(true), txns))
+	require.False(t, filterNeedsIndex(filterTxIDRange(1, 5), txns))
+
+	// Metadata fields are index-backed on either target.
+	require.True(t, filterNeedsIndex(filterMetaExists("k"), accounts))
+	require.True(t, filterNeedsIndex(filterMetaExists("k"), txns))
+
+	// Boolean nodes propagate their children's index needs.
+	require.False(t, filterNeedsIndex(filterAnd(filterReverted(true), filterTxIDRange(1, 5)), txns))
+	require.True(t, filterNeedsIndex(filterAnd(filterReverted(true), filterMetaExists("k")), txns))
+	require.True(t, filterNeedsIndex(filterNot(filterMetaExists("k")), accounts))
+	require.False(t, filterNeedsIndex(filterNot(filterReverted(true)), txns))
+}
+
+func TestFilterInvalidForTarget(t *testing.T) {
+	t.Parallel()
+
+	// Transactions-only conditions are invalid on the accounts target.
+	require.True(t, filterInvalidForTarget(filterReverted(true), accounts))
+	require.True(t, filterInvalidForTarget(filterTxIDRange(1, 5), accounts))
+	// The accounts-only condition is invalid on the transactions target.
+	require.True(t, filterInvalidForTarget(filterHasAsset("USD", 2), txns))
+
+	// Each is valid on its own target.
+	require.False(t, filterInvalidForTarget(filterReverted(true), txns))
+	require.False(t, filterInvalidForTarget(filterTxIDRange(1, 5), txns))
+	require.False(t, filterInvalidForTarget(filterHasAsset("USD", 2), accounts))
+
+	// Address is valid on both targets; nil (universe) is always valid.
+	require.False(t, filterInvalidForTarget(filterAddrPrefix("acc:"), accounts))
+	require.False(t, filterInvalidForTarget(filterAddrPrefix("acc:"), txns))
+	require.False(t, filterInvalidForTarget(nil, accounts))
+
+	// Combinators propagate an invalid child; a fully-valid tree stays valid.
+	require.True(t, filterInvalidForTarget(filterAnd(filterAddrExact("acc:1"), filterReverted(true)), accounts))
+	require.True(t, filterInvalidForTarget(filterNot(filterReverted(true)), accounts))
+	require.False(t, filterInvalidForTarget(filterAnd(filterAddrExact("acc:1"), filterAddrPrefix("x:")), accounts))
+}
+
+func TestMatchAccountFilter(t *testing.T) {
+	t.Parallel()
+
+	// world → acc:1 in USD/2, so both hold a USD/2 (base "USD", precision 2)
+	// volume cell; neither holds EUR.
+	ls := buildLedger(t, oracletest.TxReq("world", "acc:1", "USD/2", 5))
+
+	require.True(t, matchAccountFilter(ls, nil, "anything")) // universe
+
+	require.True(t, matchAccountFilter(ls, filterAddrPrefix("acc:"), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterAddrPrefix("acc:"), "world"))
+
+	require.True(t, matchAccountFilter(ls, filterAddrExact("acc:1"), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterAddrExact("acc:1"), "acc:2"))
+
+	require.True(t, matchAccountFilter(ls, filterAnd(filterAddrPrefix("acc:"), filterAddrExact("acc:1")), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterAnd(filterAddrPrefix("acc:"), filterAddrExact("acc:1")), "acc:2"))
+
+	require.True(t, matchAccountFilter(ls, filterOr(filterAddrExact("acc:1"), filterAddrExact("acc:2")), "acc:2"))
+	require.False(t, matchAccountFilter(ls, filterOr(filterAddrExact("acc:1"), filterAddrExact("acc:2")), "acc:3"))
+
+	require.True(t, matchAccountFilter(ls, filterNot(filterAddrPrefix("acc:")), "world"))
+	require.False(t, matchAccountFilter(ls, filterNot(filterAddrPrefix("acc:")), "acc:1"))
+
+	// has-asset: matches an account with a volume cell in the (base, precision).
+	require.True(t, matchAccountFilter(ls, filterHasAsset("USD", 2), "acc:1"))
+	require.True(t, matchAccountFilter(ls, filterHasAsset("USD", 2), "world"))
+	require.False(t, matchAccountFilter(ls, filterHasAsset("EUR", 2), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterHasAsset("USD", 2), "acc:absent"))
+	// Composed with an index-free address leaf.
+	require.True(t, matchAccountFilter(ls, filterAnd(filterHasAsset("USD", 2), filterAddrPrefix("acc:")), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterAnd(filterHasAsset("USD", 2), filterAddrPrefix("acc:")), "world"))
+
+	// Empty And/Or match nothing, mirroring the compiler's empty iterator.
+	require.False(t, matchAccountFilter(ls, filterAnd(), "acc:1"))
+	require.False(t, matchAccountFilter(ls, filterOr(), "acc:1"))
+}
+
+func TestMatchTxIDBounds(t *testing.T) {
+	t.Parallel()
+
+	lo, hi := uint64(2), uint64(4)
+	inclusive := &commonpb.UintCondition{Min: &lo, Max: &hi}
+	require.False(t, matchUintBounds(inclusive, 1))
+	require.True(t, matchUintBounds(inclusive, 2))
+	require.True(t, matchUintBounds(inclusive, 4))
+	require.False(t, matchUintBounds(inclusive, 5))
+
+	exclusive := &commonpb.UintCondition{Min: &lo, Max: &hi, MinExclusive: true, MaxExclusive: true}
+	require.False(t, matchUintBounds(exclusive, 2))
+	require.True(t, matchUintBounds(exclusive, 3))
+	require.False(t, matchUintBounds(exclusive, 4))
+
+	openMax := &commonpb.UintCondition{Min: &lo}
+	require.True(t, matchUintBounds(openMax, 1000))
+	require.False(t, matchUintBounds(openMax, 1))
+}
+
+func TestMatchTxFilter(t *testing.T) {
+	t.Parallel()
+
+	// Two funding transactions, then revert the first: tx 1 is reverted, tx 3 is
+	// the compensating transaction (tx 2 is the second funding tx).
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:1", "USD", 5),
+		oracletest.TxReq("world", "acc:2", "USD", 5),
+		oracletest.RevertReqL("L", 1, true),
+	)
+	txs := ls.Txs()
+	require.Equal(t, 3, txs.Len())
+
+	// These leaves never read a server stamp, so every verdict must be known.
+	matchKnown := func(f *commonpb.QueryFilter, rec txRecordView) bool {
+		m, known := matchTxFilter(ls, f, rec)
+		require.True(t, known)
+
+		return m
+	}
+
+	require.True(t, matchKnown(filterReverted(true), txs.Get(int(0))))
+	require.False(t, matchKnown(filterReverted(false), txs.Get(int(0))))
+	require.True(t, matchKnown(filterReverted(false), txs.Get(int(1))))
+
+	require.True(t, matchKnown(filterTxIDRange(1, 2), txs.Get(int(0))))
+	require.False(t, matchKnown(filterTxIDRange(1, 2), txs.Get(int(2))))
+
+	require.True(t, matchKnown(filterNot(filterReverted(true)), txs.Get(int(1))))
+	require.True(t, matchKnown(filterAnd(filterReverted(true), filterTxIDRange(1, 2)), txs.Get(int(0))))
+}
+
+func TestAccountUniverse_OrderIsByteAscending(t *testing.T) {
+	t.Parallel()
+
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:2", "USD", 5),
+		oracletest.TxReq("world", "acc:10", "USD", 5),
+	)
+
+	// "acc:10" < "acc:2" bytewise ('1' < '2'), and both precede "world".
+	require.Equal(t, []string{"acc:10", "acc:2", "world"}, accountUniverse(ls))
+}
+
+func TestAccountWindow(t *testing.T) {
+	t.Parallel()
+
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:1", "USD", 5),
+		oracletest.TxReq("world", "acc:2", "USD", 5),
+		oracletest.TxReq("world", "acc:3", "USD", 5),
+	)
+	// Universe: acc:1, acc:2, acc:3, world.
+
+	require.Equal(t, []string{"acc:1", "acc:2"},
+		accountWindow(ls, nil, "", 2, false))
+
+	// Cursor is exclusive: forward drops addresses <= cursor.
+	require.Equal(t, []string{"acc:2", "acc:3", "world"},
+		accountWindow(ls, nil, "acc:1", 10, false))
+
+	require.Equal(t, []string{"world", "acc:3", "acc:2", "acc:1"},
+		accountWindow(ls, nil, "", 10, true))
+
+	// Reverse cursor drops addresses >= cursor.
+	require.Equal(t, []string{"acc:2", "acc:1"},
+		accountWindow(ls, nil, "acc:3", 10, true))
+
+	// An address filter excludes world.
+	require.Equal(t, []string{"acc:1", "acc:2", "acc:3"},
+		accountWindow(ls, filterAddrPrefix("acc:"), "", 10, false))
+}
+
+func TestTransactionWindow(t *testing.T) {
+	t.Parallel()
+
+	ls := buildLedger(t,
+		oracletest.TxReq("world", "acc:1", "USD", 1),
+		oracletest.TxReq("world", "acc:2", "USD", 1),
+		oracletest.TxReq("world", "acc:3", "USD", 1),
+		oracletest.TxReq("world", "acc:4", "USD", 1),
+	)
+	// Transactions: ids 1, 2, 3, 4. The endpoint inverts reverse: reverse=false
+	// is newest-first (descending); reverse=true is oldest-first (ascending).
+
+	// reverse=false → descending, newest first.
+	require.Equal(t, []uint64{4, 3},
+		transactionWindow(ls, nil, 0, 2, false))
+
+	// Descending cursor is exclusive older-than: drops ids >= afterID.
+	require.Equal(t, []uint64{1},
+		transactionWindow(ls, nil, 2, 10, false))
+
+	// reverse=true → ascending, oldest first.
+	require.Equal(t, []uint64{1, 2, 3, 4},
+		transactionWindow(ls, nil, 0, 10, true))
+
+	// Ascending cursor is exclusive newer-than: drops ids <= afterID.
+	require.Equal(t, []uint64{4},
+		transactionWindow(ls, nil, 3, 10, true))
+
+	// Filtered, reverse=false → matches ids 2,3 in descending order.
+	require.Equal(t, []uint64{3, 2},
+		transactionWindow(ls, filterTxIDRange(2, 3), 0, 10, false))
+}
+
+// --- Phase 2: tx-builtin leaves and the fuzzy window ----------------------
+
+func stamp(v uint64) *commonpb.Timestamp { return &commonpb.Timestamp{Data: v} }
+
+// buildGlobal applies reqs as one bulk and returns the global state, for tests
+// that need LearnTxStamps on top of the applied records.
+func buildGlobal(t *testing.T, reqs ...*servicepb.Request) oracle.GlobalState {
+	t.Helper()
+
+	res := oracle.NewGlobalState().Apply(oracle.Bulk{Requests: reqs})
+	require.True(t, res.OK, "setup bulk rejected: %s", res.Reason)
+
+	return res.State
+}
+
+// serverTxFromRec builds the wire transaction the server would return for a
+// fully-known model record, so txWindowMatches' content check passes.
+func serverTxFromRec(rec txRecordView) *commonpb.Transaction {
+	return &commonpb.Transaction{
+		Id:                    rec.Id(),
+		Reference:             rec.Reference(),
+		Reverted:              rec.Reverted(),
+		RevertedByTransaction: rec.RevertedBy(),
+		RevertsTransaction:    rec.RevertsTransaction(),
+		Timestamp:             rec.Timestamp(),
+		InsertedAt:            rec.InsertedAt(),
+		RevertedAt:            rec.RevertedAt(),
+		Postings:              rec.Postings(),
+		Metadata:              rec.Metadata(),
+	}
+}
+
+func TestMatchTxFilter_TxBuiltinLeaves(t *testing.T) {
+	t.Parallel()
+
+	// tx 1 (ref r1), tx 2, tx 3 = revert of 2. Stamps learned as the checker
+	// would from the commit response; tx 2's reverted_at is tx 3's timestamp.
+	gs := buildGlobal(t,
+		oracletest.TxReqRefL("L", "r1", "world", "acc:1", "USD", 5),
+		oracletest.TxReqL("L", "world", "acc:2", "USD", 5),
+		oracletest.RevertReqL("L", 2, true),
+	)
+	gs.LearnTxStamps("L", 1, stamp(100), stamp(110), nil)
+	gs.LearnTxStamps("L", 2, stamp(200), stamp(210), nil)
+	gs.LearnTxStamps("L", 3, stamp(300), stamp(310), nil)
+	gs.LearnTxStamps("L", 2, nil, nil, stamp(300))
+
+	txs := gs.Ledger("L").Txs()
+
+	known := func(f *commonpb.QueryFilter, rec txRecordView) bool {
+		m, k := matchTxFilter(gs.Ledger("L"), f, rec)
+		require.True(t, k)
+
+		return m
+	}
+
+	// Reference: exact match; records without one never match, nor does "".
+	require.True(t, known(filterReference("r1"), txs.Get(int(0))))
+	require.False(t, known(filterReference("r1"), txs.Get(int(1))))
+	require.False(t, known(filterReference("absent"), txs.Get(int(0))))
+	require.False(t, known(filterReference(""), txs.Get(int(2))))
+
+	// Learned timestamp / inserted_at ranges.
+	require.False(t, known(filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 150, 250), txs.Get(int(0))))
+	require.True(t, known(filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 150, 250), txs.Get(int(1))))
+	require.True(t, known(filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT, 305, 315), txs.Get(int(2))))
+
+	// reverted_at: only the reverted original matches; un-reverted is a known miss.
+	rvat := filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REVERTED_AT, 250, 350)
+	require.True(t, known(rvat, txs.Get(int(1))))
+	require.False(t, known(rvat, txs.Get(int(0))))
+	require.False(t, known(rvat, txs.Get(int(2))))
+}
+
+func TestMatchTxFilter_UnknownStamps(t *testing.T) {
+	t.Parallel()
+
+	// No stamps learned: date verdicts are unknown, and booleans propagate
+	// Kleene-style — decided by a known false (AND) or known true (OR).
+	ls := buildLedger(t, oracletest.TxReq("world", "acc:1", "USD", 5))
+	rec := ls.Txs().Get(int(0))
+
+	tsLeaf := filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 1, 2)
+
+	_, k := matchTxFilter(ls, tsLeaf, rec)
+	require.False(t, k)
+
+	_, k = matchTxFilter(ls, filterNot(tsLeaf), rec)
+	require.False(t, k)
+
+	m, k := matchTxFilter(ls, filterAnd(filterReverted(true), tsLeaf), rec)
+	require.True(t, k, "AND decided by the known-false reverted leaf")
+	require.False(t, m)
+
+	m, k = matchTxFilter(ls, filterOr(filterReverted(false), tsLeaf), rec)
+	require.True(t, k, "OR decided by the known-true reverted leaf")
+	require.True(t, m)
+
+	_, k = matchTxFilter(ls, filterOr(filterReverted(true), tsLeaf), rec)
+	require.False(t, k, "OR undecided when the known leaf misses")
+}
+
+func TestTxWindowMatches_OptionalRows(t *testing.T) {
+	t.Parallel()
+
+	// Three creates; stamps learned for 1 and 3 only — under a date filter
+	// covering both, tx 2 is an optional row (unknown verdict).
+	gs := buildGlobal(t,
+		oracletest.TxReqL("L", "world", "acc:1", "USD", 5),
+		oracletest.TxReqL("L", "world", "acc:2", "USD", 5),
+		oracletest.TxReqL("L", "world", "acc:3", "USD", 5),
+	)
+	gs.LearnTxStamps("L", 1, stamp(100), stamp(100), nil)
+	gs.LearnTxStamps("L", 3, stamp(300), stamp(300), nil)
+
+	ls := gs.Ledger("L")
+	txs := ls.Txs()
+	filter := filterDateRange(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 50, 400)
+
+	// reverse=true is ascending on the transactions target.
+	page := func(ids ...uint64) []*commonpb.Transaction {
+		out := make([]*commonpb.Transaction, len(ids))
+		for i, id := range ids {
+			out[i] = serverTxFromRec(txs.Get(int(id - 1)))
+		}
+
+		return out
+	}
+
+	require.True(t, txWindowMatches(ls, filter, 0, 10, true, page(1, 3)), "optional row absent")
+	require.True(t, txWindowMatches(ls, filter, 0, 10, true, page(1, 2, 3)), "optional row present")
+	require.False(t, txWindowMatches(ls, filter, 0, 10, true, page(3, 1)), "order violation")
+	require.False(t, txWindowMatches(ls, filter, 0, 10, true, page(1)), "required row missing with page room")
+	require.True(t, txWindowMatches(ls, filter, 0, 1, true, page(1)), "full page truncates the rest")
+	require.False(t, txWindowMatches(ls, filter, 0, 10, true, page(2, 3)), "required first row missing")
+	require.True(t, txWindowMatches(ls, filter, 1, 10, true, page(2, 3)), "cursor drops tx 1; optional 2 present")
+	require.True(t, txWindowMatches(ls, filter, 1, 10, true, page(3)), "cursor drops tx 1; optional 2 absent")
+}
+
+// --- Phase 4: address-on-transactions ---------------------------------------
+
+func TestMatchTxAddress_RolesAndExclusions(t *testing.T) {
+	t.Parallel()
+
+	// Bulk: an ephemeral wash on e:1 (its cell is excluded at end of bulk) and a
+	// normal funding of a:1. tx 1 is the wash, tx 2 the funding.
+	gs := buildGlobal(t,
+		oracletest.AddTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL),
+		oracletest.AddTypeReqP("a", commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL),
+		oracletest.TxReqL("L", "world", "e:1", "USD", 5),
+		oracletest.TxReqL("L", "e:1", "world", "USD", 5),
+		oracletest.TxReqL("L", "world", "a:1", "USD", 7),
+	)
+	ls := gs.Ledger("L")
+	txs := ls.Txs()
+	require.Equal(t, 3, txs.Len())
+
+	anyRole := commonpb.AddressRole_ADDRESS_ROLE_ANY
+	src := commonpb.AddressRole_ADDRESS_ROLE_SOURCE
+	dst := commonpb.AddressRole_ADDRESS_ROLE_DESTINATION
+
+	addr := func(f *commonpb.QueryFilter) *commonpb.AddressMatch {
+		return f.GetFilter().(*commonpb.QueryFilter_Address).Address
+	}
+
+	// The excluded ephemeral cell strips e:1 membership from both wash txs.
+	require.False(t, matchTxAddress(ls, addr(filterAddrExactRole("e:1", anyRole)), txs.Get(int(0))))
+	require.False(t, matchTxAddress(ls, addr(filterAddrExactRole("e:1", anyRole)), txs.Get(int(1))))
+
+	// world's side of the wash is a kept NORMAL cell — still indexed.
+	require.True(t, matchTxAddress(ls, addr(filterAddrExactRole("world", src)), txs.Get(int(0))))
+	require.True(t, matchTxAddress(ls, addr(filterAddrExactRole("world", dst)), txs.Get(int(1))))
+
+	// Role bits on the funding tx: world is the source, a:1 the destination.
+	require.True(t, matchTxAddress(ls, addr(filterAddrExactRole("a:1", anyRole)), txs.Get(int(2))))
+	require.True(t, matchTxAddress(ls, addr(filterAddrExactRole("a:1", dst)), txs.Get(int(2))))
+	require.False(t, matchTxAddress(ls, addr(filterAddrExactRole("a:1", src)), txs.Get(int(2))))
+	require.True(t, matchTxAddress(ls, addr(filterAddrPrefixRole("a:", dst)), txs.Get(int(2))))
+	require.False(t, matchTxAddress(ls, addr(filterAddrPrefixRole("b:", anyRole)), txs.Get(int(2))))
+}
+
+func TestMatchTxAddress_UniverseDrop(t *testing.T) {
+	t.Parallel()
+
+	// Bulk 1 funds ephemeral e:1 (non-zero at end of bulk → kept and indexed).
+	res1 := oracle.NewGlobalState().Apply(oracle.Bulk{Requests: []*servicepb.Request{
+		oracletest.AddTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL),
+		oracletest.TxReqL("L", "world", "e:1", "USD", 5),
+	}})
+	require.True(t, res1.OK)
+
+	ls1 := res1.State.Ledger("L")
+	exact := func(a string) *commonpb.AddressMatch {
+		return filterAddrExactRole(a, commonpb.AddressRole_ADDRESS_ROLE_ANY).GetFilter().(*commonpb.QueryFilter_Address).Address
+	}
+	require.True(t, matchTxAddress(ls1, exact("e:1"), ls1.Txs().Get(int(0))))
+
+	// Bulk 2 drains it to zero: the cell is purged, dropping e:1 from the V+M
+	// universe — tx 1 keeps its index membership but stops being reachable
+	// through an address match, exactly like the server's attributes-zone
+	// account resolution.
+	res2 := res1.State.Apply(oracle.Bulk{Requests: []*servicepb.Request{
+		oracletest.TxReqL("L", "e:1", "world", "USD", 5),
+	}})
+	require.True(t, res2.OK)
+
+	ls2 := res2.State.Ledger("L")
+	rec := ls2.Txs().Get(int(0))
+	require.NotZero(t, rec.IndexedAddrs()["e:1"], "membership itself is monotone")
+	require.False(t, ls2.HasAccount("e:1"))
+	require.False(t, matchTxAddress(ls2, exact("e:1"), rec))
+}
+
+func TestNeededIndexCanonicals_AddressRoles(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		role    commonpb.AddressRole
+		builtin commonpb.TransactionBuiltinIndex
+	}{
+		{commonpb.AddressRole_ADDRESS_ROLE_ANY, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS},
+		{commonpb.AddressRole_ADDRESS_ROLE_SOURCE, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS},
+		{commonpb.AddressRole_ADDRESS_ROLE_DESTINATION, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS},
+	} {
+		needed := map[string]struct{}{}
+		neededIndexCanonicals(filterAddrPrefixRole("t-", tc.role), txns, needed)
+		require.Len(t, needed, 1)
+		require.Contains(t, needed, txBuiltinCanonical(tc.builtin))
+	}
+}
+
+// --- Phase 3: metadata Field filters -----------------------------------------
+
+func TestOracle_MetadataIndexLifecycle(t *testing.T) {
+	t.Parallel()
+
+	acct := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	id := indexes.MetadataID(acct, "k1")
+	canonical := indexes.Canonical(id)
+
+	// CreateIndex on an undeclared field is rejected with the server's reason.
+	rejected := oracle.NewGlobalState().Apply(oracle.Bulk{Requests: []*servicepb.Request{
+		oracletest.CreateIndexReq(id),
+	}})
+	require.False(t, rejected.OK)
+	require.Equal(t, "METADATA_FIELD_NOT_IN_SCHEMA", rejected.Reason)
+
+	// Declared → create lands ambiguous; removing the declaration drops it.
+	declared := oracle.NewGlobalState().Apply(oracle.Bulk{Requests: []*servicepb.Request{
+		oracletest.SetFieldTypeReq(acct, "k1", commonpb.MetadataType_METADATA_TYPE_INT64),
+		oracletest.CreateIndexReq(id),
+	}})
+	require.True(t, declared.OK)
+	exists, active := declared.State.Ledger("L").IndexState(canonical)
+	require.True(t, exists)
+	require.False(t, active)
+
+	removed := declared.State.Apply(oracle.Bulk{Requests: []*servicepb.Request{
+		oracletest.RemoveFieldTypeReq(acct, "k1"),
+	}})
+	require.True(t, removed.OK)
+	exists, _ = removed.State.Ledger("L").IndexState(canonical)
+	require.False(t, exists)
+}
+
+func TestMatchFieldCondition_Coercion(t *testing.T) {
+	t.Parallel()
+
+	acct := commonpb.TargetType_TARGET_TYPE_ACCOUNT
+	str := func(s string) *commonpb.MetadataValue {
+		return &commonpb.MetadataValue{Type: &commonpb.MetadataValue_StringValue{StringValue: s}}
+	}
+
+	// k1 declared INT64; values stored verbatim: "5" coerces to 5, "junk" to
+	// null. k2 declared STRING holding an int value: coerces to its rendering.
+	gs := buildGlobal(t,
+		oracletest.SetFieldTypeReq(acct, "k1", commonpb.MetadataType_METADATA_TYPE_INT64),
+		oracletest.SetFieldTypeReq(acct, "k2", commonpb.MetadataType_METADATA_TYPE_STRING),
+		oracletest.TxReqL("L", "world", "a:1", "USD", 5),
+		oracletest.AddAccountMetaReq("a:1", "k1", str("5")),
+		oracletest.AddAccountMetaReq("a:1", "k2", &commonpb.MetadataValue{Type: &commonpb.MetadataValue_IntValue{IntValue: 7}}),
+		oracletest.TxReqL("L", "world", "a:2", "USD", 5),
+		oracletest.AddAccountMetaReq("a:2", "k1", str("junk")),
+	)
+	ls := gs.Ledger("L")
+
+	lo, hi := int64(1), int64(9)
+	intRange := filterFieldInt("k1", &lo, &hi).GetField()
+
+	lookup := func(addr string) func(string) (*commonpb.MetadataValue, bool) {
+		return func(key string) (*commonpb.MetadataValue, bool) {
+			v, ok := ls.Metadata().Get(oracle.MetaKey{Address: addr, Key: key})
+
+			return v, ok
+		}
+	}
+
+	// "5" on an INT64 field coerces into range; "junk" coerces to null.
+	require.True(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:1"), intRange))
+	require.False(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:2"), intRange))
+
+	// Exists: null-coerced values are excluded unless include_null.
+	require.True(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:1"), filterFieldExists("k1", false).GetField()))
+	require.False(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:2"), filterFieldExists("k1", false).GetField()))
+	require.True(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:2"), filterFieldExists("k1", true).GetField()))
+
+	// Int 7 on a STRING field coerces to its string rendering.
+	require.True(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:1"), filterFieldString("k2", "7").GetField()))
+	require.False(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:1"), filterFieldString("k2", "8").GetField()))
+
+	// Undeclared key or absent value never match.
+	require.False(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("a:1"), filterFieldString("k9", "x").GetField()))
+	require.False(t, matchFieldCondition(ls.AccountFieldTypes(), lookup("world"), intRange))
+
+	// Kind mismatch classification: a string condition on the INT64 field.
+	require.True(t, fieldKindMismatch(ls, filterFieldString("k1", "x"), accounts))
+	require.False(t, fieldKindMismatch(ls, intRange2Filter(intRange), accounts))
+	require.False(t, fieldKindMismatch(ls, filterFieldString("k9", "x"), accounts), "undeclared is not a mismatch")
+
+	// Field-filtered account window: only a:1 matches the int range.
+	require.Equal(t, []string{"a:1"}, accountWindow(ls, intRange2Filter(intRange), "", 10, false))
+
+	// Needed-set classification per target.
+	needed := map[string]struct{}{}
+	neededIndexCanonicals(intRange2Filter(intRange), accounts, needed)
+	require.Contains(t, needed, metadataCanonical(accounts, "k1"))
+}
+
+// intRange2Filter rewraps a FieldCondition into a QueryFilter (test helper).
+func intRange2Filter(fc *commonpb.FieldCondition) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{Field: fc}}
+}
+
+// TestTxRecordMatches_LearnedInsertedAt pins inserted_at's place in row
+// equality: once the stamp is learned it also drives inserted_at filter
+// evaluation, so a row serving a different value must fail the match — while
+// an unlearned (nil) stamp keeps the server-dated tolerance.
+func TestTxRecordMatches_LearnedInsertedAt(t *testing.T) {
+	t.Parallel()
+
+	gs := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5))
+	gs.LearnTxStamps("L", 1, stamp(100), stamp(110), nil)
+
+	rec := gs.Ledger("L").Txs().Get(0)
+
+	require.True(t, txRecordMatches(rec, serverTxFromRec(rec)))
+
+	mismatched := serverTxFromRec(rec)
+	mismatched.InsertedAt = stamp(999)
+	require.False(t, txRecordMatches(rec, mismatched),
+		"a learned inserted_at must reject a row serving a different value")
+
+	unlearned := buildGlobal(t, oracletest.TxReqL("L", "world", "acc:1", "USD", 5)).Ledger("L").Txs().Get(0)
+	anyStamp := serverTxFromRec(unlearned)
+	anyStamp.InsertedAt = stamp(123)
+	require.True(t, txRecordMatches(unlearned, anyStamp),
+		"an unlearned inserted_at stays server-dated and unchecked")
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/restore.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/restore.go
@@ -116,6 +116,11 @@ func runRestoreCycle(ctx context.Context, c *Checker, trigger RestoreTrigger, in
 		log.Printf("restore cycle: drained, firing restore")
 		err := func() error {
 			defer c.resume()
+			// LIFO: demote before workers wake. The restored node rebuilds its
+			// read-store from the log, so its indexes re-enter BUILDING until the
+			// backfill catches up; the model must tolerate a not-ready rejection
+			// again until the poller reconfirms readiness.
+			defer c.demoteAllIndexes()
 			return trigger.Fire(ctx)
 		}()
 		if err != nil {
@@ -125,6 +130,13 @@ func runRestoreCycle(ctx context.Context, c *Checker, trigger RestoreTrigger, in
 			// green run with this never hit exercised nothing (the local
 			// runner's zero-cycles guard, for Antithesis).
 			assert.Sometimes(true, "singleton_driver_model: restore cycle completed", internal.Details{})
+
+			// The restored nodes rebuild their read-stores from the log under
+			// the live schema, so nothing serves an old-typed index anymore:
+			// open retype windows are over, and their pre-restore closure
+			// observations describe fold cursors that no longer exist.
+			c.closeAllRetypeWindows()
+
 			log.Printf("restore cycle: complete, resumed")
 		}
 	}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
@@ -26,6 +27,33 @@ func (c *Checker) validateBulkSuccess(bulk oracle.Bulk, resp *servicepb.ApplyRes
 	dbg("BULK OK: ledgers=%s reqKinds=%s logSeqs=%s typeOps=%s meta=%s", bulkLedgers(bulk), requestKinds(bulk), logSeqs(resp.GetLogs()), typeOps(bulk), bulkMeta(bulk))
 
 	c.crossCheckCommit(bulk, resp)
+	c.recordIndexCreates(bulk, resp)
+}
+
+// recordIndexCreates advances the create frontier of every index this bulk
+// created: the committed log sequence of the CreateIndex is the incarnation
+// the readiness poller must prove each replica has folded before crediting a
+// status report to it. The response log at index i pairs with
+// bulk.Requests[i]. Caller holds c.mu.
+func (c *Checker) recordIndexCreates(bulk oracle.Bulk, resp *servicepb.ApplyResponse) {
+	logs := resp.GetLogs()
+	for i, req := range bulk.Requests {
+		if i >= len(logs) {
+			break
+		}
+
+		ci := req.GetCreateIndex()
+		if ci == nil || ci.GetId() == nil || logs[i].GetSequence() == 0 {
+			continue
+		}
+
+		ledger := ci.GetLedger()
+		if c.indexCreateSeq[ledger] == nil {
+			c.indexCreateSeq[ledger] = map[string]uint64{}
+		}
+
+		c.indexCreateSeq[ledger][indexes.Canonical(ci.GetId())] = logs[i].GetSequence()
+	}
 }
 
 // crossCheckCommit validates a committed bulk against the forward model
@@ -110,6 +138,13 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 			return
 		}
 	}
+
+	// droppedInBulk collects the (ledger, canonical) pairs earlier orders of
+	// THIS bulk already removed, so a duplicate remove-field-type correctly
+	// expects no second drop. The ledger is part of the key: one bulk can
+	// remove the same (target, key) on several ledgers, and each ledger's
+	// index is dropped independently.
+	droppedInBulk := map[string]bool{}
 
 	// Check the remaining write ops against their response logs: the assigned
 	// transaction id and echoed reference/postings, and the schema / account-type
@@ -249,12 +284,39 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 				return
 			}
 
-			// The workload never creates indexes, so removing a field type must
-			// never report dropping one.
-			if lg.GetDroppedIndex() != nil {
-				assert.Unreachable("singleton_driver_model: remove-field-type unexpectedly dropped an index", internal.Details{
-					"ledger": oracle.LedgerOf(req),
-					"key":    rq.GetKey(),
+			// A metadata index cannot outlive its field declaration: the server
+			// reports the dropped index on the log exactly when one existed.
+			// Compare against the pre-bulk model state, minus keys an earlier
+			// order of this bulk already removed (the second remove is a no-op).
+			canonical := indexes.Canonical(indexes.MetadataID(rq.GetTargetType(), rq.GetKey()))
+			bulkKey := oracle.LedgerOf(req) + "\x00" + canonical
+			earlierInBulk := droppedInBulk[bulkKey]
+			hadIndex := false
+			if exists, _ := c.modelState.Ledger(oracle.LedgerOf(req)).IndexState(canonical); exists && !earlierInBulk {
+				hadIndex = true
+			}
+			droppedInBulk[bulkKey] = true
+
+			if (lg.GetDroppedIndex() != nil) != hadIndex {
+				assert.Unreachable("singleton_driver_model: remove-field-type dropped-index mismatch", internal.Details{
+					"ledger":        oracle.LedgerOf(req),
+					"key":           rq.GetKey(),
+					"target":        rq.GetTargetType().String(),
+					"canonical":     canonical,
+					"modelHadIdx":   hadIndex,
+					"serverDropped": lg.GetDroppedIndex() != nil,
+					"modelIndexes":  modelIndexDump(c.modelState.Ledger(oracle.LedgerOf(req))),
+					"earlierInBulk": earlierInBulk,
+				})
+
+				return
+			}
+
+			if lg.GetDroppedIndex() != nil && indexes.Canonical(lg.GetDroppedIndex()) != canonical {
+				assert.Unreachable("singleton_driver_model: remove-field-type dropped wrong index", internal.Details{
+					"ledger":   oracle.LedgerOf(req),
+					"key":      rq.GetKey(),
+					"returned": indexes.Canonical(lg.GetDroppedIndex()),
 				})
 
 				return
@@ -288,10 +350,68 @@ func (c *Checker) crossCheckCommit(bulk oracle.Bulk, resp *servicepb.ApplyRespon
 
 	c.modelState = res.State
 
+	// A committed retype of an indexed key opened (or chained onto) a serving
+	// window in the fold above; arm its closure observation at this bulk's
+	// frontier so the poller can prove the per-replica switch happened after
+	// THIS retype, not a previous one.
+	for _, req := range bulk.Requests {
+		smft := req.GetSetMetadataFieldType()
+		if smft == nil {
+			continue
+		}
+
+		tt := smft.GetTargetType()
+		if tt != commonpb.TargetType_TARGET_TYPE_ACCOUNT && tt != commonpb.TargetType_TARGET_TYPE_TRANSACTION {
+			continue
+		}
+
+		ledger := oracle.LedgerOf(req)
+		canonical := indexes.Canonical(indexes.MetadataID(tt, smft.GetKey()))
+
+		if _, open := c.modelState.Ledger(ledger).RetypeWindow(canonical); open {
+			c.noteRetypeCommit(ledger, canonical, maxLogSequence(resp.GetLogs()))
+		}
+	}
+	learnTxStamps(c.modelState, bulk, logs)
+
 	// A committed keyed bulk is frozen in modelState; remember it (with the
 	// sequences it committed at) so runReplay can re-send it and check the server
 	// replays this same outcome.
 	c.rememberReplayable(bulk, resp.GetLogs())
+}
+
+// learnTxStamps folds the server-stamped transaction dates from a committed
+// bulk's response logs into the just-advanced model state (LearnTxStamps): the
+// created/revert transaction's timestamp and inserted_at, and the reverted
+// original's reverted_at (the compensating transaction's timestamp). Runs in
+// the same critical section that advanced the state — the safety condition
+// LearnTxStamps documents.
+func learnTxStamps(gs oracle.GlobalState, bulk oracle.Bulk, logs []*commonpb.Log) {
+	for i, req := range bulk.Requests {
+		if i >= len(logs) {
+			break
+		}
+
+		ledger := oracle.LedgerOf(req)
+		entry := logs[i].GetPayload().GetApply().GetLog()
+		data := entry.GetData()
+
+		// The log's date is the one part of the stream the model cannot
+		// derive; its id is derived, so it is checked against the server
+		// rather than copied from it.
+		gs.LearnLogDate(ledger, entry.GetId(), entry.GetDate())
+
+		switch {
+		case data.GetCreatedTransaction() != nil:
+			tx := data.GetCreatedTransaction().GetTransaction()
+			gs.LearnTxStamps(ledger, tx.GetId(), tx.GetTimestamp(), tx.GetInsertedAt(), nil)
+		case data.GetRevertedTransaction() != nil:
+			rt := data.GetRevertedTransaction()
+			revTx := rt.GetRevertTransaction()
+			gs.LearnTxStamps(ledger, revTx.GetId(), revTx.GetTimestamp(), revTx.GetInsertedAt(), nil)
+			gs.LearnTxStamps(ledger, rt.GetRevertedTransactionId(), nil, nil, revTx.GetTimestamp())
+		}
+	}
 }
 
 // validateFailure accepts the observed failure of failedBulk iff some
@@ -488,6 +608,8 @@ func (c *Checker) validateLedgerRead(maxTicket uint64, ledger string, serverType
 		"serverTypes": len(serverTypes),
 		"serverMeta":  renderMetaMap(serverMeta),
 		"modelMeta":   c.modelLedgerMetaDump(ledger),
+		"serverChart": renderChart(serverTypes),
+		"modelChart":  c.modelChartDump(ledger),
 	})
 }
 
@@ -547,33 +669,7 @@ func (c *Checker) validateTransactionRead(maxTicket uint64, ledger string, id ui
 			return false // base has a tx at this id, but the server returned NotFound
 		}
 
-		rec := txs.Get(int(id - 1))
-		// A user-supplied timestamp is echoed verbatim; when the model has none
-		// (nil) the server stamped its own command date, which is unpredictable,
-		// so the timestamp is not checked for that record.
-		tsOK := rec.Timestamp() == nil || rec.Timestamp().GetData() == serverTx.GetTimestamp().GetData()
-
-		// reverted_at follows the same convention: nil in the model means the
-		// compensating transaction was server-dated (unpredictable) — but only a
-		// reverted record may carry one at all.
-		var raOK bool
-		switch {
-		case rec.RevertedAt() != nil:
-			raOK = serverTx.GetRevertedAt() != nil && rec.RevertedAt().GetData() == serverTx.GetRevertedAt().GetData()
-		case rec.Reverted():
-			raOK = true
-		default:
-			raOK = serverTx.GetRevertedAt() == nil
-		}
-
-		return rec.Id() == serverTx.GetId() &&
-			rec.Reference() == serverTx.GetReference() &&
-			rec.Reverted() == serverTx.GetReverted() &&
-			rec.RevertedBy() == serverTx.GetRevertedByTransaction() &&
-			rec.RevertsTransaction() == serverTx.GetRevertsTransaction() &&
-			tsOK && raOK &&
-			postingsEqual(rec.Postings(), serverTx.GetPostings()) &&
-			metaMapEqual(rec.Metadata(), serverTx.GetMetadata())
+		return txRecordMatches(txs.Get(int(id-1)), serverTx)
 	}) {
 		return
 	}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/validate.go
@@ -400,6 +400,7 @@ func learnTxStamps(gs oracle.GlobalState, bulk oracle.Bulk, logs []*commonpb.Log
 		// derive; its id is derived, so it is checked against the server
 		// rather than copied from it.
 		gs.LearnLogDate(ledger, entry.GetId(), entry.GetDate())
+		gs.LearnLogSequence(ledger, entry.GetId(), logs[i].GetSequence())
 
 		switch {
 		case data.GetCreatedTransaction() != nil:

--- a/tests/antithesis/workload/internal/client.go
+++ b/tests/antithesis/workload/internal/client.go
@@ -348,6 +348,21 @@ func IsAmbiguousCommit(err error) bool {
 	return IsDeadlineExceeded(err)
 }
 
+// IsWritesBlockedDiskFull returns true for the write gate's disk-pressure
+// rejection (ResourceExhausted / WRITES_BLOCKED_DISK_FULL). The gate refuses
+// the write before consensus, so the bulk definitively did not commit and a
+// retry is sound; under fault injection disk pressure comes and goes, so the
+// workload treats it as transient. The clock-skew twin is Unavailable and
+// already lands in the transient set through IsUnavailable. The documented
+// pre-consensus guarantee is the full code/reason tuple, so both are
+// required: the reason under any other code is an unexpected response, not
+// a transient.
+func IsWritesBlockedDiskFull(err error) bool {
+	st, ok := status.FromError(err)
+
+	return ok && st.Code() == codes.ResourceExhausted && HasErrorReason(err, "WRITES_BLOCKED_DISK_FULL")
+}
+
 // HasErrorReason returns true if the error is a gRPC status with an
 // ErrorInfo detail matching the given reason.
 func HasErrorReason(err error, reason string) bool {
@@ -461,6 +476,8 @@ func IsNoFullCheckpoint(err error) bool {
 //   - Unavailable (cluster unhealthy / no leader / Raft transients)
 //   - DeadlineExceeded (wire-level timeout, also see IsAmbiguousCommit)
 //   - ExternalServiceError (S3 / NATS down, etc.)
+//   - ResourceExhausted + WRITES_BLOCKED_DISK_FULL (write gate under disk
+//     pressure; refused before consensus, see IsWritesBlockedDiskFull)
 //
 // NOT in IsTransient:
 //   - Aborted (see IsAborted comment — surfaced loud, not retried)
@@ -470,7 +487,8 @@ func IsNoFullCheckpoint(err error) bool {
 func IsTransient(err error) bool {
 	return IsUnavailable(err) ||
 		IsDeadlineExceeded(err) ||
-		IsExternalServiceError(err)
+		IsExternalServiceError(err) ||
+		IsWritesBlockedDiskFull(err)
 }
 
 // IsTolerated returns true for any error the workload should NOT surface as a

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -1,6 +1,8 @@
 package oracle
 
-import "github.com/formancehq/ledger/v3/internal/proto/commonpb"
+import (
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
 
 // Exported read accessors over the model's internal state. The driver and the
 // replay tool inspect a committed state (chart, volumes, metadata, declared
@@ -42,11 +44,266 @@ func (t *txRecord) Postings() []*commonpb.Posting                { return t.post
 func (t *txRecord) Metadata() map[string]*commonpb.MetadataValue { return t.metadata }
 func (t *txRecord) Reverted() bool                               { return t.reverted }
 func (t *txRecord) Timestamp() *commonpb.Timestamp               { return t.timestamp }
+func (t *txRecord) InsertedAt() *commonpb.Timestamp              { return t.insertedAt }
 func (t *txRecord) RevertedBy() uint64                           { return t.revertedBy }
 func (t *txRecord) RevertedAt() *commonpb.Timestamp              { return t.revertedAt }
 func (t *txRecord) RevertsTransaction() uint64                   { return t.revertsTransaction }
+
+// IndexedAddrs is the transaction's account→tx index membership, keyed by
+// account with AddrIndexedSource/AddrIndexedDestination bits — see
+// txRecord.indexedAddrs. Read-only, like the other map accessors.
+func (t *txRecord) IndexedAddrs() map[string]uint8 { return t.indexedAddrs }
+
+// HasAccount reports whether the account currently holds a volume cell or a
+// metadata entry — membership in the merged V+M attributes universe the
+// server's address matching scans (pebbleAccountExists / the account prefix
+// iterator). A purged account with no metadata is NOT in the universe even
+// when older index rows still reference it.
+func (s LedgerState) HasAccount(addr string) bool {
+	// Each map is sorted with Address as the leading key field, so the first
+	// entry at or after {addr} decides membership in that map — but a miss in
+	// volumes must still fall through to the metadata scan.
+	for k := range s.volumes.From(VolumeKey{Address: addr}) {
+		if k.Address == addr {
+			return true
+		}
+
+		break
+	}
+
+	for k := range s.metadata.From(MetaKey{Address: addr}) {
+		if k.Address == addr {
+			return true
+		}
+
+		break
+	}
+
+	return false
+}
+
+// Indexes returns the ledger's index set keyed by canonical IndexID (value is
+// the active flag: true active, false ambiguous). Mutate index state through
+// SetIndexActive / SetIndexAmbiguous.
+func (s LedgerState) Indexes() Map[string, bool] { return s.indexes }
+
+// IndexState reports whether the ledger has an index with the given canonical
+// IndexID, and if so whether it is active (READY confirmed) or ambiguous
+// (created, readiness not yet confirmed — a not-ready error is tolerated).
+func (s LedgerState) IndexState(canonical string) (exists, active bool) {
+	active, exists = s.indexes.Get(canonical)
+
+	return exists, active
+}
+
+// SetIndexActive flips an existing ambiguous index to active on the named
+// ledger, for the driver's readiness poller once it has confirmed the index
+// READY across replicas. A no-op if the ledger or index is absent (e.g. a
+// concurrent DropIndex already removed it). The rebound entry lands in the
+// shared ledgers map, updating the committed state; forks copied earlier hold
+// their own persistent values and are unaffected. Callers hold the checker
+// mutex.
+func (g GlobalState) SetIndexActive(ledger, canonical string) {
+	g.setIndexReadiness(ledger, canonical, true)
+}
+
+// SetIndexAmbiguous flips an existing active index back to ambiguous on the
+// named ledger, for the driver's readiness poller when a replica reports the
+// index not-ready again (e.g. a restored node rebuilding its read-store). This
+// only ever widens what the model tolerates — an ambiguous index accepts both a
+// not-ready error and a validated result window — so it can never manufacture a
+// finding. Same no-op / rebind semantics as SetIndexActive.
+func (g GlobalState) SetIndexAmbiguous(ledger, canonical string) {
+	g.setIndexReadiness(ledger, canonical, false)
+}
+
+func (g GlobalState) setIndexReadiness(ledger, canonical string, active bool) {
+	ls, ok := g.ledgers[ledger]
+	if !ok {
+		return
+	}
+
+	if ls.indexes.Has(canonical) {
+		ls.indexes = ls.indexes.Set(canonical, active)
+		g.ledgers[ledger] = ls
+	}
+}
+
+// HasEverAsset reports whether the account has ever touched (base, precision) via
+// a committed, non-excluded posting — its membership in the account-by-asset
+// index the has-asset filter reads.
+func (s LedgerState) HasEverAsset(address, base string, precision uint32) bool {
+	return s.everAsset.Has(assetTouch{address: address, base: base, precision: precision})
+}
+
+// EverAssetAccounts returns, sorted ascending by address, every account that has
+// ever touched (base, precision) — the exact account set a bare has-asset query
+// over (base, precision) returns, in the server's address order.
+func (s LedgerState) EverAssetAccounts(base string, precision uint32) []string {
+	var out []string
+	for k := range s.everAsset.All() {
+		if k.base == base && k.precision == precision {
+			out = append(out, k.address)
+		}
+	}
+
+	// The map iterates in (address, base, precision) order, so out is sorted.
+	return out
+}
 
 func (m *metaEffect) Saved() map[string]*commonpb.MetadataValue { return m.saved }
 
 func (r *revertEffect) RevertedID() uint64            { return r.revertedID }
 func (r *revertEffect) Postings() []*commonpb.Posting { return r.postings }
+
+// LearnTxStamps fills the server-stamped dates of transaction id that the model
+// could not predict at apply time: a nil timestamp, the always-server-stamped
+// insertedAt, and a nil revertedAt on a reverted original. Known (client-
+// supplied) values are never overwritten — reads validate those directly. The
+// values come from the commit response's logs; they are deterministic FSM
+// outputs, so folding them in keeps the model exact and lets later reads and
+// filter windows check them for equality instead of skipping.
+//
+// Mutation safety: the record is replaced through the persistent list (whose
+// fingerprint the replacement keeps current), and the rebound ledger lands in
+// the shared ledgers map, updating the committed state. The caller must hold
+// the checker's lock and call this only on the committed state, in the same
+// critical section that advanced it — forks copied earlier hold their own
+// persistent values and are unaffected.
+func (g GlobalState) LearnTxStamps(ledger string, id uint64, timestamp, insertedAt, revertedAt *commonpb.Timestamp) {
+	ls, ok := g.ledgers[ledger]
+	if !ok || id == 0 || id > uint64(ls.txs.Len()) {
+		return
+	}
+
+	rec := *ls.txs.Get(int(id - 1))
+	if rec.timestamp == nil {
+		rec.timestamp = timestamp
+	}
+	if rec.insertedAt == nil {
+		rec.insertedAt = insertedAt
+	}
+	if rec.revertedAt == nil && rec.reverted {
+		rec.revertedAt = revertedAt
+	}
+
+	ls.txs = ls.txs.Set(int(id-1), &rec)
+	g.ledgers[ledger] = ls
+}
+
+// LearnLogDate fills in a log's server-assigned date, the one field of the
+// stream the model cannot derive. The id is not learned: it is derived from
+// the stream's density, so a server that assigned a different one must be
+// caught, not copied.
+func (g GlobalState) LearnLogDate(ledger string, id uint64, date *commonpb.Timestamp) {
+	ls, ok := g.ledgers[ledger]
+	if !ok || id == 0 || id > uint64(ls.logs.Len()) {
+		return
+	}
+
+	rec := *ls.logs.Get(int(id - 1))
+	if rec.date == nil {
+		rec.date = date
+	}
+
+	ls.logs = ls.logs.Set(int(id-1), &rec)
+	g.ledgers[ledger] = ls
+}
+
+// LogKinds returns each committed log's kind, ascending by id.
+func (s LedgerState) LogKinds() []string {
+	out := make([]string, 0, s.logs.Len())
+	for i := range s.logs.Len() {
+		out = append(out, s.logs.Get(i).kind)
+	}
+
+	return out
+}
+
+// LogDates returns each committed log's (id, date), ascending. A nil date is
+// one not yet learned from a commit response.
+func (s LedgerState) LogDates() []struct {
+	ID   uint64
+	Date *commonpb.Timestamp
+} {
+	out := make([]struct {
+		ID   uint64
+		Date *commonpb.Timestamp
+	}, 0, s.logs.Len())
+
+	for i := range s.logs.Len() {
+		rec := s.logs.Get(i)
+		out = append(out, struct {
+			ID   uint64
+			Date *commonpb.Timestamp
+		}{ID: rec.id, Date: rec.date})
+	}
+
+	return out
+}
+
+// FieldTypesFor returns the declared-type map for a metadata target — the
+// schema slice the generator consults for indexable fields.
+func (s LedgerState) FieldTypesFor(target commonpb.TargetType) Map[string, commonpb.MetadataType] {
+	return s.fieldTypes(target)
+}
+
+// FieldTypeFor returns the declared type of one (target, key), false when
+// undeclared. Ledger-target keys resolve like the map accessors do.
+func (s LedgerState) FieldTypeFor(target commonpb.TargetType, key string) (commonpb.MetadataType, bool) {
+	return s.FieldTypesFor(target).Get(key)
+}
+
+// RetypeWindow returns the declared types an index's served version may still
+// be bound to while retype rewrites converge — the window's accumulated set,
+// in enum order — false when no window is open for that canonical index ID.
+// The CURRENT declared type is not part of the set; callers always evaluate it
+// as the default view.
+func (s LedgerState) RetypeWindow(canonical string) ([]commonpb.MetadataType, bool) {
+	mask, ok := s.retypeWindows.Get(canonical)
+	if !ok {
+		return nil, false
+	}
+
+	var types []commonpb.MetadataType
+	for t := range 32 {
+		if mask&(1<<uint(t)) != 0 {
+			types = append(types, commonpb.MetadataType(t))
+		}
+	}
+
+	return types, true
+}
+
+// WithDeclaredType returns a view of the state whose declared type for one
+// (target, key) is overridden — the evaluation view for one side of a retype
+// window. The receiver is untouched; the view shares every other collection.
+func (s LedgerState) WithDeclaredType(target commonpb.TargetType, key string, t commonpb.MetadataType) LedgerState {
+	switch target {
+	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
+		s.accountFieldTypes = s.accountFieldTypes.Set(key, t)
+	case commonpb.TargetType_TARGET_TYPE_TRANSACTION:
+		s.transactionFieldTypes = s.transactionFieldTypes.Set(key, t)
+	}
+
+	// The memoized chart derives from types (account types, not metadata
+	// types), but keep the view self-contained regardless.
+	return s
+}
+
+// CloseRetypeWindow removes an index's retype window on the committed state,
+// for the driver once it has PROVEN every replica switched: a poll showed the
+// retype's own log folded, and a later poll showed no rewrite pending. From
+// then on only the new type is legal. Same no-op / rebind semantics as
+// SetIndexActive.
+func (g GlobalState) CloseRetypeWindow(ledger, canonical string) {
+	ls, ok := g.ledgers[ledger]
+	if !ok {
+		return
+	}
+
+	if ls.retypeWindows.Has(canonical) {
+		ls.retypeWindows = ls.retypeWindows.Delete(canonical)
+		g.ledgers[ledger] = ls
+	}
+}

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -54,6 +54,10 @@ func (t *txRecord) RevertsTransaction() uint64                   { return t.reve
 // txRecord.indexedAddrs. Read-only, like the other map accessors.
 func (t *txRecord) IndexedAddrs() map[string]uint8 { return t.indexedAddrs }
 
+// PostCommitVolumes returns the transaction's frozen post-commit snapshot,
+// keyed by the cell its postings touched.
+func (t *txRecord) PostCommitVolumes() map[VolumeKey]VolumePair { return t.pcv }
+
 // HasAccount reports whether the account currently holds a volume cell or a
 // metadata entry — membership in the merged V+M attributes universe the
 // server's address matching scans (pebbleAccountExists / the account prefix

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -247,6 +247,9 @@ func (s LedgerState) LogKinds() []string {
 // learned from the commit response. A nil date or a zero sequence is one not
 // yet learned.
 //
+// TxID names the transaction a created_transaction / reverted_transaction log
+// announces, zero for every other kind.
+//
 // PurgedVolumes, NewKeptVolumes and EphemeralVolumes are the end-of-bulk volume
 // annotations, rendered as a comma-separated "account:asset" list ascending by
 // account then asset. Empty means the log carries none of that class.
@@ -254,6 +257,7 @@ type LogRow struct {
 	ID               uint64
 	Kind             string
 	Payload          string
+	TxID             uint64
 	Date             *commonpb.Timestamp
 	Sequence         uint64
 	PurgedVolumes    string
@@ -270,6 +274,7 @@ func (s LedgerState) LogRows() []LogRow {
 			ID:               rec.id,
 			Kind:             rec.kind,
 			Payload:          rec.payload,
+			TxID:             rec.txID,
 			Date:             rec.date,
 			Sequence:         rec.sequence,
 			PurgedVolumes:    rec.purged,

--- a/tests/oracle/accessors.go
+++ b/tests/oracle/accessors.go
@@ -210,11 +210,68 @@ func (g GlobalState) LearnLogDate(ledger string, id uint64, date *commonpb.Times
 	g.ledgers[ledger] = ls
 }
 
+// LearnLogSequence fills in a log's global sequence, the second field of the
+// stream the model cannot derive: it counts every ledger's logs and the
+// technical entries among them. Fill-once, like the date.
+func (g GlobalState) LearnLogSequence(ledger string, id, sequence uint64) {
+	ls, ok := g.ledgers[ledger]
+	if !ok || id == 0 || id > uint64(ls.logs.Len()) || sequence == 0 {
+		return
+	}
+
+	rec := *ls.logs.Get(int(id - 1))
+	if rec.sequence == 0 {
+		rec.sequence = sequence
+	}
+
+	ls.logs = ls.logs.Set(int(id-1), &rec)
+	g.ledgers[ledger] = ls
+}
+
 // LogKinds returns each committed log's kind, ascending by id.
 func (s LedgerState) LogKinds() []string {
 	out := make([]string, 0, s.logs.Len())
 	for i := range s.logs.Len() {
 		out = append(out, s.logs.Get(i).kind)
+	}
+
+	return out
+}
+
+// LogRow is one committed log as the model holds it: the id it derives, the
+// kind it derives from the request, and the date and global sequence it
+// learned from the commit response. A nil date or a zero sequence is one not
+// yet learned.
+//
+// PurgedVolumes, NewKeptVolumes and EphemeralVolumes are the end-of-bulk volume
+// annotations, rendered as a comma-separated "account:asset" list ascending by
+// account then asset. Empty means the log carries none of that class.
+type LogRow struct {
+	ID               uint64
+	Kind             string
+	Payload          string
+	Date             *commonpb.Timestamp
+	Sequence         uint64
+	PurgedVolumes    string
+	NewKeptVolumes   string
+	EphemeralVolumes string
+}
+
+// LogRows returns every committed log, ascending by id.
+func (s LedgerState) LogRows() []LogRow {
+	out := make([]LogRow, 0, s.logs.Len())
+	for i := range s.logs.Len() {
+		rec := s.logs.Get(i)
+		out = append(out, LogRow{
+			ID:               rec.id,
+			Kind:             rec.kind,
+			Payload:          rec.payload,
+			Date:             rec.date,
+			Sequence:         rec.sequence,
+			PurgedVolumes:    rec.purged,
+			NewKeptVolumes:   rec.newKept,
+			EphemeralVolumes: rec.ephemeral,
+		})
 	}
 
 	return out

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -85,12 +86,60 @@ type LedgerState struct {
 	txByRef               Map[string, int]
 	transactionFieldTypes Map[string, commonpb.MetadataType]
 
+	// indexes tracks the read-store indexes the ledger has, keyed by canonical
+	// IndexID string. The value is the readiness flag: false = ambiguous (created,
+	// backfill may still be BUILDING on some replica — a not-ready error is
+	// tolerated), true = active (confirmed READY on all replicas — results are
+	// required). CreateIndex adds an ambiguous entry; the driver's readiness
+	// poller flips it to active; DropIndex removes it (instantaneous: a
+	// linearizable read issued after the drop's response observes it gone).
+	indexes Map[string, bool]
+
+	// logs is the ledger's log stream: index i holds the log with ledger-local
+	// id i+1, dense from 1, mirroring the server's LedgerBoundaries.NextLogId
+	// (initialised to 1 at CreateLedger, so the first apply lands on 1). Every
+	// committed ledger-scoped order appends exactly one entry; a rejected one
+	// appends none, since the workload never opts into skippable_reasons —
+	// which is what makes a skip consume a log id (processor.go's skip branch)
+	// without committing anything.
+	logs List[*logRecord]
+
+	// retypeWindows holds, per canonical metadata-index ID, the SET of declared
+	// types the index's served version may still be bound to while retype
+	// rewrites converge (EN-1724), encoded as a bitmask over MetadataType. The
+	// schema flips at commit — fieldTypes above hold the new type — but each
+	// replica serves its current version's bound type until that rewrite's
+	// atomic switch, and a CHAIN of retypes advances the replica through every
+	// intermediate binding: each switch briefly serves the superseded target
+	// before the next rewrite lands. A query during the window is therefore
+	// legal under any accumulated type, each as a whole window. A
+	// SetMetadataFieldType on an indexed key adds the type it supersedes;
+	// closed by the driver once every replica provably switched with no
+	// rewrite pending; dies with the index on removal.
+	retypeWindows Map[string, uint32]
+
+	// everAsset is the account-by-asset index projection: the set of
+	// (account, assetBase, precision) any committed, non-excluded posting has ever
+	// touched, on either side. This is the exact set the has-asset filter serves
+	// (see recordAssetTouches) — a monotonic history, NOT the current volume set:
+	// an account drained to zero and purged from the volume table stays here.
+	everAsset Map[assetTouch, struct{}]
+
 	// compiledChart memoizes compiled() for the current types value — nil means
 	// not yet compiled (an empty chart compiles to a non-nil empty slice). Every
 	// types rebind must reset it to nil. Derived state: never mutated in place
 	// (only replaced), so forks may share it, and it is no part of the state's
 	// identity (collections/Fingerprint exclude it).
 	compiledChart []accounttype.CompiledType
+}
+
+// assetTouch identifies one account's historical touch of an (assetBase,
+// precision) pair — a member of the account-by-asset index the has-asset filter
+// reads. precision is uint32 to match AccountHasAssetCondition.
+type assetTouch struct {
+	address   string
+	base      string
+	precision uint32
 }
 
 func NewLedgerState() LedgerState {
@@ -105,6 +154,11 @@ func NewLedgerState() LedgerState {
 		txs:                   NewList[*txRecord](txTerm),
 		txByRef:               NewMap[string, int](stringComparer{}, txRefTerm),
 		transactionFieldTypes: NewMap[string, commonpb.MetadataType](stringComparer{}, fieldTypeTerm("TF")),
+
+		indexes:       NewMap[string, bool](stringComparer{}, indexTerm),
+		retypeWindows: NewMap[string, uint32](stringComparer{}, retypeWindowTerm),
+		logs:          NewList[*logRecord](logTerm),
+		everAsset:     NewMap[assetTouch, struct{}](assetTouchComparer{}, assetTouchTerm),
 	}
 }
 
@@ -122,7 +176,7 @@ func (s *LedgerState) collections() []interface {
 	}{
 		s.types, s.volumes, s.metadata, s.ledgerMeta,
 		s.accountFieldTypes, s.ledgerFieldTypes, s.transactionFieldTypes,
-		s.txs,
+		s.txs, s.indexes, s.everAsset, s.logs, s.retypeWindows,
 	}
 }
 
@@ -227,6 +281,63 @@ func fieldTypeTerm(tag string) func(string, commonpb.MetadataType) Digest {
 	}
 }
 
+// indexTerm fingerprints one index-registry entry. Readiness is part of the
+// identity: two bases differing only in whether an index exists or is active
+// predict different query outcomes, so they must not dedup.
+func indexTerm(canonical string, active bool) Digest {
+	t := newTerm("IX")
+	t.str(canonical)
+	t.boolean(active)
+
+	return t.sum()
+}
+
+// retypeWindowTerm fingerprints one open retype window. Part of the identity:
+// bases differing only in whether a window is open — or in which types it has
+// accumulated — accept different query outcomes, so they must not dedup.
+func retypeWindowTerm(canonical string, typeMask uint32) Digest {
+	t := newTerm("RW")
+	t.str(canonical)
+	t.u64(uint64(typeMask))
+
+	return t.sum()
+}
+
+// assetTouchTerm fingerprints one ever-touched (account, assetBase, precision)
+// member. Derivable from the tx log + chart, but two partial candidate-base
+// foldings can reach equal logs with a different ever-touched set (types added
+// at different points change per-order purge exclusion), so the set carries
+// its own terms to keep dedup from collapsing bases that predict different
+// has-asset outcomes.
+func assetTouchTerm(k assetTouch, _ struct{}) Digest {
+	t := newTerm("EA")
+	t.str(k.address, k.base)
+	t.u64(uint64(k.precision))
+
+	return t.sum()
+}
+
+type assetTouchComparer struct{}
+
+func (assetTouchComparer) Compare(a, b assetTouch) int {
+	if c := strings.Compare(a.address, b.address); c != 0 {
+		return c
+	}
+
+	if c := strings.Compare(a.base, b.base); c != 0 {
+		return c
+	}
+
+	switch {
+	case a.precision < b.precision:
+		return -1
+	case a.precision > b.precision:
+		return 1
+	default:
+		return 0
+	}
+}
+
 func txRefTerm(ref string, id int) Digest {
 	t := newTerm("R")
 	t.str(ref)
@@ -245,6 +356,29 @@ func txRefTerm(ref string, id int) Digest {
 // relationships (revertedBy, revertsTransaction, revertedAt) distinguish
 // serializations where the same id is reverted by, or reverts, a different
 // transaction.
+// logRecord is one entry of the ledger log stream. The id is DERIVED, never
+// taken from the server: the stream is dense from 1, so the model can predict
+// it, and predicting it is what lets a mis-assigned id be caught at all. Only
+// the date is learned from the commit response (LearnLogDate) — it is
+// server-assigned with no derivable value, and nil means not yet learned.
+type logRecord struct {
+	id   uint64
+	kind string
+	date *commonpb.Timestamp
+}
+
+func logTerm(idx int, l *logRecord) Digest {
+	t := newTerm("LOG")
+	t.u64(uint64(idx), l.id)
+	t.str(l.kind)
+
+	// A nil date (not yet learned) must not collide with any concrete value.
+	t.boolean(l.date != nil)
+	t.u64(l.date.GetData())
+
+	return t.sum()
+}
+
 func txTerm(idx int, tx *txRecord) Digest {
 	t := newTerm("TX")
 	t.u64(uint64(idx), tx.id)
@@ -257,8 +391,25 @@ func txTerm(idx int, tx *txRecord) Digest {
 	// Same for revertedAt.
 	t.boolean(tx.timestamp != nil)
 	t.u64(tx.timestamp.GetData())
+	t.boolean(tx.insertedAt != nil)
+	t.u64(tx.insertedAt.GetData())
 	t.boolean(tx.revertedAt != nil)
 	t.u64(tx.revertedAt.GetData())
+
+	// indexedAddrs is derived at end of bulk, but two partial foldings can
+	// stamp the same postings differently (exclusion depends on the chart and
+	// balances at the stamping bulk's end), and the stamps drive address-query
+	// predictions — so they are part of the record's identity.
+	addrs := make([]string, 0, len(tx.indexedAddrs))
+	for a := range tx.indexedAddrs {
+		addrs = append(addrs, a)
+	}
+	sort.Strings(addrs)
+	t.u64(uint64(len(addrs)))
+	for _, a := range addrs {
+		t.str(a)
+		t.u64(uint64(tx.indexedAddrs[a]))
+	}
 
 	var amt uint256.Int
 	t.u64(uint64(len(tx.postings)))
@@ -470,8 +621,12 @@ type txRecord struct {
 	// timestamp is the user-supplied CreateTransaction timestamp, stored verbatim
 	// and echoed on reads. nil when the client sent none — the server then stamps
 	// its own command date, which the model cannot predict, so reads skip the
-	// timestamp check for such records.
+	// timestamp check for such records. The checker may later fill a nil via
+	// LearnTxStamps with the value the commit response carried.
 	timestamp *commonpb.Timestamp
+	// insertedAt is always server-stamped (never client-supplied), so it starts
+	// nil and is known only once the checker learns it from the commit response.
+	insertedAt *commonpb.Timestamp
 	// Revert relationships, mirroring the server's Transaction fields: on a
 	// reverted original, revertedBy carries the compensating transaction's id
 	// and revertedAt its timestamp (nil when the compensating transaction is
@@ -481,7 +636,20 @@ type txRecord struct {
 	revertedBy         uint64
 	revertedAt         *commonpb.Timestamp
 	revertsTransaction uint64
+	// indexedAddrs is the transaction's account→tx index membership: per
+	// posting-side account, which role rows (AddrIndexedSource /
+	// AddrIndexedDestination bits) the index builder writes for this
+	// transaction. Stamped at end of bulk (recordIndexedAddrs) — a posting side
+	// whose cell lands in the exclusion projection gets no row. The any-role
+	// index is the union of the two bits.
+	indexedAddrs map[string]uint8
 }
+
+// Bits of txRecord.indexedAddrs / IndexedAddrs.
+const (
+	AddrIndexedSource      uint8 = 1 << 0
+	AddrIndexedDestination uint8 = 1 << 1
+)
 
 // revertEffect is a committed revert's predicted effect: the original
 // transaction id (echoed as reverted_transaction_id) and the reversed postings.
@@ -524,6 +692,10 @@ func LedgerOf(req *servicepb.Request) string {
 		return r.SetMetadataFieldType.GetLedger()
 	case *servicepb.Request_RemoveMetadataFieldType:
 		return r.RemoveMetadataFieldType.GetLedger()
+	case *servicepb.Request_CreateIndex:
+		return r.CreateIndex.GetLedger()
+	case *servicepb.Request_DropIndex:
+		return r.DropIndex.GetLedger()
 	default:
 		panic(fmt.Sprintf("LedgerOf: unmodeled request type %T", req.GetType()))
 	}
@@ -534,6 +706,34 @@ func LedgerOf(req *servicepb.Request) string {
 // end-of-bulk transient violation on any touched ledger — rejects the whole bulk
 // and leaves every ledger unchanged. A bulk may span ledgers; each request is
 // routed to its own ledger's sub-state and the end-of-bulk checks run per ledger.
+// SeedInitialSchema declares a ledger's metadata field types the way
+// CreateLedger's initial_schema does: state only, no log.
+//
+// The distinction is load-bearing. Replaying the declarations as
+// SetMetadataFieldType requests through Apply reaches the same schema state,
+// but on the server those types are recorded at creation and never processed
+// as apply orders — they consume no ledger-local log id and never appear in
+// ListLogs. Seeding through Apply would therefore put one phantom log at the
+// head of the stream per declared field and shift every real log's id by that
+// many.
+func (g GlobalState) SeedInitialSchema(reqs []*servicepb.Request) GlobalState {
+	next := g.clone()
+
+	for _, req := range reqs {
+		name := LedgerOf(req)
+
+		ls, ok := next.ledgers[name]
+		if !ok {
+			ls = NewLedgerState()
+		}
+
+		ls.applyOne(req, map[VolumeKey]bool{})
+		next.ledgers[name] = ls
+	}
+
+	return next
+}
+
 func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 	// Admission validates every order's structure and converts the whole batch
 	// before it reaches the FSM, so a single malformed order rejects the entire
@@ -584,6 +784,14 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 		}
 
 		oc := ls.applyOne(req, cells)
+		if oc.OK {
+			// Appended centrally rather than per handler: every committed
+			// ledger-scoped order produces exactly one log, so a handler that
+			// forgot would silently shorten the stream and mis-id every log
+			// after it.
+			ls.appendLog(req)
+		}
+
 		// applyOne rebinds ls's persistent collections; write the updated value
 		// back so the working copy sees the mutation.
 		next.ledgers[name] = ls
@@ -606,6 +814,8 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 			return ApplyResult{OK: false, Reason: reason, State: g, Orders: orders}
 		}
 
+		ls.recordAssetTouches(&base, cells)
+		ls.recordIndexedAddrs(&base, uint64(base.Txs().Len())+1)
 		ls.purgeZeroBalance(cells)
 		next.ledgers[name] = ls
 	}
@@ -640,6 +850,75 @@ func RequestsEqual(a, b []*servicepb.Request) bool {
 	}
 
 	return true
+}
+
+// LogIDs returns the ledger-local ids of every committed log, ascending. The
+// stream is dense from 1, so this is 1..Len() — returned explicitly so callers
+// need not depend on that density holding.
+func (s LedgerState) LogIDs() []uint64 {
+	out := make([]uint64, 0, s.logs.Len())
+	for i := range s.logs.Len() {
+		out = append(out, s.logs.Get(i).id)
+	}
+
+	return out
+}
+
+// logKindFor names the LedgerLogPayload arm a committed request produces, or
+// "" for a request that appends nothing to the ledger log stream. It is
+// derived from the request rather than declared by each apply* handler, so a
+// new request type cannot silently append a log of the wrong kind — or, if it
+// is unmodelled, reach the stream at all: the default panics in lockstep with
+// applyOne's own unmodelled-request panic.
+//
+// Only orders processed through processApply join the stream. processApply is
+// what consumes LedgerBoundaries.NextLogId, and the index builder folds a log
+// into the per-ledger limb ListLogs reads only when its payload is the Apply
+// arm. Ledger metadata is the exception: processAddLedgerMetadata and its
+// delete twin are dispatched as their own LedgerScopedOrder and return a
+// top-level SavedLedgerMetadata / DeletedLedgerMetadata payload, so they take
+// no ledger-local id and never appear in ListLogs.
+func logKindFor(req *servicepb.Request) string {
+	switch r := req.GetType().(type) {
+	case *servicepb.Request_AddAccountType:
+		return "added_account_type"
+	case *servicepb.Request_RemoveAccountType:
+		return "removed_account_type"
+	case *servicepb.Request_SaveLedgerMetadata, *servicepb.Request_DeleteLedgerMetadata:
+		return ""
+	case *servicepb.Request_SetMetadataFieldType:
+		return "set_metadata_field_type"
+	case *servicepb.Request_RemoveMetadataFieldType:
+		return "removed_metadata_field_type"
+	case *servicepb.Request_CreateIndex:
+		return "create_index"
+	case *servicepb.Request_DropIndex:
+		return "drop_index"
+	case *servicepb.Request_Apply:
+		switch r.Apply.GetAction().GetData().(type) {
+		case *servicepb.LedgerAction_CreateTransaction:
+			return "created_transaction"
+		case *servicepb.LedgerAction_AddMetadata:
+			return "saved_metadata"
+		case *servicepb.LedgerAction_DeleteMetadata:
+			return "deleted_metadata"
+		case *servicepb.LedgerAction_RevertTransaction:
+			return "reverted_transaction"
+		}
+	}
+
+	panic(fmt.Sprintf("model: no log kind for request %T", req.GetType()))
+}
+
+// appendLog records the log a committed request produced, if it produced one.
+// The id is the stream's position, dense from 1.
+func (s *LedgerState) appendLog(req *servicepb.Request) {
+	kind := logKindFor(req)
+	if kind == "" {
+		return
+	}
+
+	s.logs = s.logs.Append(&logRecord{id: uint64(s.logs.Len()) + 1, kind: kind})
 }
 
 // applyOne mutates the (already-forked) working state for one request and
@@ -680,6 +959,12 @@ func (s *LedgerState) applyOne(req *servicepb.Request, touched map[VolumeKey]boo
 
 	case *servicepb.Request_RemoveMetadataFieldType:
 		return s.applyRemoveMetadataFieldType(r.RemoveMetadataFieldType)
+
+	case *servicepb.Request_CreateIndex:
+		return s.applyCreateIndex(r.CreateIndex)
+
+	case *servicepb.Request_DropIndex:
+		return s.applyDropIndex(r.DropIndex)
 
 	case *servicepb.Request_Apply:
 		switch a := r.Apply.GetAction().GetData().(type) {
@@ -916,6 +1201,107 @@ func (s *LedgerState) applyPostings(postings []*commonpb.Posting, force bool, to
 	return pcv, ""
 }
 
+// recordAssetTouches folds this bulk's touched cells into the ever-touched
+// account-by-asset set, mirroring the read-store index writer. The index
+// builder walks every posting and skips cells in the exclusion projection
+// (LedgerLog.PurgedVolumes ∪ AppliedProposal.TransientVolumes), which the FSM
+// derives at END of bulk from the final merged volumes and the end-of-bulk
+// chart (partitionVolumes). Mirrored per touched cell:
+//
+//   - TRANSIENT-matched, all-zero pre-bulk value: steady-state transient —
+//     carried on TransientVolumes, excluded.
+//   - TRANSIENT-matched, non-zero pre-bulk value (grandfathered) or
+//     EPHEMERAL-matched: excluded when the bulk leaves the cell at zero
+//     balance (purged), recorded otherwise.
+//   - NORMAL or unmatched: always recorded.
+//
+// base is the pre-bulk state (the preloaded Old the server classifies on). A
+// touch is permanent once recorded (the index never deletes keys), so a purge
+// in a LATER bulk does not un-record it. Must run before purgeZeroBalance —
+// the classification reads the pre-purge end-of-bulk balance.
+func (s *LedgerState) recordAssetTouches(base *LedgerState, touched map[VolumeKey]bool) {
+	compiled := s.compiled()
+	for key := range touched {
+		if s.cellExcluded(base, key, compiled) {
+			continue
+		}
+
+		assetBase, prec := domain.ParseAssetPrecision(key.Asset)
+		s.everAsset = s.everAsset.Set(assetTouch{address: key.Address, base: assetBase, precision: uint32(prec)}, struct{}{})
+	}
+}
+
+// cellExcluded is the model's copy of the per-cell verdict behind the server's
+// exclusion projection (LedgerLog.PurgedVolumes ∪ AppliedProposal
+// .TransientVolumes), evaluated at END of bulk on the final pre-purge volumes
+// with the end-of-bulk chart:
+//
+//   - TRANSIENT-matched, all-zero pre-bulk value: steady-state transient —
+//     carried on TransientVolumes, excluded.
+//   - TRANSIENT-matched, non-zero pre-bulk value (grandfathered) or
+//     EPHEMERAL-matched: excluded when the bulk leaves the cell at zero
+//     balance (purged), kept otherwise.
+//   - NORMAL or unmatched: never excluded.
+//
+// base is the pre-bulk state (the preloaded Old the server classifies on). Must
+// run before purgeZeroBalance — the verdict reads the pre-purge balance. A cell
+// the bulk never wrote (absent from volumes) is vacuously excluded.
+func (s *LedgerState) cellExcluded(base *LedgerState, key VolumeKey, compiled []accounttype.CompiledType) bool {
+	vp, ok := s.volumes.Get(key)
+	if !ok {
+		return true
+	}
+
+	t := s.match(key.Address, compiled)
+	if t == nil {
+		return false
+	}
+
+	switch t.Persistence {
+	case commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT:
+		bv := base.vol(key)
+		if bv.Input.IsZero() && bv.Output.IsZero() {
+			return true
+		}
+
+		return vp.Input.Cmp(&vp.Output) == 0
+	case commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL:
+		return vp.Input.Cmp(&vp.Output) == 0
+	default:
+		return false
+	}
+}
+
+// recordIndexedAddrs stamps every transaction this bulk appended (ids in
+// (firstNew-1, len(txs)]) with its account→tx index membership: for each
+// posting side, the (account, role) pair is indexed unless the posting's cell
+// is in the end-of-bulk exclusion projection — mirroring the index builder's
+// per-posting sourceExcluded/destinationExcluded skip. The any-role index is
+// the union of the two sides, so only source/destination bits are stored.
+// Replacing the records is safe: they were allocated by this Apply, so no
+// older clone aliases them. Must run before purgeZeroBalance, like
+// recordAssetTouches.
+func (s *LedgerState) recordIndexedAddrs(base *LedgerState, firstNew uint64) {
+	compiled := s.compiled()
+
+	for id := firstNew; id <= uint64(s.txs.Len()); id++ {
+		rec := *s.txs.Get(int(id - 1))
+		rec.indexedAddrs = map[string]uint8{}
+
+		for _, p := range rec.postings {
+			if !s.cellExcluded(base, VolumeKey{Address: p.GetSource(), Asset: p.GetAsset()}, compiled) {
+				rec.indexedAddrs[p.GetSource()] |= AddrIndexedSource
+			}
+
+			if !s.cellExcluded(base, VolumeKey{Address: p.GetDestination(), Asset: p.GetAsset()}, compiled) {
+				rec.indexedAddrs[p.GetDestination()] |= AddrIndexedDestination
+			}
+		}
+
+		s.txs = s.txs.Set(int(id-1), &rec)
+	}
+}
+
 // applyAddMetadata predicts a SaveMetadata, dispatching on the target. Metadata
 // lives outside the volume table, so it never touches the transient/purge
 // write-set.
@@ -1035,6 +1421,54 @@ func (s *LedgerState) applyDeleteLedgerMetadata(req *servicepb.DeleteLedgerMetad
 	return OrderResult{OK: true}
 }
 
+// applyCreateIndex records a newly created index as ambiguous (readiness unknown
+// until the driver's poller confirms it READY). CreateIndex is idempotent on the
+// server (a duplicate on a present index is a no-op, no AlreadyExists), so an
+// existing entry keeps its current readiness flag.
+func (s *LedgerState) applyCreateIndex(req *servicepb.CreateIndexRequest) OrderResult {
+	// A metadata index targets a declared schema field; creating one for an
+	// undeclared (target, key) is rejected (validateIndexTarget).
+	if meta, ok := req.GetId().GetKind().(*commonpb.IndexID_Metadata); ok {
+		if !s.fieldTypes(meta.Metadata.GetTarget()).Has(meta.Metadata.GetKey()) {
+			return OrderResult{Reason: domain.ErrReasonMetadataFieldNotInSchema}
+		}
+	}
+
+	canonical := indexes.Canonical(req.GetId())
+	if !s.indexes.Has(canonical) {
+		s.indexes = s.indexes.Set(canonical, false) // ambiguous: created, readiness not yet confirmed
+	}
+
+	return OrderResult{OK: true}
+}
+
+// fieldTypes returns the declared-type map for a metadata target. Ledger-target
+// declarations exist but have no index surface; unknown targets are the empty
+// map (the caller treats every key as undeclared).
+func (s *LedgerState) fieldTypes(target commonpb.TargetType) Map[string, commonpb.MetadataType] {
+	switch target {
+	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
+		return s.accountFieldTypes
+	case commonpb.TargetType_TARGET_TYPE_LEDGER:
+		return s.ledgerFieldTypes
+	case commonpb.TargetType_TARGET_TYPE_TRANSACTION:
+		return s.transactionFieldTypes
+	default:
+		return NewMap[string, commonpb.MetadataType](stringComparer{}, fieldTypeTerm("XF"))
+	}
+}
+
+// applyDropIndex removes an index. Drop is instantaneous: once this order is in
+// the committed prefix, a linearizable read issued after its response observes
+// it gone. Dropping an absent index is a harmless no-op.
+func (s *LedgerState) applyDropIndex(req *servicepb.DropIndexRequest) OrderResult {
+	canonical := indexes.Canonical(req.GetId())
+	s.indexes = s.indexes.Delete(canonical)
+	s.retypeWindows = s.retypeWindows.Delete(canonical)
+
+	return OrderResult{OK: true}
+}
+
 // applySetMetadataFieldType declares (or re-declares) a metadata field's type.
 //
 // Stored values are immutable: declaring a type only records the declared type
@@ -1042,6 +1476,26 @@ func (s *LedgerState) applyDeleteLedgerMetadata(req *servicepb.DeleteLedgerMetad
 // a value survives any retype chain losslessly (a STRING "01" retyped INT64 then
 // back to STRING still reads "01"). Always succeeds.
 func (s *LedgerState) applySetMetadataFieldType(req *servicepb.SetMetadataFieldTypeRequest) OrderResult {
+	// A retype of an indexed key opens a serving window: the index keeps
+	// answering under the type it was built with until the background rewrite
+	// switches, so both types stay legal until the driver observes the switch
+	// on every replica. A CHAINED retype mid-window adds the type it
+	// supersedes to the window's set: each rewrite switch advances the
+	// replica's served version through that intermediate binding before the
+	// next rewrite lands, so a query may legally observe any of them until
+	// the driver proves the chain quiescent. CreateIndex requires a declared
+	// field, so the previous type always exists here. Ledger-target keys have
+	// no metadata index.
+	if tt := req.GetTargetType(); tt == commonpb.TargetType_TARGET_TYPE_ACCOUNT || tt == commonpb.TargetType_TARGET_TYPE_TRANSACTION {
+		canonical := indexes.Canonical(indexes.MetadataID(tt, req.GetKey()))
+		if s.indexes.Has(canonical) {
+			if oldType, declared := s.FieldTypeFor(tt, req.GetKey()); declared {
+				mask, _ := s.retypeWindows.Get(canonical)
+				s.retypeWindows = s.retypeWindows.Set(canonical, mask|1<<uint(oldType))
+			}
+		}
+	}
+
 	switch req.GetTargetType() {
 	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
 		s.accountFieldTypes = s.accountFieldTypes.Set(req.GetKey(), req.GetType())
@@ -1059,6 +1513,10 @@ func (s *LedgerState) applySetMetadataFieldType(req *servicepb.SetMetadataFieldT
 // applyRemoveMetadataFieldType drops a field's declared type. Stored values are
 // untouched; without a declared type, reads no longer coerce the key. Removing an
 // undeclared field is a no-op, matching the server. Always succeeds.
+//
+// A metadata index on the removed field cannot outlive its declaration — the
+// server drops it in the same order (the RemovedMetadataFieldType log carries
+// the DroppedIndex), so the model removes it too.
 func (s *LedgerState) applyRemoveMetadataFieldType(req *servicepb.RemoveMetadataFieldTypeRequest) OrderResult {
 	switch req.GetTargetType() {
 	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
@@ -1070,6 +1528,10 @@ func (s *LedgerState) applyRemoveMetadataFieldType(req *servicepb.RemoveMetadata
 	default:
 		panic(fmt.Sprintf("model: RemoveMetadataFieldType target %v is unmodeled", req.GetTargetType()))
 	}
+
+	removedCanonical := indexes.Canonical(indexes.MetadataID(req.GetTargetType(), req.GetKey()))
+	s.indexes = s.indexes.Delete(removedCanonical)
+	s.retypeWindows = s.retypeWindows.Delete(removedCanonical)
 
 	return OrderResult{OK: true}
 }

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -358,19 +358,30 @@ func txRefTerm(ref string, id int) Digest {
 // transaction.
 // logRecord is one entry of the ledger log stream. The id is DERIVED, never
 // taken from the server: the stream is dense from 1, so the model can predict
-// it, and predicting it is what lets a mis-assigned id be caught at all. Only
-// the date is learned from the commit response (LearnLogDate) — it is
-// server-assigned with no derivable value, and nil means not yet learned.
+// it, and predicting it is what lets a mis-assigned id be caught at all. The
+// date and the global sequence are learned from the commit response
+// (LearnLogDate, LearnLogSequence): both are server-assigned with no derivable
+// value — the sequence spans every ledger and the technical entries between
+// them — and a zero or nil one means not yet learned.
 type logRecord struct {
-	id   uint64
-	kind string
-	date *commonpb.Timestamp
+	id      uint64
+	kind    string
+	payload string
+	// purged, newKept and ephemeral are the volume annotations the FSM hangs
+	// on this log: the cells this order touched that the end-of-bulk partition
+	// classified as drained-to-zero, newly kept, and created-and-zeroed within
+	// the bulk. Derived, never learned — the model runs the same partition.
+	purged    string
+	newKept   string
+	ephemeral string
+	date      *commonpb.Timestamp
+	sequence  uint64
 }
 
 func logTerm(idx int, l *logRecord) Digest {
 	t := newTerm("LOG")
-	t.u64(uint64(idx), l.id)
-	t.str(l.kind)
+	t.u64(uint64(idx), l.id, l.sequence)
+	t.str(l.kind, l.payload, l.purged, l.newKept, l.ephemeral)
 
 	// A nil date (not yet learned) must not collide with any concrete value.
 	t.boolean(l.date != nil)
@@ -768,6 +779,17 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 	orders := make([]OrderResult, 0, len(bulk.Requests))
 	touched := map[string]map[VolumeKey]bool{}
 
+	// Per-order cells, kept beside the per-ledger union: the FSM hangs each
+	// log's volume annotations on the cells THAT order touched, so the union
+	// alone cannot reproduce them.
+	type orderTouch struct {
+		ledger string
+		logIdx int
+		cells  map[VolumeKey]bool
+	}
+
+	var orderTouches []orderTouch
+
 	for _, req := range bulk.Requests {
 		name := LedgerOf(req)
 
@@ -783,13 +805,26 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 			touched[name] = cells
 		}
 
-		oc := ls.applyOne(req, cells)
+		orderCells := map[VolumeKey]bool{}
+
+		oc := ls.applyOne(req, orderCells)
+
+		for key := range orderCells {
+			cells[key] = true
+		}
+
+		logsBefore := ls.logs.Len()
+
 		if oc.OK {
 			// Appended centrally rather than per handler: every committed
 			// ledger-scoped order produces exactly one log, so a handler that
 			// forgot would silently shorten the stream and mis-id every log
 			// after it.
 			ls.appendLog(req)
+		}
+
+		if ls.logs.Len() > logsBefore {
+			orderTouches = append(orderTouches, orderTouch{ledger: name, logIdx: ls.logs.Len() - 1, cells: orderCells})
 		}
 
 		// applyOne rebinds ls's persistent collections; write the updated value
@@ -816,7 +851,16 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 
 		ls.recordAssetTouches(&base, cells)
 		ls.recordIndexedAddrs(&base, uint64(base.Txs().Len())+1)
-		ls.purgeZeroBalance(cells)
+
+		purged := ls.purgeZeroBalance(cells)
+
+		ann := ls.classifyVolumes(&base, cells, purged)
+		for _, ot := range orderTouches {
+			if ot.ledger == name {
+				ls.annotateLog(ot.logIdx, ot.cells, ann)
+			}
+		}
+
 		next.ledgers[name] = ls
 	}
 
@@ -910,6 +954,110 @@ func logKindFor(req *servicepb.Request) string {
 	panic(fmt.Sprintf("model: no log kind for request %T", req.GetType()))
 }
 
+// logPayloadFor renders the payload a committed request implies, canonically,
+// so a served log can be held to it field for field (CanonicalServedLogPayload
+// renders the served side into the same shape — the two must agree).
+//
+// Transaction logs render empty: their content is server-assigned and is
+// validated against the model's transaction records by the ListTransactions
+// path, which compares ids, references, revert relationships and stamps.
+func logPayloadFor(req *servicepb.Request) string {
+	switch r := req.GetType().(type) {
+	case *servicepb.Request_AddAccountType:
+		at := r.AddAccountType.GetAccountType()
+
+		return "type=" + at.GetName() + "|pattern=" + at.GetPattern()
+	case *servicepb.Request_RemoveAccountType:
+		return "type=" + r.RemoveAccountType.GetName()
+	case *servicepb.Request_SetMetadataFieldType:
+		return "target=" + strconv.Itoa(int(r.SetMetadataFieldType.GetTargetType())) +
+			"|key=" + r.SetMetadataFieldType.GetKey() +
+			"|type=" + strconv.Itoa(int(r.SetMetadataFieldType.GetType()))
+	case *servicepb.Request_RemoveMetadataFieldType:
+		return "target=" + strconv.Itoa(int(r.RemoveMetadataFieldType.GetTargetType())) +
+			"|key=" + r.RemoveMetadataFieldType.GetKey()
+	case *servicepb.Request_CreateIndex:
+		return "index=" + indexes.Canonical(r.CreateIndex.GetId())
+	case *servicepb.Request_DropIndex:
+		return "index=" + indexes.Canonical(r.DropIndex.GetId())
+	case *servicepb.Request_Apply:
+		switch a := r.Apply.GetAction().GetData().(type) {
+		case *servicepb.LedgerAction_AddMetadata:
+			return "target=" + canonicalTarget(a.AddMetadata.GetTarget()) + "|" + canonicalMetadata(a.AddMetadata.GetMetadata())
+		case *servicepb.LedgerAction_DeleteMetadata:
+			return "target=" + canonicalTarget(a.DeleteMetadata.GetTarget()) + "|key=" + a.DeleteMetadata.GetKey()
+		}
+	}
+
+	return ""
+}
+
+// CanonicalServedLogPayload renders a served log's payload the way
+// logPayloadFor renders the request that produced it. Empty means the payload
+// is one this rendering does not pin (a transaction).
+func CanonicalServedLogPayload(data *commonpb.LedgerLogPayload) string {
+	switch {
+	case data.GetAddedAccountType() != nil:
+		at := data.GetAddedAccountType().GetAccountType()
+
+		return "type=" + at.GetName() + "|pattern=" + at.GetPattern()
+	case data.GetRemovedAccountType() != nil:
+		return "type=" + data.GetRemovedAccountType().GetName()
+	case data.GetSetMetadataFieldType() != nil:
+		f := data.GetSetMetadataFieldType()
+
+		return "target=" + strconv.Itoa(int(f.GetTargetType())) +
+			"|key=" + f.GetKey() +
+			"|type=" + strconv.Itoa(int(f.GetType()))
+	case data.GetRemovedMetadataFieldType() != nil:
+		f := data.GetRemovedMetadataFieldType()
+
+		return "target=" + strconv.Itoa(int(f.GetTargetType())) + "|key=" + f.GetKey()
+	case data.GetCreateIndex() != nil:
+		return "index=" + indexes.Canonical(data.GetCreateIndex().GetId())
+	case data.GetDropIndex() != nil:
+		return "index=" + indexes.Canonical(data.GetDropIndex().GetId())
+	case data.GetSavedMetadata() != nil:
+		m := data.GetSavedMetadata()
+
+		return "target=" + canonicalTarget(m.GetTarget()) + "|" + canonicalMetadata(m.GetMetadata())
+	case data.GetDeletedMetadata() != nil:
+		m := data.GetDeletedMetadata()
+
+		return "target=" + canonicalTarget(m.GetTarget()) + "|key=" + m.GetKey()
+	default:
+		return ""
+	}
+}
+
+// canonicalTarget names a metadata target: an account by address, a
+// transaction by id.
+func canonicalTarget(t *commonpb.Target) string {
+	if acct := t.GetAccount(); acct != nil {
+		return "acct:" + acct.GetAddr()
+	}
+
+	return "tx:" + strconv.FormatUint(t.GetTransactionId(), 10)
+}
+
+// canonicalMetadata renders a metadata map key-sorted, values type-tagged
+// (MetaValueString), so equality of the rendering is equality of the map.
+func canonicalMetadata(m map[string]*commonpb.MetadataValue) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+MetaValueString(m[k]))
+	}
+
+	return strings.Join(parts, ",")
+}
+
 // appendLog records the log a committed request produced, if it produced one.
 // The id is the stream's position, dense from 1.
 func (s *LedgerState) appendLog(req *servicepb.Request) {
@@ -918,7 +1066,108 @@ func (s *LedgerState) appendLog(req *servicepb.Request) {
 		return
 	}
 
-	s.logs = s.logs.Append(&logRecord{id: uint64(s.logs.Len()) + 1, kind: kind})
+	s.logs = s.logs.Append(&logRecord{id: uint64(s.logs.Len()) + 1, kind: kind, payload: logPayloadFor(req)})
+}
+
+// volumeAnnotations are the three per-log volume lists the FSM derives at end
+// of bulk (write_set_new_volumes.go): a purged cell that held a non-zero value
+// before the bulk drained to zero, one that was created and zeroed inside the
+// bulk is ephemeral, and a surviving cell that did not exist before is newly
+// kept. "Did not exist" covers an absent cell and a zero placeholder alike,
+// matching isNewVolumeUpdate.
+type volumeAnnotations struct {
+	purged    map[VolumeKey]bool
+	newKept   map[VolumeKey]bool
+	ephemeral map[VolumeKey]bool
+}
+
+// classifyVolumes runs the model's copy of that partition over the cells this
+// bulk touched in one ledger. purged names the cells purgeZeroBalance dropped;
+// s is the post-purge state and base the pre-bulk one.
+//
+// A steady-state TRANSIENT cell — one matching a transient type whose pre-bulk
+// value is absent or zero — is carved out: partitionVolumes files it under
+// `transient`, which is neither `kept` nor `purged`, and only those two feed
+// the annotation sets. Such a cell therefore carries no annotation whatever its
+// closing balance.
+func (s *LedgerState) classifyVolumes(base *LedgerState, touched, purged map[VolumeKey]bool) volumeAnnotations {
+	out := volumeAnnotations{
+		purged:    map[VolumeKey]bool{},
+		newKept:   map[VolumeKey]bool{},
+		ephemeral: map[VolumeKey]bool{},
+	}
+
+	compiled := s.compiled()
+
+	for key := range touched {
+		prior := base.vol(key)
+		newCell := prior.Input.IsZero() && prior.Output.IsZero()
+
+		if newCell {
+			if t := s.match(key.Address, compiled); t != nil &&
+				t.Persistence == commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT {
+				continue
+			}
+		}
+
+		switch {
+		case purged[key] && newCell:
+			out.ephemeral[key] = true
+		case purged[key]:
+			out.purged[key] = true
+		case newCell:
+			// Not purged and not transient, so the cell is in the FSM's `kept`
+			// partition — the only classification left for a first write.
+			out.newKept[key] = true
+		}
+	}
+
+	return out
+}
+
+// renderTouchedVolumes names a set of cells the way the FSM orders them on a
+// log: deduplicated, ascending by account then asset. Colour is a dimension of
+// the server's key that the model does not carry, so a colour split cannot be
+// caught here.
+func renderTouchedVolumes(cells map[VolumeKey]bool) string {
+	if len(cells) == 0 {
+		return ""
+	}
+
+	keys := make([]VolumeKey, 0, len(cells))
+	for key := range cells {
+		keys = append(keys, key)
+	}
+
+	sort.Slice(keys, func(a, b int) bool { return CompareVolumeKey(keys[a], keys[b]) < 0 })
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key.Address+":"+key.Asset)
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// annotateLog hangs one order's share of the bulk's volume classification on
+// the log it produced: the cells IT touched, intersected with each class.
+func (s *LedgerState) annotateLog(idx int, cells map[VolumeKey]bool, ann volumeAnnotations) {
+	intersect := func(set map[VolumeKey]bool) map[VolumeKey]bool {
+		out := map[VolumeKey]bool{}
+		for key := range cells {
+			if set[key] {
+				out[key] = true
+			}
+		}
+
+		return out
+	}
+
+	rec := *s.logs.Get(idx)
+	rec.purged = renderTouchedVolumes(intersect(ann.purged))
+	rec.newKept = renderTouchedVolumes(intersect(ann.newKept))
+	rec.ephemeral = renderTouchedVolumes(intersect(ann.ephemeral))
+	s.logs = s.logs.Set(idx, &rec)
 }
 
 // applyOne mutates the (already-forked) working state for one request and
@@ -1571,8 +1820,10 @@ func (s *LedgerState) transientViolation(base *LedgerState, touched map[VolumeKe
 
 // purgeZeroBalance drops touched EPHEMERAL/TRANSIENT cells that landed at a zero
 // balance, mirroring the server's post-commit write-set sweep (PR #151).
-func (s *LedgerState) purgeZeroBalance(touched map[VolumeKey]bool) {
+func (s *LedgerState) purgeZeroBalance(touched map[VolumeKey]bool) map[VolumeKey]bool {
+	purged := map[VolumeKey]bool{}
 	compiled := s.compiled()
+
 	for key := range touched {
 		vp, ok := s.volumes.Get(key)
 		if !ok {
@@ -1589,7 +1840,10 @@ func (s *LedgerState) purgeZeroBalance(touched map[VolumeKey]bool) {
 			commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT:
 			if vp.Input.Cmp(&vp.Output) == 0 {
 				s.volumes = s.volumes.Delete(key)
+				purged[key] = true
 			}
 		}
 	}
+
+	return purged
 }

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -1699,10 +1699,15 @@ func (s *LedgerState) applyDeleteLedgerMetadata(req *servicepb.DeleteLedgerMetad
 }
 
 // applyCreateIndex records a newly created index as ambiguous (readiness unknown
-// until the driver's poller confirms it READY). CreateIndex is idempotent on the
-// server (a duplicate on a present index is a no-op, no AlreadyExists), so an
-// existing entry keeps its current readiness flag.
+// until the driver's poller confirms it READY). Creating one that already
+// exists is rejected (EN-2009); the checks run in processCreateIndex's order,
+// existence before target validation.
 func (s *LedgerState) applyCreateIndex(req *servicepb.CreateIndexRequest) OrderResult {
+	canonical := indexes.Canonical(req.GetId())
+	if s.indexes.Has(canonical) {
+		return OrderResult{Reason: domain.ErrReasonIndexAlreadyExists}
+	}
+
 	// A metadata index targets a declared schema field; creating one for an
 	// undeclared (target, key) is rejected (validateIndexTarget).
 	if meta, ok := req.GetId().GetKind().(*commonpb.IndexID_Metadata); ok {
@@ -1711,10 +1716,7 @@ func (s *LedgerState) applyCreateIndex(req *servicepb.CreateIndexRequest) OrderR
 		}
 	}
 
-	canonical := indexes.Canonical(req.GetId())
-	if !s.indexes.Has(canonical) {
-		s.indexes = s.indexes.Set(canonical, false) // ambiguous: created, readiness not yet confirmed
-	}
+	s.indexes = s.indexes.Set(canonical, false) // ambiguous: created, readiness not yet confirmed
 
 	return OrderResult{OK: true}
 }

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -407,6 +407,14 @@ func txTerm(idx int, tx *txRecord) Digest {
 	t.boolean(tx.revertedAt != nil)
 	t.u64(tx.revertedAt.GetData())
 
+	// The snapshot is frozen at the transaction's own sequence, so two states
+	// agreeing on current balances can still disagree on it.
+	for _, key := range sortedVolumeKeys(tx.pcv) {
+		vp := tx.pcv[key]
+		t.str(key.Address, key.Asset)
+		t.str(vp.Input.Dec(), vp.Output.Dec())
+	}
+
 	// indexedAddrs is derived at end of bulk, but two partial foldings can
 	// stamp the same postings differently (exclusion depends on the chart and
 	// balances at the stamping bulk's end), and the stamps drive address-query
@@ -647,6 +655,11 @@ type txRecord struct {
 	revertedBy         uint64
 	revertedAt         *commonpb.Timestamp
 	revertsTransaction uint64
+	// pcv is the transaction's post-commit volumes: for every cell its own
+	// postings touched, the running volume once they had all applied. An
+	// immutable historical snapshot, so a read must echo it unchanged however
+	// far the balances have since moved. Derived, never learned.
+	pcv map[VolumeKey]VolumePair
 	// indexedAddrs is the transaction's account→tx index membership: per
 	// posting-side account, which role rows (AddrIndexedSource /
 	// AddrIndexedDestination bits) the index builder writes for this
@@ -1125,6 +1138,18 @@ func (s *LedgerState) classifyVolumes(base *LedgerState, touched, purged map[Vol
 	return out
 }
 
+// sortedVolumeKeys orders a cell map for stable hashing and rendering.
+func sortedVolumeKeys[V any](cells map[VolumeKey]V) []VolumeKey {
+	keys := make([]VolumeKey, 0, len(cells))
+	for key := range cells {
+		keys = append(keys, key)
+	}
+
+	sort.Slice(keys, func(a, b int) bool { return CompareVolumeKey(keys[a], keys[b]) < 0 })
+
+	return keys
+}
+
 // renderTouchedVolumes names a set of cells the way the FSM orders them on a
 // log: deduplicated, ascending by account then asset. Colour is a dimension of
 // the server's key that the model does not carry, so a colour split cannot be
@@ -1134,12 +1159,7 @@ func renderTouchedVolumes(cells map[VolumeKey]bool) string {
 		return ""
 	}
 
-	keys := make([]VolumeKey, 0, len(cells))
-	for key := range cells {
-		keys = append(keys, key)
-	}
-
-	sort.Slice(keys, func(a, b int) bool { return CompareVolumeKey(keys[a], keys[b]) < 0 })
+	keys := sortedVolumeKeys(cells)
 
 	parts := make([]string, 0, len(keys))
 	for _, key := range keys {
@@ -1290,6 +1310,7 @@ func (s *LedgerState) applyTransaction(ct *servicepb.CreateTransactionPayload, t
 		postings:  postings,
 		metadata:  ct.GetMetadata(),
 		timestamp: ct.GetTimestamp(),
+		pcv:       pcv,
 	})
 	if ref != "" {
 		s.txByRef = s.txByRef.Set(ref, int(id))
@@ -1363,7 +1384,14 @@ func (s *LedgerState) applyRevert(rt *servicepb.RevertTransactionPayload, touche
 	reverted.revertedAt = revertTS
 	s.txs = s.txs.Set(int(id-1), &reverted)
 
-	s.txs = s.txs.Append(&txRecord{id: revertID, postings: reversed, metadata: rt.GetMetadata(), timestamp: revertTS, revertsTransaction: orig.id})
+	s.txs = s.txs.Append(&txRecord{
+		id:                 revertID,
+		postings:           reversed,
+		metadata:           rt.GetMetadata(),
+		timestamp:          revertTS,
+		revertsTransaction: orig.id,
+		pcv:                pcv,
+	})
 
 	return OrderResult{
 		OK:     true,

--- a/tests/oracle/model.go
+++ b/tests/oracle/model.go
@@ -376,11 +376,16 @@ type logRecord struct {
 	ephemeral string
 	date      *commonpb.Timestamp
 	sequence  uint64
+	// txID links a created_transaction / reverted_transaction log to the
+	// transaction it announces, so the transaction embedded in the served log
+	// can be held to the same record ListTransactions is held to. Zero for
+	// every other kind.
+	txID uint64
 }
 
 func logTerm(idx int, l *logRecord) Digest {
 	t := newTerm("LOG")
-	t.u64(uint64(idx), l.id, l.sequence)
+	t.u64(uint64(idx), l.id, l.sequence, l.txID)
 	t.str(l.kind, l.payload, l.purged, l.newKept, l.ephemeral)
 
 	// A nil date (not yet learned) must not collide with any concrete value.
@@ -833,7 +838,7 @@ func (g GlobalState) Apply(bulk Bulk) ApplyResult {
 			// ledger-scoped order produces exactly one log, so a handler that
 			// forgot would silently shorten the stream and mis-id every log
 			// after it.
-			ls.appendLog(req)
+			ls.appendLog(req, oc.TxID)
 		}
 
 		if ls.logs.Len() > logsBefore {
@@ -1073,13 +1078,18 @@ func canonicalMetadata(m map[string]*commonpb.MetadataValue) string {
 
 // appendLog records the log a committed request produced, if it produced one.
 // The id is the stream's position, dense from 1.
-func (s *LedgerState) appendLog(req *servicepb.Request) {
+func (s *LedgerState) appendLog(req *servicepb.Request, txID uint64) {
 	kind := logKindFor(req)
 	if kind == "" {
 		return
 	}
 
-	s.logs = s.logs.Append(&logRecord{id: uint64(s.logs.Len()) + 1, kind: kind, payload: logPayloadFor(req)})
+	s.logs = s.logs.Append(&logRecord{
+		id:      uint64(s.logs.Len()) + 1,
+		kind:    kind,
+		payload: logPayloadFor(req),
+		txID:    txID,
+	})
 }
 
 // volumeAnnotations are the three per-log volume lists the FSM derives at end

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -243,6 +243,66 @@ func TestGlobalState_Apply_TransientGrandfather(t *testing.T) {
 	require.Equal(t, "8", dec(rl.vol(VolumeKey{"g:1", "USD"}).Input))
 }
 
+// Asset touches land in everAsset iff the cell escapes the server's exclusion
+// projection, which is derived at END of bulk (end-of-bulk chart, final merged
+// volumes) — not per order.
+func TestGlobalState_Apply_AssetTouchExclusions(t *testing.T) {
+	t.Parallel()
+
+	// Transient at order time but un-churned within the same bulk: the
+	// end-of-bulk chart classifies the cell NORMAL, so the touch is recorded.
+	churned := NewGlobalState().Apply(bulkOf(
+		oracletest.AddTypeReqP("t", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+		oracletest.TxReq("world", "t:1", "USD", 5),
+		oracletest.TxReq("t:1", "world", "USD", 5),
+		oracletest.RemoveTypeReq("t"),
+	))
+	require.True(t, churned.OK)
+	require.True(t, churned.State.Ledger("L").HasEverAsset("t:1", "USD", 0))
+
+	// Steady-state transient (zero pre-bulk value, transient at end of bulk):
+	// carried on TransientVolumes, never recorded.
+	steady := NewGlobalState().Apply(bulkOf(
+		oracletest.AddTypeReqP("t", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+		oracletest.TxReq("world", "t:1", "USD", 5),
+		oracletest.TxReq("t:1", "world", "USD", 5),
+	))
+	require.True(t, steady.OK)
+	require.False(t, steady.State.Ledger("L").HasEverAsset("t:1", "USD", 0))
+
+	eph := NewGlobalState().Apply(bulkOf(oracletest.AddTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL))).State
+
+	// Ephemeral drained across two orders of one bulk: the purge is decided on
+	// the end-of-bulk balance, so the touch is excluded even though the first
+	// order left the cell non-zero.
+	drained := eph.Apply(bulkOf(
+		oracletest.TxReq("world", "e:1", "USD", 5),
+		oracletest.TxReq("e:1", "world", "USD", 5),
+	))
+	require.True(t, drained.OK)
+	require.False(t, drained.State.Ledger("L").HasEverAsset("e:1", "USD", 0))
+
+	// Ephemeral left non-zero: kept, recorded.
+	kept := eph.Apply(bulkOf(oracletest.TxReq("world", "e:1", "USD", 5)))
+	require.True(t, kept.OK)
+	require.True(t, kept.State.Ledger("L").HasEverAsset("e:1", "USD", 0))
+
+	// Exclusion is per (account, asset) cell: a recorded USD touch survives a
+	// later bulk whose EUR wash on the same (now transient) account is excluded.
+	funded := NewGlobalState().Apply(bulkOf(oracletest.TxReq("world", "g:1", "USD", 5)))
+	require.True(t, funded.OK)
+	require.True(t, funded.State.Ledger("L").HasEverAsset("g:1", "USD", 0))
+
+	washed := funded.State.Apply(bulkOf(
+		oracletest.AddTypeReqP("g", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+		oracletest.TxReq("world", "g:1", "EUR", 3),
+		oracletest.TxReq("g:1", "world", "EUR", 3),
+	))
+	require.True(t, washed.OK)
+	require.True(t, washed.State.Ledger("L").HasEverAsset("g:1", "USD", 0))
+	require.False(t, washed.State.Ledger("L").HasEverAsset("g:1", "EUR", 0))
+}
+
 func TestGlobalState_Apply_EphemeralPurge(t *testing.T) {
 	t.Parallel()
 
@@ -525,4 +585,23 @@ func TestApplyTransaction_EmptyBeatsFsmRejection(t *testing.T) {
 	}})
 	require.False(t, res.OK)
 	require.Equal(t, domain.ErrReasonValidation, res.Reason)
+}
+
+func TestHasAccount_MetadataOnlyMembership(t *testing.T) {
+	t.Parallel()
+
+	// a:1 holds volumes; m:1 holds ONLY metadata (no volume cell). Both are in
+	// the merged V+M universe; z:9 is in neither. The metadata-only account is
+	// the regression case: a volumes-map miss must fall through to the
+	// metadata scan.
+	s := NewGlobalState().Apply(bulkOf(
+		oracletest.TxReq("world", "a:1", "USD", 5),
+		oracletest.AddAccountMetaReq("m:1", "k", commonpb.NewStringValue("v")),
+	)).State
+
+	ls := s.Ledger("L")
+	require.True(t, ls.HasAccount("a:1"))
+	require.True(t, ls.HasAccount("world"))
+	require.True(t, ls.HasAccount("m:1"))
+	require.False(t, ls.HasAccount("z:9"))
 }

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -605,3 +605,82 @@ func TestHasAccount_MetadataOnlyMembership(t *testing.T) {
 	require.True(t, ls.HasAccount("m:1"))
 	require.False(t, ls.HasAccount("z:9"))
 }
+
+// The three end-of-bulk volume annotations must land on exactly the logs whose
+// order touched the cell, split into the same classes partitionVolumes and
+// splitPurged produce.
+func TestGlobalState_Apply_VolumeAnnotations(t *testing.T) {
+	t.Parallel()
+
+	base := NewGlobalState().Apply(bulkOf(
+		oracletest.AddTypeReqP("e", commonpb.AccountTypePersistence_ACCOUNT_TYPE_EPHEMERAL),
+		oracletest.AddTypeReqP("t", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+		oracletest.AddTypeReqP("n", commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL),
+		oracletest.TxReq("world", "e:1", "USD", 7),
+	))
+	require.True(t, base.OK)
+
+	got := base.State.Apply(bulkOf(
+		oracletest.TxReq("e:1", "world", "USD", 7), // drains a funded ephemeral
+		oracletest.TxReqMulti(false, // three first writes in one order
+			commonpb.NewPosting("world", "n:3", "USD", big.NewInt(1)),
+			commonpb.NewPosting("world", "n:1", "USD", big.NewInt(1)),
+			commonpb.NewPosting("world", "n:2", "USD", big.NewInt(1)),
+		),
+		oracletest.TxReq("world", "e:2", "USD", 4), // creates...
+		oracletest.TxReq("e:2", "world", "USD", 4), // ...and drains it in the same bulk
+		oracletest.TxReq("world", "t:1", "USD", 2), // steady-state transient:
+		oracletest.TxReq("t:1", "world", "USD", 2), // never persisted, never annotated
+	))
+	require.True(t, got.OK)
+
+	type ann struct{ purged, newKept, ephemeral string }
+
+	have := map[uint64]ann{}
+	for _, row := range got.State.Ledger("L").LogRows() {
+		have[row.ID] = ann{row.PurgedVolumes, row.NewKeptVolumes, row.EphemeralVolumes}
+	}
+
+	require.Equal(t, map[uint64]ann{
+		1:  {},                                   // added_account_type: no cells
+		2:  {},                                   //
+		3:  {},                                   //
+		4:  {newKept: "e:1:USD,world:USD"},       // both cells born here, both survive
+		5:  {purged: "e:1:USD"},                  // drained a cell that held 7
+		6:  {newKept: "n:1:USD,n:2:USD,n:3:USD"}, // sorted, and world was already recorded
+		7:  {ephemeral: "e:2:USD"},               // born and zeroed inside the bulk,
+		8:  {ephemeral: "e:2:USD"},               // so both its orders carry it
+		9:  {},                                   // transient, absent before the bulk
+		10: {},                                   //
+	}, have)
+}
+
+// The volume annotations are part of a state's identity: the same transactions
+// grouped into different bulks leave identical volumes and identical logs, yet
+// the FSM annotates them differently. A fingerprint that collapsed the two
+// would let the checker substitute one candidate base for the other.
+func TestGlobalState_Fingerprint_DistinguishesVolumeAnnotations(t *testing.T) {
+	t.Parallel()
+
+	one := NewGlobalState().
+		Apply(bulkOf(oracletest.TxReq("world", "a:1", "USD", 5))).State.
+		Apply(bulkOf(oracletest.TxReq("world", "a:2", "USD", 5)))
+	require.True(t, one.OK)
+
+	together := NewGlobalState().Apply(bulkOf(
+		oracletest.TxReq("world", "a:1", "USD", 5),
+		oracletest.TxReq("world", "a:2", "USD", 5),
+	))
+	require.True(t, together.OK)
+
+	// Everything else about the two ledgers agrees.
+	require.Equal(t, one.State.Ledger("L").LogKinds(), together.State.Ledger("L").LogKinds())
+	require.Equal(t, one.State.Ledger("L").volumes.Fingerprint(), together.State.Ledger("L").volumes.Fingerprint())
+
+	// world is born inside the second bulk, so its second order is annotated
+	// too; across two bulks it is already old by then.
+	require.Equal(t, "a:2:USD", one.State.Ledger("L").LogRows()[1].NewKeptVolumes)
+	require.Equal(t, "a:2:USD,world:USD", together.State.Ledger("L").LogRows()[1].NewKeptVolumes)
+
+	require.NotEqual(t, hashState(one.State), hashState(together.State))
+}

--- a/tests/oracle/model_test.go
+++ b/tests/oracle/model_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/tests/oracle/oracletest"
@@ -683,4 +684,46 @@ func TestGlobalState_Fingerprint_DistinguishesVolumeAnnotations(t *testing.T) {
 	require.Equal(t, "a:2:USD,world:USD", together.State.Ledger("L").LogRows()[1].NewKeptVolumes)
 
 	require.NotEqual(t, hashState(one.State), hashState(together.State))
+}
+
+// A second creation of a live index is rejected (EN-2009).
+func TestGlobalState_Apply_CreateIndexRejectsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)
+
+	first := NewGlobalState().Apply(bulkOf(oracletest.CreateIndexReq(id)))
+	require.True(t, first.OK)
+
+	dup := first.State.Apply(bulkOf(oracletest.CreateIndexReq(id)))
+	require.False(t, dup.OK)
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists, dup.Reason)
+
+	// Dropping frees the name again.
+	dropped := first.State.Apply(bulkOf(oracletest.DropIndexReq(id)))
+	require.True(t, dropped.OK)
+	require.True(t, dropped.State.Apply(bulkOf(oracletest.CreateIndexReq(id))).OK)
+
+	// The schema check still owns a first creation over an undeclared field.
+	metaID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "undeclared")
+	require.Equal(t, domain.ErrReasonMetadataFieldNotInSchema,
+		NewGlobalState().Apply(bulkOf(oracletest.CreateIndexReq(metaID))).Reason)
+
+	// A metadata index is duplicable exactly like a builtin one, and dropping
+	// its declaration takes the index with it, so the name frees up again.
+	declared := NewGlobalState().Apply(bulkOf(
+		oracletest.SetFieldTypeReq(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "undeclared", commonpb.MetadataType_METADATA_TYPE_STRING),
+		oracletest.CreateIndexReq(metaID),
+	))
+	require.True(t, declared.OK)
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists,
+		declared.State.Apply(bulkOf(oracletest.CreateIndexReq(metaID))).Reason)
+
+	removed := declared.State.Apply(bulkOf(
+		oracletest.RemoveFieldTypeReq(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "undeclared"),
+	))
+	require.True(t, removed.OK)
+	require.Equal(t, domain.ErrReasonMetadataFieldNotInSchema,
+		removed.State.Apply(bulkOf(oracletest.CreateIndexReq(metaID))).Reason,
+		"the index died with its declaration, so this is a fresh creation again")
 }

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -135,3 +135,59 @@ func AddTxMetaReq(txID uint64, md map[string]*commonpb.MetadataValue) *servicepb
 		},
 	}
 }
+
+// SetFieldTypeReq declares (target, key) with the given metadata type on
+// ledger "L".
+func SetFieldTypeReq(target commonpb.TargetType, key string, t commonpb.MetadataType) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_SetMetadataFieldType{
+			SetMetadataFieldType: &servicepb.SetMetadataFieldTypeRequest{
+				Ledger:     "L",
+				TargetType: target,
+				Key:        key,
+				Type:       t,
+			},
+		},
+	}
+}
+
+// RemoveFieldTypeReq drops the (target, key) declaration on ledger "L".
+func RemoveFieldTypeReq(target commonpb.TargetType, key string) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_RemoveMetadataFieldType{
+			RemoveMetadataFieldType: &servicepb.RemoveMetadataFieldTypeRequest{
+				Ledger:     "L",
+				TargetType: target,
+				Key:        key,
+			},
+		},
+	}
+}
+
+// CreateIndexReq creates an index on ledger "L".
+func CreateIndexReq(id *commonpb.IndexID) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_CreateIndex{
+			CreateIndex: &servicepb.CreateIndexRequest{Ledger: "L", Id: id},
+		},
+	}
+}
+
+// AddAccountMetaReq writes one metadata value on an account of ledger "L".
+func AddAccountMetaReq(addr, key string, v *commonpb.MetadataValue) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_Apply{
+			Apply: &servicepb.LedgerApplyRequest{
+				Ledger: "L",
+				Action: &servicepb.LedgerAction{
+					Data: &servicepb.LedgerAction_AddMetadata{
+						AddMetadata: &commonpb.SaveMetadataCommand{
+							Target:   &commonpb.Target{Target: &commonpb.Target_Account{Account: &commonpb.TargetAccount{Addr: addr}}},
+							Metadata: map[string]*commonpb.MetadataValue{key: v},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/oracle/oracletest/oracletest.go
+++ b/tests/oracle/oracletest/oracletest.go
@@ -173,6 +173,15 @@ func CreateIndexReq(id *commonpb.IndexID) *servicepb.Request {
 	}
 }
 
+// DropIndexReq drops an index on ledger "L".
+func DropIndexReq(id *commonpb.IndexID) *servicepb.Request {
+	return &servicepb.Request{
+		Type: &servicepb.Request_DropIndex{
+			DropIndex: &servicepb.DropIndexRequest{Ledger: "L", Id: id},
+		},
+	}
+}
+
 // AddAccountMetaReq writes one metadata value on an account of ledger "L".
 func AddAccountMetaReq(addr, key string, v *commonpb.MetadataValue) *servicepb.Request {
 	return &servicepb.Request{

--- a/tests/oracle/pmap_test.go
+++ b/tests/oracle/pmap_test.go
@@ -112,12 +112,34 @@ func TestGlobalStateFingerprint_CommutingBulks(t *testing.T) {
 
 // Apply materializes a ledger entry even when the operation stores nothing;
 // such an entry must not change the state's identity (see Fingerprint).
+// Materializing a ledger entry must not, by itself, change the global
+// identity. Every committed order now appends a log, so a committed order can
+// no longer leave an entry empty: the two reachable cases are a rejection
+// (nothing materializes) and a commit (the log is state, and it counts).
 func TestGlobalStateFingerprint_EmptyLedgerMaterialization(t *testing.T) {
 	t.Parallel()
 
 	base := NewGlobalState().Apply(Bulk{Requests: []*servicepb.Request{oracletest.TxReq("world", "a:1", "USD", 5)}}).State
 
-	// Removing an undeclared field type is a committed no-op on a fresh ledger.
+	// A rejected order leaves the prior state untouched — the entry it would
+	// have materialized is discarded with the fork, so identity is unchanged
+	// and the ledger does not appear at all.
+	rejected := base.Apply(Bulk{Requests: []*servicepb.Request{{
+		Type: &servicepb.Request_RemoveAccountType{
+			RemoveAccountType: &servicepb.RemoveAccountTypeLedgerRequest{
+				Ledger: "untouched",
+				Name:   "never-declared",
+			},
+		},
+	}}})
+	require.False(t, rejected.OK)
+	require.NotContains(t, rejected.State.Ledgers(), "untouched")
+	require.Equal(t, base.Fingerprint(), rejected.State.Fingerprint(), "a rejected order must not change the identity")
+
+	// Removing an undeclared field type changes no schema, but the server
+	// emits its log unconditionally (processRemoveMetadataFieldType returns a
+	// payload whether or not the key was declared), so the ledger gains a log
+	// and with it an identity.
 	noop := base.Apply(Bulk{Requests: []*servicepb.Request{{
 		Type: &servicepb.Request_RemoveMetadataFieldType{
 			RemoveMetadataFieldType: &servicepb.RemoveMetadataFieldTypeRequest{
@@ -128,7 +150,6 @@ func TestGlobalStateFingerprint_EmptyLedgerMaterialization(t *testing.T) {
 		},
 	}}})
 	require.True(t, noop.OK)
-	require.Contains(t, noop.State.Ledgers(), "untouched", "the entry is materialized")
-	require.True(t, noop.State.Ledger("untouched").IsEmpty())
-	require.Equal(t, base.Fingerprint(), noop.State.Fingerprint(), "stateless entry must not change the identity")
+	require.False(t, noop.State.Ledger("untouched").IsEmpty(), "the committed log is state")
+	require.NotEqual(t, base.Fingerprint(), noop.State.Fingerprint())
 }


### PR DESCRIPTION
## Query coverage (EN-1625)

Extends `singleton_driver_model` and `tests/oracle` to validate filtered, paginated `ListAccounts`, `ListTransactions`, and `ListLogs` as exact ordered windows against candidate oracle states. Coverage includes cursors/page sizes/reverse where supported, boolean filter composition, index create/drop/recreate, per-replica readiness, transaction builtins, address roles, and typed metadata on accounts and transactions.

- Readiness polls are locally served and bound to the sampled index creation frontier. Every replica must have folded that incarnation before promotion.
- The oracle records end-of-bulk account/asset and account/transaction memberships under the committed exclusion verdict, and hashes those memberships when deduplicating candidates.
- Server-assigned transaction/log dates are learned from commit responses and checked. Unknown dates in in-flight candidates use three-valued filter evaluation and exact optional-row truncation; known values require equality.
- Metadata filters use the public coercion rules. Undeclared index creation and kind-mismatched filters are probed on both entity targets. Indexed-key retypes retain their serving window until the per-replica two-phase `last_indexed_sequence` / `pending_version` proof closes it. Not-ready tolerance during a window is restricted to the index named by the rejection; an unrelated active sibling must still produce a finding.
- `INDEX_BUILDING` and `INDEX_NOT_FOUND` are validated before generic transport transients and require the documented gRPC code and reason.

The broader Jira ticket also lists aggregate reads; this PR preserves the existing filtered-list/index/typed-metadata scope and does not claim new `AggregateVolumes`/`GetLedgerStats` coverage.

## Server defect exposed by Tests-Model

The log-date backfill skipped schema, account-type, and index-lifecycle logs while unfiltered `ListLogs` included them. For example, `NOT(ledger=current AND logDate>3)` returned configuration logs even though every committed date exceeded 3. The driver correctly rejected that page.

The fix for it lives in #1960 (EN-1987), so this PR is test-only again: its server commit was reverted in 5213f1a5c. `Tests-Model` here stays red until #1960 lands.

## Harness scope

- Bearer `ANTITHESIS_API_KEY` / `ANTITHESIS_TENANT` launch authentication, `k8s-launch-minutes`, `k8s-run-minutes`, `check-run`, and the 72-hour `check-k8s-image-freshness` gate prevent soaks against stale images.
- `env -u SOURCE_DATE_EPOCH` applies to five Justfile build recipes (seven Docker build invocations) so reproducible-build timestamps do not invalidate freshness checks.
- Local model servers enable Pebble `invariants`; `MODEL_DUMP_BATCHES` supports offline replay. Kubernetes `MODEL_DEBUG=1` preserves per-bulk diagnostics; the workload ignore entry excludes its generated binary.
- `WRITES_BLOCKED_DISK_FULL` is a code-and-reason-checked transient for every workload, reflecting fault-injected disk pressure.

## Base and prior fixes

Rebased onto `release/v3.0` at `37ccf5238ed460e0df2b9844869bdb9c7031f532` (2026-09-09). Prior server fixes are already in the base, including the iterator fixes, index-registry restore, version-bound metadata types, degenerate ranges, and fixed-horizon read alignment. The removed `min_log_sequence` field and `READ_INDEX_NOT_CAUGHT_UP` transient are not reintroduced. There is no dependency on the closed, unmerged #1817.

Jira: [EN-1625](https://formance-team.atlassian.net/browse/EN-1625)

## Validation

- `bash scripts/agent-check`: PASS.
- `AI_REVIEW_BASE_SHA=37ccf5238ed460e0df2b9844869bdb9c7031f532 bash scripts/agent-check-pr`: PASS (generation/tidy/lint, invariants, root build, focused indexbuilder/oracle race suites).
- Pinned Nix workload module `go test -race ./...`: PASS.
- Pinned Nix `just test-model-cluster 180`: PASS, 3 nodes, 4 completed restart/recovery cycles, no findings.
- Deterministic server regressions: failed before the fix, passed after it. Mutation checks prove the retype attribution and both-target generator regressions fail when their respective fixes are removed.
- Final diff/whitespace review: PASS; no generated drift; working tree clean.


CI on `350b4b188`: [Default run 34372646436](https://github.com/formancehq/ledger/actions/runs/34372646436) completed successfully, including `Tests-Model`, both E2E suites, `Tests`, `Dirty`, workload tests, build, Schemathesis and Coverage. Repository invariants and NumaryBot review are also green. Release/image jobs were not applicable and were skipped by the existing workflow conditions. GitHub still reports `CHANGES_REQUESTED`; reviewer sign-off is the remaining merge gate.


[EN-1625]: https://formance-team.atlassian.net/browse/EN-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
