### PR TITLE
chore: add trusted PR validation tools

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -188,6 +188,35 @@ The blocker payload and originating review result are immutable inputs. The orch
 
 After a successful fix command, the orchestrator runs `bash scripts/agent-check` by default. A validation failure stops the loop immediately. Only after validation succeeds does it invoke the reviewer again.
 
+## Local PR validation helper
+
+`scripts/agent-check-pr` provides the local validation profile that can be
+selected from an immutable base-to-worktree diff:
+
+```bash
+AI_REVIEW_BASE_SHA="$(git rev-parse origin/release/v3.0)" \
+  bash scripts/agent-check-pr
+```
+
+It always runs the baseline checks and unit tests, then selects additional
+local gates for production Go paths, scenarios and Numscript, HTTP/OpenAPI,
+the operator module, and stateful cluster paths. Stateful changes run the
+three-node model checker with rolling restarts. These gates are local
+correctness profiles selected for the changed architecture, not a mirror of
+GitHub Actions jobs.
+
+The helper routes Just recipes through `scripts/agent-just`. That wrapper pins
+the recipe definitions to the checkout containing the wrapper, disables dotenv
+loading, and keeps the reviewed repository as the recipe working directory.
+Script-backed Schemathesis and model-checker gates use runners from that same
+tool checkout while building the reviewed server and reading reviewed inputs
+through explicit paths. The model driver and oracle remain tool-pinned.
+
+This helper is intentionally introduced independently of the `review-loop`
+approval policy. Wiring it as a mandatory guarded-publish validator is a
+separate activation step, after the helper exists in the base-pinned trusted
+tool worktree.
+
 ## Claude Code fix adapter
 
 `scripts/ai-fix-claude` is the first provider-specific fixer adapter. It deliberately exposes a narrower autonomous surface than an interactive Claude Code session.

--- a/scripts/agent-check
+++ b/scripts/agent-check
@@ -11,12 +11,13 @@ fi
 
 # Never inherit a host GOROOT into pinned Go commands.
 unset GOROOT || true
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "==> agent-check: mechanical repository invariants"
-bash scripts/check-repo-invariants
+bash "$SCRIPT_DIR/check-repo-invariants"
 
 echo "==> agent-check: repository pre-commit validation"
-just pre-commit
+bash "$SCRIPT_DIR/agent-just" pre-commit
 
 echo "==> agent-check: compile all root-module packages"
 go build ./...

--- a/scripts/agent-check-full
+++ b/scripts/agent-check-full
@@ -8,11 +8,12 @@ if [[ "${LEDGER_AGENT_CHECK_IN_NIX:-}" != "1" ]]; then
 fi
 
 unset GOROOT || true
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "==> agent-check-full: baseline validation"
-bash scripts/agent-check
+bash "$SCRIPT_DIR/agent-check"
 
 echo "==> agent-check-full: root-module unit tests"
-just test
+bash "$SCRIPT_DIR/agent-just" test
 
 echo "==> agent-check-full: PASS"

--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -100,7 +100,7 @@ classify_path() {
 
 while IFS= read -r -d '' path; do
     classify_path "$path"
-done < <(git diff --name-only --diff-filter=ACDMRTUXB -z "$base_sha" --)
+done < <(git diff --no-renames --name-only --diff-filter=ACDMRTUXB -z "$base_sha" --)
 while IFS= read -r -d '' path; do
     classify_path "$path"
 done < <(git ls-files --others --exclude-standard -z)

--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: AI_REVIEW_BASE_SHA=<commit> bash scripts/agent-check-pr [--list]
+
+Runs the local validation gates required by the changes since the immutable
+review base. --list prints the selected gates without executing them.
+EOF
+}
+
+list_only=false
+case "${1:-}" in
+    "") ;;
+    --list) list_only=true ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "agent-check-pr: unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+base_sha=${AI_REVIEW_BASE_SHA:-}
+if [[ -z "$base_sha" ]]; then
+    echo "agent-check-pr: AI_REVIEW_BASE_SHA is required" >&2
+    exit 1
+fi
+if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+    echo "agent-check-pr: invalid review base commit: $base_sha" >&2
+    exit 1
+fi
+
+needs_e2e=false
+needs_scenarios=false
+needs_schemathesis=false
+needs_operator=false
+needs_model_cluster=false
+
+classify_path() {
+    local path=$1
+
+    case "$path" in
+        main.go|cmd/server/*|internal/*|misc/proto/*|pkg/*|tests/e2e/*)
+            needs_e2e=true
+            ;;
+    esac
+    case "$path" in
+        tests/scenarios/*|misc/numscript/*)
+            needs_scenarios=true
+            ;;
+    esac
+    case "$path" in
+        openapi.yml|internal/adapter/http/*|internal/adapter/json/*|internal/adapter/v2/*|tests/schemathesis/*)
+            needs_schemathesis=true
+            ;;
+    esac
+    case "$path" in
+        misc/operator/*)
+            needs_operator=true
+            ;;
+    esac
+    case "$path" in
+        cmd/server/*|\
+        internal/application/admission/*|\
+        internal/application/backup/*|\
+        internal/application/membership/*|\
+        internal/bootstrap/*|\
+        internal/domain/processing/*|\
+        internal/domain/replay/*|\
+        internal/infra/attributes/*|\
+        internal/infra/backup/*|\
+        internal/infra/cache/*|\
+        internal/infra/membership/*|\
+        internal/infra/node/*|\
+        internal/infra/preload/*|\
+        internal/infra/state/*|\
+        internal/infra/transport/*|\
+        internal/storage/dal/*|\
+        internal/storage/pebblecfg/*|\
+        internal/storage/spool/*|\
+        internal/storage/wal/*|\
+        misc/proto/cluster.proto|\
+        misc/proto/cluster_bootstrap.proto|\
+        misc/proto/proposal.proto|\
+        misc/proto/raft_cmd.proto|\
+        misc/proto/raft_transport.proto|\
+        misc/proto/restore.proto|\
+        misc/proto/snapshot.proto|\
+        tests/antithesis/*|\
+        tests/oracle/*)
+            needs_model_cluster=true
+            ;;
+    esac
+}
+
+while IFS= read -r -d '' path; do
+    classify_path "$path"
+done < <(git diff --name-only --diff-filter=ACDMRTUXB -z "$base_sha" --)
+while IFS= read -r -d '' path; do
+    classify_path "$path"
+done < <(git ls-files --others --exclude-standard -z)
+
+gates=(agent-check-full)
+if [[ "$needs_e2e" == true ]]; then
+    gates+=(test-e2e)
+fi
+if [[ "$needs_scenarios" == true ]]; then
+    gates+=(test-scenarios)
+fi
+if [[ "$needs_schemathesis" == true ]]; then
+    gates+=(test-schemathesis)
+fi
+if [[ "$needs_operator" == true ]]; then
+    gates+=(test-operator)
+fi
+if [[ "$needs_model_cluster" == true ]]; then
+    gates+=(test-model-cluster)
+fi
+
+if [[ "$list_only" == true ]]; then
+    printf '%s\n' "${gates[@]}"
+    exit 0
+fi
+
+# Run every selected gate in the repository-pinned toolchain. Publish mode may
+# set the marker itself after entering the immutable base toolchain.
+if [[ "${LEDGER_AGENT_CHECK_IN_NIX:-}" != "1" ]]; then
+    exec env -u GOROOT nix develop --command \
+        env LEDGER_AGENT_CHECK_IN_NIX=1 AI_REVIEW_BASE_SHA="$base_sha" bash "$0" "$@"
+fi
+
+unset GOROOT || true
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> agent-check-pr: selected local gates: ${gates[*]}"
+bash "$SCRIPT_DIR/agent-check-full"
+if [[ "$needs_e2e" == true ]]; then
+    bash "$SCRIPT_DIR/agent-just" test-e2e
+fi
+if [[ "$needs_scenarios" == true ]]; then
+    bash "$SCRIPT_DIR/agent-just" test-scenarios
+fi
+if [[ "$needs_schemathesis" == true ]]; then
+    bash "$SCRIPT_DIR/agent-just" test-schemathesis
+fi
+if [[ "$needs_operator" == true ]]; then
+    go -C misc/operator test ./... -timeout 20m
+fi
+if [[ "$needs_model_cluster" == true ]]; then
+    bash "$SCRIPT_DIR/agent-just" test-model-cluster 180
+fi
+
+echo "==> agent-check-pr: PASS"

--- a/scripts/agent-just
+++ b/scripts/agent-just
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+
+# The wrapper may come from a base-pinned tool worktree while commands execute
+# against a PR worktree. Pin recipe definitions to the wrapper's repository,
+# disable target-controlled dotenv loading, and keep the reviewed tree as cwd.
+case "${1:-}" in
+    test-model)
+        shift
+        exec env \
+            REPO="$WORKTREE_ROOT" \
+            MODEL_HARNESS_REPO="$TOOL_ROOT" \
+            bash "$TOOL_ROOT/tests/antithesis/run_model_test.sh" "${1:-60}"
+        ;;
+    test-model-cluster)
+        shift
+        exec env \
+            REPO="$WORKTREE_ROOT" \
+            MODEL_HARNESS_REPO="$TOOL_ROOT" \
+            bash "$TOOL_ROOT/tests/antithesis/run_model_test.sh" --cluster "${1:-180}"
+        ;;
+    test-schemathesis)
+        shift
+        exec env \
+            REPO_ROOT="$WORKTREE_ROOT" \
+            SCHEMATHESIS_OPENAPI_PATH="$WORKTREE_ROOT/openapi.yml" \
+            bash "$TOOL_ROOT/tests/schemathesis/run.sh" "$@"
+        ;;
+esac
+
+exec just \
+    --no-dotenv \
+    --justfile "$TOOL_ROOT/justfile" \
+    --working-directory "$WORKTREE_ROOT" \
+    "$@"

--- a/scripts/agentcheckpr/selector_test.go
+++ b/scripts/agentcheckpr/selector_test.go
@@ -1,0 +1,110 @@
+package agentcheckpr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		paths          []string
+		leaveUntracked bool
+		expected       []string
+	}{
+		{
+			name:     "documentation only",
+			paths:    []string{"docs/example.md"},
+			expected: []string{"agent-check-full"},
+		},
+		{
+			name:           "uncommitted HTTP contract",
+			paths:          []string{"openapi.yml", "internal/adapter/http/example.go"},
+			leaveUntracked: true,
+			expected:       []string{"agent-check-full", "test-e2e", "test-schemathesis"},
+		},
+		{
+			name:     "production and scenario behavior",
+			paths:    []string{"internal/domain/example.go", "tests/scenarios/example_test.go"},
+			expected: []string{"agent-check-full", "test-e2e", "test-scenarios"},
+		},
+		{
+			name:     "FSM and cluster persistence",
+			paths:    []string{"internal/infra/state/example.go", "internal/storage/dal/example.go"},
+			expected: []string{"agent-check-full", "test-e2e", "test-model-cluster"},
+		},
+		{
+			name:     "restore protocol",
+			paths:    []string{"misc/proto/restore.proto"},
+			expected: []string{"agent-check-full", "test-e2e", "test-model-cluster"},
+		},
+		{
+			name:     "operator module",
+			paths:    []string{"misc/operator/internal/example.go"},
+			expected: []string{"agent-check-full", "test-operator"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			repository := t.TempDir()
+			runGit(t, repository, "init")
+			require.NoError(t, os.WriteFile(filepath.Join(repository, "base.txt"), []byte("base\n"), 0o644))
+			runGit(t, repository, "add", "base.txt")
+			runGit(t, repository, "-c", "user.name=Agent Check PR Test", "-c", "user.email=agent-check-pr@example.com", "commit", "-m", "base")
+			baseSHA := runGitOutput(t, repository, "rev-parse", "HEAD")
+
+			for _, path := range testCase.paths {
+				absolutePath := filepath.Join(repository, filepath.FromSlash(path))
+				require.NoError(t, os.MkdirAll(filepath.Dir(absolutePath), 0o755))
+				require.NoError(t, os.WriteFile(absolutePath, []byte("change\n"), 0o644))
+			}
+			if !testCase.leaveUntracked {
+				runGit(t, repository, "add", ".")
+				runGit(t, repository, "-c", "user.name=Agent Check PR Test", "-c", "user.email=agent-check-pr@example.com", "commit", "-m", "changes")
+			}
+
+			command := exec.Command("bash", selectorPath(t), "--list")
+			command.Dir = repository
+			command.Env = append(os.Environ(), "AI_REVIEW_BASE_SHA="+baseSHA)
+			output, err := command.CombinedOutput()
+			require.NoError(t, err, string(output))
+			require.Equal(t, testCase.expected, strings.Fields(string(output)))
+		})
+	}
+}
+
+func selectorPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "agent-check-pr"))
+	require.NoError(t, err)
+
+	return path
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	_ = runGitOutput(t, directory, arguments...)
+}
+
+func runGitOutput(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+
+	return strings.TrimSpace(string(output))
+}

--- a/scripts/agentcheckpr/selector_test.go
+++ b/scripts/agentcheckpr/selector_test.go
@@ -16,7 +16,9 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 
 	testCases := []struct {
 		name           string
+		basePaths      []string
 		paths          []string
+		renames        [][2]string
 		leaveUntracked bool
 		expected       []string
 	}{
@@ -51,6 +53,14 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 			paths:    []string{"misc/operator/internal/example.go"},
 			expected: []string{"agent-check-full", "test-operator"},
 		},
+		{
+			name:      "production file renamed outside gated paths",
+			basePaths: []string{"internal/domain/example.go"},
+			renames: [][2]string{
+				{"internal/domain/example.go", "docs/example.md"},
+			},
+			expected: []string{"agent-check-full", "test-e2e"},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -60,14 +70,20 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 			repository := t.TempDir()
 			runGit(t, repository, "init")
 			require.NoError(t, os.WriteFile(filepath.Join(repository, "base.txt"), []byte("base\n"), 0o644))
-			runGit(t, repository, "add", "base.txt")
+			for _, path := range testCase.basePaths {
+				writeTestFile(t, repository, path)
+			}
+			runGit(t, repository, "add", ".")
 			runGit(t, repository, "-c", "user.name=Agent Check PR Test", "-c", "user.email=agent-check-pr@example.com", "commit", "-m", "base")
 			baseSHA := runGitOutput(t, repository, "rev-parse", "HEAD")
 
 			for _, path := range testCase.paths {
-				absolutePath := filepath.Join(repository, filepath.FromSlash(path))
-				require.NoError(t, os.MkdirAll(filepath.Dir(absolutePath), 0o755))
-				require.NoError(t, os.WriteFile(absolutePath, []byte("change\n"), 0o644))
+				writeTestFile(t, repository, path)
+			}
+			for _, rename := range testCase.renames {
+				destination := filepath.Join(repository, filepath.FromSlash(rename[1]))
+				require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o755))
+				runGit(t, repository, "mv", "--", rename[0], rename[1])
 			}
 			if !testCase.leaveUntracked {
 				runGit(t, repository, "add", ".")
@@ -82,6 +98,14 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 			require.Equal(t, testCase.expected, strings.Fields(string(output)))
 		})
 	}
+}
+
+func writeTestFile(t *testing.T, repository, path string) {
+	t.Helper()
+
+	absolutePath := filepath.Join(repository, filepath.FromSlash(path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(absolutePath), 0o755))
+	require.NoError(t, os.WriteFile(absolutePath, []byte("change\n"), 0o644))
 }
 
 func selectorPath(t *testing.T) string {

--- a/scripts/agentjust/wrapper_test.go
+++ b/scripts/agentjust/wrapper_test.go
@@ -1,0 +1,130 @@
+package agentjust
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapperPinsJustfileAndUsesReviewedWorktree(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	toolRoot := filepath.Join(root, "trusted-tools")
+	worktree := filepath.Join(root, "reviewed-worktree")
+	for _, directory := range []string{filepath.Join(toolRoot, "scripts"), worktree} {
+		require.NoError(t, os.MkdirAll(directory, 0o755))
+	}
+
+	wrapper, err := os.ReadFile(wrapperPath(t))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(toolRoot, "scripts", "agent-just"), wrapper, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(toolRoot, "justfile"), []byte("trusted:\n    printf 'trusted\\n' > \"$TEST_RESULT\"\n    pwd > \"$TEST_WORKING_DIRECTORY\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "justfile"), []byte("trusted:\n    printf 'target-controlled\\n' > \"$TEST_RESULT\"\n"), 0o644))
+	runGit(t, worktree, "init")
+	resolvedWorktree, err := filepath.EvalSymlinks(worktree)
+	require.NoError(t, err)
+
+	resultPath := filepath.Join(root, "result")
+	workingDirectoryPath := filepath.Join(root, "working-directory")
+	command := exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "trusted")
+	command.Dir = worktree
+	command.Env = append(os.Environ(),
+		"TEST_RESULT="+resultPath,
+		"TEST_WORKING_DIRECTORY="+workingDirectoryPath,
+	)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	result, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	require.Equal(t, "trusted", strings.TrimSpace(string(result)))
+	workingDirectory, err := os.ReadFile(workingDirectoryPath)
+	require.NoError(t, err)
+	require.Equal(t, resolvedWorktree, strings.TrimSpace(string(workingDirectory)))
+}
+
+func TestWrapperPinsScriptBackedGatesToTrustedTools(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	toolRoot := filepath.Join(root, "trusted-tools")
+	worktree := filepath.Join(root, "reviewed-worktree")
+	paths := []string{
+		filepath.Join(toolRoot, "scripts"),
+		filepath.Join(toolRoot, "tests", "antithesis"),
+		filepath.Join(toolRoot, "tests", "schemathesis"),
+		filepath.Join(worktree, "tests", "antithesis"),
+		filepath.Join(worktree, "tests", "schemathesis"),
+	}
+	for _, path := range paths {
+		require.NoError(t, os.MkdirAll(path, 0o755))
+	}
+
+	wrapper, err := os.ReadFile(wrapperPath(t))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(toolRoot, "scripts", "agent-just"), wrapper, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(toolRoot, "tests", "antithesis", "run_model_test.sh"), []byte(`#!/usr/bin/env bash
+printf 'trusted-model\n%s\n%s\n%s\n' "$REPO" "$MODEL_HARNESS_REPO" "$*" > "$TEST_RESULT"
+`), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "tests", "antithesis", "run_model_test.sh"), []byte("printf 'target-controlled-model\\n' > \"$TEST_RESULT\"\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(toolRoot, "tests", "schemathesis", "run.sh"), []byte(`#!/usr/bin/env bash
+printf 'trusted-schemathesis\n%s\n%s\n' "$REPO_ROOT" "$SCHEMATHESIS_OPENAPI_PATH" > "$TEST_RESULT"
+`), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "tests", "schemathesis", "run.sh"), []byte("printf 'target-controlled-schemathesis\\n' > \"$TEST_RESULT\"\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "openapi.yml"), []byte("openapi: 3.0.3\n"), 0o644))
+	runGit(t, worktree, "init")
+	resolvedWorktree, err := filepath.EvalSymlinks(worktree)
+	require.NoError(t, err)
+
+	resultPath := filepath.Join(root, "result")
+	command := exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "test-model-cluster", "180")
+	command.Dir = worktree
+	command.Env = append(os.Environ(), "TEST_RESULT="+resultPath)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	result, err := os.ReadFile(resultPath)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"trusted-model",
+		resolvedWorktree,
+		toolRoot,
+		"--cluster 180",
+	}, strings.Split(strings.TrimSpace(string(result)), "\n"))
+
+	command = exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "test-schemathesis")
+	command.Dir = worktree
+	command.Env = append(os.Environ(), "TEST_RESULT="+resultPath)
+	output, err = command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	result, err = os.ReadFile(resultPath)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"trusted-schemathesis",
+		resolvedWorktree,
+		filepath.Join(resolvedWorktree, "openapi.yml"),
+	}, strings.Split(strings.TrimSpace(string(result)), "\n"))
+}
+
+func wrapperPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("..", "agent-just"))
+	require.NoError(t, err)
+
+	return path
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+}

--- a/tests/antithesis/run_model_test.sh
+++ b/tests/antithesis/run_model_test.sh
@@ -26,6 +26,7 @@
 #
 # Environment:
 #   REPO              path to the ledger repo checkout (default: the repo root, two levels up from this script)
+#   MODEL_HARNESS_REPO path providing the trusted model driver/oracle sources (default: REPO)
 #   NODES             node count (default 1); --nodes / --cluster override it
 #   GRPC_BASE         base gRPC port; raft = +100, http = +200 per band (default: random)
 #   RESTART_INTERVAL  seconds to soak between restarts, N>1 only; 0 disables restarts (default: 15)
@@ -120,6 +121,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # This script lives at tests/antithesis/ inside the repo; default REPO to the
 # repo root (two levels up). Override REPO=... to point at another checkout.
 REPO="${REPO:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+MODEL_HARNESS_REPO="${MODEL_HARNESS_REPO:-$REPO}"
 
 # Randomized port bands per run: a leaked node/driver from a killed shell can
 # never reach a new run's cluster (fixed ports would let an orphan corrupt a
@@ -267,6 +269,10 @@ if [ ! -d "$REPO" ]; then
 	echo "ERROR: REPO not found at $REPO (set REPO=...)" >&2
 	exit 2
 fi
+if [ ! -d "$MODEL_HARNESS_REPO/tests/antithesis/workload" ]; then
+	echo "ERROR: model harness not found under $MODEL_HARNESS_REPO (set MODEL_HARNESS_REPO=...)" >&2
+	exit 2
+fi
 
 # --- Launch one node ------------------------------------------------------
 # mode: bootstrap (new cluster) | join (learner via node 1's Raft transport,
@@ -379,7 +385,7 @@ build_cmd="go build $server_tags -o '$SERVER_BIN' . && "
 if [ "$NODES" -gt 1 ] || [ "$RESTORE" = 1 ]; then
 	build_cmd="${build_cmd}go build $server_tags -o '$LEDGERCTL_BIN' ./cmd/ledgerctl && "
 fi
-build_cmd="${build_cmd}cd tests/antithesis/workload && go build -o '$DRIVER_BIN' ./bin/cmds/model/singleton_driver_model"
+build_cmd="${build_cmd}cd '$MODEL_HARNESS_REPO/tests/antithesis/workload' && go build -o '$DRIVER_BIN' ./bin/cmds/model/singleton_driver_model"
 
 # Build inside the nix dev shell for a reproducible toolchain — unless we are
 # already in one (CI runs this as `nix develop --command just test-model`), in

--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -6,7 +6,7 @@
 #
 # Usage: bash tests/schemathesis/run.sh
 # Env vars: HTTP_PORT, GRPC_PORT, RAFT_PORT, MAX_EXAMPLES, SCHEMATHESIS_WORKERS,
-#   SCHEMATHESIS_SHRINK
+#   SCHEMATHESIS_SHRINK, REPO_ROOT, SCHEMATHESIS_OPENAPI_PATH
 #   SCHEMATHESIS_WORKERS=N runs the endpoint suite across N concurrent workers
 #   (default 1). Keep at 1 for the reproducible gate: >1 breaks the
 #   `derandomize` determinism (see test_api.py). The suite is fast at 1 worker.
@@ -15,7 +15,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SCHEMATHESIS_OPENAPI_PATH="${SCHEMATHESIS_OPENAPI_PATH:-$REPO_ROOT/openapi.yml}"
 
 HTTP_PORT=${HTTP_PORT:-9099}
 GRPC_PORT=${GRPC_PORT:-8899}
@@ -133,7 +134,7 @@ fi
 # Tee the full run (stdout+stderr) to an uploadable report. `set -o pipefail`
 # (see `set` above) makes the pipeline inherit test_api.py's non-zero exit, so a
 # conformity failure still fails the job. Filename matches the CI artifact glob.
-python3 "$SCRIPT_DIR/test_api.py" \
+SCHEMATHESIS_OPENAPI_PATH="$SCHEMATHESIS_OPENAPI_PATH" python3 "$SCRIPT_DIR/test_api.py" \
     --base-url "http://localhost:$HTTP_PORT" \
     --max-examples "$MAX_EXAMPLES" \
     --workers "$SCHEMATHESIS_WORKERS" \

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -10,6 +10,7 @@ Usage:
 
 import argparse
 import copy
+import os
 import re
 import sys
 from datetime import timedelta
@@ -31,7 +32,12 @@ from schemathesis.runner import from_schema
 from schemathesis.runner.events import AfterExecution, Finished
 from schemathesis.stateful import Stateful
 
-OPENAPI_PATH = Path(__file__).resolve().parents[2] / "openapi.yml"
+OPENAPI_PATH = Path(
+    os.environ.get(
+        "SCHEMATHESIS_OPENAPI_PATH",
+        Path(__file__).resolve().parents[2] / "openapi.yml",
+    )
+)
 
 VALID_LEDGER_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{2,20}$")
 


### PR DESCRIPTION
## Summary

- add the dormant `agent-check-pr` gate selector and base-pinned `agent-just` wrapper
- pin model-checker and Schemathesis harnesses while keeping reviewed source inputs explicit
- keep `review-loop` and `ai-pr-loop` unchanged so this bootstrap does not authorize itself
- prepare the trusted base required to activate local approval validation in #1732

## Validation

- `go test ./scripts/agentcheckpr ./scripts/agentjust -count=10`
- shell syntax checks for all changed scripts
- `AI_REVIEW_BASE_SHA=77d1473a... bash scripts/agent-check-pr --list`
- `bash scripts/agent-check`
- GitNexus impact/detect-changes: LOW, no affected execution flow

## Follow-up

After this PR is merged, #1732 will be rebased onto it and will contain only the policy/launcher activation. This guarantees that guarded publish resolves `agent-check-pr` from an already trusted base commit.