### PR TITLE
fix(EN-1622): serialize transactions/chapters/log responses through their MarshalJSON

### DIFF
--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -559,6 +559,25 @@ func (r *RoutedController) Apply(ctx context.Context, requests ...*servicepb.Req
 }
 ```
 
+## Response serialization
+
+Two encoders serve HTTP response bodies, and the choice is **not** a matter of taste:
+
+| Writer | Encoder | Use for |
+|---|---|---|
+| `writeOK` / `writeOKChecked` | sonic (`internal/adapter/json`) | Anything whose type has a custom `MarshalJSON`, and all hand-written DTOs |
+| `writeProtoOK` / `writeProtoListOK` | `protojson` | Proto messages with **no** custom `MarshalJSON` |
+
+**The rule: when a type has a hand-written `MarshalJSON`, that method is the public contract.** Route it through `writeOKChecked`. `protojson` works off protobuf reflection and ignores `json.Marshaler`, so sending such a type through it silently discards the intended shape.
+
+The camelCase convention cannot arbitrate between the two — both encoders satisfy it. The deciding fact is whether a marshaller exists. `internal/adapter/http/encoder_contract_test.go` enforces this in both directions.
+
+Prefer `writeOKChecked` over `writeOK` when the marshaller can fail (e.g. it marshals a metadata map): `writeOK` streams, so a mid-encode failure appends an error object to an already-committed 200.
+
+This was EN-1622: the transactions list, chapters and single-log routes sent marshaller-carrying types through `protojson` and shipped `amount: {"v0":"12345"}`, `timestamp: {"data":"1786540255458491"}`, base64 hashes where the contract is hex, and quoted numeric ids.
+
+**Before adding a `MarshalJSON` to a proto type, check the blast radius.** `cmd/ledgerctl/cmdutil/output.go` also prefers a custom marshaller when one exists, so adding one changes CLI output too — and `misc/operator` parses `ledgerctl indexes list --json` with a struct that hard-codes the protojson shape, in a separate Go module that a root `go build ./...` never compiles. For types that need a clean HTTP shape without moving the CLI, use an HTTP-local response DTO instead.
+
 ## OpenAPI Documentation
 
 The OpenAPI specification is available in `openapi.yml`. It can be used for:

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -61,7 +61,7 @@ The event carries the full `Log` entry, which contains the typed payload (transa
 
 ### JSON Format
 
-When `format=json` in the events config, the event is serialized as JSON using `protojson`. Property names follow protobuf JSON mapping conventions (camelCase):
+When `format=json` in the events config, the event is serialized as JSON via `internal/adapter/json` (sonic), which honors each proto type's hand-written `MarshalJSON` rather than protobuf reflection — see [Response serialization](../api/http-api.md#response-serialization) for the encoder rule. Property names follow protobuf JSON mapping conventions (camelCase):
 
 ```json
 {

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -2,7 +2,13 @@ package http
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,5 +89,70 @@ func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 					"MarshalJSON: without it sonic emits the protoc-gen snake_case tags.",
 				msg)
 		})
+	}
+}
+
+// TestProtojsonRoutes_TableIsComplete keeps protojsonRoutes honest. The table
+// above is hand-written, so a new protojson handler added without a row would
+// escape the guard entirely. Parse this package and assert the number of
+// protojson call sites matches the number of rows.
+//
+// Counting is deliberate rather than name-matching: a call site cannot be mapped
+// back to a route path statically without much heavier analysis, and a count
+// mismatch is enough to force the author to look at the table.
+func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+
+	var sites []string
+
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				name := calleeName(call.Fun)
+				if name == "writeProtoOK" || name == "writeProtoListOK" || name == "protojson.Marshal" {
+					sites = append(sites, filepath.Base(path)+": "+name)
+				}
+
+				return true
+			})
+		}
+	}
+
+	// response.go defines writeProtoOK and writeProtoListOK, each containing one
+	// protojson.Marshal call. Those two are implementations, not routes.
+	const implementationSites = 2
+
+	require.Lenf(t, sites, len(protojsonRoutes)+implementationSites,
+		"protojson call sites (%v) do not match protojsonRoutes (%d rows) + %d implementation sites. "+
+			"If you added a protojson handler, add it to protojsonRoutes. If you removed one, delete its row.",
+		sites, len(protojsonRoutes), implementationSites)
+}
+
+// calleeName renders a call's function as "name" or "pkg.name".
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.IndexExpr: // Generic instantiation, e.g. writeProtoListOK[T].
+		return calleeName(f.X)
+	case *ast.SelectorExpr:
+		if x, ok := f.X.(*ast.Ident); ok {
+			return x.Name + "." + f.Sel.Name
+		}
+
+		return f.Sel.Name
+	default:
+		return ""
 	}
 }

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -106,6 +106,16 @@ func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 // reachable as protojson.Marshal(m), as protojson.MarshalOptions{...}.Marshal(m)
 // (the idiom used in cmd/ledgerctl), through a variable, or under an import
 // alias. An import cannot be disguised, so gating it catches every form.
+//
+// KNOWN LIMIT: this allowlist is per-FILE, so an allowlisted file could later
+// add a response-side protojson call and slip past both checks — the import
+// gate because the file is exempt, and TestProtojsonRoutes_TableIsComplete
+// because calleeName cannot see a protojson.MarshalOptions{...}.Marshal(...)
+// receiver either. Closing that gap would require symbol-level analysis, which
+// reopens the call-shape unsoundness this gate replaced, so it is accepted
+// rather than closed. Keep the allowlist minimal, justify every entry, and
+// treat a new entry as a review checkpoint: state whether the file marshals a
+// RESPONSE (needs a protojsonRoutes row) or only decodes a REQUEST (does not).
 var allowedProtojsonImporters = map[string]bool{
 	"response.go":                  true,
 	"handlers_get_events_sinks.go": true,

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -103,30 +102,37 @@ func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
 	t.Parallel()
 
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	// parser.ParseDir is deprecated as of Go 1.25 (SA1019); walk the directory
+	// and parse each non-test file individually instead of grouping by package.
+	entries, err := os.ReadDir(".")
 	require.NoError(t, err)
+
+	fset := token.NewFileSet()
 
 	var sites []string
 
-	for _, pkg := range pkgs {
-		for path, file := range pkg.Files {
-			ast.Inspect(file, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-
-				name := calleeName(call.Fun)
-				if name == "writeProtoOK" || name == "writeProtoListOK" || name == "protojson.Marshal" {
-					sites = append(sites, filepath.Base(path)+": "+name)
-				}
-
-				return true
-			})
+	for _, entry := range entries {
+		filename := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(filename, ".go") || strings.HasSuffix(filename, "_test.go") {
+			continue
 		}
+
+		file, err := parser.ParseFile(fset, filename, nil, 0)
+		require.NoError(t, err)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			name := calleeName(call.Fun)
+			if name == "writeProtoOK" || name == "writeProtoListOK" || name == "protojson.Marshal" {
+				sites = append(sites, filename+": "+name)
+			}
+
+			return true
+		})
 	}
 
 	// response.go defines writeProtoOK and writeProtoListOK, each containing one

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -1,0 +1,87 @@
+package http
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// protojsonRoutes lists every HTTP route whose 200 body is serialized by
+// protojson — writeProtoOK, writeProtoListOK, or an inline protojson.Marshal.
+//
+// protojson works off protobuf reflection and ignores json.Marshaler, so a type
+// that has BOTH is silently rendered by the wrong one. That is the EN-1622
+// defect: Transaction, Chapter and Log each had a hand-written MarshalJSON that
+// the protojson writers bypassed, so the list routes disagreed with their
+// sibling detail routes and leaked {v0}/{data} proto wrappers.
+//
+// If this test fails because you added a MarshalJSON to one of these types, do
+// NOT delete the row. The marshaller is the public contract once it exists:
+// move the handler to writeOKChecked, add wire assertions to its handler test,
+// and type the response in openapi.yml. Note the blast radius first — the CLI
+// (cmd/ledgerctl/cmdutil/output.go) also prefers a custom MarshalJSON when one
+// exists, and misc/operator parses `ledgerctl indexes list --json`.
+//
+// See docs/technical/architecture/subsystems/api/http-api.md for the rule.
+var protojsonRoutes = []struct {
+	route string
+	msg   proto.Message
+}{
+	{"GET /v3/{ledgerName}/indexes", &commonpb.Index{}},
+	{"GET /v3/{ledgerName}/indexes/{canonicalId}", &commonpb.Index{}},
+	{"GET /v3/_/indexes", &commonpb.Index{}},
+	{"GET /v3/_/indexes/{canonicalId}", &commonpb.Index{}},
+	{"GET /v3/{ledgerName}/indexes/{canonicalId}/status", &servicepb.IndexEntry{}},
+	{"GET /v3/_/indexes/{canonicalId}/status", &servicepb.IndexEntry{}},
+	{"GET /v3/_/indexes/status", &servicepb.GetIndexStatusResponse{}},
+	{"GET /v3/_/signing-keys", &commonpb.SigningKey{}},
+	{"GET /v3/_/events-sinks", &servicepb.GetEventsSinksResponse{}},
+}
+
+func TestProtojsonRoutes_PayloadHasNoCustomMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range protojsonRoutes {
+		t.Run(tc.route, func(t *testing.T) {
+			t.Parallel()
+
+			_, hasCustom := tc.msg.(json.Marshaler)
+			require.Falsef(t, hasCustom,
+				"%s serializes %T via protojson, but %T now implements json.Marshaler. "+
+					"protojson ignores it, so the custom shape is silently discarded. "+
+					"Move the handler to writeOKChecked and type the response in openapi.yml.",
+				tc.route, tc.msg, tc.msg)
+		})
+	}
+}
+
+// TestSonicRoutes_PayloadHasCustomMarshalJSON is the converse: the three routes
+// fixed by EN-1622 rely on their type's marshaller being the contract. If a
+// marshaller is ever deleted, sonic falls back to the protoc-gen `json:` tags,
+// which are snake_case — a silent wire regression. The handler tests assert the
+// resulting shape; this asserts the mechanism they depend on.
+func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, msg := range []proto.Message{
+		&commonpb.Transaction{},
+		&commonpb.Chapter{},
+		&commonpb.Log{},
+	} {
+		t.Run(reflect.TypeOf(msg).Elem().Name(), func(t *testing.T) {
+			t.Parallel()
+
+			_, hasCustom := msg.(json.Marshaler)
+			require.Truef(t, hasCustom,
+				"%T is served through writeOKChecked (sonic) and MUST keep its custom "+
+					"MarshalJSON: without it sonic emits the protoc-gen snake_case tags.",
+				msg)
+		})
+	}
+}

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -36,17 +36,18 @@ import (
 // See docs/technical/architecture/subsystems/api/http-api.md for the rule.
 var protojsonRoutes = []struct {
 	route string
+	file  string // Handler file containing this route's protojson call site.
 	msg   proto.Message
 }{
-	{"GET /v3/{ledgerName}/indexes", &commonpb.Index{}},
-	{"GET /v3/{ledgerName}/indexes/{canonicalId}", &commonpb.Index{}},
-	{"GET /v3/_/indexes", &commonpb.Index{}},
-	{"GET /v3/_/indexes/{canonicalId}", &commonpb.Index{}},
-	{"GET /v3/{ledgerName}/indexes/{canonicalId}/status", &servicepb.IndexEntry{}},
-	{"GET /v3/_/indexes/{canonicalId}/status", &servicepb.IndexEntry{}},
-	{"GET /v3/_/indexes/status", &servicepb.GetIndexStatusResponse{}},
-	{"GET /v3/_/signing-keys", &commonpb.SigningKey{}},
-	{"GET /v3/_/events-sinks", &servicepb.GetEventsSinksResponse{}},
+	{"GET /v3/{ledgerName}/indexes", "handlers_list_ledger_indexes.go", &commonpb.Index{}},
+	{"GET /v3/{ledgerName}/indexes/{canonicalId}", "handlers_get_index.go", &commonpb.Index{}},
+	{"GET /v3/_/indexes", "handlers_list_bucket_indexes.go", &commonpb.Index{}},
+	{"GET /v3/_/indexes/{canonicalId}", "handlers_get_bucket_index.go", &commonpb.Index{}},
+	{"GET /v3/{ledgerName}/indexes/{canonicalId}/status", "handlers_get_index_entry_status.go", &servicepb.IndexEntry{}},
+	{"GET /v3/_/indexes/{canonicalId}/status", "handlers_get_bucket_index_entry_status.go", &servicepb.IndexEntry{}},
+	{"GET /v3/_/indexes/status", "handlers_get_index_status.go", &servicepb.GetIndexStatusResponse{}},
+	{"GET /v3/_/signing-keys", "handlers_list_signing_keys.go", &commonpb.SigningKey{}},
+	{"GET /v3/_/events-sinks", "handlers_get_events_sinks.go", &servicepb.GetEventsSinksResponse{}},
 }
 
 func TestProtojsonRoutes_PayloadHasNoCustomMarshalJSON(t *testing.T) {
@@ -91,14 +92,71 @@ func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 	}
 }
 
+// allowedProtojsonImporters are the only files in this package permitted to
+// import protojson directly. response.go implements writeProtoOK and
+// writeProtoListOK; handlers_get_events_sinks.go predates those helpers and
+// calls protojson inline; handlers_create_ledger.go is the odd one out — it
+// uses protojson.Unmarshal (decode-side) to parse a MirrorRewriteRule oneof
+// out of an incoming request body, which sonic's decoder cannot dispatch.
+// That file never marshals a response through protojson, so it carries no
+// protojsonRoutes row, but the gate below fires on the import itself, so it
+// still needs an entry here.
+//
+// This gate exists because matching call SHAPES is not sound: protojson is
+// reachable as protojson.Marshal(m), as protojson.MarshalOptions{...}.Marshal(m)
+// (the idiom used in cmd/ledgerctl), through a variable, or under an import
+// alias. An import cannot be disguised, so gating it catches every form.
+var allowedProtojsonImporters = map[string]bool{
+	"response.go":                  true,
+	"handlers_get_events_sinks.go": true,
+	"handlers_create_ledger.go":    true,
+}
+
+func TestProtojsonImportIsRestricted(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		require.NoError(t, err)
+
+		for _, imp := range file.Imports {
+			if imp.Path.Value != `"google.golang.org/protobuf/encoding/protojson"` {
+				continue
+			}
+
+			require.Truef(t, allowedProtojsonImporters[name],
+				"%s imports protojson directly. Serialize through writeProtoOK or "+
+					"writeProtoListOK and add the route to protojsonRoutes with the exact "+
+					"message type the handler writes. If the handler genuinely must call "+
+					"protojson itself, add %s to allowedProtojsonImporters AND add its "+
+					"protojsonRoutes row — do not do only one.",
+				name, name)
+		}
+	}
+}
+
 // TestProtojsonRoutes_TableIsComplete keeps protojsonRoutes honest. The table
 // above is hand-written, so a new protojson handler added without a row would
-// escape the guard entirely. Parse this package and assert the number of
-// protojson call sites matches the number of rows.
+// escape the guard entirely. Parse this package and compare the SET of files
+// containing a protojson call site against the set of files the table expects.
 //
-// Counting is deliberate rather than name-matching: a call site cannot be mapped
-// back to a route path statically without much heavier analysis, and a count
-// mismatch is enough to force the author to look at the table.
+// A bare count is not enough: a compensating add/remove pair (one handler
+// added, one removed) leaves the total unchanged, so a stale row plus an
+// unguarded new route would both pass a count check. Comparing sets keyed by
+// filename catches that, since the added file is present but unexpected and
+// the removed file is expected but absent. A call site still cannot be mapped
+// back to a specific route path without much heavier analysis, which is why
+// the table's `file` field — not `route` — is what this test checks against.
 func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
 	t.Parallel()
 
@@ -109,7 +167,8 @@ func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
 
 	fset := token.NewFileSet()
 
-	var sites []string
+	var sites []string     // "filename: calleeName", for the diagnosable failure message.
+	var siteFiles []string // filename only, for the set comparison below.
 
 	for _, entry := range entries {
 		filename := entry.Name()
@@ -129,20 +188,32 @@ func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
 			name := calleeName(call.Fun)
 			if name == "writeProtoOK" || name == "writeProtoListOK" || name == "protojson.Marshal" {
 				sites = append(sites, filename+": "+name)
+				siteFiles = append(siteFiles, filename)
 			}
 
 			return true
 		})
 	}
 
-	// response.go defines writeProtoOK and writeProtoListOK, each containing one
-	// protojson.Marshal call. Those two are implementations, not routes.
-	const implementationSites = 2
+	// Built from the table so it cannot drift: one entry per route row, plus
+	// response.go twice for the two implementation call sites inside
+	// writeProtoOK and writeProtoListOK themselves — those two functions are
+	// what every route row calls through, not routes of their own.
+	expected := make([]string, 0, len(protojsonRoutes)+2)
+	for _, tc := range protojsonRoutes {
+		expected = append(expected, tc.file)
+	}
 
-	require.Lenf(t, sites, len(protojsonRoutes)+implementationSites,
-		"protojson call sites (%v) do not match protojsonRoutes (%d rows) + %d implementation sites. "+
-			"If you added a protojson handler, add it to protojsonRoutes. If you removed one, delete its row.",
-		sites, len(protojsonRoutes), implementationSites)
+	expected = append(expected, "response.go", "response.go")
+
+	require.ElementsMatchf(t, siteFiles, expected,
+		"protojson call sites %v do not match the expected set %v. If you added a "+
+			"protojson handler, add a row with the exact message type the handler "+
+			"writes — a placeholder type satisfies this check while guarding nothing. "+
+			"If you removed a handler, delete its row. If you added neither, calleeName "+
+			"probably did not recognise your call shape — fix the parser, do not delete "+
+			"a row.",
+		sites, expected)
 }
 
 // calleeName renders a call's function as "name" or "pkg.name".
@@ -151,6 +222,8 @@ func calleeName(fun ast.Expr) string {
 	case *ast.Ident:
 		return f.Name
 	case *ast.IndexExpr: // Generic instantiation, e.g. writeProtoListOK[T].
+		return calleeName(f.X)
+	case *ast.IndexListExpr: // Generic instantiation with multiple type parameters.
 		return calleeName(f.X)
 	case *ast.SelectorExpr:
 		if x, ok := f.X.(*ast.Ident); ok {

--- a/internal/adapter/http/handlers_analyze_accounts.go
+++ b/internal/adapter/http/handlers_analyze_accounts.go
@@ -32,6 +32,20 @@ type patternSegmentJSON struct {
 	Examples        []string `json:"examples"`
 }
 
+// nonNilStrings returns s unchanged when non-nil, or an empty (non-nil) slice
+// otherwise. The OpenAPI schema types these fields as plain (non-nullable)
+// arrays; a proto GetX() getter returns nil for an absent repeated field,
+// which would otherwise serialize as JSON null and violate the schema. Shared
+// with handlers_analyze_transactions.go, whose FlowPattern.MetadataKeys has
+// the same shape.
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+
+	return s
+}
+
 func toAnalyzeAccountsJSON(resp *servicepb.AnalyzeAccountsResponse) *analyzeAccountsResponseJSON {
 	result := &analyzeAccountsResponseJSON{
 		TotalAccounts: resp.GetTotalAccounts(),
@@ -49,8 +63,8 @@ func toAccountPatternJSON(p *servicepb.AccountPattern) *accountPatternJSON {
 	result := &accountPatternJSON{
 		Pattern:      p.GetPattern(),
 		AccountCount: p.GetAccountCount(),
-		Assets:       p.GetAssets(),
-		MetadataKeys: p.GetMetadataKeys(),
+		Assets:       nonNilStrings(p.GetAssets()),
+		MetadataKeys: nonNilStrings(p.GetMetadataKeys()),
 	}
 
 	result.Segments = make([]*patternSegmentJSON, 0, len(p.GetSegments()))
@@ -74,7 +88,7 @@ func toPatternSegmentJSON(s *servicepb.PatternSegment) *patternSegmentJSON {
 		VariableName:    s.GetVariableName(),
 		InferredPattern: s.GetInferredPattern(),
 		UniqueValues:    s.GetUniqueValues(),
-		Examples:        s.GetExamples(),
+		Examples:        nonNilStrings(s.GetExamples()),
 	}
 }
 

--- a/internal/adapter/http/handlers_analyze_accounts_test.go
+++ b/internal/adapter/http/handlers_analyze_accounts_test.go
@@ -197,6 +197,51 @@ func TestHandleAnalyzeAccounts_EmptyResponse(t *testing.T) {
 	require.Empty(t, wrapper.Data.Patterns)
 }
 
+// TestHandleAnalyzeAccounts_NoNullCollections pins the fix for a real
+// conformance failure: the OpenAPI schema types assets/metadataKeys/examples
+// as non-nullable arrays, but AccountPattern.GetAssets() /
+// GetMetadataKeys() and PatternSegment.GetExamples() return nil for an
+// absent repeated field, which serialized as JSON null. Left unset here to
+// reproduce that case, mirroring TestTransaction_MarshalJSON_NoNullCollections.
+func TestHandleAnalyzeAccounts_NoNullCollections(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().AnalyzeAccounts(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ uint32, _ func(uint64, uint64)) (*servicepb.AnalyzeAccountsResponse, error) {
+			return &servicepb.AnalyzeAccountsResponse{
+				TotalAccounts: 1,
+				Patterns: []*servicepb.AccountPattern{
+					{
+						Pattern:      "world",
+						AccountCount: 1,
+						Segments: []*servicepb.PatternSegment{
+							{Position: 0, Type: servicepb.PatternSegmentType_PATTERN_SEGMENT_TYPE_FIXED, FixedValue: "world"},
+						},
+					},
+				},
+			}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/my-ledger/analyze-accounts", nil, map[string]string{
+		"ledgerName": "my-ledger",
+	})
+
+	srv.handleAnalyzeAccounts(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	require.Contains(t, body, `"assets":[]`)
+	require.Contains(t, body, `"metadataKeys":[]`)
+	require.Contains(t, body, `"examples":[]`)
+	require.NotContains(t, body, `"assets":null`)
+	require.NotContains(t, body, `"metadataKeys":null`)
+	require.NotContains(t, body, `"examples":null`)
+}
+
 func TestHandleAnalyzeAccounts_NoLeaderError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_analyze_transactions.go
+++ b/internal/adapter/http/handlers_analyze_transactions.go
@@ -91,7 +91,7 @@ func toFlowPatternJSON(fp *servicepb.FlowPattern) *flowPatternJSON {
 		Signature:        fp.GetSignature(),
 		Structure:        postingStructureToString(fp.GetStructure()),
 		TransactionCount: fp.GetTransactionCount(),
-		MetadataKeys:     fp.GetMetadataKeys(),
+		MetadataKeys:     nonNilStrings(fp.GetMetadataKeys()),
 	}
 
 	result.Postings = make([]*normalizedPostingJSON, 0, len(fp.GetPostings()))

--- a/internal/adapter/http/handlers_analyze_transactions_test.go
+++ b/internal/adapter/http/handlers_analyze_transactions_test.go
@@ -210,6 +210,47 @@ func TestHandleAnalyzeTransactions_EmptyResponse(t *testing.T) {
 	require.Empty(t, wrapper.Data.FlowPatterns)
 }
 
+// TestHandleAnalyzeTransactions_NoNullCollections pins the fix for a real
+// conformance failure: the OpenAPI schema types metadataKeys as a
+// non-nullable array, but FlowPattern.GetMetadataKeys() returns nil for an
+// absent repeated field, which serialized as JSON null. Left unset here to
+// reproduce that case, mirroring TestTransaction_MarshalJSON_NoNullCollections.
+func TestHandleAnalyzeTransactions_NoNullCollections(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().AnalyzeTransactions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ uint32, _ func(uint64, uint64)) (*servicepb.AnalyzeTransactionsResponse, error) {
+			return &servicepb.AnalyzeTransactionsResponse{
+				TotalTransactions: 1,
+				FlowPatterns: []*servicepb.FlowPattern{
+					{
+						Signature:        "world->alice[USD/2]",
+						Structure:        servicepb.PostingStructure_POSTING_STRUCTURE_SIMPLE,
+						TransactionCount: 1,
+						Postings: []*servicepb.NormalizedPosting{
+							{SourcePattern: "world", DestinationPattern: "alice", Asset: "USD/2"},
+						},
+					},
+				},
+			}, nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/my-ledger/analyze-transactions", nil, map[string]string{
+		"ledgerName": "my-ledger",
+	})
+
+	srv.handleAnalyzeTransactions(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	require.Contains(t, body, `"metadataKeys":[]`)
+	require.NotContains(t, body, `"metadataKeys":null`)
+}
+
 func TestHandleAnalyzeTransactions_NoLeaderError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_get_log.go
+++ b/internal/adapter/http/handlers_get_log.go
@@ -27,5 +27,5 @@ func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeProtoOK(w, log)
+	writeOKChecked(w, r, log)
 }

--- a/internal/adapter/http/handlers_get_log_test.go
+++ b/internal/adapter/http/handlers_get_log_test.go
@@ -70,11 +70,12 @@ func TestHandleGetLog_Success(t *testing.T) {
 	require.NotContains(t, body, `"id":"1"`)
 }
 
-// TestHandleGetLog_ShapeMatchesLogsList pins the property EN-1622 is about: the
-// single-log and logs-list routes must serialize the same commonpb.Log
-// identically. They diverged because get-log used protojson while the list used
-// sonic, so the same type had two wire shapes depending on which route you asked.
-func TestHandleGetLog_ShapeMatchesLogsList(t *testing.T) {
+// TestHandleGetLog_SerializesThroughMarshalJSON pins the property EN-1622 is
+// about: the single-log route must serialize its commonpb.Log through
+// Log.MarshalJSON, matching the shape the logs-list route also produces. It
+// diverged because get-log used protojson while the list used sonic, so the
+// same type had two wire shapes depending on which route you asked.
+func TestHandleGetLog_SerializesThroughMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	logValue := func() *commonpb.Log {

--- a/internal/adapter/http/handlers_get_log_test.go
+++ b/internal/adapter/http/handlers_get_log_test.go
@@ -18,7 +18,25 @@ func TestHandleGetLog_Success(t *testing.T) {
 	backend := NewMockBackend(gomock.NewController(t))
 	backend.EXPECT().GetLog(gomock.Any(), uint64(7)).DoAndReturn(
 		func(_ context.Context, _ uint64) (*commonpb.Log, error) {
-			return &commonpb.Log{}, nil
+			return &commonpb.Log{
+				Sequence: 7,
+				Payload: &commonpb.LogPayload{
+					Type: &commonpb.LogPayload_Apply{
+						Apply: &commonpb.ApplyLedgerLog{
+							LedgerName: "ledger1",
+							Log: &commonpb.LedgerLog{
+								Data: &commonpb.LedgerLogPayload{
+									Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+										CreatedTransaction: &commonpb.CreatedTransaction{
+											Transaction: &commonpb.Transaction{Id: 1},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil
 		}).AnyTimes()
 	srv := newTestServer(t, backend)
 
@@ -30,6 +48,74 @@ func TestHandleGetLog_Success(t *testing.T) {
 	srv.handleGetLog(w, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
+
+	// The swap to writeOKChecked routes the log through Log.MarshalJSON, which
+	// emits the synthetic `type` discriminator LedgerLog.MarshalJSON injects.
+	// protojson cannot emit it at all (it is not a proto field), so before this
+	// change the body carried no discriminator and disagreed with the logs-list
+	// route, which has always used sonic for the same commonpb.Log type.
+	//
+	// This does NOT yet round-trip: LedgerLogPayload.MarshalJSON wraps the
+	// payload in its oneof field-name key ({"createdTransaction":{...}}) while
+	// HydrateLog unmarshals `data` straight into the bare inner type, so
+	// LedgerLog.UnmarshalJSON cannot rehydrate it. That asymmetry is a separate
+	// pre-existing defect affecting the logs-list route identically, tracked on
+	// its own ticket — deliberately not fixed here, because the encode side is
+	// also the events-sink wire.
+	body := w.Body.String()
+	require.Contains(t, body, `"type":"NEW_TRANSACTION"`)
+	require.Contains(t, body, `"sequence":7`)
+	require.NotContains(t, body, `"sequence":"7"`)
+	require.Contains(t, body, `"createdTransaction":`)
+	require.NotContains(t, body, `"id":"1"`)
+}
+
+// TestHandleGetLog_ShapeMatchesLogsList pins the property EN-1622 is about: the
+// single-log and logs-list routes must serialize the same commonpb.Log
+// identically. They diverged because get-log used protojson while the list used
+// sonic, so the same type had two wire shapes depending on which route you asked.
+func TestHandleGetLog_ShapeMatchesLogsList(t *testing.T) {
+	t.Parallel()
+
+	logValue := func() *commonpb.Log {
+		return &commonpb.Log{
+			Sequence: 7,
+			Payload: &commonpb.LogPayload{
+				Type: &commonpb.LogPayload_Apply{
+					Apply: &commonpb.ApplyLedgerLog{
+						LedgerName: "ledger1",
+						Log: &commonpb.LedgerLog{
+							Data: &commonpb.LedgerLogPayload{
+								Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+									CreatedTransaction: &commonpb.CreatedTransaction{
+										Transaction: &commonpb.Transaction{Id: 1},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	direct, err := logValue().MarshalJSON()
+	require.NoError(t, err)
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetLog(gomock.Any(), uint64(7)).DoAndReturn(
+		func(_ context.Context, _ uint64) (*commonpb.Log, error) {
+			return logValue(), nil
+		}).AnyTimes()
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	r := newRequest(t, http.MethodGet, "/logs/7", nil, map[string]string{"sequence": "7"})
+
+	srv.handleGetLog(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{"data":`+string(direct)+`}`, w.Body.String())
 }
 
 func TestHandleGetLog_InvalidSequence(t *testing.T) {

--- a/internal/adapter/http/handlers_list_chapters.go
+++ b/internal/adapter/http/handlers_list_chapters.go
@@ -23,5 +23,5 @@ func (s *Server) handleListChapters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeProtoListOK(w, chapters)
+	writeOKChecked(w, r, chapters)
 }

--- a/internal/adapter/http/handlers_list_chapters_test.go
+++ b/internal/adapter/http/handlers_list_chapters_test.go
@@ -21,7 +21,12 @@ func TestHandleListChapters_Success(t *testing.T) {
 	backend.EXPECT().ListChapters(gomock.Any()).DoAndReturn(
 		func(_ context.Context) (cursor.Cursor[*commonpb.Chapter], error) {
 			return cursor.NewSliceCursor([]*commonpb.Chapter{
-				{Id: 1},
+				{
+					Id:          1,
+					Status:      commonpb.ChapterStatus_CHAPTER_CLOSED,
+					SealingHash: []byte{0xde, 0xad, 0xbe, 0xef},
+					Start:       &commonpb.Timestamp{Data: 1786540255458491},
+				},
 				{Id: 2},
 			}), nil
 		}).AnyTimes()
@@ -33,6 +38,16 @@ func TestHandleListChapters_Success(t *testing.T) {
 	srv.handleListChapters(w, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
+
+	// Chapter.MarshalJSON hex-encodes the bytes hash fields and renders the
+	// timestamp as RFC3339. protojson would emit base64 ("3q2+7w==") and
+	// {"data":"1786540255458491"} instead, because it ignores json.Marshaler.
+	body := w.Body.String()
+	require.Contains(t, body, `"sealingHash":"deadbeef"`)
+	require.NotContains(t, body, "3q2+7w==")
+	require.Contains(t, body, `"status":"CHAPTER_CLOSED"`)
+	require.NotContains(t, body, `"start":{"data":`)
+	require.Contains(t, body, `"start":"2026-08-12T13:10:55.458491Z"`)
 }
 
 func TestHandleListChapters_BackendError(t *testing.T) {

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -128,5 +128,5 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 		writeProfileHeader(w, profile)
 	}
 
-	writeProtoListOK(w, transactions)
+	writeOKChecked(w, r, transactions)
 }

--- a/internal/adapter/http/handlers_list_transactions_test.go
+++ b/internal/adapter/http/handlers_list_transactions_test.go
@@ -39,13 +39,18 @@ func TestHandleListTransactions_Success(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 
-	// Transactions must serialize in protobuf-JSON camelCase (revertedByTransaction)
-	// inside the {data:[...]} envelope — not the snake_case Go struct tags
-	// (reverted_by_transaction) a plain sonic marshal would emit. Parity with
-	// the sibling proto-returning handlers (see writeProtoListOK).
+	// A list item must be byte-identical in shape to what the detail route
+	// emits, i.e. Transaction.MarshalJSON's output — camelCase, unquoted
+	// numeric ids, RFC3339 timestamps. protojson would instead emit
+	// "revertedByTransaction":"7" (different key, quoted) and drop `color`,
+	// because it works off protobuf reflection and ignores json.Marshaler.
+	// See encoder_contract_test.go and http-api.md for the rule.
 	body := w.Body.String()
-	require.Contains(t, body, `"revertedByTransaction":"7"`)
+	require.Contains(t, body, `"revertedByTransactionId":7`)
+	require.NotContains(t, body, `"revertedByTransaction":`)
 	require.NotContains(t, body, "reverted_by_transaction")
+	require.Contains(t, body, `"postings":[]`)
+	require.Contains(t, body, `"metadata":{}`)
 }
 
 func TestHandleListTransactions_WithPaginationAndReverse(t *testing.T) {

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -75,9 +75,14 @@ func writeCreated(w http.ResponseWriter, data any) {
 // This matters for the audit surface: audit DTOs render chain-bound submessages
 // (callerSnapshot, idempotency, signature) via protojson, whose MarshalJSON can
 // genuinely fail (e.g. invalid UTF-8) and MUST propagate as an error rather than
-// a valid-looking truncated record (invariant #7). The other list/get handlers
-// keep the streaming writeOK: their struct marshaling cannot fail, so buffering
-// would only add an allocation.
+// a valid-looking truncated record (invariant #7).
+//
+// The transactions list, chapters and single-log routes are the second
+// legitimate caller (EN-1622): their payload types carry a hand-written
+// MarshalJSON that marshals a metadata map and can genuinely fail, so the
+// streaming writeOK would append an error object to an already-committed 200.
+// The remaining list/get handlers keep writeOK: their struct marshaling cannot
+// fail, so buffering would only add an allocation.
 func writeOKChecked(w http.ResponseWriter, r *http.Request, data any) {
 	body, err := json.Marshal(BaseResponse[any]{Data: data})
 	if err != nil {
@@ -92,13 +97,18 @@ func writeOKChecked(w http.ResponseWriter, r *http.Request, data any) {
 }
 
 // writeProtoOK writes a 200 OK response whose `data` is a single protobuf
-// message serialized via protojson. Handlers that return a proto message
-// directly (index registry entries, index status, logs, …) MUST use this
-// rather than writeOK: sonic serializes from the Go `json:` struct tags, which
-// protoc-gen emits in snake_case (e.g. last_indexed_sequence), whereas the
-// wire/OpenAPI contract is protobuf-JSON camelCase (lastIndexedSequence).
-// Routing through protojson keeps the HTTP body byte-identical to the gRPC-
-// gateway shape. See handlers_get_events_sinks.go for the original precedent.
+// message serialized via protojson, which renders protobuf-JSON camelCase from
+// the descriptor (e.g. lastIndexedSequence) rather than the snake_case Go
+// `json:` tags protoc-gen emits.
+//
+// Use this ONLY for messages that have no custom MarshalJSON. protojson works
+// off protobuf reflection and ignores json.Marshaler, so for a message that has
+// one it silently discards the intended shape — that was EN-1622, where the
+// transactions list leaked amount:{v0} and timestamp:{data} while the detail
+// route emitted decimals and RFC3339. When the message has a MarshalJSON, that
+// method IS the public contract: use writeOKChecked.
+//
+// encoder_contract_test.go enforces this split.
 func writeProtoOK(w http.ResponseWriter, msg proto.Message) {
 	raw, err := protojson.Marshal(msg)
 	if err != nil {
@@ -111,10 +121,12 @@ func writeProtoOK(w http.ResponseWriter, msg proto.Message) {
 }
 
 // writeProtoListOK writes a 200 OK response whose `data` is a JSON array of
-// protobuf messages, each serialized via protojson (camelCase — see
-// writeProtoOK). protojson has no slice entry point, so each element is
-// marshaled individually and assembled into the array here. A nil/empty slice
-// serializes as `[]`, matching the drained-cursor list handlers.
+// protobuf messages, each serialized via protojson (see writeProtoOK for when
+// that is correct — messages with no custom MarshalJSON only). protojson has no
+// slice entry point, so each element is marshaled individually and assembled
+// into the array here; sonic needs no equivalent, since it walks a slice and
+// calls MarshalJSON per element. A nil/empty slice serializes as `[]`, matching
+// the drained-cursor list handlers.
 func writeProtoListOK[T proto.Message](w http.ResponseWriter, msgs []T) {
 	var buf bytes.Buffer
 

--- a/internal/proto/commonpb/transaction.go
+++ b/internal/proto/commonpb/transaction.go
@@ -155,7 +155,7 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		Metadata                map[string]any     `json:"metadata"`
 		Timestamp               *time.Time         `json:"timestamp,omitempty"`
 		Reference               string             `json:"reference,omitempty"`
-		ID                      *uint64            `json:"id,omitempty"`
+		ID                      uint64             `json:"id"`
 		InsertedAt              *time.Time         `json:"insertedAt,omitempty"`
 		UpdatedAt               *time.Time         `json:"updatedAt,omitempty"`
 		RevertedAt              *time.Time         `json:"revertedAt,omitempty"`
@@ -165,18 +165,30 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		PostCommitVolumes       *PostCommitVolumes `json:"postCommitVolumes,omitempty"`
 	}
 
+	// Collections are emitted unconditionally and must never be null: the
+	// OpenAPI schema types them as non-nullable and lists them in `required`.
+	// GetPostings() and MetadataToAnyMap() both return nil for an absent value,
+	// so normalise here rather than in MetadataToAnyMap, which has 7+ non-test
+	// callers whose payloads must not change.
+	postings := tx.GetPostings()
+	if postings == nil {
+		postings = []*Posting{}
+	}
+
+	metadata := MetadataToAnyMap(tx.GetMetadata())
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+
 	aux := Aux{
-		Postings:                tx.GetPostings(),
-		Metadata:                MetadataToAnyMap(tx.GetMetadata()),
+		Postings:                postings,
+		Metadata:                metadata,
 		Reference:               tx.GetReference(),
+		ID:                      tx.GetId(),
 		Reverted:                tx.IsReverted(),
 		RevertedByTransactionID: tx.GetRevertedByTransaction(),
 		RevertsTransactionID:    tx.GetRevertsTransaction(),
 		PostCommitVolumes:       tx.GetPostCommitVolumes(),
-	}
-
-	if tx.GetId() != 0 {
-		aux.ID = new(tx.GetId())
 	}
 
 	if tx.GetTimestamp() != nil {

--- a/internal/proto/commonpb/transaction.go
+++ b/internal/proto/commonpb/transaction.go
@@ -168,21 +168,21 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	// Collections are emitted unconditionally and must never be null: the
 	// OpenAPI schema types them as non-nullable and lists them in `required`.
 	// GetPostings() and MetadataToAnyMap() both return nil for an absent value,
-	// so normalise here rather than in MetadataToAnyMap, which has 7+ non-test
-	// callers whose payloads must not change.
+	// so normalise here rather than in MetadataToAnyMap, which has 7 non-test
+	// callers (this one included) whose payloads must not change.
 	postings := tx.GetPostings()
 	if postings == nil {
 		postings = []*Posting{}
 	}
 
-	metadata := MetadataToAnyMap(tx.GetMetadata())
-	if metadata == nil {
-		metadata = map[string]any{}
+	metadataMap := MetadataToAnyMap(tx.GetMetadata())
+	if metadataMap == nil {
+		metadataMap = map[string]any{}
 	}
 
 	aux := Aux{
 		Postings:                postings,
-		Metadata:                metadata,
+		Metadata:                metadataMap,
 		Reference:               tx.GetReference(),
 		ID:                      tx.GetId(),
 		Reverted:                tx.IsReverted(),

--- a/internal/proto/commonpb/transactions_json_test.go
+++ b/internal/proto/commonpb/transactions_json_test.go
@@ -152,3 +152,35 @@ func TestTransaction_MarshalJSON_RevertRelationship(t *testing.T) {
 		require.NotContains(t, out, "revertedAt")
 	})
 }
+
+// TestTransaction_MarshalJSON_NoNullCollections pins the presence policy:
+// collections are always emitted and never null, so the OpenAPI schema can
+// declare `postings`/`metadata` as non-nullable and list them in `required`.
+// `id` is required by TransactionResponse, so it is emitted unconditionally
+// rather than relying on ids never being 0. Mirrors Account.MarshalJSON.
+func TestTransaction_MarshalJSON_NoNullCollections(t *testing.T) {
+	t.Parallel()
+
+	data, err := (&Transaction{Id: 7}).MarshalJSON()
+	require.NoError(t, err)
+
+	out := string(data)
+
+	require.NotContains(t, out, `"postings":null`)
+	require.NotContains(t, out, `"metadata":null`)
+	require.Contains(t, out, `"postings":[]`)
+	require.Contains(t, out, `"metadata":{}`)
+	require.Contains(t, out, `"id":7`)
+}
+
+// TestTransaction_MarshalJSON_ZeroIDStillEmitted guards the `required: [id]`
+// claim in openapi.yml: a schema-required field must never be absent, even for
+// the zero value that NextTransactionId should make unreachable.
+func TestTransaction_MarshalJSON_ZeroIDStillEmitted(t *testing.T) {
+	t.Parallel()
+
+	data, err := (&Transaction{}).MarshalJSON()
+	require.NoError(t, err)
+
+	require.Contains(t, string(data), `"id":0`)
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -734,8 +734,7 @@ paths:
                   data:
                     type: array
                     items:
-                      type: object
-                      description: Transaction (protobuf JSON representation)
+                      $ref: '#/components/schemas/TransactionResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -3853,8 +3852,15 @@ components:
 
     TransactionResponse:
       type: object
+      # required <=> always emitted. postings and metadata are emitted
+      # unconditionally as [] / {} (see Transaction.MarshalJSON), reverted is a
+      # non-pointer bool, and id is emitted even when 0. Anything not listed
+      # here carries omitempty and is legitimately absent.
       required:
         - id
+        - postings
+        - metadata
+        - reverted
       properties:
         postings:
           type: array

--- a/openapi.yml
+++ b/openapi.yml
@@ -393,7 +393,11 @@ paths:
                     type: array
                     items:
                       type: object
-                      description: System log entry (protobuf JSON representation)
+                      description: |
+                        System log entry, serialized by Log.MarshalJSON (camelCase,
+                        RFC3339 timestamps, synthetic `type` discriminator on each
+                        ledger log). A dedicated schema is tracked separately — the
+                        payload is a deeply recursive protobuf oneof.
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -2253,7 +2257,11 @@ paths:
                 properties:
                   data:
                     type: object
-                    description: System log entry (protobuf JSON representation)
+                    description: |
+                      System log entry, serialized by Log.MarshalJSON (camelCase,
+                      RFC3339 timestamps, synthetic `type` discriminator on each
+                      ledger log). A dedicated schema is tracked separately — the
+                      payload is a deeply recursive protobuf oneof.
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -5309,7 +5317,11 @@ components:
               type: array
               items:
                 type: object
-                description: System log entry (protobuf JSON representation)
+                description: |
+                  System log entry, serialized by Log.MarshalJSON (camelCase,
+                  RFC3339 timestamps, synthetic `type` discriminator on each
+                  ledger log). A dedicated schema is tracked separately — the
+                  payload is a deeply recursive protobuf oneof.
         aggregateResult:
           $ref: '#/components/schemas/AggregateVolumesData'
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -2295,8 +2295,7 @@ paths:
                   data:
                     type: array
                     items:
-                      type: object
-                      description: Chapter (protobuf JSON representation)
+                      $ref: '#/components/schemas/Chapter'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3964,6 +3963,52 @@ components:
             uncolored bucket. Always present on responses (never omitted); two
             postings on the same (account, asset) but different colors operate
             on strictly isolated balances.
+
+    Chapter:
+      type: object
+      description: |
+        A bucket chapter. Serialized by Chapter.MarshalJSON: the hash fields are
+        hex-encoded (not base64) and status is the protobuf enum name.
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [CHAPTER_OPEN, CHAPTER_CLOSING, CHAPTER_CLOSED, CHAPTER_ARCHIVED, CHAPTER_ARCHIVING]
+        closeSequence:
+          type: integer
+          format: int64
+        startSequence:
+          type: integer
+          format: int64
+        startAuditSequence:
+          type: integer
+          format: int64
+        closeAuditSequence:
+          type: integer
+          format: int64
+        sealingHash:
+          type: string
+          pattern: '^[0-9a-f]*$'
+          description: Hex-encoded sealing hash.
+        lastAuditHash:
+          type: string
+          pattern: '^[0-9a-f]*$'
+          description: Hex-encoded audit-chain hash at chapter close.
+        stateHash:
+          type: string
+          pattern: '^[0-9a-f]*$'
+          description: Hex-encoded BLAKE3 hash of computed attributes at seal time.
 
     LedgerClusterStateResponse:
       type: object

--- a/tests/e2e/business/transactions_list_shape_test.go
+++ b/tests/e2e/business/transactions_list_shape_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+package business
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// EN-1622: the transactions list route (writeOKChecked, sonic) and the
+// transaction detail route (writeOK, sonic) must serialize the SAME
+// transaction to the SAME JSON shape. Before this ticket the list route went
+// through protojson instead, which ignores Transaction's custom MarshalJSON
+// and rendered {"amount":{"v0":"12345"}} / snake_case / base64 instead of the
+// hand-written camelCase shape the detail route already produced.
+//
+// A per-route unit test pins each shape independently and cannot catch this
+// class of bug: a field added to one path leaves both unit tests green while
+// the routes still disagree. Deep-equating the two live payloads is the only
+// assertion that tracks the property the ticket is actually about.
+//
+// TestTransactionsListShape (see suite_test.go's TestBusiness, which runs this
+// spec) is the greppable entry point for this guard.
+var _ = Describe("TestTransactionsListShape: list/detail item parity (EN-1622)", Ordered, func() {
+	const ledgerName = "tx-list-shape-ledger"
+
+	restURL := func(path string) string {
+		return fmt.Sprintf("http://localhost:%d/v3/%s%s", testutil.TestSingleHTTPPort, ledgerName, path)
+	}
+
+	var createdTxID uint64
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		logs, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.WithReference(
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "list-shape-dest", big.NewInt(12345), "USD"),
+			}, map[string]string{"category": "list-shape-test"}, nil),
+			"list-shape-ref-001",
+		)))
+		Expect(err).To(Succeed())
+		Expect(logs.GetLogs()).NotTo(BeEmpty())
+
+		createdTxID = logs.GetLogs()[0].GetPayload().GetApply().GetLog().GetData().GetCreatedTransaction().GetTransaction().GetId()
+
+		// Revert the transaction so the reversion fields (reverted, revertedAt,
+		// revertedByTransactionId, revertsTransactionId) are populated on the
+		// original — those are exactly the fields the pre-fix protojson writer
+		// rendered under snake_case/wrapped shapes on the list route only.
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.RevertTransactionAction(ledgerName, createdTxID, false, false, nil)))
+		Expect(err).To(Succeed())
+	})
+
+	It("renders the same JSON shape for a transaction on the list route and the detail route", func() {
+		// Detail: GET /v3/{ledger}/transactions/{id} -> data.transaction.
+		getReq, err := http.NewRequestWithContext(sharedCtx, http.MethodGet, restURL(fmt.Sprintf("/transactions/%d", createdTxID)), nil)
+		Expect(err).To(Succeed())
+
+		getResp, err := http.DefaultClient.Do(getReq)
+		Expect(err).To(Succeed())
+		defer func() { _ = getResp.Body.Close() }()
+
+		getRaw, err := io.ReadAll(getResp.Body)
+		Expect(err).To(Succeed())
+		Expect(getResp.StatusCode).To(Equal(http.StatusOK), "unexpected status on detail route; body=%s", string(getRaw))
+
+		var detailBody struct {
+			Data struct {
+				Transaction map[string]any `json:"transaction"`
+			} `json:"data"`
+		}
+		Expect(json.Unmarshal(getRaw, &detailBody)).To(Succeed(), "detail body=%s", string(getRaw))
+		Expect(detailBody.Data.Transaction).NotTo(BeEmpty())
+
+		// List: GET /v3/{ledger}/transactions -> data[] — select the matching
+		// item by id rather than assuming ordering, since the ticket's contract
+		// is about the ITEM SHAPE, not the list ordering.
+		listReq, err := http.NewRequestWithContext(sharedCtx, http.MethodGet, restURL("/transactions"), nil)
+		Expect(err).To(Succeed())
+
+		listResp, err := http.DefaultClient.Do(listReq)
+		Expect(err).To(Succeed())
+		defer func() { _ = listResp.Body.Close() }()
+
+		listRaw, err := io.ReadAll(listResp.Body)
+		Expect(err).To(Succeed())
+		Expect(listResp.StatusCode).To(Equal(http.StatusOK), "unexpected status on list route; body=%s", string(listRaw))
+
+		var listBody struct {
+			Data []map[string]any `json:"data"`
+		}
+		Expect(json.Unmarshal(listRaw, &listBody)).To(Succeed(), "list body=%s", string(listRaw))
+		Expect(listBody.Data).NotTo(BeEmpty())
+
+		var (
+			listItem map[string]any
+			found    bool
+		)
+
+		for _, item := range listBody.Data {
+			id, ok := item["id"].(float64)
+			if ok && uint64(id) == createdTxID {
+				listItem = item
+				found = true
+
+				break
+			}
+		}
+
+		Expect(found).To(BeTrue(), "transaction %d not found in list route response; body=%s", createdTxID, string(listRaw))
+
+		// The core assertion: the two routes must produce byte-for-byte
+		// equivalent JSON structures for the same transaction. Do NOT weaken
+		// this to a field-by-field spot check — a partial check is exactly the
+		// kind of drift this test exists to prevent.
+		Expect(listItem).To(Equal(detailBody.Data.Transaction), "list item and detail transaction diverge for id %d\nlist item:   %#v\ndetail item: %#v", createdTxID, listItem, detailBody.Data.Transaction)
+
+		// Precise signature of the EN-1622 regression: before the fix, an
+		// amount rendered as a protobuf object ({"v0":"12345"}) rather than a
+		// JSON number. A map[string]any decodes a bare JSON number as float64,
+		// so asserting that type is the exact fingerprint of the bug returning.
+		postings, ok := listItem["postings"].([]any)
+		Expect(ok).To(BeTrue(), "list item postings is not a JSON array: %#v", listItem["postings"])
+		Expect(postings).NotTo(BeEmpty())
+
+		firstPosting, ok := postings[0].(map[string]any)
+		Expect(ok).To(BeTrue(), "list item posting is not a JSON object: %#v", postings[0])
+
+		amount := firstPosting["amount"]
+		_, isNumber := amount.(float64)
+		Expect(isNumber).To(BeTrue(), "list item posting.amount must decode as a JSON number, not an object "+
+			"(pre-fix signature was {\"v0\":\"...\"}); got %T: %#v", amount, amount)
+	})
+})

--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -62,6 +62,53 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
+# Seed deterministic rows. Without this the list/detail operations return empty
+# arrays, and `response_schema_conformance` validates nothing: an empty [] can
+# satisfy ANY items schema, so the whole gate is vacuous on those routes. The
+# ledger name matches the coercion in test_api.py, which rewrites any invalid
+# ledgerName path parameter to "test-ledger".
+echo "==> Seeding fixture data..."
+API="http://localhost:$HTTP_PORT/v3"
+
+seed() {
+    local desc="$1"
+    shift
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' "$@")
+    case "$code" in
+        2*) echo "    $desc -> $code" ;;
+        *)
+            echo "ERROR: seed step '$desc' returned $code" >&2
+            echo "Server log:" >&2
+            cat "$TMPDIR/server.log" >&2
+            exit 1
+            ;;
+    esac
+}
+
+seed "create ledger" -X POST "$API/test-ledger"
+
+# Sacrificial ledger for DELETE /v3/{ledgerName}. That operation is itself
+# fuzzed, and test_api.py's before_call hook routes it here instead of the
+# fixture ledger above — see the hook for why. It needs no data; existence is
+# enough for the fuzzer's first delete attempt to get a 2xx.
+seed "create delete-sacrifice ledger" -X POST "$API/delete-me-ledger"
+
+seed "transaction 1" -X POST "$API/test-ledger/transactions" \
+    -H 'Content-Type: application/json' \
+    -d '{"postings":[{"source":"world","destination":"alice","amount":12345,"asset":"USD/2"}],"metadata":{"kind":"seed"},"reference":"seed-ref-1"}'
+
+seed "transaction 2" -X POST "$API/test-ledger/transactions" \
+    -H 'Content-Type: application/json' \
+    -d '{"postings":[{"source":"world","destination":"bob","amount":500,"asset":"USD/2"}],"reference":"seed-ref-2"}'
+
+# Populates reverted / revertedAt / revertedByTransactionId / revertsTransactionId,
+# so the reversion half of TransactionResponse is exercised too. Sourced from
+# "world" rather than "alice" for transaction 2 above: alice's balance must
+# still hold the full posted amount for the revert (which reverses it exactly)
+# to succeed, and a prior alice->bob spend leaves her short.
+seed "revert transaction 1" -X POST "$API/test-ledger/transactions/1/revert"
+
 # Set up Python venv and install deps if needed
 VENV_DIR="$SCRIPT_DIR/.venv"
 if [ ! -d "$VENV_DIR" ]; then

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -35,6 +35,14 @@ OPENAPI_PATH = Path(__file__).resolve().parents[2] / "openapi.yml"
 
 VALID_LEDGER_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{2,20}$")
 
+# Fixture ledger name every coerced/invalid ledgerName path parameter resolves
+# to. Seeded by run.sh with two transactions and a revert so
+# response_schema_conformance validates real rows instead of an empty [].
+FIXTURE_LEDGER_NAME = "test-ledger"
+# Sacrificial ledger name for DELETE /v3/{ledgerName} specifically — see the
+# before_call hook below for why it needs its own name.
+DELETE_LEDGER_SACRIFICE_NAME = "delete-me-ledger"
+
 SAMPLE_NUMSCRIPTS = [
     'send [USD/2 100] (\n  source = @world\n  destination = @user:001\n)',
     'send [EUR/2 50] (\n  source = @users:alice\n  destination = @users:bob\n)',
@@ -66,11 +74,23 @@ def before_call(context, case):
                 file=sys.stderr,
             )
 
+    # DELETE /v3/{ledgerName} is itself a fuzzed operation, and the coercion
+    # below would point it at the seeded fixture ledger. With workers=1 the
+    # operations run in openapi.yml declaration order, and this one is
+    # declared before the transaction endpoints — so the fuzzer deleted the
+    # fixture within seconds of the run starting, and every later request
+    # returned "ledger has been deleted", validating against an error schema
+    # instead of TransactionResponse. That made response_schema_conformance
+    # vacuous for every seeded route. Send ledger-level deletes to a
+    # sacrificial ledger so the fixture survives the whole run.
+    if case.path == "/v3/{ledgerName}" and case.method == "DELETE":
+        if case.path_parameters:
+            case.path_parameters["ledgerName"] = DELETE_LEDGER_SACRIFICE_NAME
     # Ledger names: lowercase alphanumeric with hyphens
-    if case.path_parameters and "ledgerName" in case.path_parameters:
+    elif case.path_parameters and "ledgerName" in case.path_parameters:
         name = case.path_parameters["ledgerName"]
         if not isinstance(name, str) or not VALID_LEDGER_NAME_RE.match(name):
-            case.path_parameters["ledgerName"] = "test-ledger"
+            case.path_parameters["ledgerName"] = FIXTURE_LEDGER_NAME
 
     if case.body and isinstance(case.body, dict):
         # Transaction: postings/script mutual exclusion


### PR DESCRIPTION
Fixes [EN-1622](https://formance-team.atlassian.net/browse/EN-1622).

## The problem

One Go type, `commonpb.Transaction`, was rendered by two different encoders depending on which route you asked. The detail route (`writeOK` → sonic) honours `Transaction.MarshalJSON`; the list route (`writeProtoListOK` → `protojson.Marshal`) works off protobuf reflection and **ignores `json.Marshaler`**, so the marshaller was silently bypassed:

| Field | List (before) | Detail | `TransactionResponse` declares |
|---|---|---|---|
| `amount` | `{"v0":"12345"}` | `12345` | `type: integer` |
| `timestamp` | `{"data":"1786540255458491"}` | `"2026-08-12T13:10:55.458491Z"` | `format: date-time` |
| `id` | `"7"` (quoted) | `7` | `type: integer` |
| revert link | `revertedByTransaction` | `revertedByTransactionId` | `revertedByTransactionId` |
| `color` | omitted | always present | `required` |

The list's OpenAPI schema was a bare `type: object`, which every JSON object satisfies — so Speakeasy generated `z.object({})` and stripped every key, which is the symptom the frontend reported.

## Scope: the ticket was wrong in both directions

Re-verified at HEAD:

- The **logs list is healthy** — it already used `writeOK`. The ticket's "no clean `MarshalJSON`" premise is false; `Log`, `LogPayload`, `ApplyLedgerLog`, `LedgerLog` and `LedgerLogPayload` all have one.
- The actually-broken log route is **`GET /v3/_/logs/{sequence}`**, and its defect is worse than cosmetic: protojson cannot emit the synthetic `type` discriminator, so the two log routes disagreed for the same type.
- **`GET /v3/_/chapters`** was a third instance — shipping base64 hashes where `Chapter.MarshalJSON` hex-encodes them.
- `GET /v3/_/signing-keys` and `GET /v3/_/events-sinks` are **correct** on protojson and were left alone: their types have no marshaller, so sonic would emit snake_case.

The rule that separates them: protojson is correct for a type with **no** custom `MarshalJSON`, and wrong for a type that has one. Exactly 3 of the 12 protojson call sites carried a marshaller — the 3 broken routes.

## What changed

**Encoders (3 routes → `writeOKChecked`).** Buffered rather than streaming is deliberate: `writeOK` commits the 200 header before encoding, so a mid-encode failure appends an error object to a sent body — and these marshallers marshal a metadata map and can fail.

**Nullability.** `Transaction.MarshalJSON` emitted `"postings":null` / `"metadata":null` (no `omitempty`, nil sources) against non-nullable schema types, and omitted `id` at zero while the schema requires it. Normalised to always-emitted empty collections, mirroring the existing `Account.MarshalJSON`. Policy adopted: **`required` ⟺ always emitted.**

**Schemas.** Transactions-list items now `$ref: TransactionResponse` (+ `required` extended to the four always-emitted fields); new `Chapter` component; three descriptions corrected that claimed "protobuf JSON representation" for sonic-served routes.

**The guard test** (`internal/adapter/http/encoder_contract_test.go`) — the load-bearing piece. Asserts the rule itself: no type implementing `json.Marshaler` may be routed through protojson, and vice versa for the three fixed routes. Plus an import gate, because matching call *shapes* is unsound — `protojson.MarshalOptions{…}.Marshal(m)`, an aliased import, or a variable receiver all evade a shape matcher, and an import cannot be disguised. The gate immediately surfaced a previously-undeclared protojson importer (`handlers_create_ledger.go`, decode-side oneof parsing — legitimate, now declared).

**The documented rule** (`http-api.md`). The page had no serialization section at all; the repo's only stated rule ("camelCase") cannot arbitrate because *both* encoders satisfy it. That absence is the root-cause class. Also corrected `events.md`, which claimed sinks use protojson when they use sonic.

## Why CI never caught this

Three compounding causes, each sufficient alone — which is why the gate passed **72/72 with the leak live**, and passed again with a *correct* schema against the *unfixed* handler:

1. Response schemas were bare `type: object` — any object conforms.
2. No seed data, so lists returned `[]`, and an empty array satisfies any `items` schema.
3. **`DELETE /v3/{ledgerName}` is itself fuzzed**, and `test_api.py`'s `ledgerName` coercion aimed it at the fixture ledger. With `workers=1` operations run in declaration order and this one precedes the transaction endpoints, so the fuzzer deleted the fixture seconds into every run — every later response then validated against an error schema.

Cause 3 was invisible to static reading and to `MAX_EXAMPLES=30` (deterministic, not sampling luck). Fixed by seeding a sacrificial ledger and coercing only ledger-level DELETE to it; nested DELETEs still target the fixture. It is deliberately not exempted from coercion outright — it would then only ever 404, trading one vacuous check for another.

**The gate's first genuinely load-bearing run failed**, on two pre-existing defects outside this ticket's routes: `analyze-accounts` and `analyze-transactions` emit `metadataKeys: null` against a non-nullable array. Same class as the `metadata`/`postings` nulls above, invisible for the same reason. Fixed rather than suppressed — excluding the checks would re-introduce deliberate vacuity, the direction `9bf16816b` already took and had reverted. A sweep of those DTOs found four such fields (`Assets`, `Examples`, both `MetadataKeys`).

## Evidence

| Check | Result |
|---|---|
| `just pre-commit` (root + operator) | 0 issues, nothing regenerated |
| `go test ./...` full suite | clean |
| `golangci-lint` on all touched packages | 0 issues |
| e2e list/detail deep equality | PASS with live data |
| schemathesis, clean schema | **64/64, `Skipped: 0`** |
| schemathesis, `reverted` corrupted to `string` | **1 failure** — the transactions list |
| operator module build + `TestParseActualIndexes` | PASS |
| Guard probe: throwaway `Index.MarshalJSON` | RED, 4 rows, actionable message |
| Guard probe: disguised `MarshalOptions{…}.Marshal` | RED via the import gate |

The RED/GREEN pair is the point: before this branch, corrupting a response schema could not turn the gate red.

e2e body — list item and detail item deeply equal, `amount` a real number:

```
{id:1, metadata:{category:list-shape-test},
 postings:[{amount:12345 (float64), asset:USD, destination:..., source:world}],
 reference:list-shape-ref-001, reverted:true, revertedByTransactionId:2, ...}
```

## Acceptance criteria

AC1 (list shape == detail shape) is met and asserted by unit + e2e tests.

**AC2 as written is not verifiable in this repository** — there is no `.speakeasy/`, no `gen.yaml`, and no SDK job in either workflow, so "the generated SDK types `data[]` as `TransactionResponse`" has no exit condition here. Restated as two locally checkable facts: the affected 200 responses declare concrete `$ref` schemas, and `response_schema_conformance` passes against them with seeded rows. The SDK regeneration needs tracking wherever that pipeline lives.

One consequence to note: `amount` is now **usable but lossy** above 2^53 in JavaScript. protojson rendered the `fixed64` limbs as quoted strings, so the list was previously unusable but lossless. The detail, create, revert and bulk routes were already on the number shape, so this removes an outlier rather than creating exposure — but AC2 should not be read as "the SDK is correct for amounts"; consumers need a BigInt-aware reviver. EN-1469 declined quoting on 2026-07-07 and that decision stands.

## Deliberately out of scope

- **`Log` OpenAPI schema** (~39 recursive oneof variants) — still needs a ticket. Note this PR makes the two log routes emit an identical shape for the first time, which is the precondition for typing them with one component.
- **`LedgerLog` round-trip.** `LedgerLogPayload.MarshalJSON` wraps the payload in its oneof field-name key while `HydrateLog` expects the bare inner type, so rehydration fails for every variant except `OrderSkipped`. Pre-existing, encoder-independent, equally live on the logs-list route. Not fixed here because the encode side is also the **events-sink wire** (Kafka/NATS/ClickHouse/Databricks/HTTP) plus the prepared-query `logData`; the decode side is wire-safe but has no production callers, which is how it survived. Filed as [EN-1790](https://formance-team.atlassian.net/browse/EN-1790).
- **The index/signing/sinks surface** (9 routes, 5 marshaller-less types). Giving those types a `MarshalJSON` is **not** HTTP-local: the CLI prefers a custom marshaller when one exists (`cmd/ledgerctl/cmdutil/output.go:123-165`), so it would silently reshape four CLI commands and break the operator's index reconciler — which parses `ledgerctl indexes list --json` with a struct hard-coding the protojson shape, in a separate Go module that root `go build ./...` never compiles, with tests that feed literal JSON and would stay green. Filed as [EN-1791](https://formance-team.atlassian.net/browse/EN-1791), which leads with a do-NOT-add-MarshalJSON warning and the missing operator contract test.

## Review notes

- `writeProtoOK`/`writeProtoListOK` survive: 8 routes still use them legitimately. Their doc comments lost three false claims (sonic-leaks-snake_case as an unqualified rule, a nonexistent gRPC gateway, byte-identity) and the blanket `MUST` that directed the original author into this bug.
- The guard's allowlist is **per-file**, so an allowlisted file could later add a disguised response-side protojson call. Documented in the test; closing it needs symbol-level analysis, which reopens the unsoundness the import gate replaced.


[EN-1622]: https://formance-team.atlassian.net/browse/EN-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1790]: https://formance-team.atlassian.net/browse/EN-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ