### PR TITLE
fix(indexbuilder): scope the generic backfill replay to the task's ledger

### DIFF
--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -1318,6 +1318,19 @@ func (b *Builder) processBackfill(ctx context.Context, stop <-chan struct{}, tas
 				continue
 			}
 
+			// This task only builds task.ledger's index, but the cursor
+			// replays the GLOBAL log and indexLogEntry keys writes by the
+			// log's own ledger — a foreign log would pass the task config's
+			// gates and write forward+rmap rows into ITS ledger's keyspace
+			// for a field that ledger never indexed. Skip foreign logs,
+			// exactly as processBackfillPostings does.
+			if log.GetPayload().GetApply().GetLedgerName() != task.ledger {
+				lastSeq = log.GetSequence()
+				batchCount++
+
+				continue
+			}
+
 			if err := b.indexLogEntry(cfg, log, proposals); err != nil {
 				_ = batch.Cancel()
 

--- a/internal/application/indexbuilder/backfill_test.go
+++ b/internal/application/indexbuilder/backfill_test.go
@@ -2192,3 +2192,116 @@ func mustReadHandle(t *testing.T, b *Builder) *dal.ReadHandle {
 
 	return handle
 }
+
+// makeSavedAccountMetadataLog builds a standalone account-metadata write log.
+func makeSavedAccountMetadataLog(seq uint64, ledger, account, key, value string) *commonpb.Log {
+	return &commonpb.Log{
+		Sequence: seq,
+		Payload: &commonpb.LogPayload{
+			Type: &commonpb.LogPayload_Apply{
+				Apply: &commonpb.ApplyLedgerLog{
+					LedgerName: ledger,
+					Log: &commonpb.LedgerLog{
+						Id: seq,
+						Data: &commonpb.LedgerLogPayload{
+							Payload: &commonpb.LedgerLogPayload_SavedMetadata{
+								SavedMetadata: &commonpb.SavedMetadata{
+									Target: &commonpb.Target{
+										Target: &commonpb.Target_Account{
+											Account: &commonpb.TargetAccount{Addr: account},
+										},
+									},
+									Metadata: map[string]*commonpb.MetadataValue{
+										key: commonpb.NewStringValue(value),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// countKeysWithPrefix returns how many readstore keys live under prefix.
+func countKeysWithPrefix(t *testing.T, store *readstore.Store, prefix []byte) int {
+	t.Helper()
+
+	iter, err := store.DB().NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: readstore.IncrementBytes(prefix),
+	})
+	require.NoError(t, err)
+
+	defer func() { _ = iter.Close() }()
+
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+
+	require.NoError(t, iter.Error())
+
+	return n
+}
+
+// TestMetadataBackfillSkipsForeignLedgerLogs pins the generic backfill
+// driver's ledger scoping: processBackfill replays the GLOBAL log with a
+// temporary config holding the task's index, and indexLogEntry keys writes
+// by each log's own ledger — so a foreign ledger's SavedMetadata on the same
+// key would pass the config gates and write forward+rmap rows into the
+// foreign keyspace for a field that ledger never indexed, surfacing as
+// reverse-map orphans in compareReverseMapOrphans (EN-1458). The postings
+// driver carries the same guard, pinned by
+// TestAccountAssetBackfillDoesNotWipeUnrelatedLedger.
+func TestMetadataBackfillSkipsForeignLedgerLogs(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+
+	const (
+		taskLedger    = "task"
+		foreignLedger = "other"
+		metaKey       = "leak"
+	)
+
+	writeLogToFSM(t, b, makeSavedAccountMetadataLog(1, taskLedger, "accounts:own", metaKey, "v1"))
+	writeAppliedProposalToFSM(t, b, 1, 1, 1)
+
+	writeLogToFSM(t, b, makeSavedAccountMetadataLog(2, foreignLedger, "accounts:foreign", metaKey, "v2"))
+	writeAppliedProposalToFSM(t, b, 2, 2, 2)
+
+	globalCursor, err := query.ReadLastSequence(mustReadHandle(t, b))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), globalCursor)
+
+	// CreateIndex on (ACCOUNT, metaKey) in taskLedger only.
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.handleCreatedIndexLog(taskLedger, &commonpb.CreatedIndexLog{
+		Id: indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey),
+	})
+	require.NoError(t, b.wb.Flush())
+	require.Len(t, b.backfillTasks, 1, "CreateIndex must schedule one metadata backfill task")
+
+	b.backfillBudget = time.Second
+	stop := make(chan struct{})
+	for range 10 {
+		if len(b.backfillTasks) == 0 {
+			break
+		}
+		b.processBackfills(context.Background(), stop, globalCursor)
+	}
+	require.Empty(t, b.backfillTasks, "backfill task must be retired after catch-up")
+
+	// The task ledger's rows were backfilled — guards against this test
+	// passing vacuously on a backfill that indexed nothing at all.
+	taskRmap := readstore.ReverseMapPrefix(dal.NewKeyBuilder(), taskLedger, readstore.NamespaceAccount)
+	assert.NotZero(t, countKeysWithPrefix(t, b.readStore, taskRmap), "task ledger's rmap rows must be backfilled")
+
+	// The foreign ledger's keyspace stayed untouched: it never indexed
+	// anything, so any row here is an orphan.
+	foreignRmap := readstore.ReverseMapPrefix(dal.NewKeyBuilder(), foreignLedger, readstore.NamespaceAccount)
+	assert.Zero(t, countKeysWithPrefix(t, b.readStore, foreignRmap), "foreign ledger must have no rmap rows")
+}


### PR DESCRIPTION
## Problem

`release/v3.0` CI is currently red (runs on `92b85b942`, `47da27c24`, and every PR merge-ref since): the e2e `CheckStore` spec reports `REVERSE_MAP_ORPHAN` errors such as

```
reverse-map rows survive for metadata field "score" (namespace "a:") on ledger "nsx-meta-writes",
which the audit-derived metadata schema no longer declares: rows=1, sample account vts:acct
```

for ledgers that never declared or indexed those fields. The reporting pass (`compareReverseMapOrphans`, EN-1458 / #1649) is **correct** — the rows are genuinely illegitimate. It flaked rather than failed consistently because the verdict only runs when the read index is exactly aligned with the checker's verified sequence: busy runs skip it, quiescent runs flag it.

## Root cause

The generic backfill driver (`processBackfill`, used for metadata-index builds) replays the **global** log stream with a temporary config holding only the index under construction. `indexLogEntry` keys every write by the log's own ledger but gates on that passed config — so a foreign ledger's write of the same metadata key passes the gate and `dualWriteMetadataIndex` leaves forward+rmap rows in the **foreign** ledger's keyspace for a field it never indexed.

Every flagged `(ledger, key)` pair on CI matches this shape: `score`/`tier`/`status` are each indexed by some other e2e suite in its own ledger, and the plain metadata writes in `nsx-meta-writes` / `account-metadata-ledger` / `tx-metadata-ledger` got picked up by those suites' backfills.

The postings driver (`processBackfillPostings`) already guards against exactly this (`parsed.Ledger != task.ledger → skip`, plus the EN-1368 own-ledger-only `DeleteLedger` handling). The generic driver was missing the same scoping.

## Fix

Skip foreign-ledger logs in `processBackfill`'s replay loop, mirroring the postings driver. `DeleteLedger` logs are unaffected here: `isDataLog` filters them before the new guard, so the pinned lifecycle behaviors (`TestAccountAssetBackfillWipesDeletedLedgerGeneration`, `TestAccountAssetBackfillDoesNotWipeUnrelatedLedger`) are untouched — both still pass.

## Tests

- `TestMetadataBackfillSkipsForeignLedgerLogs`: drives `processBackfills` end-to-end over a two-ledger log stream (metadata index created in one ledger, same key written in both), asserts the task ledger's reverse-map rows are backfilled and the foreign ledger's reverse-map keyspace stays empty. **Red before the guard** (`foreign ledger must have no rmap rows`), green after.
- `internal/application/indexbuilder` + `internal/storage/readstore` unit suites green; full `tests/e2e/business` suite green locally (including the `CheckStore` spec that is red on CI).

## Note on `DeleteLedger` asymmetry (no action needed)

The generic driver lacks the postings driver's mid-stream own-ledger `DeleteLedger` wipe. That asymmetry is currently harmless: the wipe only matters for a delete + same-name recreate, and the FSM permanently rejects recreation of a deleted name (`processCreateLedger` returns `ErrLedgerDeleted` on the soft-delete tombstone, which `deleteLedgerData` deliberately never removes). The postings driver's handling — and its lifecycle tests — are defensive depth for a log shape the FSM cannot emit today; revisit only if the tombstone policy ever changes.
