### PR TITLE
fix(ledger): upsert transaction accounts inside the operation's transaction

### DIFF
--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -307,7 +307,7 @@ func (ctrl *DefaultController) importLog(ctx context.Context, store Store, log l
 				if err := store.CommitTransaction(ctx, &payload.Transaction); err != nil {
 					return nil, fmt.Errorf("failed to commit transaction: %w", err)
 				}
-				if err := ctrl.upsertTransactionAccounts(ctx, schema, &payload.Transaction, payload.AccountMetadata); err != nil {
+				if err := ctrl.upsertTransactionAccounts(ctx, store, schema, &payload.Transaction, payload.AccountMetadata); err != nil {
 					return nil, fmt.Errorf("failed to upsert transaction accounts: %w", err)
 				}
 				logging.FromContext(ctx).Debugf("Imported transaction %d", *payload.Transaction.ID)
@@ -374,10 +374,15 @@ func (ctrl *DefaultController) importLog(ctx context.Context, store Store, log l
 	return err
 }
 
-func (ctrl *DefaultController) upsertTransactionAccounts(ctx context.Context, schema *ledger.Schema, tx *ledger.Transaction, accountMetadata ledger.AccountMetadata) error {
+// upsertTransactionAccounts writes the accounts a transaction involves. It must
+// run on the operation's store: the upsert lowers first_usage to the transaction's
+// effective date, so on any other handle it would autocommit independently of the
+// transaction — visible before the transaction, and durable even when the
+// transaction never commits.
+func (ctrl *DefaultController) upsertTransactionAccounts(ctx context.Context, store Store, schema *ledger.Schema, tx *ledger.Transaction, accountMetadata ledger.AccountMetadata) error {
 	accountsToUpsert := tx.AccountsWithDefaultMetadata(schema, accountMetadata)
 
-	err := ctrl.store.UpsertAccounts(
+	err := store.UpsertAccounts(
 		ctx,
 		accountsToUpsert...,
 	)
@@ -501,7 +506,7 @@ func (ctrl *DefaultController) createTransaction(ctx context.Context, store Stor
 	if err != nil {
 		return nil, err
 	}
-	err = ctrl.upsertTransactionAccounts(ctx, schema, &transaction, accountMetadata)
+	err = ctrl.upsertTransactionAccounts(ctx, store, schema, &transaction, accountMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/api_transactions_dry_run_accounts_test.go
+++ b/test/e2e/api_transactions_dry_run_accounts_test.go
@@ -1,0 +1,120 @@
+//go:build it
+
+package test_suite
+
+import (
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	. "github.com/formancehq/go-libs/v5/pkg/testing/deferred/ginkgo"
+	"github.com/formancehq/go-libs/v5/pkg/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
+
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
+	. "github.com/formancehq/ledger/pkg/testserver"
+	. "github.com/formancehq/ledger/pkg/testserver/ginkgo"
+)
+
+// A transaction writes its accounts through the operation's store. When that
+// store was not the transaction's, the accounts were autocommitted: they
+// survived an operation that never committed, and because the upsert lowers
+// first_usage to the transaction's effective date (LEAST over the involved
+// accounts), an existing account's first_usage was pulled back permanently.
+//
+// A dry run is the observable form of "the operation never commits": the whole
+// transaction is rolled back by design, so nothing it wrote may remain. The
+// ledger must be warm — the first write to a ledger runs under a
+// controller-level transaction that hides the defect.
+var _ = Context("Ledger transactions dry run account persistence", func() {
+	var (
+		db         = UseTemplatedDatabase()
+		ctx        = logging.TestingContext()
+		testServer = DeferTestServer(
+			DeferMap(db, (*pgtesting.Database).ConnectionOptions),
+			testservice.WithInstruments(
+				testservice.DebugInstrumentation(debug),
+				testservice.OutputInstrumentation(GinkgoWriter),
+			),
+			testservice.WithLogger(GinkgoT()),
+		)
+		backdated = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	)
+
+	BeforeEach(func(specContext SpecContext) {
+		_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		// Warm the ledger: the very first write is wrapped in a controller-level
+		// transaction, which would mask the defect.
+		_, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+			Ledger: "default",
+			V2PostTransaction: components.V2PostTransaction{
+				Postings: []components.V2Posting{{
+					Source: "world", Destination: "seed", Amount: big.NewInt(10), Asset: "USD",
+				}},
+			},
+		})
+		Expect(err).To(BeNil())
+	})
+
+	When("dry running a backdated transaction to a new account", func() {
+		var worldBefore *time.Time
+
+		BeforeEach(func(specContext SpecContext) {
+			world, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+				Ledger: "default", Address: "world",
+			})
+			Expect(err).To(BeNil())
+			worldBefore = world.V2AccountResponse.Data.FirstUsage
+
+			_, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				DryRun: pointer.For(true),
+				V2PostTransaction: components.V2PostTransaction{
+					Timestamp: &backdated,
+					Postings: []components.V2Posting{{
+						Source: "world", Destination: "ghost", Amount: big.NewInt(5), Asset: "USD",
+					}},
+				},
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("should not persist the transaction", func(specContext SpecContext) {
+			txs, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListTransactions(ctx, operations.V2ListTransactionsRequest{
+				Ledger: "default",
+			})
+			Expect(err).To(BeNil())
+			Expect(txs.V2TransactionsCursorResponse.Cursor.Data).To(HaveLen(1))
+		})
+
+		It("should not create the account the dry run touched", func(specContext SpecContext) {
+			accounts, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+				Ledger: "default",
+			})
+			Expect(err).To(BeNil())
+
+			addresses := make([]string, 0, len(accounts.V2AccountsCursorResponse.Cursor.Data))
+			for _, account := range accounts.V2AccountsCursorResponse.Cursor.Data {
+				addresses = append(addresses, account.Address)
+			}
+			Expect(addresses).ToNot(ContainElement("ghost"))
+		})
+
+		It("should not backdate first_usage of an existing account", func(specContext SpecContext) {
+			world, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+				Ledger: "default", Address: "world",
+			})
+			Expect(err).To(BeNil())
+			Expect(world.V2AccountResponse.Data.FirstUsage).To(Equal(worldBefore))
+		})
+	})
+})


### PR DESCRIPTION
Fixes EN-1753.

## The bug

A transaction's `accounts` rows can be committed **outside the operation's database transaction**, so they survive an operation that never commits. Because the upsert lowers `first_usage` to the transaction's effective date (`LEAST` over the involved accounts), this permanently backdates existing accounts.

`createTransaction` writes the transaction, moves and log through the transaction-scoped `store` that `forgeLog` passes down, but writes accounts through `ctrl.store`:

```go
err = store.CommitTransaction(ctx, &transaction)                                   // txStore
err = ctrl.upsertTransactionAccounts(ctx, schema, &transaction, accountMetadata)   // ignores `store`
```

```go
func (ctrl *DefaultController) upsertTransactionAccounts(...) error {
	err := ctrl.store.UpsertAccounts(ctx, accountsToUpsert...)   // base handle → autocommit
```

`saveAccountMetadata` already does this correctly, using the `store` parameter.

## Why it hid for so long

The **first** write to a ledger runs under a controller-level transaction, so `ctrl.store` is transaction-scoped and the upsert is atomic *by accident*. Only from the second write onward is `ctrl.store` the pool. Instrumenting both write sites with the underlying `*sql.Tx` shows it directly:

```
first create in a ledger:   INSERTTX handle=TX:0x…c880   UPSERT handle=TX:0x…c880   ← atomic
second create, same ledger: INSERTTX handle=TX:0x…5b80   UPSERT handle=POOL         ← not atomic
```

Over a 3-minute concurrent workload: 375/375 transaction inserts in a transaction, but 338 of 748 account upserts on the pool.

## Impact

`first_usage` is the sole gate for the as-of-pit account universe (`resource_accounts.go:27`, `where accounts.first_usage <= pit`), and it is only ever lowered. So one operation that fails after the upsert corrupts that account's history permanently: `GET /accounts?pit=…` then lists it as in use at a time nothing touched it, with no volumes and no transaction to explain it. `firstUsage` is also returned by the API, so the wrong value is directly visible.

Found by the v2 model-based conformance test (DST), which could not reproduce such a page under any legal serialization. Confirmed on a frozen database: an account whose `first_usage` matched, to the second, the effective date of an in-flight operation for which no transaction, no moves and no log exist.

## The fix

Take the store as a parameter and pass each caller's own — matching `saveAccountMetadata`. Two call sites: the create path and the import/replay path. I audited the remaining `ctrl.store` uses in the controller; they are read paths and transaction-lifecycle helpers (`BeginTX`/`Commit`/`Rollback`/`LockLedger`), so this was the only instance.

## Regression test

`test/e2e/api_transactions_dry_run_accounts_test.go`. A dry run is the observable form of "the operation never commits" — it is rolled back by design, so nothing it wrote may remain. The test warms the ledger first (otherwise the controller-level transaction on the first write masks the defect), then dry-runs a backdated transaction to a new account.

Before the fix: the transaction is correctly absent, but the account is created **and** `world`'s `first_usage` is backdated to 2020.

```
[FAIL] should not create the account the dry run touched
[FAIL] should not backdate first_usage of an existing account
Ran 3 of 321 Specs — 1 Passed | 2 Failed
```

After: `3 Passed | 0 Failed`.

## Performance

The concern with moving the upsert into the transaction is holding the account row lock for longer. Measured with the repo's own write benchmark, arms interleaved across 3 rounds to cancel drift, 6 samples each, `FULL` feature set:

| scenario | main | this branch | Δ |
| --- | --- | --- | --- |
| `world_to_any` (fresh account each tx → INSERT) | 294.9 ± 18.6 t/s | 310.2 ± 16.1 t/s | +5.2%, not significant (t=+1.52) |
| same account, decreasing effective date (→ UPDATE, row-locked every tx) | 80.5 ± 9.1 t/s | 78.8 ± 9.6 t/s | −2.2%, not significant (t=−0.33) |

Both deltas are inside run-to-run variance. That matches the mechanism: for ordinary traffic the upsert's `WHERE (d.first_usage < a.first_usage OR NOT a.metadata @> d.metadata)` matches nothing, so no row is touched at all; and when it does fire, `UpdateVolumes` in the same transaction already holds locks on the same accounts.

## Note for operators

Existing deployments may already carry corrupted `first_usage` values. This stops new corruption; it does not repair old rows.

The corruption does **not** require a backdated operation. Any operation that fails, is retried, or is dry-run stamps `first_usage` a few milliseconds-to-seconds early, and because the upsert uses `LEAST` a later legitimate transaction can never raise it back. How far back the value lands is simply how far back the discarded operation was dated — usually seconds, years when it was backdated.

Auditing therefore has to compare `first_usage` against the value reconstructed from the logs, which record what actually committed:

```sql
-- replace <bucket> with the bucket schema and <ledger> with the ledger name
with contrib as (
    select p->>'source' as address,
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC') as ts
      from "<bucket>".logs l, jsonb_array_elements(l.data->'transaction'->'postings') p
     where l.ledger = '<ledger>' and l.type in ('NEW_TRANSACTION','REVERTED_TRANSACTION')
    union all
    select p->>'destination',
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC')
      from "<bucket>".logs l, jsonb_array_elements(l.data->'transaction'->'postings') p
     where l.ledger = '<ledger>' and l.type in ('NEW_TRANSACTION','REVERTED_TRANSACTION')
    union all
    select jsonb_object_keys(l.data->'accountMetadata'),
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC')
      from "<bucket>".logs l
     where l.ledger = '<ledger>' and l.type = 'NEW_TRANSACTION'
       and l.data->'accountMetadata' <> 'null'::jsonb
    union all
    select l.data->>'targetId', (l.date at time zone 'UTC')
      from "<bucket>".logs l
     where l.ledger = '<ledger>' and l.type in ('SET_METADATA','DELETE_METADATA')
       and l.data->>'targetType' = 'ACCOUNT'
)
select a.address, a.first_usage as actual, min(c.ts) as expected
  from "<bucket>".accounts a
  left join contrib c on c.address = a.address
 where a.ledger = '<ledger>'
 group by a.address, a.first_usage
having min(c.ts) is null or a.first_usage <> min(c.ts);
```

`expected` is `LEAST` over the effective date of every committed transaction touching the account (the create path passes `tx.Timestamp` for postings and for `accountMetadata` targets) and the log date of every standalone account-metadata write (that path passes no date, so it coalesces to the log date). A null `expected` means no committed log explains the account at all.

Verified against a fixture holding a metadata-only account, a metadata-then-backdated-transaction account, a phantom account left by a dry run, and an account corrupted by a *non-backdated* dry run followed by a legitimate transaction: it flags exactly the corrupted rows.

Two cheaper checks were tried and are **not** sufficient, for the record:

- `first_usage < insertion_date` with no move that early — finds only the *backdated* subset. A non-backdated discarded operation leaves `first_usage == insertion_date`, indistinguishable by dates from a legitimately metadata-created account.
- "account not referenced by any log" — finds phantom accounts, but misses any account that a legitimate transaction later touched, which is the common case.

The reconstruction assumes the log is complete for the ledger; if logs have been pruned, it can only be trusted from the earliest retained log onward.
