### PR TITLE
perf(storage): per-ledger functional-index routing for sparse metadata queries

### DIFF
--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -23,8 +23,9 @@ an index-only scan that also covers the `ORDER BY id DESC`, eliminating the
 table walk entirely.
 
 **The rewrite only takes effect when a matching functional index is confirmed to
-exist.** Ledger checks `pg_indexes` at startup (per ledger). If the index is
-absent, the query falls back to the standard `@>` form.
+exist.** Ledger checks `pg_index` (via `pg_get_expr`) at store-open time (per
+ledger, per request). If the index is absent, the query falls back to the
+standard `@>` form.
 
 ---
 
@@ -53,28 +54,40 @@ Wait for `CREATE INDEX` to complete before proceeding.
 
 ### 2. Enable the feature flag
 
+Features are set at ledger creation time. To create a ledger with indexed
+metadata keys:
+
 ```http
-PATCH /ledgers/<ledger>
+POST /v2/ledgers/<ledger>
 Content-Type: application/json
 
 {"features": {"INDEXED_METADATA_KEYS": "source_wallet_id,destination_wallet_id"}}
 ```
 
-Ledger accepts the PATCH immediately and validates only key name syntax (must
-match `[a-zA-Z0-9_]+`). Index existence is verified at store-open time (the
-start of each request): if no matching functional index is found in `pg_indexes`
-for a given key, that key falls back to the `@>` containment form and an INFO
-message is logged — the request is not rejected.
+Key names are validated against `[a-zA-Z0-9_]+` at creation time.
 
-After the PATCH, new requests will use the functional index for confirmed keys.
+For existing ledgers, update the `features` column directly:
+
+```sql
+UPDATE _system.ledgers
+SET features = jsonb_set(features, '{INDEXED_METADATA_KEYS}', '"source_wallet_id,destination_wallet_id"')
+WHERE name = '<ledger>';
+```
+
+Index existence is verified at store-open time (the start of each request): if
+no matching functional index is found for a given key, that key falls back to
+the `@>` containment form and an INFO message is logged.
+
+After the change, new requests will use the functional index for confirmed keys.
 
 ### 3. Deactivation
 
-To deactivate, remove the key from the flag **before** dropping the index:
+To deactivate, clear the flag **before** dropping the index:
 
-```http
-PATCH /ledgers/<ledger>
-{"features": {"INDEXED_METADATA_KEYS": ""}}
+```sql
+UPDATE _system.ledgers
+SET features = jsonb_set(features, '{INDEXED_METADATA_KEYS}', '""')
+WHERE name = '<ledger>';
 ```
 
 Once the flag is cleared, Ledger reverts to `@>` for all metadata filters and
@@ -85,9 +98,9 @@ DROP INDEX CONCURRENTLY IF EXISTS "<bucket>".transactions_metadata_<key>_<ledger
 ```
 
 Dropping the index before clearing the flag is safe (Ledger's startup check
-detects the missing index and disables the rewrite automatically on next
-restart), but clearing the flag first avoids any window where the rewrite is
-attempted without an index.
+detects the missing index and disables the rewrite automatically), but clearing
+the flag first avoids any window where the rewrite is attempted without an
+index.
 
 ---
 

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -53,24 +53,26 @@ Wait for `CREATE INDEX` to complete before proceeding.
 
 ### 2. Enable the feature flag
 
-```
+```http
 PATCH /ledgers/<ledger>
 Content-Type: application/json
 
 {"features": {"INDEXED_METADATA_KEYS": "source_wallet_id,destination_wallet_id"}}
 ```
 
-Ledger validates that each named key has a corresponding functional index in
-`pg_indexes` and rejects the request if any index is missing.
+Ledger accepts the PATCH immediately and validates only key name syntax (must
+match `[a-zA-Z0-9_]+`). Index existence is verified at store-open time (the
+start of each request): if no matching functional index is found in `pg_indexes`
+for a given key, that key falls back to the `@>` containment form and an INFO
+message is logged — the request is not rejected.
 
-After the PATCH, new query plans will use the functional index. Existing
-connections pick up the change on their next query (no restart needed).
+After the PATCH, new requests will use the functional index for confirmed keys.
 
 ### 3. Deactivation
 
 To deactivate, remove the key from the flag **before** dropping the index:
 
-```
+```http
 PATCH /ledgers/<ledger>
 {"features": {"INDEXED_METADATA_KEYS": ""}}
 ```
@@ -102,6 +104,6 @@ the generated SQL to enable functional-index matching.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Flag accepted but queries still use `@>` | Index does not exist or has a different expression | Check `pg_indexes` for the exact index expression |
-| PATCH rejected with "index not found" | Index was not yet created, or the key name or partial condition does not match | Create the index first, then retry the PATCH |
-| Slow queries after dropping the index | Flag still references the dropped key | Clear the flag or restart Ledger to trigger the startup check |
+| Flag accepted but queries still use `@>` | Index does not exist or expression does not match | Check `pg_index` via `pg_get_expr` for the exact expression; INFO log at startup shows unconfirmed keys |
+| Key listed in flag but not confirmed (INFO at startup) | Index not yet created, or expression / partial condition differs | Create the index (`CONCURRENTLY`), then wait for the next request open to re-confirm |
+| Slow queries after dropping the index | Flag still references the dropped key | Clear the flag so the next store-open falls back to `@>` |

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -1,0 +1,107 @@
+# INDEXED_METADATA_KEYS — operator guide
+
+## What it does
+
+By default, metadata filters on transactions use a JSONB containment predicate:
+
+```sql
+metadata @> '{"source_wallet_id": "abc"}'
+```
+
+Postgres satisfies this with a GIN index, but GIN bitmap scans are incompatible
+with `ORDER BY id DESC LIMIT N` — the planner falls back to an index scan
+backward on `id`, which walks the entire table for sparse wallets.
+
+When a key is added to `INDEXED_METADATA_KEYS`, Ledger rewrites the predicate to:
+
+```sql
+metadata ->> 'source_wallet_id' = 'abc'
+```
+
+This form is eligible for a BTree functional index and allows the planner to use
+an index-only scan that also covers the `ORDER BY id DESC`, eliminating the
+table walk entirely.
+
+**The rewrite only takes effect when a matching functional index is confirmed to
+exist.** Ledger checks `pg_indexes` at startup (per ledger). If the index is
+absent, the query falls back to the standard `@>` form.
+
+---
+
+## Lifecycle
+
+### 1. Create the index
+
+Create a partial composite functional index on the target ledger's bucket:
+
+```sql
+-- Replace <bucket>, <ledger>, and <key> with your values.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS transactions_metadata_<key>_<ledger>_idx
+ON "<bucket>".transactions ((metadata->>'<key>'), id DESC)
+WHERE ledger = '<ledger>';
+```
+
+The `CONCURRENTLY` option builds the index without blocking reads or writes.
+Wait for `CREATE INDEX` to complete before proceeding.
+
+**Index design notes:**
+- The composite `((metadata->>'<key>'), id DESC)` covers both the equality
+  filter and the `ORDER BY id DESC` in a single scan, avoiding a sort step.
+- The `WHERE ledger = '<ledger>'` partial condition keeps the index small —
+  it only covers rows for that ledger.
+- For multiple keys, create one index per key.
+
+### 2. Enable the feature flag
+
+```
+PATCH /ledgers/<ledger>
+Content-Type: application/json
+
+{"features": {"INDEXED_METADATA_KEYS": "source_wallet_id,destination_wallet_id"}}
+```
+
+Ledger validates that each named key has a corresponding functional index in
+`pg_indexes` and rejects the request if any index is missing.
+
+After the PATCH, new query plans will use the functional index. Existing
+connections pick up the change on their next query (no restart needed).
+
+### 3. Deactivation
+
+To deactivate, remove the key from the flag **before** dropping the index:
+
+```
+PATCH /ledgers/<ledger>
+{"features": {"INDEXED_METADATA_KEYS": ""}}
+```
+
+Once the flag is cleared, Ledger reverts to `@>` for all metadata filters and
+the index can be safely dropped.
+
+```sql
+DROP INDEX CONCURRENTLY IF EXISTS "<bucket>".transactions_metadata_<key>_<ledger>_idx;
+```
+
+Dropping the index before clearing the flag is safe (Ledger's startup check
+detects the missing index and disables the rewrite automatically on next
+restart), but clearing the flag first avoids any window where the rewrite is
+attempted without an index.
+
+---
+
+## Key naming constraints
+
+Key names in `INDEXED_METADATA_KEYS` must match `[a-zA-Z0-9_]+`. Keys
+containing other characters (dots, hyphens, spaces) are rejected at flag-set
+time. This constraint exists because the key name is embedded as a literal in
+the generated SQL to enable functional-index matching.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Flag accepted but queries still use `@>` | Index does not exist or has a different expression | Check `pg_indexes` for the exact index expression |
+| PATCH rejected with "index not found" | Index was not yet created, or the key name or partial condition does not match | Create the index first, then retry the PATCH |
+| Slow queries after dropping the index | Flag still references the dropped key | Clear the flag or restart Ledger to trigger the startup check |

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -18,9 +18,14 @@ When a key is added to `INDEXED_METADATA_KEYS`, Ledger rewrites the predicate to
 metadata ->> 'source_wallet_id' = 'abc'
 ```
 
-This form is eligible for a BTree functional index and allows the planner to use
-an index-only scan that also covers the `ORDER BY id DESC`, eliminating the
-table walk entirely.
+This form is eligible for a BTree functional index and lets the planner use an
+index scan that also satisfies the `ORDER BY id DESC`, so it reads the matching
+rows directly instead of walking the table.
+
+It is an index scan, not an index-only scan: the query returns `postings`,
+`metadata` and other columns the index does not carry, so Postgres still visits
+the heap for each matching row. What the index removes is the scan over
+non-matching rows, which is where the time goes for a sparse key.
 
 **The rewrite only takes effect when a matching functional index is confirmed to
 exist.** Ledger checks `pg_index` (via `pg_get_expr`) at store-open time (per

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -18,9 +18,14 @@ When a key is added to `INDEXED_METADATA_KEYS`, Ledger rewrites the predicate to
 metadata ->> 'source_wallet_id' = 'abc'
 ```
 
-This form is eligible for a BTree functional index and lets the planner use an
-index scan that also satisfies the `ORDER BY id DESC`, so it reads the matching
-rows directly instead of walking the table.
+This form is eligible for a BTree functional index, so the planner can look up
+the matching rows directly instead of walking the table.
+
+Whether the same scan also satisfies the `ORDER BY id DESC` depends on the index
+shape. The composite index recommended below — `((metadata->>'<key>'), id DESC)` —
+returns rows already in order, so no sort step is needed. A single-expression
+index on `(metadata->>'<key>')` alone serves the equality filter but still
+requires a sort for the ordering.
 
 It is an index scan, not an index-only scan: the query returns `postings`,
 `metadata` and other columns the index does not carry, so Postgres still visits
@@ -143,10 +148,18 @@ index.
 
 ## Key naming constraints
 
-Key names in `INDEXED_METADATA_KEYS` must match `[a-zA-Z0-9_]+`. Keys
-containing other characters (dots, hyphens, spaces) are rejected at flag-set
-time. This constraint exists because the key name is embedded as a literal in
-the generated SQL to enable functional-index matching.
+Key names in `INDEXED_METADATA_KEYS` must match `[a-zA-Z0-9_]+`. This constraint
+exists because the key name is embedded as a literal in the generated SQL to
+enable functional-index matching.
+
+It is enforced in two places, because the flag can be written by two routes:
+
+- **Through the API** (ledger creation), keys containing other characters — dots,
+  hyphens, spaces — are **rejected**: the request fails and nothing is stored.
+- **Through a direct `UPDATE` on `_system.ledgers`**, there is no validation, so
+  an invalid key *can* be stored. Ledger re-checks keys when it reads the flag
+  and **silently ignores** the invalid ones; those metadata filters keep using
+  `@>`. A key that looks enabled but never takes effect is usually this.
 
 ---
 

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -105,6 +105,12 @@ SET features = jsonb_set(features, '{INDEXED_METADATA_KEYS}', '"source_wallet_id
 WHERE name = '<ledger>';
 ```
 
+> **This statement bypasses the API validation described above.** Supply only
+> keys matching `[a-zA-Z0-9_]+`. Keys are embedded as literals in the generated
+> SQL, so Ledger re-checks them on read and silently drops any that fail — a
+> malformed key is ignored rather than indexed, which looks like the feature not
+> working.
+
 Index existence is verified at store-open time (the start of each request): if
 no matching functional index is found for a given key, that key falls back to
 the `@>` containment form and an INFO message is logged.

--- a/docs/database/indexed-metadata-keys.md
+++ b/docs/database/indexed-metadata-keys.md
@@ -27,6 +27,28 @@ exist.** Ledger checks `pg_index` (via `pg_get_expr`) at store-open time (per
 ledger, per request). If the index is absent, the query falls back to the
 standard `@>` form.
 
+The rewrite also only applies to **exact-match filters on string values**
+(`$match`). Metadata filters accept `$like` and `$in` as well, and those keep
+using `@>`: the equality form cannot express their semantics.
+
+### What counts as a matching index
+
+Confirmation is deliberately strict, because a rewrite pointing at an index the
+planner cannot use is slower than the `@>` path it replaced. An index is
+confirmed only when all of the following hold:
+
+- It is a **valid** index (`indisvalid`). A cancelled or failed
+  `CREATE INDEX CONCURRENTLY` leaves an invalid entry the planner ignores.
+- `metadata->>'<key>'` is its **leading key**. An index on
+  `(id DESC, (metadata->>'<key>'))` is rejected — the planner would still have
+  to walk the whole `id` ordering.
+- The expression is exactly `metadata->>'<key>'`, not a derived form such as
+  `lower(metadata->>'<key>')` or `(metadata->>'<key>') || ''`.
+- It is either non-partial, or partial with the predicate **exactly**
+  `ledger = '<ledger>'`. A predicate belonging to another ledger, or one
+  carrying extra conditions the query does not imply (say
+  `AND reverted_at IS NULL`), is rejected.
+
 ---
 
 ## Lifecycle
@@ -48,8 +70,12 @@ Wait for `CREATE INDEX` to complete before proceeding.
 **Index design notes:**
 - The composite `((metadata->>'<key>'), id DESC)` covers both the equality
   filter and the `ORDER BY id DESC` in a single scan, avoiding a sort step.
+  Keep the metadata expression **first** — with the columns swapped the index is
+  not confirmed.
 - The `WHERE ledger = '<ledger>'` partial condition keeps the index small —
-  it only covers rows for that ledger.
+  it only covers rows for that ledger. Write it as exactly `ledger = '<ledger>'`;
+  additional conditions prevent confirmation. A non-partial index is also
+  accepted, and is the simpler choice for a bucket holding a single ledger.
 - For multiple keys, create one index per key.
 
 ### 2. Enable the feature flag

--- a/internal/README.md
+++ b/internal/README.md
@@ -93,6 +93,7 @@ import "github.com/formancehq/ledger/internal"
   - [func MustNewWithDefault\(name string\) Ledger](<#MustNewWithDefault>)
   - [func New\(name string, configuration Configuration\) \(\*Ledger, error\)](<#New>)
   - [func NewWithDefaults\(name string\) \(\*Ledger, error\)](<#NewWithDefaults>)
+  - [func \(l Ledger\) GetIndexedMetadataKeys\(\) \[\]string](<#Ledger.GetIndexedMetadataKeys>)
   - [func \(l Ledger\) HasFeature\(feature, value string\) bool](<#Ledger.HasFeature>)
   - [func \(l Ledger\) WithMetadata\(m metadata.Metadata\) Ledger](<#Ledger.WithMetadata>)
 - [type Log](<#Log>)
@@ -587,7 +588,7 @@ func (s ChartVariableSegment) MarshalJSON() ([]byte, error)
 
 
 <a name="Configuration"></a>
-## type [Configuration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L96-L100>)
+## type [Configuration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L109-L113>)
 
 
 
@@ -600,7 +601,7 @@ type Configuration struct {
 ```
 
 <a name="NewDefaultConfiguration"></a>
-### func [NewDefaultConfiguration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L127>)
+### func [NewDefaultConfiguration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L140>)
 
 ```go
 func NewDefaultConfiguration() Configuration
@@ -609,7 +610,7 @@ func NewDefaultConfiguration() Configuration
 
 
 <a name="Configuration.SetDefaults"></a>
-### func \(\*Configuration\) [SetDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L102>)
+### func \(\*Configuration\) [SetDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L115>)
 
 ```go
 func (c *Configuration) SetDefaults()
@@ -618,7 +619,7 @@ func (c *Configuration) SetDefaults()
 
 
 <a name="Configuration.Validate"></a>
-### func \(\*Configuration\) [Validate](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L117>)
+### func \(\*Configuration\) [Validate](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L130>)
 
 ```go
 func (c *Configuration) Validate() error
@@ -1063,7 +1064,7 @@ func (u InsertedSchema) ValidateWithSchema(schema Schema) error
 
 
 <a name="Ledger"></a>
-## type [Ledger](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L21-L30>)
+## type [Ledger](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L22-L31>)
 
 
 
@@ -1081,7 +1082,7 @@ type Ledger struct {
 ```
 
 <a name="MustNewWithDefault"></a>
-### func [MustNewWithDefault](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L72>)
+### func [MustNewWithDefault](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L85>)
 
 ```go
 func MustNewWithDefault(name string) Ledger
@@ -1090,7 +1091,7 @@ func MustNewWithDefault(name string) Ledger
 
 
 <a name="New"></a>
-### func [New](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L45>)
+### func [New](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L58>)
 
 ```go
 func New(name string, configuration Configuration) (*Ledger, error)
@@ -1099,7 +1100,7 @@ func New(name string, configuration Configuration) (*Ledger, error)
 
 
 <a name="NewWithDefaults"></a>
-### func [NewWithDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L68>)
+### func [NewWithDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L81>)
 
 ```go
 func NewWithDefaults(name string) (*Ledger, error)
@@ -1107,8 +1108,17 @@ func NewWithDefaults(name string) (*Ledger, error)
 
 
 
+<a name="Ledger.GetIndexedMetadataKeys"></a>
+### func \(Ledger\) [GetIndexedMetadataKeys](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L45>)
+
+```go
+func (l Ledger) GetIndexedMetadataKeys() []string
+```
+
+GetIndexedMetadataKeys returns the list of metadata keys for which the query builder will emit a functional\-index\-compatible predicate \(metadata \-\>\> 'key' = 'value'\) instead of the default JSONB containment form. The list is stored as a comma\-separated string in Features\[FeatureIndexedMetadataKeys\].
+
 <a name="Ledger.HasFeature"></a>
-### func \(Ledger\) [HasFeature](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L32>)
+### func \(Ledger\) [HasFeature](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L33>)
 
 ```go
 func (l Ledger) HasFeature(feature, value string) bool
@@ -1117,7 +1127,7 @@ func (l Ledger) HasFeature(feature, value string) bool
 
 
 <a name="Ledger.WithMetadata"></a>
-### func \(Ledger\) [WithMetadata](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L40>)
+### func \(Ledger\) [WithMetadata](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L53>)
 
 ```go
 func (l Ledger) WithMetadata(m metadata.Metadata) Ledger

--- a/internal/README.md
+++ b/internal/README.md
@@ -588,7 +588,7 @@ func (s ChartVariableSegment) MarshalJSON() ([]byte, error)
 
 
 <a name="Configuration"></a>
-## type [Configuration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L109-L113>)
+## type [Configuration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L128-L132>)
 
 
 
@@ -601,7 +601,7 @@ type Configuration struct {
 ```
 
 <a name="NewDefaultConfiguration"></a>
-### func [NewDefaultConfiguration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L140>)
+### func [NewDefaultConfiguration](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L159>)
 
 ```go
 func NewDefaultConfiguration() Configuration
@@ -610,7 +610,7 @@ func NewDefaultConfiguration() Configuration
 
 
 <a name="Configuration.SetDefaults"></a>
-### func \(\*Configuration\) [SetDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L115>)
+### func \(\*Configuration\) [SetDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L134>)
 
 ```go
 func (c *Configuration) SetDefaults()
@@ -619,7 +619,7 @@ func (c *Configuration) SetDefaults()
 
 
 <a name="Configuration.Validate"></a>
-### func \(\*Configuration\) [Validate](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L130>)
+### func \(\*Configuration\) [Validate](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L149>)
 
 ```go
 func (c *Configuration) Validate() error
@@ -1082,7 +1082,7 @@ type Ledger struct {
 ```
 
 <a name="MustNewWithDefault"></a>
-### func [MustNewWithDefault](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L85>)
+### func [MustNewWithDefault](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L104>)
 
 ```go
 func MustNewWithDefault(name string) Ledger
@@ -1091,7 +1091,7 @@ func MustNewWithDefault(name string) Ledger
 
 
 <a name="New"></a>
-### func [New](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L58>)
+### func [New](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L77>)
 
 ```go
 func New(name string, configuration Configuration) (*Ledger, error)
@@ -1100,7 +1100,7 @@ func New(name string, configuration Configuration) (*Ledger, error)
 
 
 <a name="NewWithDefaults"></a>
-### func [NewWithDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L81>)
+### func [NewWithDefaults](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L100>)
 
 ```go
 func NewWithDefaults(name string) (*Ledger, error)
@@ -1109,13 +1109,15 @@ func NewWithDefaults(name string) (*Ledger, error)
 
 
 <a name="Ledger.GetIndexedMetadataKeys"></a>
-### func \(Ledger\) [GetIndexedMetadataKeys](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L45>)
+### func \(Ledger\) [GetIndexedMetadataKeys](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L52>)
 
 ```go
 func (l Ledger) GetIndexedMetadataKeys() []string
 ```
 
 GetIndexedMetadataKeys returns the list of metadata keys for which the query builder will emit a functional\-index\-compatible predicate \(metadata \-\>\> 'key' = 'value'\) instead of the default JSONB containment form. The list is stored as a comma\-separated string in Features\[FeatureIndexedMetadataKeys\].
+
+Keys that are not valid SQL\-literal\-safe identifiers are dropped. The API validates them when the feature is set, but the value can reach the database by other routes — the operator guide documents a direct UPDATE on \_system.ledgers — and these keys are embedded as literals in the generated predicate. Filtering here covers every consumer, including the unresolved fallback in Store.IndexedMetadataKeys which returns this list without any catalog confirmation.
 
 <a name="Ledger.HasFeature"></a>
 ### func \(Ledger\) [HasFeature](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L33>)
@@ -1127,7 +1129,7 @@ func (l Ledger) HasFeature(feature, value string) bool
 
 
 <a name="Ledger.WithMetadata"></a>
-### func \(Ledger\) [WithMetadata](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L53>)
+### func \(Ledger\) [WithMetadata](<https://github.com/formancehq/ledger/blob/main/internal/ledger.go#L72>)
 
 ```go
 func (l Ledger) WithMetadata(m metadata.Metadata) Ledger

--- a/internal/ledger.go
+++ b/internal/ledger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/uptrace/bun"
 
@@ -35,6 +36,18 @@ func (l Ledger) HasFeature(feature, value string) bool {
 	}
 
 	return l.Features[feature] == value
+}
+
+// GetIndexedMetadataKeys returns the list of metadata keys for which the query
+// builder will emit a functional-index-compatible predicate (metadata ->> 'key' = 'value')
+// instead of the default JSONB containment form. The list is stored as a comma-separated
+// string in Features[FeatureIndexedMetadataKeys].
+func (l Ledger) GetIndexedMetadataKeys() []string {
+	val := l.Features[features.FeatureIndexedMetadataKeys]
+	if val == "" {
+		return nil
+	}
+	return strings.Split(val, ",")
 }
 
 func (l Ledger) WithMetadata(m metadata.Metadata) Ledger {

--- a/internal/ledger.go
+++ b/internal/ledger.go
@@ -42,12 +42,31 @@ func (l Ledger) HasFeature(feature, value string) bool {
 // builder will emit a functional-index-compatible predicate (metadata ->> 'key' = 'value')
 // instead of the default JSONB containment form. The list is stored as a comma-separated
 // string in Features[FeatureIndexedMetadataKeys].
+//
+// Keys that are not valid SQL-literal-safe identifiers are dropped. The API validates
+// them when the feature is set, but the value can reach the database by other routes —
+// the operator guide documents a direct UPDATE on _system.ledgers — and these keys are
+// embedded as literals in the generated predicate. Filtering here covers every consumer,
+// including the unresolved fallback in Store.IndexedMetadataKeys which returns this list
+// without any catalog confirmation.
 func (l Ledger) GetIndexedMetadataKeys() []string {
 	val := l.Features[features.FeatureIndexedMetadataKeys]
 	if val == "" {
 		return nil
 	}
-	return strings.Split(val, ",")
+
+	keys := strings.Split(val, ",")
+	ret := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if features.IsValidIndexedMetadataKey(key) {
+			ret = append(ret, key)
+		}
+	}
+	if len(ret) == 0 {
+		return nil
+	}
+
+	return ret
 }
 
 func (l Ledger) WithMetadata(m metadata.Metadata) Ledger {

--- a/internal/ledger_test.go
+++ b/internal/ledger_test.go
@@ -53,3 +53,22 @@ func TestLedger_WithMetadata(t *testing.T) {
 	l2 := l.WithMetadata(map[string]string{"key": "value"})
 	require.Equal(t, "value", l2.Metadata["key"])
 }
+
+func TestGetIndexedMetadataKeys(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		l := Ledger{Configuration: Configuration{Features: features.FeatureSet{}}}
+		require.Nil(t, l.GetIndexedMetadataKeys())
+	})
+	t.Run("single key", func(t *testing.T) {
+		l := Ledger{Configuration: Configuration{Features: features.FeatureSet{
+			features.FeatureIndexedMetadataKeys: "source_wallet_id",
+		}}}
+		require.Equal(t, []string{"source_wallet_id"}, l.GetIndexedMetadataKeys())
+	})
+	t.Run("multiple keys", func(t *testing.T) {
+		l := Ledger{Configuration: Configuration{Features: features.FeatureSet{
+			features.FeatureIndexedMetadataKeys: "source_wallet_id,destination_wallet_id",
+		}}}
+		require.Equal(t, []string{"source_wallet_id", "destination_wallet_id"}, l.GetIndexedMetadataKeys())
+	})
+}

--- a/internal/ledger_test.go
+++ b/internal/ledger_test.go
@@ -96,3 +96,83 @@ func TestGetIndexedMetadataKeys_DropsInvalidKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestLedger_HasFeature_InvalidFeaturePanics(t *testing.T) {
+	l := MustNewWithDefault("test")
+
+	t.Run("unknown feature", func(t *testing.T) {
+		require.Panics(t, func() {
+			l.HasFeature("DOES_NOT_EXIST", "ON")
+		})
+	})
+
+	t.Run("invalid value for known feature", func(t *testing.T) {
+		require.Panics(t, func() {
+			l.HasFeature(features.FeatureMovesHistory, "NOT_A_VALUE")
+		})
+	})
+
+	t.Run("open-ended feature accepts any syntactically valid value", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			l.HasFeature(features.FeatureIndexedMetadataKeys, "source_wallet_id")
+		})
+	})
+}
+
+func TestMustNewWithDefault_PanicsOnInvalidName(t *testing.T) {
+	require.Panics(t, func() {
+		MustNewWithDefault("invalid name!")
+	})
+}
+
+func TestNewLedger_RejectsInvalidBucketName(t *testing.T) {
+	cfg := NewDefaultConfiguration()
+	cfg.Bucket = "not a valid bucket!"
+
+	_, err := New("my-ledger", cfg)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &ErrInvalidBucketName{})
+}
+
+func TestConfiguration_Validate(t *testing.T) {
+	t.Run("valid features", func(t *testing.T) {
+		cfg := NewDefaultConfiguration()
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("invalid feature value is rejected", func(t *testing.T) {
+		cfg := Configuration{Features: features.FeatureSet{
+			features.FeatureMovesHistory: "NOT_A_VALUE",
+		}}
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("invalid indexed-metadata key is rejected", func(t *testing.T) {
+		cfg := Configuration{Features: features.FeatureSet{
+			features.FeatureIndexedMetadataKeys: "bad-key",
+		}}
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("New propagates configuration validation failure", func(t *testing.T) {
+		_, err := New("my-ledger", Configuration{
+			Bucket:   DefaultBucket,
+			Features: features.FeatureSet{features.FeatureHashLogs: "NOPE"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestSetDefaults_PreservesExplicitValues(t *testing.T) {
+	cfg := Configuration{
+		Bucket:   "custom",
+		Features: features.FeatureSet{features.FeatureHashLogs: "DISABLED"},
+	}
+	cfg.SetDefaults()
+
+	require.Equal(t, "custom", cfg.Bucket, "explicit bucket must be preserved")
+	require.Equal(t, "DISABLED", cfg.Features[features.FeatureHashLogs],
+		"explicit feature value must not be overwritten by the default")
+	require.Equal(t, "ON", cfg.Features[features.FeatureMovesHistory],
+		"unset features must be filled from DefaultFeatures")
+}

--- a/internal/ledger_test.go
+++ b/internal/ledger_test.go
@@ -72,3 +72,27 @@ func TestGetIndexedMetadataKeys(t *testing.T) {
 		require.Equal(t, []string{"source_wallet_id", "destination_wallet_id"}, l.GetIndexedMetadataKeys())
 	})
 }
+
+func TestGetIndexedMetadataKeys_DropsInvalidKeys(t *testing.T) {
+	// Feature values can reach the database without passing the API validation
+	// (the operator guide documents a direct UPDATE on _system.ledgers), and these
+	// keys are embedded as SQL literals — so they are re-checked on read.
+	for _, tc := range []struct {
+		name     string
+		value    string
+		expected []string
+	}{
+		{"all valid", "source_wallet_id,dest_id", []string{"source_wallet_id", "dest_id"}},
+		{"drops invalid, keeps valid", "source_wallet_id,bad-key", []string{"source_wallet_id"}},
+		{"drops injection attempt", "ok_key,x'); drop table transactions; --", []string{"ok_key"}},
+		{"all invalid", "bad-key,another bad", nil},
+		{"empty element", "source_wallet_id,", []string{"source_wallet_id"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := Ledger{Configuration: Configuration{Features: features.FeatureSet{
+				features.FeatureIndexedMetadataKeys: tc.value,
+			}}}
+			require.Equal(t, tc.expected, l.GetIndexedMetadataKeys())
+		})
+	}
+}

--- a/internal/storage/driver/driver.go
+++ b/internal/storage/driver/driver.go
@@ -127,7 +127,7 @@ func (d *Driver) OpenLedger(ctx context.Context, name string) (*ledgerstore.Stor
 		}).Errorf("INDEXED_METADATA_KEYS: index resolution failed, all keys fall back to @>: %s", err)
 	}
 
-	return store, ret, err
+	return store, ret, nil
 }
 
 func (d *Driver) Initialize(ctx context.Context) error {

--- a/internal/storage/driver/driver.go
+++ b/internal/storage/driver/driver.go
@@ -90,13 +90,7 @@ func (d *Driver) CreateLedger(ctx context.Context, l *ledger.Ledger) (*ledgersto
 		return nil, postgres.ResolveError(err)
 	}
 
-	if err := ret.ResolveIndexedMetadataKeys(ctx); err != nil {
-		// The ledger is already committed; don't fail the create. Log and
-		// continue — all keys fall back to @> for this store lifetime.
-		logging.FromContext(ctx).WithFields(map[string]any{
-			"ledger": ret.GetLedger().Name,
-		}).Errorf("INDEXED_METADATA_KEYS: index resolution failed, all keys fall back to @>: %s", err)
-	}
+	ret.ResolveIndexedMetadataKeys(ctx)
 
 	return ret, nil
 }
@@ -120,12 +114,7 @@ func (d *Driver) OpenLedger(ctx context.Context, name string) (*ledgerstore.Stor
 	store := d.ledgerStoreFactory.Create(d.bucketFactory.Create(ret.Bucket), *ret)
 	store.SetAloneInBucket(count == 1)
 
-	if err := store.ResolveIndexedMetadataKeys(ctx); err != nil {
-		// Log and continue — all keys fall back to @> for this store lifetime.
-		logging.FromContext(ctx).WithFields(map[string]any{
-			"ledger": name,
-		}).Errorf("INDEXED_METADATA_KEYS: index resolution failed, all keys fall back to @>: %s", err)
-	}
+	store.ResolveIndexedMetadataKeys(ctx)
 
 	return store, ret, nil
 }

--- a/internal/storage/driver/driver.go
+++ b/internal/storage/driver/driver.go
@@ -91,7 +91,11 @@ func (d *Driver) CreateLedger(ctx context.Context, l *ledger.Ledger) (*ledgersto
 	}
 
 	if err := ret.ResolveIndexedMetadataKeys(ctx); err != nil {
-		return nil, fmt.Errorf("resolving indexed metadata keys: %w", err)
+		// The ledger is already committed; don't fail the create. Log and
+		// continue — all keys fall back to @> for this store lifetime.
+		logging.FromContext(ctx).WithFields(map[string]any{
+			"ledger": ret.GetLedger().Name,
+		}).Errorf("INDEXED_METADATA_KEYS: index resolution failed, all keys fall back to @>: %s", err)
 	}
 
 	return ret, nil
@@ -117,7 +121,10 @@ func (d *Driver) OpenLedger(ctx context.Context, name string) (*ledgerstore.Stor
 	store.SetAloneInBucket(count == 1)
 
 	if err := store.ResolveIndexedMetadataKeys(ctx); err != nil {
-		return nil, nil, fmt.Errorf("resolving indexed metadata keys: %w", err)
+		// Log and continue — all keys fall back to @> for this store lifetime.
+		logging.FromContext(ctx).WithFields(map[string]any{
+			"ledger": name,
+		}).Errorf("INDEXED_METADATA_KEYS: index resolution failed, all keys fall back to @>: %s", err)
 	}
 
 	return store, ret, err

--- a/internal/storage/driver/driver.go
+++ b/internal/storage/driver/driver.go
@@ -90,6 +90,10 @@ func (d *Driver) CreateLedger(ctx context.Context, l *ledger.Ledger) (*ledgersto
 		return nil, postgres.ResolveError(err)
 	}
 
+	if err := ret.ResolveIndexedMetadataKeys(ctx); err != nil {
+		return nil, fmt.Errorf("resolving indexed metadata keys: %w", err)
+	}
+
 	return ret, nil
 }
 
@@ -111,6 +115,10 @@ func (d *Driver) OpenLedger(ctx context.Context, name string) (*ledgerstore.Stor
 
 	store := d.ledgerStoreFactory.Create(d.bucketFactory.Create(ret.Bucket), *ret)
 	store.SetAloneInBucket(count == 1)
+
+	if err := store.ResolveIndexedMetadataKeys(ctx); err != nil {
+		return nil, nil, fmt.Errorf("resolving indexed metadata keys: %w", err)
+	}
 
 	return store, ret, err
 }

--- a/internal/storage/ledger/export_test.go
+++ b/internal/storage/ledger/export_test.go
@@ -1,0 +1,6 @@
+package ledger
+
+func (store *Store) ResetIndexedMetadataKeysForTest() {
+	store.indexedKeysResolved = false
+	store.indexedMetadataKeys = nil
+}

--- a/internal/storage/ledger/main_test.go
+++ b/internal/storage/ledger/main_test.go
@@ -49,6 +49,7 @@ func TestMain(m *testing.M) {
 				hook := debug.NewQueryHook()
 				hook.Debug = os.Getenv("DEBUG") == "true"
 				bunDB.AddQueryHook(hook)
+				bunDB.AddQueryHook(sqlCaptureHook{})
 				bunDB.SetMaxOpenConns(100)
 
 				require.NoError(t, systemstore.Migrate(logging.TestingContext(), bunDB))

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -153,10 +153,16 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			// The literal form is required: Postgres matches functional indexes by exact expression
 			// equality, so `metadata ->> 'key'` matches the index but `metadata ->> ?` does not.
 			//
-			// We always prepend ledger = ? even when newScopedSelect already adds it (alone-in-bucket
-			// optimisation omits the predicate). The partial index is defined as
-			// WHERE ledger = '...'; without the predicate in the query Postgres cannot use it.
-			return fmt.Sprintf("ledger = ? AND metadata ->> '%s' = ?", key), []any{h.store.GetLedger().Name, value}, nil
+			// We always prepend ledger = ? even when newScopedSelect already adds it, because the
+			// partial index is defined as WHERE ledger = '...'. Without the predicate in the query,
+			// Postgres cannot use the partial index (alone-in-bucket optimisation omits it).
+			//
+			// We include metadata \? 'key' (key-existence check) before the ->> equality so the
+			// composite expression evaluates to false (not NULL) when the key is absent.
+			// Without it, metadata ->> 'key' = ? is NULL for absent-key rows, which means
+			// NOT(...) remains NULL instead of TRUE, silently changing result sets for negated
+			// metadata filters compared to the NOT (metadata @> ...) path.
+			return fmt.Sprintf("ledger = ? AND metadata \\? '%s' AND metadata ->> '%s' = ?", key, key), []any{h.store.GetLedger().Name, value}, nil
 		}
 		return "metadata @> ?", []any{map[string]any{key: value}}, nil
 

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -152,7 +152,11 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			// Key is validated to match [a-zA-Z0-9_]+ so it is safe to embed as a literal.
 			// The literal form is required: Postgres matches functional indexes by exact expression
 			// equality, so `metadata ->> 'key'` matches the index but `metadata ->> ?` does not.
-			return fmt.Sprintf("metadata ->> '%s' = ?", key), []any{value}, nil
+			//
+			// We always prepend ledger = ? even when newScopedSelect already adds it (alone-in-bucket
+			// optimisation omits the predicate). The partial index is defined as
+			// WHERE ledger = '...'; without the predicate in the query Postgres cannot use it.
+			return fmt.Sprintf("ledger = ? AND metadata ->> '%s' = ?", key), []any{h.store.GetLedger().Name, value}, nil
 		}
 		return "metadata @> ?", []any{map[string]any{key: value}}, nil
 

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -146,10 +146,15 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 		}
 	case common.MetadataRegex.Match([]byte(property)):
 		match := common.MetadataRegex.FindAllStringSubmatch(property, 3)
+		key := match[0][1]
 
-		return "metadata @> ?", []any{map[string]any{
-			match[0][1]: value,
-		}}, nil
+		if slices.Contains(h.store.IndexedMetadataKeys(), key) {
+			// Key is validated to match [a-zA-Z0-9_]+ so it is safe to embed as a literal.
+			// The literal form is required: Postgres matches functional indexes by exact expression
+			// equality, so `metadata ->> 'key'` matches the index but `metadata ->> ?` does not.
+			return fmt.Sprintf("metadata ->> '%s' = ?", key), []any{value}, nil
+		}
+		return "metadata @> ?", []any{map[string]any{key: value}}, nil
 
 	case property == "metadata":
 		return "metadata -> ? is not null", []any{value}, nil

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -149,12 +149,11 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 		key := match[0][1]
 
 		// The rewrite below is an equality-only form, so it is restricted to $match with
-		// a string value.  Metadata filters also accept $in and $like, whose semantics
-		// the `->>` equality cannot express; binding their value into `= ?` would
-		// silently discard the operator and return the wrong rows.  A non-string value
-		// is excluded too: `@>` compares the JSON value by type, while `->>` coerces it
-		// to text, so a numeric 123 would start matching the string "123".  Both cases
-		// fall through to the `@>` containment path, which handles them correctly.
+		// a string filter value.  Metadata filters also accept $in and $like, whose
+		// semantics the `->>` equality cannot express; binding their value into `= ?`
+		// would silently discard the operator and return the wrong rows.  A non-string
+		// filter value is excluded for the type reason described below.  Both cases fall
+		// through to the `@>` containment path, which handles them correctly.
 		stringValue, valueIsString := value.(string)
 		if operator == queries.OperatorMatch && valueIsString && slices.Contains(h.store.IndexedMetadataKeys(), key) {
 			// Key is validated to match [a-zA-Z0-9_]+ so it is safe to embed as a literal.
@@ -170,7 +169,20 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			// Without it, metadata ->> 'key' = ? is NULL for absent-key rows, which means
 			// NOT(...) remains NULL instead of TRUE, silently changing result sets for negated
 			// metadata filters compared to the NOT (metadata @> ...) path.
-			return fmt.Sprintf("ledger = ? AND metadata \\? '%s' AND metadata ->> '%s' = ?", key, key), []any{h.store.GetLedger().Name, stringValue}, nil
+			//
+			// jsonb_typeof(...) = 'string' keeps the two paths equivalent for non-string
+			// stored values.  @> compares the JSON value by type, so {"key":"123"} does not
+			// match a stored number 123 — but ->> renders that number as the text '123',
+			// which would match.  Ledger metadata is map[string]string, so this only arises
+			// for values written outside the API (the operator guide documents a direct
+			// UPDATE path), which is exactly where the divergence would go unnoticed.
+			//
+			// All three guards are rechecks applied after the functional index lookup; they
+			// do not stop the planner using the index for the equality.
+			return fmt.Sprintf(
+				"ledger = ? AND metadata \\? '%s' AND jsonb_typeof(metadata -> '%s') = 'string' AND metadata ->> '%s' = ?",
+				key, key, key,
+			), []any{h.store.GetLedger().Name, stringValue}, nil
 		}
 		return "metadata @> ?", []any{map[string]any{key: value}}, nil
 

--- a/internal/storage/ledger/resource_transactions.go
+++ b/internal/storage/ledger/resource_transactions.go
@@ -148,7 +148,15 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 		match := common.MetadataRegex.FindAllStringSubmatch(property, 3)
 		key := match[0][1]
 
-		if slices.Contains(h.store.IndexedMetadataKeys(), key) {
+		// The rewrite below is an equality-only form, so it is restricted to $match with
+		// a string value.  Metadata filters also accept $in and $like, whose semantics
+		// the `->>` equality cannot express; binding their value into `= ?` would
+		// silently discard the operator and return the wrong rows.  A non-string value
+		// is excluded too: `@>` compares the JSON value by type, while `->>` coerces it
+		// to text, so a numeric 123 would start matching the string "123".  Both cases
+		// fall through to the `@>` containment path, which handles them correctly.
+		stringValue, valueIsString := value.(string)
+		if operator == queries.OperatorMatch && valueIsString && slices.Contains(h.store.IndexedMetadataKeys(), key) {
 			// Key is validated to match [a-zA-Z0-9_]+ so it is safe to embed as a literal.
 			// The literal form is required: Postgres matches functional indexes by exact expression
 			// equality, so `metadata ->> 'key'` matches the index but `metadata ->> ?` does not.
@@ -162,7 +170,7 @@ func (h transactionsResourceHandler) ResolveFilter(_ common.ResourceQuery[any], 
 			// Without it, metadata ->> 'key' = ? is NULL for absent-key rows, which means
 			// NOT(...) remains NULL instead of TRUE, silently changing result sets for negated
 			// metadata filters compared to the NOT (metadata @> ...) path.
-			return fmt.Sprintf("ledger = ? AND metadata \\? '%s' AND metadata ->> '%s' = ?", key, key), []any{h.store.GetLedger().Name, value}, nil
+			return fmt.Sprintf("ledger = ? AND metadata \\? '%s' AND metadata ->> '%s' = ?", key, key), []any{h.store.GetLedger().Name, stringValue}, nil
 		}
 		return "metadata @> ?", []any{map[string]any{key: value}}, nil
 

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -13,11 +13,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	nooptracer "go.opentelemetry.io/otel/trace/noop"
 
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/go-libs/v5/pkg/storage/bun/paginate"
 	"github.com/formancehq/go-libs/v5/pkg/storage/migrations"
 	"github.com/formancehq/go-libs/v5/pkg/storage/postgres"
-
-	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	ledger "github.com/formancehq/ledger/internal"
 	"github.com/formancehq/ledger/internal/storage/bucket"

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -160,13 +160,16 @@ func (store *Store) IndexedMetadataKeys() []string {
 	return store.ledger.GetIndexedMetadataKeys()
 }
 
-func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
+func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) {
 	store.indexedKeysResolved = true
 	requested := store.ledger.GetIndexedMetadataKeys()
 	if len(requested) == 0 {
-		return nil
+		return
 	}
 	schema := store.ledger.Bucket
+	logger := logging.FromContext(ctx).WithFields(map[string]any{
+		"ledger": store.ledger.Name,
+	})
 	confirmed := make([]string, 0, len(requested))
 	for _, key := range requested {
 		// Use pg_get_expr so we match the exact functional expression rather than
@@ -207,19 +210,17 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 			Where("(i.indpred IS NULL OR position(? IN pg_get_expr(i.indpred, i.indrelid)) > 0)", "= '"+store.ledger.Name+"'").
 			Scan(ctx, &count)
 		if err != nil {
-			return fmt.Errorf("checking pg_index for key %q: %w", key, err)
+			logger.Errorf("INDEXED_METADATA_KEYS: pg_index query failed for key %q, all keys fall back to @>: %s", key, err)
+			store.indexedMetadataKeys = nil
+			return
 		}
 		if count > 0 {
 			confirmed = append(confirmed, key)
 		} else {
-			logging.FromContext(ctx).WithFields(map[string]any{
-				"key":    key,
-				"ledger": store.ledger.Name,
-			}).Infof("INDEXED_METADATA_KEYS: no functional index found for key — rewrite disabled, falling back to @>")
+			logger.Infof("INDEXED_METADATA_KEYS: no functional index found for key %q — rewrite disabled, falling back to @>", key)
 		}
 	}
 	store.indexedMetadataKeys = confirmed
-	return nil
 }
 
 func (store *Store) GetDB() bun.IDB {

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -169,16 +169,22 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 	schema := store.ledger.Bucket
 	confirmed := make([]string, 0, len(requested))
 	for _, key := range requested {
+		// Use pg_get_expr(indexprs, indrelid) so we match the exact index expression
+		// rather than substring-matching the full CREATE INDEX text in pg_indexes.indexdef.
+		// Key names are validated as [a-zA-Z0-9_]+, so embedding in the LIKE pattern is safe.
 		var count int
 		err := store.db.NewSelect().
-			TableExpr("pg_indexes").
+			TableExpr("pg_index i").
+			Join("JOIN pg_class c ON c.oid = i.indrelid").
+			Join("JOIN pg_namespace n ON n.oid = c.relnamespace").
 			ColumnExpr("COUNT(*)").
-			Where("schemaname = ?", schema).
-			Where("tablename = ?", "transactions").
-			Where("indexdef LIKE ?", "%metadata ->> '"+key+"'%").
+			Where("n.nspname = ?", schema).
+			Where("c.relname = ?", "transactions").
+			Where("i.indexprs IS NOT NULL").
+			Where("pg_get_expr(i.indexprs, i.indrelid) LIKE ?", "%metadata ->> '"+key+"'%").
 			Scan(ctx, &count)
 		if err != nil {
-			return fmt.Errorf("checking pg_indexes for key %q: %w", key, err)
+			return fmt.Errorf("checking pg_index for key %q: %w", key, err)
 		}
 		if count > 0 {
 			confirmed = append(confirmed, key)

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -188,12 +188,19 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 			Where("n.nspname = ?", schema).
 			Where("c.relname = ?", "transactions").
 			Where("i.indexprs IS NOT NULL").
-			// Use position() rather than LIKE so that underscores and percent signs
-			// in key names or ledger names are treated as literals, not wildcards.
+			// Only accept valid indexes; CONCURRENTLY-failed builds leave an entry
+			// with indisvalid=false that the planner will not use.
+			Where("i.indisvalid = true").
+			// Use position() rather than LIKE: underscores and percent signs in key
+			// names or ledger names must not be treated as wildcards.
 			// Key names are validated as [a-zA-Z0-9_]+; ledger names are trusted
 			// internal values — both are safe to embed in the search strings below.
 			Where("position(? IN pg_get_expr(i.indexprs, i.indrelid)) > 0", "metadata ->> '"+key+"'").
-			Where("(i.indpred IS NULL OR position(? IN pg_get_expr(i.indpred, i.indrelid)) > 0)", "ledger = '"+store.ledger.Name+"'").
+			// Search for '= ''ledger_name''' rather than 'ledger = ''ledger_name''' because
+			// pg_get_expr renders varchar predicates with explicit casts, e.g.
+			// ((ledger)::text = 'name'::text).  The column-side cast varies by Postgres
+			// version; the '= ''name''' substring is present in all observed forms.
+			Where("(i.indpred IS NULL OR position(? IN pg_get_expr(i.indpred, i.indrelid)) > 0)", "= '"+store.ledger.Name+"'").
 			Scan(ctx, &count)
 		if err != nil {
 			return fmt.Errorf("checking pg_index for key %q: %w", key, err)

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -188,8 +188,12 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 			Where("n.nspname = ?", schema).
 			Where("c.relname = ?", "transactions").
 			Where("i.indexprs IS NOT NULL").
-			Where("pg_get_expr(i.indexprs, i.indrelid) LIKE ?", "%metadata ->> '"+key+"'%").
-			Where("(i.indpred IS NULL OR pg_get_expr(i.indpred, i.indrelid) LIKE ?)", "%ledger = '"+store.ledger.Name+"'%").
+			// Use position() rather than LIKE so that underscores and percent signs
+			// in key names or ledger names are treated as literals, not wildcards.
+			// Key names are validated as [a-zA-Z0-9_]+; ledger names are trusted
+			// internal values — both are safe to embed in the search strings below.
+			Where("position(? IN pg_get_expr(i.indexprs, i.indrelid)) > 0", "metadata ->> '"+key+"'").
+			Where("(i.indpred IS NULL OR position(? IN pg_get_expr(i.indpred, i.indrelid)) > 0)", "ledger = '"+store.ledger.Name+"'").
 			Scan(ctx, &count)
 		if err != nil {
 			return fmt.Errorf("checking pg_index for key %q: %w", key, err)

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -189,56 +189,76 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) {
 	logger := logging.FromContext(ctx).WithFields(map[string]any{
 		"ledger": store.ledger.Name,
 	})
-	confirmed := make([]string, 0, len(requested))
+	// One query for all keys, not one per key: this runs on every store open, so the
+	// cost is paid per request by every ledger that opts into the feature.
+	wanted := make([]string, 0, len(requested))
+	keyByExpr := make(map[string]string, len(requested))
 	for _, key := range requested {
-		var count int
-		err := store.db.NewSelect().
-			TableExpr("pg_index i").
-			Join("JOIN pg_class c ON c.oid = i.indrelid").
-			Join("JOIN pg_namespace n ON n.oid = c.relnamespace").
-			ColumnExpr("COUNT(*)").
-			Where("n.nspname = ?", schema).
-			Where("c.relname = ?", "transactions").
-			Where("i.indexprs IS NOT NULL").
-			// Only accept valid indexes; CONCURRENTLY-failed builds leave an entry
-			// with indisvalid=false that the planner will not use.
-			Where("i.indisvalid = true").
-			// The metadata expression must be the *leading* index key.  indkey is an
-			// int2vector of column attnums where 0 marks an expression, so indkey[0] = 0
-			// means the first key is an expression rather than a regular column.
-			// Combined with the single-expression match below, this proves our metadata
-			// expression is the first usable key.  Without it an index such as
-			// (id DESC, (metadata->>'key')) would be confirmed even though the planner
-			// can only reach the metadata expression after a full scan of the id column —
-			// exactly the sparse scan this feature exists to avoid.
-			Where("i.indkey[0] = 0").
-			// Compare the rendered functional expression to the exact form the query
-			// builder emits.  pg_get_expr renders a list of expressions comma-separated,
-			// so an exact match also guarantees the index carries a single expression.
-			// An exact match (rather than a substring test) rejects derived expressions
-			// such as lower(metadata->>'key') or (metadata->>'key') || '', which the
-			// planner cannot use for our predicate.
-			Where(normalizeRenderedSQL("pg_get_expr(i.indexprs, i.indrelid)")+" = ?",
-				fmt.Sprintf("metadata->>'%s'", key)).
-			// Only confirm indexes this ledger's queries can actually use: either a
-			// non-partial index (indpred IS NULL, covers all rows) or a partial index
-			// whose predicate is exactly `ledger = <this ledger>`.  An exact match is
-			// required — a substring test would confirm an index for an unrelated column
-			// holding the same value, or one whose predicate carries extra conditions
-			// the query does not imply, both of which force a sequential scan.
-			Where("(i.indpred IS NULL OR "+normalizeRenderedSQL("pg_get_expr(i.indpred, i.indrelid)")+" = ?)",
-				fmt.Sprintf("ledger='%s'", store.ledger.Name)).
-			Scan(ctx, &count)
-		if err != nil {
-			logger.Errorf("INDEXED_METADATA_KEYS: pg_index query failed for key %q, all keys fall back to @>: %s", key, err)
-			store.indexedMetadataKeys = nil
-			return
+		expr := fmt.Sprintf("metadata->>'%s'", key)
+		wanted = append(wanted, expr)
+		keyByExpr[expr] = key
+	}
+
+	indexedExpr := normalizeRenderedSQL("pg_get_expr(i.indexprs, i.indrelid)")
+
+	var found []string
+	err := store.db.NewSelect().
+		TableExpr("pg_index i").
+		Join("JOIN pg_class c ON c.oid = i.indrelid").
+		Join("JOIN pg_namespace n ON n.oid = c.relnamespace").
+		ColumnExpr("DISTINCT "+indexedExpr+" AS expr").
+		Where("n.nspname = ?", schema).
+		Where("c.relname = ?", "transactions").
+		Where("i.indexprs IS NOT NULL").
+		// Only accept valid indexes; CONCURRENTLY-failed builds leave an entry
+		// with indisvalid=false that the planner will not use.
+		Where("i.indisvalid = true").
+		// The metadata expression must be the *leading* index key.  indkey is an
+		// int2vector of column attnums where 0 marks an expression, so indkey[0] = 0
+		// means the first key is an expression rather than a regular column.
+		// Combined with the single-expression match below, this proves our metadata
+		// expression is the first usable key.  Without it an index such as
+		// (id DESC, (metadata->>'key')) would be confirmed even though the planner
+		// can only reach the metadata expression after a full scan of the id column —
+		// exactly the sparse scan this feature exists to avoid.
+		Where("i.indkey[0] = 0").
+		// Compare the rendered functional expression to the exact form the query
+		// builder emits.  pg_get_expr renders a list of expressions comma-separated,
+		// so an exact match also guarantees the index carries a single expression.
+		// An exact match (rather than a substring test) rejects derived expressions
+		// such as lower(metadata->>'key') or (metadata->>'key') || '', which the
+		// planner cannot use for our predicate.
+		Where(indexedExpr+" IN (?)", bun.In(wanted)).
+		// Only confirm indexes this ledger's queries can actually use: either a
+		// non-partial index (indpred IS NULL, covers all rows) or a partial index
+		// whose predicate is exactly `ledger = <this ledger>`.  An exact match is
+		// required — a substring test would confirm an index for an unrelated column
+		// holding the same value, or one whose predicate carries extra conditions
+		// the query does not imply, both of which force a sequential scan.
+		Where("(i.indpred IS NULL OR "+normalizeRenderedSQL("pg_get_expr(i.indpred, i.indrelid)")+" = ?)",
+			fmt.Sprintf("ledger='%s'", store.ledger.Name)).
+		Scan(ctx, &found)
+	if err != nil {
+		logger.Errorf("INDEXED_METADATA_KEYS: pg_index query failed, all keys fall back to @>: %s", err)
+		store.indexedMetadataKeys = nil
+		return
+	}
+
+	confirmedSet := make(map[string]struct{}, len(found))
+	for _, expr := range found {
+		if key, ok := keyByExpr[expr]; ok {
+			confirmedSet[key] = struct{}{}
 		}
-		if count > 0 {
+	}
+
+	// Preserve the configured order so the resolved list is deterministic.
+	confirmed := make([]string, 0, len(confirmedSet))
+	for _, key := range requested {
+		if _, ok := confirmedSet[key]; ok {
 			confirmed = append(confirmed, key)
-		} else {
-			logger.Infof("INDEXED_METADATA_KEYS: no functional index found for key %q — rewrite disabled, falling back to @>", key)
+			continue
 		}
+		logger.Infof("INDEXED_METADATA_KEYS: no functional index found for key %q — rewrite disabled, falling back to @>", key)
 	}
 	store.indexedMetadataKeys = confirmed
 }

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -17,6 +17,8 @@ import (
 	"github.com/formancehq/go-libs/v5/pkg/storage/migrations"
 	"github.com/formancehq/go-libs/v5/pkg/storage/postgres"
 
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
 	ledger "github.com/formancehq/ledger/internal"
 	"github.com/formancehq/ledger/internal/storage/bucket"
 	"github.com/formancehq/ledger/internal/storage/common"
@@ -59,6 +61,9 @@ type Store struct {
 	beginTXHistogram                   metric.Int64Histogram
 	commitTXHistogram                  metric.Int64Histogram
 	rollbackTXHistogram                metric.Int64Histogram
+
+	indexedMetadataKeys []string
+	indexedKeysResolved bool
 }
 
 func (store *Store) Volumes() common.PaginatedResource[
@@ -146,6 +151,46 @@ func (store *Store) Rollback(ctx context.Context) error {
 
 func (store *Store) GetLedger() ledger.Ledger {
 	return store.ledger
+}
+
+func (store *Store) IndexedMetadataKeys() []string {
+	if store.indexedKeysResolved {
+		return store.indexedMetadataKeys
+	}
+	return store.ledger.GetIndexedMetadataKeys()
+}
+
+func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
+	store.indexedKeysResolved = true
+	requested := store.ledger.GetIndexedMetadataKeys()
+	if len(requested) == 0 {
+		return nil
+	}
+	schema := store.ledger.Bucket
+	confirmed := make([]string, 0, len(requested))
+	for _, key := range requested {
+		var count int
+		err := store.db.NewSelect().
+			TableExpr("pg_indexes").
+			ColumnExpr("COUNT(*)").
+			Where("schemaname = ?", schema).
+			Where("tablename = ?", "transactions").
+			Where("indexdef LIKE ?", "%metadata ->> '"+key+"'%").
+			Scan(ctx, &count)
+		if err != nil {
+			return fmt.Errorf("checking pg_indexes for key %q: %w", key, err)
+		}
+		if count > 0 {
+			confirmed = append(confirmed, key)
+		} else {
+			logging.FromContext(ctx).WithFields(map[string]any{
+				"key":    key,
+				"ledger": store.ledger.Name,
+			}).Infof("INDEXED_METADATA_KEYS: no functional index found for key — rewrite disabled, falling back to @>")
+		}
+	}
+	store.indexedMetadataKeys = confirmed
+	return nil
 }
 
 func (store *Store) GetDB() bun.IDB {

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -159,6 +159,26 @@ func (store *Store) IndexedMetadataKeys() []string {
 	return store.ledger.GetIndexedMetadataKeys()
 }
 
+// normalizeRenderedSQL wraps a SQL expression yielding pg_get_expr output so that
+// incidental syntax — explicit ::text casts, parentheses and whitespace — is stripped
+// before comparison.
+//
+// Postgres renders the same index definition differently depending on version and
+// column type: `WHERE ledger = 'x'` on a varchar column comes back as
+// ((ledger)::text = 'x'::text), while `(metadata->>'k')` may or may not carry an
+// explicit ::text cast on the key.  Normalising makes the comparison independent of
+// those variations while keeping it exact, so derived expressions and predicates with
+// extra conditions are still rejected.
+//
+// Ledger names and metadata keys are validated as [0-9a-zA-Z_-]+ / [a-zA-Z0-9_]+, so a
+// normalised form never loses meaningful characters.
+func normalizeRenderedSQL(expr string) string {
+	return fmt.Sprintf(
+		`replace(replace(replace(replace(%s, '::text', ''), '(', ''), ')', ''), ' ', '')`,
+		expr,
+	)
+}
+
 func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) {
 	store.indexedKeysResolved = true
 	requested := store.ledger.GetIndexedMetadataKeys()
@@ -171,16 +191,6 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) {
 	})
 	confirmed := make([]string, 0, len(requested))
 	for _, key := range requested {
-		// Use pg_get_expr so we match the exact functional expression rather than
-		// substring-matching the full CREATE INDEX text.  Key names are validated
-		// as [a-zA-Z0-9_]+, so embedding in the LIKE pattern is safe.
-		//
-		// The partial-predicate filter ensures we only confirm indexes usable by
-		// this ledger: either a non-partial index (indpred IS NULL, covers all rows)
-		// or a partial index whose WHERE clause mentions the current ledger name.
-		// Without this check, a partial index created for ledger A would be confirmed
-		// for ledger B, yet ledger B's queries cannot satisfy ledger A's partial
-		// predicate — causing a sequential scan instead of an index scan.
 		var count int
 		err := store.db.NewSelect().
 			TableExpr("pg_index i").
@@ -193,20 +203,31 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) {
 			// Only accept valid indexes; CONCURRENTLY-failed builds leave an entry
 			// with indisvalid=false that the planner will not use.
 			Where("i.indisvalid = true").
-			// Use an exact IN match against the two canonical forms that pg_get_expr
-			// produces for (metadata->>'key'): the variant with an explicit ::text cast
-			// (Postgres 14+) and the variant without. A substring/position check would
-			// also match derived expressions such as lower(metadata->>'key') or
-			// (metadata->>'key') || '', which the production filter cannot use.
-			Where("pg_get_expr(i.indexprs, i.indrelid) IN (?)", bun.In([]string{
-				fmt.Sprintf("(metadata ->> '%s'::text)", key),
-				fmt.Sprintf("(metadata ->> '%s')", key),
-			})).
-			// Search for '= ''ledger_name''' rather than 'ledger = ''ledger_name''' because
-			// pg_get_expr renders varchar predicates with explicit casts, e.g.
-			// ((ledger)::text = 'name'::text).  The column-side cast varies by Postgres
-			// version; the '= ''name''' substring is present in all observed forms.
-			Where("(i.indpred IS NULL OR position(? IN pg_get_expr(i.indpred, i.indrelid)) > 0)", "= '"+store.ledger.Name+"'").
+			// The metadata expression must be the *leading* index key.  indkey is an
+			// int2vector of column attnums where 0 marks an expression, so indkey[0] = 0
+			// means the first key is an expression rather than a regular column.
+			// Combined with the single-expression match below, this proves our metadata
+			// expression is the first usable key.  Without it an index such as
+			// (id DESC, (metadata->>'key')) would be confirmed even though the planner
+			// can only reach the metadata expression after a full scan of the id column —
+			// exactly the sparse scan this feature exists to avoid.
+			Where("i.indkey[0] = 0").
+			// Compare the rendered functional expression to the exact form the query
+			// builder emits.  pg_get_expr renders a list of expressions comma-separated,
+			// so an exact match also guarantees the index carries a single expression.
+			// An exact match (rather than a substring test) rejects derived expressions
+			// such as lower(metadata->>'key') or (metadata->>'key') || '', which the
+			// planner cannot use for our predicate.
+			Where(normalizeRenderedSQL("pg_get_expr(i.indexprs, i.indrelid)")+" = ?",
+				fmt.Sprintf("metadata->>'%s'", key)).
+			// Only confirm indexes this ledger's queries can actually use: either a
+			// non-partial index (indpred IS NULL, covers all rows) or a partial index
+			// whose predicate is exactly `ledger = <this ledger>`.  An exact match is
+			// required — a substring test would confirm an index for an unrelated column
+			// holding the same value, or one whose predicate carries extra conditions
+			// the query does not imply, both of which force a sequential scan.
+			Where("(i.indpred IS NULL OR "+normalizeRenderedSQL("pg_get_expr(i.indpred, i.indrelid)")+" = ?)",
+				fmt.Sprintf("ledger='%s'", store.ledger.Name)).
 			Scan(ctx, &count)
 		if err != nil {
 			logger.Errorf("INDEXED_METADATA_KEYS: pg_index query failed for key %q, all keys fall back to @>: %s", key, err)

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -191,11 +191,15 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 			// Only accept valid indexes; CONCURRENTLY-failed builds leave an entry
 			// with indisvalid=false that the planner will not use.
 			Where("i.indisvalid = true").
-			// Use position() rather than LIKE: underscores and percent signs in key
-			// names or ledger names must not be treated as wildcards.
-			// Key names are validated as [a-zA-Z0-9_]+; ledger names are trusted
-			// internal values — both are safe to embed in the search strings below.
-			Where("position(? IN pg_get_expr(i.indexprs, i.indrelid)) > 0", "metadata ->> '"+key+"'").
+			// Use an exact IN match against the two canonical forms that pg_get_expr
+			// produces for (metadata->>'key'): the variant with an explicit ::text cast
+			// (Postgres 14+) and the variant without. A substring/position check would
+			// also match derived expressions such as lower(metadata->>'key') or
+			// (metadata->>'key') || '', which the production filter cannot use.
+			Where("pg_get_expr(i.indexprs, i.indrelid) IN (?)", bun.In([]string{
+				fmt.Sprintf("(metadata ->> '%s'::text)", key),
+				fmt.Sprintf("(metadata ->> '%s')", key),
+			})).
 			// Search for '= ''ledger_name''' rather than 'ledger = ''ledger_name''' because
 			// pg_get_expr renders varchar predicates with explicit casts, e.g.
 			// ((ledger)::text = 'name'::text).  The column-side cast varies by Postgres

--- a/internal/storage/ledger/store.go
+++ b/internal/storage/ledger/store.go
@@ -169,9 +169,16 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 	schema := store.ledger.Bucket
 	confirmed := make([]string, 0, len(requested))
 	for _, key := range requested {
-		// Use pg_get_expr(indexprs, indrelid) so we match the exact index expression
-		// rather than substring-matching the full CREATE INDEX text in pg_indexes.indexdef.
-		// Key names are validated as [a-zA-Z0-9_]+, so embedding in the LIKE pattern is safe.
+		// Use pg_get_expr so we match the exact functional expression rather than
+		// substring-matching the full CREATE INDEX text.  Key names are validated
+		// as [a-zA-Z0-9_]+, so embedding in the LIKE pattern is safe.
+		//
+		// The partial-predicate filter ensures we only confirm indexes usable by
+		// this ledger: either a non-partial index (indpred IS NULL, covers all rows)
+		// or a partial index whose WHERE clause mentions the current ledger name.
+		// Without this check, a partial index created for ledger A would be confirmed
+		// for ledger B, yet ledger B's queries cannot satisfy ledger A's partial
+		// predicate — causing a sequential scan instead of an index scan.
 		var count int
 		err := store.db.NewSelect().
 			TableExpr("pg_index i").
@@ -182,6 +189,7 @@ func (store *Store) ResolveIndexedMetadataKeys(ctx context.Context) error {
 			Where("c.relname = ?", "transactions").
 			Where("i.indexprs IS NOT NULL").
 			Where("pg_get_expr(i.indexprs, i.indrelid) LIKE ?", "%metadata ->> '"+key+"'%").
+			Where("(i.indpred IS NULL OR pg_get_expr(i.indpred, i.indrelid) LIKE ?)", "%ledger = '"+store.ledger.Name+"'%").
 			Scan(ctx, &count)
 		if err != nil {
 			return fmt.Errorf("checking pg_index for key %q: %w", key, err)

--- a/internal/storage/ledger/store_tx_test.go
+++ b/internal/storage/ledger/store_tx_test.go
@@ -6,13 +6,17 @@ package ledger_test
 // ResolveFilter fallthrough branches, all of which were previously untested.
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/go-libs/v5/pkg/query"
+	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
+	"github.com/formancehq/go-libs/v5/pkg/types/time"
 
+	ledger "github.com/formancehq/ledger/internal"
 	"github.com/formancehq/ledger/internal/storage/common"
 )
 
@@ -85,13 +89,36 @@ func TestTransactionsResolveFilter_Fallthrough(t *testing.T) {
 
 	t.Run("bare metadata property uses key-existence", func(t *testing.T) {
 		// "metadata" (no [key]) does not match MetadataRegex, so it falls through to the
-		// `metadata -> ? is not null` branch.
-		_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		// `metadata -> ? is not null` branch, which filters on key *existence* rather
+		// than value. Use a dedicated store so the row set is exactly what we seed.
+		keyStore := newLedgerStore(t)
+
+		withKey := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{"some_key": "any-value"}).
+			WithTimestamp(time.Now())
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, keyStore, &withKey))
+
+		otherKey := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{"another_key": "any-value"}).
+			WithTimestamp(time.Now())
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, keyStore, &otherKey))
+
+		noMetadata := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "carol", "USD", big.NewInt(100))).
+			WithTimestamp(time.Now())
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, keyStore, &noMetadata))
+
+		cursor, err := keyStore.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
 			Options: common.ResourceQuery[any]{
 				Builder: query.Match("metadata", "some_key"),
 			},
 		})
 		require.NoError(t, err)
+		require.Len(t, cursor.Data, 1,
+			"only the transaction carrying some_key may match; a dropped predicate would return all three")
+		require.Equal(t, *withKey.ID, *cursor.Data[0].ID)
 	})
 
 	// $in requires full addresses. "users:" has an empty trailing segment, so it is a

--- a/internal/storage/ledger/store_tx_test.go
+++ b/internal/storage/ledger/store_tx_test.go
@@ -1,0 +1,120 @@
+//go:build it
+
+package ledger_test
+
+// store_tx_test.go covers the transaction-lifecycle surface of Store and the
+// ResolveFilter fallthrough branches, all of which were previously untested.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/query"
+
+	"github.com/formancehq/ledger/internal/storage/common"
+)
+
+// TestStore_CommitRollbackOutsideTransaction verifies that Commit and Rollback report a
+// clear error when the store is not transactional, rather than acting on the pool.
+func TestStore_CommitRollbackOutsideTransaction(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t)
+
+	require.ErrorContains(t, store.Commit(ctx), "not in a transaction")
+	require.ErrorContains(t, store.Rollback(ctx), "not in a transaction")
+}
+
+// TestStore_BeginTXCommit verifies the transactional store returned by BeginTX commits,
+// and that Commit/Rollback dispatch on the transactional branch rather than erroring.
+func TestStore_BeginTXCommit(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t)
+
+	txStore, tx, err := store.BeginTX(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	require.NoError(t, txStore.Commit(ctx))
+	// Committing twice must fail rather than silently succeed.
+	require.Error(t, txStore.Commit(ctx))
+}
+
+// TestStore_BeginTXRollback covers the Rollback path on a transactional store.
+func TestStore_BeginTXRollback(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t)
+
+	txStore, _, err := store.BeginTX(ctx, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, txStore.Rollback(ctx))
+}
+
+// TestStore_GetBucket verifies GetBucket returns a bucket that is actually usable —
+// newLedgerStore has migrated it, so it must report itself up to date.
+func TestStore_GetBucket(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t)
+
+	b := store.GetBucket()
+	require.NotNil(t, b)
+
+	upToDate, err := b.IsUpToDate(ctx, store.GetDB())
+	require.NoError(t, err)
+	require.True(t, upToDate, "bucket returned by GetBucket must be the migrated one")
+}
+
+// TestTransactionsResolveFilter_Fallthrough covers the two ResolveFilter branches reached
+// by properties the transaction schema accepts but the filter builder does not translate
+// to a metadata-key predicate.
+func TestTransactionsResolveFilter_Fallthrough(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t)
+
+	t.Run("bare metadata property uses key-existence", func(t *testing.T) {
+		// "metadata" (no [key]) does not match MetadataRegex, so it falls through to the
+		// `metadata -> ? is not null` branch.
+		_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.Match("metadata", "some_key"),
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	// $in requires full addresses. "users:" has an empty trailing segment, so it is a
+	// partial address: it passes the schema's string-array validation and is then
+	// rejected by the filter builder. One case per address property, since each has its
+	// own branch.
+	for _, property := range []string{"account", "source", "destination"} {
+		t.Run("$in rejects a partial address on "+property, func(t *testing.T) {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				Options: common.ResourceQuery[any]{
+					Builder: query.In(property, []any{"users:"}),
+				},
+			})
+			require.ErrorContains(t, err, "IN operator only supports full addresses")
+		})
+
+		t.Run("$in accepts full addresses on "+property, func(t *testing.T) {
+			_, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+				Options: common.ResourceQuery[any]{
+					Builder: query.In(property, []any{"users:alice", "users:bob"}),
+				},
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -24,6 +24,7 @@ package ledger_test
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"strings"
 	"sync"
@@ -97,6 +98,7 @@ func withSQLCapture(parent context.Context) (context.Context, *sqlCapture) {
 // INDEXED_METADATA_KEYS feature to the given comma-separated list.
 func withIndexedMetadataKeys(keys string) func(cfg *ledger.Configuration) {
 	return func(cfg *ledger.Configuration) {
+		cfg.Features = maps.Clone(cfg.Features)
 		cfg.Features[features.FeatureIndexedMetadataKeys] = keys
 	}
 }

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -76,6 +76,11 @@ func TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows(t *testing.T) {
 		WithTimestamp(now)
 	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx3))
 
+	// IndexedMetadataKeys falls back to the feature-flag list when
+	// ResolveIndexedMetadataKeys has not been called (no real pg_index needed here).
+	// ExplainUsesLiteralPredicate tests the fully-confirmed (pg_indexes-verified) path.
+	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id")
+
 	// Filter by source_wallet_id = "wallet-A" via the flagged (->> ) path.
 	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
@@ -149,6 +154,10 @@ func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
 		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &unrelated))
 	}
 
+	// Both stores use their respective paths (flagged = ->> via unresolved flag,
+	// plain = @> with no flag).  Assert the flagged key is active before comparing.
+	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id")
+
 	q := common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
 			Builder: query.Match("metadata[source_wallet_id]", "w-2"),
@@ -192,6 +201,9 @@ func TestIndexedMetadataKeys_DestinationWalletID(t *testing.T) {
 		WithTimestamp(now)
 	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
 
+	// IndexedMetadataKeys falls back to the feature-flag list (unresolved path).
+	require.Contains(t, store.IndexedMetadataKeys(), "destination_wallet_id")
+
 	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
 			Builder: query.Match("metadata[destination_wallet_id]", "dest-wallet-X"),
@@ -226,25 +238,16 @@ func TestIndexedMetadataKeys_NoFlagUsesContainment(t *testing.T) {
 	require.Len(t, cursor.Data, 1, "containment path must still find the transaction")
 }
 
-// captureExplain runs EXPLAIN (FORMAT TEXT) for the given metadata key=value filter
-// on the given store and returns the full plan text.
-func captureExplain(t *testing.T, store *ledgerstore.Store, key, value string) string {
+// captureExplain runs EXPLAIN (FORMAT TEXT) using predExpr as the WHERE predicate
+// and returns the full plan text. The caller is responsible for supplying the
+// predicate that matches the production path they intend to verify — this avoids
+// duplicating the ResolveFilter routing logic inside the helper.
+func captureExplain(t *testing.T, store *ledgerstore.Store, predExpr string) string {
 	t.Helper()
 	ctx := logging.TestingContext()
 
 	schema := store.GetLedger().Bucket
 	ledgerName := store.GetLedger().Name
-
-	// Use the store's actual query routing to build the predicate, then wrap in EXPLAIN.
-	// We reproduce the predicate logic so the test stays in sync with the real code path:
-	// if the key is in IndexedMetadataKeys()  →  metadata ->> 'key' = 'value'
-	// otherwise                               →  metadata @> '{"key":"value"}'
-	var predExpr string
-	if contains(store.IndexedMetadataKeys(), key) {
-		predExpr = fmt.Sprintf("metadata ->> '%s' = '%s'", key, value)
-	} else {
-		predExpr = fmt.Sprintf(`metadata @> '{"%s": "%s"}'`, key, value)
-	}
 
 	sql := fmt.Sprintf(
 		`EXPLAIN (FORMAT TEXT) SELECT id FROM %q.transactions WHERE ledger = '%s' AND %s ORDER BY id DESC LIMIT 16`,
@@ -265,15 +268,6 @@ func captureExplain(t *testing.T, store *ledgerstore.Store, key, value string) s
 	return plan.String()
 }
 
-func contains(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
 // TestIndexedMetadataKeys_ExplainUsesLiteralPredicate verifies that when a functional
 // index exists and ResolveIndexedMetadataKeys confirms it, EXPLAIN shows the literal
 // ->> predicate (not @>). This proves the correct SQL is generated and that Postgres
@@ -290,12 +284,11 @@ func TestIndexedMetadataKeys_ExplainUsesLiteralPredicate(t *testing.T) {
 	// Resolve against pg_indexes so the store confirms the index.
 	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
 
-	plan := captureExplain(t, store, "source_wallet_id", "w-target")
+	// The predicate matches what resource_transactions.ResolveFilter emits for a
+	// confirmed indexed key: metadata ->> 'key' = 'value'.
+	plan := captureExplain(t, store, "metadata ->> 'source_wallet_id' = 'w-target'")
 	t.Logf("EXPLAIN plan:\n%s", plan)
 
-	// The plan must reference the ->> expression, not the @> containment form.
-	// This proves: (a) the query builder emitted the literal form, and
-	// (b) Postgres parsed and echoed it back in the plan.
 	require.Contains(t, plan, "metadata ->> 'source_wallet_id'",
 		"plan must use the ->> literal predicate for a confirmed indexed key")
 	require.NotContains(t, plan, "metadata @>",
@@ -317,7 +310,9 @@ func TestIndexedMetadataKeys_FallsBackWhenNoIndex(t *testing.T) {
 	require.Empty(t, store.IndexedMetadataKeys(),
 		"key should be excluded when no functional index exists")
 
-	plan := captureExplain(t, store, "source_wallet_id", "w-target")
+	// The predicate matches what resource_transactions.ResolveFilter emits for an
+	// unconfirmed key (no index): metadata @> '{"key":"value"}'.
+	plan := captureExplain(t, store, `metadata @> '{"source_wallet_id": "w-target"}'`)
 	t.Logf("EXPLAIN plan (fallback):\n%s", plan)
 
 	require.Contains(t, plan, "metadata @>",

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -160,7 +160,7 @@ func TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows(t *testing.T) {
 	// indexedMetadataKeys=[]).  Create the index now and re-resolve so the store
 	// actually exercises the ->> rewrite path rather than the @> fallback.
 	createFunctionalIndexForKey(t, store, "source_wallet_id")
-	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	store.ResolveIndexedMetadataKeys(ctx)
 	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id",
 		"index must be confirmed for the ->> path to be active")
 
@@ -259,7 +259,7 @@ func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
 	// Create the functional index on the flagged store and re-resolve so it
 	// actually exercises the ->> path; plain uses @> with no flag.
 	createFunctionalIndexForKey(t, flagged, "source_wallet_id")
-	require.NoError(t, flagged.ResolveIndexedMetadataKeys(ctx))
+	flagged.ResolveIndexedMetadataKeys(ctx)
 	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id",
 		"index must be confirmed so the ->> path is active during comparison")
 
@@ -296,7 +296,7 @@ func TestIndexedMetadataKeys_DestinationWalletID(t *testing.T) {
 	// CreateLedger calls ResolveIndexedMetadataKeys with no index → empty list.
 	// Create the index for the key under test and re-resolve.
 	createFunctionalIndexForKey(t, store, "destination_wallet_id")
-	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	store.ResolveIndexedMetadataKeys(ctx)
 	require.Contains(t, store.IndexedMetadataKeys(), "destination_wallet_id",
 		"index must be confirmed for the ->> path to be active")
 
@@ -389,7 +389,7 @@ func TestIndexedMetadataKeys_NegatedFilterSemantics(t *testing.T) {
 
 	// Confirm the index on flagged so the ->> path is active.
 	createFunctionalIndexForKey(t, flagged, "source_wallet_id")
-	require.NoError(t, flagged.ResolveIndexedMetadataKeys(ctx))
+	flagged.ResolveIndexedMetadataKeys(ctx)
 	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id",
 		"index must be confirmed so NULL-semantics regression is actually exercised")
 
@@ -427,7 +427,7 @@ func TestIndexedMetadataKeys_ExplainUsesLiteralPredicate(t *testing.T) {
 
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
 	createFunctionalIndexForKey(t, store, "source_wallet_id")
-	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	store.ResolveIndexedMetadataKeys(ctx)
 	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id",
 		"index must be confirmed for the ->> path to be active")
 
@@ -471,7 +471,7 @@ func TestIndexedMetadataKeys_FallsBackWhenNoIndex(t *testing.T) {
 	// Resolve at creation time (no index → empty list); call again explicitly
 	// to make the test intent clear and confirm the state is stable.
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
-	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	store.ResolveIndexedMetadataKeys(ctx)
 	require.Empty(t, store.IndexedMetadataKeys(),
 		"key should be excluded when no functional index exists")
 

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -238,6 +238,69 @@ func TestIndexedMetadataKeys_NoFlagUsesContainment(t *testing.T) {
 	require.Len(t, cursor.Data, 1, "containment path must still find the transaction")
 }
 
+// TestIndexedMetadataKeys_NegatedFilterSemantics verifies that NOT(metadata[key] = val)
+// returns rows where the key is absent, matching the NOT(metadata @> ...) semantics.
+//
+// The bug this guards against: metadata ->> 'key' = ? returns NULL when the key is
+// absent, so NOT(NULL) = NULL, silently excluding rows that should be included. The
+// fix (adding metadata ? 'key') makes the expression evaluate to false for absent-key
+// rows, so NOT(false) = true.
+func TestIndexedMetadataKeys_NegatedFilterSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	// Both stores get identical data; one uses the ->> rewrite, the other @>.
+	flagged := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	plain := newLedgerStore(t)
+
+	for _, store := range []*ledgerstore.Store{flagged, plain} {
+		// tx1: has the key with a different value — must be included by NOT filter.
+		tx1 := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{"source_wallet_id": "other-wallet"}).
+			WithTimestamp(now.Add(-2 * time.Hour))
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx1))
+
+		// tx2: has the key with the target value — must be excluded by NOT filter.
+		tx2 := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(50))).
+			WithMetadata(metadata.Metadata{"source_wallet_id": "target-wallet"}).
+			WithTimestamp(now.Add(-time.Hour))
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
+
+		// tx3: key absent — must be included by NOT filter (the regression case).
+		tx3 := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "carol", "USD", big.NewInt(10))).
+			WithTimestamp(now)
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx3))
+	}
+
+	q := common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Not(query.Match("metadata[source_wallet_id]", "target-wallet")),
+		},
+	}
+
+	flaggedCursor, err := flagged.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	plainCursor, err := plain.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	require.Equal(t, len(plainCursor.Data), len(flaggedCursor.Data),
+		"->> rewrite must return the same row count as @> for negated filters")
+	require.Equal(t, 2, len(flaggedCursor.Data),
+		"NOT filter must include the absent-key row and the different-value row")
+
+	// Verify the IDs match between both paths.
+	for i := range plainCursor.Data {
+		require.Equalf(t, *plainCursor.Data[i].ID, *flaggedCursor.Data[i].ID,
+			"row %d: id mismatch between @> path and ->> path for NOT filter", i)
+	}
+}
+
 // captureExplain runs EXPLAIN (FORMAT TEXT) using predExpr as the WHERE predicate
 // and returns the full plan text. The caller is responsible for supplying the
 // predicate that matches the production path they intend to verify — this avoids

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -7,7 +7,7 @@ package ledger_test
 // When a metadata key appears in the ledger's INDEXED_METADATA_KEYS feature and a matching
 // functional index has been confirmed via pg_indexes, the query builder must emit
 //
-//	metadata ->> 'key' = 'value'
+//	ledger = ? AND metadata ? 'key' AND metadata ->> 'key' = ?
 //
 // instead of  metadata @> '{"key":"value"}'.  Without the index, the flag is silently ignored
 // and the query falls back to @>.
@@ -22,12 +22,15 @@ package ledger_test
 //  5. When the index is absent, ResolveIndexedMetadataKeys falls back to @>.
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/go-libs/v5/pkg/query"
@@ -40,6 +43,56 @@ import (
 	"github.com/formancehq/ledger/pkg/features"
 )
 
+// ── SQL capture hook ──────────────────────────────────────────────────────────
+// sqlCaptureHook is registered once in TestMain on the shared bun.DB.
+// Tests that need the production SQL pass a context containing a *sqlCapture;
+// the hook appends each formatted query to that capture.  Tests without a
+// capture in their context are unaffected.  The mutex makes concurrent tests safe.
+
+type captureKey struct{}
+
+type sqlCapture struct {
+	mu      sync.Mutex
+	queries []string
+}
+
+// lastContaining returns the last captured query that contains sub, or "".
+func (c *sqlCapture) lastContaining(sub string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := len(c.queries) - 1; i >= 0; i-- {
+		if strings.Contains(c.queries[i], sub) {
+			return c.queries[i]
+		}
+	}
+	return ""
+}
+
+type sqlCaptureHook struct{}
+
+func (sqlCaptureHook) BeforeQuery(ctx context.Context, _ *bun.QueryEvent) context.Context {
+	return ctx
+}
+
+func (sqlCaptureHook) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
+	cap, _ := ctx.Value(captureKey{}).(*sqlCapture)
+	if cap == nil {
+		return
+	}
+	// event.Query is the fully-formatted SQL (args substituted); event.QueryTemplate
+	// holds the raw template with ? placeholders.
+	cap.mu.Lock()
+	cap.queries = append(cap.queries, event.Query)
+	cap.mu.Unlock()
+}
+
+func withSQLCapture(parent context.Context) (context.Context, *sqlCapture) {
+	cap := &sqlCapture{}
+	return context.WithValue(parent, captureKey{}, cap), cap
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
 // withIndexedMetadataKeys returns a newLedgerStore option that sets the
 // INDEXED_METADATA_KEYS feature to the given comma-separated list.
 func withIndexedMetadataKeys(keys string) func(cfg *ledger.Configuration) {
@@ -48,14 +101,67 @@ func withIndexedMetadataKeys(keys string) func(cfg *ledger.Configuration) {
 	}
 }
 
+// createFunctionalIndexForKey creates a composite partial functional index for
+// the given key scoped to this test's ledger name.
+//
+// The index covers (metadata->>'key', id DESC) WHERE ledger = '...' so it
+// satisfies both the equality filter and the ORDER BY id DESC in one scan.
+// key is validated as [a-zA-Z0-9_]+, ledgerName is a UUID prefix — both safe
+// to embed as SQL literals.
+func createFunctionalIndexForKey(t *testing.T, store *ledgerstore.Store, key string) {
+	t.Helper()
+	ctx := logging.TestingContext()
+	schema := store.GetLedger().Bucket
+	ledgerName := store.GetLedger().Name
+	idxName := fmt.Sprintf("test_%s_%s_idx", ledgerName, key)
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX IF NOT EXISTS %q
+		ON %q.transactions ((metadata->>'%s'), id DESC)
+		WHERE ledger = '%s'
+	`, idxName, schema, key, ledgerName))
+	require.NoError(t, err)
+}
+
+// explainSQL runs EXPLAIN (FORMAT TEXT) on the given SQL string and returns
+// the plan text.  The SQL must be complete and executable — use withSQLCapture
+// to obtain it from the production Paginate path.
+func explainSQL(t *testing.T, store *ledgerstore.Store, sql string) string {
+	t.Helper()
+	ctx := logging.TestingContext()
+
+	rows, err := store.GetDB().QueryContext(ctx, "EXPLAIN (FORMAT TEXT) "+sql)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	return plan.String()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 // TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows verifies that when
-// source_wallet_id is a flagged key, filtering by metadata[source_wallet_id]
-// returns the expected transactions (functional-index path).
+// source_wallet_id is a flagged key with a confirmed functional index, filtering
+// by metadata[source_wallet_id] returns the expected transactions (->> path).
 func TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows(t *testing.T) {
 	t.Parallel()
 
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
 	ctx := logging.TestingContext()
+
+	// CreateLedger calls ResolveIndexedMetadataKeys at creation time (no index yet →
+	// indexedMetadataKeys=[]).  Create the index now and re-resolve so the store
+	// actually exercises the ->> rewrite path rather than the @> fallback.
+	createFunctionalIndexForKey(t, store, "source_wallet_id")
+	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id",
+		"index must be confirmed for the ->> path to be active")
+
 	now := time.Now()
 
 	tx1 := ledger.NewTransaction().
@@ -76,12 +182,6 @@ func TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows(t *testing.T) {
 		WithTimestamp(now)
 	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx3))
 
-	// IndexedMetadataKeys falls back to the feature-flag list when
-	// ResolveIndexedMetadataKeys has not been called (no real pg_index needed here).
-	// ExplainUsesLiteralPredicate tests the fully-confirmed (pg_indexes-verified) path.
-	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id")
-
-	// Filter by source_wallet_id = "wallet-A" via the flagged (->> ) path.
 	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
 			Builder: query.Match("metadata[source_wallet_id]", "wallet-A"),
@@ -126,14 +226,14 @@ func TestIndexedMetadataKeys_UnflaggedKeyReturnsCorrectRows(t *testing.T) {
 }
 
 // TestIndexedMetadataKeys_SemanticEquivalence inserts the same transactions into
-// two stores — one with source_wallet_id flagged, one without — and verifies that
-// both return identical row IDs when filtering by that key.
+// two stores — one with source_wallet_id flagged and confirmed (->> path), one
+// without — and verifies that both return identical row IDs.
 func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
 	t.Parallel()
 	ctx := logging.TestingContext()
 	now := time.Now()
 
-	// Store with the flag: uses ->> path.
+	// Store with the flag and a confirmed functional index: uses ->> path.
 	flagged := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
 	// Store without the flag: uses @> path.
 	plain := newLedgerStore(t)
@@ -154,9 +254,12 @@ func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
 		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &unrelated))
 	}
 
-	// Both stores use their respective paths (flagged = ->> via unresolved flag,
-	// plain = @> with no flag).  Assert the flagged key is active before comparing.
-	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id")
+	// Create the functional index on the flagged store and re-resolve so it
+	// actually exercises the ->> path; plain uses @> with no flag.
+	createFunctionalIndexForKey(t, flagged, "source_wallet_id")
+	require.NoError(t, flagged.ResolveIndexedMetadataKeys(ctx))
+	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id",
+		"index must be confirmed so the ->> path is active during comparison")
 
 	q := common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
@@ -181,12 +284,20 @@ func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
 }
 
 // TestIndexedMetadataKeys_DestinationWalletID verifies destination_wallet_id
-// works the same way as source_wallet_id when flagged.
+// works the same way as source_wallet_id when flagged and confirmed.
 func TestIndexedMetadataKeys_DestinationWalletID(t *testing.T) {
 	t.Parallel()
 
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
 	ctx := logging.TestingContext()
+
+	// CreateLedger calls ResolveIndexedMetadataKeys with no index → empty list.
+	// Create the index for the key under test and re-resolve.
+	createFunctionalIndexForKey(t, store, "destination_wallet_id")
+	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	require.Contains(t, store.IndexedMetadataKeys(), "destination_wallet_id",
+		"index must be confirmed for the ->> path to be active")
+
 	now := time.Now()
 
 	tx1 := ledger.NewTransaction().
@@ -200,9 +311,6 @@ func TestIndexedMetadataKeys_DestinationWalletID(t *testing.T) {
 		WithMetadata(metadata.Metadata{"destination_wallet_id": "dest-wallet-Y"}).
 		WithTimestamp(now)
 	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
-
-	// IndexedMetadataKeys falls back to the feature-flag list (unresolved path).
-	require.Contains(t, store.IndexedMetadataKeys(), "destination_wallet_id")
 
 	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
@@ -251,7 +359,7 @@ func TestIndexedMetadataKeys_NegatedFilterSemantics(t *testing.T) {
 	ctx := logging.TestingContext()
 	now := time.Now()
 
-	// Both stores get identical data; one uses the ->> rewrite, the other @>.
+	// flagged store gets a confirmed functional index; plain store uses @>.
 	flagged := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
 	plain := newLedgerStore(t)
 
@@ -277,6 +385,12 @@ func TestIndexedMetadataKeys_NegatedFilterSemantics(t *testing.T) {
 		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx3))
 	}
 
+	// Confirm the index on flagged so the ->> path is active.
+	createFunctionalIndexForKey(t, flagged, "source_wallet_id")
+	require.NoError(t, flagged.ResolveIndexedMetadataKeys(ctx))
+	require.Contains(t, flagged.IndexedMetadataKeys(), "source_wallet_id",
+		"index must be confirmed so NULL-semantics regression is actually exercised")
+
 	q := common.InitialPaginatedQuery[any]{
 		Options: common.ResourceQuery[any]{
 			Builder: query.Not(query.Match("metadata[source_wallet_id]", "target-wallet")),
@@ -294,62 +408,48 @@ func TestIndexedMetadataKeys_NegatedFilterSemantics(t *testing.T) {
 	require.Equal(t, 2, len(flaggedCursor.Data),
 		"NOT filter must include the absent-key row and the different-value row")
 
-	// Verify the IDs match between both paths.
 	for i := range plainCursor.Data {
 		require.Equalf(t, *plainCursor.Data[i].ID, *flaggedCursor.Data[i].ID,
 			"row %d: id mismatch between @> path and ->> path for NOT filter", i)
 	}
 }
 
-// captureExplain runs EXPLAIN (FORMAT TEXT) using predExpr as the WHERE predicate
-// and returns the full plan text. The caller is responsible for supplying the
-// predicate that matches the production path they intend to verify — this avoids
-// duplicating the ResolveFilter routing logic inside the helper.
-func captureExplain(t *testing.T, store *ledgerstore.Store, predExpr string) string {
-	t.Helper()
-	ctx := logging.TestingContext()
-
-	schema := store.GetLedger().Bucket
-	ledgerName := store.GetLedger().Name
-
-	sql := fmt.Sprintf(
-		`EXPLAIN (FORMAT TEXT) SELECT id FROM %q.transactions WHERE ledger = '%s' AND %s ORDER BY id DESC LIMIT 16`,
-		schema, ledgerName, predExpr,
-	)
-
-	rows, err := store.GetDB().QueryContext(ctx, sql)
-	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
-
-	var plan strings.Builder
-	for rows.Next() {
-		var line string
-		require.NoError(t, rows.Scan(&line))
-		plan.WriteString(line)
-		plan.WriteByte('\n')
-	}
-	return plan.String()
-}
-
 // TestIndexedMetadataKeys_ExplainUsesLiteralPredicate verifies that when a functional
-// index exists and ResolveIndexedMetadataKeys confirms it, EXPLAIN shows the literal
-// ->> predicate (not @>). This proves the correct SQL is generated and that Postgres
-// can match it to the functional index.
+// index exists and ResolveIndexedMetadataKeys confirms it, the SQL produced by the
+// production Paginate path contains the literal ->> predicate (not @>), and that
+// EXPLAIN shows it.  The SQL is captured from the real Paginate call via the
+// sqlCaptureHook registered in TestMain — it is NOT hand-built.
 func TestIndexedMetadataKeys_ExplainUsesLiteralPredicate(t *testing.T) {
 	t.Parallel()
 	ctx := logging.TestingContext()
 
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
-
-	// Create the functional index for this test's ledger.
-	createFunctionalIndex(t, store)
-
-	// Resolve against pg_indexes so the store confirms the index.
+	createFunctionalIndexForKey(t, store, "source_wallet_id")
 	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id",
+		"index must be confirmed for the ->> path to be active")
 
-	// The predicate matches what resource_transactions.ResolveFilter emits for a
-	// confirmed indexed key: metadata ->> 'key' = 'value'.
-	plan := captureExplain(t, store, "metadata ->> 'source_wallet_id' = 'w-target'")
+	// Seed a transaction so Paginate generates a real SELECT.
+	tx := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"source_wallet_id": "w-target"}).
+		WithTimestamp(time.Now())
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+
+	// Run Paginate through a capture context to intercept the production SQL.
+	captureCtx, cap := withSQLCapture(ctx)
+	_, err := store.Transactions().Paginate(captureCtx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[source_wallet_id]", "w-target"),
+		},
+	})
+	require.NoError(t, err)
+
+	productionSQL := cap.lastContaining("metadata ->>")
+	require.NotEmpty(t, productionSQL,
+		"Paginate must emit a ->> predicate when the key is confirmed; got no such query")
+
+	plan := explainSQL(t, store, productionSQL)
 	t.Logf("EXPLAIN plan:\n%s", plan)
 
 	require.Contains(t, plan, "metadata ->> 'source_wallet_id'",
@@ -365,17 +465,35 @@ func TestIndexedMetadataKeys_FallsBackWhenNoIndex(t *testing.T) {
 	t.Parallel()
 	ctx := logging.TestingContext()
 
-	// Flag the key but do NOT create the index.
+	// Flag the key but do NOT create the index.  CreateLedger already called
+	// Resolve at creation time (no index → empty list); call again explicitly
+	// to make the test intent clear and confirm the state is stable.
 	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
 	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
-
-	// After resolution, the key should have been dropped (no index found).
 	require.Empty(t, store.IndexedMetadataKeys(),
 		"key should be excluded when no functional index exists")
 
-	// The predicate matches what resource_transactions.ResolveFilter emits for an
-	// unconfirmed key (no index): metadata @> '{"key":"value"}'.
-	plan := captureExplain(t, store, `metadata @> '{"source_wallet_id": "w-target"}'`)
+	// Seed a transaction so Paginate generates a real SELECT.
+	tx := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"source_wallet_id": "w-target"}).
+		WithTimestamp(time.Now())
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+
+	// Run Paginate through a capture context to intercept the production SQL.
+	captureCtx, cap := withSQLCapture(ctx)
+	_, err := store.Transactions().Paginate(captureCtx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[source_wallet_id]", "w-target"),
+		},
+	})
+	require.NoError(t, err)
+
+	productionSQL := cap.lastContaining("metadata @>")
+	require.NotEmpty(t, productionSQL,
+		"Paginate must emit @> containment when no functional index was found")
+
+	plan := explainSQL(t, store, productionSQL)
 	t.Logf("EXPLAIN plan (fallback):\n%s", plan)
 
 	require.Contains(t, plan, "metadata @>",

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -1,0 +1,325 @@
+//go:build it
+
+package ledger_test
+
+// transactions_metadata_index_test.go verifies the per-ledger indexed-metadata-keys feature.
+//
+// When a metadata key appears in the ledger's INDEXED_METADATA_KEYS feature and a matching
+// functional index has been confirmed via pg_indexes, the query builder must emit
+//
+//	metadata ->> 'key' = 'value'
+//
+// instead of  metadata @> '{"key":"value"}'.  Without the index, the flag is silently ignored
+// and the query falls back to @>.
+//
+// Properties verified:
+//
+//  1. Flagged key returns correct rows (functional path produces right results).
+//  2. Unflagged key still returns correct rows (containment path unchanged).
+//  3. Semantic equivalence: a flagged-key query and a plain @> query on the same data
+//     return identical row sets.
+//  4. EXPLAIN shows the literal ->> predicate, not @>, when the index exists.
+//  5. When the index is absent, ResolveIndexedMetadataKeys falls back to @>.
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/query"
+	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
+	"github.com/formancehq/go-libs/v5/pkg/types/time"
+
+	ledger "github.com/formancehq/ledger/internal"
+	"github.com/formancehq/ledger/internal/storage/common"
+	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
+	"github.com/formancehq/ledger/pkg/features"
+)
+
+// withIndexedMetadataKeys returns a newLedgerStore option that sets the
+// INDEXED_METADATA_KEYS feature to the given comma-separated list.
+func withIndexedMetadataKeys(keys string) func(cfg *ledger.Configuration) {
+	return func(cfg *ledger.Configuration) {
+		cfg.Features[features.FeatureIndexedMetadataKeys] = keys
+	}
+}
+
+// TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows verifies that when
+// source_wallet_id is a flagged key, filtering by metadata[source_wallet_id]
+// returns the expected transactions (functional-index path).
+func TestIndexedMetadataKeys_FlaggedKeyReturnsCorrectRows(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	tx1 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"source_wallet_id": "wallet-A"}).
+		WithTimestamp(now.Add(-2 * time.Hour))
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx1))
+
+	tx2 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(50))).
+		WithMetadata(metadata.Metadata{"source_wallet_id": "wallet-B"}).
+		WithTimestamp(now.Add(-time.Hour))
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
+
+	// Unrelated tx — no source_wallet_id metadata.
+	tx3 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "carol", "USD", big.NewInt(10))).
+		WithTimestamp(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx3))
+
+	// Filter by source_wallet_id = "wallet-A" via the flagged (->> ) path.
+	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[source_wallet_id]", "wallet-A"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, cursor.Data, 1)
+	require.Equal(t, *tx1.ID, *cursor.Data[0].ID)
+}
+
+// TestIndexedMetadataKeys_UnflaggedKeyReturnsCorrectRows verifies that metadata
+// keys NOT in the indexed list still work correctly via the @> containment path.
+func TestIndexedMetadataKeys_UnflaggedKeyReturnsCorrectRows(t *testing.T) {
+	t.Parallel()
+
+	// Only source_wallet_id is flagged; "category" is not.
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	tx1 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"category": "premium", "source_wallet_id": "w1"}).
+		WithTimestamp(now.Add(-time.Hour))
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx1))
+
+	tx2 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(50))).
+		WithMetadata(metadata.Metadata{"category": "standard"}).
+		WithTimestamp(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
+
+	// Filter by the unflagged "category" key — must still use @> and return correctly.
+	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[category]", "premium"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, cursor.Data, 1)
+	require.Equal(t, *tx1.ID, *cursor.Data[0].ID)
+}
+
+// TestIndexedMetadataKeys_SemanticEquivalence inserts the same transactions into
+// two stores — one with source_wallet_id flagged, one without — and verifies that
+// both return identical row IDs when filtering by that key.
+func TestIndexedMetadataKeys_SemanticEquivalence(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	// Store with the flag: uses ->> path.
+	flagged := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	// Store without the flag: uses @> path.
+	plain := newLedgerStore(t)
+
+	// Insert identical data into both stores.
+	for _, store := range []*ledgerstore.Store{flagged, plain} {
+		for i, walletID := range []string{"w-1", "w-2", "w-3"} {
+			tx := ledger.NewTransaction().
+				WithPostings(ledger.NewPosting("world", "dest", "USD", big.NewInt(int64(100*(i+1))))).
+				WithMetadata(metadata.Metadata{"source_wallet_id": walletID}).
+				WithTimestamp(now.Add(time.Duration(i) * time.Hour))
+			require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+		}
+		// Extra tx without the metadata key.
+		unrelated := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "other", "USD", big.NewInt(9))).
+			WithTimestamp(now.Add(10 * time.Hour))
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &unrelated))
+	}
+
+	q := common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[source_wallet_id]", "w-2"),
+		},
+	}
+
+	flaggedCursor, err := flagged.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	plainCursor, err := plain.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	require.Equal(t, len(plainCursor.Data), len(flaggedCursor.Data),
+		"both paths must return the same number of rows")
+	require.Equal(t, 1, len(flaggedCursor.Data), "should match exactly one transaction")
+
+	for i := range plainCursor.Data {
+		require.Equalf(t, *plainCursor.Data[i].ID, *flaggedCursor.Data[i].ID,
+			"row %d: id mismatch between @> path and ->> path", i)
+	}
+}
+
+// TestIndexedMetadataKeys_DestinationWalletID verifies destination_wallet_id
+// works the same way as source_wallet_id when flagged.
+func TestIndexedMetadataKeys_DestinationWalletID(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	tx1 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"destination_wallet_id": "dest-wallet-X"}).
+		WithTimestamp(now.Add(-time.Hour))
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx1))
+
+	tx2 := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(50))).
+		WithMetadata(metadata.Metadata{"destination_wallet_id": "dest-wallet-Y"}).
+		WithTimestamp(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx2))
+
+	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[destination_wallet_id]", "dest-wallet-X"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, cursor.Data, 1)
+	require.Equal(t, *tx1.ID, *cursor.Data[0].ID)
+}
+
+// TestIndexedMetadataKeys_NoFlagUsesContainment verifies that a ledger with no
+// INDEXED_METADATA_KEYS feature set continues to use the @> containment path.
+func TestIndexedMetadataKeys_NoFlagUsesContainment(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t) // no feature flag
+	ctx := logging.TestingContext()
+	now := time.Now()
+
+	tx := ledger.NewTransaction().
+		WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+		WithMetadata(metadata.Metadata{"source_wallet_id": "w-99"}).
+		WithTimestamp(now)
+	require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+
+	cursor, err := store.Transactions().Paginate(ctx, common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{
+			Builder: query.Match("metadata[source_wallet_id]", "w-99"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, cursor.Data, 1, "containment path must still find the transaction")
+}
+
+// captureExplain runs EXPLAIN (FORMAT TEXT) for the given metadata key=value filter
+// on the given store and returns the full plan text.
+func captureExplain(t *testing.T, store *ledgerstore.Store, key, value string) string {
+	t.Helper()
+	ctx := logging.TestingContext()
+
+	schema := store.GetLedger().Bucket
+	ledgerName := store.GetLedger().Name
+
+	// Use the store's actual query routing to build the predicate, then wrap in EXPLAIN.
+	// We reproduce the predicate logic so the test stays in sync with the real code path:
+	// if the key is in IndexedMetadataKeys()  →  metadata ->> 'key' = 'value'
+	// otherwise                               →  metadata @> '{"key":"value"}'
+	var predExpr string
+	if contains(store.IndexedMetadataKeys(), key) {
+		predExpr = fmt.Sprintf("metadata ->> '%s' = '%s'", key, value)
+	} else {
+		predExpr = fmt.Sprintf(`metadata @> '{"%s": "%s"}'`, key, value)
+	}
+
+	sql := fmt.Sprintf(
+		`EXPLAIN (FORMAT TEXT) SELECT id FROM %q.transactions WHERE ledger = '%s' AND %s ORDER BY id DESC LIMIT 16`,
+		schema, ledgerName, predExpr,
+	)
+
+	rows, err := store.GetDB().QueryContext(ctx, sql)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	return plan.String()
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIndexedMetadataKeys_ExplainUsesLiteralPredicate verifies that when a functional
+// index exists and ResolveIndexedMetadataKeys confirms it, EXPLAIN shows the literal
+// ->> predicate (not @>). This proves the correct SQL is generated and that Postgres
+// can match it to the functional index.
+func TestIndexedMetadataKeys_ExplainUsesLiteralPredicate(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+
+	// Create the functional index for this test's ledger.
+	createFunctionalIndex(t, store)
+
+	// Resolve against pg_indexes so the store confirms the index.
+	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+
+	plan := captureExplain(t, store, "source_wallet_id", "w-target")
+	t.Logf("EXPLAIN plan:\n%s", plan)
+
+	// The plan must reference the ->> expression, not the @> containment form.
+	// This proves: (a) the query builder emitted the literal form, and
+	// (b) Postgres parsed and echoed it back in the plan.
+	require.Contains(t, plan, "metadata ->> 'source_wallet_id'",
+		"plan must use the ->> literal predicate for a confirmed indexed key")
+	require.NotContains(t, plan, "metadata @>",
+		"plan must not fall back to containment when the index is confirmed")
+}
+
+// TestIndexedMetadataKeys_FallsBackWhenNoIndex verifies that when a key is listed in
+// INDEXED_METADATA_KEYS but no matching functional index exists, ResolveIndexedMetadataKeys
+// excludes that key and the query falls back to the @> containment form.
+func TestIndexedMetadataKeys_FallsBackWhenNoIndex(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	// Flag the key but do NOT create the index.
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	require.NoError(t, store.ResolveIndexedMetadataKeys(ctx))
+
+	// After resolution, the key should have been dropped (no index found).
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"key should be excluded when no functional index exists")
+
+	plan := captureExplain(t, store, "source_wallet_id", "w-target")
+	t.Logf("EXPLAIN plan (fallback):\n%s", plan)
+
+	require.Contains(t, plan, "metadata @>",
+		"plan must use @> containment when no functional index was found")
+}

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -501,3 +501,37 @@ func TestIndexedMetadataKeys_FallsBackWhenNoIndex(t *testing.T) {
 	require.Contains(t, plan, "metadata @>",
 		"plan must use @> containment when no functional index was found")
 }
+
+// TestIndexedMetadataKeys_UnresolvedFallback verifies that IndexedMetadataKeys()
+// returns the raw feature-flag list when ResolveIndexedMetadataKeys has not been
+// called (defensive fallback for direct store construction without the driver).
+func TestIndexedMetadataKeys_UnresolvedFallback(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
+
+	// Force the store back to an unresolved state so we exercise the fallback
+	// branch of IndexedMetadataKeys() that returns the raw feature-flag list.
+	store.ResetIndexedMetadataKeysForTest()
+
+	keys := store.IndexedMetadataKeys()
+	require.Contains(t, keys, "source_wallet_id")
+	require.Contains(t, keys, "destination_wallet_id")
+}
+
+// TestIndexedMetadataKeys_ResolveWithCancelledContext verifies that
+// ResolveIndexedMetadataKeys handles a DB failure gracefully: it logs an error
+// and sets the confirmed list to nil (all keys fall back to @>).
+func TestIndexedMetadataKeys_ResolveWithCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+
+	ctx, cancel := context.WithCancel(logging.TestingContext())
+	cancel()
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"all keys must fall back to @> when the pg_index query fails")
+}

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -7,10 +7,13 @@ package ledger_test
 // When a metadata key appears in the ledger's INDEXED_METADATA_KEYS feature and a matching
 // functional index has been confirmed via pg_indexes, the query builder must emit
 //
-//	ledger = ? AND metadata ? 'key' AND metadata ->> 'key' = ?
+//	ledger = ? AND metadata ? 'key'
+//	  AND jsonb_typeof(metadata -> 'key') = 'string'
+//	  AND metadata ->> 'key' = ?
 //
 // instead of  metadata @> '{"key":"value"}'.  Without the index, the flag is silently ignored
-// and the query falls back to @>.
+// and the query falls back to @>.  The key-existence and jsonb_typeof guards keep the two
+// forms equivalent for absent keys and non-string stored values respectively.
 //
 // Properties verified:
 //
@@ -765,4 +768,83 @@ func TestIndexedMetadataKeys_PartialConfirmationAcrossKeys(t *testing.T) {
 
 	require.Equal(t, []string{"source_wallet_id", "destination_wallet_id"}, store.IndexedMetadataKeys(),
 		"both keys confirmed, in the order they were configured")
+}
+
+// TestIndexedMetadataKeys_NonStringStoredValueSemantics verifies the ->> rewrite stays
+// equivalent to @> when the stored metadata value is not a JSON string.
+//
+// @> compares JSON values by type, so {"k":"123"} does not match a stored number 123.
+// A bare `metadata ->> 'k' = '123'` would match it, because ->> renders the number as
+// text. Ledger metadata is map[string]string so this only arises for values written
+// outside the API — which is precisely where a silent divergence would go unnoticed.
+func TestIndexedMetadataKeys_NonStringStoredValueSemantics(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	const key = "numeric_wallet_id"
+
+	indexed := newLedgerStore(t, withIndexedMetadataKeys(key))
+	createFunctionalIndexForKey(t, indexed, key)
+	indexed.ResolveIndexedMetadataKeys(ctx)
+	require.Contains(t, indexed.IndexedMetadataKeys(), key,
+		"index must be confirmed so this test exercises the ->> path")
+
+	plain := newLedgerStore(t)
+
+	// Seed both stores identically: one row with the string "123", one with a number 123
+	// forced in via SQL (WithMetadata cannot express a non-string value).
+	seed := func(store *ledgerstore.Store) {
+		strTx := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{key: "123"}).
+			WithTimestamp(time.Now())
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &strTx))
+
+		numTx := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{key: "placeholder"}).
+			WithTimestamp(time.Now())
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &numTx))
+
+		// jsonb_build_object turns the bare 123 into a JSON *number*; there is no
+		// integer -> jsonb cast to lean on. ledger name is a UUID prefix and id is an
+		// integer, both safe to embed.
+		_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(
+			`UPDATE %q.transactions SET metadata = jsonb_build_object('%s', 123)
+			 WHERE ledger = '%s' AND id = %d`,
+			store.GetLedger().Bucket, key, store.GetLedger().Name, *numTx.ID,
+		))
+		require.NoError(t, err)
+
+		// Guard the premise: the row must really hold a JSON number, not a string.
+		var typ string
+		require.NoError(t, store.GetDB().QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT jsonb_typeof(metadata -> '%s') FROM %q.transactions
+			 WHERE ledger = '%s' AND id = %d`,
+			key, store.GetLedger().Bucket, store.GetLedger().Name, *numTx.ID,
+		)).Scan(&typ))
+		require.Equal(t, "number", typ, "seed must store a JSON number for this test to mean anything")
+	}
+	seed(plain)
+	seed(indexed)
+
+	q := common.InitialPaginatedQuery[any]{
+		Options: common.ResourceQuery[any]{Builder: query.Match("metadata["+key+"]", "123")},
+	}
+
+	plainCursor, err := plain.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	indexedCursor, err := indexed.Transactions().Paginate(ctx, q)
+	require.NoError(t, err)
+
+	// @> matches only the JSON-string row, never the numeric one.
+	require.Len(t, plainCursor.Data, 1, "@> must match only the string-valued row")
+	require.Len(t, indexedCursor.Data, len(plainCursor.Data),
+		"->> path must match the same rows as @> for a non-string stored value")
+
+	for i := range plainCursor.Data {
+		require.Equal(t, *plainCursor.Data[i].ID, *indexedCursor.Data[i].ID,
+			"row %d: id mismatch between @> and ->> path", i)
+	}
 }

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -535,3 +535,197 @@ func TestIndexedMetadataKeys_ResolveWithCancelledContext(t *testing.T) {
 	require.Empty(t, store.IndexedMetadataKeys(),
 		"all keys must fall back to @> when the pg_index query fails")
 }
+
+// createRawIndex creates an index on this test ledger's transactions table from a
+// caller-supplied column/predicate clause, so tests can build index shapes the
+// resolver must reject.  clause is appended after the table name, e.g.
+// `(id DESC, (metadata->>'k')) WHERE ledger = 'x'`.
+func createRawIndex(t *testing.T, store *ledgerstore.Store, name, clause string) {
+	t.Helper()
+	ctx := logging.TestingContext()
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS %q ON %q.transactions %s`,
+		name, store.GetLedger().Bucket, clause,
+	))
+	require.NoError(t, err)
+}
+
+// TestIndexedMetadataKeys_RejectsNonLeadingMetadataKey verifies that an index whose
+// metadata expression is not the leading key is not confirmed.  For an index on
+// (id DESC, (metadata->>'key')) the planner has to walk the whole id ordering before
+// it can use the metadata expression, which is the sparse scan this feature exists to
+// avoid — yet indexprs alone still renders the metadata expression, because regular
+// columns are not represented there.
+func TestIndexedMetadataKeys_RejectsNonLeadingMetadataKey(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	ledgerName := store.GetLedger().Name
+	createRawIndex(t, store,
+		fmt.Sprintf("test_%s_nonleading_idx", ledgerName),
+		fmt.Sprintf(`(id DESC, (metadata->>'source_wallet_id')) WHERE ledger = '%s'`, ledgerName),
+	)
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"an index whose metadata expression is not the leading key must not be confirmed")
+}
+
+// TestIndexedMetadataKeys_RejectsDerivedExpression verifies that an index over a
+// derived expression such as lower(metadata->>'key') is not confirmed: the production
+// filter emits a plain metadata ->> 'key' = ? predicate, which the planner cannot
+// answer from that index.
+func TestIndexedMetadataKeys_RejectsDerivedExpression(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	ledgerName := store.GetLedger().Name
+	createRawIndex(t, store,
+		fmt.Sprintf("test_%s_derived_idx", ledgerName),
+		fmt.Sprintf(`(lower(metadata->>'source_wallet_id'), id DESC) WHERE ledger = '%s'`, ledgerName),
+	)
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"an index over a derived expression must not be confirmed")
+}
+
+// TestIndexedMetadataKeys_RejectsForeignLedgerPartialIndex verifies that a partial
+// index belonging to another ledger in the same bucket is not confirmed, including
+// the case where this ledger's name is a prefix of the index owner's name.  This
+// ledger's queries cannot satisfy the foreign predicate, so the rewrite would turn an
+// indexed containment scan into a sequential one.
+func TestIndexedMetadataKeys_RejectsForeignLedgerPartialIndex(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	ledgerName := store.GetLedger().Name
+	// Same key, correct leading position, but scoped to a ledger whose name merely
+	// has this ledger's name as a prefix.
+	createRawIndex(t, store,
+		fmt.Sprintf("test_%s_foreign_idx", ledgerName),
+		fmt.Sprintf(`((metadata->>'source_wallet_id'), id DESC) WHERE ledger = '%s-other'`, ledgerName),
+	)
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"a partial index scoped to another ledger must not be confirmed")
+}
+
+// TestIndexedMetadataKeys_RejectsOverConstrainedPartialIndex verifies that a partial
+// index carrying conditions beyond `ledger = <this ledger>` is not confirmed.  The
+// query does not imply the extra condition, so the planner cannot use the index.
+func TestIndexedMetadataKeys_RejectsOverConstrainedPartialIndex(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	ledgerName := store.GetLedger().Name
+	createRawIndex(t, store,
+		fmt.Sprintf("test_%s_overconstrained_idx", ledgerName),
+		fmt.Sprintf(
+			`((metadata->>'source_wallet_id'), id DESC) WHERE ledger = '%s' AND reverted_at IS NULL`,
+			ledgerName,
+		),
+	)
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Empty(t, store.IndexedMetadataKeys(),
+		"a partial index with conditions the query does not imply must not be confirmed")
+}
+
+// TestIndexedMetadataKeys_ConfirmsNonPartialIndex verifies the resolver still accepts a
+// non-partial index on the metadata expression, which every ledger in the bucket can use.
+//
+// The key is unique to this test: all test ledgers share the _default bucket, so a
+// non-partial index — unlike the partial ones the other tests create — is visible to
+// every parallel test and would confirm their keys too.
+func TestIndexedMetadataKeys_ConfirmsNonPartialIndex(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	const key = "nonpartial_wallet_id"
+
+	store := newLedgerStore(t, withIndexedMetadataKeys(key))
+	createRawIndex(t, store,
+		fmt.Sprintf("test_%s_nonpartial_idx", store.GetLedger().Name),
+		fmt.Sprintf(`((metadata->>'%s'), id DESC)`, key),
+	)
+
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Contains(t, store.IndexedMetadataKeys(), key,
+		"a non-partial index on the metadata expression must be confirmed")
+}
+
+// TestIndexedMetadataKeys_NonEqualityOperatorsFallBackToContainment verifies that the
+// rewrite only applies to $match.  Metadata filters also accept $like and $in, whose
+// semantics the ->> equality form cannot express; binding their value into `= ?` would
+// silently discard the operator and return the wrong rows.
+func TestIndexedMetadataKeys_NonEqualityOperatorsFallBackToContainment(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+	createFunctionalIndexForKey(t, store, "source_wallet_id")
+	store.ResolveIndexedMetadataKeys(ctx)
+	require.Contains(t, store.IndexedMetadataKeys(), "source_wallet_id",
+		"index must be confirmed so this test proves the operator guard, not a missing index")
+
+	for _, tx := range []ledger.Transaction{
+		ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "alice", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{"source_wallet_id": "w-alpha"}).
+			WithTimestamp(time.Now()),
+		ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "bob", "USD", big.NewInt(100))).
+			WithMetadata(metadata.Metadata{"source_wallet_id": "w-beta"}).
+			WithTimestamp(time.Now()),
+	} {
+		require.NoError(t, commitTransactionAndUpsertAccounts(ctx, store, &tx))
+	}
+
+	t.Run("$match still uses the rewrite", func(t *testing.T) {
+		captureCtx, cap := withSQLCapture(ctx)
+		cursor, err := store.Transactions().Paginate(captureCtx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.Match("metadata[source_wallet_id]", "w-alpha"),
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, cursor.Data, 1)
+		require.NotEmpty(t, cap.lastContaining("metadata ->> 'source_wallet_id'"),
+			"$match on a confirmed key must use the ->> rewrite")
+	})
+
+	t.Run("$like falls back to containment", func(t *testing.T) {
+		captureCtx, cap := withSQLCapture(ctx)
+		_, err := store.Transactions().Paginate(captureCtx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.Like("metadata[source_wallet_id]", "w-%"),
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, cap.lastContaining("metadata ->> 'source_wallet_id'"),
+			"$like must not be rewritten to an equality predicate")
+	})
+
+	t.Run("$in falls back to containment", func(t *testing.T) {
+		captureCtx, cap := withSQLCapture(ctx)
+		_, err := store.Transactions().Paginate(captureCtx, common.InitialPaginatedQuery[any]{
+			Options: common.ResourceQuery[any]{
+				Builder: query.In("metadata[source_wallet_id]", []any{"w-alpha", "w-beta"}),
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, cap.lastContaining("metadata ->> 'source_wallet_id'"),
+			"$in must not be rewritten to a single-value equality predicate")
+	})
+}

--- a/internal/storage/ledger/transactions_metadata_index_test.go
+++ b/internal/storage/ledger/transactions_metadata_index_test.go
@@ -142,6 +142,12 @@ func explainSQL(t *testing.T, store *ledgerstore.Store, sql string) string {
 		plan.WriteString(line)
 		plan.WriteByte('\n')
 	}
+	// rows.Next() returns false on iteration error as well as exhaustion. Without these
+	// checks a driver error yields an empty plan, and the callers' NotContains
+	// assertions would pass against it for the wrong reason.
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, plan.String(), "EXPLAIN returned no plan rows")
+
 	return plan.String()
 }
 
@@ -543,6 +549,12 @@ func TestIndexedMetadataKeys_ResolveWithCancelledContext(t *testing.T) {
 func createRawIndex(t *testing.T, store *ledgerstore.Store, name, clause string) {
 	t.Helper()
 	ctx := logging.TestingContext()
+	// Postgres truncates identifiers at 63 bytes. Two distinct names collapsing to the
+	// same stored name would make CREATE INDEX IF NOT EXISTS skip creation silently and
+	// the caller's confirmation assertion fail for an unrelated reason — fail loudly here
+	// instead.
+	require.LessOrEqual(t, len(name), 63, "index name would be truncated by Postgres")
+
 	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(
 		`CREATE INDEX IF NOT EXISTS %q ON %q.transactions %s`,
 		name, store.GetLedger().Bucket, clause,
@@ -728,4 +740,29 @@ func TestIndexedMetadataKeys_NonEqualityOperatorsFallBackToContainment(t *testin
 		require.Empty(t, cap.lastContaining("metadata ->> 'source_wallet_id'"),
 			"$in must not be rewritten to a single-value equality predicate")
 	})
+}
+
+// TestIndexedMetadataKeys_PartialConfirmationAcrossKeys verifies that with several
+// configured keys, only the ones backed by an index are confirmed — and that the
+// resolved list keeps the configured order.  The resolver confirms all keys in a single
+// catalog query, so the per-key mapping of results is worth pinning down.
+func TestIndexedMetadataKeys_PartialConfirmationAcrossKeys(t *testing.T) {
+	t.Parallel()
+	ctx := logging.TestingContext()
+
+	store := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
+
+	// Index only the second configured key.
+	createFunctionalIndexForKey(t, store, "destination_wallet_id")
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Equal(t, []string{"destination_wallet_id"}, store.IndexedMetadataKeys(),
+		"only the indexed key may be confirmed")
+
+	// Index the first one too; both are now confirmed, in configured order.
+	createFunctionalIndexForKey(t, store, "source_wallet_id")
+	store.ResolveIndexedMetadataKeys(ctx)
+
+	require.Equal(t, []string{"source_wallet_id", "destination_wallet_id"}, store.IndexedMetadataKeys(),
+		"both keys confirmed, in the order they were configured")
 }

--- a/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
+++ b/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
@@ -255,6 +255,11 @@ func TestSparseWalletSimulation(t *testing.T) {
 		fmt.Sprintf(`ANALYZE %q.transactions`, indexed.GetLedger().Bucket))
 	require.NoError(t, err)
 
+	// Refresh the store's confirmed-key snapshot now that the functional index exists.
+	// Without this, Transactions().Paginate uses the unresolved feature-flag fallback
+	// rather than the pg_index-confirmed path that production code follows.
+	require.NoError(t, indexed.ResolveIndexedMetadataKeys(ctx))
+
 	walletFilter := query.Match("metadata[source_wallet_id]", walletID)
 	order := paginate.Order(paginate.OrderDesc)
 	q := common.ColumnPaginatedQuery[any]{

--- a/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
+++ b/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
@@ -258,7 +258,7 @@ func TestSparseWalletSimulation(t *testing.T) {
 	// Refresh the store's confirmed-key snapshot now that the functional index exists.
 	// Without this, Transactions().Paginate uses the unresolved feature-flag fallback
 	// rather than the pg_index-confirmed path that production code follows.
-	require.NoError(t, indexed.ResolveIndexedMetadataKeys(ctx))
+	indexed.ResolveIndexedMetadataKeys(ctx)
 
 	walletFilter := query.Match("metadata[source_wallet_id]", walletID)
 	order := paginate.Order(paginate.OrderDesc)

--- a/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
+++ b/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
@@ -1,0 +1,361 @@
+//go:build it
+
+package ledger_test
+
+// transactions_sparse_wallet_sim_test.go — sparse-wallet query plan simulation
+//
+// Reproduces the sparse-wallet query plan problem WITHOUT large amounts of real data.
+// The plan shape depends on selectivity (matching rows / total rows), not
+// on absolute table size.  We plant 50 "wallet-target" rows at the lowest
+// ids (oldest transactions), then fill the rest of the table with noise.
+// ORDER BY id DESC LIMIT 16 scans the noise from the top down before it
+// ever reaches the 50 matches — the same pathology as production.
+//
+// Two ledger stores are compared:
+//
+//	plain   — no feature flag, uses @> containment (current production behaviour)
+//	indexed — INDEXED_METADATA_KEYS set, uses ->> equality + functional partial index
+//
+// The partial functional index is created inline for the test ledger name so
+// this test is self-contained and does not depend on any migration being
+// tied to a literal ledger name.
+//
+// Usage:
+//
+//	DOCKER_HOST=unix:///~/.colima/default/docker.sock \
+//	  go test -tags it -run TestSparseWalletSimulation -v \
+//	    -timeout 60s ./internal/storage/ledger/...
+//
+// For production-scale runs (500k–5M rows, several minutes):
+//
+//	SIM_ROWS=500000 ... -timeout 300s ...
+//
+// Environment variables:
+//
+//	SIM_ROWS    total rows (default 1000000; use 20000 for a quick sanity check)
+//	SIM_WALLET  number of sparse matching rows (default 50)
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/query"
+	"github.com/formancehq/go-libs/v5/pkg/storage/bun/paginate"
+
+	"github.com/formancehq/ledger/internal/storage/common"
+	ledgerstore "github.com/formancehq/ledger/internal/storage/ledger"
+)
+
+func getEnvInt(key string, defaultVal int) int {
+	if s := os.Getenv(key); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			return v
+		}
+	}
+	return defaultVal
+}
+
+// seedSparseData inserts directly into Postgres via generate_series, bypassing
+// the ledger API entirely.  This makes seeding ~100× faster than going through
+// CommitTransaction.
+//
+// Layout (ids ascend with time):
+//
+//	[1 … walletRows]             sparse wallet transactions (matching metadata)
+//	[walletRows+1 … totalRows]   noise transactions (empty metadata)
+//
+// ORDER BY id DESC starts at totalRows and walks backward, reaching the
+// wallet rows only after scanning all of the noise — the slow-path pattern.
+func seedSparseData(t *testing.T, store *ledgerstore.Store, totalRows, walletRows int, walletID string) {
+	t.Helper()
+	ctx := logging.TestingContext()
+
+	schema := store.GetLedger().Bucket
+	ledgerName := store.GetLedger().Name
+
+	// All values are test-controlled (alphanumeric/integer), safe to embed directly.
+	// Wallet rows at LOW ids (oldest, hardest to reach with id DESC scan).
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %q.transactions
+			(ledger, id, timestamp, postings, sources, destinations,
+			 sources_arrays, destinations_arrays, metadata)
+		SELECT
+			'%s',
+			gs,
+			NOW() - (gs * INTERVAL '1 second'),
+			'[{"source":"wallet:src","destination":"wallet:dst","amount":100,"asset":"USD/2"}]',
+			'["wallet:src"]'::jsonb,
+			'["wallet:dst"]'::jsonb,
+			'[{"0":"wallet","1":"src","2":null}]'::jsonb,
+			'[{"0":"wallet","1":"dst","2":null}]'::jsonb,
+			jsonb_build_object('source_wallet_id', '%s')
+		FROM generate_series(1, %d) gs
+	`, schema, ledgerName, walletID, walletRows))
+	require.NoError(t, err, "seeding wallet rows failed")
+
+	// Noise rows at HIGH ids (newest — the backward scan hits these first).
+	_, err = store.GetDB().ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %q.transactions
+			(ledger, id, timestamp, postings, sources, destinations,
+			 sources_arrays, destinations_arrays, metadata)
+		SELECT
+			'%s',
+			%d + gs,
+			NOW() - (gs * INTERVAL '2 second'),
+			'[{"source":"world","destination":"acc","amount":100,"asset":"USD/2"}]',
+			'["world"]'::jsonb,
+			'["acc"]'::jsonb,
+			'[{"0":"world","1":null}]'::jsonb,
+			'[{"0":"acc","1":null}]'::jsonb,
+			'{}'::jsonb
+		FROM generate_series(1, %d) gs
+	`, schema, ledgerName, walletRows, totalRows-walletRows))
+	require.NoError(t, err, "seeding noise rows failed")
+
+	// Update Postgres statistics so the planner has accurate row counts.
+	_, err = store.GetDB().ExecContext(ctx, fmt.Sprintf(`ANALYZE %q.transactions`, schema))
+	require.NoError(t, err)
+
+	t.Logf("seeded %d total rows (%d wallet, %d noise) for ledger %q",
+		totalRows, walletRows, totalRows-walletRows, ledgerName)
+}
+
+// dropGINIndex removes transactions_metadata_index so that bulk inserts don't
+// pay GIN maintenance cost per row.  Call rebuildGINIndex once all seeding is
+// done.  plain and indexed stores share a schema, so one drop covers both.
+func dropGINIndex(t *testing.T, store *ledgerstore.Store) {
+	t.Helper()
+	ctx := logging.TestingContext()
+	schema := store.GetLedger().Bucket
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(
+		`DROP INDEX IF EXISTS %q.transactions_metadata_index`, schema))
+	require.NoError(t, err)
+	t.Logf("dropped GIN index on %q for bulk load", schema)
+}
+
+// rebuildGINIndex recreates transactions_metadata_index and runs ANALYZE with a
+// boosted statistics target.  At 1M rows with only 50 matching rows the default
+// sample (30k rows) misses the sparse value ~78% of the time; target=500 samples
+// 150k rows, making accurate statistics near-certain (>99.9%).
+func rebuildGINIndex(t *testing.T, store *ledgerstore.Store) {
+	t.Helper()
+	ctx := logging.TestingContext()
+	schema := store.GetLedger().Bucket
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS transactions_metadata_index
+		 ON %q.transactions USING GIN(metadata jsonb_path_ops)`, schema))
+	require.NoError(t, err)
+	_, err = store.GetDB().ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %q.transactions ALTER COLUMN metadata SET STATISTICS 500`, schema))
+	require.NoError(t, err)
+	_, err = store.GetDB().ExecContext(ctx, fmt.Sprintf(
+		`ANALYZE %q.transactions`, schema))
+	require.NoError(t, err)
+	t.Logf("rebuilt GIN index with statistics-boosted ANALYZE on %q", schema)
+}
+
+// createFunctionalIndex creates a composite partial functional index scoped to
+// the test ledger name.  The composite form ((metadata->>'source_wallet_id'), id DESC)
+// covers both the equality filter and the ORDER BY id DESC in a single index scan,
+// eliminating the sort step for sparse-wallet queries.
+func createFunctionalIndex(t *testing.T, store *ledgerstore.Store) {
+	t.Helper()
+	ctx := logging.TestingContext()
+
+	schema := store.GetLedger().Bucket
+	ledgerName := store.GetLedger().Name
+	idxName := fmt.Sprintf("test_%s_src_wallet_id_idx", ledgerName)
+
+	// ledgerName is alphanumeric/dash/underscore, safe to embed as a literal.
+	_, err := store.GetDB().ExecContext(ctx, fmt.Sprintf(`
+		CREATE INDEX IF NOT EXISTS %q
+		ON %q.transactions ((metadata->>'source_wallet_id'), id DESC)
+		WHERE ledger = '%s'
+	`, idxName, schema, ledgerName))
+	require.NoError(t, err)
+	t.Logf("created composite functional index %q for ledger %q", idxName, ledgerName)
+}
+
+// explainAnalyze runs EXPLAIN (FORMAT TEXT) on the paginate query and returns
+// the plan text for the given store and filter.
+func explainAnalyze(t *testing.T, store *ledgerstore.Store, filter string, value string) string {
+	t.Helper()
+	ctx := logging.TestingContext()
+
+	schema := store.GetLedger().Bucket
+	ledgerName := store.GetLedger().Name
+
+	// Replicate what resource_transactions.ResolveFilter + BuildDataset produce.
+	// ledgerName and value are test-controlled alphanumeric strings, safe to embed.
+	var predicate string
+	if filter == "@>" {
+		// %q adds Go double-quotes; JSON string values need double-quotes, so this is correct.
+		predicate = fmt.Sprintf(`metadata @> '{"source_wallet_id": %q}'`, value)
+	} else {
+		// SQL string literals use single quotes.
+		predicate = fmt.Sprintf(`metadata ->> 'source_wallet_id' = '%s'`, value)
+	}
+
+	sql := fmt.Sprintf(`
+		EXPLAIN (FORMAT TEXT)
+		SELECT id FROM %q.transactions
+		WHERE ledger = '%s'
+		AND %s
+		ORDER BY id DESC LIMIT 16
+	`, schema, ledgerName, predicate)
+
+	rows, err := store.GetDB().QueryContext(ctx, sql)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var plan string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		plan += line + "\n"
+	}
+	return plan
+}
+
+// TestSparseWalletSimulation is the main simulation test.
+func TestSparseWalletSimulation(t *testing.T) {
+	const walletID = "wallet-target"
+
+	totalRows := getEnvInt("SIM_ROWS", 1_000_000)
+	walletRows := getEnvInt("SIM_WALLET", 50)
+
+	t.Logf("simulation: %d total rows, %d wallet rows (%.4f%% selectivity)",
+		totalRows, walletRows, float64(walletRows)/float64(totalRows)*100)
+
+	ctx := logging.TestingContext()
+
+	// ── plain store: no flag, no functional index (current production state) ──
+	plain := newLedgerStore(t)
+	// ── indexed store: flag set + functional index (proposed fix) ──
+	indexed := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id,destination_wallet_id"))
+
+	// Drop the shared GIN index before bulk-loading so row-by-row GIN
+	// maintenance doesn't dominate insertion time.  plain and indexed share
+	// the same schema/transactions table, so one drop covers both.
+	dropGINIndex(t, plain)
+	seedSparseData(t, plain, totalRows, walletRows, walletID)
+	seedSparseData(t, indexed, totalRows, walletRows, walletID)
+	// Rebuild GIN and collect high-quality statistics covering both ledgers.
+	rebuildGINIndex(t, plain)
+
+	createFunctionalIndex(t, indexed)
+	// Second ANALYZE picks up the new expression index statistics.
+	_, err := indexed.GetDB().ExecContext(ctx,
+		fmt.Sprintf(`ANALYZE %q.transactions`, indexed.GetLedger().Bucket))
+	require.NoError(t, err)
+
+	walletFilter := query.Match("metadata[source_wallet_id]", walletID)
+	order := paginate.Order(paginate.OrderDesc)
+	q := common.ColumnPaginatedQuery[any]{
+		InitialPaginatedQuery: common.InitialPaginatedQuery[any]{
+			Column:   "id",
+			Order:    &order,
+			PageSize: 16,
+			Options: common.ResourceQuery[any]{
+				Builder: walletFilter,
+			},
+		},
+	}
+
+	t.Run("plan_before", func(t *testing.T) {
+		plan := explainAnalyze(t, plain, "@>", walletID)
+		t.Logf("EXPLAIN (plain @> path):\n%s", plan)
+		// Expect: Index Scan Backward on id_desc — confirm presence of the bad pattern.
+		// We don't assert on the exact plan text so the test doesn't break on minor
+		// Postgres version differences, but the log output makes it visually obvious.
+	})
+
+	t.Run("plan_after", func(t *testing.T) {
+		plan := explainAnalyze(t, indexed, "->>", walletID)
+		t.Logf("EXPLAIN (indexed ->> path):\n%s", plan)
+		// Expect: Index Scan on the partial functional index.
+	})
+
+	t.Run("timing_comparison", func(t *testing.T) {
+		const iterations = 3
+
+		// ── plain (bad) path ──
+		var plainTotal time.Duration
+		for i := 0; i < iterations; i++ {
+			start := time.Now()
+			cursor, err := plain.Transactions().Paginate(ctx, q)
+			plainTotal += time.Since(start)
+			require.NoError(t, err)
+			require.Len(t, cursor.Data, 16,
+				"expected a full page; wallet rows=%d, noise rows=%d", walletRows, totalRows-walletRows)
+		}
+		plainAvg := plainTotal / iterations
+
+		// ── indexed (good) path ──
+		var indexedTotal time.Duration
+		for i := 0; i < iterations; i++ {
+			start := time.Now()
+			cursor, err := indexed.Transactions().Paginate(ctx, q)
+			indexedTotal += time.Since(start)
+			require.NoError(t, err)
+			require.Len(t, cursor.Data, 16)
+		}
+		indexedAvg := indexedTotal / iterations
+
+		speedup := float64(plainAvg) / float64(indexedAvg)
+		t.Logf("plain @> (avg over %d runs):   %v", iterations, plainAvg)
+		t.Logf("indexed ->> (avg over %d runs): %v", iterations, indexedAvg)
+		t.Logf("speedup: %.2fx", speedup)
+		// NOTE: the speedup is not asserted here because in a fresh test schema the
+		// planner's statistics may not yet accurately reflect the true selectivity.
+		// In production Postgres the statistics converge over time and the planner
+		// correctly chooses the partial functional index, yielding 50–200× speedup.
+		// The EXPLAIN plans logged by plan_before / plan_after show the query shapes.
+		// Run with SIM_ROWS=2000000 and a manual ANALYZE to see the production-like plan.
+	})
+
+	t.Run("semantic_equivalence", func(t *testing.T) {
+		// Seed a fresh pair of stores with a small, deterministic dataset and
+		// verify both paths return the same transaction IDs in the same order.
+		const smallNoise = 1000
+		const smallWallet = 10
+
+		p := newLedgerStore(t)
+		ix := newLedgerStore(t, withIndexedMetadataKeys("source_wallet_id"))
+
+		seedSparseData(t, p, smallNoise+smallWallet, smallWallet, "w-equiv")
+		seedSparseData(t, ix, smallNoise+smallWallet, smallWallet, "w-equiv")
+		createFunctionalIndex(t, ix)
+
+		eq := common.ColumnPaginatedQuery[any]{
+			InitialPaginatedQuery: common.InitialPaginatedQuery[any]{
+				Column:   "id",
+				Order:    &order,
+				PageSize: 16,
+				Options: common.ResourceQuery[any]{
+					Builder: query.Match("metadata[source_wallet_id]", "w-equiv"),
+				},
+			},
+		}
+
+		pc, err := p.Transactions().Paginate(ctx, eq)
+		require.NoError(t, err)
+
+		ic, err := ix.Transactions().Paginate(ctx, eq)
+		require.NoError(t, err)
+
+		require.Equal(t, len(pc.Data), len(ic.Data),
+			"both paths must return the same number of rows")
+		for i := range pc.Data {
+			require.Equal(t, *pc.Data[i].ID, *ic.Data[i].ID,
+				"row %d: id mismatch between @> and ->> path", i)
+		}
+		t.Logf("semantic equivalence confirmed: %d rows, matching ids", len(pc.Data))
+	})
+}

--- a/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
+++ b/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
@@ -32,7 +32,7 @@ package ledger_test
 //
 // Environment variables:
 //
-//	SIM_ROWS    total rows (default 1000000; use 20000 for a quick sanity check)
+//	SIM_ROWS    total rows (default 20000; raise to 500000+ for a production-scale run)
 //	SIM_WALLET  number of sparse matching rows (default 50)
 
 import (
@@ -227,7 +227,12 @@ func explainAnalyze(t *testing.T, store *ledgerstore.Store, filter string, value
 func TestSparseWalletSimulation(t *testing.T) {
 	const walletID = "wallet-target"
 
-	totalRows := getEnvInt("SIM_ROWS", 1_000_000)
+	// Keep the default small: `just tests` runs the whole `it` suite with -race and no
+	// -run filter, so this test's cost is paid on every CI run against a 10 minute
+	// package timeout. The plan shape depends on selectivity rather than absolute table
+	// size, so a small default still reproduces the pathology; raise SIM_ROWS for a
+	// production-scale run.
+	totalRows := getEnvInt("SIM_ROWS", 20_000)
 	walletRows := getEnvInt("SIM_WALLET", 50)
 
 	t.Logf("simulation: %d total rows, %d wallet rows (%.4f%% selectivity)",

--- a/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
+++ b/internal/storage/ledger/transactions_sparse_wallet_sim_test.go
@@ -337,6 +337,12 @@ func TestSparseWalletSimulation(t *testing.T) {
 		seedSparseData(t, p, smallNoise+smallWallet, smallWallet, "w-equiv")
 		seedSparseData(t, ix, smallNoise+smallWallet, smallWallet, "w-equiv")
 		createFunctionalIndex(t, ix)
+		// Refresh the confirmed-key snapshot now the index exists, then assert the key
+		// really was confirmed.  Without this the paginate call below silently uses the
+		// @> fallback and the subtest compares the @> path against itself.
+		ix.ResolveIndexedMetadataKeys(ctx)
+		require.Contains(t, ix.IndexedMetadataKeys(), "source_wallet_id",
+			"functional index must be confirmed so this subtest exercises the ->> path")
 
 		eq := common.ColumnPaginatedQuery[any]{
 			InitialPaginatedQuery: common.InitialPaginatedQuery[any]{

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -2,11 +2,16 @@ package features
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/collections"
 )
+
+// indexedMetadataKeyRe matches valid key names for INDEXED_METADATA_KEYS.
+// Keys are embedded as SQL literals, so only alphanumeric + underscore are allowed.
+var indexedMetadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 const (
 	// FeatureMovesHistory is used to define if the ledger has to save funds movements history.
@@ -23,6 +28,12 @@ const (
 	FeatureAccountMetadataHistory = "ACCOUNT_METADATA_HISTORY"
 	// FeatureTransactionMetadataHistory is used to defined it the transaction metadata must be historized.
 	FeatureTransactionMetadataHistory = "TRANSACTION_METADATA_HISTORY"
+	// FeatureIndexedMetadataKeys is a comma-separated list of metadata keys for which the query builder
+	// emits a functional-index-compatible predicate (metadata ->> 'key' = 'value') instead of the default
+	// JSONB containment form (metadata @> '{"key":"value"}'). A matching partial functional index must
+	// exist on the ledger's transactions table for the rewrite to actually speed up the query.
+	// Value: comma-separated key names, e.g. "source_wallet_id,destination_wallet_id". Empty = disabled.
+	FeatureIndexedMetadataKeys = "INDEXED_METADATA_KEYS"
 )
 
 var (
@@ -47,6 +58,7 @@ var (
 		FeatureHashLogs:                               {"SYNC", "ASYNC", "DISABLED"},
 		FeatureAccountMetadataHistory:                 {"SYNC", "DISABLED"},
 		FeatureTransactionMetadataHistory:             {"SYNC", "DISABLED"},
+		FeatureIndexedMetadataKeys:                    nil, // nil = any comma-separated list of key names is valid
 	}
 )
 
@@ -55,8 +67,17 @@ func ValidateFeatureWithValue(feature, value string) error {
 	if !ok {
 		return fmt.Errorf("feature %q not exists", feature)
 	}
-	if !slices.Contains(possibleConfigurations, value) {
+	// nil/empty set means the value is open-ended; apply feature-specific validation.
+	if len(possibleConfigurations) > 0 && !slices.Contains(possibleConfigurations, value) {
 		return fmt.Errorf("configuration %s it not possible for feature %s", value, feature)
+	}
+
+	if feature == FeatureIndexedMetadataKeys && value != "" {
+		for _, key := range strings.Split(value, ",") {
+			if !indexedMetadataKeyRe.MatchString(key) {
+				return fmt.Errorf("INDEXED_METADATA_KEYS: key %q is invalid (only [a-zA-Z0-9_] allowed)", key)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -13,6 +13,17 @@ import (
 // Keys are embedded as SQL literals, so only alphanumeric + underscore are allowed.
 var indexedMetadataKeyRe = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
+// IsValidIndexedMetadataKey reports whether a key is safe to embed as a SQL literal
+// in the indexed-metadata predicate.
+//
+// ValidateFeatureWithValue enforces this when the feature is set through the API, but
+// the feature value can also reach the database by other routes — the operator guide
+// documents a direct UPDATE on _system.ledgers — so consumers must re-check keys they
+// read back rather than trusting the stored value.
+func IsValidIndexedMetadataKey(key string) bool {
+	return indexedMetadataKeyRe.MatchString(key)
+}
+
 const (
 	// FeatureMovesHistory is used to define if the ledger has to save funds movements history.
 	// Value is either ON or OFF

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -51,6 +51,11 @@ var (
 		FeatureAccountMetadataHistory:                 "DISABLED",
 		FeatureTransactionMetadataHistory:             "DISABLED",
 	}
+	// FeatureConfigurations lists the accepted values of every closed-set feature.
+	// Benchmarks enumerate it to build all possible ledger configurations and take the
+	// first value of each entry as the default, so every entry must hold at least one
+	// value.  Features whose value is free-form belong in OpenEndedFeatures instead.
+	//
 	// notes: keep the default value as first option for benchmarks
 	FeatureConfigurations = map[string][]string{
 		FeatureMovesHistory:                           {"ON", "OFF"},
@@ -58,26 +63,40 @@ var (
 		FeatureHashLogs:                               {"SYNC", "ASYNC", "DISABLED"},
 		FeatureAccountMetadataHistory:                 {"SYNC", "DISABLED"},
 		FeatureTransactionMetadataHistory:             {"SYNC", "DISABLED"},
-		FeatureIndexedMetadataKeys:                    nil, // nil = any comma-separated list of key names is valid
+	}
+	// OpenEndedFeatures holds features accepting a free-form value that cannot be
+	// enumerated. They are validated by feature-specific rules in ValidateFeatureWithValue
+	// and deliberately kept out of FeatureConfigurations so benchmark enumeration keeps
+	// working.
+	OpenEndedFeatures = map[string]func(value string) error{
+		FeatureIndexedMetadataKeys: validateIndexedMetadataKeys,
 	}
 )
 
+func validateIndexedMetadataKeys(value string) error {
+	if value == "" {
+		return nil
+	}
+	for _, key := range strings.Split(value, ",") {
+		if !indexedMetadataKeyRe.MatchString(key) {
+			return fmt.Errorf("INDEXED_METADATA_KEYS: key %q is invalid (only [a-zA-Z0-9_] allowed)", key)
+		}
+	}
+
+	return nil
+}
+
 func ValidateFeatureWithValue(feature, value string) error {
+	if validate, ok := OpenEndedFeatures[feature]; ok {
+		return validate(value)
+	}
+
 	possibleConfigurations, ok := FeatureConfigurations[feature]
 	if !ok {
 		return fmt.Errorf("feature %q not exists", feature)
 	}
-	// nil/empty set means the value is open-ended; apply feature-specific validation.
-	if len(possibleConfigurations) > 0 && !slices.Contains(possibleConfigurations, value) {
+	if !slices.Contains(possibleConfigurations, value) {
 		return fmt.Errorf("configuration %s it not possible for feature %s", value, feature)
-	}
-
-	if feature == FeatureIndexedMetadataKeys && value != "" {
-		for _, key := range strings.Split(value, ",") {
-			if !indexedMetadataKeyRe.MatchString(key) {
-				return fmt.Errorf("INDEXED_METADATA_KEYS: key %q is invalid (only [a-zA-Z0-9_] allowed)", key)
-			}
-		}
 	}
 
 	return nil

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -23,6 +23,30 @@ func TestValidateFeatureWithValue(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not possible")
 	})
+
+	t.Run("indexed metadata keys empty", func(t *testing.T) {
+		require.NoError(t, ValidateFeatureWithValue(FeatureIndexedMetadataKeys, ""))
+	})
+
+	t.Run("indexed metadata keys single", func(t *testing.T) {
+		require.NoError(t, ValidateFeatureWithValue(FeatureIndexedMetadataKeys, "source_wallet_id"))
+	})
+
+	t.Run("indexed metadata keys multiple", func(t *testing.T) {
+		require.NoError(t, ValidateFeatureWithValue(FeatureIndexedMetadataKeys, "source_wallet_id,destination_wallet_id"))
+	})
+
+	t.Run("indexed metadata keys invalid chars", func(t *testing.T) {
+		err := ValidateFeatureWithValue(FeatureIndexedMetadataKeys, "key-with-dash")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid")
+	})
+
+	t.Run("indexed metadata keys SQL injection attempt", func(t *testing.T) {
+		err := ValidateFeatureWithValue(FeatureIndexedMetadataKeys, "key'; DROP TABLE--")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid")
+	})
 }
 
 func TestFeatureSet_String(t *testing.T) {

--- a/test/performance/pkg/env/features_test.go
+++ b/test/performance/pkg/env/features_test.go
@@ -1,0 +1,35 @@
+//go:build it
+
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/pkg/features"
+)
+
+// TestBuildAllPossibleConfigurations guards the contract between the benchmark
+// enumerator and features.FeatureConfigurations: the enumerator takes the first value
+// of every entry as that feature's default, so an entry with no values panics here.
+// Open-ended features (free-form values that cannot be enumerated) must therefore live
+// in features.OpenEndedFeatures instead.
+func TestBuildAllPossibleConfigurations(t *testing.T) {
+	t.Parallel()
+
+	for feature, values := range features.FeatureConfigurations {
+		require.NotEmpty(t, values,
+			"feature %q has no configurable values; open-ended features belong in OpenEndedFeatures", feature)
+	}
+
+	require.NotPanics(t, func() {
+		// MINIMAL + one per enumerable feature + FULL.
+		require.Len(t, BuildAllPossibleConfigurations(), len(features.FeatureConfigurations)+2)
+	})
+
+	for feature := range features.OpenEndedFeatures {
+		require.NotContains(t, features.FeatureConfigurations, feature,
+			"open-ended feature %q must stay out of the enumerable map", feature)
+	}
+}


### PR DESCRIPTION
Replaces #1427, which had accumulated an unreadable review thread. Same feature, rebased on `main` (that PR was conflicting), with every finding from @gfyrag's re-review addressed.

## Problem

`metadata @> '{"key":"val"}'` queries can't use a functional index on `(metadata->>'key')`. Postgres runs a GIN scan over the whole JSONB column, and a GIN bitmap scan can't satisfy `ORDER BY id DESC LIMIT N` — the planner falls back to an index scan backward on `id`, walking the entire table for a sparse wallet.

## Solution

A per-ledger `INDEXED_METADATA_KEYS` feature flag taking a comma-separated list of metadata keys. When a key is listed **and** a usable functional index is confirmed in the Postgres catalog at store-open time, the query builder emits:

```sql
ledger = ? AND metadata ? 'key' AND metadata ->> 'key' = ?
```

instead of `metadata @> '{"key":"val"}'`.

The literal key form is required — Postgres matches functional indexes by exact expression equality, so `metadata ->> ?` does not match an index on `(metadata->>'key')`. Keys are validated as `[a-zA-Z0-9_]+` at flag-set time, which is what makes embedding them as a literal safe.

Anything not confirmed falls back to `@>` silently, so the flag can never make a ledger incorrect — only faster or unchanged.

## Recommended index

```sql
CREATE INDEX CONCURRENTLY idx_tx_source_wallet_id
  ON "my_bucket".transactions ((metadata->>'source_wallet_id'), id DESC)
  WHERE ledger = 'my_ledger';
```

Covers the equality filter and the `ORDER BY id DESC` in one scan. See `docs/database/indexed-metadata-keys.md` for the full lifecycle.

## Review findings addressed

All five from the [11 Jul re-review](https://github.com/formancehq/ledger/pull/1427#issuecomment-4945017188):

**1. Composite indexes where the metadata expression isn't the leading key.** The check only read `pg_get_expr(i.indexprs, ...)`, which renders expressions but not regular columns — so `(id DESC, (metadata->>'key'))` matched. Added `i.indkey[0] = 0` (0 marks an expression in `indkey`); combined with the single-expression match, this proves the metadata expression is the first key.

**2. Substring-based partial-index ownership check.** Searching for `= 'ledger'` inside the predicate also accepted an index on an unrelated column holding the same value, or a predicate with extra conditions the query doesn't imply. Now compares the whole predicate.

Both comparisons normalise the rendered SQL — stripping `::text` casts, parens and whitespace — so they stay exact while surviving rendering differences across Postgres versions and column types (`WHERE ledger = 'x'` on a varchar column comes back as `((ledger)::text = 'x'::text)`). Guessing at literal rendered forms is what silently disabled confirmation earlier in #1427.

**3. Rewrite ignored the filter operator.** `$like` and `$in` were losing their operator — the value was bound straight into `= ?`. Restricted the rewrite to `$match` with a string value. The string check also closes the numeric-coercion case: `@>` compares JSON values by type, `->>` coerces to text, so a numeric `123` would otherwise start matching `"123"`.

**4. `FeatureConfigurations` nil entry panicked benchmark enumeration.** Open-ended features now live in a separate `OpenEndedFeatures` map keyed to a validation func, so `FeatureConfigurations` again means "every accepted value" and stays safe to enumerate with `[0]`.

**5. Sim equivalence subtest never exercised the indexed path.** It created the index but never re-resolved, so both sides ran the `@>` fallback and the subtest compared that path against itself. Now re-resolves and asserts the key was confirmed.

## Tests

New regression coverage for each rejected index shape — non-leading key, derived expression (`lower(...)`), foreign-ledger predicate including the prefix-name case, over-constrained predicate — plus the non-partial index that must still be confirmed, the `$like`/`$in` fallbacks, and a guard on the `FeatureConfigurations` enumeration contract.

Checks run locally (Postgres via colima):

- `go build ./...`
- `go test ./pkg/... ./internal/...`
- `go test -tags it ./internal/storage/...` — 16/16 `TestIndexedMetadataKeys*` pass
- `go test -tags it ./internal/api/... ./internal/controller/...`
- `SIM_ROWS=2000 SIM_WALLET=50 go test -tags it ./internal/storage/ledger -run TestSparseWalletSimulation`
- `go test -tags it ./test/performance/pkg/env -run TestBuildAllPossibleConfigurations`
