### PR TITLE
fix(admission): exempt leader-internal system proposals from signature enforcement

### DIFF
--- a/docs/technical/architecture/subsystems/admission/pipeline.md
+++ b/docs/technical/architecture/subsystems/admission/pipeline.md
@@ -67,7 +67,7 @@ If the cluster is in maintenance mode, only `SetMaintenanceMode` requests are al
 
 `resolveBatch()` looks up the signing key by ID, calls `signing.Verify(pubkey, payload, sig)` (`internal/domain/crypto/signing/signing.go`), and unwraps the opaque payload into an `ApplyBatch`. The verifier is fed the **exact bytes the client signed** — the server never re-serializes the batch before verification, which is what makes cross-language clients work. See [signing.md](signing.md) for the full signing model.
 
-If `RequireSignatures()` is true cluster-wide, an unsigned batch is rejected here. If signing is not required, an unsigned batch follows `authorizeUnsignedBatch()` and continues.
+If `RequireSignatures()` is true cluster-wide, an unsigned batch is rejected here. If signing is not required, an unsigned batch follows `authorizeUnsignedBatch()` and continues. Leader-internal proposals (a system actor set by `WithSystemActor` — chapter archiver, sealer, schedulers, query-checkpoint scheduler) are exempt even when signing is mandatory: they originate in server-internal code, never carry client-supplied identity, and are audited under a `system_component` source. See [signing.md](signing.md#leader-internal-proposals).
 
 ### 4. Order conversion
 

--- a/docs/technical/architecture/subsystems/admission/signing.md
+++ b/docs/technical/architecture/subsystems/admission/signing.md
@@ -4,7 +4,7 @@
 
 Request signing is what makes a Ledger v3 batch **tamper-evident end-to-end**: the client signs the exact bytes it submits, the server verifies them without re-serialising, and the resulting log entries carry the original signature into the audit trail. Response signing does the symmetric thing on the way back: the server signs the committed logs so clients can audit them after the fact.
 
-Signing is **optional by default** and can be made mandatory cluster-wide via `signing require`. When mandatory, unsigned batches are rejected at admission. Operations documentation lives in [`docs/ops/signing.md`](../../../../ops/signing.md) and the maintenance-mode interaction is covered in [`docs/ops/maintenance-mode.md`](../../../../ops/maintenance-mode.md); this page covers the architecture.
+Signing is **optional by default** and can be made mandatory cluster-wide via `signing require`. When mandatory, unsigned batches are rejected at admission, except for the narrow cases below (bootstrap registration, maintenance mode, and leader-internal proposals). Operations documentation lives in [`docs/ops/signing.md`](../../../../ops/signing.md) and the maintenance-mode interaction is covered in [`docs/ops/maintenance-mode.md`](../../../../ops/maintenance-mode.md); this page covers the architecture.
 
 ## Algorithm
 
@@ -77,6 +77,10 @@ Because registrations and revocations go through Raft, key changes are subject t
 ### Maintenance mode interaction
 
 When signing is required and the operator needs to register a fresh key without an existing signer (e.g. all parents revoked), the cluster can be put into maintenance mode. In maintenance, admission rejects every request type *except* `SetMaintenanceMode` — and `authorizeUnsignedBatch()` is allowed to admit an unsigned registration on the way out. See `docs/ops/maintenance-mode.md`.
+
+### Leader-internal proposals
+
+Background work the leader schedules — chapter archiving, sealing, rotation, and query-checkpoint creation — travels through admission as an unsigned batch under a **system actor** (`auth.WithSystemActor`, attributed to a `commands.Component*`). `authorizeUnsignedBatch()` admits these even when signing is mandatory. The exception is safe because the system actor is set only by server-internal code and is never derived from client input, so it cannot be forged over the wire; and the resulting order is audited under a `system_component` caller source, so it is still attributable in the audit chain. Mandatory signing authenticates *client* writes; the leader's own audited proposals are already inside the trust boundary. Without this exception a signed cluster could never archive/seal chapters or create query checkpoints.
 
 ## Signing is not replay protection
 

--- a/internal/adapter/auth/caller_snapshot.go
+++ b/internal/adapter/auth/caller_snapshot.go
@@ -63,6 +63,16 @@ func systemActorFromContext(ctx context.Context) (string, bool) {
 	return c, ok && c != ""
 }
 
+// IsSystemActor reports whether the context carries a system actor set by
+// WithSystemActor — a leader-internal proposal (chapter archiver, sealer,
+// schedulers) rather than a client request. The flag is set only by
+// server-internal code, never derived from client input.
+func IsSystemActor(ctx context.Context) bool {
+	_, ok := systemActorFromContext(ctx)
+
+	return ok
+}
+
 // ResolveCallerSnapshot returns the caller snapshot for the current context,
 // in precedence order:
 //  1. an explicit system actor (WithSystemActor) — a background action;

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -543,7 +543,7 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) (log
 
 	ctx, sigSpan := tracer.Start(ctx, "admission.verify_signatures")
 	resolveBatchStart := time.Now()
-	batch, err := a.resolveBatch(req)
+	batch, err := a.resolveBatch(ctx, req)
 	a.resolveBatchDurationHistogram.Record(ctx, time.Since(resolveBatchStart).Microseconds())
 
 	sigSpan.End()
@@ -941,7 +941,7 @@ type verifiedBatch struct {
 // signature is verified against the payload bytes and the trusted batch is
 // unmarshaled from them — the server never re-serializes. An unsigned batch is
 // admitted only when signatures are not required (or for signing bootstrap).
-func (a *Admission) resolveBatch(req *servicepb.ApplyRequest) (verifiedBatch, error) {
+func (a *Admission) resolveBatch(ctx context.Context, req *servicepb.ApplyRequest) (verifiedBatch, error) {
 	switch v := req.GetVariant().(type) {
 	case *servicepb.ApplyRequest_Signed:
 		sb := v.Signed
@@ -971,7 +971,7 @@ func (a *Admission) resolveBatch(req *servicepb.ApplyRequest) (verifiedBatch, er
 			return verifiedBatch{}, fmt.Errorf("%w: empty unsigned batch", signing.ErrMissingSignature)
 		}
 
-		if err := a.authorizeUnsignedBatch(batch.GetRequests()); err != nil {
+		if err := a.authorizeUnsignedBatch(ctx, batch.GetRequests()); err != nil {
 			return verifiedBatch{}, err
 		}
 
@@ -990,7 +990,16 @@ func (a *Admission) resolveBatch(req *servicepb.ApplyRequest) (verifiedBatch, er
 //   - RegisterSigningKey is allowed unsigned when no keys exist yet (bootstrap)
 //   - all other signing-management requests require a signature once keys exist
 //   - regular requests check the requireSignatures flag
-func (a *Admission) authorizeUnsignedBatch(reqs []*servicepb.Request) error {
+func (a *Admission) authorizeUnsignedBatch(ctx context.Context, reqs []*servicepb.Request) error {
+	// Leader-internal proposals (chapter archiver, sealer, schedulers, the
+	// query-checkpoint scheduler) travel through admission unsigned under a system
+	// actor set only by server-internal code. RequireSignatures authenticates
+	// client writes; the leader's own audited proposals are inside the trust
+	// boundary and would otherwise be permanently rejected on a signed cluster.
+	if auth.IsSystemActor(ctx) {
+		return nil
+	}
+
 	for _, req := range reqs {
 		if isSigningManagementRequest(req) {
 			// HasUndecodableRows closes the bootstrap window on a store whose signing

--- a/internal/application/admission/admission_test.go
+++ b/internal/application/admission/admission_test.go
@@ -1373,7 +1373,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		result, err := adm.resolveBatch(req)
+		result, err := adm.resolveBatch(context.Background(), req)
 		require.NoError(t, err)
 		require.Len(t, result.requests, 1)
 		require.Nil(t, result.sig, "bootstrap request should have no signature")
@@ -1398,7 +1398,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		_, err := adm.resolveBatch(req)
+		_, err := adm.resolveBatch(context.Background(), req)
 		require.ErrorIs(t, err, signing.ErrMissingSignature)
 	})
 
@@ -1418,7 +1418,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		_, err := adm.resolveBatch(req)
+		_, err := adm.resolveBatch(context.Background(), req)
 		require.ErrorIs(t, err, signing.ErrMissingSignature)
 	})
 
@@ -1438,7 +1438,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		_, err := adm.resolveBatch(req)
+		_, err := adm.resolveBatch(context.Background(), req)
 		require.ErrorIs(t, err, signing.ErrMissingSignature)
 	})
 
@@ -1461,7 +1461,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		}
 
-		result, err := adm.resolveBatch(signedBatchRequest(t, req, "existing", existingPrivKey))
+		result, err := adm.resolveBatch(context.Background(), signedBatchRequest(t, req, "existing", existingPrivKey))
 		require.NoError(t, err)
 		require.Len(t, result.requests, 1)
 		require.NotNil(t, result.sig, "signature should be preserved for propagation")
@@ -1480,7 +1480,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		result, err := adm.resolveBatch(req)
+		result, err := adm.resolveBatch(context.Background(), req)
 		require.NoError(t, err)
 		require.Len(t, result.requests, 1)
 	})
@@ -1500,7 +1500,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		})
 
-		_, err := adm.resolveBatch(req)
+		_, err := adm.resolveBatch(context.Background(), req)
 		require.ErrorIs(t, err, signing.ErrMissingSignature)
 	})
 
@@ -1521,7 +1521,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		}
 
-		result, err := adm.resolveBatch(signedBatchRequest(t, req, "my-key", privKey))
+		result, err := adm.resolveBatch(context.Background(), signedBatchRequest(t, req, "my-key", privKey))
 		require.NoError(t, err)
 		require.Len(t, result.requests, 1)
 		require.NotNil(t, result.sig)
@@ -1542,7 +1542,7 @@ func TestResolveBatch(t *testing.T) {
 			},
 		}
 
-		_, err := adm.resolveBatch(signedBatchRequest(t, req, "unknown-key", privKey))
+		_, err := adm.resolveBatch(context.Background(), signedBatchRequest(t, req, "unknown-key", privKey))
 		require.ErrorIs(t, err, signing.ErrUnknownKeyID)
 	})
 
@@ -1565,7 +1565,7 @@ func TestResolveBatch(t *testing.T) {
 		}
 
 		// Sign with a different private key
-		_, err := adm.resolveBatch(signedBatchRequest(t, req, "my-key", otherPrivKey))
+		_, err := adm.resolveBatch(context.Background(), signedBatchRequest(t, req, "my-key", otherPrivKey))
 		require.ErrorIs(t, err, signing.ErrInvalidSignature)
 	})
 }

--- a/internal/application/admission/authorize_unsigned_batch_test.go
+++ b/internal/application/admission/authorize_unsigned_batch_test.go
@@ -1,13 +1,17 @@
 package admission
 
 import (
+	"context"
 	"crypto/ed25519"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	"github.com/formancehq/ledger/v3/internal/domain/crypto/keystore"
+	"github.com/formancehq/ledger/v3/internal/domain/crypto/signing"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/commands"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -48,7 +52,7 @@ func TestAuthorizeUnsignedBatch_BootstrapExceptionClosesOnUndecodableRows(t *tes
 	t.Run("fresh cluster may bootstrap unsigned", func(t *testing.T) {
 		t.Parallel()
 
-		require.NoError(t, newAdmission(nil).authorizeUnsignedBatch(registerRequest),
+		require.NoError(t, newAdmission(nil).authorizeUnsignedBatch(context.Background(), registerRequest),
 			"an empty key store with no corrupt rows is a genuinely fresh cluster")
 	})
 
@@ -59,7 +63,7 @@ func TestAuthorizeUnsignedBatch_BootstrapExceptionClosesOnUndecodableRows(t *tes
 			ks.MarkUndecodableRows(1)
 		})
 
-		require.Error(t, a.authorizeUnsignedBatch(registerRequest),
+		require.Error(t, a.authorizeUnsignedBatch(context.Background(), registerRequest),
 			"a store whose signing rows exist but do not decode is not a fresh cluster")
 	})
 
@@ -70,7 +74,7 @@ func TestAuthorizeUnsignedBatch_BootstrapExceptionClosesOnUndecodableRows(t *tes
 			ks.AddPublicKey("root", make([]byte, ed25519.PublicKeySize), "")
 		})
 
-		require.Error(t, a.authorizeUnsignedBatch(registerRequest),
+		require.Error(t, a.authorizeUnsignedBatch(context.Background(), registerRequest),
 			"the pre-existing guard must keep rejecting once a usable key is loaded")
 	})
 
@@ -82,7 +86,7 @@ func TestAuthorizeUnsignedBatch_BootstrapExceptionClosesOnUndecodableRows(t *tes
 			ks.MarkUndecodableRows(1)
 		})
 
-		require.Error(t, a.authorizeUnsignedBatch(registerRequest))
+		require.Error(t, a.authorizeUnsignedBatch(context.Background(), registerRequest))
 	})
 }
 
@@ -105,4 +109,28 @@ func TestKeyStoreUndecodableRowsResetWithKeys(t *testing.T) {
 
 	ks.MarkUndecodableRows(0)
 	require.False(t, ks.HasUndecodableRows(), "a clean load must not set the marker")
+}
+
+// TestAuthorizeUnsignedBatch_ExemptsSystemActor pins that a leader-internal
+// proposal (system actor) is admitted unsigned even under RequireSignatures,
+// while the same unsigned batch from a client is rejected. Without the exemption
+// the chapter workers and schedulers can never propose on a signed cluster.
+func TestAuthorizeUnsignedBatch_ExemptsSystemActor(t *testing.T) {
+	t.Parallel()
+
+	businessReq := []*servicepb.Request{{
+		Type: &servicepb.Request_CreateLedger{
+			CreateLedger: &servicepb.CreateLedgerRequest{Name: "l"},
+		},
+	}}
+
+	a := &Admission{keyStore: keystore.NewKeyStore(), sharedState: state.NewSharedState()}
+	a.sharedState.SetRequireSignatures(true)
+
+	require.ErrorIs(t, a.authorizeUnsignedBatch(context.Background(), businessReq), signing.ErrMissingSignature,
+		"a client's unsigned business write is rejected under RequireSignatures")
+
+	sysCtx := internalauth.WithSystemActor(context.Background(), commands.ComponentChapterArchiver)
+	require.NoError(t, a.authorizeUnsignedBatch(sysCtx, businessReq),
+		"a leader-internal system proposal is admitted unsigned")
 }


### PR DESCRIPTION
## Problem

`authorizeUnsignedBatch` rejects **every** unsigned request when `RequireSignatures` is enabled (only a narrow signing-key bootstrap exception). But all leader-internal proposals — chapter archiver, sealer, scheduler, and the query-checkpoint scheduler — travel through admission as **unsigned** batches under a `WithSystemActor` context:

```go
admissionHandler.Admit(internalauth.WithSystemActor(ctx, commands.ComponentChapterArchiver),
    servicepb.UnsignedApplyRequest("", ...))
```

So on a **signed cluster** these components can never propose: chapter rotation/sealing/archiving and query-checkpoint creation are permanently rejected. This is pre-existing on `release/v3.0`.

It was surfaced by NumaryBot on #1750 (the cluster-policy reconciler, same pattern), where the upcoming write-readiness gate escalates the reconciler case from advisory `NOT_SERVING` to a permanent write block — but the root gap is general, hence this standalone fix.

## Fix

Exempt system actors from the unsigned-batch check. This is safe:

- `WithSystemActor` is set **only** by server-internal code (`internal/bootstrap/module.go`), never derived from client input — a client request can't forge it.
- System proposals are already audited under a `system_component` caller source.
- `RequireSignatures` exists to authenticate **client** writes; the leader's own audited internal proposals are inside the trust boundary.

Adds `auth.IsSystemActor(ctx)` and threads the context through `resolveBatch` → `authorizeUnsignedBatch`.

## Tests

- `TestAuthorizeUnsignedBatch_ExemptsSystemActor`: under `RequireSignatures`, a client's unsigned business write is rejected, the same batch from a system actor is admitted.
- Existing `authorize_unsigned_batch_test.go` (bootstrap exception) updated for the new signature and still passing.

Validation: `go build ./...`, admission + auth suites green, gofmt clean.