### PR TITLE
fix: require local validation before AI approval

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -31,6 +31,8 @@ A full PR URL is accepted as well. The launcher:
 - creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
 - passes the verified base commit SHA to `review-loop`, so a later update of the shared remote-tracking ref cannot change the reviewed delta;
 - runs the standard Codex review + Claude fix composition against the PR base;
+- runs repository validation locally before accepting any approval; no GitHub
+  Actions status participates in the decision;
 - never checks out or edits the primary checkout;
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
@@ -47,7 +49,7 @@ bash scripts/ai-pr-loop 1732 --push
 
 `--push` does not weaken the review boundary. If the first bounded loop reaches `READY_FOR_HUMAN_REVIEW` with a dirty worktree, the launcher:
 
-1. creates a second detached worktree at the exact verified base SHA, builds the policy engine in that base's pinned Nix environment, and uses only the base-pinned reviewer/fixer adapters; the PR under review cannot supply the tooling that authorizes its own publication;
+1. creates a second detached worktree at the exact verified base SHA, builds the policy engine in that base's pinned Nix environment, and uses only the base-pinned reviewer, fixer, and validation tools; the PR under review cannot supply the tooling that authorizes its own publication;
 2. stages the complete isolated fix set and creates one local `fix: address AI review findings` candidate commit;
 3. runs a second **review-only** pass on that exact clean commit, with no fixer configured;
 4. refuses publication unless that candidate commit is approved as-is, `HEAD` still equals its immutable SHA, and the worktree remains clean;
@@ -186,36 +188,32 @@ The fix agent must:
 
 The blocker payload and originating review result are immutable inputs. The orchestrator snapshots both files before invoking the fixer and rejects the pass if either file's contents change or can no longer be read.
 
-After a successful fix command, the orchestrator runs `bash scripts/agent-check` by default. A validation failure stops the loop immediately. Only after validation succeeds does it invoke the reviewer again.
-
-## Local PR validation helper
-
-`scripts/agent-check-pr` provides the local validation profile that can be
-selected from an immutable base-to-worktree diff:
-
-```bash
-AI_REVIEW_BASE_SHA="$(git rev-parse origin/release/v3.0)" \
-  bash scripts/agent-check-pr
-```
-
-It always runs the baseline checks and unit tests, then selects additional
-local gates for production Go paths, scenarios and Numscript, HTTP/OpenAPI,
-the operator module, and stateful cluster paths. Stateful changes run the
-three-node model checker with rolling restarts. These gates are local
+After a successful fix command, the orchestrator runs
+`bash scripts/agent-check-pr` by default. It runs the baseline checks and unit
+tests, then selects additional local gates from the complete
+base-to-worktree diff: E2E tests for production Go paths, scenario tests for
+scenario/Numscript paths, Schemathesis for the HTTP/OpenAPI surface, and
+operator tests for the operator module. Changes to FSM, admission, Raft,
+cluster membership, cache/preload, primary persistence, snapshot/restore, or
+the model-checker harness additionally run the three-node
+`just test-model-cluster 180` gate with rolling restarts. These are local
 correctness profiles selected for the changed architecture, not a mirror of
-GitHub Actions jobs.
+GitHub Actions jobs. A validation failure stops the loop immediately. Only
+after validation succeeds does it invoke the reviewer again.
 
-The helper routes Just recipes through `scripts/agent-just`. That wrapper pins
-the recipe definitions to the checkout containing the wrapper, disables dotenv
-loading, and keeps the reviewed repository as the recipe working directory.
-Script-backed Schemathesis and model-checker gates use runners from that same
-tool checkout while building the reviewed server and reading reviewed inputs
-through explicit paths. The model driver and oracle remain tool-pinned.
-
-This helper is intentionally introduced independently of the `review-loop`
-approval policy. Wiring it as a mandatory guarded-publish validator is a
-separate activation step, after the helper exists in the base-pinned trusted
-tool worktree.
+The same local validation runs after an `APPROVE` decision and before
+`READY_FOR_HUMAN_REVIEW` is emitted. The orchestrator fingerprints the
+workspace again and rejects readiness if a validator changed the state that the
+reviewer approved. It passes the immutable review-base SHA to the validator as
+`AI_REVIEW_BASE_SHA`; in guarded publish mode, the validator itself comes from
+the base-pinned trusted tool worktree. Its `agent-just` wrapper also loads the
+base-pinned `justfile` with dotenv loading disabled while setting the reviewed
+PR worktree as the recipe working directory. A PR therefore cannot replace a
+required recipe with a no-op. Script-backed gates are split the same way:
+Schemathesis and model-checker runners come from the trusted base, while their
+server build, OpenAPI input, and other reviewed sources come from the candidate
+worktree. The model driver/oracle is also base-pinned. The loop does not query
+or wait for GitHub Actions checks.
 
 ## Claude Code fix adapter
 
@@ -240,7 +238,8 @@ The adapter:
 - uses `--permission-mode dontAsk` with project-relative `Read(/**)` and `Edit(/**)` approval, so repository inspection and edits succeed while parent, sibling-worktree, and other external filesystem access fails closed without an interactive prompt;
 - explicitly denies `Bash`, `WebFetch`, `WebSearch`, and edits to `.git` as defense in depth, so the fixer cannot run tests, mutate Git/GitHub state, or access the network through those tools;
 - instructs Claude to make only finding-traceable edits and to avoid guessing through product/design/invariant ambiguity;
-- leaves all validation to the orchestrator's mandatory `bash scripts/agent-check` step before re-review.
+- leaves all validation to the orchestrator's mandatory local
+  `bash scripts/agent-check-pr` gates before re-review and final readiness.
 
 Safe mode deliberately disables automatic instruction discovery, so the trusted prompt explicitly tells Claude to read the repository's `AGENTS.md` and only the relevant subsystem documentation. Administrator-managed policy still applies and may further restrict the invocation, but repository/user settings and extensions are not loaded. The adapter does not use `--dangerously-skip-permissions`. Authentication and the installed Claude Code binary remain machine prerequisites.
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -149,24 +149,36 @@ git worktree add --detach "$worktree" "$head_sha"
 review_loop=(bash scripts/review-loop)
 review_cmd='bash scripts/ai-review-codex'
 fix_cmd='bash scripts/ai-fix-claude'
+validation_cmd='bash scripts/agent-check-pr'
 if [[ "$push_changes" == "true" ]]; then
     if ! command -v nix >/dev/null 2>&1; then
         echo "ai-pr-loop: required command not found in PATH: nix" >&2
         exit 1
     fi
 
-    # A PR must not supply the policy engine or provider adapters that authorize
-    # its own publication. Build the orchestrator from the exact verified base
-    # commit and invoke the adapters from the same immutable tool worktree.
+    # A PR must not supply the policy engine, provider adapters, or validator
+    # that authorize its own publication. Build the orchestrator from the exact
+    # verified base commit and invoke its tools from that immutable worktree.
     trusted_tool_worktree="$worktree_run_dir/trusted-tools"
     review_loop_binary="$worktree_run_dir/review-loop"
     git worktree add --detach "$trusted_tool_worktree" "$base_sha"
+    for trusted_tool in ai-review-codex ai-fix-claude agent-check-pr; do
+        trusted_tool_path="$trusted_tool_worktree/scripts/$trusted_tool"
+        if [[ ! -x "$trusted_tool_path" ]]; then
+            echo "ai-pr-loop: trusted base does not provide executable scripts/$trusted_tool" >&2
+            exit 1
+        fi
+    done
     nix develop "path:$trusted_tool_worktree" --command \
         env -u GOROOT go -C "$trusted_tool_worktree" build \
         -o "$review_loop_binary" ./scripts/reviewloop
     review_loop=("$review_loop_binary")
     printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-codex"
     printf -v fix_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-fix-claude"
+    printf -v validation_cmd \
+        'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q' \
+        "path:$trusted_tool_worktree" \
+        "$trusted_tool_worktree/scripts/agent-check-pr"
 fi
 
 printf '==> ai-pr-loop: PR #%s\n' "$pr_number"
@@ -187,7 +199,8 @@ run_full_loop() {
     "${review_loop[@]}" \
         --base "$base_sha" \
         --review-cmd "$review_cmd" \
-        --fix-cmd "$fix_cmd"
+        --fix-cmd "$fix_cmd" \
+        --validation-cmd "$validation_cmd"
 }
 
 run_commit_review() {
@@ -195,7 +208,8 @@ run_commit_review() {
     # approved as-is. Any new blocker stops publication and requires a rerun.
     "${review_loop[@]}" \
         --base "$base_sha" \
-        --review-cmd "$review_cmd"
+        --review-cmd "$review_cmd" \
+        --validation-cmd "$validation_cmd"
 }
 
 set +e

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -61,10 +61,23 @@ func TestPushUsesBasePinnedReviewToolchain(t *testing.T) {
 	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
 }
 
+func TestPushRefusesBaseWithoutTrustedValidator(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, pushFixtureOptions{omitTrustedValidator: true})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 1, exitCode, output)
+	require.Contains(t, output, "trusted base does not provide executable scripts/agent-check-pr")
+
+	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
+	require.Equal(t, fixture.headSHA, remoteHead)
+}
+
 type pushFixtureOptions struct {
 	moveRemote            bool
 	moveLocalHead         bool
 	tamperTargetToolchain bool
+	omitTrustedValidator  bool
 }
 
 type pushFixture struct {
@@ -95,12 +108,18 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	launcher, err := os.ReadFile(launcherPath(t))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	if !options.omitTrustedValidator {
+		validator, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "agent-check-pr"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-check-pr"), validator, 0o755))
+	}
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
 review_cmd=""
 fix_cmd=""
+validation_cmd=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --review-cmd)
@@ -109,6 +128,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --fix-cmd)
             fix_cmd=$2
+            shift 2
+            ;;
+        --validation-cmd)
+            validation_cmd=$2
             shift 2
             ;;
         *)
@@ -126,6 +149,10 @@ if [[ -n "$fix_cmd" ]]; then
         *) exit 94 ;;
     esac
 fi
+case "$validation_cmd" in
+    *trusted-tools/scripts/agent-check-pr) ;;
+    *) exit 93 ;;
+esac
 count=0
 if [[ -f "$TEST_REVIEW_COUNT_FILE" ]]; then
     count=$(cat "$TEST_REVIEW_COUNT_FILE")
@@ -157,10 +184,11 @@ exit 0
 		writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), "#!/usr/bin/env bash\nexit 97\n")
 		writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 97\n")
 		writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 97\n")
+		writeExecutable(t, filepath.Join(seed, "scripts", "agent-check-pr"), "#!/usr/bin/env bash\nexit 97\n")
 	}
 	runGit(t, seed, "add", "feature.txt")
 	if options.tamperTargetToolchain {
-		runGit(t, seed, "add", "scripts/review-loop", "scripts/ai-review-codex", "scripts/ai-fix-claude")
+		runGit(t, seed, "add", "scripts/review-loop", "scripts/ai-review-codex", "scripts/ai-fix-claude", "scripts/agent-check-pr")
 	}
 	runGit(t, seed, "commit", "-m", "feature")
 	headSHA := runGitOutput(t, seed, "rev-parse", "HEAD")

--- a/scripts/reviewloop/main.go
+++ b/scripts/reviewloop/main.go
@@ -24,7 +24,7 @@ const (
 	exitHumanDecision    = 2
 	exitAutoFixRequired  = 3
 	defaultMaxPasses     = 3
-	defaultValidationCmd = "bash scripts/agent-check"
+	defaultValidationCmd = "bash scripts/agent-check-pr"
 	changeTargetKind     = "BASE_COMPARISON"
 )
 
@@ -102,7 +102,7 @@ func main() {
 
 	flag.StringVar(&reviewCmd, "review-cmd", "", "command that writes the review JSON to $AI_REVIEW_RESULT")
 	flag.StringVar(&fixCmd, "fix-cmd", "", "command that fixes findings from $AI_REVIEW_FINDINGS")
-	flag.StringVar(&validationCmd, "validation-cmd", defaultValidationCmd, "command run after every auto-fix pass")
+	flag.StringVar(&validationCmd, "validation-cmd", defaultValidationCmd, "local validation command run after fixes and before approval")
 	flag.StringVar(&stateDir, "state-dir", "build/ai-review-loop", "directory for review-loop state")
 	flag.StringVar(&baseRef, "base", "", "explicit git ref for committed changes under review")
 	flag.IntVar(&maxPasses, "max-passes", defaultMaxPasses, "maximum review passes")
@@ -110,6 +110,9 @@ func main() {
 
 	if strings.TrimSpace(reviewCmd) == "" {
 		fatal(errors.New("--review-cmd is required"))
+	}
+	if strings.TrimSpace(validationCmd) == "" {
+		fatal(errors.New("--validation-cmd must not be empty"))
 	}
 	if strings.TrimSpace(baseRef) == "" {
 		fatal(errors.New("--base is required"))
@@ -124,6 +127,9 @@ func main() {
 	base, err := resolveReviewBase(repositoryRoot, baseRef)
 	if err != nil {
 		fatal(err)
+	}
+	validationEnv := map[string]string{
+		"AI_REVIEW_BASE_SHA": base.SHA,
 	}
 	runStateDir, err := createRunStateDir(stateDir)
 	if err != nil {
@@ -198,6 +204,23 @@ func main() {
 
 		switch action {
 		case actionReady:
+			fmt.Println("==> review-loop: local validation before readiness")
+			if err := runCommand(validationCmd, validationEnv); err != nil {
+				fatal(fmt.Errorf("local validation failed before readiness: %w", err))
+			}
+			validatedState, err := captureWorkspaceState(repositoryRoot, runStateDir)
+			if err != nil {
+				fatal(err)
+			}
+			if validatedState != reviewedState {
+				fatal(fmt.Errorf(
+					"local validation changed the approved workspace: before %s/%s, after %s/%s",
+					reviewedState.Head,
+					reviewedState.Fingerprint,
+					validatedState.Head,
+					validatedState.Fingerprint,
+				))
+			}
 			printOutcome(action, pass, result, blockers)
 
 			return
@@ -237,7 +260,7 @@ func main() {
 			}
 
 			fmt.Println("==> review-loop: validation after auto-fix")
-			if err := runCommand(validationCmd, nil); err != nil {
+			if err := runCommand(validationCmd, validationEnv); err != nil {
 				fatal(fmt.Errorf("validation failed after auto-fix: %w", err))
 			}
 			previousResult = resultPath

--- a/scripts/reviewloop/main_test.go
+++ b/scripts/reviewloop/main_test.go
@@ -429,6 +429,69 @@ func TestVerifyFileSnapshotsUnchangedRejectsFixerStateMutation(t *testing.T) {
 	require.ErrorContains(t, err, resultPath+" content changed")
 }
 
+func TestApprovedReviewFailsWhenLocalValidationFails(t *testing.T) {
+	t.Parallel()
+
+	repository := t.TempDir()
+	runGit(t, repository, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(repository, "base.txt"), []byte("base\n"), 0o644))
+	runGit(t, repository, "add", "base.txt")
+	runGit(t, repository, "-c", "user.name=Review Loop Test", "-c", "user.email=review-loop@example.com", "commit", "-m", "base")
+	baseSHA := strings.TrimSpace(runGitOutput(t, repository, "rev-parse", "HEAD"))
+
+	reviewer := filepath.Join(repository, "reviewer.sh")
+	require.NoError(t, os.WriteFile(reviewer, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+cat > "$AI_REVIEW_RESULT" <<EOF
+{"decision":"APPROVE","head":"$AI_REVIEW_HEAD","worktree_fingerprint":"$AI_REVIEW_WORKTREE_FINGERPRINT","previous_findings":[],"findings":[],"residual_risk":"LOW","human_decision_context":""}
+EOF
+`), 0o755))
+	validationBase := filepath.Join(t.TempDir(), "validation-base")
+	validator := filepath.Join(repository, "validator.sh")
+	require.NoError(t, os.WriteFile(validator, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "$AI_REVIEW_BASE_SHA" > "$TEST_VALIDATION_BASE"
+exit 42
+`), 0o755))
+
+	binary := filepath.Join(t.TempDir(), "review-loop")
+	build := exec.Command("go", "build", "-o", binary, ".")
+	build.Dir = "."
+	output, err := build.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	command := exec.Command(binary,
+		"--base", baseSHA,
+		"--review-cmd", "bash reviewer.sh",
+		"--validation-cmd", "bash validator.sh",
+		"--state-dir", filepath.Join(repository, ".review-state"),
+	)
+	command.Dir = repository
+	command.Env = append(os.Environ(), "TEST_VALIDATION_BASE="+validationBase)
+	output, err = command.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.Contains(t, string(output), "local validation before readiness")
+	require.Contains(t, string(output), "local validation failed before readiness")
+	content, readErr := os.ReadFile(validationBase)
+	require.NoError(t, readErr)
+	require.Equal(t, baseSHA, string(content))
+
+	require.NoError(t, os.WriteFile(validator, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+printf 'changed by validation\n' > base.txt
+`), 0o755))
+	command = exec.Command(binary,
+		"--base", baseSHA,
+		"--review-cmd", "bash reviewer.sh",
+		"--validation-cmd", "bash validator.sh",
+		"--state-dir", filepath.Join(repository, ".review-state"),
+	)
+	command.Dir = repository
+	output, err = command.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.Contains(t, string(output), "local validation changed the approved workspace")
+}
+
 func writeReviewResult(t *testing.T, content string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- require local validation after an agent approval and before `READY_FOR_HUMAN_REVIEW`
- select deterministic local gates from the immutable base-to-worktree diff (unit, E2E, scenarios, Schemathesis, operator)
- reject approvals when validation fails or mutates the reviewed workspace
- use the base-pinned validator in guarded publish mode
- keep GitHub Actions entirely outside the readiness decision

## Validation

- `AI_REVIEW_BASE_SHA=$(git rev-parse origin/release/v3.0) bash scripts/agent-check-pr`
- `go test ./scripts/reviewloop ./scripts/aiprloop ./scripts/agentcheckpr -count=1`
- `nix develop --command bash -c "just pre-commit"`
- `GOROOT= go build ./...`
- GitNexus `detect-changes`: low risk, no affected execution flow