### PR TITLE
chore: add guarded AI PR fix publishing

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -47,12 +47,13 @@ bash scripts/ai-pr-loop 1732 --push
 
 `--push` does not weaken the review boundary. If the first bounded loop reaches `READY_FOR_HUMAN_REVIEW` with a dirty worktree, the launcher:
 
-1. stages the complete isolated fix set and creates one local `fix: address AI review findings` candidate commit;
-2. runs a second **review-only** pass on that exact clean commit, with no fixer configured;
-3. refuses publication unless that candidate commit is approved as-is and the worktree remains clean;
-4. verifies that the remote PR branch still points to the exact head SHA observed before any agent ran;
-5. checks that the candidate is a descendant of that original head;
-6. pushes `HEAD` to the PR branch with an explicit lease on the original head SHA.
+1. creates a second detached worktree at the exact verified base SHA, builds the policy engine in that base's pinned Nix environment, and uses only the base-pinned reviewer/fixer adapters; the PR under review cannot supply the tooling that authorizes its own publication;
+2. stages the complete isolated fix set and creates one local `fix: address AI review findings` candidate commit;
+3. runs a second **review-only** pass on that exact clean commit, with no fixer configured;
+4. refuses publication unless that candidate commit is approved as-is, `HEAD` still equals its immutable SHA, and the worktree remains clean;
+5. verifies that the remote PR branch still points to the exact head SHA observed before any agent ran;
+6. checks that the candidate is a descendant of that original head;
+7. pushes the candidate SHA, rather than the mutable `HEAD` name, to the PR branch with an explicit lease on the original head SHA.
 
 The lease acts as an atomic compare-and-swap guard. The candidate update is still a normal fast-forward, but the push is rejected if another actor updates or rewrites the PR branch between the initial metadata lookup and publication. A failed candidate review, moved remote head, dirty post-review worktree, or failed push preserves the candidate worktree for inspection and never overwrites the remote branch.
 

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -31,11 +31,32 @@ A full PR URL is accepted as well. The launcher:
 - creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
 - passes the verified base commit SHA to `review-loop`, so a later update of the shared remote-tracking ref cannot change the reviewed delta;
 - runs the standard Codex review + Claude fix composition against the PR base;
-- never checks out, edits, commits, pushes, comments, resolves threads, or merges from the primary checkout;
+- never checks out or edits the primary checkout;
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
 
-Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Commit/push automation is intentionally out of scope: this layer only produces an isolated reviewed/fixed worktree and reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
+Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
+
+### Guarded publish mode
+
+Publishing reviewed fixes is explicit and opt-in:
+
+```bash
+bash scripts/ai-pr-loop 1732 --push
+```
+
+`--push` does not weaken the review boundary. If the first bounded loop reaches `READY_FOR_HUMAN_REVIEW` with a dirty worktree, the launcher:
+
+1. stages the complete isolated fix set and creates one local `fix: address AI review findings` candidate commit;
+2. runs a second **review-only** pass on that exact clean commit, with no fixer configured;
+3. refuses publication unless that candidate commit is approved as-is and the worktree remains clean;
+4. verifies that the remote PR branch still points to the exact head SHA observed before any agent ran;
+5. checks that the candidate is a descendant of that original head;
+6. pushes `HEAD` to the PR branch with an explicit lease on the original head SHA.
+
+The lease acts as an atomic compare-and-swap guard. The candidate update is still a normal fast-forward, but the push is rejected if another actor updates or rewrites the PR branch between the initial metadata lookup and publication. A failed candidate review, moved remote head, dirty post-review worktree, or failed push preserves the candidate worktree for inspection and never overwrites the remote branch.
+
+If the bounded loop produces no fixes, `--push` reports `NO_CHANGES` and does not create a commit. The launcher never comments on GitHub, resolves review threads, marks a PR ready, or merges it.
 
 ## Loop states
 
@@ -206,4 +227,4 @@ The adapter does not commit, push, comment on GitHub, resolve threads, or decide
 
 ## Safety boundary
 
-This script deliberately does not post comments, resolve threads, push commits, or merge pull requests. GitHub write automation belongs in a later integration layer after this local state machine has proven stable.
+`review-loop` itself never posts comments, resolves threads, pushes commits, or merges pull requests. The higher-level `ai-pr-loop` also remains read-only with respect to GitHub by default. Its explicit `--push` mode may create a local candidate commit and update only the existing same-repository PR head branch under the verified lease described above; it still never comments, resolves threads, changes PR metadata, or merges.

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -120,10 +120,18 @@ worktree_parent="$repo_parent/.${repo_name}-ai-worktrees"
 mkdir -p "$worktree_parent"
 worktree_run_dir=$(mktemp -d "$worktree_parent/pr-$pr_number.XXXXXX")
 worktree="$worktree_run_dir/worktree"
+trusted_tool_worktree=""
+review_loop_binary=""
 
 cleanup() {
     exit_status=$?
     trap - EXIT
+    if [[ -n "$trusted_tool_worktree" ]] && [[ -d "$trusted_tool_worktree" ]] && git -C "$trusted_tool_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git worktree remove "$trusted_tool_worktree" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$review_loop_binary" ]] && [[ "$review_loop_binary" == "$worktree_run_dir/review-loop" ]]; then
+        rm -f -- "$review_loop_binary"
+    fi
     if [[ "$keep_worktree" == false ]]; then
         if [[ -d "$worktree" ]] && git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             if [[ -z "$(git -C "$worktree" status --porcelain 2>/dev/null || true)" ]]; then
@@ -137,6 +145,29 @@ cleanup() {
 trap cleanup EXIT
 
 git worktree add --detach "$worktree" "$head_sha"
+
+review_loop=(bash scripts/review-loop)
+review_cmd='bash scripts/ai-review-codex'
+fix_cmd='bash scripts/ai-fix-claude'
+if [[ "$push_changes" == "true" ]]; then
+    if ! command -v nix >/dev/null 2>&1; then
+        echo "ai-pr-loop: required command not found in PATH: nix" >&2
+        exit 1
+    fi
+
+    # A PR must not supply the policy engine or provider adapters that authorize
+    # its own publication. Build the orchestrator from the exact verified base
+    # commit and invoke the adapters from the same immutable tool worktree.
+    trusted_tool_worktree="$worktree_run_dir/trusted-tools"
+    review_loop_binary="$worktree_run_dir/review-loop"
+    git worktree add --detach "$trusted_tool_worktree" "$base_sha"
+    nix develop "path:$trusted_tool_worktree" --command \
+        env -u GOROOT go -C "$trusted_tool_worktree" build \
+        -o "$review_loop_binary" ./scripts/reviewloop
+    review_loop=("$review_loop_binary")
+    printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-codex"
+    printf -v fix_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-fix-claude"
+fi
 
 printf '==> ai-pr-loop: PR #%s\n' "$pr_number"
 printf '    URL: %s\n' "$pr_url"
@@ -153,18 +184,18 @@ fi
 cd "$worktree"
 
 run_full_loop() {
-    bash scripts/review-loop \
+    "${review_loop[@]}" \
         --base "$base_sha" \
-        --review-cmd 'bash scripts/ai-review-codex' \
-        --fix-cmd 'bash scripts/ai-fix-claude'
+        --review-cmd "$review_cmd" \
+        --fix-cmd "$fix_cmd"
 }
 
 run_commit_review() {
     # No fixer on this pass: the exact clean commit that may be pushed must be
     # approved as-is. Any new blocker stops publication and requires a rerun.
-    bash scripts/review-loop \
+    "${review_loop[@]}" \
         --base "$base_sha" \
-        --review-cmd 'bash scripts/ai-review-codex'
+        --review-cmd "$review_cmd"
 }
 
 set +e
@@ -241,6 +272,16 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
+current_head=$(git rev-parse HEAD)
+if [[ "$current_head" != "$candidate_sha" ]]; then
+    echo "AI_PR_LOOP_PUSH_RESULT: REFUSED (reviewed candidate HEAD changed)"
+    echo "Reviewed: $candidate_sha"
+    echo "Current:  $current_head"
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit 1
+fi
+
 # Verify the remote still points at the exact PR head observed before any agent
 # ran. The explicit force-with-lease is used only as an atomic compare-and-swap
 # guard; candidate_sha is a normal descendant of head_sha, so the update itself
@@ -270,7 +311,7 @@ fi
 if ! git push \
     --force-with-lease="refs/heads/$head_ref:$head_sha" \
     "$remote" \
-    "HEAD:refs/heads/$head_ref"; then
+    "$candidate_sha:refs/heads/$head_ref"; then
     echo "AI_PR_LOOP_PUSH_RESULT: REFUSED (remote changed during push or push failed)"
     echo "Candidate worktree preserved for inspection: $worktree"
     keep_worktree=true

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -3,11 +3,16 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: bash scripts/ai-pr-loop <pr-number-or-url> [--keep-worktree]
+Usage: bash scripts/ai-pr-loop <pr-number-or-url> [--keep-worktree] [--push]
 
 Creates an isolated git worktree for the PR head and runs the bounded
 Codex review -> Claude fix -> validation -> re-review loop against the
-PR base branch. The launcher never commits, pushes, comments, or merges.
+PR base branch.
+
+By default the launcher never commits or pushes. With --push, fixes are
+committed locally, that exact clean commit is reviewed once more, and it
+is pushed only if the remote PR branch still equals the SHA observed at
+startup. The launcher never comments, resolves threads, or merges.
 EOF
 }
 
@@ -26,10 +31,14 @@ fi
 pr=$1
 shift
 keep_worktree=false
+push_changes=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --keep-worktree)
             keep_worktree=true
+            ;;
+        --push)
+            push_changes=true
             ;;
         -h|--help)
             usage
@@ -137,16 +146,29 @@ printf '    worktree: %s\n' "$worktree"
 if [[ "$is_draft" == "true" ]]; then
     echo "    note: PR is currently draft"
 fi
+if [[ "$push_changes" == "true" ]]; then
+    echo "    publish: guarded commit + push enabled"
+fi
 
 cd "$worktree"
 
+run_full_loop() {
+    bash scripts/review-loop \
+        --base "$base_sha" \
+        --review-cmd 'bash scripts/ai-review-codex' \
+        --fix-cmd 'bash scripts/ai-fix-claude'
+}
+
+run_commit_review() {
+    # No fixer on this pass: the exact clean commit that may be pushed must be
+    # approved as-is. Any new blocker stops publication and requires a rerun.
+    bash scripts/review-loop \
+        --base "$base_sha" \
+        --review-cmd 'bash scripts/ai-review-codex'
+}
+
 set +e
-# The remote-tracking ref is shared and can move after the verification above.
-# Pass the verified commit identity so review-loop always captures this base.
-bash scripts/review-loop \
-    --base "$base_sha" \
-    --review-cmd 'bash scripts/ai-review-codex' \
-    --fix-cmd 'bash scripts/ai-fix-claude'
+run_full_loop
 loop_status=$?
 set -e
 
@@ -163,11 +185,97 @@ case "$loop_status" in
         ;;
 esac
 
-if [[ -n "$(git status --porcelain)" ]]; then
-    echo "Worktree contains fixes to inspect: $worktree"
-    keep_worktree=true
-else
-    echo "Worktree is clean."
+if [[ "$loop_status" -ne 0 ]]; then
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Worktree contains fixes to inspect: $worktree"
+        keep_worktree=true
+    fi
+    exit "$loop_status"
 fi
 
-exit "$loop_status"
+if [[ "$push_changes" == "false" ]]; then
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Worktree contains fixes to inspect: $worktree"
+        keep_worktree=true
+    else
+        echo "Worktree is clean."
+    fi
+    exit 0
+fi
+
+if [[ -z "$(git status --porcelain)" ]]; then
+    echo "No local fixes to publish; remote PR branch is unchanged."
+    echo "AI_PR_LOOP_PUSH_RESULT: NO_CHANGES"
+    exit 0
+fi
+
+# The worktree is isolated and all mutations came from the bounded fixer.
+# Stage the complete resulting fix set, then create one local candidate commit.
+git add -A
+if git diff --cached --quiet; then
+    echo "ai-pr-loop: worktree reported changes but nothing is staged" >&2
+    keep_worktree=true
+    exit 1
+fi
+
+git commit -m "fix: address AI review findings"
+candidate_sha=$(git rev-parse HEAD)
+printf '==> ai-pr-loop: candidate commit %s\n' "$candidate_sha"
+
+set +e
+run_commit_review
+commit_review_status=$?
+set -e
+
+if [[ "$commit_review_status" -ne 0 ]]; then
+    echo "AI_PR_LOOP_PUSH_RESULT: REFUSED (candidate commit was not approved)"
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit "$commit_review_status"
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "ai-pr-loop: candidate review left the worktree dirty; refusing push" >&2
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit 1
+fi
+
+# Verify the remote still points at the exact PR head observed before any agent
+# ran. The explicit force-with-lease is used only as an atomic compare-and-swap
+# guard; candidate_sha is a normal descendant of head_sha, so the update itself
+# remains a fast-forward.
+remote_head=""
+read -r remote_head _ < <(git ls-remote --exit-code "$remote" "refs/heads/$head_ref") || true
+if [[ -z "$remote_head" ]]; then
+    echo "ai-pr-loop: could not resolve current remote PR head" >&2
+    keep_worktree=true
+    exit 1
+fi
+if [[ "$remote_head" != "$head_sha" ]]; then
+    echo "AI_PR_LOOP_PUSH_RESULT: REFUSED (remote PR head moved)"
+    echo "Expected: $head_sha"
+    echo "Current:  $remote_head"
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit 2
+fi
+
+if ! git merge-base --is-ancestor "$head_sha" "$candidate_sha"; then
+    echo "ai-pr-loop: candidate commit is not a descendant of the original PR head" >&2
+    keep_worktree=true
+    exit 1
+fi
+
+if ! git push \
+    --force-with-lease="refs/heads/$head_ref:$head_sha" \
+    "$remote" \
+    "HEAD:refs/heads/$head_ref"; then
+    echo "AI_PR_LOOP_PUSH_RESULT: REFUSED (remote changed during push or push failed)"
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit 2
+fi
+
+echo "AI_PR_LOOP_PUSH_RESULT: PUSHED $candidate_sha"
+exit 0

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -1,0 +1,153 @@
+package aiprloop
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushReviewsCandidateCommitBeforePublishing(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, false)
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 0, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+
+	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
+	require.NotEqual(t, fixture.headSHA, remoteHead)
+	require.Equal(t, fixture.headSHA, runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", remoteHead+"^"))
+
+	countBytes, err := os.ReadFile(fixture.reviewCountFile)
+	require.NoError(t, err)
+	require.Equal(t, "2", strings.TrimSpace(string(countBytes)))
+}
+
+func TestPushRefusesWhenRemoteHeadMoves(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, true)
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 2, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: REFUSED (remote PR head moved)")
+
+	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
+	require.Equal(t, fixture.baseSHA, remoteHead)
+}
+
+type pushFixture struct {
+	root            string
+	remote          string
+	checkout        string
+	fakeBin         string
+	baseSHA         string
+	headSHA         string
+	reviewCountFile string
+	moveRemote      bool
+}
+
+func newPushFixture(t *testing.T, moveRemote bool) pushFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	seed := filepath.Join(root, "seed")
+	checkout := filepath.Join(root, "checkout")
+
+	runGit(t, root, "init", "--bare", remote)
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "scripts"), 0o755))
+	runGit(t, seed, "init")
+	runGit(t, seed, "config", "user.name", "AI PR Loop Test")
+	runGit(t, seed, "config", "user.email", "ai-pr-loop@example.com")
+
+	launcher, err := os.ReadFile(launcherPath(t))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [[ -f "$TEST_REVIEW_COUNT_FILE" ]]; then
+    count=$(cat "$TEST_REVIEW_COUNT_FILE")
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$TEST_REVIEW_COUNT_FILE"
+if [[ "$count" -eq 1 ]]; then
+    printf 'review fix\n' >> feature.txt
+elif [[ "$count" -eq 2 && "${TEST_MOVE_REMOTE:-false}" == "true" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/feature "$TEST_BASE_SHA"
+fi
+exit 0
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
+	runGit(t, seed, "add", ".")
+	runGit(t, seed, "commit", "-m", "base")
+	runGit(t, seed, "branch", "-M", "release/v3.0")
+	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "remote", "add", "origin", remote)
+	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+
+	runGit(t, seed, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
+	runGit(t, seed, "add", "feature.txt")
+	runGit(t, seed, "commit", "-m", "feature")
+	headSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "push", "-u", "origin", "feature")
+	runGit(t, root, "clone", "--branch", "release/v3.0", remote, checkout)
+	runGit(t, checkout, "config", "user.name", "AI PR Loop Test")
+	runGit(t, checkout, "config", "user.email", "ai-pr-loop@example.com")
+
+	fakeBin := filepath.Join(root, "bin")
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+	writeExecutable(t, filepath.Join(fakeBin, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+    "repo view")
+        printf 'owner/repo\n'
+        ;;
+    "pr view")
+        printf '{"number":123,"url":"https://github.com/owner/repo/pull/123","state":"OPEN","isDraft":false,"baseRefName":"release/v3.0","baseRefOid":"%s","headRefName":"feature","headRefOid":"%s","headRepositoryOwner":{"login":"owner"},"headRepository":{"name":"repo"}}\n' "$TEST_BASE_SHA" "$TEST_HEAD_SHA"
+        ;;
+    *)
+        exit 98
+        ;;
+esac
+`)
+
+	return pushFixture{
+		root:            root,
+		remote:          remote,
+		checkout:        checkout,
+		fakeBin:         fakeBin,
+		baseSHA:         baseSHA,
+		headSHA:         headSHA,
+		reviewCountFile: filepath.Join(root, "review-count"),
+		moveRemote:      moveRemote,
+	}
+}
+
+func (fixture pushFixture) run(t *testing.T) (string, int) {
+	t.Helper()
+
+	command := exec.Command("bash", filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123", "--push", "--keep-worktree")
+	command.Dir = fixture.checkout
+	command.Env = append(os.Environ(),
+		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_BASE_SHA="+fixture.baseSHA,
+		"TEST_HEAD_SHA="+fixture.headSHA,
+		"TEST_REVIEW_COUNT_FILE="+fixture.reviewCountFile,
+		"TEST_MOVE_REMOTE="+strconv.FormatBool(fixture.moveRemote),
+		"TEST_REMOTE="+fixture.remote,
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		return string(output), 0
+	}
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError, string(output))
+	return string(output), exitError.ExitCode()
+}

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -14,7 +14,7 @@ import (
 func TestPushReviewsCandidateCommitBeforePublishing(t *testing.T) {
 	t.Parallel()
 
-	fixture := newPushFixture(t, false)
+	fixture := newPushFixture(t, pushFixtureOptions{})
 	output, exitCode := fixture.run(t)
 	require.Equal(t, 0, exitCode, output)
 	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
@@ -31,13 +31,40 @@ func TestPushReviewsCandidateCommitBeforePublishing(t *testing.T) {
 func TestPushRefusesWhenRemoteHeadMoves(t *testing.T) {
 	t.Parallel()
 
-	fixture := newPushFixture(t, true)
+	fixture := newPushFixture(t, pushFixtureOptions{moveRemote: true})
 	output, exitCode := fixture.run(t)
 	require.Equal(t, 2, exitCode, output)
 	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: REFUSED (remote PR head moved)")
 
 	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
 	require.Equal(t, fixture.baseSHA, remoteHead)
+}
+
+func TestPushRefusesWhenReviewedCandidateHeadMoves(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, pushFixtureOptions{moveLocalHead: true})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 1, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: REFUSED (reviewed candidate HEAD changed)")
+
+	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
+	require.Equal(t, fixture.headSHA, remoteHead)
+}
+
+func TestPushUsesBasePinnedReviewToolchain(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, pushFixtureOptions{tamperTargetToolchain: true})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 0, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+}
+
+type pushFixtureOptions struct {
+	moveRemote            bool
+	moveLocalHead         bool
+	tamperTargetToolchain bool
 }
 
 type pushFixture struct {
@@ -48,10 +75,10 @@ type pushFixture struct {
 	baseSHA         string
 	headSHA         string
 	reviewCountFile string
-	moveRemote      bool
+	options         pushFixtureOptions
 }
 
-func newPushFixture(t *testing.T, moveRemote bool) pushFixture {
+func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	t.Helper()
 
 	root := t.TempDir()
@@ -68,8 +95,37 @@ func newPushFixture(t *testing.T, moveRemote bool) pushFixture {
 	launcher, err := os.ReadFile(launcherPath(t))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
+	writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
+review_cmd=""
+fix_cmd=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --review-cmd)
+            review_cmd=$2
+            shift 2
+            ;;
+        --fix-cmd)
+            fix_cmd=$2
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+case "$review_cmd" in
+    *trusted-tools/scripts/ai-review-codex) ;;
+    *) exit 95 ;;
+esac
+if [[ -n "$fix_cmd" ]]; then
+    case "$fix_cmd" in
+        *trusted-tools/scripts/ai-fix-claude) ;;
+        *) exit 94 ;;
+    esac
+fi
 count=0
 if [[ -f "$TEST_REVIEW_COUNT_FILE" ]]; then
     count=$(cat "$TEST_REVIEW_COUNT_FILE")
@@ -80,6 +136,10 @@ if [[ "$count" -eq 1 ]]; then
     printf 'review fix\n' >> feature.txt
 elif [[ "$count" -eq 2 && "${TEST_MOVE_REMOTE:-false}" == "true" ]]; then
     git --git-dir="$TEST_REMOTE" update-ref refs/heads/feature "$TEST_BASE_SHA"
+elif [[ "$count" -eq 2 && "${TEST_MOVE_LOCAL_HEAD:-false}" == "true" ]]; then
+    printf 'unreviewed commit\n' > unreviewed.txt
+    git add unreviewed.txt
+    git commit -m 'test: move reviewed candidate head'
 fi
 exit 0
 `)
@@ -93,7 +153,15 @@ exit 0
 
 	runGit(t, seed, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
+	if options.tamperTargetToolchain {
+		writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), "#!/usr/bin/env bash\nexit 97\n")
+		writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 97\n")
+		writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 97\n")
+	}
 	runGit(t, seed, "add", "feature.txt")
+	if options.tamperTargetToolchain {
+		runGit(t, seed, "add", "scripts/review-loop", "scripts/ai-review-codex", "scripts/ai-fix-claude")
+	}
 	runGit(t, seed, "commit", "-m", "feature")
 	headSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
 	runGit(t, seed, "push", "-u", "origin", "feature")
@@ -117,6 +185,31 @@ case "$1 $2" in
         ;;
 esac
 `)
+	writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
+set -euo pipefail
+source_root=""
+output=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C)
+            source_root=$2
+            shift 2
+            ;;
+        -o)
+            output=$2
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [[ -z "$source_root" || -z "$output" ]]; then
+    exit 96
+fi
+cp "$source_root/scripts/review-loop" "$output"
+chmod 755 "$output"
+`)
 
 	return pushFixture{
 		root:            root,
@@ -126,7 +219,7 @@ esac
 		baseSHA:         baseSHA,
 		headSHA:         headSHA,
 		reviewCountFile: filepath.Join(root, "review-count"),
-		moveRemote:      moveRemote,
+		options:         options,
 	}
 }
 
@@ -140,7 +233,8 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 		"TEST_BASE_SHA="+fixture.baseSHA,
 		"TEST_HEAD_SHA="+fixture.headSHA,
 		"TEST_REVIEW_COUNT_FILE="+fixture.reviewCountFile,
-		"TEST_MOVE_REMOTE="+strconv.FormatBool(fixture.moveRemote),
+		"TEST_MOVE_REMOTE="+strconv.FormatBool(fixture.options.moveRemote),
+		"TEST_MOVE_LOCAL_HEAD="+strconv.FormatBool(fixture.options.moveLocalHead),
 		"TEST_REMOTE="+fixture.remote,
 	)
 	output, err := command.CombinedOutput()
@@ -149,5 +243,6 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 	}
 	var exitError *exec.ExitError
 	require.ErrorAs(t, err, &exitError, string(output))
+
 	return string(output), exitError.ExitCode()
 }


### PR DESCRIPTION
## What changed

Extend `scripts/ai-pr-loop` with an explicit `--push` mode for publishing agent-produced fixes back to an existing same-repository PR.

- keep the current no-write behavior as the default
- after the bounded Codex → Claude loop reaches `READY_FOR_HUMAN_REVIEW`, stage and commit the isolated fix set
- re-run a **review-only** pass on the exact clean candidate commit before publication
- refuse to push if that candidate review does not approve as-is or leaves the worktree dirty
- require the remote PR branch to still equal the head SHA observed before any agent ran
- verify the candidate remains a descendant of that original head
- push with an explicit `--force-with-lease=<ref>:<original-sha>` compare-and-swap guard
- preserve the candidate worktree on review/push refusal
- add integration-style tests for candidate re-review and moved-remote refusal
- document guarded publish semantics

## Why

`ai-pr-loop` can now review and fix an arbitrary PR in an isolated worktree, but fixes still require a manual commit/push step. The intended workflow is to let mechanical fixes reach the PR branch without weakening the strong property that the exact state being pushed was reviewed and without overwriting concurrent human/agent changes.

## Risk

MEDIUM

This is the first mode that can update an existing PR branch. It is opt-in and fail-closed: no force overwrite is intended, no GitHub metadata is changed, and no merge/comment/thread action is performed.

## Validation

- existing no-push behavior remains the default
- candidate changes are committed only after the first bounded loop approves them
- the exact clean candidate commit gets a second review-only pass before push
- a moved remote PR head refuses publication and preserves the local candidate
- the push lease is bound to the original GitHub-reported head SHA
- the candidate must be a normal descendant of that original head
- integration tests use a real bare Git remote/worktree flow and verify two review passes before publication

## Architecture / behavior impact

Contributor tooling only. No Ledger runtime behavior changes.

## Review focus

Please focus on:

- whether the `--force-with-lease=<ref>:<original-sha>` usage is a safe atomic compare-and-swap here and cannot overwrite a moved PR branch
- whether any race remains between remote verification and the actual push
- whether the candidate commit is always the exact state approved by the second review
- behavior when the second review returns `AUTO_FIX_REQUIRED`, `HUMAN_DECISION_REQUIRED`, or an orchestration error
- staging/commit scope inside the isolated worktree
- preservation/cleanup of detached candidate commits on failures
- whether a no-change `--push` run behaves correctly
- whether tests sufficiently exercise the publish boundary

## Known concerns

The commit message is intentionally generic (`fix: address AI review findings`) in this first version. Fork/cross-repository PRs remain unsupported. Automatic comments, thread resolution, PR readiness changes, and merging remain out of scope.