### PR TITLE
chore: gate AI PR loop on legitimacy triage

### DIFF
--- a/docs/technical/contributing/ai-pr-triage-loop.md
+++ b/docs/technical/contributing/ai-pr-triage-loop.md
@@ -19,3 +19,5 @@ The triage result is persisted in the launcher run directory and its path is pri
 The PR head may not choose or modify the triage policy that authorizes its own review. `ai-pr-loop` therefore uses a base-pinned trusted triage adapter for every invocation, not only guarded publish mode.
 
 `ai-pr-triage` accepts optional launcher-provided expected base/head SHAs. It still resolves current GitHub metadata itself, but refuses to run if those SHAs no longer match. This turns a concurrent PR update into a safe restart instead of triaging one state and reviewing another.
+
+The base-pinned triage adapter may predate that binding, so `ai-pr-loop` does not rely on the tool enforcing it: before accepting any decision, the launcher requires the result's `base_sha` and `head` to equal the SHAs it fetched and verified. A result describing another PR state is a target mismatch and stops the run.

--- a/docs/technical/contributing/ai-pr-triage-loop.md
+++ b/docs/technical/contributing/ai-pr-triage-loop.md
@@ -1,0 +1,21 @@
+# PR legitimacy gate in `ai-pr-loop`
+
+`ai-pr-loop` runs the advisory legitimacy triage before the expensive review/fix loop.
+
+The triage policy and adapter are always loaded from the exact verified PR base commit, never from the proposed head. The launcher binds triage to the same immutable base/head SHAs that will be reviewed.
+
+## Outcomes
+
+- `KEEP`: continue into the normal Codex review / Claude fix / validation loop.
+- `QUESTION`: stop before review with `AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED`.
+- `REJECT`: stop before review with `AI_PR_LOOP_RESULT: LEGITIMACY_REJECTED`. This is advisory only; no PR is closed or commented on.
+
+A triage provider error or target mismatch fails closed and does not start technical review.
+
+The triage result is persisted in the launcher run directory and its path is printed for inspection.
+
+## Trust boundary
+
+The PR head may not choose or modify the triage policy that authorizes its own review. `ai-pr-loop` therefore uses a base-pinned trusted triage adapter for every invocation, not only guarded publish mode.
+
+`ai-pr-triage` accepts optional launcher-provided expected base/head SHAs. It still resolves current GitHub metadata itself, but refuses to run if those SHAs no longer match. This turns a concurrent PR update into a safe restart instead of triaging one state and reviewing another.

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -29,6 +29,8 @@ A full PR URL is accepted as well. The launcher:
 - requires an open same-repository PR and currently rejects fork/cross-repository heads;
 - fetches the exact GitHub-reported base and head refs and verifies both SHAs before running agents;
 - creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
+- runs the [legitimacy triage](ai-pr-triage-loop.md) before any technical review, using the `scripts/ai-pr-triage` adapter from a detached worktree pinned at the verified base SHA, so the PR under review cannot supply the policy that authorizes its own review;
+- accepts a triage result only when its `base_sha` and `head` equal the SHAs the launcher fetched and verified, and continues into technical review only on a `KEEP` decision;
 - passes the verified base commit SHA to `review-loop`, so a later update of the shared remote-tracking ref cannot change the reviewed delta;
 - runs the standard Codex review + Claude fix composition against the PR base;
 - runs repository validation locally before accepting any approval; no GitHub
@@ -37,7 +39,9 @@ A full PR URL is accepted as well. The launcher:
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
 
-Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, or an orchestration error.
+Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, `LEGITIMACY_REJECTED`, or an orchestration error.
+
+`LEGITIMACY_REJECTED` is emitted when triage returns `REJECT`; a `QUESTION` decision stops the run with `HUMAN_DECISION_REQUIRED`. Both stop before technical review and exit `2`. A triage provider error or target mismatch fails closed as an orchestration error. Every triage outcome is advisory: the launcher never closes, comments on, or otherwise changes the PR.
 
 ### Guarded publish mode
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -146,8 +146,8 @@ git worktree add --detach "$worktree" "$head_sha"
 # Legitimacy policy must not come from the PR that it is judging.
 git worktree add --detach "$trusted_tool_worktree" "$base_sha"
 triage_tool="$trusted_tool_worktree/scripts/ai-pr-triage"
-if [[ ! -x "$triage_tool" ]]; then
-    echo "ai-pr-loop: trusted base does not provide executable scripts/ai-pr-triage" >&2
+if [[ ! -f "$triage_tool" ]]; then
+    echo "ai-pr-loop: trusted base does not provide scripts/ai-pr-triage" >&2
     exit 1
 fi
 triage_result="$worktree_run_dir/triage.json"
@@ -205,7 +205,7 @@ if [[ "$push_changes" == "true" ]]; then
     # that authorize its own publication. Build the orchestrator from the exact
     # verified base commit and invoke its tools from that immutable worktree.
     review_loop_binary="$worktree_run_dir/review-loop"
-    for trusted_tool in ai-pr-triage ai-review-codex ai-fix-claude agent-check-pr; do
+    for trusted_tool in ai-review-codex ai-fix-claude agent-check-pr; do
         trusted_tool_path="$trusted_tool_worktree/scripts/$trusted_tool"
         if [[ ! -x "$trusted_tool_path" ]]; then
             echo "ai-pr-loop: trusted base does not provide executable scripts/$trusted_tool" >&2

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -5,14 +5,14 @@ usage() {
     cat <<'EOF'
 Usage: bash scripts/ai-pr-loop <pr-number-or-url> [--keep-worktree] [--push]
 
-Creates an isolated git worktree for the PR head and runs the bounded
-Codex review -> Claude fix -> validation -> re-review loop against the
-PR base branch.
+Creates an isolated git worktree for the PR head, runs the base-pinned
+legitimacy triage, then (for KEEP) runs the bounded Codex review -> Claude
+fix -> validation -> re-review loop against the PR base branch.
 
 By default the launcher never commits or pushes. With --push, fixes are
 committed locally, that exact clean commit is reviewed once more, and it
 is pushed only if the remote PR branch still equals the SHA observed at
-startup. The launcher never comments, resolves threads, or merges.
+startup. The launcher never comments, resolves threads, closes, or merges.
 EOF
 }
 
@@ -96,7 +96,7 @@ if ! git remote get-url "$remote" >/dev/null 2>&1; then
     exit 1
 fi
 
-# Fetch exactly the GitHub-resolved base/head refs before creating the worktree.
+# Fetch exactly the GitHub-resolved base/head refs before creating worktrees.
 git fetch --no-tags "$remote" \
     "+refs/heads/$base_ref:refs/remotes/$remote/$base_ref" \
     "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
@@ -112,21 +112,19 @@ if [[ "$fetched_head" != "$head_sha" ]]; then
     exit 1
 fi
 
-# Keep linked worktrees outside the primary checkout so the review loop cannot
-# accidentally include launcher state in the PR worktree/fingerprint.
 repo_parent=$(dirname "$repo_root")
 repo_name=$(basename "$repo_root")
 worktree_parent="$repo_parent/.${repo_name}-ai-worktrees"
 mkdir -p "$worktree_parent"
 worktree_run_dir=$(mktemp -d "$worktree_parent/pr-$pr_number.XXXXXX")
 worktree="$worktree_run_dir/worktree"
-trusted_tool_worktree=""
+trusted_tool_worktree="$worktree_run_dir/trusted-tools"
 review_loop_binary=""
 
 cleanup() {
     exit_status=$?
     trap - EXIT
-    if [[ -n "$trusted_tool_worktree" ]] && [[ -d "$trusted_tool_worktree" ]] && git -C "$trusted_tool_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -d "$trusted_tool_worktree" ]] && git -C "$trusted_tool_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         git worktree remove "$trusted_tool_worktree" >/dev/null 2>&1 || true
     fi
     if [[ -n "$review_loop_binary" ]] && [[ "$review_loop_binary" == "$worktree_run_dir/review-loop" ]]; then
@@ -145,6 +143,43 @@ cleanup() {
 trap cleanup EXIT
 
 git worktree add --detach "$worktree" "$head_sha"
+# Legitimacy policy must not come from the PR that it is judging.
+git worktree add --detach "$trusted_tool_worktree" "$base_sha"
+triage_tool="$trusted_tool_worktree/scripts/ai-pr-triage"
+if [[ ! -x "$triage_tool" ]]; then
+    echo "ai-pr-loop: trusted base does not provide executable scripts/ai-pr-triage" >&2
+    exit 1
+fi
+triage_result="$worktree_run_dir/triage.json"
+set +e
+AI_PR_TRIAGE_EXPECT_BASE_SHA="$base_sha" \
+AI_PR_TRIAGE_EXPECT_HEAD_SHA="$head_sha" \
+    bash "$triage_tool" "$pr_number" --output "$triage_result"
+triage_status=$?
+set -e
+if [[ $triage_status -ne 0 ]]; then
+    echo "AI_PR_LOOP_RESULT: ERROR (triage exit $triage_status)"
+    exit "$triage_status"
+fi
+triage_decision=$(jq -r '.decision' "$triage_result")
+printf '==> ai-pr-loop: legitimacy triage %s\n' "$triage_decision"
+printf '    triage result: %s\n' "$triage_result"
+case "$triage_decision" in
+    KEEP)
+        ;;
+    QUESTION)
+        echo "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED"
+        exit 2
+        ;;
+    REJECT)
+        echo "AI_PR_LOOP_RESULT: LEGITIMACY_REJECTED"
+        exit 2
+        ;;
+    *)
+        echo "ai-pr-loop: invalid triage decision: $triage_decision" >&2
+        exit 1
+        ;;
+esac
 
 review_loop=(bash scripts/review-loop)
 review_cmd='bash scripts/ai-review-codex'
@@ -159,10 +194,8 @@ if [[ "$push_changes" == "true" ]]; then
     # A PR must not supply the policy engine, provider adapters, or validator
     # that authorize its own publication. Build the orchestrator from the exact
     # verified base commit and invoke its tools from that immutable worktree.
-    trusted_tool_worktree="$worktree_run_dir/trusted-tools"
     review_loop_binary="$worktree_run_dir/review-loop"
-    git worktree add --detach "$trusted_tool_worktree" "$base_sha"
-    for trusted_tool in ai-review-codex ai-fix-claude agent-check-pr; do
+    for trusted_tool in ai-pr-triage ai-review-codex ai-fix-claude agent-check-pr; do
         trusted_tool_path="$trusted_tool_worktree/scripts/$trusted_tool"
         if [[ ! -x "$trusted_tool_path" ]]; then
             echo "ai-pr-loop: trusted base does not provide executable scripts/$trusted_tool" >&2
@@ -204,8 +237,6 @@ run_full_loop() {
 }
 
 run_commit_review() {
-    # No fixer on this pass: the exact clean commit that may be pushed must be
-    # approved as-is. Any new blocker stops publication and requires a rerun.
     "${review_loop[@]}" \
         --base "$base_sha" \
         --review-cmd "$review_cmd" \
@@ -219,15 +250,9 @@ set -e
 
 echo
 case "$loop_status" in
-    0)
-        echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
-        ;;
-    2)
-        echo "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED"
-        ;;
-    *)
-        echo "AI_PR_LOOP_RESULT: ERROR (review-loop exit $loop_status)"
-        ;;
+    0) echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW" ;;
+    2) echo "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED" ;;
+    *) echo "AI_PR_LOOP_RESULT: ERROR (review-loop exit $loop_status)" ;;
 esac
 
 if [[ "$loop_status" -ne 0 ]]; then
@@ -254,8 +279,6 @@ if [[ -z "$(git status --porcelain)" ]]; then
     exit 0
 fi
 
-# The worktree is isolated and all mutations came from the bounded fixer.
-# Stage the complete resulting fix set, then create one local candidate commit.
 git add -A
 if git diff --cached --quiet; then
     echo "ai-pr-loop: worktree reported changes but nothing is staged" >&2
@@ -296,10 +319,6 @@ if [[ "$current_head" != "$candidate_sha" ]]; then
     exit 1
 fi
 
-# Verify the remote still points at the exact PR head observed before any agent
-# ran. The explicit force-with-lease is used only as an atomic compare-and-swap
-# guard; candidate_sha is a normal descendant of head_sha, so the update itself
-# remains a fast-forward.
 remote_head=""
 read -r remote_head _ < <(git ls-remote --exit-code "$remote" "refs/heads/$head_ref") || true
 if [[ -z "$remote_head" ]]; then

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -159,7 +159,7 @@ triage_status=$?
 set -e
 if [[ $triage_status -ne 0 ]]; then
     echo "AI_PR_LOOP_RESULT: ERROR (triage exit $triage_status)"
-    exit "$triage_status"
+    exit 1
 fi
 # The trusted base may predate the launcher-provided SHA binding, so the
 # launcher must itself confirm that the triaged target is the state it fetched

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -161,6 +161,16 @@ if [[ $triage_status -ne 0 ]]; then
     echo "AI_PR_LOOP_RESULT: ERROR (triage exit $triage_status)"
     exit "$triage_status"
 fi
+# The trusted base may predate the launcher-provided SHA binding, so the
+# launcher must itself confirm that the triaged target is the state it fetched
+# and is about to review.
+if ! jq -e --arg base "$base_sha" --arg head "$head_sha" \
+    '.base_sha == $base and .head == $head' "$triage_result" >/dev/null; then
+    echo "ai-pr-loop: triage result does not describe the verified PR target" >&2
+    printf 'ai-pr-loop: expected base %s head %s\n' "$base_sha" "$head_sha" >&2
+    echo "AI_PR_LOOP_RESULT: ERROR (triage target mismatch)"
+    exit 1
+fi
 triage_decision=$(jq -r '.decision' "$triage_result")
 printf '==> ai-pr-loop: legitimacy triage %s\n' "$triage_decision"
 printf '    triage result: %s\n' "$triage_result"

--- a/scripts/ai-pr-triage
+++ b/scripts/ai-pr-triage
@@ -32,6 +32,16 @@ state=$(jq -r .state <<<"$metadata")
 [[ "$state" == "OPEN" ]] || { echo "ai-pr-triage: PR #$pr_number is not open" >&2; exit 1; }
 base_sha=$(jq -r .baseRefOid <<<"$metadata")
 head_sha=$(jq -r .headRefOid <<<"$metadata")
+expected_base=${AI_PR_TRIAGE_EXPECT_BASE_SHA:-}
+expected_head=${AI_PR_TRIAGE_EXPECT_HEAD_SHA:-}
+if [[ -n "$expected_base" && "$base_sha" != "$expected_base" ]]; then
+    echo "ai-pr-triage: PR base moved since launcher verification: got $base_sha expected $expected_base" >&2
+    exit 2
+fi
+if [[ -n "$expected_head" && "$head_sha" != "$expected_head" ]]; then
+    echo "ai-pr-triage: PR head moved since launcher verification: got $head_sha expected $expected_head" >&2
+    exit 2
+fi
 head_owner=$(jq -r '.headRepositoryOwner.login // ""' <<<"$metadata")
 head_repo=$(jq -r '.headRepository.name // ""' <<<"$metadata")
 [[ -n "$head_owner" && -n "$head_repo" && "$head_owner/$head_repo" == "$repo" ]] || {

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -24,8 +24,54 @@ func TestHelpDoesNotRequirePRMetadata(t *testing.T) {
 	require.Contains(t, string(output), "Usage: bash scripts/ai-pr-loop")
 }
 
-func TestLauncherUsesUniqueWorktreesAndImmutableBase(t *testing.T) {
+func TestLauncherUsesUniqueWorktreesImmutableBaseAndKeepTriage(t *testing.T) {
 	t.Parallel()
+
+	fixture := newLauncherFixture(t)
+	firstCapture := filepath.Join(fixture.root, "first-args")
+	firstOutput, firstErr := runLauncher(t, fixture, firstCapture, "KEEP")
+	require.NoError(t, firstErr, firstOutput)
+	secondCapture := filepath.Join(fixture.root, "second-args")
+	secondOutput, secondErr := runLauncher(t, fixture, secondCapture, "KEEP")
+	require.NoError(t, secondErr, secondOutput)
+
+	firstWorktree := worktreeFromOutput(t, firstOutput)
+	secondWorktree := worktreeFromOutput(t, secondOutput)
+	require.NotEqual(t, firstWorktree, secondWorktree)
+	require.DirExists(t, firstWorktree)
+	require.DirExists(t, secondWorktree)
+	require.Equal(t, fixture.baseSHA, baseArgument(t, firstCapture))
+	require.Equal(t, fixture.baseSHA, baseArgument(t, secondCapture))
+	require.Contains(t, firstOutput, "legitimacy triage KEEP")
+}
+
+func TestLauncherStopsBeforeReviewForQuestionAndReject(t *testing.T) {
+	for _, decision := range []string{"QUESTION", "REJECT"} {
+		t.Run(decision, func(t *testing.T) {
+			fixture := newLauncherFixture(t)
+			capture := filepath.Join(fixture.root, "review-args")
+			output, err := runLauncher(t, fixture, capture, decision)
+			require.Error(t, err, output)
+			require.NoFileExists(t, capture, "technical review must not run")
+			if decision == "QUESTION" {
+				require.Contains(t, output, "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED")
+			} else {
+				require.Contains(t, output, "AI_PR_LOOP_RESULT: LEGITIMACY_REJECTED")
+			}
+		})
+	}
+}
+
+type launcherFixture struct {
+	root     string
+	checkout string
+	fakeBin  string
+	baseSHA  string
+	headSHA  string
+}
+
+func newLauncherFixture(t *testing.T) launcherFixture {
+	t.Helper()
 
 	testRoot := t.TempDir()
 	remote := filepath.Join(testRoot, "remote.git")
@@ -44,6 +90,20 @@ func TestLauncherUsesUniqueWorktreesAndImmutableBase(t *testing.T) {
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
+`)
+	writeExecutable(t, filepath.Join(seed, "scripts", "ai-pr-triage"), `#!/usr/bin/env bash
+set -euo pipefail
+[[ "${AI_PR_TRIAGE_EXPECT_BASE_SHA:-}" == "$TEST_BASE_SHA" ]]
+[[ "${AI_PR_TRIAGE_EXPECT_HEAD_SHA:-}" == "$TEST_HEAD_SHA" ]]
+output=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+[[ -n "$output" ]]
+printf '{"decision":"%s"}\n' "$TEST_TRIAGE_DECISION" > "$output"
 `)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
 	runGit(t, seed, "add", ".")
@@ -66,74 +126,52 @@ printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
 	writeExecutable(t, filepath.Join(fakeBin, "gh"), `#!/usr/bin/env bash
 set -euo pipefail
 case "$1 $2" in
-    "repo view")
-        printf 'owner/repo\n'
-        ;;
+    "repo view") printf 'owner/repo\n' ;;
     "pr view")
         printf '{"number":123,"url":"https://github.com/owner/repo/pull/123","state":"OPEN","isDraft":false,"baseRefName":"release/v3.0","baseRefOid":"%s","headRefName":"feature","headRefOid":"%s","headRepositoryOwner":{"login":"owner"},"headRepository":{"name":"repo"}}\n' "$TEST_BASE_SHA" "$TEST_HEAD_SHA"
         ;;
-    *)
-        exit 98
-        ;;
+    *) exit 98 ;;
 esac
 `)
 
-	firstCapture := filepath.Join(testRoot, "first-args")
-	firstOutput := runLauncher(t, checkout, fakeBin, baseSHA, headSHA, firstCapture)
-	secondCapture := filepath.Join(testRoot, "second-args")
-	secondOutput := runLauncher(t, checkout, fakeBin, baseSHA, headSHA, secondCapture)
-
-	firstWorktree := worktreeFromOutput(t, firstOutput)
-	secondWorktree := worktreeFromOutput(t, secondOutput)
-	require.NotEqual(t, firstWorktree, secondWorktree)
-	require.DirExists(t, firstWorktree)
-	require.DirExists(t, secondWorktree)
-	require.Equal(t, baseSHA, baseArgument(t, firstCapture))
-	require.Equal(t, baseSHA, baseArgument(t, secondCapture))
+	return launcherFixture{root: testRoot, checkout: checkout, fakeBin: fakeBin, baseSHA: baseSHA, headSHA: headSHA}
 }
 
 func launcherPath(t *testing.T) string {
 	t.Helper()
-
 	path, err := filepath.Abs(filepath.Join("..", "ai-pr-loop"))
 	require.NoError(t, err)
-
 	return path
 }
 
-func runLauncher(t *testing.T, checkout, fakeBin, baseSHA, headSHA, capturePath string) string {
+func runLauncher(t *testing.T, fixture launcherFixture, capturePath, decision string) (string, error) {
 	t.Helper()
-
-	command := exec.Command("bash", filepath.Join(checkout, "scripts", "ai-pr-loop"), "123", "--keep-worktree")
-	command.Dir = checkout
+	command := exec.Command("bash", filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123", "--keep-worktree")
+	command.Dir = fixture.checkout
 	command.Env = append(os.Environ(),
-		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"TEST_BASE_SHA="+baseSHA,
-		"TEST_HEAD_SHA="+headSHA,
+		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TEST_BASE_SHA="+fixture.baseSHA,
+		"TEST_HEAD_SHA="+fixture.headSHA,
 		"TEST_CAPTURE_FILE="+capturePath,
+		"TEST_TRIAGE_DECISION="+decision,
 	)
 	output, err := command.CombinedOutput()
-	require.NoError(t, err, string(output))
-
-	return string(output)
+	return string(output), err
 }
 
 func worktreeFromOutput(t *testing.T, output string) string {
 	t.Helper()
-
 	for line := range strings.SplitSeq(output, "\n") {
 		if worktree, found := strings.CutPrefix(strings.TrimSpace(line), "worktree: "); found {
 			return worktree
 		}
 	}
 	t.Fatalf("worktree path not found in output:\n%s", output)
-
 	return ""
 }
 
 func baseArgument(t *testing.T, capturePath string) string {
 	t.Helper()
-
 	content, err := os.ReadFile(capturePath)
 	require.NoError(t, err)
 	arguments := strings.Fields(string(content))
@@ -143,7 +181,6 @@ func baseArgument(t *testing.T, capturePath string) string {
 		}
 	}
 	t.Fatalf("--base not found in captured arguments: %q", content)
-
 	return ""
 }
 
@@ -159,11 +196,9 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-
 	command := exec.Command("git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
-
 	return strings.TrimSpace(string(output))
 }

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -84,6 +84,18 @@ func TestLauncherRefusesTriageResultForAnotherTarget(t *testing.T) {
 	}
 }
 
+func TestLauncherTreatsTriageFailureAsOrchestrationError(t *testing.T) {
+	fixture := newLauncherFixture(t)
+	capture := filepath.Join(fixture.root, "review-args")
+	output, err := runLauncher(t, fixture, capture, triageResult{exitCode: 2})
+	require.Error(t, err, output)
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, 1, exitError.ExitCode(), output)
+	require.NoFileExists(t, capture, "technical review must not run")
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (triage exit 2)")
+}
+
 type launcherFixture struct {
 	root     string
 	checkout string
@@ -117,6 +129,9 @@ printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
 set -euo pipefail
 [[ "${AI_PR_TRIAGE_EXPECT_BASE_SHA:-}" == "$TEST_BASE_SHA" ]]
 [[ "${AI_PR_TRIAGE_EXPECT_HEAD_SHA:-}" == "$TEST_HEAD_SHA" ]]
+if [[ "$TEST_TRIAGE_EXIT_CODE" -ne 0 ]]; then
+    exit "$TEST_TRIAGE_EXIT_CODE"
+fi
 output=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -174,6 +189,7 @@ type triageResult struct {
 	decision string
 	baseSHA  string
 	headSHA  string
+	exitCode int
 }
 
 func runLauncher(t *testing.T, fixture launcherFixture, capturePath string, triage triageResult) (string, error) {
@@ -194,6 +210,7 @@ func runLauncher(t *testing.T, fixture launcherFixture, capturePath string, tria
 		"TEST_TRIAGE_DECISION="+triage.decision,
 		"TEST_TRIAGE_BASE_SHA="+triage.baseSHA,
 		"TEST_TRIAGE_HEAD_SHA="+triage.headSHA,
+		fmt.Sprintf("TEST_TRIAGE_EXIT_CODE=%d", triage.exitCode),
 	)
 	output, err := command.CombinedOutput()
 

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -125,7 +125,7 @@ func newLauncherFixture(t *testing.T) launcherFixture {
 set -euo pipefail
 printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
 `)
-	writeExecutable(t, filepath.Join(seed, "scripts", "ai-pr-triage"), `#!/usr/bin/env bash
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-triage"), []byte(`#!/usr/bin/env bash
 set -euo pipefail
 [[ "${AI_PR_TRIAGE_EXPECT_BASE_SHA:-}" == "$TEST_BASE_SHA" ]]
 [[ "${AI_PR_TRIAGE_EXPECT_HEAD_SHA:-}" == "$TEST_HEAD_SHA" ]]
@@ -142,7 +142,7 @@ done
 [[ -n "$output" ]]
 printf '{"decision":"%s","base_sha":"%s","head":"%s"}\n' \
     "$TEST_TRIAGE_DECISION" "$TEST_TRIAGE_BASE_SHA" "$TEST_TRIAGE_HEAD_SHA" > "$output"
-`)
+`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
 	runGit(t, seed, "add", ".")
 	runGit(t, seed, "commit", "-m", "base")

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -29,10 +29,10 @@ func TestLauncherUsesUniqueWorktreesImmutableBaseAndKeepTriage(t *testing.T) {
 
 	fixture := newLauncherFixture(t)
 	firstCapture := filepath.Join(fixture.root, "first-args")
-	firstOutput, firstErr := runLauncher(t, fixture, firstCapture, "KEEP")
+	firstOutput, firstErr := runLauncher(t, fixture, firstCapture, triageResult{decision: "KEEP"})
 	require.NoError(t, firstErr, firstOutput)
 	secondCapture := filepath.Join(fixture.root, "second-args")
-	secondOutput, secondErr := runLauncher(t, fixture, secondCapture, "KEEP")
+	secondOutput, secondErr := runLauncher(t, fixture, secondCapture, triageResult{decision: "KEEP"})
 	require.NoError(t, secondErr, secondOutput)
 
 	firstWorktree := worktreeFromOutput(t, firstOutput)
@@ -50,7 +50,7 @@ func TestLauncherStopsBeforeReviewForQuestionAndReject(t *testing.T) {
 		t.Run(decision, func(t *testing.T) {
 			fixture := newLauncherFixture(t)
 			capture := filepath.Join(fixture.root, "review-args")
-			output, err := runLauncher(t, fixture, capture, decision)
+			output, err := runLauncher(t, fixture, capture, triageResult{decision: decision})
 			require.Error(t, err, output)
 			require.NoFileExists(t, capture, "technical review must not run")
 			if decision == "QUESTION" {
@@ -58,6 +58,28 @@ func TestLauncherStopsBeforeReviewForQuestionAndReject(t *testing.T) {
 			} else {
 				require.Contains(t, output, "AI_PR_LOOP_RESULT: LEGITIMACY_REJECTED")
 			}
+		})
+	}
+}
+
+func TestLauncherRefusesTriageResultForAnotherTarget(t *testing.T) {
+	for _, moved := range []string{"head", "base"} {
+		t.Run(moved, func(t *testing.T) {
+			fixture := newLauncherFixture(t)
+			// A base-pinned triage tool that ignores the launcher-provided
+			// expected SHAs can answer for a PR state the launcher never
+			// fetched.
+			triage := triageResult{decision: "KEEP"}
+			if moved == "head" {
+				triage.headSHA = fixture.baseSHA
+			} else {
+				triage.baseSHA = fixture.headSHA
+			}
+			capture := filepath.Join(fixture.root, "review-args")
+			output, err := runLauncher(t, fixture, capture, triage)
+			require.Error(t, err, output)
+			require.NoFileExists(t, capture, "technical review must not run")
+			require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (triage target mismatch)")
 		})
 	}
 }
@@ -103,7 +125,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 [[ -n "$output" ]]
-printf '{"decision":"%s"}\n' "$TEST_TRIAGE_DECISION" > "$output"
+printf '{"decision":"%s","base_sha":"%s","head":"%s"}\n' \
+    "$TEST_TRIAGE_DECISION" "$TEST_TRIAGE_BASE_SHA" "$TEST_TRIAGE_HEAD_SHA" > "$output"
 `)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
 	runGit(t, seed, "add", ".")
@@ -141,11 +164,26 @@ func launcherPath(t *testing.T) string {
 	t.Helper()
 	path, err := filepath.Abs(filepath.Join("..", "ai-pr-loop"))
 	require.NoError(t, err)
+
 	return path
 }
 
-func runLauncher(t *testing.T, fixture launcherFixture, capturePath, decision string) (string, error) {
+// triageResult is the result the fake triage tool reports. Empty SHAs mean the
+// tool answers for the exact target the launcher verified.
+type triageResult struct {
+	decision string
+	baseSHA  string
+	headSHA  string
+}
+
+func runLauncher(t *testing.T, fixture launcherFixture, capturePath string, triage triageResult) (string, error) {
 	t.Helper()
+	if triage.baseSHA == "" {
+		triage.baseSHA = fixture.baseSHA
+	}
+	if triage.headSHA == "" {
+		triage.headSHA = fixture.headSHA
+	}
 	command := exec.Command("bash", filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123", "--keep-worktree")
 	command.Dir = fixture.checkout
 	command.Env = append(os.Environ(),
@@ -153,9 +191,12 @@ func runLauncher(t *testing.T, fixture launcherFixture, capturePath, decision st
 		"TEST_BASE_SHA="+fixture.baseSHA,
 		"TEST_HEAD_SHA="+fixture.headSHA,
 		"TEST_CAPTURE_FILE="+capturePath,
-		"TEST_TRIAGE_DECISION="+decision,
+		"TEST_TRIAGE_DECISION="+triage.decision,
+		"TEST_TRIAGE_BASE_SHA="+triage.baseSHA,
+		"TEST_TRIAGE_HEAD_SHA="+triage.headSHA,
 	)
 	output, err := command.CombinedOutput()
+
 	return string(output), err
 }
 
@@ -167,6 +208,7 @@ func worktreeFromOutput(t *testing.T, output string) string {
 		}
 	}
 	t.Fatalf("worktree path not found in output:\n%s", output)
+
 	return ""
 }
 
@@ -181,6 +223,7 @@ func baseArgument(t *testing.T, capturePath string) string {
 		}
 	}
 	t.Fatalf("--base not found in captured arguments: %q", content)
+
 	return ""
 }
 
@@ -200,5 +243,6 @@ func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+
 	return strings.TrimSpace(string(output))
 }

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -115,6 +115,24 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	}
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 0\n")
+	writeExecutable(t, filepath.Join(seed, "scripts", "ai-pr-triage"), `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--output)
+			output=$2
+			shift 2
+			;;
+		*)
+			shift
+			;;
+	esac
+done
+[[ -n "$output" ]]
+printf '{"decision":"KEEP","base_sha":"%s","head":"%s"}\n' \
+	"$AI_PR_TRIAGE_EXPECT_BASE_SHA" "$AI_PR_TRIAGE_EXPECT_HEAD_SHA" > "$output"
+`)
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
 review_cmd=""

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -115,7 +115,7 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	}
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 0\n")
-	writeExecutable(t, filepath.Join(seed, "scripts", "ai-pr-triage"), `#!/usr/bin/env bash
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-triage"), []byte(`#!/usr/bin/env bash
 set -euo pipefail
 output=""
 while [[ $# -gt 0 ]]; do
@@ -132,7 +132,7 @@ done
 [[ -n "$output" ]]
 printf '{"decision":"KEEP","base_sha":"%s","head":"%s"}\n' \
 	"$AI_PR_TRIAGE_EXPECT_BASE_SHA" "$AI_PR_TRIAGE_EXPECT_HEAD_SHA" > "$output"
-`)
+`), 0o644))
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
 review_cmd=""


### PR DESCRIPTION
## Summary

Integrate the advisory PR legitimacy triage directly before the expensive AI review/fix loop.

- run legitimacy triage before Codex review / Claude fix
- load the triage adapter and policy from the exact verified PR base commit, never from the proposed head
- bind triage to the same immutable base/head SHAs already resolved by `ai-pr-loop`
- continue only on `KEEP`
- map `QUESTION` to `HUMAN_DECISION_REQUIRED`
- map advisory `REJECT` to `LEGITIMACY_REJECTED`
- never comment, close, merge, or otherwise mutate PR metadata
- fail closed if GitHub base/head moves between launcher verification and triage
- add launcher regression coverage proving QUESTION/REJECT stop before technical review

## Why

The review loop is now capable of spending substantial agent and human attention on technically reviewable changes. The standalone legitimacy triage exists to answer an earlier question: whether a PR has enough documented product/operational need and proportionality to deserve that attention at all.

This integration makes that gate the default entry point while preserving human authority over ambiguous or rejected proposals.

## Trust boundary

A PR must not provide the policy that legitimizes itself. `ai-pr-loop` therefore creates a base-pinned trusted tool worktree for every invocation, not only `--push` mode, and executes `scripts/ai-pr-triage` from that base.

The triage adapter receives `AI_PR_TRIAGE_EXPECT_BASE_SHA` and `AI_PR_TRIAGE_EXPECT_HEAD_SHA`; after resolving live GitHub metadata it refuses any mismatch. This prevents triaging one state and reviewing another if the PR moves concurrently.

## Outcomes

```text
KEEP      -> normal review/fix loop
QUESTION  -> HUMAN_DECISION_REQUIRED, no review/fix
REJECT    -> LEGITIMACY_REJECTED, no review/fix
```

REJECT remains advisory; no GitHub action is taken.

## Review focus

Please focus on:

- whether the base-pinned triage policy can ever be replaced by PR-controlled content
- races between initial metadata/fetch and the triage's metadata resolution
- whether QUESTION/REJECT can reach any review/fix/write path
- worktree lifecycle now that trusted tools are created for non-push runs too
- exit-code semantics for QUESTION vs REJECT
- whether keeping REJECT advisory/non-destructive is preserved
- test fixture realism and any regressions to existing push/no-push behavior

## Follow-up

Product-to-technical traceability remains a separate follow-up. This PR only makes the existing legitimacy decision an automatic pre-review gate.