### PR TITLE
fix(monitoring): repair Ledger dashboard queries

### DIFF
--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -79,6 +79,14 @@ data, without `_bucket` / `_count` / `_sum` split and without the
 `le` label. The dashboard uses `histogram_quantile(rate(metric))`
 and `histogram_avg` directly on those names.
 
+Histogram sums and observation rates are also representation-aware:
+the generator uses `_sum`/`_count` for classic histograms and
+`histogram_sum`/`histogram_count` for native histograms. Generated
+classic dashboards default to the `Prometheus` Grafana datasource;
+native dashboards default to `Prometheus Native`. The standard
+devenv stack uses
+`ledger-metrics-prom-noprefix-normalized-native.json`.
+
 All seven are regenerated from the same Jsonnet source via
 `just generate-dashboards`. See
 [`misc/devenv/monitoring-dashboards/README.md`](../../misc/devenv/monitoring-dashboards/README.md).

--- a/docs/technical/architecture/subsystems/api/grpc-connections.md
+++ b/docs/technical/architecture/subsystems/api/grpc-connections.md
@@ -557,12 +557,13 @@ The transport exposes several metrics for monitoring:
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `raft.transport.recv.queued` | Gauge | `priority`, `priority_name` | Message batches queued for reception per priority |
-| `raft.transport.recv.merged.queued` | Gauge | - | Individual messages queued in merged output |
-| `raft.transport.peer.sending.queued` | Gauge | `peer`, `priority`, `priority_name` | Message batches queued for sending per peer/priority |
+| `raft.transport.recv.load` | Histogram | `priority`, `priority_name` | Reception queue depth observations per priority |
+| `raft.transport.recv.full` | Counter | `priority`, `priority_name` | Reception queue overflow count per priority |
+| `raft.transport.peer.sending.load` | Histogram | `peer`, `priority`, `priority_name` | Per-peer send queue depth observations |
+| `raft.transport.peer.sending.full` | Counter | `peer`, `priority`, `priority_name` | Per-peer send queue overflow count |
 | `raft.transport.ping.latency` | Histogram | `peer` | Ping round-trip time in microseconds |
 | `raft.transport.sending.pending_response` | UpDownCounter | `peer` | Messages awaiting response |
-| `raft.transport.unreachable.queued` | Gauge | - | Unreachable reports in queue |
+| `raft.transport.unreachable.load` | Histogram | - | Unreachable-report queue depth observations |
 
 **Priority Labels**:
 - `priority=0, priority_name=high`: Heartbeat messages

--- a/internal/infra/node/transport.go
+++ b/internal/infra/node/transport.go
@@ -69,6 +69,7 @@ type DefaultTransport struct {
 	// Metrics for recv queues (indexed by priority: 0=high, 1=medium, 2=low)
 	recvQueueLoadHistogram [3]metric.Int64Histogram
 	recvQueueFullCounter   [3]metric.Float64Counter
+	recvQueueAttributes    [3]attribute.Set
 	recvQueueInflight      [3]atomic.Int32
 
 	// Metrics for unreachable queue
@@ -172,6 +173,10 @@ func NewTransport(
 	// Initialize recv queue metrics for each priority level
 	priorityNames := []string{"high", "medium", "low"}
 	for priority, name := range priorityNames {
+		t.recvQueueAttributes[priority] = attribute.NewSet(
+			attribute.Int("priority", priority),
+			attribute.String("priority_name", name),
+		)
 		m := meterProvider.Meter("raft.transport", metric.WithInstrumentationAttributes(
 			attribute.Int("priority", priority),
 			attribute.String("priority_name", name),
@@ -253,7 +258,11 @@ func (t *DefaultTransport) pushToRecvQueue(priority int, msgs []*raftpb.Message)
 
 	select {
 	case queue <- msgs:
-		t.recvQueueLoadHistogram[priority].Record(context.Background(), int64(t.recvQueueInflight[priority].Add(1)))
+		t.recvQueueLoadHistogram[priority].Record(
+			context.Background(),
+			int64(t.recvQueueInflight[priority].Add(1)),
+			metric.WithAttributeSet(t.recvQueueAttributes[priority]),
+		)
 
 		return true
 	default:
@@ -261,7 +270,11 @@ func (t *DefaultTransport) pushToRecvQueue(priority int, msgs []*raftpb.Message)
 			"channel":  "raft.transport.recv",
 			"priority": priority,
 		}).Errorf("Channel full")
-		t.recvQueueFullCounter[priority].Add(context.Background(), 1)
+		t.recvQueueFullCounter[priority].Add(
+			context.Background(),
+			1,
+			metric.WithAttributeSet(t.recvQueueAttributes[priority]),
+		)
 
 		return false
 	}
@@ -341,7 +354,7 @@ func (t *DefaultTransport) AddPeer(id uint64, addr string) {
 
 	meter := t.meterProvider.Meter("raft.transport",
 		metric.WithInstrumentationAttributes(
-			attribute.Int("peer", int(id)),
+			attribute.String("peer", strconv.FormatUint(id, 10)),
 		),
 	)
 	logger := t.logger.WithFields(map[string]any{"peer": strconv.FormatUint(id, 16)})
@@ -378,14 +391,20 @@ func (t *DefaultTransport) AddPeer(id uint64, addr string) {
 		reconnected:            make(chan struct{}),
 		advertiseAddr:          t.advertiseAddr,
 		serviceAdvertiseAddr:   t.serviceAdvertiseAddr,
+		peerAttributes:         attribute.NewSet(attribute.String("peer", strconv.FormatUint(id, 10))),
 	}
 
 	// Initialize send queue metrics for each priority level
 	priorityNames := []string{"high", "medium", "low"}
 	for priority, name := range priorityNames {
+		conn.sendQueueAttributes[priority] = attribute.NewSet(
+			attribute.String("peer", strconv.FormatUint(id, 10)),
+			attribute.Int("priority", priority),
+			attribute.String("priority_name", name),
+		)
 		m := t.meterProvider.Meter("raft.transport",
 			metric.WithInstrumentationAttributes(
-				attribute.Int("peer", int(id)),
+				attribute.String("peer", strconv.FormatUint(id, 10)),
 				attribute.Int("priority", priority),
 				attribute.String("priority_name", name),
 			),
@@ -742,7 +761,9 @@ type peerConnection struct {
 	// Metrics for sending queues (indexed by priority: 0=high, 1=medium, 2=low)
 	sendQueueLoadHistogram [3]metric.Int64Histogram
 	sendQueueFullCounter   [3]metric.Float64Counter
+	sendQueueAttributes    [3]attribute.Set
 	sendQueueInflight      [3]atomic.Int32
+	peerAttributes         attribute.Set
 
 	// pubMu guards stopped vs. send-into-queue. Publishers (pushMessages)
 	// hold pubMu.RLock for the duration of the send so stop() — which takes
@@ -795,7 +816,11 @@ func (conn *peerConnection) pushMessages(priority int, msgs []*raftpb.Message) b
 
 	select {
 	case queue <- msgs:
-		conn.sendQueueLoadHistogram[priority].Record(context.Background(), int64(conn.sendQueueInflight[priority].Add(1)))
+		conn.sendQueueLoadHistogram[priority].Record(
+			context.Background(),
+			int64(conn.sendQueueInflight[priority].Add(1)),
+			metric.WithAttributeSet(conn.sendQueueAttributes[priority]),
+		)
 
 		return true
 	default:
@@ -803,7 +828,11 @@ func (conn *peerConnection) pushMessages(priority int, msgs []*raftpb.Message) b
 			"channel":  "raft.transport.peer.sending",
 			"priority": priority,
 		}).Errorf("Channel full")
-		conn.sendQueueFullCounter[priority].Add(context.Background(), 1)
+		conn.sendQueueFullCounter[priority].Add(
+			context.Background(),
+			1,
+			metric.WithAttributeSet(conn.sendQueueAttributes[priority]),
+		)
 
 		// Signal Unreachable to Raft so it throttles this peer's Progress
 		// to StateProbe instead of continuing optimistic replication.
@@ -991,7 +1020,11 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 		mu.Unlock()
 
 		if orphaned > 0 {
-			conn.pendingResponseCounter.Add(context.Background(), -float64(orphaned))
+			conn.pendingResponseCounter.Add(
+				context.Background(),
+				-float64(orphaned),
+				metric.WithAttributeSet(conn.peerAttributes),
+			)
 			conn.logger.WithFields(map[string]any{
 				"orphanedMessages": orphaned,
 			}).Infof("Cleaned up orphaned pending responses on connection close")
@@ -1053,7 +1086,11 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 						continue
 					}
 
-					conn.pingLatency.Record(context.Background(), time.Since(lp.at).Microseconds())
+					conn.pingLatency.Record(
+						context.Background(),
+						time.Since(lp.at).Microseconds(),
+						metric.WithAttributeSet(conn.peerAttributes),
+					)
 
 				case *rafttransportpb.SendMessageResponse_Raft:
 					mu.Lock()
@@ -1061,7 +1098,11 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 						nodeID, ok := pending[raftResp.GetRequestId()]
 						if ok {
 							delete(pending, raftResp.GetRequestId())
-							conn.pendingResponseCounter.Add(context.Background(), -1)
+							conn.pendingResponseCounter.Add(
+								context.Background(),
+								-1,
+								metric.WithAttributeSet(conn.peerAttributes),
+							)
 						} else {
 							conn.logger.
 								WithFields(map[string]any{
@@ -1130,7 +1171,11 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 			return nil
 		}
 
-		conn.pendingResponseCounter.Add(context.Background(), float64(len(raftMessages)))
+		conn.pendingResponseCounter.Add(
+			context.Background(),
+			float64(len(raftMessages)),
+			metric.WithAttributeSet(conn.peerAttributes),
+		)
 
 		err := stream.Send(&rafttransportpb.SendMessageRequest{
 			Message: &rafttransportpb.SendMessageRequest_Raft{
@@ -1151,7 +1196,11 @@ func (conn *peerConnection) handleConnection(grpcPeerConnection *grpc.ClientConn
 				delete(pending, msgID)
 			}
 			mu.Unlock()
-			conn.pendingResponseCounter.Add(context.Background(), -float64(len(raftMessages)))
+			conn.pendingResponseCounter.Add(
+				context.Background(),
+				-float64(len(raftMessages)),
+				metric.WithAttributeSet(conn.peerAttributes),
+			)
 			// Report peer as unreachable
 			if !conn.pushUnreachable(conn.peerID) {
 				conn.logger.Errorf("Unreachable channel full, dropping unreachable")

--- a/internal/infra/node/transport_test.go
+++ b/internal/infra/node/transport_test.go
@@ -1,17 +1,65 @@
 package node
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/protobuf/proto"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
+
+func TestTransportRecvQueueMetricsExposePriorityAttributes(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	transport := NewTransport(
+		logging.Testing(),
+		nil,
+		provider,
+		1,
+		TransportConfig{Reception: []int{1, 1, 1}, Send: []int{1, 1, 1}},
+		"test-cluster",
+		1,
+		"",
+		"",
+	)
+	require.True(t, transport.pushToRecvQueue(0, []*raftpb.Message{{}}))
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+
+	found := false
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, recordedMetric := range scopeMetrics.Metrics {
+			if recordedMetric.Name != "raft.transport.recv.load" {
+				continue
+			}
+			histogram, ok := recordedMetric.Data.(metricdata.Histogram[int64])
+			require.True(t, ok)
+			for _, point := range histogram.DataPoints {
+				priority, hasPriority := point.Attributes.Value(attribute.Key("priority"))
+				priorityName, hasPriorityName := point.Attributes.Value(attribute.Key("priority_name"))
+				if hasPriority && hasPriorityName && priority.AsInt64() == 0 && priorityName.AsString() == "high" {
+					found = true
+				}
+			}
+		}
+	}
+
+	require.True(t, found, "queue measurements must expose priority labels as metric attributes")
+}
 
 // captureUnreachable wires a channel-backed sink for the pushUnreachable
 // callback on a peerConnection so tests can observe which peer IDs Raft

--- a/misc/devenv/monitoring-dashboards/README.md
+++ b/misc/devenv/monitoring-dashboards/README.md
@@ -55,8 +55,8 @@ just generate-dashboards
 ```
 
 The recipe runs `jb install` once to vendor `grafonnet`, then
-`jsonnet -m config/dashboards jsonnet/main.jsonnet`. The output is two
-JSON files under `config/dashboards/`. Both are committed so Pulumi
+`jsonnet -m config/dashboards jsonnet/main.jsonnet`. The output is seven
+JSON files under `config/dashboards/`. All seven are committed so Pulumi
 can deploy without invoking Jsonnet.
 
 `generate-dashboards` is part of `just pre-commit`; CI fails if the
@@ -113,6 +113,17 @@ This is necessary because `histogram_avg` is undefined on classic
 histograms and the `_sum` / `_count` series do not exist on native
 histograms. The helper picks the right form at generation time so
 every variant has working ratio panels.
+
+Panels that need the cumulative value or observation rate use the
+companion `queries.histogramSumRate` and
+`queries.histogramCountRate` helpers. They expand to `_sum`/`_count`
+series for classic histograms and to `histogram_sum`/
+`histogram_count` for native histograms.
+
+The generated datasource default follows the histogram mode:
+classic variants select `Prometheus`, while native variants select
+`Prometheus Native`. In the standard devenv monitoring stack use
+`ledger-metrics-prom-noprefix-normalized-native.json`.
 
 The "**normalised**" variants assume the standard OTel→Prom
 transformation: dots → underscores, the UCUM unit suffix (`By` →

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-otel.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-otel.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft.transport.ping.latency_sum\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service.node_id}} / Peer {{scope.attributes.peer}}",
+                     "expr": "sum(rate(raft.transport.ping.latency_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, peer) / sum(rate(raft.transport.ping.latency_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, peer)",
+                     "legendFormat": "Node {{service.node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http.server.request.duration_count\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])) by (service.node_id, http.response.status_code)",
+                     "expr": "sum(rate(http.server.request.duration_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, http.response.status_code)",
                      "legendFormat": "Node {{service.node_id}} : {{http.response.status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service.node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.transport.recv.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service.node_id}}: p{{scope.attributes.priority}}",
+                     "expr": "sum(rate(raft.transport.recv.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, priority, priority_name)",
+                     "legendFormat": "Node {{service.node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"1\"}[$__rate_interval])\n) by (service.node_id, le)\n",
+                     "expr": "sum(rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service.node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"1\"}[$__rate_interval])\n) by (service.node_id, le)",
+                     "expr": "sum(rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service.node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"2\"}[$__rate_interval])\n) by (service.node_id, le)\n",
+                     "expr": "sum(rate(raft.transport.recv.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service.node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft.transport.recv.full{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, scope.attributes.priority_name)",
-                     "legendFormat": "{{scope.attributes.priority_name}}",
+                     "expr": "sum(increase(raft.transport.recv.full{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.transport.unreachable.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.transport.unreachable.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(raft.transport.unreachable.full{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
-                     "legendFormat": "{{scope.name}}",
+                     "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft.transport.peer.sending.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, scope.attributes.peer, type)",
-                     "legendFormat": "Node {{service.node_id}}: Peer {{scope.attributes.peer}}",
+                     "expr": "sum(rate(raft.transport.peer.sending.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service.node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft.transport.peer.sending.full{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, scope.attributes.priority_name)",
-                     "legendFormat": "Node {{service.node_id}} : Peer {{peer}}: p{{scope.attributes.priority}}",
+                     "expr": "sum(increase(raft.transport.peer.sending.full{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service.node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"1\"}[$__rate_interval])\n) by (service.node_id, scope.attributes.peer, le)\n",
+                     "expr": "sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service.node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"1\"}[$__rate_interval])\n) by (service.node_id, le)",
+                     "expr": "sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service.node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", scope.attributes.priority=~\"2\"}[$__rate_interval])\n) by (service.node_id, scope.attributes.peer, le)\n",
+                     "expr": "sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service.node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(admission.propose_queue.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(admission.propose_queue.load_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(admission.propose_queue.load_bucket[$__rate_interval])\n) by (le)\n",
+                     "expr": "sum(rate(admission.propose_queue.load_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"raft.transport.sending.pending_response\", service.cluster=~\"$cluster\", service.node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service.node_id}} / Peer : {{scope.attributes.peer}}",
+                     "legendFormat": "Node {{service.node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft.process_entry_sum\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.process_entry_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(wal.append.cache.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service.node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(wal.append.save.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(wal.append.save.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft.node.ready.wait_duration_sum\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "sum(rate(raft.node.ready.wait_duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
+                     "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.node.unspool.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.node.unspool.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.node.maintenance.snapshot_creation.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.node.maintenance.snapshot_creation.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.node.maintenance.replay_spool.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.node.maintenance.replay_spool.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.fsm.rotation.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.fsm.rotation.duration_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft.apply_entries.duration_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft.apply_entries.duration_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service.node_id, status, reason) (rate({__name__=\"pebble.flush.total\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service.node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service.node_id, status, reason) (rate({__name__=\"pebble.flush.total\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service.node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service.node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service.node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service.node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__=\"pebble.flush.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble.flush.duration.milliseconds_sum{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.flush.duration.milliseconds_count{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id)",
-                     "legendFormat": "Node {{service.node_id}} mean {{db}}",
+                     "expr": "sum(rate(pebble.flush.duration.milliseconds_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.flush.duration.milliseconds_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
+                     "legendFormat": "Node {{service.node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service.node_id) (rate({__name__=\"pebble.flush.input.bytes_sum\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum(rate(pebble.flush.input.bytes_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service.node_id, db, status, reason) (rate({__name__=\"pebble.compaction.total\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service.node_id, status, reason) (rate({__name__=\"pebble.compaction.total\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service.node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service.node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service.node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service.node_id, le) (rate({__name__=\"pebble.compaction.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service.node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble.compaction.duration.milliseconds_sum{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.compaction.duration.milliseconds_count{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id)",
+                     "expr": "sum(rate(pebble.compaction.duration.milliseconds_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.compaction.duration.milliseconds_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
                      "legendFormat": "Node {{service.node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service.node_id, reason) (rate({__name__=\"pebble.compaction.total\", status=\"error\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service.node_id, reason) (rate({__name__=\"pebble.compaction.total\", status=\"error\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service.node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service.node_id, reason) ({__name__=\"pebble.write_stall.active\"})",
+                     "expr": "max by (service.node_id, reason) ({__name__=\"pebble.write_stall.active\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"})",
                      "legendFormat": "{{service.node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"pebble.write_stall.total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service.node_id, reason) (rate({__name__=\"pebble.write_stall.total\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service.node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, db) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, db) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, db) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__=\"pebble.write_stall.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble.write_stall.duration.milliseconds_sum{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.write_stall.duration.milliseconds_count{\"scope.name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service.node_id)",
-                     "legendFormat": "mean",
+                     "expr": "sum(rate(pebble.write_stall.duration.milliseconds_sum{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id) / sum(rate(pebble.write_stall.duration.milliseconds_count{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}[$__rate_interval])) by (service.node_id)",
+                     "legendFormat": "Node {{service.node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble.vfs.read.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble.vfs.read.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service.node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble.vfs.write.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble.vfs.write.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service.node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble.vfs.sync.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble.vfs.sync.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service.node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble.vfs.read.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble.vfs.read.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service.node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble.vfs.write.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble.vfs.write.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service.node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble.vfs.sync.ops\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble.vfs.sync.ops\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service.node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"pebble.disk_slow.total\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service.node_id, op) (rate({__name__=\"pebble.disk_slow.total\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service.node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service.node_id, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service.node_id, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"scope.name\"=\"pebble.runtime_store\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service.node_id, op) (rate({__name__=\"pebble.disk_slow.duration.milliseconds_bucket\", \"service.cluster\"=~\"$cluster\", \"service.node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service.node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "cache.size{service.cluster=~\"$cluster\", service.node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service.node_id}})",
+                     "expr": "cache.size{service.cluster=~\"$cluster\", service.node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service.node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache.size{service.cluster=~\"$cluster\", service.node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service.node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache.size{service.cluster=~\"$cluster\", service.node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service.node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache.size{service.cluster=~\"$cluster\", service.node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service.node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage.disk.volume.bytes{service.cluster=~\"$cluster\", service.node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service.node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage.disk.volume.bytes{service.cluster=~\"$cluster\", service.node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service.node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus",
+               "value": "Prometheus"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service\\.node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix-normalized-native.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix-normalized-native.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_transport_ping_latency_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "histogram_avg(sum(rate(raft_transport_ping_latency_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer))",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_seconds_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "histogram_count(sum(rate(http_server_request_duration_seconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code))",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "histogram_count(sum(rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name))",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)\n",
+                     "expr": "sum(rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)",
+                     "expr": "sum(rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id)\n",
+                     "expr": "sum(rate(raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(raft_transport_unreachable_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(raft_transport_unreachable_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2132,7 +2111,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_send_pending_messages_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(raft_send_pending_messages_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "histogram_count(sum(rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name))",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)",
+                     "expr": "sum(rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(admission_propose_queue_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(admission_propose_queue_load[$__rate_interval])\n)\n",
+                     "expr": "sum(rate(admission_propose_queue_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_process_entry_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(raft_process_entry_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3342,7 +3321,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_process_entry_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(raft_process_entry_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3573,7 +3552,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_append_entries_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_sum(sum(rate(raft_append_entries_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(wal_append_save_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4398,7 +4278,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_node_ready_wait_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(raft_node_ready_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_node_ready_wait_duration_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "histogram_sum(sum(rate(raft_node_ready_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(raft_node_unspool_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(raft_node_maintenance_snapshot_creation_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(raft_node_maintenance_replay_spool_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(raft_fsm_rotation_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5356,7 +5236,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_apply_entries_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_sum(sum(rate(raft_apply_entries_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(raft_apply_entries_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(pebble_flush_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "histogram_avg(sum(rate(pebble_flush_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "histogram_sum(sum(rate(pebble_flush_input_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(pebble_compaction_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
+                     "expr": "histogram_avg(sum(rate(pebble_compaction_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (db) (rate({__name__=\"pebble_write_stall_duration_milliseconds\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (db) (rate({__name__=\"pebble_write_stall_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (db) (rate({__name__=\"pebble_write_stall_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(pebble_write_stall_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
-                     "legendFormat": "mean",
+                     "expr": "histogram_avg(sum(rate(pebble_write_stall_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10422,7 +10028,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(admission_proposal_guard_rebuild_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(admission_proposal_guard_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(admission_proposal_guard_rebuild_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / histogram_count(sum(rate(admission_proposal_guard_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Rebuild ratio - Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus Native",
+               "value": "Prometheus Native"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix-normalized.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix-normalized.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_transport_ping_latency_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(raft_transport_ping_latency_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer) / sum(rate(raft_transport_ping_latency_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer)",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_seconds_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "sum(rate(http_server_request_duration_seconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(rate(raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(raft_transport_unreachable_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(admission_propose_queue_load_bucket[$__rate_interval])\n) by (le)\n",
+                     "expr": "sum(rate(admission_propose_queue_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_process_entry_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_process_entry_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_node_ready_wait_duration_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "sum(rate(raft_node_ready_wait_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_flush_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_flush_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "sum(rate(pebble_flush_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_flush_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum(rate(pebble_flush_input_bytes_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_compaction_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_compaction_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(pebble_compaction_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_compaction_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_write_stall_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_write_stall_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "mean",
+                     "expr": "sum(rate(pebble_write_stall_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_write_stall_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus",
+               "value": "Prometheus"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-noprefix.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_transport_ping_latency_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(raft_transport_ping_latency_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer) / sum(rate(raft_transport_ping_latency_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer)",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "sum(rate(http_server_request_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(rate(raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_recv_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(raft_transport_recv_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(raft_transport_unreachable_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(raft_transport_peer_sending_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(raft_transport_peer_sending_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(admission_propose_queue_load_bucket[$__rate_interval])\n) by (le)\n",
+                     "expr": "sum(rate(admission_propose_queue_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_process_entry_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_process_entry_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(wal_append_save_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(wal_append_save_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"raft_node_ready_wait_duration_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "sum(rate(raft_node_ready_wait_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_unspool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_unspool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_snapshot_creation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_maintenance_snapshot_creation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_node_maintenance_replay_spool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_node_maintenance_replay_spool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_fsm_rotation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_fsm_rotation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(raft_apply_entries_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(raft_apply_entries_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_flush_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_flush_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "sum(rate(pebble_flush_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_flush_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum(rate(pebble_flush_input_bytes_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_compaction_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_compaction_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(pebble_compaction_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_compaction_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, db) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(pebble_write_stall_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_write_stall_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "mean",
+                     "expr": "sum(rate(pebble_write_stall_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(pebble_write_stall_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_read_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_read_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_write_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_write_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"pebble_vfs_sync_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"pebble_vfs_sync_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_read_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_read_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_write_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_write_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"pebble_vfs_sync_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"pebble_vfs_sync_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id, op) (rate({__name__=\"pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus",
+               "value": "Prometheus"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-normalized-native.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-normalized-native.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_transport_ping_latency_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "histogram_avg(sum(rate(ledger_raft_transport_ping_latency_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer))",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_seconds_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "histogram_count(sum(rate(http_server_request_duration_seconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code))",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "histogram_count(sum(rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name))",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(ledger_raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(ledger_raft_transport_unreachable_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(ledger_raft_transport_unreachable_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2132,7 +2111,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_send_pending_messages_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(ledger_raft_send_pending_messages_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "histogram_count(sum(rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name))",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id)",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(ledger_admission_propose_queue_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_admission_propose_queue_load[$__rate_interval])\n)\n",
+                     "expr": "sum(rate(ledger_admission_propose_queue_load{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"ledger_raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_process_entry_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_process_entry_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3342,7 +3321,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_process_entry_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(ledger_raft_process_entry_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3573,7 +3552,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_append_entries_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_append_entries_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_wal_append_save_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4398,7 +4278,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_node_ready_wait_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_count(sum(rate(ledger_raft_node_ready_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_node_ready_wait_duration_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_node_ready_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_node_unspool_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_node_maintenance_snapshot_creation_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_node_maintenance_replay_spool_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_fsm_rotation_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5356,7 +5236,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_apply_entries_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "histogram_sum(sum(rate(ledger_raft_apply_entries_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "histogram_count(sum(rate(ledger_raft_apply_entries_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_fsm_prepare_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(ledger_pebble_flush_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "histogram_avg(sum(rate(ledger_pebble_flush_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "histogram_sum(sum(rate(ledger_pebble_flush_input_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(ledger_pebble_compaction_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
+                     "expr": "histogram_avg(sum(rate(ledger_pebble_compaction_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"ledger_pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_avg(sum(rate(ledger_pebble_write_stall_duration_milliseconds{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id))",
-                     "legendFormat": "mean",
+                     "expr": "histogram_avg(sum(rate(ledger_pebble_write_stall_duration_milliseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10422,7 +10028,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_admission_proposal_guard_rebuild_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_admission_proposal_guard_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(ledger_admission_proposal_guard_rebuild_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / histogram_count(sum(rate(ledger_admission_proposal_guard_duration_microseconds{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id))",
                      "legendFormat": "Rebuild ratio - Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus Native",
+               "value": "Prometheus Native"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-normalized.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom-normalized.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_transport_ping_latency_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(ledger_raft_transport_ping_latency_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer) / sum(rate(ledger_raft_transport_ping_latency_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer)",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_seconds_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "sum(rate(http_server_request_duration_seconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(ledger_raft_transport_recv_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(ledger_raft_transport_unreachable_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full_total{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_admission_propose_queue_load_bucket[$__rate_interval])\n) by (le)\n",
+                     "expr": "sum(rate(ledger_admission_propose_queue_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"ledger_raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_process_entry_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_process_entry_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_wal_append_save_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_node_ready_wait_duration_microseconds_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "sum(rate(ledger_raft_node_ready_wait_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_unspool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_maintenance_snapshot_creation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_maintenance_replay_spool_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_fsm_rotation_duration_microseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_apply_entries_duration_microseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_applier_commit_wait_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_fsm_prepare_duration_microseconds_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_flush_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_flush_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "sum(rate(ledger_pebble_flush_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_flush_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum(rate(ledger_pebble_flush_input_bytes_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_compaction_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_compaction_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(ledger_pebble_compaction_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_compaction_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"ledger_pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_write_stall_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_write_stall_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "mean",
+                     "expr": "sum(rate(ledger_pebble_write_stall_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_write_stall_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus",
+               "value": "Prometheus"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom.json
+++ b/misc/devenv/monitoring-dashboards/config/dashboards/ledger-metrics-prom.json
@@ -219,8 +219,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_transport_ping_latency_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}} / Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(ledger_raft_transport_ping_latency_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer) / sum(rate(ledger_raft_transport_ping_latency_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer)",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -318,7 +318,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate({\"http_server_request_duration_count\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
+                     "expr": "sum(rate(http_server_request_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, http_response_status_code)",
                      "legendFormat": "Node {{service_node_id}} : {{http_response_status_code}}",
                      "range": true,
                      "refId": "A"
@@ -543,16 +543,6 @@
                      "legendFormat": "Node {{service_node_id}}: Limit",
                      "range": true,
                      "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "range": true,
-                     "refId": "C"
                   }
                ],
                "title": "Process CPU time",
@@ -959,17 +949,6 @@
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "",
-                     "legendFormat": "__auto",
-                     "range": true,
-                     "refId": "B"
                   }
                ],
                "title": "Leadership status",
@@ -1474,8 +1453,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[30s])",
-                     "legendFormat": "Node {{service_node_id}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1488,7 +1467,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 1).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
+               "description": "Heatmap showing queue depth distribution for high-priority received messages (priority 0).\n\nHigh-priority messages include:\n- AppendEntries responses (AppResp)\n- Vote requests/responses (Vote, VoteResp)\n- Pre-vote requests (PreVote, PreVoteResp)\n\nConsistently high queue depth indicates the node cannot process messages fast enough. This may delay leader election or log replication acknowledgments.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -1554,7 +1533,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1635,7 +1614,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1716,7 +1695,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_recv_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -1785,8 +1764,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_recv_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "{{scope_attributes_priority_name}}",
+                     "expr": "sum(increase(ledger_raft_transport_recv_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, priority_name)",
+                     "legendFormat": "{{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -1884,7 +1863,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_name=\"raft.transport\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_transport_unreachable_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -2034,7 +2013,7 @@
                      },
                      "editorMode": "code",
                      "expr": "sum(increase(ledger_raft_transport_unreachable_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "{{scope_name}}",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2411,8 +2390,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_peer, type)",
-                     "legendFormat": "Node {{service_node_id}}: Peer {{scope_attributes_peer}}",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2510,8 +2489,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, scope_attributes_priority_name)",
-                     "legendFormat": "Node {{service_node_id}} : Peer {{peer}}: p{{scope_attributes_priority}}",
+                     "expr": "sum(increase(ledger_raft_transport_peer_sending_full{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, peer, priority_name)",
+                     "legendFormat": "Node {{service_node_id}}: Peer {{peer}} / {{priority_name}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -2524,7 +2503,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 1).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
+               "description": "Heatmap showing per-peer send queue depth for high-priority messages (priority 0).\n\nHigh-priority outbound messages:\n- AppendEntries responses\n- Vote requests/responses\n- Pre-vote requests/responses\n\nThese messages are critical for consensus. High queue depth may delay leader election or acknowledgment of replicated entries.\n\nSee: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#per-peer-sending-metrics\n",
                "fieldConfig": {
                   "defaults": {
                      "custom": {
@@ -2590,7 +2569,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"0\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2671,7 +2650,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"1\"}[$__rate_interval])\n) by (service_node_id, le)",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"1\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2752,7 +2731,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", scope_attributes_priority=~\"2\"}[$__rate_interval])\n) by (service_node_id, scope_attributes_peer, le)\n",
+                     "expr": "sum(rate(ledger_raft_transport_peer_sending_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\", priority=\"2\"}[$__rate_interval])) by (service_node_id, peer, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -2852,7 +2831,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_admission_propose_queue_load_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Incoming",
                      "range": true,
                      "refId": "A"
@@ -2932,7 +2911,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(\n  rate(ledger_admission_propose_queue_load_bucket[$__rate_interval])\n) by (le)\n",
+                     "expr": "sum(rate(ledger_admission_propose_queue_load_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id, le)",
                      "format": "heatmap",
                      "legendFormat": "__auto",
                      "range": true,
@@ -3131,7 +3110,7 @@
                      },
                      "editorMode": "code",
                      "expr": "{\"ledger_raft_transport_sending_pending_response\", service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
-                     "legendFormat": "Node {{service_node_id}} / Peer : {{scope_attributes_peer}}",
+                     "legendFormat": "Node {{service_node_id}} / Peer {{peer}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -3243,7 +3222,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_process_entry_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_process_entry_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -3851,105 +3830,6 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.\n\nThis measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.\n\nHigh values may indicate:\n- Memory pressure\n- Large entry batches\n- GC pauses\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
-               },
-               "id": 43,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_cache_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "Node {{service_node_id}}",
-                     "range": true,
-                     "refId": "A"
-                  }
-               ],
-               "title": "WAL cache update time",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
                "description": "Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.\n\nThis is the actual disk I/O time for persisting entries. High values indicate:\n- Slow disk I/O\n- Disk saturation\n- Need for faster storage (SSD/NVMe)\n\nThis metric directly impacts transaction latency as WAL writes must complete before entries can be committed.\n",
                "fieldConfig": {
                   "defaults": {
@@ -4014,7 +3894,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 44,
+               "id": 43,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4035,7 +3915,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_wal_append_save_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_wal_append_save_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4111,9 +3991,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 45,
+               "id": 44,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4245,7 +4125,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 46,
+               "id": 45,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4375,9 +4255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 47,
+               "id": 46,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4475,7 +4355,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 48,
+               "id": 47,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4496,8 +4376,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({\"ledger_raft_node_ready_wait_duration_sum\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
-                     "legendFormat": "__auto",
+                     "expr": "sum(rate(ledger_raft_node_ready_wait_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -4574,7 +4454,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 49,
+               "id": 48,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4680,11 +4560,11 @@
                },
                "gridPos": {
                   "h": 7,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 50,
+               "id": 49,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4705,7 +4585,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_unspool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_unspool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -4781,9 +4661,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 63
+                  "y": 55
                },
-               "id": 51,
+               "id": 50,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -4892,7 +4772,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 52,
+               "id": 51,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5000,9 +4880,9 @@
                   "h": 7,
                   "w": 24,
                   "x": 0,
-                  "y": 70
+                  "y": 62
                },
-               "id": 53,
+               "id": 52,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5023,7 +4903,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_snapshot_creation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_maintenance_snapshot_creation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Snapshot creation",
                      "range": true,
                      "refId": "A"
@@ -5034,7 +4914,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_node_maintenance_replay_spool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_node_maintenance_replay_spool_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: Replay spool",
                      "range": true,
                      "refId": "B"
@@ -5110,9 +4990,9 @@
                   "h": 7,
                   "w": 16,
                   "x": 0,
-                  "y": 77
+                  "y": 69
                },
-               "id": 54,
+               "id": 53,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5133,7 +5013,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_fsm_rotation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_fsm_rotation_duration_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5209,9 +5089,9 @@
                   "h": 7,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 69
                },
-               "id": 55,
+               "id": 54,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5264,7 +5144,7 @@
             "x": 0,
             "y": 164
          },
-         "id": 56,
+         "id": 55,
          "panels": [
             {
                "datasource": {
@@ -5335,7 +5215,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 57,
+               "id": 56,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5433,7 +5313,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 58,
+               "id": 57,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5565,7 +5445,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 59,
+               "id": 58,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5697,7 +5577,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 60,
+               "id": 59,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5718,7 +5598,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate(ledger_raft_apply_entries_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])",
+                     "expr": "sum(rate(ledger_raft_apply_entries_duration_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -5795,7 +5675,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 61,
+               "id": 60,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -5915,7 +5795,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 62,
+               "id": 61,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6036,248 +5916,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 63,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_applier_commit_wait_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Commit Wait Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 64,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum(rate(ledger_raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p50",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum(rate(ledger_raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p95",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum(rate(ledger_raft_fsm_prepare_duration_bucket{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (le))",
-                     "legendFormat": "p99",
-                     "range": true,
-                     "refId": "C"
-                  }
-               ],
-               "title": "Prepare Duration (p50, p95, p99)",
-               "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Time spent waiting for the previous batch's async commit to finish. Near zero = pipelining effective.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "µs"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 65,
+               "id": 62,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6341,7 +5980,7 @@
             "x": 0,
             "y": 165
          },
-         "id": 66,
+         "id": 63,
          "panels": [
             {
                "datasource": {
@@ -6411,7 +6050,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 67,
+               "id": 64,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6432,8 +6071,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "Node {{service_node_id}} {{db}} {{status}} {{reason}}",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_flush_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -6510,7 +6149,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 68,
+               "id": 65,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6531,8 +6170,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -6542,8 +6181,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -6553,8 +6192,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "Node {{service_node_id}} p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_flush_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -6564,8 +6203,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_flush_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_flush_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "Node {{service_node_id}} mean {{db}}",
+                     "expr": "sum(rate(ledger_pebble_flush_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_flush_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -6642,7 +6281,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 69,
+               "id": 66,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6663,7 +6302,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id) (rate({__name__=\"ledger_pebble_flush_input_bytes_sum\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum(rate(ledger_pebble_flush_input_bytes_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}",
                      "range": true,
                      "refId": "A"
@@ -6740,7 +6379,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 70,
+               "id": 67,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6761,7 +6400,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, db, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, status, reason) (rate({__name__=\"ledger_pebble_compaction_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{status}} {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -6839,7 +6478,7 @@
                   "x": 8,
                   "y": 8
                },
-               "id": 71,
+               "id": 68,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6860,7 +6499,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.50, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p50",
                      "range": true,
                      "refId": "A"
@@ -6871,7 +6510,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.95, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p95 ",
                      "range": true,
                      "refId": "B"
@@ -6882,7 +6521,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
+                     "expr": "histogram_quantile(0.99, sum by (service_node_id, le) (rate({__name__=\"ledger_pebble_compaction_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
                      "legendFormat": "Node {{service_node_id}}: p99",
                      "range": true,
                      "refId": "C"
@@ -6893,7 +6532,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_compaction_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_compaction_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
+                     "expr": "sum(rate(ledger_pebble_compaction_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_compaction_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
                      "legendFormat": "Node {{service_node_id}}: mean",
                      "range": true,
                      "refId": "D"
@@ -6970,7 +6609,7 @@
                   "x": 16,
                   "y": 8
                },
-               "id": 72,
+               "id": 69,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -6991,7 +6630,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval]))",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_compaction_total\", status=\"error\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
                      "legendFormat": "Node {{service_node_id}}: {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7068,7 +6707,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 73,
+               "id": 70,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7089,7 +6728,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\"})",
+                     "expr": "max by (service_node_id, reason) ({__name__=\"ledger_pebble_write_stall_active\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"})",
                      "legendFormat": "{{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
@@ -7166,7 +6805,7 @@
                   "x": 8,
                   "y": 16
                },
-               "id": 74,
+               "id": 71,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7187,8 +6826,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (db, reason) (rate({__name__=\"ledger_pebble_write_stall_total\"}[$__rate_interval]))",
-                     "legendFormat": "{{db}} / {{reason}}",
+                     "expr": "sum by (service_node_id, reason) (rate({__name__=\"ledger_pebble_write_stall_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{reason}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7265,7 +6904,7 @@
                   "x": 16,
                   "y": 16
                },
-               "id": 75,
+               "id": 72,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7286,8 +6925,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{db}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50",
                      "range": true,
                      "refId": "A"
                   },
@@ -7297,8 +6936,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{db}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95",
                      "range": true,
                      "refId": "B"
                   },
@@ -7308,8 +6947,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, db) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{db}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id) (rate({__name__=\"ledger_pebble_write_stall_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99",
                      "range": true,
                      "refId": "C"
                   },
@@ -7319,8 +6958,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum(rate(ledger_pebble_write_stall_duration_milliseconds_sum{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_write_stall_duration_milliseconds_count{\"scope_name\"=\"pebble.runtime_store\"}[$__rate_interval])) by (service_node_id)",
-                     "legendFormat": "mean",
+                     "expr": "sum(rate(ledger_pebble_write_stall_duration_milliseconds_sum{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id) / sum(rate(ledger_pebble_write_stall_duration_milliseconds_count{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}[$__rate_interval])) by (service_node_id)",
+                     "legendFormat": "Node {{service_node_id}} mean",
                      "range": true,
                      "refId": "D"
                   }
@@ -7397,7 +7036,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 76,
+               "id": 73,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7418,7 +7057,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_read_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — reads/s",
                      "range": true,
                      "refId": "A"
@@ -7429,7 +7068,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_write_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — writes/s",
                      "range": true,
                      "refId": "B"
@@ -7507,7 +7146,7 @@
                   "x": 8,
                   "y": 24
                },
-               "id": 77,
+               "id": 74,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7528,7 +7167,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
+                     "expr": "rate({__name__=\"ledger_pebble_vfs_sync_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])",
                      "legendFormat": "Node {{service_node_id}} — syncs/s",
                      "range": true,
                      "refId": "A"
@@ -7605,7 +7244,7 @@
                   "x": 16,
                   "y": 24
                },
-               "id": 78,
+               "id": 75,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7626,7 +7265,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_read_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — reads",
                      "range": true,
                      "refId": "A"
@@ -7637,7 +7276,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_write_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — writes",
                      "range": true,
                      "refId": "B"
@@ -7648,7 +7287,7 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
+                     "expr": "{__name__=\"ledger_pebble_vfs_sync_ops\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}",
                      "legendFormat": "Node {{service_node_id}} — syncs",
                      "range": true,
                      "refId": "C"
@@ -7725,7 +7364,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 79,
+               "id": 76,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7746,8 +7385,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "sum by (op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
-                     "legendFormat": "{{op}}",
+                     "expr": "sum by (service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_total\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval]))",
+                     "legendFormat": "Node {{service_node_id}} / {{op}}",
                      "range": true,
                      "refId": "A"
                   }
@@ -7824,7 +7463,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 80,
+               "id": 77,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -7845,8 +7484,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.50, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p50 {{op}}",
+                     "expr": "histogram_quantile(0.50, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p50 {{op}}",
                      "range": true,
                      "refId": "A"
                   },
@@ -7856,8 +7495,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.95, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p95 {{op}}",
+                     "expr": "histogram_quantile(0.95, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p95 {{op}}",
                      "range": true,
                      "refId": "B"
                   },
@@ -7867,8 +7506,8 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "histogram_quantile(0.99, sum by (le, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"scope_name\"=\"pebble.runtime_store\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
-                     "legendFormat": "p99 {{op}}",
+                     "expr": "histogram_quantile(0.99, sum by (le, service_node_id, op) (rate({__name__=\"ledger_pebble_disk_slow_duration_milliseconds_bucket\", \"service_cluster\"=~\"$cluster\", \"service_node_id\"=~\"$node\"}[$__rate_interval])))",
+                     "legendFormat": "Node {{service_node_id}} p99 {{op}}",
                      "range": true,
                      "refId": "C"
                   }
@@ -7888,7 +7527,7 @@
             "x": 0,
             "y": 166
          },
-         "id": 81,
+         "id": 78,
          "panels": [
             {
                "datasource": {
@@ -7959,7 +7598,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 82,
+               "id": 79,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8058,7 +7697,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 83,
+               "id": 80,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8157,7 +7796,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 84,
+               "id": 81,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8233,7 +7872,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 85,
+               "id": 82,
                "options": {
                   "colorMode": "value",
                   "graphMode": "area",
@@ -8280,14 +7919,14 @@
             "x": 0,
             "y": 167
          },
-         "id": 86,
+         "id": 83,
          "panels": [
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "description": "Number of entries in the attribute cache by type.\n\n- volumes: Account volumes (input/output)\n- account_metadata: Account metadata\n- ledger_metadata: Ledger metadata\n- reversions: Transaction reversion status\n- idempotency_keys: Idempotency keys\n- references: Transaction references\n- ledgers: Ledger info\n- boundaries: Ledger boundaries\n",
+               "description": "Number of entries in the attribute cache by type.\n\nThe `type` label is displayed dynamically so newly introduced cache\nregistries appear without requiring a dashboard update.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -8351,7 +7990,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 87,
+               "id": 84,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8372,43 +8011,10 @@
                         "uid": "${datasource}"
                      },
                      "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"volumes\"}",
-                     "legendFormat": "Volumes (Node {{service_node_id}})",
+                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\"}",
+                     "legendFormat": "{{type}} (Node {{service_node_id}})",
                      "range": true,
                      "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"account_metadata\"}",
-                     "legendFormat": "Account Metadata (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"idempotency_keys\"}",
-                     "legendFormat": "Idempotency Keys (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "C"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_cache_size{service_cluster=~\"$cluster\", service_node_id=~\"$node\", type=\"boundaries\"}",
-                     "legendFormat": "Boundaries (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "D"
                   }
                ],
                "title": "Cache Size by Type",
@@ -8483,7 +8089,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 88,
+               "id": 85,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8582,7 +8188,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 89,
+               "id": 86,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8635,7 +8241,7 @@
             "x": 0,
             "y": 168
          },
-         "id": 90,
+         "id": 87,
          "panels": [
             {
                "datasource": {
@@ -8706,7 +8312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 91,
+               "id": 88,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8805,7 +8411,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 92,
+               "id": 89,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -8904,7 +8510,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 93,
+               "id": 90,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9003,7 +8609,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 94,
+               "id": 91,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9102,7 +8708,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 95,
+               "id": 92,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9201,7 +8807,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 96,
+               "id": 93,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9243,7 +8849,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 97,
+         "id": 94,
          "panels": [
             {
                "datasource": {
@@ -9314,7 +8920,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 98,
+               "id": 95,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9435,7 +9041,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 99,
+               "id": 96,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9534,7 +9140,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 100,
+               "id": 97,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9633,7 +9239,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 101,
+               "id": 98,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9732,7 +9338,7 @@
                   "x": 0,
                   "y": 16
                },
-               "id": 102,
+               "id": 99,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9842,7 +9448,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 103,
+               "id": 100,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -9963,7 +9569,7 @@
                   "x": 0,
                   "y": 24
                },
-               "id": 104,
+               "id": 101,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10084,7 +9690,7 @@
                   "x": 12,
                   "y": 24
                },
-               "id": 105,
+               "id": 102,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10205,7 +9811,7 @@
                   "x": 0,
                   "y": 32
                },
-               "id": 106,
+               "id": 103,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10302,7 +9908,7 @@
                   "x": 12,
                   "y": 32
                },
-               "id": 107,
+               "id": 104,
                "options": {
                   "bucketOffset": 0,
                   "combine": false,
@@ -10401,7 +10007,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 108,
+               "id": 105,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10511,7 +10117,7 @@
                   "x": 12,
                   "y": 40
                },
-               "id": 109,
+               "id": 106,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10632,7 +10238,7 @@
                   "x": 0,
                   "y": 48
                },
-               "id": 110,
+               "id": 107,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10753,7 +10359,7 @@
                   "x": 12,
                   "y": 48
                },
-               "id": 111,
+               "id": 108,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10852,7 +10458,7 @@
                   "x": 0,
                   "y": 56
                },
-               "id": 112,
+               "id": 109,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -10973,7 +10579,7 @@
                   "x": 12,
                   "y": 56
                },
-               "id": 113,
+               "id": 110,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11094,7 +10700,7 @@
                   "x": 0,
                   "y": 64
                },
-               "id": 114,
+               "id": 111,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11215,7 +10821,7 @@
                   "x": 0,
                   "y": 72
                },
-               "id": 115,
+               "id": 112,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11279,7 +10885,7 @@
             "x": 0,
             "y": 170
          },
-         "id": 116,
+         "id": 113,
          "panels": [
             {
                "datasource": {
@@ -11350,7 +10956,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 117,
+               "id": 114,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11471,7 +11077,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 118,
+               "id": 115,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11535,7 +11141,7 @@
             "x": 0,
             "y": 171
          },
-         "id": 119,
+         "id": 116,
          "panels": [
             {
                "datasource": {
@@ -11606,7 +11212,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 120,
+               "id": 117,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11705,7 +11311,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 121,
+               "id": 118,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11804,7 +11410,7 @@
                   "x": 0,
                   "y": 8
                },
-               "id": 122,
+               "id": 119,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -11925,7 +11531,7 @@
                   "x": 12,
                   "y": 8
                },
-               "id": 123,
+               "id": 120,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12068,7 +11674,7 @@
                   "x": 12,
                   "y": 16
                },
-               "id": 124,
+               "id": 121,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12121,7 +11727,7 @@
             "x": 0,
             "y": 172
          },
-         "id": 125,
+         "id": 122,
          "panels": [
             {
                "datasource": {
@@ -12188,11 +11794,11 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 126,
+               "id": 123,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12232,116 +11838,6 @@
                ],
                "title": "Disk Usage by Volume",
                "type": "timeseries"
-            },
-            {
-               "datasource": {
-                  "type": "prometheus",
-                  "uid": "${datasource}"
-               },
-               "description": "Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisBorderShow": false,
-                        "axisCenteredZero": false,
-                        "axisColorMode": "text",
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "barWidthFactor": 0.59999999999999998,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "insertNulls": false,
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "showValues": false,
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [ ],
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                           {
-                              "color": "green",
-                              "value": 0
-                           },
-                           {
-                              "color": "red",
-                              "value": 80
-                           }
-                        ]
-                     },
-                     "unit": "bytes"
-                  },
-                  "overrides": [ ]
-               },
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 0
-               },
-               "id": 127,
-               "options": {
-                  "legend": {
-                     "calcs": [ ],
-                     "displayMode": "list",
-                     "placement": "bottom",
-                     "showLegend": true
-                  },
-                  "tooltip": {
-                     "hideZeros": false,
-                     "mode": "single",
-                     "sort": "none"
-                  }
-               },
-               "targets": [
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"wal\"}",
-                     "legendFormat": "WAL (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "A"
-                  },
-                  {
-                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "${datasource}"
-                     },
-                     "editorMode": "code",
-                     "expr": "ledger_storage_disk_volume_bytes{service_cluster=~\"$cluster\", service_node_id=~\"$node\", volume=\"data\"}",
-                     "legendFormat": "Data (Node {{service_node_id}})",
-                     "range": true,
-                     "refId": "B"
-                  }
-               ],
-               "title": "Disk Usage by Volume",
-               "type": "timeseries"
             }
          ],
          "title": "Storage Disk Usage",
@@ -12355,7 +11851,7 @@
             "x": 0,
             "y": 173
          },
-         "id": 128,
+         "id": 124,
          "panels": [
             {
                "datasource": {
@@ -12392,7 +11888,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 129,
+               "id": 125,
                "options": {
                   "minVizHeight": 75,
                   "minVizWidth": 75,
@@ -12493,7 +11989,7 @@
                   "x": 8,
                   "y": 0
                },
-               "id": 130,
+               "id": 126,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12592,7 +12088,7 @@
                   "x": 16,
                   "y": 0
                },
-               "id": 131,
+               "id": 127,
                "options": {
                   "legend": {
                      "calcs": [ ],
@@ -12645,21 +12141,21 @@
             "x": 0,
             "y": 174
          },
-         "id": 132,
+         "id": 128,
          "panels": [
             {
                "datasource": {
                   "type": "grafana-pyroscope-datasource",
                   "uid": "${pyroscope}"
                },
-               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\nUse the version tag to compare profiles between different builds.\n",
+               "description": "CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.\n\n",
                "gridPos": {
                   "h": 20,
                   "w": 24,
                   "x": 0,
                   "y": 0
                },
-               "id": 133,
+               "id": 129,
                "options": { },
                "targets": [
                   {
@@ -12668,7 +12164,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
                      "queryType": "profile",
                      "refId": "A"
@@ -12689,7 +12185,7 @@
                   "x": 0,
                   "y": 20
                },
-               "id": 134,
+               "id": 130,
                "options": { },
                "targets": [
                   {
@@ -12698,7 +12194,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:alloc_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12719,7 +12215,7 @@
                   "x": 0,
                   "y": 40
                },
-               "id": 135,
+               "id": 131,
                "options": { },
                "targets": [
                   {
@@ -12728,7 +12224,7 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
+                     "labelSelector": "{service_name=\"ledger\"}",
                      "profileTypeId": "memory:inuse_space:bytes:space:bytes",
                      "queryType": "profile",
                      "refId": "A"
@@ -12749,7 +12245,7 @@
                   "x": 0,
                   "y": 60
                },
-               "id": 136,
+               "id": 132,
                "options": { },
                "targets": [
                   {
@@ -12758,8 +12254,8 @@
                         "uid": "${pyroscope}"
                      },
                      "groupBy": [ ],
-                     "labelSelector": "{service_name=\"ledger\", version=\"$version\"}",
-                     "profileTypeId": "goroutine:goroutine:count:goroutine:count",
+                     "labelSelector": "{service_name=\"ledger\"}",
+                     "profileTypeId": "goroutines:goroutine:count:goroutine:count",
                      "queryType": "profile",
                      "refId": "A"
                   }
@@ -12784,8 +12280,8 @@
          {
             "current": {
                "selected": true,
-               "text": "VictoriaMetrics",
-               "value": "VictoriaMetrics"
+               "text": "Prometheus",
+               "value": "Prometheus"
             },
             "includeAll": false,
             "label": "Datasource",
@@ -12854,28 +12350,6 @@
             },
             "refresh": 1,
             "regex": "/service_node_id=\"([^\"]+)\"/",
-            "sort": 1,
-            "type": "query"
-         },
-         {
-            "allValue": ".*",
-            "datasource": {
-               "type": "grafana-pyroscope-datasource",
-               "uid": "${pyroscope}"
-            },
-            "definition": "",
-            "description": "Select a version to filter Pyroscope profiles (for comparison)",
-            "includeAll": true,
-            "label": "Version",
-            "name": "version",
-            "options": [ ],
-            "query": {
-               "labelSelector": "{service_name=\"ledger\"}",
-               "profileTypeId": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-               "refId": "PyroscopeVariableQueryEditor-VariableQuery"
-            },
-            "refresh": 1,
-            "regex": "/version=\"([^\"]+)\"/",
             "sort": 1,
             "type": "query"
          }

--- a/misc/devenv/monitoring-dashboards/dashboard_test.go
+++ b/misc/devenv/monitoring-dashboards/dashboard_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+var nativeClassicHistogramSuffix = regexp.MustCompile(`(?:raft|admission|wal|pebble|http)[A-Za-z0-9_]*(?:_sum|_count)(?:\{|\[)`)
+
+func TestGeneratedDashboards(t *testing.T) {
+	t.Parallel()
+
+	files, err := filepath.Glob("config/dashboards/*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 7 {
+		t.Fatalf("expected 7 generated dashboard variants, got %d", len(files))
+	}
+	sort.Strings(files)
+
+	for _, file := range files {
+		file := file
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var dashboard map[string]any
+			if err := json.Unmarshal(raw, &dashboard); err != nil {
+				t.Fatalf("invalid dashboard JSON: %v", err)
+			}
+
+			assertDatasourceDefault(t, dashboard, strings.Contains(file, "-native"))
+			assertDashboardTree(t, dashboard, strings.Contains(file, "-native"))
+		})
+	}
+}
+
+func assertDatasourceDefault(t *testing.T, dashboard map[string]any, native bool) {
+	t.Helper()
+
+	templating := objectField(t, dashboard, "templating")
+	variables := arrayField(t, templating, "list")
+	if len(variables) != 4 {
+		t.Fatalf("expected datasource, Pyroscope, cluster and node variables; got %d", len(variables))
+	}
+
+	datasource := variables[0].(map[string]any)
+	current := objectField(t, datasource, "current")
+	want := "Prometheus"
+	if native {
+		want = "Prometheus Native"
+	}
+	if got := current["value"]; got != want {
+		t.Errorf("datasource default = %v, want %q", got, want)
+	}
+
+	for _, raw := range variables {
+		variable := raw.(map[string]any)
+		if variable["name"] == "version" {
+			t.Error("version variable must not be generated: live Ledger profiles do not expose that label")
+		}
+	}
+}
+
+func assertDashboardTree(t *testing.T, value any, native bool) {
+	t.Helper()
+
+	panelTitles := map[string]struct{}{}
+	var walk func(any, string)
+	walk = func(value any, path string) {
+		switch value := value.(type) {
+		case map[string]any:
+			if _, hasTargets := value["targets"]; hasTargets {
+				if title, ok := value["title"].(string); ok {
+					if _, duplicate := panelTitles[title]; duplicate {
+						t.Errorf("duplicate panel title %q", title)
+					}
+					panelTitles[title] = struct{}{}
+				}
+			}
+
+			if expr, ok := value["expr"].(string); ok {
+				if strings.TrimSpace(expr) == "" {
+					t.Errorf("empty Prometheus expression at %s", path)
+				}
+				if !strings.Contains(expr, "$cluster") {
+					t.Errorf("unscoped Prometheus expression at %s: %s", path, expr)
+				}
+				if strings.Contains(expr, "scope.name") || strings.Contains(expr, "scope_name") ||
+					strings.Contains(expr, "scope.attributes") || strings.Contains(expr, "scope_attributes") {
+					t.Errorf("expression relies on dropped instrumentation-scope labels at %s: %s", path, expr)
+				}
+				if strings.Contains(expr, "wal.append.cache") || strings.Contains(expr, "wal_append_cache") {
+					t.Errorf("expression references removed WAL cache metric at %s: %s", path, expr)
+				}
+				if native && nativeClassicHistogramSuffix.MatchString(expr) {
+					t.Errorf("native dashboard references a classic histogram suffix at %s: %s", path, expr)
+				}
+			}
+
+			if profileType, ok := value["profileTypeId"].(string); ok && strings.HasPrefix(profileType, "goroutine:") {
+				t.Errorf("obsolete singular goroutine profile type at %s: %s", path, profileType)
+			}
+			if selector, ok := value["labelSelector"].(string); ok && strings.Contains(selector, "version=") {
+				t.Errorf("Pyroscope selector relies on absent version label at %s: %s", path, selector)
+			}
+
+			for key, child := range value {
+				walk(child, fmt.Sprintf("%s.%s", path, key))
+			}
+		case []any:
+			for index, child := range value {
+				walk(child, fmt.Sprintf("%s[%d]", path, index))
+			}
+		}
+	}
+
+	walk(value, "dashboard")
+}
+
+func objectField(t *testing.T, object map[string]any, field string) map[string]any {
+	t.Helper()
+	value, ok := object[field].(map[string]any)
+	if !ok {
+		t.Fatalf("field %q is not an object", field)
+	}
+	return value
+}
+
+func arrayField(t *testing.T, object map[string]any, field string) []any {
+	t.Helper()
+	value, ok := object[field].([]any)
+	if !ok {
+		t.Fatalf("field %q is not an array", field)
+	}
+	return value
+}

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/dashboard.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/dashboard.libsonnet
@@ -7,14 +7,16 @@
 
 {
   // The templating variable list. Two datasources (Prometheus +
-  // Pyroscope) followed by three query variables (cluster, node,
-  // version). Regex fields use the OTel dot-notation form;
+  // Pyroscope) followed by two query variables (cluster and node).
+  // Regex fields use the OTel dot-notation form;
   // transform.libsonnet rewrites them for the prom variant.
   templating(uidSuffix='')::
     {
       list: [
         {
-          current: { selected: true, text: 'VictoriaMetrics', value: 'VictoriaMetrics' },
+          // transform.dashboard replaces this with the datasource that
+          // matches the generated histogram mode.
+          current: { selected: true, text: 'Prometheus', value: 'Prometheus' },
           includeAll: false,
           label: 'Datasource',
           multi: false,
@@ -72,25 +74,6 @@
           },
           refresh: 1,
           regex: '/service\\.node_id="([^"]+)"/',
-          sort: 1,
-          type: 'query',
-        },
-        {
-          allValue: '.*',
-          datasource: { type: 'grafana-pyroscope-datasource', uid: '${pyroscope}' },
-          definition: '',
-          description: 'Select a version to filter Pyroscope profiles (for comparison)',
-          includeAll: true,
-          label: 'Version',
-          name: 'version',
-          options: [],
-          query: {
-            labelSelector: '{service_name="ledger"}',
-            profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
-            refId: 'PyroscopeVariableQueryEditor-VariableQuery',
-          },
-          refresh: 1,
-          regex: '/version="([^"]+)"/',
           sort: 1,
           type: 'query',
         },

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/naming.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/naming.libsonnet
@@ -193,12 +193,10 @@ local metadata = import 'metric_metadata.libsonnet';
   //
   // In `native` mode the `_bucket` suffix is dropped because a
   // native histogram exposes the buckets through the bare metric
-  // (e.g. `histogram_quantile(0.95, rate(metric[5m]))`). The
-  // `_sum` and `_count` suffixes are deliberately preserved — they
-  // don't exist as separate series in native histograms, so the
-  // panels that depend on `_sum / _count` ratios surface a "No
-  // data" rather than a silent ratio of 1; the operator can then
-  // rewrite those panels to `histogram_avg`.
+  // (e.g. `histogram_quantile(0.95, rate(metric[5m]))`). Section
+  // files must use the representation-aware query helpers for
+  // histogram sums and counts; raw `_sum`/`_count` references are
+  // invalid in native mode.
   transformMetric(name, mode):: (
     local cfg = $.modeConfig(mode);
     if cfg.otel then name

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/panels.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/panels.libsonnet
@@ -355,7 +355,7 @@ local promTarget(expr, refId='A', legendFormat=null) = {
     targets: [{
       datasource: pyroDatasource,
       groupBy: [],
-      labelSelector: '{service_name="ledger", version="$version"}',
+      labelSelector: '{service_name="ledger"}',
       profileTypeId: profileType,
       queryType: 'profile',
       refId: 'A',

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/queries.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/queries.libsonnet
@@ -35,6 +35,19 @@
     local sel = if selector == null then $.clusterNode else selector;
     '__hist_avg(' + metric + '|' + std.join(',', by) + '|' + sel + ')__',
 
+  // histogramSumRate and histogramCountRate expose the two components
+  // of a histogram rate without assuming the backend representation.
+  // Classic histograms use the generated _sum/_count series, whereas
+  // Prometheus native histograms use histogram_sum/histogram_count on
+  // the base histogram sample.
+  histogramSumRate(metric, by=[], selector=null)::
+    local sel = if selector == null then $.clusterNode else selector;
+    '__hist_sum_rate(' + metric + '|' + std.join(',', by) + '|' + sel + ')__',
+
+  histogramCountRate(metric, by=[], selector=null)::
+    local sel = if selector == null then $.clusterNode else selector;
+    '__hist_count_rate(' + metric + '|' + std.join(',', by) + '|' + sel + ')__',
+
   // cluster filters only by cluster (used for cluster-wide rollups
   // like the leader gauge).
   cluster:: 'service.cluster=~"$cluster"',

--- a/misc/devenv/monitoring-dashboards/jsonnet/lib/transform.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/lib/transform.libsonnet
@@ -155,13 +155,23 @@ local naming = import 'naming.libsonnet';
       'sum(rate(' + metric + '_sum' + braced + '[$__rate_interval]))' + byClause +
       ' / sum(rate(' + metric + '_count' + braced + '[$__rate_interval]))' + byClause,
 
-  // preExpandHelpers replaces every `__hist_avg(metric|by|sel)__`
-  // sentinel emitted by queries.histogramAvg with the histogram-
-  // mode-appropriate PromQL. Runs before the walker so the emitted
-  // PromQL still goes through the regular prefix / unit-suffix /
-  // label rewriting like any other expression.
-  preExpandHelpers(expr, mode)::
-    local marker = '__hist_avg(';
+  expandHistSumRate(metric, by, selector, native)::
+    local byClause = if std.length(by) == 0 then '' else ' by (' + std.join(', ', by) + ')';
+    local braced = if selector == '' then '' else '{' + selector + '}';
+    if native then
+      'histogram_sum(sum(rate(' + metric + braced + '[$__rate_interval]))' + byClause + ')'
+    else
+      'sum(rate(' + metric + '_sum' + braced + '[$__rate_interval]))' + byClause,
+
+  expandHistCountRate(metric, by, selector, native)::
+    local byClause = if std.length(by) == 0 then '' else ' by (' + std.join(', ', by) + ')';
+    local braced = if selector == '' then '' else '{' + selector + '}';
+    if native then
+      'histogram_count(sum(rate(' + metric + braced + '[$__rate_interval]))' + byClause + ')'
+    else
+      'sum(rate(' + metric + '_count' + braced + '[$__rate_interval]))' + byClause,
+
+  expandHelper(expr, marker, mode, kind)::
     local chunks = std.split(expr, marker);
     if std.length(chunks) == 1 then expr
     else
@@ -178,11 +188,25 @@ local naming = import 'naming.libsonnet';
             if std.length(parts) < 2 || parts[1] == '' then []
             else std.split(parts[1], ',');
           local selector = if std.length(parts) < 3 then '' else parts[2];
-          $.expandHistAvg(metric, by, selector, cfg.native) + rest;
+          local expanded =
+            if kind == 'avg' then $.expandHistAvg(metric, by, selector, cfg.native)
+            else if kind == 'sum_rate' then $.expandHistSumRate(metric, by, selector, cfg.native)
+            else $.expandHistCountRate(metric, by, selector, cfg.native);
+          expanded + rest;
       chunks[0] + std.join('', [
         processChunk(chunks[i])
         for i in std.range(1, std.length(chunks) - 1)
       ]),
+
+  // preExpandHelpers replaces every `__hist_avg(metric|by|sel)__`
+  // sentinel emitted by queries.histogramAvg with the histogram-
+  // mode-appropriate PromQL. Runs before the walker so the emitted
+  // PromQL still goes through the regular prefix / unit-suffix /
+  // label rewriting like any other expression.
+  preExpandHelpers(expr, mode)::
+    local withAvg = $.expandHelper(expr, '__hist_avg(', mode, 'avg');
+    local withSums = $.expandHelper(withAvg, '__hist_sum_rate(', mode, 'sum_rate');
+    $.expandHelper(withSums, '__hist_count_rate(', mode, 'count_rate'),
 
   // dropLeFromGrouping removes the `le` label from PromQL grouping
   // clauses (by/without/on/ignoring/group_*). Used in native
@@ -398,10 +422,22 @@ local naming = import 'naming.libsonnet';
   // dashboard renders the final dashboard JSON for a given mode by
   // walking the source tree.
   dashboard(source, mode)::
-    $.walkValue(source, mode) + {
+    local transformed = $.walkValue(source, mode);
+    local datasource = if naming.modeConfig(mode).native then 'Prometheus Native' else 'Prometheus';
+    transformed + {
       // Distinguish the variants in Grafana so the operator can
       // import the one that matches their collector.
       title: std.get(source, 'title', 'Ledger Metrics') + ' (' + std.asciiUpper(mode) + ')',
       uid: std.get(source, 'uid', 'ledger-metrics') + '-' + $.uidSuffix(mode),
+      templating: transformed.templating + {
+        list: std.mapWithIndex(
+          function(i, variable)
+            if i == 0 then variable + {
+              current: { selected: true, text: datasource, value: datasource },
+            }
+            else variable,
+          transformed.templating.list,
+        ),
+      },
     },
 }

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/admission.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/admission.libsonnet
@@ -2,6 +2,7 @@
 // Edit freely: panel constructors live in ../lib/panels.libsonnet.
 
 local panels = import '../lib/panels.libsonnet';
+local queries = import '../lib/queries.libsonnet';
 
 panels.row('Admission', 169, [
   panels.timeseries(
@@ -179,7 +180,7 @@ panels.row('Admission', 169, [
     'Proposal Guard Rebuild Rate & Ratio',
     { h: 8, w: 12, x: 0, y: 116 },
     [
-      { expr: 'sum(rate(admission.proposal_guard.rebuild{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id) / sum(rate(admission.proposal_guard.duration_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Rebuild ratio - Node {{service.node_id}}' },
+      { expr: 'sum(rate(admission.proposal_guard.rebuild{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id) / ' + queries.histogramCountRate('admission.proposal_guard.duration', by=['service.node_id']), legendFormat: 'Rebuild ratio - Node {{service.node_id}}' },
       { expr: 'sum(rate(admission.proposal_guard.rebuild{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Rebuilds/s - Node {{service.node_id}}' },
     ], unit='percentunit',
     description=|||

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/applier.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/applier.libsonnet
@@ -9,7 +9,7 @@ panels.row('Applier', 164, [
     'Applying entries time passed',
     { h: 8, w: 12, x: 12, y: 1 },
     [
-      { expr: 'sum(rate(raft.apply_entries.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('raft.apply_entries.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Total time spent applying committed entries to the FSM (in microseconds per second).
@@ -74,7 +74,7 @@ panels.row('Applier', 164, [
     'Applying entries rate',
     { h: 8, w: 12, x: 12, y: 25 },
     [
-      { expr: 'rate(raft.apply_entries.duration_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramCountRate('raft.apply_entries.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='ops',
     description=|||
       Rate of apply operations per second (how often the FSM processes batches).
@@ -120,24 +120,4 @@ panels.row('Applier', 164, [
     description='Time spent waiting for the previous batch\'s async commit to finish before starting the next prepare. Near zero = pipelining is effective (commit finishes before next batch arrives). Near commit duration = fully I/O-bound, no pipelining benefit.',
   ),
 
-  panels.timeseries(
-    'Prepare Duration (p50, p95, p99)',
-    { h: 8, w: 12, x: 0, y: 125 },
-    [
-      { expr: 'histogram_quantile(0.50, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p50' },
-      { expr: 'histogram_quantile(0.95, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p95' },
-      { expr: 'histogram_quantile(0.99, sum(rate(raft.fsm.prepare.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p99' },
-    ], unit='µs',
-  ),
-
-  panels.timeseries(
-    'Commit Wait Duration (p50, p95, p99)',
-    { h: 8, w: 12, x: 12, y: 125 },
-    [
-      { expr: 'histogram_quantile(0.50, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p50' },
-      { expr: 'histogram_quantile(0.95, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p95' },
-      { expr: 'histogram_quantile(0.99, sum(rate(raft.applier.commit_wait.duration_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (le))', legendFormat: 'p99' },
-    ], unit='µs',
-    description='Time spent waiting for the previous batch\'s async commit to finish. Near zero = pipelining effective.',
-  ),
 ])

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/caching.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/caching.libsonnet
@@ -8,22 +8,13 @@ panels.row('Caching & Attributes', 167, [
     'Cache Size by Type',
     { h: 8, w: 12, x: 0, y: 89 },
     [
-      { expr: 'cache.size{service.cluster=~"$cluster", service.node_id=~"$node", type="volumes"}', legendFormat: 'Volumes (Node {{service.node_id}})' },
-      { expr: 'cache.size{service.cluster=~"$cluster", service.node_id=~"$node", type="account_metadata"}', legendFormat: 'Account Metadata (Node {{service.node_id}})' },
-      { expr: 'cache.size{service.cluster=~"$cluster", service.node_id=~"$node", type="idempotency_keys"}', legendFormat: 'Idempotency Keys (Node {{service.node_id}})' },
-      { expr: 'cache.size{service.cluster=~"$cluster", service.node_id=~"$node", type="boundaries"}', legendFormat: 'Boundaries (Node {{service.node_id}})' },
+      { expr: 'cache.size{service.cluster=~"$cluster", service.node_id=~"$node"}', legendFormat: '{{type}} (Node {{service.node_id}})' },
     ], unit='none',
     description=|||
       Number of entries in the attribute cache by type.
       
-      - volumes: Account volumes (input/output)
-      - account_metadata: Account metadata
-      - ledger_metadata: Ledger metadata
-      - reversions: Transaction reversion status
-      - idempotency_keys: Idempotency keys
-      - references: Transaction references
-      - ledgers: Ledger info
-      - boundaries: Ledger boundaries
+      The `type` label is displayed dynamically so newly introduced cache
+      registries appear without requiring a dashboard update.
    |||,
   ),
 

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/pebble.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/pebble.libsonnet
@@ -9,7 +9,7 @@ panels.row('Pebble', 165, [
     'Flush / second',
     { h: 8, w: 8, x: 0, y: 88 },
     [
-      { expr: 'sum by (service.node_id, status, reason) (rate({__name__="pebble.flush.total", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}} {{db}} {{status}} {{reason}}' },
+      { expr: 'sum by (service.node_id, status, reason) (rate({__name__="pebble.flush.total", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}} {{status}} {{reason}}' },
     ],
     description=|||
       Number of Pebble flush operations per second. Flushes write data from memory (memtable) to disk (SSTable).
@@ -29,10 +29,10 @@ panels.row('Pebble', 165, [
     'Flush duration (ms)',
     { h: 8, w: 8, x: 8, y: 88 },
     [
-      { expr: 'histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p50 {{db}}' },
-      { expr: 'histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p95 {{db}}' },
-      { expr: 'histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p99 {{db}}' },
-      { expr: queries.histogramAvg('pebble.flush.duration.milliseconds', by=['service.node_id'], selector='"scope.name"="pebble.runtime_store"'), legendFormat: 'Node {{service.node_id}} mean {{db}}' },
+      { expr: 'histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p50' },
+      { expr: 'histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p95' },
+      { expr: 'histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__="pebble.flush.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p99' },
+      { expr: queries.histogramAvg('pebble.flush.duration.milliseconds', by=['service.node_id']), legendFormat: 'Node {{service.node_id}} mean' },
     ], unit='ms',
     description=|||
       Pebble flush duration percentiles (P50, P95, P99) in milliseconds.
@@ -52,7 +52,7 @@ panels.row('Pebble', 165, [
     'Flush input bytes / second',
     { h: 8, w: 8, x: 16, y: 88 },
     [
-      { expr: 'sum by (service.node_id) (rate({__name__="pebble.flush.input.bytes_sum", "scope.name"="pebble.runtime_store"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('pebble.flush.input.bytes', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='Bps',
     description=|||
       Rate of bytes flushed from memtables to SSTables per second.
@@ -72,7 +72,7 @@ panels.row('Pebble', 165, [
     'Compactions / second',
     { h: 8, w: 8, x: 0, y: 96 },
     [
-      { expr: 'sum by (service.node_id, db, status, reason) (rate({__name__="pebble.compaction.total", "scope.name"="pebble.runtime_store"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}}: {{status}} {{reason}}' },
+      { expr: 'sum by (service.node_id, status, reason) (rate({__name__="pebble.compaction.total", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}}: {{status}} {{reason}}' },
     ],
     description=|||
       Number of Pebble compaction operations per second. Compactions merge and reorganize SSTables.
@@ -93,10 +93,10 @@ panels.row('Pebble', 165, [
     'Compaction duration (ms)',
     { h: 8, w: 8, x: 8, y: 96 },
     [
-      { expr: 'histogram_quantile(0.50, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p50' },
-      { expr: 'histogram_quantile(0.95, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p95 ' },
-      { expr: 'histogram_quantile(0.99, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p99' },
-      { expr: queries.histogramAvg('pebble.compaction.duration.milliseconds', by=['service.node_id'], selector='"scope.name"="pebble.runtime_store"'), legendFormat: 'Node {{service.node_id}}: mean' },
+      { expr: 'histogram_quantile(0.50, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p50' },
+      { expr: 'histogram_quantile(0.95, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p95 ' },
+      { expr: 'histogram_quantile(0.99, sum by (service.node_id, le) (rate({__name__="pebble.compaction.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}}: p99' },
+      { expr: queries.histogramAvg('pebble.compaction.duration.milliseconds', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}: mean' },
     ], unit='ms',
     description=|||
       Pebble compaction duration percentiles (P50, P95, P99) in milliseconds.
@@ -116,7 +116,7 @@ panels.row('Pebble', 165, [
     'Compaction errors / second',
     { h: 8, w: 8, x: 16, y: 96 },
     [
-      { expr: 'sum by (service.node_id, reason) (rate({__name__="pebble.compaction.total", status="error", "scope.name"="pebble.runtime_store"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}}: {{reason}}' },
+      { expr: 'sum by (service.node_id, reason) (rate({__name__="pebble.compaction.total", status="error", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}}: {{reason}}' },
     ],
     description=|||
       Rate of compaction errors per second.
@@ -139,7 +139,7 @@ panels.row('Pebble', 165, [
     'Write stall active (max)',
     { h: 8, w: 8, x: 0, y: 104 },
     [
-      { expr: 'max by (service.node_id, reason) ({__name__="pebble.write_stall.active"})', legendFormat: '{{service.node_id}} / {{reason}}' },
+      { expr: 'max by (service.node_id, reason) ({__name__="pebble.write_stall.active", "service.cluster"=~"$cluster", "service.node_id"=~"$node"})', legendFormat: '{{service.node_id}} / {{reason}}' },
     ],
     description=|||
       Shows if Pebble is currently stalling writes (1 = stalling, 0 = normal).
@@ -164,7 +164,7 @@ panels.row('Pebble', 165, [
     'Write stalls / second',
     { h: 8, w: 8, x: 8, y: 104 },
     [
-      { expr: 'sum by (db, reason) (rate({__name__="pebble.write_stall.total"}[$__rate_interval]))', legendFormat: '{{db}} / {{reason}}' },
+      { expr: 'sum by (service.node_id, reason) (rate({__name__="pebble.write_stall.total", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}} / {{reason}}' },
     ],
     description=|||
       Number of write stall events per second. Each stall temporarily blocks write operations.
@@ -187,10 +187,10 @@ panels.row('Pebble', 165, [
     'Write stall duration',
     { h: 8, w: 8, x: 16, y: 104 },
     [
-      { expr: 'histogram_quantile(0.50, sum by (le, db) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket"}[$__rate_interval])))', legendFormat: 'p50 {{db}}' },
-      { expr: 'histogram_quantile(0.95, sum by (le, db) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'p95 {{db}}' },
-      { expr: 'histogram_quantile(0.99, sum by (le, db) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store"}[$__rate_interval])))', legendFormat: 'p99 {{db}}' },
-      { expr: queries.histogramAvg('pebble.write_stall.duration.milliseconds', by=['service.node_id'], selector='"scope.name"="pebble.runtime_store"'), legendFormat: 'mean' },
+      { expr: 'histogram_quantile(0.50, sum by (le, service.node_id) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p50' },
+      { expr: 'histogram_quantile(0.95, sum by (le, service.node_id) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p95' },
+      { expr: 'histogram_quantile(0.99, sum by (le, service.node_id) (rate({__name__="pebble.write_stall.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p99' },
+      { expr: queries.histogramAvg('pebble.write_stall.duration.milliseconds', by=['service.node_id']), legendFormat: 'Node {{service.node_id}} mean' },
     ], unit='ms',
     description=|||
       Duration of write stalls (P50, P95, P99) in seconds. Shows how long writes are blocked.
@@ -210,8 +210,8 @@ panels.row('Pebble', 165, [
     'VFS IOPS (read / write)',
     { h: 8, w: 8, x: 0, y: 112 },
     [
-      { expr: 'rate({__name__="pebble.vfs.read.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — reads/s' },
-      { expr: 'rate({__name__="pebble.vfs.write.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — writes/s' },
+      { expr: 'rate({__name__="pebble.vfs.read.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — reads/s' },
+      { expr: 'rate({__name__="pebble.vfs.write.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — writes/s' },
     ], unit='ops',
     description=|||
       VFS-level read and write operations per second. Counted at the Pebble VFS layer — each Read()/ReadAt() or Write()/WriteAt() syscall increments the counter.
@@ -224,7 +224,7 @@ panels.row('Pebble', 165, [
     'VFS Sync ops/s',
     { h: 8, w: 8, x: 8, y: 112 },
     [
-      { expr: 'rate({__name__="pebble.vfs.sync.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — syncs/s' },
+      { expr: 'rate({__name__="pebble.vfs.sync.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} — syncs/s' },
     ], unit='ops',
     description=|||
       VFS-level sync (fsync) operations per second. Each Sync(), SyncTo(), or SyncData() call is counted.
@@ -237,9 +237,9 @@ panels.row('Pebble', 165, [
     'VFS Total ops (cumulative)',
     { h: 8, w: 8, x: 16, y: 112 },
     [
-      { expr: '{__name__="pebble.vfs.read.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — reads' },
-      { expr: '{__name__="pebble.vfs.write.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — writes' },
-      { expr: '{__name__="pebble.vfs.sync.ops", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — syncs' },
+      { expr: '{__name__="pebble.vfs.read.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — reads' },
+      { expr: '{__name__="pebble.vfs.write.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — writes' },
+      { expr: '{__name__="pebble.vfs.sync.ops", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}} — syncs' },
     ],
     description='Cumulative VFS read, write, and sync operations. Useful for comparing total I/O volume across nodes.',
   ),
@@ -248,7 +248,7 @@ panels.row('Pebble', 165, [
     'Disk slow events / second',
     { h: 8, w: 12, x: 0, y: 120 },
     [
-      { expr: 'sum by (op) (rate({__name__="pebble.disk_slow.total", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: '{{op}}' },
+      { expr: 'sum by (service.node_id, op) (rate({__name__="pebble.disk_slow.total", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval]))', legendFormat: 'Node {{service.node_id}} / {{op}}' },
     ],
     description=|||
       Number of slow disk operations detected by Pebble per second. A slow disk event fires when a write operation exceeds Pebble's disk slowness threshold.
@@ -263,9 +263,9 @@ panels.row('Pebble', 165, [
     'Disk slow duration',
     { h: 8, w: 12, x: 12, y: 120 },
     [
-      { expr: 'histogram_quantile(0.50, sum by (le, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'p50 {{op}}' },
-      { expr: 'histogram_quantile(0.95, sum by (le, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'p95 {{op}}' },
-      { expr: 'histogram_quantile(0.99, sum by (le, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "scope.name"="pebble.runtime_store", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'p99 {{op}}' },
+      { expr: 'histogram_quantile(0.50, sum by (le, service.node_id, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p50 {{op}}' },
+      { expr: 'histogram_quantile(0.95, sum by (le, service.node_id, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p95 {{op}}' },
+      { expr: 'histogram_quantile(0.99, sum by (le, service.node_id, op) (rate({__name__="pebble.disk_slow.duration.milliseconds_bucket", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])))', legendFormat: 'Node {{service.node_id}} p99 {{op}}' },
     ], unit='ms',
     description=|||
       Duration of slow disk operations (P50, P95, P99). Shows how long disk operations have been stalled when Pebble detects slowness.

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/pyroscope.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/pyroscope.libsonnet
@@ -11,7 +11,6 @@ panels.row('Profiling (Pyroscope)', 174, [
     description=|||
       CPU flame graph from Pyroscope continuous profiling. Shows where CPU time is spent in the application.
       
-      Use the version tag to compare profiles between different builds.
    |||,
   ),
 
@@ -32,7 +31,7 @@ panels.row('Profiling (Pyroscope)', 174, [
   panels.flamegraph(
     'Goroutines Flame Graph',
     { h: 20, w: 24, x: 0, y: 152 },
-    'goroutine:goroutine:count:goroutine:count',
+    'goroutines:goroutine:count:goroutine:count',
     description='Goroutine flame graph from Pyroscope. Shows goroutine stack traces.',
   ),
 ])

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/ready_loop.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/ready_loop.libsonnet
@@ -9,7 +9,7 @@ panels.row('Ready Loop', 2, [
     'Process ready entry time passed',
     { h: 8, w: 12, x: 0, y: 3 },
     [
-      { expr: 'rate({"raft.process_entry_sum", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('raft.process_entry', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Time spent processing Raft 'Ready' state (in microseconds). The Ready loop is the main Raft processing cycle.
@@ -30,7 +30,7 @@ panels.row('Ready Loop', 2, [
     'Process ready entry rate',
     { h: 8, w: 12, x: 0, y: 11 },
     [
-      { expr: 'sum(rate(raft.process_entry_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramCountRate('raft.process_entry', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='ops',
     description=|||
       Number of Raft ready entries processed per second.
@@ -66,7 +66,7 @@ panels.row('Ready Loop', 2, [
     'Append entries time passed',
     { h: 8, w: 12, x: 0, y: 27 },
     [
-      { expr: 'sum(rate(raft.append_entries_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('raft.append_entries', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Time spent appending entries to the Write-Ahead Log (WAL) in microseconds.
@@ -122,28 +122,10 @@ panels.row('Ready Loop', 2, [
   ),
 
   panels.timeseries(
-    'WAL cache update time',
-    { h: 8, w: 12, x: 0, y: 51 },
-    [
-      { expr: 'rate(wal.append.cache.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
-    ], unit='µs',
-    description=|||
-      Time spent updating the in-memory cache (s.entries) during WAL append operations, in microseconds.
-      
-      This measures the time to update the in-memory entry cache before persisting to disk. Should be very fast as it's purely in-memory operations.
-      
-      High values may indicate:
-      - Memory pressure
-      - Large entry batches
-      - GC pauses
-   |||, opts={ fillOpacity: 0, showPoints: 'auto' },
-  ),
-
-  panels.timeseries(
     'WAL save time',
     { h: 8, w: 12, x: 12, y: 59 },
     [
-      { expr: 'rate(wal.append.save.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('wal.append.save.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Time spent saving entries to the Write-Ahead Log (WAL) on disk, in microseconds.
@@ -203,7 +185,7 @@ panels.row('Ready Loop', 2, [
     'Ready rate',
     { h: 8, w: 12, x: 0, y: 83 },
     [
-      { expr: 'sum(rate(raft.node.ready.wait_duration_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramCountRate('raft.node.ready.wait_duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='ops',
     description=|||
       Number of Ready events processed per second. Each Ready contains a batch of entries to apply to the state machine.
@@ -218,7 +200,7 @@ panels.row('Ready Loop', 2, [
     'Ready wait cumulated',
     { h: 8, w: 12, x: 12, y: 91 },
     [
-      { expr: 'rate({"raft.node.ready.wait_duration_sum", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: '__auto' },
+      { expr: queries.histogramSumRate('raft.node.ready.wait_duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs', opts={ fillOpacity: 0, showPoints: 'auto' },
   ),
 
@@ -240,7 +222,7 @@ panels.row('Ready Loop', 2, [
     'Unspool duration',
     { h: 7, w: 12, x: 0, y: 115 },
     [
-      { expr: 'rate(raft.node.unspool.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('raft.node.unspool.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Time spent in unspoolAndResume after a maintenance task (snapshot or checkpoint restore). During this time, spooled entries are replayed into the store.
@@ -281,8 +263,8 @@ panels.row('Ready Loop', 2, [
     'Gating timeline (snapshot creation vs replay spool)',
     { h: 7, w: 24, x: 0, y: 143 },
     [
-      { expr: 'rate(raft.node.maintenance.snapshot_creation.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}: Snapshot creation' },
-      { expr: 'rate(raft.node.maintenance.replay_spool.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}: Replay spool' },
+      { expr: queries.histogramSumRate('raft.node.maintenance.snapshot_creation.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}: Snapshot creation' },
+      { expr: queries.histogramSumRate('raft.node.maintenance.replay_spool.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}: Replay spool' },
     ], unit='µs',
     description=|||
       Gating timeline breakdown: snapshot creation time vs replay spool time (stacked bars).
@@ -301,7 +283,7 @@ panels.row('Ready Loop', 2, [
     'FSM rotation duration',
     { h: 7, w: 8, x: 0, y: 150 },
     [
-      { expr: 'rate(raft.fsm.rotation.duration_sum{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramSumRate('raft.fsm.rotation.duration', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='µs',
     description=|||
       Time spent in generation rotation (boundary flush) during ApplyEntries.

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/storage_disk.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/storage_disk.libsonnet
@@ -6,20 +6,10 @@ local panels = import '../lib/panels.libsonnet';
 panels.row('Storage Disk Usage', 172, [
   panels.timeseries(
     'Disk Usage by Volume',
-    { h: 8, w: 12, x: 0, y: 91 },
+    { h: 8, w: 24, x: 0, y: 91 },
     [
       { expr: 'storage.disk.volume.bytes{service.cluster=~"$cluster", service.node_id=~"$node", volume="wal"}', legendFormat: 'WAL Volume (Node {{service.node_id}})' },
       { expr: 'storage.disk.volume.bytes{service.cluster=~"$cluster", service.node_id=~"$node", volume="data"}', legendFormat: 'Data Volume (Node {{service.node_id}})' },
-    ], unit='bytes',
-    description='Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.',
-  ),
-
-  panels.timeseries(
-    'Disk Usage by Volume',
-    { h: 8, w: 12, x: 12, y: 91 },
-    [
-      { expr: 'storage.disk.volume.bytes{service.cluster=~"$cluster", service.node_id=~"$node", volume="wal"}', legendFormat: 'WAL (Node {{service.node_id}})' },
-      { expr: 'storage.disk.volume.bytes{service.cluster=~"$cluster", service.node_id=~"$node", volume="data"}', legendFormat: 'Data (Node {{service.node_id}})' },
     ], unit='bytes',
     description='Disk space used by each storage volume (WAL volume, data volume). Updated every 10 seconds by a background collector.',
   ),

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/system.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/system.libsonnet
@@ -2,6 +2,7 @@
 // Edit freely: panel constructors live in ../lib/panels.libsonnet.
 
 local panels = import '../lib/panels.libsonnet';
+local queries = import '../lib/queries.libsonnet';
 
 panels.row('System', 0, [
   panels.timeseries(
@@ -26,7 +27,7 @@ panels.row('System', 0, [
     'Ping latency',
     { h: 8, w: 12, x: 12, y: 1 },
     [
-      { expr: 'rate({"raft.transport.ping.latency_sum", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}} / Peer {{scope.attributes.peer}}' },
+      { expr: queries.histogramAvg('raft.transport.ping.latency', by=['service.node_id', 'peer']), legendFormat: 'Node {{service.node_id}} / Peer {{peer}}' },
     ], unit='µs',
     description=|||
       Round-trip time (RTT) latency of ping requests between nodes. Measures network health between cluster members.
@@ -46,7 +47,7 @@ panels.row('System', 0, [
     'HTTP requests count',
     { h: 8, w: 12, x: 0, y: 93 },
     [
-      { expr: 'sum(rate({"http.server.request.duration_count", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}[$__rate_interval])) by (service.node_id, http.response.status_code)', legendFormat: 'Node {{service.node_id}} : {{http.response.status_code}}' },
+      { expr: queries.histogramCountRate('http.server.request.duration', by=['service.node_id', 'http.response.status_code']), legendFormat: 'Node {{service.node_id}} : {{http.response.status_code}}' },
     ], unit='ops',
     description=|||
       HTTP request rate per node, grouped by status code. Shows API traffic and error rates.
@@ -93,7 +94,6 @@ panels.row('System', 0, [
       { expr: 'max by (service.node_id) (
   go.processor.limit{service.cluster=~"$cluster", service.node_id=~"$node"}
 )', legendFormat: 'Node {{service.node_id}}: Limit' },
-      '',
     ], unit='percentunit',
     description=|||
       CPU utilization as a ratio of process CPU time to available processor limit. Shows how much CPU capacity the process is using.
@@ -166,7 +166,6 @@ panels.row('System', 0, [
     { h: 8, w: 8, x: 16, y: 109 },
     [
       { expr: '{"raft.node.lead", "service.cluster"=~"$cluster", "service.node_id"=~"$node"}', legendFormat: 'Node {{service.node_id}}' },
-      { expr: '', legendFormat: '__auto' },
     ],
     description=|||
       Shows which node is recognized as the Raft leader by each node. All nodes should report the same leader ID.

--- a/misc/devenv/monitoring-dashboards/jsonnet/sections/transport.libsonnet
+++ b/misc/devenv/monitoring-dashboards/jsonnet/sections/transport.libsonnet
@@ -2,13 +2,14 @@
 // Edit freely: panel constructors live in ../lib/panels.libsonnet.
 
 local panels = import '../lib/panels.libsonnet';
+local queries = import '../lib/queries.libsonnet';
 
 panels.row('Transport & Queues', 1, [
   panels.timeseries(
     'Reception channel incoming messages',
     { h: 6, w: 24, x: 0, y: 2 },
     [
-      { expr: 'rate(raft.transport.recv.load_count{service.cluster=~"$cluster", service.node_id=~"$node", scope.name="raft.transport"}[30s])', legendFormat: 'Node {{service.node_id}}: p{{scope.attributes.priority}}' },
+      { expr: queries.histogramCountRate('raft.transport.recv.load', by=['service.node_id', 'priority', 'priority_name']), legendFormat: 'Node {{service.node_id}}: {{priority_name}}' },
     ], unit='short',
     description=|||
       Rate of Raft messages received from other nodes, grouped by message type.
@@ -28,12 +29,9 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Reception channel load (High Priority: Heartbeats)',
     { h: 10, w: 8, x: 0, y: 92 },
-    'sum(
-  rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"1"}[$__rate_interval])
-) by (service.node_id, le)
-',
+    'sum(rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="0"}[$__rate_interval])) by (service.node_id, le)',
     description=|||
-      Heatmap showing queue depth distribution for high-priority received messages (priority 1).
+      Heatmap showing queue depth distribution for high-priority received messages (priority 0).
       
       High-priority messages include:
       - AppendEntries responses (AppResp)
@@ -50,9 +48,7 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Reception channel load (Medium Priority: Votes/Responses)',
     { h: 10, w: 8, x: 8, y: 92 },
-    'sum(
-  rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"1"}[$__rate_interval])
-) by (service.node_id, le)',
+    'sum(rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="1"}[$__rate_interval])) by (service.node_id, le)',
     description=|||
       Heatmap showing queue depth distribution for medium-priority received messages (priority 1).
       
@@ -66,10 +62,7 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Reception channel load (Low Priority: Data)',
     { h: 10, w: 8, x: 16, y: 92 },
-    'sum(
-  rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"2"}[$__rate_interval])
-) by (service.node_id, le)
-',
+    'sum(rate(raft.transport.recv.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="2"}[$__rate_interval])) by (service.node_id, le)',
     description=|||
       Heatmap showing queue depth distribution for lower-priority received messages (priority 2).
       
@@ -85,7 +78,7 @@ panels.row('Transport & Queues', 1, [
   panels.gauge(
     'Reception channel full count',
     { h: 4, w: 24, x: 0, y: 102 },
-    'sum(increase(raft.transport.recv.full{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, scope.attributes.priority_name)', unit='short',
+    'sum(increase(raft.transport.recv.full{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, priority_name)', unit='short',
     description=|||
       Total number of times the reception channel was full and messages were dropped.
       
@@ -99,14 +92,14 @@ panels.row('Transport & Queues', 1, [
       Increase queue capacity or investigate why processing is slow.
       
       See: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#reception-channel-metrics
-   |||, opts={ legendFormat: '{{scope.attributes.priority_name}}' },
+   |||, opts={ legendFormat: '{{priority_name}}' },
   ),
 
   panels.timeseries(
     'Transport Unreachable Channel - Incoming Messages',
     { h: 10, w: 8, x: 0, y: 106 },
     [
-      { expr: 'rate(raft.transport.unreachable.load_count{service.cluster=~"$cluster", service.node_id=~"$node", scope.name="raft.transport"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramCountRate('raft.transport.unreachable.load', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='ops',
     description=|||
       Rate of 'unreachable' notifications received. These indicate that a peer node could not be reached.
@@ -148,14 +141,14 @@ panels.row('Transport & Queues', 1, [
       Non-zero values indicate the system cannot process unreachable notifications fast enough, which may delay failure detection.
       
       See: https://github.com/formancehq/ledger/v3/blob/master/docs/metrics.md#unreachable-channel-metrics
-   |||, opts={ legendFormat: '{{scope.name}}' },
+   |||, opts={ legendFormat: 'Node {{service.node_id}}' },
   ),
 
   panels.timeseries(
     'Pending Send Queue Throughput',
     { h: 10, w: 8, x: 0, y: 116 },
     [
-      { expr: 'sum(rate(raft.send.pending_messages.load_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id)', legendFormat: 'Node {{service.node_id}}' },
+      { expr: queries.histogramCountRate('raft.send.pending_messages.load', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}' },
     ], unit='ops',
     description=|||
       Throughput of the pending send queue. This is the rate at which message batches are being queued for dispatch to peers.
@@ -197,7 +190,7 @@ panels.row('Transport & Queues', 1, [
     'Send channel incoming messages',
     { h: 6, w: 12, x: 0, y: 126 },
     [
-      { expr: 'sum(rate(raft.transport.peer.sending.load_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, scope.attributes.peer, type)', legendFormat: 'Node {{service.node_id}}: Peer {{scope.attributes.peer}}' },
+      { expr: queries.histogramCountRate('raft.transport.peer.sending.load', by=['service.node_id', 'peer', 'priority_name']), legendFormat: 'Node {{service.node_id}}: Peer {{peer}} / {{priority_name}}' },
     ], unit='short',
     description=|||
       Rate of Raft messages being queued for sending to each peer, grouped by message type.
@@ -217,7 +210,7 @@ panels.row('Transport & Queues', 1, [
     'Send channel full count',
     { h: 6, w: 12, x: 12, y: 126 },
     [
-      { expr: 'sum(increase(raft.transport.peer.sending.full{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, scope.attributes.priority_name)', legendFormat: 'Node {{service.node_id}} : Peer {{peer}}: p{{scope.attributes.priority}}' },
+      { expr: 'sum(increase(raft.transport.peer.sending.full{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, peer, priority_name)', legendFormat: 'Node {{service.node_id}}: Peer {{peer}} / {{priority_name}}' },
     ], unit='ops',
     description=|||
       Rate of times the per-peer send channel was full and messages were dropped.
@@ -238,12 +231,9 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Send channel load (High Priority: Heartbeats)',
     { h: 10, w: 8, x: 0, y: 132 },
-    'sum(
-  rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"1"}[$__rate_interval])
-) by (service.node_id, scope.attributes.peer, le)
-',
+    'sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="0"}[$__rate_interval])) by (service.node_id, peer, le)',
     description=|||
-      Heatmap showing per-peer send queue depth for high-priority messages (priority 1).
+      Heatmap showing per-peer send queue depth for high-priority messages (priority 0).
       
       High-priority outbound messages:
       - AppendEntries responses
@@ -260,9 +250,7 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Send channel load (Medium Priority: Votes/Responses)',
     { h: 10, w: 8, x: 8, y: 132 },
-    'sum(
-  rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"1"}[$__rate_interval])
-) by (service.node_id, le)',
+    'sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="1"}[$__rate_interval])) by (service.node_id, peer, le)',
     description=|||
       Heatmap showing queue depth distribution for medium-priority outgoing messages (priority 1).
       
@@ -276,10 +264,7 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Send channel load (Low Priority: Data)',
     { h: 10, w: 8, x: 16, y: 132 },
-    'sum(
-  rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", scope.attributes.priority=~"2"}[$__rate_interval])
-) by (service.node_id, scope.attributes.peer, le)
-',
+    'sum(rate(raft.transport.peer.sending.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node", priority="2"}[$__rate_interval])) by (service.node_id, peer, le)',
     description=|||
       Heatmap showing per-peer send queue depth for lower-priority messages (priority 2).
       
@@ -299,7 +284,7 @@ panels.row('Transport & Queues', 1, [
     'Propose queue incoming messages',
     { h: 8, w: 8, x: 0, y: 142 },
     [
-      { expr: 'rate(admission.propose_queue.load_count{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])', legendFormat: 'Node {{service.node_id}}: Incoming' },
+      { expr: queries.histogramCountRate('admission.propose_queue.load', by=['service.node_id']), legendFormat: 'Node {{service.node_id}}: Incoming' },
     ], unit='ops',
     description=|||
       Rate of proposals (transactions) entering and leaving the propose queue.
@@ -319,10 +304,7 @@ panels.row('Transport & Queues', 1, [
   panels.heatmap(
     'Propose channel load',
     { h: 8, w: 8, x: 8, y: 142 },
-    'sum(
-  rate(admission.propose_queue.load_bucket[$__rate_interval])
-) by (le)
-',
+    'sum(rate(admission.propose_queue.load_bucket{service.cluster=~"$cluster", service.node_id=~"$node"}[$__rate_interval])) by (service.node_id, le)',
     description=|||
       Heatmap showing propose queue depth distribution over time.
       
@@ -365,7 +347,7 @@ panels.row('Transport & Queues', 1, [
     'Pending responses',
     { h: 7, w: 12, x: 0, y: 150 },
     [
-      { expr: '{"raft.transport.sending.pending_response", service.cluster=~"$cluster", service.node_id=~"$node"}', legendFormat: 'Node {{service.node_id}} / Peer : {{scope.attributes.peer}}' },
+      { expr: '{"raft.transport.sending.pending_response", service.cluster=~"$cluster", service.node_id=~"$node"}', legendFormat: 'Node {{service.node_id}} / Peer {{peer}}' },
     ],
     description=|||
       Number of responses awaited from each peer node. Shows in-flight requests to other cluster members.


### PR DESCRIPTION
## What changed

- Make the generated dashboards representation-aware for histogram averages, sums, and counts, and default native variants to the healthy Prometheus Native datasource.
- Remove stale metrics, dropped scope labels, empty and duplicate panels, and invalid Pyroscope/cache selectors; scope every Prometheus panel by cluster and node.
- Export transport peer and priority as measurement attributes and add generated-dashboard plus OTel regression tests.

## Why

The devenv Ledger dashboard mixed classic and native histogram queries, selected a nonexistent datasource, and filtered on labels that the Prometheus pipeline does not retain. Many panels therefore returned no data even though their base metrics were present.

## Risk

**MEDIUM** — query and dashboard generation changes are operational only, but transport metric label emission runs on the Raft network path. No routing, Raft state, persisted format, or business behavior changes.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `go test ./internal/infra/node`
- [x] Targeted tests: `go test ./...` in `misc/devenv/monitoring-dashboards`
- [x] Regeneration: `just generate-dashboards`
- [x] Live Prometheus Native audit: all 202 unique generated PromQL expressions parsed successfully; 153 returned data now and 26 more returned data in the previous 7 days

## Architecture / behavior impact

No persisted state, FSM, API, or compatibility impact. Transport metrics now carry `peer`, `priority`, and `priority_name` as measurement attributes because instrumentation-scope attributes are not exported as Prometheus labels by the deployed pipeline.

## Review focus

Please focus on native/classic histogram helper expansion and the transport metric attribute cardinality.

## Known concerns

The shared VictoriaMetrics-backed `Prometheus` datasource is still unhealthy in the live Grafana environment because of external DNS/connectivity. The standard devenv dashboard now selects the healthy `Prometheus Native` datasource. The 23 expressions with no samples over 7 days cover inactive mirror paths and healthy zero-event error, queue-full, disk-slow, or write-stall paths.