### PR TITLE
fix(check): bound the stored exclusion scan to the archived audit boundary

### DIFF
--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -213,6 +213,7 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	var (
 		hasArchivedChapters  bool
 		archiveEndSeq        uint64 // max close_sequence among archived chapters
+		archiveAuditEndSeq   uint64 // max close_audit_sequence among archived chapters
 		archiveLastAuditHash []byte // last_audit_hash from the latest archived chapter
 	)
 
@@ -231,6 +232,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			if p.GetCloseSequence() > archiveEndSeq {
 				archiveEndSeq = p.GetCloseSequence()
 				archiveLastAuditHash = p.GetLastAuditHash()
+			}
+
+			if p.GetCloseAuditSequence() > archiveAuditEndSeq {
+				archiveAuditEndSeq = p.GetCloseAuditSequence()
 			}
 		}
 	}
@@ -805,7 +810,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	// projection. Combined with the LedgerLog.PurgedVolumes already
 	// accumulated above, `stored` now represents the full per-ledger
 	// exclusion set the index builder will consume.
-	if err := c.collectStoredTransientVolumes(ctx, snap, addStored); err != nil {
+	//
+	// The scan starts strictly above the archived audit boundary, mirroring
+	// the replay loop's `seq <= archiveEndSeq` skip on the log side: the
+	// derived set only covers post-boundary history, and rows at or below the
+	// boundary can legitimately sit in hot storage — a restore re-ingests the
+	// backfilled archived ranges and never re-purges them, and out-of-order
+	// archiving leaves an un-archived chapter's rows below the max archived
+	// close — so comparing them against a replay that skipped their logs
+	// reports a healthy store as corrupt. Same trade-off as the log-side
+	// skip: retained sub-boundary rows go unverified.
+	if err := c.collectStoredTransientVolumes(ctx, snap, archiveAuditEndSeq, addStored); err != nil {
 		return fmt.Errorf("reading applied proposals for exclusion check: %w", err)
 	}
 
@@ -910,9 +925,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 func (c *Checker) collectStoredTransientVolumes(
 	ctx context.Context,
 	reader dal.PebbleReader,
+	archiveAuditEndSeq uint64,
 	addStored func(ledger, account, asset, color string),
 ) error {
-	proposals, err := query.ReadAppliedProposals(ctx, reader, nil)
+	// Proposals at or below the archived audit boundary are outside the
+	// replay's derivation window (see the call site) — start above it.
+	var afterSeq *uint64
+	if archiveAuditEndSeq > 0 {
+		afterSeq = &archiveAuditEndSeq
+	}
+
+	proposals, err := query.ReadAppliedProposals(ctx, reader, afterSeq)
 	if err != nil {
 		return fmt.Errorf("reading applied proposals: %w", err)
 	}

--- a/internal/application/check/checker_exclusion_archived_test.go
+++ b/internal/application/check/checker_exclusion_archived_test.go
@@ -1,0 +1,136 @@
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/proposalpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// writeAppliedProposal persists an AppliedProposal row at the given audit
+// sequence, byte-for-byte as the FSM (and a restore's raw segment ingest)
+// would store it.
+func writeAppliedProposal(t *testing.T, store *dal.Store, entry *proposalpb.AppliedProposal) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	key := dal.NewKeyBuilder().
+		PutZonePrefix(dal.ZoneCold, dal.SubColdAppliedProposal).
+		PutUint64(entry.GetSequence()).
+		Build()
+	require.NoError(t, batch.SetProto(key, entry))
+	require.NoError(t, batch.Commit())
+}
+
+func transientProposal(seq uint64, ledger, account, asset string) *proposalpb.AppliedProposal {
+	return &proposalpb.AppliedProposal{
+		Sequence: seq,
+		TransientVolumes: map[string]*proposalpb.TouchedVolumeList{
+			ledger: {Volumes: []*commonpb.TouchedVolume{{Account: account, Asset: asset}}},
+		},
+	}
+}
+
+// TestCollectStoredTransientVolumes_SkipsArchivedAuditRange pins the scan's
+// lower bound: proposals at or below the archived audit boundary are outside
+// the replay's derivation window and must not enter the stored exclusion set.
+func TestCollectStoredTransientVolumes_SkipsArchivedAuditRange(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeAppliedProposal(t, store, transientProposal(1, "L", "t:below", "USD"))
+	writeAppliedProposal(t, store, transientProposal(2, "L", "t:boundary", "USD"))
+	writeAppliedProposal(t, store, transientProposal(3, "L", "t:above", "USD"))
+
+	checker := NewChecker(store, nil, "test-cluster", nil, nil, nil, logging.Testing())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	var got []string
+
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 2,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:above"}, got,
+		"rows at or below the archived audit boundary must be skipped")
+
+	got = nil
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 0,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:below", "t:boundary", "t:above"}, got,
+		"without archived chapters the scan stays unbounded")
+}
+
+// TestCheck_RetainedTransientRecordsBelowArchiveBoundary is the model-test
+// regression: a restore re-ingests the backfilled archived ranges — including
+// AppliedProposal rows carrying TransientVolumes — and never re-purges them.
+// The replay skips the matching logs (seq <= archiveEndSeq), so deriving
+// nothing for them is correct; the stored side must skip the same window or a
+// healthy restored store reports EXCLUSION_RECORD_MISMATCH for every
+// transient account used before the archival.
+func TestCheck_RetainedTransientRecordsBelowArchiveBoundary(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestEngine(t)
+	engine.processAndCommit(createLedgerOrder("test"))
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "alice", "USD", 100)))
+
+	handle, err := engine.store.NewReadHandle()
+	require.NoError(t, err)
+
+	lastLog, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+
+	lastAudit, err := query.ReadLastAuditSequence(handle)
+	require.NoError(t, err)
+
+	// The boundary-time baseline snapshot, as chapter close writes it — without
+	// it Check() skips entry-by-entry verification entirely under archiving.
+	baselinePath, err := engine.store.BaselineSnapshotDir()
+	require.NoError(t, err)
+	require.NoError(t, attributes.CreateBaselineSnapshot(handle, baselinePath))
+	require.NoError(t, handle.Close())
+
+	// The transient record lives in the range about to be marked archived,
+	// exactly as a backfilled restore retains it.
+	writeAppliedProposal(t, engine.store, transientProposal(1, "test", "t:42", "USD"))
+
+	// Post-boundary activity so the replay window is non-empty.
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "bob", "USD", 5)))
+
+	batch := engine.store.OpenWriteSession()
+	require.NoError(t, state.StoreChapter(batch, &commonpb.Chapter{
+		Id:                 1,
+		Status:             commonpb.ChapterStatus_CHAPTER_ARCHIVED,
+		StartSequence:      1,
+		CloseSequence:      lastLog.GetSequence(),
+		StartAuditSequence: 1,
+		CloseAuditSequence: lastAudit,
+	}))
+	require.NoError(t, batch.Commit())
+
+	for _, e := range collectCheckErrors(t, engine.store, engine.attrs) {
+		require.NotEqual(t,
+			servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_EXCLUSION_RECORD_MISMATCH,
+			e.GetErrorType(),
+			"retained sub-boundary exclusion records must not be reported: %s", e.GetMessage())
+	}
+}


### PR DESCRIPTION
## What changed

The checker's exclusion pass bounds its `AppliedProposal` scan to the archived
audit boundary, so both sides of the comparison cover the same range. It used to
scan every row in the store while the derived side skipped the archived range.

## Why

`store check` reported a **healthy** restored store as corrupt: one
`CHECK_STORE_ERROR_TYPE_EXCLUSION_RECORD_MISMATCH` per transient
`(account, asset)` pair used before an archival — 8 of them in the run that found
this, while the model itself was clean.

The exclusion pass compares two sets and reports their symmetric difference:

- **derived** — the audit-bound ground truth, collected during log replay as
  `SimulateEphemeralPurge` decides to delete a volume.
- **stored** — the two records read back from the store: `LedgerLog.PurgedVolumes`
  (accumulated *inside* the replay loop) plus `AppliedProposal.TransientVolumes`
  (collected separately).

Under archiving the replay loop skips everything at or below the archive boundary
(`seq <= archiveEndSeq`), because down there the baseline checkpoint and the audit
chain are authoritative rather than replay. The derived set and the `LedgerLog`
half of the stored set both inherit that skip — but `collectStoredTransientVolumes`
scanned **every** `AppliedProposal` row. Any sub-boundary row therefore appeared on
the stored side with nothing to match on the derived side.

Such rows legitimately exist in hot storage for two independent reasons:

- A restore re-ingests the archived ranges that the EN-1598 cold backfill (#1673)
  puts into the backup, and `RebuildDelta` replays chapter logs without
  re-executing the purge. This is why the false positive only appeared now: before
  #1673 those ranges were silently missing from the backup, which was the bug.
- Out-of-order archiving leaves an un-archived chapter's rows below the max
  archived close sequence, with no restore involved. That trigger is gone since
  #1683 merged; the restore one remains.

## Product / operational motivation

- **Need:** operators must be able to treat a red `store check` as a real
  integrity failure.
- **Current limitation:** `Check()` has no warning channel, so a red result on a
  healthy cluster is indistinguishable from genuine corruption. No data is
  damaged here; the signal is.
- **Requirement:** a healthy restored store, including one whose backup carries
  archival-purged ranges, must produce no integrity findings.
- **Evidence:** `docs/technical/architecture/subsystems/checker/`; the combined
  `--archive --restore` model run below.

## Technical decision

- **Decision:** bound the scan with `archiveAuditEndSeq` (max
  `close_audit_sequence` over `ARCHIVED` chapters), computed by `Check()`'s
  existing chapter scan and passed to `ReadAppliedProposals`' `afterSequence`.
- **Why a second boundary:** logs and audit entries advance on independent
  counters. `AppliedProposal` rows are keyed by audit sequence (1:1 with
  `AuditEntry.sequence`), while the replay skip is expressed in log sequences.
  `archiveAuditEndSeq` is the audit-counter twin of the same boundary, and the
  identical value is what `verifyAuditHashChain` and `newProposalBoundaryReader`
  already derive locally — this scan was the outlier among the checker's cold-zone
  readers; the replay iterator, both audit readers, and
  `collectAuditOrderBoundaryEffects` all bound or filter equivalently.
- **Alternatives considered:** verify the sub-boundary rows instead of skipping
  them, by folding the archived chapters from cold storage the way
  `signingVerifier` does. Much larger and cold-dependent; rejected for now.

## Risk

**LOW** — checker-only. No data path, no persisted format, and no FSM behavior
changes; the failure mode it removes is a false positive. The cost is a narrowing
of verification scope, stated under Known concerns.

## Validation

- [x] `bash scripts/agent-check` — run at `51381b60c`, which is based on #1713;
      the branch has not been rebased onto current `release/v3.0`
- [x] `internal/application/check`
- [x] Targeted tests: `TestCollectStoredTransientVolumes_SkipsArchivedAuditRange`
      (rows at or below the boundary are skipped; passing 0 keeps the scan
      unbounded when nothing is archived) and
      `TestCheck_RetainedTransientRecordsBelowArchiveBoundary` (a `Check()`-level
      regression over a synthetic archived store, asserting no
      `EXCLUSION_RECORD_MISMATCH`). Both red-checked by temporarily restoring the
      unbounded scan.
- [x] Combined model run (`run_model_test.sh --archive --restore`): passes end to
      end, 4 restores interleaved with 9 archival cycles, clean teardown
      `store check`. The same run is what surfaced the bug, with the model itself
      reporting no findings and only the teardown check flagging 8 records.
- [x] 2h Antithesis run: 224 in-cluster `CheckStore` invocations, zero integrity
      errors.

## Architecture / behavior impact

The checker's verification scope narrows: retained `AppliedProposal` rows at or
below the archived audit boundary are no longer compared against the derived set.
This matches the scope the log-side replay skip already had.

## Review focus

Whether inheriting the replay skip's scope is the right trade for the exclusion
pass specifically, given that the rows going unverified are exactly the ones a
restore re-ingests.

Also worth knowing for anyone extending these tests: under `hasArchivedChapters`
with no baseline checkpoint, `Check()` logs "skipping entry-by-entry verification"
and returns early, so an archived-store test is silently vacuous unless it writes a
real baseline snapshot via `attributes.CreateBaselineSnapshot`.

## Known concerns

Retained sub-boundary rows go **unverified** rather than being checked against
another oracle — the trade-off the log-side skip already made, now inherited here
and stated in the code comment. Closing it means the cold-storage fold described
under Alternatives considered.
