### PR TITLE
feat(EN-1779): opt-in string encoding for posting amounts

### DIFF
--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -172,6 +172,86 @@ Clients should:
 - **Idempotency**: Ensure write operations are idempotent to safely retry after leader election
 - **Monitoring**: Track `503` responses to monitor cluster health and leader election frequency
 
+### Bigint-As-String Header
+
+`Posting.amount` is a 256-bit unsigned integer, and it is the only money field on the v3 HTTP surface serialized as a bare JSON number — volume fields (`input`, `output`, `balance`) are already quoted decimal strings. A JavaScript `JSON.parse` decodes every JSON number into a `Number`, an IEEE-754 double that represents integers exactly only up to 2^53 - 1: the amount `9007199254740993` (2^53 + 1) silently becomes `9007199254740992`, with no error raised anywhere.
+
+`Formance-Bigint-As-String` is the opt-in request header that removes that truncation. When a request carries it with a truthy value, every posting amount in the response body is a quoted decimal string, which `JSON.parse` returns verbatim for the client to hand to `BigInt`. Without the header, response bodies are byte-identical to what the API emitted before the header existed.
+
+#### Header Value
+
+The truthy values are `true`, `yes`, `y` and `1`, compared case-insensitively with surrounding whitespace ignored. Any other value — including an unrecognised one — is treated exactly as if the header were absent. **A malformed header is never an error**: it never turns a readable response into a `400`. The header name and this lenient parsing match Ledger v2, so a client can send the same header to both versions (`internal/adapter/http/string_amounts.go`).
+
+#### Operations That Accept It
+
+| Operation | Route |
+|---|---|
+| Create a transaction | `POST /v3/{ledgerName}/transactions` |
+| Revert a transaction | `POST /v3/{ledgerName}/transactions/{transactionId}/revert` |
+| Get a transaction | `GET /v3/{ledgerName}/transactions/{transactionId}` |
+| List transactions | `GET /v3/{ledgerName}/transactions` |
+| List ledger logs | `GET /v3/{ledgerName}/logs` |
+| Get a log | `GET /v3/_/logs/{sequence}` |
+| Bulk operations | `POST /v3/{ledgerName}/bulk` |
+| Execute a prepared query | `POST /v3/{ledgerName}/prepared-queries/{queryName}/execute` |
+
+These are exactly the responses that can carry a posting — directly, or nested inside a log payload, a bulk result or a prepared-query cursor page. On any other route the header is inert. `openapi.yml` expresses the same set as the reusable `BigintAsString` header parameter, referenced from those eight operations; both `PostingRequest.amount` and `PostingResponse.amount` are typed as a `oneOf` of an integer and a quoted decimal string (`pattern: '^[0-9]+$'`, deliberately not `format: int64` — the value can exceed 2^64).
+
+#### Response Format
+
+Default (header absent), `GET /v3/{ledgerName}/transactions/{transactionId}`:
+
+```json
+{
+  "data": {
+    "transaction": {
+      "postings": [
+        {"source": "world", "destination": "alice", "amount": 9007199254740993, "asset": "USD/2", "color": ""}
+      ],
+      "metadata": {},
+      "id": 42,
+      "reverted": false
+    },
+    "receipt": ""
+  }
+}
+```
+
+With `Formance-Bigint-As-String: true`, the same request returns the same document with the amount quoted:
+
+```json
+{
+  "data": {
+    "transaction": {
+      "postings": [
+        {"source": "world", "destination": "alice", "amount": "9007199254740993", "asset": "USD/2", "color": ""}
+      ],
+      "metadata": {},
+      "id": 42,
+      "reverted": false
+    },
+    "receipt": ""
+  }
+}
+```
+
+**Only the amount's format changes; the response shape never does.** Field names, field presence, ordering and nesting are identical in both modes at every level of the payload — a nil child still renders `null`, and an empty collection still renders `[]`. That is mechanically enforced, not merely intended: each of the eight routes pins both bodies byte-for-byte and asserts they differ at the posting amounts and nowhere else. The implementation mechanism (how the mode travels down the marshaller chain, and what a new amount-bearing level must do) is specified in `internal/proto/commonpb/string_amounts.go`.
+
+#### Request Side
+
+Independently of the header, a posting amount is accepted **both** as a bare JSON number and as a quoted decimal string on input. A client that read string amounts can therefore post them back unchanged, with no conversion step and without sending the header on the write. This is a relaxation only — numeric input behaves exactly as before — and it is not gated by anything. Hexadecimal (`0x...`) is rejected in both forms.
+
+#### Known Limitation: Integer Metadata
+
+The header covers posting amounts and nothing else. Metadata values of integer type are **bare JSON numbers in both modes**, and an unsigned metadata value can reach 2^64 - 1, far above `Number.MAX_SAFE_INTEGER`. A JavaScript client that opts in will still truncate those silently. This is by design — the header's scope is the amount field, not every integer on the wire — but it means the header must not be read as "no truncation anywhere". A client that has to read large integer metadata losslessly needs a big-integer-aware JSON parser, or must take that field from the raw response text.
+
+#### Best Practices
+
+- **Send the header on writes as well as reads**: the response of a create, revert or bulk request carries postings too.
+- **Parse with `BigInt`**: `BigInt(posting.amount)` accepts the quoted decimal directly. Never route it through `Number` first — the truncation happens in `JSON.parse`, before any check the client could make.
+- **Do not branch on the mode when writing**: input accepts both forms unconditionally, so a client can pick one form and keep it.
+- **Skip the header when the client does not decode into a float**: Go, Java, Python and other arbitrary-precision decoders read the default numeric wire losslessly, and that wire is unchanged.
+
 ## Main Endpoints
 
 ### Ledgers

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -235,7 +235,7 @@ With `Formance-Bigint-As-String: true`, the same request returns the same docume
 }
 ```
 
-**Only the amount's format changes; the response shape never does.** Field names, field presence, ordering and nesting are identical in both modes at every level of the payload — a nil child still renders `null`, and an empty collection still renders `[]`. That is mechanically enforced, not merely intended: each of the eight routes pins both bodies byte-for-byte and asserts they differ at the posting amounts and nowhere else. The implementation mechanism (how the mode travels down the marshaller chain, and what a new amount-bearing level must do) is specified in `internal/proto/commonpb/string_amounts.go`.
+**Only the amount's format changes; the response shape never does.** Field names, field presence, ordering and nesting are identical in both modes at every level of the payload — a nil child renders identically in both modes, `null` where the field is always present and omitted where it is optional, and an empty collection still renders `[]`. That is mechanically enforced, not merely intended: each of the eight routes pins both bodies byte-for-byte and asserts they differ at the posting amounts and nowhere else. The implementation mechanism (how the mode travels down the marshaller chain, and what a new amount-bearing level must do) is specified in `internal/proto/commonpb/string_amounts.go`.
 
 #### Request Side
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -415,6 +415,17 @@ date coercion (EN-1544), AND-combination, and the removed `prefix`/`reference`
 aliases (EN-1540) — is documented once in
 [query-filter.md](../architecture/subsystems/read-path/query-filter.md).
 
+### Amount output formats (dual-format contract, EN-1779)
+
+`Posting.amount` is emitted as a bare JSON number by default and as a quoted
+decimal string when the request carries the opt-in `Formance-Bigint-As-String`
+header, so JavaScript clients do not truncate above 2^53; on input both forms
+are accepted unconditionally. The full contract — truthy header values and
+lenient parsing, the eight operations that accept it, the unchanged default
+wire, the response-shape guarantee and the integer-metadata limitation — is
+documented once in
+[http-api.md](../architecture/subsystems/api/http-api.md#bigint-as-string-header).
+
 ### 10. Prepared Queries and User-Configurable Indexes
 
 Prepared queries are reusable, named filter queries stored per-ledger. They can be executed in two modes: `LIST` (returns matching entity IDs with cursor pagination) and `AGGREGATE_VOLUMES` (returns aggregated volumes per asset for matched accounts).

--- a/internal/adapter/http/encoder_contract_test.go
+++ b/internal/adapter/http/encoder_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -67,11 +68,20 @@ func TestProtojsonRoutes_PayloadHasNoCustomMarshalJSON(t *testing.T) {
 	}
 }
 
-// TestSonicRoutes_PayloadHasCustomMarshalJSON is the converse: the three routes
-// fixed by EN-1622 rely on their type's marshaller being the contract. If a
-// marshaller is ever deleted, sonic falls back to the protoc-gen `json:` tags,
-// which are snake_case — a silent wire regression. The handler tests assert the
-// resulting shape; this asserts the mechanism they depend on.
+// TestSonicRoutes_PayloadHasCustomMarshalJSON is the converse: every payload
+// served through one of the sonic writers relies on its type's marshaller being
+// the contract. If a marshaller is ever deleted, sonic falls back to the
+// protoc-gen `json:` tags, which are snake_case — a silent wire regression with
+// no compile error. The handler tests assert the resulting shape; this asserts
+// the mechanism they depend on.
+//
+// Transaction, Chapter and Log are the three EN-1622 routes. The other three
+// arrived with EN-1779's opt-in string amounts, which routed them through the
+// checked writers as well: PreparedQueryCursor on the prepared-query execute
+// route (an exposure that predates EN-1779 — the cursor already carried its own
+// marshaller), CreatedTransaction on create-transaction and RevertedTransaction
+// on revert-transaction. Their opt-in wrappers delegate to the same buildAux
+// the marshaller uses, so deleting a marshaller breaks BOTH modes at once.
 func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 	t.Parallel()
 
@@ -79,13 +89,16 @@ func TestSonicRoutes_PayloadHasCustomMarshalJSON(t *testing.T) {
 		&commonpb.Transaction{},
 		&commonpb.Chapter{},
 		&commonpb.Log{},
+		&commonpb.PreparedQueryCursor{},
+		&commonpb.CreatedTransaction{},
+		&commonpb.RevertedTransaction{},
 	} {
 		t.Run(reflect.TypeOf(msg).Elem().Name(), func(t *testing.T) {
 			t.Parallel()
 
 			_, hasCustom := msg.(json.Marshaler)
 			require.Truef(t, hasCustom,
-				"%T is served through writeOKChecked (sonic) and MUST keep its custom "+
+				"%T is served through a checked sonic writer and MUST keep its custom "+
 					"MarshalJSON: without it sonic emits the protoc-gen snake_case tags.",
 				msg)
 		})
@@ -224,6 +237,185 @@ func TestProtojsonRoutes_TableIsComplete(t *testing.T) {
 			"probably did not recognise your call shape — fix the parser, do not delete "+
 			"a row.",
 		sites, expected)
+}
+
+// responseWriterCallSites pins which JSON response writer each file in this
+// package calls. The mapping is a wire contract, not a style choice: this
+// package writes JSON through two different sonic configurations, and the
+// writer a route calls decides which one it gets.
+//
+//	writer               encoder                        a `&` in the body   trailing newline
+//	-------------------- ------------------------------ ------------------- ----------------
+//	writeJSONResponse    json.MarshalWrite, ConfigStd   escaped             appended
+//	writeOK              via writeJSONResponse          escaped             appended
+//	writeCreated         via writeJSONResponse          escaped             appended
+//	writeOKChecked       json.Marshal, ConfigDefault    literal             absent
+//	writeCheckedBody     json.MarshalWrite, ConfigStd   escaped             appended
+//	writeCheckedStatus   via writeCheckedBody           escaped             appended
+//
+// So swapping a route from writeOKChecked to writeCheckedStatus — or the other
+// way — changes every response body that route ever emits: a literal `&`
+// becomes the six-byte escape \u0026, and a newline appears (or disappears)
+// at the end. Nothing in the type
+// system stops that swap, and no handler test catches it unless its pinned body
+// happens to contain an HTML-sensitive character. This table is the guard.
+//
+// The checked writers exist for two independent reasons, which is why a route
+// cannot pick one freely:
+//   - error routing: a payload whose MarshalJSON can genuinely fail must be
+//     buffered before the header is written, so the failure becomes a clean 500
+//     instead of an error object appended to a committed 200 (invariant #7);
+//   - encoder preservation: writeCheckedStatus is the ConfigStd twin of
+//     writeOKChecked, added by EN-1779 so a route that gained the opt-in
+//     string-amount branch could become buffered WITHOUT changing encoder.
+//
+// A row lists the DISTINCT writers a file calls, not one entry per call site:
+// two branches of the same handler calling the same writer is normal (the
+// EN-1779 opt-in branch does exactly that), while a branch calling a different
+// writer than its sibling is the bug this pins.
+var responseWriterCallSites = []struct {
+	file    string
+	writers []string
+}{
+	{"handlers_aggregate_volumes.go", []string{"writeOK"}},
+	{"handlers_analyze_accounts.go", []string{"writeOK"}},
+	{"handlers_analyze_transactions.go", []string{"writeOK"}},
+	// The bulk route builds its own top-level envelope, so the success path
+	// takes writeCheckedBody rather than writeCheckedStatus; the error path
+	// still streams through writeJSONResponse.
+	{"handlers_bulk.go", []string{"writeCheckedBody", "writeJSONResponse"}},
+	{"handlers_create_index.go", []string{"writeCreated"}},
+	{"handlers_create_ledger.go", []string{"writeCreated"}},
+	// Both transaction-creating routes pair writeCreated (default wire) with
+	// writeCheckedStatus (opt-in wire). That pairing is the EN-1779 invariant:
+	// writeCheckedStatus shares writeCreated's ConfigStd encoder, so the two
+	// branches differ only in the amount's quoting.
+	{"handlers_create_transaction.go", []string{"writeCreated", "writeCheckedStatus"}},
+	{"handlers_execute_prepared_query.go", []string{"writeCheckedBody"}},
+	{"handlers_get_account.go", []string{"writeOK"}},
+	{"handlers_get_account_type.go", []string{"writeOK"}},
+	{"handlers_get_audit_entry.go", []string{"writeOKChecked"}},
+	{"handlers_get_chapter_schedule.go", []string{"writeOK"}},
+	{"handlers_get_events_sinks.go", []string{"writeOK"}},
+	{"handlers_get_ledger.go", []string{"writeOK"}},
+	{"handlers_get_ledger_stats.go", []string{"writeOK"}},
+	{"handlers_get_log.go", []string{"writeOKChecked"}},
+	{"handlers_get_metadata_schema.go", []string{"writeOK"}},
+	{"handlers_get_numscript.go", []string{"writeOK"}},
+	{"handlers_get_numscript_usage.go", []string{"writeOK"}},
+	{"handlers_get_transaction.go", []string{"writeCheckedStatus"}},
+	{"handlers_health.go", []string{"writeOK"}},
+	{"handlers_inspect_index.go", []string{"writeOK"}},
+	{"handlers_list_account_types.go", []string{"writeOK"}},
+	{"handlers_list_accounts.go", []string{"writeOK"}},
+	{"handlers_list_all_ledgers.go", []string{"writeOK"}},
+	{"handlers_list_audit_entries.go", []string{"writeOKChecked"}},
+	{"handlers_list_chapters.go", []string{"writeOKChecked"}},
+	{"handlers_list_ledger_logs.go", []string{"writeCheckedStatus"}},
+	{"handlers_list_numscript_versions.go", []string{"writeOK"}},
+	{"handlers_list_numscripts.go", []string{"writeOK"}},
+	{"handlers_list_prepared_queries.go", []string{"writeOK"}},
+	{"handlers_list_transactions.go", []string{"writeOKChecked"}},
+	{"handlers_promote_ledger.go", []string{"writeCreated"}},
+	{"handlers_revert_transaction.go", []string{"writeCreated", "writeCheckedStatus"}},
+	{"handlers_save_numscript.go", []string{"writeCreated"}},
+	// response.go is not a route: these are the internal delegations that give
+	// the table above its meaning — writeOK and writeCreated forward to
+	// writeJSONResponse, writeCheckedStatus forwards to writeCheckedBody, and
+	// writeProtoOK/writeProtoListOK forward to writeOK. They are listed for the
+	// same reason TestProtojsonRoutes_TableIsComplete lists response.go twice:
+	// the AST sees them, so the table must too.
+	{"response.go", []string{"writeCheckedBody", "writeJSONResponse", "writeOK"}},
+}
+
+// responseWriterNames is the set of writers the AST scan below recognises.
+// Every function that writes a JSON body with a status code belongs here; a
+// new one that is not listed would be invisible to the guard.
+var responseWriterNames = map[string]bool{
+	"writeJSONResponse":  true,
+	"writeOK":            true,
+	"writeCreated":       true,
+	"writeOKChecked":     true,
+	"writeCheckedBody":   true,
+	"writeCheckedStatus": true,
+}
+
+// TestResponseWriters_TableIsComplete pins the file-to-writer mapping above by
+// AST-scanning the package, exactly as TestProtojsonRoutes_TableIsComplete pins
+// the protojson call sites. It compares SETS of "file: writer" pairs, and the
+// pair — not just the file — is what makes it useful: a route that keeps its
+// file but changes writer changes encoder, so it must show up as one missing
+// pair and one unexpected pair rather than cancelling out.
+//
+// A count would not do. Moving a route from writeOKChecked to
+// writeCheckedStatus leaves the number of writer call sites unchanged, and so
+// does any compensating add/remove pair across two files.
+func TestResponseWriters_TableIsComplete(t *testing.T) {
+	t.Parallel()
+
+	// parser.ParseDir is deprecated as of Go 1.25 (SA1019); walk the directory
+	// and parse each non-test file individually instead of grouping by package.
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	seen := map[string]bool{}
+
+	for _, entry := range entries {
+		filename := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(filename, ".go") || strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, filename, nil, 0)
+		require.NoError(t, err)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			if name := calleeName(call.Fun); responseWriterNames[name] {
+				seen[filename+": "+name] = true
+			}
+
+			return true
+		})
+	}
+
+	expected := map[string]bool{}
+
+	for _, row := range responseWriterCallSites {
+		for _, writer := range row.writers {
+			expected[row.file+": "+writer] = true
+		}
+	}
+
+	require.ElementsMatch(t, sortedKeys(seen), sortedKeys(expected),
+		"the JSON writers this package calls do not match responseWriterCallSites: "+
+			"list A above is what the AST found, list B is what the table declares.\n\n"+
+			"If you added a route, add a row naming the writer the route ACTUALLY "+
+			"calls — a row naming a different writer satisfies this check while "+
+			"guarding nothing. If you removed a route, delete its row. If a row's "+
+			"writer changed, that is a WIRE CHANGE: the two encoders differ in HTML "+
+			"escaping and in the trailing newline, so update the row deliberately and "+
+			"re-pin every affected body in the handler test. If you changed neither, "+
+			"calleeName probably did not recognise your call shape, or the writer is "+
+			"missing from responseWriterNames — fix the scan, do not delete a row.")
+}
+
+// sortedKeys returns a set's keys in a stable order, so a failure message reads
+// the same on every run.
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+
+	sort.Strings(out)
+
+	return out
 }
 
 // calleeName renders a call's function as "name" or "pkg.name".

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -102,7 +102,7 @@ func (s *Server) serveBulk(w http.ResponseWriter, r *http.Request) {
 	results := s.runBulk(r.Context(), ledgerName, elements, opts)
 
 	// Write response
-	writeBulkResponse(w, elements, results, opts.continueOnFailure)
+	writeBulkResponse(w, r, elements, results, opts.continueOnFailure)
 }
 
 // bulkOptions contains options for bulk processing.
@@ -231,10 +231,14 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 //
 // Any 5xx/429 status from infra/retryable/rate-limit errors always surfaces,
 // with `Retry-After: 1` on 503 to match handleError.
-func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
+func writeBulkResponse(w http.ResponseWriter, r *http.Request, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
 	worstBusiness := 0 // highest 4xx from a per-element business failure
 	worstInfra := 0    // highest ≥429 from a retryable/infra/rate-limit error
 	apiResults := make([]bulkAPIResult, len(results))
+
+	// Resolve the EN-1779 amount wire once for the whole batch rather than per
+	// element: the header applies to the response, not to an entry.
+	amountsAsString := wantsBigintAsString(r)
 
 	for i, result := range results {
 		responseType := servicepb.GetLedgerActionType(elements[i].Action)
@@ -284,7 +288,20 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 			if payload := log.GetData(); payload != nil {
 				switch p := payload.GetPayload().(type) {
 				case *commonpb.LedgerLogPayload_CreatedTransaction:
-					data = p.CreatedTransaction.GetTransaction()
+					// EN-1779: the amount wire is applied here, in the only arm
+					// that carries an amount, and never at the write site — the
+					// OrderSkipped arm below must stay byte-identical in both
+					// modes. The value is a bare *commonpb.Transaction, so the
+					// wrapper is StringAmountTransaction; a nil inner pointer
+					// renders `"data":null` in both modes (a typed nil behind an
+					// `any` is a non-nil interface, so `omitempty` does not fire,
+					// and the wrapper's nil guard emits the same null).
+					transaction := p.CreatedTransaction.GetTransaction()
+
+					data = transaction
+					if amountsAsString {
+						data = commonpb.StringAmountTransaction{Transaction: transaction}
+					}
 				case *commonpb.LedgerLogPayload_OrderSkipped:
 					data = OrderSkippedResponse{
 						Skipped: true,
@@ -315,8 +332,13 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 		statusCode = worstBusiness
 	}
 
+	// writeCheckedBody, not writeJSONResponse: bulk builds its own top-level
+	// envelope, so it must not be wrapped in BaseResponse. It is the same
+	// ConfigStd encoder writeJSONResponse used — no response byte moves — and a
+	// marshal failure on a per-element transaction now becomes a clean 500
+	// instead of an error object appended to an already-committed status.
 	response := bulkResponse{Data: apiResults}
-	writeJSONResponse(w, statusCode, response)
+	writeCheckedBody(w, r, statusCode, response)
 }
 
 // perElementStatus returns the HTTP status a given per-element error would

--- a/internal/adapter/http/handlers_bulk_test.go
+++ b/internal/adapter/http/handlers_bulk_test.go
@@ -325,3 +325,198 @@ func TestHandleBulk_AuthDisabled_NoToken_Allowed(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
+
+// TestHandleBulk_StringAmountWire pins the bulk route's two amount wires
+// (EN-1779), one case per payload arm the per-element `data` field can carry.
+//
+// Two of the three arms must be byte-identical in both modes, and that is the
+// point of the table: the mode is applied inside the CreatedTransaction arm, not
+// at the write site, so an OrderSkipped element (which carries no amount) and a
+// CreatedTransaction whose inner transaction is nil both come out unchanged. The
+// nil case also measures the `omitempty` question on bulkAPIResult.Data: a typed
+// nil pointer behind an `any` is a non-nil interface, so the field is NOT
+// dropped and already renders `"data":null` today — exactly what the wrapper's
+// nil-inner-pointer guard emits.
+//
+// Bulk writes through writeCheckedBody (ConfigStd), so `<`/`&` come out escaped
+// and the body ends in a newline, in both modes.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleBulk_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name    string
+		payload *commonpb.LedgerLogPayload
+		// amountMoves marks the only arm whose rendering the header may change.
+		// Every other arm asserts the two bodies are equal instead.
+		amountMoves   bool
+		htmlSensitive bool
+		defaultBody   string
+		optInBody     string
+	}
+
+	testCases := []testCase{
+		{
+			name: "created transaction carries the amount",
+			payload: &commonpb.LedgerLogPayload{
+				Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+					CreatedTransaction: &commonpb.CreatedTransaction{
+						Transaction: bigAmountTransaction(t, 1),
+					},
+				},
+			},
+			amountMoves:   true,
+			htmlSensitive: true,
+			defaultBody:   `{"data":[{"data":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false},"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+			optInBody:     `{"data":[{"data":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false},"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+		},
+		{
+			name: "order skipped carries no amount",
+			payload: &commonpb.LedgerLogPayload{
+				Payload: &commonpb.LedgerLogPayload_OrderSkipped{
+					OrderSkipped: &commonpb.OrderSkippedLog{
+						Reason:  commonpb.ErrorReason_ERROR_REASON_TRANSACTION_REFERENCE_CONFLICT,
+						Context: map[string]string{"reference": "dup<&>"},
+					},
+				},
+			},
+			htmlSensitive: true,
+			defaultBody:   `{"data":[{"data":{"skipped":true,"reason":"TRANSACTION_REFERENCE_CONFLICT","context":{"reference":"dup\u003c\u0026\u003e"}},"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+			optInBody:     `{"data":[{"data":{"skipped":true,"reason":"TRANSACTION_REFERENCE_CONFLICT","context":{"reference":"dup\u003c\u0026\u003e"}},"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+		},
+		{
+			name: "created transaction with a nil inner transaction",
+			payload: &commonpb.LedgerLogPayload{
+				Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+					CreatedTransaction: &commonpb.CreatedTransaction{},
+				},
+			},
+			defaultBody: `{"data":[{"data":null,"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+			optInBody:   `{"data":[{"data":null,"responseType":"CREATE_TRANSACTION","logID":17}]}` + "\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.amountMoves {
+				requireOnlyAmountQuotingDiffers(t, tc.defaultBody, tc.optInBody)
+			} else {
+				require.Equal(t, tc.defaultBody, tc.optInBody,
+					"an arm that carries no amount must be byte-identical in both modes")
+			}
+
+			modes := []struct {
+				name        string
+				headerValue string // empty means the header is not sent at all
+				wantBody    string
+			}{
+				{name: "default wire", wantBody: tc.defaultBody},
+				{name: "opt-in wire", headerValue: "true", wantBody: tc.optInBody},
+			}
+
+			for _, mode := range modes {
+				t.Run(mode.name, func(t *testing.T) {
+					t.Parallel()
+
+					backend := NewMockBackend(gomock.NewController(t))
+					backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+							return []*commonpb.Log{{
+								Payload: &commonpb.LogPayload{
+									Type: &commonpb.LogPayload_Apply{
+										Apply: &commonpb.ApplyLedgerLog{
+											Log: &commonpb.LedgerLog{Id: 17, Data: tc.payload},
+										},
+									},
+								},
+							}}, nil
+						}).Times(1)
+					srv := newTestServer(t, backend)
+
+					w := httptest.NewRecorder()
+					r := newRequest(t, http.MethodPost, "/ledger1/bulk",
+						strings.NewReader(bulkWriteBody), map[string]string{"ledgerName": "ledger1"})
+
+					if mode.headerValue != "" {
+						r.Header.Set("Formance-Bigint-As-String", mode.headerValue)
+					}
+
+					srv.handleBulk(w, r)
+
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					require.Equal(t, mode.wantBody, w.Body.String())
+
+					// Bulk stays on ConfigStd in both modes: writeCheckedBody is
+					// byte-identical to the writeJSONResponse it replaced.
+					require.True(t, strings.HasSuffix(w.Body.String(), "\n"),
+						"bulk writes through ConfigStd, which appends a trailing newline")
+
+					if tc.htmlSensitive {
+						require.NotContains(t, w.Body.String(), "<",
+							"bulk writes through ConfigStd, which HTML-escapes")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestHandleBulk_StringAmountWireOnlyWrapsTheTransactionArm asserts the amount
+// rendering is decided inside the CreatedTransaction arm rather than at the
+// write site. Wrapping the whole bulkResponse would also reach the OrderSkipped
+// arm, so this pins the negative: an opted-in response whose single element is a
+// skip must be identical to the default one, and must never quote a number.
+func TestHandleBulk_StringAmountWireOnlyWrapsTheTransactionArm(t *testing.T) {
+	t.Parallel()
+
+	bodies := make([]string, 0, 2)
+
+	for _, headerValue := range []string{"", "true"} {
+		backend := NewMockBackend(gomock.NewController(t))
+		backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+				return []*commonpb.Log{{
+					Payload: &commonpb.LogPayload{
+						Type: &commonpb.LogPayload_Apply{
+							Apply: &commonpb.ApplyLedgerLog{
+								Log: &commonpb.LedgerLog{
+									Id: 17,
+									Data: &commonpb.LedgerLogPayload{
+										Payload: &commonpb.LedgerLogPayload_OrderSkipped{
+											OrderSkipped: &commonpb.OrderSkippedLog{
+												Reason: commonpb.ErrorReason_ERROR_REASON_TRANSACTION_REFERENCE_CONFLICT,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}}, nil
+			}).Times(1)
+
+		w := httptest.NewRecorder()
+		r := newRequest(t, http.MethodPost, "/ledger1/bulk",
+			strings.NewReader(bulkWriteBody), map[string]string{"ledgerName": "ledger1"})
+
+		if headerValue != "" {
+			r.Header.Set("Formance-Bigint-As-String", headerValue)
+		}
+
+		newTestServer(t, backend).handleBulk(w, r)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		require.Contains(t, w.Body.String(), `"logID":17`)
+		require.NotContains(t, w.Body.String(), `"logID":"17"`,
+			"the header quotes posting amounts, never other numbers")
+
+		bodies = append(bodies, w.Body.String())
+	}
+
+	require.Equal(t, bodies[0], bodies[1],
+		"a skip-only bulk response must not change when the opt-in header is sent")
+}

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -964,7 +964,7 @@ func TestWriteBulkResponse_WithErrors(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -1002,7 +1002,7 @@ func TestWriteBulkResponse_KindDispatch(t *testing.T) {
 			}}}
 
 			w := httptest.NewRecorder()
-			writeBulkResponse(w, elements, []bulkResult{{err: tc.err}}, true)
+			writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, []bulkResult{{err: tc.err}}, true)
 
 			require.Equal(t, tc.wantStatus, w.Code, "unexpected top-level status for %q", tc.name)
 
@@ -1049,7 +1049,7 @@ func TestWriteBulkResponse_ContinueOnFailure(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, true)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, true)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1081,7 +1081,7 @@ func TestWriteBulkResponse_AllSuccess(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1100,7 +1100,7 @@ func TestWriteBulkResponse_NilLog(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1238,7 +1238,7 @@ func TestWriteBulkResponse_AbortedElementsDontEscalate(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -1457,7 +1457,7 @@ func TestWriteBulkResponse_LogWithCreatedTransaction(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Body.String(), "CREATE_TRANSACTION")
@@ -1482,7 +1482,7 @@ func TestWriteBulkResponse_LogWithoutData(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/adapter/http/handlers_create_transaction.go
+++ b/internal/adapter/http/handlers_create_transaction.go
@@ -67,9 +67,7 @@ func (s *Server) handleCreateTransaction(w http.ResponseWriter, r *http.Request)
 	}
 
 	// EN-1779: the opt-in branch changes the amount format, not the transport, so
-	// it keeps this route's ConfigStd encoder. The wrapper has a value receiver —
-	// store the value, never a pointer to it, or sonic reflects the protobuf
-	// struct instead of calling the declared MarshalJSON.
+	// it keeps this route's ConfigStd encoder.
 	if wantsBigintAsString(r) {
 		writeCheckedStatus(w, r, http.StatusCreated,
 			commonpb.StringAmountCreatedTransaction{CreatedTransaction: created.CreatedTransaction})

--- a/internal/adapter/http/handlers_create_transaction.go
+++ b/internal/adapter/http/handlers_create_transaction.go
@@ -66,5 +66,16 @@ func (s *Server) handleCreateTransaction(w http.ResponseWriter, r *http.Request)
 		panic(emptyLogPayload("create-transaction", logEntry, details))
 	}
 
+	// EN-1779: the opt-in branch changes the amount format, not the transport, so
+	// it keeps this route's ConfigStd encoder. The wrapper has a value receiver —
+	// store the value, never a pointer to it, or sonic reflects the protobuf
+	// struct instead of calling the declared MarshalJSON.
+	if wantsBigintAsString(r) {
+		writeCheckedStatus(w, r, http.StatusCreated,
+			commonpb.StringAmountCreatedTransaction{CreatedTransaction: created.CreatedTransaction})
+
+		return
+	}
+
 	writeCreated(w, created.CreatedTransaction)
 }

--- a/internal/adapter/http/handlers_create_transaction_test.go
+++ b/internal/adapter/http/handlers_create_transaction_test.go
@@ -328,3 +328,81 @@ func TestHandleCreateTransaction_UnknownFieldsAreLenient(t *testing.T) {
 
 	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
 }
+
+// TestHandleCreateTransaction_StringAmountWire pins both amount wires of the
+// create route (EN-1779). Both pinned literals carry this route's ConfigStd
+// framing — `<`/`&` HTML-escaped and a trailing newline — so giving the opt-in
+// branch a ConfigDefault writer would fail here instead of quietly making the
+// header change the escaping as well as the amount.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleCreateTransaction_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}}` + "\n"
+		optInBody   = `{"data":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}}` + "\n"
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServer(t, backendReturningLogs(t, []*commonpb.Log{
+				{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{
+					Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: &commonpb.LedgerLogPayload{
+						Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+							CreatedTransaction: &commonpb.CreatedTransaction{
+								Transaction: bigAmountTransaction(t, 1),
+							},
+						},
+					}}},
+				}}},
+			}))
+
+			w := httptest.NewRecorder()
+			body := strings.NewReader(`{"script":{"plain":"send [USD 1] (source = @world destination = @a)"}}`)
+			r := newRequest(t, http.MethodPost, "/ledger1/transactions", body, map[string]string{
+				"ledgerName": "ledger1",
+			})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleCreateTransaction(w, r)
+
+			require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+			require.Contains(t, w.Body.String(), tc.wantAmount)
+			require.NotContains(t, w.Body.String(), tc.notAmount)
+		})
+	}
+}

--- a/internal/adapter/http/handlers_execute_prepared_query.go
+++ b/internal/adapter/http/handlers_execute_prepared_query.go
@@ -120,18 +120,53 @@ func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Reque
 	case *servicepb.ExecutePreparedQueryResponse_Aggregate:
 		envelope.AggregateResult = toAggregateVolumesJSON(result.Aggregate)
 	case *servicepb.ExecutePreparedQueryResponse_Cursor:
-		envelope.Cursor = result.Cursor
+		// The assignment stays INSIDE this case: the aggregate branch must leave
+		// the field zero so `omitempty` drops it. Hoisting it out would turn an
+		// omitted key into `"cursor":null` on every aggregate response.
+		envelope.Cursor = preparedQueryCursorValue(result.Cursor, wantsBigintAsString(r))
 	}
 
-	writeJSONResponse(w, http.StatusOK, envelope)
+	// writeCheckedBody, not writeJSONResponse: the envelope is already the
+	// top-level shape, so it must not be wrapped in BaseResponse. It is the same
+	// ConfigStd encoder this route already used, so no response byte moves, and a
+	// marshal failure inside the cursor's hand-written MarshalJSON now becomes a
+	// clean 500 instead of an error object appended to a committed 200.
+	writeCheckedBody(w, r, http.StatusOK, envelope)
 }
 
 // executePreparedQueryResponseJSON is the clean camelCase envelope for the
 // prepared-query result oneof: exactly one of cursor / aggregateResult is set
 // (both omitempty), replacing the leaked PascalCase proto oneof shape.
+//
+// Cursor is typed `any` so the same struct serves both amount wire modes
+// (EN-1779). Because it carries `omitempty`, the emptiness test moves from the
+// encoder to preparedQueryCursorValue.
 type executePreparedQueryResponseJSON struct {
-	Cursor          *commonpb.PreparedQueryCursor `json:"cursor,omitempty"`
+	Cursor          any                           `json:"cursor,omitempty"`
 	AggregateResult *aggregateVolumesResponseJSON `json:"aggregateResult,omitempty"`
+}
+
+// preparedQueryCursorValue fills the retyped `cursor` field of the envelope.
+//
+// It returns a nil interface for a nil cursor because the field carries
+// `omitempty`: once the field is typed `any`, a typed nil pointer stored in it
+// is a non-nil interface and would render `"cursor":null` where the previously
+// concrete *commonpb.PreparedQueryCursor field was dropped. It mirrors
+// commonpb's childValue helper, which owns the same invariant one level down.
+//
+// What makes the wrapper reachable behind an `any` field is the invariant that
+// every wrapper declares a VALUE receiver — see
+// internal/proto/commonpb/string_amounts.go.
+func preparedQueryCursorValue(cursor *commonpb.PreparedQueryCursor, amountsAsString bool) any {
+	if cursor == nil {
+		return nil
+	}
+
+	if amountsAsString {
+		return commonpb.StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor}
+	}
+
+	return cursor
 }
 
 // convertJSONParameters converts raw JSON values into typed ParameterValue messages.

--- a/internal/adapter/http/handlers_execute_prepared_query_test.go
+++ b/internal/adapter/http/handlers_execute_prepared_query_test.go
@@ -358,3 +358,195 @@ func TestHandleExecutePreparedQuery_UnsupportedParameterType(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// TestHandleExecutePreparedQuery_StringAmountWire pins both amount wires of the
+// prepared-query execute route (EN-1779), one case per result the oneof can
+// carry.
+//
+// The cursor covers three targets and only two of them carry amounts, so half
+// this table asserts the response does NOT move: an ACCOUNTS page is
+// byte-identical in both modes (nothing below Account renders an amount as a bare
+// JSON number), and the aggregate branch must keep the `cursor` key omitted
+// rather than gaining `"cursor":null` — which is what retyping the field to `any`
+// would cause if the assignment were hoisted out of the cursor case, or if the
+// nil guard in preparedQueryCursorValue were dropped.
+//
+// The LOGS target is the deepest chain on the HTTP surface: cursor → log →
+// payload → apply → ledger log → payload → created transaction → transaction →
+// posting → amount.
+//
+// This route writes through writeCheckedBody (ConfigStd), so `<`/`&` come out
+// escaped and the body ends in a newline, in both modes.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleExecutePreparedQuery_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name     string
+		response *servicepb.ExecutePreparedQueryResponse
+		// amountMoves marks the targets whose rendering the header may change.
+		// The others assert the two bodies are equal instead.
+		amountMoves   bool
+		htmlSensitive bool
+		// forbidden are substrings that must appear in neither mode's body.
+		forbidden   []string
+		defaultBody string
+		optInBody   string
+	}
+
+	testCases := []testCase{
+		{
+			name: "accounts target has no amount to move",
+			response: &servicepb.ExecutePreparedQueryResponse{
+				Result: &servicepb.ExecutePreparedQueryResponse_Cursor{
+					Cursor: &commonpb.PreparedQueryCursor{
+						PageSize:    15,
+						AccountData: []*commonpb.Account{{Address: "world<&>"}},
+					},
+				},
+			},
+			htmlSensitive: true,
+			forbidden:     []string{`"transactionData"`, `"logData"`},
+			defaultBody:   `{"cursor":{"pageSize":15,"hasMore":false,"accountData":[{"address":"world\u003c\u0026\u003e","volumes":[]}]}}` + "\n",
+			optInBody:     `{"cursor":{"pageSize":15,"hasMore":false,"accountData":[{"address":"world\u003c\u0026\u003e","volumes":[]}]}}` + "\n",
+		},
+		{
+			name: "transactions target quotes the posting amount",
+			response: &servicepb.ExecutePreparedQueryResponse{
+				Result: &servicepb.ExecutePreparedQueryResponse_Cursor{
+					Cursor: &commonpb.PreparedQueryCursor{
+						PageSize:        15,
+						TransactionData: []*commonpb.Transaction{bigAmountTransaction(t, 1)},
+					},
+				},
+			},
+			amountMoves:   true,
+			htmlSensitive: true,
+			forbidden:     []string{`"logData"`, `"accountData"`},
+			defaultBody:   `{"cursor":{"pageSize":15,"hasMore":false,"transactionData":[{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}]}}` + "\n",
+			optInBody:     `{"cursor":{"pageSize":15,"hasMore":false,"transactionData":[{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}]}}` + "\n",
+		},
+		{
+			name: "logs target quotes the amount at the bottom of the log chain",
+			response: &servicepb.ExecutePreparedQueryResponse{
+				Result: &servicepb.ExecutePreparedQueryResponse_Cursor{
+					Cursor: &commonpb.PreparedQueryCursor{
+						PageSize: 15,
+						LogData:  []*commonpb.Log{bigAmountLog(t, 1)},
+					},
+				},
+			},
+			amountMoves:   true,
+			htmlSensitive: true,
+			forbidden:     []string{`"transactionData"`, `"accountData"`},
+			defaultBody:   `{"cursor":{"pageSize":15,"hasMore":false,"logData":[{"sequence":1,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}},"id":1}}},"responseSignature":{}}]}}` + "\n",
+			optInBody:     `{"cursor":{"pageSize":15,"hasMore":false,"logData":[{"sequence":1,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}},"id":1}}},"responseSignature":{}}]}}` + "\n",
+		},
+		{
+			name: "aggregate branch never gains a cursor key",
+			response: &servicepb.ExecutePreparedQueryResponse{
+				Result: &servicepb.ExecutePreparedQueryResponse_Aggregate{
+					Aggregate: &commonpb.AggregateResult{
+						Volumes: []*commonpb.AggregatedVolume{
+							{
+								Asset:  "USD",
+								Input:  commonpb.NewUint256FromUint64(100),
+								Output: commonpb.NewUint256FromUint64(30),
+							},
+						},
+					},
+				},
+			},
+			forbidden:   []string{`"cursor"`},
+			defaultBody: `{"aggregateResult":{"volumes":[{"asset":"USD","color":"","input":"100","output":"30","balance":"70"}]}}` + "\n",
+			optInBody:   `{"aggregateResult":{"volumes":[{"asset":"USD","color":"","input":"100","output":"30","balance":"70"}]}}` + "\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.amountMoves {
+				requireOnlyAmountQuotingDiffers(t, tc.defaultBody, tc.optInBody)
+			} else {
+				require.Equal(t, tc.defaultBody, tc.optInBody,
+					"a result that carries no amount must be byte-identical in both modes")
+			}
+
+			modes := []struct {
+				name        string
+				headerValue string // empty means the header is not sent at all
+				wantBody    string
+			}{
+				{name: "default wire", wantBody: tc.defaultBody},
+				{name: "opt-in wire", headerValue: "true", wantBody: tc.optInBody},
+			}
+
+			for _, mode := range modes {
+				t.Run(mode.name, func(t *testing.T) {
+					t.Parallel()
+
+					backend := NewMockBackend(gomock.NewController(t))
+					backend.EXPECT().ExecutePreparedQuery(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, _ *servicepb.ExecutePreparedQueryRequest) (*servicepb.ExecutePreparedQueryResponse, error) {
+							return tc.response, nil
+						}).Times(1)
+					srv := newTestServer(t, backend)
+
+					w := httptest.NewRecorder()
+					r := newRequest(t, http.MethodPost, "/ledger1/prepared-queries/my-query/execute",
+						strings.NewReader(`{"pageSize":15}`), map[string]string{
+							"ledgerName": "ledger1",
+							"queryName":  "my-query",
+						})
+
+					if mode.headerValue != "" {
+						r.Header.Set("Formance-Bigint-As-String", mode.headerValue)
+					}
+
+					srv.handleExecutePreparedQuery(w, r)
+
+					require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+					require.Equal(t, mode.wantBody, w.Body.String())
+
+					for _, forbidden := range tc.forbidden {
+						require.NotContains(t, w.Body.String(), forbidden)
+					}
+
+					// The route stays on ConfigStd in both modes:
+					// writeCheckedBody is byte-identical to the
+					// writeJSONResponse it replaced.
+					require.True(t, strings.HasSuffix(w.Body.String(), "\n"),
+						"the prepared-query route writes through ConfigStd, which appends a trailing newline")
+
+					if tc.htmlSensitive {
+						require.NotContains(t, w.Body.String(), "<",
+							"the prepared-query route writes through ConfigStd, which HTML-escapes")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestPreparedQueryCursorValue covers the guard that keeps the retyped `cursor`
+// field omitted rather than rendering `"cursor":null`. Once the field is typed
+// `any`, a typed nil pointer stored in it is a non-nil interface and `omitempty`
+// stops firing, so the emptiness test lives in this helper instead of the encoder.
+func TestPreparedQueryCursorValue(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, preparedQueryCursorValue(nil, false),
+		"a nil cursor must produce a nil interface so omitempty still drops the key")
+	require.Nil(t, preparedQueryCursorValue(nil, true),
+		"the opt-in mode must not turn an absent cursor into a rendered null")
+
+	cursor := &commonpb.PreparedQueryCursor{PageSize: 15}
+	require.Equal(t, cursor, preparedQueryCursorValue(cursor, false))
+	require.Equal(t,
+		commonpb.StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor},
+		preparedQueryCursorValue(cursor, true))
+}

--- a/internal/adapter/http/handlers_get_log.go
+++ b/internal/adapter/http/handlers_get_log.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
 // handleGetLog handles GET /logs/{sequence} to fetch a single system log by
@@ -27,5 +29,14 @@ func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeOKChecked(w, r, log)
+	// EN-1779: the opt-in header changes the amount format only, so both branches
+	// keep writeOKChecked — moving one to a ConfigStd writer would also change the
+	// HTML escaping and add a trailing newline. This route is deliberately not
+	// unified with the logs-list route, which has always used ConfigStd.
+	var logValue any = log
+	if wantsBigintAsString(r) {
+		logValue = commonpb.StringAmountLog{Log: log}
+	}
+
+	writeOKChecked(w, r, logValue)
 }

--- a/internal/adapter/http/handlers_get_log_test.go
+++ b/internal/adapter/http/handlers_get_log_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -152,4 +153,87 @@ func TestHandleGetLog_NotFound(t *testing.T) {
 	srv.handleGetLog(w, r)
 
 	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestHandleGetLog_StringAmountWire pins both amount wires of the single-log
+// route (EN-1779).
+//
+// This route writes through writeOKChecked, whose sonic ConfigDefault leaves `<`
+// and `&` unescaped and appends no trailing newline. The logs-list route serves
+// the very same fixture (bigAmountLog) through ConfigStd, so its pinned bytes in
+// TestHandleListLedgerLogs_StringAmountWire are deliberately different. The two
+// log routes are NOT unified: each keeps the encoder it already had, because the
+// opt-in header changes the amount format and nothing else. The encoder
+// assertions below fail if either route drifts onto the other's writer.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleGetLog_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":{"sequence":7,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world<&>","destination":"alice&<bob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":7,"reverted":false}}},"id":7}}},"responseSignature":{}}}`
+		optInBody   = `{"data":{"sequence":7,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world<&>","destination":"alice&<bob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":7,"reverted":false}}},"id":7}}},"responseSignature":{}}}`
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := NewMockBackend(gomock.NewController(t))
+			backend.EXPECT().GetLog(gomock.Any(), uint64(7)).DoAndReturn(
+				func(_ context.Context, _ uint64) (*commonpb.Log, error) {
+					return bigAmountLog(t, 7), nil
+				}).AnyTimes()
+			srv := newTestServer(t, backend)
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodGet, "/logs/7", nil, map[string]string{"sequence": "7"})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleGetLog(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+			require.Contains(t, w.Body.String(), tc.wantAmount)
+			require.NotContains(t, w.Body.String(), tc.notAmount)
+
+			// Encoder assertions, in both modes: this route must stay on
+			// ConfigDefault. Without them a swap to the logs-list route's writer
+			// would only show up as two edited literals.
+			require.False(t, strings.HasSuffix(w.Body.String(), "\n"),
+				"the single-log route writes through ConfigDefault, which appends no trailing newline")
+			require.Contains(t, w.Body.String(), "<",
+				"the single-log route writes through ConfigDefault, which does not HTML-escape")
+		})
+	}
 }

--- a/internal/adapter/http/handlers_get_transaction.go
+++ b/internal/adapter/http/handlers_get_transaction.go
@@ -16,9 +16,13 @@ import (
 // clients see a stable field rather than a sometimes-absent key. The receipt is
 // reused verbatim from the backend — never recomputed here — so checkpoint/live
 // consistency stays owned by the controller read path.
+//
+// Transaction is typed `any` so the same struct serves both amount wire modes
+// (EN-1779). It carries no `omitempty`, so a nil value renders as null in both,
+// matching the previous *commonpb.Transaction.
 type getTransactionData struct {
-	Transaction *commonpb.Transaction `json:"transaction"`
-	Receipt     string                `json:"receipt"`
+	Transaction any    `json:"transaction"`
+	Receipt     string `json:"receipt"`
 }
 
 // handleGetTransaction handles GET /{ledgerName}/transactions/{transactionId} to retrieve a transaction.
@@ -61,8 +65,20 @@ func (s *Server) handleGetTransaction(w http.ResponseWriter, r *http.Request) {
 		receiptToken = *receipt
 	}
 
-	writeOK(w, getTransactionData{
-		Transaction: transaction,
+	// The wrapper has a value receiver, so the value goes into the interface: a
+	// pointer to it is not addressable behind an `any` field, the declared
+	// MarshalJSON is bypassed, and sonic reflects the protobuf struct into
+	// PascalCase field names with neither a compile nor a runtime error.
+	var transactionValue any = transaction
+	if wantsBigintAsString(r) {
+		transactionValue = commonpb.StringAmountTransaction{Transaction: transaction}
+	}
+
+	// writeCheckedStatus, not writeOKChecked: this route has always written
+	// through the ConfigStd encoder, and writeOKChecked would silently drop the
+	// HTML escaping and the trailing newline for every client (EN-1779).
+	writeCheckedStatus(w, r, http.StatusOK, getTransactionData{
+		Transaction: transactionValue,
 		Receipt:     receiptToken,
 	})
 }

--- a/internal/adapter/http/handlers_get_transaction.go
+++ b/internal/adapter/http/handlers_get_transaction.go
@@ -65,10 +65,11 @@ func (s *Server) handleGetTransaction(w http.ResponseWriter, r *http.Request) {
 		receiptToken = *receipt
 	}
 
-	// The wrapper has a value receiver, so the value goes into the interface: a
-	// pointer to it is not addressable behind an `any` field, the declared
-	// MarshalJSON is bypassed, and sonic reflects the protobuf struct into
-	// PascalCase field names with neither a compile nor a runtime error.
+	// What makes the wrapper reachable behind this `any` field is the invariant
+	// that every wrapper declares a VALUE receiver — see
+	// internal/proto/commonpb/string_amounts.go. A pointer-receiver wrapper whose
+	// value is stored here would have its MarshalJSON silently skipped, and sonic
+	// would reflect the protobuf struct into PascalCase names with no error.
 	var transactionValue any = transaction
 	if wantsBigintAsString(r) {
 		transactionValue = commonpb.StringAmountTransaction{Transaction: transaction}

--- a/internal/adapter/http/handlers_get_transaction_test.go
+++ b/internal/adapter/http/handlers_get_transaction_test.go
@@ -235,3 +235,81 @@ func TestHandleGetTransaction_MissingLedgerName(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// TestHandleGetTransaction_StringAmountWire pins both amount wires of the detail
+// route (EN-1779). The default body is asserted byte-for-byte against what the
+// route emitted before the opt-in existed, and the opt-in body against a literal
+// that requireOnlyAmountQuotingDiffers proves differs from it in the amount
+// alone — including the HTML escaping and the trailing newline this route's
+// ConfigStd encoder produces, which is what a change of writer would break.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleGetTransaction_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":42,"reverted":false},"receipt":""}}` + "\n"
+		optInBody   = `{"data":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":42,"reverted":false},"receipt":""}}` + "\n"
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := NewMockBackend(gomock.NewController(t))
+			backend.EXPECT().GetLedgerByName(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ string) (*commonpb.LedgerInfo, error) {
+					return &commonpb.LedgerInfo{Name: "ledger1"}, nil
+				}).AnyTimes()
+			backend.EXPECT().GetTransaction(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ string, txID uint64) (*commonpb.Transaction, *string, error) {
+					return bigAmountTransaction(t, txID), nil, nil
+				}).AnyTimes()
+			srv := newTestServer(t, backend)
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodGet, "/ledger1/transactions/42", nil, map[string]string{
+				"ledgerName":    "ledger1",
+				"transactionId": "42",
+			})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleGetTransaction(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+			require.Contains(t, w.Body.String(), tc.wantAmount)
+			require.NotContains(t, w.Body.String(), tc.notAmount)
+		})
+	}
+}

--- a/internal/adapter/http/handlers_list_ledger_logs.go
+++ b/internal/adapter/http/handlers_list_ledger_logs.go
@@ -104,5 +104,19 @@ func (s *Server) handleListLedgerLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeOK(w, logs)
+	// writeCheckedStatus, not writeOK: commonpb.Log carries a hand-written
+	// MarshalJSON that marshals a metadata map and can genuinely fail, so the
+	// streaming writer would append an error object to an already-committed 200
+	// (the EN-1622 class). It is the same ConfigStd encoder writeOK used, so no
+	// response byte moves for clients that never opt in.
+	//
+	// EN-1779: the opt-in branch changes the amount format, not the transport.
+	// StringAmountLogs is always non-nil, matching drainCursor's always-non-nil
+	// slice, so an empty page renders `[]` in both modes.
+	var logsValue any = logs
+	if wantsBigintAsString(r) {
+		logsValue = commonpb.StringAmountLogs(logs)
+	}
+
+	writeCheckedStatus(w, r, http.StatusOK, logsValue)
 }

--- a/internal/adapter/http/handlers_list_ledger_logs_test.go
+++ b/internal/adapter/http/handlers_list_ledger_logs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -341,4 +342,110 @@ func TestHandleListLedgerLogs_WithAfterParam(t *testing.T) {
 	srv.handleListLedgerLogs(w, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestHandleListLedgerLogs_StringAmountWire pins both amount wires of the
+// ledger-logs list route (EN-1779). The amount sits nine levels down, at the
+// bottom of the global-log chain, so this is the route that proves the mode
+// really travels through the whole encoder recursion.
+//
+// This route writes through the ConfigStd encoder: `<` and `&` come out
+// HTML-escaped and the body ends in a newline. The single-log route
+// (TestHandleGetLog_StringAmountWire) serves the same fixture through
+// ConfigDefault and its pinned bytes are deliberately different — the two log
+// routes are not unified, and that asymmetry is asserted on both sides.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleListLedgerLogs_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":[{"sequence":1,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}},"id":1}}},"responseSignature":{}}]}` + "\n"
+		optInBody   = `{"data":[{"sequence":1,"payload":{"apply":{"ledgerName":"ledger1","log":{"type":"NEW_TRANSACTION","data":{"createdTransaction":{"transaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}}},"id":1}}},"responseSignature":{}}]}` + "\n"
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		logs        []*commonpb.Log
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			logs:       []*commonpb.Log{bigAmountLog(t, 1)},
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			logs:        []*commonpb.Log{bigAmountLog(t, 1)},
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+		{
+			// The wrapper slice is always non-nil, matching drainCursor's
+			// always-non-nil slice: an empty page must stay `[]` rather than
+			// becoming `null` in one mode only. The header moves the amount
+			// format, never the response shape.
+			name:     "default wire renders an empty page as an array",
+			logs:     nil,
+			wantBody: `{"data":[]}` + "\n",
+		},
+		{
+			name:        "opt-in wire renders an empty page as the same array",
+			headerValue: "true",
+			logs:        nil,
+			wantBody:    `{"data":[]}` + "\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := NewMockBackend(gomock.NewController(t))
+			backend.EXPECT().ListLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ string, _ uint64, _ uint32, _ *commonpb.QueryFilter) (cursor.Cursor[*commonpb.Log], error) {
+					return cursor.NewSliceCursor(tc.logs), nil
+				}).AnyTimes()
+			srv := newTestServer(t, backend)
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodGet, "/ledger1/logs", nil, map[string]string{
+				"ledgerName": "ledger1",
+			})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleListLedgerLogs(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+
+			if tc.wantAmount != "" {
+				require.Contains(t, w.Body.String(), tc.wantAmount)
+				require.NotContains(t, w.Body.String(), tc.notAmount)
+			}
+
+			// Encoder assertions, in both modes: this route must stay on
+			// ConfigStd. Without them a swap to the single-log route's writer
+			// would only show up as two edited literals.
+			require.True(t, strings.HasSuffix(w.Body.String(), "\n"),
+				"the logs-list route writes through ConfigStd, which appends a trailing newline")
+			require.NotContains(t, w.Body.String(), "<",
+				"the logs-list route writes through ConfigStd, which HTML-escapes")
+		})
+	}
 }

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -128,5 +128,14 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 		writeProfileHeader(w, profile)
 	}
 
+	// EN-1779: the opt-in header changes the amount format only, so both branches
+	// keep writeOKChecked — moving one to a ConfigStd writer would also change the
+	// HTML escaping and add a trailing newline.
+	if wantsBigintAsString(r) {
+		writeOKChecked(w, r, commonpb.StringAmountTransactions(transactions))
+
+		return
+	}
+
 	writeOKChecked(w, r, transactions)
 }

--- a/internal/adapter/http/handlers_list_transactions_test.go
+++ b/internal/adapter/http/handlers_list_transactions_test.go
@@ -294,3 +294,76 @@ func TestHandleListTransactions_BackendError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), "INTERNAL_ERROR")
 }
+
+// TestHandleListTransactions_StringAmountWire pins both amount wires of the list
+// route (EN-1779). This route writes through writeOKChecked, whose sonic
+// ConfigDefault leaves `<` and `&` unescaped and appends no trailing newline —
+// the opposite of the ConfigStd writers used elsewhere in this package. Both
+// pinned literals therefore carry the raw characters, and any move to the other
+// writer fails here rather than silently changing the default wire.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleListTransactions_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":[{"postings":[{"source":"world<&>","destination":"alice&<bob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}]}`
+		optInBody   = `{"data":[{"postings":[{"source":"world<&>","destination":"alice&<bob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":1,"reverted":false}]}`
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend := NewMockBackend(gomock.NewController(t))
+			backend.EXPECT().ListTransactions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ string, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*commonpb.Transaction], error) {
+					return cursor.NewSliceCursor([]*commonpb.Transaction{bigAmountTransaction(t, 1)}), nil
+				}).AnyTimes()
+			srv := newTestServer(t, backend)
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodGet, "/ledger1/transactions", nil, map[string]string{
+				"ledgerName": "ledger1",
+			})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleListTransactions(w, r)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+			require.Contains(t, w.Body.String(), tc.wantAmount)
+			require.NotContains(t, w.Body.String(), tc.notAmount)
+		})
+	}
+}

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -106,9 +106,7 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 	}
 
 	// EN-1779: the opt-in branch changes the amount format, not the transport, so
-	// it keeps this route's ConfigStd encoder. The wrapper has a value receiver —
-	// store the value, never a pointer to it, or sonic reflects the protobuf
-	// struct instead of calling the declared MarshalJSON.
+	// it keeps this route's ConfigStd encoder.
 	if wantsBigintAsString(r) {
 		writeCheckedStatus(w, r, http.StatusCreated,
 			commonpb.StringAmountRevertedTransaction{RevertedTransaction: rt.RevertedTransaction})

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -105,5 +105,16 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 		panic(emptyLogPayload("revert-transaction", logEntry, details))
 	}
 
+	// EN-1779: the opt-in branch changes the amount format, not the transport, so
+	// it keeps this route's ConfigStd encoder. The wrapper has a value receiver —
+	// store the value, never a pointer to it, or sonic reflects the protobuf
+	// struct instead of calling the declared MarshalJSON.
+	if wantsBigintAsString(r) {
+		writeCheckedStatus(w, r, http.StatusCreated,
+			commonpb.StringAmountRevertedTransaction{RevertedTransaction: rt.RevertedTransaction})
+
+		return
+	}
+
 	writeCreated(w, rt.RevertedTransaction)
 }

--- a/internal/adapter/http/handlers_revert_transaction_test.go
+++ b/internal/adapter/http/handlers_revert_transaction_test.go
@@ -330,3 +330,82 @@ func TestHandleRevertTransaction_InvalidMetadata(t *testing.T) {
 	resp := decodeResponse[ErrorResponse](t, w)
 	require.Equal(t, "INVALID_REQUEST", resp.ErrorCode)
 }
+
+// TestHandleRevertTransaction_StringAmountWire pins both amount wires of the
+// revert route (EN-1779). Both pinned literals carry this route's ConfigStd
+// framing — `<`/`&` HTML-escaped and a trailing newline — so giving the opt-in
+// branch a ConfigDefault writer would fail here instead of quietly making the
+// header change the escaping as well as the amount.
+//
+// Amount assertions read the raw body bytes and never decode: the repository's
+// sonic wrapper has no UseNumber, so decoding silently truncates 2^53+1.
+func TestHandleRevertTransaction_StringAmountWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultBody = `{"data":{"revertedTransactionId":1,"revertTransaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":9007199254740993,"asset":"USD/2","color":""}],"metadata":{},"id":2,"reverted":false}}}` + "\n"
+		optInBody   = `{"data":{"revertedTransactionId":1,"revertTransaction":{"postings":[{"source":"world\u003c\u0026\u003e","destination":"alice\u0026\u003cbob","amount":"9007199254740993","asset":"USD/2","color":""}],"metadata":{},"id":2,"reverted":false}}}` + "\n"
+	)
+
+	requireOnlyAmountQuotingDiffers(t, defaultBody, optInBody)
+
+	type testCase struct {
+		name        string
+		headerValue string // empty means the header is not sent at all
+		wantBody    string
+		wantAmount  string // the amount rendering that must appear
+		notAmount   string // the other mode's rendering, which must not
+	}
+
+	testCases := []testCase{
+		{
+			name:       "default wire keeps the bare number",
+			wantBody:   defaultBody,
+			wantAmount: `"amount":` + aboveJSNumberLimit,
+			notAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+		},
+		{
+			name:        "opt-in wire quotes the decimal",
+			headerValue: "true",
+			wantBody:    optInBody,
+			wantAmount:  `"amount":"` + aboveJSNumberLimit + `"`,
+			notAmount:   `"amount":` + aboveJSNumberLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newTestServer(t, backendReturningLogs(t, []*commonpb.Log{
+				{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{
+					Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: &commonpb.LedgerLogPayload{
+						Payload: &commonpb.LedgerLogPayload_RevertedTransaction{
+							RevertedTransaction: &commonpb.RevertedTransaction{
+								RevertedTransactionId: 1,
+								RevertTransaction:     bigAmountTransaction(t, 2),
+							},
+						},
+					}}},
+				}}},
+			}))
+
+			w := httptest.NewRecorder()
+			r := newRequest(t, http.MethodPost, "/ledger1/transactions/1/revert", nil, map[string]string{
+				"ledgerName":    "ledger1",
+				"transactionId": "1",
+			})
+
+			if tc.headerValue != "" {
+				r.Header.Set("Formance-Bigint-As-String", tc.headerValue)
+			}
+
+			srv.handleRevertTransaction(w, r)
+
+			require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+			require.Equal(t, tc.wantBody, w.Body.String())
+			require.Contains(t, w.Body.String(), tc.wantAmount)
+			require.NotContains(t, w.Body.String(), tc.notAmount)
+		})
+	}
+}

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -96,6 +96,31 @@ func writeOKChecked(w http.ResponseWriter, r *http.Request, data any) {
 	_, _ = w.Write(body)
 }
 
+// writeCheckedStatus writes a JSON response like writeJSONResponse, but marshals
+// the body to a buffer BEFORE writing any header, so a marshal failure is routed
+// through handleError (a clean 500 with no partial body) instead of being
+// appended to an already-committed status.
+//
+// It exists alongside writeOKChecked because the two use DIFFERENT encoders:
+// writeOKChecked marshals with json.Marshal (sonic ConfigDefault) while this uses
+// json.MarshalWrite (sonic ConfigStd, which HTML-escapes and appends a trailing
+// newline). A route must keep the encoder it already had, so the choice between
+// them is determined by the writer the route used before, never by preference
+// (EN-1779).
+func writeCheckedStatus(w http.ResponseWriter, r *http.Request, statusCode int, data any) {
+	var buf bytes.Buffer
+
+	if err := json.MarshalWrite(&buf, BaseResponse[any]{Data: data}); err != nil {
+		handleError(w, r, err)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(buf.Bytes())
+}
+
 // writeProtoOK writes a 200 OK response whose `data` is a single protobuf
 // message serialized via protojson, which renders protobuf-JSON camelCase from
 // the descriptor (e.g. lastIndexedSequence) rather than the snake_case Go

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -96,21 +96,20 @@ func writeOKChecked(w http.ResponseWriter, r *http.Request, data any) {
 	_, _ = w.Write(body)
 }
 
-// writeCheckedStatus writes a JSON response like writeJSONResponse, but marshals
-// the body to a buffer BEFORE writing any header, so a marshal failure is routed
-// through handleError (a clean 500 with no partial body) instead of being
-// appended to an already-committed status.
+// writeCheckedBody marshals an already-shaped response body to a buffer BEFORE
+// writing any header, so a marshal failure becomes a clean 500 through
+// handleError instead of an error object appended to an already-committed
+// status. Callers that want the standard BaseResponse envelope should use
+// writeCheckedStatus instead.
 //
-// It exists alongside writeOKChecked because the two use DIFFERENT encoders:
-// writeOKChecked marshals with json.Marshal (sonic ConfigDefault) while this uses
-// json.MarshalWrite (sonic ConfigStd, which HTML-escapes and appends a trailing
-// newline). A route must keep the encoder it already had, so the choice between
-// them is determined by the writer the route used before, never by preference
-// (EN-1779).
-func writeCheckedStatus(w http.ResponseWriter, r *http.Request, statusCode int, data any) {
+// This is the ConfigStd (json.MarshalWrite) side of the package's two encoders;
+// writeOKChecked is the ConfigDefault side. A route must keep the encoder it
+// already had, so the choice between them follows the writer the route used
+// before, never preference (EN-1779).
+func writeCheckedBody(w http.ResponseWriter, r *http.Request, statusCode int, body any) {
 	var buf bytes.Buffer
 
-	if err := json.MarshalWrite(&buf, BaseResponse[any]{Data: data}); err != nil {
+	if err := json.MarshalWrite(&buf, body); err != nil {
 		handleError(w, r, err)
 
 		return
@@ -119,6 +118,25 @@ func writeCheckedStatus(w http.ResponseWriter, r *http.Request, statusCode int, 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(buf.Bytes())
+}
+
+// writeCheckedStatus writes a JSON response like writeJSONResponse, but marshals
+// the body to a buffer BEFORE writing any header, so a marshal failure is routed
+// through handleError (a clean 500 with no partial body) instead of being
+// appended to an already-committed status.
+//
+// It exists alongside writeOKChecked because the two use DIFFERENT encoders:
+// writeOKChecked marshals with json.Marshal (sonic ConfigDefault) while this
+// goes through writeCheckedBody's json.MarshalWrite (sonic ConfigStd, which
+// HTML-escapes and appends a trailing newline). A route must keep the encoder it
+// already had, so the choice between them is determined by the writer the route
+// used before, never by preference (EN-1779).
+//
+// It differs from writeCheckedBody only in wrapping data in the BaseResponse
+// envelope: routes that build their own top-level envelope (bulk,
+// prepared-query) must call writeCheckedBody so they are not double-wrapped.
+func writeCheckedStatus(w http.ResponseWriter, r *http.Request, statusCode int, data any) {
+	writeCheckedBody(w, r, statusCode, BaseResponse[any]{Data: data})
 }
 
 // writeProtoOK writes a 200 OK response whose `data` is a single protobuf

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -67,6 +67,25 @@ func writeCreated(w http.ResponseWriter, data any) {
 	})
 }
 
+// failCheckedWrite routes a buffered-marshal failure to handleError, dropping
+// Retry-After first.
+//
+// A caller may have set that hint for the status it intended — writeBulkResponse
+// does, on its 503 infra rollup — but that status is never written when the
+// marshal fails, and handleError only ever Sets the header, never clears it. The
+// hint would then outlive the status it was chosen for and tell a client to retry
+// a non-retryable 500. For bulk that is not cosmetic: the operations are already
+// applied by the time the response is written, so a retry without an idempotency
+// key risks duplicating committed work. handleError re-sets the header for the
+// statuses that do earn it, so the legitimate 503 hint is unaffected.
+//
+// Only Retry-After is cleared: the header map also carries middleware-set
+// entries (CORS, correlation) that must survive the status change.
+func failCheckedWrite(w http.ResponseWriter, r *http.Request, err error) {
+	w.Header().Del("Retry-After")
+	handleError(w, r, err)
+}
+
 // writeOKChecked writes a 200 OK response like writeOK, but marshals the body
 // to a buffer BEFORE writing any header, so a marshal failure is routed through
 // handleError (a clean 500 with no partial body) instead of being appended to
@@ -86,7 +105,7 @@ func writeCreated(w http.ResponseWriter, data any) {
 func writeOKChecked(w http.ResponseWriter, r *http.Request, data any) {
 	body, err := json.Marshal(BaseResponse[any]{Data: data})
 	if err != nil {
-		handleError(w, r, err)
+		failCheckedWrite(w, r, err)
 
 		return
 	}
@@ -110,7 +129,7 @@ func writeCheckedBody(w http.ResponseWriter, r *http.Request, statusCode int, bo
 	var buf bytes.Buffer
 
 	if err := json.MarshalWrite(&buf, body); err != nil {
-		handleError(w, r, err)
+		failCheckedWrite(w, r, err)
 
 		return
 	}

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -368,7 +368,17 @@ func TestWriteCheckedStatus(t *testing.T) {
 				w := httptest.NewRecorder()
 				r := httptest.NewRequest(http.MethodPost, "/", nil)
 
+				// A caller that chose its status before the marshal may also
+				// have set the retry hint for it — writeBulkResponse does on its
+				// 503 infra rollup. The status is never written when the marshal
+				// fails, so the hint must not ride along on the 500.
+				w.Header().Set("Retry-After", "1")
+
 				wr.write(w, r, failingMarshaler{})
+
+				require.Empty(t, w.Header().Get("Retry-After"),
+					"a marshal failure answers 500, which is not retryable: the "+
+						"hint set for the intended status must not outlive it")
 
 				// The status must NOT have been committed before the marshal:
 				// a writer that writes its header first turns a marshal failure
@@ -429,6 +439,56 @@ func TestWriteCheckedStatus(t *testing.T) {
 					require.Equal(t, ref.Header(), w.Header())
 				})
 			}
+		})
+	}
+}
+
+// noLeaderMarshaler is a payload whose MarshalJSON fails with an error wrapping
+// commonpb.ErrNoLeader, the one marshal failure that legitimately earns a
+// Retry-After. It is the positive control for failCheckedWrite's Del: clearing
+// the caller's stale hint must not also suppress the hint handleError owes for
+// the status it actually writes.
+type noLeaderMarshaler struct{}
+
+// MarshalJSON implements json.Marshaler, always failing with a retryable error.
+func (noLeaderMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("marshal: %w", commonpb.ErrNoLeader)
+}
+
+// TestCheckedWriters_RetryableFailureKeepsRetryAfter is the counterpart to the
+// stale-hint assertion in TestWriteCheckedStatus: that one proves the hint is
+// dropped, this one proves it is dropped by clearing the map and not by
+// suppressing handleError's own Set. Without it, a failCheckedWrite that moved
+// the Del after handleError — or a handleError that stopped setting the header —
+// would still pass the negative test.
+func TestCheckedWriters_RetryableFailureKeepsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	writers := map[string]func(w http.ResponseWriter, r *http.Request, data any){
+		"writeOKChecked": func(w http.ResponseWriter, r *http.Request, data any) {
+			writeOKChecked(w, r, data)
+		},
+		"writeCheckedBody": func(w http.ResponseWriter, r *http.Request, data any) {
+			writeCheckedBody(w, r, http.StatusServiceUnavailable, data)
+		},
+		"writeCheckedStatus": func(w http.ResponseWriter, r *http.Request, data any) {
+			writeCheckedStatus(w, r, http.StatusServiceUnavailable, data)
+		},
+	}
+
+	for name, write := range writers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+			write(w, httptest.NewRequest(http.MethodPost, "/", nil), noLeaderMarshaler{})
+
+			require.Equal(t, http.StatusServiceUnavailable, w.Code)
+			require.Equal(t, "1", w.Header().Get("Retry-After"),
+				"handleError owes a retry hint for the 503 it writes itself")
+
+			resp := decodeResponse[ErrorResponse](t, w)
+			require.Equal(t, "NO_LEADER", resp.ErrorCode)
 		})
 	}
 }

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/internal/query"
 )
@@ -213,6 +215,189 @@ func TestQueryParamBool(t *testing.T) {
 
 			r := httptest.NewRequest(http.MethodGet, "/"+tc.query, nil)
 			require.Equal(t, tc.expected, queryParamBool(r, tc.key))
+		})
+	}
+}
+
+// failingMarshaler is a payload whose MarshalJSON always fails. It is the only
+// way to reach the error path of the buffered writers below, and no other
+// fixture in this package provides one. The error text is a sentinel so the
+// tests can assert it never reaches the client.
+type failingMarshaler struct{}
+
+// MarshalJSON implements json.Marshaler, always failing.
+func (failingMarshaler) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("sentinel-payload-detail")
+}
+
+// checkedWriter describes one of this package's two buffered response writers.
+// Both marshal the body to a buffer BEFORE writing any header; they differ in
+// the sonic configuration they marshal with, and that difference is part of
+// every route's wire contract, so the table keeps their expectations separate
+// rather than sharing one (EN-1779).
+type checkedWriter struct {
+	name string
+	// write invokes the writer under test, closing over its status code.
+	write func(w http.ResponseWriter, r *http.Request, data any)
+	// wantStatus is the status the writer emits on success. The error-path
+	// subtest asserts the response is NOT this, which is what catches a writer
+	// that commits its header before marshaling.
+	wantStatus int
+	// stream is the pre-existing streaming writer this one must stay
+	// byte-identical to, or nil when it has no counterpart on the same encoder
+	// (writeOKChecked runs on ConfigDefault, which no streaming writer uses).
+	stream func(w http.ResponseWriter, data any)
+	// wantHTMLEscaped and wantTrailingNewline pin the sonic configuration:
+	// ConfigStd escapes `<`/`&` and appends a trailing newline, ConfigDefault
+	// does neither. Asserting them is what makes a swapped encoder fail here
+	// instead of silently changing every route's default wire.
+	wantHTMLEscaped     bool
+	wantTrailingNewline bool
+}
+
+// TestWriteCheckedStatus covers both buffered writers — writeCheckedStatus and
+// writeOKChecked, whose error path was equally untested — as one table.
+//
+// It exists because two mutations of writeCheckedStatus previously survived the
+// whole package suite: hoisting w.WriteHeader above the marshal call (which
+// reduces the writer to the very behaviour it was created to prevent, a
+// committed success status carrying a failure payload), and deleting the
+// Content-Type header (after which a real net/http server sniffs the body as
+// text/plain). The error-path and byte-identity subtests below kill both.
+func TestWriteCheckedStatus(t *testing.T) {
+	t.Parallel()
+
+	writers := []checkedWriter{
+		{
+			name: "writeOKChecked",
+			write: func(w http.ResponseWriter, r *http.Request, data any) {
+				writeOKChecked(w, r, data)
+			},
+			wantStatus:          http.StatusOK,
+			stream:              nil,
+			wantHTMLEscaped:     false,
+			wantTrailingNewline: false,
+		},
+		{
+			name: "writeCheckedStatus 200",
+			write: func(w http.ResponseWriter, r *http.Request, data any) {
+				writeCheckedStatus(w, r, http.StatusOK, data)
+			},
+			wantStatus:          http.StatusOK,
+			stream:              writeOK,
+			wantHTMLEscaped:     true,
+			wantTrailingNewline: true,
+		},
+		{
+			name: "writeCheckedStatus 201",
+			write: func(w http.ResponseWriter, r *http.Request, data any) {
+				writeCheckedStatus(w, r, http.StatusCreated, data)
+			},
+			wantStatus:          http.StatusCreated,
+			stream:              writeCreated,
+			wantHTMLEscaped:     true,
+			wantTrailingNewline: true,
+		},
+	}
+
+	type payloadCase struct {
+		name string
+		data any
+		// htmlSensitive marks payloads carrying `<`/`&`, the only characters
+		// that make the two encoders distinguishable in the body.
+		htmlSensitive bool
+	}
+
+	payloads := []payloadCase{
+		{name: "nil data", data: nil},
+		{name: "string with HTML-sensitive characters", data: "a<b&c>d", htmlSensitive: true},
+		{name: "map with HTML-sensitive characters", data: map[string]string{"account": "world<&>"}, htmlSensitive: true},
+		{name: "typed nil pointer", data: (*commonpb.Transaction)(nil)},
+		{name: "populated transaction", data: bigAmountTransaction(t, 7), htmlSensitive: true},
+		{
+			name:          "detail-route envelope",
+			data:          getTransactionData{Transaction: bigAmountTransaction(t, 7), Receipt: "receipt"},
+			htmlSensitive: true,
+		},
+		{
+			name:          "string-amount wrapper",
+			data:          commonpb.StringAmountTransaction{Transaction: bigAmountTransaction(t, 7)},
+			htmlSensitive: true,
+		},
+		{name: "wrapper over a nil inner pointer", data: commonpb.StringAmountTransaction{Transaction: nil}},
+	}
+
+	for _, wr := range writers {
+		t.Run(wr.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("marshal failure yields a sanitized 500", func(t *testing.T) {
+				t.Parallel()
+
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest(http.MethodPost, "/", nil)
+
+				wr.write(w, r, failingMarshaler{})
+
+				// The status must NOT have been committed before the marshal:
+				// a writer that writes its header first turns a marshal failure
+				// into a success status carrying an error body.
+				require.Equal(t, http.StatusInternalServerError, w.Code)
+				require.NotEqual(t, wr.wantStatus, w.Code)
+				require.NotContains(t, w.Body.String(), `"data"`,
+					"a failed marshal must not emit any part of the success envelope")
+
+				resp := decodeResponse[ErrorResponse](t, w)
+				require.Equal(t, "INTERNAL_ERROR", resp.ErrorCode)
+
+				// Routed through handleError, so the message is the sanitized
+				// correlation-ID form (EN-1442). The streaming writers instead
+				// append the raw marshal error to an already-committed body,
+				// which is what this writer exists to avoid.
+				require.Contains(t, resp.ErrorMessage, "correlation ID")
+				require.NotContains(t, w.Body.String(), "sentinel-payload-detail")
+			})
+
+			for _, pc := range payloads {
+				t.Run(pc.name, func(t *testing.T) {
+					t.Parallel()
+
+					w := httptest.NewRecorder()
+					wr.write(w, httptest.NewRequest(http.MethodGet, "/", nil), pc.data)
+
+					require.Equal(t, wr.wantStatus, w.Code)
+					require.Equal(t, "application/json", w.Header().Get("Content-Type"),
+						"a missing Content-Type makes a real server sniff the body as text/plain")
+
+					body := w.Body.String()
+					require.Equal(t, wr.wantTrailingNewline, strings.HasSuffix(body, "\n"),
+						"trailing newline pins the sonic configuration: body %q", body)
+
+					if pc.htmlSensitive {
+						if wr.wantHTMLEscaped {
+							require.Contains(t, body, `\u003c`)
+							require.NotContains(t, body, "<")
+						} else {
+							require.Contains(t, body, "<")
+							require.NotContains(t, body, `\u003c`)
+						}
+					}
+
+					if wr.stream == nil {
+						return
+					}
+
+					// Byte-identity with the streaming writer the routes used
+					// before, headers included: adding the buffered marshal must
+					// not move a single byte for clients that never opt in.
+					ref := httptest.NewRecorder()
+					wr.stream(ref, pc.data)
+
+					require.Equal(t, ref.Body.String(), body)
+					require.Equal(t, ref.Code, w.Code)
+					require.Equal(t, ref.Header(), w.Header())
+				})
+			}
 		})
 	}
 }

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -230,8 +230,8 @@ func (failingMarshaler) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("sentinel-payload-detail")
 }
 
-// checkedWriter describes one of this package's two buffered response writers.
-// Both marshal the body to a buffer BEFORE writing any header; they differ in
+// checkedWriter describes one of this package's buffered response writers. All
+// of them marshal the body to a buffer BEFORE writing any header; they differ in
 // the sonic configuration they marshal with, and that difference is part of
 // every route's wire contract, so the table keeps their expectations separate
 // rather than sharing one (EN-1779).
@@ -255,8 +255,9 @@ type checkedWriter struct {
 	wantTrailingNewline bool
 }
 
-// TestWriteCheckedStatus covers both buffered writers — writeCheckedStatus and
-// writeOKChecked, whose error path was equally untested — as one table.
+// TestWriteCheckedStatus covers every buffered writer — writeCheckedBody,
+// writeCheckedStatus and writeOKChecked, whose error path was equally untested —
+// as one table.
 //
 // It exists because two mutations of writeCheckedStatus previously survived the
 // whole package suite: hoisting w.WriteHeader above the marshal call (which
@@ -264,6 +265,12 @@ type checkedWriter struct {
 // committed success status carrying a failure payload), and deleting the
 // Content-Type header (after which a real net/http server sniffs the body as
 // text/plain). The error-path and byte-identity subtests below kill both.
+//
+// writeCheckedBody is listed separately from writeCheckedStatus even though the
+// latter now delegates to it: the two differ in whether the payload is wrapped in
+// the BaseResponse envelope, and each one's byte-identity reference is the
+// streaming writer the routes on it used before — writeJSONResponse for the
+// no-envelope form, writeOK/writeCreated for the enveloped one.
 func TestWriteCheckedStatus(t *testing.T) {
 	t.Parallel()
 
@@ -277,6 +284,30 @@ func TestWriteCheckedStatus(t *testing.T) {
 			stream:              nil,
 			wantHTMLEscaped:     false,
 			wantTrailingNewline: false,
+		},
+		{
+			name: "writeCheckedBody 200",
+			write: func(w http.ResponseWriter, r *http.Request, data any) {
+				writeCheckedBody(w, r, http.StatusOK, data)
+			},
+			wantStatus: http.StatusOK,
+			stream: func(w http.ResponseWriter, data any) {
+				writeJSONResponse(w, http.StatusOK, data)
+			},
+			wantHTMLEscaped:     true,
+			wantTrailingNewline: true,
+		},
+		{
+			name: "writeCheckedBody 409",
+			write: func(w http.ResponseWriter, r *http.Request, data any) {
+				writeCheckedBody(w, r, http.StatusConflict, data)
+			},
+			wantStatus: http.StatusConflict,
+			stream: func(w http.ResponseWriter, data any) {
+				writeJSONResponse(w, http.StatusConflict, data)
+			},
+			wantHTMLEscaped:     true,
+			wantTrailingNewline: true,
 		},
 		{
 			name: "writeCheckedStatus 200",
@@ -400,4 +431,25 @@ func TestWriteCheckedStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWriteCheckedBody_DoesNotWrapInBaseResponse pins the one behavioural
+// difference between this package's two ConfigStd buffered writers. Bulk and
+// prepared-query build their own top-level envelope, so a writeCheckedBody that
+// wrapped its argument the way writeCheckedStatus does would double-wrap them
+// into {"data":{"data":…}} — which is why the extraction kept two entry points
+// instead of routing every caller through the enveloping one (EN-1779).
+func TestWriteCheckedBody_DoesNotWrapInBaseResponse(t *testing.T) {
+	t.Parallel()
+
+	payload := bulkResponse{Data: []bulkAPIResult{{ResponseType: "CREATE_TRANSACTION", LogID: 17}}}
+
+	bare := httptest.NewRecorder()
+	writeCheckedBody(bare, httptest.NewRequest(http.MethodPost, "/", nil), http.StatusOK, payload)
+
+	enveloped := httptest.NewRecorder()
+	writeCheckedStatus(enveloped, httptest.NewRequest(http.MethodPost, "/", nil), http.StatusOK, payload)
+
+	require.Equal(t, `{"data":[{"responseType":"CREATE_TRANSACTION","logID":17}]}`+"\n", bare.Body.String())
+	require.Equal(t, `{"data":{"data":[{"responseType":"CREATE_TRANSACTION","logID":17}]}}`+"\n", enveloped.Body.String())
 }

--- a/internal/adapter/http/string_amounts.go
+++ b/internal/adapter/http/string_amounts.go
@@ -1,0 +1,26 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+)
+
+// httpHeaderBigintAsString is the EN-1779 opt-in: when a client sends it, every
+// Posting.amount in the response body is a quoted decimal string instead of a
+// bare JSON number, so JavaScript clients do not truncate above 2^53. The header
+// name and its lenient parsing match Ledger v2 for client parity.
+const httpHeaderBigintAsString = "Formance-Bigint-As-String"
+
+// wantsBigintAsString reports whether the client opted into quoted decimal
+// amounts. Parsing is lenient and matches v2: true|yes|y|1, case-insensitive,
+// surrounding whitespace ignored. Anything else — including an unrecognised
+// value — is treated as absent rather than rejected, so a malformed header
+// never turns a readable response into a 400.
+func wantsBigintAsString(r *http.Request) bool {
+	switch strings.ToLower(strings.TrimSpace(r.Header.Get(httpHeaderBigintAsString))) {
+	case "true", "yes", "y", "1":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/adapter/http/string_amounts_test.go
+++ b/internal/adapter/http/string_amounts_test.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWantsBigintAsString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name        string
+		headerSet   bool
+		headerValue string
+		want        bool
+	}
+
+	testCases := []testCase{
+		{name: "header absent", headerSet: false, want: false},
+		{name: "empty value", headerSet: true, headerValue: "", want: false},
+		{name: "true", headerSet: true, headerValue: "true", want: true},
+		{name: "True", headerSet: true, headerValue: "True", want: true},
+		{name: "TRUE", headerSet: true, headerValue: "TRUE", want: true},
+		{name: "yes", headerSet: true, headerValue: "yes", want: true},
+		{name: "y", headerSet: true, headerValue: "y", want: true},
+		{name: "one", headerSet: true, headerValue: "1", want: true},
+		{name: "padded", headerSet: true, headerValue: "  true  ", want: true},
+		{name: "false", headerSet: true, headerValue: "false", want: false},
+		{name: "zero", headerSet: true, headerValue: "0", want: false},
+		{name: "unparseable is treated as absent", headerSet: true, headerValue: "maybe", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.headerSet {
+				r.Header.Set(httpHeaderBigintAsString, tc.headerValue)
+			}
+
+			require.Equal(t, tc.want, wantsBigintAsString(r))
+		})
+	}
+}

--- a/internal/adapter/http/string_amounts_test.go
+++ b/internal/adapter/http/string_amounts_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestHTTPHeaderBigintAsStringSpelling pins the header's wire spelling. Every
+// subtest of TestWantsBigintAsString sets the header through the constant, so it
+// would keep passing if the constant's value changed and silently break every
+// client that sends the documented name.
+func TestHTTPHeaderBigintAsStringSpelling(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "Formance-Bigint-As-String", httpHeaderBigintAsString)
+}
+
 func TestWantsBigintAsString(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/test_helpers_test.go
+++ b/internal/adapter/http/test_helpers_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -91,4 +93,46 @@ func decodeResponse[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 	}
 
 	return out
+}
+
+// aboveJSNumberLimit is 2^53 + 1, the smallest integer a JavaScript double
+// cannot represent exactly. The EN-1779 route tests pin it so that a body routed
+// through a float would lose its last digit and fail.
+const aboveJSNumberLimit = "9007199254740993"
+
+// bigAmountTransaction is the shared EN-1779 route fixture: one posting whose
+// amount is aboveJSNumberLimit, between accounts containing `<` and `&`.
+//
+// Those two characters are load-bearing, not decoration. This package has two
+// production JSON writers running on different sonic configurations — ConfigStd
+// (HTML-escapes, appends a trailing newline) and ConfigDefault (neither) — and
+// `<`/`&` are the only thing that makes a swap between them visible in the
+// response body. A fixture without them passes even when a route silently
+// changes encoder, which is exactly the regression the opt-in header must not
+// introduce.
+func bigAmountTransaction(t *testing.T, id uint64) *commonpb.Transaction {
+	t.Helper()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok, "fixture amount must parse")
+
+	return &commonpb.Transaction{
+		Id: id,
+		Postings: []*commonpb.Posting{
+			commonpb.NewPosting("world<&>", "alice&<bob", "USD/2", amount),
+		},
+	}
+}
+
+// requireOnlyAmountQuotingDiffers asserts that two pinned response bodies are
+// identical once the opt-in body's quoted amount is unquoted. Asserting it
+// mechanically is what lets the pinned literals catch an encoder swap (EN-1779):
+// a change in HTML escaping, framing or field order would otherwise land in both
+// literals at once and pass review unnoticed.
+func requireOnlyAmountQuotingDiffers(t *testing.T, defaultBody, optInBody string) {
+	t.Helper()
+
+	require.Equal(t, defaultBody,
+		strings.Replace(optInBody, `"`+aboveJSNumberLimit+`"`, aboveJSNumberLimit, 1),
+		"the opt-in wire must differ from the default wire only in the amount's quoting")
 }

--- a/internal/adapter/http/test_helpers_test.go
+++ b/internal/adapter/http/test_helpers_test.go
@@ -132,6 +132,15 @@ func bigAmountTransaction(t *testing.T, id uint64) *commonpb.Transaction {
 func requireOnlyAmountQuotingDiffers(t *testing.T, defaultBody, optInBody string) {
 	t.Helper()
 
+	// Self-enforce the fixture's load-bearing property instead of trusting a
+	// comment: with no HTML-sensitive character in the body, an encoder swap is
+	// invisible and every assertion here passes anyway. Either form counts — the
+	// ConfigStd routes escape the ampersand, the ConfigDefault one does not.
+	require.True(t,
+		strings.Contains(defaultBody, "&") || strings.Contains(defaultBody, `\u0026`),
+		"the pinned body must carry an HTML-sensitive character, raw or escaped, "+
+			"or it cannot detect a change of encoder")
+
 	require.Equal(t, defaultBody,
 		strings.Replace(optInBody, `"`+aboveJSNumberLimit+`"`, aboveJSNumberLimit, 1),
 		"the opt-in wire must differ from the default wire only in the amount's quoting")

--- a/internal/adapter/http/test_helpers_test.go
+++ b/internal/adapter/http/test_helpers_test.go
@@ -172,7 +172,33 @@ func requireOnlyAmountQuotingDiffers(t *testing.T, defaultBody, optInBody string
 		"the pinned body must carry an HTML-sensitive character, raw or escaped, "+
 			"or it cannot detect a change of encoder")
 
+	quoted := `"` + aboveJSNumberLimit + `"`
+	amounts := strings.Count(defaultBody, aboveJSNumberLimit)
+
+	// Without this the whole helper can pass vacuously: on a body carrying no
+	// amount at all there is nothing to unquote, so the final assertion
+	// degenerates into "the two bodies are equal" — which they are precisely
+	// when the header did nothing.
+	require.Positive(t, amounts,
+		"the pinned default body must contain the fixture amount, or this helper "+
+			"asserts nothing about the amount's quoting")
+
+	// EVERY amount must be quoted, not just one. Unquoting is a rewrite, so a
+	// body with a single quoted amount among several bare ones rewrites back to
+	// the default body exactly and would satisfy the equality below on its own —
+	// while a client still truncates every amount the header failed to quote.
+	// Counting closes that hole; ReplaceAll below then keeps a correctly quoted
+	// multi-amount body from failing for the opposite reason.
+	//
+	// Every fixture carries one posting today, which is why neither is currently
+	// load-bearing. Authors paste real output into the pinned literals, so both
+	// must hold before a multi-posting fixture arrives, not after.
+	require.Equal(t, amounts, strings.Count(optInBody, quoted),
+		"the opt-in body must quote EVERY amount the default body renders bare: "+
+			"the default body has %d, the opt-in body quotes a different number",
+		amounts)
+
 	require.Equal(t, defaultBody,
-		strings.Replace(optInBody, `"`+aboveJSNumberLimit+`"`, aboveJSNumberLimit, 1),
+		strings.ReplaceAll(optInBody, quoted, aboveJSNumberLimit),
 		"the opt-in wire must differ from the default wire only in the amount's quoting")
 }

--- a/internal/adapter/http/test_helpers_test.go
+++ b/internal/adapter/http/test_helpers_test.go
@@ -124,6 +124,37 @@ func bigAmountTransaction(t *testing.T, id uint64) *commonpb.Transaction {
 	}
 }
 
+// bigAmountLog wraps bigAmountTransaction in the full nine-level global-log
+// chain (Log → LogPayload → ApplyLedgerLog → LedgerLog → LedgerLogPayload →
+// CreatedTransaction → Transaction → Posting → amount), the shape the log
+// routes and the LOGS-target prepared-query cursor all serve. Sharing one
+// fixture is what makes the two log routes' pinned bodies comparable: they
+// differ only in their encoder, never in their input.
+func bigAmountLog(t *testing.T, sequence uint64) *commonpb.Log {
+	t.Helper()
+
+	return &commonpb.Log{
+		Sequence: sequence,
+		Payload: &commonpb.LogPayload{
+			Type: &commonpb.LogPayload_Apply{
+				Apply: &commonpb.ApplyLedgerLog{
+					LedgerName: "ledger1",
+					Log: &commonpb.LedgerLog{
+						Id: sequence,
+						Data: &commonpb.LedgerLogPayload{
+							Payload: &commonpb.LedgerLogPayload_CreatedTransaction{
+								CreatedTransaction: &commonpb.CreatedTransaction{
+									Transaction: bigAmountTransaction(t, sequence),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // requireOnlyAmountQuotingDiffers asserts that two pinned response bodies are
 // identical once the opt-in body's quoted amount is unquoted. Asserting it
 // mechanically is what lets the pinned literals catch an encoder swap (EN-1779):

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -282,15 +282,9 @@ func (x *Account) MarshalJSON() ([]byte, error) {
 // decimals (see string_amounts.go); MarshalJSON delegates with false, and
 // that output is byte-identical to what it always emitted.
 func (x *CreatedTransaction) buildAux(amountsAsString bool) any {
-	var transaction any
-
-	if tx := x.GetTransaction(); tx != nil {
-		if amountsAsString {
-			transaction = StringAmountTransaction{Transaction: tx}
-		} else {
-			transaction = tx
-		}
-	}
+	transaction := childValue(x.GetTransaction(), amountsAsString, func(tx *Transaction) StringAmountTransaction {
+		return StringAmountTransaction{Transaction: tx}
+	})
 
 	return &struct {
 		Transaction     any                       `json:"transaction,omitempty"`
@@ -315,15 +309,9 @@ func (x *CreatedTransaction) MarshalJSON() ([]byte, error) {
 // amounts as quoted decimals (see string_amounts.go); MarshalJSON delegates
 // with false, and that output is byte-identical to what it always emitted.
 func (x *RevertedTransaction) buildAux(amountsAsString bool) any {
-	var revertTransaction any
-
-	if tx := x.GetRevertTransaction(); tx != nil {
-		if amountsAsString {
-			revertTransaction = StringAmountTransaction{Transaction: tx}
-		} else {
-			revertTransaction = tx
-		}
-	}
+	revertTransaction := childValue(x.GetRevertTransaction(), amountsAsString, func(tx *Transaction) StringAmountTransaction {
+		return StringAmountTransaction{Transaction: tx}
+	})
 
 	return &struct {
 		RevertedTransactionID uint64 `json:"revertedTransactionId,omitempty"`

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -32,23 +32,33 @@ func protoFieldJSON(msg proto.Message) json.RawValue {
 
 // Note: Transaction.MarshalJSON is already implemented in transaction.go
 
-// MarshalJSON implements json.Marshaler for Log (global log).
-func (x *Log) MarshalJSON() ([]byte, error) {
+// buildAux builds the JSON representation of Log (global log). When
+// amountsAsString is true, the payload renders posting amounts as quoted
+// decimals (see string_amounts.go); MarshalJSON delegates with false, and that
+// output is byte-identical to what it always emitted.
+func (x *Log) buildAux(amountsAsString bool) any {
 	type Aux struct {
 		Sequence          uint64        `json:"sequence,omitempty"`
-		Payload           *LogPayload   `json:"payload,omitempty"`
+		Payload           any           `json:"payload,omitempty"`
 		Receipt           string        `json:"receipt,omitempty"`
 		ResponseSignature json.RawValue `json:"responseSignature,omitempty"`
 	}
 
 	aux := Aux{
-		Sequence:          x.GetSequence(),
-		Payload:           x.GetPayload(),
+		Sequence: x.GetSequence(),
+		Payload: childValue(x.GetPayload(), amountsAsString, func(p *LogPayload) stringAmountLogPayload {
+			return stringAmountLogPayload{LogPayload: p}
+		}),
 		ResponseSignature: protoFieldJSON(x.GetResponseSignature()),
 		Receipt:           x.GetReceipt(),
 	}
 
-	return json.Marshal(aux)
+	return aux
+}
+
+// MarshalJSON implements json.Marshaler for Log (global log).
+func (x *Log) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.buildAux(false))
 }
 
 // MarshalJSON implements json.Marshaler for LogPayload (oneof dispatch).
@@ -69,6 +79,25 @@ func (x *LogPayload) MarshalJSON() ([]byte, error) {
 	default:
 		// Other variants (signing, sinks, chapters, etc.) — use protojson for camelCase
 		return protojson.Marshal(x)
+	}
+}
+
+// marshalStringAmounts renders the EN-1779 opt-in wire for LogPayload. Only the
+// posting-bearing variant is rebuilt here; every other variant delegates to
+// MarshalJSON so both modes stay byte-identical for payloads that carry no
+// amount. The non-posting variants are deliberately not re-listed: re-listing
+// them would let the hand-rolled and protojson outputs drift apart at some
+// variant no test covers.
+func (x *LogPayload) marshalStringAmounts() ([]byte, error) {
+	switch p := x.GetType().(type) {
+	case *LogPayload_Apply:
+		return json.Marshal(&struct {
+			Apply any `json:"apply,omitempty"`
+		}{Apply: childValue(p.Apply, true, func(a *ApplyLedgerLog) stringAmountApplyLedgerLog {
+			return stringAmountApplyLedgerLog{ApplyLedgerLog: a}
+		})})
+	default:
+		return x.MarshalJSON()
 	}
 }
 
@@ -104,15 +133,25 @@ func (x *DeletedLedgerLog) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// MarshalJSON implements json.Marshaler for ApplyLedgerLog.
-func (x *ApplyLedgerLog) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		LedgerName string     `json:"ledgerName,omitempty"`
-		Log        *LedgerLog `json:"log,omitempty"`
+// buildAux builds the JSON representation of ApplyLedgerLog. When
+// amountsAsString is true, the nested ledger log renders posting amounts as
+// quoted decimals (see string_amounts.go); MarshalJSON delegates with false,
+// and that output is byte-identical to what it always emitted.
+func (x *ApplyLedgerLog) buildAux(amountsAsString bool) any {
+	return &struct {
+		LedgerName string `json:"ledgerName,omitempty"`
+		Log        any    `json:"log,omitempty"`
 	}{
 		LedgerName: x.GetLedgerName(),
-		Log:        x.GetLog(),
-	})
+		Log: childValue(x.GetLog(), amountsAsString, func(l *LedgerLog) stringAmountLedgerLog {
+			return stringAmountLedgerLog{LedgerLog: l}
+		}),
+	}
+}
+
+// MarshalJSON implements json.Marshaler for ApplyLedgerLog.
+func (x *ApplyLedgerLog) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.buildAux(false))
 }
 
 // MarshalJSON implements json.Marshaler for LedgerLogPayload (oneof dispatch).
@@ -139,6 +178,33 @@ func (x *LedgerLogPayload) MarshalJSON() ([]byte, error) {
 	default:
 		// Other variants — use protojson for camelCase
 		return protojson.Marshal(x)
+	}
+}
+
+// marshalStringAmounts renders the EN-1779 opt-in wire for LedgerLogPayload.
+// Only the posting-bearing variants are rebuilt here; every other variant
+// delegates to MarshalJSON so both modes stay byte-identical for payloads that
+// carry no amount. The non-posting variants are deliberately not re-listed:
+// re-listing them would let the hand-rolled and protojson outputs drift apart
+// at some variant no test covers.
+func (x *LedgerLogPayload) marshalStringAmounts() ([]byte, error) {
+	switch p := x.GetPayload().(type) {
+	case *LedgerLogPayload_CreatedTransaction:
+		return json.Marshal(&struct {
+			CreatedTransaction any `json:"createdTransaction,omitempty"`
+		}{CreatedTransaction: childValue(p.CreatedTransaction, true,
+			func(ct *CreatedTransaction) StringAmountCreatedTransaction {
+				return StringAmountCreatedTransaction{CreatedTransaction: ct}
+			})})
+	case *LedgerLogPayload_RevertedTransaction:
+		return json.Marshal(&struct {
+			RevertedTransaction any `json:"revertedTransaction,omitempty"`
+		}{RevertedTransaction: childValue(p.RevertedTransaction, true,
+			func(rt *RevertedTransaction) StringAmountRevertedTransaction {
+				return StringAmountRevertedTransaction{RevertedTransaction: rt}
+			})})
+	default:
+		return x.MarshalJSON()
 	}
 }
 

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -88,6 +88,10 @@ func (x *LogPayload) MarshalJSON() ([]byte, error) {
 // amount. The non-posting variants are deliberately not re-listed: re-listing
 // them would let the hand-rolled and protojson outputs drift apart at some
 // variant no test covers.
+//
+// The mode is fixed true here, so childValue's `return child` branch is
+// unreachable: it is called for its nil guard, which keeps the omitempty
+// contract in one place rather than restated per variant.
 func (x *LogPayload) marshalStringAmounts() ([]byte, error) {
 	switch p := x.GetType().(type) {
 	case *LogPayload_Apply:
@@ -187,6 +191,10 @@ func (x *LedgerLogPayload) MarshalJSON() ([]byte, error) {
 // carry no amount. The non-posting variants are deliberately not re-listed:
 // re-listing them would let the hand-rolled and protojson outputs drift apart
 // at some variant no test covers.
+//
+// The mode is fixed true here, so childValue's `return child` branch is
+// unreachable: it is called for its nil guard, which keeps the omitempty
+// contract in one place rather than restated per variant.
 func (x *LedgerLogPayload) marshalStringAmounts() ([]byte, error) {
 	switch p := x.GetPayload().(type) {
 	case *LedgerLogPayload_CreatedTransaction:
@@ -579,28 +587,41 @@ var queryTargetToJSON = map[QueryTarget]string{
 	QueryTarget_QUERY_TARGET_LOGS:         "LOGS",
 }
 
-// MarshalJSON implements json.Marshaler for PreparedQueryCursor.
-//
-// The cursor carries exactly one populated data field per query target:
-// accountData (ACCOUNTS), transactionData (TRANSACTIONS) or logData (LOGS).
-func (x *PreparedQueryCursor) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		PageSize        uint32         `json:"pageSize"`
-		HasMore         bool           `json:"hasMore"`
-		Previous        string         `json:"previous,omitempty"`
-		Next            string         `json:"next,omitempty"`
-		AccountData     []*Account     `json:"accountData,omitempty"`
-		TransactionData []*Transaction `json:"transactionData,omitempty"`
-		LogData         []*Log         `json:"logData,omitempty"`
+// buildAux builds the JSON representation of PreparedQueryCursor. When
+// amountsAsString is true, the transaction and log pages render posting amounts
+// as quoted decimals (see string_amounts.go); MarshalJSON delegates with false,
+// and that output is byte-identical to what it always emitted.
+func (x *PreparedQueryCursor) buildAux(amountsAsString bool) any {
+	return &struct {
+		PageSize uint32 `json:"pageSize"`
+		HasMore  bool   `json:"hasMore"`
+		Previous string `json:"previous,omitempty"`
+		Next     string `json:"next,omitempty"`
+		// accountData is the one data field left concretely typed: nothing below
+		// Account carries a Uint256 or a bare JSON number. Volumes and
+		// VolumeEntry already render their big.Int values through String() into
+		// Go string fields, so an accounts page is identical in both modes and
+		// needs no wrapper.
+		AccountData     []*Account `json:"accountData,omitempty"`
+		TransactionData any        `json:"transactionData,omitempty"`
+		LogData         any        `json:"logData,omitempty"`
 	}{
 		PageSize:        x.GetPageSize(),
 		HasMore:         x.GetHasMore(),
 		Previous:        x.GetPrevious(),
 		Next:            x.GetNext(),
 		AccountData:     x.GetAccountData(),
-		TransactionData: x.GetTransactionData(),
-		LogData:         x.GetLogData(),
-	})
+		TransactionData: sliceValue(x.GetTransactionData(), amountsAsString, StringAmountTransactions),
+		LogData:         sliceValue(x.GetLogData(), amountsAsString, StringAmountLogs),
+	}
+}
+
+// MarshalJSON implements json.Marshaler for PreparedQueryCursor.
+//
+// The cursor carries exactly one populated data field per query target:
+// accountData (ACCOUNTS), transactionData (TRANSACTIONS) or logData (LOGS).
+func (x *PreparedQueryCursor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.buildAux(false))
 }
 
 // MarshalJSON implements json.Marshaler for LedgerInfo.

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -598,10 +598,12 @@ func (x *PreparedQueryCursor) buildAux(amountsAsString bool) any {
 		Previous string `json:"previous,omitempty"`
 		Next     string `json:"next,omitempty"`
 		// accountData is the one data field left concretely typed: nothing below
-		// Account carries a Uint256 or a bare JSON number. Volumes and
-		// VolumeEntry already render their big.Int values through String() into
-		// Go string fields, so an accounts page is identical in both modes and
-		// needs no wrapper.
+		// Account carries a Uint256, and no amount below it renders as a bare
+		// JSON number. Volumes and VolumeEntry already render their big.Int
+		// values through String() into Go string fields, so an accounts page is
+		// identical in both modes and needs no wrapper. Account metadata does
+		// carry bare JSON numbers - int_value and uint_value, the latter up to
+		// 2^64-1 - but the header moves amounts only, so they stay as they are.
 		AccountData     []*Account `json:"accountData,omitempty"`
 		TransactionData any        `json:"transactionData,omitempty"`
 		LogData         any        `json:"logData,omitempty"`

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -275,32 +275,68 @@ func (x *Account) MarshalJSON() ([]byte, error) {
 
 // Note: Log.MarshalJSON is already implemented in log.go
 
-// MarshalJSON implements json.Marshaler for CreatedTransaction. Post-commit
+// buildAux builds the JSON representation of CreatedTransaction. Post-commit
 // volumes ride on the embedded Transaction, so they surface via the
-// "transaction" field rather than as a sibling here.
-func (x *CreatedTransaction) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Transaction     *Transaction              `json:"transaction,omitempty"`
+// "transaction" field rather than as a sibling here. When amountsAsString is
+// true, the embedded transaction renders its posting amounts as quoted
+// decimals (see string_amounts.go); MarshalJSON delegates with false, and
+// that output is byte-identical to what it always emitted.
+func (x *CreatedTransaction) buildAux(amountsAsString bool) any {
+	var transaction any
+
+	if tx := x.GetTransaction(); tx != nil {
+		if amountsAsString {
+			transaction = StringAmountTransaction{Transaction: tx}
+		} else {
+			transaction = tx
+		}
+	}
+
+	return &struct {
+		Transaction     any                       `json:"transaction,omitempty"`
 		AccountMetadata map[string]map[string]any `json:"accountMetadata,omitempty"`
 		ChapterID       uint64                    `json:"chapterId,omitempty"`
 	}{
-		Transaction:     x.GetTransaction(),
+		Transaction:     transaction,
 		AccountMetadata: AccountMetadataToAnyMap(x.GetAccountMetadata()),
 		ChapterID:       x.GetChapterId(),
-	})
+	}
 }
 
-// MarshalJSON implements json.Marshaler for RevertedTransaction. Post-commit
+// MarshalJSON implements json.Marshaler for CreatedTransaction.
+func (x *CreatedTransaction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.buildAux(false))
+}
+
+// buildAux builds the JSON representation of RevertedTransaction. Post-commit
 // volumes ride on the embedded revert Transaction, so they surface via the
-// "revertTransaction" field rather than as a sibling here.
-func (x *RevertedTransaction) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		RevertedTransactionID uint64       `json:"revertedTransactionId,omitempty"`
-		RevertTransaction     *Transaction `json:"revertTransaction,omitempty"`
+// "revertTransaction" field rather than as a sibling here. When
+// amountsAsString is true, the embedded transaction renders its posting
+// amounts as quoted decimals (see string_amounts.go); MarshalJSON delegates
+// with false, and that output is byte-identical to what it always emitted.
+func (x *RevertedTransaction) buildAux(amountsAsString bool) any {
+	var revertTransaction any
+
+	if tx := x.GetRevertTransaction(); tx != nil {
+		if amountsAsString {
+			revertTransaction = StringAmountTransaction{Transaction: tx}
+		} else {
+			revertTransaction = tx
+		}
+	}
+
+	return &struct {
+		RevertedTransactionID uint64 `json:"revertedTransactionId,omitempty"`
+		RevertTransaction     any    `json:"revertTransaction,omitempty"`
 	}{
 		RevertedTransactionID: x.GetRevertedTransactionId(),
-		RevertTransaction:     x.GetRevertTransaction(),
-	})
+		RevertTransaction:     revertTransaction,
+	}
+}
+
+// MarshalJSON implements json.Marshaler for RevertedTransaction.
+func (x *RevertedTransaction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(x.buildAux(false))
 }
 
 // MarshalJSON implements json.Marshaler for SavedMetadata.

--- a/internal/proto/commonpb/fuzz_test.go
+++ b/internal/proto/commonpb/fuzz_test.go
@@ -6,8 +6,9 @@ import (
 )
 
 // FuzzUint256UnmarshalJSON fuzzes the Uint256 JSON decoder with arbitrary byte slices.
-// It targets the decimal string parser (no quotes) looking for panics, hangs,
-// or unexpected behavior on malformed input.
+// It targets the decimal string parser, covering both the bare JSON number form
+// and the quoted-string form (EN-1779), looking for panics, hangs, or unexpected
+// behavior on malformed input.
 func FuzzUint256UnmarshalJSON(f *testing.F) {
 	// Seed corpus: valid values, edge cases, and known tricky inputs.
 	f.Add([]byte("0"))
@@ -27,6 +28,13 @@ func FuzzUint256UnmarshalJSON(f *testing.F) {
 	f.Add([]byte("42 "))
 	f.Add([]byte("\x00"))
 	f.Add([]byte("1.5"))
+	// Quoted-string form (EN-1779) and its edge cases.
+	f.Add([]byte(`"42"`))
+	f.Add([]byte(`"`))
+	f.Add([]byte(`""`))
+	f.Add([]byte(`"\"42\""`))
+	f.Add([]byte(`"0x1"`))
+	f.Add([]byte(`"+1"`))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var u Uint256

--- a/internal/proto/commonpb/log.go
+++ b/internal/proto/commonpb/log.go
@@ -115,18 +115,23 @@ func (l *LedgerLog) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements json.Marshaler for LedgerLog.
-func (l *LedgerLog) MarshalJSON() ([]byte, error) {
+// buildAux builds the JSON representation of LedgerLog. When amountsAsString is
+// true, the payload renders posting amounts as quoted decimals (see
+// string_amounts.go); MarshalJSON delegates with false, and that output is
+// byte-identical to what it always emitted.
+func (l *LedgerLog) buildAux(amountsAsString bool) any {
 	type auxLog struct {
-		Type LogType           `json:"type"`
-		Data *LedgerLogPayload `json:"data"`
-		Date *time.Time        `json:"date,omitempty"`
-		ID   *uint64           `json:"id,omitempty"`
+		Type LogType    `json:"type"`
+		Data any        `json:"data"`
+		Date *time.Time `json:"date,omitempty"`
+		ID   *uint64    `json:"id,omitempty"`
 	}
 
 	aux := auxLog{
 		Type: GetLogTypeFromLog(l),
-		Data: l.GetData(),
+		Data: childValue(l.GetData(), amountsAsString, func(p *LedgerLogPayload) stringAmountLedgerLogPayload {
+			return stringAmountLedgerLogPayload{LedgerLogPayload: p}
+		}),
 	}
 
 	if l.GetDate() != nil {
@@ -138,5 +143,10 @@ func (l *LedgerLog) MarshalJSON() ([]byte, error) {
 		aux.ID = new(l.GetId())
 	}
 
-	return json.Marshal(aux)
+	return aux
+}
+
+// MarshalJSON implements json.Marshaler for LedgerLog.
+func (l *LedgerLog) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.buildAux(false))
 }

--- a/internal/proto/commonpb/posting.go
+++ b/internal/proto/commonpb/posting.go
@@ -8,24 +8,46 @@ import (
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 )
 
+// buildAux renders the Posting's JSON shape. amountsAsString selects the
+// EN-1779 opt-in wire, where amount is a quoted decimal instead of a bare JSON
+// number; it is the ONLY field that differs between the two modes.
+//
+// Amount is typed `any` so one struct serves both modes. Because the field is
+// `omitempty` and an interface holding a typed nil is not empty, it must be
+// left as a nil interface when there is no amount — otherwise an absent amount
+// would start emitting `null`.
+func (x *Posting) buildAux(amountsAsString bool) any {
+	var amount any
+
+	if a := x.GetAmount(); a != nil {
+		if amountsAsString {
+			amount = a.Dec()
+		} else {
+			amount = a
+		}
+	}
+
+	return &struct {
+		Source      string `json:"source"`
+		Destination string `json:"destination"`
+		Amount      any    `json:"amount,omitempty"`
+		Asset       string `json:"asset"`
+		Color       string `json:"color"`
+	}{
+		Source:      x.GetSource(),
+		Destination: x.GetDestination(),
+		Amount:      amount,
+		Asset:       x.GetAsset(),
+		Color:       x.GetColor(),
+	}
+}
+
 // MarshalJSON implements json.Marshaler for Posting. Color is always emitted
 // (even when empty) so clients can distinguish the uncolored bucket from an
 // older response shape that predates the dimension — same contract as
 // VolumeEntry and accountVolumeJSON.
 func (x *Posting) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Source      string   `json:"source"`
-		Destination string   `json:"destination"`
-		Amount      *Uint256 `json:"amount,omitempty"`
-		Asset       string   `json:"asset"`
-		Color       string   `json:"color"`
-	}{
-		Source:      x.GetSource(),
-		Destination: x.GetDestination(),
-		Amount:      x.GetAmount(),
-		Asset:       x.GetAsset(),
-		Color:       x.GetColor(),
-	})
+	return json.Marshal(x.buildAux(false))
 }
 
 // NewPosting creates a new uncolored Posting. Use NewColoredPosting to set a

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -24,6 +24,19 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 // Uint256.MarshalJSON is deliberately untouched: ledgerctl and misc/operator
 // consume it, so the CLI wire must not move.
 
+// wrapAll wraps every element for the opt-in wire. The result is always
+// non-nil, so a nil or empty input still marshals as `[]` rather than `null`:
+// making that a property of one generic function means no per-level wrapper
+// can silently reintroduce `null` via a bare `var out []W`.
+func wrapAll[T, W any](items []T, wrap func(T) W) []W {
+	out := make([]W, 0, len(items))
+	for _, item := range items {
+		out = append(out, wrap(item))
+	}
+
+	return out
+}
+
 // StringAmountPosting renders a Posting with a quoted decimal amount. Exported
 // because StringAmountPostings returns a slice of it, and revive's
 // unexported-return rule forbids an exported function returning an unexported
@@ -49,12 +62,9 @@ func (w StringAmountPosting) MarshalJSON() ([]byte, error) {
 // postings field has no omitempty and the OpenAPI schema types it as a
 // non-nullable required array.
 func StringAmountPostings(postings []*Posting) []StringAmountPosting {
-	out := make([]StringAmountPosting, 0, len(postings))
-	for _, p := range postings {
-		out = append(out, StringAmountPosting{Posting: p})
-	}
-
-	return out
+	return wrapAll(postings, func(p *Posting) StringAmountPosting {
+		return StringAmountPosting{Posting: p}
+	})
 }
 
 // StringAmountTransaction renders a Transaction with quoted decimal posting
@@ -78,10 +88,7 @@ func (w StringAmountTransaction) MarshalJSON() ([]byte, error) {
 // StringAmountTransactions wraps each transaction for the opt-in wire. The
 // result is always non-nil so a drained empty cursor still marshals as `[]`.
 func StringAmountTransactions(transactions []*Transaction) []StringAmountTransaction {
-	out := make([]StringAmountTransaction, 0, len(transactions))
-	for _, tx := range transactions {
-		out = append(out, StringAmountTransaction{Transaction: tx})
-	}
-
-	return out
+	return wrapAll(transactions, func(tx *Transaction) StringAmountTransaction {
+		return StringAmountTransaction{Transaction: tx}
+	})
 }

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -56,3 +56,32 @@ func StringAmountPostings(postings []*Posting) []StringAmountPosting {
 
 	return out
 }
+
+// StringAmountTransaction renders a Transaction with quoted decimal posting
+// amounts. Exported because the HTTP adapter constructs it at the write sites.
+type StringAmountTransaction struct {
+	*Transaction
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountTransaction.
+func (w StringAmountTransaction) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *Transaction. Match the
+	// default wire explicitly.
+	if w.Transaction == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// StringAmountTransactions wraps each transaction for the opt-in wire. The
+// result is always non-nil so a drained empty cursor still marshals as `[]`.
+func StringAmountTransactions(transactions []*Transaction) []StringAmountTransaction {
+	out := make([]StringAmountTransaction, 0, len(transactions))
+	for _, tx := range transactions {
+		out = append(out, StringAmountTransaction{Transaction: tx})
+	}
+
+	return out
+}

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -19,9 +19,19 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 // empty, so the field must be left as a nil interface unless there is
 // something to emit. Guard pointers with `!= nil` and slices/maps with
 // `len(x) > 0` — `!= nil` is not sufficient for a slice, because `omitempty`
-// drops empty non-nil slices too. childValue below makes that guard a
-// property of one generic function for the common case of a single retyped
-// child pointer, the same way wrapAll does for slices.
+// drops empty non-nil slices too. childValue and sliceValue below each make
+// that guard a property of one generic function: childValue for a single
+// retyped child pointer, sliceValue for a retyped slice field. wrapAll serves
+// the opposite case, a slice field with no `omitempty` that must always render
+// as `[]`.
+//
+// Every wrapper's MarshalJSON must return `[]byte("null")` when its embedded
+// pointer is nil. A value wrapper over a nil pointer is not itself nil, so the
+// encoder will not substitute `null` as it does for a nil *T; without the guard
+// it would call MarshalJSON on the zero value and emit an object. The header
+// must change the amount format only, never the response *shape*, so the guard
+// is not optional at any level — the per-site comments below say only that,
+// and point back here.
 //
 // Two marshaller shapes exist in this chain. A marshaller that always
 // produces one aux struct uses buildAux(amountsAsString bool) any, as above:
@@ -34,6 +44,20 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 //
 // Uint256.MarshalJSON is deliberately untouched: ledgerctl and misc/operator
 // consume it, so the CLI wire must not move.
+//
+// Adding a level to the chain:
+//  1. Split the type's MarshalJSON into buildAux(amountsAsString bool) any, and
+//     have MarshalJSON delegate with false. If the type dispatches a oneof,
+//     write marshalStringAmounts() ([]byte, error) instead and rebuild only the
+//     amount-bearing variants.
+//  2. Retype the child field in the aux struct to `any`.
+//  3. Fill it through childValue (single child pointer) or sliceValue (slice
+//     field with `omitempty`), never by hand: those hold the emptiness guard.
+//  4. Declare the wrapper type here, with the nil-inner-pointer guard returning
+//     `[]byte("null")` as its first statement. Export it only if a caller
+//     outside this package constructs it.
+//  5. Register the wrapper in the encoder-contract test so the declared
+//     MarshalJSON cannot be lost to the promoted one.
 
 // wrapAll wraps every element for the opt-in wire. The result is always
 // non-nil, so a nil or empty input still marshals as `[]` rather than `null`:
@@ -66,6 +90,25 @@ func childValue[T, W any](child *T, amountsAsString bool, wrap func(*T) W) any {
 	return child
 }
 
+// sliceValue returns a nil interface when items is empty, so a retyped `any`
+// field carrying `omitempty` stays omitted instead of emitting null or `[]`.
+// The guard is `len(items) == 0`, not `items != nil`: `omitempty` drops an
+// empty non-nil slice too, so a nil-checked guard would turn an omitted field
+// into `[]`. Note this is the opposite contract to wrapAll's always-non-nil
+// result: wrapAll serves Transaction.postings, which has no `omitempty` and
+// must render `[]`; sliceValue serves fields that have it and must vanish.
+func sliceValue[T, W any](items []T, amountsAsString bool, wrapAllOf func([]T) []W) any {
+	if len(items) == 0 {
+		return nil
+	}
+
+	if amountsAsString {
+		return wrapAllOf(items)
+	}
+
+	return items
+}
+
 // StringAmountPosting renders a Posting with a quoted decimal amount. Exported
 // because StringAmountPostings returns a slice of it, and revive's
 // unexported-return rule forbids an exported function returning an unexported
@@ -76,9 +119,8 @@ type StringAmountPosting struct {
 
 // MarshalJSON implements json.Marshaler for StringAmountPosting.
 func (w StringAmountPosting) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *Posting. Match the default
-	// wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.Posting == nil {
 		return []byte("null"), nil
 	}
@@ -104,9 +146,8 @@ type StringAmountTransaction struct {
 
 // MarshalJSON implements json.Marshaler for StringAmountTransaction.
 func (w StringAmountTransaction) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *Transaction. Match the
-	// default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.Transaction == nil {
 		return []byte("null"), nil
 	}
@@ -130,9 +171,8 @@ type StringAmountCreatedTransaction struct {
 
 // MarshalJSON implements json.Marshaler for StringAmountCreatedTransaction.
 func (w StringAmountCreatedTransaction) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *CreatedTransaction. Match
-	// the default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.CreatedTransaction == nil {
 		return []byte("null"), nil
 	}
@@ -148,9 +188,8 @@ type StringAmountRevertedTransaction struct {
 
 // MarshalJSON implements json.Marshaler for StringAmountRevertedTransaction.
 func (w StringAmountRevertedTransaction) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *RevertedTransaction. Match
-	// the default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.RevertedTransaction == nil {
 		return []byte("null"), nil
 	}
@@ -159,7 +198,8 @@ func (w StringAmountRevertedTransaction) MarshalJSON() ([]byte, error) {
 }
 
 // stringAmountLedgerLogPayload renders a LedgerLogPayload whose posting-bearing
-// variants carry quoted decimal amounts. Unexported: it is only ever returned
+// variants carry quoted decimal amounts (oneof dispatch). Unexported: it is
+// only ever returned
 // as `any` from LedgerLog.buildAux, never from an exported function, so
 // revive's unexported-return rule does not apply.
 type stringAmountLedgerLogPayload struct {
@@ -168,9 +208,8 @@ type stringAmountLedgerLogPayload struct {
 
 // MarshalJSON implements json.Marshaler for stringAmountLedgerLogPayload.
 func (w stringAmountLedgerLogPayload) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *LedgerLogPayload. Match the
-	// default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.LedgerLogPayload == nil {
 		return []byte("null"), nil
 	}
@@ -187,9 +226,8 @@ type stringAmountLedgerLog struct {
 
 // MarshalJSON implements json.Marshaler for stringAmountLedgerLog.
 func (w stringAmountLedgerLog) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *LedgerLog. Match the
-	// default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.LedgerLog == nil {
 		return []byte("null"), nil
 	}
@@ -206,9 +244,8 @@ type stringAmountApplyLedgerLog struct {
 
 // MarshalJSON implements json.Marshaler for stringAmountApplyLedgerLog.
 func (w stringAmountApplyLedgerLog) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *ApplyLedgerLog. Match the
-	// default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.ApplyLedgerLog == nil {
 		return []byte("null"), nil
 	}
@@ -217,17 +254,16 @@ func (w stringAmountApplyLedgerLog) MarshalJSON() ([]byte, error) {
 }
 
 // stringAmountLogPayload renders a LogPayload whose posting-bearing variant
-// carries quoted decimal amounts. Unexported for the same reason as
-// stringAmountLedgerLogPayload.
+// carries quoted decimal amounts (oneof dispatch). Unexported for the same
+// reason as stringAmountLedgerLogPayload.
 type stringAmountLogPayload struct {
 	*LogPayload
 }
 
 // MarshalJSON implements json.Marshaler for stringAmountLogPayload.
 func (w stringAmountLogPayload) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *LogPayload. Match the
-	// default wire explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.LogPayload == nil {
 		return []byte("null"), nil
 	}
@@ -244,9 +280,8 @@ type StringAmountLog struct {
 
 // MarshalJSON implements json.Marshaler for StringAmountLog.
 func (w StringAmountLog) MarshalJSON() ([]byte, error) {
-	// A value wrapper over a nil pointer is not nil, so the encoder will not
-	// substitute `null` for us as it does for a nil *Log. Match the default wire
-	// explicitly.
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
 	if w.Log == nil {
 		return []byte("null"), nil
 	}
@@ -260,4 +295,22 @@ func StringAmountLogs(logs []*Log) []StringAmountLog {
 	return wrapAll(logs, func(l *Log) StringAmountLog {
 		return StringAmountLog{Log: l}
 	})
+}
+
+// StringAmountPreparedQueryCursor renders a PreparedQueryCursor whose
+// transaction or log page carries quoted decimal posting amounts. Exported
+// because the HTTP adapter constructs it at the prepared-query execute route.
+type StringAmountPreparedQueryCursor struct {
+	*PreparedQueryCursor
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountPreparedQueryCursor.
+func (w StringAmountPreparedQueryCursor) MarshalJSON() ([]byte, error) {
+	// A nil inner pointer must render as `null`, not as an object: see the
+	// nil-receiver rule in the file header.
+	if w.PreparedQueryCursor == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
 }

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -19,7 +19,18 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 // empty, so the field must be left as a nil interface unless there is
 // something to emit. Guard pointers with `!= nil` and slices/maps with
 // `len(x) > 0` — `!= nil` is not sufficient for a slice, because `omitempty`
-// drops empty non-nil slices too.
+// drops empty non-nil slices too. childValue below makes that guard a
+// property of one generic function for the common case of a single retyped
+// child pointer, the same way wrapAll does for slices.
+//
+// Two marshaller shapes exist in this chain. A marshaller that always
+// produces one aux struct uses buildAux(amountsAsString bool) any, as above:
+// MarshalJSON delegates with false. A marshaller that dispatches a oneof and
+// returns a different struct per variant — bytes, not an aux value — instead
+// uses marshalStringAmounts() ([]byte, error): every non-posting-bearing
+// variant delegates to the type's own MarshalJSON so both modes stay
+// byte-identical there, and only the variant(s) that actually carry an
+// amount build the opt-in wire themselves.
 //
 // Uint256.MarshalJSON is deliberately untouched: ledgerctl and misc/operator
 // consume it, so the CLI wire must not move.
@@ -35,6 +46,24 @@ func wrapAll[T, W any](items []T, wrap func(T) W) []W {
 	}
 
 	return out
+}
+
+// childValue returns a nil interface when child is nil, so a retyped `any`
+// field carrying `omitempty` stays omitted instead of emitting null. Callers
+// must use this at every retyped child field rather than deciding per field
+// whether the guard is needed: it is safe where omitempty is absent (a nil
+// interface and a nil pointer both render null there) and load-bearing where
+// omitempty is present.
+func childValue[T, W any](child *T, amountsAsString bool, wrap func(*T) W) any {
+	if child == nil {
+		return nil
+	}
+
+	if amountsAsString {
+		return wrap(child)
+	}
+
+	return child
 }
 
 // StringAmountPosting renders a Posting with a quoted decimal amount. Exported

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -1,0 +1,58 @@
+package commonpb
+
+import "github.com/formancehq/ledger/v3/internal/adapter/json"
+
+// This file carries the EN-1779 opt-in wire, where Posting.amount is a quoted
+// decimal string instead of a bare JSON number so JavaScript clients do not
+// truncate above 2^53.
+//
+// The mechanism: every marshaller in the posting chain owns its field list in a
+// buildAux(amountsAsString bool); MarshalJSON delegates with false and is
+// byte-identical to what it always emitted. Each wrapper below delegates with
+// true. A parent types its child field `any` and stores the child's wrapper, so
+// the mode travels down the existing encoder recursion instead of through a
+// parallel type tree. An explicitly declared MarshalJSON on the wrapper takes
+// precedence over the one promoted from the embedded pointer.
+//
+// When a retyped field carries `omitempty`, the emptiness test moves from the
+// encoder to us: an interface holding a typed nil or an empty slice/map is not
+// empty, so the field must be left as a nil interface unless there is
+// something to emit. Guard pointers with `!= nil` and slices/maps with
+// `len(x) > 0` — `!= nil` is not sufficient for a slice, because `omitempty`
+// drops empty non-nil slices too.
+//
+// Uint256.MarshalJSON is deliberately untouched: ledgerctl and misc/operator
+// consume it, so the CLI wire must not move.
+
+// StringAmountPosting renders a Posting with a quoted decimal amount. Exported
+// because StringAmountPostings returns a slice of it, and revive's
+// unexported-return rule forbids an exported function returning an unexported
+// type.
+type StringAmountPosting struct {
+	*Posting
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountPosting.
+func (w StringAmountPosting) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *Posting. Match the default
+	// wire explicitly.
+	if w.Posting == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// StringAmountPostings wraps each posting for the opt-in wire. The result is
+// always non-nil so it marshals as `[]` rather than `null`: Transaction's
+// postings field has no omitempty and the OpenAPI schema types it as a
+// non-nullable required array.
+func StringAmountPostings(postings []*Posting) []StringAmountPosting {
+	out := make([]StringAmountPosting, 0, len(postings))
+	for _, p := range postings {
+		out = append(out, StringAmountPosting{Posting: p})
+	}
+
+	return out
+}

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -53,6 +53,9 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 //  2. Retype the child field in the aux struct to `any`.
 //  3. Fill it through childValue (single child pointer) or sliceValue (slice
 //     field with `omitempty`), never by hand: those hold the emptiness guard.
+//     A slice field with no `omitempty` is the exception: it has no emptiness
+//     to guard and must always render `[]`, so it is filled with wrapAll
+//     instead (Transaction.postings in transaction.go is the one such field).
 //  4. Declare the wrapper type here, with the nil-inner-pointer guard returning
 //     `[]byte("null")` as its first statement. Export it only if a caller
 //     outside this package constructs it.
@@ -199,9 +202,8 @@ func (w StringAmountRevertedTransaction) MarshalJSON() ([]byte, error) {
 
 // stringAmountLedgerLogPayload renders a LedgerLogPayload whose posting-bearing
 // variants carry quoted decimal amounts (oneof dispatch). Unexported: it is
-// only ever returned
-// as `any` from LedgerLog.buildAux, never from an exported function, so
-// revive's unexported-return rule does not apply.
+// only ever returned as `any` from LedgerLog.buildAux, never from an exported
+// function, so revive's unexported-return rule does not apply.
 type stringAmountLedgerLogPayload struct {
 	*LedgerLogPayload
 }

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -59,8 +59,13 @@ import "github.com/formancehq/ledger/v3/internal/adapter/json"
 //  4. Declare the wrapper type here, with the nil-inner-pointer guard returning
 //     `[]byte("null")` as its first statement. Export it only if a caller
 //     outside this package constructs it.
-//  5. Register the wrapper in the encoder-contract test so the declared
-//     MarshalJSON cannot be lost to the promoted one.
+//  5. Register the wrapper in stringAmountWrappers, in string_amounts_test.go.
+//     That table pins both properties a wrapper cannot lose silently: its
+//     MarshalJSON must be reachable on the VALUE (a pointer receiver compiles,
+//     but the wrapper then falls back to the embedded pointer's marshaller and
+//     emits the default bare-number amount), and a nil embedded pointer must
+//     render `null`. Skipping this step fails
+//     TestStringAmountWrappers_TableIsComplete.
 
 // wrapAll wraps every element for the opt-in wire. The result is always
 // non-nil, so a nil or empty input still marshals as `[]` rather than `null`:

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -92,3 +92,39 @@ func StringAmountTransactions(transactions []*Transaction) []StringAmountTransac
 		return StringAmountTransaction{Transaction: tx}
 	})
 }
+
+// StringAmountCreatedTransaction renders a CreatedTransaction with quoted
+// decimal posting amounts on its embedded transaction.
+type StringAmountCreatedTransaction struct {
+	*CreatedTransaction
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountCreatedTransaction.
+func (w StringAmountCreatedTransaction) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *CreatedTransaction. Match
+	// the default wire explicitly.
+	if w.CreatedTransaction == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// StringAmountRevertedTransaction renders a RevertedTransaction with quoted
+// decimal posting amounts on its embedded revert transaction.
+type StringAmountRevertedTransaction struct {
+	*RevertedTransaction
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountRevertedTransaction.
+func (w StringAmountRevertedTransaction) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *RevertedTransaction. Match
+	// the default wire explicitly.
+	if w.RevertedTransaction == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}

--- a/internal/proto/commonpb/string_amounts.go
+++ b/internal/proto/commonpb/string_amounts.go
@@ -157,3 +157,107 @@ func (w StringAmountRevertedTransaction) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(w.buildAux(true))
 }
+
+// stringAmountLedgerLogPayload renders a LedgerLogPayload whose posting-bearing
+// variants carry quoted decimal amounts. Unexported: it is only ever returned
+// as `any` from LedgerLog.buildAux, never from an exported function, so
+// revive's unexported-return rule does not apply.
+type stringAmountLedgerLogPayload struct {
+	*LedgerLogPayload
+}
+
+// MarshalJSON implements json.Marshaler for stringAmountLedgerLogPayload.
+func (w stringAmountLedgerLogPayload) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *LedgerLogPayload. Match the
+	// default wire explicitly.
+	if w.LedgerLogPayload == nil {
+		return []byte("null"), nil
+	}
+
+	return w.marshalStringAmounts()
+}
+
+// stringAmountLedgerLog renders a LedgerLog with quoted decimal posting amounts
+// in its payload. Unexported for the same reason as
+// stringAmountLedgerLogPayload.
+type stringAmountLedgerLog struct {
+	*LedgerLog
+}
+
+// MarshalJSON implements json.Marshaler for stringAmountLedgerLog.
+func (w stringAmountLedgerLog) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *LedgerLog. Match the
+	// default wire explicitly.
+	if w.LedgerLog == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// stringAmountApplyLedgerLog renders an ApplyLedgerLog with quoted decimal
+// posting amounts in its nested ledger log. Unexported for the same reason as
+// stringAmountLedgerLogPayload.
+type stringAmountApplyLedgerLog struct {
+	*ApplyLedgerLog
+}
+
+// MarshalJSON implements json.Marshaler for stringAmountApplyLedgerLog.
+func (w stringAmountApplyLedgerLog) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *ApplyLedgerLog. Match the
+	// default wire explicitly.
+	if w.ApplyLedgerLog == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// stringAmountLogPayload renders a LogPayload whose posting-bearing variant
+// carries quoted decimal amounts. Unexported for the same reason as
+// stringAmountLedgerLogPayload.
+type stringAmountLogPayload struct {
+	*LogPayload
+}
+
+// MarshalJSON implements json.Marshaler for stringAmountLogPayload.
+func (w stringAmountLogPayload) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *LogPayload. Match the
+	// default wire explicitly.
+	if w.LogPayload == nil {
+		return []byte("null"), nil
+	}
+
+	return w.marshalStringAmounts()
+}
+
+// StringAmountLog renders a global Log with quoted decimal posting amounts
+// anywhere down its payload chain. Exported because the HTTP adapter constructs
+// it at the write sites.
+type StringAmountLog struct {
+	*Log
+}
+
+// MarshalJSON implements json.Marshaler for StringAmountLog.
+func (w StringAmountLog) MarshalJSON() ([]byte, error) {
+	// A value wrapper over a nil pointer is not nil, so the encoder will not
+	// substitute `null` for us as it does for a nil *Log. Match the default wire
+	// explicitly.
+	if w.Log == nil {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(w.buildAux(true))
+}
+
+// StringAmountLogs wraps each log for the opt-in wire. The result is always
+// non-nil so a drained empty cursor still marshals as `[]`.
+func StringAmountLogs(logs []*Log) []StringAmountLog {
+	return wrapAll(logs, func(l *Log) StringAmountLog {
+		return StringAmountLog{Log: l}
+	})
+}

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -688,3 +688,206 @@ func TestLogs_EmptyAndNilSliceMarshalAsArray(t *testing.T) {
 		})
 	}
 }
+
+// newTestCursorAccount returns an account page entry. Nothing below Account
+// carries a Uint256 or a bare JSON number, so this exists to prove an
+// ACCOUNTS-target cursor is byte-identical in both modes.
+func newTestCursorAccount(t *testing.T) *Account {
+	t.Helper()
+
+	return &Account{
+		Address: "alice",
+		Volumes: []*AccountVolume{
+			{
+				Asset: "USD/2",
+				Volumes: &VolumesWithBalance{
+					Input:   aboveJSNumberLimit,
+					Output:  "0",
+					Balance: aboveJSNumberLimit,
+				},
+			},
+		},
+	}
+}
+
+// newTestCursorLog wraps a transaction carrying the given amount in the full
+// nine-level chain a LOGS-target cursor serves.
+func newTestCursorLog(t *testing.T, amount *big.Int) *Log {
+	t.Helper()
+
+	return newTestLog(t, &LedgerLogPayload{
+		Payload: &LedgerLogPayload_CreatedTransaction{
+			CreatedTransaction: &CreatedTransaction{Transaction: newTestTransaction(t, amount)},
+		},
+	})
+}
+
+func TestPreparedQueryCursor_StringAmountReachesTransactionData(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	cursor := &PreparedQueryCursor{
+		PageSize:        15,
+		TransactionData: []*Transaction{newTestTransaction(t, amount)},
+	}
+
+	def, err := json.Marshal(cursor)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"amount":`+aboveJSNumberLimit,
+		"the default cursor wire must stay an unquoted number")
+
+	str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the cursor must forward the mode into its transaction page")
+}
+
+func TestPreparedQueryCursor_StringAmountReachesLogData(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	cursor := &PreparedQueryCursor{
+		PageSize: 15,
+		LogData:  []*Log{newTestCursorLog(t, amount)},
+	}
+
+	def, err := json.Marshal(cursor)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"amount":`+aboveJSNumberLimit,
+		"the default cursor wire must stay an unquoted number")
+
+	str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the cursor must forward the mode down the whole log chain")
+}
+
+func TestPreparedQueryCursor_StringAmountOnlyChangesAmountShape(t *testing.T) {
+	t.Parallel()
+
+	// A small amount: requireOnlyAmountsDiffer decodes numbers through float64
+	// and is lossy above 2^53 (see its doc comment). The above-2^53 exactness
+	// is covered by the two require.Contains tests above.
+	cursors := map[string]*PreparedQueryCursor{
+		"transactions target": {
+			PageSize:        15,
+			HasMore:         true,
+			Next:            "cursor-next",
+			TransactionData: []*Transaction{newTestTransaction(t, big.NewInt(4200))},
+		},
+		"logs target": {
+			PageSize: 15,
+			HasMore:  true,
+			Next:     "cursor-next",
+			LogData:  []*Log{newTestCursorLog(t, big.NewInt(4200))},
+		},
+	}
+
+	for name, cursor := range cursors {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			def, err := json.Marshal(cursor)
+			require.NoError(t, err)
+
+			str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor})
+			require.NoError(t, err)
+
+			requireOnlyAmountsDiffer(t, def, str)
+		})
+	}
+}
+
+func TestPreparedQueryCursor_AccountsTargetIsByteIdenticalInBothModes(t *testing.T) {
+	t.Parallel()
+
+	cursor := &PreparedQueryCursor{
+		PageSize:    15,
+		HasMore:     true,
+		Previous:    "cursor-previous",
+		AccountData: []*Account{newTestCursorAccount(t)},
+	}
+
+	def, err := json.Marshal(cursor)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor})
+	require.NoError(t, err)
+
+	require.Equal(t, string(def), string(str),
+		"an accounts page carries no bare number: the opt-in wire must be byte-identical")
+
+	// The two unpopulated data fields must stay absent, not become `[]`: this is
+	// what the len()==0 guard in sliceValue buys over a `!= nil` check.
+	for _, body := range []string{string(def), string(str)} {
+		require.NotContains(t, body, "transactionData")
+		require.NotContains(t, body, "logData")
+	}
+}
+
+func TestPreparedQueryCursor_EmptyDataSliceStaysOmittedInBothModes(t *testing.T) {
+	t.Parallel()
+
+	cursors := map[string]struct {
+		cursor  *PreparedQueryCursor
+		absent  string
+		present string
+	}{
+		"empty transaction page": {
+			cursor:  &PreparedQueryCursor{PageSize: 15, TransactionData: []*Transaction{}},
+			absent:  "transactionData",
+			present: `{"pageSize":15,"hasMore":false}`,
+		},
+		"empty log page": {
+			cursor:  &PreparedQueryCursor{PageSize: 15, LogData: []*Log{}},
+			absent:  "logData",
+			present: `{"pageSize":15,"hasMore":false}`,
+		},
+	}
+
+	for name, tc := range cursors {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			def, err := json.Marshal(tc.cursor)
+			require.NoError(t, err)
+
+			str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: tc.cursor})
+			require.NoError(t, err)
+
+			require.NotContains(t, string(def), tc.absent)
+			require.NotContains(t, string(str), tc.absent,
+				"an empty non-nil page must stay omitted, never render as []")
+			require.JSONEq(t, tc.present, string(def))
+			require.JSONEq(t, tc.present, string(str))
+		})
+	}
+}
+
+func TestPreparedQueryCursor_DrainedCursorIsByteIdenticalInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// emptyListResponse (internal/query/executor.go) builds exactly this: a page
+	// size and nothing else.
+	cursor := &PreparedQueryCursor{PageSize: 15}
+
+	def, err := json.Marshal(cursor)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"pageSize":15,"hasMore":false}`, string(def))
+
+	str, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: cursor})
+	require.NoError(t, err)
+	require.Equal(t, string(def), string(str))
+}
+
+func TestPreparedQueryCursor_NilReceiverIsNull(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: nil})
+	require.NoError(t, err)
+	require.Equal(t, "null", string(got))
+}

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -333,3 +333,123 @@ func TestTransactions_EmptyAndNilSliceMarshalAsArray(t *testing.T) {
 		})
 	}
 }
+
+func TestCreatedTransaction_StringAmountKeepsAboveJSLimitExact(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	ct := &CreatedTransaction{Transaction: newTestTransaction(t, amount)}
+
+	def, err := json.Marshal(ct)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: ct})
+	require.NoError(t, err)
+
+	require.NotEqual(t, string(def), string(str))
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the opt-in wire must carry the above-2^53 amount digit for digit")
+}
+
+func TestCreatedTransaction_StringAmountOnlyChangesAmountShape(t *testing.T) {
+	t.Parallel()
+
+	ct := &CreatedTransaction{Transaction: newTestTransaction(t, big.NewInt(4200))}
+
+	def, err := json.Marshal(ct)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: ct})
+	require.NoError(t, err)
+
+	requireOnlyAmountsDiffer(t, def, str)
+}
+
+func TestCreatedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// Transaction is `omitempty`. Retyping it to `any` would make a nil
+	// transaction emit `null` unless the nil guard holds, so assert the
+	// absence explicitly in both modes.
+	ct := &CreatedTransaction{ChapterId: 3}
+
+	def, err := json.Marshal(ct)
+	require.NoError(t, err)
+	require.NotContains(t, string(def), "transaction")
+	require.NotContains(t, string(def), "null")
+
+	str, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: ct})
+	require.NoError(t, err)
+	require.NotContains(t, string(str), "transaction")
+	require.NotContains(t, string(str), "null")
+}
+
+func TestCreatedTransaction_NilReceiverIsNull(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: nil})
+	require.NoError(t, err)
+	require.Equal(t, "null", string(got))
+}
+
+func TestRevertedTransaction_StringAmountKeepsAboveJSLimitExact(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	rt := &RevertedTransaction{RevertTransaction: newTestTransaction(t, amount)}
+
+	def, err := json.Marshal(rt)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: rt})
+	require.NoError(t, err)
+
+	require.NotEqual(t, string(def), string(str))
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the opt-in wire must carry the above-2^53 amount digit for digit")
+}
+
+func TestRevertedTransaction_StringAmountOnlyChangesAmountShape(t *testing.T) {
+	t.Parallel()
+
+	rt := &RevertedTransaction{RevertTransaction: newTestTransaction(t, big.NewInt(4200))}
+
+	def, err := json.Marshal(rt)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: rt})
+	require.NoError(t, err)
+
+	requireOnlyAmountsDiffer(t, def, str)
+}
+
+func TestRevertedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// RevertTransaction is `omitempty`. Retyping it to `any` would make a nil
+	// transaction emit `null` unless the nil guard holds, so assert the
+	// absence explicitly in both modes.
+	rt := &RevertedTransaction{RevertedTransactionId: 4}
+
+	def, err := json.Marshal(rt)
+	require.NoError(t, err)
+	require.NotContains(t, string(def), "revertTransaction")
+	require.NotContains(t, string(def), "null")
+
+	str, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: rt})
+	require.NoError(t, err)
+	require.NotContains(t, string(str), "revertTransaction")
+	require.NotContains(t, string(str), "null")
+}
+
+func TestRevertedTransaction_NilReceiverIsNull(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: nil})
+	require.NoError(t, err)
+	require.Equal(t, "null", string(got))
+}

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -2,7 +2,13 @@ package commonpb
 
 import (
 	"bytes"
+	stdjson "encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"math/big"
+	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 	libtime "time"
@@ -392,14 +398,6 @@ func TestCreatedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
 	require.NotContains(t, string(str), "transaction")
 }
 
-func TestCreatedTransaction_NilReceiverIsNull(t *testing.T) {
-	t.Parallel()
-
-	got, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: nil})
-	require.NoError(t, err)
-	require.Equal(t, "null", string(got))
-}
-
 func TestRevertedTransaction_StringAmountKeepsAboveJSLimitExact(t *testing.T) {
 	t.Parallel()
 
@@ -451,14 +449,6 @@ func TestRevertedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
 	str, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: rt})
 	require.NoError(t, err)
 	require.NotContains(t, string(str), "revertTransaction")
-}
-
-func TestRevertedTransaction_NilReceiverIsNull(t *testing.T) {
-	t.Parallel()
-
-	got, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: nil})
-	require.NoError(t, err)
-	require.Equal(t, "null", string(got))
 }
 
 // newTestLog wraps a ledger-log payload in the full five-level chain a log
@@ -644,14 +634,6 @@ func TestLedgerLog_NilDataStaysNullInBothModes(t *testing.T) {
 	require.Contains(t, string(str), `"data":null`)
 
 	require.Equal(t, string(def), string(str))
-}
-
-func TestLog_NilReceiverIsNull(t *testing.T) {
-	t.Parallel()
-
-	got, err := json.Marshal(StringAmountLog{Log: nil})
-	require.NoError(t, err)
-	require.Equal(t, "null", string(got))
 }
 
 func TestLogs_NilElementStaysNullInBothModes(t *testing.T) {
@@ -889,12 +871,192 @@ func TestPreparedQueryCursor_DrainedCursorIsByteIdenticalInBothModes(t *testing.
 	require.Equal(t, string(def), string(str))
 }
 
-func TestPreparedQueryCursor_NilReceiverIsNull(t *testing.T) {
+// --- EN-1779 wrapper contract ------------------------------------------------
+
+// stringAmountWrappers holds one zero value per opt-in wrapper declared in
+// string_amounts.go, each stored in an `any`.
+//
+// Storing the VALUE rather than a pointer to it is the whole point of the two
+// tests below. Every wrapper must declare MarshalJSON on a VALUE receiver,
+// because that is how the encoder meets it: a parent's aux struct types the
+// child field `any` and stores the wrapper value, so dispatch happens on the
+// value's method set.
+//
+// Declaring it on a pointer receiver instead compiles, runs, and emits a
+// perfectly well-formed body — the WRONG one. The declaration shadows the
+// MarshalJSON promoted from the embedded protobuf pointer, so the wrapper VALUE
+// stops satisfying json.Marshaler and the encoder falls back to the embedded
+// pointer's own marshaller: the DEFAULT wire, amount bare. Measured on a
+// pointer-receiver StringAmountPosting, the body comes out as
+// `{"source":"world","destination":"alice","amount":9007199254740993,...}` —
+// camelCase, valid, and truncating in JavaScript. The opt-in path silently
+// degrades into the very bug it exists to fix, with neither a compile error nor
+// a runtime error. (The inverse is harmless: *T's method set includes T's
+// value-receiver methods, so passing a pointer to a correctly declared wrapper
+// marshals fine. Only the value case needs pinning.)
+//
+// The zero value also has a nil embedded pointer, which is exactly the input
+// the second property needs.
+//
+// Registering an eleventh wrapper here is step 5 of the "adding a level"
+// checklist in string_amounts.go, and
+// TestStringAmountWrappers_TableIsComplete fails until you do.
+var stringAmountWrappers = []any{
+	StringAmountPosting{},
+	StringAmountTransaction{},
+	StringAmountCreatedTransaction{},
+	StringAmountRevertedTransaction{},
+	stringAmountLedgerLogPayload{},
+	stringAmountLedgerLog{},
+	stringAmountApplyLedgerLog{},
+	stringAmountLogPayload{},
+	StringAmountLog{},
+	StringAmountPreparedQueryCursor{},
+}
+
+// wrapperTypeName names a wrapper from its dynamic type, so a row cannot carry
+// a subtest label that disagrees with the type it actually holds.
+func wrapperTypeName(wrapper any) string {
+	return reflect.TypeOf(wrapper).Name()
+}
+
+// TestStringAmountWrappers_ValueImplementsJSONMarshaler pins the value-receiver
+// requirement for every level of the chain. See stringAmountWrappers for why a
+// pointer receiver is a silent wire regression rather than a build failure.
+func TestStringAmountWrappers_ValueImplementsJSONMarshaler(t *testing.T) {
 	t.Parallel()
 
-	got, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: nil})
+	for _, wrapper := range stringAmountWrappers {
+		t.Run(wrapperTypeName(wrapper), func(t *testing.T) {
+			t.Parallel()
+
+			_, ok := wrapper.(stdjson.Marshaler)
+			require.Truef(t, ok,
+				"%T does not implement json.Marshaler as a VALUE. Its MarshalJSON is "+
+					"almost certainly declared on a pointer receiver: change it to "+
+					"`func (w %T) MarshalJSON()`. A parent stores this wrapper as a value "+
+					"in an `any` field, so with a pointer receiver the encoder never sees "+
+					"the method and falls back to the embedded pointer's own marshaller — "+
+					"a valid body carrying the DEFAULT bare-number amount, which is the "+
+					"truncation bug the opt-in header exists to fix.",
+				wrapper, wrapper)
+		})
+	}
+}
+
+// TestStringAmountWrappers_NilInnerPointerIsNull pins the nil-inner-pointer
+// guard the file header of string_amounts.go declares mandatory at every level.
+//
+// A wrapper VALUE over a nil embedded pointer is not itself nil, so the encoder
+// does not substitute `null` the way it does for a nil *T: without the guard it
+// calls MarshalJSON on the zero value and emits an object. The opt-in header
+// must change the amount FORMAT only, never the response SHAPE, so a level that
+// loses its guard turns an omitted-or-null field into `{}` on the opt-in wire
+// only.
+func TestStringAmountWrappers_NilInnerPointerIsNull(t *testing.T) {
+	t.Parallel()
+
+	for _, wrapper := range stringAmountWrappers {
+		t.Run(wrapperTypeName(wrapper), func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(wrapper)
+			require.NoError(t, err)
+			require.Equalf(t, "null", string(got),
+				"%T over a nil embedded pointer must marshal to `null`. Restore the "+
+					"`if w.X == nil { return []byte(\"null\"), nil }` guard as the first "+
+					"statement of its MarshalJSON: the opt-in header may change the amount "+
+					"format, never the response shape.",
+				wrapper)
+		})
+	}
+}
+
+// TestStringAmountWrappers_TableIsComplete keeps stringAmountWrappers honest.
+// The list is hand-written, so an eleventh wrapper added without a row would
+// escape both properties above entirely — and a wrapper is exactly the kind of
+// small mechanical type that gets added by copying a sibling and editing two
+// identifiers, which is how a pointer receiver or a missing nil guard gets in.
+//
+// Comparing SETS rather than counting is what makes this useful: adding one
+// wrapper while deleting another leaves the count unchanged.
+//
+// The scan keys off string_amounts.go being the single declaration site for the
+// opt-in wrappers, which the file header states. A wrapper declared elsewhere
+// would be invisible here; keep them in this file.
+func TestStringAmountWrappers_TableIsComplete(t *testing.T) {
+	t.Parallel()
+
+	const declarationFile = "string_amounts.go"
+
+	file, err := parser.ParseFile(token.NewFileSet(), declarationFile, nil, 0)
 	require.NoError(t, err)
-	require.Equal(t, "null", string(got))
+
+	var declared []string
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+
+		if _, isStruct := spec.Type.(*ast.StructType); isStruct {
+			declared = append(declared, spec.Name.Name)
+		}
+
+		return true
+	})
+
+	registered := make([]string, 0, len(stringAmountWrappers))
+	for _, wrapper := range stringAmountWrappers {
+		registered = append(registered, wrapperTypeName(wrapper))
+	}
+
+	sort.Strings(declared)
+	sort.Strings(registered)
+
+	require.ElementsMatch(t, declared, registered,
+		"the wrapper types declared in "+declarationFile+" do not match "+
+			"stringAmountWrappers: list A above is what the AST found, list B is what "+
+			"the table registers. Adding a level to the chain ends with registering "+
+			"its wrapper here (step 5 of the checklist in "+declarationFile+"); "+
+			"removing a level ends with deleting its row.")
+}
+
+// TestStringAmountSliceConstructors_ReturnNonNilSlice pins the always-non-nil
+// contract of the three slice constructors. Sonic dispatches MarshalJSON on the
+// ELEMENT type, so the wrapper's marshaller is what renders each entry, but the
+// slice itself decides between `[]` and `null` — and a nil slice renders `null`.
+//
+// The per-level tests above assert the marshaled bytes; this asserts the
+// property they rest on, at the constructor. A future `var out []W` rewrite of
+// wrapAll would be caught here even for a field whose emptiness handling has
+// since changed.
+func TestStringAmountSliceConstructors_ReturnNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	// nil is the input that actually occurs in production — GetPostings() and a
+	// drained cursor both return nil, never an empty non-nil slice — but both
+	// must survive the round trip.
+	testCases := map[string]any{
+		"StringAmountPostings from nil slice":       StringAmountPostings(nil),
+		"StringAmountPostings from empty slice":     StringAmountPostings([]*Posting{}),
+		"StringAmountTransactions from nil slice":   StringAmountTransactions(nil),
+		"StringAmountTransactions from empty slice": StringAmountTransactions([]*Transaction{}),
+		"StringAmountLogs from nil slice":           StringAmountLogs(nil),
+		"StringAmountLogs from empty slice":         StringAmountLogs([]*Log{}),
+	}
+
+	for name, got := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NotNil(t, got,
+				"the constructor must return a non-nil slice, or the field renders as "+
+					"`null` instead of `[]` and the opt-in header changes the response "+
+					"shape. Build the result with wrapAll, never with a bare `var out []W`.")
+		})
+	}
 }
 
 // --- EN-1779 default-wire golden gate ---------------------------------------

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -455,3 +455,236 @@ func TestRevertedTransaction_NilReceiverIsNull(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "null", string(got))
 }
+
+// newTestLog wraps a ledger-log payload in the full five-level chain a log
+// route actually serves: Log -> LogPayload_Apply -> ApplyLedgerLog ->
+// LedgerLog -> LedgerLogPayload. Every level must forward the mode for the
+// amount at the bottom to come out quoted.
+func newTestLog(t *testing.T, payload *LedgerLogPayload) *Log {
+	t.Helper()
+
+	return &Log{
+		Sequence: 5,
+		Receipt:  "receipt-1",
+		Payload: &LogPayload{
+			Type: &LogPayload_Apply{
+				Apply: &ApplyLedgerLog{
+					LedgerName: "ledger0",
+					Log: &LedgerLog{
+						Id:   9,
+						Data: payload,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLog_StringAmountReachesPostingThroughCreatedTransaction(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	log := newTestLog(t, &LedgerLogPayload{
+		Payload: &LedgerLogPayload_CreatedTransaction{
+			CreatedTransaction: &CreatedTransaction{Transaction: newTestTransaction(t, amount)},
+		},
+	})
+
+	def, err := json.Marshal(log)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"amount":`+aboveJSNumberLimit,
+		"the default wire must stay the bare number at full depth")
+
+	str, err := json.Marshal(StringAmountLog{Log: log})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the mode must survive all five log levels down to the posting")
+}
+
+func TestLog_StringAmountReachesPostingThroughRevertedTransaction(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	log := newTestLog(t, &LedgerLogPayload{
+		Payload: &LedgerLogPayload_RevertedTransaction{
+			RevertedTransaction: &RevertedTransaction{
+				RevertedTransactionId: 3,
+				RevertTransaction:     newTestTransaction(t, amount),
+			},
+		},
+	})
+
+	def, err := json.Marshal(log)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"amount":`+aboveJSNumberLimit,
+		"the default wire must stay the bare number at full depth")
+
+	str, err := json.Marshal(StringAmountLog{Log: log})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the mode must survive all five log levels down to the posting")
+}
+
+func TestLog_StringAmountOnlyChangesAmountShapeAtFullDepth(t *testing.T) {
+	t.Parallel()
+
+	// A small amount: requireOnlyAmountsDiffer decodes numbers through float64
+	// (see its doc comment), which is lossy above 2^53. Exactness above the
+	// limit is covered by the two reach tests above.
+	log := newTestLog(t, &LedgerLogPayload{
+		Payload: &LedgerLogPayload_CreatedTransaction{
+			CreatedTransaction: &CreatedTransaction{Transaction: newTestTransaction(t, big.NewInt(4200))},
+		},
+	})
+
+	def, err := json.Marshal(log)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountLog{Log: log})
+	require.NoError(t, err)
+
+	requireOnlyAmountsDiffer(t, def, str)
+}
+
+func TestLog_NonPostingPayloadIsByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	// The opt-in path rebuilds only the posting-bearing variants; every other
+	// variant delegates to MarshalJSON. Assert byte equality rather than
+	// structural equality: this is the check that catches a hand-rolled variant
+	// struct drifting away from the delegated output.
+	testCases := map[string]*Log{
+		"ledger-level variant carrying no postings": {
+			Sequence: 2,
+			Payload: &LogPayload{
+				Type: &LogPayload_DeleteLedger{
+					DeleteLedger: &DeletedLedgerLog{Name: "ledger0"},
+				},
+			},
+		},
+		"ledger-log payload variant carrying no postings": newTestLog(t, &LedgerLogPayload{
+			Payload: &LedgerLogPayload_SavedMetadata{
+				SavedMetadata: &SavedMetadata{
+					Target: &Target{Target: &Target_TransactionId{TransactionId: 7}},
+				},
+			},
+		}),
+	}
+
+	for name, log := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			def, err := json.Marshal(log)
+			require.NoError(t, err)
+
+			str, err := json.Marshal(StringAmountLog{Log: log})
+			require.NoError(t, err)
+
+			require.Equal(t, string(def), string(str),
+				"a payload carrying no amount must be byte-identical in both modes")
+		})
+	}
+}
+
+func TestLog_NilPayloadStaysOmittedInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// Log.payload is `omitempty`. Retyping it to `any` would make a nil payload
+	// emit `null` unless the childValue guard holds.
+	log := &Log{Sequence: 1}
+
+	def, err := json.Marshal(log)
+	require.NoError(t, err)
+	require.NotContains(t, string(def), "payload")
+
+	str, err := json.Marshal(StringAmountLog{Log: log})
+	require.NoError(t, err)
+	require.NotContains(t, string(str), "payload")
+}
+
+func TestApplyLedgerLog_NilLogStaysOmittedInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// ApplyLedgerLog.log is `omitempty`, same guard as Log.payload.
+	apply := &ApplyLedgerLog{LedgerName: "ledger0"}
+
+	def, err := json.Marshal(apply)
+	require.NoError(t, err)
+	require.NotContains(t, string(def), `"log"`)
+
+	str, err := json.Marshal(stringAmountApplyLedgerLog{ApplyLedgerLog: apply})
+	require.NoError(t, err)
+	require.NotContains(t, string(str), `"log"`)
+}
+
+func TestLedgerLog_NilDataStaysNullInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// LedgerLog.data has NO omitempty, so a nil payload renders as `null`
+	// today. The retyped `any` field must keep emitting exactly that: the
+	// childValue guard leaves a nil interface, which renders `null` as well.
+	ledgerLog := &LedgerLog{}
+
+	def, err := json.Marshal(ledgerLog)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"data":null`)
+
+	str, err := json.Marshal(stringAmountLedgerLog{LedgerLog: ledgerLog})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"data":null`)
+
+	require.Equal(t, string(def), string(str))
+}
+
+func TestLog_NilReceiverIsNull(t *testing.T) {
+	t.Parallel()
+
+	got, err := json.Marshal(StringAmountLog{Log: nil})
+	require.NoError(t, err)
+	require.Equal(t, "null", string(got))
+}
+
+func TestLogs_NilElementStaysNullInBothModes(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	logs := []*Log{
+		newTestLog(t, &LedgerLogPayload{
+			Payload: &LedgerLogPayload_CreatedTransaction{
+				CreatedTransaction: &CreatedTransaction{Transaction: newTestTransaction(t, amount)},
+			},
+		}),
+		nil,
+	}
+
+	def, err := json.Marshal(logs)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `,null]`)
+
+	str, err := json.Marshal(StringAmountLogs(logs))
+	require.NoError(t, err)
+	require.Contains(t, string(str), `,null]`,
+		"a nil element must stay null: the header may change amount formatting, never shape")
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`)
+}
+
+func TestLogs_EmptyAndNilSliceMarshalAsArray(t *testing.T) {
+	t.Parallel()
+
+	for name, in := range map[string][]*Log{"nil slice": nil, "empty slice": {}} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(StringAmountLogs(in))
+			require.NoError(t, err)
+			require.Equal(t, "[]", string(got))
+		})
+	}
+}

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -1,10 +1,15 @@
 package commonpb
 
 import (
+	"bytes"
 	"math/big"
+	"strconv"
 	"testing"
+	libtime "time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/types/time"
 
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 )
@@ -890,4 +895,365 @@ func TestPreparedQueryCursor_NilReceiverIsNull(t *testing.T) {
 	got, err := json.Marshal(StringAmountPreparedQueryCursor{PreparedQueryCursor: nil})
 	require.NoError(t, err)
 	require.Equal(t, "null", string(got))
+}
+
+// --- EN-1779 default-wire golden gate ---------------------------------------
+//
+// TestDefaultWireGolden pins the DEFAULT wire byte for byte for every
+// marshaller EN-1779 rewrote.
+//
+// A FAILURE HERE MEANS THE CHANGE IS WRONG. These bytes are what every client
+// that does not send Formance-Bigint-As-String already receives, and every
+// expectation below was verified against the pre-change base branch. Never edit
+// a `want` value to make a new implementation pass: fix the implementation, or
+// escalate if the wire genuinely has to move.
+//
+// Two encoders are asserted because they disagree, and only one of them is
+// production:
+//   - json.Marshal is sonic ConfigDefault. It does NOT escape HTML, so a
+//     golden captured with it alone would not describe what clients receive.
+//   - json.MarshalWrite is sonic ConfigStd, which is what writeJSONResponse
+//     (internal/adapter/http/response.go) serves: it escapes `<`, `>` and `&`,
+//     and appends a trailing newline that is part of the response body.
+//
+// Every fixture carries at most ONE metadata key. sonic does not sort map keys
+// in either config, so a byte comparison over two or more keys would flake on
+// iteration order.
+
+// goldenAmount is aboveJSNumberLimit as a uint64. Fixtures build their amount
+// from it while the expectations concatenate aboveJSNumberLimit, and
+// TestDefaultWireGolden asserts the two agree, so neither can drift alone.
+const goldenAmount uint64 = 9007199254740993
+
+// goldenDate is the single instant every golden fixture carries. RFC3339Nano
+// drops the fractional part at whole seconds, so the rendered form is stable.
+const goldenDate = "2026-08-18T10:00:00Z"
+
+// goldenPostingJSON is the pinned default wire of goldenPosting.
+const goldenPostingJSON = `{"source":"world","destination":"alice","amount":` +
+	aboveJSNumberLimit + `,"asset":"USD/2","color":"red"}`
+
+// goldenTransactionJSON is the pinned default wire of goldenTransaction. One
+// line per field, in the order Transaction.buildAux declares them: that order
+// is part of the wire contract, not an implementation detail.
+//
+// The `weight` metadata value is deliberately 2^64-1 and renders as a bare JSON
+// number. Metadata is the counter-example to "nothing below Account carries a
+// bare number", and it is unaffected by the header: only amounts move.
+const goldenTransactionJSON = `{"postings":[` + goldenPostingJSON + `]` +
+	`,"metadata":{"weight":18446744073709551615}` +
+	`,"timestamp":"` + goldenDate + `"` +
+	`,"reference":"ref-1"` +
+	`,"id":42` +
+	`,"insertedAt":"` + goldenDate + `"` +
+	`,"updatedAt":"` + goldenDate + `"` +
+	`,"revertedAt":"` + goldenDate + `"` +
+	`,"revertedByTransactionId":43` +
+	`,"revertsTransactionId":41` +
+	`,"reverted":true` +
+	`,"postCommitVolumes":{"world":[{"asset":"USD/2","color":"","input":"0"` +
+	`,"output":"` + aboveJSNumberLimit + `"}]}}`
+
+// goldenCreatedTransactionJSON is the pinned default wire of
+// goldenCreatedTransaction.
+const goldenCreatedTransactionJSON = `{"transaction":` + goldenTransactionJSON +
+	`,"accountMetadata":{"alice":{"tier":"gold"}}` +
+	`,"chapterId":3}`
+
+// goldenLedgerLogJSON is the pinned default wire of goldenLedgerLog.
+const goldenLedgerLogJSON = `{"type":"NEW_TRANSACTION"` +
+	`,"data":{"createdTransaction":` + goldenCreatedTransactionJSON + `}` +
+	`,"date":"` + goldenDate + `"` +
+	`,"id":9}`
+
+// goldenApplyLedgerLogJSON is the pinned default wire of goldenApplyLedgerLog.
+const goldenApplyLedgerLogJSON = `{"ledgerName":"ledger0","log":` + goldenLedgerLogJSON + `}`
+
+// goldenLogJSON is the pinned default wire of goldenLog.
+//
+// responseSignature is `{}` and not absent even though the log carries no
+// signature: Log.buildAux fills it through protoFieldJSON, whose `msg == nil`
+// guard cannot see a typed nil behind the proto.Message interface, so
+// protojson renders the nil message as `{}` and `omitempty` keeps a two-byte
+// value. That is pre-existing behaviour on both sides of EN-1779 (the base
+// branch builds the field the same way), so it is pinned here rather than
+// quietly corrected: changing it would move the default wire.
+const goldenLogJSON = `{"sequence":5` +
+	`,"payload":{"apply":` + goldenApplyLedgerLogJSON + `}` +
+	`,"receipt":"receipt-1"` +
+	`,"responseSignature":{}}`
+
+// goldenTimestamp returns goldenDate as the proto Timestamp the payload types
+// carry.
+func goldenTimestamp() *Timestamp {
+	return NewTimestamp(time.New(libtime.Date(2026, 8, 18, 10, 0, 0, 0, libtime.UTC)))
+}
+
+// goldenPosting returns the posting every golden fixture carries: one
+// above-2^53 amount, so the wire is pinned exactly where a JavaScript client
+// would truncate it.
+func goldenPosting() *Posting {
+	return &Posting{
+		Source:      "world",
+		Destination: "alice",
+		Amount:      NewUint256FromUint64(goldenAmount),
+		Asset:       "USD/2",
+		Color:       "red",
+	}
+}
+
+// goldenTransaction returns a transaction with every optional field populated,
+// so the golden pins the position of each one rather than only the postings.
+func goldenTransaction() *Transaction {
+	at := goldenTimestamp()
+
+	return &Transaction{
+		Postings:              []*Posting{goldenPosting()},
+		Metadata:              map[string]*MetadataValue{"weight": NewUintValue(18446744073709551615)},
+		Timestamp:             at,
+		Reference:             "ref-1",
+		Id:                    42,
+		InsertedAt:            at,
+		UpdatedAt:             at,
+		RevertedAt:            at,
+		RevertedByTransaction: 43,
+		RevertsTransaction:    41,
+		Reverted:              true,
+		PostCommitVolumes: &PostCommitVolumes{
+			VolumesByAccount: map[string]*VolumesByAssets{
+				"world": {
+					Volumes: []*VolumeEntry{
+						{Asset: "USD/2", Volumes: &Volumes{Input: "0", Output: aboveJSNumberLimit}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// goldenCreatedTransaction returns the created-transaction payload the log
+// chain carries.
+func goldenCreatedTransaction() *CreatedTransaction {
+	return &CreatedTransaction{
+		Transaction: goldenTransaction(),
+		AccountMetadata: map[string]*MetadataMap{
+			"alice": {Values: map[string]*MetadataValue{"tier": NewStringValue("gold")}},
+		},
+		ChapterId: 3,
+	}
+}
+
+// goldenLedgerLog returns the ledger log wrapping goldenCreatedTransaction.
+func goldenLedgerLog() *LedgerLog {
+	return &LedgerLog{
+		Id:   9,
+		Date: goldenTimestamp(),
+		Data: &LedgerLogPayload{
+			Payload: &LedgerLogPayload_CreatedTransaction{
+				CreatedTransaction: goldenCreatedTransaction(),
+			},
+		},
+	}
+}
+
+// goldenApplyLedgerLog returns the apply payload wrapping goldenLedgerLog.
+func goldenApplyLedgerLog() *ApplyLedgerLog {
+	return &ApplyLedgerLog{LedgerName: "ledger0", Log: goldenLedgerLog()}
+}
+
+// goldenLog returns the nine-level payload a logs response serves: Log ->
+// LogPayload_Apply -> ApplyLedgerLog -> LedgerLog ->
+// LedgerLogPayload_CreatedTransaction -> CreatedTransaction -> Transaction ->
+// Posting -> amount.
+func goldenLog() *Log {
+	return &Log{
+		Sequence: 5,
+		Payload: &LogPayload{
+			Type: &LogPayload_Apply{Apply: goldenApplyLedgerLog()},
+		},
+		Receipt: "receipt-1",
+	}
+}
+
+// defaultWireGolden pins one payload to the exact bytes the default wire must
+// produce. wantProduction is the json.MarshalWrite (ConfigStd) form without its
+// trailing newline; leave it empty when ConfigStd cannot differ from
+// ConfigDefault, which is every fixture carrying no `<`, `>` or `&`.
+type defaultWireGolden struct {
+	value          any
+	want           string
+	wantProduction string
+}
+
+// defaultWireGoldens returns the pinned default wire of every marshaller
+// EN-1779 rewrote, plus the omitted-field and empty-collection cases whose
+// shape the opt-in mechanism could otherwise have changed unnoticed.
+func defaultWireGoldens() map[string]defaultWireGolden {
+	return map[string]defaultWireGolden{
+		"posting": {
+			value: goldenPosting(),
+			want:  goldenPostingJSON,
+		},
+		"posting without an amount": {
+			// amount is `omitempty` and typed `any`, so it must stay absent
+			// rather than start emitting null.
+			value: &Posting{Source: "world", Destination: "alice", Asset: "USD/2"},
+			want:  `{"source":"world","destination":"alice","asset":"USD/2","color":""}`,
+		},
+		"posting with an HTML-escapable account address": {
+			// The only fixture where the two encoders diverge, and the reason
+			// the golden cannot be captured with json.Marshal alone.
+			value: &Posting{
+				Source:      "orders:<a&b>",
+				Destination: "alice",
+				Amount:      NewUint256FromUint64(1),
+				Asset:       "USD/2",
+			},
+			want: `{"source":"orders:<a&b>","destination":"alice"` +
+				`,"amount":1,"asset":"USD/2","color":""}`,
+			wantProduction: `{"source":"orders:\u003ca\u0026b\u003e","destination":"alice"` +
+				`,"amount":1,"asset":"USD/2","color":""}`,
+		},
+		"transaction": {
+			value: goldenTransaction(),
+			want:  goldenTransactionJSON,
+		},
+		"transaction with nil postings": {
+			// postings has no `omitempty` and the OpenAPI schema types it as a
+			// non-nullable required array, so a posting-less transaction renders
+			// `[]` and never null.
+			value: &Transaction{Id: 7},
+			want:  `{"postings":[],"metadata":{},"id":7,"reverted":false}`,
+		},
+		"created transaction": {
+			value: goldenCreatedTransaction(),
+			want:  goldenCreatedTransactionJSON,
+		},
+		"created transaction without a transaction": {
+			// transaction is an `omitempty` pointer retyped to `any`: absent,
+			// not null.
+			value: &CreatedTransaction{ChapterId: 3},
+			want:  `{"chapterId":3}`,
+		},
+		"reverted transaction": {
+			value: &RevertedTransaction{RevertedTransactionId: 3, RevertTransaction: goldenTransaction()},
+			want:  `{"revertedTransactionId":3,"revertTransaction":` + goldenTransactionJSON + `}`,
+		},
+		"reverted transaction without a revert transaction": {
+			// revertTransaction is an `omitempty` pointer retyped to `any`:
+			// absent, not null.
+			value: &RevertedTransaction{RevertedTransactionId: 3},
+			want:  `{"revertedTransactionId":3}`,
+		},
+		"ledger log payload carrying a created transaction": {
+			value: goldenLedgerLog().GetData(),
+			want:  `{"createdTransaction":` + goldenCreatedTransactionJSON + `}`,
+		},
+		"ledger log payload carrying no amount": {
+			// The oneof variants that carry no amount are deliberately not
+			// re-listed in marshalStringAmounts, so this pins the branch both
+			// modes share.
+			value: &LedgerLogPayload{
+				Payload: &LedgerLogPayload_SavedMetadata{
+					SavedMetadata: &SavedMetadata{
+						Target:   &Target{Target: &Target_TransactionId{TransactionId: 7}},
+						Metadata: map[string]*MetadataValue{"tier": NewStringValue("gold")},
+					},
+				},
+			},
+			want: `{"savedMetadata":{"targetType":"TRANSACTION","transactionId":7` +
+				`,"metadata":{"tier":"gold"}}}`,
+		},
+		"ledger log": {
+			value: goldenLedgerLog(),
+			want:  goldenLedgerLogJSON,
+		},
+		"apply ledger log": {
+			value: goldenApplyLedgerLog(),
+			want:  goldenApplyLedgerLogJSON,
+		},
+		"log payload": {
+			value: goldenLog().GetPayload(),
+			want:  `{"apply":` + goldenApplyLedgerLogJSON + `}`,
+		},
+		"log at full depth": {
+			value: goldenLog(),
+			want:  goldenLogJSON,
+		},
+		"prepared query cursor drained": {
+			// The shape emptyListResponse (internal/query/executor.go) produces.
+			value: &PreparedQueryCursor{PageSize: 15},
+			want:  `{"pageSize":15,"hasMore":false}`,
+		},
+		"prepared query cursor on accounts": {
+			value: &PreparedQueryCursor{
+				PageSize: 15,
+				HasMore:  true,
+				Previous: "prev-token",
+				Next:     "next-token",
+				AccountData: []*Account{
+					{
+						Address: "alice",
+						Volumes: []*AccountVolume{
+							{
+								Asset: "USD/2",
+								Volumes: &VolumesWithBalance{
+									Input:   aboveJSNumberLimit,
+									Output:  "0",
+									Balance: aboveJSNumberLimit,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `{"pageSize":15,"hasMore":true,"previous":"prev-token","next":"next-token"` +
+				`,"accountData":[{"address":"alice","volumes":[{"asset":"USD/2","color":""` +
+				`,"volumes":{"input":"` + aboveJSNumberLimit + `","output":"0"` +
+				`,"balance":"` + aboveJSNumberLimit + `"}}]}]}`,
+		},
+		"prepared query cursor on transactions": {
+			value: &PreparedQueryCursor{PageSize: 15, TransactionData: []*Transaction{goldenTransaction()}},
+			want:  `{"pageSize":15,"hasMore":false,"transactionData":[` + goldenTransactionJSON + `]}`,
+		},
+		"prepared query cursor on logs": {
+			value: &PreparedQueryCursor{PageSize: 15, LogData: []*Log{goldenLog()}},
+			want:  `{"pageSize":15,"hasMore":false,"logData":[` + goldenLogJSON + `]}`,
+		},
+	}
+}
+
+// TestDefaultWireGolden asserts the default wire is byte-identical to what it
+// was before EN-1779 rewrote the marshaller chain. Read the note above
+// defaultWireGolden before changing anything here: a failure means the
+// implementation moved the wire, not that the expectation is stale.
+func TestDefaultWireGolden(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, aboveJSNumberLimit, strconv.FormatUint(goldenAmount, 10),
+		"the fixture amount and the expectation constant must be the same number")
+
+	for name, tc := range defaultWireGoldens() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tc.value)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got),
+				"the default wire moved: fix the implementation, never this expectation")
+
+			wantProduction := tc.want
+			if tc.wantProduction != "" {
+				wantProduction = tc.wantProduction
+			}
+
+			var buf bytes.Buffer
+
+			require.NoError(t, json.MarshalWrite(&buf, tc.value))
+			// The trailing newline is appended by sonic's Encoder, so it is part
+			// of the body writeJSONResponse sends.
+			require.Equal(t, wantProduction+"\n", buf.String(),
+				"the production wire moved: fix the implementation, never this expectation")
+		})
+	}
 }

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -372,18 +372,19 @@ func TestCreatedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
 
 	// Transaction is `omitempty`. Retyping it to `any` would make a nil
 	// transaction emit `null` unless the nil guard holds, so assert the
-	// absence explicitly in both modes.
+	// absence explicitly in both modes. Asserting on the field name alone is
+	// sufficient: the counterfactual `"transaction":null` output also
+	// contains the field name, so this loses no detection power over also
+	// asserting "null" separately.
 	ct := &CreatedTransaction{ChapterId: 3}
 
 	def, err := json.Marshal(ct)
 	require.NoError(t, err)
 	require.NotContains(t, string(def), "transaction")
-	require.NotContains(t, string(def), "null")
 
 	str, err := json.Marshal(StringAmountCreatedTransaction{CreatedTransaction: ct})
 	require.NoError(t, err)
 	require.NotContains(t, string(str), "transaction")
-	require.NotContains(t, string(str), "null")
 }
 
 func TestCreatedTransaction_NilReceiverIsNull(t *testing.T) {
@@ -432,18 +433,19 @@ func TestRevertedTransaction_NilChildStaysOmittedInBothModes(t *testing.T) {
 
 	// RevertTransaction is `omitempty`. Retyping it to `any` would make a nil
 	// transaction emit `null` unless the nil guard holds, so assert the
-	// absence explicitly in both modes.
+	// absence explicitly in both modes. Asserting on the field name alone is
+	// sufficient: the counterfactual `"revertTransaction":null` output also
+	// contains the field name, so this loses no detection power over also
+	// asserting "null" separately.
 	rt := &RevertedTransaction{RevertedTransactionId: 4}
 
 	def, err := json.Marshal(rt)
 	require.NoError(t, err)
 	require.NotContains(t, string(def), "revertTransaction")
-	require.NotContains(t, string(def), "null")
 
 	str, err := json.Marshal(StringAmountRevertedTransaction{RevertedTransaction: rt})
 	require.NoError(t, err)
 	require.NotContains(t, string(str), "revertTransaction")
-	require.NotContains(t, string(str), "null")
 }
 
 func TestRevertedTransaction_NilReceiverIsNull(t *testing.T) {

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -114,15 +114,12 @@ func TestPosting_NilElementStaysNullInBothModes(t *testing.T) {
 		string(str))
 }
 
-// newTestTransaction returns a transaction whose single posting carries an
-// amount above the JavaScript integer limit, so any accidental float round-trip
-// anywhere in the chain fails the test rather than passing with a plausible
-// number.
-func newTestTransaction(t *testing.T) *Transaction {
+// newTestTransaction returns a transaction whose single posting carries the
+// given amount. Callers needing to exercise the JavaScript integer limit pass
+// a value parsed from aboveJSNumberLimit; callers exercising
+// requireOnlyAmountsDiffer must stay below it (see that helper's doc comment).
+func newTestTransaction(t *testing.T, amount *big.Int) *Transaction {
 	t.Helper()
-
-	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
-	require.True(t, ok)
 
 	return &Transaction{
 		Id:        7,
@@ -153,30 +150,37 @@ func requireOnlyAmountsDiffer(t *testing.T, defaultBody, stringBody []byte) {
 	require.NoError(t, json.Unmarshal(defaultBody, &a))
 	require.NoError(t, json.Unmarshal(stringBody, &b))
 
-	require.Equal(t, normalizeAmounts(a), normalizeAmounts(b))
+	require.Equal(t, normalizeAmounts(t, a), normalizeAmounts(t, b))
 }
 
-// normalizeAmounts walks a decoded JSON tree and rewrites every "amount" value
-// to its decimal string, so a number and its quoted form compare equal.
-func normalizeAmounts(v any) any {
-	switch t := v.(type) {
+// normalizeAmounts walks a decoded JSON tree and, inside every "postings"
+// array it finds, rewrites each posting's "amount" value to its decimal
+// string, so a number and its quoted form compare equal. The rewrite is
+// scoped to postings[].amount rather than every "amount" key at any depth:
+// the repository has other unrelated "amount" JSON keys (events, adapter/v2
+// types, receipts), and a document embedding one of those must not have it
+// silently normalised away by this test helper.
+func normalizeAmounts(t *testing.T, v any) any {
+	t.Helper()
+
+	switch node := v.(type) {
 	case map[string]any:
-		out := make(map[string]any, len(t))
-		for k, val := range t {
-			if k == "amount" {
-				out[k] = amountToString(val)
+		out := make(map[string]any, len(node))
+		for k, val := range node {
+			if k == "postings" {
+				out[k] = normalizePostingsAmounts(t, val)
 
 				continue
 			}
 
-			out[k] = normalizeAmounts(val)
+			out[k] = normalizeAmounts(t, val)
 		}
 
 		return out
 	case []any:
-		out := make([]any, 0, len(t))
-		for _, val := range t {
-			out = append(out, normalizeAmounts(val))
+		out := make([]any, 0, len(node))
+		for _, val := range node {
+			out = append(out, normalizeAmounts(t, val))
 		}
 
 		return out
@@ -185,21 +189,71 @@ func normalizeAmounts(v any) any {
 	}
 }
 
-func amountToString(v any) string {
-	switch t := v.(type) {
+// normalizePostingsAmounts rewrites the "amount" field of every posting in a
+// decoded postings array to its decimal string. A posting element may be nil
+// (decoded as a non-map value), which is passed through unchanged.
+func normalizePostingsAmounts(t *testing.T, v any) any {
+	t.Helper()
+
+	postings, ok := v.([]any)
+	if !ok {
+		return v
+	}
+
+	out := make([]any, 0, len(postings))
+
+	for _, posting := range postings {
+		p, ok := posting.(map[string]any)
+		if !ok {
+			out = append(out, posting)
+
+			continue
+		}
+
+		normalized := make(map[string]any, len(p))
+		for k, val := range p {
+			if k == "amount" {
+				normalized[k] = amountToString(t, val)
+
+				continue
+			}
+
+			normalized[k] = val
+		}
+
+		out = append(out, normalized)
+	}
+
+	return out
+}
+
+// amountToString renders a decoded "amount" value as a decimal string. It
+// fails the test rather than masking a regression: a silent "" default for an
+// unexpected type would let a future bug that turns amount into null or an
+// object pass requireOnlyAmountsDiffer, because both sides would normalise to
+// the same empty string.
+func amountToString(t *testing.T, v any) string {
+	t.Helper()
+
+	switch n := v.(type) {
 	case string:
-		return t
+		return n
 	case float64:
-		return new(big.Float).SetFloat64(t).Text('f', 0)
+		return new(big.Float).SetFloat64(n).Text('f', 0)
 	default:
+		t.Fatalf("amount decoded as unexpected type %T (%#v); expected string or number", v, v)
+
 		return ""
 	}
 }
 
-func TestTransaction_StringAmountDiffersOnlyAtAmount(t *testing.T) {
+func TestTransaction_StringAmountKeepsAboveJSLimitExact(t *testing.T) {
 	t.Parallel()
 
-	tx := newTestTransaction(t)
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	tx := newTestTransaction(t, amount)
 
 	def, err := json.Marshal(tx)
 	require.NoError(t, err)
@@ -219,15 +273,8 @@ func TestTransaction_StringAmountOnlyChangesAmountShape(t *testing.T) {
 	// comment), which is lossy above 2^53. Use a small amount here so the
 	// structural comparison itself is not defeated by float rounding; the
 	// above-2^53 exactness is covered separately by
-	// TestTransaction_StringAmountDiffersOnlyAtAmount.
-	amount := big.NewInt(4200)
-	tx := &Transaction{
-		Id:        7,
-		Reference: "ref-1",
-		Postings: []*Posting{
-			NewPosting("world", "alice", "USD/2", amount),
-		},
-	}
+	// TestTransaction_StringAmountKeepsAboveJSLimitExact.
+	tx := newTestTransaction(t, big.NewInt(4200))
 
 	def, err := json.Marshal(tx)
 	require.NoError(t, err)
@@ -257,7 +304,10 @@ func TestTransaction_NilPostingsStillEmitsEmptyArray(t *testing.T) {
 func TestTransaction_NilElementStaysNullInBothModes(t *testing.T) {
 	t.Parallel()
 
-	txs := []*Transaction{newTestTransaction(t), nil}
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	txs := []*Transaction{newTestTransaction(t, amount), nil}
 
 	def, err := json.Marshal(txs)
 	require.NoError(t, err)

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -1,0 +1,115 @@
+package commonpb
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/json"
+)
+
+// aboveJSNumberLimit is 2^53 + 1, the smallest integer a JavaScript double
+// cannot represent exactly. Every string-amount assertion uses it so the test
+// fails if the value is ever routed through a float.
+const aboveJSNumberLimit = "9007199254740993"
+
+func TestPosting_DefaultWireIsUnquoted(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	p := NewPosting("world", "alice", "USD/2", amount)
+
+	got, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		`{"source":"world","destination":"alice","amount":`+aboveJSNumberLimit+`,"asset":"USD/2","color":""}`,
+		string(got))
+	require.Contains(t, string(got), `"amount":`+aboveJSNumberLimit,
+		"default wire must carry the bare number with every digit intact")
+}
+
+func TestPosting_StringAmountWireIsQuoted(t *testing.T) {
+	t.Parallel()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	p := NewPosting("world", "alice", "USD/2", amount)
+
+	got, err := json.Marshal(StringAmountPostings([]*Posting{p}))
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		`[{"source":"world","destination":"alice","amount":"`+aboveJSNumberLimit+`","asset":"USD/2","color":""}]`,
+		string(got))
+}
+
+func TestPosting_NilAmountStaysOmitted(t *testing.T) {
+	t.Parallel()
+
+	// The amount field is `omitempty`. Retyping it to `any` would make a nil
+	// amount emit `null` unless the nil guard in buildAux holds, so assert the
+	// absence explicitly in both modes.
+	p := &Posting{Source: "world", Destination: "alice", Asset: "USD/2"}
+
+	def, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.NotContains(t, string(def), "amount")
+
+	str, err := json.Marshal(StringAmountPostings([]*Posting{p}))
+	require.NoError(t, err)
+	require.NotContains(t, string(str), "amount")
+}
+
+func TestPosting_EmptySliceMarshalsAsArray(t *testing.T) {
+	t.Parallel()
+
+	// nil is the input that actually occurs in production: tx.GetPostings()
+	// returns nil for a posting-less transaction, never an empty non-nil
+	// slice. Both must still marshal as `[]`, not `null`.
+	testCases := map[string][]*Posting{
+		"nil slice":   nil,
+		"empty slice": {},
+	}
+
+	for name, postings := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(StringAmountPostings(postings))
+			require.NoError(t, err)
+			require.Equal(t, "[]", string(got),
+				"must not become null: Transaction.postings has no omitempty")
+		})
+	}
+}
+
+func TestPosting_NilElementStaysNullInBothModes(t *testing.T) {
+	t.Parallel()
+
+	// StringAmountPosting.buildAux is nil-receiver-safe via GetX() accessors,
+	// so a nil embedded *Posting would silently produce a full zero-valued
+	// object instead of null unless the wrapper's MarshalJSON guards for it.
+	// The opt-in header must not change the shape of a nil element, only the
+	// amount's formatting.
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	postings := []*Posting{NewPosting("world", "alice", "USD/2", amount), nil}
+
+	def, err := json.Marshal(postings)
+	require.NoError(t, err)
+	require.JSONEq(t,
+		`[{"source":"world","destination":"alice","amount":`+aboveJSNumberLimit+`,"asset":"USD/2","color":""},null]`,
+		string(def))
+
+	str, err := json.Marshal(StringAmountPostings(postings))
+	require.NoError(t, err)
+	require.JSONEq(t,
+		`[{"source":"world","destination":"alice","amount":"`+aboveJSNumberLimit+`","asset":"USD/2","color":""},null]`,
+		string(str))
+}

--- a/internal/proto/commonpb/string_amounts_test.go
+++ b/internal/proto/commonpb/string_amounts_test.go
@@ -113,3 +113,173 @@ func TestPosting_NilElementStaysNullInBothModes(t *testing.T) {
 		`[{"source":"world","destination":"alice","amount":"`+aboveJSNumberLimit+`","asset":"USD/2","color":""},null]`,
 		string(str))
 }
+
+// newTestTransaction returns a transaction whose single posting carries an
+// amount above the JavaScript integer limit, so any accidental float round-trip
+// anywhere in the chain fails the test rather than passing with a plausible
+// number.
+func newTestTransaction(t *testing.T) *Transaction {
+	t.Helper()
+
+	amount, ok := new(big.Int).SetString(aboveJSNumberLimit, 10)
+	require.True(t, ok)
+
+	return &Transaction{
+		Id:        7,
+		Reference: "ref-1",
+		Postings: []*Posting{
+			NewPosting("world", "alice", "USD/2", amount),
+		},
+	}
+}
+
+// requireOnlyAmountsDiffer decodes both bodies and asserts they are structurally
+// identical once every postings[].amount is normalised to its decimal string.
+// This is the load-bearing guarantee of EN-1779: the opt-in wire may differ from
+// the default wire at posting amounts and nowhere else.
+//
+// Caveat: the repo json wrapper (internal/adapter/json, backed by sonic) decodes
+// numbers into `any` as float64 with no UseNumber-style option, which is lossy
+// above 2^53 - confirmed empirically: 9007199254740993 decodes as
+// 9007199254740992. So this helper alone cannot validate exactness above the
+// limit; callers that need the differential check must use an amount below
+// 2^53, and assert the above-2^53 digit-for-digit behaviour separately via
+// require.Contains against the raw wire bytes.
+func requireOnlyAmountsDiffer(t *testing.T, defaultBody, stringBody []byte) {
+	t.Helper()
+
+	var a, b any
+
+	require.NoError(t, json.Unmarshal(defaultBody, &a))
+	require.NoError(t, json.Unmarshal(stringBody, &b))
+
+	require.Equal(t, normalizeAmounts(a), normalizeAmounts(b))
+}
+
+// normalizeAmounts walks a decoded JSON tree and rewrites every "amount" value
+// to its decimal string, so a number and its quoted form compare equal.
+func normalizeAmounts(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if k == "amount" {
+				out[k] = amountToString(val)
+
+				continue
+			}
+
+			out[k] = normalizeAmounts(val)
+		}
+
+		return out
+	case []any:
+		out := make([]any, 0, len(t))
+		for _, val := range t {
+			out = append(out, normalizeAmounts(val))
+		}
+
+		return out
+	default:
+		return v
+	}
+}
+
+func amountToString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return new(big.Float).SetFloat64(t).Text('f', 0)
+	default:
+		return ""
+	}
+}
+
+func TestTransaction_StringAmountDiffersOnlyAtAmount(t *testing.T) {
+	t.Parallel()
+
+	tx := newTestTransaction(t)
+
+	def, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountTransaction{Transaction: tx})
+	require.NoError(t, err)
+
+	require.NotEqual(t, string(def), string(str))
+	require.Contains(t, string(str), `"amount":"`+aboveJSNumberLimit+`"`,
+		"the opt-in wire must carry the above-2^53 amount digit for digit")
+}
+
+func TestTransaction_StringAmountOnlyChangesAmountShape(t *testing.T) {
+	t.Parallel()
+
+	// requireOnlyAmountsDiffer decodes numbers through float64 (see its doc
+	// comment), which is lossy above 2^53. Use a small amount here so the
+	// structural comparison itself is not defeated by float rounding; the
+	// above-2^53 exactness is covered separately by
+	// TestTransaction_StringAmountDiffersOnlyAtAmount.
+	amount := big.NewInt(4200)
+	tx := &Transaction{
+		Id:        7,
+		Reference: "ref-1",
+		Postings: []*Posting{
+			NewPosting("world", "alice", "USD/2", amount),
+		},
+	}
+
+	def, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountTransaction{Transaction: tx})
+	require.NoError(t, err)
+
+	requireOnlyAmountsDiffer(t, def, str)
+}
+
+func TestTransaction_NilPostingsStillEmitsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	// postings has no omitempty and the schema types it non-nullable, so a nil
+	// slice behind the `any` field must still marshal as [] and never null.
+	tx := &Transaction{Id: 1}
+
+	def, err := json.Marshal(tx)
+	require.NoError(t, err)
+	require.Contains(t, string(def), `"postings":[]`)
+
+	str, err := json.Marshal(StringAmountTransaction{Transaction: tx})
+	require.NoError(t, err)
+	require.Contains(t, string(str), `"postings":[]`)
+}
+
+func TestTransaction_NilElementStaysNullInBothModes(t *testing.T) {
+	t.Parallel()
+
+	txs := []*Transaction{newTestTransaction(t), nil}
+
+	def, err := json.Marshal(txs)
+	require.NoError(t, err)
+
+	str, err := json.Marshal(StringAmountTransactions(txs))
+	require.NoError(t, err)
+
+	require.Contains(t, string(def), `,null]`)
+	require.Contains(t, string(str), `,null]`,
+		"a nil element must stay null: the header may change amount formatting, never shape")
+}
+
+func TestTransactions_EmptyAndNilSliceMarshalAsArray(t *testing.T) {
+	t.Parallel()
+
+	for name, in := range map[string][]*Transaction{"nil slice": nil, "empty slice": {}} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(StringAmountTransactions(in))
+			require.NoError(t, err)
+			require.Equal(t, "[]", string(got))
+		})
+	}
+}

--- a/internal/proto/commonpb/transaction.go
+++ b/internal/proto/commonpb/transaction.go
@@ -148,10 +148,13 @@ func (tx *Transaction) InvolvedAccounts() []string {
 	return slices.Compact(ret)
 }
 
-// MarshalJSON implements json.Marshaler for Transaction.
-func (tx *Transaction) MarshalJSON() ([]byte, error) {
+// buildAux builds the JSON representation of Transaction. When amountsAsString
+// is true, postings render their amount as a quoted decimal string (see
+// string_amounts.go); MarshalJSON delegates with false, and that output is
+// byte-identical to what it always emitted.
+func (tx *Transaction) buildAux(amountsAsString bool) any {
 	type Aux struct {
-		Postings                []*Posting         `json:"postings"`
+		Postings                any                `json:"postings"`
 		Metadata                map[string]any     `json:"metadata"`
 		Timestamp               *time.Time         `json:"timestamp,omitempty"`
 		Reference               string             `json:"reference,omitempty"`
@@ -180,8 +183,15 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		metadataMap = map[string]any{}
 	}
 
+	// Typed `any` above, so hand it a concrete non-nil slice in both modes: a
+	// nil slice behind an interface with no omitempty would marshal as null.
+	var postingsValue any = postings
+	if amountsAsString {
+		postingsValue = StringAmountPostings(postings)
+	}
+
 	aux := Aux{
-		Postings:                postings,
+		Postings:                postingsValue,
 		Metadata:                metadataMap,
 		Reference:               tx.GetReference(),
 		ID:                      tx.GetId(),
@@ -211,5 +221,10 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		aux.RevertedAt = &t
 	}
 
-	return json.Marshal(aux)
+	return aux
+}
+
+// MarshalJSON implements json.Marshaler for Transaction.
+func (tx *Transaction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(tx.buildAux(false))
 }

--- a/internal/proto/commonpb/uint256.go
+++ b/internal/proto/commonpb/uint256.go
@@ -93,11 +93,32 @@ func (u *Uint256) MarshalJSON() ([]byte, error) {
 	return []byte(u.Dec()), nil
 }
 
-// UnmarshalJSON decodes a decimal string (no quotes) into the Uint256.
+// UnmarshalJSON decodes a decimal into the Uint256. Both the bare JSON number
+// form (the default wire) and the quoted-string form are accepted, so a client
+// that received string amounts via Formance-Bigint-As-String can post them back
+// unchanged (EN-1779). A bare `null` or `""` passed to this method is an error;
+// a `null` field value is nil'd out by the surrounding JSON decoder before this
+// method ever runs, so that case never reaches here.
+//
+// Quotes are stripped by hand rather than JSON-unescaped. The only inputs this
+// treats differently from a json.Unmarshal-into-string decode (the
+// Timestamp.UnmarshalJSON idiom in this package) are escape-encoded digits:
+// `"\u00342"` is valid JSON for "42" but is rejected here. That narrowness is
+// deliberate — no real client escapes ASCII digits, and the raw bytes never
+// reach the parser as anything but a literal decimal.
+//
+// Note that hex is kept out by parsing with SetFromDecimal, not by the
+// hand-slice: uint256's own UnmarshalText/UnmarshalJSON accept an 0x prefix,
+// SetFromDecimal does not. Do not swap in UnmarshalText.
 func (u *Uint256) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		s = s[1 : len(s)-1]
+	}
+
 	var v uint256.Int
 
-	err := v.SetFromDecimal(string(data))
+	err := v.SetFromDecimal(s)
 	if err != nil {
 		return err
 	}

--- a/internal/proto/commonpb/uint256_test.go
+++ b/internal/proto/commonpb/uint256_test.go
@@ -145,3 +145,44 @@ func TestUint256_NilIntoUint256(t *testing.T) {
 	(*Uint256)(nil).IntoUint256(&dst)
 	require.True(t, dst.IsZero(), "nil should clear dst to zero")
 }
+
+func TestUint256_UnmarshalJSON_AcceptsQuotedDecimal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "unquoted", input: `12345`, want: "12345"},
+		{name: "quoted", input: `"12345"`, want: "12345"},
+		{name: "quoted value a JS client would round", input: `"9007199254740993"`, want: "9007199254740993"},
+		{name: "quoted 256-bit max", input: `"115792089237316195423570985008687907853269984665640564039457584007913129639935"`, want: "115792089237316195423570985008687907853269984665640564039457584007913129639935"},
+		{name: "quoted zero", input: `"0"`, want: "0"},
+		{name: "quoted leading plus", input: `"+123"`, want: "123"},
+		{name: "quoted leading zeros", input: `"0123"`, want: "123"},
+		{name: "null still rejected", input: `null`, wantErr: true},
+		{name: "empty string still rejected", input: `""`, wantErr: true},
+		{name: "lone quote rejected", input: `"`, wantErr: true},
+		{name: "quoted non-numeric still rejected", input: `"abc"`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var u Uint256
+
+			err := u.UnmarshalJSON([]byte(tt.input))
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, u.Dec())
+		})
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -379,6 +379,7 @@ paths:
             dates are rejected with a 400.
             Requires the builtin `LOG_DATE` index to be enabled on the ledger.
         - $ref: '#/components/parameters/ListFilter'
+        - $ref: '#/components/parameters/BigintAsString'
       responses:
         '200':
           description: Logs retrieved successfully
@@ -616,6 +617,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/IdempotencyKey'
+        - $ref: '#/components/parameters/BigintAsString'
       requestBody:
         required: true
         content:
@@ -725,6 +727,7 @@ paths:
             Filter transactions with timestamp < endDate (exclusive, RFC3339 format).
             Requires the builtin `TX_BUILTIN_INDEX_TIMESTAMP` index to be enabled on the ledger.
         - $ref: '#/components/parameters/ListFilter'
+        - $ref: '#/components/parameters/BigintAsString'
       responses:
         '200':
           description: Transactions retrieved successfully.
@@ -767,6 +770,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/TransactionId'
+        - $ref: '#/components/parameters/BigintAsString'
       responses:
         '200':
           description: Transaction retrieved successfully
@@ -1205,6 +1209,7 @@ paths:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/TransactionId'
         - $ref: '#/components/parameters/IdempotencyKey'
+        - $ref: '#/components/parameters/BigintAsString'
       requestBody:
         required: false
         content:
@@ -1800,6 +1805,7 @@ paths:
             type: boolean
             default: false
           description: Execute all operations atomically (not yet supported)
+        - $ref: '#/components/parameters/BigintAsString'
       requestBody:
         required: true
         content:
@@ -2017,6 +2023,7 @@ paths:
           description: Cursor for pagination (overrides body value)
           schema:
             type: string
+        - $ref: '#/components/parameters/BigintAsString'
       requestBody:
         required: false
         content:
@@ -2245,6 +2252,7 @@ paths:
           schema:
             type: integer
             format: uint64
+        - $ref: '#/components/parameters/BigintAsString'
       responses:
         '200':
           description: Log retrieved successfully.
@@ -2925,6 +2933,21 @@ components:
         maxLength: 256
       description: Idempotency key for the request
 
+    BigintAsString:
+      name: Formance-Bigint-As-String
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |
+        Opt into lossless amount encoding. When set to a truthy value
+        (true, yes, y or 1 — case-insensitive, surrounding whitespace
+        ignored), every posting amount in the response is a quoted decimal
+        string instead of a JSON number, so JavaScript clients do not
+        truncate values above 2^53. Any other value, or omitting the header,
+        selects the default numeric encoding; an unrecognised value is never
+        an error.
+
     ListFilter:
       name: filter
       in: query
@@ -3326,9 +3349,14 @@ components:
           type: string
           description: Destination account address
         amount:
-          type: integer
-          format: bigint
-          description: Amount as a big integer
+          oneOf:
+            - type: integer
+              format: bigint
+            - type: string
+              pattern: '^[0-9]+$'
+          description: |
+            Amount as a big integer. Both a JSON number and a quoted decimal
+            string are accepted.
         asset:
           type: string
           description: Asset identifier
@@ -3957,9 +3985,15 @@ components:
         destination:
           type: string
         amount:
-          type: integer
-          format: bigint
-          description: Amount as a big integer
+          oneOf:
+            - type: integer
+              format: bigint
+            - type: string
+              pattern: '^[0-9]+$'
+          description: |
+            Amount as a big integer. A JSON number by default; a quoted
+            decimal string when the request carries the
+            Formance-Bigint-As-String header.
         asset:
           type: string
         color:

--- a/tests/e2e/business/transactions_amount_wire_test.go
+++ b/tests/e2e/business/transactions_amount_wire_test.go
@@ -1,0 +1,257 @@
+//go:build e2e
+
+package business
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// EN-1779: the Formance-Bigint-As-String request header is an opt-in. With a
+// truthy value every Posting.amount is a quoted decimal string; without it the
+// wire stays a bare JSON number, byte for byte as before the ticket.
+//
+// The unit tests pin each marshaller and each handler in isolation, and the
+// schemathesis suite checks both branches against the schema. Neither proves
+// exact value preservation: the string branch is constrained by
+// `pattern: '^[0-9]+$'`, which happily accepts a truncated "9007199254740992",
+// and the `oneOf` accepts either branch whatever the request asked for — so a
+// server that ignored the header, or quoted amounts nobody asked for, still
+// conforms. This spec is the end-to-end assertion that the exact 16-digit value
+// survives on the real REST surface, in both modes, on two routes.
+//
+// TestTransactionAmountWire (see suite_test.go's TestBusiness, which runs this
+// spec) is the greppable entry point for this guard.
+var _ = Describe("TestTransactionAmountWire: amount parity above 2^53 (EN-1779)", Ordered, func() {
+	const (
+		ledgerName = "tx-amount-wire-ledger"
+		headerName = "Formance-Bigint-As-String"
+
+		// 2^53 + 1, the smallest positive integer a float64 cannot represent
+		// exactly: any decoder that routes this amount through a float64 yields
+		// 9007199254740992 instead. Asserting the full literal is what separates
+		// "the digits look like an integer" from "the value is intact".
+		hugeAmount = "9007199254740993"
+	)
+
+	restURL := func(path string) string {
+		return fmt.Sprintf("http://localhost:%d/v3/%s%s", sharedHTTPPort, ledgerName, path)
+	}
+
+	// getRaw performs the GET and returns the response body unparsed. An empty
+	// headerValue means the request carries no opt-in header at all, which is
+	// the pre-EN-1779 client behaviour.
+	getRaw := func(path, headerValue string) []byte {
+		req, err := http.NewRequestWithContext(sharedCtx, http.MethodGet, restURL(path), nil)
+		Expect(err).To(Succeed())
+
+		if headerValue != "" {
+			req.Header.Set(headerName, headerValue)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(Succeed())
+
+		defer func() { _ = resp.Body.Close() }()
+
+		raw, err := io.ReadAll(resp.Body)
+		Expect(err).To(Succeed())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), "unexpected status for %s with header %q; body=%s", path, headerValue, string(raw))
+
+		return raw
+	}
+
+	// decodeUseNumber is the non-negotiable part of this spec. Decoding into a
+	// plain map[string]any or interface{} sends a bare JSON number through
+	// float64 and silently returns 9007199254740992, which would make this test
+	// pass on a truncated value and defeat its whole purpose. json.Decoder with
+	// UseNumber keeps the literal digits in a json.Number, and a quoted amount
+	// still lands in a Go string, so the two wire forms stay distinguishable by
+	// type. The repository's sonic wrapper (internal/adapter/json) exposes no
+	// UseNumber option, hence the deliberate use of stdlib encoding/json here.
+	decodeUseNumber := func(raw []byte, target any) error {
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+
+		if err := decoder.Decode(target); err != nil {
+			return fmt.Errorf("decode response body: %w", err)
+		}
+
+		return nil
+	}
+
+	var createdTxID uint64
+
+	// detailAmount extracts data.transaction.postings[0].amount from the
+	// GET /transactions/{id} payload, still in its wire form.
+	detailAmount := func(raw []byte) any {
+		var body struct {
+			Data struct {
+				Transaction struct {
+					ID       uint64 `json:"id"`
+					Postings []struct {
+						Amount any `json:"amount"`
+					} `json:"postings"`
+				} `json:"transaction"`
+			} `json:"data"`
+		}
+
+		Expect(decodeUseNumber(raw, &body)).To(Succeed(), "detail body=%s", string(raw))
+		Expect(body.Data.Transaction.ID).To(Equal(createdTxID), "detail body=%s", string(raw))
+		Expect(body.Data.Transaction.Postings).NotTo(BeEmpty(), "detail body=%s", string(raw))
+
+		return body.Data.Transaction.Postings[0].Amount
+	}
+
+	// listAmount extracts postings[0].amount for the created transaction from
+	// the GET /transactions payload. The item is selected by id rather than by
+	// position, since the property under test is the amount wire, not ordering.
+	listAmount := func(raw []byte) any {
+		var body struct {
+			Data []struct {
+				ID       uint64 `json:"id"`
+				Postings []struct {
+					Amount any `json:"amount"`
+				} `json:"postings"`
+			} `json:"data"`
+		}
+
+		Expect(decodeUseNumber(raw, &body)).To(Succeed(), "list body=%s", string(raw))
+		Expect(body.Data).NotTo(BeEmpty(), "list body=%s", string(raw))
+
+		for _, item := range body.Data {
+			if item.ID != createdTxID {
+				continue
+			}
+
+			Expect(item.Postings).NotTo(BeEmpty(), "list body=%s", string(raw))
+
+			return item.Postings[0].Amount
+		}
+
+		Fail(fmt.Sprintf("transaction %d not found in list route response; body=%s", createdTxID, string(raw)))
+
+		return nil
+	}
+
+	// expectNumericWire asserts the default wire: a bare JSON number whose full
+	// 16 digits are present. json.Number is only produced for an unquoted
+	// number, so the type assertion is itself the "not quoted" assertion.
+	expectNumericWire := func(amount any, raw []byte, what string) string {
+		number, isNumber := amount.(json.Number)
+		Expect(isNumber).To(BeTrue(), "%s: posting.amount must be a bare JSON number on the default wire; got %T (%#v); body=%s", what, amount, amount, string(raw))
+		Expect(number.String()).To(Equal(hugeAmount), "%s: posting.amount lost precision on the default wire; body=%s", what, string(raw))
+		Expect(string(raw)).To(ContainSubstring(`"amount":`+hugeAmount), "%s: the raw bytes must carry the unquoted amount; body=%s", what, string(raw))
+
+		return number.String()
+	}
+
+	// expectStringWire asserts the opt-in wire: exactly the quoted decimal.
+	expectStringWire := func(amount any, raw []byte, what string) string {
+		text, isString := amount.(string)
+		Expect(isString).To(BeTrue(), "%s: posting.amount must be a quoted decimal string when the client opts in; got %T (%#v); body=%s", what, amount, amount, string(raw))
+		Expect(text).To(Equal(hugeAmount), "%s: posting.amount is not the exact opted-in value; body=%s", what, string(raw))
+		Expect(string(raw)).To(ContainSubstring(fmt.Sprintf(`"amount":%q`, hugeAmount)), "%s: the raw bytes must carry the quoted amount; body=%s", what, string(raw))
+
+		return text
+	}
+
+	var (
+		defaultDetailRaw   []byte
+		defaultListRaw     []byte
+		optInDetailRaw     []byte
+		optInListRaw       []byte
+		nonTruthyDetailRaw []byte
+		nonTruthyListRaw   []byte
+		paddedDetailRaw    []byte
+	)
+
+	BeforeAll(func() {
+		amount, ok := new(big.Int).SetString(hugeAmount, 10)
+		Expect(ok).To(BeTrue(), "%q is not a valid decimal integer", hugeAmount)
+
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		logs, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "amount-wire-dest", amount, "USD"),
+			}, nil)))
+		Expect(err).To(Succeed())
+		Expect(logs.GetLogs()).NotTo(BeEmpty())
+
+		createdTxID = logs.GetLogs()[0].GetPayload().GetApply().GetLog().GetData().GetCreatedTransaction().GetTransaction().GetId()
+
+		detailPath := fmt.Sprintf("/transactions/%d", createdTxID)
+
+		defaultDetailRaw = getRaw(detailPath, "")
+		defaultListRaw = getRaw("/transactions", "")
+		optInDetailRaw = getRaw(detailPath, "true")
+		optInListRaw = getRaw("/transactions", "true")
+		nonTruthyDetailRaw = getRaw(detailPath, "false")
+		nonTruthyListRaw = getRaw("/transactions", "false")
+		paddedDetailRaw = getRaw(detailPath, "  YES  ")
+	})
+
+	It("keeps the full 16-digit amount as a bare JSON number when the client does not opt in", func() {
+		expectNumericWire(detailAmount(defaultDetailRaw), defaultDetailRaw, "detail route, no header")
+		expectNumericWire(listAmount(defaultListRaw), defaultListRaw, "list route, no header")
+	})
+
+	It("renders the exact amount as a quoted decimal string when the client opts in", func() {
+		expectStringWire(detailAmount(optInDetailRaw), optInDetailRaw, "detail route, opt-in")
+		expectStringWire(listAmount(optInListRaw), optInListRaw, "list route, opt-in")
+	})
+
+	It("agrees between the detail route and the list route within each mode", func() {
+		// Compare the amount values, never whole bodies: the detail route writes
+		// through the ConfigStd encoder (HTML escaping, trailing newline) while
+		// the list route writes through ConfigDefault (neither). Diffing bodies
+		// across the two routes, or trimming them first, would mask exactly the
+		// encoder swap that internal/adapter/http/encoder_contract_test.go
+		// exists to catch.
+		defaultDetail := expectNumericWire(detailAmount(defaultDetailRaw), defaultDetailRaw, "detail route, no header")
+		defaultList := expectNumericWire(listAmount(defaultListRaw), defaultListRaw, "list route, no header")
+		Expect(defaultList).To(Equal(defaultDetail), "the two routes disagree on the default amount wire")
+
+		optInDetail := expectStringWire(detailAmount(optInDetailRaw), optInDetailRaw, "detail route, opt-in")
+		optInList := expectStringWire(listAmount(optInListRaw), optInListRaw, "list route, opt-in")
+		Expect(optInList).To(Equal(optInDetail), "the two routes disagree on the opted-in amount wire")
+	})
+
+	It("carries the same value in both modes, differing only in the quoting", func() {
+		Expect(expectStringWire(detailAmount(optInDetailRaw), optInDetailRaw, "detail route, opt-in")).
+			To(Equal(expectNumericWire(detailAmount(defaultDetailRaw), defaultDetailRaw, "detail route, no header")),
+				"the opt-in header must change the quoting of the amount, not its value")
+
+		Expect(expectStringWire(listAmount(optInListRaw), optInListRaw, "list route, opt-in")).
+			To(Equal(expectNumericWire(listAmount(defaultListRaw), defaultListRaw, "list route, no header")),
+				"the opt-in header must change the quoting of the amount, not its value")
+	})
+
+	It("keeps the default numeric wire for a non-truthy header value", func() {
+		// This is the assertion an existing client depends on, and the one that
+		// catches a boundary helper reading "header present" as "opted in".
+		nonTruthyDetail := expectNumericWire(detailAmount(nonTruthyDetailRaw), nonTruthyDetailRaw, "detail route, header=false")
+		nonTruthyList := expectNumericWire(listAmount(nonTruthyListRaw), nonTruthyListRaw, "list route, header=false")
+
+		Expect(nonTruthyDetail).To(Equal(expectNumericWire(detailAmount(defaultDetailRaw), defaultDetailRaw, "detail route, no header")),
+			"a non-truthy header must serve the same wire as no header at all")
+		Expect(nonTruthyList).To(Equal(expectNumericWire(listAmount(defaultListRaw), defaultListRaw, "list route, no header")),
+			"a non-truthy header must serve the same wire as no header at all")
+	})
+
+	It("accepts a truthy header value that needs trimming and case folding", func() {
+		expectStringWire(detailAmount(paddedDetailRaw), paddedDetailRaw, `detail route, header="  YES  "`)
+	})
+})

--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -110,6 +110,32 @@ seed "transaction 2" -X POST "$API/test-ledger/transactions" \
 # to succeed, and a prior alice->bob spend leaves her short.
 seed "revert transaction 1" -X POST "$API/test-ledger/transactions/1/revert"
 
+# EN-1779: an amount above 2^53, so the suite carries a value whose encoding is
+# actually observable. 9007199254740993 is 2^53 + 1, the smallest positive
+# integer an IEEE-754 double cannot represent: a client that reads the response
+# with JavaScript's JSON.parse gets 9007199254740992 back unless the amount
+# arrives quoted. Every other seeded amount is far below 2^53, where the numeric
+# and the string wire carry the same value, so without this row the `oneOf` on
+# PostingResponse.amount is only ever validated against amounts that could not
+# expose a truncation.
+#
+# Sourced from "world" for the same reason as transaction 2: it must not spend
+# alice's or bob's balance, because "revert transaction 1" above reverses
+# transaction 1 exactly and needs alice's full posted amount still there.
+# Seeded last on purpose — the list routes default to newest-first, so the
+# above-2^53 amount lands on the first page even at a small pageSize.
+#
+# The metadata value carries `<`, `>` and `&` deliberately. An account address
+# cannot: invariants.ValidateLedgerAccountAddress restricts addresses to
+# `[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*`, while a metadata string accepts any
+# NUL-free text. Those three characters are the only bytes that differ between
+# this repository's two sonic encoder configurations (one HTML-escapes them, one
+# does not), so a response written through the wrong configuration is visible in
+# the captured report instead of passing silently.
+seed "transaction 3 (amount above 2^53)" -X POST "$API/test-ledger/transactions" \
+    -H 'Content-Type: application/json' \
+    -d '{"postings":[{"source":"world","destination":"carol:bigint","amount":9007199254740993,"asset":"USD/2"}],"metadata":{"kind":"seed","note":"amount > 2^53 & <js-unsafe>"},"reference":"seed-ref-3"}'
+
 # Set up Python venv and install deps if needed
 VENV_DIR="$SCRIPT_DIR/.venv"
 if [ ! -d "$VENV_DIR" ]; then

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -10,10 +10,12 @@ Usage:
 
 import argparse
 import copy
+import json
 import os
 import re
 import sys
 from datetime import timedelta
+from decimal import Decimal
 from pathlib import Path
 
 from hypothesis import HealthCheck, Phase, settings as hypothesis_settings
@@ -42,7 +44,7 @@ OPENAPI_PATH = Path(
 VALID_LEDGER_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{2,20}$")
 
 # Fixture ledger name every coerced/invalid ledgerName path parameter resolves
-# to. Seeded by run.sh with two transactions and a revert so
+# to. Seeded by run.sh with three transactions and a revert so
 # response_schema_conformance validates real rows instead of an empty [].
 FIXTURE_LEDGER_NAME = "test-ledger"
 # Sacrificial ledger name for DELETE /v3/{ledgerName} specifically — see the
@@ -55,6 +57,218 @@ SAMPLE_NUMSCRIPTS = [
 ]
 
 _numscript_idx = 0
+
+# --- EN-1779: the opt-in string-amount wire ------------------------------
+# openapi.yml declares this header (components.parameters.BigintAsString) on
+# every operation whose response carries posting amounts. A truthy value makes
+# each Posting.amount a quoted decimal string instead of a bare JSON number, so
+# a JavaScript client does not truncate above 2^53.
+BIGINT_AS_STRING_HEADER = "Formance-Bigint-As-String"
+
+# Mirrors wantsBigintAsString in internal/adapter/http/string_amounts.go:
+# true|yes|y|1, case-insensitive, surrounding whitespace ignored. Anything else,
+# including an unrecognised value, selects the default numeric encoding and is
+# never an error.
+BIGINT_TRUTHY_VALUES = frozenset({"true", "yes", "y", "1"})
+
+# Applied per operation, one entry per request, cycling. Half the steps opt in
+# (in two spellings, which also exercises the case-insensitive parse); `None`
+# omits the header entirely, which is the pre-EN-1779 request shape whose
+# response must stay a bare JSON number; the explicitly non-truthy value must be
+# treated as absent rather than rejected. Four tightly alternating steps mean
+# even an operation drawn only a handful of times covers both wire formats.
+#
+# Every value must be a valid HTTP header value. Do not pad one with leading
+# whitespace to exercise the server's TrimSpace: `requests` raises InvalidHeader
+# and never sends the request, Schemathesis reports that as `network_other`,
+# which `_is_network_error` below classifies as transient and ignores, and
+# Hypothesis stops generating for that operation after the first example. The
+# measured cost of a single padded value here was 28-50 examples per amount-
+# carrying operation collapsing to 1, with the run still printing ALL CHECKS
+# PASSED. Trimming is unobservable through a conforming client anyway, since Go's
+# net/http strips surrounding whitespace from header values before the handler
+# sees them.
+BIGINT_HEADER_ROTATION = ("true", None, "Yes", "false")
+
+# Per-operation rotation cursor, keyed by verbose_name ("GET /v3/...").
+_bigint_header_step = {}
+
+# A quoted amount must be a plain decimal integer, matching the `oneOf` string
+# branch in openapi.yml. Anchored here too so a value that is technically a
+# string but not losslessly readable (exponent notation, a leading "+", a
+# decimal point) is caught rather than accepted.
+_DECIMAL_STRING_RE = re.compile(r"^[0-9]+$")
+
+
+def _operation_declares_bigint_header(operation) -> bool:
+    """Report whether the operation declares the EN-1779 opt-in header.
+
+    Read from the loaded schema rather than a hardcoded path list, so this
+    follows openapi.yml automatically: the operations that return posting
+    amounts carry `$ref: '#/components/parameters/BigintAsString'`, and one
+    added later is covered without touching this file. Sending the header to an
+    operation that does not declare it would exercise the fuzzer, not the
+    feature.
+    """
+    return any(
+        parameter.name.lower() == BIGINT_AS_STRING_HEADER.lower()
+        for parameter in operation.headers
+    )
+
+
+def _remove_header(case, name):
+    """Drop every spelling of `name` from the case headers.
+
+    Generated headers are a plain dict, not a case-insensitive mapping, so
+    deleting only the canonical spelling could leave a differently-cased
+    duplicate behind and the server would receive two values for one header.
+    """
+    if not case.headers:
+        return
+
+    lowered = name.lower()
+    for key in [key for key in case.headers if key.lower() == lowered]:
+        del case.headers[key]
+
+
+def _sent_bigint_header(case):
+    """Return the Formance-Bigint-As-String value attached to the case, or None.
+
+    Read back from the case rather than from the rotation cursor so the
+    assertion below is driven by what was actually sent.
+    """
+    if not case.headers:
+        return None
+
+    lowered = BIGINT_AS_STRING_HEADER.lower()
+    for key, value in case.headers.items():
+        if key.lower() == lowered:
+            return value
+
+    return None
+
+
+def _requested_bigint_as_string(case) -> bool:
+    """Report whether the request opted into quoted amounts."""
+    value = _sent_bigint_header(case)
+    if not isinstance(value, str):
+        return False
+
+    return value.strip().lower() in BIGINT_TRUTHY_VALUES
+
+
+def _apply_bigint_as_string_header(case):
+    """Force a deterministic header value on the operations that declare it.
+
+    The generated value is always overwritten, never merged: the header schema
+    is a bare `type: string`, so the fuzzer draws mostly arbitrary text, which is
+    non-truthy — the opt-in branch of the amount `oneOf` would otherwise almost
+    never be exercised, and a `oneOf` validated against a single branch is close
+    to no constraint at all.
+
+    Determinism is the point. `derandomize=True` makes the generated inputs
+    reproducible, so a randomly chosen header would leave a wire-format
+    violation reproducing on only some runs. The rotation is a per-operation
+    counter (the same idiom as `_numscript_idx` above) rather than a hash of the
+    drawn inputs, because it guarantees an exact alternation even for an
+    operation whose inputs repeat — a hash would pin such an operation to one
+    mode forever. It is deterministic at workers=1, the only supported
+    configuration for the reproducible gate (see --workers).
+    """
+    if not _operation_declares_bigint_header(case.operation):
+        return
+
+    key = case.operation.verbose_name
+    step = _bigint_header_step.get(key, 0)
+    _bigint_header_step[key] = step + 1
+    value = BIGINT_HEADER_ROTATION[step % len(BIGINT_HEADER_ROTATION)]
+
+    _remove_header(case, BIGINT_AS_STRING_HEADER)
+    if value is not None:
+        if case.headers is None:
+            case.headers = {}
+        case.headers[BIGINT_AS_STRING_HEADER] = value
+
+
+def _iter_posting_amounts(node):
+    """Yield every `amount` found inside a `postings` array, at any depth.
+
+    Posting amounts sit at a different depth on every route (`data.postings`,
+    `data[].postings`, inside a cursor page, inside a bulk element, inside the
+    log payload chain), so the walk is recursive rather than per-route.
+
+    It anchors on the enclosing `postings` array instead of matching every key
+    named `amount`: metadata keys are client-supplied, and a fuzzed metadata key
+    called `amount` would otherwise be read as a posting amount and fail the run
+    for no reason. Postings contain no nested `postings`, so the generic descent
+    below never yields the same amount twice.
+    """
+    if isinstance(node, dict):
+        postings = node.get("postings")
+        if isinstance(postings, list):
+            for posting in postings:
+                if isinstance(posting, dict) and "amount" in posting:
+                    yield posting["amount"]
+
+        for value in node.values():
+            yield from _iter_posting_amounts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_posting_amounts(item)
+
+
+def _assert_amount_wire_format(case, response):
+    """Assert every posting amount uses the wire format the request asked for.
+
+    `response_schema_conformance` cannot do this: the amount schema is a `oneOf`
+    of a number and a string, so it accepts either branch whatever the request
+    header said. It would pass a server that ignored the header outright, or one
+    that quoted amounts nobody asked to have quoted (a breaking change for every
+    existing client). That comparison needs the request, which only a hook sees.
+
+    Non-2xx responses and responses without a posting amount are skipped rather
+    than failed — they are simply out of scope for this check.
+    """
+    if not 200 <= response.status_code < 300:
+        return
+
+    body = response.text
+    if not body:
+        return
+
+    try:
+        # parse_float=Decimal so nothing in the body can become a float:
+        # 9007199254740993 (seeded by run.sh) must survive the round trip
+        # exactly, and a float would truncate it to 9007199254740992 — the very
+        # defect this assertion exists to catch. Integer literals are parsed by
+        # Python's arbitrary-precision int, which is exact by construction, so
+        # the values compared and reported below are the ones on the wire.
+        payload = json.loads(body, parse_float=Decimal)
+    except ValueError:
+        return
+
+    amounts = list(_iter_posting_amounts(payload))
+    if not amounts:
+        return
+
+    wants_string = _requested_bigint_as_string(case)
+    for amount in amounts:
+        if wants_string:
+            # isinstance(str) is the wire-format assertion: a JSON string is the
+            # only thing json.loads turns into str.
+            valid = isinstance(amount, str) and bool(_DECIMAL_STRING_RE.match(amount))
+        else:
+            # bool is a subclass of int, so exclude it explicitly: JSON `true`
+            # would otherwise pass as a number.
+            valid = isinstance(amount, int) and not isinstance(amount, bool)
+
+        if not valid:
+            expected = "quoted decimal string" if wants_string else "bare JSON number"
+            raise AssertionError(
+                f"{case.operation.verbose_name}: requested {expected} amounts "
+                f"({BIGINT_AS_STRING_HEADER}={_sent_bigint_header(case)!r}) but a "
+                f"posting amount was {amount!r}. Body: {body[:400]}"
+            )
 
 
 def load_schema(base_url: str):
@@ -126,10 +340,13 @@ def before_call(context, case):
         if "metadata" in case.body and not isinstance(case.body["metadata"], dict):
             case.body["metadata"] = {}
 
+    # Last, so the rotation sees the request as it will actually be sent.
+    _apply_bigint_as_string_header(case)
+
 
 @schemathesis.hook
 def after_call(context, case, response):
-    """Log details of server errors and connection failures for debugging."""
+    """Log server errors, then assert the amount wire format matches the request."""
     if response is not None and response.status_code >= 500:
         print(
             f"  >> SERVER ERROR {response.status_code} on "
@@ -137,6 +354,9 @@ def after_call(context, case, response):
             f"body={case.body!r:.200} resp={response.text[:200]}",
             file=sys.stderr,
         )
+
+    if response is not None:
+        _assert_amount_wire_format(case, response)
 
 
 # --- Prepared-query body generation override -------------------------------


### PR DESCRIPTION
[EN-1779](https://formance-team.atlassian.net/browse/EN-1779)

## Problem

`Posting.amount` is a 256-bit unsigned integer and the only money field on the v3 HTTP surface serialized as a **bare JSON number**. Volume fields (`input`, `output`, `balance`) are already quoted decimal strings.

`JSON.parse` decodes every JSON number into an IEEE-754 double, which represents integers exactly only up to 2^53 − 1. So `9007199254740993` silently becomes `9007199254740992` in any JavaScript client, with no error raised anywhere.

## Approach

An **opt-in** request header, `Formance-Bigint-As-String` (v2 parity). When a request carries a truthy value, every posting amount in the response is a quoted decimal string. Without it, **response bodies are byte-identical to before this change**.

Each marshaller in the posting chain moves its field list into `buildAux(amountsAsString bool) any`; `MarshalJSON` delegates `false`, and a value-receiver wrapper type delegates `true`. A parent types its child field `any` and stores the child's wrapper, so the mode rides the existing encoder recursion rather than a parallel type tree. Ten levels, from `Posting` up through `PreparedQueryCursor`.

Independently of the header, `Uint256.UnmarshalJSON` now accepts **both** a bare number and a quoted decimal, so a client can post back what it received. Non-breaking relaxation; hex stays rejected.

`Uint256.MarshalJSON` is deliberately untouched — `ledgerctl` and `misc/operator` consume it, so the CLI wire must not move. No `docs/ops/cli.md` change.

## Scope

Eight operations accept the header: create / revert / get / list transactions, get log, list ledger logs, bulk, execute prepared query.

## The two invariants, and how they are enforced

**1. The default wire does not move.** `TestDefaultWireGolden` pins the exact default bytes of every affected payload type across 19 fixtures, under both encoder configurations. The expectations were validated by running the same table against `release/v3.0` in a detached worktree — 19/19 pass there, which is what makes them a description of the pre-change wire rather than a transcript of current output. 14 mutants were built against it; all 14 fail the gate, including a field-order swap that a structural (`JSONEq`) comparison would have missed.

**2. The header changes the amount's format, never the response shape.** A nil child renders `null` and an empty collection renders `[]` identically in both modes, pinned per wrapper. Each of the eight routes pins both bodies byte-for-byte and asserts they differ at the posting amounts and nowhere else.

## A trap worth knowing about

This package has **two** production JSON writers over different sonic configurations: `writeOK`/`writeCreated`/`writeJSONResponse` use `ConfigStd` (HTML-escapes, appends a trailing newline), while `writeOKChecked` uses `ConfigDefault` (neither). The two log routes sit on opposite sides.

So **a route must never change which writer it uses** — a swap silently changes every response body on that route. This PR adds `writeCheckedBody`/`writeCheckedStatus` (buffered, `ConfigStd`) so the marshal-before-header guarantee is available *without* moving bytes, rather than reusing `writeOKChecked` and changing the encoder.

Nothing previously enforced this. `TestResponseWriters_TableIsComplete` now pins the route→writer mapping by AST-walking the package and comparing `file: writer` pairs. Its acceptance test: flipping `handlers_list_chapters.go` between the two encoders used to pass the entire suite, and now fails.

Test fixtures deliberately contain `<` and `&` in account addresses. Those characters are the only thing that makes an encoder swap visible in a body — without them, the assertions pass under the defective wiring too.

## Testing

- `TestDefaultWireGolden`: 19 fixtures, both encoders, exact byte comparison, validated against `release/v3.0`.
- Eight route tests, each pinning both bodies with an above-2^53 amount asserted on **raw bytes** (the repo's sonic wrapper has no `UseNumber`; decoding truncates).
- Wrapper contract: all ten wrappers asserted to implement `json.Marshaler` **as values** (which is what pins the value-receiver requirement) and to render `null` over a nil embedded pointer.
- `TestWriteCheckedStatus`: covers both checked writers' error paths, including the previously untested `writeOKChecked` path. A mutant hoisting `WriteHeader` above the marshal produced a `201 Created` carrying an error body and passed the whole suite before this test existed.
- Schemathesis: seeds an above-2^53 amount and sets the header deterministically on a subset of cases, with an `after_call` assertion that the requested mode actually took effect. `oneOf` conformance is request-blind, so it cannot catch "server ignored the header" on its own.
- e2e (`transactions_amount_wire_test.go`): exact-value round-trip on the detail and list routes in both modes, plus a non-truthy header and a `"  YES  "` case. Verified to fail under both an always-true and an always-false boundary helper.

Validation: `go build ./...`, `go vet`, `golangci-lint` with the justfile tag set (0 issues, no `--fix`), the `commonpb` and `adapter/http` suites, and the full 562-spec e2e business suite under `-race`.

## Notes for the reviewer

- **Based on `release/v3.0` at `97a488a1c`.** EN-1791 (#1703) is still open and overlaps these files; the plan is to rebase once it merges.
- **Commits are unsigned.** ssh-agent holds no identities in this environment and the key is passphrase-protected. `release/v3.0` lands work as GitHub squash-merges, which GitHub signs, so this does not affect the target branch.
- `"responseSignature":{}` appears in the pinned log bodies. That is **pre-existing** behaviour, not introduced here: `protoFieldJSON` guards `msg == nil` but receives a `proto.Message` interface holding a typed nil `*Signature`, so the guard misses and `protojson` renders `{}`. Identical on `release/v3.0`. Pinned deliberately with the reason inline — fixing it is a separate ticket.

## Follow-ups (not in this PR)

1. **Platform-UI SDK regeneration** for the `oneOf` amount type — agreed as a separate change.
2. `protoFieldJSON`'s typed-nil guard, per the `"responseSignature":{}` note above.
3. `_is_network_error()` in the schemathesis suite treats a `"network_other"` token as a network error, so a **client-side** failure can turn a run green. Pre-existing; it masked a real bug twice during this work.
4. Only 2 of the 8 header-declaring operations produce amount-bearing responses under fuzzing — fuzzed `transactionId` values never match a seeded id, so the detail route returned 404 on all 50 examples. Pre-existing vacuity; the fix is a `transactionId` coercion mirroring the existing `ledgerName` one, which changes what those routes fuzz.
5. `writeOK`/`writeCreated` could be reimplemented over the buffered writer, retiring the streaming error path package-wide. Measured byte-identical on every value tried. Real correctness upside, deliberately out of scope here.


[EN-1779]: https://formance-team.atlassian.net/browse/EN-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ