### PR TITLE
fix(backup): rebuild the index registry from CreateIndex/DropIndex logs

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -320,7 +320,7 @@ The server-side job:
 3. Reads the manifest from S3 and downloads the checkpoint files in parallel
    through an `errgroup` worker pool. The pool size is set by the server flag
    `--restore-download-parallelism` (default 16, clamped to `[1, 64]`).
-4. Applies any incremental export segments on top of the checkpoint and rebuilds derived state (volumes, metadata, transactions, reversion bitsets, the chapter registry) from the exported logs, starting at the checkpoint's last log sequence. This is the same `ApplyExports` + `RebuildDelta` path used by the offline `ledgerctl store bootstrap` command, so a manifest with incremental backups restores all data written after the last full checkpoint.
+4. Applies any incremental export segments on top of the checkpoint and rebuilds derived state (volumes, metadata, transactions, reversion bitsets, the chapter registry, the index registry) from the exported logs, starting at the checkpoint's last log sequence. This is the same `ApplyExports` + `RebuildDelta` path used by the offline `ledgerctl store bootstrap` command, so a manifest with incremental backups restores all data written after the last full checkpoint. The index registry fold covers the full lifecycle — create, retype version bump, drop, and the removal cascade — see [Restore Lifecycle](../technical/architecture/subsystems/indexer/indexes.md#restore-lifecycle); per-replica read indexes are deliberately NOT restored and are rebuilt by each node's indexbuilder from the restored registry.
 5. On success, marks the staging as ready.
 
 If the job fails or is cancelled, the staging directory is wiped so the

--- a/docs/technical/architecture/subsystems/indexer/indexes.md
+++ b/docs/technical/architecture/subsystems/indexer/indexes.md
@@ -92,6 +92,19 @@ An index gets a fast path when it is declared in the **same atomic apply batch**
 
 The classification is deliberately conservative: only the same-atomic-batch-before-any-data case qualifies as initial. A separate-batch index on a still-empty ledger backfills exactly as before — safe (it replays an empty history and completes immediately), just not routed through the zero-cost promotion.
 
+## Restore Lifecycle
+
+The index registry (the bucket-scoped `Index` rows under `SubAttrIndex`) is a persisted projection of the audited order stream, so a cross-cluster restore must reproduce it the same way the live apply path built it: the checkpoint's attribute zone carries the rows as of the checkpoint, and `RebuildDelta` (`internal/infra/backup/rebuild.go`, shared with `ledgerctl store bootstrap`) folds every post-checkpoint ledger log into them. The replay evidence is the exported logs themselves — each registry mutation is derived from a log payload alone, never from state the source cluster held outside the export:
+
+- **`CreateIndex`** writes the same fresh registry row the live `processCreateIndex` writes, at `forward_encoding_version` 1, stamped with the enclosing `LedgerLog`'s date (the apply-time effective date). A duplicate `CreateIndex` overwrites the row, matching the live handler.
+- **`SetMetadataFieldType`** applies the retype cascade: when a registry row covers the retyped `(target, key)`, its `forward_encoding_version` is bumped, mirroring the live `processSetMetadataFieldType`. A field with no covering index is a registry no-op.
+- **`DropIndex`** deletes the registry row.
+- **`RemovedMetadataFieldType`** carries the removal cascade in the log itself: the payload names the index the removal dropped (`dropped_index`), and the row is deleted from the log alone — the replay never re-derives which index a removal covered.
+
+Same-window visibility follows the pattern of the other replayed projections (cf. volumes): replay-touched rows — including deletions, kept as explicit markers — are read back from the in-flight overlay, untouched rows from the committed checkpoint store. The deletion markers are what keep a later read in the same replay window from resurrecting a checkpoint row the replay already deleted (drop-then-recreate folds to exactly one live row).
+
+What is deliberately **not** restored: the per-replica `IndexVersionState` rows and the read-store keyspaces. Both live in each node's read store, outside the checkpoint. A restored node boots with an empty read store against the restored registry, so `loadIndexRegistry` schedules a fresh backfill for every registry entry (no local `CurrentVersion` yet) and the normal build lifecycle repopulates the keyspaces. A data directory whose `read-indexes/` survived an offline restore of an *older* backup is the classic corruption shape the checker's cursor pass reports — see [Checker Coverage](#checker-coverage).
+
 ## Statistics (computed on demand)
 
 There is **no persisted statistics structure**. The figures returned by `InspectIndex` are recomputed by scanning the live Pebble keyspace at the version the caller asks for.

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -641,7 +641,7 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 					}
 
 					if payload.Apply.GetLog() != nil && payload.Apply.GetLog().GetData() != nil {
-						if err := domainreplay.ReplayLedgerLog(ledgerName, seq, payload.Apply.GetLog().GetData(), replayWriter, rawLedgerTypes, ledgerAccountTypes, ephemeralPurgeBuffer); err != nil {
+						if err := domainreplay.ReplayLedgerLog(ledgerName, seq, payload.Apply.GetLog().GetData(), payload.Apply.GetLog().GetDate(), replayWriter, rawLedgerTypes, ledgerAccountTypes, ephemeralPurgeBuffer); err != nil {
 							return fmt.Errorf("replaying log %d: %w", seq, err)
 						}
 

--- a/internal/application/check/replay_store.go
+++ b/internal/application/check/replay_store.go
@@ -398,6 +398,17 @@ func (s *replayStore) RemoveMetadataFieldType(string, commonpb.TargetType, strin
 	return nil
 }
 
+// CreateIndex / DropIndex are no-ops here: the checker folds the index
+// registry itself (expectedIndexes in the Check() replay loop) and verifies
+// it against the stored rows in compareIndexes.
+func (s *replayStore) CreateIndex(string, *commonpb.IndexID, *commonpb.Timestamp) error {
+	return nil
+}
+
+func (s *replayStore) DropIndex(string, *commonpb.IndexID) error {
+	return nil
+}
+
 // AddAccountType / RemoveAccountType are no-ops here for the same reason as the
 // schema callbacks: account types live on LedgerInfo, not in this attribute merge
 // store. The checker maintains the account-type chart via ReplayLedgerLog's

--- a/internal/domain/replay/replay.go
+++ b/internal/domain/replay/replay.go
@@ -11,6 +11,8 @@ import (
 )
 
 // ReplayLedgerLog updates expected state in the writer based on a ledger log payload.
+// date is the enclosing LedgerLog's date — the apply-time effective date a
+// replayed CreateIndex stamps on its registry row.
 // rawLedgerTypes tracks the raw account type map for add/remove mutations.
 // ledgerAccountTypes tracks pre-compiled account types for ephemeral purge simulation.
 //
@@ -20,6 +22,7 @@ func ReplayLedgerLog(
 	ledger string,
 	seq uint64,
 	payload *commonpb.LedgerLogPayload,
+	date *commonpb.Timestamp,
 	w Writer,
 	rawLedgerTypes map[string]map[string]*commonpb.AccountType,
 	ledgerAccountTypes map[string][]accounttype.CompiledType,
@@ -206,15 +209,31 @@ func ReplayLedgerLog(
 			if err := w.RemoveMetadataFieldType(ledger, l.GetTargetType(), l.GetKey()); err != nil {
 				return fmt.Errorf("replaying removed metadata field type: %w", err)
 			}
+
+			// The cascade: the log names the index the removal dropped, so
+			// the registry row is deleted from the log alone.
+			if dropped := l.GetDroppedIndex(); dropped != nil {
+				if err := w.DropIndex(ledger, dropped); err != nil {
+					return fmt.Errorf("replaying removed field's dropped index: %w", err)
+				}
+			}
 		}
 	case *commonpb.LedgerLogPayload_FillGap:
 		// The log carries only the original v2 id; the skipped transaction
 		// ids live on the MirrorFillGap order, which the restore rebuild
 		// folds in from AuditItem.serialized_order (applyAuditOrderEffects).
 	case *commonpb.LedgerLogPayload_CreateIndex:
-		// Index operations — no state to track
+		if l := p.CreateIndex; l != nil && l.GetId() != nil {
+			if err := w.CreateIndex(ledger, l.GetId(), date); err != nil {
+				return fmt.Errorf("replaying created index: %w", err)
+			}
+		}
 	case *commonpb.LedgerLogPayload_DropIndex:
-		// Index operations — no state to track
+		if l := p.DropIndex; l != nil && l.GetId() != nil {
+			if err := w.DropIndex(ledger, l.GetId()); err != nil {
+				return fmt.Errorf("replaying dropped index: %w", err)
+			}
+		}
 	case *commonpb.LedgerLogPayload_UpdatedDefaultEnforcementMode:
 		if p.UpdatedDefaultEnforcementMode == nil {
 			return nil

--- a/internal/domain/replay/replay_test.go
+++ b/internal/domain/replay/replay_test.go
@@ -1,0 +1,237 @@
+package replay_test
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
+	"github.com/formancehq/ledger/v3/internal/domain/replay"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// writerStub satisfies replay.Writer with no-ops; the index hooks are
+// overridable so the dispatch tests can observe calls and inject failures.
+type writerStub struct {
+	createIndex func(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error
+	dropIndex   func(ledger string, id *commonpb.IndexID) error
+
+	removedFieldTypes int
+}
+
+func (w *writerStub) AddVolumeDelta([]byte, *big.Int, *big.Int) error { return nil }
+func (w *writerStub) GetVolume([]byte) (*raftcmdpb.VolumePair, error) { return nil, nil }
+func (w *writerStub) DeleteVolume([]byte) error                       { return nil }
+func (w *writerStub) MoveVolume([]byte, []byte) error                 { return nil }
+func (w *writerStub) SetMetadata([]byte, *commonpb.MetadataValue) error {
+	return nil
+}
+func (w *writerStub) DeleteMetadata([]byte) error       { return nil }
+func (w *writerStub) MoveMetadata([]byte, []byte) error { return nil }
+func (w *writerStub) CreateTransaction([]byte, uint64, *commonpb.Timestamp, map[string]*commonpb.MetadataValue, []*commonpb.Posting, uint64) error {
+	return nil
+}
+func (w *writerStub) SetTransactionReference(string, string, uint64) error { return nil }
+func (w *writerStub) SetRevertedBy([]byte, uint64, *commonpb.Timestamp) error {
+	return nil
+}
+func (w *writerStub) SaveTxMetadata([]byte, map[string]*commonpb.MetadataValue) error {
+	return nil
+}
+func (w *writerStub) DeleteTxMetadata([]byte, string) error { return nil }
+func (w *writerStub) SetMetadataFieldType(string, commonpb.TargetType, string, commonpb.MetadataType) error {
+	return nil
+}
+
+func (w *writerStub) RemoveMetadataFieldType(string, commonpb.TargetType, string) error {
+	w.removedFieldTypes++
+
+	return nil
+}
+
+func (w *writerStub) CreateIndex(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error {
+	if w.createIndex != nil {
+		return w.createIndex(ledger, id, createdAt)
+	}
+
+	return nil
+}
+
+func (w *writerStub) DropIndex(ledger string, id *commonpb.IndexID) error {
+	if w.dropIndex != nil {
+		return w.dropIndex(ledger, id)
+	}
+
+	return nil
+}
+
+func (w *writerStub) AddAccountType(string, *commonpb.AccountType) error { return nil }
+func (w *writerStub) RemoveAccountType(string, string) error             { return nil }
+func (w *writerStub) SetDefaultEnforcementMode(string, commonpb.ChartEnforcementMode) error {
+	return nil
+}
+
+func metaIndexID(key string) *commonpb.IndexID {
+	return &commonpb.IndexID{
+		Kind: &commonpb.IndexID_Metadata{
+			Metadata: &commonpb.MetadataIndexID{
+				Target: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:    key,
+			},
+		},
+	}
+}
+
+func replayOne(t *testing.T, w replay.Writer, date *commonpb.Timestamp, payload *commonpb.LedgerLogPayload) error {
+	t.Helper()
+
+	return replay.ReplayLedgerLog("ledger", 1, payload, date, w,
+		map[string]map[string]*commonpb.AccountType{},
+		map[string][]accounttype.CompiledType{}, nil)
+}
+
+func TestReplayLedgerLog_CreateIndexDispatch(t *testing.T) {
+	t.Parallel()
+
+	id := metaIndexID("k0")
+	date := &commonpb.Timestamp{Data: 42}
+
+	var gotLedger string
+	var gotID *commonpb.IndexID
+	var gotDate *commonpb.Timestamp
+
+	w := &writerStub{createIndex: func(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error {
+		gotLedger, gotID, gotDate = ledger, id, createdAt
+
+		return nil
+	}}
+
+	require.NoError(t, replayOne(t, w, date, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{
+			CreateIndex: &commonpb.CreatedIndexLog{Id: id},
+		},
+	}))
+	require.Equal(t, "ledger", gotLedger)
+	require.Same(t, id, gotID)
+	require.Same(t, date, gotDate)
+
+	// A malformed log with no id is skipped, not dispatched.
+	called := false
+	w = &writerStub{createIndex: func(string, *commonpb.IndexID, *commonpb.Timestamp) error {
+		called = true
+
+		return nil
+	}}
+	require.NoError(t, replayOne(t, w, date, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{CreateIndex: &commonpb.CreatedIndexLog{}},
+	}))
+	require.False(t, called)
+
+	// A writer failure surfaces.
+	boom := errors.New("boom")
+	w = &writerStub{createIndex: func(string, *commonpb.IndexID, *commonpb.Timestamp) error { return boom }}
+	require.ErrorIs(t, replayOne(t, w, date, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{
+			CreateIndex: &commonpb.CreatedIndexLog{Id: id},
+		},
+	}), boom)
+}
+
+func TestReplayLedgerLog_DropIndexDispatch(t *testing.T) {
+	t.Parallel()
+
+	id := metaIndexID("k0")
+
+	var gotID *commonpb.IndexID
+	w := &writerStub{dropIndex: func(_ string, id *commonpb.IndexID) error {
+		gotID = id
+
+		return nil
+	}}
+
+	require.NoError(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_DropIndex{
+			DropIndex: &commonpb.DroppedIndexLog{Id: id},
+		},
+	}))
+	require.Same(t, id, gotID)
+
+	called := false
+	w = &writerStub{dropIndex: func(string, *commonpb.IndexID) error {
+		called = true
+
+		return nil
+	}}
+	require.NoError(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_DropIndex{DropIndex: &commonpb.DroppedIndexLog{}},
+	}))
+	require.False(t, called)
+
+	boom := errors.New("boom")
+	w = &writerStub{dropIndex: func(string, *commonpb.IndexID) error { return boom }}
+	require.ErrorIs(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_DropIndex{
+			DropIndex: &commonpb.DroppedIndexLog{Id: id},
+		},
+	}), boom)
+}
+
+func TestReplayLedgerLog_RemovedFieldTypeCascade(t *testing.T) {
+	t.Parallel()
+
+	id := metaIndexID("k0")
+
+	// The cascade drops exactly the index the log names.
+	var gotID *commonpb.IndexID
+	w := &writerStub{dropIndex: func(_ string, id *commonpb.IndexID) error {
+		gotID = id
+
+		return nil
+	}}
+
+	require.NoError(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_RemovedMetadataFieldType{
+			RemovedMetadataFieldType: &commonpb.RemovedMetadataFieldTypeLog{
+				TargetType:   commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:          "k0",
+				DroppedIndex: id,
+			},
+		},
+	}))
+	require.Equal(t, 1, w.removedFieldTypes)
+	require.Same(t, id, gotID)
+
+	// A removal that dropped nothing leaves the registry untouched.
+	called := false
+	w = &writerStub{dropIndex: func(string, *commonpb.IndexID) error {
+		called = true
+
+		return nil
+	}}
+	require.NoError(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_RemovedMetadataFieldType{
+			RemovedMetadataFieldType: &commonpb.RemovedMetadataFieldTypeLog{
+				TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:        "k0",
+			},
+		},
+	}))
+	require.Equal(t, 1, w.removedFieldTypes)
+	require.False(t, called)
+
+	// A cascade failure surfaces.
+	boom := errors.New("boom")
+	w = &writerStub{dropIndex: func(string, *commonpb.IndexID) error { return boom }}
+	require.ErrorIs(t, replayOne(t, w, nil, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_RemovedMetadataFieldType{
+			RemovedMetadataFieldType: &commonpb.RemovedMetadataFieldTypeLog{
+				TargetType:   commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:          "k0",
+				DroppedIndex: id,
+			},
+		},
+	}), boom)
+}

--- a/internal/domain/replay/writer.go
+++ b/internal/domain/replay/writer.go
@@ -27,6 +27,12 @@ type Writer interface {
 	// a canonical attribute key.
 	SetMetadataFieldType(ledger string, target commonpb.TargetType, key string, fieldType commonpb.MetadataType) error
 	RemoveMetadataFieldType(ledger string, target commonpb.TargetType, key string) error
+	// Index registry rows live in the SubAttrIndex attribute zone, keyed by
+	// (ledger, IndexID). The removal cascade carries the dropped id on the
+	// RemovedMetadataFieldType log, so ReplayLedgerLog routes it through
+	// DropIndex with no schema lookup.
+	CreateIndex(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error
+	DropIndex(ledger string, id *commonpb.IndexID) error
 	// Account types also live on LedgerInfo and are keyed by ledger.
 	AddAccountType(ledger string, accountType *commonpb.AccountType) error
 	RemoveAccountType(ledger string, name string) error

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -512,6 +512,7 @@ func RebuildDelta(
 			writer.batch = batch
 			clear(writer.pendingVolumes)
 			clear(writer.pendingTx)
+			clear(writer.pendingIndexes)
 
 			logger.WithFields(map[string]any{
 				"logsProcessed": count,
@@ -905,10 +906,12 @@ type attributeReplayWriter struct {
 	pendingVolumes map[string]*raftcmdpb.VolumePair
 	pendingTx      map[string]*commonpb.TransactionState
 
-	// Index registry rows touched by the replay, keyed by the canonical
-	// IndexKey bytes. w.batch is non-indexed, so same-window reads (the
-	// retype version bump) resolve here first; a nil value marks a row the
-	// replay deleted, shadowing a committed checkpoint row.
+	// Index registry rows touched by the replay window, keyed by the
+	// canonical IndexKey bytes. w.batch is non-indexed, so same-window reads
+	// (the retype version bump) resolve here first; a nil value marks a row
+	// the replay deleted, shadowing a committed checkpoint row. Cleared at
+	// every batch commit alongside pendingVolumes/pendingTx — the committed
+	// rows are then visible through the direct store read.
 	pendingIndexes map[string]*commonpb.Index
 
 	// LedgerInfo per ledger, carrying the evolving metadata schema and account

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/accounttype"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/domain/replay"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
@@ -50,8 +51,10 @@ func RebuildDelta(
 		ledger:          attrs.Ledger,
 		references:      attrs.References,
 		boundary:        attrs.Boundary,
+		index:           attrs.Index,
 		pendingVolumes:  make(map[string]*raftcmdpb.VolumePair),
 		pendingTx:       make(map[string]*commonpb.TransactionState),
+		pendingIndexes:  make(map[string]*commonpb.Index),
 		ledgerInfos:     make(map[string]*commonpb.LedgerInfo),
 		boundaries:      make(map[string]*raftcmdpb.LedgerBoundaries),
 		reversions:      make(map[string]*bitset.Bitset),
@@ -186,7 +189,7 @@ func RebuildDelta(
 
 			ledgerName := p.Apply.GetLedgerName()
 
-			if err := replay.ReplayLedgerLog(ledgerName, seq, p.Apply.GetLog().GetData(), writer, rawLedgerTypes, ledgerAccountTypes, ephemeralPurgeBuffer); err != nil {
+			if err := replay.ReplayLedgerLog(ledgerName, seq, p.Apply.GetLog().GetData(), p.Apply.GetLog().GetDate(), writer, rawLedgerTypes, ledgerAccountTypes, ephemeralPurgeBuffer); err != nil {
 				_ = batch.Cancel()
 
 				return fmt.Errorf("replaying ledger log %d: %w", seq, err)
@@ -722,7 +725,81 @@ func (w *attributeReplayWriter) SetMetadataFieldType(ledger string, target commo
 		info.MetadataSchema.LedgerFields[key] = field
 	}
 
-	return w.saveLedgerInfo(info)
+	if err := w.saveLedgerInfo(info); err != nil {
+		return err
+	}
+
+	// The retype cascade processSetMetadataFieldType applies: if an index
+	// covers this field, bump its forward_encoding_version so the restored
+	// registry row matches the one the live apply wrote.
+	id := indexes.MetadataID(target, key)
+
+	row, err := w.getIndex(ledger, id)
+	if err != nil {
+		return fmt.Errorf("reading index registry row for retype cascade: %w", err)
+	}
+
+	if row == nil {
+		return nil
+	}
+
+	row = row.CloneVT()
+	row.BuildStatus = commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING
+	row.ForwardEncodingVersion++
+
+	return w.putIndex(ledger, id, row)
+}
+
+// CreateIndex writes the registry row the live processCreateIndex writes: a
+// fresh BUILDING entry at forward-encoding version 1, stamped with the log's
+// apply date. A duplicate CreateIndex overwrites the row, matching the live
+// handler.
+func (w *attributeReplayWriter) CreateIndex(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error {
+	return w.putIndex(ledger, id, &commonpb.Index{
+		Id:                     id,
+		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
+		CreatedAt:              createdAt,
+		Ledger:                 ledger,
+		ForwardEncodingVersion: 1,
+	})
+}
+
+// DropIndex deletes the registry row for (ledger, id) — the DropIndex log and
+// the RemovedMetadataFieldType cascade both land here. The pending entry is
+// set to nil (not removed) so a later same-window read does not resurrect a
+// committed checkpoint row the replay already deleted.
+func (w *attributeReplayWriter) DropIndex(ledger string, id *commonpb.IndexID) error {
+	key := indexes.KeyFor(ledger, id).Bytes()
+	w.pendingIndexes[string(key)] = nil
+
+	if err := w.index.Delete(w.batch, key); err != nil {
+		return fmt.Errorf("deleting index registry row: %w", err)
+	}
+
+	return nil
+}
+
+func (w *attributeReplayWriter) putIndex(ledger string, id *commonpb.IndexID, row *commonpb.Index) error {
+	key := indexes.KeyFor(ledger, id).Bytes()
+	w.pendingIndexes[string(key)] = row
+
+	if _, err := w.index.Set(w.batch, key, row); err != nil {
+		return fmt.Errorf("writing index registry row: %w", err)
+	}
+
+	return nil
+}
+
+// getIndex resolves the registry row for (ledger, id): replay-touched rows
+// (including nil deletion markers) come from pendingIndexes, checkpoint rows
+// from the committed store — same-batch visibility, cf. GetVolume.
+func (w *attributeReplayWriter) getIndex(ledger string, id *commonpb.IndexID) (*commonpb.Index, error) {
+	key := indexes.KeyFor(ledger, id).Bytes()
+	if row, ok := w.pendingIndexes[string(key)]; ok {
+		return row, nil
+	}
+
+	return w.index.Get(w.store, key)
 }
 
 // RemoveMetadataFieldType drops a field-type declaration from the ledger's
@@ -824,8 +901,15 @@ type attributeReplayWriter struct {
 	ledger         *attributes.Attribute[*commonpb.LedgerInfo]
 	references     *attributes.Attribute[*commonpb.TransactionReferenceValue]
 	boundary       *attributes.Attribute[*raftcmdpb.LedgerBoundaries]
+	index          *attributes.Attribute[*commonpb.Index]
 	pendingVolumes map[string]*raftcmdpb.VolumePair
 	pendingTx      map[string]*commonpb.TransactionState
+
+	// Index registry rows touched by the replay, keyed by the canonical
+	// IndexKey bytes. w.batch is non-indexed, so same-window reads (the
+	// retype version bump) resolve here first; a nil value marks a row the
+	// replay deleted, shadowing a committed checkpoint row.
+	pendingIndexes map[string]*commonpb.Index
 
 	// LedgerInfo per ledger, carrying the evolving metadata schema and account
 	// types. Both live on LedgerInfo (not a per-key attribute), so schema and

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -745,20 +745,18 @@ func (w *attributeReplayWriter) SetMetadataFieldType(ledger string, target commo
 	}
 
 	row = row.CloneVT()
-	row.BuildStatus = commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING
 	row.ForwardEncodingVersion++
 
 	return w.putIndex(ledger, id, row)
 }
 
 // CreateIndex writes the registry row the live processCreateIndex writes: a
-// fresh BUILDING entry at forward-encoding version 1, stamped with the log's
-// apply date. A duplicate CreateIndex overwrites the row, matching the live
+// fresh entry at forward-encoding version 1, stamped with the log's apply
+// date. A duplicate CreateIndex overwrites the row, matching the live
 // handler.
 func (w *attributeReplayWriter) CreateIndex(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error {
 	return w.putIndex(ledger, id, &commonpb.Index{
 		Id:                     id,
-		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
 		CreatedAt:              createdAt,
 		Ledger:                 ledger,
 		ForwardEncodingVersion: 1,

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -767,6 +767,8 @@ func newAttributeReplayWriter(t *testing.T) (*attributeReplayWriter, *attributes
 		reversions:      make(map[string]*bitset.Bitset),
 		dirtyReversions: make(map[string]struct{}),
 		readHandle:      readHandle,
+		index:           attrs.Index,
+		pendingIndexes:  make(map[string]*commonpb.Index),
 	}
 	t.Cleanup(func() { _ = writer.batch.Cancel() })
 
@@ -1334,4 +1336,104 @@ func TestRebuildDelta_BumpsCheckpointIndexOnRetype(t *testing.T) {
 	require.NotNil(t, row)
 	require.Equal(t, uint32(3), row.GetForwardEncodingVersion(), "the retype must bump the checkpoint row's version")
 	require.Equal(t, uint64(111), row.GetCreatedAt().GetData(), "the bump must not touch created_at")
+}
+
+// TestAttributeReplayWriter_SetMetadataFieldType_LedgerTarget pins the
+// ledger- and transaction-target arms of the replayed schema fold: each
+// declaration lands in its target's field map, and the ledger-target retype
+// cascade finds no covering index (there is no ledger-target metadata index),
+// so no registry row appears.
+func TestAttributeReplayWriter_SetMetadataFieldType_LedgerTarget(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	writer.ledgerInfos["ledger"] = &commonpb.LedgerInfo{Name: "ledger"}
+
+	require.NoError(t, writer.SetMetadataFieldType("ledger", commonpb.TargetType_TARGET_TYPE_LEDGER, "env",
+		commonpb.MetadataType_METADATA_TYPE_STRING))
+	require.NoError(t, writer.SetMetadataFieldType("ledger", commonpb.TargetType_TARGET_TYPE_TRANSACTION, "batch_id",
+		commonpb.MetadataType_METADATA_TYPE_UINT64))
+	require.NoError(t, writer.batch.Commit())
+
+	info, err := attrs.Ledger.Get(store, domain.LedgerKey{Name: "ledger"}.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_STRING,
+		info.GetMetadataSchema().GetLedgerFields()["env"].GetType())
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_UINT64,
+		info.GetMetadataSchema().GetTransactionFields()["batch_id"].GetType())
+
+	row, err := attrs.Index.Get(store, indexes.KeyFor("ledger",
+		indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_LEDGER, "env")).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, row)
+}
+
+// TestAttributeReplayWriter_RetypeCascade_MissingRowIsNoOp pins the cascade's
+// missing-row path: a field declaration with no covering index folds the
+// schema and writes no registry row.
+func TestAttributeReplayWriter_RetypeCascade_MissingRowIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	writer.ledgerInfos["ledger"] = &commonpb.LedgerInfo{Name: "ledger"}
+
+	metaID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier")
+
+	require.NoError(t, writer.SetMetadataFieldType("ledger", commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier",
+		commonpb.MetadataType_METADATA_TYPE_INT64))
+	require.NoError(t, writer.batch.Commit())
+
+	row, err := attrs.Index.Get(store, indexes.KeyFor("ledger", metaID).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, row)
+}
+
+// TestAttributeReplayWriter_RetypeCascade_TombstoneShadowsCheckpointRow pins
+// the same-window deletion marker: a checkpoint row dropped earlier in the
+// replay window must read as absent for the rest of the window, so a
+// subsequent retype of the same field neither bumps nor resurrects it.
+func TestAttributeReplayWriter_RetypeCascade_TombstoneShadowsCheckpointRow(t *testing.T) {
+	t.Parallel()
+
+	writer, attrs, store := newAttributeReplayWriter(t)
+	writer.ledgerInfos["ledger"] = &commonpb.LedgerInfo{Name: "ledger"}
+
+	metaID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier")
+
+	// Checkpoint state: the row is committed before the replay window opens.
+	seed := store.OpenWriteSession()
+	_, err := attrs.Index.Set(seed, indexes.KeyFor("ledger", metaID).Bytes(), &commonpb.Index{
+		Id:                     metaID,
+		Ledger:                 "ledger",
+		ForwardEncodingVersion: 2,
+	})
+	require.NoError(t, err)
+	require.NoError(t, seed.Commit())
+
+	require.NoError(t, writer.DropIndex("ledger", metaID))
+	require.NoError(t, writer.SetMetadataFieldType("ledger", commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier",
+		commonpb.MetadataType_METADATA_TYPE_UINT64))
+	require.NoError(t, writer.batch.Commit())
+
+	row, err := attrs.Index.Get(store, indexes.KeyFor("ledger", metaID).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, row, "the dropped checkpoint row must not be bumped back into existence")
+}
+
+// TestAttributeReplayWriter_RetypeCascade_ReadFailureSurfaces pins the
+// cascade's read error path: a failing registry read fails the schema fold
+// loudly instead of silently restoring a registry missing the version bump.
+func TestAttributeReplayWriter_RetypeCascade_ReadFailureSurfaces(t *testing.T) {
+	t.Parallel()
+
+	writer, _, _ := newAttributeReplayWriter(t)
+	writer.ledgerInfos["ledger"] = &commonpb.LedgerInfo{Name: "ledger"}
+
+	closed := newRebuildTestStore(t)
+	require.NoError(t, closed.Close())
+	writer.store = closed
+
+	err := writer.SetMetadataFieldType("ledger", commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier",
+		commonpb.MetadataType_METADATA_TYPE_INT64)
+	require.ErrorContains(t, err, "retype cascade")
 }

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -1306,7 +1306,6 @@ func TestRebuildDelta_BumpsCheckpointIndexOnRetype(t *testing.T) {
 	seed := store.OpenWriteSession()
 	_, err := attrs.Index.Set(seed, indexes.KeyFor("ledger", metaID).Bytes(), &commonpb.Index{
 		Id:                     metaID,
-		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
 		CreatedAt:              &commonpb.Timestamp{Data: 111},
 		Ledger:                 "ledger",
 		ForwardEncodingVersion: 2,

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -11,6 +11,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
@@ -1194,4 +1195,144 @@ func TestRebuildDelta_ReplaysRevokeSigningKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+// applyLedgerLogAt is applyLedgerLog with an explicit log date — the replayed
+// CreateIndex stamps it on the registry row.
+func applyLedgerLogAt(seq uint64, ledger string, date uint64, payload *commonpb.LedgerLogPayload) *commonpb.Log {
+	log := applyLedgerLog(seq, ledger, payload)
+	log.GetPayload().GetApply().GetLog().Date = &commonpb.Timestamp{Data: date}
+
+	return log
+}
+
+func TestRebuildDelta_ReplaysIndexRegistry(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+
+	metaID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "k0")
+	refID := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	dateID := indexes.LogBuiltinID(commonpb.LogBuiltinIndex_LOG_BUILTIN_INDEX_DATE)
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetProto(coldLogKey(1), createLedgerLog(1, "ledger", 1)))
+	require.NoError(t, batch.SetProto(coldLogKey(2), applyLedgerLog(2, "ledger", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_SetMetadataFieldType{
+			SetMetadataFieldType: &commonpb.SetMetadataFieldTypeLog{
+				TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:        "k0",
+				Type:       commonpb.MetadataType_METADATA_TYPE_INT64,
+			},
+		},
+	})))
+	require.NoError(t, batch.SetProto(coldLogKey(3), applyLedgerLogAt(3, "ledger", 777, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{
+			CreateIndex: &commonpb.CreatedIndexLog{Id: metaID},
+		},
+	})))
+	// Retype: bumps the covered index's forward-encoding version.
+	require.NoError(t, batch.SetProto(coldLogKey(4), applyLedgerLog(4, "ledger", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_SetMetadataFieldType{
+			SetMetadataFieldType: &commonpb.SetMetadataFieldTypeLog{
+				TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:        "k0",
+				Type:       commonpb.MetadataType_METADATA_TYPE_UINT64,
+			},
+		},
+	})))
+	require.NoError(t, batch.SetProto(coldLogKey(5), applyLedgerLogAt(5, "ledger", 888, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{
+			CreateIndex: &commonpb.CreatedIndexLog{Id: refID},
+		},
+	})))
+	require.NoError(t, batch.SetProto(coldLogKey(6), applyLedgerLogAt(6, "ledger", 999, &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_CreateIndex{
+			CreateIndex: &commonpb.CreatedIndexLog{Id: dateID},
+		},
+	})))
+	// The removal cascade: the log carries the dropped index id.
+	require.NoError(t, batch.SetProto(coldLogKey(7), applyLedgerLog(7, "ledger", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_RemovedMetadataFieldType{
+			RemovedMetadataFieldType: &commonpb.RemovedMetadataFieldTypeLog{
+				TargetType:   commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:          "k0",
+				DroppedIndex: metaID,
+			},
+		},
+	})))
+	require.NoError(t, batch.SetProto(coldLogKey(8), applyLedgerLog(8, "ledger", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_DropIndex{
+			DropIndex: &commonpb.DroppedIndexLog{Id: refID},
+		},
+	})))
+	require.NoError(t, batch.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	attrs := attributes.New()
+
+	metaRow, err := attrs.Index.Get(handle, indexes.KeyFor("ledger", metaID).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, metaRow, "the field removal's cascade must drop the registry row")
+
+	refRow, err := attrs.Index.Get(handle, indexes.KeyFor("ledger", refID).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, refRow, "the DropIndex log must drop the registry row")
+
+	dateRow, err := attrs.Index.Get(handle, indexes.KeyFor("ledger", dateID).Bytes())
+	require.NoError(t, err)
+	require.NotNil(t, dateRow, "a created index must survive the rebuild")
+	require.Equal(t, "ledger", dateRow.GetLedger())
+	require.True(t, indexes.Equal(dateID, dateRow.GetId()))
+	require.Equal(t, uint32(1), dateRow.GetForwardEncodingVersion())
+	require.Equal(t, uint64(999), dateRow.GetCreatedAt().GetData())
+}
+
+func TestRebuildDelta_BumpsCheckpointIndexOnRetype(t *testing.T) {
+	t.Parallel()
+
+	store := newRebuildTestStore(t)
+	attrs := attributes.New()
+
+	metaID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "k0")
+
+	// Checkpoint state: the index predates the delta, so the retype's bump
+	// must read it from the committed store, not from the replay window.
+	seed := store.OpenWriteSession()
+	_, err := attrs.Index.Set(seed, indexes.KeyFor("ledger", metaID).Bytes(), &commonpb.Index{
+		Id:                     metaID,
+		BuildStatus:            commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING,
+		CreatedAt:              &commonpb.Timestamp{Data: 111},
+		Ledger:                 "ledger",
+		ForwardEncodingVersion: 2,
+	})
+	require.NoError(t, err)
+	require.NoError(t, seed.SetProto(coldLogKey(1), createLedgerLog(1, "ledger", 1)))
+	require.NoError(t, seed.SetProto(coldLogKey(2), applyLedgerLog(2, "ledger", &commonpb.LedgerLogPayload{
+		Payload: &commonpb.LedgerLogPayload_SetMetadataFieldType{
+			SetMetadataFieldType: &commonpb.SetMetadataFieldTypeLog{
+				TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:        "k0",
+				Type:       commonpb.MetadataType_METADATA_TYPE_UINT64,
+			},
+		},
+	})))
+	require.NoError(t, seed.Commit())
+
+	require.NoError(t, RebuildDelta(context.Background(), testLogger(), store, 0, 0))
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	row, err := attrs.Index.Get(handle, indexes.KeyFor("ledger", metaID).Bytes())
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.Equal(t, uint32(3), row.GetForwardEncodingVersion(), "the retype must bump the checkpoint row's version")
+	require.Equal(t, uint64(111), row.GetCreatedAt().GetData(), "the bump must not touch created_at")
 }

--- a/tests/e2e/cluster/restore_index_registry_test.go
+++ b/tests/e2e/cluster/restore_index_registry_test.go
@@ -32,18 +32,29 @@ import (
 // (singleton_driver_model: remove-field-type dropped-index mismatch): after a
 // backup/restore cycle, a removeFieldType on an indexed field reports nothing
 // dropped even though the CreateIndex committed before the backup. The live
-// FSM persists index registry rows in the main store, but the restore rebuild
-// (backup.RebuildDelta → replay.ReplayLedgerLog) discards CreateIndex and
-// DropIndex logs (internal/domain/replay/replay.go, "no state to track"), so
-// a restored store keeps the metadata schema while losing every index
-// registry row. The removal's cascade then finds no entry, dropped_index
-// stays empty, and the index outlives its declaration on the read side.
+// FSM persists index registry rows in the main store, and the restore rebuild
+// (backup.RebuildDelta → replay.ReplayLedgerLog) must fold CreateIndex /
+// DropIndex / the removal cascade / the retype version bump back into them.
+//
+// Per the incremental-restore contract, the registry lifecycle spans the
+// checkpoint boundary: rows seeded BEFORE the full checkpoint are then
+// retyped (version fold over checkpoint state) and cascade-deleted by the
+// delta, one row is created inside the delta, and the restored store must
+// hold the complete logical rows the source held — verified field by field
+// and by a clean CheckStore pass.
 var _ = Describe("Restore index registry", Ordered, func() {
 	const (
 		ledgerName = "idxreg-ledger"
 		s3Bucket   = "restore-index-registry"
 		clusterID  = "idxreg-cluster"
-		fieldKey   = "k0"
+
+		// retypedKey's index is seeded before the checkpoint and version-bumped
+		// by the delta; removedKey's index is seeded before the checkpoint and
+		// cascade-deleted by the delta; deltaKey's index only ever exists in
+		// the delta.
+		retypedKey = "k0"
+		removedKey = "k1"
+		deltaKey   = "k2"
 	)
 
 	// One logical node stops and returns across the three phases, so every
@@ -56,33 +67,37 @@ var _ = Describe("Restore index registry", Ordered, func() {
 		restoreWalDir  string
 		restoreDataDir string
 		minioEndpoint  string
+
+		// sourceRows carries the source node's complete registry rows (keyed
+		// by metadata field key) from Phase 1 into the Phase 3 comparison.
+		sourceRows map[string]*commonpb.Index
 	)
 
-	indexID := &commonpb.IndexID{
-		Kind: &commonpb.IndexID_Metadata{
-			Metadata: &commonpb.MetadataIndexID{
-				Target: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
-				Key:    fieldKey,
+	metaIndexID := func(key string) *commonpb.IndexID {
+		return &commonpb.IndexID{
+			Kind: &commonpb.IndexID_Metadata{
+				Metadata: &commonpb.MetadataIndexID{
+					Target: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+					Key:    key,
+				},
 			},
-		},
+		}
 	}
 
-	// expectRegisteredIndex asserts the (ACCOUNT, k0) metadata index is present
-	// in the ledger's registry. Used both as the live-side premise guard and as
-	// the post-restore check.
-	expectRegisteredIndex := func(client servicepb.BucketServiceClient, phase string) {
+	// registryRow returns the (ACCOUNT, key) metadata index row from the
+	// ledger's registry, or nil when absent.
+	registryRow := func(client servicepb.BucketServiceClient, key string) *commonpb.Index {
 		st, err := client.GetIndexStatus(ctx, &servicepb.GetIndexStatusRequest{Ledger: ledgerName})
-		Expect(err).To(Succeed(), "%s: GetIndexStatus", phase)
+		Expect(err).To(Succeed(), "GetIndexStatus")
 
-		found := false
 		for _, e := range st.GetIndexes() {
 			meta := e.GetIndex().GetId().GetMetadata()
-			if meta.GetTarget() == commonpb.TargetType_TARGET_TYPE_ACCOUNT && meta.GetKey() == fieldKey {
-				found = true
+			if meta.GetTarget() == commonpb.TargetType_TARGET_TYPE_ACCOUNT && meta.GetKey() == key {
+				return e.GetIndex()
 			}
 		}
 
-		Expect(found).To(BeTrue(), "%s: metadata index (ACCOUNT, %s) missing from registry: %v", phase, fieldKey, st.GetIndexes())
+		return nil
 	}
 
 	storage := func() *commonpb.BackupStorage {
@@ -137,7 +152,7 @@ var _ = Describe("Restore index registry", Ordered, func() {
 		Expect(err).To(Succeed())
 	})
 
-	Describe("Phase 1: index registration in the exported delta", Ordered, func() {
+	Describe("Phase 1: registry lifecycle across the checkpoint boundary", Ordered, func() {
 		var (
 			sourceServer  *testservice.Service
 			client        servicepb.BucketServiceClient
@@ -169,14 +184,6 @@ var _ = Describe("Restore index registry", Ordered, func() {
 				g.Expect(err).To(Succeed())
 				return state.Leader != 0
 			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
-
-			// Full checkpoint on the EMPTY store: everything after it lands in
-			// the incremental delta, so the restore reconstructs the registry
-			// purely by replaying the exported log instead of copying
-			// checkpoint files.
-			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
-			Expect(err).To(Succeed())
-			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
 		})
 
 		AfterAll(func() {
@@ -186,29 +193,84 @@ var _ = Describe("Restore index registry", Ordered, func() {
 			Expect(sourceServer.Stop(stopCtx)).To(Succeed())
 		})
 
-		It("declares the field and creates its index", func() {
+		It("seeds registry rows and checkpoints them", func() {
 			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
 				actions.CreateLedgerAction(ledgerName, nil),
-				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, fieldKey, commonpb.MetadataType_METADATA_TYPE_INT64),
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, retypedKey, commonpb.MetadataType_METADATA_TYPE_INT64),
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, removedKey, commonpb.MetadataType_METADATA_TYPE_INT64),
 				&servicepb.Request{
 					Type: &servicepb.Request_CreateIndex{
-						CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledgerName, Id: indexID},
+						CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledgerName, Id: metaIndexID(retypedKey)},
+					},
+				},
+				&servicepb.Request{
+					Type: &servicepb.Request_CreateIndex{
+						CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledgerName, Id: metaIndexID(removedKey)},
 					},
 				},
 			))
 			Expect(err).To(Succeed())
+
+			// The full checkpoint carries both rows; everything after this
+			// backup reaches the restored store only through the delta fold.
+			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
 		})
 
-		It("serves the index back on the live node", func() {
-			// Premise guard: the live path must register the index; without it
-			// the restore assertions would be vacuous.
-			expectRegisteredIndex(client, "live")
+		It("mutates the registry in the delta", func() {
+			// Retype: the delta must fold a version bump onto a checkpoint row.
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, retypedKey, commonpb.MetadataType_METADATA_TYPE_UINT64),
+			))
+			Expect(err).To(Succeed())
+
+			// Delta-created row.
+			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, deltaKey, commonpb.MetadataType_METADATA_TYPE_INT64),
+				&servicepb.Request{
+					Type: &servicepb.Request_CreateIndex{
+						CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledgerName, Id: metaIndexID(deltaKey)},
+					},
+				},
+			))
+			Expect(err).To(Succeed())
+
+			// Cascade-delete a checkpoint row; the live side must report the
+			// drop (the model finding's premise).
+			resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.RemoveMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, removedKey),
+			))
+			Expect(err).To(Succeed())
+
+			var removed *commonpb.RemovedMetadataFieldTypeLog
+			for _, lg := range resp.GetLogs() {
+				if rm := lg.GetPayload().GetApply().GetLog().GetData().GetRemovedMetadataFieldType(); rm != nil {
+					removed = rm
+				}
+			}
+			Expect(removed).ToNot(BeNil())
+			Expect(removed.GetDroppedIndex()).ToNot(BeNil(), "live premise: the removal must drop the checkpoint-seeded index")
 		})
 
-		It("exports the delta", func() {
+		It("exports the delta and captures the source registry", func() {
 			incResp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{Storage: storage()})
 			Expect(err).To(Succeed())
 			Expect(incResp.GetLogEntriesExported()).To(BeNumerically(">", 0))
+
+			sourceRows = map[string]*commonpb.Index{
+				retypedKey: registryRow(client, retypedKey),
+				removedKey: registryRow(client, removedKey),
+				deltaKey:   registryRow(client, deltaKey),
+			}
+
+			// Source premises: the comparison below is only meaningful if the
+			// live node holds the expected end state.
+			Expect(sourceRows[retypedKey]).ToNot(BeNil())
+			Expect(sourceRows[retypedKey].GetForwardEncodingVersion()).To(Equal(uint32(2)), "the retype must have bumped the checkpoint row")
+			Expect(sourceRows[removedKey]).To(BeNil(), "the cascade must have deleted the checkpoint row")
+			Expect(sourceRows[deltaKey]).ToNot(BeNil())
+			Expect(sourceRows[deltaKey].GetForwardEncodingVersion()).To(Equal(uint32(1)))
 		})
 	})
 
@@ -306,13 +368,37 @@ var _ = Describe("Restore index registry", Ordered, func() {
 			_ = os.RemoveAll(restoreDataDir)
 		})
 
-		It("preserves the index registry entry across the rebuild", func() {
-			expectRegisteredIndex(client, "restored")
+		It("restores the complete registry rows", func() {
+			// expectSameRow compares the full logical row, not just presence:
+			// identity, scope, forward-encoding version, build status and
+			// creation date must all survive the checkpoint+delta composition.
+			expectSameRow := func(key string) {
+				source := sourceRows[key]
+				restored := registryRow(client, key)
+				Expect(restored).ToNot(BeNil(), "row for %q missing after restore", key)
+				Expect(restored.GetId().GetMetadata().GetKey()).To(Equal(source.GetId().GetMetadata().GetKey()))
+				Expect(restored.GetId().GetMetadata().GetTarget()).To(Equal(source.GetId().GetMetadata().GetTarget()))
+				Expect(restored.GetLedger()).To(Equal(source.GetLedger()), "%q: ledger", key)
+				Expect(restored.GetForwardEncodingVersion()).To(Equal(source.GetForwardEncodingVersion()), "%q: forward_encoding_version", key)
+				Expect(restored.GetBuildStatus()).To(Equal(source.GetBuildStatus()), "%q: build_status", key)
+				Expect(restored.GetCreatedAt().GetData()).To(Equal(source.GetCreatedAt().GetData()), "%q: created_at", key)
+			}
+
+			expectSameRow(retypedKey)
+			expectSameRow(deltaKey)
+
+			Expect(registryRow(client, removedKey)).To(BeNil(), "the cascade-deleted checkpoint row must not resurrect")
 		})
 
-		It("drops the index when its field is removed", func() {
+		It("passes CheckStore on the restored store", func() {
+			result, err := actions.CollectCheckStoreEvents(ctx, client)
+			Expect(err).To(Succeed())
+			Expect(result.Errors).To(BeEmpty(), "CheckStore errors on the restored store: %v", result.Errors)
+		})
+
+		It("drops the retyped index when its field is removed", func() {
 			resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
-				actions.RemoveMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, fieldKey),
+				actions.RemoveMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, retypedKey),
 			))
 			Expect(err).To(Succeed())
 

--- a/tests/e2e/cluster/restore_index_registry_test.go
+++ b/tests/e2e/cluster/restore_index_registry_test.go
@@ -1,0 +1,331 @@
+//go:build e2e && s3
+
+package cluster
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc"
+)
+
+// This suite pins the dropped-index loss the model test surfaced
+// (singleton_driver_model: remove-field-type dropped-index mismatch): after a
+// backup/restore cycle, a removeFieldType on an indexed field reports nothing
+// dropped even though the CreateIndex committed before the backup. The live
+// FSM persists index registry rows in the main store, but the restore rebuild
+// (backup.RebuildDelta → replay.ReplayLedgerLog) discards CreateIndex and
+// DropIndex logs (internal/domain/replay/replay.go, "no state to track"), so
+// a restored store keeps the metadata schema while losing every index
+// registry row. The removal's cascade then finds no entry, dropped_index
+// stays empty, and the index outlives its declaration on the read side.
+var _ = Describe("Restore index registry", Ordered, func() {
+	const (
+		ledgerName = "idxreg-ledger"
+		s3Bucket   = "restore-index-registry"
+		clusterID  = "idxreg-cluster"
+		fieldKey   = "k0"
+	)
+
+	// One logical node stops and returns across the three phases, so every
+	// phase reuses the same allocated ports (cf. restore_metadata_type_test).
+	lease := testserver.AllocateNodeLease()
+	ports := lease.Ports()
+
+	var (
+		ctx            context.Context
+		restoreWalDir  string
+		restoreDataDir string
+		minioEndpoint  string
+	)
+
+	indexID := &commonpb.IndexID{
+		Kind: &commonpb.IndexID_Metadata{
+			Metadata: &commonpb.MetadataIndexID{
+				Target: commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+				Key:    fieldKey,
+			},
+		},
+	}
+
+	// expectRegisteredIndex asserts the (ACCOUNT, k0) metadata index is present
+	// in the ledger's registry. Used both as the live-side premise guard and as
+	// the post-restore check.
+	expectRegisteredIndex := func(client servicepb.BucketServiceClient, phase string) {
+		st, err := client.GetIndexStatus(ctx, &servicepb.GetIndexStatusRequest{Ledger: ledgerName})
+		Expect(err).To(Succeed(), "%s: GetIndexStatus", phase)
+
+		found := false
+		for _, e := range st.GetIndexes() {
+			meta := e.GetIndex().GetId().GetMetadata()
+			if meta.GetTarget() == commonpb.TargetType_TARGET_TYPE_ACCOUNT && meta.GetKey() == fieldKey {
+				found = true
+			}
+		}
+
+		Expect(found).To(BeTrue(), "%s: metadata index (ACCOUNT, %s) missing from registry: %v", phase, fieldKey, st.GetIndexes())
+	}
+
+	storage := func() *commonpb.BackupStorage {
+		return testutil.S3BackupStorage(&commonpb.S3StorageConfig{
+			Bucket:   s3Bucket,
+			Region:   restoreS3Region,
+			Endpoint: minioEndpoint,
+		})
+	}
+
+	BeforeAll(func() {
+		ctx = logging.TestingContext()
+
+		container, err := testcontainers.Run(context.Background(), testutil.MinIOImage,
+			testcontainers.WithEnv(map[string]string{
+				"MINIO_ROOT_USER":     restoreMinioAccessKey,
+				"MINIO_ROOT_PASSWORD": restoreMinioSecretKey,
+			}),
+			testcontainers.WithCmd("server", "/data"),
+			testcontainers.WithExposedPorts("9000/tcp"),
+			testcontainers.WithWaitStrategy(
+				wait.ForHTTP("/minio/health/live").WithPort("9000/tcp").WithStartupTimeout(30*time.Second),
+			),
+		)
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { _ = container.Terminate(context.Background()) })
+
+		minioEndpoint, err = container.Endpoint(context.Background(), "http")
+		Expect(err).To(Succeed())
+
+		cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(restoreS3Region),
+			awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				restoreMinioAccessKey, restoreMinioSecretKey, "",
+			)),
+		)
+		Expect(err).To(Succeed())
+
+		s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(minioEndpoint)
+			o.UsePathStyle = true
+		})
+		_, err = s3Client.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(s3Bucket)})
+		Expect(err).To(Succeed())
+
+		GinkgoT().Setenv("AWS_ACCESS_KEY_ID", restoreMinioAccessKey)
+		GinkgoT().Setenv("AWS_SECRET_ACCESS_KEY", restoreMinioSecretKey)
+
+		restoreWalDir, err = os.MkdirTemp("", "idxreg-restore-wal-*")
+		Expect(err).To(Succeed())
+		restoreDataDir, err = os.MkdirTemp("", "idxreg-restore-data-*")
+		Expect(err).To(Succeed())
+	})
+
+	Describe("Phase 1: index registration in the exported delta", Ordered, func() {
+		var (
+			sourceServer  *testservice.Service
+			client        servicepb.BucketServiceClient
+			clusterClient clusterpb.ClusterServiceClient
+			grpcConn      *grpc.ClientConn
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				Ports:     ports,
+				WalDir:    GinkgoT().TempDir(),
+				DataDir:   GinkgoT().TempDir(),
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			sourceServer = lease.NewService(cmdserver.NewRunCommandWithBindings, testservice.WithInstruments(instruments...))
+			Expect(sourceServer.Start(ctx)).To(Succeed())
+
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(ports.GRPC())
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+
+			// Full checkpoint on the EMPTY store: everything after it lands in
+			// the incremental delta, so the restore reconstructs the registry
+			// purely by replaying the exported log instead of copying
+			// checkpoint files.
+			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(sourceServer.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("declares the field and creates its index", func() {
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateLedgerAction(ledgerName, nil),
+				actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, fieldKey, commonpb.MetadataType_METADATA_TYPE_INT64),
+				&servicepb.Request{
+					Type: &servicepb.Request_CreateIndex{
+						CreateIndex: &servicepb.CreateIndexRequest{Ledger: ledgerName, Id: indexID},
+					},
+				},
+			))
+			Expect(err).To(Succeed())
+		})
+
+		It("serves the index back on the live node", func() {
+			// Premise guard: the live path must register the index; without it
+			// the restore assertions would be vacuous.
+			expectRegisteredIndex(client, "live")
+		})
+
+		It("exports the delta", func() {
+			incResp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(incResp.GetLogEntriesExported()).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("Phase 2: restore", Ordered, func() {
+		var (
+			restoreClient restorepb.RestoreServiceClient
+			grpcConn      *grpc.ClientConn
+			server        *testservice.Service
+		)
+
+		BeforeAll(func() {
+			server = lease.NewService(cmdserver.NewRunCommandWithBindings,
+				testservice.WithInstruments(
+					testservice.DebugInstrumentation(testutil.Debug),
+					testservice.OutputInstrumentation(GinkgoWriter),
+					testserver.WithNodeID(1),
+					testserver.WithClusterID(clusterID),
+					testserver.WithHTTPPort(ports.HTTP()),
+					testserver.WithWalDir(restoreWalDir),
+					testserver.WithDataDir(restoreDataDir),
+					testserver.WithRaftPort(ports.Raft()),
+					testserver.WithGRPCPort(ports.GRPC()),
+					testserver.WithRestore(),
+				),
+			)
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var err error
+			restoreClient, grpcConn, err = newRestoreGRPCClient(ports.GRPC())
+			Expect(err).To(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+		})
+
+		It("downloads and finalizes the backup", func() {
+			startResp, err := restoreClient.StartDownloadBackup(ctx, &restorepb.StartDownloadBackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+
+			Eventually(func() restorepb.DownloadState {
+				resp, statusErr := restoreClient.GetDownloadStatus(ctx, &restorepb.GetDownloadStatusRequest{JobId: startResp.GetJobId()})
+				Expect(statusErr).To(Succeed())
+				return resp.GetState()
+			}, 2*time.Minute, 500*time.Millisecond).Should(Equal(restorepb.DownloadState_DOWNLOAD_STATE_SUCCEEDED))
+
+			_, err = restoreClient.FinalizeRestore(ctx, &restorepb.FinalizeRestoreRequest{})
+			Expect(err).To(Succeed())
+		})
+	})
+
+	Describe("Phase 3: verify the restored registry", Ordered, func() {
+		var (
+			client   servicepb.BucketServiceClient
+			grpcConn *grpc.ClientConn
+			server   *testservice.Service
+		)
+
+		BeforeAll(func() {
+			instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+				NodeID:    1,
+				ClusterID: clusterID,
+				Ports:     ports,
+				WalDir:    restoreWalDir,
+				DataDir:   restoreDataDir,
+				Debug:     testutil.Debug,
+				Output:    GinkgoWriter,
+			})
+			instruments = append(instruments, testserver.WithBootstrap())
+
+			server = lease.NewService(cmdserver.NewRunCommandWithBindings, testservice.WithInstruments(instruments...))
+			Expect(server.Start(ctx)).To(Succeed())
+
+			var clusterClient clusterpb.ClusterServiceClient
+			var err error
+			client, clusterClient, grpcConn, err = testutil.NewGRPCClient(ports.GRPC())
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				state, err := clusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+				g.Expect(err).To(Succeed())
+				return state.Leader != 0
+			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
+		})
+
+		AfterAll(func() {
+			_ = grpcConn.Close()
+			stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+			_ = os.RemoveAll(restoreWalDir)
+			_ = os.RemoveAll(restoreDataDir)
+		})
+
+		It("preserves the index registry entry across the rebuild", func() {
+			expectRegisteredIndex(client, "restored")
+		})
+
+		It("drops the index when its field is removed", func() {
+			resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.RemoveMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, fieldKey),
+			))
+			Expect(err).To(Succeed())
+
+			var removed *commonpb.RemovedMetadataFieldTypeLog
+			for _, lg := range resp.GetLogs() {
+				if rm := lg.GetPayload().GetApply().GetLog().GetData().GetRemovedMetadataFieldType(); rm != nil {
+					removed = rm
+				}
+			}
+
+			Expect(removed).ToNot(BeNil(), "removal log missing from response: %v", resp.GetLogs())
+			Expect(removed.GetDroppedIndex()).ToNot(BeNil(),
+				"field removal reported nothing dropped — the registry lost the index across the restore")
+		})
+	})
+})

--- a/tests/e2e/cluster/restore_index_registry_test.go
+++ b/tests/e2e/cluster/restore_index_registry_test.go
@@ -380,7 +380,6 @@ var _ = Describe("Restore index registry", Ordered, func() {
 				Expect(restored.GetId().GetMetadata().GetTarget()).To(Equal(source.GetId().GetMetadata().GetTarget()))
 				Expect(restored.GetLedger()).To(Equal(source.GetLedger()), "%q: ledger", key)
 				Expect(restored.GetForwardEncodingVersion()).To(Equal(source.GetForwardEncodingVersion()), "%q: forward_encoding_version", key)
-				Expect(restored.GetBuildStatus()).To(Equal(source.GetBuildStatus()), "%q: build_status", key)
 				Expect(restored.GetCreatedAt().GetData()).To(Equal(source.GetCreatedAt().GetData()), "%q: created_at", key)
 			}
 


### PR DESCRIPTION
## The bug

`RebuildDelta` → `replay.ReplayLedgerLog` discarded `CreateIndex`/`DropIndex` logs (`// Index operations — no state to track`), so a restored store kept the metadata schema while losing **every index registry row**. The next `removeFieldType` on an indexed field found nothing to drop, `dropped_index` stayed empty, and the read-side index (which folds logs itself) survived a field that no longer existed.

This is the root cause of the Antithesis `singleton_driver_model: remove-field-type dropped-index mismatch` finding (~30–57/run): every composer restore cycle silently emptied the registry. Traced end-to-end on run `6991af2a…`: k0's CreateIndex = log seq 351, restore-cycle backup `lastLogSequence: 386` (the create **was** in the backup), restored cluster at term 1, rmFT at seq 429 → empty drop. Replaying the same committed stream sequentially on one node (no restore) behaves correctly — the op stream is clean, the restore rebuild was the divergence.

## The fix

`ReplayLedgerLog` routes index activity through the `replay.Writer`:

- `CreatedIndexLog` → put the row `processCreateIndex` writes (BUILDING, version 1, created_at = the log's date; overwrite on duplicate, same as live).
- `DroppedIndexLog` → delete the row.
- `RemovedMetadataFieldType` cascade → delete the row named by the log's `dropped_index` (carried on the log — no schema rederivation).
- Retype (`SetMetadataFieldType`) → bump `forward_encoding_version` on a covered index, mirroring the live cascade. The bump matters: the registry version and the readstore's refolded `IndexVersionState` must agree on which versioned keyspace is current.

Backup writer details: same-window reads resolve through a `pendingIndexes` map with nil deletion markers (the write session is non-indexed, cf. `GetVolume`); checkpoint rows come from the committed store, covering incremental restores where the create predates the delta. The checker's `replayStore` implements the new interface methods as documented no-ops — the checker folds `expectedIndexes` itself. `DeleteLedger` needs nothing here: the pending-cleanup marker the rebuild already records drives the covering purge that range-deletes the ledger's `SubAttrIndex` zone.

## Tests

- `tests/e2e/cluster/restore_index_registry_test.go` — mirrors `restore_metadata_type_test.go` (which pinned the same class of rebuild loss for typed metadata): create index → full backup → incremental → restore → the registry entry must survive and a `removeFieldType` must report it dropped. **Red on base, green with the fix** (verified both directions).
- `TestRebuildDelta_ReplaysIndexRegistry` — unit fold: create/retype/cascade-drop/drop + a surviving index with exact field assertions (date stamp, version).
- `TestRebuildDelta_BumpsCheckpointIndexOnRetype` — incremental path: the retype bump reads the checkpoint row from the committed store.

Note: `BuildStatus` handling here mirrors the current live writes; #1766 (EN-1858) deletes the field, and whichever lands second rebases trivially (compile error on the removed field).