### PR TITLE
fix(chapters): archive chapters oldest-first

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3475,7 +3475,7 @@ ledgerctl chapters archive 1
 
 **Notes:**
 - The chapter must be in `CLOSED` state (sealed). `OPEN`, `CLOSING`, or `ARCHIVED` chapters are rejected.
-- **Chapters must be archived oldest-first.** Archiving a chapter while an older one is not yet `ARCHIVED` is rejected with `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter to archive first. Archived chapters form a contiguous prefix of history, so a chapter whose archive cannot complete blocks newer ones until the underlying cold-storage problem is resolved — it is never stepped over, which would leave a permanent hole in cold storage.
+- **Chapters must be archived oldest-first.** Archiving a chapter while an older one is not yet `ARCHIVED` is rejected with `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter to archive first. Re-archiving a chapter that is already inside the archived prefix — a retry after a timeout, say — is rejected with `CHAPTER_ALREADY_ARCHIVED` and `archivedThroughChapterId` instead: the work is done, and there is no chapter to archive first. Archived chapters form a contiguous prefix of history, so a chapter whose archive cannot complete blocks newer ones until the underlying cold-storage problem is resolved — it is never stepped over, which would leave a permanent hole in cold storage.
 - Archival is asynchronous: the command returns immediately after validation, and a background Archiver exports the data and confirms the transition to `ARCHIVED`.
 - Cold storage is configured on the server with `--cold-storage-driver`, `--cold-storage-path`, and S3 flags (`--cold-storage-bucket-id`, `--cold-storage-s3-bucket`, `--cold-storage-s3-region`, `--cold-storage-s3-endpoint`).
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3475,6 +3475,7 @@ ledgerctl chapters archive 1
 
 **Notes:**
 - The chapter must be in `CLOSED` state (sealed). `OPEN`, `CLOSING`, or `ARCHIVED` chapters are rejected.
+- **Chapters must be archived oldest-first.** Archiving a chapter while an older one is not yet `ARCHIVED` is rejected with `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter to archive first. Archived chapters form a contiguous prefix of history, so a chapter whose archive cannot complete blocks newer ones until the underlying cold-storage problem is resolved — it is never stepped over, which would leave a permanent hole in cold storage.
 - Archival is asynchronous: the command returns immediately after validation, and a background Archiver exports the data and confirms the transition to `ARCHIVED`.
 - Cold storage is configured on the server with `--cold-storage-driver`, `--cold-storage-path`, and S3 flags (`--cold-storage-bucket-id`, `--cold-storage-s3-bucket`, `--cold-storage-s3-region`, `--cold-storage-s3-endpoint`).
 

--- a/docs/technical/architecture/subsystems/chapters/lifecycle.md
+++ b/docs/technical/architecture/subsystems/chapters/lifecycle.md
@@ -328,7 +328,7 @@ Once a chapter is sealed (CLOSED), it can be archived to cold storage. Archival 
 
 ### Archival is strictly ordered
 
-**Archived chapters always form a contiguous prefix of history.** `ArchiveChapter` admits only the chapter immediately after that prefix; anything else is rejected with reason `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter that must be archived first.
+**Archived chapters always form a contiguous prefix of history.** `ArchiveChapter` admits only the chapter immediately after that prefix. A chapter beyond it is rejected with reason `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter that must be archived first. A chapter *inside* it is rejected with `CHAPTER_ALREADY_ARCHIVED`, whose `archivedThroughChapterId` reports how far the prefix reaches: the order has already been carried out, and since every chapter outside the prefix is newer, no archive makes an older one archivable again — a client handed a blocker there would walk forward forever.
 
 The prefix is an explicit marker on the chapter tracker (`archivedThroughID`), advanced by `ConfirmArchiveChapter` and derived at recovery as the longest run of `ARCHIVED` rows from chapter 1. It is deliberately **not** inferred from which chapters are still in the in-memory map: that map holds only chapters whose data is still in hot storage (see [In-Memory Chapter Management](#in-memory-chapter-management)), so absence there means "purged", and reading it as "archived" would conflate a residency fact with a history one — and would answer differently on a restarted node, which reloads archived rows.
 

--- a/docs/technical/architecture/subsystems/chapters/lifecycle.md
+++ b/docs/technical/architecture/subsystems/chapters/lifecycle.md
@@ -309,28 +309,32 @@ data/
 
 All non-purged chapters are kept in memory in the FSM's `allChapters` map, eliminating Pebble reads for chapter lookups. The `currentOpenChapter` and `closingChapter` fields are convenience pointers into this map for fast access on the hot path.
 
-- `WriteSet.GetChapterByID()` reads from the in-memory map (no Pebble fallback).
-- `DefaultController.ListChapters()` reads from `Machine.AllChapters()` via the `ChapterProvider` interface.
-- When a chapter is archived and purged, it is removed from the in-memory map.
-- Chapters are still persisted to Pebble (for crash recovery and startup), but never read from Pebble during normal operation after startup.
+The map's membership rule is **hot-storage residency**, not existence: in steady state it holds the `OPEN` chapter plus every `CLOSING`, `CLOSED` and `ARCHIVING` one. An `ARCHIVED` chapter is dropped, because the FSM has no remaining decision to make about data that is no longer in Pebble.
 
-## FSM Snapshot
+- `WriteSet.GetChapterByID()` reads from the in-memory map (no Pebble fallback) — required, since the FSM apply path may not read Pebble at all.
+- When a chapter is archived and purged, it is removed from the in-memory map. History questions ("is this chapter archived?") therefore cannot be answered from the map; the archived prefix is tracked explicitly as `archivedThroughID` (see [Archival is strictly ordered](#archival-is-strictly-ordered)).
+- `DefaultController.ListChapters()` reads the persisted rows from Pebble (`query.ReadChapters`), so it returns the full history including archived chapters — the query path is not restricted to the FSM's working set.
+- The `ZoneGlobal/SubGlobChapters` rows are the durable, complete registry: every chapter that ever existed, never deleted. They are the source the tracker is rebuilt from at startup and on follower checkpoint-sync, and what cold-read routing, the checker, and the incremental-backup backfill consult.
 
-The chapter state is included in Raft snapshots:
+## Recovering chapter state
 
-```protobuf
-message MemorySnapshot {
-  // ... other fields ...
-  common.Chapter open_chapter = 10;               // Current open chapter
-  common.Chapter closing_chapter = 11;            // Chapter being sealed (nil when idle)
-  fixed64 next_chapter_id = 12;
-  repeated common.Chapter closed_chapters = 13;   // CLOSED + ARCHIVED chapters (non-purged)
-}
-```
+Chapter state is **not** serialized into a memory snapshot; it is rebuilt from the persisted `ZoneGlobal/SubGlobChapters` rows. `state.Recovery` reads them with `query.ReadChapters`, partitions them into the current `OPEN` chapter and the `CLOSING` set, reads `SubGlobNextChapterID`, derives the archived prefix, and installs the result with `ChapterTracker.Reset`.
+
+The same path runs for a follower joining through checkpoint-sync (`SynchronizeWithLeader`), since a checkpoint ships the SSTs holding those rows. A node that has just recovered therefore sees archived chapters as present-and-`ARCHIVED`, whereas a long-running node has dropped them from the map — the two representations must never lead to different FSM decisions, which is why the archived prefix is a tracked marker rather than an inference from the map.
 
 ## Archival (CLOSED → ARCHIVED)
 
 Once a chapter is sealed (CLOSED), it can be archived to cold storage. Archival exports logs and audit entries to an external storage backend and purges them from Pebble, reducing hot storage size and compaction pressure. Attributes (volumes, metadata, reversion status) remain in Pebble to serve read queries.
+
+### Archival is strictly ordered
+
+**Archived chapters always form a contiguous prefix of history.** `ArchiveChapter` admits only the chapter immediately after that prefix; anything else is rejected with reason `CHAPTER_ARCHIVE_OUT_OF_ORDER`, whose `blockingChapterId` names the chapter that must be archived first.
+
+The prefix is an explicit marker on the chapter tracker (`archivedThroughID`), advanced by `ConfirmArchiveChapter` and derived at recovery as the longest run of `ARCHIVED` rows from chapter 1. It is deliberately **not** inferred from which chapters are still in the in-memory map: that map holds only chapters whose data is still in hot storage (see [In-Memory Chapter Management](#in-memory-chapter-management)), so absence there means "purged", and reading it as "archived" would conflate a residency fact with a history one — and would answer differently on a restarted node, which reloads archived rows.
+
+The rule exists because the purge deletes *everything* up to the archived chapter's close sequence. Archiving out of order would leave an older, un-archived chapter's logs retained *below* the archive boundary, which has two consequences: the checker's replay skips everything at or below that boundary, so those logs become a permanently unverified window; and cold storage keeps a hole that no later archive ever fills. Enforcing the order makes "below the archive boundary" and "archived" the same statement, which is what every archive-aware pass assumes.
+
+Because a chapter may not be archived until its predecessor is `ARCHIVED` (not merely `ARCHIVING`), **at most one chapter is ever in `ARCHIVING`**. The trade-off is deliberate: a chapter whose upload cannot complete blocks archival of newer chapters rather than being stepped over, so hot storage grows until the underlying cold-storage problem is fixed. A skip would trade a loud, recoverable stall for a silent permanent gap.
 
 ### Two-Step Archive Process
 
@@ -338,7 +342,7 @@ Like the seal process, archival uses two Raft commands to avoid blocking consens
 
 #### Step 1: ArchiveChapter (validation, state transition to ARCHIVING)
 
-The `ArchiveChapter` order validates that the chapter is CLOSED and transitions it to `ARCHIVING`. This state change is deterministic across all nodes via Raft. Only the **leader** dispatches the actual archive request to the background Archiver — followers apply the state transition but do not perform the S3 upload. This avoids N redundant exports in an N-node cluster.
+The `ArchiveChapter` order validates that the chapter is CLOSED, that every older chapter is already ARCHIVED (see above), and transitions it to `ARCHIVING`. This state change is deterministic across all nodes via Raft. Only the **leader** dispatches the actual archive request to the background Archiver — followers apply the state transition but do not perform the S3 upload. This avoids N redundant exports in an N-node cluster.
 
 **File**: `internal/domain/processing/processor_chapter.go`
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -914,6 +914,9 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Chapter not closing | `FAILED_PRECONDITION` | `CHAPTER_NOT_CLOSING` | `chapterId` |
 | Chapter not closed | `FAILED_PRECONDITION` | `CHAPTER_NOT_CLOSED` | `chapterId` |
 | Chapter not archiving | `FAILED_PRECONDITION` | `CHAPTER_NOT_ARCHIVING` | `chapterId` |
+| Chapter archive out of order | `FAILED_PRECONDITION` | `CHAPTER_ARCHIVE_OUT_OF_ORDER` | `chapterId`, `blockingChapterId` |
+| Chapter already archived | `FAILED_PRECONDITION` | `CHAPTER_ALREADY_ARCHIVED` | `chapterId`, `archivedThroughChapterId` |
+| Chapter archive incarnation mismatch | `FAILED_PRECONDITION` | `CHAPTER_ARCHIVE_IDENTITY_MISMATCH` | `chapterId`, `expectedSealingHash`, `gotSealingHash` |
 | Metadata not found | `NOT_FOUND` | `METADATA_NOT_FOUND` | `target`, `key` |
 | Metadata field not in schema | `FAILED_PRECONDITION` | `METADATA_FIELD_NOT_IN_SCHEMA` | `target`, `key` |
 | Invalid receipt | `INVALID_ARGUMENT` | `INVALID_RECEIPT` | `reason` |

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -710,7 +710,7 @@ func (s *scopeImpl) GetChapterByID(_ uint64) (commonpb.ChapterReader, bool) {
 // archived prefix stays at its genesis value.
 func (s *scopeImpl) GetArchivedThroughChapterID() uint64 { return 0 }
 
-func (s *scopeImpl) SetArchivedThroughChapterID(_ uint64) {}
+func (s *scopeImpl) AdvanceArchivedThroughChapterID() {}
 
 func (s *scopeImpl) GetNextAuditSequenceID() uint64 { return 0 }
 

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -706,6 +706,12 @@ func (s *scopeImpl) GetChapterByID(_ uint64) (commonpb.ChapterReader, bool) {
 	return nil, false
 }
 
+// The checker's test engine drives ledger orders, never chapter archival, so the
+// archived prefix stays at its genesis value.
+func (s *scopeImpl) GetArchivedThroughChapterID() uint64 { return 0 }
+
+func (s *scopeImpl) SetArchivedThroughChapterID(_ uint64) {}
+
 func (s *scopeImpl) GetNextAuditSequenceID() uint64 { return 0 }
 
 func (s *scopeImpl) UpdateChapter(_ *commonpb.Chapter) {}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -193,6 +193,7 @@ const (
 	ErrReasonChapterNotArchiving            = "CHAPTER_NOT_ARCHIVING"
 	ErrReasonChapterArchiveOutOfOrder       = "CHAPTER_ARCHIVE_OUT_OF_ORDER"
 	ErrReasonChapterArchiveIdentityMismatch = "CHAPTER_ARCHIVE_IDENTITY_MISMATCH"
+	ErrReasonChapterAlreadyArchived         = "CHAPTER_ALREADY_ARCHIVED"
 	ErrReasonMetadataNotFound               = "METADATA_NOT_FOUND"
 	ErrReasonInvalidReceipt                 = "INVALID_RECEIPT"
 	ErrReasonMaintenanceMode                = "MAINTENANCE_MODE"
@@ -896,6 +897,27 @@ func (e *ErrChapterArchiveOutOfOrder) Metadata() map[string]string {
 	return map[string]string{
 		"chapterId":         strconv.FormatUint(e.ChapterID, 10),
 		"blockingChapterId": strconv.FormatUint(e.BlockingChapterID, 10),
+	}
+}
+
+// ErrChapterAlreadyArchived — attempting to archive a chapter inside the
+// archived prefix. The order has already been carried out: the chapter's logs
+// are purged and its archive is in cold storage, so there is no chapter to
+// archive first and no retry that succeeds.
+type ErrChapterAlreadyArchived struct {
+	ChapterID uint64
+	// ArchivedThroughChapterID is the newest chapter in the archived prefix.
+	ArchivedThroughChapterID uint64
+}
+
+func (e *ErrChapterAlreadyArchived) Error() string {
+	return fmt.Sprintf("chapter %d is already archived (archived through chapter %d)", e.ChapterID, e.ArchivedThroughChapterID)
+}
+func (*ErrChapterAlreadyArchived) Reason() string { return ErrReasonChapterAlreadyArchived }
+func (e *ErrChapterAlreadyArchived) Metadata() map[string]string {
+	return map[string]string{
+		"chapterId":                strconv.FormatUint(e.ChapterID, 10),
+		"archivedThroughChapterId": strconv.FormatUint(e.ArchivedThroughChapterID, 10),
 	}
 }
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -191,6 +191,7 @@ const (
 	ErrReasonChapterNotClosing              = "CHAPTER_NOT_CLOSING"
 	ErrReasonChapterNotClosed               = "CHAPTER_NOT_CLOSED"
 	ErrReasonChapterNotArchiving            = "CHAPTER_NOT_ARCHIVING"
+	ErrReasonChapterArchiveOutOfOrder       = "CHAPTER_ARCHIVE_OUT_OF_ORDER"
 	ErrReasonChapterArchiveIdentityMismatch = "CHAPTER_ARCHIVE_IDENTITY_MISMATCH"
 	ErrReasonMetadataNotFound               = "METADATA_NOT_FOUND"
 	ErrReasonInvalidReceipt                 = "INVALID_RECEIPT"
@@ -873,6 +874,28 @@ func (e *ErrChapterArchiveIdentityMismatch) Metadata() map[string]string {
 		"chapterId":           strconv.FormatUint(e.ChapterID, 10),
 		"expectedSealingHash": hex.EncodeToString(e.Expected),
 		"gotSealingHash":      hex.EncodeToString(e.Got),
+	}
+}
+
+// ErrChapterArchiveOutOfOrder — attempting to archive a CLOSED chapter while an
+// older one is not ARCHIVED yet. Archived chapters must form a contiguous
+// prefix: the purge deletes everything up to the archived chapter's close
+// sequence, so a hole would leave an un-archived chapter's logs retained below
+// the archive boundary, where the checker's replay skips them.
+type ErrChapterArchiveOutOfOrder struct {
+	ChapterID uint64
+	// BlockingChapterID is the oldest chapter that must be archived first.
+	BlockingChapterID uint64
+}
+
+func (e *ErrChapterArchiveOutOfOrder) Error() string {
+	return fmt.Sprintf("chapter %d cannot be archived while older chapter %d is not archived", e.ChapterID, e.BlockingChapterID)
+}
+func (*ErrChapterArchiveOutOfOrder) Reason() string { return ErrReasonChapterArchiveOutOfOrder }
+func (e *ErrChapterArchiveOutOfOrder) Metadata() map[string]string {
+	return map[string]string{
+		"chapterId":         strconv.FormatUint(e.ChapterID, 10),
+		"blockingChapterId": strconv.FormatUint(e.BlockingChapterID, 10),
 	}
 }
 

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -171,6 +171,11 @@ func TestErrorTypes(t *testing.T) {
 			expected: "chapter 5 has sealing hash abcd, but the archive confirmation carries 01",
 		},
 		{
+			name:     "ErrChapterArchiveOutOfOrder",
+			err:      &ErrChapterArchiveOutOfOrder{ChapterID: 5, BlockingChapterID: 3},
+			expected: "chapter 5 cannot be archived while older chapter 3 is not archived",
+		},
+		{
 			name:     "ErrInvalidCronExpression",
 			err:      &ErrInvalidCronExpression{Expression: "bad", Details: "parse failed"},
 			expected: `invalid cron expression "bad": parse failed`,
@@ -354,6 +359,7 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrChapterNotClosing":              &ErrChapterNotClosing{},
 		"ErrChapterNotClosed":               &ErrChapterNotClosed{},
 		"ErrChapterNotArchiving":            &ErrChapterNotArchiving{},
+		"ErrChapterArchiveOutOfOrder":       &ErrChapterArchiveOutOfOrder{},
 		"ErrChapterArchiveIdentityMismatch": &ErrChapterArchiveIdentityMismatch{},
 		"ErrInvalidCronExpression":          &ErrInvalidCronExpression{},
 		"ErrLedgerInMirrorMode":             &ErrLedgerInMirrorMode{},

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -176,6 +176,11 @@ func TestErrorTypes(t *testing.T) {
 			expected: "chapter 5 cannot be archived while older chapter 3 is not archived",
 		},
 		{
+			name:     "ErrChapterAlreadyArchived",
+			err:      &ErrChapterAlreadyArchived{ChapterID: 1, ArchivedThroughChapterID: 3},
+			expected: "chapter 1 is already archived (archived through chapter 3)",
+		},
+		{
 			name:     "ErrInvalidCronExpression",
 			err:      &ErrInvalidCronExpression{Expression: "bad", Details: "parse failed"},
 			expected: `invalid cron expression "bad": parse failed`,
@@ -361,6 +366,7 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrChapterNotArchiving":            &ErrChapterNotArchiving{},
 		"ErrChapterArchiveOutOfOrder":       &ErrChapterArchiveOutOfOrder{},
 		"ErrChapterArchiveIdentityMismatch": &ErrChapterArchiveIdentityMismatch{},
+		"ErrChapterAlreadyArchived":         &ErrChapterAlreadyArchived{},
 		"ErrInvalidCronExpression":          &ErrInvalidCronExpression{},
 		"ErrLedgerInMirrorMode":             &ErrLedgerInMirrorMode{},
 		"ErrLedgerNotInMirrorMode":          &ErrLedgerNotInMirrorMode{},

--- a/internal/domain/processing/processor_chapter.go
+++ b/internal/domain/processing/processor_chapter.go
@@ -119,9 +119,9 @@ func processArchiveChapter(order *raftcmdpb.ArchiveChapterOrder, ctx *Context) (
 	// failures, which are hash-chained, would diverge across replicas.
 	archivedThrough := s.GetArchivedThroughChapterID()
 	if order.GetChapterId() <= archivedThrough {
-		return nil, &domain.ErrChapterArchiveOutOfOrder{
-			ChapterID:         order.GetChapterId(),
-			BlockingChapterID: archivedThrough + 1,
+		return nil, &domain.ErrChapterAlreadyArchived{
+			ChapterID:                order.GetChapterId(),
+			ArchivedThroughChapterID: archivedThrough,
 		}
 	}
 
@@ -181,6 +181,13 @@ func processConfirmArchiveChapter(order *raftcmdpb.ConfirmArchiveChapterOrder, c
 	// gate, so refusing it surfaces the anomaly (audited failure, and the
 	// archiver retries visibly) instead of silently papering over it.
 	archivedThrough := s.GetArchivedThroughChapterID()
+	if order.GetChapterId() <= archivedThrough {
+		return nil, &domain.ErrChapterAlreadyArchived{
+			ChapterID:                order.GetChapterId(),
+			ArchivedThroughChapterID: archivedThrough,
+		}
+	}
+
 	if order.GetChapterId() != archivedThrough+1 {
 		return nil, &domain.ErrChapterArchiveOutOfOrder{
 			ChapterID:         order.GetChapterId(),

--- a/internal/domain/processing/processor_chapter.go
+++ b/internal/domain/processing/processor_chapter.go
@@ -101,14 +101,6 @@ func processSealChapter(order *raftcmdpb.SealChapterOrder, ctx *Context) (*commo
 // sequence range the worker needs).
 func processArchiveChapter(order *raftcmdpb.ArchiveChapterOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
 	s := ctx.Scope
-	chapterReader, ok := s.GetChapterByID(order.GetChapterId())
-	if !ok {
-		return nil, &domain.ErrChapterNotFound{ChapterID: order.GetChapterId()}
-	}
-
-	if chapterReader.GetStatus() != commonpb.ChapterStatus_CHAPTER_CLOSED {
-		return nil, &domain.ErrChapterNotClosed{ChapterID: order.GetChapterId()}
-	}
 
 	// Archived chapters must form a contiguous prefix of history, so the only
 	// archivable chapter is the one right after the archived prefix. The purge
@@ -118,11 +110,34 @@ func processArchiveChapter(order *raftcmdpb.ArchiveChapterOrder, ctx *Context) (
 	// them, leaving a permanently unverified window, and where cold storage has
 	// a hole no later archive ever fills.
 	//
-	// The prefix is read from the tracker's explicit marker rather than inferred
-	// from which chapters are still resident: the purge drops archived chapters
-	// from the tracker, so residency answers "does this chapter still have hot
-	// data", not "is it archived".
-	if archivedThrough := s.GetArchivedThroughChapterID(); order.GetChapterId() != archivedThrough+1 {
+	// The prefix comes from the tracker's explicit marker, and chapters inside it
+	// are rejected BEFORE the residency lookup below: an archived chapter is
+	// absent from the tracker on a running node (the purge drops it) and present
+	// with status ARCHIVED after a restart (recovery reloads its row), so a
+	// lookup-first order would answer the same Raft order with two different
+	// reasons — CHAPTER_NOT_FOUND or CHAPTER_NOT_CLOSED — and the audited
+	// failures, which are hash-chained, would diverge across replicas.
+	archivedThrough := s.GetArchivedThroughChapterID()
+	if order.GetChapterId() <= archivedThrough {
+		return nil, &domain.ErrChapterArchiveOutOfOrder{
+			ChapterID:         order.GetChapterId(),
+			BlockingChapterID: archivedThrough + 1,
+		}
+	}
+
+	// Past the prefix the lookup is representation-independent: a chapter that is
+	// not archived is never purged, so it is resident on every node, and one that
+	// never existed has no row anywhere.
+	chapterReader, ok := s.GetChapterByID(order.GetChapterId())
+	if !ok {
+		return nil, &domain.ErrChapterNotFound{ChapterID: order.GetChapterId()}
+	}
+
+	if chapterReader.GetStatus() != commonpb.ChapterStatus_CHAPTER_CLOSED {
+		return nil, &domain.ErrChapterNotClosed{ChapterID: order.GetChapterId()}
+	}
+
+	if order.GetChapterId() != archivedThrough+1 {
 		return nil, &domain.ErrChapterArchiveOutOfOrder{
 			ChapterID:         order.GetChapterId(),
 			BlockingChapterID: archivedThrough + 1,
@@ -149,6 +164,30 @@ func processArchiveChapter(order *raftcmdpb.ArchiveChapterOrder, ctx *Context) (
 // from the ConfirmedArchiveChapterLog by deriveSignals.
 func processConfirmArchiveChapter(order *raftcmdpb.ConfirmArchiveChapterOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
 	s := ctx.Scope
+
+	// The confirm is what extends the archived prefix and triggers the purge, so
+	// it must land exactly on prefix + 1 — checked before any mutation, and
+	// before the residency lookup for the same reason as processArchiveChapter
+	// (an already-archived chapter reads as absent on a running node and as
+	// ARCHIVED after a restart, which would audit two different reasons for one
+	// order).
+	//
+	// A confirm past the prefix is not merely redundant: the recovery derivation
+	// stops at a gap while DispatchArchiveRequests republishes every ARCHIVING
+	// chapter, so a store holding {1 ARCHIVED, 2 un-archived, 3 ARCHIVING} would
+	// otherwise have reconciliation confirm 3 and carry the prefix past 2 —
+	// re-authorising archives while chapter 2's logs sit un-archived below the
+	// resulting archive boundary. That state is impossible through the ordering
+	// gate, so refusing it surfaces the anomaly (audited failure, and the
+	// archiver retries visibly) instead of silently papering over it.
+	archivedThrough := s.GetArchivedThroughChapterID()
+	if order.GetChapterId() != archivedThrough+1 {
+		return nil, &domain.ErrChapterArchiveOutOfOrder{
+			ChapterID:         order.GetChapterId(),
+			BlockingChapterID: archivedThrough + 1,
+		}
+	}
+
 	chapterReader, ok := s.GetChapterByID(order.GetChapterId())
 	if !ok {
 		return nil, &domain.ErrChapterNotFound{ChapterID: order.GetChapterId()}
@@ -179,11 +218,10 @@ func processConfirmArchiveChapter(order *raftcmdpb.ConfirmArchiveChapterOrder, c
 	chapter.Status = commonpb.ChapterStatus_CHAPTER_ARCHIVED
 	s.UpdateChapter(chapter)
 
-	// Extend the archived prefix. The ordering rule (processArchiveChapter) only
-	// admits the chapter right after the prefix, so a confirm always lands on
-	// prefix + 1 and the prefix stays contiguous. Advancing here rather than in
-	// the purge means a later order in the same proposal sees it.
-	s.SetArchivedThroughChapterID(chapter.GetId())
+	// Advancing here rather than at purge time means a later order in the same
+	// proposal sees it. The Scope exposes only a one-step advance, so no caller
+	// can carry the prefix over a gap.
+	s.AdvanceArchivedThroughChapterID()
 
 	return &commonpb.LogPayload{
 		Type: &commonpb.LogPayload_ConfirmArchiveChapter{

--- a/internal/domain/processing/processor_chapter.go
+++ b/internal/domain/processing/processor_chapter.go
@@ -110,6 +110,25 @@ func processArchiveChapter(order *raftcmdpb.ArchiveChapterOrder, ctx *Context) (
 		return nil, &domain.ErrChapterNotClosed{ChapterID: order.GetChapterId()}
 	}
 
+	// Archived chapters must form a contiguous prefix of history, so the only
+	// archivable chapter is the one right after the archived prefix. The purge
+	// deletes everything up to the archived chapter's close sequence, so
+	// archiving out of order would leave an older, un-archived chapter's logs
+	// retained *below* the archive boundary — where the checker's replay skips
+	// them, leaving a permanently unverified window, and where cold storage has
+	// a hole no later archive ever fills.
+	//
+	// The prefix is read from the tracker's explicit marker rather than inferred
+	// from which chapters are still resident: the purge drops archived chapters
+	// from the tracker, so residency answers "does this chapter still have hot
+	// data", not "is it archived".
+	if archivedThrough := s.GetArchivedThroughChapterID(); order.GetChapterId() != archivedThrough+1 {
+		return nil, &domain.ErrChapterArchiveOutOfOrder{
+			ChapterID:         order.GetChapterId(),
+			BlockingChapterID: archivedThrough + 1,
+		}
+	}
+
 	chapter := chapterReader.Mutate()
 
 	// Transition to ARCHIVING deterministically on all nodes
@@ -159,6 +178,12 @@ func processConfirmArchiveChapter(order *raftcmdpb.ConfirmArchiveChapterOrder, c
 
 	chapter.Status = commonpb.ChapterStatus_CHAPTER_ARCHIVED
 	s.UpdateChapter(chapter)
+
+	// Extend the archived prefix. The ordering rule (processArchiveChapter) only
+	// admits the chapter right after the prefix, so a confirm always lands on
+	// prefix + 1 and the prefix stays contiguous. Advancing here rather than in
+	// the purge means a later order in the same proposal sees it.
+	s.SetArchivedThroughChapterID(chapter.GetId())
 
 	return &commonpb.LogPayload{
 		Type: &commonpb.LogPayload_ConfirmArchiveChapter{

--- a/internal/domain/processing/processor_chapter_test.go
+++ b/internal/domain/processing/processor_chapter_test.go
@@ -327,9 +327,6 @@ func TestProcessArchiveChapter_RejectsOutOfOrder(t *testing.T) {
 		"one chapter ahead of the prefix":   {target: 3, archivedThrough: 1, wantBlockingID: 2},
 		"several chapters ahead":            {target: 7, archivedThrough: 2, wantBlockingID: 3},
 		"nothing archived yet, skips first": {target: 2, archivedThrough: 0, wantBlockingID: 1},
-		// Re-archiving something inside the prefix is equally out of order: its
-		// data is already gone, so a purge here would delete a later chapter's.
-		"already inside the prefix": {target: 1, archivedThrough: 3, wantBlockingID: 4},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -347,7 +344,6 @@ func TestProcessArchiveChapter_RejectsOutOfOrder(t *testing.T) {
 			}
 
 			mockStore.EXPECT().GetArchivedThroughChapterID().Return(tc.archivedThrough)
-			// Ids inside the prefix are rejected before the lookup runs at all.
 			mockStore.EXPECT().GetChapterByID(tc.target).Return(target.AsReader(), true).AnyTimes()
 
 			payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: tc.target}, &Context{Scope: mockStore})
@@ -359,6 +355,53 @@ func TestProcessArchiveChapter_RejectsOutOfOrder(t *testing.T) {
 			require.Equal(t, tc.target, outOfOrderErr.ChapterID)
 			require.Equal(t, tc.wantBlockingID, outOfOrderErr.BlockingChapterID,
 				"the rejection must name the chapter that has to be archived first")
+		})
+	}
+}
+
+// TestProcessArchiveChapter_RejectsAlreadyArchived covers the retry path: the
+// order names a chapter inside the archived prefix, so it has already been
+// carried out. The rejection must say so rather than name a blocking chapter —
+// every chapter outside the prefix is newer, and archiving one can never make an
+// older, already-archived chapter archivable again, so a client following the
+// blocker would walk forward forever.
+func TestProcessArchiveChapter_RejectsAlreadyArchived(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		target          uint64
+		archivedThrough uint64
+	}{
+		"oldest chapter in the prefix": {target: 1, archivedThrough: 3},
+		"newest chapter in the prefix": {target: 3, archivedThrough: 3},
+		"the only archived chapter":    {target: 1, archivedThrough: 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := NewMockScope(ctrl)
+			mockStore.EXPECT().GetArchivedThroughChapterID().Return(tc.archivedThrough)
+			// Ids inside the prefix are rejected before the lookup runs at all: an
+			// archived chapter is purged from the tracker on a running node and
+			// reloaded as ARCHIVED after a restart, so consulting it would answer the
+			// same Raft order with two different reasons.
+			mockStore.EXPECT().GetChapterByID(gomock.Any()).Times(0)
+
+			payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: tc.target}, &Context{Scope: mockStore})
+			require.Error(t, err)
+			require.Nil(t, payload, "a rejected archive must emit no log")
+
+			var alreadyArchived *domain.ErrChapterAlreadyArchived
+			require.ErrorAs(t, err, &alreadyArchived)
+			require.Equal(t, tc.target, alreadyArchived.ChapterID)
+			require.Equal(t, tc.archivedThrough, alreadyArchived.ArchivedThroughChapterID,
+				"the rejection must report how far the archived prefix reaches")
+
+			var outOfOrder *domain.ErrChapterArchiveOutOfOrder
+			require.NotErrorAs(t, err, &outOfOrder, "an already-archived chapter is not waiting on another chapter")
 		})
 	}
 }
@@ -593,10 +636,10 @@ func TestProcessChapter_ArchivedChapterRejectedIdenticallyAcrossRepresentations(
 				require.Error(t, err)
 				require.Nil(t, payload, "%s: a rejected order must emit no log", name)
 
-				var outOfOrderErr *domain.ErrChapterArchiveOutOfOrder
-				require.ErrorAs(t, err, &outOfOrderErr,
+				var alreadyArchived *domain.ErrChapterAlreadyArchived
+				require.ErrorAs(t, err, &alreadyArchived,
 					"%s: an archived chapter must be rejected by the prefix gate, not by the residency lookup", name)
-				require.Equal(t, archivedThrough+1, outOfOrderErr.BlockingChapterID)
+				require.Equal(t, archivedThrough, alreadyArchived.ArchivedThroughChapterID)
 
 				reasons[name] = err.Reason()
 			}

--- a/internal/domain/processing/processor_chapter_test.go
+++ b/internal/domain/processing/processor_chapter_test.go
@@ -273,6 +273,7 @@ func TestProcessArchiveChapter_NotFound(t *testing.T) {
 
 	mockStore := NewMockScope(ctrl)
 
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
 	mockStore.EXPECT().GetChapterByID(uint64(99)).Return(nil, false)
 
 	payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: 99}, &Context{Scope: mockStore})
@@ -297,6 +298,7 @@ func TestProcessArchiveChapter_NotClosed(t *testing.T) {
 		Status: commonpb.ChapterStatus_CHAPTER_OPEN,
 	}
 
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
 	mockStore.EXPECT().GetChapterByID(uint64(1)).Return(openChapter.AsReader(), true)
 
 	payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: 1}, &Context{Scope: mockStore})
@@ -344,8 +346,9 @@ func TestProcessArchiveChapter_RejectsOutOfOrder(t *testing.T) {
 				CloseSequence: 300,
 			}
 
-			mockStore.EXPECT().GetChapterByID(tc.target).Return(target.AsReader(), true)
 			mockStore.EXPECT().GetArchivedThroughChapterID().Return(tc.archivedThrough)
+			// Ids inside the prefix are rejected before the lookup runs at all.
+			mockStore.EXPECT().GetChapterByID(tc.target).Return(target.AsReader(), true).AnyTimes()
 
 			payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: tc.target}, &Context{Scope: mockStore})
 			require.Error(t, err)
@@ -417,13 +420,14 @@ func TestProcessConfirmArchiveChapter_Success(t *testing.T) {
 		SealingHash:   []byte("seal-hash"),
 	}
 
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
 	mockStore.EXPECT().GetChapterByID(uint64(1)).Return(archivingChapter.AsReader(), true)
 	mockStore.EXPECT().UpdateChapter(gomock.Any()).Do(func(chapter *commonpb.Chapter) {
 		require.Equal(t, commonpb.ChapterStatus_CHAPTER_ARCHIVED, chapter.GetStatus())
 	})
 	// The confirm extends the archived prefix, which is what the ordering gate
 	// reads to admit the next chapter.
-	mockStore.EXPECT().SetArchivedThroughChapterID(uint64(1))
+	mockStore.EXPECT().AdvanceArchivedThroughChapterID()
 
 	payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{
 		ChapterId:   1,
@@ -466,6 +470,9 @@ func TestProcessConfirmArchiveChapter_RefusesAnotherIncarnation(t *testing.T) {
 				SealingHash:   []byte("seal-hash"),
 			}
 
+			// Chapter 1 is the prefix successor, so the continuity check passes and the
+			// incarnation check is what rejects the order.
+			mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
 			mockStore.EXPECT().GetChapterByID(uint64(1)).Return(archivingChapter.AsReader(), true)
 
 			payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{
@@ -487,6 +494,7 @@ func TestProcessConfirmArchiveChapter_NotFound(t *testing.T) {
 
 	mockStore := NewMockScope(ctrl)
 
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(98))
 	mockStore.EXPECT().GetChapterByID(uint64(99)).Return(nil, false)
 
 	payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{ChapterId: 99}, &Context{Scope: mockStore})
@@ -506,12 +514,15 @@ func TestProcessConfirmArchiveChapter_NotArchiving(t *testing.T) {
 
 	mockStore := NewMockScope(ctrl)
 
-	archivedChapter := &commonpb.Chapter{
+	// The prefix successor, but never archived — a confirm for an already-ARCHIVED
+	// chapter is caught earlier by the prefix gate instead.
+	closedChapter := &commonpb.Chapter{
 		Id:     1,
-		Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED,
+		Status: commonpb.ChapterStatus_CHAPTER_CLOSED,
 	}
 
-	mockStore.EXPECT().GetChapterByID(uint64(1)).Return(archivedChapter.AsReader(), true)
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
+	mockStore.EXPECT().GetChapterByID(uint64(1)).Return(closedChapter.AsReader(), true)
 
 	payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{ChapterId: 1}, &Context{Scope: mockStore})
 	require.Error(t, err)
@@ -520,4 +531,117 @@ func TestProcessConfirmArchiveChapter_NotArchiving(t *testing.T) {
 	var notArchivingErr *domain.ErrChapterNotArchiving
 	require.ErrorAs(t, err, &notArchivingErr)
 	require.Equal(t, uint64(1), notArchivingErr.ChapterID)
+}
+
+// TestProcessChapter_ArchivedChapterRejectedIdenticallyAcrossRepresentations is
+// the restart/no-restart lock. An archived chapter has two in-memory shapes: it
+// is absent from the tracker on a node that has been running since the purge,
+// and present with status ARCHIVED on one that recovered from the persisted rows.
+// Both must produce the SAME rejection, because the failure is audited and the
+// audit entries are hash-chained — two reasons for one Raft order would diverge
+// the FSM across replicas.
+func TestProcessChapter_ArchivedChapterRejectedIdenticallyAcrossRepresentations(t *testing.T) {
+	t.Parallel()
+
+	const (
+		archivedThrough = uint64(3)
+		target          = uint64(2) // inside the archived prefix
+	)
+
+	// Whether the tracker still holds the chapter is exactly what must NOT matter.
+	representations := map[string]func(*MockScope){
+		"purged from the tracker (running node)": func(m *MockScope) {
+			m.EXPECT().GetChapterByID(target).Return(nil, false).AnyTimes()
+		},
+		"reloaded as ARCHIVED (after restart)": func(m *MockScope) {
+			reloaded := &commonpb.Chapter{Id: target, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVED}
+			m.EXPECT().GetChapterByID(target).Return(reloaded.AsReader(), true).AnyTimes()
+		},
+	}
+
+	for _, order := range []struct {
+		name string
+		run  func(Scope) (*commonpb.LogPayload, domain.Describable)
+	}{
+		{
+			name: "ArchiveChapter",
+			run: func(s Scope) (*commonpb.LogPayload, domain.Describable) {
+				return processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: target}, &Context{Scope: s})
+			},
+		},
+		{
+			name: "ConfirmArchiveChapter",
+			run: func(s Scope) (*commonpb.LogPayload, domain.Describable) {
+				return processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{ChapterId: target}, &Context{Scope: s})
+			},
+		},
+	} {
+		t.Run(order.name, func(t *testing.T) {
+			t.Parallel()
+
+			reasons := map[string]string{}
+
+			for name, stub := range representations {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+
+				mockStore := NewMockScope(ctrl)
+				mockStore.EXPECT().GetArchivedThroughChapterID().Return(archivedThrough)
+				stub(mockStore)
+
+				payload, err := order.run(mockStore)
+				require.Error(t, err)
+				require.Nil(t, payload, "%s: a rejected order must emit no log", name)
+
+				var outOfOrderErr *domain.ErrChapterArchiveOutOfOrder
+				require.ErrorAs(t, err, &outOfOrderErr,
+					"%s: an archived chapter must be rejected by the prefix gate, not by the residency lookup", name)
+				require.Equal(t, archivedThrough+1, outOfOrderErr.BlockingChapterID)
+
+				reasons[name] = err.Reason()
+			}
+
+			require.Len(t, reasons, 2)
+
+			var distinct []string
+			for _, reason := range reasons {
+				distinct = append(distinct, reason)
+			}
+
+			require.Equal(t, distinct[0], distinct[1],
+				"the two representations produced different audited reasons (%v) — the same order would hash differently on a restarted and a non-restarted replica", reasons)
+		})
+	}
+}
+
+// TestProcessConfirmArchiveChapter_RefusesToJumpAGap covers the reconciliation
+// path: DispatchArchiveRequests republishes every ARCHIVING chapter, and the
+// recovery derivation deliberately stops at a gap, so a store holding
+// {1 ARCHIVED, 2 un-archived, 3 ARCHIVING} would otherwise have the confirm for
+// 3 carry the prefix past 2 — re-authorising archival while chapter 2's logs sit
+// un-archived below the resulting archive boundary.
+func TestProcessConfirmArchiveChapter_RefusesToJumpAGap(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+
+	// Chapter 3 is genuinely ARCHIVING, but chapter 2 never got archived, so the
+	// prefix stopped at 1.
+	archiving := &commonpb.Chapter{Id: 3, Status: commonpb.ChapterStatus_CHAPTER_ARCHIVING}
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(1))
+	mockStore.EXPECT().GetChapterByID(uint64(3)).Return(archiving.AsReader(), true).AnyTimes()
+
+	// No UpdateChapter and no AdvanceArchivedThroughChapterID are stubbed: the
+	// order must be refused before any mutation, and the prefix must not move.
+	payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{ChapterId: 3}, &Context{Scope: mockStore})
+	require.Error(t, err)
+	require.Nil(t, payload)
+
+	var outOfOrderErr *domain.ErrChapterArchiveOutOfOrder
+	require.ErrorAs(t, err, &outOfOrderErr)
+	require.Equal(t, uint64(3), outOfOrderErr.ChapterID)
+	require.Equal(t, uint64(2), outOfOrderErr.BlockingChapterID, "the gap must be named")
 }

--- a/internal/domain/processing/processor_chapter_test.go
+++ b/internal/domain/processing/processor_chapter_test.go
@@ -249,6 +249,8 @@ func TestProcessArchiveChapter_Success(t *testing.T) {
 	}
 
 	mockStore.EXPECT().GetChapterByID(uint64(1)).Return(closedChapter.AsReader(), true)
+	// Nothing archived yet, so chapter 1 is the prefix successor.
+	mockStore.EXPECT().GetArchivedThroughChapterID().Return(uint64(0))
 	mockStore.EXPECT().UpdateChapter(gomock.Any()).Do(func(chapter *commonpb.Chapter) {
 		require.Equal(t, commonpb.ChapterStatus_CHAPTER_ARCHIVING, chapter.GetStatus())
 	})
@@ -306,6 +308,99 @@ func TestProcessArchiveChapter_NotClosed(t *testing.T) {
 	require.Equal(t, uint64(1), notClosedErr.ChapterID)
 }
 
+// TestProcessArchiveChapter_RejectsOutOfOrder pins the archival ordering rule:
+// archived chapters form a contiguous prefix of history, so the only archivable
+// chapter is the one right after that prefix. Skipping ahead would purge past an
+// un-archived chapter, leaving its logs below the archive boundary — a
+// permanently unverified window for the checker's replay, and a hole in cold
+// storage no later archive fills.
+func TestProcessArchiveChapter_RejectsOutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		target          uint64
+		archivedThrough uint64
+		wantBlockingID  uint64
+	}{
+		"one chapter ahead of the prefix":   {target: 3, archivedThrough: 1, wantBlockingID: 2},
+		"several chapters ahead":            {target: 7, archivedThrough: 2, wantBlockingID: 3},
+		"nothing archived yet, skips first": {target: 2, archivedThrough: 0, wantBlockingID: 1},
+		// Re-archiving something inside the prefix is equally out of order: its
+		// data is already gone, so a purge here would delete a later chapter's.
+		"already inside the prefix": {target: 1, archivedThrough: 3, wantBlockingID: 4},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := NewMockScope(ctrl)
+
+			target := &commonpb.Chapter{
+				Id:            tc.target,
+				Status:        commonpb.ChapterStatus_CHAPTER_CLOSED,
+				StartSequence: 200,
+				CloseSequence: 300,
+			}
+
+			mockStore.EXPECT().GetChapterByID(tc.target).Return(target.AsReader(), true)
+			mockStore.EXPECT().GetArchivedThroughChapterID().Return(tc.archivedThrough)
+
+			payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: tc.target}, &Context{Scope: mockStore})
+			require.Error(t, err)
+			require.Nil(t, payload, "a rejected archive must emit no log")
+
+			var outOfOrderErr *domain.ErrChapterArchiveOutOfOrder
+			require.ErrorAs(t, err, &outOfOrderErr)
+			require.Equal(t, tc.target, outOfOrderErr.ChapterID)
+			require.Equal(t, tc.wantBlockingID, outOfOrderErr.BlockingChapterID,
+				"the rejection must name the chapter that has to be archived first")
+		})
+	}
+}
+
+// TestProcessArchiveChapter_AllowsPrefixSuccessor is the positive counterpart:
+// the chapter immediately after the archived prefix archives normally, whatever
+// happened to its predecessors' tracker entries — they are purged (and hence
+// absent) on a running node, reloaded as ARCHIVED after a restart, and the gate
+// consults neither, only the marker.
+func TestProcessArchiveChapter_AllowsPrefixSuccessor(t *testing.T) {
+	t.Parallel()
+
+	for name, archivedThrough := range map[string]uint64{
+		"first chapter, empty prefix": 0,
+		"successor of a long prefix":  9,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := NewMockScope(ctrl)
+
+			targetID := archivedThrough + 1
+			target := &commonpb.Chapter{
+				Id:            targetID,
+				Status:        commonpb.ChapterStatus_CHAPTER_CLOSED,
+				StartSequence: 200,
+				CloseSequence: 300,
+			}
+
+			mockStore.EXPECT().GetChapterByID(targetID).Return(target.AsReader(), true)
+			mockStore.EXPECT().GetArchivedThroughChapterID().Return(archivedThrough)
+			mockStore.EXPECT().UpdateChapter(gomock.Any()).Do(func(chapter *commonpb.Chapter) {
+				require.Equal(t, commonpb.ChapterStatus_CHAPTER_ARCHIVING, chapter.GetStatus())
+			})
+
+			payload, err := processArchiveChapter(&raftcmdpb.ArchiveChapterOrder{ChapterId: targetID}, &Context{Scope: mockStore})
+			require.NoError(t, err)
+			require.Equal(t, targetID, payload.GetArchiveChapter().GetChapter().GetId())
+		})
+	}
+}
+
 func TestProcessConfirmArchiveChapter_Success(t *testing.T) {
 	t.Parallel()
 
@@ -326,6 +421,9 @@ func TestProcessConfirmArchiveChapter_Success(t *testing.T) {
 	mockStore.EXPECT().UpdateChapter(gomock.Any()).Do(func(chapter *commonpb.Chapter) {
 		require.Equal(t, commonpb.ChapterStatus_CHAPTER_ARCHIVED, chapter.GetStatus())
 	})
+	// The confirm extends the archived prefix, which is what the ordering gate
+	// reads to admit the next chapter.
+	mockStore.EXPECT().SetArchivedThroughChapterID(uint64(1))
 
 	payload, err := processConfirmArchiveChapter(&raftcmdpb.ConfirmArchiveChapterOrder{
 		ChapterId:   1,

--- a/internal/domain/processing/processor_dispatch_test.go
+++ b/internal/domain/processing/processor_dispatch_test.go
@@ -262,7 +262,10 @@ func TestProcessOrder_DispatchEverySystemScopedVariant(t *testing.T) {
 			payload: &raftcmdpb.SystemScopedOrder{Payload: &raftcmdpb.SystemScopedOrder_ArchiveChapter{
 				ArchiveChapter: &raftcmdpb.ArchiveChapterOrder{ChapterId: 42},
 			}},
-			setup: func(m *MockScope) { m.EXPECT().GetChapterByID(uint64(42)).Return(nil, false) },
+			setup: func(m *MockScope) {
+				m.EXPECT().GetArchivedThroughChapterID().Return(uint64(41))
+				m.EXPECT().GetChapterByID(uint64(42)).Return(nil, false)
+			},
 			check: requireErr(new(*domain.ErrChapterNotFound)),
 		},
 		{
@@ -270,7 +273,10 @@ func TestProcessOrder_DispatchEverySystemScopedVariant(t *testing.T) {
 			payload: &raftcmdpb.SystemScopedOrder{Payload: &raftcmdpb.SystemScopedOrder_ConfirmArchiveChapter{
 				ConfirmArchiveChapter: &raftcmdpb.ConfirmArchiveChapterOrder{ChapterId: 42},
 			}},
-			setup: func(m *MockScope) { m.EXPECT().GetChapterByID(uint64(42)).Return(nil, false) },
+			setup: func(m *MockScope) {
+				m.EXPECT().GetArchivedThroughChapterID().Return(uint64(41))
+				m.EXPECT().GetChapterByID(uint64(42)).Return(nil, false)
+			},
 			check: requireErr(new(*domain.ErrChapterNotFound)),
 		},
 		{

--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -202,8 +202,8 @@ func (s *skipSafeScope) GetArchivedThroughChapterID() uint64 {
 	return s.inner.GetArchivedThroughChapterID()
 }
 
-func (s *skipSafeScope) SetArchivedThroughChapterID(chapterID uint64) {
-	trapUnbuffered("SetArchivedThroughChapterID", nil)
+func (s *skipSafeScope) AdvanceArchivedThroughChapterID() {
+	trapUnbuffered("AdvanceArchivedThroughChapterID", nil)
 }
 
 func (s *skipSafeScope) GetChapterByID(chapterID uint64) (commonpb.ChapterReader, bool) {

--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -198,6 +198,14 @@ func (s *skipSafeScope) RemoveClosingChapter(chapterID uint64) {
 func (s *skipSafeScope) GetNextChapterID() uint64       { return s.inner.GetNextChapterID() }
 func (s *skipSafeScope) IncrementNextChapterID() uint64 { return s.inner.IncrementNextChapterID() }
 
+func (s *skipSafeScope) GetArchivedThroughChapterID() uint64 {
+	return s.inner.GetArchivedThroughChapterID()
+}
+
+func (s *skipSafeScope) SetArchivedThroughChapterID(chapterID uint64) {
+	trapUnbuffered("SetArchivedThroughChapterID", nil)
+}
+
 func (s *skipSafeScope) GetChapterByID(chapterID uint64) (commonpb.ChapterReader, bool) {
 	return s.inner.GetChapterByID(chapterID)
 }

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -96,7 +96,10 @@ type Scope interface {
 	// in-memory tracker when their data is purged, so residency cannot answer
 	// "is this chapter archived?" — this does.
 	GetArchivedThroughChapterID() uint64
-	SetArchivedThroughChapterID(chapterID uint64)
+	// AdvanceArchivedThroughChapterID extends the archived prefix by exactly one
+	// chapter. It takes no id on purpose: a setter could carry the prefix over a
+	// gap, which would re-authorise archival past an un-archived chapter.
+	AdvanceArchivedThroughChapterID()
 
 	// Archive chapter operations (purge range / archive request moved to the WriteSet sink via Absorb).
 	GetChapterByID(chapterID uint64) (commonpb.ChapterReader, bool)

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -91,6 +91,12 @@ type Scope interface {
 	RemoveClosingChapter(chapterID uint64)
 	GetNextChapterID() uint64
 	IncrementNextChapterID() uint64
+	// GetArchivedThroughChapterID returns the archived prefix: every chapter
+	// from 1 to the returned id is ARCHIVED. Chapters are dropped from the
+	// in-memory tracker when their data is purged, so residency cannot answer
+	// "is this chapter archived?" — this does.
+	GetArchivedThroughChapterID() uint64
+	SetArchivedThroughChapterID(chapterID uint64)
 
 	// Archive chapter operations (purge range / archive request moved to the WriteSet sink via Absorb).
 	GetChapterByID(chapterID uint64) (commonpb.ChapterReader, bool)

--- a/internal/domain/processing/store_generated_test.go
+++ b/internal/domain/processing/store_generated_test.go
@@ -322,6 +322,44 @@ func (c *MockScopeDeleteQueryCheckpointCall) DoAndReturn(f func(uint64)) *MockSc
 	return c
 }
 
+// GetArchivedThroughChapterID mocks base method.
+func (m *MockScope) GetArchivedThroughChapterID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArchivedThroughChapterID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetArchivedThroughChapterID indicates an expected call of GetArchivedThroughChapterID.
+func (mr *MockScopeMockRecorder) GetArchivedThroughChapterID() *MockScopeGetArchivedThroughChapterIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchivedThroughChapterID", reflect.TypeOf((*MockScope)(nil).GetArchivedThroughChapterID))
+	return &MockScopeGetArchivedThroughChapterIDCall{Call: call}
+}
+
+// MockScopeGetArchivedThroughChapterIDCall wrap *gomock.Call
+type MockScopeGetArchivedThroughChapterIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeGetArchivedThroughChapterIDCall) Return(arg0 uint64) *MockScopeGetArchivedThroughChapterIDCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeGetArchivedThroughChapterIDCall) Do(f func() uint64) *MockScopeGetArchivedThroughChapterIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeGetArchivedThroughChapterIDCall) DoAndReturn(f func() uint64) *MockScopeGetArchivedThroughChapterIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetChapterByID mocks base method.
 func (m *MockScope) GetChapterByID(chapterID uint64) (commonpb.ChapterReader, bool) {
 	m.ctrl.T.Helper()
@@ -1418,6 +1456,42 @@ func (c *MockScopeSaveQueryCheckpointCall) Do(f func(*raftcmdpb.QueryCheckpointS
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockScopeSaveQueryCheckpointCall) DoAndReturn(f func(*raftcmdpb.QueryCheckpointState)) *MockScopeSaveQueryCheckpointCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetArchivedThroughChapterID mocks base method.
+func (m *MockScope) SetArchivedThroughChapterID(chapterID uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetArchivedThroughChapterID", chapterID)
+}
+
+// SetArchivedThroughChapterID indicates an expected call of SetArchivedThroughChapterID.
+func (mr *MockScopeMockRecorder) SetArchivedThroughChapterID(chapterID any) *MockScopeSetArchivedThroughChapterIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetArchivedThroughChapterID", reflect.TypeOf((*MockScope)(nil).SetArchivedThroughChapterID), chapterID)
+	return &MockScopeSetArchivedThroughChapterIDCall{Call: call}
+}
+
+// MockScopeSetArchivedThroughChapterIDCall wrap *gomock.Call
+type MockScopeSetArchivedThroughChapterIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeSetArchivedThroughChapterIDCall) Return() *MockScopeSetArchivedThroughChapterIDCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeSetArchivedThroughChapterIDCall) Do(f func(uint64)) *MockScopeSetArchivedThroughChapterIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeSetArchivedThroughChapterIDCall) DoAndReturn(f func(uint64)) *MockScopeSetArchivedThroughChapterIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/processing/store_generated_test.go
+++ b/internal/domain/processing/store_generated_test.go
@@ -210,6 +210,42 @@ func (c *MockScopeAddSigningKeyCall) DoAndReturn(f func(string, []byte, string))
 	return c
 }
 
+// AdvanceArchivedThroughChapterID mocks base method.
+func (m *MockScope) AdvanceArchivedThroughChapterID() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AdvanceArchivedThroughChapterID")
+}
+
+// AdvanceArchivedThroughChapterID indicates an expected call of AdvanceArchivedThroughChapterID.
+func (mr *MockScopeMockRecorder) AdvanceArchivedThroughChapterID() *MockScopeAdvanceArchivedThroughChapterIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvanceArchivedThroughChapterID", reflect.TypeOf((*MockScope)(nil).AdvanceArchivedThroughChapterID))
+	return &MockScopeAdvanceArchivedThroughChapterIDCall{Call: call}
+}
+
+// MockScopeAdvanceArchivedThroughChapterIDCall wrap *gomock.Call
+type MockScopeAdvanceArchivedThroughChapterIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeAdvanceArchivedThroughChapterIDCall) Return() *MockScopeAdvanceArchivedThroughChapterIDCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeAdvanceArchivedThroughChapterIDCall) Do(f func()) *MockScopeAdvanceArchivedThroughChapterIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeAdvanceArchivedThroughChapterIDCall) DoAndReturn(f func()) *MockScopeAdvanceArchivedThroughChapterIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Boundaries mocks base method.
 func (m *MockScope) Boundaries() Accessor[domain.LedgerKey, *raftcmdpb.LedgerBoundaries, raftcmdpb.LedgerBoundariesReader] {
 	m.ctrl.T.Helper()
@@ -1456,42 +1492,6 @@ func (c *MockScopeSaveQueryCheckpointCall) Do(f func(*raftcmdpb.QueryCheckpointS
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockScopeSaveQueryCheckpointCall) DoAndReturn(f func(*raftcmdpb.QueryCheckpointState)) *MockScopeSaveQueryCheckpointCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetArchivedThroughChapterID mocks base method.
-func (m *MockScope) SetArchivedThroughChapterID(chapterID uint64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetArchivedThroughChapterID", chapterID)
-}
-
-// SetArchivedThroughChapterID indicates an expected call of SetArchivedThroughChapterID.
-func (mr *MockScopeMockRecorder) SetArchivedThroughChapterID(chapterID any) *MockScopeSetArchivedThroughChapterIDCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetArchivedThroughChapterID", reflect.TypeOf((*MockScope)(nil).SetArchivedThroughChapterID), chapterID)
-	return &MockScopeSetArchivedThroughChapterIDCall{Call: call}
-}
-
-// MockScopeSetArchivedThroughChapterIDCall wrap *gomock.Call
-type MockScopeSetArchivedThroughChapterIDCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockScopeSetArchivedThroughChapterIDCall) Return() *MockScopeSetArchivedThroughChapterIDCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockScopeSetArchivedThroughChapterIDCall) Do(f func(uint64)) *MockScopeSetArchivedThroughChapterIDCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockScopeSetArchivedThroughChapterIDCall) DoAndReturn(f func(uint64)) *MockScopeSetArchivedThroughChapterIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -86,7 +86,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_TRANSACTION_ALREADY_REVERTED,
 		commonpb.ErrorReason_ERROR_REASON_LEDGER_IN_MIRROR_MODE,
 		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_HAS_ACCOUNTS,
-		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_CONFLICT:
+		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_CONFLICT,
+		commonpb.ErrorReason_ERROR_REASON_CHAPTER_ALREADY_ARCHIVED:
 		return KindConflict
 	case commonpb.ErrorReason_ERROR_REASON_INSUFFICIENT_FUNDS,
 		commonpb.ErrorReason_ERROR_REASON_VOLUME_OVERFLOW,

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -98,6 +98,7 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CHAPTER_NOT_CLOSED,
 		commonpb.ErrorReason_ERROR_REASON_CHAPTER_NOT_ARCHIVING,
 		commonpb.ErrorReason_ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH,
+		commonpb.ErrorReason_ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER,
 		commonpb.ErrorReason_ERROR_REASON_LEDGER_NOT_IN_MIRROR_MODE,
 		commonpb.ErrorReason_ERROR_REASON_INDEX_NOT_FOUND,
 		commonpb.ErrorReason_ERROR_REASON_METADATA_FIELD_NOT_IN_SCHEMA,

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -426,6 +426,12 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"chapterId": "7", "expectedSealingHash": "dead", "gotSealingHash": "beef"},
 		},
 		{
+			name:        "ChapterArchiveOutOfOrder",
+			err:         &domain.ErrChapterArchiveOutOfOrder{ChapterID: 7, BlockingChapterID: 5},
+			wantReason:  domain.ErrReasonChapterArchiveOutOfOrder,
+			wantContext: map[string]string{"chapterId": "7", "blockingChapterId": "5"},
+		},
+		{
 			name:        "MirrorV2LogIDGap",
 			err:         &domain.ErrMirrorV2LogIDGap{Name: "mirror-ledger", Got: 12, Expected: 9},
 			wantReason:  domain.ErrReasonMirrorV2LogIDGap,

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -432,6 +432,12 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"chapterId": "7", "blockingChapterId": "5"},
 		},
 		{
+			name:        "ChapterAlreadyArchived",
+			err:         &domain.ErrChapterAlreadyArchived{ChapterID: 2, ArchivedThroughChapterID: 5},
+			wantReason:  domain.ErrReasonChapterAlreadyArchived,
+			wantContext: map[string]string{"chapterId": "2", "archivedThroughChapterId": "5"},
+		},
+		{
 			name:        "MirrorV2LogIDGap",
 			err:         &domain.ErrMirrorV2LogIDGap{Name: "mirror-ledger", Got: 12, Expected: 9},
 			wantReason:  domain.ErrReasonMirrorV2LogIDGap,

--- a/internal/infra/state/chapter_tracker.go
+++ b/internal/infra/state/chapter_tracker.go
@@ -19,6 +19,16 @@ type ChapterTracker struct {
 	closingChapters    []*commonpb.Chapter
 	nextChapterID      uint64
 
+	// archivedThroughID is the highest chapter id such that every chapter from
+	// 1 to it is ARCHIVED — the archived prefix of history. allChapters holds
+	// only chapters whose data is still in hot storage (purged ones are
+	// removed), so it cannot answer "is this chapter archived?" for the very
+	// chapters the question is about; this scalar records that history fact
+	// explicitly instead of inferring it from residency. Its twin is
+	// nextChapterID: same monotonic-chapter-bookkeeping character, same need to
+	// survive recovery.
+	archivedThroughID uint64
+
 	// schedule is the cron expression for automatic chapter rotation (empty = disabled).
 	schedule string
 	// scheduleChanged fires when the schedule is updated via Raft.
@@ -42,9 +52,39 @@ func NewChapterTracker(
 		currentOpenChapter: currentOpenChapter,
 		closingChapters:    closingChapters,
 		nextChapterID:      nextChapterID,
+		archivedThroughID:  deriveArchivedThroughID(allChapters, nextChapterID),
 		schedule:           schedule,
 		scheduleChanged:    signal.New(),
 	}
+}
+
+// deriveArchivedThroughID computes the archived prefix from persisted chapter
+// rows: the highest id such that every chapter from 1 up to it is ARCHIVED.
+//
+// Both recovery paths (boot and follower checkpoint-sync) rebuild the tracker
+// from the SubGlobChapters rows, which are never deleted — so a row is present
+// for every chapter that ever existed and carries its final status. A missing
+// row therefore stops the prefix: it cannot be shown to be archived, and
+// counting it would let the ordering gate authorise a purge over a chapter
+// whose fate is unknown.
+//
+// The scan is over a fixed id range rather than a map iteration, so the result
+// does not depend on map order — a requirement, since the ordering gate's
+// accept/reject verdict is recorded in the audit chain and must be identical on
+// every replica.
+func deriveArchivedThroughID(allChapters map[uint64]*commonpb.Chapter, nextChapterID uint64) uint64 {
+	var through uint64
+
+	for id := uint64(1); id < nextChapterID; id++ {
+		chapter, ok := allChapters[id]
+		if !ok || chapter.GetStatus() != commonpb.ChapterStatus_CHAPTER_ARCHIVED {
+			break
+		}
+
+		through = id
+	}
+
+	return through
 }
 
 // AllChapters returns a slice of all non-purged chapters.
@@ -250,6 +290,26 @@ func (pt *ChapterTracker) Reset(
 	pt.currentOpenChapter = currentOpenChapter
 	pt.closingChapters = closingChapters
 	pt.nextChapterID = nextChapterID
+	pt.archivedThroughID = deriveArchivedThroughID(allChapters, nextChapterID)
+}
+
+// ArchivedThroughID returns the archived prefix: every chapter from 1 to the
+// returned id is ARCHIVED. 0 means no chapter is archived yet.
+func (pt *ChapterTracker) ArchivedThroughID() uint64 {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+
+	return pt.archivedThroughID
+}
+
+// SetArchivedThroughID records the archived prefix. Advanced by the
+// confirm-archive handler; the ordering rule keeps the prefix contiguous, so it
+// only ever moves forward by one.
+func (pt *ChapterTracker) SetArchivedThroughID(id uint64) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+
+	pt.archivedThroughID = id
 }
 
 // Clone returns a deep copy of the ChapterTracker suitable for use in a Buffer.
@@ -279,5 +339,6 @@ func (pt *ChapterTracker) Clone() *ChapterTracker {
 		currentOpenChapter: clonedOpen,
 		closingChapters:    clonedClosing,
 		nextChapterID:      pt.nextChapterID,
+		archivedThroughID:  pt.archivedThroughID,
 	}
 }

--- a/internal/infra/state/chapter_tracker_test.go
+++ b/internal/infra/state/chapter_tracker_test.go
@@ -323,3 +323,86 @@ func TestChapterTrackerCloneNilChapters(t *testing.T) {
 	require.Empty(t, clone.ClosingChapters())
 	require.Len(t, clone.AllChapters(), 1)
 }
+
+// TestChapterTrackerArchivedThroughDerivation covers the recovery side of the
+// archived-prefix marker: both boot and follower checkpoint-sync rebuild the
+// tracker from the persisted chapter rows, so the marker has to be derived from
+// them and must agree with the value a running node carries incrementally.
+func TestChapterTrackerArchivedThroughDerivation(t *testing.T) {
+	t.Parallel()
+
+	chapter := func(id uint64, status commonpb.ChapterStatus) *commonpb.Chapter {
+		return &commonpb.Chapter{Id: id, Status: status}
+	}
+
+	for name, tc := range map[string]struct {
+		rows          map[uint64]*commonpb.Chapter
+		nextChapterID uint64
+		want          uint64
+	}{
+		"nothing archived": {
+			rows:          map[uint64]*commonpb.Chapter{1: chapter(1, commonpb.ChapterStatus_CHAPTER_OPEN)},
+			nextChapterID: 2,
+			want:          0,
+		},
+		"contiguous archived prefix": {
+			rows: map[uint64]*commonpb.Chapter{
+				1: chapter(1, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				2: chapter(2, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				3: chapter(3, commonpb.ChapterStatus_CHAPTER_CLOSED),
+				4: chapter(4, commonpb.ChapterStatus_CHAPTER_OPEN),
+			},
+			nextChapterID: 5,
+			want:          2,
+		},
+		// A gap stops the prefix rather than counting past it: chapter 3 is not
+		// archived, so a purge for 4 would delete data 3 still owns.
+		"gap in the middle stops the prefix": {
+			rows: map[uint64]*commonpb.Chapter{
+				1: chapter(1, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				2: chapter(2, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				3: chapter(3, commonpb.ChapterStatus_CHAPTER_CLOSED),
+				4: chapter(4, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				5: chapter(5, commonpb.ChapterStatus_CHAPTER_OPEN),
+			},
+			nextChapterID: 6,
+			want:          2,
+		},
+		// Rows are never deleted, so a missing one is anomalous; it cannot be
+		// shown to be archived and therefore stops the prefix too.
+		"missing row stops the prefix": {
+			rows: map[uint64]*commonpb.Chapter{
+				1: chapter(1, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				3: chapter(3, commonpb.ChapterStatus_CHAPTER_ARCHIVED),
+				4: chapter(4, commonpb.ChapterStatus_CHAPTER_OPEN),
+			},
+			nextChapterID: 5,
+			want:          1,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			built := NewChapterTracker(tc.rows, nil, nil, tc.nextChapterID, "")
+			require.Equal(t, tc.want, built.ArchivedThroughID())
+
+			// Reset is the runtime path (RecoverState, SynchronizeWithLeader) and
+			// must derive identically to construction.
+			reset := newTestChapterTracker()
+			reset.Reset(tc.rows, nil, nil, tc.nextChapterID)
+			require.Equal(t, tc.want, reset.ArchivedThroughID())
+		})
+	}
+}
+
+// TestChapterTrackerCloneCarriesArchivedThrough guards the WriteSet path: the
+// per-proposal buffer works on a clone, so a clone that dropped the marker would
+// read 0 and reject every archive.
+func TestChapterTrackerCloneCarriesArchivedThrough(t *testing.T) {
+	t.Parallel()
+
+	tracker := newTestChapterTracker()
+	tracker.SetArchivedThroughID(7)
+
+	require.Equal(t, uint64(7), tracker.Clone().ArchivedThroughID())
+}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -860,6 +860,7 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		b.fsm.Chapters.SetCurrentOpenChapter(b.chapters.CurrentOpenChapter())
 		b.fsm.Chapters.SetClosingChapters(b.chapters.ClosingChapters())
 		b.fsm.Chapters.SetNextChapterID(b.chapters.NextChapterID())
+		b.fsm.Chapters.SetArchivedThroughID(b.chapters.ArchivedThroughID())
 	}
 
 	return nil
@@ -1647,6 +1648,21 @@ func (b *WriteSet) IncrementNextChapterID() uint64 {
 	b.chapters.SetNextChapterID(id + 1)
 
 	return id
+}
+
+func (b *WriteSet) GetArchivedThroughChapterID() uint64 {
+	b.ensureChapters()
+
+	return b.chapters.ArchivedThroughID()
+}
+
+// SetArchivedThroughChapterID advances the archived prefix on the buffer, so a
+// later order in the SAME proposal (a batched ApplyRequest can carry
+// ConfirmArchiveChapter for N and ArchiveChapter for N+1) observes it. Merge
+// propagates the value to the FSM tracker.
+func (b *WriteSet) SetArchivedThroughChapterID(chapterID uint64) {
+	b.ensureChapters()
+	b.chapters.SetArchivedThroughID(chapterID)
 }
 
 // GetChapterByID looks up a chapter by ID from in-memory state only.

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1656,13 +1656,13 @@ func (b *WriteSet) GetArchivedThroughChapterID() uint64 {
 	return b.chapters.ArchivedThroughID()
 }
 
-// SetArchivedThroughChapterID advances the archived prefix on the buffer, so a
-// later order in the SAME proposal (a batched ApplyRequest can carry
-// ConfirmArchiveChapter for N and ArchiveChapter for N+1) observes it. Merge
-// propagates the value to the FSM tracker.
-func (b *WriteSet) SetArchivedThroughChapterID(chapterID uint64) {
+// AdvanceArchivedThroughChapterID extends the archived prefix by one on the
+// buffer, so a later order in the SAME proposal (a batched ApplyRequest can
+// carry ConfirmArchiveChapter for N and ArchiveChapter for N+1) observes it.
+// Merge propagates the value to the FSM tracker.
+func (b *WriteSet) AdvanceArchivedThroughChapterID() {
 	b.ensureChapters()
-	b.chapters.SetArchivedThroughID(chapterID)
+	b.chapters.SetArchivedThroughID(b.chapters.ArchivedThroughID() + 1)
 }
 
 // GetChapterByID looks up a chapter by ID from in-memory state only.

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -726,6 +726,12 @@ const (
 	// and "archived" mean the same thing — see the archival ordering rule in
 	// docs/technical/architecture/subsystems/chapters/lifecycle.md.
 	ErrorReason_ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER ErrorReason = 71
+	// ERROR_REASON_CHAPTER_ALREADY_ARCHIVED: the chapter is inside the archived
+	// prefix, so this order has already been carried out and no later archive
+	// changes that. Distinct from CHAPTER_ARCHIVE_OUT_OF_ORDER, which names a
+	// chapter that must be archived first: here there is nothing to archive
+	// first, and the metadata reports how far the prefix reaches instead.
+	ErrorReason_ERROR_REASON_CHAPTER_ALREADY_ARCHIVED ErrorReason = 72
 )
 
 // Enum value maps for ErrorReason.
@@ -803,6 +809,7 @@ var (
 		69: "ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP",
 		70: "ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH",
 		71: "ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER",
+		72: "ERROR_REASON_CHAPTER_ALREADY_ARCHIVED",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                       0,
@@ -877,6 +884,7 @@ var (
 		"ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP":          69,
 		"ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH": 70,
 		"ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER":      71,
+		"ERROR_REASON_CHAPTER_ALREADY_ARCHIVED":          72,
 	}
 )
 
@@ -13727,7 +13735,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xcd\x16\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xf8\x16\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13801,7 +13809,8 @@ const file_common_proto_rawDesc = "" +
 	"\x1eERROR_REASON_BALANCE_NOT_FOUND\x10D\x12)\n" +
 	"%ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP\x10E\x122\n" +
 	".ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH\x10F\x12-\n" +
-	")ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER\x10G*Q\n" +
+	")ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER\x10G\x12)\n" +
+	"%ERROR_REASON_CHAPTER_ALREADY_ARCHIVED\x10H*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -720,6 +720,12 @@ const (
 	// trade hot history for belongs to a timeline this store no longer has — see
 	// docs/technical/architecture/subsystems/chapters/backup.md.
 	ErrorReason_ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH ErrorReason = 70
+	// ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER: the chapter is CLOSED, but it is
+	// not the one immediately after the archived prefix. Archived chapters must
+	// form a contiguous prefix of history so that "below the archive boundary"
+	// and "archived" mean the same thing — see the archival ordering rule in
+	// docs/technical/architecture/subsystems/chapters/lifecycle.md.
+	ErrorReason_ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER ErrorReason = 71
 )
 
 // Enum value maps for ErrorReason.
@@ -796,6 +802,7 @@ var (
 		68: "ERROR_REASON_BALANCE_NOT_FOUND",
 		69: "ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP",
 		70: "ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH",
+		71: "ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                       0,
@@ -869,6 +876,7 @@ var (
 		"ERROR_REASON_BALANCE_NOT_FOUND":                 68,
 		"ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP":          69,
 		"ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH": 70,
+		"ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER":      71,
 	}
 )
 
@@ -13719,7 +13727,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\x9e\x16\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xcd\x16\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13792,7 +13800,8 @@ const file_common_proto_rawDesc = "" +
 	"\x1fERROR_REASON_AGGREGATE_OVERFLOW\x10C\x12\"\n" +
 	"\x1eERROR_REASON_BALANCE_NOT_FOUND\x10D\x12)\n" +
 	"%ERROR_REASON_READ_INDEX_NOT_CAUGHT_UP\x10E\x122\n" +
-	".ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH\x10F*Q\n" +
+	".ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH\x10F\x12-\n" +
+	")ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER\x10G*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1270,6 +1270,12 @@ enum ErrorReason {
   // and "archived" mean the same thing — see the archival ordering rule in
   // docs/technical/architecture/subsystems/chapters/lifecycle.md.
   ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER = 71;
+  // ERROR_REASON_CHAPTER_ALREADY_ARCHIVED: the chapter is inside the archived
+  // prefix, so this order has already been carried out and no later archive
+  // changes that. Distinct from CHAPTER_ARCHIVE_OUT_OF_ORDER, which names a
+  // chapter that must be archived first: here there is nothing to archive
+  // first, and the metadata reports how far the prefix reaches instead.
+  ERROR_REASON_CHAPTER_ALREADY_ARCHIVED = 72;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1264,6 +1264,12 @@ enum ErrorReason {
   // trade hot history for belongs to a timeline this store no longer has — see
   // docs/technical/architecture/subsystems/chapters/backup.md.
   ERROR_REASON_CHAPTER_ARCHIVE_IDENTITY_MISMATCH = 70;
+  // ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER: the chapter is CLOSED, but it is
+  // not the one immediately after the archived prefix. Archived chapters must
+  // form a contiguous prefix of history so that "below the archive boundary"
+  // and "archived" mean the same thing — see the archival ordering rule in
+  // docs/technical/architecture/subsystems/chapters/lifecycle.md.
+  ERROR_REASON_CHAPTER_ARCHIVE_OUT_OF_ORDER = 71;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key


### PR DESCRIPTION
Archival was unordered: `ArchiveChapter` accepted any `CLOSED` chapter, so chapter 3 could be archived while chapter 2 was still merely closed.

## Why that is a problem

The purge that follows a confirm deletes **everything** up to the archived chapter's close sequence. Archiving out of order therefore leaves an older, un-archived chapter's logs retained *below* the archive boundary, and that has two consequences:

- The checker's replay skips every log at or below the boundary (the baseline checkpoint and the audit chain are authoritative down there), so those retained logs become a **permanently unverified window** in the middle of history.
- Cold storage keeps a **hole no later archive ever fills** — nothing ever comes back for chapter 2.

It also silently violates an assumption the archive-aware checker passes already make, namely that "below the archive boundary" and "archived" are the same statement. That mismatch is not hypothetical: it is the live-path trigger of the false `EXCLUSION_RECORD_MISMATCH` fixed separately in `fix/exclusion-check-archived-ranges` — the same false positive is reachable on a never-restored cluster purely by archiving out of order.

## The change

`processArchiveChapter` now admits only the chapter immediately after the archived prefix, rejecting anything else with a new `CHAPTER_ARCHIVE_OUT_OF_ORDER` reason whose metadata carries `blockingChapterId`. Archived chapters are consequently always a contiguous prefix of history.

**The prefix is tracked explicitly, not inferred from the tracker.** This is the substance of the second review round, and it turns on what each structure means:

- `ChapterTracker.allChapters` is the FSM's working set of chapters **whose data is still in hot storage** — it exists so the apply path never reads Pebble (invariant #3). The confirm-archive purge drops archived chapters from it (`WriteSet.Merge` → `DeleteChapter`), so *absence there means "purged", not "archived"*.
- `ZoneGlobal/SubGlobChapters` is the durable, complete registry — every chapter that ever existed, never deleted — and it is what recovery, the query path, cold-read routing, the checker and the backup backfill read.

So asking the tracker "is chapter N archived?" asks a history question of a residency structure. The first version of this PR did exactly that and was wrong twice over: it rejected every sequential archive past the first (by then the predecessor is purged), and it made the verdict restart-dependent, since recovery reloads archived rows as `ARCHIVED` — a restarted replica would accept an order a non-restarted one rejects and diverge the FSM (invariant #2).

`ChapterTracker.archivedThroughID` records the fact directly. `ConfirmArchiveChapter` advances it through a `Scope` method rather than at merge time, so a later order in the *same* proposal sees it — a batched `ApplyRequest` can carry confirm N and archive N+1, and `WriteSet.GetChapterByID` already made that pair work. `Merge` propagates it to the FSM tracker beside `NextChapterID`, and both recovery paths (boot and follower checkpoint-sync, which share `RecoverState`) derive it from the persisted rows as the longest run of `ARCHIVED` from chapter 1 — stopping at a gap or a missing row rather than counting past it. No new persisted state: the marker is derived from rows the registry already keeps forever, so it adds no projection for invariant #8 to cover.

Requiring the predecessor to be fully `ARCHIVED` rather than merely `ARCHIVING` matters: an in-flight upload must not let a successor's confirm, and therefore its purge, land first. A side effect is that at most one chapter is ever in `ARCHIVING`, which shrinks the archiver's state space.

The gate lives in the FSM rather than the CLI because the checker's correctness assumption now rests on it and it must hold identically on every node. It is deterministic: a scalar comparison, and the recovery derivation scans a fixed id range rather than iterating a map, so the accept/reject verdict the audit chain records cannot depend on map order.

## Trade-off, stated plainly

This removes an escape hatch. A chapter whose upload cannot complete — persistent cold-storage failure, or an object that fails the identity check added in #1679 — now blocks archival of newer chapters instead of being stepped over, so hot storage grows until the underlying problem is fixed. That is intentional: a loud, recoverable stall beats a silent permanent gap in cold storage. If a step-over is ever genuinely needed it should be an explicit flag on the order rather than the default behaviour.

## Blast radius

Nothing relied on the old freedom. The chapter scheduler only ever proposes `CloseChapter`; archival is exclusively operator-driven (`ledgerctl chapters archive <id>`) or driver-driven in tests, and both go oldest-first in practice. No automated component picks a chapter id.

## Tests

- `TestProcessArchiveChapter_RejectsOutOfOrder` — table-driven over one-ahead, several-ahead, skipping the first chapter, and re-archiving inside the prefix; asserts the typed error, the blocking id, and that no log is emitted.
- `TestProcessArchiveChapter_AllowsPrefixSuccessor` — the prefix successor archives normally, for an empty prefix and a long one.
- `TestChapterTrackerArchivedThroughDerivation` — the recovery side, which mocks cannot reach: derivation from persisted rows via both `NewChapterTracker` and `Reset`, including a status gap and a missing row stopping the prefix.
- `TestChapterTrackerCloneCarriesArchivedThrough` — a clone that dropped the marker would read 0 and reject every archive.
- `tests/e2e/business/audit_purge_test.go` archives **two** chapters sequentially through the real tracker, which is what caught the first round's bug. Verified failing both on that version and on a marker that never advances; passing now, along with the rest of the chapter/cold-storage e2e specs and the full `./internal/...` unit suite.

Docs: the ordering rule and the residency-vs-history distinction are documented in the chapter lifecycle page and the `chapters archive` CLI reference. While confirming the tracker's contract I also found and corrected two stale claims in `lifecycle.md`: `ListChapters` reads Pebble (not `Machine.AllChapters()`), and the documented `MemorySnapshot` message does not exist — chapter state is rebuilt from the persisted rows, including on follower checkpoint-sync.
