### PR TITLE
fix: harden local AI PR validation

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -216,8 +216,16 @@ PR worktree as the recipe working directory. A PR therefore cannot replace a
 required recipe with a no-op. Script-backed gates are split the same way:
 Schemathesis and model-checker runners come from the trusted base, while their
 server build, OpenAPI input, and other reviewed sources come from the candidate
-worktree. The model driver/oracle is also base-pinned. The loop does not query
-or wait for GitHub Actions checks.
+worktree. When the candidate exposes historical balances, the trusted
+Schemathesis runner enables the projection on its fixture ledger and waits for
+its first readable manifest. Before a generated historical-volume GET, it also
+retries only the documented replica-local `HISTORY_BUILDING` and
+`HISTORY_BEHIND` states for a bounded interval; persistent lag and every other
+5xx still fail `not_a_server_error`. Its ephemeral server sets disk-write
+thresholds to 100%, so host occupancy cannot replace API conformance failures
+with environment-specific `WRITES_BLOCKED_DISK_FULL` responses. The model
+driver/oracle is also base-pinned. The loop does not query or wait for GitHub
+Actions checks.
 
 ## Claude Code fix adapter
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -207,8 +207,11 @@ if [[ "$push_changes" == "true" ]]; then
     review_loop_binary="$worktree_run_dir/review-loop"
     for trusted_tool in ai-review-codex ai-fix-claude agent-check-pr; do
         trusted_tool_path="$trusted_tool_worktree/scripts/$trusted_tool"
-        if [[ ! -x "$trusted_tool_path" ]]; then
-            echo "ai-pr-loop: trusted base does not provide executable scripts/$trusted_tool" >&2
+        # These adapters are invoked explicitly through bash below. Requiring
+        # an executable bit adds no trust boundary and made publish mode reject
+        # otherwise valid base-pinned scripts after a mode-only merge drift.
+        if [[ ! -f "$trusted_tool_path" ]]; then
+            echo "ai-pr-loop: trusted base does not provide scripts/$trusted_tool" >&2
             exit 1
         fi
     done

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -61,23 +61,33 @@ func TestPushUsesBasePinnedReviewToolchain(t *testing.T) {
 	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
 }
 
+func TestPushAcceptsNonExecutableBasePinnedScripts(t *testing.T) {
+	t.Parallel()
+
+	fixture := newPushFixture(t, pushFixtureOptions{trustedToolsNonExecutable: true})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 0, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+}
+
 func TestPushRefusesBaseWithoutTrustedValidator(t *testing.T) {
 	t.Parallel()
 
 	fixture := newPushFixture(t, pushFixtureOptions{omitTrustedValidator: true})
 	output, exitCode := fixture.run(t)
 	require.Equal(t, 1, exitCode, output)
-	require.Contains(t, output, "trusted base does not provide executable scripts/agent-check-pr")
+	require.Contains(t, output, "trusted base does not provide scripts/agent-check-pr")
 
 	remoteHead := runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature")
 	require.Equal(t, fixture.headSHA, remoteHead)
 }
 
 type pushFixtureOptions struct {
-	moveRemote            bool
-	moveLocalHead         bool
-	tamperTargetToolchain bool
-	omitTrustedValidator  bool
+	moveRemote                bool
+	moveLocalHead             bool
+	tamperTargetToolchain     bool
+	omitTrustedValidator      bool
+	trustedToolsNonExecutable bool
 }
 
 type pushFixture struct {
@@ -108,13 +118,17 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	launcher, err := os.ReadFile(launcherPath(t))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	trustedToolMode := os.FileMode(0o755)
+	if options.trustedToolsNonExecutable {
+		trustedToolMode = 0o644
+	}
 	if !options.omitTrustedValidator {
 		validator, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "agent-check-pr"))
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-check-pr"), validator, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-check-pr"), validator, trustedToolMode))
 	}
-	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
-	writeExecutable(t, filepath.Join(seed, "scripts", "ai-fix-claude"), "#!/usr/bin/env bash\nexit 0\n")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-review-codex"), []byte("#!/usr/bin/env bash\nexit 0\n"), trustedToolMode))
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-fix-claude"), []byte("#!/usr/bin/env bash\nexit 0\n"), trustedToolMode))
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-triage"), []byte(`#!/usr/bin/env bash
 set -euo pipefail
 output=""

--- a/tests/schemathesis/requirements.txt
+++ b/tests/schemathesis/requirements.txt
@@ -1,8 +1,9 @@
 # Pinned exactly so the gate is reproducible: `derandomize=True` (see
 # test_api.py) makes Hypothesis generate a fixed input set, but only for a
 # given Hypothesis version — a different resolved version would generate
-# different inputs and could surface a failure locally != CI. Pin both so a
-# local run reproduces CI exactly. Bump deliberately (and re-run the suite) to
-# widen fuzzing coverage.
+# different inputs and could surface a failure locally != CI. Pin the runner,
+# generator, and unit-test harness so a local run reproduces CI exactly. Bump
+# deliberately (and re-run the suite) to widen fuzzing coverage.
 schemathesis==3.39.16
 hypothesis==6.156.6
+pytest==8.4.2

--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -23,6 +23,10 @@ GRPC_PORT=${GRPC_PORT:-8899}
 RAFT_PORT=${RAFT_PORT:-7779}
 MAX_EXAMPLES=${MAX_EXAMPLES:-50}
 SCHEMATHESIS_WORKERS=${SCHEMATHESIS_WORKERS:-1}
+HISTORICAL_BALANCES_AVAILABLE=false
+if grep -q '^message ConfigureHistoricalBalancesRequest' "$REPO_ROOT/misc/proto/bucket.proto" 2>/dev/null; then
+    HISTORICAL_BALANCES_AVAILABLE=true
+fi
 
 TMPDIR=$(mktemp -d)
 # On exit, preserve the server log as an uploadable diagnostic BEFORE removing
@@ -38,12 +42,18 @@ trap 'kill "${SERVER_PID:-}" 2>/dev/null || true; wait "${SERVER_PID:-}" 2>/dev/
 echo "==> Building server..."
 cd "$REPO_ROOT"
 go build -o "$TMPDIR/ledger-server" .
+if [[ "$HISTORICAL_BALANCES_AVAILABLE" == true ]]; then
+    go build -o "$TMPDIR/ledgerctl" ./cmd/ledgerctl
+fi
 
 echo "==> Starting server (single-node, bootstrap, no auth)..."
+# The temporary store shares the developer/agent host filesystem. Keep API
+# conformance independent from that host's production disk-pressure threshold.
 "$TMPDIR/ledger-server" run \
     --node-id 1 --cluster-id schemathesis-test --bootstrap \
     --bind-addr "127.0.0.1:$RAFT_PORT" \
     --wal-dir "$TMPDIR/wal" --data-dir "$TMPDIR/data" \
+    --health-wal-threshold 1 --health-data-threshold 1 \
     --http-port "$HTTP_PORT" --grpc-port "$GRPC_PORT" \
     > "$TMPDIR/server.log" 2>&1 &
 SERVER_PID=$!
@@ -109,6 +119,45 @@ seed "transaction 2" -X POST "$API/test-ledger/transactions" \
 # still hold the full posted amount for the revert (which reverses it exactly)
 # to succeed, and a prior alice->bob spend leaves her short.
 seed "revert transaction 1" -X POST "$API/test-ledger/transactions/1/revert"
+
+if [[ "$HISTORICAL_BALANCES_AVAILABLE" == true ]]; then
+    echo "==> Enabling historical balances for fixture ledger..."
+    if ! "$TMPDIR/ledgerctl" \
+        --server "localhost:$GRPC_PORT" --insecure \
+        ledgers historical-balances enable test-ledger --timeout 10s; then
+        echo "ERROR: failed to enable historical balances" >&2
+        echo "Server log:" >&2
+        cat "$TMPDIR/server.log" >&2
+        exit 1
+    fi
+
+    echo "==> Waiting for historical balance readiness..."
+    for i in $(seq 1 100); do
+        code=$(curl -s -o "$TMPDIR/history-readiness.json" -w '%{http_code}' \
+            "$API/test-ledger/volumes?at=2100-01-01T00%3A00%3A00Z")
+        case "$code" in
+            200)
+                echo "    Historical balances ready."
+                break
+                ;;
+            503)
+                if [[ "$i" -eq 100 ]]; then
+                    echo "ERROR: historical balances did not become ready" >&2
+                    cat "$TMPDIR/history-readiness.json" >&2
+                    cat "$TMPDIR/server.log" >&2
+                    exit 1
+                fi
+                sleep 0.1
+                ;;
+            *)
+                echo "ERROR: historical readiness probe returned $code" >&2
+                cat "$TMPDIR/history-readiness.json" >&2
+                cat "$TMPDIR/server.log" >&2
+                exit 1
+                ;;
+        esac
+    done
+fi
 
 # Set up Python venv and install deps if needed
 VENV_DIR="$SCRIPT_DIR/.venv"

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -13,6 +13,7 @@ import copy
 import os
 import re
 import sys
+import time
 from datetime import timedelta
 from pathlib import Path
 
@@ -48,6 +49,12 @@ FIXTURE_LEDGER_NAME = "test-ledger"
 # Sacrificial ledger name for DELETE /v3/{ledgerName} specifically — see the
 # before_call hook below for why it needs its own name.
 DELETE_LEDGER_SACRIFICE_NAME = "delete-me-ledger"
+
+HISTORICAL_READ_RETRY_ATTEMPTS = 100
+HISTORICAL_READ_RETRY_DELAY_SECONDS = 0.1
+TRANSIENT_HISTORY_ERROR_CODES = frozenset(
+    {"HISTORY_BUILDING", "HISTORY_BEHIND"}
+)
 
 SAMPLE_NUMSCRIPTS = [
     'send [USD/2 100] (\n  source = @world\n  destination = @user:001\n)',
@@ -125,6 +132,57 @@ def before_call(context, case):
         # Metadata: ensure it's a valid object
         if "metadata" in case.body and not isinstance(case.body["metadata"], dict):
             case.body["metadata"] = {}
+
+    _wait_for_historical_read(case)
+
+
+def _wait_for_historical_read(case):
+    """Wait out only the documented asynchronous history lag states.
+
+    The Schemathesis runner is intentionally single-worker by default, so once
+    this probe observes a non-transient response no other generated operation
+    can move the projection before the real checked request. The direct
+    transport call bypasses hooks and therefore cannot recurse into this hook.
+    Persistent lag still reaches the real request after the bounded retries and
+    remains a blocking ``not_a_server_error`` failure.
+    """
+    if (
+        case.path != "/v3/{ledgerName}/volumes"
+        or case.method != "GET"
+        or not isinstance(case.query, dict)
+        or "at" not in case.query
+    ):
+        return
+
+    for attempt in range(HISTORICAL_READ_RETRY_ATTEMPTS):
+        response = case.operation.schema.transport.send(
+            case,
+            base_url=case.operation.schema.base_url,
+        )
+        if not _is_transient_history_response(response):
+            return
+        if attempt + 1 < HISTORICAL_READ_RETRY_ATTEMPTS:
+            time.sleep(HISTORICAL_READ_RETRY_DELAY_SECONDS)
+
+    print(
+        "  >> historical projection remained transient after "
+        f"{HISTORICAL_READ_RETRY_ATTEMPTS} readiness probes",
+        file=sys.stderr,
+    )
+
+
+def _is_transient_history_response(response):
+    if response.status_code != 503:
+        return False
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        return False
+
+    return (
+        isinstance(payload, dict)
+        and payload.get("errorCode") in TRANSIENT_HISTORY_ERROR_CODES
+    )
 
 
 @schemathesis.hook

--- a/tests/schemathesis/test_test_api.py
+++ b/tests/schemathesis/test_test_api.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import test_api
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def send(self, case, base_url):
+        self.calls.append((case, base_url))
+        return self.responses.pop(0)
+
+
+def historical_case(responses):
+    transport = FakeTransport(responses)
+    schema = SimpleNamespace(
+        base_url="http://ledger.test",
+        transport=transport,
+    )
+    case = SimpleNamespace(
+        path="/v3/{ledgerName}/volumes",
+        method="GET",
+        query={"at": "2026-01-15T12:30:45Z"},
+        operation=SimpleNamespace(schema=schema),
+    )
+    return case, transport
+
+
+def test_wait_for_historical_read_retries_only_transient_states(monkeypatch):
+    monkeypatch.setattr(test_api.time, "sleep", lambda _: None)
+    case, transport = historical_case(
+        [
+            FakeResponse(503, {"errorCode": "HISTORY_BUILDING"}),
+            FakeResponse(503, {"errorCode": "HISTORY_BEHIND"}),
+            FakeResponse(200, {}),
+        ]
+    )
+
+    test_api._wait_for_historical_read(case)
+
+    assert len(transport.calls) == 3
+    assert all(base_url == "http://ledger.test" for _, base_url in transport.calls)
+
+
+def test_wait_for_historical_read_keeps_other_server_errors_blocking(monkeypatch):
+    monkeypatch.setattr(test_api.time, "sleep", lambda _: None)
+    case, transport = historical_case(
+        [FakeResponse(503, {"errorCode": "ANOTHER_UNAVAILABLE_STATE"})]
+    )
+
+    test_api._wait_for_historical_read(case)
+
+    assert len(transport.calls) == 1
+
+
+def test_wait_for_historical_read_is_bounded(monkeypatch):
+    monkeypatch.setattr(test_api, "HISTORICAL_READ_RETRY_ATTEMPTS", 3)
+    monkeypatch.setattr(test_api.time, "sleep", lambda _: None)
+    case, transport = historical_case(
+        [
+            FakeResponse(503, {"errorCode": "HISTORY_BUILDING"}),
+            FakeResponse(503, {"errorCode": "HISTORY_BUILDING"}),
+            FakeResponse(503, {"errorCode": "HISTORY_BUILDING"}),
+        ]
+    )
+
+    test_api._wait_for_historical_read(case)
+
+    assert len(transport.calls) == 3
+
+
+def test_wait_for_historical_read_ignores_non_historical_cases():
+    case, transport = historical_case([])
+    case.query = {}
+
+    test_api._wait_for_historical_read(case)
+
+    assert transport.calls == []


### PR DESCRIPTION
## Summary

- accept trusted base-pinned review adapters without an executable bit, since the loop invokes them explicitly through Bash
- make the trusted Schemathesis runner configure historical balances when the candidate supports them and retry only `HISTORY_BUILDING` / `HISTORY_BEHIND` for a bounded interval
- isolate API conformance from host disk occupancy and add focused regression tests and documentation

## Validation

- `nix develop --command env -u GOROOT bash -c "just pre-commit"`
- `nix develop --command env -u GOROOT go build ./...`
- `go test ./scripts/aiprloop ./scripts/reviewloop ./scripts/aireviewcodex ./scripts/aifixclaude -count=1`
- `pytest -q tests/schemathesis/test_test_api.py` (4 passed)
- `nix develop --command env -u GOROOT bash tests/schemathesis/run.sh` (64/64 endpoints passed)

## Safety

The retry is restricted to the historical volumes GET and the two documented replica-local transient error codes. It is bounded; persistent lag and all other 5xx remain blocking. A cross-run against PR #1662 still fails on its persistent `HISTORY_BUILDING` state, confirming that this change does not mask that underlying projection issue.