### PR TITLE
fix(antithesis): catalogue every assertion properly (literal messages + runtime-registered block properties)

### DIFF
--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 
@@ -50,10 +51,18 @@ func newSkipSafeScope(inner Scope) *skipSafeScope {
 // message format stays uniform and the two-tier enforcement is applied
 // consistently. The panic MUST run after assert.Unreachable so the
 // Antithesis finding is captured even on a run that later crashes.
+//
+// The assert.Unreachable message must stay a string literal: the
+// antithesis-go-instrumentor catalogues assertions by statically resolving
+// that argument, and anything else degrades to an anonymous catalog entry.
+// The offending method therefore travels in the details map and in the
+// panic value.
 func trapUnbuffered(method string, details map[string]any) {
-	msg := fmt.Sprintf("skippable order attempted %s — the overlay does not buffer this mutation, and letting it through would leak past a rollback", method)
-	assert.Unreachable(msg, details)
-	panic("skip_safe_scope: " + msg)
+	d := make(map[string]any, len(details)+1)
+	maps.Copy(d, details)
+	d["method"] = method
+	assert.Unreachable("skippable order attempted a non-buffered scope mutation", d)
+	panic(fmt.Sprintf("skip_safe_scope: skippable order attempted %s — the overlay does not buffer this mutation, and letting it through would leak past a rollback", method))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/tests/antithesis/workload/internal/block/block.go
+++ b/tests/antithesis/workload/internal/block/block.go
@@ -111,6 +111,8 @@ func RunLoop(ctx context.Context, client servicepb.BucketServiceClient, groups [
 
 	log.Printf("scenario_blocks: %d blocks active, entering loop", len(allBlocks))
 
+	registerBlockProperties(allBlocks)
+
 	randFn := scenario.RandFunc(func() uint64 { return internal.Rand().Uint64() })
 
 	for {
@@ -124,7 +126,7 @@ func RunLoop(ctx context.Context, client servicepb.BucketServiceClient, groups [
 		resp, err := b.Run(ctx, client, randFn)
 		switch {
 		case err == nil:
-			assert.Reachable(fmt.Sprintf("block %s succeeded", b.Name), details)
+			emitBlockSucceeded(b.Name, wasHit, details)
 			CheckPostCommitVolumes(resp, details)
 		case errors.Is(err, scenario.ErrSkip):
 		case internal.IsUnavailable(err):
@@ -134,10 +136,46 @@ func RunLoop(ctx context.Context, client servicepb.BucketServiceClient, groups [
 			// (e.g. reverting an already-reverted transaction).
 			log.Printf("scenario_blocks: %s precondition failed (expected): %v", b.Name, err)
 		default:
-			assert.Unreachable(fmt.Sprintf("block %s failed", b.Name), details.With(internal.Details{"error": err}))
+			emitBlockFailed(b.Name, wasHit, details.With(internal.Details{"error": err}))
 			log.Printf("scenario_blocks: %s failed: %v", b.Name, err)
 		}
 	}
+}
+
+// The per-block properties are data-driven, so the antithesis-go-instrumentor
+// cannot catalogue them (it only resolves literal message arguments). They are
+// instead registered at runtime through assert.AssertRaw — the same not-hit
+// emission the generated catalog performs for literal assertions — and the
+// hit-time emissions reuse the identical message/ID so they land on the
+// registered property. AssertRaw is invisible to the instrumentor's scanner,
+// so these call sites produce no anonymous catalog entries.
+const (
+	blockClass = "github.com/formancehq/ledger/v3/tests/antithesis/workload/internal/block"
+	blockFile  = "tests/antithesis/workload/internal/block/block.go"
+
+	wasHit = true
+	notHit = false
+)
+
+// registerBlockProperties pre-registers both properties of every block about
+// to enter the run loop: "block X succeeded" is a must-hit Reachable — a block
+// that never succeeds during the run fails it — and "block X failed" is an
+// Unreachable that stands passing until a failure fires it.
+func registerBlockProperties(blocks []*scenario.Block) {
+	for _, b := range blocks {
+		emitBlockSucceeded(b.Name, notHit, nil)
+		emitBlockFailed(b.Name, notHit, nil)
+	}
+}
+
+func emitBlockSucceeded(name string, hit bool, details internal.Details) {
+	msg := fmt.Sprintf("block %s succeeded", name)
+	assert.AssertRaw(true, msg, details, blockClass, "RunLoop", blockFile, 0, hit, true, "reachability", "Reachable", msg)
+}
+
+func emitBlockFailed(name string, hit bool, details internal.Details) {
+	msg := fmt.Sprintf("block %s failed", name)
+	assert.AssertRaw(false, msg, details, blockClass, "RunLoop", blockFile, 0, hit, false, "reachability", "Unreachable", msg)
 }
 
 // isAlreadyExists checks if the gRPC error code is AlreadyExists.


### PR DESCRIPTION
## Context

The antithesis-go-instrumentor catalogues an assertion only when it can statically resolve the message argument (a string literal or a same-file const). A full audit of both instrumented modules (main ledger binary set + the workload) found three call sites composing messages at runtime, each degrading to an anonymous `Message from "<file>[<line>]"` catalog entry whose ID can never match a runtime emission. Found while fixing the same pattern in the http adapter's unitary-log assertions (#1639, EN-1537).

## Changes

**1. `trapUnbuffered` (`internal/domain/processing/skip_safe_scope.go`)** — `assert.Unreachable` now takes a literal message ("skippable order attempted a non-buffered scope mutation") and the offending method moves into the details map. The panic value is byte-identical, so the `PanicsWithValue` enforcement test is untouched.

**2. Scenario-blocks driver (`tests/antithesis/workload/internal/block/block.go`)** — the per-block properties (`block X succeeded` / `block X failed`) are data-driven, so they cannot be literal at the call site. Worse, `block X succeeded` is a **must-hit Reachable**: uncatalogued, a block that never succeeded during a run produced no failing property at all — the exact coverage regression the assertion exists to flag. `registerBlockProperties` now emits a not-hit `assert.AssertRaw` registration for both properties of every block before the run loop (the same emission the generated catalog performs for literal assertions), and the hit sites emit through `AssertRaw` with the identical message/ID. `AssertRaw` is invisible to the instrumentor's scanner, so the anonymous entries disappear.

Note the intended behavior change from (2): `block X succeeded` is now genuinely must-hit per block — a scenario-blocks run where a registered block never succeeds fails that property instead of staying silent.

## Verification

`antithesis-go-instrumentor -assert_only` over both modules: every property catalogued with an ID matching its runtime emission, zero anonymous entries across all 64 generated catalogs (the only remaining one repo-wide is the http-adapter entry that #1639 removes). Also audited all catalogued messages for the scanner's cross-file-const fallback (identifier name catalogued instead of value) — none present.
