### PR TITLE
fix(EN-1501): bound live query checkpoints, enforced softly at admission

### DIFF
--- a/cmd/ledgerctl/querycheckpoint/create.go
+++ b/cmd/ledgerctl/querycheckpoint/create.go
@@ -14,7 +14,7 @@ func newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "create",
 		Short:             "Create a query checkpoint via Raft consensus",
-		Long:              "Create a query checkpoint that captures a physical Pebble snapshot of the current state. The checkpoint is replicated to all nodes and enables point-in-time queries.",
+		Long:              "Create a query checkpoint that captures a physical Pebble snapshot of the current state. The checkpoint is replicated to all nodes and enables point-in-time queries. At most 10 query checkpoints may be live at once; once the cap is reached creation fails and an existing checkpoint must be deleted to free a slot.",
 		Args:              cobra.ExactArgs(0),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              runCreate,

--- a/cmd/ledgerctl/querycheckpoint/list.go
+++ b/cmd/ledgerctl/querycheckpoint/list.go
@@ -19,8 +19,8 @@ func newListCommand() *cobra.Command {
 		Short:   "List all query checkpoints",
 		Long: `List all query checkpoints registered on the cluster.
 
-Query checkpoints are stored in replicated state and naturally bounded in size;
-this endpoint is intentionally not paginated.`,
+Query checkpoints are stored in replicated state and capped at 10 live
+checkpoints, so the result set is small and this endpoint is not paginated.`,
 		Args:              cobra.ExactArgs(0),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              runList,

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -29,6 +29,7 @@ import (
 	otlptraces "github.com/formancehq/go-libs/v5/pkg/observe/traces"
 	"github.com/formancehq/go-libs/v5/pkg/service"
 
+	"github.com/formancehq/ledger/v3/internal/application/admission"
 	"github.com/formancehq/ledger/v3/internal/bootstrap"
 	"github.com/formancehq/ledger/v3/internal/infra/monitoring/flightrecorder"
 	"github.com/formancehq/ledger/v3/internal/infra/monitoring/pyroscope"
@@ -128,6 +129,7 @@ func NewRunCommand() *cobra.Command {
 	bytesize.ByteSizeVar(runCmd, new(bytesize.ByteSize), "spool-segment-max-bytes", 0, "Maximum spool segment size before rotation/sealing (0 = use default 256Mi)")
 	bytesize.ByteSizeVar(runCmd, new(bytesize.ByteSize), "backup-max-segment-bytes", 0, "Maximum incremental-backup export segment size before splitting into a new segment (0 = use default 4Gi)")
 	runCmd.Flags().Int("numscript-cache-size", 1024, "Maximum number of parsed Numscript programs to cache (LRU eviction)")
+	runCmd.Flags().Uint64("query-checkpoint-limit", admission.DefaultQueryCheckpointLimit, "Maximum number of live query checkpoints; admission rejects creation beyond this (soft, per-node). Must be greater than zero")
 	runCmd.Flags().Int("mirror-max-batch-size", 500, "Maximum allowed batch size for mirror sync (server-side cap on user-configured batch size)")
 	runCmd.Flags().Int("max-execution-plan-size", 4096, "Maximum number of AttributePlan entries an ExecutionPlan may carry; admission rejects proposals beyond this (0 = unlimited)")
 
@@ -532,6 +534,7 @@ func LoadConfig(ctx context.Context, cmd *cobra.Command) (*bootstrap.Config, err
 	cfg.SpoolSegmentMaxBytes = bytesize.Get(cmd, "spool-segment-max-bytes").Int64()
 	cfg.BackupMaxSegmentBytes = bytesize.Get(cmd, "backup-max-segment-bytes").Int64()
 	cfg.NumscriptCacheSize = getInt("numscript-cache-size", 1024)
+	cfg.QueryCheckpointLimit = getUint64("query-checkpoint-limit", admission.DefaultQueryCheckpointLimit)
 	cfg.MirrorMaxBatchSize = getInt("mirror-max-batch-size", 500)
 	cfg.MaxExecutionPlanSize = getInt("max-execution-plan-size", 4096)
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -165,7 +165,7 @@ collection is bounded by design:
 | `indexes list` | Streamed in full from the `SubAttrIndex` registry; cardinality bounded by ledger config (per-ledger / bucket-scope). |
 | `events list` | Raft-state cluster-wide sink config; cardinality bounded by deployment topology. |
 | `queries list` | Raft-state per-ledger prepared queries; cardinality bounded by ledger config. |
-| `querycheckpoint list` | Replicated state; cardinality bounded by retention policy. |
+| `querycheckpoint list` | Replicated state; cardinality bounded by the per-node live-checkpoint limit (`--query-checkpoint-limit`, default 10). |
 
 These commands still honor `--json` / `--yaml`.
 
@@ -3854,6 +3854,22 @@ ledger run --node-id 1 --cluster-id prod-ledger --bootstrap ...
 ledger run --node-id 1 --cluster-id prod-ledger --bootstrap --mirror-max-batch-size 1000 ...
 ```
 
+### Server `--query-checkpoint-limit` Flag
+
+Caps the number of live query checkpoints. Enforced softly at admission: before proposing a create, the leader counts its live checkpoints and rejects at the limit with `CHECKPOINT_LIMIT_REACHED`. There is no automatic eviction. Because enforcement is admission-side (not part of the committed command), concurrent in-flight creates can briefly overshoot the limit. Must be greater than zero — the server refuses to start otherwise.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--query-checkpoint-limit` | `10` | Maximum number of live query checkpoints (soft, per-node; must be > 0) |
+
+```bash
+# Use default (10 live checkpoints)
+ledger run --node-id 1 --cluster-id prod-ledger --bootstrap ...
+
+# Raise the ceiling on deployments with more disk headroom
+ledger run --node-id 1 --cluster-id prod-ledger --bootstrap --query-checkpoint-limit 25 ...
+```
+
 ---
 
 ### Server `--unsafe-skip-config-validation` Flag
@@ -4988,6 +5004,7 @@ ledgerctl query-checkpoint create [flags]
 - The FSM commits pending state and creates a main store Pebble checkpoint; the read index checkpoint is created asynchronously by the index builder
 - Checkpoints are stored under `{dataDir}/query-checkpoints/{id}/main/` and `{dataDir}/query-checkpoints/{id}/readindex/`
 - Not cleaned up on restart — use `query-checkpoint delete` to remove
+- The number of live checkpoints is bounded by a per-node startup limit (`--query-checkpoint-limit`, default 10), enforced softly at admission: before proposing a create, the leader counts its live checkpoints and rejects at the limit. Once the limit is reached, creation fails with `CHECKPOINT_LIMIT_REACHED` (gRPC `ResourceExhausted` / HTTP 429); delete a checkpoint to free a slot. There is no automatic eviction. Because enforcement is admission-side and not part of the committed command, concurrent in-flight creates can briefly overshoot the limit.
 
 **Example:**
 
@@ -5139,3 +5156,5 @@ ledgerctl query-checkpoint get-schedule
 # Output (no schedule):
 #  SUCCESS  No query checkpoint schedule configured (automatic creation disabled)
 ```
+
+The live-checkpoint limit is a per-node startup setting (`--query-checkpoint-limit`, default 10), not a runtime CLI command — see the `query-checkpoint create` behavior notes above.

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -35,6 +35,22 @@ The read index materializes asynchronously and **per-replica** (step 5). Readine
 
 The `.ready` marker and the checkpoint directories are rebuildable filesystem lifecycle state (a projection of the audit log), not a persisted Pebble projection, so they are outside the checker's scope.
 
+## Retention and the Live Checkpoint Limit
+
+The number of live query checkpoints is bounded by a **per-node startup limit** (`--query-checkpoint-limit`, default **10**), enforced softly at admission. There is no automatic eviction — once the live count reaches the limit, creation fails until an operator deletes one.
+
+**Why a limit, why configurable, and why 10 by default.** Each query checkpoint is a full `db.Checkpoint()` of the main store plus a read-index snapshot — directories of hard-linked SSTs that pin disk as the live store compacts. Left unbounded, a scheduler or a client loop grows disk and `ListQueryCheckpoints` payloads without end (the EN-1501 hazard). The *right* ceiling depends on deployment (disk headroom, checkpoint cadence, how many point-in-time views a workload needs), so it is an infrastructure setting rather than a baked-in constant. **10 is a conservative default**, not a derived optimum: enough for typical point-in-time use while keeping worst-case disk bounded.
+
+- **Enforcement is soft, at admission — the FSM apply path is unconditional.** Before proposing a `CreateQueryCheckpoint`, the leader counts its current live checkpoints (`query.ReadLiveQueryCheckpointIDs`, a proposer-side Pebble read) and rejects at the limit with `ErrCheckpointLimitReached` — reason `CHECKPOINT_LIMIT_REACHED`, gRPC `ResourceExhausted` / HTTP 429. The committed command carries no limit and the apply path counts nothing: `processCreateQueryCheckpoint` always applies identically on every node (FSM determinism, invariant #2), so the node-local limit never enters replicated state. This is why the limit can be a plain startup flag rather than a Raft-committed setting.
+- **Delete existence is also checked at admission.** `DeleteQueryCheckpoint` for an id that is zero, not live, or already deleted earlier in the same bulk is rejected before proposal with `ErrCheckpointNotFound` — reason `CHECKPOINT_NOT_FOUND`, gRPC `NotFound` / HTTP 404. A committed delete applies unconditionally: emitting the `DeletedQueryCheckpointLog` on every node is what drives the per-node physical file cleanup.
+- **Same-bulk effects are folded in.** Within one Apply bulk, admission tracks creates and deletes staged by earlier requests (in the admission-side bulk overlay), so a batch that deletes a checkpoint then creates one is admitted atomically at the cap, and a second create in one bulk counts the first. The evaluated live count is `committed + bulkCreates − bulkDeletes`.
+- **Bounded overshoot, no reservation machinery.** Because the committed count is read at propose time and the limit is not serialized into the command, concurrent in-flight creates *across separate proposals* can each pass the check before any commits, briefly overshooting the limit by up to the number of simultaneous creates. This is accepted deliberately — a slot reservation / serialization scheme would add complexity for a soft disk ceiling that tolerates a small transient overshoot.
+- **Rolling-upgrade behavior.** Enforcement lives on whichever node is leader when a create is admitted. A pre-upgrade leader that lacks the check will not enforce; an upgraded leader will. Because the check is admission-side and the committed command is unchanged, the two never disagree about *applied* state — only about whether a given create was admitted — so replicas stay deterministic throughout the upgrade. Operators wanting uniform enforcement should complete the rollout.
+- **Checker coverage.** The stored checkpoint rows are verified against the audit chain **both ways**: the checker re-derives the live set from the `CreatedQueryCheckpointLog` / `DeletedQueryCheckpointLog` stream (baseline-seeded under archiving) and flags a stored row with no create / a later delete *and* an audit-live checkpoint with no stored row (`CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH`), per invariant #8. For a present row it also compares `max_sequence`, `created_at`, and the key-vs-payload `checkpoint_id`. The audit-rebuild path (`internal/infra/backup`) recreates the metadata rows and the monotonic next-ID counter from the logs — the physical files cannot be, so a rebuilt checkpoint reads `Unavailable` until deleted — so a missing row is always corruption, never a restore artifact. The limit itself is not a persisted projection, so there is no limit checker pass. `NextQueryCheckpointID` is monotonic and is **not** the live count (deletes do not decrement it).
+- **Orphaned directory reclamation.** A follower caught up by a snapshot install receives the leader's row-absent state without running the per-entry file-delete hook, so its local `query-checkpoints/<id>/` can survive with no live row. Recovery (`RecoverState`, at boot and after every follower sync) sweeps `query-checkpoints/*` against the live IDs read from Pebble (`query.ReadLiveQueryCheckpointIDs`) and removes any directory with no live row — best-effort, so a transient filesystem error never blocks recovery. Without it those hard-linked Pebble checkpoints would pin disk indefinitely, since deletion is otherwise only log-driven.
+
+Because the live cardinality is bounded by the limit, `ListQueryCheckpoints` stays small and is intentionally not paginated.
+
 ## Automatic Checkpoint Creation (Cron Scheduler)
 
 Checkpoint creation can be automated via a cron schedule. The schedule is a runtime-modifiable configuration stored in Raft, following the same pattern as chapter schedule (`SetChapterSchedule`).
@@ -65,7 +81,7 @@ The `QueryCheckpointScheduler` runs on every node but only triggers checkpoint c
 2. When the schedule changes, a notification signal wakes the scheduler goroutine to recompute the next fire time.
 3. On leader change, the new leader's scheduler is already running and will fire at the next scheduled time.
 
-Checkpoints accumulate over time. Old checkpoints are **not** automatically cleaned up — use `ledgerctl query-checkpoint delete` to remove them when no longer needed.
+Checkpoints are never automatically evicted, but the number live at once is capped by the [per-node limit](#retention-and-the-live-checkpoint-limit). Once the limit is reached the scheduler stops creating checkpoints — logging the condition once rather than on every tick — and resumes automatically after an operator frees a slot with `ledgerctl query-checkpoint delete`.
 
 **File**: `internal/infra/state/query_checkpoint_scheduler.go`
 
@@ -126,6 +142,8 @@ ledgerctl query-checkpoint delete-schedule
 # Show current schedule
 ledgerctl query-checkpoint get-schedule
 ```
+
+The live-checkpoint limit is a per-node startup flag (`--query-checkpoint-limit`, default 10), not a runtime command.
 
 ## Storage
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -939,6 +939,8 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Storage operation failed | `INTERNAL` | `STORAGE_OPERATION_FAILED` | `operation` |
 | Preload coverage miss (admission contract violation) | `INTERNAL` | `COVERAGE_MISS` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
 | Checkpoint ID required | `INVALID_ARGUMENT` | `CHECKPOINT_ID_REQUIRED` | *(none)* |
+| Checkpoint limit reached | `RESOURCE_EXHAUSTED` | `CHECKPOINT_LIMIT_REACHED` | `limit` |
+| Checkpoint not found | `NOT_FOUND` | `CHECKPOINT_NOT_FOUND` | `checkpointId` |
 
 ### REST/HTTP Error Mapping
 

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -69,6 +69,12 @@ type Admission struct {
 	authEnabled        bool
 	waitLeaderReady    func(context.Context) error
 
+	// queryCheckpointLimit is the operator-configured max live query checkpoints,
+	// enforced softly here (admission rejects a create at the limit) rather than
+	// in the FSM apply path — a committed CreateQueryCheckpoint always applies
+	// identically on every node regardless of this node's configured value.
+	queryCheckpointLimit uint64
+
 	// Metrics (noop when metricsEnabled is false)
 	metricsEnabled                 bool
 	commandDurationHistogram       metric.Int64Histogram
@@ -155,6 +161,17 @@ func WithAuthEnabled() func(*Admission) {
 	}
 }
 
+// DefaultQueryCheckpointLimit is the max live query checkpoints when the operator
+// configures none. Enforced softly at admission; not a Raft protocol invariant.
+const DefaultQueryCheckpointLimit uint64 = 10
+
+// WithQueryCheckpointLimit sets the operator-configured max live query checkpoints.
+func WithQueryCheckpointLimit(limit uint64) func(*Admission) {
+	return func(a *Admission) {
+		a.queryCheckpointLimit = limit
+	}
+}
+
 func NewAdmission(
 	store *dal.Store,
 	logger logging.Logger,
@@ -170,16 +187,17 @@ func NewAdmission(
 	opts ...func(*Admission),
 ) *Admission {
 	a := &Admission{
-		store:           store,
-		logger:          logger,
-		proposer:        proposer,
-		builder:         builder,
-		writeGate:       writeGate,
-		keyStore:        keyStore,
-		sharedState:     sharedState,
-		attrs:           attrs,
-		numscriptCache:  numscriptCache,
-		waitLeaderReady: waitLeaderReady,
+		store:                store,
+		logger:               logger,
+		proposer:             proposer,
+		builder:              builder,
+		writeGate:            writeGate,
+		keyStore:             keyStore,
+		sharedState:          sharedState,
+		attrs:                attrs,
+		numscriptCache:       numscriptCache,
+		waitLeaderReady:      waitLeaderReady,
+		queryCheckpointLimit: DefaultQueryCheckpointLimit,
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -1981,6 +1999,72 @@ func (a *Admission) resolveScriptsAndEnrichNeeds(ctx context.Context, orders []*
 	return nil
 }
 
+// checkQueryCheckpointLimit rejects a create once the live checkpoint count has
+// reached the configured limit. Soft enforcement: it reads the leader's committed
+// count from Pebble and folds in same-bulk creates/deletes via the overlay, so a
+// batch that deletes a checkpoint then creates one is admitted atomically.
+// Concurrent creates across separate proposals may still overshoot until a
+// checkpoint is deleted. The FSM applies a committed create unconditionally.
+// Records the admitted create in the overlay so a later create in the same bulk
+// counts it.
+func (a *Admission) checkQueryCheckpointLimit(overlay *bulkOverlay) error {
+	handle, err := a.store.NewReadHandle()
+	if err != nil {
+		return fmt.Errorf("reading query checkpoints: %w", err)
+	}
+
+	defer func() { _ = handle.Close() }()
+
+	ids, err := query.ReadLiveQueryCheckpointIDs(handle)
+	if err != nil {
+		return fmt.Errorf("counting query checkpoints: %w", err)
+	}
+
+	live := len(ids) + overlay.checkpointNetLive()
+	if live >= int(a.queryCheckpointLimit) {
+		return &domain.ErrCheckpointLimitReached{Limit: a.queryCheckpointLimit}
+	}
+
+	overlay.recordCheckpointCreate()
+
+	return nil
+}
+
+// checkQueryCheckpointExists rejects a delete for a checkpoint id that is zero,
+// has no committed row, or was already deleted earlier in this bulk. Soft: it
+// reads committed state, so a create/delete in flight across proposals can race.
+// Records the delete in the overlay so it frees a limit slot for a same-bulk
+// create and a repeated delete in the same bulk is rejected.
+func (a *Admission) checkQueryCheckpointExists(id uint64, overlay *bulkOverlay) error {
+	if id == 0 {
+		return domain.ErrCheckpointIDRequired
+	}
+
+	if overlay.isCheckpointDeletedInBulk(id) {
+		return &domain.ErrCheckpointNotFound{CheckpointID: id}
+	}
+
+	handle, err := a.store.NewReadHandle()
+	if err != nil {
+		return fmt.Errorf("reading query checkpoint: %w", err)
+	}
+
+	defer func() { _ = handle.Close() }()
+
+	cp, err := query.ReadQueryCheckpoint(handle, id)
+	if err != nil {
+		return fmt.Errorf("reading query checkpoint %d: %w", id, err)
+	}
+
+	if cp == nil {
+		return &domain.ErrCheckpointNotFound{CheckpointID: id}
+	}
+
+	overlay.recordCheckpointDelete(id)
+
+	return nil
+}
+
 // requestToOrder converts a single Request into its ledger- or system-scoped
 // raftcmdpb.Order. batchSig is consulted only by the signing-key registration
 // path, to record the signing key as the new key's parent.
@@ -2246,12 +2330,20 @@ func (a *Admission) requestToOrder(ctx context.Context, req *servicepb.Request, 
 			reqType.SaveNumscript.GetContent(),
 		)
 	case *servicepb.Request_CreateQueryCheckpoint:
+		if err := a.checkQueryCheckpointLimit(overlay); err != nil {
+			return nil, err
+		}
+
 		wrapSystemScoped(order, &raftcmdpb.SystemScopedOrder{
 			Payload: &raftcmdpb.SystemScopedOrder_CreateQueryCheckpoint{
 				CreateQueryCheckpoint: &raftcmdpb.CreateQueryCheckpointOrder{},
 			},
 		})
 	case *servicepb.Request_DeleteQueryCheckpoint:
+		if err := a.checkQueryCheckpointExists(reqType.DeleteQueryCheckpoint.GetCheckpointId(), overlay); err != nil {
+			return nil, err
+		}
+
 		wrapSystemScoped(order, &raftcmdpb.SystemScopedOrder{
 			Payload: &raftcmdpb.SystemScopedOrder_DeleteQueryCheckpoint{
 				DeleteQueryCheckpoint: &raftcmdpb.DeleteQueryCheckpointOrder{

--- a/internal/application/admission/admission_test.go
+++ b/internal/application/admission/admission_test.go
@@ -62,7 +62,7 @@ func createTestStore(t *testing.T) *dal.Store {
 // createTestAdmission creates an Admission instance for testing.
 // It returns both the Admission and the Attributes so tests can set up
 // transaction state directly in Pebble.
-func createTestAdmission(t *testing.T, store *dal.Store) (*Admission, *attributes.Attributes) {
+func createTestAdmission(t *testing.T, store *dal.Store, opts ...func(*Admission)) (*Admission, *attributes.Attributes) {
 	t.Helper()
 
 	ctx := logging.TestingContext()
@@ -87,6 +87,7 @@ func createTestAdmission(t *testing.T, store *dal.Store) (*Admission, *attribute
 		attrs,
 		numscript.NewNumscriptCache(0),
 		func(context.Context) error { return nil },
+		opts...,
 	), attrs
 }
 

--- a/internal/application/admission/overlay.go
+++ b/internal/application/admission/overlay.go
@@ -81,6 +81,15 @@ type bulkOverlay struct {
 	// order: the FSM re-derives them from the coverage-gated TransactionState,
 	// and only caller intent is bound into the audit chain.
 	revertOriginalPostings map[domain.TransactionKey][]*commonpb.Posting
+
+	// Query-checkpoint effects staged earlier in this bulk, so the admission
+	// limit/existence checks see committed Pebble plus same-bulk changes:
+	// checkpointCreates counts creates admitted so far; checkpointDeletes holds
+	// the committed-live ids a delete has already targeted. Without this, a
+	// batch that deletes a checkpoint then creates one is rejected at the limit
+	// even though the delete frees a slot atomically.
+	checkpointCreates int
+	checkpointDeletes map[uint64]struct{}
 }
 
 func newBulkOverlay() *bulkOverlay {
@@ -89,7 +98,34 @@ func newBulkOverlay() *bulkOverlay {
 		numscriptLatest:        newOverlay[numscriptNameKey, string](),
 		sinks:                  newOverlay[string, *commonpb.SinkConfig](),
 		revertOriginalPostings: make(map[domain.TransactionKey][]*commonpb.Posting),
+		checkpointDeletes:      make(map[uint64]struct{}),
 	}
+}
+
+// recordCheckpointCreate marks that a CreateQueryCheckpoint was admitted earlier
+// in this bulk, so a later create in the same bulk counts it against the limit.
+func (o *bulkOverlay) recordCheckpointCreate() {
+	o.checkpointCreates++
+}
+
+// recordCheckpointDelete marks a committed-live id as deleted earlier in this
+// bulk, so it both frees a limit slot and is no longer deletable again.
+func (o *bulkOverlay) recordCheckpointDelete(id uint64) {
+	o.checkpointDeletes[id] = struct{}{}
+}
+
+// isCheckpointDeletedInBulk reports whether a delete for id was already staged
+// in this bulk.
+func (o *bulkOverlay) isCheckpointDeletedInBulk(id uint64) bool {
+	_, ok := o.checkpointDeletes[id]
+
+	return ok
+}
+
+// checkpointNetLive returns the same-bulk delta to add to the committed live
+// count: creates staged so far minus committed-live ids deleted so far.
+func (o *bulkOverlay) checkpointNetLive() int {
+	return o.checkpointCreates - len(o.checkpointDeletes)
 }
 
 // recordRevertOriginalPostings stores the postings admission resolved for a

--- a/internal/application/admission/query_checkpoint_admission_test.go
+++ b/internal/application/admission/query_checkpoint_admission_test.go
@@ -1,0 +1,102 @@
+package admission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// checkQueryCheckpointLimit rejects a create once the live count reaches the
+// configured per-node limit; below it, creation is admitted.
+func TestCheckQueryCheckpointLimit(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	admission, _ := createTestAdmission(t, store, WithQueryCheckpointLimit(2))
+
+	saveCheckpoint := func(id uint64) {
+		batch := store.OpenWriteSession()
+		require.NoError(t, state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{CheckpointId: id}))
+		require.NoError(t, batch.Commit())
+	}
+
+	// Empty store: 0 < 2, admitted.
+	require.NoError(t, admission.checkQueryCheckpointLimit(newBulkOverlay()))
+
+	// One live: 1 < 2, still admitted.
+	saveCheckpoint(1)
+	require.NoError(t, admission.checkQueryCheckpointLimit(newBulkOverlay()))
+
+	// At the cap: 2 >= 2, rejected with the typed error carrying the limit.
+	saveCheckpoint(2)
+	err := admission.checkQueryCheckpointLimit(newBulkOverlay())
+	var limitErr *domain.ErrCheckpointLimitReached
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, uint64(2), limitErr.Limit)
+}
+
+// A single bulk that folds same-batch effects: a second create in one bulk
+// counts the first against the limit, and a delete earlier in the bulk frees a
+// slot for a later create even at the committed cap.
+func TestCheckQueryCheckpointLimit_BulkOverlay(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	admission, _ := createTestAdmission(t, store, WithQueryCheckpointLimit(2))
+
+	saveCheckpoint := func(id uint64) {
+		batch := store.OpenWriteSession()
+		require.NoError(t, state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{CheckpointId: id}))
+		require.NoError(t, batch.Commit())
+	}
+
+	// One committed live checkpoint (limit 2). Two creates in one bulk: the first
+	// is admitted (1 < 2) and recorded; the second sees 1+1 = 2 and is rejected.
+	saveCheckpoint(1)
+	overlay := newBulkOverlay()
+	require.NoError(t, admission.checkQueryCheckpointLimit(overlay))
+
+	err := admission.checkQueryCheckpointLimit(overlay)
+	var limitErr *domain.ErrCheckpointLimitReached
+	require.ErrorAs(t, err, &limitErr)
+
+	// Fresh bulk at the committed cap (2 live): a delete earlier in the bulk
+	// frees a slot, so the following create is admitted atomically.
+	saveCheckpoint(2)
+	batchOverlay := newBulkOverlay()
+	require.NoError(t, admission.checkQueryCheckpointExists(1, batchOverlay))
+	require.NoError(t, admission.checkQueryCheckpointLimit(batchOverlay),
+		"a same-bulk delete must free a slot for a later create")
+}
+
+// checkQueryCheckpointExists rejects a zero id and a non-live id, admits a
+// delete for a live checkpoint, and rejects a repeated delete within one bulk.
+func TestCheckQueryCheckpointExists(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	admission, _ := createTestAdmission(t, store)
+	overlay := newBulkOverlay()
+
+	// id 0 is invalid regardless of store contents.
+	require.ErrorIs(t, admission.checkQueryCheckpointExists(0, overlay), domain.ErrCheckpointIDRequired)
+
+	// A non-live id is not found.
+	err := admission.checkQueryCheckpointExists(5, overlay)
+	var notFoundErr *domain.ErrCheckpointNotFound
+	require.ErrorAs(t, err, &notFoundErr)
+	require.Equal(t, uint64(5), notFoundErr.CheckpointID)
+
+	// A live id is admitted.
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{CheckpointId: 5}))
+	require.NoError(t, batch.Commit())
+	require.NoError(t, admission.checkQueryCheckpointExists(5, overlay))
+
+	// Deleting the same id again in the same bulk is rejected (already staged).
+	require.ErrorAs(t, admission.checkQueryCheckpointExists(5, overlay), &notFoundErr)
+}

--- a/internal/application/admission/request_to_order_test.go
+++ b/internal/application/admission/request_to_order_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -514,6 +515,13 @@ func TestRequestToOrder_WrapsEveryRequestVariant(t *testing.T) {
 	}
 
 	store := createTestStore(t)
+
+	// The delete_query_checkpoint variant passes through admission's existence
+	// check, so seed a live checkpoint (id 1) for it to target.
+	seed := store.OpenWriteSession()
+	require.NoError(t, state.SaveQueryCheckpoint(seed, &raftcmdpb.QueryCheckpointState{CheckpointId: 1}))
+	require.NoError(t, seed.Commit())
+
 	admission, _ := createTestAdmission(t, store)
 
 	for _, tc := range cases {

--- a/internal/application/admission/wrapper_exhaustiveness_test.go
+++ b/internal/application/admission/wrapper_exhaustiveness_test.go
@@ -111,5 +111,6 @@ func systemScopedCoveredByDispatchTest(t *testing.T) map[string]struct{} {
 		"delete_query_checkpoint":          {},
 		"set_query_checkpoint_schedule":    {},
 		"delete_query_checkpoint_schedule": {},
+		"set_query_checkpoint_limit":       {},
 	}
 }

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -396,6 +396,15 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 		// SubAttrNumscriptVersion (latest pointer = greatest stored semver).
 		expectedNumscriptContent = make(map[domain.NumscriptEntryKey]*commonpb.NumscriptInfo)
 		expectedNumscriptLatest  = make(map[domain.NumscriptVersionKey]string)
+
+		// derivedLiveCheckpoints is the audit-derived set of live query-checkpoints
+		// (cluster-global), keyed by id with the CreatedQueryCheckpoint log as the
+		// value so max_sequence / created_at can be verified. A create sets the
+		// entry, a later delete removes it. Seeded from the baseline under archiving
+		// (the create logs are purged with the chapter), then advanced by the
+		// replayed create/delete logs. compareQueryCheckpoints compares it against
+		// the stored rows both ways, contents included.
+		derivedLiveCheckpoints = make(map[uint64]*commonpb.CreatedQueryCheckpointLog)
 	)
 
 	// excluded is built incrementally as SimulateEphemeralPurge decides to
@@ -479,6 +488,13 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 		// does not make the checker expect a lower latest than the store holds,
 		// and archived immutable content stays verified.
 		if err := c.foldBaselineNumscripts(baselineDB, expectedNumscriptContent, expectedNumscriptLatest); err != nil {
+			return err
+		}
+
+		// Seed the live query-checkpoint set from the baseline: the pre-archive
+		// CreatedQueryCheckpoint logs are purged with the archived chapter, so
+		// replay alone would under-derive the set and false-flag live rows.
+		if err := c.foldBaselineQueryCheckpoints(baselineDB, derivedLiveCheckpoints); err != nil {
 			return err
 		}
 
@@ -640,6 +656,14 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 					if cur, ok := expectedNumscriptLatest[vk]; !ok || numscriptVersionGreater(info.GetVersion(), cur) {
 						expectedNumscriptLatest[vk] = info.GetVersion()
 					}
+				}
+			case *commonpb.LogPayload_CreatedQueryCheckpoint:
+				if cp := payload.CreatedQueryCheckpoint; cp != nil {
+					derivedLiveCheckpoints[cp.GetCheckpointId()] = cp
+				}
+			case *commonpb.LogPayload_DeletedQueryCheckpoint:
+				if cp := payload.DeletedQueryCheckpoint; cp != nil {
+					delete(derivedLiveCheckpoints, cp.GetCheckpointId())
 				}
 			case *commonpb.LogPayload_Apply:
 				if payload.Apply != nil {
@@ -898,6 +922,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	}
 
 	c.compareNumscripts(snap, expectedNumscriptContent, expectedNumscriptLatest, deletedInReplay, pendingCleanupLedgers, callback)
+
+	if err := c.compareQueryCheckpoints(snap, derivedLiveCheckpoints, callback); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -1297,6 +1325,95 @@ func (c *Checker) compareMirrorV2LogID(reader dal.PebbleReader, chainBound *chai
 				0, name, "", ""))
 		}
 	}
+}
+
+// compareQueryCheckpoints verifies the live query-checkpoint rows stored in the
+// primary store (ZoneGlobal/SubGlobQueryCheckpoint) against `derived`, the live
+// set re-derived from the CreatedQueryCheckpoint / DeletedQueryCheckpoint logs
+// (baseline-seeded under archiving). It emits
+// CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH on:
+//   - a stored row absent from the audit set (never created, or later deleted) —
+//     a phantom or stale row;
+//   - an audit-live checkpoint with no stored row — a lost or dropped projection;
+//   - a row whose key id, max_sequence, or created_at diverges from the
+//     audit-derived value — content corruption.
+//
+// The audit-rebuild path recreates the rows (and their max_sequence / created_at)
+// from the logs (internal/infra/backup), so a missing row is corruption, never a
+// legitimate restore artifact. Stored rows are keyed by the Pebble key id, not
+// the payload (see query.ReadQueryCheckpointRows).
+func (c *Checker) compareQueryCheckpoints(reader dal.PebbleReader, derived map[uint64]*commonpb.CreatedQueryCheckpointLog, callback func(*servicepb.CheckStoreEvent)) error {
+	stored, err := query.ReadQueryCheckpointRows(reader)
+	if err != nil {
+		return fmt.Errorf("reading stored query checkpoints: %w", err)
+	}
+
+	all := make(map[uint64]struct{}, len(stored)+len(derived))
+	for id := range stored {
+		all[id] = struct{}{}
+	}
+
+	for id := range derived {
+		all[id] = struct{}{}
+	}
+
+	ids := make([]uint64, 0, len(all))
+	for id := range all {
+		ids = append(ids, id)
+	}
+
+	slices.Sort(ids)
+
+	emit := func(msg string) {
+		callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH, msg, 0, "", "", ""))
+	}
+
+	for _, id := range ids {
+		row, inStored := stored[id]
+		want, inDerived := derived[id]
+
+		switch {
+		case inStored && !inDerived:
+			emit(fmt.Sprintf("stored query checkpoint %d is not justified by the audit chain (no CreatedQueryCheckpoint, or a later DeletedQueryCheckpoint)", id))
+		case inDerived && !inStored:
+			emit(fmt.Sprintf("audit chain has live query checkpoint %d but no stored row (lost or dropped projection)", id))
+		default:
+			if pid := row.GetCheckpointId(); pid != id {
+				emit(fmt.Sprintf("stored query checkpoint keyed %d carries a mismatched payload checkpoint_id %d (corrupted row)", id, pid))
+			}
+
+			if row.GetMaxSequence() != want.GetMaxSequence() {
+				emit(fmt.Sprintf("query checkpoint %d max_sequence %d does not match the audit chain %d", id, row.GetMaxSequence(), want.GetMaxSequence()))
+			}
+
+			if row.GetCreatedAt().GetData() != want.GetCreatedAt().GetData() {
+				emit(fmt.Sprintf("query checkpoint %d created_at %d does not match the audit chain %d", id, row.GetCreatedAt().GetData(), want.GetCreatedAt().GetData()))
+			}
+		}
+	}
+
+	return nil
+}
+
+// foldBaselineQueryCheckpoints seeds the audit-derived live-checkpoint set from
+// the boundary-time baseline, whose SubGlobQueryCheckpoint rows (with their
+// max_sequence / created_at) stand in for the pre-archive CreatedQueryCheckpoint
+// logs purged with the archived chapter.
+func (c *Checker) foldBaselineQueryCheckpoints(baselineDB *pebble.DB, into map[uint64]*commonpb.CreatedQueryCheckpointLog) error {
+	rows, err := query.ReadQueryCheckpointRows(baselineDB)
+	if err != nil {
+		return fmt.Errorf("folding baseline query checkpoints: %w", err)
+	}
+
+	for id, cp := range rows {
+		into[id] = &commonpb.CreatedQueryCheckpointLog{
+			CheckpointId: id,
+			MaxSequence:  cp.GetMaxSequence(),
+			CreatedAt:    cp.GetCreatedAt(),
+		}
+	}
+
+	return nil
 }
 
 // numscriptVersionGreater reports whether a is a strictly greater full semver

--- a/internal/application/check/checker_query_checkpoint_test.go
+++ b/internal/application/check/checker_query_checkpoint_test.go
@@ -1,0 +1,175 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// writeQueryCheckpointRow persists a query-checkpoint row (max_sequence = id*10,
+// created_at = id*100) directly at its ZoneGlobal/SubGlobQueryCheckpoint key,
+// matching the on-disk layout the FSM writes.
+func writeQueryCheckpointRow(t *testing.T, store *dal.Store, id uint64) {
+	t.Helper()
+	writeQueryCheckpointRowKeyed(t, store, id, id, id*10, id*100)
+}
+
+// writeQueryCheckpointRowKeyed persists a row at key keyID carrying a payload
+// with checkpoint_id=payloadID, the given max_sequence and created_at, so tests
+// can build the corrupted key≠payload and content-mismatch cases.
+func writeQueryCheckpointRowKeyed(t *testing.T, store *dal.Store, keyID, payloadID, maxSeq, createdAt uint64) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	batch.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).PutUint64(keyID)
+	require.NoError(t, batch.SetProto(batch.KeyBuilder.Consume(), &raftcmdpb.QueryCheckpointState{
+		CheckpointId: payloadID,
+		MaxSequence:  maxSeq,
+		CreatedAt:    &commonpb.Timestamp{Data: createdAt},
+	}))
+	require.NoError(t, batch.Commit())
+}
+
+// derivedLog is the audit-derived value for one checkpoint id (max_sequence =
+// id*10, created_at = id*100), matching writeQueryCheckpointRow.
+func derivedLog(id uint64) *commonpb.CreatedQueryCheckpointLog {
+	return &commonpb.CreatedQueryCheckpointLog{
+		CheckpointId: id,
+		MaxSequence:  id * 10,
+		CreatedAt:    &commonpb.Timestamp{Data: id * 100},
+	}
+}
+
+// collectQueryCheckpointEvents runs compareQueryCheckpoints against the store's
+// live checkpoint rows with the given audit-derived set and returns only the
+// QUERY_CHECKPOINT_MISMATCH errors.
+func collectQueryCheckpointEvents(t *testing.T, store *dal.Store, derived map[uint64]*commonpb.CreatedQueryCheckpointLog) []*servicepb.CheckStoreError {
+	t.Helper()
+
+	checker := NewChecker(store, attributes.New(), "query-checkpoint-cluster", nil, nil, nil, logging.Testing())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	var got []*servicepb.CheckStoreError
+
+	require.NoError(t, checker.compareQueryCheckpoints(handle, derived, func(event *servicepb.CheckStoreEvent) {
+		if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
+			e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH {
+			got = append(got, e.Error)
+		}
+	}))
+
+	return got
+}
+
+// TestCompareQueryCheckpoints_PhantomFlagged: a stored row the audit chain never
+// created (or later deleted) is corruption and must emit exactly one mismatch.
+func TestCompareQueryCheckpoints_PhantomFlagged(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRow(t, store, 5)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "5")
+}
+
+// TestCompareQueryCheckpoints_ConsistentPasses: every stored row justified by
+// the derived set, with matching contents, emits nothing.
+func TestCompareQueryCheckpoints_ConsistentPasses(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRow(t, store, 5)
+	writeQueryCheckpointRow(t, store, 6)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5), 6: derivedLog(6)})
+	require.Empty(t, events)
+}
+
+// TestCompareQueryCheckpoints_KeyAuthoritative: a row whose Pebble key id (99)
+// differs from its payload checkpoint_id (5) must be judged by the KEY — the
+// check sees a phantom key 99 and a missing row for the audit-live 5.
+func TestCompareQueryCheckpoints_KeyAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 99, 5, 50, 500)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
+	require.Len(t, events, 2)
+
+	msgs := events[0].GetMessage() + "\n" + events[1].GetMessage()
+	require.Contains(t, msgs, "stored query checkpoint 99", "the phantom key 99 must be flagged, not laundered by payload id 5")
+	require.Contains(t, msgs, "live query checkpoint 5", "the audit-live id 5 has no stored row")
+}
+
+// TestCompareQueryCheckpoints_MissingRowFlagged: an audit-live checkpoint with
+// no stored row is a lost/dropped projection and must be flagged.
+func TestCompareQueryCheckpoints_MissingRowFlagged(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{7: derivedLog(7)})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "7")
+}
+
+// TestCompareQueryCheckpoints_MaxSequenceMismatch: a present row whose stored
+// max_sequence diverges from the audit-derived value is content corruption.
+func TestCompareQueryCheckpoints_MaxSequenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+
+	// Audit says max_sequence 99, store holds 50 (created_at matches).
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
+		5: {CheckpointId: 5, MaxSequence: 99, CreatedAt: &commonpb.Timestamp{Data: 500}},
+	})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "max_sequence")
+}
+
+// TestCompareQueryCheckpoints_CreatedAtMismatch: a present row whose stored
+// created_at diverges from the audit-derived value is content corruption.
+func TestCompareQueryCheckpoints_CreatedAtMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+
+	// Audit says created_at 999, store holds 500 (max_sequence matches).
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
+		5: {CheckpointId: 5, MaxSequence: 50, CreatedAt: &commonpb.Timestamp{Data: 999}},
+	})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "created_at")
+}
+
+// TestCompareQueryCheckpoints_PayloadIDMismatch: a present row whose payload
+// checkpoint_id disagrees with its key is a corrupted row.
+func TestCompareQueryCheckpoints_PayloadIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	// Keyed 5, payload says 6, matching max_sequence and created_at.
+	writeQueryCheckpointRowKeyed(t, store, 5, 6, 50, 500)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "mismatched payload checkpoint_id")
+}

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -184,6 +184,9 @@ type Config struct {
 	BackupMaxSegmentBytes int64
 	NumscriptCacheSize    int
 	MirrorMaxBatchSize    int
+	// QueryCheckpointLimit is the operator-configured max live query checkpoints,
+	// enforced softly at admission (not a replicated setting).
+	QueryCheckpointLimit uint64
 	// MaxExecutionPlanSize caps the number of AttributeCoverage entries an
 	// ExecutionPlan may carry. 0 disables the cap. See plan.Builder.
 	MaxExecutionPlanSize        int
@@ -297,6 +300,11 @@ func (c Config) Validate() error {
 	}
 	if err := validateHealthThresholds(c.HealthConfig.DataThreshold, c.HealthConfig.DataResumeThreshold); err != nil {
 		return fmt.Errorf("data: %w", err)
+	}
+
+	// Zero would reject every checkpoint creation, silently disabling the feature.
+	if c.QueryCheckpointLimit == 0 {
+		return errors.New("--query-checkpoint-limit must be greater than zero")
 	}
 
 	return nil

--- a/internal/bootstrap/config_test.go
+++ b/internal/bootstrap/config_test.go
@@ -54,6 +54,7 @@ func validBaseConfig() Config {
 			WALResumeThreshold:  0.75,
 			DataResumeThreshold: 0.75,
 		},
+		QueryCheckpointLimit: 10,
 	}
 }
 
@@ -114,6 +115,16 @@ func TestValidateClusterSecretRequiresTLS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateQueryCheckpointLimit(t *testing.T) {
+	t.Parallel()
+
+	cfg := validBaseConfig()
+	cfg.QueryCheckpointLimit = 0
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--query-checkpoint-limit must be greater than zero")
 }
 
 func TestValidateTLSConfig(t *testing.T) {

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -741,6 +741,8 @@ func Module() fx.Option {
 					opts = append(opts, admission.WithAuthEnabled())
 				}
 
+				opts = append(opts, admission.WithQueryCheckpointLimit(cfg.QueryCheckpointLimit))
+
 				return admission.NewAdmission(
 					store,
 					logger,

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -225,6 +225,8 @@ const (
 	ErrReasonTransactionStateInconsistent  = "TRANSACTION_STATE_INCONSISTENT"
 	ErrReasonCheckpointIDRequired          = "CHECKPOINT_ID_REQUIRED"
 	ErrReasonCheckpointNotReady            = "CHECKPOINT_NOT_READY"
+	ErrReasonCheckpointLimitReached        = "CHECKPOINT_LIMIT_REACHED"
+	ErrReasonCheckpointNotFound            = "CHECKPOINT_NOT_FOUND"
 	ErrReasonNumscriptRuntime              = "NUMSCRIPT_RUNTIME"
 	ErrReasonVolumeNotMaterialized         = "VOLUME_NOT_MATERIALIZED"
 	ErrReasonStaleInputsResolution         = "STALE_INPUTS_RESOLUTION"
@@ -1017,6 +1019,38 @@ func (e *ErrCheckpointNotReady) Error() string {
 }
 func (*ErrCheckpointNotReady) Reason() string { return ErrReasonCheckpointNotReady }
 func (e *ErrCheckpointNotReady) Metadata() map[string]string {
+	return map[string]string{"checkpointId": strconv.FormatUint(e.CheckpointID, 10)}
+}
+
+// ErrCheckpointLimitReached — admission rejected a CreateQueryCheckpoint
+// because the leader already holds the maximum number of live query
+// checkpoints. Maps to KindResourceExhausted (gRPC ResourceExhausted / HTTP
+// 429). Creation never evicts; an operator must delete an existing checkpoint
+// before another can be created.
+type ErrCheckpointLimitReached struct {
+	Limit uint64
+}
+
+func (e *ErrCheckpointLimitReached) Error() string {
+	return fmt.Sprintf("query checkpoint limit reached (max %d); delete an existing checkpoint before creating another", e.Limit)
+}
+func (*ErrCheckpointLimitReached) Reason() string { return ErrReasonCheckpointLimitReached }
+func (e *ErrCheckpointLimitReached) Metadata() map[string]string {
+	return map[string]string{"limit": strconv.FormatUint(e.Limit, 10)}
+}
+
+// ErrCheckpointNotFound — admission rejected a DeleteQueryCheckpoint targeting a
+// checkpoint ID that is not live (never created, or already deleted). Maps to
+// KindNotFound.
+type ErrCheckpointNotFound struct {
+	CheckpointID uint64
+}
+
+func (e *ErrCheckpointNotFound) Error() string {
+	return fmt.Sprintf("query checkpoint %d not found", e.CheckpointID)
+}
+func (*ErrCheckpointNotFound) Reason() string { return ErrReasonCheckpointNotFound }
+func (e *ErrCheckpointNotFound) Metadata() map[string]string {
 	return map[string]string{"checkpointId": strconv.FormatUint(e.CheckpointID, 10)}
 }
 

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -360,6 +360,8 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrMetadataFieldNotInSchema":      &ErrMetadataFieldNotInSchema{},
 		"ErrIndexBuilding":                 &ErrIndexBuilding{},
 		"ErrCheckpointNotReady":            &ErrCheckpointNotReady{},
+		"ErrCheckpointLimitReached":        &ErrCheckpointLimitReached{},
+		"ErrCheckpointNotFound":            &ErrCheckpointNotFound{},
 		"ErrIndexInconsistent":             &ErrIndexInconsistent{},
 		"ErrInvalidReceipt":                &ErrInvalidReceipt{},
 		"ErrNumscriptNotFound":             &ErrNumscriptNotFound{},

--- a/internal/domain/processing/processor_query_checkpoint.go
+++ b/internal/domain/processing/processor_query_checkpoint.go
@@ -6,8 +6,13 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
+// processCreateQueryCheckpoint applies a CreateQueryCheckpoint order
+// unconditionally: the live-checkpoint limit is enforced softly at admission, so
+// a committed create always applies identically on every node regardless of that
+// node's configured limit (FSM determinism).
 func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
 	s := ctx.Scope
+
 	checkpointID := s.IncrementNextQueryCheckpointID()
 
 	cp := &raftcmdpb.QueryCheckpointState{
@@ -25,16 +30,16 @@ func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, c
 			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
 				CheckpointId: checkpointID,
 				MaxSequence:  cp.GetMaxSequence(),
+				CreatedAt:    cp.GetCreatedAt(),
 			},
 		},
 	}, nil
 }
 
+// processDeleteQueryCheckpoint applies a delete unconditionally (id validity and
+// existence are checked softly at admission). Emitting the log on every node is
+// what drives the per-node physical file cleanup.
 func processDeleteQueryCheckpoint(order *raftcmdpb.DeleteQueryCheckpointOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
-	if order.GetCheckpointId() == 0 {
-		return nil, domain.ErrCheckpointIDRequired
-	}
-
 	ctx.Scope.DeleteQueryCheckpoint(order.GetCheckpointId())
 	// QueryCheckpointDeleted is derived from DeletedQueryCheckpointLog by
 	// deriveSignals.

--- a/internal/domain/processing/processor_query_checkpoint_test.go
+++ b/internal/domain/processing/processor_query_checkpoint_test.go
@@ -1,0 +1,87 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+func createQueryCheckpointOrder() *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_CreateQueryCheckpoint{
+					CreateQueryCheckpoint: &raftcmdpb.CreateQueryCheckpointOrder{},
+				},
+			},
+		},
+	}
+}
+
+func deleteQueryCheckpointOrder(id uint64) *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_DeleteQueryCheckpoint{
+					DeleteQueryCheckpoint: &raftcmdpb.DeleteQueryCheckpointOrder{CheckpointId: id},
+				},
+			},
+		},
+	}
+}
+
+// Create applies unconditionally on the FSM path — the live-checkpoint limit is
+// enforced softly at admission, never here.
+func TestProcessCreateQueryCheckpoint_Success(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	now := &commonpb.Timestamp{Data: 42}
+
+	mockStore.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(7))
+	mockStore.EXPECT().GetNextSequenceID().Return(uint64(100))
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+	mockStore.EXPECT().SaveQueryCheckpoint(gomock.Any())
+
+	result, err := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	createdLog := result.GetCreatedQueryCheckpoint()
+	require.NotNil(t, createdLog)
+	require.Equal(t, uint64(7), createdLog.GetCheckpointId())
+	require.Equal(t, uint64(99), createdLog.GetMaxSequence())
+}
+
+// Delete applies unconditionally on the FSM path — id validity and existence are
+// checked softly at admission. The tombstone drives per-node file cleanup.
+func TestProcessDeleteQueryCheckpoint_Success(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	mockStore.EXPECT().DeleteQueryCheckpoint(uint64(5))
+
+	result, err := processor.ProcessOrder(deleteQueryCheckpointOrder(5), mockStore)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	deletedLog := result.GetDeletedQueryCheckpoint()
+	require.NotNil(t, deletedLog)
+	require.Equal(t, uint64(5), deletedLog.GetCheckpointId())
+}

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -104,7 +104,9 @@ type Scope interface {
 	SetNumscriptLatestVersion(ledgerName string, name, version string)
 	ResolveNumscriptContent(ledgerName string, name, version string) (commonpb.NumscriptInfoReader, error)
 
-	// Query checkpoint operations
+	// Query checkpoint operations. Enforcement of the live-checkpoint limit and
+	// delete existence is done softly at admission, so the FSM apply path neither
+	// counts nor gates — it only assigns ids and stages saves/deletes.
 	GetNextQueryCheckpointID() uint64
 	IncrementNextQueryCheckpointID() uint64
 	SaveQueryCheckpoint(cp *raftcmdpb.QueryCheckpointState)

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -72,7 +72,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CHAPTER_NOT_FOUND,
 		commonpb.ErrorReason_ERROR_REASON_PREPARED_QUERY_NOT_FOUND,
 		commonpb.ErrorReason_ERROR_REASON_NUMSCRIPT_NOT_FOUND,
-		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_NOT_FOUND:
+		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_NOT_FOUND,
+		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND:
 		return KindNotFound
 	case commonpb.ErrorReason_ERROR_REASON_LEDGER_ALREADY_EXISTS,
 		commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT,
@@ -114,7 +115,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CLUSTER_UNHEALTHY,
 		commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW:
 		return KindUnavailable
-	case commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_DISK_FULL:
+	case commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_DISK_FULL,
+		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_LIMIT_REACHED:
 		return KindResourceExhausted
 	case commonpb.ErrorReason_ERROR_REASON_UNSPECIFIED,
 		commonpb.ErrorReason_ERROR_REASON_INDEX_INCONSISTENT,

--- a/internal/infra/attributes/baseline.go
+++ b/internal/infra/attributes/baseline.go
@@ -13,9 +13,9 @@ import (
 // CreateBaselineSnapshot copies the entire attribute zone (every attribute
 // type, final value per canonical key) from the source reader into a compact
 // Pebble DB at destPath. No history, no logs. It also copies the LedgerInfo
-// entries from the Global zone (query.ReadLedgers reads them from there) so the
-// checker can verify the schema / account-type / presence projections against
-// this boundary-time baseline rather than the live store.
+// entries and the query-checkpoint rows from the Global zone so the checker can
+// verify the schema / account-type / presence / query-checkpoint projections
+// against this boundary-time baseline rather than the live store.
 //
 // The whole attribute zone is copied (not just the types a compare pass reads
 // today) so every checker baseline read — compareVolumes / compareMetadata /
@@ -89,7 +89,8 @@ func CreateBaselineSnapshot(reader dal.PebbleReader, destPath string) error {
 }
 
 // writeBaselineAttributes copies the whole attribute zone verbatim from the
-// source reader into the baseline DB, then the Global-zone LedgerInfo entries.
+// source reader into the baseline DB, then the Global-zone LedgerInfo entries,
+// then the Global-zone query-checkpoint rows.
 func writeBaselineAttributes(reader dal.PebbleReader, db *pebble.DB) error {
 	if err := copyBaselineRange(reader, db, []byte{dal.ZoneAttributes}, []byte{dal.ZoneAttributes + 1}); err != nil {
 		return fmt.Errorf("writing baseline attributes: %w", err)
@@ -97,6 +98,10 @@ func writeBaselineAttributes(reader dal.PebbleReader, db *pebble.DB) error {
 
 	if err := copyBaselineLedgers(reader, db); err != nil {
 		return fmt.Errorf("writing baseline ledgers: %w", err)
+	}
+
+	if err := copyBaselineQueryCheckpoints(reader, db); err != nil {
+		return fmt.Errorf("writing baseline query checkpoints: %w", err)
 	}
 
 	return nil
@@ -133,4 +138,16 @@ func copyBaselineLedgers(reader dal.PebbleReader, db *pebble.DB) error {
 	return copyBaselineRange(reader, db,
 		[]byte{dal.ZoneGlobal, dal.SubGlobLedgerInfo},
 		[]byte{dal.ZoneGlobal, dal.SubGlobLedgerInfo + 1})
+}
+
+// copyBaselineQueryCheckpoints copies the live query-checkpoint rows (zone
+// ZoneGlobal / SubGlobQueryCheckpoint) verbatim into the baseline DB. The
+// checker seeds its audit-derived live-checkpoint set from these under
+// archiving, where the CreatedQueryCheckpointLog that would otherwise rebuild
+// the set is purged with the archived chapter's logs. The SubGlobNextQueryCheckpointID
+// counter (0x0F) is excluded by the [0x0E, 0x0F) bound.
+func copyBaselineQueryCheckpoints(reader dal.PebbleReader, db *pebble.DB) error {
+	return copyBaselineRange(reader, db,
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint},
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint + 1})
 }

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -138,7 +138,13 @@ func RebuildDelta(
 		ephemeralPurgeBuffer = replay.NewEphemeralPurgeBuffer()
 	}
 
-	var count uint64
+	var (
+		count uint64
+		// Highest query-checkpoint id seen across CreatedQueryCheckpoint logs
+		// (deleted ones included). Used after the replay to restore the
+		// monotonic SubGlobNextQueryCheckpointID counter.
+		maxQueryCheckpointID uint64
+	)
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -415,6 +421,36 @@ func RebuildDelta(
 				}
 			}
 
+		case *commonpb.LogPayload_CreatedQueryCheckpoint:
+			// Rebuild the metadata row (id + max_sequence) from the log. The
+			// physical checkpoint files cannot be reconstructed from the audit,
+			// so a rebuilt checkpoint reads as Unavailable until an operator
+			// deletes it — the same registered-but-not-ready state EN-1460
+			// already defines. The row keeps the projection audit-consistent so
+			// the cap and compareQueryCheckpoints stay correct after a rebuild.
+			if cp := p.CreatedQueryCheckpoint; cp != nil {
+				if err := state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{
+					CheckpointId: cp.GetCheckpointId(),
+					MaxSequence:  cp.GetMaxSequence(),
+					CreatedAt:    cp.GetCreatedAt(),
+				}); err != nil {
+					_ = batch.Cancel()
+
+					return fmt.Errorf("rebuilding query checkpoint at log %d: %w", seq, err)
+				}
+
+				maxQueryCheckpointID = max(maxQueryCheckpointID, cp.GetCheckpointId())
+			}
+
+		case *commonpb.LogPayload_DeletedQueryCheckpoint:
+			if cp := p.DeletedQueryCheckpoint; cp != nil {
+				if err := state.DeleteQueryCheckpointFromBatch(batch, cp.GetCheckpointId()); err != nil {
+					_ = batch.Cancel()
+
+					return fmt.Errorf("removing query checkpoint at log %d: %w", seq, err)
+				}
+			}
+
 		// Log types with no persistent state to rebuild:
 		case *commonpb.LogPayload_RemovedEventsSink:
 		case *commonpb.LogPayload_CloseChapter:
@@ -423,8 +459,6 @@ func RebuildDelta(
 		case *commonpb.LogPayload_ConfirmArchiveChapter:
 		case *commonpb.LogPayload_DeleteChapterSchedule:
 		case *commonpb.LogPayload_DeletedPreparedQuery:
-		case *commonpb.LogPayload_CreatedQueryCheckpoint:
-		case *commonpb.LogPayload_DeletedQueryCheckpoint:
 		case *commonpb.LogPayload_DeleteQueryCheckpointSchedule:
 		}
 
@@ -468,6 +502,18 @@ func RebuildDelta(
 			_ = batch.Cancel()
 
 			return fmt.Errorf("flushing final replay ephemeral purge: %w", err)
+		}
+	}
+
+	// Restore the monotonic next-ID counter above every replayed checkpoint id
+	// (deleted ids included — the counter never rewinds), so post-rebuild
+	// creates allocate fresh ids instead of reissuing one and overwriting a
+	// rebuilt row.
+	if maxQueryCheckpointID > 0 {
+		if err := state.StoreNextQueryCheckpointID(batch, maxQueryCheckpointID+1); err != nil {
+			_ = batch.Cancel()
+
+			return fmt.Errorf("restoring next query checkpoint ID: %w", err)
 		}
 	}
 

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -1001,6 +1001,17 @@ func registerSigningKeyLog(seq uint64, keyID string, pub []byte, parentKeyID str
 	}
 }
 
+func createdQueryCheckpointLog(seq, id, maxSeq uint64) *commonpb.Log {
+	return &commonpb.Log{
+		Sequence: seq,
+		Payload: &commonpb.LogPayload{
+			Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+				CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{CheckpointId: id, MaxSequence: maxSeq, CreatedAt: &commonpb.Timestamp{Data: maxSeq * 10}},
+			},
+		},
+	}
+}
+
 func revokeSigningKeyLog(seq uint64, keyID string, cascaded []string) *commonpb.Log {
 	return &commonpb.Log{
 		Sequence: seq,
@@ -1009,6 +1020,17 @@ func revokeSigningKeyLog(seq uint64, keyID string, cascaded []string) *commonpb.
 				RevokeSigningKey: &commonpb.RevokedSigningKeyLog{
 					KeyId: keyID, CascadedKeyIds: cascaded,
 				},
+			},
+		},
+	}
+}
+
+func deletedQueryCheckpointLog(seq, id uint64) *commonpb.Log {
+	return &commonpb.Log{
+		Sequence: seq,
+		Payload: &commonpb.LogPayload{
+			Type: &commonpb.LogPayload_DeletedQueryCheckpoint{
+				DeletedQueryCheckpoint: &commonpb.DeletedQueryCheckpointLog{CheckpointId: id},
 			},
 		},
 	}
@@ -1096,4 +1118,49 @@ func TestRebuildDelta_ReplaysRevokeSigningKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRebuildDelta_ReplaysQueryCheckpoints pins that the audit-rebuild path
+// recreates the query-checkpoint metadata rows from the CreatedQueryCheckpoint /
+// DeletedQueryCheckpoint logs (id + max_sequence) and honors deletes, so the
+// projection the cap and compareQueryCheckpoints read stays audit-consistent
+// after a rebuild.
+func TestRebuildDelta_ReplaysQueryCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	// Create 1..5, then delete the two highest live ones (4, 5). The counter
+	// must still land at 6: it is monotonic and must never reissue 5, even
+	// though the highest surviving row is 3.
+	batch := store.OpenWriteSession()
+	for id := uint64(1); id <= 5; id++ {
+		require.NoError(t, batch.SetProto(coldLogKey(id), createdQueryCheckpointLog(id, id, id*10)))
+	}
+	require.NoError(t, batch.SetProto(coldLogKey(6), deletedQueryCheckpointLog(6, 4)))
+	require.NoError(t, batch.SetProto(coldLogKey(7), deletedQueryCheckpointLog(7, 5)))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	ids, err := query.ReadLiveQueryCheckpointIDs(handle)
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, ids,
+		"rebuild must recreate live checkpoint rows and drop deleted ones")
+
+	cp, err := query.ReadQueryCheckpoint(handle, 3)
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	require.Equal(t, uint64(30), cp.GetMaxSequence(), "max_sequence must survive the rebuild")
+	require.Equal(t, uint64(300), cp.GetCreatedAt().GetData(), "created_at must survive the rebuild")
+
+	// The monotonic counter must be restored to max(created)+1 = 6, not
+	// max(surviving)+1 = 4 — else a post-rebuild create would reissue id 4/5.
+	next, err := query.ReadNextQueryCheckpointID(handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(6), next, "next-ID counter must sit above every created id, deleted ones included")
 }

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -468,6 +468,21 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"checkpointId": "18"},
 		},
 		{
+			// Admission-only (soft cap) rejection; carried here because the type is
+			// a Describable and the coverage test forces a row for every one.
+			name:        "CheckpointLimitReached",
+			err:         &domain.ErrCheckpointLimitReached{Limit: 10},
+			wantReason:  domain.ErrReasonCheckpointLimitReached,
+			wantContext: map[string]string{"limit": "10"},
+		},
+		{
+			// Admission-only (soft existence check) rejection; see above.
+			name:        "CheckpointNotFound",
+			err:         &domain.ErrCheckpointNotFound{CheckpointID: 7},
+			wantReason:  domain.ErrReasonCheckpointNotFound,
+			wantContext: map[string]string{"checkpointId": "7"},
+		},
+		{
 			// The Go field is Detail; the wire key is "reason" (legacy contract,
 			// errors.go:1051) — a rename here would break the audited key set.
 			name:        "InvalidReceipt",

--- a/internal/infra/state/batch.go
+++ b/internal/infra/state/batch.go
@@ -311,7 +311,9 @@ func SavePreparedQuery(b *dal.WriteSession, ledger string, pq *commonpb.Prepared
 }
 
 // SaveQueryCheckpoint stores a query checkpoint state in the batch (Raft-replicated).
-func saveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState) error {
+// Exported for the audit-rebuild path (internal/infra/backup), which recreates
+// the row from CreatedQueryCheckpoint logs.
+func SaveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState) error {
 	b.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
 		PutUint64(cp.GetCheckpointId())
 
@@ -324,7 +326,9 @@ func saveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState
 }
 
 // DeleteQueryCheckpointFromBatch removes a query checkpoint from the batch (Raft-replicated).
-func deleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) error {
+// Exported for the audit-rebuild path (internal/infra/backup), which drops the
+// row on DeletedQueryCheckpoint logs.
+func DeleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) error {
 	b.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
 		PutUint64(checkpointID)
 
@@ -337,7 +341,9 @@ func deleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) er
 }
 
 // StoreNextQueryCheckpointID writes the next query checkpoint ID as 8-byte big-endian uint64.
-func storeNextQueryCheckpointID(b *dal.WriteSession, id uint64) error {
+// Exported for the audit-rebuild path (internal/infra/backup), which restores the
+// monotonic counter alongside the rebuilt checkpoint rows.
+func StoreNextQueryCheckpointID(b *dal.WriteSession, id uint64) error {
 	value := make([]byte, 8)
 	binary.BigEndian.PutUint64(value, id)
 

--- a/internal/infra/state/query_checkpoint_cap_test.go
+++ b/internal/infra/state/query_checkpoint_cap_test.go
@@ -1,0 +1,92 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+// TestWriteSetQueryCheckpointMerge pins that staged creates/deletes are written
+// to Pebble on Merge and are readable back via the recovery read path. The FSM
+// apply path stages unconditionally; the live-checkpoint limit is enforced at
+// admission, not here.
+func TestWriteSetQueryCheckpointMerge(t *testing.T) {
+	t.Parallel()
+	buf, machine, dataStore := newTestBuffer(t)
+
+	buf.SaveQueryCheckpoint(&raftcmdpb.QueryCheckpointState{CheckpointId: 1})
+	buf.SaveQueryCheckpoint(&raftcmdpb.QueryCheckpointState{CheckpointId: 2})
+
+	batch := dataStore.OpenWriteSession()
+	require.NoError(t, buf.Merge(batch, nil))
+	require.NoError(t, batch.Commit())
+
+	rh, err := dataStore.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rh.Close() })
+
+	ids, err := query.ReadLiveQueryCheckpointIDs(rh)
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]struct{}{1: {}, 2: {}}, ids, "recovery read must see the committed rows")
+
+	// Proposal 2: deleting one removes its row.
+	buf2 := NewWriteSet(machine)
+	buf2.Reset(&commonpb.Timestamp{Data: 1700000001})
+	buf2.DeleteQueryCheckpoint(1)
+
+	batch2 := dataStore.OpenWriteSession()
+	require.NoError(t, buf2.Merge(batch2, nil))
+	require.NoError(t, batch2.Commit())
+
+	rh2, err := dataStore.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rh2.Close() })
+
+	ids2, err := query.ReadLiveQueryCheckpointIDs(rh2)
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]struct{}{2: {}}, ids2)
+}
+
+// TestWriteSetQueryCheckpointRollback pins that a proposal aborted via Reset (no
+// Merge) writes nothing to the store.
+func TestWriteSetQueryCheckpointRollback(t *testing.T) {
+	t.Parallel()
+	buf, _, dataStore := newTestBuffer(t)
+
+	buf.SaveQueryCheckpoint(&raftcmdpb.QueryCheckpointState{CheckpointId: 9})
+	buf.Reset(&commonpb.Timestamp{Data: 1700000002})
+
+	batch := dataStore.OpenWriteSession()
+	require.NoError(t, buf.Merge(batch, nil))
+	require.NoError(t, batch.Commit())
+
+	rh, err := dataStore.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rh.Close() })
+
+	ids, err := query.ReadLiveQueryCheckpointIDs(rh)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+}
+
+// TestIsCheckpointLimitReached pins the scheduler's reason classification: only
+// the typed CHECKPOINT_LIMIT_REACHED business rejection is treated as the
+// expected cap steady-state; every other error (and nil) is not.
+func TestIsCheckpointLimitReached(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isCheckpointLimitReached(&domain.ErrCheckpointLimitReached{Limit: 10}))
+	require.True(t, isCheckpointLimitReached(&domain.BusinessError{Err: &domain.ErrCheckpointLimitReached{Limit: 10}}))
+	require.True(t, isCheckpointLimitReached(fmt.Errorf("propose: %w", &domain.ErrCheckpointLimitReached{Limit: 10})))
+
+	require.False(t, isCheckpointLimitReached(&domain.ErrCheckpointNotFound{CheckpointID: 3}))
+	require.False(t, isCheckpointLimitReached(errors.New("transient")))
+	require.False(t, isCheckpointLimitReached(nil))
+}

--- a/internal/infra/state/query_checkpoint_scheduler.go
+++ b/internal/infra/state/query_checkpoint_scheduler.go
@@ -1,10 +1,12 @@
 package state
 
 import (
+	"errors"
 	"time"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	"github.com/formancehq/ledger/v3/internal/pkg/signal"
 	"github.com/formancehq/ledger/v3/internal/pkg/worker"
@@ -20,6 +22,12 @@ type QueryCheckpointScheduler struct {
 	proposeFn       func() error
 	scheduleChanged signal.Signal
 	w               worker.Worker
+
+	// limitReached remembers that the last fire was rejected because the
+	// checkpoint cap is full, so the condition is logged once rather than on
+	// every subsequent tick. Cleared on the next successful creation. Accessed
+	// only from the single scheduler goroutine.
+	limitReached bool
 }
 
 // NewQueryCheckpointScheduler creates a new QueryCheckpointScheduler.
@@ -49,6 +57,15 @@ func (s *QueryCheckpointScheduler) Start() {
 // Stop signals the scheduler to stop and waits for it to finish.
 func (s *QueryCheckpointScheduler) Stop() {
 	s.w.Stop()
+}
+
+// isCheckpointLimitReached reports whether err is the typed
+// CHECKPOINT_LIMIT_REACHED business rejection, so the scheduler can treat a
+// full cap as an expected steady state rather than a transient failure.
+func isCheckpointLimitReached(err error) bool {
+	var describable domain.Describable
+
+	return errors.As(err, &describable) && describable.Reason() == domain.ErrReasonCheckpointLimitReached
 }
 
 // loop is the main scheduler loop.
@@ -111,7 +128,20 @@ func (s *QueryCheckpointScheduler) loop(stop <-chan struct{}) {
 			if s.isLeader() {
 				s.logger.Infof("Query checkpoint scheduler firing: proposing CreateQueryCheckpoint")
 
-				if err := s.proposeFn(); err != nil {
+				switch err := s.proposeFn(); {
+				case err == nil:
+					s.limitReached = false
+				case isCheckpointLimitReached(err):
+					// Expected steady-state once the cap is full: keep the
+					// timer armed so creation resumes automatically once an
+					// operator deletes a checkpoint, but log only on entry to
+					// avoid a per-tick error every cron period.
+					if !s.limitReached {
+						s.limitReached = true
+
+						s.logger.Infof("Query checkpoint limit reached; skipping scheduled creation until a checkpoint is deleted")
+					}
+				default:
 					s.logger.Errorf("Failed to propose CreateQueryCheckpoint: %v (will retry on next tick)", err)
 				}
 			}

--- a/internal/infra/state/recovery.go
+++ b/internal/infra/state/recovery.go
@@ -215,7 +215,49 @@ func (r *Recovery) RecoverState() error {
 		"pendingCleanups":       len(newState.PendingLedgerCleanups),
 	}).Infof("Recovered FSM state from store")
 
+	// Reclaim any physical query-checkpoint directory with no live row
+	// (best-effort). The live-ID set is read straight from Pebble.
+	r.reclaimOrphanedQueryCheckpoints(handle)
+
 	return nil
+}
+
+// reclaimOrphanedQueryCheckpoints removes physical query-checkpoint directories
+// whose id has no live row in the store. Orphans arise when a node is caught up
+// by a snapshot install (or crashes) and so never runs the per-entry post-commit
+// file-delete hook for a checkpoint the leader had already removed — deletion is
+// otherwise only log-driven, and without this sweep the directory (a hard-linked
+// Pebble checkpoint) would pin disk forever. Runs at boot and after every
+// follower sync via RecoverState. Best-effort: failures are logged, never fatal,
+// so a transient filesystem error cannot block recovery.
+func (r *Recovery) reclaimOrphanedQueryCheckpoints(handle *dal.ReadHandle) {
+	dirs, err := r.apply.queryCheckpoints.ListQueryCheckpointDirs()
+	if err != nil {
+		r.apply.logger.Errorf("listing query checkpoint dirs for orphan reclamation: %v", err)
+
+		return
+	}
+
+	live, err := query.ReadLiveQueryCheckpointIDs(handle)
+	if err != nil {
+		r.apply.logger.Errorf("reading live query checkpoint IDs for orphan reclamation: %v", err)
+
+		return
+	}
+
+	for _, id := range dirs {
+		if _, ok := live[id]; ok {
+			continue
+		}
+
+		if err := r.apply.queryCheckpoints.DeleteQueryCheckpointFiles(id); err != nil {
+			r.apply.logger.Errorf("reclaiming orphaned query checkpoint %d: %v", id, err)
+
+			continue
+		}
+
+		r.apply.logger.Infof("reclaimed orphaned query checkpoint directory %d (no live row)", id)
+	}
 }
 
 // RestoreCacheFromStore re-hydrates the in-memory cache from the 0xFF zone in

--- a/internal/infra/state/recovery_query_checkpoint_test.go
+++ b/internal/infra/state/recovery_query_checkpoint_test.go
@@ -1,0 +1,40 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// TestReclaimOrphanedQueryCheckpoints pins that recovery removes physical
+// query-checkpoint directories with no live row (the snapshot-install orphan
+// case) while keeping the ones that are still live. The live set is read from
+// Pebble, so only id 2 has a persisted row here.
+func TestReclaimOrphanedQueryCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	machine, dataStore, _ := newTestMachine(t)
+
+	// Physical directories for 1, 2, 3; only 2 has a live Pebble row.
+	for _, id := range []uint64{1, 2, 3} {
+		_, err := dataStore.CreateQueryCheckpoint(id)
+		require.NoError(t, err)
+	}
+
+	batch := dataStore.OpenWriteSession()
+	require.NoError(t, SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{CheckpointId: 2}))
+	require.NoError(t, batch.Commit())
+
+	handle, err := dataStore.NewReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+
+	NewRecovery(machine, dataStore).reclaimOrphanedQueryCheckpoints(handle)
+
+	remaining, err := dataStore.ListQueryCheckpointDirs()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint64{2}, remaining,
+		"orphaned directories 1 and 3 must be reclaimed; the live one (2) kept")
+}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -745,20 +745,20 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 	// sub-prefix. The (checkpoint_id BE 8) tail keeps per-call ordering
 	// deterministic; the contract is at zone+sub only.
 	for _, cp := range b.pendingQueryCheckpointSaves {
-		if err := saveQueryCheckpoint(batch, cp); err != nil {
+		if err := SaveQueryCheckpoint(batch, cp); err != nil {
 			return fmt.Errorf("saving query checkpoint %d: %w", cp.GetCheckpointId(), err)
 		}
 	}
 
 	for _, cpID := range b.pendingQueryCheckpointDeletes {
-		if err := deleteQueryCheckpointFromBatch(batch, cpID); err != nil {
+		if err := DeleteQueryCheckpointFromBatch(batch, cpID); err != nil {
 			return fmt.Errorf("deleting query checkpoint %d: %w", cpID, err)
 		}
 	}
 
 	// SubGlobNextQueryCheckpointID (0x0F)
 	if b.NextQueryCheckpointID != b.fsm.State.NextQueryCheckpointID {
-		if err := storeNextQueryCheckpointID(batch, b.NextQueryCheckpointID); err != nil {
+		if err := StoreNextQueryCheckpointID(batch, b.NextQueryCheckpointID); err != nil {
 			return fmt.Errorf("storing next query checkpoint ID: %w", err)
 		}
 	}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -709,6 +709,14 @@ const (
 	ErrorReason_ERROR_REASON_PRELOAD_UNAVAILABLE ErrorReason = 66
 	ErrorReason_ERROR_REASON_AGGREGATE_OVERFLOW  ErrorReason = 67
 	ErrorReason_ERROR_REASON_BALANCE_NOT_FOUND   ErrorReason = 68
+	// ERROR_REASON_CHECKPOINT_LIMIT_REACHED: admission rejected a
+	// CreateQueryCheckpoint because the leader already holds the maximum number of
+	// live query checkpoints. Maps to gRPC ResourceExhausted / HTTP 429; delete an
+	// existing checkpoint before creating another.
+	ErrorReason_ERROR_REASON_CHECKPOINT_LIMIT_REACHED ErrorReason = 69
+	// ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted a
+	// checkpoint ID that is not live. Maps to gRPC NotFound / HTTP 404.
+	ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND ErrorReason = 70
 )
 
 // Enum value maps for ErrorReason.
@@ -783,6 +791,8 @@ var (
 		66: "ERROR_REASON_PRELOAD_UNAVAILABLE",
 		67: "ERROR_REASON_AGGREGATE_OVERFLOW",
 		68: "ERROR_REASON_BALANCE_NOT_FOUND",
+		69: "ERROR_REASON_CHECKPOINT_LIMIT_REACHED",
+		70: "ERROR_REASON_CHECKPOINT_NOT_FOUND",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                      0,
@@ -854,6 +864,8 @@ var (
 		"ERROR_REASON_PRELOAD_UNAVAILABLE":              66,
 		"ERROR_REASON_AGGREGATE_OVERFLOW":               67,
 		"ERROR_REASON_BALANCE_NOT_FOUND":                68,
+		"ERROR_REASON_CHECKPOINT_LIMIT_REACHED":         69,
+		"ERROR_REASON_CHECKPOINT_NOT_FOUND":             70,
 	}
 )
 
@@ -4841,9 +4853,13 @@ func (*DeletedQueryCheckpointScheduleLog) Descriptor() ([]byte, []int) {
 
 // CreatedQueryCheckpointLog records a query checkpoint being created.
 type CreatedQueryCheckpointLog struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CheckpointId  uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
-	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	CheckpointId uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
+	MaxSequence  uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`
+	// Creation timestamp, carried so a full audit rebuild reconstructs the same
+	// QueryCheckpointState.created_at the FSM originally wrote (rather than the
+	// zero value) and the checker can verify it. Set from the proposal date.
+	CreatedAt     *Timestamp `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4890,6 +4906,13 @@ func (x *CreatedQueryCheckpointLog) GetMaxSequence() uint64 {
 		return x.MaxSequence
 	}
 	return 0
+}
+
+func (x *CreatedQueryCheckpointLog) GetCreatedAt() *Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.
@@ -13088,10 +13111,12 @@ const file_common_proto_rawDesc = "" +
 	"\tlast_used\x18\x02 \x01(\v2\x11.common.TimestampR\blastUsed\"3\n" +
 	"\x1dSetQueryCheckpointScheduleLog\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"#\n" +
-	"!DeletedQueryCheckpointScheduleLog\"c\n" +
+	"!DeletedQueryCheckpointScheduleLog\"\x95\x01\n" +
 	"\x19CreatedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\x12!\n" +
-	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\"@\n" +
+	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\x120\n" +
+	"\n" +
+	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\"@\n" +
 	"\x19DeletedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xc6\x03\n" +
 	"\n" +
@@ -13704,7 +13729,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xbf\x15\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\x91\x16\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13775,7 +13800,9 @@ const file_common_proto_rawDesc = "" +
 	"$ERROR_REASON_STALE_INPUTS_RESOLUTION\x10A\x12$\n" +
 	" ERROR_REASON_PRELOAD_UNAVAILABLE\x10B\x12#\n" +
 	"\x1fERROR_REASON_AGGREGATE_OVERFLOW\x10C\x12\"\n" +
-	"\x1eERROR_REASON_BALANCE_NOT_FOUND\x10D*Q\n" +
+	"\x1eERROR_REASON_BALANCE_NOT_FOUND\x10D\x12)\n" +
+	"%ERROR_REASON_CHECKPOINT_LIMIT_REACHED\x10E\x12%\n" +
+	"!ERROR_REASON_CHECKPOINT_NOT_FOUND\x10F*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +
@@ -14110,199 +14137,200 @@ var file_common_proto_depIdxs = []int32{
 	63,  // 83: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
 	18,  // 84: common.NumscriptVersionEntry.created_at:type_name -> common.Timestamp
 	18,  // 85: common.TemplateUsage.last_used:type_name -> common.Timestamp
-	74,  // 86: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
-	75,  // 87: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
-	76,  // 88: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
-	77,  // 89: common.SinkConfig.http:type_name -> common.HttpSinkConfig
-	78,  // 90: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
-	7,   // 91: common.SinkConfig.event_types:type_name -> common.EventType
-	73,  // 92: common.SinkStatus.error:type_name -> common.SinkError
-	18,  // 93: common.SinkError.occurred_at:type_name -> common.Timestamp
-	79,  // 94: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
-	18,  // 95: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
-	37,  // 96: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
-	9,   // 97: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
-	101, // 98: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
-	186, // 99: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
-	12,  // 100: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	18,  // 101: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
-	83,  // 102: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
-	85,  // 103: common.LedgerLog.data:type_name -> common.LedgerLogPayload
-	18,  // 104: common.LedgerLog.date:type_name -> common.Timestamp
-	84,  // 105: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
-	84,  // 106: common.LedgerLog.new_kept_volumes:type_name -> common.TouchedVolume
-	84,  // 107: common.LedgerLog.ephemeral_volumes:type_name -> common.TouchedVolume
-	90,  // 108: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
-	91,  // 109: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
-	92,  // 110: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
-	93,  // 111: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
-	94,  // 112: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
-	95,  // 113: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
-	89,  // 114: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
-	87,  // 115: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
-	88,  // 116: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
-	140, // 117: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
-	141, // 118: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
-	142, // 119: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
-	86,  // 120: common.LedgerLogPayload.order_skipped:type_name -> common.OrderSkippedLog
-	11,  // 121: common.OrderSkippedLog.reason:type_name -> common.ErrorReason
-	187, // 122: common.OrderSkippedLog.context:type_name -> common.OrderSkippedLog.ContextEntry
-	40,  // 123: common.CreatedIndexLog.id:type_name -> common.IndexID
-	40,  // 124: common.DroppedIndexLog.id:type_name -> common.IndexID
-	25,  // 125: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	188, // 126: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
-	25,  // 127: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
-	35,  // 128: common.SavedMetadata.target:type_name -> common.Target
-	189, // 129: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
-	35,  // 130: common.DeletedMetadata.target:type_name -> common.Target
-	0,   // 131: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	1,   // 132: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
-	0,   // 133: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	40,  // 134: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
-	18,  // 135: common.Chapter.start:type_name -> common.Timestamp
-	18,  // 136: common.Chapter.end:type_name -> common.Timestamp
-	8,   // 137: common.Chapter.status:type_name -> common.ChapterStatus
-	96,  // 138: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
-	96,  // 139: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
-	96,  // 140: common.SealedChapterLog.chapter:type_name -> common.Chapter
-	96,  // 141: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
-	96,  // 142: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
-	121, // 143: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
-	123, // 144: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
-	102, // 145: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
-	103, // 146: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
-	104, // 147: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
-	105, // 148: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
-	106, // 149: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
-	107, // 150: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
-	108, // 151: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
-	109, // 152: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
-	110, // 153: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
-	111, // 154: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
-	112, // 155: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
-	113, // 156: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	114, // 157: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	115, // 158: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	116, // 159: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
-	117, // 160: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
-	118, // 161: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
-	120, // 162: common.CreatedTransactionAction.drop:type_name -> common.DropAction
-	113, // 163: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	114, // 164: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	115, // 165: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	120, // 166: common.RevertedTransactionAction.drop:type_name -> common.DropAction
-	113, // 167: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	114, // 168: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
-	115, // 169: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	120, // 170: common.SavedMetadataAction.drop:type_name -> common.DropAction
-	113, // 171: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	120, // 172: common.DeletedMetadataAction.drop:type_name -> common.DropAction
-	113, // 173: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
-	120, // 174: common.AnyVariantAction.drop:type_name -> common.DropAction
-	119, // 175: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
-	122, // 176: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
-	124, // 177: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
-	18,  // 178: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
-	10,  // 179: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
-	125, // 180: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
-	18,  // 181: common.LedgerInfo.created_at:type_name -> common.Timestamp
-	18,  // 182: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
-	37,  // 183: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
-	9,   // 184: common.LedgerInfo.mode:type_name -> common.LedgerMode
-	101, // 185: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
-	126, // 186: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	190, // 187: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
-	12,  // 188: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	191, // 189: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
-	35,  // 190: common.SaveMetadataCommand.target:type_name -> common.Target
-	192, // 191: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
-	35,  // 192: common.DeleteMetadataCommand.target:type_name -> common.Target
-	193, // 193: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
-	18,  // 194: common.TransactionState.timestamp:type_name -> common.Timestamp
-	24,  // 195: common.TransactionState.postings:type_name -> common.Posting
-	18,  // 196: common.TransactionState.reverted_at:type_name -> common.Timestamp
-	132, // 197: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
-	11,  // 198: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	194, // 199: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	136, // 200: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	137, // 201: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	138, // 202: common.SegmentType.bytes:type_name -> common.BytesConstraint
-	13,  // 203: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	195, // 204: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	139, // 205: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
-	12,  // 206: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	156, // 207: common.QueryFilter.field:type_name -> common.FieldCondition
-	162, // 208: common.QueryFilter.address:type_name -> common.AddressMatch
-	152, // 209: common.QueryFilter.and:type_name -> common.AndFilter
-	153, // 210: common.QueryFilter.or:type_name -> common.OrFilter
-	154, // 211: common.QueryFilter.not:type_name -> common.NotFilter
-	144, // 212: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	149, // 213: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	147, // 214: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	148, // 215: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	150, // 216: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	151, // 217: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	145, // 218: common.QueryFilter.reverted:type_name -> common.RevertedCondition
-	146, // 219: common.QueryFilter.audit:type_name -> common.AuditCondition
-	157, // 220: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	14,  // 221: common.AuditCondition.field:type_name -> common.AuditField
-	157, // 222: common.AuditCondition.string_cond:type_name -> common.StringCondition
-	159, // 223: common.AuditCondition.uint_cond:type_name -> common.UintCondition
-	157, // 224: common.LedgerCondition.cond:type_name -> common.StringCondition
-	159, // 225: common.LogIdCondition.cond:type_name -> common.UintCondition
-	3,   // 226: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	159, // 227: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	5,   // 228: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	159, // 229: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	143, // 230: common.AndFilter.filters:type_name -> common.QueryFilter
-	143, // 231: common.OrFilter.filters:type_name -> common.QueryFilter
-	143, // 232: common.NotFilter.filter:type_name -> common.QueryFilter
-	155, // 233: common.FieldCondition.field:type_name -> common.FieldRef
-	157, // 234: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	158, // 235: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	159, // 236: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	160, // 237: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	161, // 238: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	15,  // 239: common.AddressMatch.role:type_name -> common.AddressRole
-	143, // 240: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	16,  // 241: common.PreparedQuery.target:type_name -> common.QueryTarget
-	23,  // 242: common.AggregatedVolume.input:type_name -> common.Uint256
-	23,  // 243: common.AggregatedVolume.output:type_name -> common.Uint256
-	164, // 244: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	166, // 245: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	164, // 246: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	33,  // 247: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	25,  // 248: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	43,  // 249: common.PreparedQueryCursor.log_data:type_name -> common.Log
-	170, // 250: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	172, // 251: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	173, // 252: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	175, // 253: common.ListOptions.read:type_name -> common.ReadOptions
-	143, // 254: common.ListOptions.filter:type_name -> common.QueryFilter
-	20,  // 255: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	20,  // 256: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	29,  // 257: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	20,  // 258: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	36,  // 259: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	36,  // 260: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	36,  // 261: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	20,  // 262: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	139, // 263: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	21,  // 264: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	20,  // 265: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	139, // 266: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 267: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	20,  // 268: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	20,  // 269: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	135, // 270: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	197, // 271: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
-	197, // 272: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
-	16,  // 273: common.allowed_query_targets:type_name -> common.QueryTarget
-	274, // [274:274] is the sub-list for method output_type
-	274, // [274:274] is the sub-list for method input_type
-	273, // [273:274] is the sub-list for extension type_name
-	271, // [271:273] is the sub-list for extension extendee
-	0,   // [0:271] is the sub-list for field type_name
+	18,  // 86: common.CreatedQueryCheckpointLog.created_at:type_name -> common.Timestamp
+	74,  // 87: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
+	75,  // 88: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
+	76,  // 89: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
+	77,  // 90: common.SinkConfig.http:type_name -> common.HttpSinkConfig
+	78,  // 91: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
+	7,   // 92: common.SinkConfig.event_types:type_name -> common.EventType
+	73,  // 93: common.SinkStatus.error:type_name -> common.SinkError
+	18,  // 94: common.SinkError.occurred_at:type_name -> common.Timestamp
+	79,  // 95: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
+	18,  // 96: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
+	37,  // 97: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
+	9,   // 98: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
+	101, // 99: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
+	186, // 100: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
+	12,  // 101: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	18,  // 102: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
+	83,  // 103: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
+	85,  // 104: common.LedgerLog.data:type_name -> common.LedgerLogPayload
+	18,  // 105: common.LedgerLog.date:type_name -> common.Timestamp
+	84,  // 106: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
+	84,  // 107: common.LedgerLog.new_kept_volumes:type_name -> common.TouchedVolume
+	84,  // 108: common.LedgerLog.ephemeral_volumes:type_name -> common.TouchedVolume
+	90,  // 109: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
+	91,  // 110: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
+	92,  // 111: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
+	93,  // 112: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
+	94,  // 113: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
+	95,  // 114: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
+	89,  // 115: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
+	87,  // 116: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
+	88,  // 117: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
+	140, // 118: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
+	141, // 119: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
+	142, // 120: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
+	86,  // 121: common.LedgerLogPayload.order_skipped:type_name -> common.OrderSkippedLog
+	11,  // 122: common.OrderSkippedLog.reason:type_name -> common.ErrorReason
+	187, // 123: common.OrderSkippedLog.context:type_name -> common.OrderSkippedLog.ContextEntry
+	40,  // 124: common.CreatedIndexLog.id:type_name -> common.IndexID
+	40,  // 125: common.DroppedIndexLog.id:type_name -> common.IndexID
+	25,  // 126: common.CreatedTransaction.transaction:type_name -> common.Transaction
+	188, // 127: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	25,  // 128: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
+	35,  // 129: common.SavedMetadata.target:type_name -> common.Target
+	189, // 130: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	35,  // 131: common.DeletedMetadata.target:type_name -> common.Target
+	0,   // 132: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	1,   // 133: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
+	0,   // 134: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	40,  // 135: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
+	18,  // 136: common.Chapter.start:type_name -> common.Timestamp
+	18,  // 137: common.Chapter.end:type_name -> common.Timestamp
+	8,   // 138: common.Chapter.status:type_name -> common.ChapterStatus
+	96,  // 139: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
+	96,  // 140: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
+	96,  // 141: common.SealedChapterLog.chapter:type_name -> common.Chapter
+	96,  // 142: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
+	96,  // 143: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
+	121, // 144: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
+	123, // 145: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
+	102, // 146: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
+	103, // 147: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
+	104, // 148: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
+	105, // 149: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
+	106, // 150: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
+	107, // 151: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
+	108, // 152: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
+	109, // 153: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
+	110, // 154: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
+	111, // 155: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
+	112, // 156: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
+	113, // 157: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	114, // 158: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	115, // 159: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	116, // 160: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
+	117, // 161: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
+	118, // 162: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
+	120, // 163: common.CreatedTransactionAction.drop:type_name -> common.DropAction
+	113, // 164: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	114, // 165: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	115, // 166: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	120, // 167: common.RevertedTransactionAction.drop:type_name -> common.DropAction
+	113, // 168: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	114, // 169: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
+	115, // 170: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	120, // 171: common.SavedMetadataAction.drop:type_name -> common.DropAction
+	113, // 172: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	120, // 173: common.DeletedMetadataAction.drop:type_name -> common.DropAction
+	113, // 174: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
+	120, // 175: common.AnyVariantAction.drop:type_name -> common.DropAction
+	119, // 176: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
+	122, // 177: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
+	124, // 178: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
+	18,  // 179: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
+	10,  // 180: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
+	125, // 181: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
+	18,  // 182: common.LedgerInfo.created_at:type_name -> common.Timestamp
+	18,  // 183: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
+	37,  // 184: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
+	9,   // 185: common.LedgerInfo.mode:type_name -> common.LedgerMode
+	101, // 186: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
+	126, // 187: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
+	190, // 188: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	12,  // 189: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	191, // 190: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	35,  // 191: common.SaveMetadataCommand.target:type_name -> common.Target
+	192, // 192: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	35,  // 193: common.DeleteMetadataCommand.target:type_name -> common.Target
+	193, // 194: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	18,  // 195: common.TransactionState.timestamp:type_name -> common.Timestamp
+	24,  // 196: common.TransactionState.postings:type_name -> common.Posting
+	18,  // 197: common.TransactionState.reverted_at:type_name -> common.Timestamp
+	132, // 198: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	11,  // 199: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
+	194, // 200: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	136, // 201: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	137, // 202: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	138, // 203: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	13,  // 204: common.AccountType.persistence:type_name -> common.AccountTypePersistence
+	195, // 205: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	139, // 206: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	12,  // 207: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
+	156, // 208: common.QueryFilter.field:type_name -> common.FieldCondition
+	162, // 209: common.QueryFilter.address:type_name -> common.AddressMatch
+	152, // 210: common.QueryFilter.and:type_name -> common.AndFilter
+	153, // 211: common.QueryFilter.or:type_name -> common.OrFilter
+	154, // 212: common.QueryFilter.not:type_name -> common.NotFilter
+	144, // 213: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	149, // 214: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	147, // 215: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	148, // 216: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	150, // 217: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	151, // 218: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	145, // 219: common.QueryFilter.reverted:type_name -> common.RevertedCondition
+	146, // 220: common.QueryFilter.audit:type_name -> common.AuditCondition
+	157, // 221: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	14,  // 222: common.AuditCondition.field:type_name -> common.AuditField
+	157, // 223: common.AuditCondition.string_cond:type_name -> common.StringCondition
+	159, // 224: common.AuditCondition.uint_cond:type_name -> common.UintCondition
+	157, // 225: common.LedgerCondition.cond:type_name -> common.StringCondition
+	159, // 226: common.LogIdCondition.cond:type_name -> common.UintCondition
+	3,   // 227: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	159, // 228: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	5,   // 229: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	159, // 230: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	143, // 231: common.AndFilter.filters:type_name -> common.QueryFilter
+	143, // 232: common.OrFilter.filters:type_name -> common.QueryFilter
+	143, // 233: common.NotFilter.filter:type_name -> common.QueryFilter
+	155, // 234: common.FieldCondition.field:type_name -> common.FieldRef
+	157, // 235: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	158, // 236: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	159, // 237: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	160, // 238: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	161, // 239: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	15,  // 240: common.AddressMatch.role:type_name -> common.AddressRole
+	143, // 241: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	16,  // 242: common.PreparedQuery.target:type_name -> common.QueryTarget
+	23,  // 243: common.AggregatedVolume.input:type_name -> common.Uint256
+	23,  // 244: common.AggregatedVolume.output:type_name -> common.Uint256
+	164, // 245: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	166, // 246: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	164, // 247: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	33,  // 248: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	25,  // 249: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	43,  // 250: common.PreparedQueryCursor.log_data:type_name -> common.Log
+	170, // 251: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	172, // 252: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	173, // 253: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	175, // 254: common.ListOptions.read:type_name -> common.ReadOptions
+	143, // 255: common.ListOptions.filter:type_name -> common.QueryFilter
+	20,  // 256: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	20,  // 257: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	29,  // 258: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	20,  // 259: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	36,  // 260: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	36,  // 261: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	36,  // 262: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	20,  // 263: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	139, // 264: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	21,  // 265: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	20,  // 266: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	139, // 267: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 268: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	20,  // 269: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	20,  // 270: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	135, // 271: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	197, // 272: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
+	197, // 273: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
+	16,  // 274: common.allowed_query_targets:type_name -> common.QueryTarget
+	275, // [275:275] is the sub-list for method output_type
+	275, // [275:275] is the sub-list for method input_type
+	274, // [274:275] is the sub-list for extension type_name
+	272, // [272:274] is the sub-list for extension extendee
+	0,   // [0:272] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -4207,6 +4207,7 @@ func NewDeletedQueryCheckpointScheduleLogListReader(s []*DeletedQueryCheckpointS
 type CreatedQueryCheckpointLogReader interface {
 	GetCheckpointId() uint64
 	GetMaxSequence() uint64
+	GetCreatedAt() TimestampReader
 	Mutate() *CreatedQueryCheckpointLog
 }
 
@@ -4218,6 +4219,14 @@ func (r *createdQueryCheckpointLogReadonly) GetCheckpointId() uint64 {
 
 func (r *createdQueryCheckpointLogReadonly) GetMaxSequence() uint64 {
 	return (*CreatedQueryCheckpointLog)(r).GetMaxSequence()
+}
+
+func (r *createdQueryCheckpointLogReadonly) GetCreatedAt() TimestampReader {
+	v := (*CreatedQueryCheckpointLog)(r).GetCreatedAt()
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
 }
 
 func (r *createdQueryCheckpointLogReadonly) Mutate() *CreatedQueryCheckpointLog {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -1447,6 +1447,7 @@ func (m *CreatedQueryCheckpointLog) CloneVT() *CreatedQueryCheckpointLog {
 	r := new(CreatedQueryCheckpointLog)
 	r.CheckpointId = m.CheckpointId
 	r.MaxSequence = m.MaxSequence
+	r.CreatedAt = m.CreatedAt.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6906,6 +6907,9 @@ func (this *CreatedQueryCheckpointLog) EqualVT(that *CreatedQueryCheckpointLog) 
 		return false
 	}
 	if this.MaxSequence != that.MaxSequence {
+		return false
+	}
+	if !this.CreatedAt.EqualVT(that.CreatedAt) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15715,6 +15719,16 @@ func (m *CreatedQueryCheckpointLog) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CreatedAt != nil {
+		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if m.MaxSequence != 0 {
 		i -= 8
@@ -24708,6 +24722,10 @@ func (m *CreatedQueryCheckpointLog) SizeVT() (n int) {
 	}
 	if m.MaxSequence != 0 {
 		n += 9
+	}
+	if m.CreatedAt != nil {
+		l = m.CreatedAt.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -36526,6 +36544,42 @@ func (m *CreatedQueryCheckpointLog) UnmarshalVT(dAtA []byte) error {
 			}
 			m.MaxSequence = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
 			iNdEx += 8
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatedAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CreatedAt == nil {
+				m.CreatedAt = &Timestamp{}
+			}
+			if err := m.CreatedAt.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -168,6 +168,14 @@ const (
 	// never seeded from the live projection -- that would verify old,
 	// never-touched keys against a copy of themselves.
 	CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE CheckStoreErrorType = 23
+	// Emitted when the live query-checkpoint rows (ZoneGlobal/SubGlobQueryCheckpoint)
+	// diverge from the set the checker re-derives from the CreatedQueryCheckpoint /
+	// DeletedQueryCheckpoint logs (baseline-seeded under archiving). Both directions
+	// are flagged: a stored id that was never created or was later deleted (phantom
+	// or stale row), and an audit-live checkpoint with no stored row (lost or
+	// dropped projection). The audit-rebuild path recreates the rows from the logs,
+	// so a missing row is corruption, not a restore artifact.
+	CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH CheckStoreErrorType = 24
 )
 
 // Enum value maps for CheckStoreErrorType.
@@ -197,6 +205,7 @@ var (
 		21: "CHECK_STORE_ERROR_TYPE_SIGNING_KEY_MISMATCH",
 		22: "CHECK_STORE_ERROR_TYPE_SIGNING_CONFIG_MISMATCH",
 		23: "CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE",
+		24: "CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH",
 	}
 	CheckStoreErrorType_value = map[string]int32{
 		"CHECK_STORE_ERROR_TYPE_UNSPECIFIED":                     0,
@@ -223,6 +232,7 @@ var (
 		"CHECK_STORE_ERROR_TYPE_SIGNING_KEY_MISMATCH":            21,
 		"CHECK_STORE_ERROR_TYPE_SIGNING_CONFIG_MISMATCH":         22,
 		"CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE": 23,
+		"CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH":       24,
 	}
 )
 
@@ -9712,7 +9722,7 @@ const file_bucket_proto_rawDesc = "" +
 	"\x12entities_with_null\x18\x05 \x01(\x06R\x10entitiesWithNull\"\x10\n" +
 	"\x0eBarrierRequest\"4\n" +
 	"\x0fBarrierResponse\x12!\n" +
-	"\fcommit_index\x18\x01 \x01(\x06R\vcommitIndex*\xfc\b\n" +
+	"\fcommit_index\x18\x01 \x01(\x06R\vcommitIndex*\xb2\t\n" +
 	"\x13CheckStoreErrorType\x12&\n" +
 	"\"CHECK_STORE_ERROR_TYPE_UNSPECIFIED\x10\x00\x12(\n" +
 	"$CHECK_STORE_ERROR_TYPE_HASH_MISMATCH\x10\x01\x12'\n" +
@@ -9738,7 +9748,8 @@ const file_bucket_proto_rawDesc = "" +
 	")CHECK_STORE_ERROR_TYPE_REVERSE_MAP_ORPHAN\x10\x14\x12/\n" +
 	"+CHECK_STORE_ERROR_TYPE_SIGNING_KEY_MISMATCH\x10\x15\x122\n" +
 	".CHECK_STORE_ERROR_TYPE_SIGNING_CONFIG_MISMATCH\x10\x16\x12:\n" +
-	"6CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE\x10\x17*W\n" +
+	"6CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE\x10\x17\x124\n" +
+	"0CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH\x10\x18*W\n" +
 	"\x12PatternSegmentType\x12\x1e\n" +
 	"\x1aPATTERN_SEGMENT_TYPE_FIXED\x10\x00\x12!\n" +
 	"\x1dPATTERN_SEGMENT_TYPE_VARIABLE\x10\x01*\x9c\x01\n" +

--- a/internal/query/query_checkpoint.go
+++ b/internal/query/query_checkpoint.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
@@ -52,4 +53,66 @@ func ListQueryCheckpoints(reader dal.PebbleReader) ([]*raftcmdpb.QueryCheckpoint
 	}
 
 	return checkpoints, nil
+}
+
+// ReadLiveQueryCheckpointIDs returns the set of query-checkpoint IDs currently
+// live in the store. Used at recovery to rehydrate FSMState so the FSM can
+// enforce the checkpoint cap and reject deletes of non-live IDs without
+// scanning Pebble on the apply path, and by the checker to compare the stored
+// rows against the audit chain.
+//
+// The ID is read from the Pebble KEY, never the payload's checkpoint_id: the
+// key is what CreateQueryCheckpoint / DeleteQueryCheckpoint address, so it is
+// the authoritative identity of the row. Trusting the payload would let a row
+// whose key and embedded id diverge (a corrupted or hand-repaired store)
+// collapse or rename in the derived set, under-counting the cap and hiding a
+// phantom key from the checker.
+func ReadLiveQueryCheckpointIDs(reader dal.PebbleReader) (map[uint64]struct{}, error) {
+	iter, err := dal.NewBoundedIter(reader,
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint},
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint + 1})
+	if err != nil {
+		return nil, fmt.Errorf("iterating query checkpoints: %w", err)
+	}
+
+	defer func() { _ = iter.Close() }()
+
+	ids := make(map[uint64]struct{})
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Key layout: [ZoneGlobal][SubGlobQueryCheckpoint][checkpoint_id BE 8].
+		key := iter.Key()
+		if len(key) != 10 {
+			return nil, fmt.Errorf("malformed query checkpoint key (len %d): % x", len(key), key)
+		}
+
+		ids[binary.BigEndian.Uint64(key[2:])] = struct{}{}
+	}
+
+	return ids, iter.Error()
+}
+
+// ReadQueryCheckpointRows returns the live query-checkpoint rows keyed by their
+// Pebble KEY id (see ReadLiveQueryCheckpointIDs — the key is authoritative). The
+// value is the stored QueryCheckpointState; its embedded checkpoint_id may
+// differ from the map key on a corrupted row, which the checker flags. Used to
+// verify row contents (max_sequence, created_at) against the audit chain.
+func ReadQueryCheckpointRows(reader dal.PebbleReader) (map[uint64]*raftcmdpb.QueryCheckpointState, error) {
+	ids, err := ReadLiveQueryCheckpointIDs(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make(map[uint64]*raftcmdpb.QueryCheckpointState, len(ids))
+
+	for id := range ids {
+		cp, err := ReadQueryCheckpoint(reader, id)
+		if err != nil {
+			return nil, err
+		}
+
+		rows[id] = cp
+	}
+
+	return rows, nil
 }

--- a/internal/storage/dal/capabilities.go
+++ b/internal/storage/dal/capabilities.go
@@ -104,6 +104,9 @@ type CheckpointStaging interface {
 type QueryCheckpoints interface {
 	CreateQueryCheckpoint(id uint64) (string, error)
 	DeleteQueryCheckpointFiles(id uint64) error
+	// ListQueryCheckpointDirs returns the ids of the physical checkpoint
+	// directories present on this node, so recovery can reclaim orphans.
+	ListQueryCheckpointDirs() ([]uint64, error)
 }
 
 // ColdStorageScanner exposes the cold-storage iteration primitive used to

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -961,6 +961,38 @@ func (s *Store) DeleteQueryCheckpointFiles(id uint64) error {
 	return os.RemoveAll(dir)
 }
 
+// ListQueryCheckpointDirs returns the ids of every physical query-checkpoint
+// directory on this node (query-checkpoints/<id>/). Recovery uses it to reclaim
+// directories with no live row. Returns nil when the parent directory does not
+// exist (no checkpoint ever created); non-numeric entries are ignored.
+func (s *Store) ListQueryCheckpointDirs() ([]uint64, error) {
+	entries, err := os.ReadDir(filepath.Join(s.dataDir, queryCheckpointsDir))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("reading query checkpoints dir: %w", err)
+	}
+
+	var ids []uint64
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		id, perr := strconv.ParseUint(e.Name(), 10, 64)
+		if perr != nil {
+			continue
+		}
+
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
 // QueryCheckpointReadIndexDir returns the path for the read index within a query checkpoint.
 func (s *Store) QueryCheckpointReadIndexDir(id uint64) string {
 	return filepath.Join(s.dataDir, queryCheckpointsDir, strconv.FormatUint(id, 10), "readindex")

--- a/misc/operator/api/v1alpha1/cluster_types.go
+++ b/misc/operator/api/v1alpha1/cluster_types.go
@@ -176,6 +176,13 @@ type ClusterSpec struct {
 	// +optional
 	MaxExecutionPlanSize *int32 `json:"maxExecutionPlanSize,omitempty"`
 
+	// QueryCheckpointLimit is the maximum number of live query checkpoints.
+	// Admission rejects creation beyond this (soft, per-node). Must be greater
+	// than zero. Default: 10.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	QueryCheckpointLimit *int32 `json:"queryCheckpointLimit,omitempty"`
+
 	// IdempotencyTTL is the time-to-live for idempotency keys (0 = never expire).
 	// Default: 24h.
 	// +optional

--- a/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -653,6 +653,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.QueryCheckpointLimit != nil {
+		in, out := &in.QueryCheckpointLimit, &out.QueryCheckpointLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.UnsafeSkipConfigValidation != nil {
 		in, out := &in.UnsafeSkipConfigValidation, &out.UnsafeSkipConfigValidation
 		*out = new(bool)

--- a/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
@@ -2854,6 +2854,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              queryCheckpointLimit:
+                description: |-
+                  QueryCheckpointLimit is the maximum number of live query checkpoints.
+                  Admission rejects creation beyond this (soft, per-node). Must be greater
+                  than zero. Default: 10.
+                format: int32
+                minimum: 1
+                type: integer
               queryProfileThreshold:
                 description: QueryProfileThreshold logs and emits OTel attributes
                   for queries exceeding this duration (0 to disable).

--- a/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
@@ -2854,6 +2854,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              queryCheckpointLimit:
+                description: |-
+                  QueryCheckpointLimit is the maximum number of live query checkpoints.
+                  Admission rejects creation beyond this (soft, per-node). Must be greater
+                  than zero. Default: 10.
+                format: int32
+                minimum: 1
+                type: integer
               queryProfileThreshold:
                 description: QueryProfileThreshold logs and emits OTel attributes
                   for queries exceeding this duration (0 to disable).

--- a/misc/operator/internal/controller/envvars.go
+++ b/misc/operator/internal/controller/envvars.go
@@ -167,6 +167,7 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 	envs = appendIfInt32(envs, "NUMSCRIPT_CACHE_SIZE", spec.NumscriptCacheSize)
 	envs = appendIfInt32(envs, "MIRROR_MAX_BATCH_SIZE", spec.MirrorMaxBatchSize)
 	envs = appendIfInt32(envs, "MAX_EXECUTION_PLAN_SIZE", spec.MaxExecutionPlanSize)
+	envs = appendIfInt32(envs, "QUERY_CHECKPOINT_LIMIT", spec.QueryCheckpointLimit)
 	envs = appendIfStr(envs, "IDEMPOTENCY_TTL", spec.IdempotencyTTL)
 	envs = appendIfStr(envs, "IDEMPOTENCY_EVICTION_INTERVAL", spec.IdempotencyEvictionInterval)
 	envs = appendIfStr(envs, "HASH_ALGORITHM", spec.HashAlgorithm)

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -209,6 +209,16 @@ func TestBuildEnvVars_MirrorMaxBatchSize(t *testing.T) {
 	assertEnv(t, envs, "MIRROR_MAX_BATCH_SIZE", "1000")
 }
 
+func TestBuildEnvVars_QueryCheckpointLimit(t *testing.T) {
+	t.Parallel()
+
+	ls := newMinimalCluster()
+	v := int32(25)
+	ls.Spec.QueryCheckpointLimit = &v
+	envs := buildEnvVars(ls, "disabled", nil)
+	assertEnv(t, envs, "QUERY_CHECKPOINT_LIMIT", "25")
+}
+
 // ---------------------------------------------------------------------------
 // Pebble compression
 // ---------------------------------------------------------------------------

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -886,6 +886,14 @@ enum CheckStoreErrorType {
   // never seeded from the live projection -- that would verify old,
   // never-touched keys against a copy of themselves.
   CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE = 23;
+  // Emitted when the live query-checkpoint rows (ZoneGlobal/SubGlobQueryCheckpoint)
+  // diverge from the set the checker re-derives from the CreatedQueryCheckpoint /
+  // DeletedQueryCheckpoint logs (baseline-seeded under archiving). Both directions
+  // are flagged: a stored id that was never created or was later deleted (phantom
+  // or stale row), and an audit-live checkpoint with no stored row (lost or
+  // dropped projection). The audit-rebuild path recreates the rows from the logs,
+  // so a missing row is corruption, not a restore artifact.
+  CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH = 24;
 }
 
 message CheckStoreError {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -544,6 +544,10 @@ message DeletedQueryCheckpointScheduleLog {}
 message CreatedQueryCheckpointLog {
   fixed64 checkpoint_id = 1;
   fixed64 max_sequence = 2;
+  // Creation timestamp, carried so a full audit rebuild reconstructs the same
+  // QueryCheckpointState.created_at the FSM originally wrote (rather than the
+  // zero value) and the checker can verify it. Set from the proposal date.
+  Timestamp created_at = 3;
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.
@@ -1253,6 +1257,14 @@ enum ErrorReason {
   ERROR_REASON_PRELOAD_UNAVAILABLE = 66;
   ERROR_REASON_AGGREGATE_OVERFLOW = 67;
   ERROR_REASON_BALANCE_NOT_FOUND = 68;
+  // ERROR_REASON_CHECKPOINT_LIMIT_REACHED: admission rejected a
+  // CreateQueryCheckpoint because the leader already holds the maximum number of
+  // live query checkpoints. Maps to gRPC ResourceExhausted / HTTP 429; delete an
+  // existing checkpoint before creating another.
+  ERROR_REASON_CHECKPOINT_LIMIT_REACHED = 69;
+  // ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted a
+  // checkpoint ID that is not live. Maps to gRPC NotFound / HTTP 404.
+  ERROR_REASON_CHECKPOINT_NOT_FOUND = 70;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/tests/e2e/cluster/query_checkpoint_test.go
+++ b/tests/e2e/cluster/query_checkpoint_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/formancehq/ledger/v3/internal/application/admission"
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -180,6 +182,71 @@ var _ = Describe("Query Checkpoints", func() {
 			resp, err := clusterClient.ListQueryCheckpoints(ctx, &clusterpb.ListQueryCheckpointsRequest{})
 			Expect(err).To(Succeed())
 			Expect(resp.GetCheckpoints()).To(BeEmpty())
+		})
+	})
+
+	Context("Live checkpoint cap", Ordered, func() {
+		var (
+			ctx           context.Context
+			clusterClient clusterpb.ClusterServiceClient
+		)
+
+		const (
+			httpPort   = 9224
+			grpcPort   = 8224
+			ledgerName = "qcp-cap"
+		)
+
+		BeforeAll(func() {
+			var client servicepb.BucketServiceClient
+			ctx, client, clusterClient = testutil.SetupSingleNode(httpPort, grpcPort)
+
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+			Expect(err).To(Succeed())
+		})
+
+		It("allows creating up to the cap", func() {
+			for i := 0; i < int(admission.DefaultQueryCheckpointLimit); i++ {
+				_, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+				Expect(err).To(Succeed(), "creation %d of %d must succeed", i+1, admission.DefaultQueryCheckpointLimit)
+			}
+
+			resp, err := clusterClient.ListQueryCheckpoints(ctx, &clusterpb.ListQueryCheckpointsRequest{})
+			Expect(err).To(Succeed())
+			Expect(resp.GetCheckpoints()).To(HaveLen(int(admission.DefaultQueryCheckpointLimit)))
+		})
+
+		It("rejects creation past the cap with CHECKPOINT_LIMIT_REACHED", func() {
+			_, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+			Expect(err).To(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.ResourceExhausted))
+
+			info := actions.ExtractGRPCErrorInfo(err)
+			Expect(info).NotTo(BeNil())
+			Expect(info.Reason).To(Equal(domain.ErrReasonCheckpointLimitReached))
+		})
+
+		It("frees a slot on delete so creation succeeds again", func() {
+			list, err := clusterClient.ListQueryCheckpoints(ctx, &clusterpb.ListQueryCheckpointsRequest{})
+			Expect(err).To(Succeed())
+			Expect(list.GetCheckpoints()).NotTo(BeEmpty())
+
+			victim := list.GetCheckpoints()[0].GetCheckpointId()
+			_, err = clusterClient.DeleteQueryCheckpoint(ctx, &clusterpb.DeleteQueryCheckpointRequest{CheckpointId: victim})
+			Expect(err).To(Succeed())
+
+			_, err = clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+			Expect(err).To(Succeed(), "a slot was freed, so creation must succeed")
+		})
+
+		It("returns CHECKPOINT_NOT_FOUND when deleting a non-live checkpoint", func() {
+			_, err := clusterClient.DeleteQueryCheckpoint(ctx, &clusterpb.DeleteQueryCheckpointRequest{CheckpointId: 999999})
+			Expect(err).To(HaveOccurred())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+
+			info := actions.ExtractGRPCErrorInfo(err)
+			Expect(info).NotTo(BeNil())
+			Expect(info.Reason).To(Equal(domain.ErrReasonCheckpointNotFound))
 		})
 	})
 


### PR DESCRIPTION
## EN-1501: bound live query checkpoints

Query checkpoints (a `db.Checkpoint()` of the main store + a read-index snapshot) pin disk via hard-linked SSTs. Left unbounded, a scheduler or client loop grows disk and `ListQueryCheckpoints` payloads without end. This PR bounds the number of **live** checkpoints.

### Design: soft admission-time enforcement

Per @gfyrag's review, the limit is enforced at **admission**, not in the FSM:

- Before proposing a `CreateQueryCheckpoint`, the leader counts its live checkpoints (`query.ReadLiveQueryCheckpointIDs`, a proposer-side Pebble read) and rejects at the limit with `CHECKPOINT_LIMIT_REACHED` (gRPC `ResourceExhausted` / HTTP 429). `DeleteQueryCheckpoint` for a zero / non-live id is rejected with `CHECKPOINT_ID_REQUIRED` / `CHECKPOINT_NOT_FOUND`.
- The committed command carries no limit and the **FSM apply path is unconditional** — it applies identically on every node regardless of each node's configured limit, so determinism (invariant #2) holds. This is why the limit can be a plain startup flag rather than a Raft-committed setting.
- **Bounded overshoot, no reservation machinery**: concurrent in-flight creates can each pass the check before any commits, overshooting by up to the number of simultaneous creates. Accepted deliberately for a soft disk ceiling.
- **Rolling upgrade**: enforcement lives on the current leader. A pre-upgrade leader won't enforce; an upgraded one will. Since the check is admission-side and the committed command is unchanged, replicas never disagree on *applied* state.

### Configuration

Per-node startup config, not a runtime command:

- `--query-checkpoint-limit` flag (default 10)
- env `QUERY_CHECKPOINT_LIMIT`
- operator CRD field `queryCheckpointLimit` (`minimum: 1`)
- `Config.Validate()` rejects `0` at boot (would silently disable all creation)

### Kept

- **Checker**: `compareQueryCheckpoints` verifies the stored rows both ways against the `CreatedQueryCheckpoint`/`DeletedQueryCheckpoint` audit stream (id from the key, plus `max_sequence`/`created_at`/payload-id), baseline-seeded under archiving.
- **Audit rebuild** recreates the rows + the monotonic next-ID counter from the logs.
- **Recovery orphan sweep** reclaims row-less physical checkpoint directories (snapshot-install followers), re-sourced from Pebble.
- Scheduler quiet-skips once the cap is full.

### Removed vs. the earlier revision of this PR

The replicated `SetQueryCheckpointLimit` order/log/request, `GetQueryCheckpointLimit` RPC, `ledgerctl set-limit`/`get-limit`, the `SubGlobQueryCheckpointLimit` projection + its checker pass and `QUERY_CHECKPOINT_LIMIT_MISMATCH` error, and the FSM live-ID/limit state.

### Tests

Admission unit tests (limit boundary + delete existence incl. `id==0`), config-validation test for the zero rejection, checker both-ways coverage, rebuild replay, recovery orphan reclamation, and e2e cap behavior.
