### PR TITLE
fix(bloom): enforce Stop ownership boundary

### DIFF
--- a/internal/infra/state/cache_snapshotter.go
+++ b/internal/infra/state/cache_snapshotter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"sync"
 	"time"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
@@ -287,6 +288,8 @@ func newProtoSnapshotSlot[V interface {
 // the reader as a parameter and are only called from non-hot-path contexts
 // (Recovery, bootstrap).
 type CacheSnapshotter struct {
+	bloomMu      sync.Mutex
+	bloomStopped bool
 	logger       logging.Logger
 	registry     *StateRegistry
 	bloomFilters *bloom.FilterSet
@@ -774,6 +777,11 @@ func (s *CacheSnapshotter) restoreBloomFilters(store dal.RecoveryReader) error {
 // Used on first boot and after bloom config changes. The reader is captured
 // by the goroutine; the snapshotter itself does not retain it.
 func (s *CacheSnapshotter) StartAsyncBloomPopulate(store dal.RecoveryReader, reason string) {
+	s.bloomMu.Lock()
+	defer s.bloomMu.Unlock()
+	if s.bloomStopped {
+		return
+	}
 	s.runBloomTask(store, reason, s.bloomFilters.PopulateFromStore)
 }
 
@@ -936,5 +944,8 @@ func (s *CacheSnapshotter) replayBloomFromCache(ctx context.Context) error {
 
 // Stop interrupts any running bloom task and waits for it to finish.
 func (s *CacheSnapshotter) Stop() {
+	s.bloomMu.Lock()
+	s.bloomStopped = true
 	s.bloomExecutor.Interrupt()
+	s.bloomMu.Unlock()
 }

--- a/internal/infra/state/cache_snapshotter.go
+++ b/internal/infra/state/cache_snapshotter.go
@@ -290,6 +290,7 @@ func newProtoSnapshotSlot[V interface {
 type CacheSnapshotter struct {
 	bloomMu      sync.Mutex
 	bloomStopped bool
+	bloomPaused  bool
 	logger       logging.Logger
 	registry     *StateRegistry
 	bloomFilters *bloom.FilterSet
@@ -779,7 +780,7 @@ func (s *CacheSnapshotter) restoreBloomFilters(store dal.RecoveryReader) error {
 func (s *CacheSnapshotter) StartAsyncBloomPopulate(store dal.RecoveryReader, reason string) {
 	s.bloomMu.Lock()
 	defer s.bloomMu.Unlock()
-	if s.bloomStopped {
+	if s.bloomStopped || s.bloomPaused {
 		return
 	}
 	s.runBloomTask(store, reason, s.bloomFilters.PopulateFromStore)
@@ -942,7 +943,23 @@ func (s *CacheSnapshotter) replayBloomFromCache(ctx context.Context) error {
 	return nil
 }
 
-// Stop interrupts any running bloom task and waits for it to finish.
+// Pause stops the current bloom task and rejects new starts until Resume.
+// It is used while a checkpoint replaces the Pebble contents.
+func (s *CacheSnapshotter) Pause() {
+	s.bloomMu.Lock()
+	s.bloomPaused = true
+	s.bloomExecutor.Interrupt()
+	s.bloomMu.Unlock()
+}
+
+// Resume reopens a snapshotter paused for checkpoint replacement.
+func (s *CacheSnapshotter) Resume() {
+	s.bloomMu.Lock()
+	s.bloomPaused = false
+	s.bloomMu.Unlock()
+}
+
+// Stop permanently closes the snapshotter's background-work ownership.
 func (s *CacheSnapshotter) Stop() {
 	s.bloomMu.Lock()
 	s.bloomStopped = true

--- a/internal/infra/state/cache_snapshotter_test.go
+++ b/internal/infra/state/cache_snapshotter_test.go
@@ -39,6 +39,26 @@ func TestCacheSnapshotter_StopPreventsBloomRestart(t *testing.T) {
 	snapshotter.StartAsyncBloomPopulate(nil, "late dispatcher signal")
 }
 
+func TestCacheSnapshotter_PauseResumeAllowsCheckpointRepopulation(t *testing.T) {
+	t.Parallel()
+
+	meter := noop.NewMeterProvider().Meter("test")
+	bloomFilters := bloom.NewFilterSet(&commonpb.ClusterConfig{
+		BloomVolumes: &commonpb.BloomTypeConfig{ExpectedKeys: 1000, FpRate: 0.01},
+	}, meter)
+	snapshotter, dataStore, _ := newTestCacheSnapshotter(t, bloomFilters)
+
+	bloomFilters.SetReady(false)
+	snapshotter.Pause()
+	snapshotter.StartAsyncBloomPopulate(dataStore, "suppressed during checkpoint replacement")
+	require.False(t, bloomFilters.IsReady())
+
+	snapshotter.Resume()
+	snapshotter.StartAsyncBloomPopulate(dataStore, "repopulate after checkpoint replacement")
+	snapshotter.Stop()
+	require.True(t, bloomFilters.IsReady())
+}
+
 func newVolumeKey(ak domain.AccountKey, asset string) domain.VolumeKey {
 	base, prec := domain.ParseAssetPrecision(asset)
 

--- a/internal/infra/state/cache_snapshotter_test.go
+++ b/internal/infra/state/cache_snapshotter_test.go
@@ -14,10 +14,30 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
 	"github.com/formancehq/ledger/v3/internal/infra/cache"
 	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+	"github.com/formancehq/ledger/v3/internal/pkg/worker"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+// TestCacheSnapshotter_StopPreventsBloomRestart protects the ownership
+// boundary of the background bloom executor. A dispatcher can deliver a
+// rebuild signal concurrently with shutdown; once Stop returns, that signal
+// must not be able to start a new task.
+func TestCacheSnapshotter_StopPreventsBloomRestart(t *testing.T) {
+	t.Parallel()
+
+	snapshotter := &CacheSnapshotter{
+		bloomExecutor: worker.NewSingleTaskExecutor(logging.Testing()),
+	}
+	snapshotter.Stop()
+
+	// The stopped guard must return before dereferencing the reader/filter. On
+	// the pre-fix path this starts a goroutine and eventually panics because the
+	// test intentionally has no live store or filter: that is the forbidden
+	// post-Stop restart.
+	snapshotter.StartAsyncBloomPopulate(nil, "late dispatcher signal")
+}
 
 func newVolumeKey(ak domain.AccountKey, asset string) domain.VolumeKey {
 	base, prec := domain.ParseAssetPrecision(asset)

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1780,6 +1780,16 @@ func (fsm *Machine) StopBackgroundTasks() {
 	fsm.cacheSnapshotter.Stop()
 }
 
+// PauseBackgroundTasks quiesces restartable background tasks while a
+// checkpoint replaces Pebble, without closing the Machine's ownership.
+func (fsm *Machine) PauseBackgroundTasks() {
+	fsm.cacheSnapshotter.Pause()
+}
+
+func (fsm *Machine) ResumeBackgroundTasks() {
+	fsm.cacheSnapshotter.Resume()
+}
+
 // DrainBackgroundChannels empties every background-request channel without
 // blocking. Called by Synchronizer.SynchronizeWithLeader before the leader's
 // checkpoint is installed: messages enqueued by the FSM hot path pre-sync

--- a/internal/infra/state/synchronizer.go
+++ b/internal/infra/state/synchronizer.go
@@ -44,12 +44,6 @@ func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetche
 	// Stop background tasks (bloom restore, etc.) that may hold Pebble iterators.
 	// RestoreCheckpoint closes and reopens the DB — outstanding references cause a panic.
 	s.apply.PauseBackgroundTasks()
-	paused := true
-	defer func() {
-		if paused {
-			s.apply.ResumeBackgroundTasks()
-		}
-	}()
 
 	// Drop any background-request messages enqueued by the FSM hot path
 	// pre-sync: their payloads reference chapter IDs / sequence ranges /
@@ -65,15 +59,13 @@ func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetche
 	if err := s.restoreCheckpoint(ctx, snapshotFetcher, progress, s.apply.State.SnapshotIndex); err != nil {
 		return 0, fmt.Errorf("restoring checkpoint from leader: %w", err)
 	}
-	// Pebble replacement is complete; recovery must be allowed to start the
-	// bloom population required by the newly installed checkpoint.
-	s.apply.ResumeBackgroundTasks()
-	paused = false
-
 	// Restore cache from Pebble (the checkpoint contains the leader's cache data)
 	if err := s.recovery.RestoreCacheFromStore(); err != nil {
 		return 0, fmt.Errorf("restoring cache after sync: %w", err)
 	}
+	// Pebble replacement and synchronous cache restoration are complete; only
+	// now may the Bloom dispatcher resume work for the installed checkpoint.
+	s.apply.ResumeBackgroundTasks()
 
 	// Reload all FSM state from Pebble (the checkpoint contains the leader's state).
 	// This also recovers lastAppliedIndex from the restored Pebble — the fresh

--- a/internal/infra/state/synchronizer.go
+++ b/internal/infra/state/synchronizer.go
@@ -43,7 +43,13 @@ func NewSynchronizer(apply *Machine, recovery *Recovery, incomingRestore dal.Inc
 func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetcher SnapshotFetcher, progress *SyncProgress) (uint64, error) {
 	// Stop background tasks (bloom restore, etc.) that may hold Pebble iterators.
 	// RestoreCheckpoint closes and reopens the DB — outstanding references cause a panic.
-	s.apply.StopBackgroundTasks()
+	s.apply.PauseBackgroundTasks()
+	paused := true
+	defer func() {
+		if paused {
+			s.apply.ResumeBackgroundTasks()
+		}
+	}()
 
 	// Drop any background-request messages enqueued by the FSM hot path
 	// pre-sync: their payloads reference chapter IDs / sequence ranges /
@@ -59,6 +65,10 @@ func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetche
 	if err := s.restoreCheckpoint(ctx, snapshotFetcher, progress, s.apply.State.SnapshotIndex); err != nil {
 		return 0, fmt.Errorf("restoring checkpoint from leader: %w", err)
 	}
+	// Pebble replacement is complete; recovery must be allowed to start the
+	// bloom population required by the newly installed checkpoint.
+	s.apply.ResumeBackgroundTasks()
+	paused = false
 
 	// Restore cache from Pebble (the checkpoint contains the leader's cache data)
 	if err := s.recovery.RestoreCacheFromStore(); err != nil {


### PR DESCRIPTION
Fixes EN-1861.

DISCOVERY: NO_EXISTING_WORK
Searched open/closed PRs, branches, commits, and Jira references; no direct or partial Bloom lifecycle fix found.

BEFORE_FIX: BUG_REPRODUCED
Base SHA: 0213c42236ab5a7ba9cfb2b14a900138caa8e814
Evidence: after CacheSnapshotter.Stop returned, a late StartAsyncBloomPopulate could start new Bloom work.
Invariant: after terminal Stop returns, no new Bloom-owned background work may start.

AFTER_FIX: PASS
The regression rejects late starts; Pause/Resume preserves temporary quiescence and restart semantics, with targeted race repetitions passing.

BASELINE_CLASSIFICATION: ENVIRONMENTAL
The earlier swiss failure was caused by host Go 1.27; validation uses Go 1.26.5 Nix with GOROOT neutralized.

Fix: separate temporary Pause/Resume quiescence from terminal Stop ownership.