### PR TITLE
fix(EN-1784): migrate remaining business tests to leased ports

### DIFF
--- a/tests/e2e/business/cross_store_snapshot_alignment_test.go
+++ b/tests/e2e/business/cross_store_snapshot_alignment_test.go
@@ -37,15 +37,12 @@ var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
 		client servicepb.BucketServiceClient
 	)
 
-	const (
-		httpPort = 15708
-		grpcPort = 15808
-	)
-
 	const ledgerName = "cross-store-alignment-ledger"
 
 	BeforeAll(func() {
-		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort)
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
 
 		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerWithSchemaAction(ledgerName, nil, []*commonpb.SetMetadataFieldTypeCommand{
 			{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: "tier", Type: commonpb.MetadataType_METADATA_TYPE_STRING},

--- a/tests/e2e/business/cross_store_value_skew_test.go
+++ b/tests/e2e/business/cross_store_value_skew_test.go
@@ -40,15 +40,12 @@ var _ = Describe("Cross-store value skew", Ordered, func() {
 		client servicepb.BucketServiceClient
 	)
 
-	const (
-		httpPort = 15710
-		grpcPort = 15810
-	)
-
 	const ledgerName = "cross-store-value-skew-ledger"
 
 	BeforeAll(func() {
-		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort)
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
 
 		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerWithSchemaAction(ledgerName, nil, []*commonpb.SetMetadataFieldTypeCommand{
 			{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: "tier", Type: commonpb.MetadataType_METADATA_TYPE_STRING},

--- a/tests/e2e/business/index_after_field_removal_test.go
+++ b/tests/e2e/business/index_after_field_removal_test.go
@@ -28,14 +28,12 @@ var _ = Describe("Query after metadata field removal", Ordered, func() {
 		client servicepb.BucketServiceClient
 	)
 
-	const (
-		httpPort = 15714
-		grpcPort = 15814
-		metaKey  = "k2"
-	)
+	const metaKey = "k2"
 
 	BeforeAll(func() {
-		ctx, client, _ = testutil.SetupSingleNode(httpPort, grpcPort)
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
 	})
 
 	apply := func(reqs ...*servicepb.Request) {


### PR DESCRIPTION
## What changed

Migrates the three remaining business E2E tests to the leased-port SetupSingleNode contract. Each test now gets its client from ServiceWithClient instead of passing fixed HTTP and gRPC ports.

## Why

The release/v3.0 E2E gate no longer compiled after EN-1784 changed SetupSingleNode. This restores compilation and keeps all test node ports allocated through NodeLease.

## Risk

**LOW**

Test-only compatibility fix limited to three existing E2E setup blocks. No production behavior or assertions changed.

## Validation

- [x] bash scripts/agent-check
- [x] Targeted tests: the three affected Ginkgo scenarios
- [x] Full suite / broader validation: just test-e2e-full

## Architecture / behavior impact

N/A

## Review focus

Confirm the three tests use the same SetupSingleNode and ServiceWithClient pattern as the rest of the business suite.

## Known concerns

None