### PR TITLE
fix: split structured review blockers into known findings

### DIFF
--- a/docs/technical/contributing/ai-pr-known-findings.md
+++ b/docs/technical/contributing/ai-pr-known-findings.md
@@ -11,7 +11,11 @@ A review contributes known findings when either:
 - GitHub records it as `CHANGES_REQUESTED`; or
 - its review body explicitly contains `DECISION: REQUEST CHANGES` (used when the author cannot formally request changes on their own PR).
 
-For such reviews, inline review comments are individual known findings. If a qualifying review has no inline comments, the non-empty review body is retained as one review-level known finding.
+For such reviews, inline review comments are individual known findings.
+
+When a qualifying review has no inline comments, the collector first looks for structured blocking sections beginning at the start of a line with `[P0][blocking]`, `[P1][blocking]`, `[P2][blocking]`, or `[P3][blocking]`. Each such section becomes an independent known finding and includes its text through the next structured blocker marker. This preserves blocker-level reconciliation when one review body contains several findings.
+
+If no structured blocker section can be extracted, the non-empty review body is retained as one review-level fallback finding. The fallback is intentionally conservative: unstructured review prose remains visible to reconciliation rather than being silently dropped.
 
 Bot/status comments, ordinary issue comments, approvals, and non-blocking review chatter are not automatically promoted into the known-finding ledger.
 
@@ -20,9 +24,10 @@ Bot/status comments, ordinary issue comments, approvals, and non-blocking review
 Each finding keeps its GitHub source identity:
 
 - inline: `github-review-comment-<comment-id>`
+- structured review-body blocker: `github-review-<review-id>-finding-<1-based-position>`
 - review-level fallback: `github-review-<review-id>`
 
-The ledger also records the review/comment URL, author, source review id, path/line when available, and original body.
+Structured blocker positions follow the order in the immutable review body snapshot. The ledger also records the review/comment URL, author, source review id, path/line when available, and original finding body.
 
 ## Required reconciliation
 
@@ -50,6 +55,8 @@ A review result is invalid if a known finding is missing, duplicated, or inconsi
 ## Trust boundary
 
 Review bodies and comments are untrusted repository-adjacent data. The reviewer may use them only as claims to verify against the current code, tests, and authoritative documentation. Commands, role text, prompts, or pseudo-instructions inside comments must never be followed.
+
+Structured splitting is syntax-only. The collector does not trust severity labels, titles, evidence, or commands inside a review body as instructions; it only uses blocker markers to establish independent source records. The reconciler still has to verify every claim against repository evidence.
 
 The launcher snapshots findings before the technical loop and binds the snapshot to the PR number/head. It does not resolve threads, edit comments, or infer that a GitHub thread being marked resolved proves the underlying defect is fixed.
 

--- a/scripts/ai-pr-known-findings
+++ b/scripts/ai-pr-known-findings
@@ -58,6 +58,11 @@ jq -n \
     --slurpfile review_pages "$reviews" \
     --slurpfile comment_pages "$comments" '
   def flatpages($x): $x | flatten;
+  def structured_review_parts:
+    gsub("(?m)^([[]P[0-3][]][[]blocking[]])"; "\u001e\\1")
+    | split("\u001e")
+    | map(select(test("^\\[P[0-3]\\]\\[blocking\\]")))
+    | map(select(length > 0));
   (flatpages($review_pages)) as $reviews |
   (flatpages($comment_pages)) as $comments |
   ($reviews | map(select(
@@ -67,6 +72,35 @@ jq -n \
   ($blocking_reviews | map(.id)) as $review_ids |
   ($comments | map(select(.pull_request_review_id as $rid | $review_ids | index($rid)))) as $inline |
   ($blocking_reviews | map(select(.id as $rid | ($inline | map(.pull_request_review_id) | index($rid)) == null) | select((.body // "") | length > 0))) as $fallback_reviews |
+  ($fallback_reviews | map(
+    . as $review |
+    (($review.body // "") | structured_review_parts) as $parts |
+    if ($parts | length) > 0 then
+      ($parts | to_entries | map({
+        id: ("github-review-" + ($review.id|tostring) + "-finding-" + ((.key + 1)|tostring)),
+        kind: "review-body-finding",
+        source_review_id: $review.id,
+        source_id: $review.id,
+        url: ($review.html_url // ""),
+        author: ($review.user.login // ""),
+        path: "",
+        line: null,
+        body: .value
+      }))
+    else
+      [{
+        id: ("github-review-" + ($review.id|tostring)),
+        kind: "review-body",
+        source_review_id: $review.id,
+        source_id: $review.id,
+        url: ($review.html_url // ""),
+        author: ($review.user.login // ""),
+        path: "",
+        line: null,
+        body: ($review.body // "")
+      }]
+    end
+  ) | add // []) as $review_body_findings |
   {
     version: 1,
     pr_number: $pr,
@@ -82,18 +116,7 @@ jq -n \
         path: (.path // ""),
         line: (.line // .original_line // null),
         body: (.body // "")
-      })) +
-      ($fallback_reviews | map({
-        id: ("github-review-" + (.id|tostring)),
-        kind: "review-body",
-        source_review_id: .id,
-        source_id: .id,
-        url: (.html_url // ""),
-        author: (.user.login // ""),
-        path: "",
-        line: null,
-        body: (.body // "")
-      })))
+      })) + $review_body_findings)
       | sort_by(.id)
   }
 ' > "$result"
@@ -104,7 +127,7 @@ jq -e --arg head "$head" --argjson pr "$pr" '
   ([.findings[].id] | length == (unique | length)) and
   all(.findings[];
     (.id | type == "string") and
-    (.kind == "inline-review-comment" or .kind == "review-body") and
+    (.kind == "inline-review-comment" or .kind == "review-body" or .kind == "review-body-finding") and
     (.source_review_id | type == "number") and
     (.source_id | type == "number") and
     (.url | type == "string") and
@@ -114,10 +137,15 @@ jq -e --arg head "$head" --argjson pr "$pr" '
     (.body | type == "string" and length > 0) and
     (if .kind == "inline-review-comment" then
        .id == ("github-review-comment-" + (.source_id | tostring))
-     else
+     elif .kind == "review-body" then
        .id == ("github-review-" + (.source_id | tostring)) and
        .source_review_id == .source_id and
        .path == "" and .line == null
+     else
+       (.id | test("^github-review-" + (.source_id | tostring) + "-finding-[1-9][0-9]*$")) and
+       .source_review_id == .source_id and
+       .path == "" and .line == null and
+       (.body | test("^\\[P[0-3]\\]\\[blocking\\]"))
      end)
   )
 ' "$result" >/dev/null

--- a/scripts/ai-pr-known-findings
+++ b/scripts/ai-pr-known-findings
@@ -59,10 +59,18 @@ jq -n \
     --slurpfile comment_pages "$comments" '
   def flatpages($x): $x | flatten;
   def structured_review_parts:
-    gsub("(?m)^([[]P[0-3][]][[]blocking[]])"; "\u001e\\1")
-    | split("\u001e")
-    | map(select(test("^\\[P[0-3]\\]\\[blocking\\]")))
-    | map(select(length > 0));
+    . as $body |
+    [ $body | match("(?m)^\\[P[0-3]\\]\\[blocking\\]"; "g") ] as $markers |
+    if ($markers | length) == 0 then []
+    else [ range(0; ($markers | length)) as $index |
+      ($markers[$index].offset) as $start |
+      (if ($index + 1) < ($markers | length)
+       then $markers[$index + 1].offset
+       else ($body | length)
+       end) as $end |
+      $body[$start:$end]
+    ]
+    end;
   (flatpages($review_pages)) as $reviews |
   (flatpages($comment_pages)) as $comments |
   ($reviews | map(select(
@@ -142,13 +150,13 @@ jq -e --arg head "$head" --argjson pr "$pr" '
        .source_review_id == .source_id and
        .path == "" and .line == null
      else
-       (.id | test("^github-review-" + (.source_id | tostring) + "-finding-[1-9][0-9]*$")) and
+       (.id as $id | .source_id as $source_id | $id | test("^github-review-" + ($source_id | tostring) + "-finding-[1-9][0-9]*$")) and
        .source_review_id == .source_id and
        .path == "" and .line == null and
        (.body | test("^\\[P[0-3]\\]\\[blocking\\]"))
      end)
   )
-' "$result" >/dev/null
+ ' "$result" >/dev/null
 
 actual_head=$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid)
 if [[ "$actual_head" != "$head" ]]; then

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -261,7 +261,7 @@ if ! jq -e --argjson pr "$pr_number" --arg head "$head_sha" '
   ([.findings[].id] | length == (unique | length)) and
   all(.findings[];
     (.id | type == "string") and
-    (.kind == "inline-review-comment" or .kind == "review-body") and
+    (.kind == "inline-review-comment" or .kind == "review-body" or .kind == "review-body-finding") and
     (.source_review_id | type == "number") and
     (.source_id | type == "number") and
     (.url | type == "string") and
@@ -271,10 +271,15 @@ if ! jq -e --argjson pr "$pr_number" --arg head "$head_sha" '
     (.body | type == "string" and length > 0) and
     (if .kind == "inline-review-comment" then
        .id == ("github-review-comment-" + (.source_id | tostring))
-     else
+     elif .kind == "review-body" then
        .id == ("github-review-" + (.source_id | tostring)) and
        .source_review_id == .source_id and
        .path == "" and .line == null
+     else
+       (.id as $id | .source_id as $source_id | $id | test("^github-review-" + ($source_id | tostring) + "-finding-[1-9][0-9]*$")) and
+       .source_review_id == .source_id and
+       .path == "" and .line == null and
+       (.body | test("^\\[P[0-3]\\]\\[blocking\\]"))
      end)
   )
 ' "$known_findings" >/dev/null; then

--- a/scripts/ai-review-known-findings
+++ b/scripts/ai-review-known-findings
@@ -17,7 +17,7 @@ if ! jq -e \
   ([.findings[].id] | length == (unique | length)) and
   all(.findings[];
     (.id | type == "string") and
-    (.kind == "inline-review-comment" or .kind == "review-body") and
+    (.kind == "inline-review-comment" or .kind == "review-body" or .kind == "review-body-finding") and
     (.source_review_id | type == "number") and
     (.source_id | type == "number") and
     (.url | type == "string") and
@@ -27,10 +27,15 @@ if ! jq -e \
     (.body | type == "string" and length > 0) and
     (if .kind == "inline-review-comment" then
        .id == ("github-review-comment-" + (.source_id | tostring))
-     else
+     elif .kind == "review-body" then
        .id == ("github-review-" + (.source_id | tostring)) and
        .source_review_id == .source_id and
        .path == "" and .line == null
+     else
+       (.id as $id | .source_id as $source_id | $id | test("^github-review-" + ($source_id | tostring) + "-finding-[1-9][0-9]*$")) and
+       .source_review_id == .source_id and
+       .path == "" and .line == null and
+       (.body | test("^\\[P[0-3]\\]\\[blocking\\]"))
      end)
   )
 ' "$AI_REVIEW_KNOWN_FINDINGS" >/dev/null; then

--- a/scripts/aiprknownfindings/runner_test.go
+++ b/scripts/aiprknownfindings/runner_test.go
@@ -17,37 +17,78 @@ const (
 	testMovedHead = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 )
 
+type ledger struct {
+	PRNumber int `json:"pr_number"`
+	Head     string
+	Findings []struct {
+		ID   string
+		Kind string
+		Body string
+	}
+}
+
 func TestCollectorPublishesStableFindingsForExactHead(t *testing.T) {
 	t.Parallel()
 
 	fixture := newFixture(t)
-	output, err := fixture.run(t, false)
+	output, err := fixture.run(t, false, "inline")
 	require.NoError(t, err, output)
 	require.Contains(t, output, "AI_PR_KNOWN_FINDINGS_COUNT: 1")
 
-	var ledger struct {
-		PRNumber int `json:"pr_number"`
-		Head     string
-		Findings []struct {
-			ID   string
-			Kind string
-			Body string
-		}
+	var result ledger
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, fixture.output)), &result))
+	require.Equal(t, 123, result.PRNumber)
+	require.Equal(t, testHead, result.Head)
+	require.Len(t, result.Findings, 1)
+	require.Equal(t, "github-review-comment-202", result.Findings[0].ID)
+	require.Equal(t, "inline-review-comment", result.Findings[0].Kind)
+	require.Equal(t, "Untrusted review evidence", result.Findings[0].Body)
+}
+
+func TestCollectorSplitsStructuredReviewBodyIntoIndependentFindings(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	output, err := fixture.run(t, false, "structured")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "AI_PR_KNOWN_FINDINGS_COUNT: 3")
+
+	var result ledger
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, fixture.output)), &result))
+	require.Len(t, result.Findings, 3)
+	for index := range result.Findings {
+		require.Equal(t, "review-body-finding", result.Findings[index].Kind)
+		require.Equal(t, "github-review-101-finding-"+string(rune('1'+index)), result.Findings[index].ID)
+		require.Contains(t, result.Findings[index].Body, "[P")
+		require.Contains(t, result.Findings[index].Body, "[blocking]")
 	}
-	require.NoError(t, json.Unmarshal([]byte(readFile(t, fixture.output)), &ledger))
-	require.Equal(t, 123, ledger.PRNumber)
-	require.Equal(t, testHead, ledger.Head)
-	require.Len(t, ledger.Findings, 1)
-	require.Equal(t, "github-review-comment-202", ledger.Findings[0].ID)
-	require.Equal(t, "inline-review-comment", ledger.Findings[0].Kind)
-	require.Equal(t, "Untrusted review evidence", ledger.Findings[0].Body)
+	require.Contains(t, result.Findings[0].Body, "First blocker")
+	require.Contains(t, result.Findings[1].Body, "Second blocker")
+	require.Contains(t, result.Findings[2].Body, "Third blocker")
+	require.NotContains(t, result.Findings[0].Body, "Second blocker")
+}
+
+func TestCollectorFallsBackToWholeReviewWhenBodyIsUnstructured(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	output, err := fixture.run(t, false, "fallback")
+	require.NoError(t, err, output)
+	require.Contains(t, output, "AI_PR_KNOWN_FINDINGS_COUNT: 1")
+
+	var result ledger
+	require.NoError(t, json.Unmarshal([]byte(readFile(t, fixture.output)), &result))
+	require.Len(t, result.Findings, 1)
+	require.Equal(t, "github-review-101", result.Findings[0].ID)
+	require.Equal(t, "review-body", result.Findings[0].Kind)
+	require.Contains(t, result.Findings[0].Body, "Unstructured blocker")
 }
 
 func TestCollectorRefusesResultWhenHeadMovesDuringSnapshot(t *testing.T) {
 	t.Parallel()
 
 	fixture := newFixture(t)
-	output, err := fixture.run(t, true)
+	output, err := fixture.run(t, true, "inline")
 	require.Error(t, err, output)
 	require.Contains(t, output, "PR head moved during snapshot")
 	require.NoFileExists(t, fixture.output)
@@ -88,10 +129,24 @@ case "$1 $2" in
   "api --paginate")
     case "$3" in
       *'/reviews?'*)
-        printf '[{"id":101,"state":"CHANGES_REQUESTED","body":"Blocking review","html_url":"https://example/review","user":{"login":"reviewer"}}]\n'
+        case "$TEST_MODE" in
+          structured)
+            printf '%s\n' '[{"id":101,"state":"COMMENTED","body":"DECISION: REQUEST CHANGES\n\nBlocking findings:\n\n[P1][blocking] First blocker\nLocation: first.go:1\nEvidence: first evidence\nImpact: first impact\nResolution: first resolution\n\n[P2][blocking] Second blocker\nLocation: second.go:2\nEvidence: second evidence\nImpact: second impact\nResolution: second resolution\n\n[P1][blocking] Third blocker\nLocation: third.go:3\nEvidence: third evidence\nImpact: third impact\nResolution: third resolution","html_url":"https://example/review","user":{"login":"reviewer"}}]'
+            ;;
+          fallback)
+            printf '%s\n' '[{"id":101,"state":"CHANGES_REQUESTED","body":"Unstructured blocker that still must be reconciled","html_url":"https://example/review","user":{"login":"reviewer"}}]'
+            ;;
+          *)
+            printf '%s\n' '[{"id":101,"state":"CHANGES_REQUESTED","body":"Blocking review","html_url":"https://example/review","user":{"login":"reviewer"}}]'
+            ;;
+        esac
         ;;
       *'/comments?'*)
-        printf '[{"id":202,"pull_request_review_id":101,"html_url":"https://example/comment","user":{"login":"reviewer"},"path":"scripts/example","line":7,"body":"Untrusted review evidence"}]\n'
+        if [[ "$TEST_MODE" == "inline" ]]; then
+          printf '[{"id":202,"pull_request_review_id":101,"html_url":"https://example/comment","user":{"login":"reviewer"},"path":"scripts/example","line":7,"body":"Untrusted review evidence"}]\n'
+        else
+          printf '[]\n'
+        fi
         ;;
       *) exit 97 ;;
     esac
@@ -109,7 +164,7 @@ esac
 	}
 }
 
-func (fixture fixture) run(t *testing.T, moveHead bool) (string, error) {
+func (fixture fixture) run(t *testing.T, moveHead bool, mode string) (string, error) {
 	t.Helper()
 
 	command := exec.Command("bash", fixture.runner, "123", "--head", testHead, "--output", fixture.output)
@@ -120,6 +175,7 @@ func (fixture fixture) run(t *testing.T, moveHead bool) (string, error) {
 		"TEST_MOVED_HEAD="+testMovedHead,
 		"TEST_HEAD_READS="+fixture.headReads,
 		"TEST_MOVE_HEAD="+map[bool]string{true: "true", false: "false"}[moveHead],
+		"TEST_MODE="+mode,
 	)
 	output, err := command.CombinedOutput()
 

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -107,6 +107,42 @@ func TestLauncherReconcilesKnownFindingsBoundToTheVerifiedTarget(t *testing.T) {
 	require.Equal(t, fixture.headSHA, ledger.Head)
 }
 
+func TestLauncherAcceptsStructuredReviewBodyFindings(t *testing.T) {
+	t.Parallel()
+
+	fixture := newLauncherFixture(t)
+	capture := filepath.Join(fixture.root, "review-args")
+	// A review body split into blocker-level findings must reach reconciliation
+	// exactly like inline comments do.
+	structured := `[{"id":"github-review-7-finding-1","kind":"review-body-finding","source_review_id":7,` +
+		`"source_id":7,"url":"https://github.com/owner/repo/pull/123#pullrequestreview-7","author":"reviewer",` +
+		`"path":"","line":null,"body":"[P1][blocking] Structured blocking section"}]`
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"},
+		"TEST_KNOWN_FINDINGS_JSON="+structured)
+	require.NoError(t, err, output)
+	require.Contains(t, output, "1 known blocking GitHub finding(s)")
+
+	ledgerPath := strings.TrimSpace(readCapturedFile(t, capture+".known"))
+	require.NotEmpty(t, ledgerPath, "the reviewer must receive AI_REVIEW_KNOWN_FINDINGS")
+	require.Contains(t, readCapturedFile(t, ledgerPath), "github-review-7-finding-1")
+}
+
+func TestLauncherRefusesStructuredFindingWithoutBlockerMarker(t *testing.T) {
+	t.Parallel()
+
+	fixture := newLauncherFixture(t)
+	capture := filepath.Join(fixture.root, "review-args")
+	// The structured kind is only meaningful for bodies that actually start at a
+	// blocker marker, so its identity and body must stay verifiable.
+	structured := `[{"id":"github-review-7-finding-1","kind":"review-body-finding","source_review_id":7,` +
+		`"source_id":7,"url":"","author":"reviewer","path":"","line":null,"body":"unstructured prose"}]`
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"},
+		"TEST_KNOWN_FINDINGS_JSON="+structured)
+	require.Error(t, err, output)
+	require.NoFileExists(t, capture, "technical review must not run")
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (known findings target mismatch)")
+}
+
 func TestLauncherRefusesMalformedKnownFindingsLedger(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/aireviewknownfindings/adapter_test.go
+++ b/scripts/aireviewknownfindings/adapter_test.go
@@ -50,6 +50,38 @@ func TestStillValidKnownBlockerEscalatesApproval(t *testing.T) {
 	requireJSONEqual(t, final, readFile(t, fixture.result))
 }
 
+func TestStructuredKnownBlockerReachesReconciliation(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAdapterFixture(t)
+	known := newStructuredKnownFinding(112, 2)
+	base := newReview("APPROVE", "LOW")
+	final := cloneObject(t, base)
+	final["decision"] = "REQUEST_CHANGES"
+	final["residual_risk"] = "MEDIUM"
+	final["findings"] = []any{knownReviewFinding(known["id"].(string))}
+	fixture.writeInputs(t, base, newLedger(known), combined(final, classification(known, "STILL_VALID")))
+
+	output, err := fixture.run(t, nil)
+	require.NoError(t, err, output)
+	requireJSONEqual(t, final, readFile(t, fixture.result))
+	require.Contains(t, readFile(t, fixture.prompt), fixture.ledger)
+}
+
+func TestRejectsStructuredFindingWithoutBlockerMarker(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAdapterFixture(t)
+	known := newStructuredKnownFinding(113, 1)
+	known["body"] = "unstructured prose"
+	base := newReview("APPROVE", "LOW")
+	fixture.writeInputs(t, base, newLedger(known), nil)
+
+	output, err := fixture.run(t, nil)
+	require.Error(t, err, output)
+	require.Contains(t, output, "invalid or mismatched ledger")
+}
+
 func TestFixedKnownFindingLeavesBaseResultUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -373,6 +405,17 @@ func newKnownFinding(id int) map[string]any {
 		"line":             nil,
 		"body":             "Blocking review evidence",
 	}
+}
+
+// newStructuredKnownFinding is a blocker-level known finding extracted from a
+// structured review body rather than a whole review.
+func newStructuredKnownFinding(reviewID, position int) map[string]any {
+	finding := newKnownFinding(reviewID)
+	finding["id"] = "github-review-" + jsonNumber(reviewID) + "-finding-" + jsonNumber(position)
+	finding["kind"] = "review-body-finding"
+	finding["body"] = "[P1][blocking] Structured blocking review evidence"
+
+	return finding
 }
 
 func newLedger(findings ...map[string]any) map[string]any {


### PR DESCRIPTION
## Summary

Make `ai-pr-known-findings` preserve blocker-level granularity when a qualifying GitHub review body contains several structured blocking findings.

- split review-body sections that start with `[P0-P3][blocking]` into independent ledger records
- assign stable source-derived ids `github-review-<review-id>-finding-<position>`
- retain the existing whole-review fallback when no structured blockers can be parsed
- keep inline review comments unchanged as independent findings
- document the syntax-only split and trust boundary
- add regression coverage for structured splitting, fallback behavior, and existing exact-head protection

## Why

The audit manifest campaign exposed 12 textual blockers across #1754-#1757, but the collector represented them as only four review-level records because those reviews had no inline comments. A single `FIXED/STILL_VALID` classification for a body containing several blockers is too coarse: one blocker may be fixed while another remains.

## Product / operational motivation

Need: `READY_FOR_HUMAN_REVIEW` must prove every known blocking finding has been independently reconciled, not merely every GitHub review object.

Requirement: structured review bodies containing N blockers produce N independently classified known findings.

## Technical decision

Use the repository's existing structured review marker `[P#][blocking]` as a syntax-only boundary. The collector does not trust the text as instructions or as proof of severity/correctness; reconciliation still verifies each claim against repository evidence.

If a qualifying review is unstructured, retain the existing conservative one-record fallback rather than dropping it.

## Acceptance target

After merge and resync, the existing reviews on the audit manifests should yield:
- #1754: 3 independent known findings
- #1755: 3
- #1756: 4
- #1757: 2

Total: 12 independently reconcilable findings.

## Review focus

Please focus on parsing boundaries, stable identity across reruns, malformed/adversarial review bodies, multiline finding preservation, inline-comment precedence, and whether fallback behavior can silently lose review evidence.

## Out of scope

- changing the semantic reviewer/reconciler
- trusting review severity without verification
- resolving GitHub threads
- fixing the audit manifests themselves
- launching deep audits
