### PR TITLE
fix(ai-audit): set required Jira component

### DIFF
--- a/docs/technical/contributing/ai-audit-jira.md
+++ b/docs/technical/contributing/ai-audit-jira.md
@@ -26,6 +26,12 @@ The marker identifies the logical finding across repeated audits and HEADs. The 
 
 Default project: `EN`.
 Default issue type: `Bug`.
+Default component: `Ledger`.
+
+Use `--component <name>` when the target Jira project requires a different
+component. The publisher sends creation data through ACLI's structured JSON
+input because Jira Components are not exposed by ACLI's simple create flags.
+The description is encoded as Atlassian Document Format in that same request.
 
 The ticket description records:
 

--- a/scripts/ai-audit-jira
+++ b/scripts/ai-audit-jira
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --publish) publish=true; shift ;;
         --project) [[ $# -ge 2 && "$2" =~ ^[A-Z][A-Z0-9_]*$ ]] || { echo "ai-audit-jira: invalid --project" >&2; exit 1; }; project=$2; shift 2 ;;
-        --component) [[ $# -ge 2 && "$2" =~ ^[A-Za-z0-9][A-Za-z0-9._[:space:]-]*$ ]] || { echo "ai-audit-jira: invalid --component" >&2; exit 1; }; component=$2; shift 2 ;;
+        --component) [[ $# -ge 2 && -n "$2" ]] || { echo "ai-audit-jira: invalid --component" >&2; exit 1; }; component=$2; shift 2 ;;
         *) echo "ai-audit-jira: unknown argument: $1" >&2; usage >&2; exit 1 ;;
     esac
 done

--- a/scripts/ai-audit-jira
+++ b/scripts/ai-audit-jira
@@ -3,10 +3,10 @@ set -euo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: bash scripts/ai-audit-jira <challenge-result.json> [--publish] [--project <key>]
+Usage: bash scripts/ai-audit-jira <challenge-result.json> [--publish] [--project <key>] [--component <name>]
 
 Previews Jira bugs for CONFIRMED audit findings. Jira writes require --publish.
-Default project: EN.
+Default project: EN. Default component: Ledger.
 EOF
 }
 
@@ -16,10 +16,12 @@ input=$1
 shift
 publish=false
 project=EN
+component=Ledger
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --publish) publish=true; shift ;;
         --project) [[ $# -ge 2 && "$2" =~ ^[A-Z][A-Z0-9_]*$ ]] || { echo "ai-audit-jira: invalid --project" >&2; exit 1; }; project=$2; shift 2 ;;
+        --component) [[ $# -ge 2 && "$2" =~ ^[A-Za-z0-9][A-Za-z0-9._[:space:]-]*$ ]] || { echo "ai-audit-jira: invalid --component" >&2; exit 1; }; component=$2; shift 2 ;;
         *) echo "ai-audit-jira: unknown argument: $1" >&2; usage >&2; exit 1 ;;
     esac
 done
@@ -84,6 +86,7 @@ while IFS= read -r finding; do
     marker="AI-AUDIT:$id"
     summary="[$severity] $title"
     description_file="$tmp/description.txt"
+    create_request_file="$tmp/create-request.json"
 
     {
         printf 'Confirmed Ledger deep-audit finding.\n\n'
@@ -145,12 +148,38 @@ while IFS= read -r finding; do
         continue
     fi
 
+    # ACLI's simple create flags do not expose Jira Components. Build its
+    # structured request instead so the project-required component is supplied
+    # together with an Atlassian Document Format description. jq keeps every
+    # report-derived value data: none of it can alter the request structure.
+    jq -n \
+        --arg project "$project" \
+        --arg summary "$summary" \
+        --arg component "$component" \
+        --rawfile description "$description_file" '
+        {
+          projectKey: $project,
+          type: "Bug",
+          summary: $summary,
+          description: {
+            version: 1,
+            type: "doc",
+            content: ($description | rtrimstr("\n") | split("\n") | map(
+              if length == 0 then
+                {type: "paragraph", content: []}
+              else
+                {type: "paragraph", content: [{type: "text", text: .}]}
+              end
+            ))
+          },
+          labels: ["ai-audit"],
+          additionalAttributes: {
+            components: [{name: $component}]
+          }
+        }
+    ' > "$create_request_file"
     create_json=$(acli jira workitem create \
-        --project "$project" \
-        --type Bug \
-        --summary "$summary" \
-        --description-file "$description_file" \
-        --label ai-audit \
+        --from-json "$create_request_file" \
         --json)
     created_key=$(jq -r '.. | objects | .key? // empty' <<<"$create_json" | head -n1)
     [[ -n "$created_key" ]] || { echo "ai-audit-jira: Jira creation succeeded but no issue key was returned" >&2; exit 1; }

--- a/scripts/aiauditjira/runner_test.go
+++ b/scripts/aiauditjira/runner_test.go
@@ -32,6 +32,13 @@ set -euo pipefail
 if [[ "$*" == *" search "* ]]; then
 	printf '%s\n' "$FAKE_ACLI_SEARCH_JSON"
 else
+	for ((index = 1; index <= $#; index++)); do
+		if [[ "${!index}" == "--from-json" ]]; then
+			next=$((index + 1))
+			cp -- "${!next}" "$FAKE_ACLI_CREATE_REQUEST"
+			break
+		fi
+	done
 	printf '%s\n' "$FAKE_ACLI_CREATE_JSON"
 fi
 `
@@ -84,6 +91,43 @@ func TestPublisherSearchesForTheExactQuotedMarker(t *testing.T) {
 	invocations := fixture.invocations(t)
 	require.Contains(t, invocations, "\t--paginate\t")
 	require.NotContains(t, invocations, "\t--limit\t")
+}
+
+func TestPublisherCreatesWithRequiredLedgerComponentInStructuredRequest(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish")
+	require.NoError(t, err, output)
+	request := fixture.createdRequest(t)
+	require.Equal(t, "EN", request["projectKey"])
+	require.Equal(t, "Bug", request["type"])
+	require.Equal(t, "[P2] Original title of "+testFindingID, request["summary"])
+	require.Equal(t, []any{"ai-audit"}, request["labels"])
+	require.Equal(t, map[string]any{
+		"components": []any{map[string]any{"name": "Ledger"}},
+	}, request["additionalAttributes"])
+	description, err := json.Marshal(request["description"])
+	require.NoError(t, err)
+	require.Contains(t, string(description), "AI-AUDIT:"+testFindingID)
+	require.Contains(t, string(description), testHead)
+
+	invocations := fixture.invocations(t)
+	require.Contains(t, invocations, "\t--from-json\t")
+	require.NotContains(t, invocations, "\t--description-file\t")
+}
+
+func TestPublisherSupportsAnExplicitJiraComponent(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish", "--component", "Ledger Platform")
+	require.NoError(t, err, output)
+	require.Equal(t, map[string]any{
+		"components": []any{map[string]any{"name": "Ledger Platform"}},
+	}, fixture.createdRequest(t)["additionalAttributes"])
 }
 
 func TestPublisherStaysBoundToValidatedSnapshotWhenInputIsReplaced(t *testing.T) {
@@ -236,6 +280,7 @@ func searchResponse(t *testing.T, key string, description string) string {
 type fixture struct {
 	inputPath       string
 	logPath         string
+	createRequest   string
 	fakeBin         string
 	searchJSON      string
 	realJQ          string
@@ -255,12 +300,13 @@ func newFixture(t *testing.T) *fixture {
 	require.NoError(t, err)
 
 	return &fixture{
-		inputPath:    filepath.Join(root, "qualified.json"),
-		logPath:      filepath.Join(root, "acli-invocations.log"),
-		fakeBin:      fakeBin,
-		searchJSON:   `{"issues":[]}`,
-		realJQ:       realJQ,
-		replacedPath: filepath.Join(root, "jq-replaced-input"),
+		inputPath:     filepath.Join(root, "qualified.json"),
+		logPath:       filepath.Join(root, "acli-invocations.log"),
+		createRequest: filepath.Join(root, "acli-create-request.json"),
+		fakeBin:       fakeBin,
+		searchJSON:    `{"issues":[]}`,
+		realJQ:        realJQ,
+		replacedPath:  filepath.Join(root, "jq-replaced-input"),
 	}
 }
 
@@ -276,6 +322,7 @@ func (f *fixture) run(t *testing.T, result map[string]any, arguments ...string) 
 		"FAKE_ACLI_LOG="+f.logPath,
 		"FAKE_ACLI_SEARCH_JSON="+f.searchJSON,
 		`FAKE_ACLI_CREATE_JSON={"key":"`+createdKey+`"}`,
+		"FAKE_ACLI_CREATE_REQUEST="+f.createRequest,
 		"FAKE_REAL_JQ="+f.realJQ,
 		"FAKE_JQ_INPUT="+f.inputPath,
 		"FAKE_JQ_REPLACEMENT="+f.replacementPath,
@@ -320,6 +367,17 @@ func (f *fixture) invocations(t *testing.T) string {
 	require.NoError(t, err)
 
 	return string(contents)
+}
+
+func (f *fixture) createdRequest(t *testing.T) map[string]any {
+	t.Helper()
+
+	contents, err := os.ReadFile(f.createRequest)
+	require.NoError(t, err)
+	request := map[string]any{}
+	require.NoError(t, json.Unmarshal(contents, &request))
+
+	return request
 }
 
 func challengeResult(results ...map[string]any) map[string]any {

--- a/scripts/aiauditjira/runner_test.go
+++ b/scripts/aiauditjira/runner_test.go
@@ -123,10 +123,10 @@ func TestPublisherSupportsAnExplicitJiraComponent(t *testing.T) {
 
 	fixture := newFixture(t)
 
-	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish", "--component", "Ledger Platform")
+	output, err := fixture.run(t, challengeResult(confirmedResult(testFindingID)), "--publish", "--component", "Ledger / Platform (&)")
 	require.NoError(t, err, output)
 	require.Equal(t, map[string]any{
-		"components": []any{map[string]any{"name": "Ledger Platform"}},
+		"components": []any{map[string]any{"name": "Ledger / Platform (&)"}},
 	}, fixture.createdRequest(t)["additionalAttributes"])
 }
 


### PR DESCRIPTION
## Context

Publishing the qualified persistence/restore/replay audit finding failed because Jira project EN requires Components and ACLI simple create flags cannot set it.

## Change

- default Jira component to `Ledger`, with an explicit `--component` override
- create issues through ACLI structured JSON input
- encode the description as Atlassian Document Format
- test the exact request shape and preserve existing deduplication behavior

## Scope

This only changes the audit Jira publisher, its tests, and its contributor contract. It does not change Ledger business code.

## Validation

- `bash -n scripts/ai-audit-jira`
- `go test ./scripts/aiauditjira`
- `bash scripts/agent-check`