### PR TITLE
fix: report stale PR base before AI review

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -47,6 +47,8 @@ Each invocation owns a unique worktree and never reuses or removes another invoc
 
 GitHub's reported base SHA describes the PR snapshot and may legitimately lag behind the current target branch. Reviewing against a historical base can miss semantic conflicts introduced since the PR was opened, so the launcher compares the freshly fetched target-branch tip with that reported base SHA before creating any worktree:
 
+When the checkout is shallow and the first ancestry check is negative, the launcher unshallows history for the exact fetched target SHA and retries the check. A shallow boundary therefore cannot by itself turn normal target advancement into a rewrite/divergence result. Failure to restore that history is an orchestration error.
+
 - identical: the reviewed base is current and the run continues into triage;
 - the reported base is still an ancestor of the tip: the target branch advanced since the PR snapshot, so the launcher prints both SHAs, reports `AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED`, and exits `3`. Synchronize the PR with its target branch — merge or rebase, push the PR head — and rerun the launcher;
 - the reported base is not an ancestor of the tip: the target branch was rewritten or diverged, reported as `AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)` with exit `1`;

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -27,7 +27,7 @@ A full PR URL is accepted as well. The launcher:
 
 - resolves the current repository and PR metadata through `gh`;
 - requires an open same-repository PR and currently rejects fork/cross-repository heads;
-- fetches the exact GitHub-reported base and head refs and verifies both SHAs before running agents;
+- fetches the current target-branch tip and the PR head ref, requires the fetched head to equal the GitHub-reported head SHA, and requires the fetched target tip to still equal the GitHub-reported base SHA before running agents;
 - creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
 - runs the [legitimacy triage](ai-pr-triage-loop.md) before any technical review, using the `scripts/ai-pr-triage` adapter from a detached worktree pinned at the verified base SHA, so the PR under review cannot supply the policy that authorizes its own review;
 - accepts a triage result only when its `base_sha` and `head` equal the SHAs the launcher fetched and verified, and continues into technical review only on a `KEEP` decision;
@@ -39,9 +39,20 @@ A full PR URL is accepted as well. The launcher:
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
 
-Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, `LEGITIMACY_REJECTED`, or an orchestration error.
+Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, `LEGITIMACY_REJECTED`, `BASE_UPDATE_REQUIRED`, or an orchestration error.
 
 `LEGITIMACY_REJECTED` is emitted when triage returns `REJECT`; a `QUESTION` decision stops the run with `HUMAN_DECISION_REQUIRED`. Both stop before technical review and exit `2`. A triage provider error or target mismatch fails closed as an orchestration error. Every triage outcome is advisory: the launcher never closes, comments on, or otherwise changes the PR.
+
+### Stale PR base
+
+GitHub's reported base SHA describes the PR snapshot and may legitimately lag behind the current target branch. Reviewing against a historical base can miss semantic conflicts introduced since the PR was opened, so the launcher compares the freshly fetched target-branch tip with that reported base SHA before creating any worktree:
+
+- identical: the reviewed base is current and the run continues into triage;
+- the reported base is still an ancestor of the tip: the target branch advanced since the PR snapshot, so the launcher prints both SHAs, reports `AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED`, and exits `3`. Synchronize the PR with its target branch — merge or rebase, push the PR head — and rerun the launcher;
+- the reported base is not an ancestor of the tip: the target branch was rewritten or diverged, reported as `AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)` with exit `1`;
+- the reported base cannot be resolved even after an explicit fetch: an orchestration error with exit `1`.
+
+Only the first case reaches an agent; every other case stops before triage, so no legitimacy triage, technical review, fix, or validation runs.
 
 ### Guarded publish mode
 
@@ -251,12 +262,25 @@ The adapter does not commit, push, comment on GitHub, resolve threads, or decide
 
 ## Exit codes
 
+`review-loop`:
+
 | Code | Meaning |
 |---|---|
 | `0` | `READY_FOR_HUMAN_REVIEW` |
 | `1` | orchestration/reviewer/fixer/validation error |
 | `2` | `HUMAN_DECISION_REQUIRED` |
 | `3` | `AUTO_FIX_REQUIRED` but no `--fix-cmd` was supplied |
+
+`ai-pr-loop` has its own exit semantics. It forwards the bounded loop's status, but adds pre-triage outcomes of its own, so its codes must not be read with the `review-loop` meanings above:
+
+| Code | Meaning |
+|---|---|
+| `0` | `READY_FOR_HUMAN_REVIEW`, including the `--push` results `NO_CHANGES` and `PUSHED` |
+| `1` | orchestration error, including a rewritten or diverged target branch |
+| `2` | `HUMAN_DECISION_REQUIRED`, `LEGITIMACY_REJECTED`, or a `--push` refusal caused by a candidate review needing human judgment, a moved remote head, or a rejected push |
+| `3` | `BASE_UPDATE_REQUIRED` — the target branch advanced past the PR base, or, in `--push` mode, the review-only candidate pass returned `AUTO_FIX_REQUIRED` |
+
+Because one launcher exit code can cover several outcomes, automation must key on the emitted `AI_PR_LOOP_RESULT` / `AI_PR_LOOP_PUSH_RESULT` line and use the exit status only as a success/failure signal.
 
 ## Safety boundary
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -125,7 +125,22 @@ if [[ "$current_base" != "$base_sha" ]]; then
         echo "ai-pr-loop: GitHub-reported PR base commit is unavailable locally: $base_sha" >&2
         exit 1
     fi
+    base_is_ancestor=false
     if git merge-base --is-ancestor "$base_sha" "$current_base"; then
+        base_is_ancestor=true
+    elif [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+        # A shallow repository can contain both commits without their connecting
+        # history. Restore ancestry for the exact fetched target before treating
+        # a negative merge-base result as evidence of a rewrite or divergence.
+        if ! git fetch --no-tags --unshallow "$remote" "$current_base" >/dev/null 2>&1; then
+            echo "ai-pr-loop: could not deepen shallow history for target base classification" >&2
+            exit 1
+        fi
+        if git merge-base --is-ancestor "$base_sha" "$current_base"; then
+            base_is_ancestor=true
+        fi
+    fi
+    if [[ "$base_is_ancestor" == "true" ]]; then
         printf 'ai-pr-loop: target branch %s advanced since this PR snapshot\n' "$base_ref" >&2
         printf 'ai-pr-loop: PR base:      %s\n' "$base_sha" >&2
         printf 'ai-pr-loop: current base: %s\n' "$current_base" >&2

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -13,6 +13,10 @@ By default the launcher never commits or pushes. With --push, fixes are
 committed locally, that exact clean commit is reviewed once more, and it
 is pushed only if the remote PR branch still equals the SHA observed at
 startup. The launcher never comments, resolves threads, closes, or merges.
+
+If the target branch has advanced beyond the PR's GitHub-reported base SHA,
+the launcher stops before triage with AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED
+(exit 3). Synchronize the PR with its target branch, then rerun the loop.
 EOF
 }
 
@@ -96,19 +100,42 @@ if ! git remote get-url "$remote" >/dev/null 2>&1; then
     exit 1
 fi
 
-# Fetch exactly the GitHub-resolved base/head refs before creating worktrees.
+# Fetch the current target/head refs. GitHub's baseRefOid describes the PR
+# snapshot and may legitimately lag behind the current target branch.
 git fetch --no-tags "$remote" \
     "+refs/heads/$base_ref:refs/remotes/$remote/$base_ref" \
     "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
 
-fetched_base=$(git rev-parse "refs/remotes/$remote/$base_ref")
+current_base=$(git rev-parse "refs/remotes/$remote/$base_ref")
 fetched_head=$(git rev-parse "refs/remotes/$remote/$head_ref")
-if [[ "$fetched_base" != "$base_sha" ]]; then
-    echo "ai-pr-loop: fetched base SHA does not match GitHub: got $fetched_base expected $base_sha" >&2
-    exit 1
-fi
 if [[ "$fetched_head" != "$head_sha" ]]; then
     echo "ai-pr-loop: fetched head SHA does not match GitHub: got $fetched_head expected $head_sha" >&2
+    exit 1
+fi
+
+# Keep the review target synchronized with the branch that will eventually
+# receive the PR. Reviewing against a historical base can miss semantic
+# conflicts introduced since the PR was opened. Fail closed, but report this as
+# an actionable synchronization state rather than a generic orchestration error.
+if [[ "$current_base" != "$base_sha" ]]; then
+    if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+        git fetch --no-tags "$remote" "$base_sha" >/dev/null 2>&1 || true
+    fi
+    if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+        echo "ai-pr-loop: GitHub-reported PR base commit is unavailable locally: $base_sha" >&2
+        exit 1
+    fi
+    if git merge-base --is-ancestor "$base_sha" "$current_base"; then
+        printf 'ai-pr-loop: target branch %s advanced since this PR snapshot\n' "$base_ref" >&2
+        printf 'ai-pr-loop: PR base:      %s\n' "$base_sha" >&2
+        printf 'ai-pr-loop: current base: %s\n' "$current_base" >&2
+        echo "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED"
+        exit 3
+    fi
+    echo "ai-pr-loop: target branch no longer descends from the GitHub-reported PR base" >&2
+    printf 'ai-pr-loop: PR base:      %s\n' "$base_sha" >&2
+    printf 'ai-pr-loop: current base: %s\n' "$current_base" >&2
+    echo "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)"
     exit 1
 fi
 

--- a/scripts/aiprloop/stale_base_test.go
+++ b/scripts/aiprloop/stale_base_test.go
@@ -34,6 +34,35 @@ func TestLauncherReportsBaseUpdateRequiredBeforeTriage(t *testing.T) {
 	require.NoFileExists(t, capture, "technical review must not run")
 }
 
+func TestLauncherDeepensShallowCloneBeforeClassifyingBaseAdvance(t *testing.T) {
+	fixture := newLauncherFixture(t)
+
+	updater := filepath.Join(fixture.root, "updater")
+	runGit(t, fixture.root, "clone", "--branch", "release/v3.0", filepath.Join(fixture.root, "remote.git"), updater)
+	runGit(t, updater, "config", "user.name", "Target Branch Update")
+	runGit(t, updater, "config", "user.email", "target-update@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(updater, "advanced.txt"), []byte("advanced\n"), 0o644))
+	runGit(t, updater, "add", "advanced.txt")
+	runGit(t, updater, "commit", "-m", "advance target")
+	runGit(t, updater, "push", "origin", "release/v3.0")
+
+	shallowCheckout := filepath.Join(fixture.root, "shallow-checkout")
+	remoteURL := "file://" + filepath.Join(fixture.root, "remote.git")
+	runGit(t, fixture.root, "clone", "--depth=1", "--branch", "release/v3.0", remoteURL, shallowCheckout)
+	require.Equal(t, "true", runGitOutput(t, shallowCheckout, "rev-parse", "--is-shallow-repository"))
+	fixture.checkout = shallowCheckout
+
+	capture := filepath.Join(fixture.root, "review-args")
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"})
+	require.Error(t, err, output)
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, 3, exitError.ExitCode(), output)
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED")
+	require.Equal(t, "false", runGitOutput(t, shallowCheckout, "rev-parse", "--is-shallow-repository"))
+	require.NoFileExists(t, capture, "technical review must not run")
+}
+
 func TestLauncherTreatsRewrittenTargetAsError(t *testing.T) {
 	fixture := newLauncherFixture(t)
 

--- a/scripts/aiprloop/stale_base_test.go
+++ b/scripts/aiprloop/stale_base_test.go
@@ -1,0 +1,58 @@
+package aiprloop
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLauncherReportsBaseUpdateRequiredBeforeTriage(t *testing.T) {
+	fixture := newLauncherFixture(t)
+
+	updater := filepath.Join(fixture.root, "updater")
+	runGit(t, fixture.root, "clone", "--branch", "release/v3.0", filepath.Join(fixture.root, "remote.git"), updater)
+	runGit(t, updater, "config", "user.name", "Target Branch Update")
+	runGit(t, updater, "config", "user.email", "target-update@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(updater, "advanced.txt"), []byte("advanced\n"), 0o644))
+	runGit(t, updater, "add", "advanced.txt")
+	runGit(t, updater, "commit", "-m", "advance target")
+	currentBase := runGitOutput(t, updater, "rev-parse", "HEAD")
+	runGit(t, updater, "push", "origin", "release/v3.0")
+
+	capture := filepath.Join(fixture.root, "review-args")
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"})
+	require.Error(t, err, output)
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, 3, exitError.ExitCode(), output)
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED")
+	require.Contains(t, output, fixture.baseSHA)
+	require.Contains(t, output, currentBase)
+	require.NoFileExists(t, capture, "technical review must not run")
+}
+
+func TestLauncherTreatsRewrittenTargetAsError(t *testing.T) {
+	fixture := newLauncherFixture(t)
+
+	rewriter := filepath.Join(fixture.root, "rewriter")
+	runGit(t, fixture.root, "clone", "--branch", "release/v3.0", filepath.Join(fixture.root, "remote.git"), rewriter)
+	runGit(t, rewriter, "config", "user.name", "Target Branch Rewrite")
+	runGit(t, rewriter, "config", "user.email", "target-rewrite@example.com")
+	runGit(t, rewriter, "checkout", "--orphan", "rewritten")
+	require.NoError(t, os.WriteFile(filepath.Join(rewriter, "replacement.txt"), []byte("replacement\n"), 0o644))
+	runGit(t, rewriter, "add", "replacement.txt")
+	runGit(t, rewriter, "commit", "-m", "rewrite target")
+	runGit(t, rewriter, "push", "--force", "origin", "HEAD:release/v3.0")
+
+	capture := filepath.Join(fixture.root, "review-args")
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"})
+	require.Error(t, err, output)
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, 1, exitError.ExitCode(), output)
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)")
+	require.NoFileExists(t, capture, "technical review must not run")
+}


### PR DESCRIPTION
## Summary

Teach `scripts/ai-pr-loop` to distinguish a stale PR base from an orchestration failure.

- fetch the current target/head refs as usual
- keep exact head-SHA verification
- when the target branch advanced beyond the PR's GitHub-reported `baseRefOid`, stop before legitimacy triage with:

```text
AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED
```

and exit code `3`

- if the target ref was rewritten/diverged instead of advancing from the recorded base, fail as an orchestration error
- document the synchronization requirement in `--help`
- add regression tests proving neither triage/review proceeds on a stale or rewritten target

## Why

PRs #1754-#1757 exposed a workflow gap: `ai-pr-loop` previously required the current remote target ref to equal the PR's historical `baseRefOid`. Once `release/v3.0` advanced, valid but unsynchronized PRs failed with the generic error `fetched base SHA does not match GitHub` before legitimacy triage.

Reviewing them against the historical base would be unsafe because changes merged into the target branch since PR creation could introduce semantic conflicts. This change keeps the fail-closed policy but turns it into an explicit actionable state.

## Product / operational motivation

Need: AI review must evaluate a PR against the target state it will actually merge into and must provide actionable workflow states rather than opaque failures.

Current limitation: target branch movement makes unsynchronized PRs impossible to process and is reported as a generic error.

Requirement: detect target advancement before any triage/review/fix work and require synchronization without mutating the PR automatically.

## Technical decision

Decision: introduce `BASE_UPDATE_REQUIRED`/exit 3 rather than automatically rebasing or reviewing against a historical base.

Why: automatic rebasing would mutate contributor branches and introduce conflict-resolution/product decisions into the launcher; historical-base review can miss interactions with newly merged target changes.

## Risk

LOW — contributor tooling only. Existing exact-head verification, trusted-base policy, review loop, validator, and guarded push remain unchanged.

## Validation

New tests cover:
- target branch advances normally -> exit 3 / `BASE_UPDATE_REQUIRED`, no technical review
- target branch is rewritten/diverged -> orchestration error, no technical review
- existing aligned-base launcher tests remain applicable

## Review focus

Please focus on whether `baseRefOid` plus the live target ref are interpreted correctly, whether ancestor checking is sufficient to distinguish normal advancement from rewrite/divergence, and whether any race still permits triaging/reviewing against a stale target.

## Out of scope

- automatic rebase/update-branch
- conflict resolution
- synthetic merge review
- changing guarded push semantics
