### PR TITLE
chore: add deep audit framework for persistence

### DIFF
--- a/docs/technical/audits/persistence-restore-replay.json
+++ b/docs/technical/audits/persistence-restore-replay.json
@@ -1,0 +1,52 @@
+{
+  "id": "persistence-restore-replay",
+  "title": "Persistence, restore, snapshot, and replay",
+  "purpose": "Find latent correctness failures that can lose, duplicate, reorder, or reconstruct ledger state incorrectly across persistence, replay, snapshot, restore, and restart boundaries.",
+  "paths": [
+    "internal/storage/**",
+    "internal/infra/state/**",
+    "internal/infra/backup/**",
+    "internal/application/backup/**",
+    "internal/domain/replay/**",
+    "internal/infra/preload/**",
+    "internal/infra/cache/**",
+    "misc/proto/snapshot.proto",
+    "misc/proto/restore.proto",
+    "tests/antithesis/**",
+    "tests/oracle/**"
+  ],
+  "related_docs": [
+    "AGENTS.md",
+    "docs/technical/agent-context.md",
+    "docs/technical/architecture/README.md",
+    "docs/technical/contributing/ai-audit.md"
+  ],
+  "invariants": [
+    "An acknowledged committed write must not disappear after crash, restart, snapshot install, or restore.",
+    "Replay of the same committed log must reconstruct the same externally observable ledger state.",
+    "Snapshot and restore must preserve balances, metadata, sequencing, and any state required for subsequent deterministic execution.",
+    "A partially completed backup, restore, snapshot, or persistence operation must fail closed rather than expose a silently incomplete state as valid.",
+    "Caches and preload paths must never become authoritative over persisted primary state after restart or restore.",
+    "Repeated retry or resume of a restore/replay operation must not duplicate committed effects.",
+    "State written before a durable boundary must not be observed as committed if the corresponding durable record can still be lost.",
+    "Version or format validation must reject incompatible persisted/snapshot data before mutating authoritative state."
+  ],
+  "adversarial_questions": [
+    "Where can the process crash between durable write, projection/state update, acknowledgement, and snapshot bookkeeping?",
+    "Which operations are not idempotent when replayed after a crash or retry?",
+    "Can restore expose a mixture of old and new state if interrupted?",
+    "Can a stale cache or preload overwrite or mask newer persisted state?",
+    "Can corrupted, truncated, reordered, duplicated, or partially written persisted input be accepted as valid?",
+    "Can snapshot installation race with reads, writes, membership changes, or background persistence?",
+    "Are sequence numbers, offsets, watermarks, or checkpoints advanced before all state they represent is durable?",
+    "Do backup and restore paths preserve all data that runtime correctness depends on, including non-obvious metadata?"
+  ],
+  "dynamic_checks_to_consider": [
+    "just test-model-cluster 180",
+    "crash/restart at persistence boundaries",
+    "restore interruption and retry",
+    "snapshot corruption/truncation",
+    "race-enabled tests",
+    "property tests comparing replayed state with uninterrupted execution"
+  ]
+}

--- a/docs/technical/contributing/ai-audit.md
+++ b/docs/technical/contributing/ai-audit.md
@@ -1,0 +1,49 @@
+# AI deep-audit contract
+
+This contract defines repository-wide audit campaigns. It is intentionally separate from the PR review loop:
+
+- PR review asks whether a bounded change is safe to integrate;
+- deep audit asks which latent defects may already exist in an immutable repository state.
+
+An audit is read-only. It must never fix code, create commits, push branches, create issues, resolve review threads, or change GitHub metadata.
+
+## Audit target
+
+Every result is bound to:
+
+- the exact repository `HEAD` SHA;
+- one named audit domain manifest under `docs/technical/audits/`;
+- the complete scope and invariants declared by that manifest.
+
+The auditor must inspect the current code, tests, and relevant technical documentation. It must not infer that green CI or existing tests prove an invariant.
+
+## Evidence standard
+
+Audit findings are held to a higher evidence standard than ordinary review suggestions. Every finding must include:
+
+- a stable id;
+- severity `P0`, `P1`, `P2`, or `P3`;
+- an exact location when possible;
+- the violated invariant or expected property;
+- a concrete failure path;
+- impact;
+- evidence from the repository;
+- a reproduction plan or executable test idea;
+- the existing test gap that allowed the defect to survive, when identifiable;
+- confidence `HIGH`, `MEDIUM`, or `LOW`.
+
+`P0`, `P1`, and `P2` findings must not be speculative. They need a concrete code path, violated invariant, or reproducible state transition. If the intended behavior cannot be determined from repository evidence, report an audit question rather than inventing a defect.
+
+## Audit questions
+
+Questions are explicit uncertainties that need human/product/architecture input. They are not findings and must not be counted as defects.
+
+## Duplicate and challenge pass
+
+A future campaign orchestrator may run independent auditors and challenge findings. The first version deliberately does not auto-deduplicate or auto-fix. A finding becomes a confirmed engineering defect only after reproduction, an independent confirming review, or human validation.
+
+## Output
+
+`bash scripts/ai-audit <domain>` writes a structured JSON report. The report records the audited HEAD, manifest id, findings, questions, inspected areas, and residual risk.
+
+The audit command exits non-zero when the provider or output contract fails. The presence of findings itself is not an execution failure.

--- a/docs/technical/contributing/ai-audit.md
+++ b/docs/technical/contributing/ai-audit.md
@@ -21,7 +21,7 @@ The auditor must inspect the current code, tests, and relevant technical documen
 
 Audit findings are held to a higher evidence standard than ordinary review suggestions. Every finding must include:
 
-- a stable id;
+- a stable id in the form `<audit-id>/<short-kebab-case-name>`, unique within the report;
 - severity `P0`, `P1`, `P2`, or `P3`;
 - an exact location when possible;
 - the violated invariant or expected property;

--- a/docs/technical/contributing/ai-audit.md
+++ b/docs/technical/contributing/ai-audit.md
@@ -46,4 +46,6 @@ A future campaign orchestrator may run independent auditors and challenge findin
 
 `bash scripts/ai-audit <domain>` writes a structured JSON report. The report records the audited HEAD, manifest id, findings, questions, inspected areas, and residual risk.
 
+Publication is atomic and anchored to the validated destination directory. A concurrent rename or symlink substitution of the output path must not redirect the final write into repository content.
+
 The audit command exits non-zero when the provider or output contract fails. The presence of findings itself is not an execution failure.

--- a/scripts/ai-audit
+++ b/scripts/ai-audit
@@ -204,7 +204,12 @@ EOF
     fi
     if ! jq -e --arg id "$domain" --arg head "$head_sha" '
         .audit_id == $id and .head == $head and
-        (.findings | type == "array") and (.questions | type == "array")
+        (.findings | type == "array") and (.questions | type == "array") and
+        all(.findings[];
+            (.id | startswith($id + "/")) and
+            (.id | ltrimstr($id + "/") | test("^[a-z0-9]+(-[a-z0-9]+)*$"))
+        ) and
+        ([.findings[].id] | length == (unique | length))
     ' "$provider_output" >/dev/null; then
         echo "ai-audit: provider result does not match the requested audit target" >&2
         exit 1

--- a/scripts/ai-audit
+++ b/scripts/ai-audit
@@ -47,7 +47,7 @@ if [[ ! "$domain" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
     exit 1
 fi
 
-for command in codex git jq; do
+for command in codex git go jq; do
     if ! command -v "$command" >/dev/null 2>&1; then
         echo "ai-audit: required command not found in PATH: $command" >&2
         exit 1
@@ -91,26 +91,54 @@ if [[ -z "$output" ]]; then
 fi
 output_dir=$(dirname "$output")
 mkdir -p "$output_dir"
-output=$(cd "$output_dir" && pwd)/$(basename "$output")
+output_dir=$(cd "$output_dir" && pwd -P)
+output_basename=$(basename -- "$output")
+output="$output_dir/$output_basename"
 
-original_home=${HOME:?HOME must be set}
-original_codex_home=${CODEX_HOME:-"$original_home/.codex"}
-isolation_root=$(mktemp -d "${TMPDIR:-/tmp}/ledger-codex-audit.XXXXXX")
-cleanup() {
-    case "${isolation_root:-}" in
-        "${TMPDIR:-/tmp}"/ledger-codex-audit.*) rm -rf -- "$isolation_root" ;;
-    esac
-}
-trap cleanup EXIT
-isolated_home="$isolation_root/home"
-isolated_codex_home="$isolated_home/.codex"
-prompt_file="$isolation_root/prompt.txt"
-provider_output="$isolation_root/result.json"
-mkdir -p "$isolated_codex_home"
-if [[ -f "$original_codex_home/auth.json" ]]; then
-    cp "$original_codex_home/auth.json" "$isolated_codex_home/auth.json"
-    chmod 600 "$isolated_codex_home/auth.json"
+# The audit is read-only and bound to the exact HEAD validated above. The
+# report must never overwrite tracked repository content, and the destination
+# must not be a symlink that redirects the final copy into the audited source
+# tree. Validate the resolved destination before invoking the provider to fail
+# fast on an obviously unsafe path; the destination is re-validated and the
+# result is published atomically below so a swap during the audit cannot mutate
+# audited source state.
+if [[ -L "$output" ]]; then
+    echo "ai-audit: --output must not be a symlink: $output" >&2
+    exit 1
 fi
+if [[ -e "$output" && ! -f "$output" ]]; then
+    echo "ai-audit: --output must be a regular file: $output" >&2
+    exit 1
+fi
+if git -C "$repo_root" ls-files --error-unmatch -- "$output" >/dev/null 2>&1; then
+    echo "ai-audit: --output must not overwrite tracked repository content: $output" >&2
+    exit 1
+fi
+
+run_audit() {
+    original_home=${HOME:?HOME must be set}
+    original_codex_home=${CODEX_HOME:-"$original_home/.codex"}
+    isolation_root=$(mktemp -d "${TMPDIR:-/tmp}/ledger-codex-audit.XXXXXX")
+    cleanup() {
+        case "${isolation_root:-}" in
+            "${TMPDIR:-/tmp}"/ledger-codex-audit.*) rm -rf -- "$isolation_root" ;;
+        esac
+    }
+    trap cleanup EXIT
+    isolated_home="$isolation_root/home"
+    isolated_codex_home="$isolated_home/.codex"
+    prompt_file="$isolation_root/prompt.txt"
+    provider_output="$isolation_root/result.json"
+    publisher_binary="$isolation_root/audit-publish"
+    mkdir -p "$isolated_codex_home"
+    if [[ -f "$original_codex_home/auth.json" ]]; then
+        cp "$original_codex_home/auth.json" "$isolated_codex_home/auth.json"
+        chmod 600 "$isolated_codex_home/auth.json"
+    fi
+    if ! (cd "$repo_root" && env -u GOROOT go build -o "$publisher_binary" ./scripts/auditpublish); then
+        echo "ai-audit: failed to build the trusted output publisher" >&2
+        exit 1
+    fi
 
 cat >"$prompt_file" <<'EOF'
 You are performing a deep correctness audit of the existing Ledger codebase, not a pull-request review.
@@ -148,39 +176,61 @@ EOF
     printf '\nCopy audit_id and head exactly into the result.\n'
 } >>"$prompt_file"
 
-set +e
-HOME="$isolated_home" CODEX_HOME="$isolated_codex_home" codex exec \
-    --ephemeral --ignore-user-config --ignore-rules \
-    --disable hooks --disable plugins --disable apps --disable memories \
-    --disable multi_agent --disable skill_search \
-    --sandbox read-only \
-    --output-schema "$schema" \
-    -o "$provider_output" \
-    - <"$prompt_file"
-codex_status=$?
-set -e
-if [[ $codex_status -ne 0 ]]; then
-    exit "$codex_status"
-fi
-if [[ ! -s "$provider_output" ]]; then
-    echo "ai-audit: Codex exited successfully but did not produce a result" >&2
-    exit 1
-fi
-current_head=$(git rev-parse HEAD)
-if [[ "$current_head" != "$head_sha" || -n "$(git status --porcelain --untracked-files=normal)" ]]; then
-    echo "ai-audit: repository state changed during audit; refusing result" >&2
-    exit 1
-fi
-if ! jq -e --arg id "$domain" --arg head "$head_sha" '
-    .audit_id == $id and .head == $head and
-    (.findings | type == "array") and (.questions | type == "array")
-' "$provider_output" >/dev/null; then
-    echo "ai-audit: provider result does not match the requested audit target" >&2
-    exit 1
-fi
-cp "$provider_output" "$output"
+    set +e
+    (
+        cd "$repo_root"
+        HOME="$isolated_home" CODEX_HOME="$isolated_codex_home" codex exec \
+            --ephemeral --ignore-user-config --ignore-rules \
+            --disable hooks --disable plugins --disable apps --disable memories \
+            --disable multi_agent --disable skill_search \
+            --sandbox read-only \
+            --output-schema "$schema" \
+            -o "$provider_output" \
+            - <"$prompt_file"
+    )
+    codex_status=$?
+    set -e
+    if [[ $codex_status -ne 0 ]]; then
+        exit "$codex_status"
+    fi
+    if [[ ! -s "$provider_output" ]]; then
+        echo "ai-audit: Codex exited successfully but did not produce a result" >&2
+        exit 1
+    fi
+    current_head=$(git -C "$repo_root" rev-parse HEAD)
+    if [[ "$current_head" != "$head_sha" || -n "$(git -C "$repo_root" status --porcelain --untracked-files=normal)" ]]; then
+        echo "ai-audit: repository state changed during audit; refusing result" >&2
+        exit 1
+    fi
+    if ! jq -e --arg id "$domain" --arg head "$head_sha" '
+        .audit_id == $id and .head == $head and
+        (.findings | type == "array") and (.questions | type == "array")
+    ' "$provider_output" >/dev/null; then
+        echo "ai-audit: provider result does not match the requested audit target" >&2
+        exit 1
+    fi
 
-printf 'AI_AUDIT_RESULT: %s\n' "$output"
-printf 'AI_AUDIT_HEAD: %s\n' "$head_sha"
-printf 'AI_AUDIT_FINDINGS: %s\n' "$(jq '.findings | length' "$provider_output")"
-printf 'AI_AUDIT_QUESTIONS: %s\n' "$(jq '.questions | length' "$provider_output")"
+    # The subshell's current directory remains bound to the validated output
+    # directory inode even if its pathname is renamed or replaced during the
+    # audit. The helper uses rename(2) with basename-only paths from that
+    # anchored directory, so publication cannot follow a substituted parent,
+    # destination symlink, or hard link into tracked repository content.
+    "$publisher_binary" "$provider_output" "$output_basename"
+
+    printf 'AI_AUDIT_RESULT: %s\n' "$output"
+    printf 'AI_AUDIT_HEAD: %s\n' "$head_sha"
+    printf 'AI_AUDIT_FINDINGS: %s\n' "$(jq '.findings | length' "$provider_output")"
+    printf 'AI_AUDIT_QUESTIONS: %s\n' "$(jq '.questions | length' "$provider_output")"
+}
+
+# Keep this subshell alive for the entire provider run. Its current directory
+# is the capability that anchors final publication to the directory validated
+# above; inner subshells may enter the repository without changing that anchor.
+(
+    cd -- "$output_dir"
+    if [[ "$(pwd -P)" != "$output_dir" ]]; then
+        echo "ai-audit: --output directory changed before it could be anchored: $output_dir" >&2
+        exit 1
+    fi
+    run_audit
+)

--- a/scripts/ai-audit
+++ b/scripts/ai-audit
@@ -56,7 +56,6 @@ done
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
-
 manifest="$repo_root/docs/technical/audits/$domain.json"
 schema="$repo_root/scripts/codex-audit.schema.json"
 contract="$repo_root/docs/technical/contributing/ai-audit.md"
@@ -68,10 +67,8 @@ if [[ ! -f "$schema" || ! -f "$contract" ]]; then
     echo "ai-audit: audit contract/schema is missing" >&2
     exit 1
 fi
-
 if ! jq -e --arg id "$domain" '
-    type == "object" and
-    .id == $id and
+    type == "object" and .id == $id and
     (.title | type == "string" and length > 0) and
     (.purpose | type == "string" and length > 0) and
     (.paths | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and
@@ -89,12 +86,12 @@ if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
     echo "ai-audit: repository worktree must be clean; audit is bound to exact HEAD $head_sha" >&2
     exit 1
 fi
-
 if [[ -z "$output" ]]; then
     output="$repo_root/build/ai-audit/${domain}-${head_sha:0:12}.json"
 fi
-mkdir -p "$(dirname "$output")"
-output=$(cd "$(dirname "$output")" && pwd)/$(basename "$output")
+output_dir=$(dirname "$output")
+mkdir -p "$output_dir"
+output=$(cd "$output_dir" && pwd)/$(basename "$output")
 
 original_home=${HOME:?HOME must be set}
 original_codex_home=${CODEX_HOME:-"$original_home/.codex"}
@@ -105,10 +102,10 @@ cleanup() {
     esac
 }
 trap cleanup EXIT
-
 isolated_home="$isolation_root/home"
 isolated_codex_home="$isolated_home/.codex"
 prompt_file="$isolation_root/prompt.txt"
+provider_output="$isolation_root/result.json"
 mkdir -p "$isolated_codex_home"
 if [[ -f "$original_codex_home/auth.json" ]]; then
     cp "$original_codex_home/auth.json" "$isolated_codex_home/auth.json"
@@ -143,7 +140,6 @@ Evidence threshold:
 
 Use stable finding ids of the form <audit-id>/<short-kebab-case-name>. Do not include markdown or prose outside the structured JSON output.
 EOF
-
 {
     printf '\nTRUSTED AUDIT TARGET\n\n'
     printf -- '- audit_id: %s\n' "$domain"
@@ -154,46 +150,37 @@ EOF
 
 set +e
 HOME="$isolated_home" CODEX_HOME="$isolated_codex_home" codex exec \
-    --ephemeral \
-    --ignore-user-config \
-    --ignore-rules \
-    --disable hooks \
-    --disable plugins \
-    --disable apps \
-    --disable memories \
-    --disable multi_agent \
-    --disable skill_search \
+    --ephemeral --ignore-user-config --ignore-rules \
+    --disable hooks --disable plugins --disable apps --disable memories \
+    --disable multi_agent --disable skill_search \
     --sandbox read-only \
     --output-schema "$schema" \
-    -o "$output" \
+    -o "$provider_output" \
     - <"$prompt_file"
 codex_status=$?
 set -e
 if [[ $codex_status -ne 0 ]]; then
     exit "$codex_status"
 fi
-if [[ ! -s "$output" ]]; then
-    echo "ai-audit: Codex exited successfully but did not produce $output" >&2
+if [[ ! -s "$provider_output" ]]; then
+    echo "ai-audit: Codex exited successfully but did not produce a result" >&2
     exit 1
 fi
-
 current_head=$(git rev-parse HEAD)
 if [[ "$current_head" != "$head_sha" || -n "$(git status --porcelain --untracked-files=normal)" ]]; then
     echo "ai-audit: repository state changed during audit; refusing result" >&2
     exit 1
 fi
-
 if ! jq -e --arg id "$domain" --arg head "$head_sha" '
-    .audit_id == $id and
-    .head == $head and
-    (.findings | type == "array") and
-    (.questions | type == "array")
-' "$output" >/dev/null; then
+    .audit_id == $id and .head == $head and
+    (.findings | type == "array") and (.questions | type == "array")
+' "$provider_output" >/dev/null; then
     echo "ai-audit: provider result does not match the requested audit target" >&2
     exit 1
 fi
+cp "$provider_output" "$output"
 
 printf 'AI_AUDIT_RESULT: %s\n' "$output"
 printf 'AI_AUDIT_HEAD: %s\n' "$head_sha"
-printf 'AI_AUDIT_FINDINGS: %s\n' "$(jq '.findings | length' "$output")"
-printf 'AI_AUDIT_QUESTIONS: %s\n' "$(jq '.questions | length' "$output")"
+printf 'AI_AUDIT_FINDINGS: %s\n' "$(jq '.findings | length' "$provider_output")"
+printf 'AI_AUDIT_QUESTIONS: %s\n' "$(jq '.questions | length' "$provider_output")"

--- a/scripts/ai-audit
+++ b/scripts/ai-audit
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/ai-audit <domain> [--output <path>]
+
+Runs a read-only deep audit of the exact clean repository HEAD using the domain
+manifest under docs/technical/audits/<domain>.json.
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+    usage >&2
+    exit 1
+fi
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+domain=$1
+shift
+output=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "ai-audit: --output requires a path" >&2
+                exit 1
+            fi
+            output=$2
+            shift 2
+            ;;
+        *)
+            echo "ai-audit: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! "$domain" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "ai-audit: invalid domain name: $domain" >&2
+    exit 1
+fi
+
+for command in codex git jq; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "ai-audit: required command not found in PATH: $command" >&2
+        exit 1
+    fi
+done
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+manifest="$repo_root/docs/technical/audits/$domain.json"
+schema="$repo_root/scripts/codex-audit.schema.json"
+contract="$repo_root/docs/technical/contributing/ai-audit.md"
+if [[ ! -f "$manifest" ]]; then
+    echo "ai-audit: unknown audit domain: $domain" >&2
+    exit 1
+fi
+if [[ ! -f "$schema" || ! -f "$contract" ]]; then
+    echo "ai-audit: audit contract/schema is missing" >&2
+    exit 1
+fi
+
+if ! jq -e --arg id "$domain" '
+    type == "object" and
+    .id == $id and
+    (.title | type == "string" and length > 0) and
+    (.purpose | type == "string" and length > 0) and
+    (.paths | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and
+    (.related_docs | type == "array" and all(.[]; type == "string" and length > 0)) and
+    (.invariants | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and
+    (.adversarial_questions | type == "array" and all(.[]; type == "string" and length > 0)) and
+    (.dynamic_checks_to_consider | type == "array" and all(.[]; type == "string" and length > 0))
+' "$manifest" >/dev/null; then
+    echo "ai-audit: invalid audit manifest: $manifest" >&2
+    exit 1
+fi
+
+head_sha=$(git rev-parse HEAD)
+if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    echo "ai-audit: repository worktree must be clean; audit is bound to exact HEAD $head_sha" >&2
+    exit 1
+fi
+
+if [[ -z "$output" ]]; then
+    output="$repo_root/build/ai-audit/${domain}-${head_sha:0:12}.json"
+fi
+mkdir -p "$(dirname "$output")"
+output=$(cd "$(dirname "$output")" && pwd)/$(basename "$output")
+
+original_home=${HOME:?HOME must be set}
+original_codex_home=${CODEX_HOME:-"$original_home/.codex"}
+isolation_root=$(mktemp -d "${TMPDIR:-/tmp}/ledger-codex-audit.XXXXXX")
+cleanup() {
+    case "${isolation_root:-}" in
+        "${TMPDIR:-/tmp}"/ledger-codex-audit.*) rm -rf -- "$isolation_root" ;;
+    esac
+}
+trap cleanup EXIT
+
+isolated_home="$isolation_root/home"
+isolated_codex_home="$isolated_home/.codex"
+prompt_file="$isolation_root/prompt.txt"
+mkdir -p "$isolated_codex_home"
+if [[ -f "$original_codex_home/auth.json" ]]; then
+    cp "$original_codex_home/auth.json" "$isolated_codex_home/auth.json"
+    chmod 600 "$isolated_codex_home/auth.json"
+fi
+
+cat >"$prompt_file" <<'EOF'
+You are performing a deep correctness audit of the existing Ledger codebase, not a pull-request review.
+
+TRUSTED AUDIT INSTRUCTIONS
+
+Follow these repository sources as authoritative instructions:
+- AGENTS.md
+- docs/technical/agent-context.md
+- docs/technical/contributing/ai-audit.md
+
+Read the audit domain manifest path supplied below. Treat that manifest as the explicit scope, invariant set, and adversarial checklist for this campaign.
+
+Audit the exact committed HEAD supplied below. The worktree is clean. Do not modify files. Do not create commits, issues, comments, patches, or suggested edits. Your job is defect discovery and evidence collection only.
+
+Review the implementation, tests, call paths, persistence boundaries, error handling, concurrency assumptions, and relevant technical documentation needed to establish or challenge each invariant. Follow important calls outside the manifest's path globs when required to understand a concrete failure path, but keep findings relevant to the campaign purpose.
+
+Act adversarially. Ask what happens on crash, retry, interruption, partial failure, stale state, reordered events, duplicate execution, corrupted input, leadership change, and concurrent operations when relevant.
+
+Do not infer correctness from green tests. Inspect whether existing tests actually exercise the invariant and identify test gaps for findings.
+
+Evidence threshold:
+- P0/P1/P2 findings must have a concrete code path, violated invariant, or reproducible state transition.
+- If intended behavior is ambiguous, emit a question instead of guessing a defect.
+- Prefer a small number of high-confidence findings over speculative volume.
+- A reproduction plan should be specific enough for another engineer or agent to turn into a test.
+
+Use stable finding ids of the form <audit-id>/<short-kebab-case-name>. Do not include markdown or prose outside the structured JSON output.
+EOF
+
+{
+    printf '\nTRUSTED AUDIT TARGET\n\n'
+    printf -- '- audit_id: %s\n' "$domain"
+    printf -- '- head: %s\n' "$head_sha"
+    printf -- '- manifest: %s\n' "docs/technical/audits/$domain.json"
+    printf '\nCopy audit_id and head exactly into the result.\n'
+} >>"$prompt_file"
+
+set +e
+HOME="$isolated_home" CODEX_HOME="$isolated_codex_home" codex exec \
+    --ephemeral \
+    --ignore-user-config \
+    --ignore-rules \
+    --disable hooks \
+    --disable plugins \
+    --disable apps \
+    --disable memories \
+    --disable multi_agent \
+    --disable skill_search \
+    --sandbox read-only \
+    --output-schema "$schema" \
+    -o "$output" \
+    - <"$prompt_file"
+codex_status=$?
+set -e
+if [[ $codex_status -ne 0 ]]; then
+    exit "$codex_status"
+fi
+if [[ ! -s "$output" ]]; then
+    echo "ai-audit: Codex exited successfully but did not produce $output" >&2
+    exit 1
+fi
+
+current_head=$(git rev-parse HEAD)
+if [[ "$current_head" != "$head_sha" || -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    echo "ai-audit: repository state changed during audit; refusing result" >&2
+    exit 1
+fi
+
+if ! jq -e --arg id "$domain" --arg head "$head_sha" '
+    .audit_id == $id and
+    .head == $head and
+    (.findings | type == "array") and
+    (.questions | type == "array")
+' "$output" >/dev/null; then
+    echo "ai-audit: provider result does not match the requested audit target" >&2
+    exit 1
+fi
+
+printf 'AI_AUDIT_RESULT: %s\n' "$output"
+printf 'AI_AUDIT_HEAD: %s\n' "$head_sha"
+printf 'AI_AUDIT_FINDINGS: %s\n' "$(jq '.findings | length' "$output")"
+printf 'AI_AUDIT_QUESTIONS: %s\n' "$(jq '.questions | length' "$output")"

--- a/scripts/aiaudit/runner_test.go
+++ b/scripts/aiaudit/runner_test.go
@@ -1,0 +1,196 @@
+package aiaudit
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAuditID = "persistence-restore-replay"
+)
+
+func TestRunnerAcceptsStableUniqueFindingIDs(t *testing.T) {
+	result := validResult()
+	result["findings"] = []map[string]any{
+		finding(testAuditID + "/restore-retries-from-snapshot"),
+		finding(testAuditID + "/replay-preserves-order"),
+	}
+
+	output, err := runAudit(t, result)
+	require.NoError(t, err, output)
+}
+
+func TestRunnerRejectsFindingIDFromAnotherAudit(t *testing.T) {
+	result := validResult()
+	result["findings"] = []map[string]any{finding("another-audit/replay-preserves-order")}
+
+	output, err := runAudit(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "provider result does not match the requested audit target")
+}
+
+func TestRunnerRejectsMalformedFindingID(t *testing.T) {
+	result := validResult()
+	result["findings"] = []map[string]any{finding(testAuditID + "/Replay_preserves_order")}
+
+	output, err := runAudit(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "provider result does not match the requested audit target")
+}
+
+func TestRunnerRejectsDuplicateFindingIDs(t *testing.T) {
+	result := validResult()
+	first := finding(testAuditID + "/replay-preserves-order")
+	second := finding(testAuditID + "/replay-preserves-order")
+	second["title"] = "Different content with the same ID"
+	result["findings"] = []map[string]any{
+		first,
+		second,
+	}
+
+	output, err := runAudit(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "provider result does not match the requested audit target")
+}
+
+func runAudit(t *testing.T, result map[string]any) (string, error) {
+	t.Helper()
+
+	repositoryRoot := repositoryRoot(t)
+	checkout := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "scripts", "auditpublish"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "docs", "technical", "audits"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "docs", "technical", "contributing"), 0o700))
+	copyFile(t, filepath.Join(repositoryRoot, "scripts", "ai-audit"), filepath.Join(checkout, "scripts", "ai-audit"))
+	copyFile(t, filepath.Join(repositoryRoot, "scripts", "codex-audit.schema.json"), filepath.Join(checkout, "scripts", "codex-audit.schema.json"))
+	copyFile(t, filepath.Join(repositoryRoot, "scripts", "auditpublish", "main.go"), filepath.Join(checkout, "scripts", "auditpublish", "main.go"))
+	copyFile(t, filepath.Join(repositoryRoot, "go.mod"), filepath.Join(checkout, "go.mod"))
+	copyFile(t, filepath.Join(repositoryRoot, "go.sum"), filepath.Join(checkout, "go.sum"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(checkout, "docs", "technical", "contributing", "ai-audit.md"),
+		[]byte("# Audit contract\n"),
+		0o600,
+	))
+	manifest := fmt.Sprintf(`{
+		"id": %q,
+		"title": "Test audit",
+		"purpose": "Test the runner",
+		"paths": ["scripts/**"],
+		"related_docs": [],
+		"invariants": ["Results are validated"],
+		"adversarial_questions": [],
+		"dynamic_checks_to_consider": []
+	}`, testAuditID)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(checkout, "docs", "technical", "audits", testAuditID+".json"),
+		[]byte(manifest),
+		0o600,
+	))
+
+	fakeBin := t.TempDir()
+	fakeCodex := `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+	if [[ "$1" == "-o" ]]; then
+		output=$2
+		shift 2
+		continue
+	fi
+	shift
+done
+cp "$FAKE_CODEX_RESULT" "$output"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "codex"), []byte(fakeCodex), 0o700))
+
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "audit-test@example.com")
+	runGit(t, checkout, "config", "user.name", "Audit Test")
+	runGit(t, checkout, "add", "--", ".")
+	runGit(t, checkout, "commit", "-m", "test fixture")
+	result["head"] = gitOutput(t, checkout, "rev-parse", "HEAD")
+	encodedResult, err := json.Marshal(result)
+	require.NoError(t, err)
+	resultPath := filepath.Join(t.TempDir(), "provider-result.json")
+	require.NoError(t, os.WriteFile(resultPath, encodedResult, 0o600))
+
+	outputPath := filepath.Join(t.TempDir(), "report.json")
+	command := exec.Command("bash", filepath.Join(checkout, "scripts", "ai-audit"), testAuditID, "--output", outputPath)
+	command.Dir = checkout
+	command.Env = append(os.Environ(),
+		"FAKE_CODEX_RESULT="+resultPath,
+		"HOME="+t.TempDir(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := command.CombinedOutput()
+
+	return string(output), err
+}
+
+func validResult() map[string]any {
+	return map[string]any{
+		"audit_id":        testAuditID,
+		"summary":         "Test result",
+		"inspected_areas": []string{"scripts"},
+		"findings":        []map[string]any{},
+		"questions":       []map[string]any{},
+		"residual_risk":   "LOW",
+	}
+}
+
+func finding(id string) map[string]any {
+	return map[string]any{
+		"id":                 id,
+		"severity":           "P2",
+		"title":              "Test finding",
+		"location":           "scripts/ai-audit",
+		"violated_invariant": "Results are validated",
+		"failure_path":       "The provider returns invalid data",
+		"impact":             "The report cannot be correlated",
+		"evidence":           "The fixture contains an invalid ID",
+		"reproduction_plan":  "Run the audit fixture",
+		"test_gap":           "No prior runner test",
+		"confidence":         "HIGH",
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func copyFile(t *testing.T, source, destination string) {
+	t.Helper()
+	contents, err := os.ReadFile(source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(destination, contents, 0o600))
+}
+
+func runGit(t *testing.T, directory string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func gitOutput(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	return strings.TrimSpace(string(output))
+}

--- a/scripts/auditpublish/main.go
+++ b/scripts/auditpublish/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func publish(sourcePath, destination string) error {
+	if destination == "" || destination == "." || filepath.Base(destination) != destination {
+		return fmt.Errorf("destination must be a basename: %q", destination)
+	}
+
+	info, err := os.Lstat(destination)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("destination must not be a symlink: %s", destination)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("destination must be a regular file: %s", destination)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect destination: %w", err)
+	}
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open validated result: %w", err)
+	}
+	sourceOpen := true
+	defer func() {
+		if sourceOpen {
+			_ = source.Close() // Best effort cleanup; preserve the original error.
+		}
+	}()
+
+	temporary, err := os.CreateTemp(".", ".ai-audit-result-*")
+	if err != nil {
+		return fmt.Errorf("create publication temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() {
+		if temporaryPath != "" {
+			_ = os.Remove(temporaryPath) // Best effort cleanup; preserve the original error.
+		}
+	}()
+
+	if _, err := io.Copy(temporary, source); err != nil {
+		_ = temporary.Close() // Best effort cleanup; preserve the copy error.
+
+		return fmt.Errorf("copy validated result: %w", err)
+	}
+	if err := source.Close(); err != nil {
+		_ = temporary.Close() // Best effort cleanup; preserve the source close error.
+
+		return fmt.Errorf("close validated result: %w", err)
+	}
+	sourceOpen = false
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close() // Best effort cleanup; preserve the sync error.
+
+		return fmt.Errorf("sync validated result: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close publication temporary file: %w", err)
+	}
+	if err := os.Rename(temporaryPath, destination); err != nil {
+		return fmt.Errorf("publish validated result: %w", err)
+	}
+	temporaryPath = ""
+
+	return nil
+}
+
+func run(args []string) error {
+	if len(args) != 2 {
+		return errors.New("usage: auditpublish <validated-result> <destination-basename>")
+	}
+
+	return publish(args[0], args[1])
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "auditpublish: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/scripts/auditpublish/main_test.go
+++ b/scripts/auditpublish/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishUsesAnchoredWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	originalDirectory := filepath.Join(root, "output")
+	movedDirectory := filepath.Join(root, "moved-output")
+	replacementDirectory := filepath.Join(root, "replacement")
+	require.NoError(t, os.Mkdir(originalDirectory, 0o700))
+	require.NoError(t, os.Mkdir(replacementDirectory, 0o700))
+
+	sourcePath := filepath.Join(root, "result.json")
+	require.NoError(t, os.WriteFile(sourcePath, []byte(`{"head":"validated"}`), 0o600))
+	protectedPath := filepath.Join(replacementDirectory, "report.json")
+	require.NoError(t, os.WriteFile(protectedPath, []byte("tracked"), 0o600))
+
+	t.Chdir(originalDirectory)
+	require.NoError(t, os.Rename(originalDirectory, movedDirectory))
+	require.NoError(t, os.Symlink(replacementDirectory, originalDirectory))
+
+	require.NoError(t, publish(sourcePath, "report.json"))
+	require.FileExists(t, filepath.Join(movedDirectory, "report.json"))
+	require.Equal(t, "tracked", string(requireFile(t, protectedPath)))
+}
+
+func TestPublishReplacesHardLinkWithoutMutatingTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard links require platform-specific privileges on Windows")
+	}
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "result.json")
+	protectedPath := filepath.Join(root, "tracked")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("validated"), 0o600))
+	require.NoError(t, os.WriteFile(protectedPath, []byte("tracked"), 0o600))
+	require.NoError(t, os.Link(protectedPath, filepath.Join(root, "report.json")))
+
+	t.Chdir(root)
+
+	require.NoError(t, publish(sourcePath, "report.json"))
+	require.Equal(t, "tracked", string(requireFile(t, protectedPath)))
+	require.Equal(t, "validated", string(requireFile(t, filepath.Join(root, "report.json"))))
+}
+
+func TestPublishRejectsDestinationSymlink(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "result.json")
+	protectedPath := filepath.Join(root, "tracked")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("validated"), 0o600))
+	require.NoError(t, os.WriteFile(protectedPath, []byte("tracked"), 0o600))
+	require.NoError(t, os.Symlink(protectedPath, filepath.Join(root, "report.json")))
+
+	t.Chdir(root)
+
+	require.ErrorContains(t, publish(sourcePath, "report.json"), "must not be a symlink")
+	require.Equal(t, "tracked", string(requireFile(t, protectedPath)))
+}
+
+func requireFile(t *testing.T, path string) []byte {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return contents
+}

--- a/scripts/codex-audit.schema.json
+++ b/scripts/codex-audit.schema.json
@@ -38,7 +38,10 @@
           "confidence"
         ],
         "properties": {
-          "id": { "type": "string", "minLength": 1 },
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*/[a-z0-9]+(-[a-z0-9]+)*$"
+          },
           "severity": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
           "title": { "type": "string", "minLength": 1 },
           "location": { "type": "string" },

--- a/scripts/codex-audit.schema.json
+++ b/scripts/codex-audit.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "audit_id",
+    "head",
+    "summary",
+    "inspected_areas",
+    "findings",
+    "questions",
+    "residual_risk"
+  ],
+  "properties": {
+    "audit_id": { "type": "string", "minLength": 1 },
+    "head": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+    "summary": { "type": "string" },
+    "inspected_areas": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "severity",
+          "title",
+          "location",
+          "violated_invariant",
+          "failure_path",
+          "impact",
+          "evidence",
+          "reproduction_plan",
+          "test_gap",
+          "confidence"
+        ],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "severity": { "type": "string", "enum": ["P0", "P1", "P2", "P3"] },
+          "title": { "type": "string", "minLength": 1 },
+          "location": { "type": "string" },
+          "violated_invariant": { "type": "string", "minLength": 1 },
+          "failure_path": { "type": "string", "minLength": 1 },
+          "impact": { "type": "string", "minLength": 1 },
+          "evidence": { "type": "string", "minLength": 1 },
+          "reproduction_plan": { "type": "string", "minLength": 1 },
+          "test_gap": { "type": "string" },
+          "confidence": { "type": "string", "enum": ["HIGH", "MEDIUM", "LOW"] }
+        }
+      }
+    },
+    "questions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["location", "question", "why_it_matters"],
+        "properties": {
+          "location": { "type": "string" },
+          "question": { "type": "string", "minLength": 1 },
+          "why_it_matters": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "residual_risk": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH"] }
+  }
+}


### PR DESCRIPTION
## Summary

Introduce the first read-only deep-audit workflow for existing Ledger code, separate from PR review/fix automation.

- define an explicit deep-audit contract and evidence threshold
- add a structured persistence/restore/replay audit manifest with scope, invariants, adversarial questions, and dynamic checks to consider
- add a strict Codex structured-output schema for audit reports
- add `scripts/ai-audit <domain>` to bind an audit to an exact clean HEAD, isolate Codex user configuration, run read-only, validate target identity, and persist the report only after confirming the repository state did not change
- deliberately do not auto-fix, create issues, comment on GitHub, or deduplicate findings yet

## Pilot usage

```bash
bash scripts/ai-audit persistence-restore-replay
```

The default report is written under `build/ai-audit/` after the audit target has been revalidated.

## Audit focus

The initial manifest targets latent correctness failures around persistence, replay, backup/restore, snapshots, cache/preload reconstruction, retries, partial failure, and crash boundaries.

Findings require concrete repository evidence and a reproduction plan. Ambiguous intended behavior must be reported as a question rather than invented as a defect.

## Why

The PR review loop protects new changes, but release readiness also requires systematic discovery of latent defects already present in `release/v3.0`. This creates the first bounded campaign primitive without yet adding autonomous remediation.

## Review focus

Please pay particular attention to:

- whether the audit really binds to an immutable clean HEAD
- whether writing the report can accidentally invalidate the target state
- Codex CLI / structured-output compatibility
- user-config isolation and read-only guarantees
- whether the persistence manifest is specific enough to drive a deep audit without creating speculative noise
- schema strictness and stable finding identity
- whether any command path can mutate the repository or GitHub
- whether the initial evidence threshold is strong enough for P0/P1/P2 findings

## Follow-up

If the pilot produces useful findings, follow-ups can add independent challenge/reproduction passes, more architectural domains, historical bug mining, and eventually a bounded multi-domain campaign runner.