### PR TITLE
fix(indexbuilder): rebuild the index config after a snapshot install

### DIFF
--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -46,6 +46,10 @@ type Builder struct {
 	metricsRegistration     metric.Registration // tailworker gauge triplet
 	logsIndexedRegistration metric.Registration // builder-specific logs_indexed_total gauge
 
+	// Raised when a leader snapshot install has swapped the store this cache
+	// was built from, and lowered by the loop once it has rebuilt.
+	configReloadPending atomic.Bool
+
 	// Per-ledger index configuration cache.
 	indexConfig map[string]*ledgerIndexConfig
 
@@ -539,6 +543,13 @@ func (b *Builder) loop(ctx context.Context) {
 			return
 		case <-b.notifications.LogCommitted.C():
 		case <-ticker.C:
+		}
+
+		// Ahead of touching the store: a snapshot install may have replaced it
+		// with the leader's checkpoint, leaving the config describing a store
+		// that is gone.
+		if err := b.reloadConfigIfRequested(ctx); err != nil {
+			b.logger.Errorf("%v", err)
 		}
 
 		// Fast path: skip Pebble iterator + batch commit when the FSM

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -505,6 +505,22 @@ func (b *Builder) loop(ctx context.Context) {
 		default:
 		}
 
+		// Catch-up can run for hours, so a snapshot install landing mid-way
+		// cannot wait for the main loop: the config would describe the
+		// pre-swap store for the rest of it. The stripped view is rebuilt
+		// from the reloaded config, since restoreIndexes closes over the old.
+		if b.configReloadPending.Load() {
+			restoreIndexes()
+
+			if err := b.reloadConfigIfRequested(ctx); err != nil {
+				b.logger.Errorf("%v", err)
+
+				break
+			}
+
+			restoreIndexes = b.stripBuildingIndexes()
+		}
+
 		before := cursor
 		deadline := time.Now().Add(catchUpBudget)
 
@@ -549,7 +565,13 @@ func (b *Builder) loop(ctx context.Context) {
 		// with the leader's checkpoint, leaving the config describing a store
 		// that is gone.
 		if err := b.reloadConfigIfRequested(ctx); err != nil {
+			// initIndexConfig clears the config before repopulating it, so a
+			// failed reload leaves it incomplete — indexing against that skips
+			// writes the restored store needs. The request stays raised, so
+			// sit this tick out and retry on the next.
 			b.logger.Errorf("%v", err)
+
+			continue
 		}
 
 		// Fast path: skip Pebble iterator + batch commit when the FSM

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -513,3 +513,39 @@ func (b *Builder) handleDroppedIndexLog(ledger string, log *commonpb.DroppedInde
 		b.removeSchemaRewriteTaskByField(ledger, meta.Metadata.GetTarget(), meta.Metadata.GetKey())
 	}
 }
+
+// OnSnapshotInstalled tells the builder that a leader snapshot has been
+// installed and the store it reads is about to be — or already has been —
+// replaced by the leader's checkpoint. The index config it built at boot
+// describes the old store: it can hold indexes the restored registry has
+// dropped, whose read-store rows nothing would purge and whose declaration
+// removal would report no index to drop, and miss indexes created while this
+// node was behind, which then never build here.
+//
+// Called from the applier goroutine, so it only raises a flag — indexConfig
+// belongs to the builder loop, which rebuilds at its next safe point.
+func (b *Builder) OnSnapshotInstalled() {
+	b.configReloadPending.Store(true)
+}
+
+// reloadConfigIfRequested rebuilds the index config when a snapshot install has
+// swapped the store under it. Runs in the builder loop, which owns indexConfig.
+// On failure the request is raised again so the next iteration retries rather
+// than indexing on against a config describing a store that is gone.
+func (b *Builder) reloadConfigIfRequested(ctx context.Context) error {
+	if !b.configReloadPending.Swap(false) {
+		return nil
+	}
+
+	b.logger.WithFields(map[string]any{
+		"cmp": "index-builder",
+	}).Infof("Rebuilding index config after a snapshot install")
+
+	if err := b.initIndexConfig(ctx); err != nil {
+		b.configReloadPending.Store(true)
+
+		return fmt.Errorf("rebuilding index config after snapshot install: %w", err)
+	}
+
+	return nil
+}

--- a/internal/application/indexbuilder/snapshot_install_config_test.go
+++ b/internal/application/indexbuilder/snapshot_install_config_test.go
@@ -1,0 +1,75 @@
+package indexbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// A follower caught up by a leader InstallSnapshot has its Pebble DB reopened
+// with the leader's copy: node.processReady calls applier.SyncSnapshot, which
+// enqueues RestoreCheckpoint. Everything holding state derived from the old DB
+// has to be rebuilt across that swap, and NewNode wires a single callback for
+// it — membership.OnSnapshotInstalled, which refreshes the peer cache.
+//
+// The builder reads the registry into indexConfig once, in bootInit, so a
+// builder that finished booting before the swap keeps describing the pre-swap
+// registry. Indexes dropped while the node was away stay live to it: it holds
+// them in byCanonical, leaves their read-store rows unpurged, and reports no
+// index to drop when the declaration is removed — which is what a cluster
+// surfaces as an index outliving its field declaration.
+func TestIndexConfigFollowsTheStoreAcrossASnapshotInstall(t *testing.T) {
+	t.Parallel()
+
+	const ledger = "restored-ledger"
+
+	b := newTestBuilderWithStore(t)
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "k0")
+	canonical := indexes.Canonical(id)
+	indexKey := domain.IndexKey{LedgerName: ledger, Canonical: canonical}.Bytes()
+
+	// Boot against a store holding the ledger and its index, the way a node
+	// that indexed the field before it fell behind would.
+	fsmBatch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(fsmBatch, ledger, &commonpb.LedgerInfo{
+		Name: ledger,
+		MetadataSchema: &commonpb.MetadataSchema{
+			AccountFields: map[string]*commonpb.MetadataFieldSchema{
+				"k0": {Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+			},
+		},
+	}))
+	_, err := b.attrs.Index.Set(fsmBatch, indexKey, &commonpb.Index{
+		Ledger:                 ledger,
+		Id:                     id,
+		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
+		ForwardEncodingVersion: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fsmBatch.Commit())
+
+	require.NoError(t, b.initIndexConfig(context.Background()))
+	require.Contains(t, b.ledgerConfig(ledger).byCanonical, canonical, "boot loads the index the store holds")
+
+	// The leader's checkpoint replaces the store. This index was dropped while
+	// the node was away, so the restored registry no longer carries it.
+	swapBatch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, b.attrs.Index.Delete(swapBatch, indexKey))
+	require.NoError(t, swapBatch.Commit())
+
+	// What the node signals on install, and what the loop does with it at its
+	// next safe point.
+	b.OnSnapshotInstalled()
+	require.NoError(t, b.reloadConfigIfRequested(context.Background()))
+
+	assert.NotContains(t, b.ledgerConfig(ledger).byCanonical, canonical,
+		"the builder still holds an index the restored registry dropped: its rows are never purged, "+
+			"and removing the declaration reports no index to drop")
+}

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -312,6 +312,7 @@ func Module() fx.Option {
 				recovery *state.Recovery,
 				synchronizer *state.Synchronizer,
 				membership *raftmembership.Membership,
+				indexBuilder *indexbuilder.Builder,
 				localResponses node.LocalResponses,
 			) (*node.Applier, error) {
 				return node.NewApplier(
@@ -326,7 +327,13 @@ func Module() fx.Option {
 					cfg.CompactionMargin,
 					cfg.ReplayBatchSize,
 					snapshotFetcherProvider,
-					membership.OnSnapshotInstalled,
+					// Everything derived from the store this replaces has to be
+					// rebuilt: the peer-address cache, and the index config the
+					// builder loaded from the store being swapped out.
+					func() {
+						membership.OnSnapshotInstalled()
+						indexBuilder.OnSnapshotInstalled()
+					},
 					localResponses,
 				)
 			},


### PR DESCRIPTION
## What changed

A leader `InstallSnapshot` now also reaches the indexbuilder, which rebuilds its
per-ledger index config at the next point in its loop where it owns that config.

## Why

Catching a follower up on a leader snapshot reopens its Pebble DB with the
leader's checkpoint (`processReady` → `applier.SyncSnapshot` → `RestoreCheckpoint`).
Anything derived from the old store has to be rebuilt across that swap, and the
only callback wired for it refreshed the peer-address cache.

The builder reads the registry into `indexConfig` in `bootInit` and never again.
On a restart the two are milliseconds apart — the node boots, then Raft
discovers how far behind it is — so the builder ends up describing the pre-swap
registry: it holds indexes the restored registry dropped, leaves their
read-store rows unpurged, reports no index to drop when the declaration is
removed, and misses indexes created while the node was behind, which then never
build there. Measured on a 3-node cluster: the builder loaded its config 19ms
before the install, and answered 7 removals across 3 indexes from the stale copy.

## Risk

**LOW** — one flag and a rebuild at a point that already owns the config; no
change to what is indexed.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted: `TestIndexConfigFollowsTheStoreAcrossASnapshotInstall`, red-checked
      (fails with the production symptom when the rebuild is disabled)
- [x] `internal/application/indexbuilder`, `internal/bootstrap`

## Architecture / behavior impact

The applier's post-install callback now notifies the builder as well as
membership. No DI cycle: the builder's constructor takes only store, read store,
attributes, logger, meter and config.

## Review focus

That the rebuild runs on the builder goroutine. `OnSnapshotInstalled` is called
from the applier and only raises a flag, because `indexConfig` is not guarded by
a lock.
