### PR TITLE
fix(EN-1781): stop pterm spinners leaking goroutines that race with global config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -148,6 +148,16 @@ linters:
           If you are legitimately CONSUMING a storage fault (reading Operation for a
           log line, distinguishing an IO fault from a business outcome), the rule has
           no alternative to offer — add //nolint:forbidigo with a justification.
+      # EN-1781: pterm's SpinnerPrinter.Start always spawns an animation
+      # goroutine, and its Stop cannot terminate it while pterm.RawOutput is
+      # set, so the goroutine outlives the command and races with any later
+      # write to pterm's package-level configuration.
+      - pattern: '\bpterm\.DefaultSpinner\b'
+        msg: |
+          pterm.DefaultSpinner leaks an animation goroutine that cannot be stopped while
+          pterm.RawOutput is set (see EN-1781). Use cmdutil.StartSpinner, which creates no
+          pterm spinner when output is non-interactive. The only allowed direct use is
+          cmd/ledgerctl/cmdutil/spinner.go.
   exclusions:
     rules:
     # I2 exceptions for OpenWriteSession / NewWriteSessionFromDB.
@@ -206,6 +216,21 @@ linters:
     - path: internal/domain/errors\.go
       linters: [forbidigo]
       source: 'e\.(Operation|Cause)'
+    # EN-1781 does not reach the kubectl-ledger plugin. misc/operator is a
+    # separate Go module that cannot import cmd/ledgerctl/cmdutil, it never
+    # writes pterm's package-level configuration (no DisableStyling /
+    # DisableColor / RawOutput / SetDefaultOutput anywhere in the module), and
+    # it is a short-lived plugin process. With no concurrent writer there is no
+    # race, only pterm's inherent pattern. Tracked separately rather than
+    # duplicating the wrapper across the module boundary.
+    - path: ^misc/operator/
+      linters: [forbidigo]
+    # spinner.go is the sanctioned cmdutil.StartSpinner wrapper for EN-1781 —
+    # the one place allowed to touch pterm.DefaultSpinner. spinner_test.go
+    # drives the raw printer as the reference implementation in the
+    # output-equivalence test.
+    - path: cmd/ledgerctl/cmdutil/spinner(_test)?\.go$
+      linters: [forbidigo]
     # Tests use OpenWriteSession to seed data; the structural guarantee is on
     # production paths.
     - path: _test\.go$

--- a/cmd/ledgerctl/accounts/aggregate.go
+++ b/cmd/ledgerctl/accounts/aggregate.go
@@ -77,7 +77,7 @@ func runAggregateVolumes(cmd *cobra.Command, _ []string) error {
 		ctx = cmdutil.ProfileContext(ctx)
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start("Aggregating volumes...")
+	spinner := cmdutil.StartSpinner("Aggregating volumes...")
 
 	var trailer metadata.MD
 

--- a/cmd/ledgerctl/accounts/analyze.go
+++ b/cmd/ledgerctl/accounts/analyze.go
@@ -61,7 +61,7 @@ func runAnalyze(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Analyzing accounts...")
+	spinner := cmdutil.StartSpinner("Analyzing accounts...")
 
 	stream, err := client.AnalyzeAccounts(ctx, &servicepb.AnalyzeAccountsRequest{
 		Ledger:            ledgerName,

--- a/cmd/ledgerctl/accounts/delete_metadata.go
+++ b/cmd/ledgerctl/accounts/delete_metadata.go
@@ -111,7 +111,7 @@ func runDeleteMetadata(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Deleting metadata key %q from account %s...", key, address))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Deleting metadata key %q from account %s...", key, address))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/accounts/get.go
+++ b/cmd/ledgerctl/accounts/get.go
@@ -77,7 +77,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching account %s...", pterm.Cyan(address)))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching account %s...", pterm.Cyan(address)))
 
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 

--- a/cmd/ledgerctl/accounts/list.go
+++ b/cmd/ledgerctl/accounts/list.go
@@ -97,7 +97,7 @@ func fetchAllAccounts(cmd *cobra.Command, client servicepb.BucketServiceClient, 
 		ctx = cmdutil.ProfileContext(ctx)
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching all accounts...")
+	spinner := cmdutil.StartSpinner("Fetching all accounts...")
 
 	var lastTrailer metadata.MD
 
@@ -158,7 +158,7 @@ func fetchAccountsWithPager(cmd *cobra.Command, client servicepb.BucketServiceCl
 			ctx = cmdutil.ProfileContext(ctx)
 		}
 
-		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching page %d...", pageNum))
+		spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching page %d...", pageNum))
 
 		stream, err := client.ListAccounts(ctx, &servicepb.ListAccountsRequest{
 			Ledger:  ledgerName,

--- a/cmd/ledgerctl/accounts/set_metadata.go
+++ b/cmd/ledgerctl/accounts/set_metadata.go
@@ -119,7 +119,7 @@ func runSetMetadata(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting metadata on account %s...", address))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting metadata on account %s...", address))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/accounttypes/add.go
+++ b/cmd/ledgerctl/accounttypes/add.go
@@ -60,7 +60,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Adding account type %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Adding account type %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/accounttypes/remove.go
+++ b/cmd/ledgerctl/accounttypes/remove.go
@@ -46,7 +46,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Removing account type %s...", typeName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Removing account type %s...", typeName))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/accounttypes/set_default_enforcement.go
+++ b/cmd/ledgerctl/accounttypes/set_default_enforcement.go
@@ -57,7 +57,7 @@ func runSetDefaultEnforcement(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting default enforcement mode to %s...", modeStr))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting default enforcement mode to %s...", modeStr))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/chapters/delete_schedule.go
+++ b/cmd/ledgerctl/chapters/delete_schedule.go
@@ -1,7 +1,6 @@
 package chapters
 
 import (
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -36,7 +35,7 @@ func runDeleteSchedule(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Deleting chapter schedule...")
+	spinner := cmdutil.StartSpinner("Deleting chapter schedule...")
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/chapters/get_schedule.go
+++ b/cmd/ledgerctl/chapters/get_schedule.go
@@ -36,7 +36,7 @@ func runGetSchedule(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching chapter schedule...")
+	spinner := cmdutil.StartSpinner("Fetching chapter schedule...")
 
 	resp, err := client.GetChapterSchedule(ctx, &servicepb.GetChapterScheduleRequest{})
 	if err != nil {

--- a/cmd/ledgerctl/chapters/set_schedule.go
+++ b/cmd/ledgerctl/chapters/set_schedule.go
@@ -3,7 +3,6 @@ package chapters
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -53,7 +52,7 @@ func runSetSchedule(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting chapter schedule to %q...", cronExpr))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting chapter schedule to %q...", cronExpr))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/cluster/maintenance.go
+++ b/cmd/ledgerctl/cluster/maintenance.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -68,7 +67,7 @@ func runMaintenance(cmd *cobra.Command, args []string) error {
 		action = "Disabling"
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start(action + " maintenance mode...")
+	spinner := cmdutil.StartSpinner(action + " maintenance mode...")
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/cmdutil/pterm.go
+++ b/cmd/ledgerctl/cmdutil/pterm.go
@@ -8,13 +8,31 @@ import (
 	"golang.org/x/term"
 )
 
+// interactiveOutput reports whether stdout is a terminal.
+//
+// It is evaluated exactly once, during package initialisation and therefore
+// before any command or test spec runs, and is never written again. pterm keeps
+// its configuration in package-level variables that its printers read without
+// synchronisation, so every later write to that configuration is a potential
+// data race (EN-1781).
+var interactiveOutput = term.IsTerminal(int(os.Stdout.Fd()))
+
 func init() {
-	// Enable raw output mode when stdout is not a terminal (e.g. tests, CI,
-	// piped output). This disables the spinner animation goroutine, avoiding a
-	// known data race in pterm's SpinnerPrinter on the IsActive field.
-	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		pterm.RawOutput = true
+	if interactiveOutput {
+		return
 	}
+
+	// Non-interactive output (tests, CI, piped output): drop styling entirely,
+	// so nothing downstream has to strip escape codes.
+	//
+	// This does NOT prevent pterm from spawning spinner goroutines.
+	// SpinnerPrinter.Start launches its animation goroutine unconditionally
+	// (spinner_printer.go:157) and SpinnerPrinter.Stop returns early while
+	// RawOutput is set (spinner_printer.go:184), leaving IsActive true so the
+	// goroutine never exits and keeps reading pterm globals forever. That is
+	// why spinners must be created through StartSpinner, which creates no
+	// pterm spinner at all when output is non-interactive.
+	pterm.DisableStyling()
 }
 
 // RoutePtermForStructuredOutput inspects --json / --yaml on the command and,

--- a/cmd/ledgerctl/cmdutil/spinner.go
+++ b/cmd/ledgerctl/cmdutil/spinner.go
@@ -1,0 +1,127 @@
+package cmdutil
+
+import (
+	"io"
+
+	"github.com/pterm/pterm"
+)
+
+// Spinner reports progress for a long-running command step.
+//
+// When stdout is a terminal it wraps a real pterm spinner and behaves exactly
+// as pterm does. When stdout is not a terminal it wraps nothing: no pterm
+// spinner is created, so no animation goroutine exists.
+//
+// That distinction is the fix for EN-1781. pterm's SpinnerPrinter.Start always
+// launches a goroutine that reads pterm's package-level configuration on every
+// tick, and its Stop returns early while pterm.RawOutput is set, leaving
+// IsActive true so the goroutine outlives the command. In a long-lived
+// non-interactive process — notably the in-process E2E suite, which runs many
+// ledgerctl commands in one binary — those goroutines accumulate and race with
+// any later write to pterm's configuration. Because pterm reads IsActive
+// without synchronisation, such a goroutine cannot be stopped race-free; it can
+// only be never started.
+//
+// The non-interactive path emits the same bytes pterm would: in raw mode Start
+// prints nothing, fClearLine is a no-op, and the terminal methods print through
+// pterm.Fprinto with the same prefix printers.
+type Spinner struct {
+	inner  *pterm.SpinnerPrinter
+	writer io.Writer
+	text   string
+}
+
+// StartSpinner starts a spinner showing text.
+//
+// This is the only sanctioned way to create a spinner in ledgerctl; direct use
+// of pterm.DefaultSpinner is rejected by the forbidigo rule in .golangci.yaml.
+func StartSpinner(text string) *Spinner {
+	return startSpinner(text, interactiveOutput, pterm.DefaultSpinner.Writer)
+}
+
+// startSpinner is the injectable form used by tests.
+func startSpinner(text string, interactive bool, writer io.Writer) *Spinner {
+	if !interactive {
+		return &Spinner{writer: writer, text: text}
+	}
+
+	inner, _ := pterm.DefaultSpinner.Start(text)
+
+	return &Spinner{inner: inner, writer: writer, text: text}
+}
+
+// UpdateText replaces the message shown by the spinner.
+func (s *Spinner) UpdateText(text string) {
+	s.text = text
+
+	if s.inner != nil {
+		s.inner.UpdateText(text)
+
+		return
+	}
+
+	pterm.Fprintln(s.writer, text)
+}
+
+// Success terminates the spinner with the success prefix.
+func (s *Spinner) Success(message ...any) {
+	if s.inner != nil {
+		s.inner.Success(message...)
+
+		return
+	}
+
+	s.finish(&pterm.Success, message)
+}
+
+// Fail terminates the spinner with the error prefix.
+func (s *Spinner) Fail(message ...any) {
+	if s.inner != nil {
+		s.inner.Fail(message...)
+
+		return
+	}
+
+	s.finish(&pterm.Error, message)
+}
+
+// Warning terminates the spinner with the warning prefix.
+func (s *Spinner) Warning(message ...any) {
+	if s.inner != nil {
+		s.inner.Warning(message...)
+
+		return
+	}
+
+	s.finish(&pterm.Warning, message)
+}
+
+// Info terminates the spinner with the info prefix.
+func (s *Spinner) Info(message ...any) {
+	if s.inner != nil {
+		s.inner.Info(message...)
+
+		return
+	}
+
+	s.finish(&pterm.Info, message)
+}
+
+// Stop terminates the spinner without printing a result.
+func (s *Spinner) Stop() error {
+	if s.inner != nil {
+		return s.inner.Stop()
+	}
+
+	return nil
+}
+
+// finish reproduces pterm's terminal-method behaviour for the non-interactive
+// path: default the message to the spinner text, then print through Fprinto.
+func (s *Spinner) finish(printer *pterm.PrefixPrinter, message []any) {
+	if len(message) == 0 {
+		message = []any{s.text}
+	}
+
+	pterm.Fprinto(s.writer, printer.Sprint(message...))
+}

--- a/cmd/ledgerctl/cmdutil/spinner.go
+++ b/cmd/ledgerctl/cmdutil/spinner.go
@@ -51,6 +51,10 @@ func startSpinner(text string, interactive bool, writer io.Writer) *Spinner {
 }
 
 // UpdateText replaces the message shown by the spinner.
+//
+// The non-interactive branch prints a line. That is what pterm itself does:
+// SpinnerPrinter.UpdateText overwrites the current line with Fprinto only while
+// styling is enabled, and falls back to Fprintln in raw mode.
 func (s *Spinner) UpdateText(text string) {
 	s.text = text
 

--- a/cmd/ledgerctl/cmdutil/spinner_test.go
+++ b/cmd/ledgerctl/cmdutil/spinner_test.go
@@ -1,0 +1,109 @@
+package cmdutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/pterm/pterm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// TestStartSpinnerNonInteractiveSpawnsNoGoroutine is the EN-1781 regression
+// test. pterm's SpinnerPrinter.Start always launches an animation goroutine
+// that its Stop cannot terminate while RawOutput is set, so the only safe
+// option in a long-lived non-interactive process is to never start one.
+//
+// Deliberately not parallel: goleak inspects the whole goroutine dump.
+func TestStartSpinnerNonInteractiveSpawnsNoGoroutine(t *testing.T) {
+	ignore := goleak.IgnoreCurrent()
+
+	spinner := startSpinner("working", false, io.Discard)
+	spinner.UpdateText("still working")
+	spinner.Success("done")
+
+	goleak.VerifyNone(t, ignore)
+}
+
+// TestSpinnerNonInteractiveMatchesPterm pins the non-interactive output to what
+// pterm itself emits. The reference spinner is never Started, so it spawns no
+// goroutine: its terminal methods print and then hit Stop's early return.
+func TestSpinnerNonInteractiveMatchesPterm(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, pterm.RawOutput,
+		"cmdutil.init must have put pterm in raw mode: stdout is not a terminal under go test")
+
+	tests := []struct {
+		name    string
+		message string
+		invoke  func(s *Spinner, message string)
+		refer   func(s *pterm.SpinnerPrinter, message string)
+	}{
+		{
+			name:    "success",
+			message: "finished",
+			invoke:  func(s *Spinner, m string) { s.Success(m) },
+			refer:   func(s *pterm.SpinnerPrinter, m string) { s.Success(m) },
+		},
+		{
+			name:    "fail",
+			message: "broke",
+			invoke:  func(s *Spinner, m string) { s.Fail(m) },
+			refer:   func(s *pterm.SpinnerPrinter, m string) { s.Fail(m) },
+		},
+		{
+			name:    "warning",
+			message: "careful",
+			invoke:  func(s *Spinner, m string) { s.Warning(m) },
+			refer:   func(s *pterm.SpinnerPrinter, m string) { s.Warning(m) },
+		},
+		{
+			name:    "info",
+			message: "noted",
+			invoke:  func(s *Spinner, m string) { s.Info(m) },
+			refer:   func(s *pterm.SpinnerPrinter, m string) { s.Info(m) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var actual bytes.Buffer
+			test.invoke(startSpinner("working", false, &actual), test.message)
+
+			var expected bytes.Buffer
+			reference := pterm.DefaultSpinner
+			reference.Writer = &expected
+			reference.Text = "working"
+			test.refer(&reference, test.message)
+
+			assert.Equal(t, expected.String(), actual.String())
+		})
+	}
+}
+
+// TestSpinnerNonInteractiveDefaultsMessageToText mirrors pterm, which reuses the
+// spinner text when a terminal method is called with no message.
+func TestSpinnerNonInteractiveDefaultsMessageToText(t *testing.T) {
+	t.Parallel()
+
+	var actual bytes.Buffer
+	startSpinner("working", false, &actual).Success()
+
+	assert.Contains(t, actual.String(), "working")
+}
+
+// TestSpinnerNonInteractiveStopIsQuiet mirrors pterm, whose Stop prints nothing
+// and returns nil while RawOutput is set.
+func TestSpinnerNonInteractiveStopIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	var actual bytes.Buffer
+
+	require.NoError(t, startSpinner("working", false, &actual).Stop())
+	assert.Empty(t, actual.String())
+}

--- a/cmd/ledgerctl/cmdutil/spinner_test.go
+++ b/cmd/ledgerctl/cmdutil/spinner_test.go
@@ -86,6 +86,47 @@ func TestSpinnerNonInteractiveMatchesPterm(t *testing.T) {
 	}
 }
 
+// TestSpinnerNonInteractiveUpdateTextMatchesPterm pins UpdateText to pterm's
+// raw-mode behaviour. pterm overwrites the current line with Fprinto only while
+// styling is enabled; in raw mode it prints the new text on its own line with
+// Fprintln, and Fprintln is not suppressed by RawOutput.
+func TestSpinnerNonInteractiveUpdateTextMatchesPterm(t *testing.T) {
+	t.Parallel()
+
+	var actual bytes.Buffer
+	startSpinner("working", false, &actual).UpdateText("still working")
+
+	var expected bytes.Buffer
+	reference := pterm.DefaultSpinner
+	reference.Writer = &expected
+	reference.Text = "working"
+	reference.UpdateText("still working")
+
+	assert.Equal(t, expected.String(), actual.String())
+}
+
+// TestSpinnerNonInteractiveUpdateTextRetargetsDefaultMessage checks that the
+// text a message-less terminal method falls back to follows UpdateText, as it
+// does in pterm, where UpdateText assigns SpinnerPrinter.Text.
+func TestSpinnerNonInteractiveUpdateTextRetargetsDefaultMessage(t *testing.T) {
+	t.Parallel()
+
+	var actual bytes.Buffer
+
+	spinner := startSpinner("working", false, &actual)
+	spinner.UpdateText("still working")
+	spinner.Success()
+
+	var expected bytes.Buffer
+	reference := pterm.DefaultSpinner
+	reference.Writer = &expected
+	reference.Text = "working"
+	reference.UpdateText("still working")
+	reference.Success()
+
+	assert.Equal(t, expected.String(), actual.String())
+}
+
 // TestSpinnerNonInteractiveDefaultsMessageToText mirrors pterm, which reuses the
 // spinner text when a terminal method is called with no message.
 func TestSpinnerNonInteractiveDefaultsMessageToText(t *testing.T) {

--- a/cmd/ledgerctl/events/add_sink.go
+++ b/cmd/ledgerctl/events/add_sink.go
@@ -332,7 +332,7 @@ func runAddSink(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Adding event sink %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Adding event sink %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/events/remove_sink.go
+++ b/cmd/ledgerctl/events/remove_sink.go
@@ -52,7 +52,7 @@ func runRemoveSink(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Removing event sink %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Removing event sink %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/indexes/create.go
+++ b/cmd/ledgerctl/indexes/create.go
@@ -136,7 +136,7 @@ func runCreateIndex(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Creating index %s on %s...", indexDesc, ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Creating index %s on %s...", indexDesc, ledgerName))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/indexes/drop.go
+++ b/cmd/ledgerctl/indexes/drop.go
@@ -125,7 +125,7 @@ func runDropIndex(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Dropping index %s on %s...", indexDesc, ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Dropping index %s on %s...", indexDesc, ledgerName))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/indexes/list.go
+++ b/cmd/ledgerctl/indexes/list.go
@@ -58,7 +58,7 @@ func runListIndexes(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching indexes for %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching indexes for %s...", ledgerName))
 
 	stream, err := client.ListIndexes(ctx, &servicepb.ListIndexesRequest{
 		Scope:  servicepb.ListIndexesRequest_SCOPE_LEDGER,

--- a/cmd/ledgerctl/ledgers/configuration.go
+++ b/cmd/ledgerctl/ledgers/configuration.go
@@ -68,7 +68,7 @@ func runConfiguration(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching configuration for %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching configuration for %s...", ledgerName))
 
 	// Fetch ledger info (metadata schema, account types). Indexes are fetched
 	// separately via BucketService.ListIndexes since they no longer live in

--- a/cmd/ledgerctl/ledgers/configuration_apply.go
+++ b/cmd/ledgerctl/ledgers/configuration_apply.go
@@ -123,7 +123,7 @@ func runConfigurationApply(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Applying %d changes to %s...", len(actions), ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Applying %d changes to %s...", len(actions), ledgerName))
 
 	resp, err := client.Apply(ctx, applyReq)
 	if err != nil {

--- a/cmd/ledgerctl/ledgers/configuration_export.go
+++ b/cmd/ledgerctl/ledgers/configuration_export.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -67,7 +66,7 @@ func fetchEditableConfig(cmd *cobra.Command, ledgerName string) (*EditableConfig
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching configuration for %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching configuration for %s...", ledgerName))
 
 	ledger, err := client.GetLedger(ctx, &servicepb.GetLedgerRequest{Ledger: ledgerName})
 	if err != nil {

--- a/cmd/ledgerctl/ledgers/create.go
+++ b/cmd/ledgerctl/ledgers/create.go
@@ -117,7 +117,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 		modeStr = "mirror"
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Creating %s ledger %s...", modeStr, name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Creating %s ledger %s...", modeStr, name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/ledgers/delete.go
+++ b/cmd/ledgerctl/ledgers/delete.go
@@ -90,7 +90,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Deleting ledger %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Deleting ledger %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/ledgers/delete_metadata.go
+++ b/cmd/ledgerctl/ledgers/delete_metadata.go
@@ -92,7 +92,7 @@ func runDeleteMetadata(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Deleting metadata key %q from ledger %s...", key, ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Deleting metadata key %q from ledger %s...", key, ledgerName))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/ledgers/get.go
+++ b/cmd/ledgerctl/ledgers/get.go
@@ -45,7 +45,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching ledger %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching ledger %s...", ledgerName))
 
 	ledger, err := client.GetLedger(ctx, &servicepb.GetLedgerRequest{
 		Ledger: ledgerName,

--- a/cmd/ledgerctl/ledgers/get_schema.go
+++ b/cmd/ledgerctl/ledgers/get_schema.go
@@ -51,7 +51,7 @@ func runGetSchema(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching schema for %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching schema for %s...", ledgerName))
 
 	resp, err := client.GetMetadataSchemaStatus(ctx, &servicepb.GetMetadataSchemaStatusRequest{
 		Ledger: ledgerName,

--- a/cmd/ledgerctl/ledgers/list.go
+++ b/cmd/ledgerctl/ledgers/list.go
@@ -51,7 +51,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	pgn := cmdutil.GetPaginationFlags(cmd)
 	cns := cmdutil.GetConsistencyFlags(cmd)
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching ledgers...")
+	spinner := cmdutil.StartSpinner("Fetching ledgers...")
 
 	all, nextCursor, err := cmdutil.FetchSinglePageOrAll(cmd, pgn.Cursor, func(cur string) ([]*commonpb.LedgerInfo, metadata.MD, error) {
 		page := pgn

--- a/cmd/ledgerctl/ledgers/promote.go
+++ b/cmd/ledgerctl/ledgers/promote.go
@@ -89,7 +89,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Promoting ledger %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Promoting ledger %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/ledgers/remove_metadata_type.go
+++ b/cmd/ledgerctl/ledgers/remove_metadata_type.go
@@ -112,7 +112,7 @@ func runRemoveMetadataType(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Removing metadata type %s.%s from %s...",
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Removing metadata type %s.%s from %s...",
 		cmdutil.TargetTypeString(targetType), key, ledgerName))
 
 	requests := []*servicepb.Request{

--- a/cmd/ledgerctl/ledgers/set_metadata.go
+++ b/cmd/ledgerctl/ledgers/set_metadata.go
@@ -100,7 +100,7 @@ func runSetMetadata(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting metadata on ledger %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting metadata on ledger %s...", ledgerName))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/ledgers/set_metadata_type.go
+++ b/cmd/ledgerctl/ledgers/set_metadata_type.go
@@ -112,7 +112,7 @@ func runSetMetadataType(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting metadata type %s.%s = %s on %s...",
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting metadata type %s.%s = %s on %s...",
 		cmdutil.TargetTypeString(targetType), key, cmdutil.MetadataTypeString(mdType), ledgerName))
 
 	requests := []*servicepb.Request{

--- a/cmd/ledgerctl/ledgers/stats.go
+++ b/cmd/ledgerctl/ledgers/stats.go
@@ -48,7 +48,7 @@ func runStats(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching stats for ledger %s...", ledgerName))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching stats for ledger %s...", ledgerName))
 
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 

--- a/cmd/ledgerctl/numscripts/save.go
+++ b/cmd/ledgerctl/numscripts/save.go
@@ -83,7 +83,7 @@ func runSave(cmd *cobra.Command, args []string) error {
 
 	version, _ := cmd.Flags().GetString("version")
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Saving numscript %s...", name))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Saving numscript %s...", name))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/provision/run.go
+++ b/cmd/ledgerctl/provision/run.go
@@ -97,7 +97,7 @@ func runProvision(cmd *cobra.Command, args []string) error {
 }
 
 func runSingle(ctx context.Context, client servicepb.BucketServiceClient, scale float64, name string, fn scenario.ScenarioFunc) error {
-	spinner, _ := pterm.DefaultSpinner.Start("Running scenario: " + name)
+	spinner := cmdutil.StartSpinner("Running scenario: " + name)
 
 	runner := scenario.NewRunner(ctx, client).
 		WithScale(scale).

--- a/cmd/ledgerctl/querycheckpoint/create.go
+++ b/cmd/ledgerctl/querycheckpoint/create.go
@@ -3,7 +3,6 @@ package querycheckpoint
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -39,9 +38,9 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Creating query checkpoint...")
+		spinner = cmdutil.StartSpinner("Creating query checkpoint...")
 	}
 
 	resp, err := client.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})

--- a/cmd/ledgerctl/querycheckpoint/delete.go
+++ b/cmd/ledgerctl/querycheckpoint/delete.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -45,9 +44,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Deleting query checkpoint...")
+		spinner = cmdutil.StartSpinner("Deleting query checkpoint...")
 	}
 
 	_, err = client.DeleteQueryCheckpoint(ctx, &clusterpb.DeleteQueryCheckpointRequest{

--- a/cmd/ledgerctl/querycheckpoint/delete_schedule.go
+++ b/cmd/ledgerctl/querycheckpoint/delete_schedule.go
@@ -1,7 +1,6 @@
 package querycheckpoint
 
 import (
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -36,7 +35,7 @@ func runDeleteSchedule(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Deleting query checkpoint schedule...")
+	spinner := cmdutil.StartSpinner("Deleting query checkpoint schedule...")
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/querycheckpoint/get_schedule.go
+++ b/cmd/ledgerctl/querycheckpoint/get_schedule.go
@@ -36,7 +36,7 @@ func runGetSchedule(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching query checkpoint schedule...")
+	spinner := cmdutil.StartSpinner("Fetching query checkpoint schedule...")
 
 	resp, err := client.GetQueryCheckpointSchedule(ctx, &clusterpb.GetQueryCheckpointScheduleRequest{})
 	if err != nil {

--- a/cmd/ledgerctl/querycheckpoint/set_schedule.go
+++ b/cmd/ledgerctl/querycheckpoint/set_schedule.go
@@ -3,7 +3,6 @@ package querycheckpoint
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -53,7 +52,7 @@ func runSetSchedule(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting query checkpoint schedule to %q...", cronExpr))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting query checkpoint schedule to %q...", cronExpr))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/restore/validate.go
+++ b/cmd/ledgerctl/restore/validate.go
@@ -45,7 +45,7 @@ func runValidate(cmd *cobra.Command, _ []string) error {
 	}
 
 	var (
-		spinner, _ = pterm.DefaultSpinner.Start("Validating backup integrity...")
+		spinner    = cmdutil.StartSpinner("Validating backup integrity...")
 		errorCount int
 	)
 

--- a/cmd/ledgerctl/signing/register_key.go
+++ b/cmd/ledgerctl/signing/register_key.go
@@ -71,7 +71,7 @@ func runRegisterKey(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Registering signing key %s...", keyID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Registering signing key %s...", keyID))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/signing/require.go
+++ b/cmd/ledgerctl/signing/require.go
@@ -3,7 +3,6 @@ package signing
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -64,7 +63,7 @@ func runRequire(cmd *cobra.Command, args []string) error {
 		action = "Disabling"
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start(action + " mandatory signatures...")
+	spinner := cmdutil.StartSpinner(action + " mandatory signatures...")
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/signing/revoke_key.go
+++ b/cmd/ledgerctl/signing/revoke_key.go
@@ -54,7 +54,7 @@ func runRevokeKey(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Revoking signing key %s...", keyID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Revoking signing key %s...", keyID))
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/store/backup.go
+++ b/cmd/ledgerctl/store/backup.go
@@ -3,7 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -52,9 +51,9 @@ func runBackup(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Running backup...")
+		spinner = cmdutil.StartSpinner("Running backup...")
 	}
 
 	resp, err := client.Backup(ctx, &clusterpb.BackupRequest{

--- a/cmd/ledgerctl/store/bootstrap.go
+++ b/cmd/ledgerctl/store/bootstrap.go
@@ -93,7 +93,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 	manifestKey := bucketID + "/backups/manifest.json"
 
 	// Read manifest
-	spinner, _ := pterm.DefaultSpinner.Start("Reading backup manifest...")
+	spinner := cmdutil.StartSpinner("Reading backup manifest...")
 
 	manifestReader, err := storage.GetFile(cmd.Context(), manifestKey)
 	if err != nil {
@@ -142,7 +142,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 
 	// Download checkpoint files (if any)
 	if manifest.Checkpoint != nil && len(manifest.Checkpoint.Files) > 0 {
-		dlSpinner, _ := pterm.DefaultSpinner.Start("Downloading checkpoint files...")
+		dlSpinner := cmdutil.StartSpinner("Downloading checkpoint files...")
 
 		var totalBytes uint64
 
@@ -194,7 +194,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 
 	// Apply export segments and rebuild derived state (if any).
 	if len(manifest.Exports) > 0 {
-		exportSpinner, _ := pterm.DefaultSpinner.Start("Applying export segments and rebuilding derived state...")
+		exportSpinner := cmdutil.StartSpinner("Applying export segments and rebuilding derived state...")
 
 		exportStore, err := dal.OpenDirect(stagingDir, logger)
 		if err != nil {
@@ -268,7 +268,7 @@ func runBootstrap(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Prepare attributes for backup (Global-zone resets; no compaction).
-	prepareSpinner, _ := pterm.DefaultSpinner.Start("Preparing attributes for restore compatibility...")
+	prepareSpinner := cmdutil.StartSpinner("Preparing attributes for restore compatibility...")
 
 	prepareStore, err := dal.OpenDirect(stagingDir, logger)
 	if err != nil {

--- a/cmd/ledgerctl/store/check.go
+++ b/cmd/ledgerctl/store/check.go
@@ -50,13 +50,13 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	}
 
 	var (
-		spinner     *pterm.SpinnerPrinter
+		spinner     *cmdutil.Spinner
 		errorCount  int
 		checkErrors []*servicepb.CheckStoreError
 	)
 
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Checking store integrity...")
+		spinner = cmdutil.StartSpinner("Checking store integrity...")
 	}
 
 	for {

--- a/cmd/ledgerctl/store/checkpoint.go
+++ b/cmd/ledgerctl/store/checkpoint.go
@@ -3,7 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -41,9 +40,9 @@ func runCheckpoint(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Creating checkpoint...")
+		spinner = cmdutil.StartSpinner("Creating checkpoint...")
 	}
 
 	resp, err := client.CreateCheckpoint(ctx, &clusterpb.CreateCheckpointRequest{})

--- a/cmd/ledgerctl/store/incremental_backup.go
+++ b/cmd/ledgerctl/store/incremental_backup.go
@@ -3,7 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -52,9 +51,9 @@ func runIncrementalBackup(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Running incremental backup...")
+		spinner = cmdutil.StartSpinner("Running incremental backup...")
 	}
 
 	resp, err := client.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{

--- a/cmd/ledgerctl/store/primary_compact.go
+++ b/cmd/ledgerctl/store/primary_compact.go
@@ -3,7 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -41,9 +40,9 @@ func runPrimaryCompact(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Compacting storage...")
+		spinner = cmdutil.StartSpinner("Compacting storage...")
 	}
 
 	resp, err := client.CompactPrimary(ctx, &clusterpb.CompactPrimaryRequest{})

--- a/cmd/ledgerctl/store/primary_metrics.go
+++ b/cmd/ledgerctl/store/primary_metrics.go
@@ -44,7 +44,7 @@ func runPrimaryMetrics(cmd *cobra.Command, _ []string) error {
 
 	nodeID, _ := cmd.Flags().GetUint32("node-id")
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching store metrics...")
+	spinner := cmdutil.StartSpinner("Fetching store metrics...")
 
 	resp, err := client.GetPrimaryMetrics(ctx, &servicepb.GetPrimaryMetricsRequest{
 		NodeId: nodeID,

--- a/cmd/ledgerctl/store/rebuild_audit_index.go
+++ b/cmd/ledgerctl/store/rebuild_audit_index.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel/metric/noop"
 
@@ -54,7 +53,7 @@ func runRebuildAuditIndex(cmd *cobra.Command, _ []string) error {
 
 	logger := logging.NopZap()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Opening Pebble store (read-only)...")
+	spinner := cmdutil.StartSpinner("Opening Pebble store (read-only)...")
 
 	// The server keeps the live Pebble DB under <data-dir>/live (see dal.NewStore),
 	// while the read index lives at <data-dir>/read-indexes. Open the live subdir,
@@ -70,7 +69,7 @@ func runRebuildAuditIndex(cmd *cobra.Command, _ []string) error {
 
 	spinner.Success("Pebble store opened")
 
-	spinner, _ = pterm.DefaultSpinner.Start("Opening read index store...")
+	spinner = cmdutil.StartSpinner("Opening read index store...")
 
 	rs, err := readstore.New(readIndexDir, logger, readstore.DefaultConfig())
 	if err != nil {
@@ -83,7 +82,7 @@ func runRebuildAuditIndex(cmd *cobra.Command, _ []string) error {
 
 	spinner.Success("Read index store opened at " + rs.Path())
 
-	spinner, _ = pterm.DefaultSpinner.Start("Rebuilding audit index...")
+	spinner = cmdutil.StartSpinner("Rebuilding audit index...")
 
 	idx := auditindexer.New(auditindexer.Config{BatchSize: batchSize}, pebbleStore, rs, logger, noop.Meter{})
 	if err := idx.Rebuild(context.Background()); err != nil {

--- a/cmd/ledgerctl/store/secondary_compact.go
+++ b/cmd/ledgerctl/store/secondary_compact.go
@@ -3,7 +3,6 @@ package store
 import (
 	"fmt"
 
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
@@ -40,9 +39,9 @@ func runSecondaryCompact(cmd *cobra.Command, _ []string) error {
 
 	structuredOutput := cmdutil.IsStructuredOutput(cmd)
 
-	var spinner *pterm.SpinnerPrinter
+	var spinner *cmdutil.Spinner
 	if !structuredOutput {
-		spinner, _ = pterm.DefaultSpinner.Start("Compacting read index...")
+		spinner = cmdutil.StartSpinner("Compacting read index...")
 	}
 
 	resp, err := client.CompactSecondary(ctx, &clusterpb.CompactSecondaryRequest{})

--- a/cmd/ledgerctl/store/secondary_metrics.go
+++ b/cmd/ledgerctl/store/secondary_metrics.go
@@ -41,7 +41,7 @@ func runSecondaryMetrics(cmd *cobra.Command, _ []string) error {
 
 	nodeID, _ := cmd.Flags().GetUint32("node-id")
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching read index metrics...")
+	spinner := cmdutil.StartSpinner("Fetching read index metrics...")
 
 	resp, err := client.GetSecondaryMetrics(ctx, &servicepb.GetSecondaryMetricsRequest{
 		NodeId: nodeID,

--- a/cmd/ledgerctl/transactions/analyze.go
+++ b/cmd/ledgerctl/transactions/analyze.go
@@ -62,7 +62,7 @@ func runAnalyzeTransactions(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Analyzing transactions...")
+	spinner := cmdutil.StartSpinner("Analyzing transactions...")
 
 	stream, err := client.AnalyzeTransactions(ctx, &servicepb.AnalyzeTransactionsRequest{
 		Ledger:            ledgerName,

--- a/cmd/ledgerctl/transactions/create.go
+++ b/cmd/ledgerctl/transactions/create.go
@@ -361,7 +361,7 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start("Creating transaction...")
+	spinner := cmdutil.StartSpinner("Creating transaction...")
 
 	requests := []*servicepb.Request{
 		{

--- a/cmd/ledgerctl/transactions/delete_metadata.go
+++ b/cmd/ledgerctl/transactions/delete_metadata.go
@@ -127,7 +127,7 @@ func runDeleteMetadata(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Deleting metadata key %q from transaction #%d...", key, txID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Deleting metadata key %q from transaction #%d...", key, txID))
 
 	// Build request
 	requests := []*servicepb.Request{

--- a/cmd/ledgerctl/transactions/get.go
+++ b/cmd/ledgerctl/transactions/get.go
@@ -84,7 +84,7 @@ func runGet(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching transaction #%d...", txID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching transaction #%d...", txID))
 
 	checkpointID, _ := cmd.Flags().GetUint64("checkpoint-id")
 

--- a/cmd/ledgerctl/transactions/list.go
+++ b/cmd/ledgerctl/transactions/list.go
@@ -101,7 +101,7 @@ func fetchAllTransactions(cmd *cobra.Command, client servicepb.BucketServiceClie
 		ctx = cmdutil.ProfileContext(ctx)
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start("Fetching all transactions...")
+	spinner := cmdutil.StartSpinner("Fetching all transactions...")
 
 	var lastTrailer metadata.MD
 
@@ -162,7 +162,7 @@ func fetchTransactionsWithPager(cmd *cobra.Command, client servicepb.BucketServi
 			ctx = cmdutil.ProfileContext(ctx)
 		}
 
-		spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Fetching page %d...", pageNum))
+		spinner := cmdutil.StartSpinner(fmt.Sprintf("Fetching page %d...", pageNum))
 
 		stream, err := client.ListTransactions(ctx, &servicepb.ListTransactionsRequest{
 			Ledger:  ledgerName,

--- a/cmd/ledgerctl/transactions/revert.go
+++ b/cmd/ledgerctl/transactions/revert.go
@@ -140,7 +140,7 @@ func runRevert(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Reverting transaction #%d...", txID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Reverting transaction #%d...", txID))
 
 	// Build revert request
 	requests := []*servicepb.Request{

--- a/cmd/ledgerctl/transactions/set_metadata.go
+++ b/cmd/ledgerctl/transactions/set_metadata.go
@@ -130,7 +130,7 @@ func runSetMetadata(cmd *cobra.Command, args []string) error {
 	ctx, cancel := cmdutil.GetContext(cmd)
 	defer cancel()
 
-	spinner, _ := pterm.DefaultSpinner.Start(fmt.Sprintf("Setting metadata on transaction #%d...", txID))
+	spinner := cmdutil.StartSpinner(fmt.Sprintf("Setting metadata on transaction #%d...", txID))
 
 	// Build request
 	requests := []*servicepb.Request{

--- a/cmd/ledgerctl/upgrade/command.go
+++ b/cmd/ledgerctl/upgrade/command.go
@@ -43,7 +43,7 @@ func runUpgrade(currentVersion, channel string, force, dryRun bool) error {
 		return nil
 	}
 
-	spinner, _ := pterm.DefaultSpinner.Start(
+	spinner := cmdutil.StartSpinner(
 		fmt.Sprintf("Checking for updates (channel: %s)...", channel))
 
 	release, err := fetchRelease(channel, currentVersion)
@@ -83,7 +83,7 @@ func runUpgrade(currentVersion, channel string, force, dryRun bool) error {
 	}
 
 	// Download, verify, and extract.
-	spinner, _ = pterm.DefaultSpinner.Start(
+	spinner = cmdutil.StartSpinner(
 		fmt.Sprintf("Downloading %s...", archiveAsset.Name))
 
 	extractedPath, err := downloadAndVerify(archiveAsset, checksumsAsset, spinner)
@@ -98,7 +98,7 @@ func runUpgrade(currentVersion, channel string, force, dryRun bool) error {
 	spinner.Success("Download complete, checksum verified")
 
 	// Replace the binary.
-	spinner, _ = pterm.DefaultSpinner.Start("Installing update...")
+	spinner = cmdutil.StartSpinner("Installing update...")
 
 	binaryPath, err := replaceBinary(extractedPath)
 	if err != nil {

--- a/cmd/ledgerctl/upgrade/download.go
+++ b/cmd/ledgerctl/upgrade/download.go
@@ -13,8 +13,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/pterm/pterm"
-
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 )
 
@@ -45,7 +43,7 @@ func parseChecksums(r io.Reader) (map[string]string, error) {
 // downloadAndVerify downloads the archive and checksums, verifies the archive's
 // SHA256 hash, then extracts the ledgerctl binary to a temp file.
 // Returns the path to the temp file containing the extracted binary.
-func downloadAndVerify(archiveAsset, checksumsAsset *assetInfo, spinner *pterm.SpinnerPrinter) (string, error) {
+func downloadAndVerify(archiveAsset, checksumsAsset *assetInfo, spinner *cmdutil.Spinner) (string, error) {
 	// 1. Download checksums.txt (small, in memory).
 	spinner.UpdateText("Downloading checksums...")
 

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,10 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
-require github.com/benbjohnson/immutable v0.4.3
+require (
+	github.com/benbjohnson/immutable v0.4.3
+	go.uber.org/goleak v1.3.0
+)
 
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
@@ -302,7 +305,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.41.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect

--- a/go.mod
+++ b/go.mod
@@ -302,6 +302,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.41.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect


### PR DESCRIPTION
## Summary

The E2E suite failed under `-race` on pterm's package-level `RawOutput` flag.

**The cause is not parallel specs.** The cluster suite runs strictly serially (`go test -p 1` at `justfile:96`, a bare `RunSpecs` at `tests/e2e/cluster/suite_test.go:14`). Both racing goroutines live in one process. The race came from a spinner goroutine that outlived its spec.

Mechanism, verified against `pterm v0.12.82`:

| Fact | Evidence |
|---|---|
| `Start` spawns its animation goroutine unconditionally, even in `RawOutput` mode | `spinner_printer.go:157` |
| That goroutine reads the global `RawOutput` every tick | `spinner_printer.go:163` |
| `Stop` early-returns **without clearing `IsActive`** when `RawOutput` is set | `spinner_printer.go:184-186` |
| `Success`/`Fail`/`Warning`/`Info` all terminate via `Stop` | `:246`, `:263`, `:280`, `:229` |

Our own `cmdutil` `init()` set `RawOutput = true` for non-TTY stdout — always true under `go test` — so **no spinner could ever be stopped** and every in-process `ledgerctl` command leaked an immortal goroutine polling `RawOutput`. A later spec calling `pterm.DisableStyling()` wrote that flag (`pterm.go:62`) and the detector fired.

That `init()` came from commit `9f13b3a3b`, "disable pterm spinner animation in non-TTY to avoid data race" — a prior partial fix for this same race class. Its comment claimed it disabled the goroutine; it did not, and it is what made the goroutine immortal.

Because pterm reads `IsActive` without synchronisation, such a goroutine **cannot be stopped race-free — only never started**. That constraint drives the design.

## Changes

- **`cmdutil.Spinner` / `StartSpinner`** — creates no pterm spinner when stdout is not a terminal, so no goroutine exists. Output is byte-identical: in raw mode `Start` prints nothing, `fClearLine` is a no-op (`print.go:194`), and the terminal methods print through `pterm.Fprinto` with the same prefix printers.
- **Write-once configuration** — interactivity is decided once at package init; the misleading comment is corrected.
- **70 call sites migrated** across 62 files in `cmd/ledgerctl`.
- **`forbidigo` rule** banning direct `pterm.DefaultSpinner`, following the existing `OpenWriteSession` precedent.
- **E2E spec no longer reconfigures pterm globals** (`ledgerctl_typed_metadata_test.go`).
- **Tests:** a `goleak` regression test and a pterm output-equivalence test.

## Behaviour change

`DisableStyling()` also disables colour, where the previous code set only `RawOutput`. Non-interactive output (pipes, CI, files) no longer contains ANSI escape codes. `--json`/`--yaml` payloads come from encoders, not pterm, so machine-readable output is unaffected.

## Scope: `misc/operator` excluded, deliberately

`misc/operator` (16 spinner sites) is a separate Go module that cannot import `cmd/ledgerctl/cmdutil`. It contains **zero** pterm global writes — no `DisableStyling`, `DisableColor`, `RawOutput`, or `SetDefaultOutput` anywhere — and no in-process suite running its commands. A race needs a write concurrent with a read; there is no writer. `kubectl-ledger` therefore has the latent pattern, not this bug, in a short-lived plugin process. It is excluded from the lint rule with that rationale recorded inline, rather than duplicating the wrapper across a module boundary to fix a non-bug.

## Validation

Run locally:

- `just pre-commit` — exit 0, both golangci passes `0 issues`, no files modified.
- `just test` — 81 `ok`, 0 FAIL, 0 `DATA RACE`.
- `go test -race ./cmd/ledgerctl/...` — 8 `ok`, 0 FAIL, 0 `DATA RACE`.
- `goleak` test asserting a start/Success cycle leaves zero goroutines. Verified to genuinely guard: forcing `startSpinner` to always create a real pterm spinner fails it with the predicted stack at `spinner_printer.go:164`, created at `:157`.
- Lint rule verified to genuinely fire: a temporary `pterm.DefaultSpinner` reference produces a `forbidigo` finding; a deliberately non-matching exclusion anchor surfaces all 16 operator sites, confirming the exclusion is what suppresses them rather than the files not being linted.

**`just test-e2e-full` is NOT yet confirmed green — please rely on CI for this one.** The local run reported **0 `DATA RACE`** with the detector active, and the migrated spinners demonstrably executed. But it exited 1 for three environmental reasons unrelated to this change, so not all cluster specs ran and the result is inconclusive rather than passing:

1. Azurite rejects API version `2026-04-06` (`backup_azure_test.go:106`) — a pre-existing environment problem, independent of this branch.
2. `bind: address already in use` on port 15200, from a concurrent E2E run in another workspace on the same machine.
3. The cluster suite aborted as a cascade of (2), with no `Ran N of N Specs` summary.

CI runs E2E in an isolated environment and is the authoritative check here.

## Known limitation

A pre-existing blanket `_test\.go$` `forbidigo` exclusion (present for `OpenWriteSession` test seeding) makes the new rule inert in test files repo-wide. Narrowing it would disturb unrelated enforcement, so it is left alone and recorded here. Also: the `^misc/operator/` anchor works only because golangci matches paths repo-root-relative; adding a `misc/operator/.golangci.yaml` would silently break it.

Jira: https://formance-team.atlassian.net/browse/EN-1781