### PR TITLE
fix(operator): reconcile PVC storage growth from Cluster persistence sizes

### DIFF
--- a/misc/operator/internal/controller/reconcile_pvc_resize_test.go
+++ b/misc/operator/internal/controller/reconcile_pvc_resize_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+// createExpandableStorageClass creates a StorageClass with volume expansion
+// enabled. The PersistentVolumeClaimResize admission plugin only accepts
+// storage growth on PVCs whose class allows expansion.
+func createExpandableStorageClass(t *testing.T, name string) {
+	t.Helper()
+	allow := true
+	sc := &storagev1.StorageClass{
+		ObjectMeta:           metav1.ObjectMeta{Name: name},
+		Provisioner:          "test.ledger.formance.com/fake",
+		AllowVolumeExpansion: &allow,
+	}
+	require.NoError(t, k8sClient.Create(ctx, sc))
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, sc)
+	})
+}
+
+// createBoundPVC simulates the PVC the StatefulSet controller (absent from
+// envtest) would have provisioned for an ordinal, then marks it Bound — the
+// resize admission plugin rejects growth on unbound claims.
+func createBoundPVC(t *testing.T, namespace, name, storageClass, size string) {
+	t.Helper()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageClass,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, pvc))
+	pvc.Status.Phase = corev1.ClaimBound
+	pvc.Status.Capacity = corev1.ResourceList{
+		corev1.ResourceStorage: resource.MustParse(size),
+	}
+	require.NoError(t, k8sClient.Status().Update(ctx, pvc))
+}
+
+func TestReconcile_DataVolumeSizeGrow(t *testing.T) {
+	ns := createTestNamespace(t)
+	sc := "expandable-" + ns
+	createExpandableStorageClass(t, sc)
+
+	ls := newCluster("pvc-grow", ns)
+	ls.Spec.Persistence.Data.StorageClass = sc
+	ls.Spec.Persistence.Data.Size = resource.MustParse("1Gi")
+	require.NoError(t, k8sClient.Create(ctx, ls))
+
+	sts := &appsv1.StatefulSet{}
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: "ledger-pvc-grow", Namespace: ns}, sts) == nil
+	}, "StatefulSet should be created")
+	initialUID := sts.UID
+
+	for i := range 3 {
+		createBoundPVC(t, ns, fmt.Sprintf("data-ledger-pvc-grow-%d", i), sc, "1Gi")
+	}
+
+	updated := &ledgerv1alpha1.Cluster{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "pvc-grow", Namespace: ns}, updated))
+	updated.Spec.Persistence.Data.Size = resource.MustParse("2Gi")
+	require.NoError(t, k8sClient.Update(ctx, updated))
+
+	want := resource.MustParse("2Gi")
+	for i := range 3 {
+		name := fmt.Sprintf("data-ledger-pvc-grow-%d", i)
+		requireEventually(t, func() bool {
+			pvc := &corev1.PersistentVolumeClaim{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, pvc); err != nil {
+				return false
+			}
+			got := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			return got.Cmp(want) == 0
+		}, "PVC %s should be grown to 2Gi", name)
+	}
+
+	// envtest runs no garbage collector, so the orphan finalizer set by
+	// DeletePropagationOrphan never clears; strip it once the deletion is
+	// underway, as the GC controller would in a real cluster.
+	requireEventually(t, func() bool {
+		current := &appsv1.StatefulSet{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "ledger-pvc-grow", Namespace: ns}, current); err != nil {
+			return apierrors.IsNotFound(err)
+		}
+		if current.UID != initialUID {
+			return true
+		}
+		if current.DeletionTimestamp.IsZero() {
+			return false
+		}
+		if len(current.Finalizers) > 0 {
+			patch := client.MergeFrom(current.DeepCopy())
+			current.Finalizers = nil
+			_ = k8sClient.Patch(ctx, current, patch)
+		}
+		return false
+	}, "StatefulSet should be deleted with orphan propagation")
+
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: "ledger-pvc-grow", Namespace: ns}, sts); err != nil {
+			return false
+		}
+		if sts.UID == initialUID {
+			return false
+		}
+		for _, tmpl := range sts.Spec.VolumeClaimTemplates {
+			if tmpl.Name == "data" {
+				got := tmpl.Spec.Resources.Requests[corev1.ResourceStorage]
+				return got.Cmp(want) == 0
+			}
+		}
+		return false
+	}, "StatefulSet should be recreated with the grown data template")
+}
+
+func TestReconcile_DataVolumeSizeShrinkIgnored(t *testing.T) {
+	ns := createTestNamespace(t)
+	ls := newCluster("pvc-shrink", ns)
+	ls.Spec.Persistence.Data.Size = resource.MustParse("2Gi")
+	require.NoError(t, k8sClient.Create(ctx, ls))
+
+	sts := &appsv1.StatefulSet{}
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: "ledger-pvc-shrink", Namespace: ns}, sts) == nil
+	}, "StatefulSet should be created")
+	initialUID := sts.UID
+
+	updated := &ledgerv1alpha1.Cluster{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "pvc-shrink", Namespace: ns}, updated))
+	updated.Spec.Persistence.Data.Size = resource.MustParse("1Gi")
+	require.NoError(t, k8sClient.Update(ctx, updated))
+
+	requireEventually(t, func() bool {
+		events := &corev1.EventList{}
+		if err := k8sClient.List(ctx, events, client.InNamespace(ns)); err != nil {
+			return false
+		}
+		for _, event := range events.Items {
+			if event.Reason == "VolumeShrinkIgnored" && event.InvolvedObject.Name == "pvc-shrink" {
+				return true
+			}
+		}
+		return false
+	}, "shrinking a volume should emit a VolumeShrinkIgnored warning event")
+
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "ledger-pvc-shrink", Namespace: ns}, sts))
+	assert.Equal(t, initialUID, sts.UID, "StatefulSet should not be recreated on shrink")
+	for _, tmpl := range sts.Spec.VolumeClaimTemplates {
+		if tmpl.Name == "data" {
+			got := tmpl.Spec.Resources.Requests[corev1.ResourceStorage]
+			want := resource.MustParse("2Gi")
+			assert.Zero(t, got.Cmp(want), "data template should keep its original size")
+		}
+	}
+}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -162,6 +162,7 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 			}); err != nil {
 				return ctrl.Result{}, fmt.Errorf("deleting StatefulSet for VolumeClaimTemplate growth: %w", err)
 			}
+
 			return ctrl.Result{}, nil
 		}
 	}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -142,6 +142,28 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 			// reconciliation creates the new StatefulSet and the orphaned pods are adopted.
 			return ctrl.Result{}, nil
 		}
+
+		grown, shrunk := volumeClaimTemplateSizeChanges(existing.Spec.VolumeClaimTemplates, desired.VolumeClaimTemplates)
+		for _, tmpl := range shrunk {
+			logger.Info("ignoring volume shrink request, PVC storage is grow-only", "template", tmpl)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(ledger, corev1.EventTypeWarning, "VolumeShrinkIgnored",
+					"Ignoring size reduction for volume %q: PVC storage can only grow", tmpl)
+			}
+		}
+		if len(grown) > 0 {
+			if err := r.expandClusterPVCs(ctx, ledger, existing, grown); err != nil {
+				return ctrl.Result{}, fmt.Errorf("expanding PVCs: %w", err)
+			}
+			logger.Info("VolumeClaimTemplate sizes grew, recreating StatefulSet with orphan propagation")
+			orphan := metav1.DeletePropagationOrphan
+			if err := r.Delete(ctx, existing, &client.DeleteOptions{
+				PropagationPolicy: &orphan,
+			}); err != nil {
+				return ctrl.Result{}, fmt.Errorf("deleting StatefulSet for VolumeClaimTemplate growth: %w", err)
+			}
+			return ctrl.Result{}, nil
+		}
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {

--- a/misc/operator/internal/controller/volume_size_changes.go
+++ b/misc/operator/internal/controller/volume_size_changes.go
@@ -65,7 +65,7 @@ func (r *ClusterReconciler) expandClusterPVCs(ctx context.Context, ledger *ledge
 	}
 
 	for tmplName, size := range grown {
-		for ordinal := int32(0); ordinal < replicas; ordinal++ {
+		for ordinal := range replicas {
 			pvcName := fmt.Sprintf("%s-%s-%d", tmplName, sts.Name, ordinal)
 			pvc := &corev1.PersistentVolumeClaim{}
 			err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: sts.Namespace}, pvc)
@@ -88,6 +88,7 @@ func (r *ClusterReconciler) expandClusterPVCs(ctx context.Context, ledger *ledge
 					r.Recorder.Eventf(ledger, corev1.EventTypeWarning, "VolumeExpansionFailed",
 						"Failed to grow PVC %s to %s: %v", pvcName, size.String(), err)
 				}
+
 				return fmt.Errorf("growing PVC %s: %w", pvcName, err)
 			}
 

--- a/misc/operator/internal/controller/volume_size_changes.go
+++ b/misc/operator/internal/controller/volume_size_changes.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+// volumeClaimTemplateSizeChanges compares existing and desired
+// VolumeClaimTemplates by name and reports storage size drift. PVC storage is
+// grow-only in Kubernetes, so grows and shrinks call for different handling:
+// grown templates are returned with their target size so the caller can expand
+// the backing PVCs, shrunk templates are returned by name so the caller can
+// surface the ignored request. Templates present on only one side are the
+// PVC<->hostPath switch case, handled by volumeClaimTemplatesChanged.
+func volumeClaimTemplateSizeChanges(existing, desired []corev1.PersistentVolumeClaim) (map[string]resource.Quantity, []string) {
+	desiredSizes := make(map[string]resource.Quantity, len(desired))
+	for _, tmpl := range desired {
+		desiredSizes[tmpl.Name] = tmpl.Spec.Resources.Requests[corev1.ResourceStorage]
+	}
+
+	var grown map[string]resource.Quantity
+	var shrunk []string
+	for _, tmpl := range existing {
+		desiredSize, ok := desiredSizes[tmpl.Name]
+		if !ok {
+			continue
+		}
+		existingSize := tmpl.Spec.Resources.Requests[corev1.ResourceStorage]
+		switch desiredSize.Cmp(existingSize) {
+		case 1:
+			if grown == nil {
+				grown = map[string]resource.Quantity{}
+			}
+			grown[tmpl.Name] = desiredSize
+		case -1:
+			shrunk = append(shrunk, tmpl.Name)
+		}
+	}
+
+	return grown, shrunk
+}
+
+// expandClusterPVCs grows the existing PVCs backing the StatefulSet's grown
+// VolumeClaimTemplates, ordinal by ordinal up to the current replica count.
+// PVCs not yet provisioned are skipped: the StatefulSet recreated from the
+// grown template sizes them correctly at creation. Failures are surfaced as
+// Warning events on the Cluster — the storage class must allow volume
+// expansion for the resize to be admitted.
+func (r *ClusterReconciler) expandClusterPVCs(ctx context.Context, ledger *ledgerv1alpha1.Cluster, sts *appsv1.StatefulSet, grown map[string]resource.Quantity) error {
+	logger := log.FromContext(ctx)
+
+	replicas := int32(1)
+	if sts.Spec.Replicas != nil {
+		replicas = *sts.Spec.Replicas
+	}
+
+	for tmplName, size := range grown {
+		for ordinal := int32(0); ordinal < replicas; ordinal++ {
+			pvcName := fmt.Sprintf("%s-%s-%d", tmplName, sts.Name, ordinal)
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: sts.Namespace}, pvc)
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("fetching PVC %s: %w", pvcName, err)
+			}
+
+			current := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+			if current.Cmp(size) >= 0 {
+				continue
+			}
+
+			patch := client.MergeFrom(pvc.DeepCopy())
+			pvc.Spec.Resources.Requests[corev1.ResourceStorage] = size
+			if err := r.Patch(ctx, pvc, patch); err != nil {
+				if r.Recorder != nil {
+					r.Recorder.Eventf(ledger, corev1.EventTypeWarning, "VolumeExpansionFailed",
+						"Failed to grow PVC %s to %s: %v", pvcName, size.String(), err)
+				}
+				return fmt.Errorf("growing PVC %s: %w", pvcName, err)
+			}
+
+			logger.Info("grew PVC", "pvc", pvcName, "size", size.String())
+			if r.Recorder != nil {
+				r.Recorder.Eventf(ledger, corev1.EventTypeNormal, "VolumeExpanded",
+					"Grew PVC %s to %s", pvcName, size.String())
+			}
+		}
+	}
+
+	return nil
+}

--- a/misc/operator/internal/controller/volume_size_changes_test.go
+++ b/misc/operator/internal/controller/volume_size_changes_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func vct(name, size string) corev1.PersistentVolumeClaim {
+	return corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+}
+
+func TestVolumeClaimTemplateSizeChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no changes", func(t *testing.T) {
+		grown, shrunk := volumeClaimTemplateSizeChanges(
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "10Gi")},
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "10Gi")},
+		)
+		assert.Empty(t, grown)
+		assert.Empty(t, shrunk)
+	})
+
+	t.Run("grown template is reported with its target size", func(t *testing.T) {
+		grown, shrunk := volumeClaimTemplateSizeChanges(
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "10Gi")},
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "250Gi")},
+		)
+		assert.Empty(t, shrunk)
+		if assert.Contains(t, grown, "data") {
+			want := resource.MustParse("250Gi")
+			got := grown["data"]
+			assert.Zero(t, got.Cmp(want))
+		}
+	})
+
+	t.Run("shrunk template is reported by name and not grown", func(t *testing.T) {
+		grown, shrunk := volumeClaimTemplateSizeChanges(
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "10Gi")},
+			[]corev1.PersistentVolumeClaim{vct("wal", "1Gi"), vct("data", "10Gi")},
+		)
+		assert.Empty(t, grown)
+		assert.Equal(t, []string{"wal"}, shrunk)
+	})
+
+	t.Run("mixed grow and shrink are reported independently", func(t *testing.T) {
+		grown, shrunk := volumeClaimTemplateSizeChanges(
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi"), vct("data", "10Gi")},
+			[]corev1.PersistentVolumeClaim{vct("wal", "1Gi"), vct("data", "250Gi")},
+		)
+		assert.Contains(t, grown, "data")
+		assert.Equal(t, []string{"wal"}, shrunk)
+	})
+
+	t.Run("templates present on only one side are ignored", func(t *testing.T) {
+		grown, shrunk := volumeClaimTemplateSizeChanges(
+			[]corev1.PersistentVolumeClaim{vct("wal", "5Gi")},
+			[]corev1.PersistentVolumeClaim{vct("data", "250Gi")},
+		)
+		assert.Empty(t, grown)
+		assert.Empty(t, shrunk)
+	})
+}


### PR DESCRIPTION
## Summary

Growing `spec.persistence.<volume>.size` on an existing `Cluster` was **silently ignored**:

- `volumeClaimTemplatesChanged` only compares template **names** — it was written for the PVC↔hostPath switch, so a pure size change never triggers the orphan-recreate path.
- VolumeClaimTemplates are immutable on a live StatefulSet, and no code path expanded the existing PVCs.

The spec would say `250Gi`, reality stayed at `10Gi`, with no event, condition, or log surfacing the drift (observed on a dev env: Cluster CR updated to 250Gi by the Formance operator, StatefulSet and PVCs untouched).

## Fix

On each StatefulSet reconcile pass, after the existing name-change check:

- **Grow**: per-template size drift is detected (`volumeClaimTemplateSizeChanges`), the backing PVCs are patched to the new size ordinal-by-ordinal (`expandClusterPVCs`, grow-only, `VolumeExpanded`/`VolumeExpansionFailed` events), then the StatefulSet is recreated with orphan propagation — same mechanism as the hostPath switch — so future replicas are provisioned at the new size.
- **Shrink**: ignored (PVC storage is grow-only in Kubernetes) and surfaced with a `VolumeShrinkIgnored` warning event on the Cluster.

Notes:
- PVC expansion requires the storage class to have `allowVolumeExpansion: true`; failures surface as warning events and requeue with backoff.
- PVCs not yet provisioned are skipped — the recreated template sizes them at creation.
- RBAC already grants `patch` on `persistentvolumeclaims`; no RBAC change.
- Scope: PVCs up to the current replica count. Retained PVCs from a previous scale-down beyond that are not resized.

## Tests

- Unit: `TestVolumeClaimTemplateSizeChanges` (grow / shrink / mixed / one-sided names).
- envtest integration:
  - `TestReconcile_DataVolumeSizeGrow` — bound PVCs at 1Gi + expandable StorageClass; growing the Cluster to 2Gi patches all 3 PVCs and recreates the StatefulSet with the 2Gi template (the test plays the garbage collector for the orphan finalizer, which envtest doesn't run).
  - `TestReconcile_DataVolumeSizeShrinkIgnored` — shrink emits `VolumeShrinkIgnored`, StatefulSet untouched (same UID, template keeps its size).
- Full suite: only pre-existing failures on `release/v3.0` (`TestReconcile_EvenReplicas`, `TestReconcile_IngressEnabledNoHosts`, `TestReconcile_IngressGrpcEnabledNoHosts`) — identical on a clean checkout, unrelated to this change.
- `just pre-commit` (generate, tidy, build) clean — no generated diff.