### PR TITLE
fix(EN-1780): green the full-tag e2e suite and gate it in CI

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -520,7 +520,7 @@ plain `-tags e2e` run neither builds nor runs them:
 | `s3` | backup, restore, bootstrap, cold storage | MinIO (Testcontainers) |
 | `azure` | Azure Blob backup | Azurite (Testcontainers) |
 | `clickhouse` | ClickHouse event sink | ClickHouse (Testcontainers) |
-| `nats` | NATS event sink | NATS (Testcontainers) |
+| `nats` | NATS event sink | none (embedded in-process server) |
 | `databricks` | Databricks event sink | real workspace credentials; skips itself when unset |
 
 `just test-e2e` runs the light set for a fast local loop. **CI runs the full tag

--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -509,6 +509,44 @@ ginkgo run -tags e2e ./tests/e2e
 go test -tags e2e ./tests/e2e/...
 ```
 
+#### Feature-gated suites
+
+Some e2e files carry an extra build tag on top of `e2e` (for example
+`//go:build e2e && s3`). They are compiled only when that tag is passed, so a
+plain `-tags e2e` run neither builds nor runs them:
+
+| Tag | Coverage | External dependency |
+|-----|----------|---------------------|
+| `s3` | backup, restore, bootstrap, cold storage | MinIO (Testcontainers) |
+| `azure` | Azure Blob backup | Azurite (Testcontainers) |
+| `clickhouse` | ClickHouse event sink | ClickHouse (Testcontainers) |
+| `nats` | NATS event sink | NATS (Testcontainers) |
+| `databricks` | Databricks event sink | real workspace credentials; skips itself when unset |
+
+`just test-e2e` runs the light set for a fast local loop. **CI runs the full tag
+set** through `just test-e2e-coverage`, so a green `just test-e2e` does not
+guarantee a green pipeline. Reproduce the CI set locally with:
+
+```bash
+just test-e2e-full
+```
+
+Linting already parses these files (`just lint` passes every tag), so a
+compile error is caught without the tag. Only a real run catches a stale
+assertion — which is why the full set belongs in CI.
+
+#### Docker socket on macOS
+
+Testcontainers looks for `/var/run/docker.sock`. When Docker Desktop is
+installed but stopped, that path exists as a symlink to its inactive socket,
+and container startup fails with `Cannot connect to the Docker daemon` even
+though the `docker` CLI works against another runtime. With OrbStack, point
+Testcontainers at the right socket:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.orbstack/run/docker.sock
+```
+
 ### Operator Integration Tests
 
 ```bash

--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -531,9 +531,13 @@ guarantee a green pipeline. Reproduce the CI set locally with:
 just test-e2e-full
 ```
 
-Linting already parses these files (`just lint` passes every tag), so a
-compile error is caught without the tag. Only a real run catches a stale
-assertion — which is why the full set belongs in CI.
+`just lint` does not pass the `e2e` tag, so it excludes these packages even
+when feature tags are configured. The full CI run is therefore responsible
+for both compiling these files and exercising their assertions.
+
+The MinIO and Azurite images used by this required gate are version-pinned in
+`tests/e2e/testutil/containers.go`. Update those pins deliberately and validate
+the complete full-tag suite when upgrading either emulator.
 
 #### Docker socket on macOS
 

--- a/justfile
+++ b/justfile
@@ -180,13 +180,17 @@ test-coverage:
     GOTOOLCHAIN=$(go env GOVERSION) go test -race -coverprofile={{coverage_dir}}/unit.out -coverpkg={{coverage_pkgs}} ./... -timeout 20m
     echo "Coverage profile: {{coverage_dir}}/unit.out"
 
-# Run E2E tests with coverage
+# Run E2E tests with coverage. This is the CI gate, so it runs the full tag
+# set: the feature-gated suites (s3, azure, clickhouse, nats, ...) are only
+# compiled when their tag is present, and running them here is what stops
+# them rotting unnoticed. Suites needing external credentials, such as
+# databricks, skip themselves when the environment is not configured.
 test-e2e-coverage:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p {{coverage_dir}}
     echo "==> E2E tests with coverage..."
-    GOTOOLCHAIN=$(go env GOVERSION) go test -race -tags e2e -p 1 -coverprofile={{coverage_dir}}/e2e.out -coverpkg={{coverage_pkgs}} ./tests/e2e/business/... ./tests/e2e/cluster/... -timeout 20m
+    GOTOOLCHAIN=$(go env GOVERSION) go test -race -tags "e2e,{{all_tags}}" -p 1 -coverprofile={{coverage_dir}}/e2e.out -coverpkg={{coverage_pkgs}} ./tests/e2e/business/... ./tests/e2e/cluster/... -timeout 20m
     echo "Coverage profile: {{coverage_dir}}/e2e.out"
 
 # Run scenario tests with coverage

--- a/tests/e2e/business/backup_azure_test.go
+++ b/tests/e2e/business/backup_azure_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Azure Blob Backup", Ordered, func() {
 		// rejects the request with HTTP 400 InvalidHeaderValue rather than
 		// negotiating down. The emulator serves the request correctly once the
 		// check is skipped; without it the suite fails on every SDK bump.
-		container, err := testcontainers.Run(context.Background(), "mcr.microsoft.com/azure-storage/azurite:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.AzuriteImage,
 			testcontainers.WithCmd("azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck"),
 			testcontainers.WithExposedPorts("10000/tcp"),
 			testcontainers.WithWaitStrategy(

--- a/tests/e2e/business/backup_azure_test.go
+++ b/tests/e2e/business/backup_azure_test.go
@@ -77,8 +77,14 @@ var _ = Describe("Azure Blob Backup", Ordered, func() {
 	BeforeAll(func() {
 		// Start Azurite (the Azure Storage emulator). --blobHost 0.0.0.0 is
 		// required so the mapped port is reachable from the host process.
+		//
+		// --skipApiVersionCheck is required because the azblob SDK advertises
+		// an x-ms-version newer than the one Azurite recognises, and Azurite
+		// rejects the request with HTTP 400 InvalidHeaderValue rather than
+		// negotiating down. The emulator serves the request correctly once the
+		// check is skipped; without it the suite fails on every SDK bump.
 		container, err := testcontainers.Run(context.Background(), "mcr.microsoft.com/azure-storage/azurite:latest",
-			testcontainers.WithCmd("azurite-blob", "--blobHost", "0.0.0.0"),
+			testcontainers.WithCmd("azurite-blob", "--blobHost", "0.0.0.0", "--skipApiVersionCheck"),
 			testcontainers.WithExposedPorts("10000/tcp"),
 			testcontainers.WithWaitStrategy(
 				wait.ForListeningPort("10000/tcp").WithStartupTimeout(30*time.Second),

--- a/tests/e2e/business/backup_s3_credentials_test.go
+++ b/tests/e2e/business/backup_s3_credentials_test.go
@@ -24,8 +24,11 @@ import (
 )
 
 const (
-	s3CredsHTTPPort  = 16100
-	s3CredsGRPCPort  = 16200
+	s3CredsHTTPPort = 16100
+	// SetupSingleNode derives the Raft port as gRPC-1000, so this yields
+	// 16200. The previous value of 16200 derived 15200, the suite-wide node's
+	// HTTP port, and panicked the whole suite on startup.
+	s3CredsGRPCPort  = 17200
 	s3CredsBucket    = "creds-e2e"
 	s3CredsRegion    = "us-east-1"
 	s3CredsAccessKey = "minioadmin"

--- a/tests/e2e/business/backup_s3_credentials_test.go
+++ b/tests/e2e/business/backup_s3_credentials_test.go
@@ -45,7 +45,7 @@ var _ = Describe("S3 Backup with explicit credentials", Ordered, func() {
 
 	BeforeAll(func() {
 		// Start MinIO container
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     s3CredsAccessKey,
 				"MINIO_ROOT_PASSWORD": s3CredsSecretKey,

--- a/tests/e2e/business/backup_s3_test.go
+++ b/tests/e2e/business/backup_s3_test.go
@@ -256,7 +256,9 @@ var _ = Describe("S3 Backup", Ordered, func() {
 			Prefix: aws.String("no-prior/"),
 		})
 		Expect(listErr).To(Succeed())
-		Expect(listOut.KeyCount).To(BeEquivalentTo(0),
+		// KeyCount is a *int32: compare the pointed-to value, otherwise the
+		// matcher compares the pointer itself and can never succeed.
+		Expect(aws.ToInt32(listOut.KeyCount)).To(BeZero(),
 			"no object of any kind must be published under the no-prior/ prefix")
 	})
 

--- a/tests/e2e/business/backup_s3_test.go
+++ b/tests/e2e/business/backup_s3_test.go
@@ -85,7 +85,7 @@ var _ = Describe("S3 Backup", Ordered, func() {
 
 	BeforeAll(func() {
 		// Start MinIO container
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     backupMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": backupMinioSecretKey,
@@ -256,9 +256,7 @@ var _ = Describe("S3 Backup", Ordered, func() {
 			Prefix: aws.String("no-prior/"),
 		})
 		Expect(listErr).To(Succeed())
-		// KeyCount is a *int32: compare the pointed-to value, otherwise the
-		// matcher compares the pointer itself and can never succeed.
-		Expect(aws.ToInt32(listOut.KeyCount)).To(BeZero(),
+		Expect(listOut.Contents).To(BeEmpty(),
 			"no object of any kind must be published under the no-prior/ prefix")
 	})
 

--- a/tests/e2e/business/cold_storage_s3_test.go
+++ b/tests/e2e/business/cold_storage_s3_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Cold Storage S3", Ordered, func() {
 
 	BeforeAll(func() {
 		// Start MinIO container
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     coldMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": coldMinioSecretKey,

--- a/tests/e2e/cluster/bootstrap_test.go
+++ b/tests/e2e/cluster/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -46,6 +47,22 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 		ledgerName = "bootstrap-ledger"
 		ledger2    = "bootstrap-ledger-2"
 	)
+
+	// USD amounts posted to bootstrap-ledger. Phase 3 derives its expected
+	// volumes from these constants instead of restating them as literals, so
+	// adding or changing a posting cannot leave a stale expectation behind.
+	const (
+		bankFunding     = 10000 // world -> bank
+		aliceTransfer   = 3000  // bank -> alice
+		bobTransfer     = 2000  // bank -> bob
+		eveTransfer     = 500   // bank -> eve, posted after the first full backup
+		charlieTransfer = 1000  // bank -> charlie, posted after the bootstrap
+	)
+
+	// Everything bank paid out before the full backup that Phase 2 restores
+	// from. The eve posting is included because the second full backup taken
+	// in Phase 1 captures it.
+	const bankOutput = aliceTransfer + bobTransfer + eveTransfer
 
 	var (
 		ctx              context.Context
@@ -152,13 +169,13 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 			Expect(err).To(Succeed())
 
 			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("world", "bank", big.NewInt(10000), "USD"),
+				actions.NewPosting("world", "bank", big.NewInt(bankFunding), "USD"),
 			}, map[string]string{"type": "funding"}, nil)))
 			Expect(err).To(Succeed())
 
 			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("bank", "alice", big.NewInt(3000), "USD"),
-				actions.NewPosting("bank", "bob", big.NewInt(2000), "USD"),
+				actions.NewPosting("bank", "alice", big.NewInt(aliceTransfer), "USD"),
+				actions.NewPosting("bank", "bob", big.NewInt(bobTransfer), "USD"),
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 
@@ -200,7 +217,7 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 		It("should run incremental backup after adding more data", func() {
 			// Add more data after the full backup
 			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("bank", "eve", big.NewInt(500), "USD"),
+				actions.NewPosting("bank", "eve", big.NewInt(eveTransfer), "USD"),
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 
@@ -345,12 +362,12 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 		It("should have the correct account balances", func() {
 			aliceResp, err := client.GetAccount(ctx, &servicepb.GetAccountRequest{Ledger: ledgerName, Address: "alice"})
 			Expect(err).To(Succeed())
-			Expect(aliceResp.FindVolume("USD", "").Input).To(Equal("3000"))
+			Expect(aliceResp.FindVolume("USD", "").Input).To(Equal(strconv.Itoa(aliceTransfer)))
 
 			bankResp, err := client.GetAccount(ctx, &servicepb.GetAccountRequest{Ledger: ledgerName, Address: "bank"})
 			Expect(err).To(Succeed())
-			Expect(bankResp.FindVolume("USD", "").Input).To(Equal("10000"))
-			Expect(bankResp.FindVolume("USD", "").Output).To(Equal("5000"))
+			Expect(bankResp.FindVolume("USD", "").Input).To(Equal(strconv.Itoa(bankFunding)))
+			Expect(bankResp.FindVolume("USD", "").Output).To(Equal(strconv.Itoa(bankOutput)))
 		})
 
 		It("should have the correct account metadata", func() {
@@ -362,18 +379,18 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 		It("should have the data added after the first backup (via second full backup)", func() {
 			eveResp, err := client.GetAccount(ctx, &servicepb.GetAccountRequest{Ledger: ledgerName, Address: "eve"})
 			Expect(err).To(Succeed())
-			Expect(eveResp.FindVolume("USD", "").Input).To(Equal("500"))
+			Expect(eveResp.FindVolume("USD", "").Input).To(Equal(strconv.Itoa(eveTransfer)))
 		})
 
 		It("should accept new transactions after bootstrap", func() {
 			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("bank", "charlie", big.NewInt(1000), "USD"),
+				actions.NewPosting("bank", "charlie", big.NewInt(charlieTransfer), "USD"),
 			}, nil, nil)))
 			Expect(err).To(Succeed())
 
 			charlieResp, err := client.GetAccount(ctx, &servicepb.GetAccountRequest{Ledger: ledgerName, Address: "charlie"})
 			Expect(err).To(Succeed())
-			Expect(charlieResp.FindVolume("USD", "").Input).To(Equal("1000"))
+			Expect(charlieResp.FindVolume("USD", "").Input).To(Equal(strconv.Itoa(charlieTransfer)))
 		})
 	})
 })

--- a/tests/e2e/cluster/bootstrap_test.go
+++ b/tests/e2e/cluster/bootstrap_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 		ctx = logging.TestingContext()
 
 		// Start MinIO container
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     bootstrapMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": bootstrapMinioSecretKey,

--- a/tests/e2e/cluster/bootstrap_test.go
+++ b/tests/e2e/cluster/bootstrap_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Bootstrap from backup", Ordered, func() {
 
 	// USD amounts posted to bootstrap-ledger. Phase 3 derives its expected
 	// volumes from these constants instead of restating them as literals, so
-	// adding or changing a posting cannot leave a stale expectation behind.
+	// changing an amount cannot leave a stale expectation behind. Adding a new
+	// bank payout before the backup still needs bankOutput updated by hand.
 	const (
 		bankFunding     = 10000 // world -> bank
 		aliceTransfer   = 3000  // bank -> alice

--- a/tests/e2e/cluster/events_sinks_clickhouse_test.go
+++ b/tests/e2e/cluster/events_sinks_clickhouse_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Events Sinks ClickHouse", Ordered, func() {
 
 	BeforeAll(func() {
 		// Start ClickHouse container
-		container, err := chmodule.Run(context.Background(), "clickhouse/clickhouse-server:24-alpine")
+		container, err := chmodule.Run(context.Background(), testutil.ClickHouseImage)
 		Expect(err).To(Succeed())
 
 		DeferCleanup(func() {

--- a/tests/e2e/cluster/ledgerctl_typed_metadata_test.go
+++ b/tests/e2e/cluster/ledgerctl_typed_metadata_test.go
@@ -132,10 +132,10 @@ var _ = Describe("LedgerctlTypedMetadata", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		// Disable pterm interactive/animated output for test stability
-		pterm.DisableColor()
-		pterm.DisableStyling()
-
+		// pterm's animated output is disabled once for the whole suite in
+		// TestCluster: its settings are package-level globals, so writing them
+		// here would race with a spinner goroutine left running by an earlier
+		// spec's ledgerctl invocation.
 		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort)
 	})
 

--- a/tests/e2e/cluster/ledgerctl_typed_metadata_test.go
+++ b/tests/e2e/cluster/ledgerctl_typed_metadata_test.go
@@ -132,10 +132,8 @@ var _ = Describe("LedgerctlTypedMetadata", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		// pterm's animated output is disabled once for the whole suite in
-		// TestCluster: its settings are package-level globals, so writing them
-		// here would race with a spinner goroutine left running by an earlier
-		// spec's ledgerctl invocation.
+		// pterm output is disabled once for the whole suite in TestCluster. Its
+		// settings are package-level globals, so specs must not mutate them.
 		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort)
 	})
 

--- a/tests/e2e/cluster/restore_idempotency_test.go
+++ b/tests/e2e/cluster/restore_idempotency_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Restore idempotency keys", Ordered, func() {
 	BeforeAll(func() {
 		ctx = logging.TestingContext()
 
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     restoreMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,

--- a/tests/e2e/cluster/restore_metadata_type_test.go
+++ b/tests/e2e/cluster/restore_metadata_type_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Restore typed account metadata", Ordered, func() {
 	BeforeAll(func() {
 		ctx = logging.TestingContext()
 
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     restoreMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,

--- a/tests/e2e/cluster/restore_reversion_test.go
+++ b/tests/e2e/cluster/restore_reversion_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Restore reversion bitset", Ordered, func() {
 	BeforeAll(func() {
 		ctx = logging.TestingContext()
 
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     restoreMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,

--- a/tests/e2e/cluster/restore_stale_cache_test.go
+++ b/tests/e2e/cluster/restore_stale_cache_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Restore stale cache", Ordered, func() {
 	BeforeAll(func() {
 		ctx = logging.TestingContext()
 
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     restoreMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,

--- a/tests/e2e/cluster/restore_test.go
+++ b/tests/e2e/cluster/restore_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Restore", Ordered, func() {
 		ctx = logging.TestingContext()
 
 		// Start MinIO container
-		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
 			testcontainers.WithEnv(map[string]string{
 				"MINIO_ROOT_USER":     restoreMinioAccessKey,
 				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,

--- a/tests/e2e/cluster/suite_test.go
+++ b/tests/e2e/cluster/suite_test.go
@@ -13,9 +13,13 @@ import (
 
 func TestCluster(t *testing.T) {
 	// pterm keeps its output settings in package-level globals. Set them once,
-	// before any spec can start a printer. Keep styling enabled: RawOutput makes
-	// SpinnerPrinter.Stop return without stopping its goroutine. Disabling output
-	// suppresses test noise while preserving the normal spinner lifecycle.
+	// here, before any spec can start a printer. DisableOutput is preferred over
+	// DisableStyling because DisableStyling also sets RawOutput, which makes
+	// SpinnerPrinter.Stop return without stopping its goroutine. This only
+	// suppresses test noise; it does not by itself fix the spinner lifecycle,
+	// because cmd/ledgerctl/cmdutil is linked into this binary and its init sets
+	// RawOutput whenever stdout is not a terminal, which is always so under
+	// go test.
 	pterm.DisableColor()
 	pterm.DisableOutput()
 

--- a/tests/e2e/cluster/suite_test.go
+++ b/tests/e2e/cluster/suite_test.go
@@ -12,13 +12,12 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-	// pterm keeps its styling settings in package-level globals, and any
-	// ledgerctl command the suite invokes reads them from a spinner goroutine
-	// that outlives the call. Setting them from inside a spec therefore races
-	// against a spinner started by an earlier spec. Do it once, before any
-	// spec runs, so no goroutine can be reading them concurrently.
+	// pterm keeps its output settings in package-level globals. Set them once,
+	// before any spec can start a printer. Keep styling enabled: RawOutput makes
+	// SpinnerPrinter.Stop return without stopping its goroutine. Disabling output
+	// suppresses test noise while preserving the normal spinner lifecycle.
 	pterm.DisableColor()
-	pterm.DisableStyling()
+	pterm.DisableOutput()
 
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(5 * time.Second)

--- a/tests/e2e/cluster/suite_test.go
+++ b/tests/e2e/cluster/suite_test.go
@@ -8,9 +8,18 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pterm/pterm"
 )
 
 func TestCluster(t *testing.T) {
+	// pterm keeps its styling settings in package-level globals, and any
+	// ledgerctl command the suite invokes reads them from a spinner goroutine
+	// that outlives the call. Setting them from inside a spec therefore races
+	// against a spinner started by an earlier spec. Do it once, before any
+	// spec runs, so no goroutine can be reading them concurrently.
+	pterm.DisableColor()
+	pterm.DisableStyling()
+
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(5 * time.Second)
 	RegisterFailHandler(Fail)

--- a/tests/e2e/testutil/containers.go
+++ b/tests/e2e/testutil/containers.go
@@ -5,6 +5,13 @@ const (
 	// gate. Mutable latest tags would let an external release break that gate.
 	AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.36.0"
 
+	// ClickHouseImage is pinned for the same reason as AzuriteImage: the
+	// clickhouse-tagged suite is part of the required full-tag CI gate, and the
+	// mutable 24-alpine series tag could move under it at any time. This is the
+	// exact version that tag resolves to today (v24.10.2.80-stable, identical
+	// amd64 manifest), so pinning it changes nothing the gate already runs.
+	ClickHouseImage = "clickhouse/clickhouse-server:24.10.2.80-alpine"
+
 	// MinIOImage matches the version used by the Antithesis fixtures and keeps
 	// every S3-tagged E2E test on one reproducible emulator version.
 	MinIOImage = "minio/minio:RELEASE.2024-06-13T22-53-53Z"

--- a/tests/e2e/testutil/containers.go
+++ b/tests/e2e/testutil/containers.go
@@ -1,0 +1,11 @@
+package testutil
+
+const (
+	// AzuriteImage is pinned because the full-tag E2E suite is a required CI
+	// gate. Mutable latest tags would let an external release break that gate.
+	AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.36.0"
+
+	// MinIOImage matches the version used by the Antithesis fixtures and keeps
+	// every S3-tagged E2E test on one reproducible emulator version.
+	MinIOImage = "minio/minio:RELEASE.2024-06-13T22-53-53Z"
+)

--- a/tests/e2e/testutil/server.go
+++ b/tests/e2e/testutil/server.go
@@ -330,6 +330,44 @@ func StopServers(ctx context.Context, servers []*ServiceWithClient) {
 	}
 }
 
+// assertPortsAvailableForNode fails the spec when an auxiliary node would bind
+// a port belonging to the shared single-node server. In the business suite that
+// server is started once by SynchronizedBeforeSuite and stays up for the whole
+// run, so any overlap is fatal rather than merely untidy.
+//
+// The Raft port is the trap: SetupSingleNode derives it as grpcPort-1000, so a
+// caller who picks gRPC 16200 lands on Raft 15200 — TestSingleHTTPPort. The
+// server then dies with an opaque "bind: address already in use" panic raised
+// deep in the boot path, which aborts the suite and buries the spec that was
+// actually failing. Fail here instead, naming the offending constant.
+//
+// The shared node itself legitimately owns these ports, so it is exempt.
+func assertPortsAvailableForNode(httpPort, grpcPort, raftPort int) {
+	if httpPort == TestSingleHTTPPort && grpcPort == TestSingleGRPCPort {
+		return
+	}
+
+	reserved := map[int]string{
+		TestSingleHTTPPort:        "TestSingleHTTPPort",
+		TestSingleGRPCPort:        "TestSingleGRPCPort",
+		TestSingleGRPCPort - 1000: "the shared node's derived Raft port",
+	}
+
+	for _, p := range []struct {
+		value int
+		label string
+	}{
+		{httpPort, "HTTP port"},
+		{grpcPort, "gRPC port"},
+		{raftPort, fmt.Sprintf("Raft port (derived from gRPC port %d minus 1000)", grpcPort)},
+	} {
+		name, clashes := reserved[p.value]
+		Expect(clashes).To(BeFalse(), fmt.Sprintf(
+			"%s %d is reserved for the shared single-node server (%s); pick another port",
+			p.label, p.value, name))
+	}
+}
+
 // SetupSingleNode creates a single-node cluster for tests that don't need Raft consensus.
 // Returns the context, client, and cluster client.
 // Cleanup is handled automatically via DeferCleanup.
@@ -345,6 +383,8 @@ func SetupSingleNode(httpPort, grpcPort int, extraInstruments ...testservice.Ins
 
 	// Derive Raft port from gRPC port (e.g., 8100 -> 7100)
 	raftPort := grpcPort - 1000
+
+	assertPortsAvailableForNode(httpPort, grpcPort, raftPort)
 
 	instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
 		NodeID:    1,

--- a/tests/e2e/testutil/server.go
+++ b/tests/e2e/testutil/server.go
@@ -342,9 +342,9 @@ func StopServers(ctx context.Context, servers []*ServiceWithClient) {
 // actually failing. Fail here instead, naming the offending constant.
 //
 // The shared node itself legitimately owns these ports, so it is exempt.
-func assertPortsAvailableForNode(httpPort, grpcPort, raftPort int) {
+func nodePortConflict(httpPort, grpcPort, raftPort int) error {
 	if httpPort == TestSingleHTTPPort && grpcPort == TestSingleGRPCPort {
-		return
+		return nil
 	}
 
 	reserved := map[int]string{
@@ -362,10 +362,18 @@ func assertPortsAvailableForNode(httpPort, grpcPort, raftPort int) {
 		{raftPort, fmt.Sprintf("Raft port (derived from gRPC port %d minus 1000)", grpcPort)},
 	} {
 		name, clashes := reserved[p.value]
-		Expect(clashes).To(BeFalse(), fmt.Sprintf(
-			"%s %d is reserved for the shared single-node server (%s); pick another port",
-			p.label, p.value, name))
+		if clashes {
+			return fmt.Errorf(
+				"%s %d is reserved for the shared single-node server (%s); pick another port",
+				p.label, p.value, name)
+		}
 	}
+
+	return nil
+}
+
+func assertPortsAvailableForNode(httpPort, grpcPort, raftPort int) {
+	Expect(nodePortConflict(httpPort, grpcPort, raftPort)).NotTo(HaveOccurred())
 }
 
 // SetupSingleNode creates a single-node cluster for tests that don't need Raft consensus.

--- a/tests/e2e/testutil/server_test.go
+++ b/tests/e2e/testutil/server_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodePortConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		httpPort    int
+		grpcPort    int
+		raftPort    int
+		errContains string
+	}{
+		{
+			name:     "shared node owns its reserved ports",
+			httpPort: TestSingleHTTPPort,
+			grpcPort: TestSingleGRPCPort,
+			raftPort: TestSingleGRPCPort - 1000,
+		},
+		{
+			name:     "auxiliary node uses distinct ports",
+			httpPort: 18000,
+			grpcPort: 18100,
+			raftPort: 17100,
+		},
+		{
+			name:        "HTTP port collides",
+			httpPort:    TestSingleHTTPPort,
+			grpcPort:    18100,
+			raftPort:    17100,
+			errContains: "HTTP port 15200",
+		},
+		{
+			name:        "gRPC port collides",
+			httpPort:    18000,
+			grpcPort:    TestSingleGRPCPort,
+			raftPort:    17000,
+			errContains: "gRPC port 15100",
+		},
+		{
+			name:        "Raft port collides",
+			httpPort:    16100,
+			grpcPort:    16200,
+			raftPort:    TestSingleHTTPPort,
+			errContains: "Raft port (derived from gRPC port 16200 minus 1000) 15200",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := nodePortConflict(test.httpPort, test.grpcPort, test.raftPort)
+			if test.errContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+			require.ErrorContains(t, err, test.errContains)
+		})
+	}
+}

--- a/tests/e2e/testutil/server_test.go
+++ b/tests/e2e/testutil/server_test.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 package testutil
 
 import (
@@ -38,10 +36,12 @@ func TestNodePortConflict(t *testing.T) {
 			errContains: "HTTP port 15200",
 		},
 		{
+			// raftPort matches what SetupSingleNode derives (grpcPort - 1000),
+			// so the tuple is one the production call site can actually build.
 			name:        "gRPC port collides",
 			httpPort:    18000,
 			grpcPort:    TestSingleGRPCPort,
-			raftPort:    17000,
+			raftPort:    TestSingleGRPCPort - 1000,
 			errContains: "gRPC port 15100",
 		},
 		{
@@ -50,6 +50,28 @@ func TestNodePortConflict(t *testing.T) {
 			grpcPort:    16200,
 			raftPort:    TestSingleHTTPPort,
 			errContains: "Raft port (derived from gRPC port 16200 minus 1000) 15200",
+		},
+		{
+			// The shared node's derived Raft port is reserved too, and nothing
+			// else in this table ever passes 14100 as a port value. An auxiliary
+			// spec picking it for HTTP would collide with the shared node's Raft
+			// listener.
+			name:        "shared node's derived Raft port is reserved",
+			httpPort:    TestSingleGRPCPort - 1000,
+			grpcPort:    18100,
+			raftPort:    17100,
+			errContains: "HTTP port 14100 is reserved for the shared single-node server (the shared node's derived Raft port)",
+		},
+		{
+			// The other gRPC value that slips past the HTTP and gRPC checks and
+			// is only caught on its derived Raft port. 16100 is the live value of
+			// the business suite's s3CredsHTTPPort, so transposing that spec's
+			// HTTP and gRPC constants is the plausible next collision.
+			name:        "Raft port collides via the second uncaught gRPC value",
+			httpPort:    18000,
+			grpcPort:    16100,
+			raftPort:    TestSingleGRPCPort,
+			errContains: "Raft port (derived from gRPC port 16100 minus 1000) 15100",
 		},
 	}
 


### PR DESCRIPTION
## Summary

The restored balance was correct; the E2E fixture was stale. The fixture writes an additional `bank -> eve 500` posting before the second full backup, so the restored bank output is `5500`, not `5000`. The expectations are now derived from named posting amounts so future fixture changes cannot silently leave a frozen total behind.

This PR also makes the full feature-tagged E2E suite a required CI gate and fixes the pre-existing failures that gate exposed.

## CI gap

Before this change, `test-e2e-coverage` ran only with the `e2e` tag. The S3, Azure, NATS, ClickHouse and Databricks specs therefore had no runtime coverage in the required workflow. The gate now runs:

```
e2e,kafka,nats,clickhouse,databricks,s3,azure,pyroscope
```

Databricks specs continue to skip themselves when the environment is not configured.

`just lint` does not pass the `e2e` tag and therefore does not compile these packages. The required full-tag run is responsible for both compilation and runtime assertions.

## Defects fixed while enabling the gate

| Defect | Ticket | Fix |
|---|---|---|
| Stale restored bank balance | EN-1780 | Derive the expected total from the fixture postings |
| pterm global race / leaked spinner lifecycle | EN-1781 | Configure pterm once per suite with `DisableOutput`; keep styling enabled because `RawOutput` makes `SpinnerPrinter.Stop` return without stopping its goroutine |
| Azurite rejects the SDK API version | EN-1782 | Run the blob emulator with `--skipApiVersionCheck` |
| S3 empty-prefix assertion compared `*int32` with `int` | EN-1783 | Assert `listOut.Contents` is empty, which also reports leaked objects directly |
| Deterministic port collision on 15200 | EN-1784 | Reject HTTP, gRPC and derived Raft ports reserved by the shared node before startup; cover the helper with table tests |

The port collision was deterministic arithmetic, not a teardown race: `grpcPort = 16200` derives `raftPort = 15200`, which is the shared single-node HTTP port.

## Reproducible containers

All MinIO and Azurite E2E consumers now use centralized, immutable image pins in `tests/e2e/testutil/containers.go`:

- `minio/minio:RELEASE.2024-06-13T22-53-53Z`
- `mcr.microsoft.com/azure-storage/azurite:3.36.0`

The MinIO version matches the Antithesis fixtures. Emulator upgrades are now explicit code changes validated by the complete gate.

## Validation

- `nix develop --command bash -c "just pre-commit"` — pass, 0 lint issues and no generated-file drift
- `GOROOT= go build ./...` — pass
- `just test-full` — pass with all optional features and the race detector
- Full-tag business suite with coverage and `-race` — pass
- Full-tag cluster suite with coverage and `-race` — pass (329 specs); an initial run hit the existing transient follower-election assertion in `rolling_config_test.go:43`, then the focused test and the complete cluster suite rerun with the exact failing seed both passed
- Focused Azure, S3 credentials and rejected incremental-backup specs against the pinned containers — pass
- GitHub Actions on commit `43b64b694`: Build, Dirty, Tests, Tests-E2E, Tests-Model, Tests-Scenarios, Tests-Schemathesis, Coverage and repository invariants — all pass

## Documentation

`docs/technical/contributing/testing.md` documents the required full-tag gate, the distinction from the light local target, the actual lint coverage, the pinned emulator images and the macOS Docker socket trap.

## Tickets

Fixes https://formance-team.atlassian.net/browse/EN-1780  
Also fixes https://formance-team.atlassian.net/browse/EN-1781  
Also fixes https://formance-team.atlassian.net/browse/EN-1782  
Also fixes https://formance-team.atlassian.net/browse/EN-1783  
Also fixes https://formance-team.atlassian.net/browse/EN-1784
