### PR TITLE
feat(EN-1501): enforce the query-checkpoint limit in the FSM (stacked on #1750)

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -35,6 +35,17 @@ The read index materializes asynchronously and **per-replica** (step 5). Readine
 
 The `.ready` marker and the checkpoint directories are rebuildable filesystem lifecycle state (a projection of the audit log), not a persisted Pebble projection, so they are outside the checker's scope.
 
+## Retention cap (query-checkpoint limit)
+
+The number of *live* query checkpoints is bounded by the Raft-replicated cluster policy (`ClusterPolicy.query_checkpoint_limit`; see [the cluster policy](../fsm/deterministic-fsm.md#35-raft-replicated-cluster-policy)). Enforcement is in the **FSM apply path, after the idempotency gate**, so a committed order resolves identically on every node:
+
+- **`CreateQueryCheckpoint`** is rejected with `ErrCheckpointLimitReached` (`CHECKPOINT_LIMIT_REACHED`) when the live count is already at the limit. Creation never evicts; an operator deletes a checkpoint to free a slot. A limit of `0` (the unset default before any policy is committed) means uncapped — write readiness holds business writes until a policy is committed, so a real create sees a configured limit.
+- **`DeleteQueryCheckpoint`** is rejected with `ErrCheckpointNotFound` (`CHECKPOINT_NOT_FOUND`) for an id that is not live, and with `ErrCheckpointIDRequired` for id `0`.
+
+The live-id set is deterministic FSM state (`FSMState.LiveQueryCheckpointIDs`), rehydrated at boot by scanning the `SubGlobQueryCheckpoint` rows and updated by the create/delete handlers, so apply enforces the cap and existence without a Pebble read. The rows are a checker-verified projection: `compareQueryCheckpoints` re-derives the live set (with each row's `max_sequence` / `created_at`) from the `CreatedQueryCheckpoint` / `DeletedQueryCheckpoint` logs and diffs it against the stored rows, and the audit-rebuild path recreates the rows from those logs.
+
+Because enforcement sits after the idempotency gate, a keyed retry replays the first apply's frozen outcome: a create that filled the cap replays its original success, and a create that hit the limit replays that rejection (`ErrCheckpointLimitReached` is a definitive, freezable outcome) even after a slot later frees — one outcome per idempotency key.
+
 ## Automatic Checkpoint Creation (Cron Scheduler)
 
 Checkpoint creation can be automated via a cron schedule. The schedule is a runtime-modifiable configuration stored in Raft, following the same pattern as chapter schedule (`SetChapterSchedule`).

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -401,6 +401,15 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 		// SubAttrNumscriptVersion (latest pointer = greatest stored semver).
 		expectedNumscriptContent = make(map[domain.NumscriptEntryKey]*commonpb.NumscriptInfo)
 		expectedNumscriptLatest  = make(map[domain.NumscriptVersionKey]string)
+
+		// derivedLiveCheckpoints is the audit-derived set of live query checkpoints
+		// (cluster-global), keyed by id with the CreatedQueryCheckpoint log as the
+		// value so max_sequence / created_at can be verified. A create sets the
+		// entry, a later delete removes it. Seeded from the baseline under archiving
+		// (the create logs are purged with the chapter), then advanced by the
+		// replayed create/delete logs. compareQueryCheckpoints diffs it against the
+		// stored rows both ways, contents included.
+		derivedLiveCheckpoints = make(map[uint64]*commonpb.CreatedQueryCheckpointLog)
 	)
 
 	// excluded is built incrementally as SimulateEphemeralPurge decides to
@@ -490,6 +499,13 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 		// Pre-populate the reversion tracking from the baseline's transaction
 		// states so reversion invariant checks cover pre-archive transactions.
 		if err := c.seedTxTrackingFromBaseline(baselineDB, ledgerKnownTxIDs, ledgerRevertedTxIDs); err != nil {
+			return err
+		}
+
+		// Seed the live query-checkpoint set from the baseline: pre-archive
+		// CreatedQueryCheckpoint logs are purged with the archived chapter, so
+		// replay alone would under-derive the set and false-flag live rows.
+		if err := c.foldBaselineQueryCheckpoints(baselineDB, derivedLiveCheckpoints); err != nil {
 			return err
 		}
 	}
@@ -645,6 +661,14 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 					if cur, ok := expectedNumscriptLatest[vk]; !ok || numscriptVersionGreater(info.GetVersion(), cur) {
 						expectedNumscriptLatest[vk] = info.GetVersion()
 					}
+				}
+			case *commonpb.LogPayload_CreatedQueryCheckpoint:
+				if cp := payload.CreatedQueryCheckpoint; cp != nil {
+					derivedLiveCheckpoints[cp.GetCheckpointId()] = cp
+				}
+			case *commonpb.LogPayload_DeletedQueryCheckpoint:
+				if cp := payload.DeletedQueryCheckpoint; cp != nil {
+					delete(derivedLiveCheckpoints, cp.GetCheckpointId())
 				}
 			case *commonpb.LogPayload_Apply:
 				if payload.Apply != nil {
@@ -895,6 +919,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	}
 
 	c.compareNumscripts(snap, expectedNumscriptContent, expectedNumscriptLatest, deletedInReplay, pendingCleanupLedgers, callback)
+
+	if err := c.compareQueryCheckpoints(snap, derivedLiveCheckpoints, callback); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -1292,6 +1320,98 @@ func (c *Checker) compareMirrorV2LogID(reader dal.PebbleReader, chainBound *chai
 				0, name, "", ""))
 		}
 	}
+}
+
+// compareQueryCheckpoints verifies the live query-checkpoint rows stored in the
+// primary store (ZoneGlobal/SubGlobQueryCheckpoint) against `derived`, the live
+// set re-derived from the CreatedQueryCheckpoint / DeletedQueryCheckpoint logs
+// (baseline-seeded under archiving). It emits
+// CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH on:
+//   - a stored row absent from the audit set (never created, or later deleted) —
+//     a phantom or stale row;
+//   - an audit-live checkpoint with no stored row — a lost or dropped projection;
+//   - a row whose key id, max_sequence, or created_at diverges from the
+//     audit-derived value — content corruption.
+//
+// The audit-rebuild path recreates the rows (and their max_sequence / created_at)
+// from the logs, so a missing row is corruption, never a legitimate restore
+// artifact. Stored rows are keyed by the Pebble key id, not the payload.
+func (c *Checker) compareQueryCheckpoints(reader dal.PebbleReader, derived map[uint64]*commonpb.CreatedQueryCheckpointLog, callback func(*servicepb.CheckStoreEvent)) error {
+	stored, err := query.ReadQueryCheckpointRows(reader)
+	if err != nil {
+		return fmt.Errorf("reading stored query checkpoints: %w", err)
+	}
+
+	all := make(map[uint64]struct{}, len(stored)+len(derived))
+	for id := range stored {
+		all[id] = struct{}{}
+	}
+
+	for id := range derived {
+		all[id] = struct{}{}
+	}
+
+	ids := make([]uint64, 0, len(all))
+	for id := range all {
+		ids = append(ids, id)
+	}
+
+	slices.Sort(ids)
+
+	emit := func(msg string) {
+		callback(errorEvent(servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH, msg, 0, "", "", ""))
+	}
+
+	for _, id := range ids {
+		row, inStored := stored[id]
+		want, inDerived := derived[id]
+
+		switch {
+		case inStored && !inDerived:
+			emit(fmt.Sprintf("stored query checkpoint %d is not justified by the audit chain (no CreatedQueryCheckpoint, or a later DeletedQueryCheckpoint)", id))
+		case inDerived && !inStored:
+			emit(fmt.Sprintf("audit chain has live query checkpoint %d but no stored row (lost or dropped projection)", id))
+		default:
+			if pid := row.GetCheckpointId(); pid != id {
+				emit(fmt.Sprintf("stored query checkpoint keyed %d carries a mismatched payload checkpoint_id %d (corrupted row)", id, pid))
+			}
+
+			if row.GetMaxSequence() != want.GetMaxSequence() {
+				emit(fmt.Sprintf("query checkpoint %d max_sequence %d does not match the audit chain %d", id, row.GetMaxSequence(), want.GetMaxSequence()))
+			}
+
+			if row.GetCreatedAt().GetData() != want.GetCreatedAt().GetData() {
+				emit(fmt.Sprintf("query checkpoint %d created_at %d does not match the audit chain %d", id, row.GetCreatedAt().GetData(), want.GetCreatedAt().GetData()))
+			}
+		}
+	}
+
+	return nil
+}
+
+// foldBaselineQueryCheckpoints seeds the audit-derived live-checkpoint set from
+// the boundary-time baseline, whose SubGlobQueryCheckpoint rows (with their
+// max_sequence / created_at) stand in for the pre-archive CreatedQueryCheckpoint
+// logs purged with the archived chapter.
+func (c *Checker) foldBaselineQueryCheckpoints(baselineDB *pebble.DB, into map[uint64]*commonpb.CreatedQueryCheckpointLog) error {
+	if baselineDB == nil {
+		return nil
+	}
+
+	rows, err := query.ReadQueryCheckpointRows(baselineDB)
+	if err != nil {
+		return fmt.Errorf("folding baseline query checkpoints: %w", err)
+	}
+
+	for id, cp := range rows {
+		into[id] = &commonpb.CreatedQueryCheckpointLog{
+			CheckpointId: id,
+			MaxSequence:  cp.GetMaxSequence(),
+			CreatedAt:    cp.GetCreatedAt(),
+		}
+	}
+
+	return nil
 }
 
 // numscriptVersionGreater reports whether a is a strictly greater full semver

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -209,6 +209,15 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			return fmt.Errorf("comparing cluster policy projection: %w", err)
 		}
 
+		// Query checkpoints are cluster-global too: a zero-log store proves no
+		// CreateQueryCheckpoint order was audited, so the live set is empty and
+		// every stored SubGlobQueryCheckpoint row is unaudited. Diffing against an
+		// empty derived set reports it — otherwise the injected row is loaded into
+		// LiveQueryCheckpointIDs unchecked.
+		if err := c.compareQueryCheckpoints(snap, nil, callback); err != nil {
+			return fmt.Errorf("comparing query checkpoint projection: %w", err)
+		}
+
 		callback(&servicepb.CheckStoreEvent{
 			Type: &servicepb.CheckStoreEvent_Progress{
 				Progress: &servicepb.CheckStoreProgress{

--- a/internal/application/check/checker_query_checkpoint_test.go
+++ b/internal/application/check/checker_query_checkpoint_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -172,4 +173,30 @@ func TestCompareQueryCheckpoints_PayloadIDMismatch(t *testing.T) {
 	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
 	require.Len(t, events, 1)
 	require.Contains(t, events[0].GetMessage(), "mismatched payload checkpoint_id")
+}
+
+// TestCheck_QueryCheckpointProjection_EmptyAuditWiring pins that the checkpoint
+// comparison runs on the lastSequence == 0 fast path, which returns before the
+// replay (and thus before the compare phase every other projection pass lives
+// in). A zero-log store proves no CreateQueryCheckpoint order was audited, so a
+// stored checkpoint row is unaudited by construction; reporting it clean would
+// let it be loaded into LiveQueryCheckpointIDs unchecked.
+func TestCheck_QueryCheckpointProjection_EmptyAuditWiring(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRow(t, store, 1)
+
+	checker := NewChecker(store, attributes.New(), "test-cluster", nil, nil, nil, logging.Testing())
+
+	var got []*servicepb.CheckStoreError
+	require.NoError(t, checker.Check(context.Background(), func(event *servicepb.CheckStoreEvent) {
+		if errEvent, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok {
+			got = append(got, errEvent.Error)
+		}
+	}))
+
+	require.Len(t, got, 1, "a stored query checkpoint with no audited creation must be reported")
+	require.Equal(t, servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH, got[0].GetErrorType())
+	require.Contains(t, got[0].GetMessage(), "not justified by the audit chain")
 }

--- a/internal/application/check/checker_query_checkpoint_test.go
+++ b/internal/application/check/checker_query_checkpoint_test.go
@@ -1,0 +1,175 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// writeQueryCheckpointRow persists a query-checkpoint row (max_sequence = id*10,
+// created_at = id*100) directly at its ZoneGlobal/SubGlobQueryCheckpoint key,
+// matching the on-disk layout the FSM writes.
+func writeQueryCheckpointRow(t *testing.T, store *dal.Store, id uint64) {
+	t.Helper()
+	writeQueryCheckpointRowKeyed(t, store, id, id, id*10, id*100)
+}
+
+// writeQueryCheckpointRowKeyed persists a row at key keyID carrying a payload
+// with checkpoint_id=payloadID, the given max_sequence and created_at, so tests
+// can build the corrupted key≠payload and content-mismatch cases.
+func writeQueryCheckpointRowKeyed(t *testing.T, store *dal.Store, keyID, payloadID, maxSeq, createdAt uint64) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	batch.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).PutUint64(keyID)
+	require.NoError(t, batch.SetProto(batch.KeyBuilder.Consume(), &raftcmdpb.QueryCheckpointState{
+		CheckpointId: payloadID,
+		MaxSequence:  maxSeq,
+		CreatedAt:    &commonpb.Timestamp{Data: createdAt},
+	}))
+	require.NoError(t, batch.Commit())
+}
+
+// derivedLog is the audit-derived value for one checkpoint id (max_sequence =
+// id*10, created_at = id*100), matching writeQueryCheckpointRow.
+func derivedLog(id uint64) *commonpb.CreatedQueryCheckpointLog {
+	return &commonpb.CreatedQueryCheckpointLog{
+		CheckpointId: id,
+		MaxSequence:  id * 10,
+		CreatedAt:    &commonpb.Timestamp{Data: id * 100},
+	}
+}
+
+// collectQueryCheckpointEvents runs compareQueryCheckpoints against the store's
+// live checkpoint rows with the given audit-derived set and returns only the
+// QUERY_CHECKPOINT_MISMATCH errors.
+func collectQueryCheckpointEvents(t *testing.T, store *dal.Store, derived map[uint64]*commonpb.CreatedQueryCheckpointLog) []*servicepb.CheckStoreError {
+	t.Helper()
+
+	checker := NewChecker(store, attributes.New(), "query-checkpoint-cluster", nil, nil, nil, logging.Testing())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	var got []*servicepb.CheckStoreError
+
+	require.NoError(t, checker.compareQueryCheckpoints(handle, derived, func(event *servicepb.CheckStoreEvent) {
+		if e, ok := event.GetType().(*servicepb.CheckStoreEvent_Error); ok &&
+			e.Error.GetErrorType() == servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH {
+			got = append(got, e.Error)
+		}
+	}))
+
+	return got
+}
+
+// TestCompareQueryCheckpoints_PhantomFlagged: a stored row the audit chain never
+// created (or later deleted) is corruption and must emit exactly one mismatch.
+func TestCompareQueryCheckpoints_PhantomFlagged(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRow(t, store, 5)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "5")
+}
+
+// TestCompareQueryCheckpoints_ConsistentPasses: every stored row justified by
+// the derived set, with matching contents, emits nothing.
+func TestCompareQueryCheckpoints_ConsistentPasses(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRow(t, store, 5)
+	writeQueryCheckpointRow(t, store, 6)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5), 6: derivedLog(6)})
+	require.Empty(t, events)
+}
+
+// TestCompareQueryCheckpoints_KeyAuthoritative: a row whose Pebble key id (99)
+// differs from its payload checkpoint_id (5) must be judged by the KEY — the
+// check sees a phantom key 99 and a missing row for the audit-live 5.
+func TestCompareQueryCheckpoints_KeyAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 99, 5, 50, 500)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
+	require.Len(t, events, 2)
+
+	msgs := events[0].GetMessage() + "\n" + events[1].GetMessage()
+	require.Contains(t, msgs, "stored query checkpoint 99", "the phantom key 99 must be flagged, not laundered by payload id 5")
+	require.Contains(t, msgs, "live query checkpoint 5", "the audit-live id 5 has no stored row")
+}
+
+// TestCompareQueryCheckpoints_MissingRowFlagged: an audit-live checkpoint with
+// no stored row is a lost/dropped projection and must be flagged.
+func TestCompareQueryCheckpoints_MissingRowFlagged(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{7: derivedLog(7)})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "7")
+}
+
+// TestCompareQueryCheckpoints_MaxSequenceMismatch: a present row whose stored
+// max_sequence diverges from the audit-derived value is content corruption.
+func TestCompareQueryCheckpoints_MaxSequenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+
+	// Audit says max_sequence 99, store holds 50 (created_at matches).
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
+		5: {CheckpointId: 5, MaxSequence: 99, CreatedAt: &commonpb.Timestamp{Data: 500}},
+	})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "max_sequence")
+}
+
+// TestCompareQueryCheckpoints_CreatedAtMismatch: a present row whose stored
+// created_at diverges from the audit-derived value is content corruption.
+func TestCompareQueryCheckpoints_CreatedAtMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+
+	// Audit says created_at 999, store holds 500 (max_sequence matches).
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
+		5: {CheckpointId: 5, MaxSequence: 50, CreatedAt: &commonpb.Timestamp{Data: 999}},
+	})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "created_at")
+}
+
+// TestCompareQueryCheckpoints_PayloadIDMismatch: a present row whose payload
+// checkpoint_id disagrees with its key is a corrupted row.
+func TestCompareQueryCheckpoints_PayloadIDMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	// Keyed 5, payload says 6, matching max_sequence and created_at.
+	writeQueryCheckpointRowKeyed(t, store, 5, 6, 50, 500)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "mismatched payload checkpoint_id")
+}

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -742,6 +742,8 @@ func (s *scopeImpl) GetNextQueryCheckpointID() uint64                      { ret
 func (s *scopeImpl) IncrementNextQueryCheckpointID() uint64                { return 1 }
 func (s *scopeImpl) SaveQueryCheckpoint(_ *raftcmdpb.QueryCheckpointState) {}
 func (s *scopeImpl) DeleteQueryCheckpoint(_ uint64)                        {}
+func (s *scopeImpl) LiveQueryCheckpointCount() uint64                      { return 0 }
+func (s *scopeImpl) QueryCheckpointExists(_ uint64) bool                   { return false }
 func (s *scopeImpl) ResolveNumscriptContent(ledger, name, version string) (commonpb.NumscriptInfoReader, error) {
 	info, ok := s.engine.numscriptContent[string(domain.NumscriptEntryKey{LedgerName: ledger, Name: name, Version: version}.Bytes())]
 	if !ok {

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -239,6 +239,8 @@ const (
 	ErrReasonStaleClusterPolicy             = "STALE_CLUSTER_POLICY"
 	ErrReasonClusterPolicyRevisionConflict  = "CLUSTER_POLICY_REVISION_CONFLICT"
 	ErrReasonClusterPolicyInvalid           = "CLUSTER_POLICY_INVALID"
+	ErrReasonCheckpointLimitReached         = "CHECKPOINT_LIMIT_REACHED"
+	ErrReasonCheckpointNotFound             = "CHECKPOINT_NOT_FOUND"
 
 	// ErrReasonWritesBlockedDiskFull signals that the write gate rejected the
 	// request because disk usage is at or above the configured block threshold.
@@ -1563,6 +1565,39 @@ func (errCheckpointIDRequired) Reason() string              { return ErrReasonCh
 func (errCheckpointIDRequired) Metadata() map[string]string { return nil }
 
 var ErrCheckpointIDRequired Describable = errCheckpointIDRequired{}
+
+// ErrCheckpointLimitReached — a CreateQueryCheckpoint was rejected because the
+// live query-checkpoint count is at the replicated policy limit. Creation never
+// evicts; an existing checkpoint must be deleted before another can be created.
+// KindPrecondition (a definitive, freezable outcome): enforced in the FSM after
+// the idempotency gate, so a keyed retry replays this rejection rather than
+// re-executing once a slot frees — the idempotency contract fixes one outcome
+// per key.
+type ErrCheckpointLimitReached struct {
+	Limit uint64
+}
+
+func (e *ErrCheckpointLimitReached) Error() string {
+	return fmt.Sprintf("query checkpoint limit reached (max %d); delete an existing checkpoint before creating another", e.Limit)
+}
+func (*ErrCheckpointLimitReached) Reason() string { return ErrReasonCheckpointLimitReached }
+func (e *ErrCheckpointLimitReached) Metadata() map[string]string {
+	return map[string]string{"limit": strconv.FormatUint(e.Limit, 10)}
+}
+
+// ErrCheckpointNotFound — a DeleteQueryCheckpoint targeted a checkpoint ID that
+// is not live (never created, or already deleted). KindNotFound.
+type ErrCheckpointNotFound struct {
+	CheckpointID uint64
+}
+
+func (e *ErrCheckpointNotFound) Error() string {
+	return fmt.Sprintf("query checkpoint %d not found", e.CheckpointID)
+}
+func (*ErrCheckpointNotFound) Reason() string { return ErrReasonCheckpointNotFound }
+func (e *ErrCheckpointNotFound) Metadata() map[string]string {
+	return map[string]string{"checkpointId": strconv.FormatUint(e.CheckpointID, 10)}
+}
 
 // ErrNumscriptRuntime — the Numscript program produced output that violates
 // a server-side invariant at apply time (negative posting amount, posting

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -409,6 +409,8 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrStaleClusterPolicy":             &ErrStaleClusterPolicy{},
 		"ErrClusterPolicyRevisionConflict":  &ErrClusterPolicyRevisionConflict{},
 		"ErrClusterPolicyInvalid":           &ErrClusterPolicyInvalid{},
+		"ErrCheckpointLimitReached":         &ErrCheckpointLimitReached{},
+		"ErrCheckpointNotFound":             &ErrCheckpointNotFound{},
 		// Unexported sentinel struct types; each is exposed once via a
 		// package-level Describable var (ErrColdStorageDisabled, etc.)
 		// and must implement the interface.

--- a/internal/domain/processing/processor_query_checkpoint.go
+++ b/internal/domain/processing/processor_query_checkpoint.go
@@ -6,8 +6,24 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
 
+// processCreateQueryCheckpoint applies a create after the idempotency gate,
+// enforcing the replicated query-checkpoint cap inside the FSM. The cap is read
+// from the committed ClusterPolicy and the live count from deterministic FSM
+// state, so a committed create resolves identically on every node; a keyed retry
+// replays the frozen outcome before reaching here, so an accepted create that
+// filled the cap still returns its original success on retry.
 func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
 	s := ctx.Scope
+
+	// A committed policy always carries a limit >= 1; limit 0 is the unset
+	// default before any policy is committed and means "no cap" (write readiness
+	// gates business writes until a policy is committed, so a real create sees a
+	// configured limit).
+	limit := s.GetClusterPolicy().GetQueryCheckpointLimit()
+	if limit != 0 && s.LiveQueryCheckpointCount() >= limit {
+		return nil, &domain.ErrCheckpointLimitReached{Limit: limit}
+	}
+
 	checkpointID := s.IncrementNextQueryCheckpointID()
 
 	cp := &raftcmdpb.QueryCheckpointState{
@@ -25,24 +41,33 @@ func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, c
 			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
 				CheckpointId: checkpointID,
 				MaxSequence:  cp.GetMaxSequence(),
+				CreatedAt:    cp.GetCreatedAt(),
 			},
 		},
 	}, nil
 }
 
+// processDeleteQueryCheckpoint applies a delete after the idempotency gate,
+// rejecting a non-live id inside the FSM so the outcome is deterministic and a
+// keyed retry of a successful delete replays that success.
 func processDeleteQueryCheckpoint(order *raftcmdpb.DeleteQueryCheckpointOrder, ctx *Context) (*commonpb.LogPayload, domain.Describable) {
-	if order.GetCheckpointId() == 0 {
+	id := order.GetCheckpointId()
+	if id == 0 {
 		return nil, domain.ErrCheckpointIDRequired
 	}
 
-	ctx.Scope.DeleteQueryCheckpoint(order.GetCheckpointId())
+	if !ctx.Scope.QueryCheckpointExists(id) {
+		return nil, &domain.ErrCheckpointNotFound{CheckpointID: id}
+	}
+
+	ctx.Scope.DeleteQueryCheckpoint(id)
 	// QueryCheckpointDeleted is derived from DeletedQueryCheckpointLog by
 	// deriveSignals.
 
 	return &commonpb.LogPayload{
 		Type: &commonpb.LogPayload_DeletedQueryCheckpoint{
 			DeletedQueryCheckpoint: &commonpb.DeletedQueryCheckpointLog{
-				CheckpointId: order.GetCheckpointId(),
+				CheckpointId: id,
 			},
 		},
 	}, nil

--- a/internal/domain/processing/processor_query_checkpoint_test.go
+++ b/internal/domain/processing/processor_query_checkpoint_test.go
@@ -1,0 +1,155 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+func createQueryCheckpointOrder() *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_CreateQueryCheckpoint{
+					CreateQueryCheckpoint: &raftcmdpb.CreateQueryCheckpointOrder{},
+				},
+			},
+		},
+	}
+}
+
+func deleteQueryCheckpointOrder(id uint64) *raftcmdpb.Order {
+	return &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_SystemScoped{
+			SystemScoped: &raftcmdpb.SystemScopedOrder{
+				Payload: &raftcmdpb.SystemScopedOrder_DeleteQueryCheckpoint{
+					DeleteQueryCheckpoint: &raftcmdpb.DeleteQueryCheckpointOrder{CheckpointId: id},
+				},
+			},
+		},
+	}
+}
+
+// Below the policy cap a create is admitted and stamps id/max_sequence/created_at.
+func TestProcessCreateQueryCheckpoint_UnderLimit(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	now := &commonpb.Timestamp{Data: 42}
+
+	mockStore.EXPECT().GetClusterPolicy().Return(&commonpb.ClusterPolicy{QueryCheckpointLimit: 2})
+	mockStore.EXPECT().LiveQueryCheckpointCount().Return(uint64(1))
+	mockStore.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(7))
+	mockStore.EXPECT().GetNextSequenceID().Return(uint64(100))
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+	mockStore.EXPECT().SaveQueryCheckpoint(gomock.Any())
+
+	result, procErr := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)
+	require.Nil(t, procErr)
+
+	createdLog := result.GetCreatedQueryCheckpoint()
+	require.NotNil(t, createdLog)
+	require.Equal(t, uint64(7), createdLog.GetCheckpointId())
+	require.Equal(t, uint64(99), createdLog.GetMaxSequence())
+	require.Equal(t, uint64(42), createdLog.GetCreatedAt().GetData())
+}
+
+// At the cap a create is rejected with the typed error carrying the limit; no id
+// is consumed and nothing is saved.
+func TestProcessCreateQueryCheckpoint_AtLimit(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	mockStore.EXPECT().GetClusterPolicy().Return(&commonpb.ClusterPolicy{QueryCheckpointLimit: 2})
+	mockStore.EXPECT().LiveQueryCheckpointCount().Return(uint64(2))
+
+	_, procErr := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)
+
+	var limitErr *domain.ErrCheckpointLimitReached
+	require.ErrorAs(t, procErr, &limitErr)
+	require.Equal(t, uint64(2), limitErr.Limit)
+}
+
+// An unset limit (0, before any policy is committed) is uncapped: the live count
+// is not even consulted.
+func TestProcessCreateQueryCheckpoint_UncappedWhenLimitZero(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	now := &commonpb.Timestamp{Data: 1}
+
+	mockStore.EXPECT().GetClusterPolicy().Return(&commonpb.ClusterPolicy{QueryCheckpointLimit: 0})
+	mockStore.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(1))
+	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+	mockStore.EXPECT().SaveQueryCheckpoint(gomock.Any())
+
+	result, procErr := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)
+	require.Nil(t, procErr)
+	require.NotNil(t, result.GetCreatedQueryCheckpoint())
+}
+
+// A delete of a live checkpoint is admitted and emits the tombstone.
+func TestProcessDeleteQueryCheckpoint_Live(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	mockStore.EXPECT().QueryCheckpointExists(uint64(5)).Return(true)
+	mockStore.EXPECT().DeleteQueryCheckpoint(uint64(5))
+
+	result, procErr := processor.ProcessOrder(deleteQueryCheckpointOrder(5), mockStore)
+	require.Nil(t, procErr)
+	require.Equal(t, uint64(5), result.GetDeletedQueryCheckpoint().GetCheckpointId())
+}
+
+// A delete of a non-live id is rejected as not-found; nothing is deleted.
+func TestProcessDeleteQueryCheckpoint_NotLive(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	mockStore.EXPECT().QueryCheckpointExists(uint64(5)).Return(false)
+
+	_, procErr := processor.ProcessOrder(deleteQueryCheckpointOrder(5), mockStore)
+
+	var notFound *domain.ErrCheckpointNotFound
+	require.ErrorAs(t, procErr, &notFound)
+	require.Equal(t, uint64(5), notFound.CheckpointID)
+}
+
+// A zero id is rejected structurally before any state is consulted.
+func TestProcessDeleteQueryCheckpoint_ZeroID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	_, procErr := processor.ProcessOrder(deleteQueryCheckpointOrder(0), mockStore)
+	require.ErrorIs(t, procErr, domain.ErrCheckpointIDRequired)
+}

--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -271,6 +271,14 @@ func (s *skipSafeScope) DeleteQueryCheckpoint(checkpointID uint64) {
 	trapUnbuffered("DeleteQueryCheckpoint", map[string]any{"checkpointID": checkpointID})
 }
 
+func (s *skipSafeScope) LiveQueryCheckpointCount() uint64 {
+	return s.inner.LiveQueryCheckpointCount()
+}
+
+func (s *skipSafeScope) QueryCheckpointExists(id uint64) bool {
+	return s.inner.QueryCheckpointExists(id)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CheckCoverage — pure gate; pass through so declared-set enforcement
 // still fires under a skip-tolerant order.

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -124,6 +124,10 @@ type Scope interface {
 	IncrementNextQueryCheckpointID() uint64
 	SaveQueryCheckpoint(cp *raftcmdpb.QueryCheckpointState)
 	DeleteQueryCheckpoint(checkpointID uint64)
+	// LiveQueryCheckpointCount / QueryCheckpointExists back the FSM cap and
+	// existence checks (recovered live-ID set + this proposal's staged changes).
+	LiveQueryCheckpointCount() uint64
+	QueryCheckpointExists(id uint64) bool
 
 	// CheckCoverage exposes the gate for paths that read state directly
 	// (bypassing the engine overlay) and still want the coverage

--- a/internal/domain/processing/store_generated_test.go
+++ b/internal/domain/processing/store_generated_test.go
@@ -1238,6 +1238,44 @@ func (c *MockScopeLedgersCall) DoAndReturn(f func() Accessor[domain.LedgerKey, *
 	return c
 }
 
+// LiveQueryCheckpointCount mocks base method.
+func (m *MockScope) LiveQueryCheckpointCount() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LiveQueryCheckpointCount")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// LiveQueryCheckpointCount indicates an expected call of LiveQueryCheckpointCount.
+func (mr *MockScopeMockRecorder) LiveQueryCheckpointCount() *MockScopeLiveQueryCheckpointCountCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LiveQueryCheckpointCount", reflect.TypeOf((*MockScope)(nil).LiveQueryCheckpointCount))
+	return &MockScopeLiveQueryCheckpointCountCall{Call: call}
+}
+
+// MockScopeLiveQueryCheckpointCountCall wrap *gomock.Call
+type MockScopeLiveQueryCheckpointCountCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeLiveQueryCheckpointCountCall) Return(arg0 uint64) *MockScopeLiveQueryCheckpointCountCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeLiveQueryCheckpointCountCall) Do(f func() uint64) *MockScopeLiveQueryCheckpointCountCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeLiveQueryCheckpointCountCall) DoAndReturn(f func() uint64) *MockScopeLiveQueryCheckpointCountCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // NumscriptVersionExists mocks base method.
 func (m *MockScope) NumscriptVersionExists(ledgerName, name, version string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -1383,6 +1421,44 @@ func (c *MockScopePutRevertedCall) Do(f func(domain.TransactionKey, bool)) *Mock
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockScopePutRevertedCall) DoAndReturn(f func(domain.TransactionKey, bool)) *MockScopePutRevertedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// QueryCheckpointExists mocks base method.
+func (m *MockScope) QueryCheckpointExists(id uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryCheckpointExists", id)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// QueryCheckpointExists indicates an expected call of QueryCheckpointExists.
+func (mr *MockScopeMockRecorder) QueryCheckpointExists(id any) *MockScopeQueryCheckpointExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryCheckpointExists", reflect.TypeOf((*MockScope)(nil).QueryCheckpointExists), id)
+	return &MockScopeQueryCheckpointExistsCall{Call: call}
+}
+
+// MockScopeQueryCheckpointExistsCall wrap *gomock.Call
+type MockScopeQueryCheckpointExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeQueryCheckpointExistsCall) Return(arg0 bool) *MockScopeQueryCheckpointExistsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeQueryCheckpointExistsCall) Do(f func(uint64) bool) *MockScopeQueryCheckpointExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeQueryCheckpointExistsCall) DoAndReturn(f func(uint64) bool) *MockScopeQueryCheckpointExistsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -73,7 +73,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CHAPTER_NOT_FOUND,
 		commonpb.ErrorReason_ERROR_REASON_PREPARED_QUERY_NOT_FOUND,
 		commonpb.ErrorReason_ERROR_REASON_NUMSCRIPT_NOT_FOUND,
-		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_NOT_FOUND:
+		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_TYPE_NOT_FOUND,
+		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND:
 		return KindNotFound
 	case commonpb.ErrorReason_ERROR_REASON_LEDGER_ALREADY_EXISTS,
 		commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT,
@@ -107,7 +108,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_METADATA_FIELD_NOT_IN_SCHEMA,
 		commonpb.ErrorReason_ERROR_REASON_ACCOUNT_NOT_MATCHING_TYPE,
 		commonpb.ErrorReason_ERROR_REASON_COLD_STORAGE_DISABLED,
-		commonpb.ErrorReason_ERROR_REASON_TRANSIENT_ACCOUNT_NON_ZERO:
+		commonpb.ErrorReason_ERROR_REASON_TRANSIENT_ACCOUNT_NON_ZERO,
+		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_LIMIT_REACHED:
 		return KindPrecondition
 	case commonpb.ErrorReason_ERROR_REASON_BALANCE_NOT_PRELOADED,
 		commonpb.ErrorReason_ERROR_REASON_MAINTENANCE_MODE,

--- a/internal/infra/attributes/baseline.go
+++ b/internal/infra/attributes/baseline.go
@@ -99,6 +99,10 @@ func writeBaselineAttributes(reader dal.PebbleReader, db *pebble.DB) error {
 		return fmt.Errorf("writing baseline ledgers: %w", err)
 	}
 
+	if err := copyBaselineQueryCheckpoints(reader, db); err != nil {
+		return fmt.Errorf("writing baseline query checkpoints: %w", err)
+	}
+
 	return nil
 }
 
@@ -133,4 +137,16 @@ func copyBaselineLedgers(reader dal.PebbleReader, db *pebble.DB) error {
 	return copyBaselineRange(reader, db,
 		[]byte{dal.ZoneGlobal, dal.SubGlobLedgerInfo},
 		[]byte{dal.ZoneGlobal, dal.SubGlobLedgerInfo + 1})
+}
+
+// copyBaselineQueryCheckpoints copies the live query-checkpoint rows
+// (ZoneGlobal / SubGlobQueryCheckpoint) verbatim into the baseline DB, so the
+// checker can seed its audit-derived live-checkpoint set from them under
+// archiving, where the CreatedQueryCheckpoint logs that would otherwise rebuild
+// the set are purged with the archived chapter. The SubGlobNextQueryCheckpointID
+// counter (0x0F) is excluded by the [0x0E, 0x0F) bound.
+func copyBaselineQueryCheckpoints(reader dal.PebbleReader, db *pebble.DB) error {
+	return copyBaselineRange(reader, db,
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint},
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint + 1})
 }

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -141,7 +141,13 @@ func RebuildDelta(
 		ephemeralPurgeBuffer = replay.NewEphemeralPurgeBuffer()
 	}
 
-	var count uint64
+	var (
+		count uint64
+		// Highest query-checkpoint id seen across CreatedQueryCheckpoint logs
+		// (deleted ones included). Used after the replay to restore the monotonic
+		// SubGlobNextQueryCheckpointID counter.
+		maxQueryCheckpointID uint64
+	)
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -485,12 +491,39 @@ func RebuildDelta(
 				return fmt.Errorf("replaying archived chapter at log %d: %w", seq, err)
 			}
 
+		case *commonpb.LogPayload_CreatedQueryCheckpoint:
+			// Rebuild the metadata row (id + max_sequence + created_at) from the log.
+			// The physical checkpoint files cannot be reconstructed from the audit, so a
+			// rebuilt checkpoint reads as Unavailable until an operator deletes it. The
+			// row keeps the projection audit-consistent so the cap and
+			// compareQueryCheckpoints stay correct after a rebuild.
+			if cp := p.CreatedQueryCheckpoint; cp != nil {
+				if err := state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{
+					CheckpointId: cp.GetCheckpointId(),
+					MaxSequence:  cp.GetMaxSequence(),
+					CreatedAt:    cp.GetCreatedAt(),
+				}); err != nil {
+					_ = batch.Cancel()
+
+					return fmt.Errorf("rebuilding query checkpoint at log %d: %w", seq, err)
+				}
+
+				maxQueryCheckpointID = max(maxQueryCheckpointID, cp.GetCheckpointId())
+			}
+
+		case *commonpb.LogPayload_DeletedQueryCheckpoint:
+			if cp := p.DeletedQueryCheckpoint; cp != nil {
+				if err := state.DeleteQueryCheckpointFromBatch(batch, cp.GetCheckpointId()); err != nil {
+					_ = batch.Cancel()
+
+					return fmt.Errorf("removing query checkpoint at log %d: %w", seq, err)
+				}
+			}
+
 		// Log types with no persistent state to rebuild:
 		case *commonpb.LogPayload_RemovedEventsSink:
 		case *commonpb.LogPayload_DeleteChapterSchedule:
 		case *commonpb.LogPayload_DeletedPreparedQuery:
-		case *commonpb.LogPayload_CreatedQueryCheckpoint:
-		case *commonpb.LogPayload_DeletedQueryCheckpoint:
 		case *commonpb.LogPayload_DeleteQueryCheckpointSchedule:
 		}
 
@@ -546,6 +579,17 @@ func RebuildDelta(
 			_ = batch.Cancel()
 
 			return fmt.Errorf("storing rebuilt next chapter id: %w", err)
+		}
+	}
+
+	// Restore the monotonic next-ID counter above every replayed checkpoint id
+	// (deleted ids included — the counter never rewinds), so post-rebuild creates
+	// allocate fresh ids instead of reissuing one and overwriting a rebuilt row.
+	if maxQueryCheckpointID > 0 {
+		if err := state.StoreNextQueryCheckpointID(batch, maxQueryCheckpointID+1); err != nil {
+			_ = batch.Cancel()
+
+			return fmt.Errorf("restoring next query checkpoint ID: %w", err)
 		}
 	}
 

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -501,6 +501,50 @@ func TestRebuildDelta_ReplaysClusterPolicy(t *testing.T) {
 	require.True(t, policy.EqualVT(got))
 }
 
+// Query-checkpoint create/delete logs replayed after the checkpoint rebuild the
+// live rows (a deleted one does not survive) and advance the monotonic next-id
+// counter above every replayed id.
+func TestRebuildDelta_ReplaysQueryCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	created := func(seq, id, maxSeq, createdAt uint64) *commonpb.Log {
+		return &commonpb.Log{Sequence: seq, Payload: &commonpb.LogPayload{
+			Type: &commonpb.LogPayload_CreatedQueryCheckpoint{CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+				CheckpointId: id, MaxSequence: maxSeq, CreatedAt: &commonpb.Timestamp{Data: createdAt},
+			}},
+		}}
+	}
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetProto(coldLogKey(1), created(1, 1, 10, 100)))
+	require.NoError(t, batch.SetProto(coldLogKey(2), created(2, 2, 20, 200)))
+	require.NoError(t, batch.SetProto(coldLogKey(3), &commonpb.Log{Sequence: 3, Payload: &commonpb.LogPayload{
+		Type: &commonpb.LogPayload_DeletedQueryCheckpoint{DeletedQueryCheckpoint: &commonpb.DeletedQueryCheckpointLog{CheckpointId: 1}},
+	}}))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	rows, err := query.ReadQueryCheckpointRows(handle)
+	require.NoError(t, err)
+	require.NotContains(t, rows, uint64(1), "a deleted checkpoint must not survive the rebuild")
+	require.Contains(t, rows, uint64(2))
+	require.Equal(t, uint64(20), rows[2].GetMaxSequence())
+	require.Equal(t, uint64(200), rows[2].GetCreatedAt().GetData())
+
+	// The counter never rewinds: it advances above the highest replayed id (2),
+	// the deleted one included.
+	next, err := query.ReadNextQueryCheckpointID(handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), next)
+}
+
 func TestRebuildDelta_ReplaysDeleteLedger(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -263,6 +263,18 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"detail": "query_checkpoint_limit must be at least 1"},
 		},
 		{
+			name:        "CheckpointLimitReached",
+			err:         &domain.ErrCheckpointLimitReached{Limit: 10},
+			wantReason:  domain.ErrReasonCheckpointLimitReached,
+			wantContext: map[string]string{"limit": "10"},
+		},
+		{
+			name:        "CheckpointNotFound",
+			err:         &domain.ErrCheckpointNotFound{CheckpointID: 7},
+			wantReason:  domain.ErrReasonCheckpointNotFound,
+			wantContext: map[string]string{"checkpointId": "7"},
+		},
+		{
 			name:        "InvalidCronExpression",
 			err:         &domain.ErrInvalidCronExpression{Expression: "* * * *", Details: "expected 5 or 6 fields"},
 			wantReason:  domain.ErrReasonInvalidCronExpression,

--- a/internal/infra/state/batch.go
+++ b/internal/infra/state/batch.go
@@ -316,7 +316,7 @@ func SavePreparedQuery(b *dal.WriteSession, ledger string, pq *commonpb.Prepared
 }
 
 // SaveQueryCheckpoint stores a query checkpoint state in the batch (Raft-replicated).
-func saveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState) error {
+func SaveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState) error {
 	b.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
 		PutUint64(cp.GetCheckpointId())
 
@@ -329,7 +329,7 @@ func saveQueryCheckpoint(b *dal.WriteSession, cp *raftcmdpb.QueryCheckpointState
 }
 
 // DeleteQueryCheckpointFromBatch removes a query checkpoint from the batch (Raft-replicated).
-func deleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) error {
+func DeleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) error {
 	b.KeyBuilder.PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
 		PutUint64(checkpointID)
 
@@ -342,7 +342,7 @@ func deleteQueryCheckpointFromBatch(b *dal.WriteSession, checkpointID uint64) er
 }
 
 // StoreNextQueryCheckpointID writes the next query checkpoint ID as 8-byte big-endian uint64.
-func storeNextQueryCheckpointID(b *dal.WriteSession, id uint64) error {
+func StoreNextQueryCheckpointID(b *dal.WriteSession, id uint64) error {
 	value := make([]byte, 8)
 	binary.BigEndian.PutUint64(value, id)
 

--- a/internal/infra/state/fsmstate.go
+++ b/internal/infra/state/fsmstate.go
@@ -38,6 +38,13 @@ type FSMState struct {
 	QueryCheckpointSchedule string
 	PendingLedgerCleanups   map[string]uint64
 
+	// LiveQueryCheckpointIDs is the set of query-checkpoint IDs currently live,
+	// recovered by scanning the SubGlobQueryCheckpoint rows at boot and updated
+	// by the create/delete handlers. The FSM reads it to enforce the policy cap
+	// and reject deletes of non-live IDs deterministically, without a Pebble read
+	// on the apply path.
+	LiveQueryCheckpointIDs map[uint64]struct{}
+
 	// Last cluster config applied + derived hash generator. Persisted under
 	// ZoneGlobal so it survives restarts.
 	LastClusterConfig *commonpb.ClusterConfig
@@ -68,10 +75,11 @@ func NewFSMState(clusterID string) *FSMState {
 		NextSequenceID:        1,
 		NextAuditSequenceID:   1,
 		NextLedgerID:          1,
-		PendingLedgerCleanups: map[string]uint64{},
-		HashGenerator:         processing.NewHashGenerator(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3, clusterID),
-		ClusterID:             clusterID,
-		ClusterPolicy:         &commonpb.ClusterPolicy{},
+		PendingLedgerCleanups:  map[string]uint64{},
+		HashGenerator:          processing.NewHashGenerator(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3, clusterID),
+		ClusterID:              clusterID,
+		ClusterPolicy:          &commonpb.ClusterPolicy{},
+		LiveQueryCheckpointIDs: map[uint64]struct{}{},
 	}
 }
 
@@ -169,6 +177,13 @@ func LoadFSMStateFromStore(reader dal.RecoveryReader, handle *dal.ReadHandle, cl
 	}
 
 	s.NextQueryCheckpointID = nextQCPID
+
+	liveCheckpoints, err := query.ReadLiveQueryCheckpointIDs(handle)
+	if err != nil {
+		return nil, fmt.Errorf("reading live query checkpoint IDs: %w", err)
+	}
+
+	s.LiveQueryCheckpointIDs = liveCheckpoints
 
 	qcpSchedule, err := query.ReadQueryCheckpointSchedule(reader)
 	if err != nil {

--- a/internal/infra/state/fsmstate.go
+++ b/internal/infra/state/fsmstate.go
@@ -72,9 +72,9 @@ type FSMState struct {
 // initial values; the map is allocated empty.
 func NewFSMState(clusterID string) *FSMState {
 	return &FSMState{
-		NextSequenceID:        1,
-		NextAuditSequenceID:   1,
-		NextLedgerID:          1,
+		NextSequenceID:         1,
+		NextAuditSequenceID:    1,
+		NextLedgerID:           1,
 		PendingLedgerCleanups:  map[string]uint64{},
 		HashGenerator:          processing.NewHashGenerator(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3, clusterID),
 		ClusterID:              clusterID,

--- a/internal/infra/state/query_checkpoint_live_set_test.go
+++ b/internal/infra/state/query_checkpoint_live_set_test.go
@@ -1,0 +1,35 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// Recovery rehydrates the live query-checkpoint set from the stored rows, so the
+// FSM's cap and existence checks survive a restart.
+func TestRecoverState_QueryCheckpointLiveSet(t *testing.T) {
+	t.Parallel()
+
+	machine, store, _ := newTestMachine(t)
+
+	require.Empty(t, machine.State.LiveQueryCheckpointIDs, "a fresh store has no live checkpoints")
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{
+		CheckpointId: 3, MaxSequence: 30, CreatedAt: &commonpb.Timestamp{Data: 300},
+	}))
+	require.NoError(t, SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{
+		CheckpointId: 7, MaxSequence: 70, CreatedAt: &commonpb.Timestamp{Data: 700},
+	}))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, NewRecovery(machine, store).RecoverState())
+
+	require.Len(t, machine.State.LiveQueryCheckpointIDs, 2)
+	require.Contains(t, machine.State.LiveQueryCheckpointIDs, uint64(3))
+	require.Contains(t, machine.State.LiveQueryCheckpointIDs, uint64(7))
+}

--- a/internal/infra/state/query_checkpoint_live_set_test.go
+++ b/internal/infra/state/query_checkpoint_live_set_test.go
@@ -33,3 +33,30 @@ func TestRecoverState_QueryCheckpointLiveSet(t *testing.T) {
 	require.Contains(t, machine.State.LiveQueryCheckpointIDs, uint64(3))
 	require.Contains(t, machine.State.LiveQueryCheckpointIDs, uint64(7))
 }
+
+// The live count folds this proposal's staged creates and deletes exactly: a
+// create followed by a delete of that same new id nets to zero, so a later
+// create in the same proposal is not spuriously capped.
+func TestWriteSet_LiveQueryCheckpointCount_FoldsStagedChanges(t *testing.T) {
+	t.Parallel()
+
+	machine, _, _ := newTestMachine(t)
+	machine.State.LiveQueryCheckpointIDs = map[uint64]struct{}{1: {}, 2: {}}
+
+	buf := NewWriteSet(machine)
+	require.Equal(t, uint64(2), buf.LiveQueryCheckpointCount())
+
+	// Create a new id, then delete that same new id: net zero.
+	buf.SaveQueryCheckpoint(&raftcmdpb.QueryCheckpointState{CheckpointId: 3})
+	require.Equal(t, uint64(3), buf.LiveQueryCheckpointCount())
+	buf.DeleteQueryCheckpoint(3)
+	require.Equal(t, uint64(2), buf.LiveQueryCheckpointCount(),
+		"a create then delete of the same new id must net to zero")
+	require.False(t, buf.QueryCheckpointExists(3))
+
+	// Deleting a committed id frees a slot.
+	buf.DeleteQueryCheckpoint(1)
+	require.Equal(t, uint64(1), buf.LiveQueryCheckpointCount())
+	require.False(t, buf.QueryCheckpointExists(1))
+	require.True(t, buf.QueryCheckpointExists(2))
+}

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1875,25 +1875,26 @@ func (b *WriteSet) DeleteQueryCheckpoint(checkpointID uint64) {
 }
 
 // LiveQueryCheckpointCount returns how many query checkpoints would be live if
-// this proposal committed now: the recovered set plus creates staged so far,
-// minus committed IDs a staged delete removes. Used by the create handler to
-// enforce the replicated policy cap.
+// this proposal committed now: the recovered set with this proposal's staged
+// creates added and staged deletes removed. A staged delete of a checkpoint
+// created earlier in the same proposal nets to zero, so the effective set is
+// computed directly rather than counting saves and deletes independently. Used
+// by the create handler to enforce the replicated policy cap.
 func (b *WriteSet) LiveQueryCheckpointCount() uint64 {
-	n := len(b.fsm.State.LiveQueryCheckpointIDs)
+	live := make(map[uint64]struct{}, len(b.fsm.State.LiveQueryCheckpointIDs)+len(b.pendingQueryCheckpointSaves))
+	for id := range b.fsm.State.LiveQueryCheckpointIDs {
+		live[id] = struct{}{}
+	}
 
 	for _, cp := range b.pendingQueryCheckpointSaves {
-		if _, ok := b.fsm.State.LiveQueryCheckpointIDs[cp.GetCheckpointId()]; !ok {
-			n++
-		}
+		live[cp.GetCheckpointId()] = struct{}{}
 	}
 
 	for _, id := range b.pendingQueryCheckpointDeletes {
-		if _, ok := b.fsm.State.LiveQueryCheckpointIDs[id]; ok {
-			n--
-		}
+		delete(live, id)
 	}
 
-	return uint64(n)
+	return uint64(len(live))
 }
 
 // QueryCheckpointExists reports whether the checkpoint id is live, accounting

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1900,10 +1900,8 @@ func (b *WriteSet) LiveQueryCheckpointCount() uint64 {
 // for this proposal's staged creates/deletes (staged wins over the recovered
 // set). Used by the delete handler to reject a non-live id.
 func (b *WriteSet) QueryCheckpointExists(id uint64) bool {
-	for _, d := range b.pendingQueryCheckpointDeletes {
-		if d == id {
-			return false
-		}
+	if slices.Contains(b.pendingQueryCheckpointDeletes, id) {
+		return false
 	}
 
 	for _, cp := range b.pendingQueryCheckpointSaves {

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -761,20 +761,30 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 	// sub-prefix. The (checkpoint_id BE 8) tail keeps per-call ordering
 	// deterministic; the contract is at zone+sub only.
 	for _, cp := range b.pendingQueryCheckpointSaves {
-		if err := saveQueryCheckpoint(batch, cp); err != nil {
+		if err := SaveQueryCheckpoint(batch, cp); err != nil {
 			return fmt.Errorf("saving query checkpoint %d: %w", cp.GetCheckpointId(), err)
 		}
 	}
 
 	for _, cpID := range b.pendingQueryCheckpointDeletes {
-		if err := deleteQueryCheckpointFromBatch(batch, cpID); err != nil {
+		if err := DeleteQueryCheckpointFromBatch(batch, cpID); err != nil {
 			return fmt.Errorf("deleting query checkpoint %d: %w", cpID, err)
 		}
 	}
 
+	// Keep the in-memory live-ID set in lockstep with the persisted rows so the
+	// next proposal's cap/existence checks see this proposal's effect.
+	for _, cp := range b.pendingQueryCheckpointSaves {
+		b.fsm.State.LiveQueryCheckpointIDs[cp.GetCheckpointId()] = struct{}{}
+	}
+
+	for _, cpID := range b.pendingQueryCheckpointDeletes {
+		delete(b.fsm.State.LiveQueryCheckpointIDs, cpID)
+	}
+
 	// SubGlobNextQueryCheckpointID (0x0F)
 	if b.NextQueryCheckpointID != b.fsm.State.NextQueryCheckpointID {
-		if err := storeNextQueryCheckpointID(batch, b.NextQueryCheckpointID); err != nil {
+		if err := StoreNextQueryCheckpointID(batch, b.NextQueryCheckpointID); err != nil {
 			return fmt.Errorf("storing next query checkpoint ID: %w", err)
 		}
 	}
@@ -1862,6 +1872,49 @@ func (b *WriteSet) SaveQueryCheckpoint(cp *raftcmdpb.QueryCheckpointState) {
 // DeleteQueryCheckpoint marks a query checkpoint for deletion during Merge.
 func (b *WriteSet) DeleteQueryCheckpoint(checkpointID uint64) {
 	b.pendingQueryCheckpointDeletes = append(b.pendingQueryCheckpointDeletes, checkpointID)
+}
+
+// LiveQueryCheckpointCount returns how many query checkpoints would be live if
+// this proposal committed now: the recovered set plus creates staged so far,
+// minus committed IDs a staged delete removes. Used by the create handler to
+// enforce the replicated policy cap.
+func (b *WriteSet) LiveQueryCheckpointCount() uint64 {
+	n := len(b.fsm.State.LiveQueryCheckpointIDs)
+
+	for _, cp := range b.pendingQueryCheckpointSaves {
+		if _, ok := b.fsm.State.LiveQueryCheckpointIDs[cp.GetCheckpointId()]; !ok {
+			n++
+		}
+	}
+
+	for _, id := range b.pendingQueryCheckpointDeletes {
+		if _, ok := b.fsm.State.LiveQueryCheckpointIDs[id]; ok {
+			n--
+		}
+	}
+
+	return uint64(n)
+}
+
+// QueryCheckpointExists reports whether the checkpoint id is live, accounting
+// for this proposal's staged creates/deletes (staged wins over the recovered
+// set). Used by the delete handler to reject a non-live id.
+func (b *WriteSet) QueryCheckpointExists(id uint64) bool {
+	for _, d := range b.pendingQueryCheckpointDeletes {
+		if d == id {
+			return false
+		}
+	}
+
+	for _, cp := range b.pendingQueryCheckpointSaves {
+		if cp.GetCheckpointId() == id {
+			return true
+		}
+	}
+
+	_, ok := b.fsm.State.LiveQueryCheckpointIDs[id]
+
+	return ok
 }
 
 // BloomUpdates returns the canonical keys collected during Merge for bloom filter updates.

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -697,6 +697,14 @@ const (
 	// structurally invalid payload (missing policy, or query_checkpoint_limit
 	// below 1). See EN-1827.
 	ErrorReason_ERROR_REASON_CLUSTER_POLICY_INVALID ErrorReason = 75
+	// ERROR_REASON_CHECKPOINT_LIMIT_REACHED: a CreateQueryCheckpoint was rejected
+	// because the live query-checkpoint count is at the replicated policy limit.
+	// Creation never evicts; an existing checkpoint must be deleted first. See
+	// EN-1501.
+	ErrorReason_ERROR_REASON_CHECKPOINT_LIMIT_REACHED ErrorReason = 76
+	// ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted an id
+	// that is not live (never created, or already deleted). See EN-1501.
+	ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND ErrorReason = 77
 )
 
 // Enum value maps for ErrorReason.
@@ -778,6 +786,8 @@ var (
 		73: "ERROR_REASON_STALE_CLUSTER_POLICY",
 		74: "ERROR_REASON_CLUSTER_POLICY_REVISION_CONFLICT",
 		75: "ERROR_REASON_CLUSTER_POLICY_INVALID",
+		76: "ERROR_REASON_CHECKPOINT_LIMIT_REACHED",
+		77: "ERROR_REASON_CHECKPOINT_NOT_FOUND",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                       0,
@@ -856,6 +866,8 @@ var (
 		"ERROR_REASON_STALE_CLUSTER_POLICY":              73,
 		"ERROR_REASON_CLUSTER_POLICY_REVISION_CONFLICT":  74,
 		"ERROR_REASON_CLUSTER_POLICY_INVALID":            75,
+		"ERROR_REASON_CHECKPOINT_LIMIT_REACHED":          76,
+		"ERROR_REASON_CHECKPOINT_NOT_FOUND":              77,
 	}
 )
 
@@ -4962,6 +4974,7 @@ type CreatedQueryCheckpointLog struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CheckpointId  uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
 	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`
+	CreatedAt     *Timestamp             `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5008,6 +5021,13 @@ func (x *CreatedQueryCheckpointLog) GetMaxSequence() uint64 {
 		return x.MaxSequence
 	}
 	return 0
+}
+
+func (x *CreatedQueryCheckpointLog) GetCreatedAt() *Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.
@@ -13239,10 +13259,12 @@ const file_common_proto_rawDesc = "" +
 	"\tlast_used\x18\x02 \x01(\v2\x11.common.TimestampR\blastUsed\"3\n" +
 	"\x1dSetQueryCheckpointScheduleLog\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"#\n" +
-	"!DeletedQueryCheckpointScheduleLog\"c\n" +
+	"!DeletedQueryCheckpointScheduleLog\"\x95\x01\n" +
 	"\x19CreatedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\x12!\n" +
-	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\"@\n" +
+	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\x120\n" +
+	"\n" +
+	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\"@\n" +
 	"\x19DeletedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xc6\x03\n" +
 	"\n" +
@@ -13854,7 +13876,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xfb\x17\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xcd\x18\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13932,7 +13954,9 @@ const file_common_proto_rawDesc = "" +
 	"%ERROR_REASON_CHAPTER_ALREADY_ARCHIVED\x10H\x12%\n" +
 	"!ERROR_REASON_STALE_CLUSTER_POLICY\x10I\x121\n" +
 	"-ERROR_REASON_CLUSTER_POLICY_REVISION_CONFLICT\x10J\x12'\n" +
-	"#ERROR_REASON_CLUSTER_POLICY_INVALID\x10K*Q\n" +
+	"#ERROR_REASON_CLUSTER_POLICY_INVALID\x10K\x12)\n" +
+	"%ERROR_REASON_CHECKPOINT_LIMIT_REACHED\x10L\x12%\n" +
+	"!ERROR_REASON_CHECKPOINT_NOT_FOUND\x10M*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +
@@ -14269,200 +14293,201 @@ var file_common_proto_depIdxs = []int32{
 	64,  // 84: common.SavedNumscriptLog.info:type_name -> common.NumscriptInfo
 	17,  // 85: common.NumscriptVersionEntry.created_at:type_name -> common.Timestamp
 	17,  // 86: common.TemplateUsage.last_used:type_name -> common.Timestamp
-	75,  // 87: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
-	76,  // 88: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
-	77,  // 89: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
-	78,  // 90: common.SinkConfig.http:type_name -> common.HttpSinkConfig
-	79,  // 91: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
-	6,   // 92: common.SinkConfig.event_types:type_name -> common.EventType
-	74,  // 93: common.SinkStatus.error:type_name -> common.SinkError
-	17,  // 94: common.SinkError.occurred_at:type_name -> common.Timestamp
-	80,  // 95: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
-	17,  // 96: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
-	36,  // 97: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
-	8,   // 98: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
-	102, // 99: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
-	187, // 100: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
-	11,  // 101: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	17,  // 102: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
-	84,  // 103: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
-	86,  // 104: common.LedgerLog.data:type_name -> common.LedgerLogPayload
-	17,  // 105: common.LedgerLog.date:type_name -> common.Timestamp
-	85,  // 106: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
-	85,  // 107: common.LedgerLog.new_kept_volumes:type_name -> common.TouchedVolume
-	85,  // 108: common.LedgerLog.ephemeral_volumes:type_name -> common.TouchedVolume
-	91,  // 109: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
-	92,  // 110: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
-	93,  // 111: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
-	94,  // 112: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
-	95,  // 113: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
-	96,  // 114: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
-	90,  // 115: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
-	88,  // 116: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
-	89,  // 117: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
-	141, // 118: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
-	142, // 119: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
-	143, // 120: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
-	87,  // 121: common.LedgerLogPayload.order_skipped:type_name -> common.OrderSkippedLog
-	10,  // 122: common.OrderSkippedLog.reason:type_name -> common.ErrorReason
-	188, // 123: common.OrderSkippedLog.context:type_name -> common.OrderSkippedLog.ContextEntry
-	39,  // 124: common.CreatedIndexLog.id:type_name -> common.IndexID
-	1,   // 125: common.CreatedIndexLog.bound_type:type_name -> common.MetadataType
-	39,  // 126: common.DroppedIndexLog.id:type_name -> common.IndexID
-	24,  // 127: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	189, // 128: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
-	24,  // 129: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
-	34,  // 130: common.SavedMetadata.target:type_name -> common.Target
-	190, // 131: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
-	34,  // 132: common.DeletedMetadata.target:type_name -> common.Target
-	0,   // 133: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	1,   // 134: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
-	0,   // 135: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	39,  // 136: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
-	17,  // 137: common.Chapter.start:type_name -> common.Timestamp
-	17,  // 138: common.Chapter.end:type_name -> common.Timestamp
-	7,   // 139: common.Chapter.status:type_name -> common.ChapterStatus
-	97,  // 140: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
-	97,  // 141: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
-	97,  // 142: common.SealedChapterLog.chapter:type_name -> common.Chapter
-	97,  // 143: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
-	97,  // 144: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
-	122, // 145: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
-	124, // 146: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
-	103, // 147: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
-	104, // 148: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
-	105, // 149: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
-	106, // 150: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
-	107, // 151: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
-	108, // 152: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
-	109, // 153: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
-	110, // 154: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
-	111, // 155: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
-	112, // 156: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
-	113, // 157: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
-	114, // 158: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	115, // 159: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	116, // 160: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	117, // 161: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
-	118, // 162: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
-	119, // 163: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
-	121, // 164: common.CreatedTransactionAction.drop:type_name -> common.DropAction
-	114, // 165: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	115, // 166: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	116, // 167: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	121, // 168: common.RevertedTransactionAction.drop:type_name -> common.DropAction
-	114, // 169: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	115, // 170: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
-	116, // 171: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	121, // 172: common.SavedMetadataAction.drop:type_name -> common.DropAction
-	114, // 173: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	121, // 174: common.DeletedMetadataAction.drop:type_name -> common.DropAction
-	114, // 175: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
-	121, // 176: common.AnyVariantAction.drop:type_name -> common.DropAction
-	120, // 177: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
-	123, // 178: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
-	125, // 179: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
-	17,  // 180: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
-	9,   // 181: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
-	126, // 182: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
-	17,  // 183: common.LedgerInfo.created_at:type_name -> common.Timestamp
-	17,  // 184: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
-	36,  // 185: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
-	8,   // 186: common.LedgerInfo.mode:type_name -> common.LedgerMode
-	102, // 187: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
-	127, // 188: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	191, // 189: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
-	11,  // 190: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	192, // 191: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
-	34,  // 192: common.SaveMetadataCommand.target:type_name -> common.Target
-	193, // 193: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
-	34,  // 194: common.DeleteMetadataCommand.target:type_name -> common.Target
-	194, // 195: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
-	17,  // 196: common.TransactionState.timestamp:type_name -> common.Timestamp
-	23,  // 197: common.TransactionState.postings:type_name -> common.Posting
-	17,  // 198: common.TransactionState.reverted_at:type_name -> common.Timestamp
-	133, // 199: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
-	10,  // 200: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	195, // 201: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	137, // 202: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	138, // 203: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	139, // 204: common.SegmentType.bytes:type_name -> common.BytesConstraint
-	12,  // 205: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	196, // 206: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	140, // 207: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
-	11,  // 208: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	157, // 209: common.QueryFilter.field:type_name -> common.FieldCondition
-	163, // 210: common.QueryFilter.address:type_name -> common.AddressMatch
-	153, // 211: common.QueryFilter.and:type_name -> common.AndFilter
-	154, // 212: common.QueryFilter.or:type_name -> common.OrFilter
-	155, // 213: common.QueryFilter.not:type_name -> common.NotFilter
-	145, // 214: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	150, // 215: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	148, // 216: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	149, // 217: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	151, // 218: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	152, // 219: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	146, // 220: common.QueryFilter.reverted:type_name -> common.RevertedCondition
-	147, // 221: common.QueryFilter.audit:type_name -> common.AuditCondition
-	158, // 222: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	13,  // 223: common.AuditCondition.field:type_name -> common.AuditField
-	158, // 224: common.AuditCondition.string_cond:type_name -> common.StringCondition
-	160, // 225: common.AuditCondition.uint_cond:type_name -> common.UintCondition
-	158, // 226: common.LedgerCondition.cond:type_name -> common.StringCondition
-	160, // 227: common.LogIdCondition.cond:type_name -> common.UintCondition
-	2,   // 228: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	160, // 229: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	4,   // 230: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	160, // 231: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	144, // 232: common.AndFilter.filters:type_name -> common.QueryFilter
-	144, // 233: common.OrFilter.filters:type_name -> common.QueryFilter
-	144, // 234: common.NotFilter.filter:type_name -> common.QueryFilter
-	156, // 235: common.FieldCondition.field:type_name -> common.FieldRef
-	158, // 236: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	159, // 237: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	160, // 238: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	161, // 239: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	162, // 240: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 241: common.AddressMatch.role:type_name -> common.AddressRole
-	144, // 242: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 243: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 244: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 245: common.AggregatedVolume.output:type_name -> common.Uint256
-	165, // 246: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	167, // 247: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	165, // 248: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	32,  // 249: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 250: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	42,  // 251: common.PreparedQueryCursor.log_data:type_name -> common.Log
-	171, // 252: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	173, // 253: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	174, // 254: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	176, // 255: common.ListOptions.read:type_name -> common.ReadOptions
-	144, // 256: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 257: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 258: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	28,  // 259: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 260: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	35,  // 261: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	35,  // 262: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	35,  // 263: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 264: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	140, // 265: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 266: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 267: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	140, // 268: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 269: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 270: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 271: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	136, // 272: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	198, // 273: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
-	198, // 274: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
-	15,  // 275: common.allowed_query_targets:type_name -> common.QueryTarget
-	276, // [276:276] is the sub-list for method output_type
-	276, // [276:276] is the sub-list for method input_type
-	275, // [275:276] is the sub-list for extension type_name
-	273, // [273:275] is the sub-list for extension extendee
-	0,   // [0:273] is the sub-list for field type_name
+	17,  // 87: common.CreatedQueryCheckpointLog.created_at:type_name -> common.Timestamp
+	75,  // 88: common.SinkConfig.nats:type_name -> common.NatsSinkConfig
+	76,  // 89: common.SinkConfig.clickhouse:type_name -> common.ClickHouseSinkConfig
+	77,  // 90: common.SinkConfig.kafka:type_name -> common.KafkaSinkConfig
+	78,  // 91: common.SinkConfig.http:type_name -> common.HttpSinkConfig
+	79,  // 92: common.SinkConfig.databricks:type_name -> common.DatabricksSinkConfig
+	6,   // 93: common.SinkConfig.event_types:type_name -> common.EventType
+	74,  // 94: common.SinkStatus.error:type_name -> common.SinkError
+	17,  // 95: common.SinkError.occurred_at:type_name -> common.Timestamp
+	80,  // 96: common.DatabricksSinkConfig.oauth_m2m:type_name -> common.DatabricksOAuthM2M
+	17,  // 97: common.CreatedLedgerLog.created_at:type_name -> common.Timestamp
+	36,  // 98: common.CreatedLedgerLog.metadata_schema:type_name -> common.MetadataSchema
+	8,   // 99: common.CreatedLedgerLog.mode:type_name -> common.LedgerMode
+	102, // 100: common.CreatedLedgerLog.mirror_source:type_name -> common.MirrorSourceConfig
+	187, // 101: common.CreatedLedgerLog.account_types:type_name -> common.CreatedLedgerLog.AccountTypesEntry
+	11,  // 102: common.CreatedLedgerLog.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	17,  // 103: common.DeletedLedgerLog.deleted_at:type_name -> common.Timestamp
+	84,  // 104: common.ApplyLedgerLog.log:type_name -> common.LedgerLog
+	86,  // 105: common.LedgerLog.data:type_name -> common.LedgerLogPayload
+	17,  // 106: common.LedgerLog.date:type_name -> common.Timestamp
+	85,  // 107: common.LedgerLog.purged_volumes:type_name -> common.TouchedVolume
+	85,  // 108: common.LedgerLog.new_kept_volumes:type_name -> common.TouchedVolume
+	85,  // 109: common.LedgerLog.ephemeral_volumes:type_name -> common.TouchedVolume
+	91,  // 110: common.LedgerLogPayload.created_transaction:type_name -> common.CreatedTransaction
+	92,  // 111: common.LedgerLogPayload.reverted_transaction:type_name -> common.RevertedTransaction
+	93,  // 112: common.LedgerLogPayload.saved_metadata:type_name -> common.SavedMetadata
+	94,  // 113: common.LedgerLogPayload.deleted_metadata:type_name -> common.DeletedMetadata
+	95,  // 114: common.LedgerLogPayload.set_metadata_field_type:type_name -> common.SetMetadataFieldTypeLog
+	96,  // 115: common.LedgerLogPayload.removed_metadata_field_type:type_name -> common.RemovedMetadataFieldTypeLog
+	90,  // 116: common.LedgerLogPayload.fill_gap:type_name -> common.FilledGapLog
+	88,  // 117: common.LedgerLogPayload.create_index:type_name -> common.CreatedIndexLog
+	89,  // 118: common.LedgerLogPayload.drop_index:type_name -> common.DroppedIndexLog
+	141, // 119: common.LedgerLogPayload.added_account_type:type_name -> common.AddedAccountTypeLog
+	142, // 120: common.LedgerLogPayload.removed_account_type:type_name -> common.RemovedAccountTypeLog
+	143, // 121: common.LedgerLogPayload.updated_default_enforcement_mode:type_name -> common.UpdatedDefaultEnforcementModeLog
+	87,  // 122: common.LedgerLogPayload.order_skipped:type_name -> common.OrderSkippedLog
+	10,  // 123: common.OrderSkippedLog.reason:type_name -> common.ErrorReason
+	188, // 124: common.OrderSkippedLog.context:type_name -> common.OrderSkippedLog.ContextEntry
+	39,  // 125: common.CreatedIndexLog.id:type_name -> common.IndexID
+	1,   // 126: common.CreatedIndexLog.bound_type:type_name -> common.MetadataType
+	39,  // 127: common.DroppedIndexLog.id:type_name -> common.IndexID
+	24,  // 128: common.CreatedTransaction.transaction:type_name -> common.Transaction
+	189, // 129: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	24,  // 130: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
+	34,  // 131: common.SavedMetadata.target:type_name -> common.Target
+	190, // 132: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	34,  // 133: common.DeletedMetadata.target:type_name -> common.Target
+	0,   // 134: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	1,   // 135: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
+	0,   // 136: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	39,  // 137: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
+	17,  // 138: common.Chapter.start:type_name -> common.Timestamp
+	17,  // 139: common.Chapter.end:type_name -> common.Timestamp
+	7,   // 140: common.Chapter.status:type_name -> common.ChapterStatus
+	97,  // 141: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
+	97,  // 142: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
+	97,  // 143: common.SealedChapterLog.chapter:type_name -> common.Chapter
+	97,  // 144: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
+	97,  // 145: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
+	122, // 146: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
+	124, // 147: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
+	103, // 148: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
+	104, // 149: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
+	105, // 150: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
+	106, // 151: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
+	107, // 152: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
+	108, // 153: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
+	109, // 154: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
+	110, // 155: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
+	111, // 156: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
+	112, // 157: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
+	113, // 158: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
+	114, // 159: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	115, // 160: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	116, // 161: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	117, // 162: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
+	118, // 163: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
+	119, // 164: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
+	121, // 165: common.CreatedTransactionAction.drop:type_name -> common.DropAction
+	114, // 166: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	115, // 167: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	116, // 168: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	121, // 169: common.RevertedTransactionAction.drop:type_name -> common.DropAction
+	114, // 170: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	115, // 171: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
+	116, // 172: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	121, // 173: common.SavedMetadataAction.drop:type_name -> common.DropAction
+	114, // 174: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	121, // 175: common.DeletedMetadataAction.drop:type_name -> common.DropAction
+	114, // 176: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
+	121, // 177: common.AnyVariantAction.drop:type_name -> common.DropAction
+	120, // 178: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
+	123, // 179: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
+	125, // 180: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
+	17,  // 181: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
+	9,   // 182: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
+	126, // 183: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
+	17,  // 184: common.LedgerInfo.created_at:type_name -> common.Timestamp
+	17,  // 185: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
+	36,  // 186: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
+	8,   // 187: common.LedgerInfo.mode:type_name -> common.LedgerMode
+	102, // 188: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
+	127, // 189: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
+	191, // 190: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	11,  // 191: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	192, // 192: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	34,  // 193: common.SaveMetadataCommand.target:type_name -> common.Target
+	193, // 194: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	34,  // 195: common.DeleteMetadataCommand.target:type_name -> common.Target
+	194, // 196: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	17,  // 197: common.TransactionState.timestamp:type_name -> common.Timestamp
+	23,  // 198: common.TransactionState.postings:type_name -> common.Posting
+	17,  // 199: common.TransactionState.reverted_at:type_name -> common.Timestamp
+	133, // 200: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	10,  // 201: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
+	195, // 202: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	137, // 203: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	138, // 204: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	139, // 205: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	12,  // 206: common.AccountType.persistence:type_name -> common.AccountTypePersistence
+	196, // 207: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	140, // 208: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	11,  // 209: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
+	157, // 210: common.QueryFilter.field:type_name -> common.FieldCondition
+	163, // 211: common.QueryFilter.address:type_name -> common.AddressMatch
+	153, // 212: common.QueryFilter.and:type_name -> common.AndFilter
+	154, // 213: common.QueryFilter.or:type_name -> common.OrFilter
+	155, // 214: common.QueryFilter.not:type_name -> common.NotFilter
+	145, // 215: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	150, // 216: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	148, // 217: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	149, // 218: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	151, // 219: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	152, // 220: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	146, // 221: common.QueryFilter.reverted:type_name -> common.RevertedCondition
+	147, // 222: common.QueryFilter.audit:type_name -> common.AuditCondition
+	158, // 223: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	13,  // 224: common.AuditCondition.field:type_name -> common.AuditField
+	158, // 225: common.AuditCondition.string_cond:type_name -> common.StringCondition
+	160, // 226: common.AuditCondition.uint_cond:type_name -> common.UintCondition
+	158, // 227: common.LedgerCondition.cond:type_name -> common.StringCondition
+	160, // 228: common.LogIdCondition.cond:type_name -> common.UintCondition
+	2,   // 229: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	160, // 230: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	4,   // 231: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	160, // 232: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	144, // 233: common.AndFilter.filters:type_name -> common.QueryFilter
+	144, // 234: common.OrFilter.filters:type_name -> common.QueryFilter
+	144, // 235: common.NotFilter.filter:type_name -> common.QueryFilter
+	156, // 236: common.FieldCondition.field:type_name -> common.FieldRef
+	158, // 237: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	159, // 238: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	160, // 239: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	161, // 240: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	162, // 241: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	14,  // 242: common.AddressMatch.role:type_name -> common.AddressRole
+	144, // 243: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	15,  // 244: common.PreparedQuery.target:type_name -> common.QueryTarget
+	22,  // 245: common.AggregatedVolume.input:type_name -> common.Uint256
+	22,  // 246: common.AggregatedVolume.output:type_name -> common.Uint256
+	165, // 247: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	167, // 248: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	165, // 249: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	32,  // 250: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	24,  // 251: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	42,  // 252: common.PreparedQueryCursor.log_data:type_name -> common.Log
+	171, // 253: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	173, // 254: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	174, // 255: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	176, // 256: common.ListOptions.read:type_name -> common.ReadOptions
+	144, // 257: common.ListOptions.filter:type_name -> common.QueryFilter
+	19,  // 258: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	19,  // 259: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	28,  // 260: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	19,  // 261: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	35,  // 262: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	35,  // 263: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	35,  // 264: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	19,  // 265: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	140, // 266: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 267: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	19,  // 268: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	140, // 269: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	19,  // 270: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 271: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 272: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	136, // 273: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	198, // 274: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
+	198, // 275: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
+	15,  // 276: common.allowed_query_targets:type_name -> common.QueryTarget
+	277, // [277:277] is the sub-list for method output_type
+	277, // [277:277] is the sub-list for method input_type
+	276, // [276:277] is the sub-list for extension type_name
+	274, // [274:276] is the sub-list for extension extendee
+	0,   // [0:274] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -4350,6 +4350,7 @@ func NewDeletedQueryCheckpointScheduleLogListReader(s []*DeletedQueryCheckpointS
 type CreatedQueryCheckpointLogReader interface {
 	GetCheckpointId() uint64
 	GetMaxSequence() uint64
+	GetCreatedAt() TimestampReader
 	Mutate() *CreatedQueryCheckpointLog
 }
 
@@ -4361,6 +4362,14 @@ func (r *createdQueryCheckpointLogReadonly) GetCheckpointId() uint64 {
 
 func (r *createdQueryCheckpointLogReadonly) GetMaxSequence() uint64 {
 	return (*CreatedQueryCheckpointLog)(r).GetMaxSequence()
+}
+
+func (r *createdQueryCheckpointLogReadonly) GetCreatedAt() TimestampReader {
+	v := (*CreatedQueryCheckpointLog)(r).GetCreatedAt()
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
 }
 
 func (r *createdQueryCheckpointLogReadonly) Mutate() *CreatedQueryCheckpointLog {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -1491,6 +1491,7 @@ func (m *CreatedQueryCheckpointLog) CloneVT() *CreatedQueryCheckpointLog {
 	r := new(CreatedQueryCheckpointLog)
 	r.CheckpointId = m.CheckpointId
 	r.MaxSequence = m.MaxSequence
+	r.CreatedAt = m.CreatedAt.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -7018,6 +7019,9 @@ func (this *CreatedQueryCheckpointLog) EqualVT(that *CreatedQueryCheckpointLog) 
 		return false
 	}
 	if this.MaxSequence != that.MaxSequence {
+		return false
+	}
+	if !this.CreatedAt.EqualVT(that.CreatedAt) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15943,6 +15947,16 @@ func (m *CreatedQueryCheckpointLog) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CreatedAt != nil {
+		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if m.MaxSequence != 0 {
 		i -= 8
@@ -24993,6 +25007,10 @@ func (m *CreatedQueryCheckpointLog) SizeVT() (n int) {
 	}
 	if m.MaxSequence != 0 {
 		n += 9
+	}
+	if m.CreatedAt != nil {
+		l = m.CreatedAt.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -37007,6 +37025,42 @@ func (m *CreatedQueryCheckpointLog) UnmarshalVT(dAtA []byte) error {
 			}
 			m.MaxSequence = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
 			iNdEx += 8
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CreatedAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.CreatedAt == nil {
+				m.CreatedAt = &Timestamp{}
+			}
+			if err := m.CreatedAt.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -179,6 +179,14 @@ const (
 	// cold storage. When cold storage is unavailable or a chapter cannot be read,
 	// the pass reports this rather than presenting a partial replay as clean.
 	CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE CheckStoreErrorType = 25
+	// Emitted when the persisted query-checkpoint rows (SubGlobQueryCheckpoint)
+	// diverge from the set the checker re-derived from chain-bound
+	// CreatedQueryCheckpoint / DeletedQueryCheckpoint logs: a stored row the audit
+	// never created (or later deleted), a live checkpoint missing its row, or a
+	// row whose max_sequence / created_at differs from the audited value. The rows
+	// back point-in-time query reads and the FSM's live-count cap, so a tampered
+	// row changes which checkpoints exist. See EN-1501.
+	CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH CheckStoreErrorType = 26
 )
 
 // Enum value maps for CheckStoreErrorType.
@@ -210,6 +218,7 @@ var (
 		23: "CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE",
 		24: "CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_MISMATCH",
 		25: "CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE",
+		26: "CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH",
 	}
 	CheckStoreErrorType_value = map[string]int32{
 		"CHECK_STORE_ERROR_TYPE_UNSPECIFIED":                            0,
@@ -238,6 +247,7 @@ var (
 		"CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE":        23,
 		"CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_MISMATCH":                24,
 		"CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE": 25,
+		"CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH":              26,
 	}
 )
 
@@ -9968,7 +9978,8 @@ const file_bucket_proto_rawDesc = "" +
 	"\x12entities_with_null\x18\x05 \x01(\x06R\x10entitiesWithNull\"\x10\n" +
 	"\x0eBarrierRequest\"4\n" +
 	"\x0fBarrierResponse\x12!\n" +
-	"\fcommit_index\x18\x01 \x01(\x06R\vcommitIndex*\xf3\t\n" +
+	"\fcommit_index\x18\x01 \x01(\x06R\vcommitIndex*\xa9\n" +
+	"\n" +
 	"\x13CheckStoreErrorType\x12&\n" +
 	"\"CHECK_STORE_ERROR_TYPE_UNSPECIFIED\x10\x00\x12(\n" +
 	"$CHECK_STORE_ERROR_TYPE_HASH_MISMATCH\x10\x01\x12'\n" +
@@ -9996,7 +10007,8 @@ const file_bucket_proto_rawDesc = "" +
 	".CHECK_STORE_ERROR_TYPE_SIGNING_CONFIG_MISMATCH\x10\x16\x12:\n" +
 	"6CHECK_STORE_ERROR_TYPE_SIGNING_VERIFICATION_INCOMPLETE\x10\x17\x122\n" +
 	".CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_MISMATCH\x10\x18\x12A\n" +
-	"=CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE\x10\x19*W\n" +
+	"=CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE\x10\x19\x124\n" +
+	"0CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH\x10\x1a*W\n" +
 	"\x12PatternSegmentType\x12\x1e\n" +
 	"\x1aPATTERN_SEGMENT_TYPE_FIXED\x10\x00\x12!\n" +
 	"\x1dPATTERN_SEGMENT_TYPE_VARIABLE\x10\x01*\x9c\x01\n" +

--- a/internal/query/query_checkpoint.go
+++ b/internal/query/query_checkpoint.go
@@ -1,11 +1,69 @@
 package query
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+// ReadQueryCheckpointRows returns every live query-checkpoint row keyed by its
+// Pebble key id (the authoritative identity), for the checker to compare against
+// the audit-derived set.
+func ReadQueryCheckpointRows(reader dal.PebbleReader) (map[uint64]*raftcmdpb.QueryCheckpointState, error) {
+	ids, err := ReadLiveQueryCheckpointIDs(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := make(map[uint64]*raftcmdpb.QueryCheckpointState, len(ids))
+
+	for id := range ids {
+		cp, err := ReadQueryCheckpoint(reader, id)
+		if err != nil {
+			return nil, err
+		}
+
+		rows[id] = cp
+	}
+
+	return rows, nil
+}
+
+// ReadLiveQueryCheckpointIDs returns the set of query-checkpoint IDs currently
+// live in the store. Used at recovery to rehydrate FSMState so the FSM can
+// enforce the checkpoint cap and reject deletes of non-live IDs without
+// scanning Pebble on the apply path, by the checker to compare the stored rows
+// against the audit chain, and by orphan reclamation.
+//
+// The ID is read from the Pebble KEY, never the payload's checkpoint_id: the key
+// is what CreateQueryCheckpoint / DeleteQueryCheckpoint address, so it is the
+// authoritative identity of the row.
+func ReadLiveQueryCheckpointIDs(reader dal.PebbleReader) (map[uint64]struct{}, error) {
+	iter, err := dal.NewBoundedIter(reader,
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint},
+		[]byte{dal.ZoneGlobal, dal.SubGlobQueryCheckpoint + 1})
+	if err != nil {
+		return nil, fmt.Errorf("iterating query checkpoints: %w", err)
+	}
+
+	defer func() { _ = iter.Close() }()
+
+	ids := make(map[uint64]struct{})
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Key layout: [ZoneGlobal][SubGlobQueryCheckpoint][checkpoint_id BE 8].
+		key := iter.Key()
+		if len(key) != 10 {
+			return nil, fmt.Errorf("malformed query checkpoint key (len %d): % x", len(key), key)
+		}
+
+		ids[binary.BigEndian.Uint64(key[2:])] = struct{}{}
+	}
+
+	return ids, iter.Error()
+}
 
 // ReadQueryCheckpoint reads a single query checkpoint by ID from Pebble.
 // Returns nil if the checkpoint does not exist.

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -911,6 +911,14 @@ enum CheckStoreErrorType {
   // cold storage. When cold storage is unavailable or a chapter cannot be read,
   // the pass reports this rather than presenting a partial replay as clean.
   CHECK_STORE_ERROR_TYPE_CLUSTER_POLICY_VERIFICATION_INCOMPLETE = 25;
+  // Emitted when the persisted query-checkpoint rows (SubGlobQueryCheckpoint)
+  // diverge from the set the checker re-derived from chain-bound
+  // CreatedQueryCheckpoint / DeletedQueryCheckpoint logs: a stored row the audit
+  // never created (or later deleted), a live checkpoint missing its row, or a
+  // row whose max_sequence / created_at differs from the audited value. The rows
+  // back point-in-time query reads and the FSM's live-count cap, so a tampered
+  // row changes which checkpoints exist. See EN-1501.
+  CHECK_STORE_ERROR_TYPE_QUERY_CHECKPOINT_MISMATCH = 26;
 }
 
 message CheckStoreError {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -552,6 +552,7 @@ message DeletedQueryCheckpointScheduleLog {}
 message CreatedQueryCheckpointLog {
   fixed64 checkpoint_id = 1;
   fixed64 max_sequence = 2;
+  Timestamp created_at = 3;
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.
@@ -1311,6 +1312,14 @@ enum ErrorReason {
   // structurally invalid payload (missing policy, or query_checkpoint_limit
   // below 1). See EN-1827.
   ERROR_REASON_CLUSTER_POLICY_INVALID = 75;
+  // ERROR_REASON_CHECKPOINT_LIMIT_REACHED: a CreateQueryCheckpoint was rejected
+  // because the live query-checkpoint count is at the replicated policy limit.
+  // Creation never evicts; an existing checkpoint must be deleted first. See
+  // EN-1501.
+  ERROR_REASON_CHECKPOINT_LIMIT_REACHED = 76;
+  // ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted an id
+  // that is not live (never created, or already deleted). See EN-1501.
+  ERROR_REASON_CHECKPOINT_NOT_FOUND = 77;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/tests/e2e/cluster/query_checkpoint_test.go
+++ b/tests/e2e/cluster/query_checkpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -18,8 +19,21 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 )
+
+// withQueryCheckpointLimit sets the desired cluster-policy query-checkpoint
+// limit for a node, so the FSM caps live checkpoints at n once the reconciler
+// commits the policy.
+func withQueryCheckpointLimit(n uint64) testservice.InstrumentationFunc {
+	return func(_ context.Context, cfg *testservice.RunConfiguration) error {
+		cfg.AppendArgs("--query-checkpoint-limit", strconv.FormatUint(n, 10))
+
+		return nil
+	}
+}
 
 var _ = Describe("Query Checkpoints", func() {
 
@@ -553,3 +567,74 @@ func aggregateAssets(result *commonpb.AggregateResult) []string {
 
 	return assets
 }
+
+// FSM-enforced live-checkpoint cap (EN-1501): the limit comes from the
+// Raft-replicated cluster policy, and CreateQueryCheckpoint / DeleteQueryCheckpoint
+// are enforced in the FSM apply path. This node starts with a low limit so the
+// cap is reached quickly.
+var _ = Describe("Query Checkpoints live cap", Ordered, func() {
+	var (
+		ctx           context.Context
+		client        servicepb.BucketServiceClient
+		clusterClient clusterpb.ClusterServiceClient
+	)
+
+	const (
+		limit      = 2
+		ledgerName = "qcp-cap"
+	)
+
+	BeforeAll(func() {
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode(withQueryCheckpointLimit(limit))
+		client = node.Client
+		clusterClient = node.ClusterClient
+
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+	})
+
+	It("allows creating up to the cap", func() {
+		for i := 0; i < limit; i++ {
+			_, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+			Expect(err).To(Succeed(), "creation %d of %d must succeed", i+1, limit)
+		}
+
+		resp, err := clusterClient.ListQueryCheckpoints(ctx, &clusterpb.ListQueryCheckpointsRequest{})
+		Expect(err).To(Succeed())
+		Expect(resp.GetCheckpoints()).To(HaveLen(limit))
+	})
+
+	It("rejects creation past the cap with CHECKPOINT_LIMIT_REACHED (FailedPrecondition)", func() {
+		_, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.FailedPrecondition))
+
+		info := actions.ExtractGRPCErrorInfo(err)
+		Expect(info).NotTo(BeNil())
+		Expect(info.Reason).To(Equal(domain.ErrReasonCheckpointLimitReached))
+	})
+
+	It("frees a slot on delete so creation succeeds again", func() {
+		list, err := clusterClient.ListQueryCheckpoints(ctx, &clusterpb.ListQueryCheckpointsRequest{})
+		Expect(err).To(Succeed())
+		Expect(list.GetCheckpoints()).NotTo(BeEmpty())
+
+		victim := list.GetCheckpoints()[0].GetCheckpointId()
+		_, err = clusterClient.DeleteQueryCheckpoint(ctx, &clusterpb.DeleteQueryCheckpointRequest{CheckpointId: victim})
+		Expect(err).To(Succeed())
+
+		_, err = clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+		Expect(err).To(Succeed(), "a slot was freed, so creation must succeed again")
+	})
+
+	It("returns CHECKPOINT_NOT_FOUND when deleting a non-live checkpoint", func() {
+		_, err := clusterClient.DeleteQueryCheckpoint(ctx, &clusterpb.DeleteQueryCheckpointRequest{CheckpointId: 999999})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.NotFound))
+
+		info := actions.ExtractGRPCErrorInfo(err)
+		Expect(info).NotTo(BeNil())
+		Expect(info.Reason).To(Equal(domain.ErrReasonCheckpointNotFound))
+	})
+})


### PR DESCRIPTION
## What

PR 2 of [EN-1827](https://formance-team.atlassian.net/browse/EN-1827): move the **query-checkpoint limit + existence enforcement into the FSM apply path** (after the idempotency gate), using the Raft-replicated `ClusterPolicy.query_checkpoint_limit` introduced in PR 1.

This replaces the soft-admission approach of #1660 (which enforced at admission and, as EN-1827 notes, broke idempotent retries). **Supersedes #1660.**

> ⚠️ **Stacked on #1750** (PR 1 — the replicated cluster policy). Base is `feat/cluster-policy`; the diff shown here is PR 2 only. Retarget to `release/v3.0` once #1750 merges.

## How

- **FSM enforcement.** `processCreateQueryCheckpoint` rejects when `live_count >= ClusterPolicy.query_checkpoint_limit` (`ErrCheckpointLimitReached`); `processDeleteQueryCheckpoint` rejects a non-live id (`ErrCheckpointNotFound`), keeping the structural `id != 0` check. Both run after the idempotency gate, so a committed order resolves identically on every node and a keyed retry replays the first apply's frozen outcome. `limit == 0` (the unset default before a policy is committed) is uncapped.
- **Deterministic live state.** `FSMState.LiveQueryCheckpointIDs` — a set seeded at boot from the stored rows (`ReadLiveQueryCheckpointIDs`) and kept in lockstep by the handlers and `WriteSet.Merge`. Apply enforces the cap/existence with **no Pebble read** (invariant #3). It's a function of the already-checker-verified rows, so it adds no new persisted projection.
- **`ErrCheckpointLimitReached` is `KindPrecondition` (freezable), not `ResourceExhausted`.** EN-1827 requires a limit failure to stay frozen under an idempotency key ("remains the same outcome even after a slot becomes free"); a retryable kind wouldn't be frozen, so a keyed retry could re-execute. `FailedPrecondition` is the closest freezable fit. This is a client-facing change from #1660's `ResourceExhausted`.
- **Checker (invariant #8).** `compareQueryCheckpoints` re-derives the live set (with each row's `max_sequence` / `created_at`) from the chain-bound `CreatedQueryCheckpoint` / `DeletedQueryCheckpoint` logs (baseline-seeded under archiving) and diffs it against the stored rows both ways → `QUERY_CHECKPOINT_MISMATCH`. Closes a pre-existing gap on the checkpoint rows.
- **Rebuild / baseline.** Audit rebuild recreates the rows and advances the monotonic next-id counter; baseline snapshots copy the checkpoint rows for the checker.

## Testing

- Unit: enforcement (create under/at limit/uncapped, delete live/non-live/zero-id), checker (×7), rebuild replay, recovery live-set roundtrip.
- **e2e** (`Query Checkpoints live cap`): boots a node with a low `--query-checkpoint-limit`, then create-to-cap → reject `FailedPrecondition`/`CHECKPOINT_LIMIT_REACHED` → delete frees a slot → `CHECKPOINT_NOT_FOUND`.
- `go build ./...` + `go vet` (incl. `-tags e2e`) + targeted package tests green. (Full `agent-check` not runnable here: golangci-lint OOMs, `just pre-commit` deletes `.pb.go`.)

## Notes / follow-ups

- Physical **orphan-dir reclamation deferred** (needs a `ListQueryCheckpointDirs` capability port; disk hygiene, per-delete cleanup already exists).
- Built fresh on the cluster-policy branch rather than replaying #1660, so there's no admission enforcement to remove.

v3 is unreleased: no migration/compat shims, no reserved proto fields.


[EN-1827]: https://formance-team.atlassian.net/browse/EN-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ