### PR TITLE
chore: harden AI bugfix workflow gates

### DIFF
--- a/docs/technical/contributing/ai-bugfix-workflow.md
+++ b/docs/technical/contributing/ai-bugfix-workflow.md
@@ -1,0 +1,29 @@
+# AI bugfix workflow
+
+Runtime bugfixes follow a fail-closed sequence:
+
+`DISCOVER → REPRODUCE → FIX → VALIDATE → PRE-COMMIT → REVIEW → GUARDED PUSH`
+
+Discovery must record one of `DIRECT_FIX`, `PARTIAL_FIX`,
+`RELATED_BUT_DIFFERENT`, `STALE_OR_INVALID`, `ALREADY_FIXED`, or
+`NO_EXISTING_WORK`. A bugfix evidence record must also contain:
+
+```text
+BEFORE_FIX: BUG_REPRODUCED | REPRODUCTION_BLOCKED | ALREADY_FIXED
+AFTER_FIX: PASS
+```
+
+When a validation failure occurs, classify it as
+`BASELINE_FAILURE`, `CANDIDATE_CAUSED`, `ENVIRONMENTAL`, or `UNKNOWN` before
+attributing it to the candidate. An unclassified important failure is not
+ready for publication. Non-bugfix changes may omit bug reproduction evidence.
+
+Before Go validation, `scripts/ai-bugfix-gate environment` compares the
+effective `go version` with the repository `go.mod` directive, reports the
+selected binary and `GOROOT`, and rejects a host toolchain selected outside
+the repository environment. Being inside `nix develop` alone is not evidence
+of the effective toolchain.
+
+Immediately before a guarded push, the loop runs `just pre-commit` and checks
+`git status --porcelain`. If pre-commit changes files, the candidate must be
+updated and re-reviewed; the workflow never resets those changes to hide them.

--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -136,6 +136,9 @@ fi
 
 unset GOROOT || true
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '^/opt/homebrew' | paste -sd: -)
+export PATH
+bash "$SCRIPT_DIR/ai-bugfix-gate" environment "$(git rev-parse --show-toplevel)/go.mod"
 
 echo "==> agent-check-pr: selected local gates: ${gates[*]}"
 bash "$SCRIPT_DIR/agent-check-full"

--- a/scripts/ai-bugfix-gate
+++ b/scripts/ai-bugfix-gate
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/ai-bugfix-gate environment [go.mod]
+  scripts/ai-bugfix-gate evidence <metadata-file> [bugfix|non-bugfix]
+  scripts/ai-bugfix-gate pre-push
+EOF
+}
+
+die() { echo "ai-bugfix-gate: $*" >&2; exit 1; }
+
+environment_gate() {
+    local mod_file=${1:-go.mod}
+    [[ -f "$mod_file" ]] || die "missing module file: $mod_file"
+
+    # nix develop inherits the caller's PATH on some hosts. Remove host Go
+    # entries before observing the effective toolchain; do not hardcode a
+    # /nix/store path.
+    PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v '^/opt/homebrew' | paste -sd: -)
+    export PATH
+    unset GOROOT || true
+
+    local go_bin go_version expected actual actual_root
+    go_bin=$(command -v go) || die "ENVIRONMENT_GATE=FAIL (go not found)"
+    go_version=$(go version) || die "ENVIRONMENT_GATE=FAIL (go unusable)"
+    expected=$(awk '$1 == "go" {print $2; exit}' "$mod_file")
+    expected=$(sed -E 's/^([0-9]+\.[0-9]+).*/\1/' <<<"$expected")
+    [[ -n "$expected" ]] || die "ENVIRONMENT_GATE=FAIL (go directive missing)"
+    actual=$(sed -E 's/.*go([0-9]+\.[0-9]+).*/\1/' <<<"$go_version")
+    actual_root=$(go env GOROOT)
+
+    printf 'ENVIRONMENT_GATE=PASS\nEXPECTED_GO=%s\nACTUAL_GO=%s\nGO_BINARY=%s\nGOROOT=%s\nGOTOOLCHAIN=%s\n' \
+        "$expected" "$actual" "$go_bin" "$actual_root" "$(go env GOTOOLCHAIN)"
+    [[ "$actual" == "$expected"* ]] || die "ENVIRONMENT_GATE=FAIL (expected Go $expected, got $go_version)"
+    [[ "$go_bin" != /opt/homebrew/* && "$actual_root" != /opt/homebrew/* ]] || \
+        die "ENVIRONMENT_GATE=FAIL (Homebrew Go selected)"
+}
+
+evidence_gate() {
+    local file=$1 intent=${2:-bugfix}
+    [[ -f "$file" ]] || die "evidence file not found: $file"
+    [[ "$intent" == bugfix || "$intent" == non-bugfix ]] || die "invalid intent: $intent"
+    [[ "$intent" == non-bugfix ]] && { echo 'BUGFIX_EVIDENCE=NOT_REQUIRED'; return; }
+
+    grep -Eq '^DISCOVERY:[[:space:]]+(DIRECT_FIX|PARTIAL_FIX|RELATED_BUT_DIFFERENT|STALE_OR_INVALID|ALREADY_FIXED|NO_EXISTING_WORK)\b' "$file" ||
+        die "BUGFIX_EVIDENCE=FAIL (discovery classification missing)"
+    grep -Eq '^BEFORE_FIX:[[:space:]]+(BUG_REPRODUCED|REPRODUCTION_BLOCKED|ALREADY_FIXED)\b' "$file" ||
+        die "BUGFIX_EVIDENCE=FAIL (BEFORE_FIX missing)"
+    grep -Eq '^AFTER_FIX:[[:space:]]+PASS\b' "$file" ||
+        die "BUGFIX_EVIDENCE=FAIL (AFTER_FIX missing)"
+    if [[ "${VALIDATION_FAILURE:-0}" == 1 ]]; then
+        grep -Eq '^BASELINE_CLASSIFICATION:[[:space:]]+(BASELINE_FAILURE|CANDIDATE_CAUSED|ENVIRONMENTAL|UNKNOWN)\b' "$file" ||
+            die "BUGFIX_EVIDENCE=FAIL (baseline classification missing)"
+    fi
+    echo 'BUGFIX_EVIDENCE=PASS'
+}
+
+pre_push_gate() {
+    just pre-commit
+    [[ -z "$(git status --porcelain)" ]] || die "PRE_COMMIT=PASS but WORKTREE_CLEAN=NO"
+    echo 'PRE_COMMIT=PASS'
+    echo 'WORKTREE_CLEAN=YES'
+}
+
+case "${1:-}" in
+    environment) environment_gate "${2:-go.mod}" ;;
+    evidence) [[ $# -ge 2 ]] || { usage >&2; exit 2; }; evidence_gate "$2" "${3:-bugfix}" ;;
+    pre-push) pre_push_gate ;;
+    -h|--help) usage ;;
+    *) usage >&2; exit 2 ;;
+esac

--- a/scripts/ai-bugfix-gate
+++ b/scripts/ai-bugfix-gate
@@ -35,8 +35,8 @@ environment_gate() {
     printf 'ENVIRONMENT_GATE=PASS\nEXPECTED_GO=%s\nACTUAL_GO=%s\nGO_BINARY=%s\nGOROOT=%s\nGOTOOLCHAIN=%s\n' \
         "$expected" "$actual" "$go_bin" "$actual_root" "$(go env GOTOOLCHAIN)"
     [[ "$actual" == "$expected"* ]] || die "ENVIRONMENT_GATE=FAIL (expected Go $expected, got $go_version)"
-    [[ "$go_bin" != /opt/homebrew/* && "$actual_root" != /opt/homebrew/* ]] || \
-        die "ENVIRONMENT_GATE=FAIL (Homebrew Go selected)"
+    [[ "$go_bin" == /nix/store/* && "$actual_root" == /nix/store/* ]] || \
+        die "ENVIRONMENT_GATE=FAIL (Go is not from the Nix store)"
 }
 
 evidence_gate() {

--- a/scripts/ai-bugfix-gate-test
+++ b/scripts/ai-bugfix-gate-test
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(git rev-parse --show-toplevel)
+gate="$root/scripts/ai-bugfix-gate"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/bugfix.ok" <<'EOF'
+DISCOVERY: NO_EXISTING_WORK
+BEFORE_FIX: BUG_REPRODUCED
+AFTER_FIX: PASS
+EOF
+"$gate" evidence "$tmp/bugfix.ok" bugfix
+if "$gate" evidence "$tmp/bugfix.ok" bugfix >/dev/null 2>&1; then :; else exit 1; fi
+
+if "$gate" evidence "$tmp/bugfix.ok" bugfix </dev/null >/dev/null 2>&1; then :; else exit 1; fi
+
+: >"$tmp/non-bugfix"
+"$gate" evidence "$tmp/non-bugfix" non-bugfix
+
+cat >"$tmp/missing-before" <<'EOF'
+DISCOVERY: NO_EXISTING_WORK
+AFTER_FIX: PASS
+EOF
+if "$gate" evidence "$tmp/missing-before" bugfix >/dev/null 2>&1; then
+    echo 'expected missing BEFORE_FIX to fail' >&2
+    exit 1
+fi
+
+echo 'ai-bugfix-gate tests: PASS'

--- a/scripts/ai-bugfix-gate-test
+++ b/scripts/ai-bugfix-gate-test
@@ -28,4 +28,20 @@ if "$gate" evidence "$tmp/missing-before" bugfix >/dev/null 2>&1; then
     exit 1
 fi
 
+mkdir -p "$tmp/fake-bin"
+cat >"$tmp/fake-bin/go" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "version") echo 'go version go1.26.5 darwin/arm64' ;;
+  "env GOROOT") echo '/tmp/fake-go-root' ;;
+  "env GOTOOLCHAIN") echo 'auto' ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$tmp/fake-bin/go"
+if PATH="$tmp/fake-bin:$PATH" "$gate" environment "$root/go.mod" >/dev/null 2>&1; then
+    echo 'expected non-Nix matching Go to fail' >&2
+    exit 1
+fi
+
 echo 'ai-bugfix-gate tests: PASS'

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -108,13 +108,6 @@ if [[ "$head_owner/$head_repo" != "$repo" ]]; then
     exit 1
 fi
 
-evidence_file=$(mktemp)
-trap 'rm -f -- "$evidence_file"' RETURN
-printf '%s\n' "$pr_body" >"$evidence_file"
-bash scripts/ai-bugfix-gate evidence "$evidence_file" "$bugfix_intent"
-rm -f -- "$evidence_file"
-trap - RETURN
-
 remote=origin
 if ! git remote get-url "$remote" >/dev/null 2>&1; then
     echo "ai-pr-loop: required git remote '$remote' is missing" >&2
@@ -341,7 +334,7 @@ fix_cmd='bash scripts/ai-fix-claude'
 validation_cmd='bash scripts/agent-check-pr'
 if [[ "$push_changes" == "true" ]]; then
     # Publication additionally base-pins the mutating fixer and validator.
-    for trusted_tool in ai-fix-claude agent-check-pr; do
+    for trusted_tool in ai-fix-claude agent-check-pr agent-just; do
         trusted_tool_path="$trusted_tool_worktree/scripts/$trusted_tool"
         if [[ ! -x "$trusted_tool_path" ]]; then
             echo "ai-pr-loop: trusted base does not provide executable scripts/$trusted_tool" >&2
@@ -353,6 +346,21 @@ if [[ "$push_changes" == "true" ]]; then
         'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q' \
         "path:$trusted_tool_worktree" \
         "$trusted_tool_worktree/scripts/agent-check-pr"
+fi
+
+if [[ "$bugfix_intent" == bugfix ]]; then
+    evidence_file=$(mktemp)
+    printf '%s\n' "$pr_body" >"$evidence_file"
+    if [[ "$push_changes" == true && -x "$trusted_tool_worktree/scripts/ai-bugfix-gate" ]]; then
+        bash "$trusted_tool_worktree/scripts/ai-bugfix-gate" evidence "$evidence_file" bugfix
+    elif [[ "$push_changes" == false && -x "$repo_root/scripts/ai-bugfix-gate" ]]; then
+        bash "$repo_root/scripts/ai-bugfix-gate" evidence "$evidence_file" bugfix
+    else
+        rm -f -- "$evidence_file"
+        echo "ai-pr-loop: bugfix evidence gate is unavailable; refusing readiness" >&2
+        exit 1
+    fi
+    rm -f -- "$evidence_file"
 fi
 
 printf '==> ai-pr-loop: PR #%s\n' "$pr_number"
@@ -497,9 +505,16 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
-# Last-mile publication gate: pre-commit is authoritative and any generated
-# output must be incorporated and re-reviewed, never reset or hidden.
-bash scripts/ai-bugfix-gate pre-push
+    # Last-mile publication gate: use only the base-pinned recipe wrapper. The
+    # candidate worktree is merely its working directory; generated output is
+    # never reset or hidden.
+bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "ai-pr-loop: pre-commit left the candidate worktree dirty; refusing push" >&2
+    echo "Candidate worktree preserved for inspection: $worktree"
+    keep_worktree=true
+    exit 1
+fi
 
 current_head=$(git rev-parse HEAD)
 if [[ "$current_head" != "$candidate_sha" ]]; then

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -353,6 +353,26 @@ if [[ "$bugfix_intent" == bugfix ]]; then
     printf '%s\n' "$pr_body" >"$evidence_file"
     if [[ "$push_changes" == true && -x "$trusted_tool_worktree/scripts/ai-bugfix-gate" ]]; then
         bash "$trusted_tool_worktree/scripts/ai-bugfix-gate" evidence "$evidence_file" bugfix
+    elif [[ "$push_changes" == true ]]; then
+        # Bootstrap for bases predating ai-bugfix-gate: keep the fail-closed
+        # evidence contract inline until the trusted executable exists. This
+        # validates data only; no candidate-controlled command is executed.
+        grep -Eq '^DISCOVERY:[[:space:]]+(DIRECT_FIX|PARTIAL_FIX|RELATED_BUT_DIFFERENT|STALE_OR_INVALID|ALREADY_FIXED|NO_EXISTING_WORK)\b' "$evidence_file" || {
+            rm -f -- "$evidence_file"
+            echo "ai-pr-loop: BUGFIX_EVIDENCE=FAIL (discovery classification missing)" >&2
+            exit 1
+        }
+        grep -Eq '^BEFORE_FIX:[[:space:]]+(BUG_REPRODUCED|REPRODUCTION_BLOCKED|ALREADY_FIXED)\b' "$evidence_file" || {
+            rm -f -- "$evidence_file"
+            echo "ai-pr-loop: BUGFIX_EVIDENCE=FAIL (BEFORE_FIX missing)" >&2
+            exit 1
+        }
+        grep -Eq '^AFTER_FIX:[[:space:]]+PASS\b' "$evidence_file" || {
+            rm -f -- "$evidence_file"
+            echo "ai-pr-loop: BUGFIX_EVIDENCE=FAIL (AFTER_FIX missing)" >&2
+            exit 1
+        }
+        echo 'BUGFIX_EVIDENCE=PASS (bootstrap inline gate)'
     elif [[ "$push_changes" == false && -x "$repo_root/scripts/ai-bugfix-gate" ]]; then
         bash "$repo_root/scripts/ai-bugfix-gate" evidence "$evidence_file" bugfix
     else

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -70,7 +70,7 @@ repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-pr_json=$(gh pr view "$pr" --repo "$repo" --json number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository)
+pr_json=$(gh pr view "$pr" --repo "$repo" --json number,url,state,isDraft,title,body,labels,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository)
 
 pr_number=$(jq -r '.number' <<<"$pr_json")
 pr_url=$(jq -r '.url' <<<"$pr_json")
@@ -82,6 +82,18 @@ head_ref=$(jq -r '.headRefName' <<<"$pr_json")
 head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
 head_owner=$(jq -r '.headRepositoryOwner.login // empty' <<<"$pr_json")
 head_repo=$(jq -r '.headRepository.name // empty' <<<"$pr_json")
+pr_title=$(jq -r '.title // ""' <<<"$pr_json")
+pr_body=$(jq -r '.body // ""' <<<"$pr_json")
+
+# Bugfix intent is explicit metadata when available, with a conservative
+# fallback for the repository's established Jira/fix PR convention. Other
+# changes (docs, manifests, refactors, features) do not require reproduction.
+bugfix_intent=non-bugfix
+if jq -e '.labels[]?.name | ascii_downcase == "bugfix" or ascii_downcase == "bug-fix"' >/dev/null <<<"$pr_json" || \
+   [[ "$pr_title" == fix:* || "$pr_title" == Fix:* ]] || \
+   grep -Eiq '(^|[[:space:]])(fixes|fix|resolves)[[:space:]]+EN-[0-9]+' <<<"$pr_body"; then
+    bugfix_intent=bugfix
+fi
 
 if [[ "$state" != "OPEN" ]]; then
     echo "ai-pr-loop: PR #$pr_number is not open (state=$state)" >&2
@@ -95,6 +107,13 @@ if [[ "$head_owner/$head_repo" != "$repo" ]]; then
     echo "ai-pr-loop: fork/cross-repository PRs are not supported yet: $head_owner/$head_repo" >&2
     exit 1
 fi
+
+evidence_file=$(mktemp)
+trap 'rm -f -- "$evidence_file"' RETURN
+printf '%s\n' "$pr_body" >"$evidence_file"
+bash scripts/ai-bugfix-gate evidence "$evidence_file" "$bugfix_intent"
+rm -f -- "$evidence_file"
+trap - RETURN
 
 remote=origin
 if ! git remote get-url "$remote" >/dev/null 2>&1; then
@@ -477,6 +496,10 @@ if [[ -n "$(git status --porcelain)" ]]; then
     keep_worktree=true
     exit 1
 fi
+
+# Last-mile publication gate: pre-commit is authoritative and any generated
+# output must be incorporated and re-reviewed, never reset or hidden.
+bash scripts/ai-bugfix-gate pre-push
 
 current_head=$(git rev-parse HEAD)
 if [[ "$current_head" != "$candidate_sha" ]]; then

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -113,6 +113,7 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 		validator, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "agent-check-pr"))
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-check-pr"), validator, 0o755))
+		writeExecutable(t, filepath.Join(seed, "scripts", "agent-just"), "#!/usr/bin/env bash\nexit 0\n")
 	}
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-known-findings"), "#!/usr/bin/env bash\nexit 0\n")


### PR DESCRIPTION
Adds fail-closed bugfix workflow protections:

- existing-work discovery classification
- BEFORE_FIX/AFTER_FIX evidence gate
- baseline failure classification contract
- effective Nix/Go toolchain verification
- mandatory pre-commit and clean-worktree gate before guarded push
- documentation and shell tests

No runtime behavior changes.