### PR TITLE
fix(storage): read absent account metadata as empty when filtering as of a pit (v2.3 backport)

### DIFF
--- a/internal/storage/ledger/resource_accounts.go
+++ b/internal/storage/ledger/resource_accounts.go
@@ -47,7 +47,7 @@ func (h accountsResourceHandler) BuildDataset(opts common.RepositoryHandlerBuild
 				`left join (?) accounts_metadata on accounts_metadata.accounts_address = accounts.address`,
 				selectDistinctAccountMetadataHistories,
 			).
-			ColumnExpr("coalesce(accounts_metadata.metadata, '{}'::jsonb) as metadata")
+			ColumnExpr(metadataOrEmpty)
 	} else {
 		ret = ret.ColumnExpr("accounts.metadata")
 	}

--- a/internal/storage/ledger/resource_aggregated_balances.go
+++ b/internal/storage/ledger/resource_aggregated_balances.go
@@ -72,7 +72,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 
 				ret = ret.
 					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-					Column("metadata")
+					ColumnExpr(metadataOrEmpty)
 			} else {
 				subQuery := h.store.newScopedSelect().
 					TableExpr(h.store.GetPrefixedRelationName("accounts")).
@@ -81,7 +81,7 @@ func (h aggregatedBalancesResourceRepositoryHandler) BuildDataset(query common.R
 
 				ret = ret.
 					Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-					Column("metadata")
+					ColumnExpr(metadataOrEmpty)
 			}
 		}
 

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -115,6 +115,12 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 				ColumnExpr("first_value(metadata) over (partition by accounts_address order by revision desc) as metadata").
 				Where("accounts_metadata.accounts_address = moves.accounts_address")
 
+			// A filter as of a point in time tests the metadata as it stood then,
+			// so later revisions are out of scope.
+			if query.UsePIT() {
+				subQuery = subQuery.Where("date <= ?", query.PIT)
+			}
+
 			selectVolumes = selectVolumes.
 				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
 				ColumnExpr("(array_agg(metadata))[1] as metadata")

--- a/internal/storage/ledger/resource_volumes.go
+++ b/internal/storage/ledger/resource_volumes.go
@@ -121,9 +121,11 @@ func (h volumesResourceHandler) BuildDataset(query common.RepositoryHandlerBuild
 				subQuery = subQuery.Where("date <= ?", query.PIT)
 			}
 
+			// Stands in an empty object where the join found none, for the reason
+			// metadataOrEmpty documents.
 			selectVolumes = selectVolumes.
 				Join(`left join lateral (?) accounts_metadata on true`, subQuery).
-				ColumnExpr("(array_agg(metadata))[1] as metadata")
+				ColumnExpr("coalesce((array_agg(metadata))[1], '{}'::jsonb) as metadata")
 		}
 	}
 

--- a/internal/storage/ledger/utils.go
+++ b/internal/storage/ledger/utils.go
@@ -49,6 +49,15 @@ func filterAccountAddress(address, key string) string {
 	return strings.Join(parts, " and ")
 }
 
+// metadataOrEmpty projects an account's metadata for a filter to test, standing in
+// an empty object where the join found none. An account can legitimately have no
+// metadata row — none was ever written, or none as of the requested point in time —
+// and metadata a filter cannot find has to read as absent rather than as unknown:
+// on a NULL, a containment test is NULL instead of false and its negation is NULL
+// instead of true, so every such account would be dropped from the result rather
+// than selected by it.
+const metadataOrEmpty = `coalesce(accounts_metadata.metadata, '{}'::jsonb) as metadata`
+
 // collectAddressFilters visits all address filter values (without short-circuiting)
 // and returns the collected addresses and whether any partial address was found.
 func collectAddressFilters(q interface{ UseFilter(string, ...func(any) bool) bool }) ([]string, bool) {

--- a/test/e2e/api_pit_metadata_filter_test.go
+++ b/test/e2e/api_pit_metadata_filter_test.go
@@ -171,4 +171,53 @@ var _ = Context("Ledger accounts filtered on metadata as of a pit", func() {
 			Expect(aggregate(specContext, notPremium, nil)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(-100)}))
 		})
 	})
+
+	// The pit falls between the transactions' effective date and the moment they
+	// were written, so the accounts are visible while no metadata revision is —
+	// not even the empty one an account starts out with, which is dated when the
+	// account is created. The filter has to read metadata it cannot find as
+	// metadata the account does not carry, rather than as metadata it might.
+	When("no metadata revision exists as of the pit", func() {
+		pit := time.Now().UTC().Add(-time.Hour)
+
+		BeforeEach(func(specContext SpecContext) {
+			fund(specContext)
+			tag(specContext, "bank1", map[string]string{"category": "premium"})
+		})
+
+		It("should select every account on all three endpoints", func(specContext SpecContext) {
+			Expect(listAccounts(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(listVolumes(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(aggregate(specContext, notPremium, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(0)}))
+		})
+
+		It("should select the account a conjunction narrows to on all three endpoints", func(specContext SpecContext) {
+			// The same predicate reached through a conjunction, which is where an
+			// unknown also propagates, narrowed so the aggregate is a non-zero number
+			// rather than a conservation zero.
+			narrowed := map[string]any{
+				"$and": []any{
+					notPremium,
+					map[string]any{"$match": map[string]any{"address": "bank1"}},
+				},
+			}
+
+			Expect(listAccounts(specContext, narrowed, &pit)).To(ConsistOf("bank1"))
+			Expect(listVolumes(specContext, narrowed, &pit)).To(ConsistOf("bank1"))
+			Expect(aggregate(specContext, narrowed, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(100)}))
+		})
+
+		It("should report an absent key as absent rather than unknown", func(specContext SpecContext) {
+			// An existence check is a null check, so it is false for an account with
+			// no metadata either way. It pins the contrast: only a containment test
+			// can turn into an unknown.
+			existsFilter := map[string]any{
+				"$not": map[string]any{"$exists": map[string]any{"metadata": "category"}},
+			}
+
+			Expect(listAccounts(specContext, existsFilter, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(listVolumes(specContext, existsFilter, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(aggregate(specContext, existsFilter, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(0)}))
+		})
+	})
 })

--- a/test/e2e/api_pit_metadata_filter_test.go
+++ b/test/e2e/api_pit_metadata_filter_test.go
@@ -1,0 +1,174 @@
+//go:build it
+
+package test_suite
+
+import (
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
+	. "github.com/formancehq/go-libs/v3/testing/deferred/ginkgo"
+	"github.com/formancehq/go-libs/v3/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v3/testing/testservice"
+
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
+	. "github.com/formancehq/ledger/pkg/testserver"
+	"github.com/formancehq/ledger/pkg/testserver/ginkgo"
+)
+
+// A metadata filter has to select the same accounts on every endpoint that filters
+// accounts, and as of a pit it has to test the metadata as it stood at that point.
+var _ = Context("Ledger accounts filtered on metadata as of a pit", func() {
+	var (
+		db         = UseTemplatedDatabase()
+		ctx        = logging.TestingContext()
+		testServer = ginkgo.DeferTestServer(
+			DeferMap(db, (*pgtesting.Database).ConnectionOptions),
+			testservice.WithInstruments(
+				testservice.DebugInstrumentation(debug),
+				testservice.OutputInstrumentation(GinkgoWriter),
+			),
+			testservice.WithLogger(GinkgoT()),
+		)
+	)
+
+	// A filter negating the tag selects every account as of a point before the tag
+	// was written, and only the untagged ones after it.
+	notPremium := map[string]any{
+		"$not": map[string]any{
+			"$match": map[string]any{"metadata[category]": "premium"},
+		},
+	}
+	premium := map[string]any{
+		"$match": map[string]any{"metadata[category]": "premium"},
+	}
+
+	// Two accounts funded well before any pit these specs use, so the accounts and
+	// their volumes are visible throughout and only metadata is in question.
+	fund := func(specContext SpecContext) {
+		client := Wait(specContext, DeferClient(testServer))
+
+		_, err := client.Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		for _, posting := range []struct {
+			destination string
+			amount      int64
+		}{{"bank1", 100}, {"bank2", 50}} {
+			_, err := client.Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+				Ledger: "default",
+				V2PostTransaction: components.V2PostTransaction{
+					Timestamp: pointer.For(time.Now().UTC().Add(-2 * time.Hour)),
+					Postings: []components.V2Posting{{
+						Amount:      big.NewInt(posting.amount),
+						Asset:       "USD/2",
+						Source:      "world",
+						Destination: posting.destination,
+					}},
+				},
+			})
+			Expect(err).To(BeNil())
+		}
+	}
+
+	tag := func(specContext SpecContext, address string, metadata map[string]string) {
+		_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.AddMetadataToAccount(ctx, operations.V2AddMetadataToAccountRequest{
+			Ledger:      "default",
+			Address:     address,
+			RequestBody: metadata,
+		})
+		Expect(err).To(BeNil())
+	}
+
+	listAccounts := func(specContext SpecContext, filter map[string]any, at *time.Time) []string {
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger:      "default",
+			Pit:         at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		addresses := make([]string, 0, len(response.V2AccountsCursorResponse.Cursor.Data))
+		for _, account := range response.V2AccountsCursorResponse.Cursor.Data {
+			addresses = append(addresses, account.Address)
+		}
+
+		return addresses
+	}
+
+	listVolumes := func(specContext SpecContext, filter map[string]any, at *time.Time) []string {
+		// The volumes endpoint spells its point in time endTime, which the handler
+		// resolves to the same PIT the other two take.
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetVolumesWithBalances(ctx, operations.V2GetVolumesWithBalancesRequest{
+			Ledger:      "default",
+			EndTime:     at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		accounts := make([]string, 0, len(response.V2VolumesWithBalanceCursorResponse.Cursor.Data))
+		for _, volumes := range response.V2VolumesWithBalanceCursorResponse.Cursor.Data {
+			accounts = append(accounts, volumes.Account)
+		}
+
+		return accounts
+	}
+
+	aggregate := func(specContext SpecContext, filter map[string]any, at *time.Time) map[string]*big.Int {
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.GetBalancesAggregated(ctx, operations.V2GetBalancesAggregatedRequest{
+			Ledger:      "default",
+			Pit:         at,
+			RequestBody: filter,
+		})
+		Expect(err).To(BeNil())
+
+		return response.V2AggregateBalancesResponse.Data
+	}
+
+	// Every account is tagged before the pit, so none of them lacks a metadata row
+	// and the only question is whether a revision written afterwards is in scope.
+	When("a metadata revision is written after the pit", func() {
+		var pit time.Time
+
+		BeforeEach(func(specContext SpecContext) {
+			fund(specContext)
+
+			for _, address := range []string{"world", "bank1", "bank2"} {
+				tag(specContext, address, map[string]string{"tier": "basic"})
+			}
+
+			pit = time.Now().UTC()
+			// Wide enough that the revision below is unambiguously after the pit.
+			time.Sleep(time.Second)
+
+			tag(specContext, "bank1", map[string]string{"category": "premium"})
+		})
+
+		It("should not see the later revision on any endpoint", func(specContext SpecContext) {
+			Expect(listAccounts(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			Expect(listVolumes(specContext, notPremium, &pit)).To(ConsistOf("bank1", "bank2", "world"))
+			// Every account is selected, so the aggregate is the whole ledger and
+			// nets to zero.
+			Expect(aggregate(specContext, notPremium, &pit)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(0)}))
+
+			Expect(listAccounts(specContext, premium, &pit)).To(BeEmpty())
+			Expect(listVolumes(specContext, premium, &pit)).To(BeEmpty())
+			Expect(aggregate(specContext, premium, &pit)).To(BeEmpty())
+		})
+
+		It("should see it with no pit", func(specContext SpecContext) {
+			// The control: without a pit the revision is in scope everywhere, which
+			// holds whether or not a pit is resolved correctly.
+			Expect(listAccounts(specContext, notPremium, nil)).To(ConsistOf("bank2", "world"))
+			Expect(listVolumes(specContext, notPremium, nil)).To(ConsistOf("bank2", "world"))
+			Expect(aggregate(specContext, notPremium, nil)).To(Equal(map[string]*big.Int{"USD/2": big.NewInt(-100)}))
+		})
+	})
+})


### PR DESCRIPTION
Backport of #1709 to `release/v2.3`. Fixes EN-1794 on this line.

**Two commits, because the coalesce alone is not enough here.** Reviewable in order:

1. `fix(storage): restrict the volumes metadata filter to the point in time` — a backport this line never received.
2. `fix(storage): read absent account metadata as empty when filtering as of a pit` — the #1709 fix itself.

Each is independently tested and green, so the intermediate commit is not broken. The e2e test is also written for this line's conventions (go-libs v3).

## Commit 1 — the backport this line missed

`43bcdb4ef` ("fix: consider PIT in /volumes account metadata filter", #1208) landed on `main` on 2026-01-05. `release/v2.4` branched on 2026-03-16, so it inherited the fix. This line branched on 2025-07-18, six months before it, so it could only get the fix by an explicit backport — and never did. The backport was written: `5abd76420` ("fix dead code, backport /volumes PIT fix", 2026-01-22) carries exactly these files, but it lives inside the branch behind #1207, which was closed unmerged, and went with it. No PR based on `release/v2.3` has ever contained it.

Without it, a metadata filter on `/volumes` reads the newest revision of an account's metadata whatever point in time is asked for, so an account tagged *after* the pit is tested against a tag it did not carry then, and a filter negating that tag excludes it. `/accounts` and `/aggregate/balances` already restrict the history to the pit.

```go
if query.UsePIT() {
    subQuery = subQuery.Where("date <= ?", query.PIT)
}
```

Reviewers should note this is a behaviour change on a release line: a metadata filter combined with `endTime`/`startTime` on `/volumes` now evaluates metadata as of that time rather than as of now. That matches `/accounts`, `/aggregate/balances`, and both newer lines.

Its two specs tag **every** account before the pit, so no account is missing a metadata revision and the later revision is the only variable. One of the two fails without this commit.

## Commit 2 — the bug from #1709

As of a `pit`, `GET /volumes` and `GET /aggregate/balances` silently drop **every** account with no metadata revision at that point, when the filter negates a metadata containment test. `GET /accounts` handles the same filter correctly. All three return `200`, so a balance endpoint answers with a wrong number and no warning.

Also affected: filters combining the containment test with `$and`/`$or` instead of negating it. Not affected: the `$exists` form, and any filter without a pit.

### Cause

All three resources left-join the metadata history, find no row for such an account, and get NULL. Only the accounts resource coalesced it to `'{}'`.

Coalesced: `'{}' @> '{"category":"premium"}'` is false, `NOT false` is true, row kept. Not coalesced: `NULL @> …` is NULL, `NOT NULL` is NULL, and `WHERE` keeps only what is true — the account disappears. NULL also propagates through `$and`/`$or`, which is why merely combining the test is enough.

`$exists` escapes because it compiles to `metadata -> 'category' is not null`, plain false on NULL. Without a pit all three read `accounts.metadata`, which is NOT NULL.

### Fix

Coalesce the projected metadata to `'{}'::jsonb` in `resource_volumes.go` and both branches of `resource_aggregated_balances.go`, sharing the expression with `resource_accounts.go` as `metadataOrEmpty` in `utils.go`.

### Reaching the NULL

An account starts out with an **empty metadata revision dated when it is created**, so simply never tagging an account is not enough to produce the NULL — that empty revision would be found. The specs therefore back-date the transactions two hours and read as of a point between their effective date and the moment they were written: the accounts are visible, no revision is. Two of the three specs fail without this commit; the third is the `$exists` contrast, which must pass either way.

## Verification

Focused specs 5/5. Commit 1's specs: 1 of 2 red without commit 1. Commit 2's specs: 2 of 3 red without commit 2 (with commit 1 in place). Full e2e, unit, and storage integration suites green on `release/v2.3`.
