### PR TITLE
fix: validate incremental restore keyspace

### DIFF
--- a/internal/infra/backup/restore.go
+++ b/internal/infra/backup/restore.go
@@ -15,36 +15,34 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
+func exportKeyShape(segmentType string) ([]byte, int, error) {
+	switch segmentType {
+	case "log":
+		// [ZoneCold][SubColdLog][log_seq BE 8]
+		return []byte{dal.ZoneCold, dal.SubColdLog}, 10, nil
+	case "audit":
+		// [ZoneCold][SubColdAudit][audit_seq BE 8]
+		return []byte{dal.ZoneCold, dal.SubColdAudit}, 10, nil
+	case "auditItem":
+		// [ZoneCold][SubColdAuditItem][audit_seq BE 8][order_idx BE 4]
+		return []byte{dal.ZoneCold, dal.SubColdAuditItem}, 14, nil
+	case "appliedProposal":
+		// [ZoneCold][SubColdAppliedProposal][applied_proposal_seq BE 8]
+		return []byte{dal.ZoneCold, dal.SubColdAppliedProposal}, 10, nil
+	default:
+		return nil, 0, fmt.Errorf("unsupported export segment type %q", segmentType)
+	}
+}
+
 func validateExportKey(seg ExportSegment, key []byte) error {
 	// Each segment type has a fixed key shape, so the exact length is part of
 	// the schema and not just a lower bound: prefix scans and seqFromKey read
 	// a longer key as a valid record at the same sequence, so tolerating
 	// trailing bytes would let a tampered segment smuggle a duplicate or
 	// invalid entry into ApplyExports/RebuildDelta.
-	var (
-		expected  []byte
-		keyLength int
-	)
-
-	switch seg.Type {
-	case "log":
-		// [ZoneCold][SubColdLog][log_seq BE 8]
-		expected = []byte{dal.ZoneCold, dal.SubColdLog}
-		keyLength = 10
-	case "audit":
-		// [ZoneCold][SubColdAudit][audit_seq BE 8]
-		expected = []byte{dal.ZoneCold, dal.SubColdAudit}
-		keyLength = 10
-	case "auditItem":
-		// [ZoneCold][SubColdAuditItem][audit_seq BE 8][order_idx BE 4]
-		expected = []byte{dal.ZoneCold, dal.SubColdAuditItem}
-		keyLength = 14
-	case "appliedProposal":
-		// [ZoneCold][SubColdAppliedProposal][applied_proposal_seq BE 8]
-		expected = []byte{dal.ZoneCold, dal.SubColdAppliedProposal}
-		keyLength = 10
-	default:
-		return fmt.Errorf("unsupported export segment type %q", seg.Type)
+	expected, keyLength, err := exportKeyShape(seg.Type)
+	if err != nil {
+		return err
 	}
 
 	if len(key) != keyLength || !bytes.Equal(key[:len(expected)], expected) {
@@ -75,6 +73,12 @@ func ApplyExports(
 	}
 
 	for _, seg := range exports {
+		// Validate metadata independently of stream contents so an empty segment
+		// cannot bypass the segment-type contract.
+		if _, _, err := exportKeyShape(seg.Type); err != nil {
+			return fmt.Errorf("invalid export segment %s: %w", seg.Key, err)
+		}
+
 		logger.WithFields(map[string]any{
 			"type":     seg.Type,
 			"startSeq": seg.StartSeq,

--- a/internal/infra/backup/restore.go
+++ b/internal/infra/backup/restore.go
@@ -1,7 +1,9 @@
 package backup
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +14,37 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+func validateExportKey(seg ExportSegment, key []byte) error {
+	var expected []byte
+	switch seg.Type {
+	case "log":
+		expected = []byte{dal.ZoneCold, dal.SubColdLog}
+	case "audit":
+		expected = []byte{dal.ZoneCold, dal.SubColdAudit}
+	case "auditItem":
+		expected = []byte{dal.ZoneCold, dal.SubColdAuditItem}
+	case "appliedProposal":
+		expected = []byte{dal.ZoneCold, dal.SubColdAppliedProposal}
+	default:
+		return fmt.Errorf("unsupported export segment type %q", seg.Type)
+	}
+
+	minLen := len(expected) + 8
+	if seg.Type == "auditItem" {
+		minLen += 4
+	}
+	if len(key) < minLen || len(key) < len(expected) || !bytes.Equal(key[:len(expected)], expected) {
+		return fmt.Errorf("key %x is not valid for export segment type %q", key, seg.Type)
+	}
+
+	seq := binary.BigEndian.Uint64(key[len(expected) : len(expected)+8])
+	if seq < seg.StartSeq || seq > seg.EndSeq {
+		return fmt.Errorf("key %x sequence %d outside export range [%d,%d]", key, seq, seg.StartSeq, seg.EndSeq)
+	}
+
+	return nil
+}
 
 // ApplyExports downloads export segments from storage and writes their raw KV
 // pairs into the given Pebble store. The segment types are log (0x01), audit
@@ -64,6 +97,13 @@ func ApplyExports(
 				_ = batch.Cancel()
 
 				return fmt.Errorf("reading entry from segment %s: %w", seg.Key, err)
+			}
+
+			if err := validateExportKey(seg, key); err != nil {
+				_ = reader.Close()
+				_ = batch.Cancel()
+
+				return fmt.Errorf("invalid key in segment %s: %w", seg.Key, err)
 			}
 
 			if err := batch.Set(key, value, pebble.NoSync); err != nil {

--- a/internal/infra/backup/restore.go
+++ b/internal/infra/backup/restore.go
@@ -16,25 +16,38 @@ import (
 )
 
 func validateExportKey(seg ExportSegment, key []byte) error {
-	var expected []byte
+	// Each segment type has a fixed key shape, so the exact length is part of
+	// the schema and not just a lower bound: prefix scans and seqFromKey read
+	// a longer key as a valid record at the same sequence, so tolerating
+	// trailing bytes would let a tampered segment smuggle a duplicate or
+	// invalid entry into ApplyExports/RebuildDelta.
+	var (
+		expected  []byte
+		keyLength int
+	)
+
 	switch seg.Type {
 	case "log":
+		// [ZoneCold][SubColdLog][log_seq BE 8]
 		expected = []byte{dal.ZoneCold, dal.SubColdLog}
+		keyLength = 10
 	case "audit":
+		// [ZoneCold][SubColdAudit][audit_seq BE 8]
 		expected = []byte{dal.ZoneCold, dal.SubColdAudit}
+		keyLength = 10
 	case "auditItem":
+		// [ZoneCold][SubColdAuditItem][audit_seq BE 8][order_idx BE 4]
 		expected = []byte{dal.ZoneCold, dal.SubColdAuditItem}
+		keyLength = 14
 	case "appliedProposal":
+		// [ZoneCold][SubColdAppliedProposal][applied_proposal_seq BE 8]
 		expected = []byte{dal.ZoneCold, dal.SubColdAppliedProposal}
+		keyLength = 10
 	default:
 		return fmt.Errorf("unsupported export segment type %q", seg.Type)
 	}
 
-	minLen := len(expected) + 8
-	if seg.Type == "auditItem" {
-		minLen += 4
-	}
-	if len(key) < minLen || len(key) < len(expected) || !bytes.Equal(key[:len(expected)], expected) {
+	if len(key) != keyLength || !bytes.Equal(key[:len(expected)], expected) {
 		return fmt.Errorf("key %x is not valid for export segment type %q", key, seg.Type)
 	}
 

--- a/internal/infra/backup/restore_key_validation_test.go
+++ b/internal/infra/backup/restore_key_validation_test.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"testing"
 
-	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 )
 
 func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
@@ -18,11 +19,9 @@ func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
 
 	store := newBackupTestStore(t)
 	storage := &recordingStorage{manifestBody: stream.Bytes()}
-	err := ApplyExports(context.Background(), testLogger(), storage, store, []ExportSegment{
+	err := ApplyExports(context.Background(), logging.Testing(), storage, store, []ExportSegment{
 		{Type: "log", StartSeq: 1, EndSeq: 1, Key: "invalid"},
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid key")
 }
-
-func testLogger() logging.Logger { return logging.Testing() }

--- a/internal/infra/backup/restore_key_validation_test.go
+++ b/internal/infra/backup/restore_key_validation_test.go
@@ -28,6 +28,22 @@ func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
 	require.ErrorContains(t, err, "invalid key")
 }
 
+func TestApplyExportsRejectsUnsupportedEmptySegment(t *testing.T) {
+	t.Parallel()
+
+	var stream bytes.Buffer
+	writer := NewKVStreamWriter(&stream)
+	require.NoError(t, writer.WriteHeader())
+	require.NoError(t, writer.WriteFooter())
+
+	store := newBackupTestStore(t)
+	storage := &recordingStorage{manifestBody: stream.Bytes()}
+	err := ApplyExports(context.Background(), logging.Testing(), storage, store, []ExportSegment{
+		{Type: "unknown", Key: "empty-unsupported"},
+	})
+	require.ErrorContains(t, err, `unsupported export segment type "unknown"`)
+}
+
 // TestValidateExportKeyRequiresExactKeyShape pins the per-type key length: a key
 // carrying trailing bytes still resolves to a valid sequence for prefix scans
 // and seqFromKey, so accepting it would let a tampered segment add a second

--- a/internal/infra/backup/restore_key_validation_test.go
+++ b/internal/infra/backup/restore_key_validation_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
 func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
@@ -24,4 +26,67 @@ func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid key")
+}
+
+// TestValidateExportKeyRequiresExactKeyShape pins the per-type key length: a key
+// carrying trailing bytes still resolves to a valid sequence for prefix scans
+// and seqFromKey, so accepting it would let a tampered segment add a second
+// record for a sequence already covered by the export range.
+func TestValidateExportKeyRequiresExactKeyShape(t *testing.T) {
+	t.Parallel()
+
+	seqKey := func(sub byte) []byte {
+		return dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, sub).PutUint64(1).Build()
+	}
+
+	for _, tc := range []struct {
+		segType string
+		valid   []byte
+	}{
+		{segType: "log", valid: seqKey(dal.SubColdLog)},
+		{segType: "audit", valid: seqKey(dal.SubColdAudit)},
+		{segType: "appliedProposal", valid: seqKey(dal.SubColdAppliedProposal)},
+		{
+			segType: "auditItem",
+			valid:   dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdAuditItem).PutUint64(1).PutUint32(0).Build(),
+		},
+	} {
+		t.Run(tc.segType, func(t *testing.T) {
+			t.Parallel()
+
+			seg := ExportSegment{Type: tc.segType, StartSeq: 1, EndSeq: 1}
+
+			require.NoError(t, validateExportKey(seg, tc.valid))
+
+			trailing := append(bytes.Clone(tc.valid), 0x00)
+			require.ErrorContains(t, validateExportKey(seg, trailing), "is not valid for export segment type")
+
+			truncated := tc.valid[:len(tc.valid)-1]
+			require.ErrorContains(t, validateExportKey(seg, truncated), "is not valid for export segment type")
+		})
+	}
+}
+
+// TestApplyExportsRejectsKeyWithTrailingBytes exercises the same rejection
+// through the restore path and proves nothing is written to the staged store.
+func TestApplyExportsRejectsKeyWithTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	tampered := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneCold, dal.SubColdLog).PutUint64(1).Build()
+	tampered = append(tampered, 'x')
+
+	var stream bytes.Buffer
+	writer := NewKVStreamWriter(&stream)
+	require.NoError(t, writer.WriteHeader())
+	require.NoError(t, writer.WriteEntry(tampered, []byte("value")))
+	require.NoError(t, writer.WriteFooter())
+
+	store := newBackupTestStore(t)
+	storage := &recordingStorage{manifestBody: stream.Bytes()}
+	err := ApplyExports(context.Background(), logging.Testing(), storage, store, []ExportSegment{
+		{Type: "log", StartSeq: 1, EndSeq: 1, Key: "tampered"},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid key")
+	require.Zero(t, countKeysInSub(t, store, dal.SubColdLog), "tampered entry must not reach the store")
 }

--- a/internal/infra/backup/restore_key_validation_test.go
+++ b/internal/infra/backup/restore_key_validation_test.go
@@ -1,0 +1,28 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyExportsRejectsKeyOutsideSegmentKeyspace(t *testing.T) {
+	var stream bytes.Buffer
+	writer := NewKVStreamWriter(&stream)
+	require.NoError(t, writer.WriteHeader())
+	require.NoError(t, writer.WriteEntry([]byte{0xff, 0x01, 'x'}, []byte("value")))
+	require.NoError(t, writer.WriteFooter())
+
+	store := newBackupTestStore(t)
+	storage := &recordingStorage{manifestBody: stream.Bytes()}
+	err := ApplyExports(context.Background(), testLogger(), storage, store, []ExportSegment{
+		{Type: "log", StartSeq: 1, EndSeq: 1, Key: "invalid"},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid key")
+}
+
+func testLogger() logging.Logger { return logging.Testing() }


### PR DESCRIPTION
Fixes EN-1865.

DISCOVERY: NO_EXISTING_WORK
Searched open/closed PRs, branches, commits, and Jira references; no direct or partial existing fix found.

BEFORE_FIX: BUG_REPRODUCED
Base SHA: 0213c42236ab5a7ba9cfb2b14a900138caa8e814
Evidence: a framed incremental export containing a foreign key was accepted by ApplyExports and reached Pebble.
Invariant: imported segments may write only keys belonging to their declared keyspace/type and sequence range.

AFTER_FIX: PASS
The same regression rejects the foreign key before Pebble Set; targeted restore tests and race repetitions pass.

BASELINE_CLASSIFICATION: ENVIRONMENTAL
The earlier swiss failure was caused by host Go 1.27; validation uses Go 1.26.5 Nix with GOROOT neutralized.

Fix: validate segment type, prefix, key shape, and inclusive sequence range at restore ingestion.