### PR TITLE
fix(audit): make HTTP audit opt-in instead of enabled by default

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -217,7 +217,7 @@ func NewServeCommand() *cobra.Command {
 	cmd.Flags().String(WorkerGRPCAddressFlag, "localhost:8081", "GRPC address")
 	cmd.Flags().Bool(SemconvMetricsNames, false, "Use semconv metrics names (recommended)")
 	cmd.Flags().String(SchemaEnforcementMode, "audit", "Schema enforcement mode. Values: `audit`, `strict`")
-	cmd.Flags().Bool(audit.AuditEnabledFlag, true, "Enable HTTP audit")
+	cmd.Flags().Bool(audit.AuditEnabledFlag, false, "Enable HTTP audit")
 	cmd.Flags().Bool(AuditAsyncEnabledFlag, true, "Publish HTTP audit events asynchronously")
 	cmd.Flags().Int(AuditAsyncQueueCapacityFlag, api.DefaultAuditAsyncQueueCapacity, "HTTP audit async publish queue capacity")
 	cmd.Flags().Int(AuditAsyncWorkerCountFlag, api.DefaultAuditAsyncWorkerCount, "HTTP audit async publish worker count")

--- a/cmd/serve_audit_test.go
+++ b/cmd/serve_audit_test.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"testing"
 
-	"github.com/formancehq/go-libs/v5/pkg/audit"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/audit"
 )
 
 func TestAuditDefaultsToDisabled(t *testing.T) {

--- a/cmd/serve_audit_test.go
+++ b/cmd/serve_audit_test.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/formancehq/go-libs/v5/pkg/audit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditDefaultsToDisabled(t *testing.T) {
+	cmd := NewServeCommand()
+
+	enabled, err := cmd.Flags().GetBool(audit.AuditEnabledFlag)
+	require.NoError(t, err)
+	require.False(t, enabled, "HTTP audit must stay opt-in")
+}


### PR DESCRIPTION
## Problem

`--audit-enabled` defaults to `true`, and **the operator never passes this flag** to module deployments — I grepped `formancehq/operator` for `audit-enabled` / `AuditEnabled` and there is no match. The compiled-in default is therefore what runs in production, so the HTTP audit middleware is active without anyone having explicitly turned it on.

## Why opt-in is the right default

The audit middleware shipped in go-libs `#604` and needed four follow-up fixes (`#610` async publishing, `#620`/EN-1152 handled-header secret, `#647` body capping, `#656` query params). One gap is still open in practice: `#620` makes a shared secret *available*, but **no service in the stack configures one**, so the `audit-handled` dedup header remains spoofable — any client can set it and skip the audit trail.

Audit should be a deliberate deployment decision rather than something that happens by default while that is unresolved.

## Change

One-line default flip plus a regression test pinning it. This aligns with:

- `go-libs`' own `audit.AddFlags`, which defaults `audit-enabled` to `false`
- `webhooks`, which already defaults to `false` (`TestAuditEnabledDefaultsToFalse`)
- `auth`, being aligned in formancehq/auth#149

## Impact

**This is a behaviour change for production.** Ledger v2.4.12 (pinned in stack v3.2) has `audit-enabled` defaulting to true, so ledger *is* emitting audit events today. After this change, deployments that want audit must pass `--audit-enabled` explicitly.

If the audit trail on ledger is a compliance requirement, the flag should be set in the operator/helm layer as part of rolling this out — happy to prepare that alongside.

## Validation

- `go build ./...` — clean
- `go test -count=1 ./cmd/...` — pass, including the new `TestAuditDefaultsToDisabled`

https://claude.ai/code/session_01Tb7rgNz6hGo2wGBTmymPL1