### PR TITLE
refactor(EN-1551): remove never-populated PreviewRestoreResponse fields

### DIFF
--- a/internal/proto/restorepb/restore.pb.go
+++ b/internal/proto/restorepb/restore.pb.go
@@ -666,10 +666,6 @@ type PreviewRestoreResponse struct {
 	LastSequence         uint64                 `protobuf:"fixed64,3,opt,name=last_sequence,json=lastSequence,proto3" json:"last_sequence,omitempty"`                           // Last log sequence number
 	LedgerCount          uint32                 `protobuf:"varint,4,opt,name=ledger_count,json=ledgerCount,proto3" json:"ledger_count,omitempty"`                               // Number of ledgers in the backup
 	LedgerNames          []string               `protobuf:"bytes,5,rep,name=ledger_names,json=ledgerNames,proto3" json:"ledger_names,omitempty"`                                // Names of all ledgers
-	FirstLogSequence     uint64                 `protobuf:"fixed64,6,opt,name=first_log_sequence,json=firstLogSequence,proto3" json:"first_log_sequence,omitempty"`             // First log sequence in the backup
-	FirstAuditSequence   uint64                 `protobuf:"fixed64,7,opt,name=first_audit_sequence,json=firstAuditSequence,proto3" json:"first_audit_sequence,omitempty"`       // First audit sequence in the backup
-	HasExports           bool                   `protobuf:"varint,8,opt,name=has_exports,json=hasExports,proto3" json:"has_exports,omitempty"`                                  // Whether incremental exports are present
-	ExportCount          uint32                 `protobuf:"varint,9,opt,name=export_count,json=exportCount,proto3" json:"export_count,omitempty"`                               // Number of export segments
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -737,34 +733,6 @@ func (x *PreviewRestoreResponse) GetLedgerNames() []string {
 		return x.LedgerNames
 	}
 	return nil
-}
-
-func (x *PreviewRestoreResponse) GetFirstLogSequence() uint64 {
-	if x != nil {
-		return x.FirstLogSequence
-	}
-	return 0
-}
-
-func (x *PreviewRestoreResponse) GetFirstAuditSequence() uint64 {
-	if x != nil {
-		return x.FirstAuditSequence
-	}
-	return 0
-}
-
-func (x *PreviewRestoreResponse) GetHasExports() bool {
-	if x != nil {
-		return x.HasExports
-	}
-	return false
-}
-
-func (x *PreviewRestoreResponse) GetExportCount() uint32 {
-	if x != nil {
-		return x.ExportCount
-	}
-	return 0
 }
 
 type FinalizeRestoreRequest struct {
@@ -885,18 +853,13 @@ const file_restore_proto_rawDesc = "" +
 	"\flogs_checked\x18\x01 \x01(\x06R\vlogsChecked\x12\x1d\n" +
 	"\n" +
 	"total_logs\x18\x02 \x01(\x06R\ttotalLogs\"\x17\n" +
-	"\x15PreviewRestoreRequest\"\x8b\x03\n" +
+	"\x15PreviewRestoreRequest\"\xe7\x01\n" +
 	"\x16PreviewRestoreResponse\x12,\n" +
 	"\x12last_applied_index\x18\x01 \x01(\x06R\x10lastAppliedIndex\x124\n" +
 	"\x16last_applied_timestamp\x18\x02 \x01(\x06R\x14lastAppliedTimestamp\x12#\n" +
 	"\rlast_sequence\x18\x03 \x01(\x06R\flastSequence\x12!\n" +
 	"\fledger_count\x18\x04 \x01(\rR\vledgerCount\x12!\n" +
-	"\fledger_names\x18\x05 \x03(\tR\vledgerNames\x12,\n" +
-	"\x12first_log_sequence\x18\x06 \x01(\x06R\x10firstLogSequence\x120\n" +
-	"\x14first_audit_sequence\x18\a \x01(\x06R\x12firstAuditSequence\x12\x1f\n" +
-	"\vhas_exports\x18\b \x01(\bR\n" +
-	"hasExports\x12!\n" +
-	"\fexport_count\x18\t \x01(\rR\vexportCount\"\x18\n" +
+	"\fledger_names\x18\x05 \x03(\tR\vledgerNames\"\x18\n" +
 	"\x16FinalizeRestoreRequest\"3\n" +
 	"\x17FinalizeRestoreResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage*\xbd\x01\n" +

--- a/internal/proto/restorepb/restore_reader.pb.go
+++ b/internal/proto/restorepb/restore_reader.pb.go
@@ -792,10 +792,6 @@ type PreviewRestoreResponseReader interface {
 	GetLastSequence() uint64
 	GetLedgerCount() uint32
 	GetLedgerNames() []string
-	GetFirstLogSequence() uint64
-	GetFirstAuditSequence() uint64
-	GetHasExports() bool
-	GetExportCount() uint32
 	Mutate() *PreviewRestoreResponse
 }
 
@@ -819,22 +815,6 @@ func (r *previewRestoreResponseReadonly) GetLedgerCount() uint32 {
 
 func (r *previewRestoreResponseReadonly) GetLedgerNames() []string {
 	return slices.Clone((*PreviewRestoreResponse)(r).GetLedgerNames())
-}
-
-func (r *previewRestoreResponseReadonly) GetFirstLogSequence() uint64 {
-	return (*PreviewRestoreResponse)(r).GetFirstLogSequence()
-}
-
-func (r *previewRestoreResponseReadonly) GetFirstAuditSequence() uint64 {
-	return (*PreviewRestoreResponse)(r).GetFirstAuditSequence()
-}
-
-func (r *previewRestoreResponseReadonly) GetHasExports() bool {
-	return (*PreviewRestoreResponse)(r).GetHasExports()
-}
-
-func (r *previewRestoreResponseReadonly) GetExportCount() uint32 {
-	return (*PreviewRestoreResponse)(r).GetExportCount()
 }
 
 func (r *previewRestoreResponseReadonly) Mutate() *PreviewRestoreResponse {

--- a/internal/proto/restorepb/restore_vtproto.pb.go
+++ b/internal/proto/restorepb/restore_vtproto.pb.go
@@ -246,10 +246,6 @@ func (m *PreviewRestoreResponse) CloneVT() *PreviewRestoreResponse {
 	r.LastAppliedTimestamp = m.LastAppliedTimestamp
 	r.LastSequence = m.LastSequence
 	r.LedgerCount = m.LedgerCount
-	r.FirstLogSequence = m.FirstLogSequence
-	r.FirstAuditSequence = m.FirstAuditSequence
-	r.HasExports = m.HasExports
-	r.ExportCount = m.ExportCount
 	if rhs := m.LedgerNames; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -614,18 +610,6 @@ func (this *PreviewRestoreResponse) EqualVT(that *PreviewRestoreResponse) bool {
 		if vx != vy {
 			return false
 		}
-	}
-	if this.FirstLogSequence != that.FirstLogSequence {
-		return false
-	}
-	if this.FirstAuditSequence != that.FirstAuditSequence {
-		return false
-	}
-	if this.HasExports != that.HasExports {
-		return false
-	}
-	if this.ExportCount != that.ExportCount {
-		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -1224,33 +1208,6 @@ func (m *PreviewRestoreResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.ExportCount != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ExportCount))
-		i--
-		dAtA[i] = 0x48
-	}
-	if m.HasExports {
-		i--
-		if m.HasExports {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x40
-	}
-	if m.FirstAuditSequence != 0 {
-		i -= 8
-		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.FirstAuditSequence))
-		i--
-		dAtA[i] = 0x39
-	}
-	if m.FirstLogSequence != 0 {
-		i -= 8
-		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.FirstLogSequence))
-		i--
-		dAtA[i] = 0x31
-	}
 	if len(m.LedgerNames) > 0 {
 		for iNdEx := len(m.LedgerNames) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.LedgerNames[iNdEx])
@@ -1578,18 +1535,6 @@ func (m *PreviewRestoreResponse) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
-	}
-	if m.FirstLogSequence != 0 {
-		n += 9
-	}
-	if m.FirstAuditSequence != 0 {
-		n += 9
-	}
-	if m.HasExports {
-		n += 2
-	}
-	if m.ExportCount != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.ExportCount))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2731,65 +2676,6 @@ func (m *PreviewRestoreResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			m.LedgerNames = append(m.LedgerNames, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
-		case 6:
-			if wireType != 1 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FirstLogSequence", wireType)
-			}
-			m.FirstLogSequence = 0
-			if (iNdEx + 8) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.FirstLogSequence = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
-			iNdEx += 8
-		case 7:
-			if wireType != 1 {
-				return fmt.Errorf("proto: wrong wireType = %d for field FirstAuditSequence", wireType)
-			}
-			m.FirstAuditSequence = 0
-			if (iNdEx + 8) > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.FirstAuditSequence = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
-			iNdEx += 8
-		case 8:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field HasExports", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.HasExports = bool(v != 0)
-		case 9:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ExportCount", wireType)
-			}
-			m.ExportCount = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.ExportCount |= uint32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/misc/proto/restore.proto
+++ b/misc/proto/restore.proto
@@ -128,10 +128,6 @@ message PreviewRestoreResponse {
   fixed64 last_sequence = 3;           // Last log sequence number
   uint32 ledger_count = 4;            // Number of ledgers in the backup
   repeated string ledger_names = 5;   // Names of all ledgers
-  fixed64 first_log_sequence = 6;      // First log sequence in the backup
-  fixed64 first_audit_sequence = 7;    // First audit sequence in the backup
-  bool has_exports = 8;               // Whether incremental exports are present
-  uint32 export_count = 9;            // Number of export segments
 }
 
 // ============================================================================

--- a/tests/e2e/cluster/restore_test.go
+++ b/tests/e2e/cluster/restore_test.go
@@ -519,6 +519,7 @@ var _ = Describe("Restore", Ordered, func() {
 			Expect(resp.LedgerNames).To(ConsistOf(ledgerName, ledger2, chartLedger, deltaLedger))
 			Expect(resp.LastAppliedIndex).To(BeNumerically(">", 0))
 			Expect(resp.LastSequence).To(BeNumerically(">", 0))
+			Expect(resp.LastAppliedTimestamp).To(BeNumerically(">", 0))
 		})
 
 		It("should finalize the restore", func() {


### PR DESCRIPTION
Removes the four `restore.PreviewRestoreResponse` fields that no producer writes and no consumer reads.

Jira: https://formance-team.atlassian.net/browse/EN-1551

## What changed

`PreviewRestoreResponse` declared nine fields; the server populates five. Deleted fields 6–9:

| # | Field | Populated | Read by CLI | Tested | Documented |
|---|-------|:---------:|:-----------:|:------:|:----------:|
| 6 | `first_log_sequence` | no | no | no | no |
| 7 | `first_audit_sequence` | no | no | no | no |
| 8 | `has_exports` | no | no | no | no |
| 9 | `export_count` | no | no | no | no |

A repo-wide search for the four snake_case names and their Go accessors, excluding the generated
`internal/proto/` tree, returned **only the four `.proto` declaration lines themselves**. Every other hit
belonged to the unrelated `commonpb.IdempotencyKeyValue.first_log_sequence` (field 1 of a different message).

Retained fields 1–5 are unchanged and already sequential, so nothing was renumbered.

**Why they were never populated:** the schema was written manifest-shaped; `PreviewRestore` is implemented
store-shaped. `RestoreServiceServerImpl` retains no manifest state — the manifest is parsed inside the
download job only to sanitize filenames (`internal/adapter/grpc/server_restore.go:42-97`), then discarded, so
fields 8–9 are unreachable from the preview path. Fields 6–7 are worse than unwired: the manifest records
`LastLogSequence`/`LastAuditSequence` (`internal/infra/backup/manifest.go:24-25`) and there is no canonical
"first sequence" contract anywhere in the codebase. Populating any of them would mean new manifest lifecycle
state plus a new Pebble scan and new semantics for checkpoint-only, export-only and archived histories — all
out of scope by explicit ticket decision.

## Deliberate deviation from the ticket's approved plan

The 2026-07-14 plan required reserving **both** numbers and names, and listed *"the generated descriptor …
reserves both their wire numbers and names"* as a required review check. **This PR adds no `reserved` block**,
on explicit instruction.

Rationale: `PreviewRestoreResponse` is a pure gRPC response — never persisted, never hashed. Verified: no
`restorepb` reference exists anywhere under `internal/storage/`, `internal/infra/state/`, or
`internal/infra/backup/`. There are no bytes at rest for a future tag reuse to misparse, and no client can be
reading a meaningful value from a field that was never written.

**This reasoning does not generalize to the other protos, and no other proto was touched.** Field numbers are
part of the hashed bytes — `MarshalDeterministicVT` delegates straight to `MarshalVT`, where the tag byte is
`field_number << 3 | wire_type`. `raft_cmd.proto:735-738` states the mechanism concretely: *"the vtprotobuf
unmarshaller retains unknown-field bytes and re-emits them on MarshalVT, so an old persisted Pebble record
carrying e.g. volume_count at tag 3 would be mis-decoded as whatever new field claimed tag 3."* Of the 69
`reserved` declarations in `misc/proto/`, 63 sit in persisted, hash-bound files (`raft_cmd` 25, `bucket` 24,
`common` 11, `cluster` 4, `audit` 3). Stripping those would require bumping `CurrentStorageSchemaVersion`
(`internal/bootstrap/config_validation.go:23`), whose `SchemaVersionError` is documented as *"NOT bypassable
… because data corruption is certain"* — a separate decision needing its own ticket.

## Diff shape

Purely subtractive apart from one test line:

```
misc/proto/restore.proto                       |   4 ----
internal/proto/restorepb/restore.pb.go         |  41 +-------
internal/proto/restorepb/restore_reader.pb.go  |  20 -----
internal/proto/restorepb/restore_vtproto.pb.go | 114 -----------------
tests/e2e/cluster/restore_test.go              |   1 +
```

Generated scope is confined to `internal/proto/restorepb/`, as expected. `just generate-proto` is idempotent
(re-ran it, zero drift).

## Testing

Added one assertion closing the only coverage gap among the five retained fields —
`last_applied_timestamp` was populated by the server and rendered by the CLI but asserted nowhere:

```go
Expect(resp.LastAppliedTimestamp).To(BeNumerically(">", 0))
```

No descriptor-level unit test was added deliberately: a Go test cannot assert a field's absence — if fields
6–9 returned, such a test would still compile and pass. The compiler is the real guard.

## Verification

- `just generate-proto`, re-run → **no drift**
- generated diff confined to `internal/proto/restorepb/` → confirmed
- `GOROOT= go build ./...` → OK
- `GOROOT= go test ./internal/proto/restorepb/... ./internal/adapter/grpc/... ./cmd/ledgerctl/restore/...` → OK
- `GOROOT= go vet -tags e2e ./tests/e2e/cluster/` → OK (e2e assertion compiles)
- `just pre-commit` → 0 issues, no extra files touched
- `just test` → see check run
- GitNexus `detect_changes` → **low** risk, 1 touched symbol (`file_restore_proto_rawDesc`), **0 affected
  execution flows**

No FSM, cache, audit, checker, storage or hot-path behavior is involved. Docs need no change: `openapi.yml`
does not expose this gRPC-only message, a grep over `docs/` for the four field labels returns nothing, and
`docs/ops/backup-restore.md` / `docs/ops/cli.md` already describe only the five populated values.

## Out of scope (verified, not assumed)

| Item | Why untouched |
|---|---|
| `common.Account.first_usage/insertion_date/updated_at` (`common.proto:151-153`) | Owned by EN-1362/EN-1360/EN-1361; deferred to v3.1. Confirmed still unpopulated — `assembleAccount` sets only `Address`, `Metadata`, `Volumes` |
| `BackupRequest.base_path`, `IncrementalBackupRequest.base_path` | Live callers in `ledgerctl` + server behavior |
| `raftcmd.LedgerBoundaries` 3–10 | Migrated by EN-1334/EN-1420 in #1464. Reservation verified **fully compliant** (`raft_cmd.proto:739-742`) |
| `StartDownloadBackupRequest` reserved (`restore.proto:54-55`) | Renumbering would let an old `ledgerctl` payload silently misparse as the `BackupStorage` oneof during a rolling upgrade |

---

# Inventory findings — report only, no code changes in this PR

The ticket title asks for a *review*; its plan was written 2026-07-14, ~3 weeks of `release/v3.0` commits ago.
A fresh inventory over `misc/proto/` (12 files, 5,032 lines, 1,330 non-reserved fields) surfaced the
following. **None of it is acted on here** — it needs per-item ownership decisions, and several items belong
to other tickets.

I independently verified the five highest-stakes rows against the files (marked ✅). The rest are reported as
found and should be re-verified before anyone acts on them.

## Reservation-hygiene violations

Removals that reserved neither the number nor the name — a future field can silently claim the tag. Severity
weighted by whether the type is persisted or hash-chain-bound.

| file:line | message | issue | severity |
|---|---|---|---|
| `common.proto:1246-1247` | `ErrorReason` (enum) | ✅ Value **59** (`ERROR_REASON_NON_DETERMINISTIC_SCRIPT`) removed with **no reservation at all** — `58 → 60`, and the enum has zero `reserved` declarations. `AuditFailure.reason` is hash-chain-bound and persisted, and the checker re-derives the failure kind from it via `domain.KindForReason`, so a reused 59 would mis-map historical audit failures | **high** |
| `common.proto:326-333` | `common.Log` | ✅ Tags **3** (`idempotency`) and **5** (`signature`) removed with **neither** number nor name reserved — sequence reads `1, 2, [res 4], 6, 7, [res 8]`. `Log` is both a persisted Pebble projection and the `ApplyResponse` wire type | **high** |
| `raft_cmd.proto:98-99` | `raftcmd.LedgerScopedOrder` | ✅ Oneof tag **10** (`delete_numscript`) removed unreserved — `9 → 11`. This message sits inside the **audit-hash-bound** `AuditItem.serialized_order` bytes | **high** |
| `common.proto:352-358` | `common.LogPayload` | Oneof tags **16** (`set_audit_config`) and **22** (`deleted_numscript`) removed unreserved — `15 → 17`, `21 → 23`. Nested inside the persisted `Log` | **high** |
| `common.proto:718-722` | `common.LedgerLogPayload` | Oneof tags **7**, **8** (`convert_metadata_batch`, `metadata_conversion_complete`) and **12** (`index_ready`) removed unreserved. Persisted ledger-log stream | **high** |
| `common.proto:1117-1118` | `common.LedgerInfo` | Tags **8** (`builtin_indexes`) and **9** (`log_builtin_indexes`) removed unreserved — `7 → 10`. Persisted attribute and a checker-verified projection | **high** |
| `common.proto:1701-1707` | `common.LedgerStats` | ✅ Tag **3** (`metadata_count`) removed by #1464 with neither `reserved 3;` nor `reserved "metadata_count";` — `volume_count = 2` jumps to `reference_count = 4`. **The review comment on #1464 flagged exactly this and it was not fixed before merge** (removal confirmed in `5a2f8892d`) | medium (response-only type) |
| `raft_cmd.proto:483-495` | `raftcmd.TechnicalUpdate` | Tags **6**, **7** (`metadata_batch`, `metadata_completion`) removed unreserved. The neighbouring `reserved 8;` + `reserved "index_ready";` is correct — 6 and 7 were simply missed | medium |
| `bucket.proto:276-284` | `service.Request` | Oneof tags **20** (`set_audit_config`) and **28** (`delete_numscript`) removed unreserved. Client-facing API wire type | medium |
| `common.proto:330` | `common.Log` | `reserved 4;` reserves the number but not the name (its own comment names it: `was: bytes hash`) | medium |
| `common.proto:333` | `common.Log` | `reserved 8;` reserves the number but not the name `hash_version` | medium |
| `raft_cmd.proto:865` | `raftcmd.GenerationSnapshot` | `reserved 9;` reserves the number but not the name `idempotency_keys` | low |

Name-only reservations at `audit.proto:101`, `bucket.proto:198`, `:208`, `:459`, `:161`, `:172`, `:954` were
checked and are **correct, not violations** — the number is deliberately reused by a replacement or a
`ListOptions`/`ReadOptions` envelope, so reserving only the old name is right.

## Fields declared but never populated

| file:line | field | evidence | note |
|---|---|---|---|
| `common.proto:291` | `Index.last_built_at = 4` | No write site; every `commonpb.Index{...}` construction sets only `Id`/`BuildStatus`/`CreatedAt`/`Ledger`/`ForwardEncodingVersion` (5 sites) | ✅ **Exposed as public API** — `openapi.yml:2715` documents `lastBuiltAt` in the `GetIndex` response |
| `common.proto:292` | `Index.last_error = 5` | Same — no write site anywhere | Served over `GetIndex`/`ListIndexes` as permanently empty |
| `common.proto:95` | `Script.content_hash = 3` | Zero handwritten references; all three `Script` construction sites set only `Plain`/`Vars` | |
| `bucket.proto:735` | `TableMetrics.backing_table_count = 3` | Never populated (both producers set only `ZombieSize`/`ZombieCount`) but **is displayed** at `cmd/ledgerctl/store/primary_metrics.go:222` | CLI prints a permanent 0 |
| `bucket.proto:736` | `TableMetrics.backing_table_size = 4` | Same; displayed at `primary_metrics.go:223` | CLI prints a permanent 0 |
| `common.proto:1616` | `ExistsCondition.include_null = 1` | Never set, but its sole consumer is a fail-loudly guard whose comment says "No current builder sets it; this guards a future one" | **Deliberate — not a candidate** |

## Populated but unsound

| file:line | field | issue |
|---|---|---|
| `common.proto:289` | `Index.build_status = 2` | **Can never reach `READY`.** Every production writer writes `BUILDING` (4 sites), and the mechanism that advanced it was deleted — cf. `raft_cmd.proto:484` (`reserved 8; // was: IndexReadyUpdate index_ready`) and the removed `LedgerLogPayload` tag 12. Consequences: the READY short-circuit at `processor_index.go:39` is unreachable; `indexes/lookup.go:79 IsReady()` is an unsatisfiable predicate with **zero production callers** (test-only), as is `Status()` at `:91`. The *state* is partly documented as intentional (`bucket.proto:1229`, and invariant #8 excludes BuildStatus from the checker) — the dead branch and two dead helpers are the untracked residue |

`LedgerStats.metadata_count`'s unsound derivation is **resolved**, not outstanding — #1464 deleted the field
and the counter outright (no `CounterMetadata` in `usagestore/keys.go`). Only its reservation gap remains.
Remaining `usagestore` counters were checked and are sound: `CounterVolume` folds from the audit chain
(`usagebuilder/process_audit.go:420`), not from live cache.

## Limits of this inventory

Worth knowing before acting on any row:

1. **It detects references, not writes.** A field referenced only in a read position looks "used". Write-site
   analysis was done for the zero-reference candidates, not for all 1,330 fields — so this class is likely
   **incomplete**, and a follow-up write-site pass would probably find more (`Index.last_*` and
   `TableMetrics.backing_table_*` were only caught by manual inspection).
2. **snake_case→CamelCase derivation is naive** and produced at least one confirmed false positive
   (`oauth_m2m` → protoc's `OauthM2M`, not `OauthM2m`). Acronym-adjacent fields may be mis-derived.
3. **Reflection- and `protojson`-mediated population is invisible to grep.**
4. **Oneof gaps** were confirmed to have historically existed in that message, but it was not formally proven
   that no later commit reserved them elsewhere in the file.
5. `misc/operator/` (separate module) was not treated as a population source.
6. Severity ratings are judgement, not a project-defined scale.

Suggested next step: a follow-up ticket for the reservation-hygiene violations (the three `high` rows on
hash-chain-bound types first), and a separate one for `Index.build_status`/`last_built_at`/`last_error`, which
is really an index-lifecycle question rather than proto hygiene — `lastBuiltAt` being in `openapi.yml` while
never populated is a public-API-surface bug, not a schema-cleanup one.
