### PR TITLE
chore: add guarded audit Jira publisher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ Key rules that apply broadly:
 - Do not ignore errors. Handle them explicitly, or use `_ = ...` with a justification comment when intentional.
 - Keep a struct's methods colocated with the struct; extract composed sub-types rather than scattering methods across files.
 - Prefer existing repository patterns and DRY solutions over parallel abstractions.
+- Every CLI invoked by repository scripts or documented as a contributor prerequisite must be provided by the Nix development environment and pinned through `flake.lock`; do not add host-only CLI dependencies.
 - Build artifacts belong under `build/`, never the repository root.
 - JSON properties use camelCase.
 - In tests, do not use `time.Sleep`; prefer `require.Eventually` or deterministic synchronization.

--- a/docs/technical/contributing/ai-audit-jira.md
+++ b/docs/technical/contributing/ai-audit-jira.md
@@ -1,0 +1,48 @@
+# Publishing qualified audit findings to Jira
+
+Deep-audit findings become durable work only after independent qualification. Jira publication is therefore a separate, explicitly authorized step after `ai-audit-challenge`.
+
+## Eligibility
+
+Only `CONFIRMED` findings are Jira candidates by default. `LIKELY`, `QUESTION`, and `REJECTED` are never published by this command. A human may handle them separately.
+
+Publication does not implement a fix and does not create a pull request. The resulting Jira bug is the durable handoff into the normal engineering workflow.
+
+## Stable identity and deduplication
+
+Every ticket contains a machine-readable marker:
+
+`AI-AUDIT:<finding-id>`
+
+Before creation, the publisher searches the configured Jira project for that exact marker. If a matching issue already exists, it reports the existing key and does not create a duplicate.
+
+The marker identifies the logical finding across repeated audits and HEADs. The audited HEAD remains recorded separately as evidence provenance.
+
+## Jira mapping
+
+Default project: `EN`.
+Default issue type: `Bug`.
+
+The ticket description records:
+
+- stable audit finding id and audited HEAD;
+- severity and qualification status;
+- challenge summary;
+- invariant and reachability assessments;
+- evidence for and against the finding;
+- existing relevant tests;
+- reproduction plan;
+- recommended next action;
+- the deduplication marker.
+
+Severity remains the audit severity; this first publisher deliberately does not map it to Jira Priority because priority is a product/engineering scheduling decision.
+
+## Authorization boundary
+
+`ai-audit-jira` is dry-run by default. Jira writes require an explicit `--publish` flag. It never edits existing issues, transitions issues, assigns people, comments, commits, pushes, or modifies GitHub.
+
+The command uses the authenticated Atlassian CLI (`acli`). Authentication is an operator prerequisite and credentials are never read or copied by repository scripts.
+
+## Failure behavior
+
+Publishing is fail-closed per finding. Search failure, malformed challenge input, unsupported qualification status, or creation failure stops the command. Successfully created issues are reported so a retry can deduplicate them by stable marker.

--- a/docs/technical/contributing/ai-audit-jira.md
+++ b/docs/technical/contributing/ai-audit-jira.md
@@ -16,6 +16,10 @@ Every ticket contains a machine-readable marker:
 
 Before creation, the publisher searches the configured Jira project for that exact marker. If a matching issue already exists, it reports the existing key and does not create a duplicate.
 
+Jira text search is word-based, so the search is only a prefilter. The publisher paginates through every result, requests each description, and accepts an issue as an existing duplicate only when one of its description lines is exactly the marker, which is how the description writes it. The match is confined to the description: a returned issue that carries no marker, carries the marker only in its summary, carries another finding's marker, or carries a longer marker sharing this one's prefix is not a duplicate, and publication proceeds to creation.
+
+Because the marker becomes part of that search, the publisher re-validates finding ids instead of trusting its input: a challenge result is rejected unless every finding id is unique and has the canonical `<audit-id>/<short-kebab-case-name>` form described in `ai-audit.md`. An id carrying quotes or query operators can never reach the Jira search.
+
 The marker identifies the logical finding across repeated audits and HEADs. The audited HEAD remains recorded separately as evidence provenance.
 
 ## Jira mapping
@@ -41,7 +45,11 @@ Severity remains the audit severity; this first publisher deliberately does not 
 
 `ai-audit-jira` is dry-run by default. Jira writes require an explicit `--publish` flag. It never edits existing issues, transitions issues, assigns people, comments, commits, pushes, or modifies GitHub.
 
-The command uses the authenticated Atlassian CLI (`acli`). Authentication is an operator prerequisite and credentials are never read or copied by repository scripts.
+The command uses the Atlassian CLI (`acli`) provided by the repository's Nix development environment. Authentication is an operator prerequisite and credentials are never read or copied by repository scripts.
+
+## Input binding
+
+The challenge result is caller-owned and may live outside the worktree, so it can be edited or replaced while Jira writes are in flight. A run snapshots it once, before validation, into a private temporary directory and reads every later value from that snapshot. Replacing the external file mid-run cannot retarget publication or introduce unvalidated findings.
 
 ## Failure behavior
 

--- a/docs/technical/contributing/getting-started.md
+++ b/docs/technical/contributing/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Nix with Flakes enabled** (required) - provides Go 1.26+, Just, golangci-lint, protoc, and all other tools
+- **Nix with Flakes enabled** (required) - provides Go 1.26+, Just, golangci-lint, protoc, Atlassian CLI (`acli`), and all other repository CLI dependencies
 - **direnv** - [Installation](https://direnv.net/) and [shell hook](https://direnv.net/docs/hook.html)
 
 ## Setup
@@ -19,6 +19,8 @@ direnv allow
 ```
 
 After setup, `direnv` automatically loads the Nix development environment whenever you `cd` into the project directory.
+
+Repository scripts and contributor workflows must not rely on host-installed CLIs. When adding a CLI dependency, add it to `flake.nix` so its version is pinned by `flake.lock`. External service authentication, such as `acli` credentials, remains an explicit operator setup step and is not managed by Nix.
 
 ## Project Structure
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
               inherit system;
               overlays = [ nur.overlays.default ];
               config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+                "acli"
+                "acli-unwrapped"
                 "goreleaser-pro"
               ];
             };
@@ -42,6 +44,7 @@
       devShells = forEachSupportedSystem ({ pkgs, pkgs-unstable, system }:
         let
           stablePackages = with pkgs; [
+            acli
             go_1_26
             ffmpeg
             ginkgo

--- a/scripts/ai-audit-jira
+++ b/scripts/ai-audit-jira
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/ai-audit-jira <challenge-result.json> [--publish] [--project <key>]
+
+Previews Jira bugs for CONFIRMED audit findings. Jira writes require --publish.
+Default project: EN.
+EOF
+}
+
+[[ $# -gt 0 ]] || { usage >&2; exit 1; }
+case "${1:-}" in -h|--help) usage; exit 0 ;; esac
+input=$1
+shift
+publish=false
+project=EN
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publish) publish=true; shift ;;
+        --project) [[ $# -ge 2 && "$2" =~ ^[A-Z][A-Z0-9_]*$ ]] || { echo "ai-audit-jira: invalid --project" >&2; exit 1; }; project=$2; shift 2 ;;
+        *) echo "ai-audit-jira: unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+for command in jq; do command -v "$command" >/dev/null 2>&1 || { echo "ai-audit-jira: required command not found: $command" >&2; exit 1; }; done
+[[ -f "$input" ]] || { echo "ai-audit-jira: challenge result not found: $input" >&2; exit 1; }
+
+if ! jq -e '
+    type == "object" and
+    (.audit_id | type == "string" and length > 0) and
+    (.head | type == "string" and test("^[0-9a-f]{40,64}$")) and
+    (.results | type == "array") and
+    all(.results[];
+      (.id | type == "string" and length > 0) and
+      (.severity == "P0" or .severity == "P1" or .severity == "P2" or .severity == "P3") and
+      (.status == "CONFIRMED" or .status == "LIKELY" or .status == "QUESTION" or .status == "REJECTED") and
+      (.title | type == "string" and length > 0) and
+      (.challenge_summary | type == "string" and length > 0) and
+      (.evidence_for | type == "array") and
+      (.evidence_against | type == "array") and
+      (.invariant_assessment | type == "string" and length > 0) and
+      (.reachability_assessment | type == "string" and length > 0) and
+      (.existing_tests | type == "array") and
+      (.reproduction_plan | type == "string" and length > 0) and
+      (.recommended_next_action | type == "string" and length > 0))
+' "$input" >/dev/null; then
+    echo "ai-audit-jira: invalid challenge result" >&2
+    exit 1
+fi
+
+confirmed_count=$(jq '[.results[] | select(.status == "CONFIRMED")] | length' "$input")
+printf 'AI_AUDIT_JIRA_CANDIDATES: %s\n' "$confirmed_count"
+[[ "$confirmed_count" -gt 0 ]] || exit 0
+
+if [[ "$publish" == true ]]; then
+    command -v acli >/dev/null 2>&1 || { echo "ai-audit-jira: acli is required for --publish" >&2; exit 1; }
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/ledger-audit-jira.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+
+audit_id=$(jq -r .audit_id "$input")
+head_sha=$(jq -r .head "$input")
+
+while IFS= read -r finding; do
+    id=$(jq -r .id <<<"$finding")
+    severity=$(jq -r .severity <<<"$finding")
+    title=$(jq -r .title <<<"$finding")
+    marker="AI-AUDIT:$id"
+    summary="[$severity] $title"
+    description_file="$tmp/description.txt"
+
+    {
+        printf 'Confirmed Ledger deep-audit finding.\n\n'
+        printf 'Audit domain: %s\n' "$audit_id"
+        printf 'Finding ID: %s\n' "$id"
+        printf 'Audited HEAD: %s\n' "$head_sha"
+        printf 'Audit severity: %s\n' "$severity"
+        printf 'Qualification: CONFIRMED\n\n'
+        printf 'Challenge summary\n%s\n\n' "$(jq -r .challenge_summary <<<"$finding")"
+        printf 'Invariant assessment\n%s\n\n' "$(jq -r .invariant_assessment <<<"$finding")"
+        printf 'Reachability assessment\n%s\n\n' "$(jq -r .reachability_assessment <<<"$finding")"
+        printf 'Evidence for\n'
+        jq -r '.evidence_for[]? | "- " + .' <<<"$finding"
+        printf '\nEvidence against / caveats\n'
+        jq -r '.evidence_against[]? | "- " + .' <<<"$finding"
+        printf '\nExisting relevant tests\n'
+        jq -r '.existing_tests[]? | "- " + .' <<<"$finding"
+        printf '\nReproduction plan\n%s\n\n' "$(jq -r .reproduction_plan <<<"$finding")"
+        printf 'Recommended next action\n%s\n\n' "$(jq -r .recommended_next_action <<<"$finding")"
+        printf '%s\n' "$marker"
+    } > "$description_file"
+
+    printf '\n==> Jira candidate: %s\n' "$id"
+    printf 'Project: %s\nType: Bug\nSummary: %s\nMarker: %s\n' "$project" "$summary" "$marker"
+
+    if [[ "$publish" != true ]]; then
+        printf 'Action: DRY_RUN\n'
+        continue
+    fi
+
+    # Exact marker is quoted as a JQL phrase; finding ids are schema-constrained
+    # by the challenge contract and cannot inject JQL syntax.
+    search_json=$(acli jira workitem search \
+        --jql "project = $project AND text ~ '\"$marker\"'" \
+        --fields key,summary \
+        --limit 10 \
+        --json)
+    existing_key=$(jq -r --arg marker "$marker" '
+        [.. | objects | select((.key? | type) == "string") | .key] | unique | first // empty
+    ' <<<"$search_json")
+    if [[ -n "$existing_key" ]]; then
+        printf 'Action: EXISTS\nJira: %s\n' "$existing_key"
+        continue
+    fi
+
+    create_json=$(acli jira workitem create \
+        --project "$project" \
+        --type Bug \
+        --summary "$summary" \
+        --description-file "$description_file" \
+        --label ai-audit \
+        --json)
+    created_key=$(jq -r '.. | objects | .key? // empty' <<<"$create_json" | head -n1)
+    [[ -n "$created_key" ]] || { echo "ai-audit-jira: Jira creation succeeded but no issue key was returned" >&2; exit 1; }
+    printf 'Action: CREATED\nJira: %s\n' "$created_key"
+done < <(jq -c '.results[] | select(.status == "CONFIRMED")' "$input")

--- a/scripts/ai-audit-jira
+++ b/scripts/ai-audit-jira
@@ -27,13 +27,28 @@ done
 for command in jq; do command -v "$command" >/dev/null 2>&1 || { echo "ai-audit-jira: required command not found: $command" >&2; exit 1; }; done
 [[ -f "$input" ]] || { echo "ai-audit-jira: challenge result not found: $input" >&2; exit 1; }
 
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/ledger-audit-jira.XXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+
+# The challenge result is caller-owned and may be edited or replaced while Jira
+# writes are in flight. Snapshot it once before validation and bind every later
+# read to that private copy, so publication cannot switch to unvalidated input.
+snapshot="$tmp/challenge-result.json"
+cp -- "$input" "$snapshot"
+chmod 400 "$snapshot"
+
+# The audit_id and every finding id are untrusted report content that ends up in
+# the deduplication marker and therefore in the JQL search below. Enforce the
+# canonical `<audit-id>/<short-kebab-case-name>` finding-id format required by
+# scripts/ai-audit here too: this command runs standalone and cannot assume the
+# result was produced by a validated audit/challenge pass.
 if ! jq -e '
     type == "object" and
-    (.audit_id | type == "string" and length > 0) and
+    (.audit_id | type == "string" and test("^[a-z0-9][a-z0-9-]*$")) and
     (.head | type == "string" and test("^[0-9a-f]{40,64}$")) and
     (.results | type == "array") and
-    all(.results[];
-      (.id | type == "string" and length > 0) and
+    ((.audit_id + "/") as $prefix | all(.results[];
+      (.id | type == "string" and startswith($prefix) and (ltrimstr($prefix) | test("^[a-z0-9]+(-[a-z0-9]+)*$"))) and
       (.severity == "P0" or .severity == "P1" or .severity == "P2" or .severity == "P3") and
       (.status == "CONFIRMED" or .status == "LIKELY" or .status == "QUESTION" or .status == "REJECTED") and
       (.title | type == "string" and length > 0) and
@@ -44,13 +59,14 @@ if ! jq -e '
       (.reachability_assessment | type == "string" and length > 0) and
       (.existing_tests | type == "array") and
       (.reproduction_plan | type == "string" and length > 0) and
-      (.recommended_next_action | type == "string" and length > 0))
-' "$input" >/dev/null; then
+      (.recommended_next_action | type == "string" and length > 0))) and
+    ([.results[].id] | length == (unique | length))
+' "$snapshot" >/dev/null; then
     echo "ai-audit-jira: invalid challenge result" >&2
     exit 1
 fi
 
-confirmed_count=$(jq '[.results[] | select(.status == "CONFIRMED")] | length' "$input")
+confirmed_count=$(jq '[.results[] | select(.status == "CONFIRMED")] | length' "$snapshot")
 printf 'AI_AUDIT_JIRA_CANDIDATES: %s\n' "$confirmed_count"
 [[ "$confirmed_count" -gt 0 ]] || exit 0
 
@@ -58,11 +74,8 @@ if [[ "$publish" == true ]]; then
     command -v acli >/dev/null 2>&1 || { echo "ai-audit-jira: acli is required for --publish" >&2; exit 1; }
 fi
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/ledger-audit-jira.XXXXXX")
-trap 'rm -rf -- "$tmp"' EXIT
-
-audit_id=$(jq -r .audit_id "$input")
-head_sha=$(jq -r .head "$input")
+audit_id=$(jq -r .audit_id "$snapshot")
+head_sha=$(jq -r .head "$snapshot")
 
 while IFS= read -r finding; do
     id=$(jq -r .id <<<"$finding")
@@ -101,15 +114,31 @@ while IFS= read -r finding; do
         continue
     fi
 
-    # Exact marker is quoted as a JQL phrase; finding ids are schema-constrained
-    # by the challenge contract and cannot inject JQL syntax.
+    # Exact marker is quoted as a JQL phrase; the validation above restricts
+    # finding ids to lowercase kebab-case segments, so they cannot carry quotes
+    # or JQL operators into the search.
+    #
+    # Jira text search is word-based, so the JQL is only a prefilter: it can
+    # return issues that do not carry this marker at all, and a longer marker
+    # sharing this one's prefix must not count either. The description is
+    # therefore requested as well and an issue is accepted as an existing
+    # duplicate only when one of its own description lines is exactly the
+    # marker, which is how the description above writes it. Matching is confined
+    # to the description field on purpose: a summary that happens to be the
+    # marker must not suppress creation. Every string reachable under the
+    # description is inspected so both the plain-text and the structured
+    # document representation Jira may return are covered.
     search_json=$(acli jira workitem search \
         --jql "project = $project AND text ~ '\"$marker\"'" \
-        --fields key,summary \
-        --limit 10 \
+        --fields key,summary,description \
+        --paginate \
         --json)
     existing_key=$(jq -r --arg marker "$marker" '
-        [.. | objects | select((.key? | type) == "string") | .key] | unique | first // empty
+        [.. | objects
+         | select((.key? | type) == "string")
+         | select(any((.fields | objects | .description) | .. | strings
+                      | split("\n")[] | gsub("^\\s+|\\s+$"; ""); . == $marker))
+         | .key] | unique | first // empty
     ' <<<"$search_json")
     if [[ -n "$existing_key" ]]; then
         printf 'Action: EXISTS\nJira: %s\n' "$existing_key"
@@ -126,4 +155,4 @@ while IFS= read -r finding; do
     created_key=$(jq -r '.. | objects | .key? // empty' <<<"$create_json" | head -n1)
     [[ -n "$created_key" ]] || { echo "ai-audit-jira: Jira creation succeeded but no issue key was returned" >&2; exit 1; }
     printf 'Action: CREATED\nJira: %s\n' "$created_key"
-done < <(jq -c '.results[] | select(.status == "CONFIRMED")' "$input")
+done < <(jq -c '.results[] | select(.status == "CONFIRMED")' "$snapshot")

--- a/scripts/aiauditjira/runner_test.go
+++ b/scripts/aiauditjira/runner_test.go
@@ -1,0 +1,377 @@
+package aiauditjira
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAuditID   = "persistence-restore-replay"
+	testFindingID = testAuditID + "/restore-retries-from-snapshot"
+	testHead      = "0123456789abcdef0123456789abcdef01234567"
+	createdKey    = "EN-4242"
+)
+
+// The fake acli stands in for the Atlassian CLI: it records every invocation so
+// tests can assert the exact JQL the publisher builds, and answers searches and
+// creations with prepared JSON.
+const fakeACLI = `#!/usr/bin/env bash
+set -euo pipefail
+{
+	printf 'invocation'
+	for argument in "$@"; do printf '\t%s' "$argument"; done
+	printf '\n'
+} >>"$FAKE_ACLI_LOG"
+if [[ "$*" == *" search "* ]]; then
+	printf '%s\n' "$FAKE_ACLI_SEARCH_JSON"
+else
+	printf '%s\n' "$FAKE_ACLI_CREATE_JSON"
+fi
+`
+
+// The jq proxy can replace the caller-owned input immediately after the first
+// successful read. This deterministically exercises the boundary between input
+// validation and every later read without adding a test hook to the publisher.
+const fakeJQ = `#!/usr/bin/env bash
+set -euo pipefail
+set +e
+"$FAKE_REAL_JQ" "$@"
+status=$?
+set -e
+if [[ $status -eq 0 && -n "${FAKE_JQ_REPLACEMENT:-}" && ! -e "$FAKE_JQ_REPLACED" ]]; then
+	: >"$FAKE_JQ_REPLACED"
+	cp -- "$FAKE_JQ_REPLACEMENT" "$FAKE_JQ_INPUT"
+fi
+exit "$status"
+`
+
+func TestPublisherPreviewsConfirmedFindingsWithoutContactingJira(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)))
+	require.NoError(t, err, output)
+	require.Contains(t, output, "AI_AUDIT_JIRA_CANDIDATES: 1")
+	require.Contains(t, output, "Marker: AI-AUDIT:"+testFindingID)
+	require.Contains(t, output, "Action: DRY_RUN")
+	require.NoFileExists(t, fixture.logPath)
+}
+
+// The deduplication search is the only place an untrusted finding id reaches
+// Jira query syntax, so the published JQL must be the exact quoted marker
+// phrase and nothing else.
+func TestPublisherSearchesForTheExactQuotedMarker(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Action: CREATED")
+	require.Contains(t, output, "Jira: "+createdKey)
+	require.Equal(t,
+		`project = EN AND text ~ '"AI-AUDIT:`+testFindingID+`"'`,
+		fixture.searchedJQL(t),
+	)
+	invocations := fixture.invocations(t)
+	require.Contains(t, invocations, "\t--paginate\t")
+	require.NotContains(t, invocations, "\t--limit\t")
+}
+
+func TestPublisherStaysBoundToValidatedSnapshotWhenInputIsReplaced(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	replacementAuditID := "replaced-during-publication"
+	replacementFindingID := replacementAuditID + "/different-finding"
+	fixture.replacementPath = filepath.Join(t.TempDir(), "replacement.json")
+	writeJSON(t, fixture.replacementPath, map[string]any{
+		"audit_id":      replacementAuditID,
+		"head":          "1111111111111111111111111111111111111111",
+		"summary":       "Replacement challenge",
+		"results":       []map[string]any{confirmedResult(replacementFindingID)},
+		"questions":     []map[string]any{},
+		"residual_risk": "LOW",
+	})
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish")
+	require.NoError(t, err, output)
+	require.FileExists(t, fixture.replacedPath)
+	require.Equal(t, replacementAuditID, readJSON(t, fixture.inputPath)["audit_id"])
+	require.Contains(t, output, "==> Jira candidate: "+testFindingID)
+	require.NotContains(t, output, replacementFindingID)
+}
+
+// A crafted or malformed finding id must be refused before it can widen or
+// retarget the deduplication search, which would otherwise report an unrelated
+// issue as an existing duplicate and silently drop the confirmed finding.
+func TestPublisherRejectsFindingIDsThatCouldAlterTheJiraSearch(t *testing.T) {
+	t.Parallel()
+
+	for name, id := range map[string]string{
+		"single quote closing the marker phrase": testAuditID + "/broken' OR text ~ 'unrelated",
+		"double quote and JQL operator":          testAuditID + `/broken" OR key = ` + createdKey + ` AND text ~ "`,
+		"wildcard operator":                      testAuditID + "/broken*",
+		"another audit prefix":                   "another-audit/restore-retries-from-snapshot",
+		"missing audit prefix":                   "restore-retries-from-snapshot",
+		"non kebab-case name":                    testAuditID + "/Restore_Retries",
+		"nested path segment":                    testAuditID + "/restore/retries",
+		"empty name":                             testAuditID + "/",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newFixture(t)
+
+			output, err := fixture.run(t, challengeResult(confirmedResult(id)), "--publish")
+			require.Error(t, err)
+			require.Contains(t, output, "invalid challenge result")
+			require.NoFileExists(t, fixture.logPath)
+		})
+	}
+}
+
+// The audit id is the first segment of every finding id, so it must be
+// constrained as well; otherwise the marker inherits whatever it contains.
+func TestPublisherRejectsMalformedAuditID(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	auditID := "broken' OR text ~ 'unrelated"
+	result := challengeResult(confirmedResult(auditID + "/restore-retries-from-snapshot"))
+	result["audit_id"] = auditID
+
+	output, err := fixture.run(t, result, "--publish")
+	require.Error(t, err)
+	require.Contains(t, output, "invalid challenge result")
+	require.NoFileExists(t, fixture.logPath)
+}
+
+func TestPublisherRejectsDuplicateFindingIDsBeforeAnyJiraCall(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	result := challengeResult(
+		confirmedResult(testFindingID),
+		confirmedResult(testFindingID),
+	)
+
+	output, err := fixture.run(t, result, "--publish")
+	require.Error(t, err)
+	require.Contains(t, output, "invalid challenge result")
+	require.NoFileExists(t, fixture.logPath)
+}
+
+// An issue is only a duplicate if it actually carries the marker, so the search
+// must request the field the publisher writes the marker into.
+func TestPublisherReportsExistingIssueCarryingTheExactMarker(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	fixture.searchJSON = searchResponse(t, "EN-77", "Confirmed Ledger deep-audit finding.\n\nAI-AUDIT:"+testFindingID+"\n")
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Action: EXISTS")
+	require.Contains(t, output, "Jira: EN-77")
+	require.NotContains(t, output, "Action: CREATED")
+	require.Contains(t, fixture.searchedArgument(t, "--fields"), "description")
+}
+
+// Jira text search is word-based, so it can return issues that do not carry
+// this marker. Treating such a result as a duplicate would silently drop the
+// confirmed finding, so publication must fall through to creation whenever the
+// exact marker is absent from the description the publisher writes it into.
+func TestPublisherCreatesWhenSearchResultsLackTheExactMarker(t *testing.T) {
+	t.Parallel()
+
+	marker := "AI-AUDIT:" + testFindingID
+	for name, searchJSON := range map[string]string{
+		"issue without any marker":           searchResponse(t, "EN-77", "Unrelated issue mentioning the audit"),
+		"marker of another finding":          searchResponse(t, "EN-78", "AI-AUDIT:"+testAuditID+"/another-confirmed-finding"),
+		"longer marker sharing this prefix":  searchResponse(t, "EN-79", marker+"-extended"),
+		"issue returned without description": `{"issues":[{"key":"EN-80","fields":{"summary":"[P2] Some Jira summary"}}]}`,
+		"marker only in the summary":         `{"issues":[{"key":"EN-81","fields":{"summary":"` + marker + `","description":"No marker here"}}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newFixture(t)
+			fixture.searchJSON = searchJSON
+
+			output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish")
+			require.NoError(t, err, output)
+			require.Contains(t, output, "Action: CREATED")
+			require.Contains(t, output, "Jira: "+createdKey)
+			require.NotContains(t, output, "Action: EXISTS")
+		})
+	}
+}
+
+func searchResponse(t *testing.T, key string, description string) string {
+	t.Helper()
+
+	encoded, err := json.Marshal(map[string]any{
+		"issues": []map[string]any{{
+			"key": key,
+			"fields": map[string]any{
+				"summary":     "[P2] Some Jira summary",
+				"description": description,
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	return string(encoded)
+}
+
+type fixture struct {
+	inputPath       string
+	logPath         string
+	fakeBin         string
+	searchJSON      string
+	realJQ          string
+	replacementPath string
+	replacedPath    string
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	root := t.TempDir()
+	fakeBin := filepath.Join(root, "bin")
+	require.NoError(t, os.MkdirAll(fakeBin, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "acli"), []byte(fakeACLI), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(fakeBin, "jq"), []byte(fakeJQ), 0o700))
+	realJQ, err := exec.LookPath("jq")
+	require.NoError(t, err)
+
+	return &fixture{
+		inputPath:    filepath.Join(root, "qualified.json"),
+		logPath:      filepath.Join(root, "acli-invocations.log"),
+		fakeBin:      fakeBin,
+		searchJSON:   `{"issues":[]}`,
+		realJQ:       realJQ,
+		replacedPath: filepath.Join(root, "jq-replaced-input"),
+	}
+}
+
+func (f *fixture) run(t *testing.T, result map[string]any, arguments ...string) (string, error) {
+	t.Helper()
+
+	writeJSON(t, f.inputPath, result)
+	command := exec.Command("bash", append(
+		[]string{filepath.Join(repositoryRoot(t), "scripts", "ai-audit-jira"), f.inputPath},
+		arguments...,
+	)...)
+	command.Env = append(os.Environ(),
+		"FAKE_ACLI_LOG="+f.logPath,
+		"FAKE_ACLI_SEARCH_JSON="+f.searchJSON,
+		`FAKE_ACLI_CREATE_JSON={"key":"`+createdKey+`"}`,
+		"FAKE_REAL_JQ="+f.realJQ,
+		"FAKE_JQ_INPUT="+f.inputPath,
+		"FAKE_JQ_REPLACEMENT="+f.replacementPath,
+		"FAKE_JQ_REPLACED="+f.replacedPath,
+		"PATH="+f.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := command.CombinedOutput()
+
+	return string(output), err
+}
+
+func (f *fixture) searchedJQL(t *testing.T) string {
+	t.Helper()
+
+	return f.searchedArgument(t, "--jql")
+}
+
+func (f *fixture) searchedArgument(t *testing.T, name string) string {
+	t.Helper()
+
+	contents, err := os.ReadFile(f.logPath)
+	require.NoError(t, err)
+	for invocation := range strings.SplitSeq(strings.TrimSuffix(string(contents), "\n"), "\n") {
+		arguments := strings.Split(invocation, "\t")
+		for index, argument := range arguments {
+			if argument == name {
+				require.Less(t, index+1, len(arguments))
+
+				return arguments[index+1]
+			}
+		}
+	}
+	t.Fatalf("no acli invocation carried a %s argument: %s", name, contents)
+
+	return ""
+}
+
+func (f *fixture) invocations(t *testing.T) string {
+	t.Helper()
+
+	contents, err := os.ReadFile(f.logPath)
+	require.NoError(t, err)
+
+	return string(contents)
+}
+
+func challengeResult(results ...map[string]any) map[string]any {
+	return map[string]any{
+		"audit_id":      testAuditID,
+		"head":          testHead,
+		"summary":       "Test challenge",
+		"results":       results,
+		"questions":     []map[string]any{},
+		"residual_risk": "LOW",
+	}
+}
+
+func confirmedResult(id string) map[string]any {
+	return map[string]any{
+		"id":                      id,
+		"severity":                "P2",
+		"title":                   "Original title of " + id,
+		"status":                  "CONFIRMED",
+		"challenge_summary":       "Reconstructed the claimed failure path",
+		"evidence_for":            []string{"scripts/ai-audit-jira"},
+		"evidence_against":        []string{},
+		"invariant_assessment":    "The invariant is documented",
+		"reachability_assessment": "The state is reachable",
+		"existing_tests":          []string{},
+		"reproduction_plan":       "Run the publisher fixture",
+		"recommended_next_action": "Implement a regression test",
+	}
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func writeJSON(t *testing.T, path string, content map[string]any) {
+	t.Helper()
+	encoded, err := json.Marshal(content)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, encoded, 0o600))
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(contents, &decoded))
+
+	return decoded
+}


### PR DESCRIPTION
## Summary

Add the third stage of the deep-audit pipeline: explicitly authorized publication of independently confirmed findings to Jira.

- consume `ai-audit-challenge` structured results
- publish only `CONFIRMED` findings; ignore `LIKELY`, `QUESTION`, and `REJECTED`
- dry-run by default; Jira writes require `--publish`
- default to the existing `EN` project and `Bug` issue type
- preserve stable finding identity with an `AI-AUDIT:<finding-id>` marker
- search Jira for that exact marker before creation to avoid duplicate tickets across repeated audits
- record audited HEAD, severity, challenge evidence, invariant/reachability assessment, tests, reproduction plan, and recommended next action
- deliberately do not map audit severity to Jira priority
- never fix code, create PRs, transition/assign/edit existing Jira issues, or write to GitHub

## Usage

Preview only:

```bash
bash scripts/ai-audit-jira build/ai-audit-challenge/<result>.json
```

Publish confirmed findings:

```bash
bash scripts/ai-audit-jira build/ai-audit-challenge/<result>.json --publish
```

The publisher uses the authenticated Atlassian CLI (`acli`) only in publish mode. Credentials remain outside repository tooling.

## Jira context

The connected Formance Jira site uses project `EN`, which supports the `Bug` issue type. Existing Ledger engineering bugs are already tracked there. The project can be overridden with `--project <KEY>`.

## Safety / policy

This is intentionally an explicit write boundary. Dry-run does not require `acli`. `--publish` searches for the stable marker first and creates only missing confirmed findings. A partial run is safe to retry because already-created findings should deduplicate by marker.

## Review focus

Please focus on:

- whether only CONFIRMED findings can reach Jira creation
- ACLI command/JSON compatibility with the installed/current CLI
- JQL escaping and exact-marker deduplication
- behavior on partial publication failure and retry
- whether the description preserves enough audit/challenge provenance
- whether any Jira priority/assignment/workflow decision is being made implicitly
- whether malformed or adversarial challenge data can become CLI/JQL injection
- whether dry-run is genuinely write-free

## Follow-up

Once this publisher is trusted, qualified findings can become durable Jira work. Reproducer implementation and fix PR generation remain separate workflows.