### PR TITLE
fix(ledger): upsert transaction accounts inside the operation's transaction (v2.4 backport)

### DIFF
--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -307,7 +307,7 @@ func (ctrl *DefaultController) importLog(ctx context.Context, store Store, log l
 				if err := store.CommitTransaction(ctx, &payload.Transaction); err != nil {
 					return nil, fmt.Errorf("failed to commit transaction: %w", err)
 				}
-				if err := ctrl.upsertTransactionAccounts(ctx, schema, &payload.Transaction, payload.AccountMetadata); err != nil {
+				if err := ctrl.upsertTransactionAccounts(ctx, store, schema, &payload.Transaction, payload.AccountMetadata); err != nil {
 					return nil, fmt.Errorf("failed to upsert transaction accounts: %w", err)
 				}
 				logging.FromContext(ctx).Debugf("Imported transaction %d", *payload.Transaction.ID)
@@ -374,10 +374,15 @@ func (ctrl *DefaultController) importLog(ctx context.Context, store Store, log l
 	return err
 }
 
-func (ctrl *DefaultController) upsertTransactionAccounts(ctx context.Context, schema *ledger.Schema, tx *ledger.Transaction, accountMetadata ledger.AccountMetadata) error {
+// upsertTransactionAccounts writes the accounts a transaction involves. It must
+// run on the operation's store: the upsert lowers first_usage to the transaction's
+// effective date, so on any other handle it would autocommit independently of the
+// transaction — visible before the transaction, and durable even when the
+// transaction never commits.
+func (ctrl *DefaultController) upsertTransactionAccounts(ctx context.Context, store Store, schema *ledger.Schema, tx *ledger.Transaction, accountMetadata ledger.AccountMetadata) error {
 	accountsToUpsert := tx.AccountsWithDefaultMetadata(schema, accountMetadata)
 
-	err := ctrl.store.UpsertAccounts(
+	err := store.UpsertAccounts(
 		ctx,
 		accountsToUpsert...,
 	)
@@ -501,7 +506,7 @@ func (ctrl *DefaultController) createTransaction(ctx context.Context, store Stor
 	if err != nil {
 		return nil, err
 	}
-	err = ctrl.upsertTransactionAccounts(ctx, schema, &transaction, accountMetadata)
+	err = ctrl.upsertTransactionAccounts(ctx, store, schema, &transaction, accountMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/api_transactions_dry_run_accounts_test.go
+++ b/test/e2e/api_transactions_dry_run_accounts_test.go
@@ -1,0 +1,120 @@
+//go:build it
+
+package test_suite
+
+import (
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	. "github.com/formancehq/go-libs/v5/pkg/testing/deferred/ginkgo"
+	"github.com/formancehq/go-libs/v5/pkg/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
+
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
+	. "github.com/formancehq/ledger/pkg/testserver"
+	. "github.com/formancehq/ledger/pkg/testserver/ginkgo"
+)
+
+// A transaction writes its accounts through the operation's store. When that
+// store was not the transaction's, the accounts were autocommitted: they
+// survived an operation that never committed, and because the upsert lowers
+// first_usage to the transaction's effective date (LEAST over the involved
+// accounts), an existing account's first_usage was pulled back permanently.
+//
+// A dry run is the observable form of "the operation never commits": the whole
+// transaction is rolled back by design, so nothing it wrote may remain. The
+// ledger must be warm — the first write to a ledger runs under a
+// controller-level transaction that hides the defect.
+var _ = Context("Ledger transactions dry run account persistence", func() {
+	var (
+		db         = UseTemplatedDatabase()
+		ctx        = logging.TestingContext()
+		testServer = DeferTestServer(
+			DeferMap(db, (*pgtesting.Database).ConnectionOptions),
+			testservice.WithInstruments(
+				testservice.DebugInstrumentation(debug),
+				testservice.OutputInstrumentation(GinkgoWriter),
+			),
+			testservice.WithLogger(GinkgoT()),
+		)
+		backdated = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	)
+
+	BeforeEach(func(specContext SpecContext) {
+		_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		// Warm the ledger: the very first write is wrapped in a controller-level
+		// transaction, which would mask the defect.
+		_, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+			Ledger: "default",
+			V2PostTransaction: components.V2PostTransaction{
+				Postings: []components.V2Posting{{
+					Source: "world", Destination: "seed", Amount: big.NewInt(10), Asset: "USD",
+				}},
+			},
+		})
+		Expect(err).To(BeNil())
+	})
+
+	When("dry running a backdated transaction to a new account", func() {
+		var worldBefore *time.Time
+
+		BeforeEach(func(specContext SpecContext) {
+			world, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+				Ledger: "default", Address: "world",
+			})
+			Expect(err).To(BeNil())
+			worldBefore = world.V2AccountResponse.Data.FirstUsage
+
+			_, err = Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				DryRun: pointer.For(true),
+				V2PostTransaction: components.V2PostTransaction{
+					Timestamp: &backdated,
+					Postings: []components.V2Posting{{
+						Source: "world", Destination: "ghost", Amount: big.NewInt(5), Asset: "USD",
+					}},
+				},
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("should not persist the transaction", func(specContext SpecContext) {
+			txs, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListTransactions(ctx, operations.V2ListTransactionsRequest{
+				Ledger: "default",
+			})
+			Expect(err).To(BeNil())
+			Expect(txs.V2TransactionsCursorResponse.Cursor.Data).To(HaveLen(1))
+		})
+
+		It("should not create the account the dry run touched", func(specContext SpecContext) {
+			accounts, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+				Ledger: "default",
+			})
+			Expect(err).To(BeNil())
+
+			addresses := make([]string, 0, len(accounts.V2AccountsCursorResponse.Cursor.Data))
+			for _, account := range accounts.V2AccountsCursorResponse.Cursor.Data {
+				addresses = append(addresses, account.Address)
+			}
+			Expect(addresses).ToNot(ContainElement("ghost"))
+		})
+
+		It("should not backdate first_usage of an existing account", func(specContext SpecContext) {
+			world, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+				Ledger: "default", Address: "world",
+			})
+			Expect(err).To(BeNil())
+			Expect(world.V2AccountResponse.Data.FirstUsage).To(Equal(worldBefore))
+		})
+	})
+})


### PR DESCRIPTION
Backport of #1684 to `release/v2.4`. Fixes EN-1753.

## The bug

A transaction's `accounts` rows can be committed **outside the operation's database transaction**, so they survive an operation that never commits. The upsert lowers `first_usage` to the transaction's effective date (`LEAST` over the involved accounts), so this permanently backdates accounts that already existed.

`createTransaction` writes the transaction, moves and log through the transaction-scoped `store` that `forgeLog` passes down, but writes accounts through `ctrl.store` — the base handle, which autocommits. `saveAccountMetadata` already uses the parameter correctly.

The **first** write to a ledger runs under a controller-level transaction, so `ctrl.store` is transaction-scoped and the upsert is atomic by accident; from the second write onward it is not. That is why this went unnoticed.

## Impact

`first_usage` is the sole gate for the as-of-pit account universe (`resource_accounts.go`, `where accounts.first_usage <= pit`) and is only ever lowered, so one operation that fails after the upsert corrupts that account's history permanently: `GET /accounts?pit=…` lists it as in use when nothing had touched it, with no volumes and no transaction to explain it. `firstUsage` is also returned by the API.

Reachable in production through any operation that does not commit after the upsert — client disconnect, cancellation, log-insert failure, deadlock retry — and deterministically through `?dryRun=true`, which is rolled back by design:

```
POST /v2/{ledger}/transactions            # warm the ledger
POST /v2/{ledger}/transactions?dryRun=true
  {"timestamp":"2020-01-01T00:00:00Z",
   "postings":[{"source":"world","destination":"ghost","amount":5,"asset":"USD"}]}

→ no transaction persisted (correct), but
   ghost firstUsage=2020-01-01Z   ← account that must not exist
   world firstUsage=2020-01-01Z   ← was 2026-08-10, now permanently backdated
```

## Verification on this branch

`test/e2e/api_transactions_dry_run_accounts_test.go`, focused run against `release/v2.4`:

- without the fix: `1 Passed | 2 Failed` — the transaction is correctly absent, but the account is created and `world`'s `first_usage` is backdated
- with the fix: `3 Passed | 0 Failed`

The v2 model-based conformance test (DST) also goes red on v2.4.12 within ~15s (account read, count and query oracles) and clean against a build carrying this fix.

## Scope

`release/v2.3` is **not affected** and needs no backport: there the accounts upsert happens inside `store.CommitTransaction` (`internal/storage/ledger/transactions.go`), on the transaction-scoped store. Verified empirically — the same dry-run probe leaves no account behind on v2.3.22.

## Note for operators

Existing deployments may already carry corrupted `first_usage` values. This stops new corruption; it does not repair old rows.

The corruption does **not** require a backdated operation. Any operation that fails, is retried, or is dry-run stamps `first_usage` a few milliseconds-to-seconds early, and because the upsert uses `LEAST` a later legitimate transaction can never raise it back. How far back the value lands is simply how far back the discarded operation was dated — usually seconds, years when it was backdated.

Auditing therefore has to compare `first_usage` against the value reconstructed from the logs, which record what actually committed:

```sql
-- replace <bucket> with the bucket schema and <ledger> with the ledger name
with contrib as (
    select p->>'source' as address,
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC') as ts
      from "<bucket>".logs l, jsonb_array_elements(l.data->'transaction'->'postings') p
     where l.ledger = '<ledger>' and l.type in ('NEW_TRANSACTION','REVERTED_TRANSACTION')
    union all
    select p->>'destination',
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC')
      from "<bucket>".logs l, jsonb_array_elements(l.data->'transaction'->'postings') p
     where l.ledger = '<ledger>' and l.type in ('NEW_TRANSACTION','REVERTED_TRANSACTION')
    union all
    select jsonb_object_keys(l.data->'accountMetadata'),
           ((l.data->'transaction'->>'timestamp')::timestamptz at time zone 'UTC')
      from "<bucket>".logs l
     where l.ledger = '<ledger>' and l.type = 'NEW_TRANSACTION'
       and l.data->'accountMetadata' <> 'null'::jsonb
    union all
    select l.data->>'targetId', (l.date at time zone 'UTC')
      from "<bucket>".logs l
     where l.ledger = '<ledger>' and l.type in ('SET_METADATA','DELETE_METADATA')
       and l.data->>'targetType' = 'ACCOUNT'
)
select a.address, a.first_usage as actual, min(c.ts) as expected
  from "<bucket>".accounts a
  left join contrib c on c.address = a.address
 where a.ledger = '<ledger>'
 group by a.address, a.first_usage
having min(c.ts) is null or a.first_usage <> min(c.ts);
```

`expected` is `LEAST` over the effective date of every committed transaction touching the account (the create path passes `tx.Timestamp` for postings and for `accountMetadata` targets) and the log date of every standalone account-metadata write (that path passes no date, so it coalesces to the log date). A null `expected` means no committed log explains the account at all.

Verified against a fixture holding a metadata-only account, a metadata-then-backdated-transaction account, a phantom account left by a dry run, and an account corrupted by a *non-backdated* dry run followed by a legitimate transaction: it flags exactly the corrupted rows.

Two cheaper checks were tried and are **not** sufficient, for the record:

- `first_usage < insertion_date` with no move that early — finds only the *backdated* subset. A non-backdated discarded operation leaves `first_usage == insertion_date`, indistinguishable by dates from a legitimately metadata-created account.
- "account not referenced by any log" — finds phantom accounts, but misses any account that a legitimate transaction later touched, which is the common case.

The reconstruction assumes the log is complete for the ledger; if logs have been pruned, it can only be trusted from the earliest retained log onward.
