### PR TITLE
docs: correct pagination snapshot consistency contract

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -1,6 +1,6 @@
 # Read Path
 
-The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `internal/storage/readstore`). Indexed entity-list reads go through a `ReadIndex` quorum check (linearizability barrier), then iterate over the inverted index in the read store, enriching candidate entity IDs with volumes and metadata from the main store. Point reads and main-store-only queries use their own main-store read path and do not iterate the inverted index.
+The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `internal/storage/readstore`). Default live reads go through a `ReadIndex` quorum check (linearizability barrier). Indexed entity-list reads then iterate over the inverted index in the read store, enriching candidate entity IDs with volumes and metadata from the main store. Point reads and main-store-only queries use the same barrier but their own main-store read path; they do not iterate the inverted index. Explicit stale and checkpoint reads have the exceptions documented in the pipeline pages.
 
 ## Documents
 
@@ -17,5 +17,5 @@ The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `intern
 ## Related
 
 - [Indexer](../indexer/) — populates the read store the query path consumes.
-- [Consensus](../consensus/) — `ReadIndex` quorum that gates indexed entity-list reads.
+- [Consensus](../consensus/) — `ReadIndex` quorum that gates default live reads (with stale/checkpoint exceptions).
 - [FSM](../fsm/) — what the read path waits to catch up to via `min_log_sequence`.

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -1,6 +1,6 @@
 # Read Path
 
-The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `internal/storage/readstore`). Every read goes through a `ReadIndex` quorum check (linearizability barrier), then iterates over the inverted index in the read store, enriching candidate entity IDs with volumes and metadata from the main store.
+The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `internal/storage/readstore`). Indexed entity-list reads go through a `ReadIndex` quorum check (linearizability barrier), then iterate over the inverted index in the read store, enriching candidate entity IDs with volumes and metadata from the main store. Point reads and main-store-only queries use their own main-store read path and do not iterate the inverted index.
 
 ## Documents
 
@@ -17,5 +17,5 @@ The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `intern
 ## Related
 
 - [Indexer](../indexer/) — populates the read store the query path consumes.
-- [Consensus](../consensus/) — `ReadIndex` quorum that gates every read.
+- [Consensus](../consensus/) — `ReadIndex` quorum that gates indexed entity-list reads.
 - [FSM](../fsm/) — what the read path waits to catch up to via `min_log_sequence`.

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Every read goes through four stages: a **Raft `ReadIndex`** barrier for linearizability, an optional **`min_log_sequence`** wait for read-side freshness, a **Pebble snapshot** for point-in-time consistency, and a **composable iterator pipeline** over the read store. The result is streamed back through gRPC with cursor-based pagination.
+Every read goes through four stages: a **Raft `ReadIndex`** barrier for linearizability, an optional **`min_log_sequence`** wait for read-side freshness, coordinated **Pebble snapshots** for the main and read stores, and a **composable iterator pipeline** over the read store. The result is streamed back through gRPC with cursor-based pagination. The snapshots are aligned but distinct; their per-target consistency exceptions are described below.
 
 The pipeline is deliberately uniform across endpoints: `ListAccounts`, `ListTransactions`, `ListLogs`, and `GetX` variants all go through the same controller layer and the same iterator algebra. The differences are which read-store prefix is scanned and how iterators are composed.
 
@@ -15,7 +15,8 @@ sequenceDiagram
     participant N as Node<br/>(ReadIndex)
     participant Raft as Raft peers
     participant FSM
-    participant Peb as Pebble<br/>(main + read store)
+    participant Main as Pebble<br/>(main store)
+    participant Index as Pebble<br/>(read store)
 
     C->>G: ListAccounts(filter, min_log_seq, cursor)
     G->>G: Auth + extract min_log_seq
@@ -26,11 +27,13 @@ sequenceDiagram
     N->>FSM: WaitForApplied(commitIndex)
     FSM-->>N: applied up to commitIndex
     N-->>Ctrl: ReadBarrierInfo
-    Ctrl->>Peb: store.NewReadHandle()
-    Note over Ctrl,Peb: Pebble snapshot — point-in-time
+    Ctrl->>Main: store.NewReadHandle()
+    Ctrl->>Index: NewSnapshot / AlignedIndexSnapshot
+    Note over Ctrl,Index: Separate snapshots coordinated to the main-store horizon
     Ctrl->>Ctrl: Resolve ledger + schema
     Ctrl->>Ctrl: Compile filter → iterator tree
-    Ctrl->>Peb: Iterate read store + enrich from main store
+    Ctrl->>Index: Iterate read store
+    Ctrl->>Main: Enrich from main store
     Ctrl-->>G: Cursor[T] (page + next cursor)
     G-->>C: Streamed response
 ```
@@ -87,9 +90,9 @@ Checkpoint reads (see below) ignore `min_log_sequence` — a frozen checkpoint i
 
 ## Pebble snapshot
 
-`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, the read-store iterators (inverted index) and main-store enrichment (volumes, metadata, transaction bodies) use the **same** snapshot. The handle is owned by the returned cursor and is closed when that cursor is closed. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore a new snapshot.
+`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, main-store leaves and enrichment (volumes, metadata, transaction bodies) all read through the **one** main-store handle `query.OpenQueryHandle` opened. The read-store iterators (inverted index) run against a **separate** Pebble snapshot of the read store: `readStore.NewSnapshot()` when the read consults no index leaf, and otherwise `query.AlignedIndexSnapshot`, which returns an index snapshot whose fold cursor covers the main handle's sequence. The two are therefore *coordinated*, not identical — the index view may be **ahead** of the main handle, and `query.MainHorizonKeep` trims that excess back to the main-store horizon for TRANSACTIONS and LOGS (ACCOUNTS are served as folded). The contract and its per-target exceptions live in [read-snapshot-consistency.md](read-snapshot-consistency.md#cross-store-alignment-en-1748). The main handle — with the reclaim hold taken alongside it — is owned by the returned cursor and closed when that cursor is closed; the index snapshot and its read lease are released once the page's index iteration ends, before enrichment reads the handle. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore fresh snapshot state.
 
-The cursor carries only the exclusive resume position (for example, an account address or transaction ID); it does not identify or retain the Pebble snapshot. Consequently, point-in-time consistency is guaranteed within each request/page, but there is no general snapshot-consistency guarantee across separate pages. Inserts, deletes, or updates committed between requests may therefore affect later pages according to the documented cursor ordering and filtering semantics. Duplications or omissions across pages under concurrent writes are not, by themselves, evidence of a product defect unless an API contract explicitly promises a cross-page snapshot.
+The cursor carries only the exclusive resume position (for example, an account address or transaction ID); it does not identify or retain the Pebble snapshot. Within one request/page, results are served under the coordinated consistency contract described above: main-store leaves and enrichment reflect that request's single pin, subject to the per-target cross-store exceptions — ACCOUNTS membership is served as folded, so a page may include index members absent from the pinned main store. Because the cursor does not retain that snapshot state, there is no general snapshot-consistency guarantee across separate pages. Inserts, deletes, or updates committed between requests may therefore affect later pages according to the documented cursor ordering and filtering semantics. Duplications or omissions across pages under concurrent writes are not, by themselves, evidence of a product defect unless an API contract explicitly promises a cross-page snapshot.
 
 Multiple concurrent readers share snapshots cheaply (Pebble's snapshot is a versioned reference, not a copy).
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -87,7 +87,9 @@ Checkpoint reads (see below) ignore `min_log_sequence` — a frozen checkpoint i
 
 ## Pebble snapshot
 
-`store.NewReadHandle()` returns a Pebble snapshot. Every read in the controller layer uses the **same** snapshot for both the read store iterators (inverted index) and the main store reads (enrichment with volumes, metadata, transaction bodies). This is what makes a paginated `ListAccounts` consistent: page 2 sees the same world page 1 saw, even if the FSM committed new writes in between.
+`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, the read-store iterators (inverted index) and main-store enrichment (volumes, metadata, transaction bodies) use the **same** snapshot. The handle is owned by the returned cursor and is closed when that cursor is closed. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore a new snapshot.
+
+The cursor carries only the exclusive resume position (for example, an account address or transaction ID); it does not identify or retain the Pebble snapshot. Consequently, point-in-time consistency is guaranteed within each request/page, but there is no general snapshot-consistency guarantee across separate pages. Inserts, deletes, or updates committed between requests may therefore affect later pages according to the documented cursor ordering and filtering semantics. Duplications or omissions across pages under concurrent writes are not, by themselves, evidence of a product defect unless an API contract explicitly promises a cross-page snapshot.
 
 Multiple concurrent readers share snapshots cheaply (Pebble's snapshot is a versioned reference, not a copy).
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Every read goes through four stages: a **Raft `ReadIndex`** barrier for linearizability, an optional **`min_log_sequence`** wait for read-side freshness, coordinated **Pebble snapshots** for the main and read stores, and a **composable iterator pipeline** over the read store. The result is streamed back through gRPC with cursor-based pagination. The snapshots are aligned but distinct; their per-target consistency exceptions are described below.
+Indexed entity-list reads go through four stages: a **Raft `ReadIndex`** barrier for linearizability, an optional **`min_log_sequence`** wait for read-side freshness, coordinated **Pebble snapshots** for the main and read stores, and a **composable iterator pipeline** over the read store. The result is streamed back through gRPC with cursor-based pagination. Point reads and main-store-only queries use their own single main-store handle and do not enter this indexed-list pipeline. The indexed-list snapshots are aligned but distinct; their per-target consistency exceptions are described below.
 
-The pipeline is deliberately uniform across endpoints: `ListAccounts`, `ListTransactions`, `ListLogs`, and `GetX` variants all go through the same controller layer and the same iterator algebra. The differences are which read-store prefix is scanned and how iterators are composed.
+The indexed-list pipeline is deliberately uniform across `ListAccounts`, `ListTransactions`, and `ListLogs`. Point reads such as `GetAccount` and `GetTransaction`, plus main-store-only queries such as `ListLedgers`, use the controller layer but not the read-store iterator algebra. The differences between indexed lists are which read-store prefix is scanned and how iterators are composed.
 
 ```mermaid
 sequenceDiagram

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -96,6 +96,10 @@ The cursor carries only the exclusive resume position (for example, an account a
 
 Multiple concurrent readers share snapshots cheaply (Pebble's snapshot is a versioned reference, not a copy).
 
+For `ListLogs`, the index snapshot and read lease remain live through
+`ReadLedgerLogsCompiled` while the page is loaded; the earlier release timing
+applies to the `ListAccounts` and `ListTransactions` paths.
+
 ## The generic list pipeline
 
 `internal/application/ctrl/list_entities.go:57` — `listEntities[T]` is the shared dispatcher for everything that returns a page of entities:


### PR DESCRIPTION
## Summary
Correct the read-path documentation to match the implemented cursor and snapshot lifecycle.

## Contract
- snapshots are stable within one request/stream;
- subsequent cursor pages are new requests with fresh snapshots;
- cursors carry resume positions, not snapshot identities;
- cross-page duplicates/omissions under concurrent writes are not defects unless explicitly promised.

## Validation
- git diff --check
- verified controller, cursor, stream, and ReadHandle implementation paths