### PR TITLE
fix: expose Pebble target garbage ratio

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -122,7 +122,7 @@ func NewRunCommand() *cobra.Command {
 	bytesize.ByteSizeVar(runCmd, new(bytesize.ByteSize), "pebble-value-separation-min-size", 256, "Minimum value size for separation (default: 256)")
 	runCmd.Flags().Int("pebble-value-separation-max-depth", 4, "Max blob reference depth per SSTable (default: 4)")
 	runCmd.Flags().Duration("pebble-value-separation-rewrite-age", time.Hour, "Minimum blob file age before rewrite (default: 1h)")
-	runCmd.Flags().Float64("pebble-value-separation-garbage-ratio", 0.20, "Blob garbage ratio before rewrite (default: 0.20)")
+	runCmd.Flags().Float64("pebble-value-separation-target-garbage-ratio", 0.20, "Target blob garbage ratio before rewrite (default: 0.20)")
 
 	runCmd.Flags().Uint64("cache-rotation-threshold", 1000, "Cache rotation threshold (0 = use default 1000)")
 	bytesize.ByteSizeVar(runCmd, new(bytesize.ByteSize), "spool-segment-max-bytes", 0, "Maximum spool segment size before rotation/sealing (0 = use default 256Mi)")
@@ -1000,7 +1000,7 @@ func loadPebbleConfig(cmd *cobra.Command) dal.Config {
 	cfg.ValueSeparation.MaxBlobReferenceDepth = getInt("pebble-value-separation-max-depth", cfg.ValueSeparation.MaxBlobReferenceDepth)
 	cfg.ValueSeparation.RewriteMinimumAge = getDuration("pebble-value-separation-rewrite-age", cfg.ValueSeparation.RewriteMinimumAge)
 
-	if ratio, _ := cmd.Flags().GetFloat64("pebble-value-separation-garbage-ratio"); ratio != 0 {
+	if ratio, _ := cmd.Flags().GetFloat64("pebble-value-separation-target-garbage-ratio"); ratio != 0 {
 		cfg.ValueSeparation.TargetGarbageRatio = ratio
 	}
 

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -137,6 +137,20 @@ func TestLoadConfig_DefaultsApplyWhenFlagUnset(t *testing.T) {
 	require.InDelta(t, 0.75, cfg.HealthConfig.DataResumeThreshold, 1e-9)
 }
 
+func TestLoadConfig_ValueSeparationTargetGarbageRatio(t *testing.T) {
+	t.Parallel()
+
+	cmd := NewRunCommand()
+	require.NoError(t, cmd.Flags().Set("node-id", "1"))
+	require.NoError(t, cmd.Flags().Set("pebble-value-separation", "true"))
+	require.NoError(t, cmd.Flags().Set("pebble-value-separation-target-garbage-ratio", "0.10"))
+
+	cfg, err := LoadConfig(context.Background(), cmd)
+	require.NoError(t, err)
+	require.True(t, cfg.PebbleConfig.ValueSeparation.Enabled)
+	require.InDelta(t, 0.10, cfg.PebbleConfig.ValueSeparation.TargetGarbageRatio, 1e-9)
+}
+
 // TestLoadConfig_ResumeThresholdDerivedFromBlock pins the upgrade-safety fix:
 // when an operator lowered a block threshold below the old fixed 0.75 resume
 // default and did not set the new resume flag, a static 0.75 default would make

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4084,7 +4084,7 @@ Tune the Pebble (LSM-tree) storage engine. Size flags accept Kubernetes-style qu
 | `--pebble-value-separation-min-size` | ByteSize | `256` | Minimum value size (bytes) for separation into blob files |
 | `--pebble-value-separation-max-depth` | int | `4` | Max blob reference depth per SSTable |
 | `--pebble-value-separation-rewrite-age` | duration | `1h` | Minimum blob file age before rewrite |
-| `--pebble-value-separation-garbage-ratio` | float64 | `0.20` | Blob garbage ratio before rewrite (0.20 = 20%) |
+| `--pebble-value-separation-target-garbage-ratio` | float64 | `0.20` | Fraction of unreferenced blob data that triggers a rewrite (0.20 = 20%) |
 
 Value separation moves large values into external blob files instead of storing them inline in SSTables. This reduces compaction I/O for write-heavy workloads at the cost of slightly higher read amplification.
 
@@ -4094,7 +4094,7 @@ ledger run --pebble-value-separation [other flags...]
 
 # Tune value separation for larger values
 ledger run --pebble-value-separation --pebble-value-separation-min-size 1Ki \
-  --pebble-value-separation-garbage-ratio 0.10
+  --pebble-value-separation-target-garbage-ratio 0.10
 
 # Use zstd compression on all levels
 ledger run --pebble-compression zstd [other flags...]

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -166,6 +166,24 @@ spec:
       whenDeleted: Retain
 ```
 
+#### Pebble value separation
+
+Value separation moves large values out of SSTables and into blob files. The
+target garbage ratio is the aggregate fraction of unreferenced blob values
+that triggers Pebble rewrites:
+
+```yaml
+spec:
+  pebble:
+    valueSeparation:
+      enabled: true
+      targetGarbageRatio: "0.20"
+```
+
+Lower values reclaim blob space sooner at the cost of additional compaction
+I/O. `targetGarbageRatio` maps to the server environment variable
+`PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO`.
+
 #### Service Configuration
 
 ```yaml

--- a/docs/technical/architecture/subsystems/storage/storage-drivers.md
+++ b/docs/technical/architecture/subsystems/storage/storage-drivers.md
@@ -256,13 +256,23 @@ Pebble can be configured using command-line flags:
   --pebble-wal-bytes-per-sync=1Mi \
   --pebble-max-concurrent-compactions=2 \
   --pebble-wal-min-sync-interval=0 \
-  --pebble-disable-wal=false
+  --pebble-disable-wal=false \
+  --pebble-value-separation=true \
+  --pebble-value-separation-target-garbage-ratio=0.20
 ```
+
+When value separation is enabled, the target garbage ratio controls blob space
+reclamation. Pebble schedules blob rewrites when the aggregate fraction of
+unreferenced blob values exceeds this threshold. Lower values reclaim space
+sooner at the cost of additional compaction I/O.
 
 Or via environment variables:
 
 ```bash
-PEBBLE_MEMTABLE_SIZE=268435456 ./ledger serve
+PEBBLE_MEMTABLE_SIZE=268435456 \
+PEBBLE_VALUE_SEPARATION=true \
+PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO=0.20 \
+./ledger serve
 ```
 
 ---

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -53,6 +53,9 @@ spec:
     pebble:
       memTableSize: 268435456
       cacheSize: 1073741824
+      valueSeparation:
+        enabled: true
+        targetGarbageRatio: "0.20"
   # Cache and bloom parameters are part of the Raft-replicated ClusterConfig.
   # Editing them triggers a rolling restart of the StatefulSet; convergence
   # is deterministic via applyClusterConfig (cache reset + bloom rebuild) and

--- a/misc/operator/api/v1alpha1/cluster_types.go
+++ b/misc/operator/api/v1alpha1/cluster_types.go
@@ -518,10 +518,11 @@ type PebbleValueSeparationConfig struct {
 	// +optional
 	RewriteAge string `json:"rewriteAge,omitempty"`
 
-	// GarbageRatio is the blob garbage ratio before rewrite (0.0-1.0).
+	// TargetGarbageRatio is the fraction of unreferenced blob data that triggers
+	// a rewrite (0.0-1.0).
 	// Default: 0.20.
 	// +optional
-	GarbageRatio string `json:"garbageRatio,omitempty"`
+	TargetGarbageRatio string `json:"targetGarbageRatio,omitempty"`
 }
 
 // RaftConfig holds Raft consensus configuration.

--- a/misc/operator/cmd/kubectl-ledger/explain/explain_test.go
+++ b/misc/operator/cmd/kubectl-ledger/explain/explain_test.go
@@ -60,6 +60,14 @@ func TestLookupNestedPath(t *testing.T) {
 	if f.Type != "bool" {
 		t.Errorf("expected type bool, got %s", f.Type)
 	}
+
+	f, ok = Lookup(SpecFields(), "pebble.valueSeparation.targetGarbageRatio")
+	if !ok {
+		t.Fatal("pebble.valueSeparation.targetGarbageRatio not found")
+	}
+	if f.Type != "string" {
+		t.Errorf("expected type string, got %s", f.Type)
+	}
 }
 
 func TestAgentSpecFields(t *testing.T) {

--- a/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
@@ -2363,11 +2363,6 @@ spec:
                         description: Enabled enables value separation (large values
                           stored in blob files).
                         type: boolean
-                      garbageRatio:
-                        description: |-
-                          GarbageRatio is the blob garbage ratio before rewrite (0.0-1.0).
-                          Default: 0.20.
-                        type: string
                       maxDepth:
                         description: |-
                           MaxDepth is the max blob reference depth per SSTable.
@@ -2387,6 +2382,12 @@ spec:
                         description: |-
                           RewriteAge is the minimum blob file age before rewrite.
                           Default: 1h.
+                        type: string
+                      targetGarbageRatio:
+                        description: |-
+                          TargetGarbageRatio is the fraction of unreferenced blob data that triggers
+                          a rewrite (0.0-1.0).
+                          Default: 0.20.
                         type: string
                     type: object
                   walBytesPerSync:
@@ -3052,11 +3053,6 @@ spec:
                             description: Enabled enables value separation (large values
                               stored in blob files).
                             type: boolean
-                          garbageRatio:
-                            description: |-
-                              GarbageRatio is the blob garbage ratio before rewrite (0.0-1.0).
-                              Default: 0.20.
-                            type: string
                           maxDepth:
                             description: |-
                               MaxDepth is the max blob reference depth per SSTable.
@@ -3076,6 +3072,12 @@ spec:
                             description: |-
                               RewriteAge is the minimum blob file age before rewrite.
                               Default: 1h.
+                            type: string
+                          targetGarbageRatio:
+                            description: |-
+                              TargetGarbageRatio is the fraction of unreferenced blob data that triggers
+                              a rewrite (0.0-1.0).
+                              Default: 0.20.
                             type: string
                         type: object
                       walBytesPerSync:

--- a/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
@@ -2363,11 +2363,6 @@ spec:
                         description: Enabled enables value separation (large values
                           stored in blob files).
                         type: boolean
-                      garbageRatio:
-                        description: |-
-                          GarbageRatio is the blob garbage ratio before rewrite (0.0-1.0).
-                          Default: 0.20.
-                        type: string
                       maxDepth:
                         description: |-
                           MaxDepth is the max blob reference depth per SSTable.
@@ -2387,6 +2382,12 @@ spec:
                         description: |-
                           RewriteAge is the minimum blob file age before rewrite.
                           Default: 1h.
+                        type: string
+                      targetGarbageRatio:
+                        description: |-
+                          TargetGarbageRatio is the fraction of unreferenced blob data that triggers
+                          a rewrite (0.0-1.0).
+                          Default: 0.20.
                         type: string
                     type: object
                   walBytesPerSync:
@@ -3052,11 +3053,6 @@ spec:
                             description: Enabled enables value separation (large values
                               stored in blob files).
                             type: boolean
-                          garbageRatio:
-                            description: |-
-                              GarbageRatio is the blob garbage ratio before rewrite (0.0-1.0).
-                              Default: 0.20.
-                            type: string
                           maxDepth:
                             description: |-
                               MaxDepth is the max blob reference depth per SSTable.
@@ -3076,6 +3072,12 @@ spec:
                             description: |-
                               RewriteAge is the minimum blob file age before rewrite.
                               Default: 1h.
+                            type: string
+                          targetGarbageRatio:
+                            description: |-
+                              TargetGarbageRatio is the fraction of unreferenced blob data that triggers
+                              a rewrite (0.0-1.0).
+                              Default: 0.20.
                             type: string
                         type: object
                       walBytesPerSync:

--- a/misc/operator/internal/controller/envvars.go
+++ b/misc/operator/internal/controller/envvars.go
@@ -221,7 +221,7 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 			envs = appendIfQuantity(envs, "PEBBLE_VALUE_SEPARATION_MIN_SIZE", spec.Pebble.ValueSeparation.MinSize)
 			envs = appendIfInt32(envs, "PEBBLE_VALUE_SEPARATION_MAX_DEPTH", spec.Pebble.ValueSeparation.MaxDepth)
 			envs = appendIfStr(envs, "PEBBLE_VALUE_SEPARATION_REWRITE_AGE", spec.Pebble.ValueSeparation.RewriteAge)
-			envs = appendIfStr(envs, "PEBBLE_VALUE_SEPARATION_GARBAGE_RATIO", spec.Pebble.ValueSeparation.GarbageRatio)
+			envs = appendIfStr(envs, "PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO", spec.Pebble.ValueSeparation.TargetGarbageRatio)
 		}
 	}
 

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -289,11 +289,11 @@ func TestBuildEnvVars_PebbleValueSeparation(t *testing.T) {
 		maxDepth := int32(8)
 		ls.Spec.Pebble = &ledgerv1alpha1.PebbleConfig{
 			ValueSeparation: &ledgerv1alpha1.PebbleValueSeparationConfig{
-				Enabled:      &bTrue,
-				MinSize:      &minSize,
-				MaxDepth:     &maxDepth,
-				RewriteAge:   "2h",
-				GarbageRatio: "0.30",
+				Enabled:            &bTrue,
+				MinSize:            &minSize,
+				MaxDepth:           &maxDepth,
+				RewriteAge:         "2h",
+				TargetGarbageRatio: "0.30",
 			},
 		}
 		envs := buildEnvVars(ls, "disabled", nil)
@@ -301,7 +301,7 @@ func TestBuildEnvVars_PebbleValueSeparation(t *testing.T) {
 		assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MIN_SIZE", "512")
 		assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MAX_DEPTH", "8")
 		assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_REWRITE_AGE", "2h")
-		assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_GARBAGE_RATIO", "0.30")
+		assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO", "0.30")
 	})
 
 	t.Run("nil value separation omitted", func(t *testing.T) {
@@ -327,7 +327,7 @@ func TestBuildEnvVars_PebbleValueSeparation(t *testing.T) {
 		assertNoEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MIN_SIZE")
 		assertNoEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MAX_DEPTH")
 		assertNoEnv(t, envs, "PEBBLE_VALUE_SEPARATION_REWRITE_AGE")
-		assertNoEnv(t, envs, "PEBBLE_VALUE_SEPARATION_GARBAGE_RATIO")
+		assertNoEnv(t, envs, "PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO")
 	})
 }
 
@@ -959,11 +959,11 @@ func TestBuildEnvVars_AllNewFields(t *testing.T) {
 	ls.Spec.Pebble = &ledgerv1alpha1.PebbleConfig{
 		Compression: "zstd,zstd,zstd,zstd,zstd,zstd,zstd",
 		ValueSeparation: &ledgerv1alpha1.PebbleValueSeparationConfig{
-			Enabled:      &bTrue,
-			MinSize:      &vsMinSize,
-			MaxDepth:     &vsMaxDepth,
-			RewriteAge:   "30m",
-			GarbageRatio: "0.15",
+			Enabled:            &bTrue,
+			MinSize:            &vsMinSize,
+			MaxDepth:           &vsMaxDepth,
+			RewriteAge:         "30m",
+			TargetGarbageRatio: "0.15",
 		},
 	}
 	ls.Spec.Raft = &ledgerv1alpha1.RaftConfig{
@@ -1020,7 +1020,7 @@ func TestBuildEnvVars_AllNewFields(t *testing.T) {
 	assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MIN_SIZE", "1Ki")
 	assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_MAX_DEPTH", "6")
 	assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_REWRITE_AGE", "30m")
-	assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_GARBAGE_RATIO", "0.15")
+	assertEnv(t, envs, "PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO", "0.15")
 
 	// Raft additions
 	assertEnv(t, envs, "RAFT_PROCESSING_TICK_INTERVAL", "15ms")


### PR DESCRIPTION
## What changed

- rename the server flag to `--pebble-value-separation-target-garbage-ratio`
- expose `spec.pebble.valueSeparation.targetGarbageRatio` in the operator CRD
- propagate it as `PEBBLE_VALUE_SEPARATION_TARGET_GARBAGE_RATIO`
- regenerate both operator CRD copies and update CLI, deployment, storage, and operator documentation
- add server, operator environment, and `kubectl-ledger explain` coverage

## Why

The internal DAL and Pebble policy use `TargetGarbageRatio`, while the public CLI and operator CRD exposed the shortened `garbageRatio` name. This made the documented `targetGarbageRatio` setting unavailable on Cluster resources and obscured the fact that the threshold applies to aggregate unreferenced blob values.

Ledger v3 is unreleased, so the old field and flag are removed without a compatibility alias.

## Operational impact

Operators can configure blob rewrite pressure with:

```yaml
spec:
  pebble:
    valueSeparation:
      enabled: true
      targetGarbageRatio: "0.10"
```

Changing the value updates the StatefulSet environment and causes the normal rolling restart. Lower values reclaim blob garbage sooner at the cost of additional compaction I/O.

## Validation

- `go test ./cmd/server`
- `go test ./...` in `misc/operator`
- `bash scripts/agent-check`
- generated CRDs checked for removal of the old `garbageRatio` field
- GitNexus change-impact analysis: low risk, no affected execution flows
