### PR TITLE
docs(agents): require incremental restore parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ These are guardrails, not complete explanations. Before changing the affected su
 8. **Audit is business truth:** the audit chain is authoritative. New persisted primary-store projections must be checker-verified or have an explicitly documented valid exemption.
 9. **Never bypass the coverage gate:** use the scoped/gated cache APIs in order/TU handlers; never read the parent registry/key store directly from the FSM path.
 10. **Accepted orders are immutable until audit capture:** do not mutate business payloads, including indirectly through aliased maps/slices/messages. Only the explicitly technical order fields are outside business-intent hashing.
+11. **Incremental restore parity:** every committed effect intended to survive a cross-cluster restore must be preserved by the checkpoint or reconstructed from the exported delta. Changes to persisted state, audited orders, or deletion cascades must classify their restore behavior and prove it with a non-empty post-checkpoint delta. See [the incremental restore contract](docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md).
 
 Required reading for FSM/cache/preload work:
 - `docs/technical/architecture/subsystems/fsm/`
@@ -48,6 +49,7 @@ Required reading for FSM/cache/preload work:
 Required reading for persisted projections/checker work:
 - `docs/technical/architecture/subsystems/checker/`
 - `docs/technical/architecture/audit-vs-technical-state.md`
+- `docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md` when the projection changes during audited apply or another lifecycle path covered by incremental backup
 
 The pre-refactor, fully expanded instruction set is retained temporarily at `docs/technical/agent-reference-legacy.md` for migration safety. It is **reference material, not automatically loaded context**. If a rule in this file or current subsystem documentation conflicts with that legacy snapshot, the current file/subsystem documentation wins.
 

--- a/docs/technical/agent-context.md
+++ b/docs/technical/agent-context.md
@@ -34,6 +34,7 @@ When current code and authoritative documentation disagree, stop treating the do
 | `internal/adapter/http/**`, `openapi.yml` | `docs/technical/architecture/subsystems/api/`, `docs/technical/contributing/api-comparison.md` |
 | `internal/infra/node/**`, `internal/infra/transport/**`, `internal/infra/membership/**` | `docs/technical/architecture/subsystems/consensus/` |
 | `internal/infra/coldstorage/**`, `internal/infra/receipt/**`, `internal/application/backup/**` | `docs/technical/architecture/subsystems/chapters/`, relevant `docs/ops/` backup/restore docs |
+| `internal/infra/backup/**` | `docs/technical/architecture/subsystems/chapters/backup.md`, `docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md`, `docs/ops/backup-restore.md` |
 | `internal/application/events/**`, `internal/application/mirror/**` | `docs/technical/architecture/subsystems/events-mirror/` |
 | Numscript runtime/library | `docs/technical/architecture/subsystems/scripting/`, `docs/technical/contributing/numscript.md` |
 | `misc/proto/**`, generated protobuf code | `docs/technical/contributing/protobuf.md` |
@@ -72,6 +73,13 @@ Read:
 - the storage/FSM subsystem docs touched by the change
 
 A new primary-store projection requires checker coverage or an explicitly justified documented exemption.
+
+If a persisted value can change after a full checkpoint, also read
+`docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md`.
+Classify it as preserved, rebuilt, or deliberately discarded during a
+cross-cluster restore, then exercise the classification with a non-empty
+post-checkpoint delta. This applies to updates and deletion cascades as well as
+new projections.
 
 ### FSM / proposal changes
 

--- a/docs/technical/architecture/subsystems/chapters/README.md
+++ b/docs/technical/architecture/subsystems/chapters/README.md
@@ -10,6 +10,7 @@ Chapters partition a ledger's transaction history into discrete sealed segments.
 | [cold-storage.md](cold-storage.md) | Export of sealed chapter logs to durable cold storage (filesystem, S3) with a two-phase archive flow. |
 | [receipts.md](receipts.md) | HMAC-signed JWT receipts that allow reverting archived transactions without re-reading cold storage. |
 | [backup.md](backup.md) | Full-database backup (Pebble checkpoint + incremental segments) to S3, Azure, or filesystem; restore for disaster recovery. |
+| [incremental-restore-contract.md](incremental-restore-contract.md) | Required parity between live apply and checkpoint-plus-delta restore for persisted state. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/chapters/backup.md
+++ b/docs/technical/architecture/subsystems/chapters/backup.md
@@ -128,7 +128,15 @@ A fresh backup against an empty destination is just a "full" backup with an empt
 1. Read the manifest from the destination.
 2. Download every SST file the manifest references into a fresh Pebble directory.
 3. Apply any incremental exports on top (`ApplyExports`).
-4. Boot the node against the restored directory.
+4. Reconstruct post-checkpoint derived state from the exported log and audit streams (`RebuildDelta`).
+5. Boot the node against the restored directory.
+
+`RebuildDelta` is a second fold of committed effects: the checkpoint contains
+projection values only up to its sequence boundary, while later incremental
+segments carry the evidence needed to reconstruct their updates. Any persisted
+state that can change after the checkpoint must therefore follow the
+[incremental restore contract](incremental-restore-contract.md). A restore test
+that has no post-checkpoint export does not exercise this path.
 
 After the restore, the node rejoins (or initialises) the Raft cluster as a fresh peer. The standard config validation (`internal/bootstrap/config_validation.go`) verifies that the restored `cluster-id` matches the cluster the node is supposed to be joining.
 
@@ -163,5 +171,6 @@ The Operator's `Backup` CRD (`misc/operator/api/v1alpha1/`) wraps backups behind
 | Manifest | `internal/infra/backup/manifest.go` |
 | Cold backfill of archival-purged ranges | `internal/infra/backup/cold_backfill.go` |
 | Storage abstraction (filesystem / S3 / Azure) | `internal/infra/backup/storage*.go` |
-| Restore | `internal/infra/backup/restore.go` |
+| Restore orchestration | `internal/infra/backup/restore.go` |
+| Delta projection rebuild | `internal/infra/backup/rebuild.go`, `internal/domain/replay/` |
 | `Backup` / `BackupRun` CRDs | `misc/operator/api/v1alpha1/` |

--- a/docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md
+++ b/docs/technical/architecture/subsystems/chapters/incremental-restore-contract.md
@@ -1,0 +1,113 @@
+# Incremental Restore Parity
+
+## Invariant
+
+For every committed effect intended to survive a cross-cluster restore, applying
+the complete history live must produce the same logical persisted state as
+restoring a checkpoint of the history prefix and rebuilding the exported delta:
+
+```text
+live(prefix + delta) == restore(checkpoint(prefix), delta)
+```
+
+The comparison is logical, not necessarily byte-for-byte. Protobuf map encoding,
+cluster-local state, caches, and other explicitly reset data may differ in bytes
+or be absent after restore. Every difference requires a documented lifecycle
+classification; it must not arise accidentally from an omitted replay effect.
+
+This is a correctness invariant, not merely a backup test convention. The FSM
+apply path and `RebuildDelta` are two folds of the same committed business
+history. If one advances, deletes, or creates a durable projection and the other
+does not, the restored store can contain business data that disagrees with the
+state used to admit or apply the next order.
+
+## Restore evidence and responsibilities
+
+A full checkpoint carries the Pebble state at its log and audit sequence
+boundaries. Incremental backup segments after that boundary carry raw log,
+audit-entry, audit-item, and applied-proposal rows. `ApplyExports` restores those
+rows, then `RebuildDelta` reconstructs the derived state that the live FSM wrote
+after the checkpoint.
+
+Before changing an audited order, an FSM handler, a persisted projection, or a
+delete/purge cascade, classify every affected value:
+
+| Classification | Required behavior |
+|---|---|
+| Preserved | The checkpoint value remains correct because the delta cannot change it. Document why. |
+| Rebuilt | The delta can change the value. Identify the exported evidence and fold it into the restored projection. |
+| Discarded | The value is cluster-local, cache-like, or otherwise invalid after cross-cluster restore. Delete it in the restore preparation lifecycle and document how it is re-seeded. |
+
+"Present in the checkpoint" is not a valid explanation for a value that can
+change in the delta. Rebuild requirements include deletes and resets, not only
+creations and updates.
+
+For a rebuilt value, answer all of the following before implementation:
+
+1. Which live apply path mutates it?
+2. Which exported record contains enough authoritative evidence to reproduce the mutation?
+3. What is the fold rule: assignment, maximum, sum, set membership, tombstone, or another deterministic operation?
+4. How is the checkpoint value used as the fold seed?
+5. How do later delete, promote, purge, or recreate operations affect the result?
+6. Which checker pass independently re-derives or validates the final value?
+
+If the ledger-log payload omits information that the live apply used, inspect the
+chain-bound serialized order in `AuditItem` and the `AppliedProposal` companion
+record. Do not silently default a missing fact. Prefer a shared, pure decoder for
+authoritative replay facts, while retaining a test oracle independent of the
+restore writer so a shared mistake cannot make both sides agree incorrectly.
+
+## Required tests
+
+A change with restore impact is not complete with an isolated `RebuildDelta`
+unit test alone. Cover the behavior at the lowest useful level and prove the
+cross-lifecycle composition.
+
+The restore regression must:
+
+1. create meaningful state before the full checkpoint;
+2. perform the affected successful operation after the checkpoint;
+3. assert that the manifest contains a non-empty export covering that operation;
+4. restore the checkpoint plus delta through `ApplyExportsAndRebuild` or the real restore service;
+5. compare the restored logical projection with the live source state;
+6. run `CheckStore` on the restored store and require no integrity findings;
+7. exercise the next admission or apply decision that consumes the projection when practical.
+
+Choose assertions that expose duplicate or forgotten effects. Counts alone are
+often insufficient: a replay can overwrite a row with the same identifier while
+applying postings or counters twice. Compare balances and volumes, boundary
+fields, metadata values, idempotency outcomes, lifecycle modes, and rejection
+reasons as applicable.
+
+For field or order-kind changes, use table-driven coverage for every relevant
+variant. A test covering only an uncommon variant does not establish the common
+path. When practical, demonstrate that disabling the new rebuild fold makes the
+regression fail; this falsifies a vacuous test that never reached the delta path.
+
+## Review checklist
+
+- The delta is non-empty and contains the intended operation.
+- Live apply and restore use the same authoritative evidence but are compared by an independent oracle.
+- Checkpoint seeding and delta folding are both exercised.
+- Create, update, delete, and lifecycle transitions relevant to the projection are covered.
+- Archived-baseline behavior is considered when the projection survives log purging.
+- `CheckStore` verifies the restored primary-store projection, or the documented exemption remains valid.
+- Tests assert business values and future gate behavior, not only row presence or cardinality.
+- The subsystem documentation and code comments describe any new non-obvious restore rule.
+
+## Code and test map
+
+| Concern | Location |
+|---|---|
+| Export application and rebuild orchestration | `internal/infra/backup/restore.go` |
+| Delta reconstruction | `internal/infra/backup/rebuild.go` |
+| Shared audit/order replay facts | `internal/domain/replay/` |
+| Live persisted mutations | `internal/domain/processing/`, `internal/infra/state/` |
+| Integrity oracle | `internal/application/check/` |
+| Rebuild unit tests | `internal/infra/backup/rebuild_test.go` |
+| Cross-lifecycle restore tests | `tests/e2e/cluster/restore*_test.go` |
+| Model-driven restore cycles | `tests/antithesis/run_model_test.sh --restore` |
+
+Also read [Audit-Bound vs Technical State](../../audit-vs-technical-state.md)
+before deciding whether a value is authoritative, checker-verified, rebuildable,
+or deliberately excluded from cross-cluster restore.


### PR DESCRIPTION
## What changed

- Adds incremental restore parity as a non-negotiable agent invariant.
- Adds an authoritative contract for classifying persisted state as preserved, rebuilt, or discarded across checkpoint-plus-delta restores.
- Routes persistence and backup work to that contract and documents `RebuildDelta` in the restore flow.

## Why

Incremental restore bugs have repeatedly come from live apply mutating a durable projection without the delta rebuild reproducing the same effect. This documentation makes restore impact analysis and a non-empty-delta regression explicit requirements for agents changing persisted state, audited orders, or deletion cascades.

## Risk

**LOW** — documentation and agent guidance only; no runtime behavior changes.

## Validation

- [x] `bash scripts/agent-check`
- [x] `git diff --check`
- [x] GitNexus `detect-changes --scope staged`: low risk, 0 affected execution flows
- [ ] Targeted tests: N/A
- [ ] Full suite / broader validation: N/A

## Architecture / behavior impact

No runtime behavior change. The PR documents an existing correctness invariant for incremental backup restore and updates the context-loading contract for future changes.

## Review focus

Please review whether the required test contract is strict enough to prevent vacuous restore tests while remaining applicable to cluster-local state that is deliberately discarded.

## Known concerns

This PR establishes guidance only. Automated projection registration, differential parity tests, and mandatory restore validation remain separate follow-up work.