### PR TITLE
fix(storage): read absent account metadata as empty when filtering as of a pit

### DIFF
--- a/internal/storage/ledger/resource_accounts.go
+++ b/internal/storage/ledger/resource_accounts.go
@@ -41,7 +41,7 @@ func (h accountsResourceHandler) BuildDataset(opts common.RepositoryHandlerBuild
 				`left join (?) accounts_metadata on accounts_metadata.accounts_address = accounts.address`,
 				selectDistinctAccountMetadataHistories,
 			).
-			ColumnExpr("coalesce(accounts_metadata.metadata, '{}'::jsonb) as metadata")
+			ColumnExpr(metadataOrEmpty)
 	} else {
 		ret = ret.ColumnExpr("accounts.metadata")
 	}

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -71,7 +71,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 
 				ret = ret.
 					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-					Column("metadata")
+					ColumnExpr(metadataOrEmpty)
 			} else {
 				subQuery := h.store.newScopedSelect().
 					TableExpr(h.store.GetPrefixedRelationName("accounts")).
@@ -80,7 +80,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 
 				ret = ret.
 					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-					Column("metadata")
+					ColumnExpr(metadataOrEmpty)
 			}
 		}
 

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -114,9 +114,11 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 				subQuery = subQuery.Where("date <= ?", query.PIT)
 			}
 
+			// Stands in an empty object where the join found none, for the reason
+			// metadataOrEmpty documents.
 			selectVolumes = selectVolumes.
 				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-				ColumnExpr("(array_agg(metadata))[1] as metadata")
+				ColumnExpr("coalesce((array_agg(metadata))[1], '{}'::jsonb) as metadata")
 		}
 	}
 

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -64,6 +64,15 @@ func filterAccountAddress(address, key string) string {
 	return strings.Join(parts, " and ")
 }
 
+// metadataOrEmpty projects an account's metadata for a filter to test, standing in
+// an empty object where the join found none. An account can legitimately have no
+// metadata row — none was ever written, or none as of the requested point in time —
+// and metadata a filter cannot find has to read as absent rather than as unknown:
+// on a NULL, a containment test is NULL instead of false and its negation is NULL
+// instead of true, so every such account would be dropped from the result rather
+// than selected by it.
+const metadataOrEmpty = `coalesce(accounts_metadata.metadata, '{}'::jsonb) as metadata`
+
 // collectAddressFilters visits all address filter values (without short-circuiting)
 // and returns the collected addresses and whether any partial address was found.
 func collectAddressFilters(q interface {

--- a/test/e2e/api_pit_metadata_filter_test.go
+++ b/test/e2e/api_pit_metadata_filter_test.go
@@ -1,0 +1,190 @@
+//go:build it
+
+package test_suite
+
+import (
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	. "github.com/formancehq/go-libs/v5/pkg/testing/deferred/ginkgo"
+	"github.com/formancehq/go-libs/v5/pkg/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	"github.com/formancehq/go-libs/v5/pkg/types/pointer"
+
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
+	. "github.com/formancehq/ledger/pkg/testserver"
+	"github.com/formancehq/ledger/pkg/testserver/ginkgo"
+)
+
+// A metadata filter has to select the same accounts on every endpoint that
+// filters accounts, as of a pit as well as now.
+//
+// An account carrying no metadata as of the pit must read as having empty
+// metadata, so a containment test is false for it and a negated one is true. The
+// hazard is the metadata column being left NULL instead: in SQL a containment
+// test against NULL is NULL rather than false, NOT NULL is NULL rather than true,
+// and a WHERE clause keeps only what is true — so every such account silently
+// disappears from the result instead of being selected.
+var _ = Context("Ledger accounts filtered on metadata as of a pit", func() {
+	var (
+		db         = UseTemplatedDatabase()
+		ctx        = logging.TestingContext()
+		testServer = ginkgo.DeferTestServer(
+			DeferMap(db, (*pgtesting.Database).ConnectionOptions),
+			testservice.WithInstruments(
+				testservice.DebugInstrumentation(debug),
+				testservice.OutputInstrumentation(GinkgoWriter),
+			),
+			testservice.WithLogger(GinkgoT()),
+		)
+
+		now = time.Now().UTC().Round(time.Second)
+		// The transactions are effective before the pit and the metadata is written
+		// after it, so as of the pit the accounts exist and none of them carries
+		// metadata.
+		effective = now.Add(-2 * time.Hour)
+		pit       = now.Add(-time.Hour)
+	)
+
+	// Only bank1 ends up tagged, so a filter negating the tag selects bank2 and
+	// world now, and all three as of the pit.
+	notPremium := map[string]any{
+		"$not": map[string]any{
+			"$match": map[string]any{"metadata[category]": "premium"},
+		},
+	}
+	// The same predicate reached through a conjunction, which is where a NULL also
+	// propagates, narrowed to one account so the aggregate is a non-zero number.
+	notPremiumBank1 := map[string]any{
+		"$and": []any{
+			notPremium,
+			map[string]any{"$match": map[string]any{"address": "bank1"}},
+		},
+	}
+
+	BeforeEach(func(specContext SpecContext) {
+		client := Wait(specContext, DeferClient(testServer))
+
+		_, err := client.Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		for _, posting := range []struct {
+			destination string
+			amount      int64
+		}{{"bank1", 100}, {"bank2", 50}} {
+			_, err := client.Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				V2PostTransaction: components.V2PostTransaction{
+					Timestamp: pointer.For(effective),
+					Postings: []components.V2Posting{{
+						Amount:      big.NewInt(posting.amount),
+						Asset:       "USD/2",
+						Source:      "world",
+						Destination: posting.destination,
+					}},
+				},
+			})
+			Expect(err).To(BeNil())
+		}
+
+		// Undated, so the server stamps it now — after the pit.
+		_, err = client.Ledger.V2.AddMetadataToAccount(ctx, operations.V2AddMetadataToAccountRequest{
+			Ledger:      "default",
+			Address:     "bank1",
+			RequestBody: map[string]string{"category": "premium"},
+		})
+		Expect(err).To(BeNil())
+	})
+
+	listAccounts := func(specContext SpecContext, filter map[string]any, at *time.Time) []string {
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger:      "default",
+			Pit:         at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		addresses := make([]string, 0, len(response.V2AccountsCursorResponse.Cursor.Data))
+		for _, account := range response.V2AccountsCursorResponse.Cursor.Data {
+			addresses = append(addresses, account.Address)
+		}
+
+		return addresses
+	}
+
+	listVolumes := func(specContext SpecContext, filter map[string]any, at *time.Time) []string {
+		// The volumes endpoint spells its point in time endTime, which the handler
+		// resolves to the same PIT the other two take.
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetVolumesWithBalances(ctx, operations.V2GetVolumesWithBalancesRequest{
+			Ledger:      "default",
+			EndTime:     at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		accounts := make([]string, 0, len(response.V2VolumesWithBalanceCursorResponse.Cursor.Data))
+		for _, volumes := range response.V2VolumesWithBalanceCursorResponse.Cursor.Data {
+			accounts = append(accounts, volumes.Account)
+		}
+
+		return accounts
+	}
+
+	aggregate := func(specContext SpecContext, filter map[string]any, at *time.Time) map[string]*big.Int {
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetBalancesAggregated(ctx, operations.V2GetBalancesAggregatedRequest{
+			Ledger:      "default",
+			Pit:         at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		return response.V2AggregateBalancesResponse.Data
+	}
+
+	When("no account carries the metadata yet", func() {
+		It("should select every account on all three endpoints", func(specContext SpecContext) {
+			Expect(listAccounts(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(listVolumes(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			// Every account is selected, so the aggregate is the whole ledger: the
+			// asset is reported and nets to zero.
+			Expect(aggregate(specContext, notPremium, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(0)}))
+		})
+
+		It("should select the account a conjunction narrows to on all three endpoints", func(specContext SpecContext) {
+			Expect(listAccounts(specContext, notPremiumBank1, &pit)).To(ConsistOf("bank1"))
+			Expect(listVolumes(specContext, notPremiumBank1, &pit)).To(ConsistOf("bank1"))
+			Expect(aggregate(specContext, notPremiumBank1, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(100)}))
+		})
+
+		It("should report an absent key as absent rather than unknown", func(specContext SpecContext) {
+			// $exists compiles to a null check instead of a containment test, so it is
+			// false for an account with no metadata either way. It pins the contrast:
+			// only the containment form can turn into NULL.
+			existsFilter := map[string]any{
+				"$not": map[string]any{"$exists": map[string]any{"metadata": "category"}},
+			}
+
+			Expect(listAccounts(specContext, existsFilter, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(listVolumes(specContext, existsFilter, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(aggregate(specContext, existsFilter, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(0)}))
+		})
+	})
+
+	// Same filters without a pit, where the metadata column comes straight from the
+	// accounts table and can never be NULL. This isolates the pit as the variable:
+	// it has to pass whether or not the pit paths coalesce.
+	When("the metadata is in place and no pit is given", func() {
+		It("should exclude the tagged account on all three endpoints", func(specContext SpecContext) {
+			Expect(listAccounts(specContext, notPremium, nil)).To(ConsistOf("bank2", "world"))
+			Expect(listVolumes(specContext, notPremium, nil)).To(ConsistOf("bank2", "world"))
+			Expect(aggregate(specContext, notPremium, nil)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(-100)}))
+		})
+	})
+})


### PR DESCRIPTION
Fixes EN-1794.

## Bug

As of a `pit`, `GET /volumes` and `GET /aggregate/balances` silently drop **every** account carrying no metadata at that point, when the filter negates a metadata containment test. `GET /accounts` handles the same filter correctly. All three return `200`, so a balance endpoint answers with a wrong number and no warning.

Seed a ledger with two **backdated** transactions and one metadata write:

```
POST /v2/probe/transactions  {"timestamp":"2020-06-01T00:00:00Z",
                              "postings":[{"source":"world","destination":"a1","amount":100,"asset":"USD/2"}]}
POST /v2/probe/transactions  {"timestamp":"2020-07-01T00:00:00Z",
                              "postings":[{"source":"world","destination":"a2","amount":50,"asset":"USD/2"}]}
POST /v2/probe/accounts/a1/metadata   {"tag":"x"}
```

The metadata write takes no date, so the server stamps it now. Then one filter, three endpoints, same pit:

```
query = {"$not":{"$match":{"metadata[tag]":"x"}}}     pit = 2021-01-01T00:00:00Z
```

All three accounts are correct: the transactions are visible as of 2021, and no account has metadata then.

| request | response | |
| --- | --- | --- |
| `GET /accounts?pit=…&query=…` | `['a1','a2','world']` | correct |
| `GET /volumes?pit=…&query=…` | `[]` | **wrong** |
| `GET /aggregate/balances?pit=…&query=…` | `{"data":{}}` | **wrong** |

Also affected: filters combining the containment test with `$and`/`$or` instead of negating it. Not affected: the `$exists` form, and any filter without a pit.

## Cause

The filter compiles to `metadata @> '{"tag":"x"}'` under a `NOT`, so everything rides on the `metadata` column for an account with no metadata as of the pit. All three resources left-join the metadata history restricted to `date <= pit`, find no row, and get NULL. Only the accounts resource coalesced it:

```go
// internal/storage/ledger/resource_accounts.go:44          <- correct
ColumnExpr("coalesce(accounts_metadata.metadata, '{}'::jsonb) as metadata")

// internal/storage/ledger/resource_aggregated_balances.go:73-74
Join(`left join lateral (?) accounts_metadata on true`, subQuery).
    Column("metadata")

// internal/storage/ledger/resource_volumes.go:119
ColumnExpr("(array_agg(metadata))[1] as metadata")
```

Coalesced: `'{}' @> '{"tag":"x"}'` is false, `NOT false` is true, row kept. Not coalesced: `NULL @> …` is NULL, `NOT NULL` is NULL, and `WHERE` keeps only what is true — the account disappears. NULL also propagates through `$and`/`$or`, which is why merely combining the test is enough and an explicit negation isn't required.

Two things kept it quiet. `$exists` compiles to `metadata -> 'tag' is not null`, which is plain false on NULL, so the neighbouring case looks fine. And without a pit all three read `accounts.metadata`, which is NOT NULL.

## Fix

Coalesce the projected metadata to `'{}'::jsonb` in `resource_volumes.go` and both branches of `resource_aggregated_balances.go`. The expression moves to a shared `metadataOrEmpty` in `utils.go`, which `resource_accounts.go` now uses too, so the three agree by construction. Four lines of behaviour change.

## Test

`test/e2e/api_pit_metadata_filter_test.go` sends one filter to all three endpoints:

1. Negated metadata match as of a pit — all three must select every account.
2. The same predicate through an `$and`, narrowed to one account so the aggregate is a non-zero number — covers NULL propagation, not just explicit negation.
3. The `$exists` form, pinning the contrast: a null check can never become NULL.
4. The same filters with no pit, isolating the pit as the variable.

Specs 3 and 4 are the control. 1 & 2 go red → green with this fix. Full e2e, unit, and storage integration suites green.

## Scope

`release/v2.4` and `release/v2.3` carry the identical shape (checked against `v2.4.12` and `v2.3.22`), so both are backport candidates — not included here.

## Found by

The v2 model-based conformance harness (DST), adding an aggregated-balances oracle. That oracle now generates metadata filters under a pit, so the class stays covered: against a build without this fix it goes red in 50–96s at 8 workers (three runs).
