### PR TITLE
[sketch] read-store versioned event keys — exact reads at a pinned sequence (EN-1748)

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
+++ b/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
@@ -106,3 +106,47 @@ because it matches call names, not arguments.
 
 See also [query-checkpoints.md](query-checkpoints.md) for point-in-time reads
 across the main store and the read index.
+
+## Cross-store alignment (EN-1748)
+
+The single-handle rule covers the main store; an *indexed* query additionally
+reads the peer read index, which folds asynchronously behind it. Two
+independently-taken views therefore disagree about the freshest commits: a
+transaction visible in the main handle whose index rows have not folded yet
+leaks through complements (`not(ts[..])` returns "a transaction with no
+timestamp") and mis-windows conjunctions — a response no single committed
+state ever produced.
+
+**Rule: an indexed read opens the main `ReadHandle` first, then takes its
+index snapshot through `query.AlignedIndexSnapshot`, and wraps the compiled
+iterator with `query.MainHorizonKeep`.**
+
+`AlignedIndexSnapshot` returns a read-index snapshot whose fold cursor covers
+the handle's last applied sequence (verified through the snapshot itself, so
+the check cannot race it), waiting up to a bounded grace for the fold and
+failing with `ErrReadIndexNotCaughtUp` when the builder is stalled. Because
+the fold is ordered, such a snapshot holds every index row for the entities
+the handle sees:
+
+- main-store leaves and enrichment reflect the handle's sequence exactly;
+- index leaves can only *exceed* the handle (entities committed after it),
+  and the `MainHorizonKeep` filter trims those back for TRANSACTIONS and
+  LOGS, so the response is the state at the handle's sequence. ACCOUNTS get
+  no trim: main-store existence is not a horizon signal there (purged
+  accounts legitimately live on in the monotonic has-asset and metadata
+  indexes), and account enrichment renders absent accounts as address-only
+  rows, so index membership is served as folded.
+
+Consumers: `listEntities` (ListTransactions/ListAccounts/ListLogs — including
+the reverse LOGS arm, whose unfiltered scan also iterates the read index),
+`AggregateVolumes`, and the prepared-query executor. Index-introspection
+endpoints (GetIndexStatus, InspectIndex, GetIndexEntryStatus) read only the
+index snapshot and need no alignment.
+
+**Residual window**: destructive fold events — a `DropIndex` range-delete or
+a retype's version switch — landing between the handle's sequence and the
+snapshot's fold cursor can remove rows for entities the handle still sees.
+The window is the microseconds between the two acquisitions (the wait exits
+as soon as the cursor covers the handle); closing it entirely needs
+registry-generation comparison and retry, deferred until it is observed in
+practice.

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -965,17 +965,23 @@ func (ctrl *DefaultController) AggregateVolumes(ctx context.Context, ledgerName 
 
 	schemaFields := query.SchemaFieldsForTarget(ledgerInfo.GetMetadataSchema(), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 
-	snap := ctrl.readStore.NewSnapshot()
+	snap, mainSeq, err := query.AlignedIndexSnapshot(ctrl.readStore, handle)
+	if err != nil {
+		return nil, err
+	}
 	defer func() { _ = snap.Close() }()
 
 	kb := dal.NewKeyBuilder()
 
 	indexStart := time.Now()
 
-	iter, err := query.Compile(snap, kb, filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerInfo.GetName(), nil, schemaFields, ledgerInfo, query.NewPebbleIndexReader(ctrl.attrs.Index, handle), readstore.SnapshotVersionResolver(snap, ledgerInfo.GetName()), profile, handle)
+	compiled, err := query.Compile(snap, kb, filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerInfo.GetName(), nil, schemaFields, ledgerInfo, query.NewPebbleIndexReader(ctrl.attrs.Index, handle), readstore.SnapshotVersionResolver(snap, ledgerInfo.GetName()), profile, handle)
 	if err != nil {
 		return nil, domain.WrapCompileError(err)
 	}
+
+	iter := readstore.NewFilterIterator(compiled,
+		query.MainHorizonKeep(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, handle, snap, ledgerInfo.GetName(), mainSeq))
 	defer iter.Close()
 
 	if profile != nil {
@@ -1659,12 +1665,17 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 		}
 	}
 
-	snap := ctrl.readStore.NewSnapshot()
+	snap, mainSeq, err := query.AlignedIndexSnapshot(ctrl.readStore, handle)
+	if err != nil {
+		_ = handle.Close()
+
+		return nil, err
+	}
 	defer func() { _ = snap.Close() }()
 
 	kb := dal.NewKeyBuilder()
 
-	iter, err := query.Compile(
+	compiled, err := query.Compile(
 		snap, kb, filter,
 		commonpb.QueryTarget_QUERY_TARGET_LOGS,
 		ledgerInfo.GetName(), nil, nil,
@@ -1675,6 +1686,9 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 
 		return nil, fmt.Errorf("compiling log filter: %w", err)
 	}
+
+	iter := readstore.NewFilterIterator(compiled,
+		query.MainHorizonKeep(commonpb.QueryTarget_QUERY_TARGET_LOGS, handle, snap, ledgerInfo.GetName(), mainSeq))
 	defer iter.Close()
 
 	logIDs, _, paginateErr := readstore.PaginateForward(iter, pageSize, nil)

--- a/internal/application/ctrl/list_entities.go
+++ b/internal/application/ctrl/list_entities.go
@@ -36,6 +36,11 @@ type entityListParams[T interface{ ~string | ~uint64 }] struct {
 	indexVersionFor func(canonical string) (uint32, error)
 	// afterToBytes converts the after cursor to a byte slice for pagination.
 	afterToBytes func(T) []byte
+	// horizonKeep is filled in by listEntities: it trims read-index iteration
+	// back to pebbleReader's horizon, since the aligned index snapshot may
+	// have folded entities committed after the main handle (see
+	// query.AlignedIndexSnapshot). nil admits everything.
+	horizonKeep func([]byte) (bool, error)
 }
 
 // entityListResult holds the result of a listEntities call.
@@ -60,12 +65,17 @@ func listEntities[T interface{ ~string | ~uint64 }](
 ) (entityListResult, error) {
 	var result entityListResult
 
-	snap := readStore.NewSnapshot()
+	// The snapshot's fold cursor covers everything params.pebbleReader sees,
+	// so index leaves cannot lag the main-store leaves and enrichment
+	// (EN-1748); withinHorizon trims the other direction.
+	snap, mainSeq, err := query.AlignedIndexSnapshot(readStore, params.pebbleReader)
+	if err != nil {
+		return result, err
+	}
 	defer func() { _ = snap.Close() }()
 
 	params.indexVersionFor = readstore.SnapshotVersionResolver(snap, params.ledgerName)
-
-	var err error
+	params.horizonKeep = query.MainHorizonKeep(params.target, params.pebbleReader, snap, params.ledgerName, mainSeq)
 
 	if params.reverse {
 		if params.filter != nil {
@@ -84,7 +94,7 @@ func listEntities[T interface{ ~string | ~uint64 }](
 func listAscending[T interface{ ~string | ~uint64 }](indexReader dal.PebbleReader, params entityListParams[T], out *[][]byte) error {
 	kb := dal.NewKeyBuilder()
 
-	iter, err := query.Compile(
+	compiled, err := query.Compile(
 		indexReader, kb, params.filter,
 		params.target,
 		params.ledgerName, nil, params.schema, params.info, params.indexRegistry, params.indexVersionFor, params.profile,
@@ -92,6 +102,11 @@ func listAscending[T interface{ ~string | ~uint64 }](indexReader dal.PebbleReade
 	)
 	if err != nil {
 		return domain.WrapCompileError(err)
+	}
+
+	var iter readstore.EntityIterator = compiled
+	if params.horizonKeep != nil {
+		iter = readstore.NewFilterIterator(compiled, params.horizonKeep)
 	}
 	defer iter.Close()
 
@@ -188,7 +203,14 @@ func newReverseIterator[T interface{ ~string | ~uint64 }](indexReader dal.Pebble
 			return nil, "", "", "", fmt.Errorf("creating reverse log iterator: %w", itErr)
 		}
 
-		return &reverseCloser{it, it.Close},
+		// The log list iterates the read index, whose aligned snapshot may run
+		// ahead of the main handle the payload reads use — trim to the horizon.
+		var rev readstore.ReverseIterator = it
+		if params.horizonKeep != nil {
+			rev = readstore.NewFilterReverseIterator(it, params.horizonKeep)
+		}
+
+		return &reverseCloser{rev, it.Close},
 			fmt.Sprintf("ReverseLedgerLogIterator(%s)", params.ledgerName),
 			"ReverseLedgerLog", "pebble:llog", nil
 
@@ -201,7 +223,7 @@ func newReverseIterator[T interface{ ~string | ~uint64 }](indexReader dal.Pebble
 func listDescFiltered[T interface{ ~string | ~uint64 }](indexReader dal.PebbleReader, params entityListParams[T], out *[][]byte) error {
 	kb := dal.NewKeyBuilder()
 
-	iter, err := query.Compile(
+	compiled, err := query.Compile(
 		indexReader, kb, params.filter,
 		params.target,
 		params.ledgerName, nil, params.schema, params.info, params.indexRegistry, params.indexVersionFor, params.profile,
@@ -209,6 +231,11 @@ func listDescFiltered[T interface{ ~string | ~uint64 }](indexReader dal.PebbleRe
 	)
 	if err != nil {
 		return domain.WrapCompileError(err)
+	}
+
+	var iter readstore.EntityIterator = compiled
+	if params.horizonKeep != nil {
+		iter = readstore.NewFilterIterator(compiled, params.horizonKeep)
 	}
 	defer iter.Close()
 

--- a/internal/query/aligned_snapshot.go
+++ b/internal/query/aligned_snapshot.go
@@ -1,0 +1,140 @@
+package query
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// Cross-store alignment for indexed queries (EN-1748). A filter tree mixes
+// leaves from two stores — the main store (entity universe, tx-id ranges,
+// reverted bitset, enrichment) and the read index (builtin/metadata indexes).
+// The read index folds asynchronously behind the main store, so two
+// independently-taken views disagree about the freshest commits: an entity
+// visible in the main store whose index rows have not folded yet leaks
+// through complements ("no timestamp") and mis-windows conjunctions. No
+// single serialized state produces such a response.
+//
+// The alignment invariant: the read-index snapshot's fold cursor must cover
+// the main reader's last applied sequence. The fold is ordered, so such a
+// snapshot holds EVERY index row for the entities the main reader sees;
+// membership can then only exceed the main store (entities committed after
+// the handle), and MainHorizonKeep trims those back. The result is exactly
+// the state at the main reader's sequence.
+// alignWait bounds how long a query waits for the read index to fold up to
+// the main handle's sequence. The fold normally trails by well under a
+// millisecond; the bound bites only when the builder is stalled (backfill
+// storm, faults), where failing fast with ErrReadIndexNotCaughtUp beats
+// holding every request.
+const alignWait = 2 * time.Second
+
+// AlignedIndexSnapshot returns a read-index snapshot whose fold cursor is at
+// or beyond mainReader's last applied log sequence, plus that sequence. The
+// cursor is verified through the snapshot itself, so the check can never race
+// the snapshot it vouches for. Fails with ErrReadIndexNotCaughtUp when the
+// fold does not catch up within alignWait.
+func AlignedIndexSnapshot(rs *readstore.Store, mainReader dal.PebbleReader) (*pebble.Snapshot, uint64, error) {
+	mainSeq, err := ReadLastSequence(mainReader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("reading main-store sequence: %w", err)
+	}
+
+	// A frozen store (query checkpoint) never advances, so waiting on it is
+	// meaningless: the pair is consistent by construction at the checkpoint's
+	// sequence (the builder materializes the read index as its fold crosses
+	// the CreatedQueryCheckpoint log). Serve it as-is; the horizon filter
+	// still bounds the index-ahead direction.
+	if rs.Frozen() {
+		return rs.NewSnapshot(), mainSeq, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), alignWait)
+	defer cancel()
+
+	for {
+		snap := rs.NewSnapshot()
+
+		lastIndexed, err := rs.LastIndexedSequenceFrom(snap)
+		if err != nil {
+			_ = snap.Close()
+
+			return nil, 0, fmt.Errorf("reading index progress: %w", err)
+		}
+
+		if lastIndexed >= mainSeq {
+			return snap, mainSeq, nil
+		}
+
+		_ = snap.Close()
+
+		if waitErr := rs.WaitForSequence(ctx, mainSeq); waitErr != nil {
+			return nil, 0, &ErrReadIndexNotCaughtUp{Requested: mainSeq, Current: lastIndexed}
+		}
+	}
+}
+
+// MainHorizonKeep returns the FilterIterator predicate that trims an
+// index-snapshot iteration back to the main reader's horizon: the aligned
+// snapshot may have folded entities committed after the handle, which
+// transaction enrichment through the main store cannot resolve. A
+// transaction is admitted iff its row exists in the main reader (tx rows are
+// never deleted within a live ledger, so absence means exactly "committed
+// after the handle"); a log iff its id resolves through the index snapshot
+// to a sequence at or below mainSeq.
+//
+// ACCOUNTS get no predicate: main-store existence is NOT a horizon signal
+// there — a purged account legitimately lives on in the monotonic has-asset
+// and metadata indexes while absent from the V+M universe, and account
+// enrichment (scanAccount) renders absent accounts as address-only rows, so
+// index-only members are servable as-is.
+//
+// Returns nil for targets with no trimmable cross-store membership (callers
+// skip wrapping).
+func MainHorizonKeep(
+	target commonpb.QueryTarget,
+	handle dal.PebbleReader,
+	indexSnap dal.PebbleGetter,
+	ledgerName string,
+	mainSeq uint64,
+) func([]byte) (bool, error) {
+	switch target {
+	case commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS:
+		return func(e []byte) (bool, error) {
+			if len(e) != 8 {
+				return false, fmt.Errorf("horizon probe: transaction entity of unexpected length %d (want 8)", len(e))
+			}
+
+			return pebbleTxExists(handle, ledgerName, binary.BigEndian.Uint64(e))
+		}
+	case commonpb.QueryTarget_QUERY_TARGET_LOGS:
+		kb := dal.NewKeyBuilder()
+
+		return func(e []byte) (bool, error) {
+			if len(e) != 8 {
+				return false, fmt.Errorf("horizon probe: log entity of unexpected length %d (want 8)", len(e))
+			}
+
+			v, closer, err := indexSnap.Get(readstore.LedgerLogKey(kb, ledgerName, binary.BigEndian.Uint64(e)))
+			if err != nil {
+				return false, fmt.Errorf("horizon probe: resolving log id: %w", err)
+			}
+
+			defer func() { _ = closer.Close() }()
+
+			if len(v) != 8 {
+				return false, fmt.Errorf("horizon probe: log index value of unexpected length %d (want 8)", len(v))
+			}
+
+			return binary.BigEndian.Uint64(v) <= mainSeq, nil
+		}
+	default:
+		return nil
+	}
+}

--- a/internal/query/aligned_snapshot_test.go
+++ b/internal/query/aligned_snapshot_test.go
@@ -1,0 +1,154 @@
+package query_test
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func newTestReadStore(t *testing.T) *readstore.Store {
+	t.Helper()
+
+	rs, err := readstore.New(t.TempDir(), logging.NopZap(), readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rs.Close() })
+
+	return rs
+}
+
+func setReadStoreProgress(t *testing.T, rs *readstore.Store, seq uint64) {
+	t.Helper()
+
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteProgress(batch, seq))
+	require.NoError(t, batch.Commit())
+	rs.NotifyProgress()
+}
+
+// The alignment invariant: the returned snapshot's fold cursor covers the
+// main handle's last applied sequence, so index leaves can never lag the
+// main-store leaves of the same query (EN-1748).
+func TestAlignedIndexSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+	appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...) // sequences 1..3
+
+	rs := newTestReadStore(t)
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	lastSeq, err := query.ReadLastSequence(handle)
+	require.NoError(t, err)
+	require.Positive(t, lastSeq)
+
+	t.Run("behind then catches up", func(t *testing.T) {
+		setReadStoreProgress(t, rs, lastSeq-1)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Simulated fold catch-up while the query waits.
+			time.Sleep(20 * time.Millisecond)
+			setReadStoreProgress(t, rs, lastSeq)
+		}()
+
+		snap, mainSeq, err := query.AlignedIndexSnapshot(rs, handle)
+		require.NoError(t, err)
+		defer func() { _ = snap.Close() }()
+		<-done
+
+		require.Equal(t, lastSeq, mainSeq)
+
+		// The vouched cursor is readable through the snapshot itself.
+		got, err := rs.LastIndexedSequenceFrom(snap)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, got, mainSeq)
+	})
+
+	t.Run("already aligned", func(t *testing.T) {
+		setReadStoreProgress(t, rs, lastSeq+4)
+
+		snap, mainSeq, err := query.AlignedIndexSnapshot(rs, handle)
+		require.NoError(t, err)
+		defer func() { _ = snap.Close() }()
+
+		require.Equal(t, lastSeq, mainSeq)
+	})
+}
+
+func TestAlignedIndexSnapshot_TimesOutNotCaughtUp(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+	appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+	rs := newTestReadStore(t)
+	setReadStoreProgress(t, rs, 1) // permanently behind
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	lastSeq, err := query.ReadLastSequence(handle)
+	require.NoError(t, err)
+	require.Greater(t, lastSeq, uint64(1))
+
+	start := time.Now()
+	_, _, err = query.AlignedIndexSnapshot(rs, handle)
+
+	var notCaughtUp *query.ErrReadIndexNotCaughtUp
+	require.ErrorAs(t, err, &notCaughtUp)
+	require.Equal(t, lastSeq, notCaughtUp.Requested)
+	require.Equal(t, uint64(1), notCaughtUp.Current)
+	require.GreaterOrEqual(t, time.Since(start), time.Second, "the bounded wait ran before failing")
+}
+
+// A committed transaction whose index rows have not folded yet must be
+// admitted by the horizon (it exists in the main store); an id beyond the
+// handle must not.
+func TestMainHorizonKeep_Transactions(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+
+	rs := newTestReadStore(t)
+	setReadStoreProgress(t, rs, 5)
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	snap := rs.NewSnapshot()
+	defer func() { _ = snap.Close() }()
+
+	keep := query.MainHorizonKeep(commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, handle, snap, "l", 5)
+	require.NotNil(t, keep)
+
+	ok, err := keep(txIDBytesQ(1))
+	require.NoError(t, err)
+	require.False(t, ok, "no transaction rows in the main store at all")
+
+	_, err = keep([]byte("short"))
+	require.Error(t, err, "malformed entity is a loud error, never admitted")
+}
+
+func txIDBytesQ(id uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, id)
+
+	return b
+}

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -88,33 +88,32 @@ func Execute(
 		return nil, errors.New("AGGREGATE_VOLUMES mode is only valid for ACCOUNTS target queries")
 	}
 
-	// Check min_log_sequence freshness
-	if req.GetMinLogSequence() > 0 {
-		lastIndexed, err := rs.LastIndexedSequence()
-		if err != nil {
-			return nil, fmt.Errorf("reading index progress: %w", err)
-		}
-
-		if lastIndexed < req.GetMinLogSequence() {
-			return nil, &ErrReadIndexNotCaughtUp{
-				Requested: req.GetMinLogSequence(),
-				Current:   lastIndexed,
-			}
-		}
-	}
-
 	schema := SchemaFieldsForTarget(ledgerInfo.GetMetadataSchema(), pq.GetTarget())
 
-	// Take a Pebble snapshot for the read index for consistent reads.
-	indexSnap := rs.NewSnapshot()
-	defer func() { _ = indexSnap.Close() }()
-
-	// Always open a read handle — needed for filter compilation and entity enrichment.
+	// Always open a read handle — needed for filter compilation and entity
+	// enrichment. Opened BEFORE the index snapshot: alignment guarantees the
+	// snapshot's fold cursor covers everything the handle sees (EN-1748).
 	handle, err := pebbleStore.NewReadHandle()
 	if err != nil {
 		return nil, fmt.Errorf("creating read handle: %w", err)
 	}
 	defer func() { _ = handle.Close() }()
+
+	indexSnap, mainSeq, err := AlignedIndexSnapshot(rs, handle)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = indexSnap.Close() }()
+
+	// Check min_log_sequence freshness against the handle: alignment makes
+	// the index snapshot at least as fresh, so the handle's sequence is the
+	// response's consistent state.
+	if req.GetMinLogSequence() > 0 && mainSeq < req.GetMinLogSequence() {
+		return nil, &ErrReadIndexNotCaughtUp{
+			Requested: req.GetMinLogSequence(),
+			Current:   mainSeq,
+		}
+	}
 
 	kb := dal.NewKeyBuilder()
 
@@ -128,9 +127,16 @@ func Execute(
 	// partial results.
 	indexVersionFor := readstore.SnapshotVersionResolver(indexSnap, ledgerInfo.GetName())
 
-	iter, compileErr := Compile(indexSnap, kb, pq.GetFilter(), pq.GetTarget(), ledgerInfo.GetName(), req.GetParameters(), schema, ledgerInfo, indexRegistry, indexVersionFor, profile, handle)
+	compiled, compileErr := Compile(indexSnap, kb, pq.GetFilter(), pq.GetTarget(), ledgerInfo.GetName(), req.GetParameters(), schema, ledgerInfo, indexRegistry, indexVersionFor, profile, handle)
 	if compileErr != nil {
 		return nil, domain.WrapCompileError(compileErr)
+	}
+
+	// Trim to the handle's horizon: the aligned snapshot may hold entities
+	// committed after it, which the handle cannot enrich.
+	var iter = compiled
+	if keep := MainHorizonKeep(pq.GetTarget(), handle, indexSnap, ledgerInfo.GetName(), mainSeq); keep != nil {
+		iter = readstore.NewFilterIterator(compiled, keep)
 	}
 	defer iter.Close()
 

--- a/internal/storage/readstore/event_gc.go
+++ b/internal/storage/readstore/event_gc.go
@@ -1,0 +1,104 @@
+package readstore
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// GCMetadataEvents reclaims superseded events below the read-lease watermark
+// in one value range (design sketch, see event_keys.go and read_lease.go).
+//
+// The pruning rule per (value, entity) group: every event with seq <
+// watermark is droppable EXCEPT the latest one, and that one only survives if
+// it is an ADD. Justification: any live or future reader resolves at some
+// pin P >= watermark, and the latest event <= P is what decides —
+//
+//   - events superseded below the watermark can never be "latest <= P" again;
+//   - a surviving latest-below-watermark ADD still decides P's verdict when
+//     the group has no event in (watermark, P];
+//   - a latest-below-watermark DEL decides the same verdict as no event at
+//     all ("not matching"), so the whole dead pair is reclaimed.
+//
+// The sketch runs over a single value prefix per call; the production version
+// would walk the whole metadata event zone incrementally in the builder's
+// background-task budget.
+func GCMetadataEvents(db *pebble.DB, prefix []byte, watermark uint64) (pruned int, err error) {
+	iter, err := db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: IncrementBytes(prefix),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	batch := db.NewBatch()
+	defer func() { _ = batch.Close() }()
+
+	suffix := metadataEventSuffixLen + 1 // terminator + seq + op
+
+	var (
+		group        []byte // current entity
+		pendingBelow []byte // latest below-watermark key seen, not yet judged
+		pendingIsAdd bool
+	)
+
+	flush := func() {
+		// The group ended: the pending latest-below-watermark event survives
+		// only as a live ADD.
+		if pendingBelow != nil && !pendingIsAdd {
+			_ = batch.Delete(pendingBelow, nil)
+			pruned++
+		}
+		pendingBelow = nil
+	}
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := iter.Key()
+		rest := key[len(prefix):]
+		tpos := len(rest) - suffix
+		if tpos < 0 || rest[tpos] != metadataEventTerminator {
+			continue // malformed keys are the checker's business, not GC's
+		}
+
+		entity := rest[:tpos]
+		seq := binary.BigEndian.Uint64(rest[tpos+1 : tpos+9])
+		op := rest[tpos+9]
+
+		if !bytes.Equal(entity, group) {
+			flush()
+			group = append(group[:0], entity...)
+		}
+
+		if seq >= watermark {
+			// Above the watermark nothing is reclaimable, and the group's
+			// pending below-watermark event gets judged now: a pending ADD
+			// still decides pins in [watermark, seq) and survives; a pending
+			// DEL decides "dead", the same verdict as absence, and goes.
+			flush()
+
+			continue
+		}
+
+		// A newer below-watermark event supersedes the previous pending one.
+		if pendingBelow != nil {
+			_ = batch.Delete(pendingBelow, nil)
+			pruned++
+		}
+
+		pendingBelow = append(pendingBelow[:0], key...)
+		pendingIsAdd = op == MetadataEventAdd
+	}
+
+	flush()
+
+	if pruned > 0 {
+		if err := batch.Commit(pebble.NoSync); err != nil {
+			return 0, err
+		}
+	}
+
+	return pruned, nil
+}

--- a/internal/storage/readstore/event_gc_test.go
+++ b/internal/storage/readstore/event_gc_test.go
@@ -1,0 +1,50 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The pruning rule: below the watermark, only a group's latest event may
+// survive, and only as an ADD. Resolution at any pin >= watermark must be
+// identical before and after.
+func TestGCMetadataEvents(t *testing.T) {
+	t.Parallel()
+
+	s, prefix := eventFixture(t, "v",
+		ev{"dead", 10, MetadataEventAdd}, // add@10 del@20: whole pair reclaimed
+		ev{"dead", 20, MetadataEventDel},
+		ev{"live", 10, MetadataEventAdd}, // superseded by re-add
+		ev{"live", 20, MetadataEventDel},
+		ev{"live", 25, MetadataEventAdd}, // latest below watermark, ADD: survives
+		ev{"old", 10, MetadataEventAdd},  // single old ADD: survives
+		ev{"span", 10, MetadataEventAdd}, // ADD below + DEL above: both survive
+		ev{"span", 40, MetadataEventDel},
+	)
+
+	const watermark = 30
+
+	before := map[uint64][]string{}
+	for _, pin := range []uint64{30, 35, 45} {
+		before[pin] = collect(t, s, prefix, pin)
+	}
+
+	pruned, err := GCMetadataEvents(s.DB(), prefix, watermark)
+	require.NoError(t, err)
+	require.Equal(t, 4, pruned, "dead's pair + live's superseded pair")
+
+	for _, pin := range []uint64{30, 35, 45} {
+		require.Equal(t, before[pin], collect(t, s, prefix, pin), "pin %d verdicts unchanged", pin)
+	}
+
+	// The survivors are exactly: live@25(ADD), old@10(ADD), span@10(ADD), span@40(DEL).
+	remaining := 0
+	it, err := s.DB().NewIter(nil)
+	require.NoError(t, err)
+	defer func() { _ = it.Close() }()
+	for it.First(); it.Valid(); it.Next() {
+		remaining++
+	}
+	require.Equal(t, 4, remaining)
+}

--- a/internal/storage/readstore/event_keys.go
+++ b/internal/storage/readstore/event_keys.go
@@ -1,0 +1,98 @@
+package readstore
+
+import (
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// Event-suffixed metadata index keys — design sketch for EN-1748.
+//
+// Today a metadata index row is [prefix][encodedValue][entity], mutated in
+// place: an update deletes the old value's row and writes the new one, so a
+// snapshot only ever shows "current" membership and a reader pinned at an
+// older applied index cannot reconstruct the membership it needs.
+//
+// The sketch makes the index APPEND-ONLY: every mutation appends an event key
+//
+//	[prefix][encodedValue][entity]\x00[raftSeq BE 8][op 1]
+//
+// where op is ADD or DEL. Two invariants make reads exact at any pinned
+// sequence P:
+//
+//  1. Every transition AWAY from a value deposits a DEL event in THAT value's
+//     own key range. The question "does entity E match value V at P?" is
+//     answered entirely inside (V, E)'s event group — the latest event with
+//     seq <= P decides (ADD: yes; DEL or none: no). Ranges never consult each
+//     other, so iteration stays a plain ordered scan.
+//  2. Events are immutable once written. A reader that pinned P before a later
+//     event was appended simply ignores it (seq > P); a background GC reclaims
+//     superseded events only below the read-lease watermark (see read_lease.go
+//     and event_gc.go).
+//
+// The \x00 terminator after the entity is load-bearing: entities are
+// variable-length, and without a terminator the seq bytes of entity "a" would
+// interleave with the events of entity "ab". Entity IDs cannot contain NUL
+// (account addresses are [a-zA-Z0-9:_-]+; transaction ids are their fixed
+// 8-byte encoding, terminated uniformly for one parse rule).
+const (
+	// MetadataEventDel orders before MetadataEventAdd so that an ADD and a
+	// DEL carrying the same sequence (impossible today — one log cannot both
+	// add and remove the same (value, entity) — but cheap to make total)
+	// resolve to ADD.
+	MetadataEventDel byte = 0x00
+	MetadataEventAdd byte = 0x01
+
+	// metadataEventSuffixLen is the fixed tail after the entity terminator:
+	// 8 bytes of big-endian raft sequence plus the op byte.
+	metadataEventSuffixLen = 9
+
+	// metadataEventTerminator separates the variable-length entity from the
+	// fixed event suffix.
+	metadataEventTerminator byte = 0x00
+)
+
+// MetadataIndexEventKeyV builds one event key. Layout mirrors
+// MetadataIndexKeyV with the entity terminated and the (seq, op) suffix
+// appended.
+func MetadataIndexEventKeyV(
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	ns, metadataKey string,
+	version uint32,
+	encodedValue []byte,
+	entityID []byte,
+	seq uint64,
+	op byte,
+) []byte {
+	return kb.Reset().
+		PutByte(PrefixMetadataIndex).
+		PutLedgerNameFixed(ledgerName).
+		PutNamespace(ns).
+		PutStringNull(metadataKey).
+		PutUint32(version).
+		PutBytes(encodedValue).
+		PutBytes(entityID).
+		PutByte(metadataEventTerminator).
+		PutUint64(seq).
+		PutByte(op).
+		Consume()
+}
+
+// MetadataIndexEventValuePrefixV is the scan prefix covering every event of
+// one (metadata key, encoded value) pair — the range an equality condition
+// resolves at a pinned sequence (see EventResolveIterator).
+func MetadataIndexEventValuePrefixV(
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	ns, metadataKey string,
+	version uint32,
+	encodedValue []byte,
+) []byte {
+	return kb.Reset().
+		PutByte(PrefixMetadataIndex).
+		PutLedgerNameFixed(ledgerName).
+		PutNamespace(ns).
+		PutStringNull(metadataKey).
+		PutUint32(version).
+		PutBytes(encodedValue).
+		Consume()
+}

--- a/internal/storage/readstore/iterator_event_resolve.go
+++ b/internal/storage/readstore/iterator_event_resolve.go
@@ -1,0 +1,166 @@
+package readstore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// EventResolveIterator reads one (metadata key, encoded value) event range at
+// a pinned raft sequence, yielding — in entity order — every entity whose
+// latest event at or below the pin is an ADD (design sketch, see
+// event_keys.go).
+//
+// Events of one (value, entity) group are key-adjacent and seq-ascending, so
+// resolution is a single forward pass: within a group, the last event with
+// seq <= pin decides; events above the pin are invisible to this reader by
+// construction. Dead groups (DEL or nothing at the pin) are skipped whole.
+//
+// The absolute SeekGE contract (iterator-seek-contract.md) holds: a seek
+// positions at the first event key of the first group whose entity >= target
+// and resolves forward. The seekFloor exhaustion cache is deliberately
+// omitted from the sketch.
+type EventResolveIterator struct {
+	iter   *pebble.Iterator
+	prefix []byte // through the encoded value
+	pin    uint64
+
+	current   []byte
+	started   bool
+	exhausted bool
+	err       error
+}
+
+// NewEventResolveIterator scans the event range under prefix (built by
+// MetadataIndexEventValuePrefixV) as of pin.
+func NewEventResolveIterator(reader dal.PebbleReader, prefix []byte, pin uint64) (*EventResolveIterator, error) {
+	iter, err := reader.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: IncrementBytes(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventResolveIterator{iter: iter, prefix: prefix, pin: pin}, nil
+}
+
+// parse splits an event key into (entity, seq, op). The terminator position
+// is unambiguous from the right because entities cannot contain NUL.
+func (it *EventResolveIterator) parse(key []byte) (entity []byte, seq uint64, op byte, ok bool) {
+	rest := key[len(it.prefix):]
+	tpos := len(rest) - metadataEventSuffixLen - 1
+	if tpos < 0 || rest[tpos] != metadataEventTerminator {
+		return nil, 0, 0, false
+	}
+
+	return rest[:tpos], binary.BigEndian.Uint64(rest[tpos+1 : tpos+9]), rest[tpos+9], true
+}
+
+// settle resolves consecutive groups starting at the raw iterator's current
+// position until one is live at the pin, leaving the raw iterator at the
+// following group.
+func (it *EventResolveIterator) settle() bool {
+	for it.iter.Valid() {
+		entity, _, _, ok := it.parse(it.iter.Key())
+		if !ok {
+			it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
+
+			return false
+		}
+
+		group := append([]byte(nil), entity...)
+		live := false
+
+		for it.iter.Valid() {
+			e, seq, op, ok := it.parse(it.iter.Key())
+			if !ok {
+				it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
+
+				return false
+			}
+
+			if !bytes.Equal(e, group) {
+				break
+			}
+
+			// Events are seq-ascending within the group, so this keeps the
+			// verdict of the LATEST event at or below the pin.
+			if seq <= it.pin {
+				live = op == MetadataEventAdd
+			}
+
+			if !it.iter.Next() {
+				break
+			}
+		}
+
+		if live {
+			it.current = group
+
+			return true
+		}
+	}
+
+	it.exhausted = true
+
+	return false
+}
+
+func (it *EventResolveIterator) Next() bool {
+	if it.err != nil || it.exhausted {
+		return false
+	}
+
+	if !it.started {
+		it.started = true
+		if !it.iter.First() {
+			it.exhausted = true
+
+			return false
+		}
+	}
+
+	// After a successful settle the raw iterator already rests on the next
+	// group's first key.
+	return it.settle()
+}
+
+func (it *EventResolveIterator) Current() []byte { return it.current }
+
+func (it *EventResolveIterator) SeekGE(target []byte) bool {
+	if it.err != nil {
+		return false
+	}
+
+	it.exhausted = false
+	it.started = true
+
+	seekKey := make([]byte, 0, len(it.prefix)+len(target))
+	seekKey = append(seekKey, it.prefix...)
+	seekKey = append(seekKey, target...)
+
+	if !it.iter.SeekGE(seekKey) {
+		it.exhausted = true
+
+		return false
+	}
+
+	return it.settle()
+}
+
+func (it *EventResolveIterator) Err() error {
+	if it.err != nil {
+		return it.err
+	}
+
+	return it.iter.Error()
+}
+
+func (it *EventResolveIterator) Close() {
+	_ = it.iter.Close()
+}

--- a/internal/storage/readstore/iterator_event_resolve_test.go
+++ b/internal/storage/readstore/iterator_event_resolve_test.go
@@ -1,0 +1,132 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func eventFixture(t *testing.T, value string, events ...struct {
+	entity string
+	seq    uint64
+	op     byte
+}) (*Store, []byte) {
+	t.Helper()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	for _, e := range events {
+		key := MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, []byte(value), []byte(e.entity), e.seq, e.op)
+		require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
+	}
+
+	return s, MetadataIndexEventValuePrefixV(dal.NewKeyBuilder(), "l", NamespaceAccount, "k", 1, []byte(value))
+}
+
+type ev = struct {
+	entity string
+	seq    uint64
+	op     byte
+}
+
+func collect(t *testing.T, s *Store, prefix []byte, pin uint64) []string {
+	t.Helper()
+
+	it, err := NewEventResolveIterator(s.DB(), prefix, pin)
+	require.NoError(t, err)
+	defer it.Close()
+
+	var out []string
+	for it.Next() {
+		out = append(out, string(it.Current()))
+	}
+
+	require.NoError(t, it.Err())
+
+	return out
+}
+
+// The worked example from the design: E gets red@10, transitions to blue@25
+// (ADD in blue's range + DEL in red's range), and is unset@40. Each pin
+// resolves entirely inside one value's range.
+func TestEventResolveIterator_TransitionTimeline(t *testing.T) {
+	t.Parallel()
+
+	s, redPrefix := eventFixture(t, "red",
+		ev{"E", 10, MetadataEventAdd},
+		ev{"E", 25, MetadataEventDel},
+	)
+
+	kb := dal.NewKeyBuilder()
+	require.NoError(t, s.DB().Set(MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, []byte("blue"), []byte("E"), 25, MetadataEventAdd), nil, pebble.NoSync))
+	require.NoError(t, s.DB().Set(MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, []byte("blue"), []byte("E"), 40, MetadataEventDel), nil, pebble.NoSync))
+	bluePrefix := MetadataIndexEventValuePrefixV(dal.NewKeyBuilder(), "l", NamespaceAccount, "k", 1, []byte("blue"))
+
+	require.Empty(t, collect(t, s, redPrefix, 5), "before the first ADD")
+	require.Equal(t, []string{"E"}, collect(t, s, redPrefix, 15), "red between 10 and 25")
+	require.Empty(t, collect(t, s, redPrefix, 30), "red tombstoned at 25")
+	require.Equal(t, []string{"E"}, collect(t, s, bluePrefix, 30), "blue between 25 and 40")
+	require.Empty(t, collect(t, s, bluePrefix, 45), "blue unset at 40")
+}
+
+// A value that comes back: the group holds two intervals and each pin lands
+// in the right one.
+func TestEventResolveIterator_ReAddHistory(t *testing.T) {
+	t.Parallel()
+
+	s, prefix := eventFixture(t, "v",
+		ev{"E", 10, MetadataEventAdd},
+		ev{"E", 20, MetadataEventDel},
+		ev{"E", 30, MetadataEventAdd},
+	)
+
+	require.Equal(t, []string{"E"}, collect(t, s, prefix, 15))
+	require.Empty(t, collect(t, s, prefix, 25))
+	require.Equal(t, []string{"E"}, collect(t, s, prefix, 35))
+}
+
+// Prefix-nested entity names must form disjoint groups — the NUL terminator
+// keeps "a"'s seq bytes from interleaving with "ab"'s events.
+func TestEventResolveIterator_PrefixNestedEntities(t *testing.T) {
+	t.Parallel()
+
+	s, prefix := eventFixture(t, "v",
+		ev{"a", 10, MetadataEventAdd},
+		ev{"ab", 10, MetadataEventAdd},
+		ev{"ab", 20, MetadataEventDel},
+	)
+
+	require.Equal(t, []string{"a", "ab"}, collect(t, s, prefix, 15))
+	require.Equal(t, []string{"a"}, collect(t, s, prefix, 25), "ab's group resolves dead without touching a's")
+}
+
+// Absolute-seek contract: repeatable, backward after exhaustion, and dead
+// groups are skipped on the way.
+func TestEventResolveIterator_SeekContract(t *testing.T) {
+	t.Parallel()
+
+	s, prefix := eventFixture(t, "v",
+		ev{"a:1", 10, MetadataEventAdd},
+		ev{"a:2", 10, MetadataEventAdd},
+		ev{"a:2", 20, MetadataEventDel},
+		ev{"a:3", 10, MetadataEventAdd},
+	)
+
+	it, err := NewEventResolveIterator(s.DB(), prefix, 25)
+	require.NoError(t, err)
+	defer it.Close()
+
+	require.True(t, it.SeekGE([]byte("a:2")), "lands on the first LIVE entity >= target")
+	require.Equal(t, "a:3", string(it.Current()), "a:2 is dead at pin 25")
+	require.True(t, it.SeekGE([]byte("a:2")), "repeatable")
+	require.Equal(t, "a:3", string(it.Current()))
+	require.False(t, it.Next())
+
+	require.True(t, it.SeekGE([]byte("a:0")), "backward after exhaustion")
+	require.Equal(t, "a:1", string(it.Current()))
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_filter.go
+++ b/internal/storage/readstore/iterator_filter.go
@@ -1,0 +1,130 @@
+package readstore
+
+// FilterIterator yields the entities of inner admitted by keep. Positioning
+// preserves the absolute SeekGE contract (see iterator-seek-contract.md):
+// every operation delegates to inner and then skips forward over rejected
+// entities, so a seek lands on the first ADMITTED entity >= target and
+// repeated or backward seeks reposition like the inner iterator does.
+//
+// keep may fail (it typically probes another store); a failure latches like a
+// storage error — iteration stops and the error surfaces through Err, matching
+// the EntityIterator contract's sticky-error convention.
+type FilterIterator struct {
+	inner EntityIterator
+	keep  func(entity []byte) (bool, error)
+	err   error
+}
+
+// NewFilterIterator wraps inner so only entities admitted by keep surface.
+func NewFilterIterator(inner EntityIterator, keep func(entity []byte) (bool, error)) *FilterIterator {
+	return &FilterIterator{inner: inner, keep: keep}
+}
+
+// settle advances inner until it rests on an admitted entity. ok is the
+// result of the positioning call that preceded it.
+func (it *FilterIterator) settle(ok bool) bool {
+	for ok {
+		admit, err := it.keep(it.inner.Current())
+		if err != nil {
+			it.err = err
+
+			return false
+		}
+
+		if admit {
+			return true
+		}
+
+		ok = it.inner.Next()
+	}
+
+	return false
+}
+
+func (it *FilterIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	return it.settle(it.inner.Next())
+}
+
+func (it *FilterIterator) SeekGE(target []byte) bool {
+	if it.err != nil {
+		return false
+	}
+
+	return it.settle(it.inner.SeekGE(target))
+}
+
+func (it *FilterIterator) Current() []byte { return it.inner.Current() }
+
+func (it *FilterIterator) Err() error {
+	if it.err != nil {
+		return it.err
+	}
+
+	return it.inner.Err()
+}
+
+func (it *FilterIterator) Close() { it.inner.Close() }
+
+// FilterReverseIterator is the descending counterpart of FilterIterator: it
+// yields the entities of inner admitted by keep, with the same absolute-seek
+// and sticky-error conventions mirrored onto SeekLE.
+type FilterReverseIterator struct {
+	inner ReverseIterator
+	keep  func(entity []byte) (bool, error)
+	err   error
+}
+
+// NewFilterReverseIterator wraps inner so only entities admitted by keep
+// surface.
+func NewFilterReverseIterator(inner ReverseIterator, keep func(entity []byte) (bool, error)) *FilterReverseIterator {
+	return &FilterReverseIterator{inner: inner, keep: keep}
+}
+
+func (it *FilterReverseIterator) settle(ok bool) bool {
+	for ok {
+		admit, err := it.keep(it.inner.Current())
+		if err != nil {
+			it.err = err
+
+			return false
+		}
+
+		if admit {
+			return true
+		}
+
+		ok = it.inner.Next()
+	}
+
+	return false
+}
+
+func (it *FilterReverseIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	return it.settle(it.inner.Next())
+}
+
+func (it *FilterReverseIterator) SeekLE(target []byte) bool {
+	if it.err != nil {
+		return false
+	}
+
+	return it.settle(it.inner.SeekLE(target))
+}
+
+func (it *FilterReverseIterator) Current() []byte { return it.inner.Current() }
+
+func (it *FilterReverseIterator) Err() error {
+	if it.err != nil {
+		return it.err
+	}
+
+	return it.inner.Err()
+}

--- a/internal/storage/readstore/iterator_filter_test.go
+++ b/internal/storage/readstore/iterator_filter_test.go
@@ -1,0 +1,61 @@
+package readstore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The filter must skip rejected entities on both Next and SeekGE while
+// preserving the absolute-seek contract: a seek lands on the first ADMITTED
+// entity >= target, repeatably, including after exhaustion.
+func TestFilterIterator_SkipsAndKeepsSeekContract(t *testing.T) {
+	t.Parallel()
+
+	keepEven := func(e []byte) (bool, error) {
+		return (e[0]-'a')%2 == 0, nil // admits a, c, e
+	}
+
+	it := NewFilterIterator(newAliasingIter("a", "b", "c", "d", "e"), keepEven)
+	defer it.Close()
+
+	var got []string
+	for it.Next() {
+		got = append(got, string(it.Current()))
+	}
+	require.Equal(t, []string{"a", "c", "e"}, got)
+	require.NoError(t, it.Err())
+
+	require.True(t, it.SeekGE([]byte("b")), "seek lands on the first admitted entity >= target")
+	require.Equal(t, "c", string(it.Current()))
+	require.True(t, it.SeekGE([]byte("b")), "repeated seek is non-consuming")
+	require.Equal(t, "c", string(it.Current()))
+
+	require.True(t, it.SeekGE([]byte("a")), "backward seek after exhaustion")
+	require.Equal(t, "a", string(it.Current()))
+
+	require.False(t, it.SeekGE([]byte("f")), "nothing admitted at or beyond target")
+	require.NoError(t, it.Err())
+}
+
+func TestFilterIterator_KeepErrorLatches(t *testing.T) {
+	t.Parallel()
+
+	probeErr := errors.New("probe failed")
+	it := NewFilterIterator(newAliasingIter("a", "b"), func(e []byte) (bool, error) {
+		if string(e) == "b" {
+			return false, probeErr
+		}
+
+		return true, nil
+	})
+	defer it.Close()
+
+	require.True(t, it.Next())
+	require.Equal(t, "a", string(it.Current()))
+	require.False(t, it.Next(), "keep error stops iteration")
+	require.ErrorIs(t, it.Err(), probeErr)
+	require.False(t, it.SeekGE([]byte("a")), "error is sticky, like a storage error")
+	require.ErrorIs(t, it.Err(), probeErr)
+}

--- a/internal/storage/readstore/read_lease.go
+++ b/internal/storage/readstore/read_lease.go
@@ -1,0 +1,67 @@
+package readstore
+
+import "sync"
+
+// LeaseRegistry tracks the pinned sequences of live reads so the event GC
+// (event_gc.go) never reclaims an event a pinned reader could still resolve
+// (design sketch, see event_keys.go).
+//
+// A read registers its pinned sequence when it acquires its snapshots and
+// releases on completion — for streaming reads, the lease must live as long
+// as the cursor, not the handler call. The GC watermark is the minimum pinned
+// sequence across live leases; with none, every fold-complete sequence is
+// reclaimable.
+type LeaseRegistry struct {
+	mu     sync.Mutex
+	nextID uint64
+	leases map[uint64]uint64 // lease id -> pinned sequence
+}
+
+func NewLeaseRegistry() *LeaseRegistry {
+	return &LeaseRegistry{leases: map[uint64]uint64{}}
+}
+
+// Lease is one live read's pin. Release is idempotent.
+type Lease struct {
+	r    *LeaseRegistry
+	id   uint64
+	once sync.Once
+}
+
+// Acquire registers a read pinned at seq.
+func (r *LeaseRegistry) Acquire(seq uint64) *Lease {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.nextID++
+	r.leases[r.nextID] = seq
+
+	return &Lease{r: r, id: r.nextID}
+}
+
+func (l *Lease) Release() {
+	l.once.Do(func() {
+		l.r.mu.Lock()
+		delete(l.r.leases, l.id)
+		l.r.mu.Unlock()
+	})
+}
+
+// Watermark returns the lowest pinned sequence across live leases; ok=false
+// means no read is live and the caller may use its fold cursor instead.
+func (r *LeaseRegistry) Watermark() (uint64, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	found := false
+
+	var lowest uint64
+	for _, seq := range r.leases {
+		if !found || seq < lowest {
+			lowest = seq
+			found = true
+		}
+	}
+
+	return lowest, found
+}

--- a/internal/storage/readstore/read_lease_test.go
+++ b/internal/storage/readstore/read_lease_test.go
@@ -1,0 +1,34 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseRegistry(t *testing.T) {
+	t.Parallel()
+
+	r := NewLeaseRegistry()
+
+	_, ok := r.Watermark()
+	require.False(t, ok, "no live reads: caller may reclaim up to its fold cursor")
+
+	a := r.Acquire(10)
+	b := r.Acquire(25)
+
+	w, ok := r.Watermark()
+	require.True(t, ok)
+	require.Equal(t, uint64(10), w)
+
+	a.Release()
+	a.Release() // idempotent
+
+	w, ok = r.Watermark()
+	require.True(t, ok)
+	require.Equal(t, uint64(25), w)
+
+	b.Release()
+	_, ok = r.Watermark()
+	require.False(t, ok)
+}

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -54,7 +54,16 @@ type Store struct {
 	// NotifyProgress after each WriteProgress to wake up waiters.
 	progressMu   sync.Mutex
 	progressCond *sync.Cond
+
+	// readOnly marks a store opened via OpenReadOnly — a frozen view (query
+	// checkpoint) whose fold cursor will never advance, so freshness waits
+	// are meaningless against it.
+	readOnly bool
 }
+
+// Frozen reports whether this store is an immutable read-only view (a query
+// checkpoint) rather than the live, builder-fed read index.
+func (s *Store) Frozen() bool { return s.readOnly }
 
 // New opens or creates a Pebble database at the given directory for the read index.
 func New(dir string, logger logging.Logger, cfg Config) (*Store, error) {
@@ -148,9 +157,10 @@ func OpenReadOnly(dirPath string, logger logging.Logger) (*Store, error) {
 	}
 
 	s := &Store{
-		db:     db,
-		logger: logger.WithFields(map[string]any{"cmp": "read-store-readonly"}),
-		dir:    dirPath,
+		db:       db,
+		logger:   logger.WithFields(map[string]any{"cmp": "read-store-readonly"}),
+		dir:      dirPath,
+		readOnly: true,
 	}
 	s.progressCond = sync.NewCond(&s.progressMu)
 

--- a/internal/storage/readstore/write_batch_events.go
+++ b/internal/storage/readstore/write_batch_events.go
@@ -1,0 +1,59 @@
+package readstore
+
+import (
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// Write side of the event-suffixed metadata index (design sketch — see
+// event_keys.go). The builder folds one log at a time and knows the log's
+// raft sequence; every index mutation becomes one or two APPENDS, never a
+// delete:
+//
+//	set   k=v   (fresh)   → ADD in v's range
+//	set   k=v2  (was v1)  → ADD in v2's range + DEL in v1's range
+//	unset k     (was v1)  → DEL in v1's range
+//
+// The old value still comes from the reverse map, exactly like today's
+// delete-old-forward-key path — the rmap keeps its role and its prompt
+// deletion semantics (the checker's reverse-map pass is untouched).
+
+// AppendMetadataIndexEvent appends a single ADD or DEL event.
+func (wb *WriteBatch) AppendMetadataIndexEvent(
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	ns, metadataKey string,
+	version uint32,
+	encodedValue []byte,
+	entityID []byte,
+	seq uint64,
+	op byte,
+) error {
+	return wb.put(MetadataIndexEventKeyV(kb, ledgerName, ns, metadataKey, version, encodedValue, entityID, seq, op), nil)
+}
+
+// ReplaceMetadataIndexEvents is the update shape: tombstone the old value's
+// range and add to the new one, in the same fold batch — atomic under any
+// snapshot. oldEncoded nil means a fresh set (no tombstone); newEncoded nil
+// means an unset (no add). Costs the same number of writes as today's
+// delete-then-put.
+func (wb *WriteBatch) ReplaceMetadataIndexEvents(
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	ns, metadataKey string,
+	version uint32,
+	oldEncoded, newEncoded []byte,
+	entityID []byte,
+	seq uint64,
+) error {
+	if oldEncoded != nil {
+		if err := wb.AppendMetadataIndexEvent(kb, ledgerName, ns, metadataKey, version, oldEncoded, entityID, seq, MetadataEventDel); err != nil {
+			return err
+		}
+	}
+
+	if newEncoded != nil {
+		return wb.AppendMetadataIndexEvent(kb, ledgerName, ns, metadataKey, version, newEncoded, entityID, seq, MetadataEventAdd)
+	}
+
+	return nil
+}

--- a/tests/e2e/business/cross_store_snapshot_alignment_test.go
+++ b/tests/e2e/business/cross_store_snapshot_alignment_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package business
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Cross-store snapshot alignment (EN-1748): a transaction visible in the
+// main store whose index rows have not folded yet must never surface through
+// an index complement. not(ts[_,_]) over a READY TIMESTAMP index is the
+// sharpest probe — any transaction it returns claims "committed but absent
+// from the timestamp index", a state no aligned snapshot pair can produce.
+// The index builder is kept busy with create/drop backfill churn to stretch
+// the fold lag that made the unaligned snapshots observable.
+var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
+	const (
+		ledgerName = "cross-store-alignment-ledger"
+		seedTxs    = 1500
+	)
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)))
+		Expect(err).To(Succeed())
+
+		for i := 0; i < seedTxs; i++ {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", fmt.Sprintf("acc:%d", i%64), big.NewInt(1), "USD"),
+			}, nil, nil)))
+			Expect(err).To(Succeed())
+		}
+
+		Expect(actions.WaitForBuiltinIndexReady(sharedCtx, sharedClient, ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)).To(Succeed())
+	})
+
+	It("never surfaces a committed tx as missing from a READY index", func() {
+		stopChurn := make(chan struct{})
+
+		var churn sync.WaitGroup
+
+		// Backfill churn: create/drop cycles over a second builtin index force
+		// the builder to rescan the seeded history over and over, delaying its
+		// live fold — the condition that widens the cross-store window.
+		churn.Add(1)
+		go func() {
+			defer GinkgoRecover()
+			defer churn.Done()
+
+			for {
+				select {
+				case <-stopChurn:
+					return
+				default:
+				}
+
+				_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)))
+				Expect(err).To(Succeed())
+				_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.DropBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)))
+				Expect(err).To(Succeed())
+			}
+		}()
+
+		notTs := actions.NotFilter(actions.BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 0, ^uint64(0)))
+		deadline := time.Now().Add(30 * time.Second)
+
+		i := 0
+		for time.Now().Before(deadline) {
+			i++
+
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", fmt.Sprintf("live:%d", i%64), big.NewInt(1), "USD"),
+			}, nil, nil)))
+			Expect(err).To(Succeed())
+
+			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, notTs)
+			if err != nil {
+				// A stalled builder legitimately rejects with the
+				// not-caught-up precondition; only phantom ROWS are the bug.
+				continue
+			}
+
+			Expect(txs).To(BeEmpty(), "iteration %d: a committed tx surfaced as missing from the READY timestamp index", i)
+		}
+
+		close(stopChurn)
+		churn.Wait()
+	})
+})

--- a/tests/e2e/business/cross_store_snapshot_alignment_test.go
+++ b/tests/e2e/business/cross_store_snapshot_alignment_test.go
@@ -20,81 +20,106 @@ import (
 // an index complement. not(ts[_,_]) over a READY TIMESTAMP index is the
 // sharpest probe — any transaction it returns claims "committed but absent
 // from the timestamp index", a state no aligned snapshot pair can produce.
-// The index builder is kept busy with create/drop backfill churn to stretch
-// the fold lag that made the unaligned snapshots observable.
+//
+// The fold is made to lag by throughput asymmetry, with no artificial hooks:
+// many live indexes multiply the fold cost of every log while apply cost
+// stays flat, so sustained apply pressure drives the read-store fold hundreds
+// of sequences behind the primary head — the natural condition (load, faults,
+// backfill storms) under which unaligned snapshots serve torn responses.
 var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
-	const (
-		ledgerName = "cross-store-alignment-ledger"
-		seedTxs    = 1500
-	)
+	const ledgerName = "cross-store-alignment-ledger"
 
 	BeforeAll(func() {
-		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerWithSchemaAction(ledgerName, nil, []*commonpb.SetMetadataFieldTypeCommand{
+			{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: "tier", Type: commonpb.MetadataType_METADATA_TYPE_STRING},
+		})))
 		Expect(err).To(Succeed())
 
-		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)))
-		Expect(err).To(Succeed())
-
-		for i := 0; i < seedTxs; i++ {
-			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("world", fmt.Sprintf("acc:%d", i%64), big.NewInt(1), "USD"),
-			}, nil, nil)))
+		// Fold cost per log is multiplicative in the live index count.
+		for _, req := range []*servicepb.Request{
+			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP),
+			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT),
+			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS),
+			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS),
+			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS),
+			actions.CreateAccountMetadataIndexAction(ledgerName, "tier"),
+			actions.CreateAccountAssetIndexAction(ledgerName),
+		} {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", req))
 			Expect(err).To(Succeed())
 		}
-
 		Expect(actions.WaitForBuiltinIndexReady(sharedCtx, sharedClient, ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)).To(Succeed())
 	})
 
 	It("never surfaces a committed tx as missing from a READY index", func() {
-		stopChurn := make(chan struct{})
+		stop := make(chan struct{})
 
-		var churn sync.WaitGroup
+		var pressure sync.WaitGroup
 
-		// Backfill churn: create/drop cycles over a second builtin index force
-		// the builder to rescan the seeded history over and over, delaying its
-		// live fold — the condition that widens the cross-store window.
-		churn.Add(1)
-		go func() {
-			defer GinkgoRecover()
-			defer churn.Done()
+		for w := 0; w < 4; w++ {
+			pressure.Add(1)
+			go func(w int) {
+				defer GinkgoRecover()
+				defer pressure.Done()
 
-			for {
-				select {
-				case <-stopChurn:
-					return
-				default:
+				n := 0
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+
+					reqs := make([]*servicepb.Request, 0, 20)
+					for j := 0; j < 20; j++ {
+						n++
+						a := fmt.Sprintf("load:%d:%d:a", w, n%128)
+						b := fmt.Sprintf("load:%d:%d:b", w, n%128)
+						reqs = append(reqs, actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+							actions.NewPosting("world", a, big.NewInt(1), "COIN"),
+							actions.NewPosting("world", b, big.NewInt(1), "EUR"),
+							actions.NewPosting("world", a, big.NewInt(1), "USD/2"),
+						}, nil, map[string]*commonpb.MetadataMap{
+							a: {Values: map[string]*commonpb.MetadataValue{"tier": commonpb.NewStringValue("gold")}},
+							b: {Values: map[string]*commonpb.MetadataValue{"tier": commonpb.NewStringValue("silver")}},
+						}))
+					}
+					if _, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", reqs...)); err != nil {
+						return
+					}
 				}
-
-				_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)))
-				Expect(err).To(Succeed())
-				_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.DropBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT)))
-				Expect(err).To(Succeed())
-			}
+			}(w)
+		}
+		defer func() {
+			close(stop)
+			pressure.Wait()
 		}()
 
 		notTs := actions.NotFilter(actions.BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 0, ^uint64(0)))
-		deadline := time.Now().Add(30 * time.Second)
+		deadline := time.Now().Add(25 * time.Second)
+		probes, served := 0, 0
 
-		i := 0
 		for time.Now().Before(deadline) {
-			i++
+			probes++
 
 			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("world", fmt.Sprintf("live:%d", i%64), big.NewInt(1), "USD"),
+				actions.NewPosting("world", fmt.Sprintf("probe:%d", probes%64), big.NewInt(1), "USD"),
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 
 			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0, notTs)
 			if err != nil {
-				// A stalled builder legitimately rejects with the
+				// A lagging fold legitimately rejects with the retryable
 				// not-caught-up precondition; only phantom ROWS are the bug.
 				continue
 			}
+			served++
 
-			Expect(txs).To(BeEmpty(), "iteration %d: a committed tx surfaced as missing from the READY timestamp index", i)
+			if len(txs) > 0 {
+				Fail(fmt.Sprintf("probe %d: not(ts[_,_]) returned %d row(s), first id=%d — a committed tx surfaced as missing from the READY timestamp index", probes, len(txs), txs[0].GetId()))
+			}
 		}
 
-		close(stopChurn)
-		churn.Wait()
+		Expect(served).To(BeNumerically(">", 0), "every probe was rejected — inconclusive")
 	})
 })


### PR DESCRIPTION
> [!IMPORTANT]
> **Design sketch, not an implementation.** Opened to collect thoughts on the versioned-readstore direction for [EN-1748](https://formance-team.atlassian.net/browse/EN-1748). The new components are unit-tested but deliberately **unwired** — no compile path, backfill, or rewrite machinery consumes them yet.

## The bug (EN-1748)

Filtered queries open one handle on the main store and one snapshot on the read store, with no guarantee the two observe the same applied index. Some filter leaves read the main store, index leaves read the read store, and enrichment reads the main store again — so a response can mix memberships that **no single committed state ever had**.

Concretely, both directions are reproducible in seconds under plain sustained load, no fault injection:

- **A query filtered on `tier=gold` returns an account whose own metadata reads `tier=silver`.** Selection runs on the read-index at its fold cursor; enrichment reads the main-store handle; a tier flip folded between the two makes the returned row contradict the very filter that selected it.
- The complement direction: `not(ts[_,_])` over a **READY** timestamp index returns committed transactions as "missing from the index" while the fold lags (caught repeatedly by the model driver in #1659; also inherited by the PIT draft's filtered selection, see [#1662 comment](https://github.com/formancehq/ledger/pull/1662#issuecomment-5205419265)).

The e2e test in the last commit covers the lag direction: red on `release/v3.0` (`probe 1: not(ts[_,_]) returned 100 row(s)`), green with the alignment commit. The `tier=gold`→`tier=silver` contradiction needs the event keys sketched below and therefore **stays red on this branch** — that test is kept off the branch so CI stays green, but it is the acceptance test for the wired implementation:

<details>
<summary><code>tier=gold</code> returning <code>tier=silver</code> — e2e reproduction (red until the event keys are wired)</summary>

```go
//go:build e2e

package business

import (
	"fmt"
	"math/big"
	"sync"
	"time"

	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
	"github.com/formancehq/ledger/v3/pkg/actions"
	. "github.com/onsi/ginkgo/v2"
	. "github.com/onsi/gomega"
)

// Cross-store value skew (EN-1748, metadata-flip half): a row selected by a
// metadata index filter must satisfy that filter in its own enriched
// metadata — no single-sequence snapshot can return an account for
// tier=gold whose metadata reads tier=silver.
//
// The read path selects from the read-index at the fold cursor but enriches
// from the main-store handle pinned at query start. The fold cursor is only
// bounded from BELOW (it must reach the handle's sequence), not from above,
// so a tier flip folded past the handle makes the index select an account
// whose enrichment still carries the pre-flip value. Sustained apply
// pressure with many live indexes keeps the fold in large catch-up batches,
// which lands the index snapshot well past the handle on nearly every query.
//
// Serving index reads from versioned events resolved at the handle's
// sequence closes the window; until then this test is expected red.
var _ = Describe("Cross-store value skew", Ordered, func() {
	const ledgerName = "cross-store-value-skew-ledger"

	BeforeAll(func() {
		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerWithSchemaAction(ledgerName, nil, []*commonpb.SetMetadataFieldTypeCommand{
			{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: "tier", Type: commonpb.MetadataType_METADATA_TYPE_STRING},
		})))
		Expect(err).To(Succeed())

		// Fold cost per log is multiplicative in the live index count.
		for _, req := range []*servicepb.Request{
			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP),
			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT),
			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ADDRESS),
			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_SOURCE_ADDRESS),
			actions.CreateBuiltinTxIndexAction(ledgerName, commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_DESTINATION_ADDRESS),
			actions.CreateAccountMetadataIndexAction(ledgerName, "tier"),
			actions.CreateAccountAssetIndexAction(ledgerName),
		} {
			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", req))
			Expect(err).To(Succeed())
		}
		Expect(actions.WaitForMetadataIndexReady(sharedCtx, sharedClient, ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier")).To(Succeed())
	})

	It("never returns a tier=gold row whose own metadata disagrees", func() {
		stop := make(chan struct{})

		var pressure sync.WaitGroup

		flip := [2]string{"gold", "silver"}

		for w := 0; w < 4; w++ {
			pressure.Add(1)
			go func(w int) {
				defer GinkgoRecover()
				defer pressure.Done()

				n := 0
				for {
					select {
					case <-stop:
						return
					default:
					}

					reqs := make([]*servicepb.Request, 0, 20)
					for j := 0; j < 20; j++ {
						n++
						// Each touch of an account lands one round (128 txs)
						// after the previous one, so the round-parity value
						// inverts the account's tier on every touch.
						a := fmt.Sprintf("load:%d:%d:a", w, n%128)
						b := fmt.Sprintf("load:%d:%d:b", w, n%128)
						round := n / 128
						reqs = append(reqs, actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
							actions.NewPosting("world", a, big.NewInt(1), "COIN"),
							actions.NewPosting("world", b, big.NewInt(1), "EUR"),
							actions.NewPosting("world", a, big.NewInt(1), "USD/2"),
						}, nil, map[string]*commonpb.MetadataMap{
							a: {Values: map[string]*commonpb.MetadataValue{"tier": commonpb.NewStringValue(flip[round%2])}},
							b: {Values: map[string]*commonpb.MetadataValue{"tier": commonpb.NewStringValue(flip[(round+1)%2])}},
						}))
					}
					if _, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", reqs...)); err != nil {
						return
					}
				}
			}(w)
		}
		defer func() {
			close(stop)
			pressure.Wait()
		}()

		gold := actions.StringMetadataFilter("tier", "gold")
		deadline := time.Now().Add(25 * time.Second)
		probes, served := 0, 0

		for time.Now().Before(deadline) {
			probes++

			accs, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", gold)
			if err != nil {
				// A lagging fold legitimately rejects with the retryable
				// not-caught-up precondition; only contradictory ROWS are
				// the bug.
				continue
			}
			served++

			for _, acc := range accs {
				if got := acc.GetMetadata()["tier"].GetStringValue(); got != "gold" {
					Fail(fmt.Sprintf("probe %d: tier=gold returned %s with tier=%q — index selection and enrichment disagree on one row", probes, acc.GetAddress(), got))
				}
			}
		}

		Expect(served).To(BeNumerically(">", 0), "every probe was rejected — inconclusive")
	})
})
```

Observed failure (this branch, alignment commit included):

```
[FAILED] probe 33: tier=gold returned load:0:61:b with tier="silver"
         — index selection and enrichment disagree on one row
```

</details>

## The direction sketched here

1. Read-store index keys carry the **raft sequence as a suffix**; mutations only ever **append**:

   ```
   [prefix][encodedValue][entity]\x00[raftSeq BE][op]      op ∈ {ADD, DEL}
   ```

2. A transition away from a value appends a **DEL event in the old value's own range** — so "does E match V at sequence P?" is answered entirely inside (V, E)'s adjacent event group: latest event ≤ P decides. Ranges never consult each other; iteration stays one ordered scan.

   ```
   seq 10:  set  k=red  on E   →  [red][E][10][ADD]
   seq 25:  set  k=blue on E   →  [blue][E][25][ADD] + [red][E][25][DEL]
   seq 40:  unset k     on E   →  [blue][E][40][DEL]

   pin 15 → red ✓        pin 30 → blue ✓ (red's own range says DEL@25)
   ```

3. A query takes the **main-store handle first**, keeps its applied index as the pin, waits (bounded, condvar — the existing `min_log_sequence` machinery re-anchored) for the read-store fold to reach it, then resolves index leaves at that pin. Events newer than the pin are invisible; events older are complete — selection and enrichment can no longer disagree.

4. A background job reclaims superseded events **below the watermark of live read leases**: within a group, only the latest below-watermark event may survive, and only as an ADD (a DEL decides the same verdict as absence). Verdicts at every admissible pin are provably unchanged — that's a test.

## What's in the diff

| Commit | Content |
|---|---|
| `fix(EN-1748): align read-index snapshots…` | The acquisition foundation (ordering + bounded wait + frozen-checkpoint exemption + horizon trim). Production-quality; included because "reconstruct at the handle's sequence" is meaningless without it. Under the full design its `MainHorizonKeep` trim is subsumed by the event pin. |
| `sketch(readstore): versioned event keys…` | `event_keys.go` (layout; the NUL entity terminator is load-bearing for variable-length entities), `write_batch_events.go` (append-only set/update/unset, rmap keeps its role and prompt deletion — the checker's reverse-map pass is untouched), `iterator_event_resolve.go` (group-resolve leaf honoring the absolute-seek contract), `read_lease.go` + `event_gc.go` (reader-pinned reclamation with the keep-latest-ADD rule). |
| `test(e2e): red-to-green load regression…` | The lag-direction reproduction: throughput asymmetry (7 live indexes multiply per-log fold cost) drives the fold behind, `not(ts[_,_])` probes for committed-but-"unindexed" transactions. Red on `release/v3.0` within seconds, green here. |

## Deliberately not here

- Wiring into `Compile`/leaf compilers, backfill stamping, and the schema-rewrite interplay.
- Add-only limbs (has-asset, address→tx, reverted_at): they need only the ADD stamp, no tombstones.
- Bulk destruction (`DropIndex`): fits the same model by **deferring** the range-delete past the read horizon (registry-at-pin gates compilation) instead of tombstoning row-by-row.
- GC pacing/scheduling, streaming-cursor lease lifetimes (must span the cursor, with a max-lease), and the write/space overhead measurement (an update is two appends vs. today's delete+put — same write count, but events linger until the watermark passes).

## Open questions for reviewers

1. Event-suffix keys vs. the current in-place format: any objection to paying the group-resolve step on every metadata leaf scan (group size is 1 in steady state, 2–3 transiently)?
2. Reader-registered GC vs. a fixed retention margin?
3. Should add-only limbs get the seq suffix in the same pass (uniform format) or lazily per-limb?
4. Interaction with #1662: the PIT filtered selection would ride the same pinned resolution; its view token could then record the selection sequence next to its watermarks.


[EN-1748]: https://formance-team.atlassian.net/browse/EN-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ