### PR TITLE
chore: adopt gomodguard_v2 and make the operator forbidigo exemption path-tolerant

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,7 +44,7 @@ linters:
   - godot
   - goheader
   - gomoddirectives
-  - gomodguard
+  - gomodguard_v2
   - goprintffuncname
   - gosmopolitan
   - govet
@@ -223,7 +223,14 @@ linters:
     # it is a short-lived plugin process. With no concurrent writer there is no
     # race, only pterm's inherent pattern. Tracked separately rather than
     # duplicating the wrapper across the module boundary.
-    - path: ^misc/operator/
+    #
+    # The pattern is not anchored at the start: golangci-lint reports an issue
+    # path relative to the run directory, and its analysis cache is keyed by
+    # package content, so a cache entry produced in another checkout of the
+    # same module replays with that checkout's path (../<other-worktree>/misc/
+    # operator/...). An anchored pattern misses those and the exemption
+    # silently stops applying.
+    - path: (^|/)misc/operator/
       linters: [forbidigo]
     # spinner.go is the sanctioned cmdutil.StartSpinner wrapper for EN-1781 —
     # the one place allowed to touch pterm.DefaultSpinner. spinner_test.go


### PR DESCRIPTION
## What changed

Two lines in `.golangci.yaml`:

- `gomodguard` -> `gomodguard_v2`. golangci-lint 2.12.0 deprecated the former; the linter is enabled with no settings block, so this is behaviour-neutral and only silences the warning printed on every `just lint`.
- The `misc/operator` forbidigo exemption is now `(^|/)misc/operator/` instead of `^misc/operator/`, with a comment explaining why it must not be anchored.

## Why

golangci-lint keys its package cache by package content, not by directory. `misc/operator` is byte-identical across worktrees, so a cache entry written by a run in one worktree is replayed in another and carries the originating worktree's absolute file positions. The issue path is then rendered as `../<other-worktree>/misc/operator/...`, the root-anchored exemption stops matching, and the EN-1781 `pterm.DefaultSpinner` rule fires on the operator module inside branches that never touched it. This was reported on an unrelated PR and read exactly like a real regression in it.

Accepting a path prefix keeps the exemption matching a replayed path. `golangci-lint cache clean` also clears the symptom, but only until the next cross-worktree run.

## Risk

**LOW** — configuration only, no Go code touched. `gomodguard_v2` has no settings to migrate. The looser exemption widens forbidigo's exempt set only to paths that contain a `misc/operator/` component, which is the operator module in any checkout layout.

## Validation

- [x] `bash scripts/agent-check` — PASS, `0 issues` at the root and for the operator, no deprecation warning, no generated-file drift.
- [x] Targeted: reproduced the poisoned cache from a second checkout of `misc/operator`, then mutation-tested the pattern — anchored reports 3 findings, path-tolerant reports none.
- [ ] Full suite: N/A (no code change).

## Architecture / behavior impact

N/A

## Review focus

Whether the exemption should stay scoped to the whole operator module (current behaviour, kept) or be narrowed further now that the anchor is gone.

## Known concerns

Only 3 of the operator module's 15 `pterm.DefaultSpinner` call sites were ever reported, because `max-same-issues` defaults to 3. That default is unchanged here and will keep truncating any newly introduced rule's findings.