### PR TITLE
fix(EN-1850): preserve kubectl rollout-restart annotation on the cluster StatefulSet

### DIFF
--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -274,6 +274,12 @@ the pod template instead of reverting it on the next reconcile. Prefer
 `kubectl ledger restart`, which records the restart on the Cluster CR itself
 (`spec.podAnnotations`) and therefore survives StatefulSet recreation.
 
+**Exception:** if the Cluster CR itself sets `kubectl.kubernetes.io/restartedAt`
+in `spec.podAnnotations`, the CR value is authoritative and the operator reverts
+a direct `kubectl rollout restart` stamp on the next reconcile — the rollout
+stops after the first pod. In that configuration, restart through the CR only
+(`kubectl ledger restart`, or bump the annotation value in the CR).
+
 ## Development
 
 ### Setup

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -268,6 +268,12 @@ kubectl ledger scale my-ledger --replicas 7
 kubectl ledger restart my-ledger -y
 ```
 
+Plain `kubectl rollout restart statefulset/<name>` also works: the operator
+preserves the `kubectl.kubernetes.io/restartedAt` annotation kubectl stamps on
+the pod template instead of reverting it on the next reconcile. Prefer
+`kubectl ledger restart`, which records the restart on the Cluster CR itself
+(`spec.podAnnotations`) and therefore survives StatefulSet recreation.
+
 ## Development
 
 ### Setup

--- a/misc/operator/internal/controller/labels.go
+++ b/misc/operator/internal/controller/labels.go
@@ -11,6 +11,14 @@ const (
 	annotationSpecHash     = "ledger.formance.com/spec-hash"
 	annotationAuthKeysHash = "ledger.formance.com/auth-keys-hash"
 
+	// annotationKubectlRestartedAt is stamped on the pod template by
+	// `kubectl rollout restart`. It is user-owned state, not drift: the
+	// StatefulSet reconciler must carry it over when rebuilding the template
+	// from the Cluster CR, otherwise the reconcile triggered by kubectl's own
+	// patch reverts the template and cancels the rolling restart after the
+	// first (highest-ordinal) pod (EN-1850).
+	annotationKubectlRestartedAt = "kubectl.kubernetes.io/restartedAt"
+
 	// labelDeletionProtection (set to labelDeletionProtectionValue) is stamped on
 	// the PVCs and bound PVs of a Cluster whose spec.persistence.deletionProtection
 	// is true. The volume deletion-protection ValidatingAdmissionPolicyBinding scopes

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -507,7 +507,10 @@ func buildPodTemplate(ledger *ledgerv1alpha1.Cluster, specHash string, credentia
 //
 // A value the CR explicitly provides through spec.podAnnotations wins over the
 // live stamp: the CR is the source of truth, and only a key it does not manage
-// is treated as user-owned StatefulSet state.
+// is treated as user-owned StatefulSet state. Consequently, when the CR manages
+// this key a direct `kubectl rollout restart` is reverted on the next reconcile;
+// that configuration must restart through the CR (documented in the operator
+// README).
 //
 // The annotations map is copied before mutation: the desired template built by
 // buildStatefulSetSpec may be shared across retries of a mutate function.

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -505,11 +505,18 @@ func buildPodTemplate(ledger *ledgerv1alpha1.Cluster, specHash string, credentia
 // reconcile, so dropping the stamp would revert kubectl's patch and cancel the
 // rolling restart after the first (highest-ordinal) pod (EN-1850).
 //
+// A value the CR explicitly provides through spec.podAnnotations wins over the
+// live stamp: the CR is the source of truth, and only a key it does not manage
+// is treated as user-owned StatefulSet state.
+//
 // The annotations map is copied before mutation: the desired template built by
 // buildStatefulSetSpec may be shared across retries of a mutate function.
 func withKubectlRestartedAt(existing, desired corev1.PodTemplateSpec) corev1.PodTemplateSpec {
 	restartedAt, ok := existing.Annotations[annotationKubectlRestartedAt]
 	if !ok {
+		return desired
+	}
+	if _, crManaged := desired.Annotations[annotationKubectlRestartedAt]; crManaged {
 		return desired
 	}
 

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -90,7 +90,7 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 					sts.Spec = desired
 				} else {
 					sts.Spec.Replicas = desired.Replicas
-					sts.Spec.Template = desired.Template
+					sts.Spec.Template = withKubectlRestartedAt(sts.Spec.Template, desired.Template)
 					sts.Spec.UpdateStrategy = desired.UpdateStrategy
 					sts.Spec.PersistentVolumeClaimRetentionPolicy = desired.PersistentVolumeClaimRetentionPolicy
 					sts.Spec.MinReadySeconds = desired.MinReadySeconds
@@ -155,7 +155,7 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 			// ServiceName, Selector, PodManagementPolicy and
 			// VolumeClaimTemplates are immutable after creation.
 			sts.Spec.Replicas = desired.Replicas
-			sts.Spec.Template = desired.Template
+			sts.Spec.Template = withKubectlRestartedAt(sts.Spec.Template, desired.Template)
 			sts.Spec.UpdateStrategy = desired.UpdateStrategy
 			sts.Spec.PersistentVolumeClaimRetentionPolicy = desired.PersistentVolumeClaimRetentionPolicy
 			sts.Spec.MinReadySeconds = desired.MinReadySeconds
@@ -496,6 +496,29 @@ func buildPodTemplate(ledger *ledgerv1alpha1.Cluster, specHash string, credentia
 		},
 		Spec: podSpec,
 	}
+}
+
+// withKubectlRestartedAt returns the desired pod template, carrying over the
+// kubectl.kubernetes.io/restartedAt annotation from the existing template when
+// present. `kubectl rollout restart` works by stamping that annotation on the
+// pod template; the operator rebuilds the template from the Cluster CR on every
+// reconcile, so dropping the stamp would revert kubectl's patch and cancel the
+// rolling restart after the first (highest-ordinal) pod (EN-1850).
+//
+// The annotations map is copied before mutation: the desired template built by
+// buildStatefulSetSpec may be shared across retries of a mutate function.
+func withKubectlRestartedAt(existing, desired corev1.PodTemplateSpec) corev1.PodTemplateSpec {
+	restartedAt, ok := existing.Annotations[annotationKubectlRestartedAt]
+	if !ok {
+		return desired
+	}
+
+	annotations := make(map[string]string, len(desired.Annotations)+1)
+	maps.Copy(annotations, desired.Annotations)
+	annotations[annotationKubectlRestartedAt] = restartedAt
+	desired.Annotations = annotations
+
+	return desired
 }
 
 func buildAffinity(ledger *ledgerv1alpha1.Cluster) *corev1.Affinity {

--- a/misc/operator/internal/controller/reconcile_statefulset_test.go
+++ b/misc/operator/internal/controller/reconcile_statefulset_test.go
@@ -100,6 +100,21 @@ func TestWithKubectlRestartedAt(t *testing.T) {
 		assert.False(t, present)
 	})
 
+	t.Run("a CR-provided value wins over the live stamp", func(t *testing.T) {
+		t.Parallel()
+
+		existing := newTemplate(map[string]string{annotationKubectlRestartedAt: "2026-08-24T10:00:00Z"})
+		desired := newTemplate(map[string]string{
+			annotationKubectlRestartedAt: "2026-08-25T09:00:00Z",
+			annotationSpecHash:           "new-hash",
+		})
+
+		got := withKubectlRestartedAt(existing, desired)
+
+		assert.Equal(t, "2026-08-25T09:00:00Z", got.Annotations[annotationKubectlRestartedAt],
+			"a restartedAt explicitly managed through spec.podAnnotations must not be masked by the live stamp")
+	})
+
 	t.Run("does not mutate the desired template's annotations map", func(t *testing.T) {
 		t.Parallel()
 

--- a/misc/operator/internal/controller/reconcile_statefulset_test.go
+++ b/misc/operator/internal/controller/reconcile_statefulset_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
@@ -58,4 +59,58 @@ func TestBuildVolumeClaimTemplates_DeletionProtectionLabel(t *testing.T) {
 		_, present := tmpl.Labels[labelDeletionProtection]
 		assert.False(t, present, "VCT %q must not carry the deletion-protection label when protection is off", tmpl.Name)
 	}
+}
+
+func TestWithKubectlRestartedAt(t *testing.T) {
+	t.Parallel()
+
+	newTemplate := func(annotations map[string]string) corev1.PodTemplateSpec {
+		return corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+		}
+	}
+
+	t.Run("carries the stamp from the existing template", func(t *testing.T) {
+		t.Parallel()
+
+		existing := newTemplate(map[string]string{
+			annotationKubectlRestartedAt: "2026-08-24T10:00:00Z",
+			annotationSpecHash:           "old-hash",
+		})
+		desired := newTemplate(map[string]string{annotationSpecHash: "new-hash"})
+
+		got := withKubectlRestartedAt(existing, desired)
+
+		assert.Equal(t, "2026-08-24T10:00:00Z", got.Annotations[annotationKubectlRestartedAt],
+			"kubectl rollout restart stamp must survive the reconcile (EN-1850)")
+		assert.Equal(t, "new-hash", got.Annotations[annotationSpecHash],
+			"operator-owned annotations must still come from the desired template")
+	})
+
+	t.Run("returns the desired template unchanged when no stamp exists", func(t *testing.T) {
+		t.Parallel()
+
+		existing := newTemplate(map[string]string{annotationSpecHash: "old-hash"})
+		desired := newTemplate(map[string]string{annotationSpecHash: "new-hash"})
+
+		got := withKubectlRestartedAt(existing, desired)
+
+		assert.Equal(t, desired.Annotations, got.Annotations)
+		_, present := got.Annotations[annotationKubectlRestartedAt]
+		assert.False(t, present)
+	})
+
+	t.Run("does not mutate the desired template's annotations map", func(t *testing.T) {
+		t.Parallel()
+
+		existing := newTemplate(map[string]string{annotationKubectlRestartedAt: "2026-08-24T10:00:00Z"})
+		sharedAnnotations := map[string]string{annotationSpecHash: "new-hash"}
+		desired := newTemplate(sharedAnnotations)
+
+		got := withKubectlRestartedAt(existing, desired)
+
+		assert.Equal(t, "2026-08-24T10:00:00Z", got.Annotations[annotationKubectlRestartedAt])
+		_, present := sharedAnnotations[annotationKubectlRestartedAt]
+		assert.False(t, present, "the shared desired annotations map must not be mutated")
+	})
 }

--- a/misc/operator/internal/controller/reconcile_update_test.go
+++ b/misc/operator/internal/controller/reconcile_update_test.go
@@ -42,3 +42,49 @@ func TestReconcile_SpecHashChanges(t *testing.T) {
 
 	assert.NotEqual(t, initialHash, sts.Spec.Template.Annotations[annotationSpecHash])
 }
+
+// TestReconcile_PreservesKubectlRestartedAt covers EN-1850: the reconciler
+// rebuilds the pod template from the Cluster CR, and must carry over the
+// annotation `kubectl rollout restart` stamps on the StatefulSet, otherwise
+// the reconcile reverts kubectl's patch and cancels the rolling restart after
+// the first (highest-ordinal) pod.
+func TestReconcile_PreservesKubectlRestartedAt(t *testing.T) {
+	ns := createTestNamespace(t)
+	ls := newCluster("kubectl-restart", ns)
+	require.NoError(t, k8sClient.Create(ctx, ls))
+
+	stsName := types.NamespacedName{Name: "ledger-kubectl-restart", Namespace: ns}
+	sts := &appsv1.StatefulSet{}
+	requireEventually(t, func() bool {
+		return k8sClient.Get(ctx, stsName, sts) == nil
+	}, "StatefulSet should be created")
+
+	// Simulate `kubectl rollout restart statefulset`: stamp restartedAt on the
+	// pod template. This patch itself triggers a reconcile of the owned
+	// StatefulSet.
+	const restartedAt = "2026-08-24T10:00:00Z"
+	require.NoError(t, k8sClient.Get(ctx, stsName, sts))
+	if sts.Spec.Template.Annotations == nil {
+		sts.Spec.Template.Annotations = map[string]string{}
+	}
+	sts.Spec.Template.Annotations[annotationKubectlRestartedAt] = restartedAt
+	require.NoError(t, k8sClient.Update(ctx, sts))
+
+	// Force a reconcile that rewrites the template from the CR and wait for it
+	// to land (new spec hash). The kubectl stamp must survive that rewrite.
+	initialHash := sts.Spec.Template.Annotations[annotationSpecHash]
+	updated := &ledgerv1alpha1.Cluster{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Name: "kubectl-restart", Namespace: ns}, updated))
+	updated.Spec.Debug = true
+	require.NoError(t, k8sClient.Update(ctx, updated))
+
+	requireEventually(t, func() bool {
+		if err := k8sClient.Get(ctx, stsName, sts); err != nil {
+			return false
+		}
+		return sts.Spec.Template.Annotations[annotationSpecHash] != initialHash
+	}, "spec hash should change after spec update")
+
+	assert.Equal(t, restartedAt, sts.Spec.Template.Annotations[annotationKubectlRestartedAt],
+		"kubectl rollout restart stamp must survive template rewrites (EN-1850)")
+}


### PR DESCRIPTION
## What changed

The operator now carries the `kubectl.kubernetes.io/restartedAt` pod-template annotation over from the live StatefulSet when rebuilding the template from the Cluster CR, in both `CreateOrUpdate` mutate paths (main pass and the scale-down pre-update). Adds unit tests for the helper, an envtest integration test proving the stamp survives a CR-driven template rewrite, and a README note.

## Why

`kubectl rollout restart statefulset` stamps `restartedAt` on the pod template. The reconciler rebuilt the template from scratch, so the reconcile triggered by kubectl's own patch erased the stamp and cancelled the rolling restart after the first (highest-ordinal, `-2`) pod — leaving `-1`/`-0` on the old revision. Same class of bug as formancehq/operator#353.

Jira: [EN-1850](https://formance-team.atlassian.net/browse/EN-1850)

## Product / operational motivation

Need: operators must be able to perform a full rolling restart of a ledger cluster with the standard kubectl verb.
Current limitation: the restart silently stops after one pod, which reads as a completed restart.
Requirement / constraint: a `kubectl rollout restart` must roll every pod; operator-owned annotations (`spec-hash`, `auth-keys-hash`) must remain CR-derived.
Evidence: EN-1850; prior art formancehq/operator#353.
Durable repository evidence: `misc/operator/internal/controller/labels.go` (annotation constant comment), `misc/operator/README.md` restart section.

## Technical decision

Decision: treat the kubectl stamp as user-owned state and carry only that one key over from the existing template.
Why now / why proportionate: one-line semantic change per mutate path; no new CRD surface.
Alternatives considered: documenting `kubectl rollout restart` as unsupported (rejected — a half-completed rollout is a silent failure mode); preserving all `kubectl.kubernetes.io/*` annotations (rejected — only `restartedAt` has defined template semantics, a blanket carry-over could mask drift).

## Risk

**LOW** — scoped to the operator's StatefulSet template reconciliation; the spec-hash rolling-update mechanism is untouched.

## Validation

- [x] `bash scripts/agent-check` (PASS, root + operator lint 0 issues)
- [x] Targeted tests: `go test ./internal/controller/` (operator unit suite) and `go test -tags integration ./internal/controller/` (envtest) including the new `TestWithKubectlRestartedAt` and `TestReconcile_PreservesKubectlRestartedAt`
- [x] External review: Codex (gpt-5.5) — APPROVE, 0 blocking findings, 1 non-blocking P3 (see Known concerns)

## Architecture / behavior impact

Operator-only. The StatefulSet pod template may now carry one non-CR-derived annotation; it does not participate in the spec hash. On StatefulSet recreation (VolumeClaimTemplate change) the stamp is still lost — the README recommends `kubectl ledger restart` (CR-recorded) for that reason.

## Review focus

The interaction between the carried-over annotation and the two mutate paths in `reconcile_statefulset.go` — especially the scale-down pre-update.

## Known concerns

Codex P3 (non-blocking): if a GitOps flow manages the exact key `kubectl.kubernetes.io/restartedAt` through `spec.podAnnotations` after a prior direct `kubectl rollout restart`, the live stamp wins over the CR value until StatefulSet recreation (the rollout itself is unaffected — the spec hash still changes). Can be addressed by preserving only when the desired template lacks the key, if that usage ever materializes.

[EN-1850]: https://formance-team.atlassian.net/browse/EN-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ