### PR TITLE
chore: make agent definition of done executable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,20 +82,30 @@ Documentation is part of the change when behavior, architecture, interfaces, CLI
 
 Do not use `docs/drafts/**` as evidence of current behavior unless the task explicitly references that design.
 
-## Validation before completion
+## Definition of done
 
-Run the repository's existing validation before declaring work complete:
+A task is not complete when the code merely looks correct. Before handing work to another agent or a human reviewer:
+
+1. finish the requested implementation and documentation;
+2. run the canonical baseline validation with `bash scripts/agent-check`;
+3. run tests appropriate to the touched subsystem and risk level;
+4. inspect the final diff for unrelated or generated changes;
+5. perform a self-review against the task, loaded subsystem docs, and the invariants above;
+6. report unresolved concerns instead of silently weakening or skipping a check.
+
+For broad or high-risk changes where the root-module unit suite is appropriate, run `bash scripts/agent-check-full`. Do not run the full suite mechanically for every local documentation or narrowly scoped change when targeted validation is sufficient.
+
+### Canonical validation commands
 
 ```bash
-# Preferred reproducible path
-nix develop --command bash -c "just pre-commit"
+# Required baseline for code changes
+bash scripts/agent-check
 
-# Alternative direnv path
-direnv allow && eval "$(direnv export bash)" && GOROOT= just pre-commit
-
-# Verify compilation
-GOROOT= go build ./...
+# Baseline + full root-module unit test suite
+bash scripts/agent-check-full
 ```
+
+`scripts/agent-check` runs the existing `just pre-commit` pipeline, compiles all root-module packages with `GOROOT= go build ./...`, and runs `git diff --check`. It deliberately does not choose task-specific tests for you.
 
 After modifying `.proto` files, run `just generate-proto` immediately.
 After changing a `//go:generate mockgen` interface, run `go generate ./...`.

--- a/scripts/agent-check
+++ b/scripts/agent-check
@@ -1,13 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Canonical agent validation must run in the repository-pinned Nix environment.
+# Re-exec once under `nix develop` instead of relying on whatever tools happen
+# to be installed or loaded by the caller's shell/direnv session.
+if [[ "${LEDGER_AGENT_CHECK_IN_NIX:-}" != "1" ]]; then
+    exec env -u GOROOT nix develop --command \
+        env LEDGER_AGENT_CHECK_IN_NIX=1 bash "$0" "$@"
+fi
+
+# Never inherit a host GOROOT into pinned Go commands.
+unset GOROOT || true
+
 echo "==> agent-check: repository pre-commit validation"
 just pre-commit
 
 echo "==> agent-check: compile all root-module packages"
-GOROOT= go build ./...
+go build ./...
 
-echo "==> agent-check: verify diff whitespace"
-git diff --check
+echo "==> agent-check: verify tracked/staged diff whitespace"
+git diff --check HEAD --
+
+echo "==> agent-check: verify untracked file whitespace"
+untracked_failed=0
+while IFS= read -r -d '' file; do
+    # `git diff --no-index` returns 1 whenever files differ, even when there are
+    # no whitespace errors. Treat output from --check as the failure signal;
+    # reserve exit statuses >1 for actual command errors.
+    output=""
+    status=0
+    output=$(git diff --no-index --check -- /dev/null "$file" 2>&1) || status=$?
+    if [[ -n "$output" ]]; then
+        printf '%s\n' "$output"
+        untracked_failed=1
+    elif (( status > 1 )); then
+        echo "agent-check: failed to inspect untracked file: $file" >&2
+        exit "$status"
+    fi
+done < <(git ls-files --others --exclude-standard -z)
+
+if (( untracked_failed != 0 )); then
+    echo "agent-check: whitespace errors found in untracked files" >&2
+    exit 1
+fi
 
 echo "==> agent-check: PASS"

--- a/scripts/agent-check
+++ b/scripts/agent-check
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> agent-check: repository pre-commit validation"
+just pre-commit
+
+echo "==> agent-check: compile all root-module packages"
+GOROOT= go build ./...
+
+echo "==> agent-check: verify diff whitespace"
+git diff --check
+
+echo "==> agent-check: PASS"

--- a/scripts/agent-check-full
+++ b/scripts/agent-check-full
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Keep the baseline and the full test suite in the same pinned toolchain.
+if [[ "${LEDGER_AGENT_CHECK_IN_NIX:-}" != "1" ]]; then
+    exec env -u GOROOT nix develop --command \
+        env LEDGER_AGENT_CHECK_IN_NIX=1 bash "$0" "$@"
+fi
+
+unset GOROOT || true
+
 echo "==> agent-check-full: baseline validation"
 bash scripts/agent-check
 

--- a/scripts/agent-check-full
+++ b/scripts/agent-check-full
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> agent-check-full: baseline validation"
+bash scripts/agent-check
+
+echo "==> agent-check-full: root-module unit tests"
+just test
+
+echo "==> agent-check-full: PASS"


### PR DESCRIPTION
## Summary

This PR turns the agent Definition of Done into an executable repository contract.

- adds `scripts/agent-check` as the canonical baseline validation for agent-authored code changes
- adds `scripts/agent-check-full` for baseline validation plus the full root-module unit suite
- updates `AGENTS.md` with an explicit Definition of Done and handoff requirements
- keeps task-specific tests separate so agents must still select tests based on the touched subsystem and risk
- runs canonical validation inside the repository-pinned Nix environment rather than depending on host tooling
- validates tracked, staged, and non-ignored untracked files for whitespace errors

## Baseline contract

`bash scripts/agent-check` re-execs under `nix develop` when needed, clears inherited `GOROOT`, and runs:

1. the existing `just pre-commit` pipeline
2. `go build ./...`
3. whitespace validation across tracked/staged changes relative to `HEAD`
4. whitespace validation for non-ignored untracked files

`bash scripts/agent-check-full` runs the same pinned baseline and then `just test` in that same Nix environment.

## Why

The goal is to reduce human review load by ensuring agents complete deterministic, reproducible repository checks before handing work to another agent or a human reviewer. A task is no longer considered complete merely because the implementation appears finished.

The full unit suite is intentionally not mandatory for every narrow change. Agents must run subsystem-appropriate tests and use the full command for broad/high-risk work where it is justified.

## Scope

This PR does not add new architectural lints, CI gates, or validation logic. It composes existing repository checks into a canonical agent workflow and makes the handoff validation reproducible and complete for the current working tree.

## Review focus

Please check:

- whether the pinned Nix re-exec is robust for normal developer/agent environments
- whether the baseline validation is sufficient without being unnecessarily expensive
- whether tracked/staged/untracked whitespace coverage matches the intended handoff scope
- whether `agent-check-full` selects the right existing test target
- whether the Definition of Done is precise enough to prevent premature handoff without forcing unrelated work
