### PR TITLE
docs: add concise pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Risk
 
-<!-- Choose one and briefly justify MEDIUM/HIGH. -->
+<!-- Choose one and briefly justify the selected level. -->
 
 **LOW | MEDIUM | HIGH**
 
@@ -16,7 +16,7 @@
 
 <!-- Keep only checks that actually ran. Add targeted tests when relevant. -->
 
-- [ ] `bash scripts/agent-check`
+- [ ] Baseline validation: N/A
 - [ ] Targeted tests: N/A
 - [ ] Full suite / broader validation: N/A
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## What changed
+
+<!-- Describe the change in 2–5 lines. Focus on behavior and scope, not implementation history. -->
+
+## Why
+
+<!-- What problem does this solve? Link the issue/spec when relevant. -->
+
+## Risk
+
+<!-- Choose one and briefly justify MEDIUM/HIGH. -->
+
+**LOW | MEDIUM | HIGH**
+
+## Validation
+
+<!-- Keep only checks that actually ran. Add targeted tests when relevant. -->
+
+- [ ] `bash scripts/agent-check`
+- [ ] Targeted tests: N/A
+- [ ] Full suite / broader validation: N/A
+
+## Architecture / behavior impact
+
+<!-- N/A if none. Otherwise call out persisted state, FSM/Raft, API, storage, compatibility, or operational impact. -->
+
+N/A
+
+## Review focus
+
+<!-- Tell reviewers where judgment is most valuable. Avoid generic "please review everything". -->
+
+## Known concerns
+
+<!-- None, or list unresolved risks/tradeoffs explicitly. Do not hide a known concern behind passing CI. -->
+
+None


### PR DESCRIPTION
## What changed

Adds the concise pull request template introduced by #1715 to the repository's default branch.

## Why

GitHub only makes pull request templates available when they exist on the default branch. The original PR targets `release/v3.0`, while this repository's default branch is `main`; this dedicated backport makes the template effective for contributors.

## Impact

Contributor workflow only. No runtime, API, storage, or build behavior changes.

## Validation

- Verified the branch starts from the current `origin/main`.
- Verified the staged and committed diff contains only `.github/pull_request_template.md`.
- Ran `git diff --check`.
- Ran GitNexus change detection; no code symbols or execution flows are affected.
- `scripts/agent-check` is not present on `main`.

## Related

- #1715
