### PR TITLE
fix(EN-1783): assert the rejected backup prefix is empty via Contents

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -470,6 +470,34 @@ Expect(followerID).To(BeNumerically(">", 0))
 Expect(followerID).To(BeNumerically("<=", countInstances))
 ```
 
+### AWS SDK Pointer Fields
+
+The AWS SDK v2 models every optional scalar field as a pointer, so
+`ListObjectsV2Output.KeyCount` is `*int32`, not `int32`.
+
+`BeEquivalentTo` **converts**, it does not dereference. `*int32` is not convertible to
+`int`, so `reflect.DeepEqual` compares two different types, the matcher returns `false`
+for every possible input, and it reports no error. The result is a permanently failing
+assertion that neither the compiler nor `golangci-lint` can catch (EN-1783).
+
+❌ **Bad**:
+```go
+Expect(listOut.KeyCount).To(BeEquivalentTo(0))
+// Expected <*int32>: 0 to be equivalent to <int>: 0 — always fails
+```
+
+✅ **Good**:
+```go
+// Prefer the slice: no pointer, nil-safe, and the failure message names the objects.
+Expect(listOut.Contents).To(BeEmpty())
+
+// When only the scalar is available, dereference through the nil-safe AWS helper.
+Expect(aws.ToInt32(listOut.KeyCount)).To(BeZero())
+```
+
+Do not dereference with `*listOut.KeyCount`: the field is a pointer precisely because
+S3 can omit it, and a nil dereference panics the spec.
+
 ### Cleanup
 
 Use `DeferCleanup` for automatic cleanup:

--- a/tests/e2e/business/backup_s3_test.go
+++ b/tests/e2e/business/backup_s3_test.go
@@ -256,7 +256,7 @@ var _ = Describe("S3 Backup", Ordered, func() {
 			Prefix: aws.String("no-prior/"),
 		})
 		Expect(listErr).To(Succeed())
-		Expect(listOut.KeyCount).To(BeEquivalentTo(0),
+		Expect(listOut.Contents).To(BeEmpty(),
 			"no object of any kind must be published under the no-prior/ prefix")
 	})
 


### PR DESCRIPTION
## Problem

`tests/e2e/business/backup_s3_test.go:259` compared `*int32` with `int`:

```go
Expect(listOut.KeyCount).To(BeEquivalentTo(0))
```

`BeEquivalentTo` converts rather than dereferences. `*int32` is not `ConvertibleTo` `int`, so the conversion branch is skipped and `reflect.DeepEqual` compares two different `reflect.Type` values. The matcher returned `false` for every possible input, and returned no error.

The assertion was therefore **unconditionally false, not flaky** — it has never passed since it was written on 2026-07-13 (`154e4c2cc`, #1543).

The production behavior under test is correct: the server rejects a checkpoint-less incremental backup with `FailedPrecondition` and writes no artifact. Only the measurement was broken, and it blocked the `s3`-tagged business suite from completing.

## Change

- Assert on `listOut.Contents` with `BeEmpty()`. No pointer in the assertion, nil-safe (`KeyCount` is a pointer precisely because S3 can omit it), and the failure message names the objects that leaked instead of printing a bare count.
- Document the trap in `docs/technical/contributing/testing.md` under `### AWS SDK Pointer Fields`.

## Why it went unnoticed for a month

| Gate | Why it is blind |
|---|---|
| Go compiler | `BeEquivalentTo(expected any)` has no static type contract between actual and expected. |
| `golangci-lint` | `ginkgolinter` is enabled and the `s3` tag **is** in the lint tag set, so the file is compiled — but no rule covers a pointer compared with an untyped constant. A full lint run over `./tests/e2e/business/...` with every tag reports 86 findings in the package and zero on this file. |
| CI | `main.yml:95` runs `just test-e2e-coverage`, which is `-tags e2e` only. The `s3` tag appears only in `test-e2e-full`, which CI never calls, so the spec is excluded from every CI run. |

## Follow-up (not in this PR)

Nine `s3`-tagged E2E files have no automated execution at all:

```
tests/e2e/business/backup_s3_test.go
tests/e2e/business/backup_s3_credentials_test.go
tests/e2e/business/cold_storage_s3_test.go
tests/e2e/cluster/restore_test.go
tests/e2e/cluster/restore_idempotency_test.go
tests/e2e/cluster/restore_metadata_type_test.go
tests/e2e/cluster/restore_reversion_test.go
tests/e2e/cluster/restore_stale_cache_test.go
tests/e2e/cluster/bootstrap_test.go
```

Giving them a CI job needs Docker plus MinIO through testcontainers and changes to `main.yml` and the `justfile`. That is real CI cost and deserves its own ticket.

## Verification

Run against a live MinIO container via testcontainers, `-tags "e2e,s3"`, `-race`, focused on the affected spec.

| Stage | Result |
|---|---|
| Baseline, before the change | `Ran 1 of 567 Specs` → `1 Failed` at `backup_s3_test.go:259`, `to be equivalent to <int>: 0` — reproduces the ticket exactly |
| After the change | `Ran 1 of 567 Specs` → `SUCCESS! -- 1 Passed \| 0 Failed` |
| Negative control | Inverting to `NotTo(BeEmpty())` fails at line 259 with `not to be empty`, proving the assertion is reached at runtime and the pass is not a skipped spec |
| Class sweep | `grep -rn "BeEquivalentTo"` and `grep -rn "KeyCount"` over all `.go` files now return zero hits (one each before) |
| `just pre-commit` | 0 issues, both modules |
| `just test` | 46 packages `ok`, 0 failures |

The baseline and negative control matter here: `go build ./...` does not compile this file at all, because the `e2e,s3` tags exclude it. A `just pre-commit` pass alone could not have proven this fix.

## Ticket

https://formance-team.atlassian.net/browse/EN-1783
