### PR TITLE
chore: add PR-oriented AI review loop launcher

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -15,6 +15,27 @@ The commands are intentionally provider-agnostic. They may wrap Codex, Claude, a
 
 Each invocation creates a persistent, unique directory below `build/ai-review-loop/`. Review and fix payloads from concurrent or subsequent runs therefore never share file names. The selected directory is printed when the loop starts.
 
+## PR-oriented launcher
+
+For the common case of an existing GitHub pull request, use the higher-level launcher:
+
+```bash
+bash scripts/ai-pr-loop 1732
+```
+
+A full PR URL is accepted as well. The launcher:
+
+- resolves the current repository and PR metadata through `gh`;
+- requires an open same-repository PR and currently rejects fork/cross-repository heads;
+- fetches the exact GitHub-reported base and head refs and verifies both SHAs before running agents;
+- creates a detached linked worktree outside the primary checkout, under a sibling `.<repo>-ai-worktrees/pr-<number>` directory;
+- runs the standard Codex review + Claude fix composition against the PR base;
+- never checks out, edits, commits, pushes, comments, resolves threads, or merges from the primary checkout;
+- preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
+- removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
+
+The launcher fails closed if an existing PR worktree contains local changes rather than overwriting or reusing it. Commit/push automation is intentionally out of scope: this layer only produces an isolated reviewed/fixed worktree and reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
+
 ## Loop states
 
 The orchestrator emits exactly one terminal state:

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -28,13 +28,14 @@ A full PR URL is accepted as well. The launcher:
 - resolves the current repository and PR metadata through `gh`;
 - requires an open same-repository PR and currently rejects fork/cross-repository heads;
 - fetches the exact GitHub-reported base and head refs and verifies both SHAs before running agents;
-- creates a detached linked worktree outside the primary checkout, under a sibling `.<repo>-ai-worktrees/pr-<number>` directory;
+- creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
+- passes the verified base commit SHA to `review-loop`, so a later update of the shared remote-tracking ref cannot change the reviewed delta;
 - runs the standard Codex review + Claude fix composition against the PR base;
 - never checks out, edits, commits, pushes, comments, resolves threads, or merges from the primary checkout;
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
 
-The launcher fails closed if an existing PR worktree contains local changes rather than overwriting or reusing it. Commit/push automation is intentionally out of scope: this layer only produces an isolated reviewed/fixed worktree and reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
+Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Commit/push automation is intentionally out of scope: this layer only produces an isolated reviewed/fixed worktree and reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
 
 ## Loop states
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -37,7 +37,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-for command in git gh; do
+for command in git gh jq; do
     if ! command -v "$command" >/dev/null 2>&1; then
         echo "ai-pr-loop: required command not found in PATH: $command" >&2
         exit 1
@@ -74,11 +74,6 @@ if [[ "$head_owner/$head_repo" != "$repo" ]]; then
     exit 1
 fi
 
-if ! command -v jq >/dev/null 2>&1; then
-    echo "ai-pr-loop: jq is required" >&2
-    exit 1
-fi
-
 remote=origin
 if ! git remote get-url "$remote" >/dev/null 2>&1; then
     echo "ai-pr-loop: required git remote '$remote' is missing" >&2
@@ -101,7 +96,11 @@ if [[ "$fetched_head" != "$head_sha" ]]; then
     exit 1
 fi
 
-worktree_parent="$repo_root/build/ai-pr-loop"
+# Keep linked worktrees outside the primary checkout so the review loop cannot
+# accidentally include launcher state in the PR worktree/fingerprint.
+repo_parent=$(dirname "$repo_root")
+repo_name=$(basename "$repo_root")
+worktree_parent="$repo_parent/.${repo_name}-ai-worktrees"
 mkdir -p "$worktree_parent"
 worktree="$worktree_parent/pr-$pr_number"
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/ai-pr-loop <pr-number-or-url> [--keep-worktree]
+
+Creates an isolated git worktree for the PR head and runs the bounded
+Codex review -> Claude fix -> validation -> re-review loop against the
+PR base branch. The launcher never commits, pushes, comments, or merges.
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+fi
+
+pr=$1
+shift
+keep_worktree=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-worktree)
+            keep_worktree=true
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "ai-pr-loop: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+for command in git gh; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "ai-pr-loop: required command not found in PATH: $command" >&2
+        exit 1
+    fi
+done
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+pr_json=$(gh pr view "$pr" --repo "$repo" --json number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository)
+
+pr_number=$(jq -r '.number' <<<"$pr_json")
+pr_url=$(jq -r '.url' <<<"$pr_json")
+state=$(jq -r '.state' <<<"$pr_json")
+is_draft=$(jq -r '.isDraft' <<<"$pr_json")
+base_ref=$(jq -r '.baseRefName' <<<"$pr_json")
+base_sha=$(jq -r '.baseRefOid' <<<"$pr_json")
+head_ref=$(jq -r '.headRefName' <<<"$pr_json")
+head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+head_owner=$(jq -r '.headRepositoryOwner.login // empty' <<<"$pr_json")
+head_repo=$(jq -r '.headRepository.name // empty' <<<"$pr_json")
+
+if [[ "$state" != "OPEN" ]]; then
+    echo "ai-pr-loop: PR #$pr_number is not open (state=$state)" >&2
+    exit 1
+fi
+if [[ -z "$head_owner" || -z "$head_repo" ]]; then
+    echo "ai-pr-loop: could not resolve PR head repository" >&2
+    exit 1
+fi
+if [[ "$head_owner/$head_repo" != "$repo" ]]; then
+    echo "ai-pr-loop: fork/cross-repository PRs are not supported yet: $head_owner/$head_repo" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ai-pr-loop: jq is required" >&2
+    exit 1
+fi
+
+remote=origin
+if ! git remote get-url "$remote" >/dev/null 2>&1; then
+    echo "ai-pr-loop: required git remote '$remote' is missing" >&2
+    exit 1
+fi
+
+# Fetch exactly the GitHub-resolved base/head refs before creating the worktree.
+git fetch --no-tags "$remote" \
+    "+refs/heads/$base_ref:refs/remotes/$remote/$base_ref" \
+    "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
+
+fetched_base=$(git rev-parse "refs/remotes/$remote/$base_ref")
+fetched_head=$(git rev-parse "refs/remotes/$remote/$head_ref")
+if [[ "$fetched_base" != "$base_sha" ]]; then
+    echo "ai-pr-loop: fetched base SHA does not match GitHub: got $fetched_base expected $base_sha" >&2
+    exit 1
+fi
+if [[ "$fetched_head" != "$head_sha" ]]; then
+    echo "ai-pr-loop: fetched head SHA does not match GitHub: got $fetched_head expected $head_sha" >&2
+    exit 1
+fi
+
+worktree_parent="$repo_root/build/ai-pr-loop"
+mkdir -p "$worktree_parent"
+worktree="$worktree_parent/pr-$pr_number"
+
+if [[ -e "$worktree" ]]; then
+    if git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        if [[ -n "$(git -C "$worktree" status --porcelain)" ]]; then
+            echo "ai-pr-loop: existing worktree has local changes: $worktree" >&2
+            echo "Resolve or remove it manually before rerunning." >&2
+            exit 1
+        fi
+        git worktree remove "$worktree"
+    else
+        echo "ai-pr-loop: path exists but is not a git worktree: $worktree" >&2
+        exit 1
+    fi
+fi
+
+git worktree prune
+git worktree add --detach "$worktree" "$head_sha"
+
+cleanup() {
+    status=$?
+    if [[ "$keep_worktree" == false && -d "$worktree" ]]; then
+        if [[ -z "$(git -C "$worktree" status --porcelain 2>/dev/null || true)" ]]; then
+            git worktree remove "$worktree" >/dev/null 2>&1 || true
+        fi
+    fi
+    exit "$status"
+}
+trap cleanup EXIT
+
+printf '==> ai-pr-loop: PR #%s\n' "$pr_number"
+printf '    URL: %s\n' "$pr_url"
+printf '    base: %s (%s)\n' "$base_ref" "$base_sha"
+printf '    head: %s (%s)\n' "$head_ref" "$head_sha"
+printf '    worktree: %s\n' "$worktree"
+if [[ "$is_draft" == "true" ]]; then
+    echo "    note: PR is currently draft"
+fi
+
+cd "$worktree"
+
+set +e
+bash scripts/review-loop \
+    --base "$remote/$base_ref" \
+    --review-cmd 'bash scripts/ai-review-codex' \
+    --fix-cmd 'bash scripts/ai-fix-claude'
+loop_status=$?
+set -e
+
+echo
+case "$loop_status" in
+    0)
+        echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
+        ;;
+    2)
+        echo "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED"
+        ;;
+    *)
+        echo "AI_PR_LOOP_RESULT: ERROR (review-loop exit $loop_status)"
+        ;;
+esac
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Worktree contains fixes to inspect: $worktree"
+    keep_worktree=true
+else
+    echo "Worktree is clean."
+fi
+
+exit "$loop_status"

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -11,6 +11,13 @@ PR base branch. The launcher never commits, pushes, comments, or merges.
 EOF
 }
 
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
 if [[ $# -lt 1 ]]; then
     usage >&2
     exit 1
@@ -102,35 +109,25 @@ repo_parent=$(dirname "$repo_root")
 repo_name=$(basename "$repo_root")
 worktree_parent="$repo_parent/.${repo_name}-ai-worktrees"
 mkdir -p "$worktree_parent"
-worktree="$worktree_parent/pr-$pr_number"
-
-if [[ -e "$worktree" ]]; then
-    if git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        if [[ -n "$(git -C "$worktree" status --porcelain)" ]]; then
-            echo "ai-pr-loop: existing worktree has local changes: $worktree" >&2
-            echo "Resolve or remove it manually before rerunning." >&2
-            exit 1
-        fi
-        git worktree remove "$worktree"
-    else
-        echo "ai-pr-loop: path exists but is not a git worktree: $worktree" >&2
-        exit 1
-    fi
-fi
-
-git worktree prune
-git worktree add --detach "$worktree" "$head_sha"
+worktree_run_dir=$(mktemp -d "$worktree_parent/pr-$pr_number.XXXXXX")
+worktree="$worktree_run_dir/worktree"
 
 cleanup() {
-    status=$?
-    if [[ "$keep_worktree" == false && -d "$worktree" ]]; then
-        if [[ -z "$(git -C "$worktree" status --porcelain 2>/dev/null || true)" ]]; then
-            git worktree remove "$worktree" >/dev/null 2>&1 || true
+    exit_status=$?
+    trap - EXIT
+    if [[ "$keep_worktree" == false ]]; then
+        if [[ -d "$worktree" ]] && git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            if [[ -z "$(git -C "$worktree" status --porcelain 2>/dev/null || true)" ]]; then
+                git worktree remove "$worktree" >/dev/null 2>&1 || true
+            fi
         fi
+        rmdir "$worktree_run_dir" >/dev/null 2>&1 || true
     fi
-    exit "$status"
+    exit "$exit_status"
 }
 trap cleanup EXIT
+
+git worktree add --detach "$worktree" "$head_sha"
 
 printf '==> ai-pr-loop: PR #%s\n' "$pr_number"
 printf '    URL: %s\n' "$pr_url"
@@ -144,8 +141,10 @@ fi
 cd "$worktree"
 
 set +e
+# The remote-tracking ref is shared and can move after the verification above.
+# Pass the verified commit identity so review-loop always captures this base.
 bash scripts/review-loop \
-    --base "$remote/$base_ref" \
+    --base "$base_sha" \
     --review-cmd 'bash scripts/ai-review-codex' \
     --fix-cmd 'bash scripts/ai-fix-claude'
 loop_status=$?

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -1,0 +1,169 @@
+package aiprloop
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelpDoesNotRequirePRMetadata(t *testing.T) {
+	t.Parallel()
+
+	fakeBin := t.TempDir()
+	writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 97\n")
+
+	command := exec.Command("bash", launcherPath(t), "--help")
+	command.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.Contains(t, string(output), "Usage: bash scripts/ai-pr-loop")
+}
+
+func TestLauncherUsesUniqueWorktreesAndImmutableBase(t *testing.T) {
+	t.Parallel()
+
+	testRoot := t.TempDir()
+	remote := filepath.Join(testRoot, "remote.git")
+	seed := filepath.Join(testRoot, "seed")
+	checkout := filepath.Join(testRoot, "checkout")
+
+	runGit(t, testRoot, "init", "--bare", remote)
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "scripts"), 0o755))
+	runGit(t, seed, "init")
+	runGit(t, seed, "config", "user.name", "AI PR Loop Test")
+	runGit(t, seed, "config", "user.email", "ai-pr-loop@example.com")
+
+	launcher, err := os.ReadFile(launcherPath(t))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
+	runGit(t, seed, "add", ".")
+	runGit(t, seed, "commit", "-m", "base")
+	runGit(t, seed, "branch", "-M", "release/v3.0")
+	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "remote", "add", "origin", remote)
+	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+
+	runGit(t, seed, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
+	runGit(t, seed, "add", "feature.txt")
+	runGit(t, seed, "commit", "-m", "feature")
+	headSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "push", "-u", "origin", "feature")
+	runGit(t, testRoot, "clone", "--branch", "release/v3.0", remote, checkout)
+
+	fakeBin := filepath.Join(testRoot, "bin")
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+	writeExecutable(t, filepath.Join(fakeBin, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+    "repo view")
+        printf 'owner/repo\n'
+        ;;
+    "pr view")
+        printf '{"number":123,"url":"https://github.com/owner/repo/pull/123","state":"OPEN","isDraft":false,"baseRefName":"release/v3.0","baseRefOid":"%s","headRefName":"feature","headRefOid":"%s","headRepositoryOwner":{"login":"owner"},"headRepository":{"name":"repo"}}\n' "$TEST_BASE_SHA" "$TEST_HEAD_SHA"
+        ;;
+    *)
+        exit 98
+        ;;
+esac
+`)
+
+	firstCapture := filepath.Join(testRoot, "first-args")
+	firstOutput := runLauncher(t, checkout, fakeBin, baseSHA, headSHA, firstCapture)
+	secondCapture := filepath.Join(testRoot, "second-args")
+	secondOutput := runLauncher(t, checkout, fakeBin, baseSHA, headSHA, secondCapture)
+
+	firstWorktree := worktreeFromOutput(t, firstOutput)
+	secondWorktree := worktreeFromOutput(t, secondOutput)
+	require.NotEqual(t, firstWorktree, secondWorktree)
+	require.DirExists(t, firstWorktree)
+	require.DirExists(t, secondWorktree)
+	require.Equal(t, baseSHA, baseArgument(t, firstCapture))
+	require.Equal(t, baseSHA, baseArgument(t, secondCapture))
+}
+
+func launcherPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "ai-pr-loop"))
+	require.NoError(t, err)
+
+	return path
+}
+
+func runLauncher(t *testing.T, checkout, fakeBin, baseSHA, headSHA, capturePath string) string {
+	t.Helper()
+
+	command := exec.Command("bash", filepath.Join(checkout, "scripts", "ai-pr-loop"), "123", "--keep-worktree")
+	command.Dir = checkout
+	command.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_BASE_SHA="+baseSHA,
+		"TEST_HEAD_SHA="+headSHA,
+		"TEST_CAPTURE_FILE="+capturePath,
+	)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	return string(output)
+}
+
+func worktreeFromOutput(t *testing.T, output string) string {
+	t.Helper()
+
+	for line := range strings.SplitSeq(output, "\n") {
+		if worktree, found := strings.CutPrefix(strings.TrimSpace(line), "worktree: "); found {
+			return worktree
+		}
+	}
+	t.Fatalf("worktree path not found in output:\n%s", output)
+
+	return ""
+}
+
+func baseArgument(t *testing.T, capturePath string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(capturePath)
+	require.NoError(t, err)
+	arguments := strings.Fields(string(content))
+	for index, argument := range arguments {
+		if argument == "--base" && index+1 < len(arguments) {
+			return arguments[index+1]
+		}
+	}
+	t.Fatalf("--base not found in captured arguments: %q", content)
+
+	return ""
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	_ = runGitOutput(t, directory, arguments...)
+}
+
+func runGitOutput(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION
## What changed

Add a PR-oriented launcher for the bounded Codex review → Claude fix loop.

- add `bash scripts/ai-pr-loop <pr-number-or-url>`
- resolve PR/base/head metadata through `gh`
- require an open same-repository PR
- fetch and verify the exact GitHub-reported base/head SHAs
- create a detached linked worktree outside the primary checkout
- run the existing Codex reviewer + Claude fixer composition in that isolated worktree
- preserve the worktree automatically when fixes remain
- clean up a clean worktree unless `--keep-worktree` is supplied
- keep commit/push/GitHub writes out of scope

## Why

The provider adapters are now merged, so the next usability bottleneck is setup. The intended daily workflow should be a single command against an existing PR instead of manually checking out the correct branch, resolving the base, and composing the review/fix commands.

## Risk

MEDIUM

The launcher performs local Git fetch/worktree operations and invokes agents in an isolated linked worktree. It does not commit, push, comment, resolve threads, or merge.

## Validation

- fail closed when `git`, `gh`, or `jq` are unavailable
- reject closed and fork/cross-repository PRs
- compare fetched base/head SHAs with GitHub metadata before running agents
- refuse to reuse an existing PR worktree that contains local changes
- place linked worktrees outside the primary checkout so launcher state cannot enter review fingerprints
- preserve any worktree containing agent fixes for manual inspection

## Architecture / behavior impact

Contributor tooling only. No Ledger runtime behavior changes.

## Review focus

Please focus on:

- whether assuming the `origin` remote corresponds to `gh repo view` is safe enough or should be verified explicitly
- races if the PR head/base moves between GitHub metadata lookup and fetch
- linked-worktree lifecycle and cleanup failure cases
- whether a detached worktree is the correct choice for future commit/push automation
- whether dirty worktree preservation can ever lose or hide fixes
- path collisions when multiple clones or concurrent invocations review the same PR
- whether the launcher correctly propagates review-loop exit semantics

## Known concerns

Fork/cross-repository PRs are intentionally rejected for now. Commit/push automation is also intentionally deferred; a successful fix leaves an isolated dirty worktree for inspection.