### PR TITLE
docs: add concise pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## What changed
+
+<!-- Describe the change in 2–5 lines. Focus on behavior and scope, not implementation history. -->
+
+## Why
+
+<!-- What problem does this solve? Link the issue/spec when relevant. -->
+
+## Risk
+
+<!-- Choose one and briefly justify MEDIUM/HIGH. -->
+
+**LOW | MEDIUM | HIGH**
+
+## Validation
+
+<!-- Keep only checks that actually ran. Add targeted tests when relevant. -->
+
+- [ ] `bash scripts/agent-check`
+- [ ] Targeted tests: N/A
+- [ ] Full suite / broader validation: N/A
+
+## Architecture / behavior impact
+
+<!-- N/A if none. Otherwise call out persisted state, FSM/Raft, API, storage, compatibility, or operational impact. -->
+
+N/A
+
+## Review focus
+
+<!-- Tell reviewers where judgment is most valuable. Avoid generic "please review everything". -->
+
+## Known concerns
+
+<!-- None, or list unresolved risks/tradeoffs explicitly. Do not hide a known concern behind passing CI. -->
+
+None


### PR DESCRIPTION
## Summary

Add a compact pull request template focused on making contributions immediately reviewable.

The template asks authors to provide:

- a short description of what changed and why
- an explicit risk level
- validation actually performed
- architecture / behavior impact when relevant
- a focused request for reviewer attention
- unresolved concerns instead of hiding them behind green CI

Guidance is kept in HTML comments so completed PR descriptions stay concise.

## Scope

Template only. No bot automation, PR ownership enforcement, CI checks, or auto-fix/re-review loop in this PR.

## Why

The repository now has an AI review contract and executable agent validation. The next step is to standardize the author-to-reviewer handoff so reviewers do not have to reconstruct intent, risk, validation, and review focus from the diff.
