### PR TITLE
fix(dal): retry transient Pebble lock opens

### DIFF
--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -28,6 +29,51 @@ import (
 // ErrStoreClosed is returned when a store operation is attempted after the
 // Pebble database has been closed. This prevents panics during shutdown races.
 var ErrStoreClosed = errors.New("store closed")
+
+const (
+	pebbleOpenMaxRetries        = 10
+	pebbleOpenInitialRetryDelay = 100 * time.Millisecond
+	pebbleOpenMaxRetryDelay     = 5 * time.Second
+)
+
+type pebbleOpenFunc func(string, *pebble.Options) (*pebble.DB, error)
+
+func isRetryablePebbleOpenError(err error) bool {
+	return errors.Is(err, syscall.EAGAIN)
+}
+
+// openPebbleWithRetry absorbs the short lock-handoff window after a hard-killed
+// process exits. Ten capped waits total 26.3 seconds; every error except EAGAIN
+// still fails on the first attempt.
+func openPebbleWithRetry(
+	path string,
+	opts *pebble.Options,
+	logger logging.Logger,
+	open pebbleOpenFunc,
+	sleep func(time.Duration),
+) (*pebble.DB, error) {
+	delay := pebbleOpenInitialRetryDelay
+
+	for retry := 0; ; retry++ {
+		db, err := open(path, opts)
+		if err == nil {
+			return db, nil
+		}
+
+		if !isRetryablePebbleOpenError(err) || retry >= pebbleOpenMaxRetries {
+			return nil, err
+		}
+
+		logger.WithFields(map[string]any{
+			"retry": retry + 1,
+			"delay": delay.String(),
+			"error": err,
+		}).Infof("Pebble database lock is temporarily unavailable; retrying open")
+		sleep(delay)
+
+		delay = min(delay*2, pebbleOpenMaxRetryDelay)
+	}
+}
 
 const (
 	liveDir = "live"
@@ -504,7 +550,7 @@ func NewStore(
 
 	openStart := time.Now()
 
-	db, err = pebble.Open(liveDir, opts)
+	db, err = openPebbleWithRetry(liveDir, opts, logger, pebble.Open, time.Sleep)
 	if err != nil {
 		return nil, fmt.Errorf("opening pebble database: %w", err)
 	}

--- a/internal/storage/dal/store_open_retry_test.go
+++ b/internal/storage/dal/store_open_retry_test.go
@@ -1,0 +1,137 @@
+package dal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func testLogger() logging.Logger {
+	return logging.FromContext(logging.TestingContext())
+}
+
+func TestOpenPebbleWithRetry_RetriesTemporarilyUnavailable(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	delays := make([]time.Duration, 0, 2)
+
+	db, err := openPebbleWithRetry(
+		"unused",
+		&pebble.Options{},
+		testLogger(),
+		func(_ string, _ *pebble.Options) (*pebble.DB, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, fmt.Errorf("opening lock: %w", syscall.EAGAIN)
+			}
+
+			return nil, nil
+		},
+		func(delay time.Duration) {
+			delays = append(delays, delay)
+		},
+	)
+
+	require.NoError(t, err)
+	require.Nil(t, db)
+	require.Equal(t, 3, attempts)
+	require.Equal(t, []time.Duration{100 * time.Millisecond, 200 * time.Millisecond}, delays)
+}
+
+func TestOpenPebbleWithRetry_DoesNotRetryOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	expected := errors.New("permission denied")
+	attempts := 0
+
+	_, err := openPebbleWithRetry(
+		"unused",
+		&pebble.Options{},
+		testLogger(),
+		func(_ string, _ *pebble.Options) (*pebble.DB, error) {
+			attempts++
+
+			return nil, expected
+		},
+		func(time.Duration) {
+			t.Fatal("sleep called for a non-retryable error")
+		},
+	)
+
+	require.ErrorIs(t, err, expected)
+	require.Equal(t, 1, attempts)
+}
+
+func TestOpenPebbleWithRetry_StopsAfterBoundedBackoff(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	delays := make([]time.Duration, 0, pebbleOpenMaxRetries)
+
+	_, err := openPebbleWithRetry(
+		"unused",
+		&pebble.Options{},
+		testLogger(),
+		func(_ string, _ *pebble.Options) (*pebble.DB, error) {
+			attempts++
+
+			return nil, syscall.EAGAIN
+		},
+		func(delay time.Duration) {
+			delays = append(delays, delay)
+		},
+	)
+
+	require.ErrorIs(t, err, syscall.EAGAIN)
+	require.Equal(t, pebbleOpenMaxRetries+1, attempts)
+	require.Len(t, delays, pebbleOpenMaxRetries)
+	require.Equal(t, 26*time.Second+300*time.Millisecond, sumDurations(delays))
+	require.Equal(t, pebbleOpenMaxRetryDelay, delays[len(delays)-1])
+}
+
+func TestRetryablePebbleOpenError_RecognizesRealLockContention(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "db")
+	db, err := pebble.Open(path, &pebble.Options{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRetryablePebbleOpenError_HelperProcess$")
+	cmd.Env = append(os.Environ(), "PEBBLE_LOCK_TEST_PATH="+path)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func TestRetryablePebbleOpenError_HelperProcess(t *testing.T) {
+	t.Parallel()
+
+	path := os.Getenv("PEBBLE_LOCK_TEST_PATH")
+	if path == "" {
+		return
+	}
+
+	_, err := pebble.Open(path, &pebble.Options{})
+	require.Error(t, err)
+	require.True(t, isRetryablePebbleOpenError(err), "expected EAGAIN-shaped Pebble lock error, got %v", err)
+}
+
+func sumDurations(durations []time.Duration) time.Duration {
+	var total time.Duration
+	for _, duration := range durations {
+		total += duration
+	}
+
+	return total
+}


### PR DESCRIPTION
## Summary

- Retry Pebble startup only when the wrapped error is syscall.EAGAIN.
- Use ten capped exponential-backoff waits from 100ms to 5s, for a 26.3s total retry budget.
- Preserve immediate failure for permission, corruption, configuration, and every other non-lock error.
- Cover transient success, non-retryable failure, retry exhaustion, and real cross-process Pebble lock contention.

Fixes #1522

## Validation

- go test -race ./internal/storage/dal -count=1 -timeout 10m
- go vet ./internal/storage/dal
- go build ./...
- go mod tidy in the root and operator modules
- golangci-lint 2.12.2 on ./internal/storage/dal/... with all project build tags: 0 issues