### PR TITLE
test(antithesis): retry a bulk to a definitive outcome at the application level

### DIFF
--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/main.go
@@ -220,8 +220,38 @@ func runWorker(
 		ticket := c.registerInflight(bulk)
 		c.mu.Unlock()
 
+		// Application-level retry to a definitive outcome. The gRPC-layer
+		// retries live inside one call's context, so a cancellation that
+		// kills the call — a dying node propagates codes.Canceled from its
+		// handler, a connection teardown cancels every in-flight RPC — ends
+		// the whole chain with the bulk possibly committed. The request is
+		// rendered ONCE (the idempotency key must pin the first attempt's
+		// identity) and re-submitted until the server gives a commit — served
+		// from its idempotency cache when the lost attempt landed — or a
+		// business rejection. Only this driver's own context ending abandons
+		// a bulk, which the processor's shutdown skip already models.
 		req := applyRequest(bulk)
-		resp, err := client.Apply(ctx, req)
+
+		var (
+			resp *servicepb.ApplyResponse
+			err  error
+		)
+
+		for {
+			resp, err = client.Apply(ctx, req)
+			if err == nil || ctx.Err() != nil {
+				break
+			}
+
+			if !internal.IsTransient(err) && !internal.IsCanceled(err) {
+				break
+			}
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
 
 		dumpBatch(ticket, req, resp, err)
 


### PR DESCRIPTION
## What changed

The model driver's dispatch loop re-submits a bulk until the server gives a definitive
outcome — a commit or a business rejection — instead of treating a cancelled call as final.
The request is rendered once so its idempotency key pins the first attempt, and a landed
lost attempt replays from the server's cache. Only the driver's own context ending abandons
a bulk.

## Why

gRPC-layer retries live inside one call's context, so a cancellation that kills the call
ends the chain with the bulk possibly committed — and the processor then dropped it from
the model, forking it permanently. `codes.Canceled` sits outside `IsTransient` because it
normally means *our* context died, but gRPC uses the same code for a remote cancellation (a
dying node, a connection teardown), which is an ordinary transient. `ctx.Err()` is what
separates the two.

Closes the Canceled-skip fork class; it did not reduce total Antithesis finding counts —
a second mechanism dominates and is still under investigation.

## Risk

**LOW** — test-only, confined to the model driver's dispatch loop.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `go test ./bin/cmds/model/singleton_driver_model/...`
- [x] Broader: local 3-node cluster run, 5 node-kill cycles (0 skips / 42,651 outcomes); 1h
      Antithesis model-only run `ee460a9d…` with zero `TRANSIENT/SHUTDOWN SKIP` lines.

## Architecture / behavior impact

N/A — test harness only.

## Review focus

Rendering the request once is load-bearing: a per-attempt render would mint a new
idempotency key and genuinely double-apply.
