### PR TITLE
feat(EN-1859): expose server-side request timing on QueryProfile

### DIFF
--- a/cmd/ledgerctl/cmdutil/profile.go
+++ b/cmd/ledgerctl/cmdutil/profile.go
@@ -76,17 +76,39 @@ func RenderProfile(profile *servicepb.QueryProfile) {
 
 	// Server timing first: it is the number that answers "is the server or the
 	// network slow?", and the execution breakdown below is a subset of it.
+	residual, residualOK := residualDurationUs(profile)
+
+	barrier := formatDurationUs(profile.GetBarrierDurationUs())
+	if profile.GetForwarded() {
+		// A forwarded read runs its barrier on the remote node, so this 0 means
+		// "not measured here", not "no wait happened".
+		barrier += " (local only — read was forwarded)"
+	}
+
 	serverTiming := pterm.TableData{
 		{"Server Phase", "Value"},
-		{"Server Duration (total)", formatDurationUs(profile.GetServerDurationUs())},
+		{"Server Duration (consumer-independent)", formatDurationUs(profile.GetServerDurationUs())},
 		{"  Prepare (decode/validate/compile)", formatDurationUs(profile.GetPrepareDurationUs())},
 		{"  Execute (index+enrich+snapshot)", formatDurationUs(profile.GetExecuteDurationUs())},
-		{"  Other server work", formatDurationUs(residualDurationUs(profile))},
-		{"Read Barrier (caller-requested wait)", formatDurationUs(profile.GetBarrierDurationUs())},
+		{"  Other server work", formatDurationUs(residual)},
 		{"Deliver (serialise + stream write)", formatDurationUs(profile.GetDeliverDurationUs())},
+		{"Wall (server + deliver)", formatDurationUs(profile.GetServerDurationUs() + profile.GetDeliverDurationUs())},
+		{"Read Barrier (caller-requested wait)", barrier},
 		{"Time To First Row", formatDurationUs(profile.GetFirstRowDurationUs())},
 	}
 	_ = pterm.DefaultTable.WithHasHeader().WithData(serverTiming).Render()
+
+	if !residualOK {
+		// The phases cannot exceed the total they decompose; if they do, the
+		// server's phase bookkeeping is inconsistent. Say so rather than hiding
+		// it behind a clamped 0.
+		pterm.Warning.Printfln(
+			"Server phase breakdown is inconsistent: prepare (%s) + execute (%s) exceeds the server total (%s). Treat the breakdown as unreliable.",
+			formatDurationUs(profile.GetPrepareDurationUs()),
+			formatDurationUs(profile.GetExecuteDurationUs()),
+			formatDurationUs(profile.GetServerDurationUs()),
+		)
+	}
 
 	pterm.Println()
 
@@ -113,13 +135,18 @@ func RenderProfile(profile *servicepb.QueryProfile) {
 // attribute to the prepare or execute phase (response assembly, pagination
 // trailer, profile emission). Surfacing it keeps the breakdown honest: a large
 // residual means the phase boundaries need refining, not that the time vanished.
-func residualDurationUs(profile *servicepb.QueryProfile) int64 {
+//
+// The second return is false when the residual came out negative. That is
+// impossible if the server's bookkeeping is sound — the phases are windows inside
+// the total — so the caller must report it rather than render a clamped 0 that
+// looks like a normal reading.
+func residualDurationUs(profile *servicepb.QueryProfile) (int64, bool) {
 	residual := profile.GetServerDurationUs() - profile.GetPrepareDurationUs() - profile.GetExecuteDurationUs()
 	if residual < 0 {
-		return 0
+		return 0, false
 	}
 
-	return residual
+	return residual, true
 }
 
 func formatDurationUs(us int64) string {

--- a/cmd/ledgerctl/cmdutil/profile.go
+++ b/cmd/ledgerctl/cmdutil/profile.go
@@ -23,7 +23,7 @@ const (
 
 // AddAnalyzeFlag registers --analyze (with --analyse alias) on the command.
 func AddAnalyzeFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool("analyze", false, "Display query execution profile (iterator stats, timing)")
+	cmd.Flags().Bool("analyze", false, "Display query profile (server-side phase timing, iterator stats)")
 
 	prev := cmd.Flags().GetNormalizeFunc()
 	cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -74,8 +74,24 @@ func RenderProfile(profile *servicepb.QueryProfile) {
 	pterm.Println()
 	pterm.DefaultHeader.WithBackgroundStyle(pterm.NewStyle(pterm.BgDarkGray)).Println("Query Profile")
 
+	// Server timing first: it is the number that answers "is the server or the
+	// network slow?", and the execution breakdown below is a subset of it.
+	serverTiming := pterm.TableData{
+		{"Server Phase", "Value"},
+		{"Server Duration (total)", formatDurationUs(profile.GetServerDurationUs())},
+		{"  Prepare (decode/validate/compile)", formatDurationUs(profile.GetPrepareDurationUs())},
+		{"  Execute (index+enrich+snapshot)", formatDurationUs(profile.GetExecuteDurationUs())},
+		{"  Other server work", formatDurationUs(residualDurationUs(profile))},
+		{"Read Barrier (caller-requested wait)", formatDurationUs(profile.GetBarrierDurationUs())},
+		{"Deliver (serialise + stream write)", formatDurationUs(profile.GetDeliverDurationUs())},
+		{"Time To First Row", formatDurationUs(profile.GetFirstRowDurationUs())},
+	}
+	_ = pterm.DefaultTable.WithHasHeader().WithData(serverTiming).Render()
+
+	pterm.Println()
+
 	tableData := pterm.TableData{
-		{"Metric", "Value"},
+		{"Execution Metric", "Value"},
 		{"Index Duration", formatDurationUs(profile.GetIndexDurationUs())},
 		{"Enrichment Duration", formatDurationUs(profile.GetEnrichmentDurationUs())},
 		{"Total Duration", formatDurationUs(profile.GetIndexDurationUs() + profile.GetEnrichmentDurationUs())},
@@ -91,6 +107,19 @@ func RenderProfile(profile *servicepb.QueryProfile) {
 		pterm.DefaultSection.Println("Iterator Tree")
 		renderIteratorTree(profile.GetRootIterator(), 0)
 	}
+}
+
+// residualDurationUs is the part of server_duration_us the server did not
+// attribute to the prepare or execute phase (response assembly, pagination
+// trailer, profile emission). Surfacing it keeps the breakdown honest: a large
+// residual means the phase boundaries need refining, not that the time vanished.
+func residualDurationUs(profile *servicepb.QueryProfile) int64 {
+	residual := profile.GetServerDurationUs() - profile.GetPrepareDurationUs() - profile.GetExecuteDurationUs()
+	if residual < 0 {
+		return 0
+	}
+
+	return residual
 }
 
 func formatDurationUs(us int64) string {

--- a/cmd/ledgerctl/cmdutil/profile.go
+++ b/cmd/ledgerctl/cmdutil/profile.go
@@ -80,8 +80,11 @@ func RenderProfile(profile *servicepb.QueryProfile) {
 
 	barrier := formatDurationUs(profile.GetBarrierDurationUs())
 	if profile.GetForwarded() {
-		// A forwarded read runs its barrier on the remote node, so this 0 means
-		// "not measured here", not "no wait happened".
+		// A forwarded read runs a barrier on the remote node that is folded into
+		// its execution, so this value covers the local waits only — 0 means "not
+		// measured here", not "no wait happened", and a non-zero value is a local
+		// min_log_sequence catch-up or a failed ReadIndex attempt, not evidence
+		// about the remote node.
 		barrier += " (local only — read was forwarded)"
 	}
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -252,7 +252,7 @@ func NewRunCommandWithBindings(bindings network.Bindings) *cobra.Command {
 	runCmd.Flags().Bool("disable-audit-index", false, "Disable the audit secondary index worker")
 
 	// Query profiling
-	runCmd.Flags().Duration("query-profile-threshold", 10*time.Millisecond, "Log and emit OTel attributes for queries exceeding this duration (0 to disable)")
+	runCmd.Flags().Duration("query-profile-threshold", 10*time.Millisecond, "Log and emit OTel attributes for reads whose total server-side handling (excluding the caller-requested read barrier) exceeds this duration; 0 disables")
 
 	// gRPC slow threshold
 	runCmd.Flags().Duration("grpc-slow-threshold", time.Second, "Duration above which a gRPC call is logged as slow")

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4213,21 +4213,38 @@ ledger run --grpc-slow-threshold 500ms [other flags...]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--query-profile-threshold` | duration | `10ms` | Log and emit OTel attributes for queries whose **server duration** exceeds this value (0 to disable) |
+| `--query-profile-threshold` | duration | `10ms` | Log and emit OTel attributes for reads whose total server-side handling exceeds this value (`0` disables) |
 
 ```bash
-# Log queries slower than 50ms
+# Log reads slower than 50ms
 ledger run --query-profile-threshold 50ms [other flags...]
 
-# Disable query profiling
+# Disable the slow-read log entirely
 ledger run --query-profile-threshold 0 [other flags...]
 ```
 
-The threshold is compared against `server_duration_us` — the whole server-side
-handling of the request (decode, filter compilation, execution, response
-assembly), excluding the caller-requested read barrier and the response delivery.
-It is not the query execution time alone, so a request that spends its time in
-request decoding or filter compilation is caught as well.
+The threshold is compared against `server_duration_us + deliver_duration_us`: the
+whole server-side handling of the read — request decode, filter compilation,
+execution, response assembly, row serialisation and stream writes — excluding only
+the caller-requested read barrier. It is not the query execution time alone, so a
+read that spends its time in request decoding, filter compilation or serialisation
+is caught as well.
+
+`0` disables the log. It does not mean "log everything": every duration is `>= 0`,
+so a `0` threshold would otherwise match every single read.
+
+Two things to know before tuning it:
+
+- **It fires on more reads than the pre-3.0 behaviour**, which compared query
+  execution time only. The new total is structurally larger.
+- **Span attribute volume grows with it.** Each qualifying read attaches ~14
+  timing attributes plus a rendered iterator-tree string to its OTel span, and
+  that is gated only on the span being recorded, not on a log level. On a
+  read-heavy deployment, raise the threshold (or set `0`) if span payload size
+  matters more than the diagnostics.
+- **A slow client can trip it**, because stream writes are included. The logged
+  breakdown (`serverDurationUs` vs `deliverDurationUs` vs `firstRowDurationUs`)
+  identifies which side was actually slow.
 
 See [query-profile.md](../technical/architecture/subsystems/read-path/query-profile.md)
 for the full phase model and what each duration includes.

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1781,7 +1781,7 @@ ledgerctl accounts aggregate-volumes [flags]
 | `--filter` | | Filter expression (same DSL as account list) |
 | `--min-log-sequence` | `0` | Minimum log sequence before reading |
 | `--checkpoint-id` | `0` | Query checkpoint ID (0 = live data) |
-| `--analyze` | `false` | Display query execution profile |
+| `--analyze` | `false` | Display the query profile: server-side phase timing (prepare/execute/barrier/deliver) plus iterator stats |
 | `--json` | `false` | Output as JSON |
 | `--timeout` | `10s` | Request timeout |
 
@@ -3669,7 +3669,7 @@ ledgerctl queries execute <name> --ledger <ledger-name> [flags]
 | `--page-size` | `10` | Number of results per page |
 | `--mode` | `list` | Query mode: `list` or `aggregate` |
 | `--min-log-sequence` | `0` | Minimum log sequence before reading |
-| `--analyze` | `false` | Display query execution profile |
+| `--analyze` | `false` | Display the query profile: server-side phase timing (prepare/execute/barrier/deliver) plus iterator stats |
 | `--timeout` | `10s` | Request timeout |
 
 **Examples:**
@@ -4213,7 +4213,7 @@ ledger run --grpc-slow-threshold 500ms [other flags...]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--query-profile-threshold` | duration | `10ms` | Log and emit OTel attributes for queries exceeding this duration (0 to disable) |
+| `--query-profile-threshold` | duration | `10ms` | Log and emit OTel attributes for queries whose **server duration** exceeds this value (0 to disable) |
 
 ```bash
 # Log queries slower than 50ms
@@ -4222,6 +4222,15 @@ ledger run --query-profile-threshold 50ms [other flags...]
 # Disable query profiling
 ledger run --query-profile-threshold 0 [other flags...]
 ```
+
+The threshold is compared against `server_duration_us` — the whole server-side
+handling of the request (decode, filter compilation, execution, response
+assembly), excluding the caller-requested read barrier and the response delivery.
+It is not the query execution time alone, so a request that spends its time in
+request decoding or filter compilation is caught as well.
+
+See [query-profile.md](../technical/architecture/subsystems/read-path/query-profile.md)
+for the full phase model and what each duration includes.
 
 ---
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4224,18 +4224,19 @@ ledger run --query-profile-threshold 0 [other flags...]
 ```
 
 The threshold is compared against `server_duration_us + deliver_duration_us`: the
-whole server-side handling of the read — request decode, filter compilation,
+whole server-side handling of the read — authentication, filter compilation,
 execution, response assembly, row serialisation and stream writes — excluding only
 the caller-requested read barrier. It is not the query execution time alone, so a
-read that spends its time in request decoding, filter compilation or serialisation
-is caught as well.
+read that spends its time authenticating, compiling a filter or serialising rows
+is caught as well. (gRPC protobuf decode happens before the handler and is in
+neither total.)
 
 `0` disables the log. It does not mean "log everything": every duration is `>= 0`,
 so a `0` threshold would otherwise match every single read.
 
-Two things to know before tuning it:
+Three things to know before tuning it:
 
-- **It fires on more reads than the pre-3.0 behaviour**, which compared query
+- **It fires on more reads than it did before EN-1859**, which compared query
   execution time only. The new total is structurally larger.
 - **Span attribute volume grows with it.** Each qualifying read attaches ~14
   timing attributes plus a rendered iterator-tree string to its OTel span, and

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -13,6 +13,7 @@ The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `intern
 | [query-checkpoints.md](query-checkpoints.md) | Point-in-time snapshots of main store and read index for historical queries. |
 | [typed-metadata.md](typed-metadata.md) | Typed metadata values, per-ledger schema, and hybrid conversion strategy. |
 | [query-filter.md](query-filter.md) | Canonical HTTP QueryFilter surface: dual-format filter, parameter classification, textual/structured asymmetries, date coercion, AND-combination, audit text-only. |
+| [query-profile.md](query-profile.md) | Per-request read diagnostics: server-side phase breakdown (prepare/execute/barrier/deliver), why barrier and delivery are excluded from the server total, gRPC/HTTP parity, iterator tree. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -17,7 +17,7 @@ Source: `internal/query/profile.go`, wire type `servicepb.QueryProfile`
 Before EN-1859 the profile only reported execution: `index_duration_us +
 enrichment_duration_us`. Measured against an 87.7M-transaction ledger over an
 established gRPC connection, a client saw 56 ms end-to-end while the profile
-accounted for 2.3 ms. The remaining ~54 ms — request decode, filter compilation,
+accounted for 2.3 ms. The remaining ~54 ms — authentication, filter compilation,
 row serialisation, stream writes — was invisible, so a caller could not tell a
 slow network from a slow server, read-performance work had nothing to target,
 and no server-side latency SLO could be defined.
@@ -35,11 +35,11 @@ The request clock starts when the profile is created and stops at `Finish()`.
 
 | Field | Window | In `server_duration_us`? |
 |---|---|---|
-| `prepare_duration_us` | handler entry → executor invocation: auth, request decode/validation, filter parsing/compilation, checkpoint-store opening | yes |
+| `prepare_duration_us` | request entry → executor invocation: auth, validation, filter parsing/compilation, checkpoint-store opening, and HTTP query/body decode | yes |
 | `execute_duration_us` | the executor call: snapshot setup, ledger/schema resolution, index scan, enrichment, plus lazy row pulls | yes |
-| `barrier_duration_us` | **local** Raft `ReadIndex` quorum round-trip and `ReadOptions.min_log_sequence` read-index catch-up | **no** |
+| `barrier_duration_us` | **local** Raft `ReadIndex` quorum round-trip and `ReadOptions.min_log_sequence` read-index catch-up, successful or not | **no** |
 | `deliver_duration_us` | row serialisation + transport hand-off | **no** |
-| `first_row_duration_us` | handler entry → first row accepted by the transport | n/a |
+| `first_row_duration_us` | request entry → first row accepted by the transport | n/a |
 | `server_duration_us` | wall clock − barrier − deliver | — |
 | `forwarded` | the read was served by another node | n/a |
 
@@ -99,22 +99,33 @@ time inside `execute_duration_us`. Always read `barrier_duration_us` together wi
 | `forwarded` | `barrier_duration_us` | meaning |
 |---|---|---|
 | false | any | the whole barrier this read paid |
-| true | `0` | no barrier ran **here** — an explicit leader read (`x-consistency: leader`) never attempts one. Not "no barrier was needed": the leader's is inside `execute_duration_us`. |
-| true | non-zero | this node **attempted** a local barrier, it failed, and the read fell back to the leader (see below) |
+| true | `0` | no local wait happened. Not "no barrier was needed": the remote node's is inside `execute_duration_us`. |
+| true | non-zero | a local wait happened before the read left this node; the remote barrier is on top of it (see below) |
 
-The last row is the syncing-follower fallback in `RoutedController.readCtrl`. The
-attempt is charged even though it failed, because the caller really did wait for
-it, and it stays excluded from `server_duration_us` for the same reason a
-successful barrier is: a quorum wait is not server work. The leader's own barrier
-is then paid *on top*, inside `execute_duration_us`. Zeroing the failed attempt
-instead would push consensus latency into `prepare_duration_us` and into the
-server total — mislabelling a quorum wait as request preparation, which is the
-distortion the phase split exists to remove.
+Two independent things produce the last row, and the value does **not** say
+which:
 
-In practice the magnitude differs sharply by cause: `ErrNodeSyncing` is returned
-before any wait, so the attempt costs nanoseconds, whereas leadership lost
-mid-`ReadIndex` resolves a pending future and can account for the whole quorum
-attempt.
+- **`min_log_sequence` catch-up.** `waitMinLogSequence` charges the
+  `WaitForSequence` wait regardless of consistency level, and it runs before
+  routing — so `--consistency leader --min-log-sequence N` yields a non-zero
+  barrier on a perfectly healthy cluster, with no failed attempt anywhere.
+- **A failed `ReadIndex` attempt.** The syncing-follower fallback in
+  `RoutedController.readCtrl` records the attempt and *then* forwards. Magnitude
+  differs sharply by cause: `ErrNodeSyncing` returns before any wait, so it costs
+  nanoseconds, whereas leadership lost mid-`ReadIndex` resolves a pending future
+  and can account for the whole quorum attempt.
+
+So do not read cluster health off a non-zero forwarded barrier — the common cause
+is a caller asking for read-your-writes.
+
+Either way the wait is charged and stays excluded from `server_duration_us`, for
+the same reason a successful barrier is: the caller waited for it, and an
+abandoned quorum round-trip is no more server work than a completed one. Not
+charging the failed attempt would leave it inside `execute_duration_us` — the
+`readCtrl` call sits inside the `EnterExecute`/`LeaveExecute` bracket, so the
+subtraction that removes barrier time from execution would find nothing to
+subtract — and from there inside the server total, which is the distortion the
+phase split exists to remove.
 
 ### Why `deliver` is excluded, and how streaming ambiguity is resolved
 

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -37,10 +37,42 @@ The request clock starts when the profile is created and stops at `Finish()`.
 |---|---|---|
 | `prepare_duration_us` | handler entry → executor invocation: auth, request decode/validation, filter parsing/compilation, checkpoint-store opening | yes |
 | `execute_duration_us` | the executor call: snapshot setup, ledger/schema resolution, index scan, enrichment, plus lazy row pulls | yes |
-| `barrier_duration_us` | Raft `ReadIndex` quorum round-trip and `ReadOptions.min_log_sequence` read-index catch-up | **no** |
+| `barrier_duration_us` | **local** Raft `ReadIndex` quorum round-trip and `ReadOptions.min_log_sequence` read-index catch-up | **no** |
 | `deliver_duration_us` | row serialisation + transport hand-off | **no** |
-| `first_row_duration_us` | handler entry → first row accepted by the transport (streams only) | n/a |
+| `first_row_duration_us` | handler entry → first row accepted by the transport | n/a |
 | `server_duration_us` | wall clock − barrier − deliver | — |
+| `forwarded` | the read was served by another node | n/a |
+
+## Two totals, and what each one is blind to
+
+Neither total is a clean latency-SLO basis on a streaming read. Say which one an
+SLO uses and accept its bias:
+
+| | `server_duration_us` | `server_duration_us + deliver_duration_us` |
+|---|---|---|
+| moved by a slow client? | no | **yes**, on a stream |
+| includes row serialisation? | **no** | yes |
+| same definition on gRPC and HTTP? | yes | no (HTTP delivery is 0) |
+
+Row serialisation is excluded from `server_duration_us` because a gRPC
+`stream.Send()` marshals and writes in one inseparable call — there is no seam to
+measure between them without re-implementing the send path over
+`grpc.PreparedMsg`, which would move the hot streaming path onto a
+less-exercised codec/compression route for a measurement refinement. Not worth
+the risk; the cost is reported in `deliver_duration_us` instead.
+
+The **slow-query threshold uses the sum**, deliberately. `server_duration_us`
+alone is blind to two real costs — serialisation, which grows with page size, and
+the entire remote cost of a forwarded read, which arrives through the
+row-production side of the send loop. A threshold blind to both would fail to
+fire on exactly the requests it exists for. The price is that a slow consumer can
+trip it; the logged breakdown then says which side was slow, which is strictly
+more than a threshold that never fires says.
+
+`first_row_duration_us` is 0 in three distinct cases: an empty streaming result,
+a unary response (all HTTP routes, plus `AggregateVolumes` and
+`ExecutePreparedQuery`), and a streaming read that failed before its first send.
+Disambiguate with `items_collected` and the RPC status.
 
 `index_duration_us` and `enrichment_duration_us` are sub-phases of
 `execute_duration_us`, not peers of the total.
@@ -57,6 +89,13 @@ read additionally waits for the read index to reach `min_log_sequence`. Both are
 latency the *caller opted into*. Folding them into the server total would blame
 the server for the caller's consistency requirement, and would make the number
 move with cluster RTT rather than with server cost.
+
+Only **local** barriers are measured. On a forwarded read the leader runs its own
+`ReadIndexAndWait` (`x-consistency` is not propagated, so it defaults to
+linearizable there), and that wait is invisible here: it arrives as row-production
+time inside `execute_duration_us`, while `barrier_duration_us` reads 0. The
+`forwarded` flag exists so that 0 cannot be misread as "no barrier was needed" —
+always read the two together.
 
 ### Why `deliver` is excluded, and how streaming ambiguity is resolved
 
@@ -122,39 +161,72 @@ tables (`cmd/ledgerctl/cmdutil/profile.go`).
 
 ## Cost when the profile is not requested
 
-The profile is collected on **every** profiled read, not only when asked: the
-slow-query log and the OTel span consume the same record, and a threshold that
-could only see execution time would miss precisely the requests EN-1859 is
-about. All per-request measurements are O(1) — a handful of `time.Now()` calls.
+The profile is collected in full on **every** profiled read, not only when asked,
+and there is exactly **one** measurement regime. The gate is the presence of a
+profile in the context, never whether the caller asked to see it.
 
-The one instrumentation whose cost scales with the result size — the per-row
-`execute`/`deliver` split in the streaming loop — is gated on whether the caller
-actually asked for the profile (`QueryProfile.Detailed()`). An unprofiled request
-brackets the whole loop once and charges it to `deliver`. That direction is
-deliberate: `deliver` is excluded from the total, so `server_duration_us` can
-only be *under*-reported for an unprofiled request, never inflated by a slow
-consumer.
+That is a correctness requirement, not a convenience. Nothing sends
+`x-query-profile` in normal operation, so the slow-query log is the profile's only
+production consumer. An earlier revision of this work gated the per-row
+`execute`/`deliver` split on the caller having asked, and charged the whole send
+loop to `deliver` otherwise — and since `deliver` is subtracted from the total,
+`server_duration_us` was left blind to the entire loop in exactly the
+configuration that reads it. A forwarded read spending seconds inside `cur.Next()`
+reported sub-millisecond. Two conditional regimes also made gRPC and HTTP
+incomparable when unprofiled, which contradicts the whole point of a shared
+definition.
+
+The cost of getting it right is two `time.Now()` per row — tens of microseconds
+across a 1000-row page (`MaxPageSize`, the server-side ceiling), against a proto
+marshal and a transport write per row. Unprofiled *handlers* (every read RPC other
+than the four listed above) still pay nothing: `profile == nil` skips the clock
+reads entirely.
 
 ## Slow-query threshold
 
 `--query-profile-threshold` (default 10 ms) gates the trace-level profile log and
-the span attributes. It is compared against `ServerDuration`, not the execution
-total: thresholding on execution meant the slow requests the log exists to
-surface were the ones it could not see. See `emitProfile` in
+the span attributes. **0 disables it**; every duration is `>= 0`, so comparing
+against 0 would otherwise log every single read.
+
+It compares `WallDuration` — `server_duration_us + deliver_duration_us` — for the
+reasons in "Two totals" above: `ServerDuration` alone cannot see row serialisation
+or a forwarded read's remote cost. See `emitProfile` in
 `internal/adapter/grpc/server_bucket.go`.
 
-`LogTo` also emits `profileDetailed`. When false, `deliverDurationUs` holds the
-whole streaming loop rather than just the sends — do not read the two as
-equivalent across log lines.
+Two operational consequences:
+
+- **The threshold now fires on strictly more reads than before EN-1859**, since
+  `WallDuration >= ServerDuration >= TotalDuration` structurally. `EmitToSpan` is
+  not behind a log level (only `span.IsRecording()`), so each qualifying read
+  attaches ~14 attributes plus the rendered `query.iterator_tree` string to its
+  span. On a read-heavy deployment that is a real increase in span payload
+  volume — raise the threshold or set it to 0 if that matters more than the
+  diagnostics.
+- A slow *consumer* can trip it. That is intended; the logged
+  `deliverDurationUs` / `firstRowDurationUs` / `serverDurationUs` breakdown
+  identifies which side was slow.
+
+`LogTo` also emits `forwarded`. When true, `barrierDurationUs` is 0 for lack of a
+local barrier and the remote node's whole cost sits inside `executeDurationUs` —
+do not compare such a line's breakdown against a locally-served one.
 
 ## Known gaps
 
-- **Leader-forwarded reads.** When a follower forwards a read to the leader
-  (`ConsistencyLeader`, or the syncing-node fallback in
+- **Leader-forwarded reads report only the local hop.** When a follower forwards
+  a read (`ConsistencyLeader`, or the syncing-node fallback in
   `RoutedController.readCtrl`), the upstream RPC is charged to the local
-  `execute` phase. The remote server's own breakdown is not nested into the
-  local profile, so `execute` there conflates network hops, leader-side prepare
-  and leader-side execution.
+  `execute` phase, so `execute` there conflates network hops, leader-side
+  prepare, leader-side barrier and leader-side execution — and
+  `barrier_duration_us` reads 0.
+
+  The `forwarded` flag makes this **detectable** rather than silent, which is the
+  part that mattered: a consumer can tell "no barrier" from "barrier not measured
+  here". It does not make it *attributable*. Nesting the remote breakdown is
+  deliberately deferred: the leader's `x-query-profile-result-bin` trailer is
+  reachable from `BucketGrpcClient`, but consuming it means opting every routed
+  read into upstream profiling, plumbing a trailer that only materialises at EOF
+  out through the `cursor.Cursor` abstraction, and deciding how two phase
+  breakdowns compose into one. That is a design question, not a fix.
 - **HTTP body write** is not measurable (see above).
 - **Unary gRPC responses** (`AggregateVolumes`, `ExecutePreparedQuery`) have no
   delivery phase: the reply is marshalled by the gRPC codec after the handler

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -93,9 +93,28 @@ move with cluster RTT rather than with server cost.
 Only **local** barriers are measured. On a forwarded read the leader runs its own
 `ReadIndexAndWait` (`x-consistency` is not propagated, so it defaults to
 linearizable there), and that wait is invisible here: it arrives as row-production
-time inside `execute_duration_us`, while `barrier_duration_us` reads 0. The
-`forwarded` flag exists so that 0 cannot be misread as "no barrier was needed" —
-always read the two together.
+time inside `execute_duration_us`. Always read `barrier_duration_us` together with
+`forwarded`:
+
+| `forwarded` | `barrier_duration_us` | meaning |
+|---|---|---|
+| false | any | the whole barrier this read paid |
+| true | `0` | no barrier ran **here** — an explicit leader read (`x-consistency: leader`) never attempts one. Not "no barrier was needed": the leader's is inside `execute_duration_us`. |
+| true | non-zero | this node **attempted** a local barrier, it failed, and the read fell back to the leader (see below) |
+
+The last row is the syncing-follower fallback in `RoutedController.readCtrl`. The
+attempt is charged even though it failed, because the caller really did wait for
+it, and it stays excluded from `server_duration_us` for the same reason a
+successful barrier is: a quorum wait is not server work. The leader's own barrier
+is then paid *on top*, inside `execute_duration_us`. Zeroing the failed attempt
+instead would push consensus latency into `prepare_duration_us` and into the
+server total — mislabelling a quorum wait as request preparation, which is the
+distortion the phase split exists to remove.
+
+In practice the magnitude differs sharply by cause: `ErrNodeSyncing` is returned
+before any wait, so the attempt costs nanoseconds, whereas leadership lost
+mid-`ReadIndex` resolves a pending future and can account for the whole quorum
+attempt.
 
 ### Why `deliver` is excluded, and how streaming ambiguity is resolved
 
@@ -206,9 +225,10 @@ Two operational consequences:
   `deliverDurationUs` / `firstRowDurationUs` / `serverDurationUs` breakdown
   identifies which side was slow.
 
-`LogTo` also emits `forwarded`. When true, `barrierDurationUs` is 0 for lack of a
-local barrier and the remote node's whole cost sits inside `executeDurationUs` —
-do not compare such a line's breakdown against a locally-served one.
+`LogTo` also emits `forwarded`. When true, the remote node's whole cost sits
+inside `executeDurationUs` and `barrierDurationUs` covers the local attempt only
+(see the table above) — do not compare such a line's breakdown against a
+locally-served one.
 
 ## Known gaps
 
@@ -216,8 +236,8 @@ do not compare such a line's breakdown against a locally-served one.
   a read (`ConsistencyLeader`, or the syncing-node fallback in
   `RoutedController.readCtrl`), the upstream RPC is charged to the local
   `execute` phase, so `execute` there conflates network hops, leader-side
-  prepare, leader-side barrier and leader-side execution — and
-  `barrier_duration_us` reads 0.
+  prepare, leader-side barrier and leader-side execution. `barrier_duration_us`
+  covers only what this node attempted locally.
 
   The `forwarded` flag makes this **detectable** rather than silent, which is the
   part that mattered: a consumer can tell "no barrier" from "barrier not measured

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -1,0 +1,165 @@
+# Query Profile
+
+`QueryProfile` is the per-request diagnostic record of a read. It answers two
+different questions, and keeping them apart is the whole point of the design:
+
+1. **Where did query execution go?** — the iterator tree, index and enrichment
+   durations, item counts.
+2. **How long did the server hold the request, and doing what?** — the phase
+   breakdown (prepare / execute / barrier / deliver) and the headline
+   `server_duration_us`.
+
+Source: `internal/query/profile.go`, wire type `servicepb.QueryProfile`
+(`misc/proto/bucket.proto`).
+
+## Why the second question exists
+
+Before EN-1859 the profile only reported execution: `index_duration_us +
+enrichment_duration_us`. Measured against an 87.7M-transaction ledger over an
+established gRPC connection, a client saw 56 ms end-to-end while the profile
+accounted for 2.3 ms. The remaining ~54 ms — request decode, filter compilation,
+row serialisation, stream writes — was invisible, so a caller could not tell a
+slow network from a slow server, read-performance work had nothing to target,
+and no server-side latency SLO could be defined.
+
+## Phase model
+
+The request clock starts when the profile is created and stops at `Finish()`.
+
+```
+|<-------------------------- wall clock -------------------------->|
+[  prepare  ][  barrier  ][  execute  ][ residual ][   deliver     ]
+                   ^                                      ^
+        caller-requested wait                  consumer-dependent
+```
+
+| Field | Window | In `server_duration_us`? |
+|---|---|---|
+| `prepare_duration_us` | handler entry → executor invocation: auth, request decode/validation, filter parsing/compilation, checkpoint-store opening | yes |
+| `execute_duration_us` | the executor call: snapshot setup, ledger/schema resolution, index scan, enrichment, plus lazy row pulls | yes |
+| `barrier_duration_us` | Raft `ReadIndex` quorum round-trip and `ReadOptions.min_log_sequence` read-index catch-up | **no** |
+| `deliver_duration_us` | row serialisation + transport hand-off | **no** |
+| `first_row_duration_us` | handler entry → first row accepted by the transport (streams only) | n/a |
+| `server_duration_us` | wall clock − barrier − deliver | — |
+
+`index_duration_us` and `enrichment_duration_us` are sub-phases of
+`execute_duration_us`, not peers of the total.
+
+`prepare + execute <= server`. The difference is server work outside both phases
+(response assembly, pagination trailer, profile emission); `ledgerctl` renders it
+as *Other server work* so the breakdown stays honest instead of losing time
+silently. A large residual is a signal that the phase boundaries need refining.
+
+### Why `barrier` is excluded
+
+A linearizable read pays a `ReadIndex` quorum round-trip, and a read-your-writes
+read additionally waits for the read index to reach `min_log_sequence`. Both are
+latency the *caller opted into*. Folding them into the server total would blame
+the server for the caller's consistency requirement, and would make the number
+move with cluster RTT rather than with server cost.
+
+### Why `deliver` is excluded, and how streaming ambiguity is resolved
+
+`ListTransactions` and `ListAccounts` are server-streaming. A naive total would
+include time blocked in `stream.Send` waiting for HTTP/2 flow-control window —
+that is consumer cost, and a total that grows because the client stopped reading
+would mislead exactly the reader trying to decide whether the server is slow.
+
+So the streaming loop (`internal/adapter/grpc/stream_helper.go`) splits its own
+wall time in two:
+
+- `cur.Next()` is **row production** and is charged to `execute`. It is near-free
+  for an eagerly materialised local cursor, but on a follower that routed the
+  read to the leader each `Next()` is an upstream stream receive — genuine
+  server-side query cost that would otherwise vanish.
+- `stream.Send()` is **delivery** and is charged to `deliver`, outside the server
+  total.
+
+"Time to first row" and "total to last row" are then reported as distinct
+numbers: `first_row_duration_us` versus `server_duration_us` + `deliver`. A slow
+consumer shows up as `deliver >> first_row` with `server_duration_us` unchanged.
+
+## gRPC and HTTP agree on `server_duration_us`
+
+`server_duration_us` is defined identically on both surfaces — handler entry to
+response-ready, minus barrier, minus delivery — which is what makes the two
+comparable. Only the *content* of `deliver_duration_us` differs, because the
+transports differ:
+
+| | gRPC | HTTP |
+|---|---|---|
+| `deliver_duration_us` | sum of `stream.Send()`: marshal + transport write + flow-control wait | always 0 — not measurable, see below |
+| `first_row_duration_us` | populated for streaming reads | always 0 — the response is buffered, there is no per-row hand-off |
+| row production charged to `execute` | per row in the send loop | once around the `drainCursor` loop |
+
+The HTTP delivery gap is structural. The profile travels in the
+`X-Query-Profile-Result` response *header*, so it must be finalised and flushed
+before the body is written — which puts the body write out of reach by
+construction (`finishProfile` in `internal/adapter/http/response.go`).
+
+Only the marshal step could in principle be measured, by buffering the body. That
+was deliberately rejected: the four profiled routes use three different writers
+(`writeOK`, `writeOKChecked`, `writeJSONResponse`) whose sonic configurations
+differ in HTML escaping and map-key ordering, so funnelling them through one
+buffered marshaller would silently change their JSON output. A partial number is
+not worth an unrelated wire change.
+
+The requirement that actually matters is unaffected: `server_duration_us` excludes
+row serialisation on **both** surfaces, so the headline number stays comparable.
+
+## Transport surfaces
+
+| Surface | Request opt-in | Response channel |
+|---|---|---|
+| gRPC | `x-query-profile` metadata | `x-query-profile-result-bin` trailer |
+| HTTP | `X-Query-Profile` header | `X-Query-Profile-Result` header (base64 protobuf) |
+
+Profiled endpoints: `ListTransactions`, `ListAccounts`, `AggregateVolumes`,
+`ExecutePreparedQuery` — on both surfaces.
+
+`ledgerctl` requests the trailer with `--analyze` / `--analyse` and renders both
+tables (`cmd/ledgerctl/cmdutil/profile.go`).
+
+## Cost when the profile is not requested
+
+The profile is collected on **every** profiled read, not only when asked: the
+slow-query log and the OTel span consume the same record, and a threshold that
+could only see execution time would miss precisely the requests EN-1859 is
+about. All per-request measurements are O(1) — a handful of `time.Now()` calls.
+
+The one instrumentation whose cost scales with the result size — the per-row
+`execute`/`deliver` split in the streaming loop — is gated on whether the caller
+actually asked for the profile (`QueryProfile.Detailed()`). An unprofiled request
+brackets the whole loop once and charges it to `deliver`. That direction is
+deliberate: `deliver` is excluded from the total, so `server_duration_us` can
+only be *under*-reported for an unprofiled request, never inflated by a slow
+consumer.
+
+## Slow-query threshold
+
+`--query-profile-threshold` (default 10 ms) gates the trace-level profile log and
+the span attributes. It is compared against `ServerDuration`, not the execution
+total: thresholding on execution meant the slow requests the log exists to
+surface were the ones it could not see. See `emitProfile` in
+`internal/adapter/grpc/server_bucket.go`.
+
+`LogTo` also emits `profileDetailed`. When false, `deliverDurationUs` holds the
+whole streaming loop rather than just the sends — do not read the two as
+equivalent across log lines.
+
+## Known gaps
+
+- **Leader-forwarded reads.** When a follower forwards a read to the leader
+  (`ConsistencyLeader`, or the syncing-node fallback in
+  `RoutedController.readCtrl`), the upstream RPC is charged to the local
+  `execute` phase. The remote server's own breakdown is not nested into the
+  local profile, so `execute` there conflates network hops, leader-side prepare
+  and leader-side execution.
+- **HTTP body write** is not measurable (see above).
+- **Unary gRPC responses** (`AggregateVolumes`, `ExecutePreparedQuery`) have no
+  delivery phase: the reply is marshalled by the gRPC codec after the handler
+  returns, past the point where the trailer is set.
+- **HTTP reads do not feed the slow-query log.** `--query-profile-threshold`
+  drives `emitProfile`, which only the gRPC handlers call. An HTTP read still
+  reports its profile on request, but a slow one produces no threshold-triggered
+  log line or span attributes. Pre-existing, not introduced by EN-1859.

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -526,12 +526,21 @@ func (impl *BucketServiceServerImpl) readController(ctx context.Context, checkpo
 
 // waitMinLogSequence blocks until the Pebble read index has processed at
 // least the requested minimum log sequence, or the context is cancelled.
+//
+// The wait is charged to the profile's barrier phase rather than to server
+// work: the caller asked for read-your-writes freshness, so counting the wait
+// as server latency would blame the server for the caller's consistency
+// requirement.
 func (impl *BucketServiceServerImpl) waitMinLogSequence(ctx context.Context, minLogSequence uint64) error {
 	if minLogSequence == 0 {
 		return nil
 	}
 
-	return impl.readStore.WaitForSequence(ctx, minLogSequence)
+	start := time.Now()
+	err := impl.readStore.WaitForSequence(ctx, minLogSequence)
+	query.ProfileFromContext(ctx).AddBarrierWait(time.Since(start))
+
+	return err
 }
 
 // waitFilteredAuditConsistency gives a live, filtered ListAuditEntries read a
@@ -588,6 +597,10 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 		trace.WithAttributes(attribute.String("ledger", req.GetLedger())))
 	defer span.End()
 
+	// Start the profile clock before authentication and request decode so those
+	// phases land inside PrepareDuration instead of being invisible.
+	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeTransactionsRead); err != nil {
 		return err
 	}
@@ -613,8 +626,6 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 			req.GetLedger(), pageSize, afterTxID, opts.GetFilter() != nil, opts.GetReverse())
 	}
 
-	profileCtx, profile := query.WithProfile(ctx)
-
 	var c cursor.Cursor[*commonpb.Transaction]
 
 	if cpID := opts.GetRead().GetCheckpointId(); cpID > 0 {
@@ -628,13 +639,17 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 			_ = mainStore.Close()
 		}()
 
-		c, err = impl.localCtrl.ListTransactionsFrom(profileCtx, mainStore, readIdx, req.GetLedger(), fetchSize, afterTxID, opts.GetFilter(), opts.GetReverse())
+		profile.EnterExecute()
+		c, err = impl.localCtrl.ListTransactionsFrom(ctx, mainStore, readIdx, req.GetLedger(), fetchSize, afterTxID, opts.GetFilter(), opts.GetReverse())
+		profile.LeaveExecute()
 	} else {
 		if waitErr := impl.waitMinLogSequence(ctx, opts.GetRead().GetMinLogSequence()); waitErr != nil {
 			return waitErr
 		}
 
-		c, err = impl.ctrl.ListTransactions(profileCtx, req.GetLedger(), fetchSize, afterTxID, opts.GetFilter(), opts.GetReverse())
+		profile.EnterExecute()
+		c, err = impl.ctrl.ListTransactions(ctx, req.GetLedger(), fetchSize, afterTxID, opts.GetFilter(), opts.GetReverse())
+		profile.LeaveExecute()
 	}
 
 	if err != nil {
@@ -772,6 +787,9 @@ func (impl *BucketServiceServerImpl) ListAccounts(req *servicepb.ListAccountsReq
 		trace.WithAttributes(attribute.String("ledger", req.GetLedger())))
 	defer span.End()
 
+	// See ListTransactions: the clock must start before auth/decode.
+	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeAccountsRead); err != nil {
 		return err
 	}
@@ -802,9 +820,10 @@ func (impl *BucketServiceServerImpl) ListAccounts(req *servicepb.ListAccountsReq
 			req.GetLedger(), pageSize, opts.GetCursor(), opts.GetFilter() != nil, opts.GetReverse())
 	}
 
-	profileCtx, profile := query.WithProfile(ctx)
+	profile.EnterExecute()
+	cur, err := c.ListAccounts(ctx, req.GetLedger(), pageSizePlusOne(pageSize), opts.GetCursor(), opts.GetFilter(), opts.GetReverse())
+	profile.LeaveExecute()
 
-	cur, err := c.ListAccounts(profileCtx, req.GetLedger(), pageSizePlusOne(pageSize), opts.GetCursor(), opts.GetFilter(), opts.GetReverse())
 	if err != nil {
 		return fmt.Errorf("listing accounts: %w", err)
 	}
@@ -1353,13 +1372,18 @@ func (impl *BucketServiceServerImpl) ListPreparedQueries(ctx context.Context, re
 }
 
 func (impl *BucketServiceServerImpl) ExecutePreparedQuery(ctx context.Context, req *servicepb.ExecutePreparedQueryRequest) (*servicepb.ExecutePreparedQueryResponse, error) {
+	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeQueriesRead); err != nil {
 		return nil, err
 	}
 
-	profileCtx, profile := query.WithProfile(ctx)
+	profile.EnterExecute()
+	resp, err := impl.ctrl.ExecutePreparedQuery(ctx, req)
+	profile.LeaveExecute()
 
-	resp, err := impl.ctrl.ExecutePreparedQuery(profileCtx, req)
+	// Unary response: the reply is marshalled by the gRPC codec after the
+	// handler returns, so there is no measurable delivery phase here.
 	impl.emitProfile(ctx, profile)
 
 	return resp, err
@@ -1384,6 +1408,8 @@ func (impl *BucketServiceServerImpl) GetLedgerStats(ctx context.Context, req *se
 }
 
 func (impl *BucketServiceServerImpl) AggregateVolumes(ctx context.Context, req *servicepb.AggregateVolumesRequest) (*commonpb.AggregateResult, error) {
+	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeAccountsRead); err != nil {
 		return nil, err
 	}
@@ -1405,13 +1431,13 @@ func (impl *BucketServiceServerImpl) AggregateVolumes(ctx context.Context, req *
 		}
 	}
 
-	profileCtx, profile := query.WithProfile(ctx)
-
-	result, err := c.AggregateVolumes(profileCtx, req.GetLedger(), req.GetFilter(), query.AggregateOptions{
+	profile.EnterExecute()
+	result, err := c.AggregateVolumes(ctx, req.GetLedger(), req.GetFilter(), query.AggregateOptions{
 		UseMaxPrecision: req.GetUseMaxPrecision(),
 		GroupByPrefixes: req.GetGroupByPrefixes(),
 		CollapseColors:  req.GetCollapseColors(),
 	})
+	profile.LeaveExecute()
 	impl.emitProfile(ctx, profile)
 
 	return result, err
@@ -1596,12 +1622,22 @@ func (impl *BucketServiceServerImpl) Discovery(_ context.Context, _ *servicepb.D
 	return resp, nil
 }
 
+// emitProfile closes the request clock and publishes the profile: to the
+// slow-query log / OTel span when the request exceeded the configured
+// threshold, and to the gRPC trailer when the caller asked for it.
+//
+// The threshold is compared against ServerDuration, not the execution total.
+// EN-1859 measured a 56 ms client round-trip whose execution accounted for
+// 2.3 ms: thresholding on execution meant the slow requests this log exists to
+// surface were precisely the ones it could not see.
 func (impl *BucketServiceServerImpl) emitProfile(ctx context.Context, profile *query.QueryProfile) {
 	if profile == nil {
 		return
 	}
 
-	if profile.TotalDuration() >= impl.queryProfileThreshold {
+	profile.Finish()
+
+	if profile.ServerDuration >= impl.queryProfileThreshold {
 		profile.LogTo(impl.logger)
 		profile.EmitToSpan(trace.SpanFromContext(ctx))
 	}

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -597,8 +597,10 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 		trace.WithAttributes(attribute.String("ledger", req.GetLedger())))
 	defer span.End()
 
-	// Start the profile clock before authentication and request decode so those
-	// phases land inside PrepareDuration instead of being invisible.
+	// Start the profile clock before authentication and validation so those
+	// phases land inside PrepareDuration instead of being invisible. Protobuf
+	// decode is already done: grpc-go unmarshals the request before dispatching,
+	// so no in-handler clock can reach it.
 	ctx, profile := query.WithProfile(ctx)
 	defer impl.emitProfile(ctx, profile)
 
@@ -785,7 +787,7 @@ func (impl *BucketServiceServerImpl) ListAccounts(req *servicepb.ListAccountsReq
 		trace.WithAttributes(attribute.String("ledger", req.GetLedger())))
 	defer span.End()
 
-	// See ListTransactions: the clock must start before auth/decode.
+	// See ListTransactions: the clock must start before auth/validation.
 	ctx, profile := query.WithProfile(ctx)
 	defer impl.emitProfile(ctx, profile)
 

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -599,7 +599,8 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 
 	// Start the profile clock before authentication and request decode so those
 	// phases land inside PrepareDuration instead of being invisible.
-	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+	ctx, profile := query.WithProfile(ctx)
+	defer impl.emitProfile(ctx, profile)
 
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeTransactionsRead); err != nil {
 		return err
@@ -656,10 +657,7 @@ func (impl *BucketServiceServerImpl) ListTransactions(req *servicepb.ListTransac
 		return fmt.Errorf("listing transactions: %w", err)
 	}
 
-	err = sendPagedToStream(ctx, c, stream, "transaction", pageSize, txCursorOf)
-	impl.emitProfile(ctx, profile)
-
-	return err
+	return sendPagedToStream(ctx, c, stream, "transaction", pageSize, txCursorOf)
 }
 
 // txCursorOf returns the opaque next-page cursor for a transaction (its id
@@ -788,7 +786,8 @@ func (impl *BucketServiceServerImpl) ListAccounts(req *servicepb.ListAccountsReq
 	defer span.End()
 
 	// See ListTransactions: the clock must start before auth/decode.
-	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+	ctx, profile := query.WithProfile(ctx)
+	defer impl.emitProfile(ctx, profile)
 
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeAccountsRead); err != nil {
 		return err
@@ -828,10 +827,7 @@ func (impl *BucketServiceServerImpl) ListAccounts(req *servicepb.ListAccountsReq
 		return fmt.Errorf("listing accounts: %w", err)
 	}
 
-	err = sendPagedToStream(ctx, cur, stream, "account", pageSize, accountCursorOf)
-	impl.emitProfile(ctx, profile)
-
-	return err
+	return sendPagedToStream(ctx, cur, stream, "account", pageSize, accountCursorOf)
 }
 
 // accountCursorOf returns the opaque next-page cursor for an account (its
@@ -1372,7 +1368,8 @@ func (impl *BucketServiceServerImpl) ListPreparedQueries(ctx context.Context, re
 }
 
 func (impl *BucketServiceServerImpl) ExecutePreparedQuery(ctx context.Context, req *servicepb.ExecutePreparedQueryRequest) (*servicepb.ExecutePreparedQueryResponse, error) {
-	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+	ctx, profile := query.WithProfile(ctx)
+	defer impl.emitProfile(ctx, profile)
 
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeQueriesRead); err != nil {
 		return nil, err
@@ -1380,11 +1377,9 @@ func (impl *BucketServiceServerImpl) ExecutePreparedQuery(ctx context.Context, r
 
 	profile.EnterExecute()
 	resp, err := impl.ctrl.ExecutePreparedQuery(ctx, req)
+	// No delivery phase on a unary reply: the gRPC codec marshals it after the
+	// handler returns, past the point where the trailer is set.
 	profile.LeaveExecute()
-
-	// Unary response: the reply is marshalled by the gRPC codec after the
-	// handler returns, so there is no measurable delivery phase here.
-	impl.emitProfile(ctx, profile)
 
 	return resp, err
 }
@@ -1408,7 +1403,8 @@ func (impl *BucketServiceServerImpl) GetLedgerStats(ctx context.Context, req *se
 }
 
 func (impl *BucketServiceServerImpl) AggregateVolumes(ctx context.Context, req *servicepb.AggregateVolumesRequest) (*commonpb.AggregateResult, error) {
-	ctx, profile := query.WithProfile(ctx, wantsProfile(ctx))
+	ctx, profile := query.WithProfile(ctx)
+	defer impl.emitProfile(ctx, profile)
 
 	if _, err := internalauth.Authenticate(ctx, impl.authCfg, internalauth.ScopeAccountsRead); err != nil {
 		return nil, err
@@ -1438,7 +1434,6 @@ func (impl *BucketServiceServerImpl) AggregateVolumes(ctx context.Context, req *
 		CollapseColors:  req.GetCollapseColors(),
 	})
 	profile.LeaveExecute()
-	impl.emitProfile(ctx, profile)
 
 	return result, err
 }
@@ -1626,10 +1621,26 @@ func (impl *BucketServiceServerImpl) Discovery(_ context.Context, _ *servicepb.D
 // slow-query log / OTel span when the request exceeded the configured
 // threshold, and to the gRPC trailer when the caller asked for it.
 //
-// The threshold is compared against ServerDuration, not the execution total.
-// EN-1859 measured a 56 ms client round-trip whose execution accounted for
-// 2.3 ms: thresholding on execution meant the slow requests this log exists to
-// surface were precisely the ones it could not see.
+// Deferred at the top of every profiled handler, so a read that fails partway is
+// still logged — a slow failure is at least as interesting as a slow success, and
+// the previous placement after the happy path meant an error return produced no
+// profile at all.
+//
+// The threshold compares WallDuration, not the execution total and not
+// ServerDuration:
+//
+//   - the execution total was the pre-EN-1859 behaviour and could not see request
+//     decode or filter compilation, which is the gap this work exists to close;
+//   - ServerDuration excludes the delivery phase, which on a stream holds row
+//     serialisation AND, for a forwarded read, the entire remote cost. A
+//     threshold blind to both would still miss the slow requests it exists for.
+//
+// WallDuration therefore trades in consumer back-pressure: a slow client can trip
+// the threshold. The logged breakdown says which side was slow, and a threshold
+// that fires with an explanation beats one that never fires.
+//
+// A threshold of 0 disables the log entirely — every duration is >= 0, so
+// comparing against 0 would otherwise log every single read.
 func (impl *BucketServiceServerImpl) emitProfile(ctx context.Context, profile *query.QueryProfile) {
 	if profile == nil {
 		return
@@ -1637,7 +1648,7 @@ func (impl *BucketServiceServerImpl) emitProfile(ctx context.Context, profile *q
 
 	profile.Finish()
 
-	if profile.ServerDuration >= impl.queryProfileThreshold {
+	if impl.queryProfileThreshold > 0 && profile.WallDuration() >= impl.queryProfileThreshold {
 		profile.LogTo(impl.logger)
 		profile.EmitToSpan(trace.SpanFromContext(ctx))
 	}

--- a/internal/adapter/grpc/stream_helper.go
+++ b/internal/adapter/grpc/stream_helper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // NextCursorTrailerKey is the gRPC trailer key under which streaming list
@@ -41,6 +43,26 @@ const NextCursorTrailerKey = "x-next-cursor"
 // Callers must size the source cursor for pageSize+1 items so the peek can
 // fire. Pass pageSize == 0 (and cursorOf == nil) to drain unbounded without
 // emitting a trailer.
+//
+// # Phase attribution (EN-1859)
+//
+// The loop below is where a streaming read spends everything the QueryProfile
+// execution counters cannot see: row serialisation, the transport write, and
+// any time blocked on a slow consumer. It therefore splits its own wall time
+// between two profile phases with opposite meanings:
+//
+//   - cur.Next() is row PRODUCTION and is charged to the execution phase. It is
+//     near-free for an eagerly materialised local cursor, but on a follower that
+//     routed the read to the leader each Next() is an upstream stream receive,
+//     which is genuine server-side query cost.
+//   - stream.Send() is DELIVERY. It contains flow-control back-pressure, so it
+//     is deliberately kept out of ServerDuration — a total that grew because the
+//     client stopped reading would mislead rather than inform.
+//
+// The per-row split costs two time.Now() per row, so it is only performed when
+// the caller actually requested the profile. Otherwise the loop is bracketed
+// once and charged wholly to delivery: conservative for the slow-query log
+// (ServerDuration can only be under-reported, never inflated by the consumer).
 func sendPagedToStream[Res any](
 	ctx context.Context,
 	cur cursor.Cursor[*Res],
@@ -54,6 +76,17 @@ func sendPagedToStream[Res any](
 	}()
 
 	span := trace.SpanFromContext(ctx)
+
+	profile := query.ProfileFromContext(ctx)
+	perRow := profile.Detailed()
+
+	if profile != nil && !perRow {
+		loopStart := time.Now()
+
+		defer func() {
+			profile.AddDelivery(time.Since(loopStart))
+		}()
+	}
 
 	var (
 		count    uint32
@@ -71,7 +104,13 @@ func sendPagedToStream[Res any](
 	}
 
 	for {
+		produceStart := nowIf(perRow)
 		item, err := cur.Next()
+
+		if perRow {
+			profile.AddProduction(time.Since(produceStart))
+		}
+
 		if err != nil {
 			span.SetAttributes(attribute.Int64("stream.items_sent", int64(count)))
 
@@ -106,13 +145,33 @@ func sendPagedToStream[Res any](
 			return nil
 		}
 
-		if err := stream.Send(item); err != nil {
+		deliverStart := nowIf(perRow)
+		sendErr := stream.Send(item)
+
+		if perRow {
+			profile.AddDelivery(time.Since(deliverStart))
+		}
+
+		if sendErr != nil {
 			span.SetAttributes(attribute.Int64("stream.items_sent", int64(count)))
 
-			return fmt.Errorf("sending %s: %w", itemName, err)
+			return fmt.Errorf("sending %s: %w", itemName, sendErr)
 		}
+
+		profile.MarkFirstRow()
 
 		lastSent = item
 		count++
 	}
+}
+
+// nowIf returns the current instant only when the caller intends to use it,
+// keeping the per-row clock reads out of a request that did not ask for the
+// detailed profile.
+func nowIf(enabled bool) time.Time {
+	if !enabled {
+		return time.Time{}
+	}
+
+	return time.Now()
 }

--- a/internal/adapter/grpc/stream_helper.go
+++ b/internal/adapter/grpc/stream_helper.go
@@ -59,10 +59,15 @@ const NextCursorTrailerKey = "x-next-cursor"
 //     is deliberately kept out of ServerDuration — a total that grew because the
 //     client stopped reading would mislead rather than inform.
 //
-// The per-row split costs two time.Now() per row, so it is only performed when
-// the caller actually requested the profile. Otherwise the loop is bracketed
-// once and charged wholly to delivery: conservative for the slow-query log
-// (ServerDuration can only be under-reported, never inflated by the consumer).
+// The split is performed whenever a profile is present, never gated on whether
+// the caller asked to SEE the profile. An earlier revision gated it and charged
+// the whole loop to delivery otherwise, which made ServerDuration blind in the
+// only configuration that consumes it: nothing sends x-query-profile in normal
+// operation, so the slow-query log was reading a total from which the entire
+// send loop had been subtracted — a forwarded read taking seconds inside
+// cur.Next() reported sub-millisecond. Two time.Now() per row (tens of
+// microseconds across a 1000-row page, the server-side maximum) is not worth one
+// measurement regime per caller behaviour.
 func sendPagedToStream[Res any](
 	ctx context.Context,
 	cur cursor.Cursor[*Res],
@@ -77,16 +82,10 @@ func sendPagedToStream[Res any](
 
 	span := trace.SpanFromContext(ctx)
 
+	// Most streaming list handlers are unprofiled and share this helper, so the
+	// per-row clock reads are skipped entirely when there is no profile to feed.
 	profile := query.ProfileFromContext(ctx)
-	perRow := profile.Detailed()
-
-	if profile != nil && !perRow {
-		loopStart := time.Now()
-
-		defer func() {
-			profile.AddDelivery(time.Since(loopStart))
-		}()
-	}
+	timed := profile != nil
 
 	var (
 		count    uint32
@@ -104,10 +103,10 @@ func sendPagedToStream[Res any](
 	}
 
 	for {
-		produceStart := nowIf(perRow)
+		produceStart := nowIf(timed)
 		item, err := cur.Next()
 
-		if perRow {
+		if timed {
 			profile.AddProduction(time.Since(produceStart))
 		}
 
@@ -145,10 +144,10 @@ func sendPagedToStream[Res any](
 			return nil
 		}
 
-		deliverStart := nowIf(perRow)
+		deliverStart := nowIf(timed)
 		sendErr := stream.Send(item)
 
-		if perRow {
+		if timed {
 			profile.AddDelivery(time.Since(deliverStart))
 		}
 
@@ -166,8 +165,7 @@ func sendPagedToStream[Res any](
 }
 
 // nowIf returns the current instant only when the caller intends to use it,
-// keeping the per-row clock reads out of a request that did not ask for the
-// detailed profile.
+// keeping the per-row clock reads out of a stream that has no profile to feed.
 func nowIf(enabled bool) time.Time {
 	if !enabled {
 		return time.Time{}

--- a/internal/adapter/grpc/stream_helper_profile_test.go
+++ b/internal/adapter/grpc/stream_helper_profile_test.go
@@ -45,10 +45,17 @@ const spinPerItem = 2 * time.Millisecond
 func TestSendPagedToStream_ProfilePhaseAttribution(t *testing.T) {
 	t.Parallel()
 
-	t.Run("detailed → row production is charged to execution, not delivery", func(t *testing.T) {
+	t.Run("lazy row production is charged to execution and stays in the server total", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, profile := query.WithProfile(context.Background(), true)
+		// This is the regression that matters. Nothing sends x-query-profile in
+		// normal operation, so the slow-query log is the profile's only consumer;
+		// an earlier revision gated the per-row split on the caller having asked
+		// for the profile and charged the whole loop to delivery otherwise. Since
+		// Finish() subtracts delivery, a forwarded read that spent seconds inside
+		// cur.Next() reported a sub-millisecond ServerDuration — the log was blind
+		// in the exact configuration that uses it.
+		ctx, profile := query.WithProfile(context.Background())
 		profile.EnterExecute()
 		profile.LeaveExecute()
 
@@ -60,46 +67,44 @@ func TestSendPagedToStream_ProfilePhaseAttribution(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, stream.sent, 3)
 
-		// 3 items + the EOF probe all spin, so at least 3 spins land in the
-		// execution phase.
+		// 3 items + the EOF probe all spin, so at least 3 spins are attributed.
 		require.GreaterOrEqual(t, profile.ExecuteDuration, 3*spinPerItem,
 			"cur.Next() time must be attributed to the execution phase")
 
 		profile.Finish()
-		require.Positive(t, profile.FirstRowDuration, "the first Send must be timestamped")
-		require.LessOrEqual(t, profile.FirstRowDuration, profile.ServerDuration+profile.DeliverDuration+
-			profile.BarrierDuration, "time-to-first-row cannot exceed the whole request")
+
+		require.GreaterOrEqual(t, profile.ServerDuration, 3*spinPerItem,
+			"row production must survive into ServerDuration; if it does not, the "+
+				"slow-query threshold cannot see a slow forwarded read")
+		require.GreaterOrEqual(t, profile.WallDuration(), profile.ServerDuration,
+			"the wall total includes delivery on top of the server total")
 	})
 
-	t.Run("not detailed → the whole loop is charged to delivery", func(t *testing.T) {
+	t.Run("stream sends are charged to delivery, outside the server total", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, profile := query.WithProfile(context.Background(), false)
+		ctx, profile := query.WithProfile(context.Background())
 		profile.EnterExecute()
 		profile.LeaveExecute()
 
-		executeAfterQuery := profile.ExecuteDuration
-
 		stream := newFakeServerStream[stringItem](t)
+		stream.sendDelay = spinPerItem
 
 		err := sendPagedToStream(
-			ctx, &spinCursor{remaining: 3, per: spinPerItem}, stream, "item", 0, nil,
+			ctx, &spinCursor{remaining: 3, per: 0}, stream, "item", 0, nil,
 		)
 		require.NoError(t, err)
 
-		// A request that did not ask for the profile pays no per-row clock
-		// reads, so the loop cannot be split: it is charged wholly to delivery.
-		// That is the conservative direction — delivery is excluded from
-		// ServerDuration, so the server total can only be under-reported, never
-		// inflated by a slow consumer.
-		require.Equal(t, executeAfterQuery, profile.ExecuteDuration,
-			"no per-row production attribution without an explicit profile request")
 		require.GreaterOrEqual(t, profile.DeliverDuration, 3*spinPerItem,
-			"the whole send loop must still be accounted for somewhere")
+			"stream.Send() time must be attributed to the delivery phase")
 
 		profile.Finish()
-		require.Positive(t, profile.FirstRowDuration,
-			"time-to-first-row is O(1) and always collected")
+
+		require.Less(t, profile.ServerDuration, 3*spinPerItem,
+			"consumer back-pressure must not inflate the consumer-independent total")
+		require.GreaterOrEqual(t, profile.WallDuration(), 3*spinPerItem,
+			"but the slow-query threshold must still see it")
+		require.Positive(t, profile.FirstRowDuration, "the first Send must be timestamped")
 	})
 
 	t.Run("no profile in context → helper still streams", func(t *testing.T) {

--- a/internal/adapter/grpc/stream_helper_profile_test.go
+++ b/internal/adapter/grpc/stream_helper_profile_test.go
@@ -1,0 +1,116 @@
+package grpc
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+// spinCursor emits a fixed number of items, burning a measurable amount of
+// wall-clock inside each Next(). It stands in for the routed-read case where
+// rows are produced lazily from the leader's stream *inside* the send loop:
+// that cost is query execution, not delivery, and the profile has to say so.
+//
+// It spins rather than sleeps: the test needs elapsed monotonic time it can
+// assert on, and a busy wait keeps the measurement independent of scheduler
+// wake-up granularity.
+type spinCursor struct {
+	remaining int
+	per       time.Duration
+}
+
+func (c *spinCursor) Next() (*stringItem, error) {
+	if c.remaining == 0 {
+		return nil, errIOEOF
+	}
+
+	c.remaining--
+
+	for deadline := time.Now().Add(c.per); time.Now().Before(deadline); {
+		runtime.Gosched()
+	}
+
+	return &stringItem{name: "item"}, nil
+}
+
+func (c *spinCursor) Close() error { return nil }
+
+const spinPerItem = 2 * time.Millisecond
+
+func TestSendPagedToStream_ProfilePhaseAttribution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("detailed → row production is charged to execution, not delivery", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, profile := query.WithProfile(context.Background(), true)
+		profile.EnterExecute()
+		profile.LeaveExecute()
+
+		stream := newFakeServerStream[stringItem](t)
+
+		err := sendPagedToStream(
+			ctx, &spinCursor{remaining: 3, per: spinPerItem}, stream, "item", 0, nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stream.sent, 3)
+
+		// 3 items + the EOF probe all spin, so at least 3 spins land in the
+		// execution phase.
+		require.GreaterOrEqual(t, profile.ExecuteDuration, 3*spinPerItem,
+			"cur.Next() time must be attributed to the execution phase")
+
+		profile.Finish()
+		require.Positive(t, profile.FirstRowDuration, "the first Send must be timestamped")
+		require.LessOrEqual(t, profile.FirstRowDuration, profile.ServerDuration+profile.DeliverDuration+
+			profile.BarrierDuration, "time-to-first-row cannot exceed the whole request")
+	})
+
+	t.Run("not detailed → the whole loop is charged to delivery", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, profile := query.WithProfile(context.Background(), false)
+		profile.EnterExecute()
+		profile.LeaveExecute()
+
+		executeAfterQuery := profile.ExecuteDuration
+
+		stream := newFakeServerStream[stringItem](t)
+
+		err := sendPagedToStream(
+			ctx, &spinCursor{remaining: 3, per: spinPerItem}, stream, "item", 0, nil,
+		)
+		require.NoError(t, err)
+
+		// A request that did not ask for the profile pays no per-row clock
+		// reads, so the loop cannot be split: it is charged wholly to delivery.
+		// That is the conservative direction — delivery is excluded from
+		// ServerDuration, so the server total can only be under-reported, never
+		// inflated by a slow consumer.
+		require.Equal(t, executeAfterQuery, profile.ExecuteDuration,
+			"no per-row production attribution without an explicit profile request")
+		require.GreaterOrEqual(t, profile.DeliverDuration, 3*spinPerItem,
+			"the whole send loop must still be accounted for somewhere")
+
+		profile.Finish()
+		require.Positive(t, profile.FirstRowDuration,
+			"time-to-first-row is O(1) and always collected")
+	})
+
+	t.Run("no profile in context → helper still streams", func(t *testing.T) {
+		t.Parallel()
+
+		stream := newFakeServerStream[stringItem](t)
+
+		err := sendPagedToStream(
+			context.Background(), &spinCursor{remaining: 2, per: 0}, stream, "item", 0, nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stream.sent, 2)
+	})
+}

--- a/internal/adapter/grpc/stream_helper_test.go
+++ b/internal/adapter/grpc/stream_helper_test.go
@@ -3,7 +3,9 @@ package grpc
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -26,6 +28,10 @@ type fakeServerStream[Res any] struct {
 	trailer  metadata.MD
 	sendErr  error
 	sendStop int // when >0, return sendErr on the Nth Send (1-indexed)
+	// sendDelay burns wall-clock inside each Send, standing in for a consumer
+	// that is slow to drain the stream. Used by the profile phase-attribution
+	// tests to prove back-pressure lands in the delivery phase.
+	sendDelay time.Duration
 }
 
 func newFakeServerStream[Res any](t *testing.T) *fakeServerStream[Res] {
@@ -39,6 +45,10 @@ func newFakeServerStream[Res any](t *testing.T) *fakeServerStream[Res] {
 	f.MockServerStreamingServer.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	f.MockServerStreamingServer.EXPECT().Send(gomock.Any()).DoAndReturn(func(item *Res) error {
+		for deadline := time.Now().Add(f.sendDelay); time.Now().Before(deadline); {
+			runtime.Gosched()
+		}
+
 		f.sent = append(f.sent, item)
 
 		if f.sendStop > 0 && len(f.sent) == f.sendStop {

--- a/internal/adapter/http/handler.go
+++ b/internal/adapter/http/handler.go
@@ -64,6 +64,10 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 		}),
 		jsonRecoverer,
 		maxBodySizeMiddleware(defaultMaxBodySize),
+		// Before authentication: HTTPAuthMiddleware validates the JWT (a remote
+		// JWKS fetch on a cache miss), which is preparation work the profiled
+		// reads must account for and gRPC already does. See startRequestClock.
+		startRequestClock,
 		internalauth.HTTPAuthMiddleware(authCfg),
 	)
 
@@ -100,6 +104,33 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 	// Business API routes: mounted under APIVersionPrefix.
 	registerAPIRoutes := func(r chi.Router) {
 		r.With(contentTypeMiddleware, utf8PathParamValidator).Group(func(r chi.Router) {
+			// Profiled reads (EN-1859). Declared here, outside the scope groups
+			// below, because chi applies group middleware BEFORE route
+			// middleware: inside `r.With(requireXRead).Group(…)` the scope guard
+			// would run first and authentication would fall outside the profile
+			// window. The gRPC handlers start their profile before
+			// internalauth.Authenticate, so HTTP must too — otherwise
+			// prepare_duration_us, and through it server_duration_us, measures a
+			// different span on each transport and the two stop being comparable.
+			// The scope groups are therefore nested INSIDE the profile here, which
+			// is also the only shape chi.Walk can see — the ordering test in
+			// middleware_query_profile_test.go pins it, and a route-level
+			// `r.With(guard).Get(…)` would be invisible to it.
+			r.With(withQueryProfile).Group(func(r chi.Router) {
+				r.With(requireTransactionsRead).Group(func(r chi.Router) {
+					r.Get("/{ledgerName}/transactions", server.handleListTransactions)
+				})
+
+				r.With(requireAccountsRead).Group(func(r chi.Router) {
+					r.Get("/{ledgerName}/accounts", server.handleListAccounts)
+					r.Get("/{ledgerName}/volumes", server.handleAggregateVolumes)
+				})
+
+				r.With(requireQueriesRead).Group(func(r chi.Router) {
+					r.Post("/{ledgerName}/prepared-queries/{queryName}/execute", server.handleExecutePreparedQuery)
+				})
+			})
+
 			// Ledgers read scope
 			r.With(requireLedgersRead).Group(func(r chi.Router) {
 				r.Get("/", server.handleListAllLedgers)
@@ -118,7 +149,6 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 
 			// Transactions read scope
 			r.With(requireTransactionsRead).Group(func(r chi.Router) {
-				r.Get("/{ledgerName}/transactions", server.handleListTransactions)
 				r.Get("/{ledgerName}/transactions/{transactionId}", server.handleGetTransaction)
 			})
 
@@ -158,9 +188,7 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 
 			// Accounts read scope
 			r.With(requireAccountsRead).Group(func(r chi.Router) {
-				r.Get("/{ledgerName}/accounts", server.handleListAccounts)
 				r.Get("/{ledgerName}/accounts/{address}", server.handleGetAccount)
-				r.Get("/{ledgerName}/volumes", server.handleAggregateVolumes)
 				r.Get("/{ledgerName}/metadata-schema", server.handleGetMetadataSchema)
 				r.Get("/{ledgerName}/analyze-accounts", server.handleAnalyzeAccounts)
 				r.Get("/{ledgerName}/analyze-transactions", server.handleAnalyzeTransactions)
@@ -205,7 +233,6 @@ func NewHandler(logger logging.Logger, backend Backend, authCfg internalauth.Aut
 			// Prepared queries (read)
 			r.With(requireQueriesRead).Group(func(r chi.Router) {
 				r.Get("/{ledgerName}/prepared-queries", server.handleListPreparedQueries)
-				r.Post("/{ledgerName}/prepared-queries/{queryName}/execute", server.handleExecutePreparedQuery)
 			})
 
 			// Prepared queries (write)

--- a/internal/adapter/http/handlers_aggregate_volumes.go
+++ b/internal/adapter/http/handlers_aggregate_volumes.go
@@ -74,7 +74,7 @@ func toAggregateVolumesJSON(result *commonpb.AggregateResult) *aggregateVolumesR
 // handleAggregateVolumes handles GET /{ledgerName}/volumes.
 func (s *Server) handleAggregateVolumes(w http.ResponseWriter, r *http.Request) {
 	// See handleListTransactions: the profile clock starts before decode.
-	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	ctx, profile := query.WithProfile(r.Context())
 	r = r.WithContext(ctx)
 
 	ledgerName, ok := requireLedgerName(w, r)

--- a/internal/adapter/http/handlers_aggregate_volumes.go
+++ b/internal/adapter/http/handlers_aggregate_volumes.go
@@ -73,6 +73,10 @@ func toAggregateVolumesJSON(result *commonpb.AggregateResult) *aggregateVolumesR
 
 // handleAggregateVolumes handles GET /{ledgerName}/volumes.
 func (s *Server) handleAggregateVolumes(w http.ResponseWriter, r *http.Request) {
+	// See handleListTransactions: the profile clock starts before decode.
+	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	r = r.WithContext(ctx)
+
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
 		return
@@ -95,22 +99,20 @@ func (s *Server) handleAggregateVolumes(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ctx, profile := query.WithProfile(r.Context())
-
+	profile.EnterExecute()
 	result, err := s.backend.AggregateVolumes(ctx, ledgerName, filter, query.AggregateOptions{
 		UseMaxPrecision: useMaxPrecision,
 		CollapseColors:  collapseColors,
 		GroupByPrefixes: groupByPrefixes,
 	})
+	profile.LeaveExecute()
+
 	if err != nil {
 		handleError(w, r, err)
 
 		return
 	}
 
-	if wantsHTTPProfile(r) {
-		writeProfileHeader(w, profile)
-	}
-
+	finishProfile(w, r, profile)
 	writeOK(w, toAggregateVolumesJSON(result))
 }

--- a/internal/adapter/http/handlers_aggregate_volumes.go
+++ b/internal/adapter/http/handlers_aggregate_volumes.go
@@ -73,9 +73,9 @@ func toAggregateVolumesJSON(result *commonpb.AggregateResult) *aggregateVolumesR
 
 // handleAggregateVolumes handles GET /{ledgerName}/volumes.
 func (s *Server) handleAggregateVolumes(w http.ResponseWriter, r *http.Request) {
-	// See handleListTransactions: the profile clock starts before decode.
-	ctx, profile := query.WithProfile(r.Context())
-	r = r.WithContext(ctx)
+	// See handleListTransactions: the profile clock started in the routing layer.
+	ctx := r.Context()
+	profile := profileFromRequest(r)
 
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {

--- a/internal/adapter/http/handlers_execute_prepared_query.go
+++ b/internal/adapter/http/handlers_execute_prepared_query.go
@@ -17,6 +17,11 @@ import (
 
 // handleExecutePreparedQuery handles POST /{ledgerName}/prepared-queries/{name}/execute.
 func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Request) {
+	// See handleListTransactions: the profile clock starts before decode — here
+	// that also covers JSON body decoding and parameter conversion.
+	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	r = r.WithContext(ctx)
+
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
 		return
@@ -89,17 +94,14 @@ func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Reque
 		Mode:           mode,
 	}
 
-	ctx, profile := query.WithProfile(r.Context())
-
+	profile.EnterExecute()
 	resp, err := s.backend.ExecutePreparedQuery(ctx, req)
+	profile.LeaveExecute()
+
 	if err != nil {
 		handleError(w, r, err)
 
 		return
-	}
-
-	if wantsHTTPProfile(r) {
-		writeProfileHeader(w, profile)
 	}
 
 	// Serialize into a clean, discriminated camelCase envelope instead of the
@@ -123,6 +125,7 @@ func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Reque
 		envelope.Cursor = result.Cursor
 	}
 
+	finishProfile(w, r, profile)
 	writeJSONResponse(w, http.StatusOK, envelope)
 }
 

--- a/internal/adapter/http/handlers_execute_prepared_query.go
+++ b/internal/adapter/http/handlers_execute_prepared_query.go
@@ -12,15 +12,15 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
-	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // handleExecutePreparedQuery handles POST /{ledgerName}/prepared-queries/{name}/execute.
 func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Request) {
-	// See handleListTransactions: the profile clock starts before decode — here
-	// that also covers JSON body decoding and parameter conversion.
-	ctx, profile := query.WithProfile(r.Context())
-	r = r.WithContext(ctx)
+	// See handleListTransactions: the profile clock started in the routing layer
+	// — here the measured preparation also covers JSON body decoding and
+	// parameter conversion.
+	ctx := r.Context()
+	profile := profileFromRequest(r)
 
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {

--- a/internal/adapter/http/handlers_execute_prepared_query.go
+++ b/internal/adapter/http/handlers_execute_prepared_query.go
@@ -19,7 +19,7 @@ import (
 func (s *Server) handleExecutePreparedQuery(w http.ResponseWriter, r *http.Request) {
 	// See handleListTransactions: the profile clock starts before decode — here
 	// that also covers JSON body decoding and parameter conversion.
-	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	ctx, profile := query.WithProfile(r.Context())
 	r = r.WithContext(ctx)
 
 	ledgerName, ok := requireLedgerName(w, r)

--- a/internal/adapter/http/handlers_list_accounts.go
+++ b/internal/adapter/http/handlers_list_accounts.go
@@ -9,6 +9,10 @@ import (
 
 // handleListAccounts handles GET /{ledgerName}/accounts to list accounts.
 func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
+	// See handleListTransactions: the profile clock starts before decode.
+	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	r = r.WithContext(ctx)
+
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
 		return
@@ -33,9 +37,10 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 
 	reverse := r.URL.Query().Get("reverse") == "true"
 
-	ctx, profile := query.WithProfile(r.Context())
-
+	profile.EnterExecute()
 	cursor, err := s.backend.ListAccounts(ctx, ledgerName, pageSize, afterAddress, filter, reverse)
+	profile.LeaveExecute()
+
 	if err != nil {
 		handleError(w, r, err)
 
@@ -47,9 +52,6 @@ func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if wantsHTTPProfile(r) {
-		writeProfileHeader(w, profile)
-	}
-
+	finishProfile(w, r, profile)
 	writeOK(w, accounts)
 }

--- a/internal/adapter/http/handlers_list_accounts.go
+++ b/internal/adapter/http/handlers_list_accounts.go
@@ -4,14 +4,13 @@ import (
 	"net/http"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
-	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // handleListAccounts handles GET /{ledgerName}/accounts to list accounts.
 func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
-	// See handleListTransactions: the profile clock starts before decode.
-	ctx, profile := query.WithProfile(r.Context())
-	r = r.WithContext(ctx)
+	// See handleListTransactions: the profile clock started in the routing layer.
+	ctx := r.Context()
+	profile := profileFromRequest(r)
 
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {

--- a/internal/adapter/http/handlers_list_accounts.go
+++ b/internal/adapter/http/handlers_list_accounts.go
@@ -10,7 +10,7 @@ import (
 // handleListAccounts handles GET /{ledgerName}/accounts to list accounts.
 func (s *Server) handleListAccounts(w http.ResponseWriter, r *http.Request) {
 	// See handleListTransactions: the profile clock starts before decode.
-	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	ctx, profile := query.WithProfile(r.Context())
 	r = r.WithContext(ctx)
 
 	ledgerName, ok := requireLedgerName(w, r)

--- a/internal/adapter/http/handlers_list_accounts_test.go
+++ b/internal/adapter/http/handlers_list_accounts_test.go
@@ -187,6 +187,19 @@ func TestHandleListAccounts_WithProfileHeader(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(data, &pb))
 	assert.Equal(t, int64(2000), pb.GetIndexDurationUs())
 	assert.Equal(t, int32(1), pb.GetItemsCollected())
+
+	// Server-side request timing (EN-1859): the whole handler is measured, not
+	// just execution, so the total must be at least as large as the execution
+	// time the fake controller reported.
+	assert.GreaterOrEqual(t, pb.GetServerDurationUs(), pb.GetExecuteDurationUs(),
+		"execution is a phase of the server total, not a peer of it")
+	assert.GreaterOrEqual(t, pb.GetServerDurationUs(),
+		pb.GetPrepareDurationUs()+pb.GetExecuteDurationUs(),
+		"prepare + execute must fit inside the server total")
+	assert.Zero(t, pb.GetFirstRowDurationUs(),
+		"HTTP buffers the whole response: there is no per-row stream hand-off to timestamp")
+	assert.Zero(t, pb.GetDeliverDurationUs(),
+		"the profile header must precede the body, so HTTP cannot measure response delivery")
 }
 
 func TestHandleListAccounts_WithoutProfileHeader(t *testing.T) {

--- a/internal/adapter/http/handlers_list_accounts_test.go
+++ b/internal/adapter/http/handlers_list_accounts_test.go
@@ -171,7 +171,10 @@ func TestHandleListAccounts_WithProfileHeader(t *testing.T) {
 	})
 	r.Header.Set("X-Query-Profile", "true")
 
-	srv.handleListAccounts(w, r)
+	// Through the routing layer's contribution, not the bare handler: the profile
+	// is installed by withQueryProfile and backdated to startRequestClock's stamp,
+	// so a handler called directly reports nothing (EN-1859).
+	startRequestClock(withQueryProfile(http.HandlerFunc(srv.handleListAccounts))).ServeHTTP(w, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
 

--- a/internal/adapter/http/handlers_list_accounts_test.go
+++ b/internal/adapter/http/handlers_list_accounts_test.go
@@ -188,9 +188,11 @@ func TestHandleListAccounts_WithProfileHeader(t *testing.T) {
 	assert.Equal(t, int64(2000), pb.GetIndexDurationUs())
 	assert.Equal(t, int32(1), pb.GetItemsCollected())
 
-	// Server-side request timing (EN-1859): the whole handler is measured, not
-	// just execution, so the total must be at least as large as the execution
-	// time the fake controller reported.
+	// Server-side request timing (EN-1859). Assert the total is actually
+	// populated first: the ordering checks below are all satisfied by 0 >= 0, so
+	// on their own they would keep passing if the feature were removed.
+	assert.Positive(t, pb.GetServerDurationUs(),
+		"the request clock must have advanced and been reported")
 	assert.GreaterOrEqual(t, pb.GetServerDurationUs(), pb.GetExecuteDurationUs(),
 		"execution is a phase of the server total, not a peer of it")
 	assert.GreaterOrEqual(t, pb.GetServerDurationUs(),

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
-	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 // handleListTransactions handles GET /{ledgerName}/transactions to list a
@@ -36,12 +35,12 @@ import (
 // keeps EN-1472 scoped to "expose the reads over HTTP", not "full read-options
 // parity". Same applies to the bucket reads (chapters, signing keys) below.
 func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) {
-	// Start the profile clock before any decode/validation so query-parameter
-	// parsing and filter compilation land in PrepareDuration (EN-1859). The
-	// request is re-bound to the profiled context so drainCursor and the
-	// controller see the same profile.
-	ctx, profile := query.WithProfile(r.Context())
-	r = r.WithContext(ctx)
+	// The profile clock started in withQueryProfile, outside the scope guard, so
+	// authentication as well as query-parameter parsing and filter compilation
+	// land in PrepareDuration (EN-1859). drainCursor and the controller read the
+	// same profile off this context.
+	ctx := r.Context()
+	profile := profileFromRequest(r)
 
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -36,6 +36,13 @@ import (
 // keeps EN-1472 scoped to "expose the reads over HTTP", not "full read-options
 // parity". Same applies to the bucket reads (chapters, signing keys) below.
 func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) {
+	// Start the profile clock before any decode/validation so query-parameter
+	// parsing and filter compilation land in PrepareDuration (EN-1859). The
+	// request is re-bound to the profiled context so drainCursor and the
+	// controller see the same profile.
+	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	r = r.WithContext(ctx)
+
 	ledgerName, ok := requireLedgerName(w, r)
 	if !ok {
 		return
@@ -110,9 +117,10 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 
 	filter := combineFilters(filters...)
 
-	ctx, profile := query.WithProfile(r.Context())
-
+	profile.EnterExecute()
 	cursor, err := s.backend.ListTransactions(ctx, ledgerName, pageSize, afterTxID, filter, reverse)
+	profile.LeaveExecute()
+
 	if err != nil {
 		handleError(w, r, err)
 
@@ -124,9 +132,6 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if wantsHTTPProfile(r) {
-		writeProfileHeader(w, profile)
-	}
-
+	finishProfile(w, r, profile)
 	writeOKChecked(w, r, transactions)
 }

--- a/internal/adapter/http/handlers_list_transactions.go
+++ b/internal/adapter/http/handlers_list_transactions.go
@@ -40,7 +40,7 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request) 
 	// parsing and filter compilation land in PrepareDuration (EN-1859). The
 	// request is re-bound to the profiled context so drainCursor and the
 	// controller see the same profile.
-	ctx, profile := query.WithProfile(r.Context(), wantsHTTPProfile(r))
+	ctx, profile := query.WithProfile(r.Context())
 	r = r.WithContext(ctx)
 
 	ledgerName, ok := requireLedgerName(w, r)

--- a/internal/adapter/http/middleware_query_profile.go
+++ b/internal/adapter/http/middleware_query_profile.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+type requestClockKey struct{}
+
+// startRequestClock stamps the instant the server starts handling a request, so
+// a profiled read can measure from a point ABOVE its handler.
+//
+// It belongs immediately before internalauth.HTTPAuthMiddleware in the
+// router-wide chain (see NewHandler). That middleware is where the expensive
+// half of authentication lives — token extraction and JWT validation, a remote
+// JWKS fetch on a cache miss — and it is router-wide, so it cannot be moved
+// under a per-route profile. Stamping the time instead costs one time.Now() and
+// one context value per request, on every route, and lets the four profiled
+// reads start their clock where gRPC starts its own: after the transport
+// middlewares, before authentication.
+//
+// Placing it here rather than first in the chain is what keeps the two
+// transports comparable. gRPC calls query.WithProfile inside the handler, i.e.
+// after its own interceptor chain (recovery, consistency, logging, error
+// conversion); starting the HTTP clock at the very top would fold RequestID,
+// otelhttp and the request logger into server_duration_us on HTTP only.
+func startRequestClock(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), requestClockKey{}, time.Now())
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// withQueryProfile installs a read-path timing profile (EN-1859) in the request
+// context, backdated to the instant startRequestClock stamped so that
+// authentication is inside the measured window.
+//
+// It must still sit outside the route's scope guard: the guard is the cheap half
+// of authorization, but it is a real branch and it is inside the window on gRPC.
+// chi applies group middleware before route middleware, so a profiled route
+// cannot live inside a `r.With(requireXRead).Group(…)` block and get the ordering
+// right — see the profiled-reads block in handler.go.
+//
+// Only the four profiled reads get this middleware. The presence of a profile in
+// the context, not the caller's request for one, is what enables instrumentation
+// (see query.WithProfile), so installing it on unprofiled routes would leave
+// barrier waits accumulating into a record nobody reads.
+func withQueryProfile(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start, ok := r.Context().Value(requestClockKey{}).(time.Time)
+		if !ok {
+			// Impossible by contract: every profiled route is mounted under the
+			// router-wide chain that stamps the clock (invariant #7). Falling back
+			// to now still produces a coherent profile — it just under-reports
+			// preparation by the authentication step, which is the defect this
+			// middleware exists to close, so it must not pass unnoticed.
+			assert.Unreachable("profiled HTTP read has no request clock — startRequestClock is missing from the router chain", map[string]any{
+				"method": r.Method,
+			})
+
+			start = time.Now()
+		}
+
+		ctx, _ := query.WithProfileStartingAt(r.Context(), start)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// profileFromRequest returns the profile withQueryProfile installed for this
+// route.
+//
+// Reaching a profiled handler without one means the route was registered outside
+// the profiled block, which is impossible by contract — so it is asserted rather
+// than tolerated silently (invariant #7). A read request is the wrong place to
+// fail hard over a diagnostic: every QueryProfile method is nil-safe, so the
+// request still serves and the only consequence is an unprofiled response.
+func profileFromRequest(r *http.Request) *query.QueryProfile {
+	profile := query.ProfileFromContext(r.Context())
+	if profile == nil {
+		// Not r.URL.Path: the assertion catalogue must not be keyed on a value
+		// carrying a ledger name. RouteContext is nil when the handler is called
+		// outside the router at all, which is how the unit tests invoke it.
+		pattern := "<no route context>"
+		if rc := chi.RouteContext(r.Context()); rc != nil {
+			pattern = rc.RoutePattern()
+		}
+
+		assert.Unreachable("profiled HTTP read reached its handler with no query profile — route registered outside the profiled block", map[string]any{
+			"method":  r.Method,
+			"pattern": pattern,
+		})
+	}
+
+	return profile
+}

--- a/internal/adapter/http/middleware_query_profile_test.go
+++ b/internal/adapter/http/middleware_query_profile_test.go
@@ -1,0 +1,191 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+func TestStartRequestClock_StampsAnInstant(t *testing.T) {
+	t.Parallel()
+
+	var stamped any
+
+	startRequestClock(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		stamped = r.Context().Value(requestClockKey{})
+	})).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	at, ok := stamped.(time.Time)
+	require.True(t, ok, "the clock must be stamped as a time.Time")
+	assert.False(t, at.IsZero())
+}
+
+// The point of splitting the clock from the profile is that the profile measures
+// from ABOVE its own middleware. Proven by backdating the stamp: if
+// withQueryProfile ignored it and called time.Now(), the reported total would be
+// microseconds instead of the planted hour.
+func TestWithQueryProfile_MeasuresFromTheStampedClock(t *testing.T) {
+	t.Parallel()
+
+	var seen *query.QueryProfile
+
+	handler := withQueryProfile(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = query.ProfileFromContext(r.Context())
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), requestClockKey{}, time.Now().Add(-time.Hour)))
+
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	require.NotNil(t, seen, "the middleware must install a profile for downstream handlers")
+
+	seen.Finish()
+	assert.GreaterOrEqual(t, seen.ServerDuration, time.Hour,
+		"the profile must measure from the stamped clock, not from its own middleware")
+}
+
+// A missing clock is a router misconfiguration, not a request-time failure: the
+// read still serves, with preparation under-reported by the authentication step.
+func TestWithQueryProfile_ToleratesAMissingClock(t *testing.T) {
+	t.Parallel()
+
+	var seen *query.QueryProfile
+
+	withQueryProfile(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = query.ProfileFromContext(r.Context())
+	})).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.NotNil(t, seen)
+
+	seen.Finish()
+	assert.Positive(t, seen.ServerDuration, "the fallback clock must still produce a usable profile")
+}
+
+// profiledRoutes is the closed set of reads that carry a query profile. Kept here
+// rather than derived from the router, so that a route silently joining or
+// leaving the set fails a test.
+var profiledRoutes = []struct{ method, pattern string }{
+	{http.MethodGet, "/v3/{ledgerName}/transactions"},
+	{http.MethodGet, "/v3/{ledgerName}/accounts"},
+	{http.MethodGet, "/v3/{ledgerName}/volumes"},
+	{http.MethodPost, "/v3/{ledgerName}/prepared-queries/{queryName}/execute"},
+}
+
+// This pins the ordering that makes the two transports comparable. gRPC calls
+// query.WithProfile before internalauth.Authenticate, so authentication lands in
+// prepare_duration_us there; on HTTP authentication is router-wide, above the
+// handler, so the clock has to be stamped before it and the profile has to
+// adopt that stamp. Get the order wrong and the same field name means a
+// different span on each transport.
+//
+// Asserted structurally because the consequence of the wrong order is a duration
+// that is merely *smaller*: no assertion on a duration can distinguish "auth was
+// fast" from "auth was not measured".
+func TestProfiledReadRoutes_ClockPrecedesAuthPrecedesScopeGuard(t *testing.T) {
+	t.Parallel()
+
+	chains := walkRouteMiddlewares(t)
+
+	for _, route := range profiledRoutes {
+		key := route.method + " " + route.pattern
+
+		chain, ok := chains[key]
+		require.True(t, ok, "route %s is not registered — the profiled set drifted from the router", key)
+
+		clockAt := indexOfMiddleware(chain, "startRequestClock")
+		authAt := indexOfMiddleware(chain, "HTTPAuthMiddleware")
+		profileAt := indexOfMiddleware(chain, "withQueryProfile")
+		scopeAt := indexOfMiddleware(chain, "RequireScope")
+
+		require.GreaterOrEqual(t, clockAt, 0, "route %s does not stamp a request clock", key)
+		require.GreaterOrEqual(t, authAt, 0, "route %s does not authenticate", key)
+		require.GreaterOrEqual(t, profileAt, 0, "route %s has no query-profile middleware", key)
+		require.GreaterOrEqual(t, scopeAt, 0, "route %s has no scope guard", key)
+
+		assert.Less(t, clockAt, authAt,
+			"route %s must stamp its clock before authenticating, otherwise JWT validation is excluded from prepare_duration_us", key)
+		assert.Less(t, profileAt, scopeAt,
+			"route %s must install its profile before the scope guard, which is inside the measured window on gRPC", key)
+	}
+}
+
+// The profile is what enables instrumentation, so installing it on a route that
+// never reports one would leave barrier waits accumulating into a record nobody
+// consumes. This pins the set closed from the other side.
+func TestUnprofiledRoutes_HaveNoQueryProfile(t *testing.T) {
+	t.Parallel()
+
+	profiled := map[string]bool{}
+	for _, route := range profiledRoutes {
+		profiled[route.method+" "+route.pattern] = true
+	}
+
+	for key, chain := range walkRouteMiddlewares(t) {
+		if profiled[key] {
+			continue
+		}
+
+		assert.Equal(t, -1, indexOfMiddleware(chain, "withQueryProfile"),
+			"route %s carries a query profile but never reports one", key)
+	}
+}
+
+// indexOfMiddleware locates a middleware by the name of the function that
+// produced it, returning -1 when absent.
+//
+// By name and not by code pointer: the guards are closures returned by
+// RequireScope, which the compiler instantiates per call site, so
+// reflect.Pointer differs between the router's guard and one built in a test.
+// The produced names ("…NewHandler.RequireScope.func7") still carry the
+// constructor, which is the identity that matters here.
+func indexOfMiddleware(chain []func(http.Handler) http.Handler, name string) int {
+	for i, mw := range chain {
+		fn := runtime.FuncForPC(reflect.ValueOf(mw).Pointer())
+		if fn != nil && strings.Contains(fn.Name(), name) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// walkRouteMiddlewares maps "METHOD pattern" to the middleware chain the real
+// router applies, router-wide and group middleware included, in application
+// order. Route-level `r.With(…).Get(…)` middleware is invisible to chi.Walk,
+// which is why the profiled block nests groups instead.
+func walkRouteMiddlewares(t *testing.T) map[string][]func(http.Handler) http.Handler {
+	t.Helper()
+
+	handler := NewHandler(logging.Testing(), nil, internalauth.AuthConfig{}, version.Info{})
+
+	routes, ok := handler.(chi.Routes)
+	require.True(t, ok, "NewHandler must return a walkable chi router")
+
+	chains := map[string][]func(http.Handler) http.Handler{}
+
+	require.NoError(t, chi.Walk(routes, func(method, route string, _ http.Handler, middlewares ...func(http.Handler) http.Handler) error {
+		chains[method+" "+route] = middlewares
+
+		return nil
+	}))
+
+	require.NotEmpty(t, chains, "the walk found no routes at all")
+
+	return chains
+}

--- a/internal/adapter/http/params.go
+++ b/internal/adapter/http/params.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 const (
@@ -157,10 +159,26 @@ func parseMetadataBody(w http.ResponseWriter, r *http.Request) (map[string]*comm
 // nil), so list handlers that pass it to writeOK serialize `{"data":[]}` rather
 // than `{"data":null}` — the empty-list shape the OpenAPI schemas promise, which
 // generated clients iterate safely.
+//
+// The drain is charged to the profile's execution phase (row production): an
+// HTTP read has no streaming hand-off, so everything the loop does is query
+// work — including, on a follower that routed the read, pulling each row from
+// the leader's stream (EN-1859). Bracketing the whole loop is enough here
+// because the response is buffered; there is no per-row delivery to separate.
 func drainCursor[T any](w http.ResponseWriter, r *http.Request, cursor cursor.Cursor[T]) ([]T, bool) {
 	defer func() {
 		_ = cursor.Close()
 	}()
+
+	// Most HTTP list routes are unprofiled and share this helper, so the clock
+	// reads are skipped entirely rather than fed to a nil profile.
+	if profile := query.ProfileFromContext(r.Context()); profile != nil {
+		drainStart := time.Now()
+
+		defer func() {
+			profile.AddProduction(time.Since(drainStart))
+		}()
+	}
 
 	items := []T{}
 

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -203,6 +203,29 @@ func wantsHTTPProfile(r *http.Request) bool {
 	return r.Header.Get(httpHeaderQueryProfile) != ""
 }
 
+// finishProfile stops the request clock and, when the caller asked for it,
+// publishes the profile in the X-Query-Profile-Result response header.
+//
+// Call it once the response value is fully assembled and BEFORE handing it to a
+// response writer, because headers must be flushed ahead of the body.
+//
+// That ordering is also why HTTP reports no delivery phase: the body write
+// happens strictly after this header is committed and cannot be measured. Only
+// the marshal step could be, and only by buffering the body — but the profiled
+// routes use three different writers (writeOK, writeOKChecked,
+// writeJSONResponse) whose encoders differ in HTML escaping and map-key
+// ordering, so routing them through one buffered marshaller would silently
+// change their JSON output. Measuring a partial number is not worth an
+// unrelated wire change; server_duration_us excludes row serialisation on gRPC
+// too, so the cross-surface definition stays identical either way.
+func finishProfile(w http.ResponseWriter, r *http.Request, profile *query.QueryProfile) {
+	profile.Finish()
+
+	if wantsHTTPProfile(r) {
+		writeProfileHeader(w, profile)
+	}
+}
+
 // writeProfileHeader serializes the query profile as base64-encoded protobuf
 // and sets it as the X-Query-Profile-Result response header.
 func writeProfileHeader(w http.ResponseWriter, profile *query.QueryProfile) {

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -209,6 +209,14 @@ func wantsHTTPProfile(r *http.Request) bool {
 // Call it once the response value is fully assembled and BEFORE handing it to a
 // response writer, because headers must be flushed ahead of the body.
 //
+// Success paths only, unlike the gRPC handlers which emit on every return. The
+// asymmetry is deliberate: on gRPC the profile also feeds the slow-query log, so
+// a slow *failure* is worth capturing, whereas HTTP has no such consumer — the
+// only reader is a caller who explicitly asked, and every HTTP error already
+// returns a structured ErrorResponse through the shared handleError writer.
+// Threading a profile through that writer for all HTTP handlers, profiled or not,
+// buys a diagnostic header on responses that already explain themselves.
+//
 // That ordering is also why HTTP reports no delivery phase: the body write
 // happens strictly after this header is committed and cannot be measured. Only
 // the marshal step could be, and only by buffering the body — but the profiled

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -88,7 +88,9 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 	// The ReadIndex quorum round-trip plus the local WaitForApplied catch-up is
 	// consensus latency incurred to honour the caller's linearizable-read
 	// request, not query work. Charge it to the profile's barrier phase so it is
-	// visible but excluded from the server-cost total (EN-1859).
+	// visible but excluded from the server-cost total (EN-1859). Charged whether
+	// or not the barrier succeeds — a failed attempt is still time the caller
+	// waited (see the fallback branch below).
 	barrierStart := time.Now()
 	barrier, err := b.ReadIndexAndWait(ctx)
 	query.ProfileFromContext(ctx).AddBarrierWait(time.Since(barrierStart))
@@ -107,7 +109,12 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 			span.SetAttributes(attribute.String("route", "leader_fallback"))
 
 			// Same as the explicit-leader branch: the read leaves this node, so
-			// the phase breakdown below describes the local hop only.
+			// the phase breakdown describes the local hop only. Unlike that
+			// branch, the barrier already recorded above is KEPT: the caller
+			// really did wait for a quorum attempt that then failed, and that
+			// wait belongs in the barrier phase (excluded from the server total)
+			// rather than in prepare. Hence forwarded=true with a non-zero
+			// barrier_duration_us is a valid, documented combination.
 			query.ProfileFromContext(ctx).MarkForwarded()
 
 			c, leaderErr := b.getLeaderCtrl()

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -111,10 +111,12 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 			// Same as the explicit-leader branch: the read leaves this node, so
 			// the phase breakdown describes the local hop only. Unlike that
 			// branch, the barrier already recorded above is KEPT: the caller
-			// really did wait for a quorum attempt that then failed, and that
-			// wait belongs in the barrier phase (excluded from the server total)
-			// rather than in prepare. Hence forwarded=true with a non-zero
-			// barrier_duration_us is a valid, documented combination.
+			// really did wait for a quorum attempt that then failed. Dropping it
+			// would not delete the time — readCtrl runs inside the caller's
+			// EnterExecute/LeaveExecute bracket, so an uncharged wait stays in
+			// execute_duration_us and from there in the server total. Hence
+			// forwarded=true with a non-zero barrier_duration_us is a valid,
+			// documented combination.
 			query.ProfileFromContext(ctx).MarkForwarded()
 
 			c, leaderErr := b.getLeaderCtrl()

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -72,6 +72,14 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 	case grpcadp.ConsistencyLeader:
 		span.SetAttributes(attribute.String("route", "leader"))
 
+		// Forwarded: the leader runs its own ReadIndex barrier (x-consistency is
+		// not propagated, so it defaults to linearizable there) and its own
+		// execution. Neither is visible to this profile — the whole remote cost
+		// arrives as row-production time inside the local execute phase, and this
+		// node's barrier_duration_us stays 0. Flag it so a reader does not take
+		// that 0 to mean "no barrier was needed" (EN-1859).
+		query.ProfileFromContext(ctx).MarkForwarded()
+
 		c, err := b.getLeaderCtrl()
 
 		return c, nil, err
@@ -97,6 +105,10 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 		// after election), we must NOT serve a stale local read without a barrier.
 		if !b.IsLeader() {
 			span.SetAttributes(attribute.String("route", "leader_fallback"))
+
+			// Same as the explicit-leader branch: the read leaves this node, so
+			// the phase breakdown below describes the local hop only.
+			query.ProfileFromContext(ctx).MarkForwarded()
 
 			c, leaderErr := b.getLeaderCtrl()
 

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -76,7 +77,14 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 		return c, nil, err
 	}
 
+	// The ReadIndex quorum round-trip plus the local WaitForApplied catch-up is
+	// consensus latency incurred to honour the caller's linearizable-read
+	// request, not query work. Charge it to the profile's barrier phase so it is
+	// visible but excluded from the server-cost total (EN-1859).
+	barrierStart := time.Now()
 	barrier, err := b.ReadIndexAndWait(ctx)
+	query.ProfileFromContext(ctx).AddBarrierWait(time.Since(barrierStart))
+
 	if err == nil {
 		span.SetAttributes(attribute.String("route", "local_linearizable"))
 

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -8392,10 +8392,20 @@ type QueryProfile struct {
 	// catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
 	// the request opted into, not server cost.
 	//
-	// Only LOCAL barriers are measured. When `forwarded` is true this reads 0
-	// because no barrier ran on this node, NOT because none ran: the remote node's
-	// barrier is folded into its execution, which arrives here inside
-	// execute_duration_us. Always read this field together with `forwarded`.
+	// Only LOCAL barriers are measured, and only the local one. Always read this
+	// field together with `forwarded`:
+	//
+	//   - forwarded=false: the whole barrier this read paid.
+	//   - forwarded=true, 0: no barrier ran HERE (an explicit leader read never
+	//     attempts one). The remote node's barrier is folded into its execution
+	//     and arrives inside execute_duration_us — 0 does NOT mean "no barrier
+	//     was needed".
+	//   - forwarded=true, non-zero: this node ATTEMPTED a local barrier, it
+	//     failed (syncing follower, leadership lost mid-ReadIndex), and the read
+	//     then fell back to the leader. The value is real consensus latency the
+	//     caller paid and is still excluded from server_duration_us — a failed
+	//     quorum wait is not server work — but the leader's own barrier is on top
+	//     of it, inside execute_duration_us.
 	BarrierDurationUs int64 `protobuf:"varint,11,opt,name=barrier_duration_us,json=barrierDurationUs,proto3" json:"barrier_duration_us,omitempty"`
 	// Time spent serialising result rows and handing them to the transport.
 	// EXCLUDED from server_duration_us because on a server stream it also

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -8353,10 +8353,18 @@ type QueryProfile struct {
 	MaterializedRanges   int32                  `protobuf:"varint,5,opt,name=materialized_ranges,json=materializedRanges,proto3" json:"materialized_ranges,omitempty"`
 	MaterializedItems    int32                  `protobuf:"varint,6,opt,name=materialized_items,json=materializedItems,proto3" json:"materialized_items,omitempty"`
 	RootIterator         *IteratorProfile       `protobuf:"bytes,7,opt,name=root_iterator,json=rootIterator,proto3" json:"root_iterator,omitempty"`
-	// Consumer-independent server cost: handler entry (before request decode) to
-	// the response being ready for delivery, MINUS barrier_duration_us and MINUS
-	// deliver_duration_us. It cannot be moved by a slow client, and it is the one
-	// field defined identically on gRPC and HTTP, so the two surfaces compare.
+	// Consumer-independent server cost: server entry to the response being ready
+	// for delivery, MINUS barrier_duration_us and MINUS deliver_duration_us. It
+	// cannot be moved by a slow client.
+	//
+	// "Server entry" is the earliest instrumentable point on each transport, and
+	// that is not quite the same point: on gRPC it is the handler's first
+	// statement, because grpc-go receives and unmarshals the request message
+	// before dispatching, putting protobuf decode out of reach; on HTTP it is the
+	// router chain just before authentication, so query/body decode inside the
+	// handler is included. Both start before authentication, and both end at the
+	// same place, which is what keeps the field comparable — with the caveat that
+	// gRPC message decode is never counted on either side of the comparison.
 	//
 	// It does NOT include row serialisation. On a gRPC server stream, marshalling
 	// and the transport write happen inside one inseparable stream.Send() call, so
@@ -8378,8 +8386,10 @@ type QueryProfile struct {
 	// pagination trailer, profile emission).
 	ServerDurationUs int64 `protobuf:"varint,8,opt,name=server_duration_us,json=serverDurationUs,proto3" json:"server_duration_us,omitempty"`
 	// Portion of server_duration_us spent before the query executor was invoked:
-	// authentication, request decode/validation, filter parsing/compilation and
-	// checkpoint-store opening.
+	// authentication, request validation, filter parsing/compilation and
+	// checkpoint-store opening — plus, on HTTP, query-parameter and body decoding.
+	// gRPC protobuf decode is NOT here: grpc-go unmarshals the request before the
+	// handler runs (see server_duration_us).
 	PrepareDurationUs int64 `protobuf:"varint,9,opt,name=prepare_duration_us,json=prepareDurationUs,proto3" json:"prepare_duration_us,omitempty"`
 	// Portion of server_duration_us spent inside the query executor. Contains
 	// index_duration_us and enrichment_duration_us as sub-phases, plus snapshot
@@ -8392,20 +8402,25 @@ type QueryProfile struct {
 	// catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
 	// the request opted into, not server cost.
 	//
-	// Only LOCAL barriers are measured, and only the local one. Always read this
-	// field together with `forwarded`:
+	// Only LOCAL waits are measured, and every local wait is measured: a
+	// min_log_sequence catch-up and a ReadIndex attempt are both counted, whether
+	// or not the attempt succeeds and whether or not the read is then forwarded.
+	// Always read this field together with `forwarded`:
 	//
 	//   - forwarded=false: the whole barrier this read paid.
-	//   - forwarded=true, 0: no barrier ran HERE (an explicit leader read never
-	//     attempts one). The remote node's barrier is folded into its execution
-	//     and arrives inside execute_duration_us — 0 does NOT mean "no barrier
-	//     was needed".
-	//   - forwarded=true, non-zero: this node ATTEMPTED a local barrier, it
-	//     failed (syncing follower, leadership lost mid-ReadIndex), and the read
-	//     then fell back to the leader. The value is real consensus latency the
-	//     caller paid and is still excluded from server_duration_us — a failed
-	//     quorum wait is not server work — but the leader's own barrier is on top
-	//     of it, inside execute_duration_us.
+	//   - forwarded=true, 0: no local wait happened. The remote node's barrier is
+	//     folded into its execution and arrives inside execute_duration_us — 0
+	//     does NOT mean "no barrier was needed".
+	//   - forwarded=true, non-zero: a local wait happened before the read left
+	//     this node, and the remote node's barrier is on top of it inside
+	//     execute_duration_us. The value does NOT identify which wait: a
+	//     min_log_sequence catch-up does not prevent forwarding, and a failed
+	//     ReadIndex attempt (syncing follower, leadership lost mid-quorum) is
+	//     what triggers the fallback. Do not read cluster health off it.
+	//
+	// A failed or superseded wait is still excluded from server_duration_us: the
+	// caller waited for it, and an abandoned quorum round-trip is no more server
+	// work than a completed one.
 	BarrierDurationUs int64 `protobuf:"varint,11,opt,name=barrier_duration_us,json=barrierDurationUs,proto3" json:"barrier_duration_us,omitempty"`
 	// Time spent serialising result rows and handing them to the transport.
 	// EXCLUDED from server_duration_us because on a server stream it also
@@ -8431,10 +8446,11 @@ type QueryProfile struct {
 	// True when this node did not serve the read itself but forwarded it to
 	// another node — an explicit leader-consistency read, or the fallback taken
 	// when the local replica is still catching up. The remote node's prepare,
-	// barrier and execution all arrive inside execute_duration_us, and
-	// barrier_duration_us reads 0 for lack of a local barrier, so the phase
+	// barrier and execution all arrive inside execute_duration_us, so the phase
 	// breakdown describes the local hop only. Its purpose is to stop a zero
-	// barrier from being misread as "no barrier was needed".
+	// barrier_duration_us from being misread as "no barrier was needed"; see that
+	// field for the three cases the pair distinguishes — a forwarded read can
+	// report a non-zero local wait.
 	Forwarded     bool `protobuf:"varint,14,opt,name=forwarded,proto3" json:"forwarded,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -8353,8 +8353,49 @@ type QueryProfile struct {
 	MaterializedRanges   int32                  `protobuf:"varint,5,opt,name=materialized_ranges,json=materializedRanges,proto3" json:"materialized_ranges,omitempty"`
 	MaterializedItems    int32                  `protobuf:"varint,6,opt,name=materialized_items,json=materializedItems,proto3" json:"materialized_items,omitempty"`
 	RootIterator         *IteratorProfile       `protobuf:"bytes,7,opt,name=root_iterator,json=rootIterator,proto3" json:"root_iterator,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Consumer-independent server cost: handler entry (before request decode) to
+	// the response being ready for delivery, MINUS barrier_duration_us and MINUS
+	// deliver_duration_us. This is the headline number and the only one with an
+	// identical definition on gRPC and HTTP, so the two surfaces are comparable
+	// and it is the right basis for a server-side latency SLO.
+	//
+	// prepare_duration_us + execute_duration_us <= server_duration_us; the
+	// difference is server work outside both phases (response assembly,
+	// pagination trailer, profile emission).
+	ServerDurationUs int64 `protobuf:"varint,8,opt,name=server_duration_us,json=serverDurationUs,proto3" json:"server_duration_us,omitempty"`
+	// Portion of server_duration_us spent before the query executor was invoked:
+	// authentication, request decode/validation, filter parsing/compilation and
+	// checkpoint-store opening.
+	PrepareDurationUs int64 `protobuf:"varint,9,opt,name=prepare_duration_us,json=prepareDurationUs,proto3" json:"prepare_duration_us,omitempty"`
+	// Portion of server_duration_us spent inside the query executor. Contains
+	// index_duration_us and enrichment_duration_us as sub-phases, plus snapshot
+	// setup, ledger/schema resolution and — when rows are produced lazily
+	// (a follower routing to the leader) — the time spent pulling rows out of
+	// the cursor.
+	ExecuteDurationUs int64 `protobuf:"varint,10,opt,name=execute_duration_us,json=executeDurationUs,proto3" json:"execute_duration_us,omitempty"`
+	// Time blocked on a read-consistency barrier the CALLER asked for: the Raft
+	// ReadIndex quorum round-trip and the ReadOptions.min_log_sequence read-index
+	// catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
+	// the request opted into, not server cost.
+	BarrierDurationUs int64 `protobuf:"varint,11,opt,name=barrier_duration_us,json=barrierDurationUs,proto3" json:"barrier_duration_us,omitempty"`
+	// Time spent serialising result rows and handing them to the transport.
+	// EXCLUDED from server_duration_us because on a server stream it also
+	// contains consumer back-pressure, which is client cost, not server cost.
+	//
+	// On a gRPC server stream this is the sum of the stream.Send() calls
+	// (marshal + transport write + flow-control wait). Always 0 on HTTP, where
+	// the profile travels in a response header that must be flushed before the
+	// body, putting response serialisation out of reach. Since row serialisation
+	// is excluded from server_duration_us on both surfaces, that asymmetry does
+	// not affect the comparability of the headline number.
+	DeliverDurationUs int64 `protobuf:"varint,12,opt,name=deliver_duration_us,json=deliverDurationUs,proto3" json:"deliver_duration_us,omitempty"`
+	// Handler entry to the first row accepted by the transport. Server streams
+	// only (0 for unary responses). Compare against server_duration_us and
+	// deliver_duration_us to separate "the server was slow to produce anything"
+	// from "the consumer was slow to drain the stream".
+	FirstRowDurationUs int64 `protobuf:"varint,13,opt,name=first_row_duration_us,json=firstRowDurationUs,proto3" json:"first_row_duration_us,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *QueryProfile) Reset() {
@@ -8434,6 +8475,48 @@ func (x *QueryProfile) GetRootIterator() *IteratorProfile {
 		return x.RootIterator
 	}
 	return nil
+}
+
+func (x *QueryProfile) GetServerDurationUs() int64 {
+	if x != nil {
+		return x.ServerDurationUs
+	}
+	return 0
+}
+
+func (x *QueryProfile) GetPrepareDurationUs() int64 {
+	if x != nil {
+		return x.PrepareDurationUs
+	}
+	return 0
+}
+
+func (x *QueryProfile) GetExecuteDurationUs() int64 {
+	if x != nil {
+		return x.ExecuteDurationUs
+	}
+	return 0
+}
+
+func (x *QueryProfile) GetBarrierDurationUs() int64 {
+	if x != nil {
+		return x.BarrierDurationUs
+	}
+	return 0
+}
+
+func (x *QueryProfile) GetDeliverDurationUs() int64 {
+	if x != nil {
+		return x.DeliverDurationUs
+	}
+	return 0
+}
+
+func (x *QueryProfile) GetFirstRowDurationUs() int64 {
+	if x != nil {
+		return x.FirstRowDurationUs
+	}
+	return 0
 }
 
 // IteratorProfile describes a single iterator node in the query execution tree.
@@ -9666,7 +9749,7 @@ const file_bucket_proto_rawDesc = "" +
 	"\x11use_max_precision\x18\x04 \x01(\bR\x0fuseMaxPrecision\x12*\n" +
 	"\x11group_by_prefixes\x18\x05 \x03(\tR\x0fgroupByPrefixes\x12#\n" +
 	"\rcheckpoint_id\x18\x06 \x01(\x06R\fcheckpointId\x12'\n" +
-	"\x0fcollapse_colors\x18\a \x01(\bR\x0ecollapseColors\"\xde\x02\n" +
+	"\x0fcollapse_colors\x18\a \x01(\bR\x0ecollapseColors\"\xff\x04\n" +
 	"\fQueryProfile\x12*\n" +
 	"\x11index_duration_us\x18\x01 \x01(\x03R\x0findexDurationUs\x124\n" +
 	"\x16enrichment_duration_us\x18\x02 \x01(\x03R\x14enrichmentDurationUs\x12'\n" +
@@ -9674,7 +9757,14 @@ const file_bucket_proto_rawDesc = "" +
 	"\x0eenriched_count\x18\x04 \x01(\x05R\renrichedCount\x12/\n" +
 	"\x13materialized_ranges\x18\x05 \x01(\x05R\x12materializedRanges\x12-\n" +
 	"\x12materialized_items\x18\x06 \x01(\x05R\x11materializedItems\x12<\n" +
-	"\rroot_iterator\x18\a \x01(\v2\x17.ledger.IteratorProfileR\frootIterator\"\x91\x03\n" +
+	"\rroot_iterator\x18\a \x01(\v2\x17.ledger.IteratorProfileR\frootIterator\x12,\n" +
+	"\x12server_duration_us\x18\b \x01(\x03R\x10serverDurationUs\x12.\n" +
+	"\x13prepare_duration_us\x18\t \x01(\x03R\x11prepareDurationUs\x12.\n" +
+	"\x13execute_duration_us\x18\n" +
+	" \x01(\x03R\x11executeDurationUs\x12.\n" +
+	"\x13barrier_duration_us\x18\v \x01(\x03R\x11barrierDurationUs\x12.\n" +
+	"\x13deliver_duration_us\x18\f \x01(\x03R\x11deliverDurationUs\x121\n" +
+	"\x15first_row_duration_us\x18\r \x01(\x03R\x12firstRowDurationUs\"\x91\x03\n" +
 	"\x0fIteratorProfile\x12\x14\n" +
 	"\x05label\x18\x01 \x01(\tR\x05label\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x16\n" +

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -8355,9 +8355,23 @@ type QueryProfile struct {
 	RootIterator         *IteratorProfile       `protobuf:"bytes,7,opt,name=root_iterator,json=rootIterator,proto3" json:"root_iterator,omitempty"`
 	// Consumer-independent server cost: handler entry (before request decode) to
 	// the response being ready for delivery, MINUS barrier_duration_us and MINUS
-	// deliver_duration_us. This is the headline number and the only one with an
-	// identical definition on gRPC and HTTP, so the two surfaces are comparable
-	// and it is the right basis for a server-side latency SLO.
+	// deliver_duration_us. It cannot be moved by a slow client, and it is the one
+	// field defined identically on gRPC and HTTP, so the two surfaces compare.
+	//
+	// It does NOT include row serialisation. On a gRPC server stream, marshalling
+	// and the transport write happen inside one inseparable stream.Send() call, so
+	// serialisation is accounted in deliver_duration_us together with consumer
+	// back-pressure. Choose accordingly:
+	//
+	//   - consumer-independent, excludes serialisation:  server_duration_us
+	//   - complete server-side cost, includes serialisation but also absorbs
+	//     back-pressure on a stream:  server_duration_us + deliver_duration_us
+	//
+	// Neither is a clean latency-SLO basis on a streaming read: the first omits a
+	// real cost that grows with page size, the second admits client behaviour into
+	// the signal. Pick the one whose bias is acceptable for the specific SLO and
+	// say which. The server's own slow-query threshold uses the sum, so that
+	// serialisation and forwarded-read cost cannot hide from it.
 	//
 	// prepare_duration_us + execute_duration_us <= server_duration_us; the
 	// difference is server work outside both phases (response assembly,
@@ -8377,6 +8391,11 @@ type QueryProfile struct {
 	// ReadIndex quorum round-trip and the ReadOptions.min_log_sequence read-index
 	// catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
 	// the request opted into, not server cost.
+	//
+	// Only LOCAL barriers are measured. When `forwarded` is true this reads 0
+	// because no barrier ran on this node, NOT because none ran: the remote node's
+	// barrier is folded into its execution, which arrives here inside
+	// execute_duration_us. Always read this field together with `forwarded`.
 	BarrierDurationUs int64 `protobuf:"varint,11,opt,name=barrier_duration_us,json=barrierDurationUs,proto3" json:"barrier_duration_us,omitempty"`
 	// Time spent serialising result rows and handing them to the transport.
 	// EXCLUDED from server_duration_us because on a server stream it also
@@ -8389,13 +8408,26 @@ type QueryProfile struct {
 	// is excluded from server_duration_us on both surfaces, that asymmetry does
 	// not affect the comparability of the headline number.
 	DeliverDurationUs int64 `protobuf:"varint,12,opt,name=deliver_duration_us,json=deliverDurationUs,proto3" json:"deliver_duration_us,omitempty"`
-	// Handler entry to the first row accepted by the transport. Server streams
-	// only (0 for unary responses). Compare against server_duration_us and
-	// deliver_duration_us to separate "the server was slow to produce anything"
-	// from "the consumer was slow to drain the stream".
+	// Handler entry to the first row accepted by the transport. Compare against
+	// server_duration_us and deliver_duration_us to separate "the server was slow
+	// to produce anything" from "the consumer was slow to drain the stream".
+	//
+	// 0 means no row was ever handed to the transport, which covers three distinct
+	// cases: a streaming read that matched nothing, a unary response (HTTP, and
+	// the AggregateVolumes / ExecutePreparedQuery RPCs — these never hand rows to
+	// a stream), and a streaming read that failed before its first send. Use
+	// items_collected and the RPC's own status to tell them apart.
 	FirstRowDurationUs int64 `protobuf:"varint,13,opt,name=first_row_duration_us,json=firstRowDurationUs,proto3" json:"first_row_duration_us,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// True when this node did not serve the read itself but forwarded it to
+	// another node — an explicit leader-consistency read, or the fallback taken
+	// when the local replica is still catching up. The remote node's prepare,
+	// barrier and execution all arrive inside execute_duration_us, and
+	// barrier_duration_us reads 0 for lack of a local barrier, so the phase
+	// breakdown describes the local hop only. Its purpose is to stop a zero
+	// barrier from being misread as "no barrier was needed".
+	Forwarded     bool `protobuf:"varint,14,opt,name=forwarded,proto3" json:"forwarded,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *QueryProfile) Reset() {
@@ -8517,6 +8549,13 @@ func (x *QueryProfile) GetFirstRowDurationUs() int64 {
 		return x.FirstRowDurationUs
 	}
 	return 0
+}
+
+func (x *QueryProfile) GetForwarded() bool {
+	if x != nil {
+		return x.Forwarded
+	}
+	return false
 }
 
 // IteratorProfile describes a single iterator node in the query execution tree.
@@ -9749,7 +9788,7 @@ const file_bucket_proto_rawDesc = "" +
 	"\x11use_max_precision\x18\x04 \x01(\bR\x0fuseMaxPrecision\x12*\n" +
 	"\x11group_by_prefixes\x18\x05 \x03(\tR\x0fgroupByPrefixes\x12#\n" +
 	"\rcheckpoint_id\x18\x06 \x01(\x06R\fcheckpointId\x12'\n" +
-	"\x0fcollapse_colors\x18\a \x01(\bR\x0ecollapseColors\"\xff\x04\n" +
+	"\x0fcollapse_colors\x18\a \x01(\bR\x0ecollapseColors\"\x9d\x05\n" +
 	"\fQueryProfile\x12*\n" +
 	"\x11index_duration_us\x18\x01 \x01(\x03R\x0findexDurationUs\x124\n" +
 	"\x16enrichment_duration_us\x18\x02 \x01(\x03R\x14enrichmentDurationUs\x12'\n" +
@@ -9764,7 +9803,8 @@ const file_bucket_proto_rawDesc = "" +
 	" \x01(\x03R\x11executeDurationUs\x12.\n" +
 	"\x13barrier_duration_us\x18\v \x01(\x03R\x11barrierDurationUs\x12.\n" +
 	"\x13deliver_duration_us\x18\f \x01(\x03R\x11deliverDurationUs\x121\n" +
-	"\x15first_row_duration_us\x18\r \x01(\x03R\x12firstRowDurationUs\"\x91\x03\n" +
+	"\x15first_row_duration_us\x18\r \x01(\x03R\x12firstRowDurationUs\x12\x1c\n" +
+	"\tforwarded\x18\x0e \x01(\bR\tforwarded\"\x91\x03\n" +
 	"\x0fIteratorProfile\x12\x14\n" +
 	"\x05label\x18\x01 \x01(\tR\x05label\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x16\n" +

--- a/internal/proto/servicepb/bucket_reader.pb.go
+++ b/internal/proto/servicepb/bucket_reader.pb.go
@@ -9610,6 +9610,7 @@ type QueryProfileReader interface {
 	GetBarrierDurationUs() int64
 	GetDeliverDurationUs() int64
 	GetFirstRowDurationUs() int64
+	GetForwarded() bool
 	Mutate() *QueryProfile
 }
 
@@ -9669,6 +9670,10 @@ func (r *queryProfileReadonly) GetDeliverDurationUs() int64 {
 
 func (r *queryProfileReadonly) GetFirstRowDurationUs() int64 {
 	return (*QueryProfile)(r).GetFirstRowDurationUs()
+}
+
+func (r *queryProfileReadonly) GetForwarded() bool {
+	return (*QueryProfile)(r).GetForwarded()
 }
 
 func (r *queryProfileReadonly) Mutate() *QueryProfile {

--- a/internal/proto/servicepb/bucket_reader.pb.go
+++ b/internal/proto/servicepb/bucket_reader.pb.go
@@ -9604,6 +9604,12 @@ type QueryProfileReader interface {
 	GetMaterializedRanges() int32
 	GetMaterializedItems() int32
 	GetRootIterator() IteratorProfileReader
+	GetServerDurationUs() int64
+	GetPrepareDurationUs() int64
+	GetExecuteDurationUs() int64
+	GetBarrierDurationUs() int64
+	GetDeliverDurationUs() int64
+	GetFirstRowDurationUs() int64
 	Mutate() *QueryProfile
 }
 
@@ -9639,6 +9645,30 @@ func (r *queryProfileReadonly) GetRootIterator() IteratorProfileReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *queryProfileReadonly) GetServerDurationUs() int64 {
+	return (*QueryProfile)(r).GetServerDurationUs()
+}
+
+func (r *queryProfileReadonly) GetPrepareDurationUs() int64 {
+	return (*QueryProfile)(r).GetPrepareDurationUs()
+}
+
+func (r *queryProfileReadonly) GetExecuteDurationUs() int64 {
+	return (*QueryProfile)(r).GetExecuteDurationUs()
+}
+
+func (r *queryProfileReadonly) GetBarrierDurationUs() int64 {
+	return (*QueryProfile)(r).GetBarrierDurationUs()
+}
+
+func (r *queryProfileReadonly) GetDeliverDurationUs() int64 {
+	return (*QueryProfile)(r).GetDeliverDurationUs()
+}
+
+func (r *queryProfileReadonly) GetFirstRowDurationUs() int64 {
+	return (*QueryProfile)(r).GetFirstRowDurationUs()
 }
 
 func (r *queryProfileReadonly) Mutate() *QueryProfile {

--- a/internal/proto/servicepb/bucket_vtproto.pb.go
+++ b/internal/proto/servicepb/bucket_vtproto.pb.go
@@ -2967,6 +2967,12 @@ func (m *QueryProfile) CloneVT() *QueryProfile {
 	r.MaterializedRanges = m.MaterializedRanges
 	r.MaterializedItems = m.MaterializedItems
 	r.RootIterator = m.RootIterator.CloneVT()
+	r.ServerDurationUs = m.ServerDurationUs
+	r.PrepareDurationUs = m.PrepareDurationUs
+	r.ExecuteDurationUs = m.ExecuteDurationUs
+	r.BarrierDurationUs = m.BarrierDurationUs
+	r.DeliverDurationUs = m.DeliverDurationUs
+	r.FirstRowDurationUs = m.FirstRowDurationUs
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -7844,6 +7850,24 @@ func (this *QueryProfile) EqualVT(that *QueryProfile) bool {
 		return false
 	}
 	if !this.RootIterator.EqualVT(that.RootIterator) {
+		return false
+	}
+	if this.ServerDurationUs != that.ServerDurationUs {
+		return false
+	}
+	if this.PrepareDurationUs != that.PrepareDurationUs {
+		return false
+	}
+	if this.ExecuteDurationUs != that.ExecuteDurationUs {
+		return false
+	}
+	if this.BarrierDurationUs != that.BarrierDurationUs {
+		return false
+	}
+	if this.DeliverDurationUs != that.DeliverDurationUs {
+		return false
+	}
+	if this.FirstRowDurationUs != that.FirstRowDurationUs {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15705,6 +15729,36 @@ func (m *QueryProfile) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.FirstRowDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FirstRowDurationUs))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.DeliverDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DeliverDurationUs))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.BarrierDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.BarrierDurationUs))
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.ExecuteDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ExecuteDurationUs))
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.PrepareDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.PrepareDurationUs))
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.ServerDurationUs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ServerDurationUs))
+		i--
+		dAtA[i] = 0x40
+	}
 	if m.RootIterator != nil {
 		size, err := m.RootIterator.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -19421,6 +19475,24 @@ func (m *QueryProfile) SizeVT() (n int) {
 	if m.RootIterator != nil {
 		l = m.RootIterator.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ServerDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ServerDurationUs))
+	}
+	if m.PrepareDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.PrepareDurationUs))
+	}
+	if m.ExecuteDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ExecuteDurationUs))
+	}
+	if m.BarrierDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.BarrierDurationUs))
+	}
+	if m.DeliverDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.DeliverDurationUs))
+	}
+	if m.FirstRowDurationUs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.FirstRowDurationUs))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -36819,6 +36891,120 @@ func (m *QueryProfile) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServerDurationUs", wireType)
+			}
+			m.ServerDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ServerDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PrepareDurationUs", wireType)
+			}
+			m.PrepareDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.PrepareDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExecuteDurationUs", wireType)
+			}
+			m.ExecuteDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ExecuteDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BarrierDurationUs", wireType)
+			}
+			m.BarrierDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BarrierDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeliverDurationUs", wireType)
+			}
+			m.DeliverDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.DeliverDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FirstRowDurationUs", wireType)
+			}
+			m.FirstRowDurationUs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FirstRowDurationUs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/servicepb/bucket_vtproto.pb.go
+++ b/internal/proto/servicepb/bucket_vtproto.pb.go
@@ -2973,6 +2973,7 @@ func (m *QueryProfile) CloneVT() *QueryProfile {
 	r.BarrierDurationUs = m.BarrierDurationUs
 	r.DeliverDurationUs = m.DeliverDurationUs
 	r.FirstRowDurationUs = m.FirstRowDurationUs
+	r.Forwarded = m.Forwarded
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -7868,6 +7869,9 @@ func (this *QueryProfile) EqualVT(that *QueryProfile) bool {
 		return false
 	}
 	if this.FirstRowDurationUs != that.FirstRowDurationUs {
+		return false
+	}
+	if this.Forwarded != that.Forwarded {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15729,6 +15733,16 @@ func (m *QueryProfile) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Forwarded {
+		i--
+		if m.Forwarded {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x70
+	}
 	if m.FirstRowDurationUs != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FirstRowDurationUs))
 		i--
@@ -19493,6 +19507,9 @@ func (m *QueryProfile) SizeVT() (n int) {
 	}
 	if m.FirstRowDurationUs != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.FirstRowDurationUs))
+	}
+	if m.Forwarded {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -37005,6 +37022,26 @@ func (m *QueryProfile) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Forwarded", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Forwarded = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/query/profile.go
+++ b/internal/query/profile.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -39,16 +40,26 @@ import (
 //	     caller-requested wait               consumer-dependent
 //	     (excluded from ServerDuration)  (excluded from ServerDuration)
 //
-// ServerDuration is the headline consumer-independent server cost:
-// wall clock - BarrierDuration - DeliverDuration. It is defined identically on
-// gRPC and HTTP, which is what makes the two surfaces comparable, and it is the
-// only field a server-side latency SLO should be written against.
+// There are two totals, and which one to use depends on the question:
 //
-// BarrierDuration is excluded because it is a wait the caller opted into (Raft
-// ReadIndex quorum, ReadOptions.min_log_sequence catch-up), not work.
-// DeliverDuration is excluded because on a server stream it contains consumer
-// back-pressure: folding it in would make the total move with client behaviour
-// and mislead exactly the reader trying to decide whether the server is slow.
+//   - ServerDuration = wall clock - BarrierDuration - DeliverDuration. The
+//     consumer-independent number: it cannot be moved by a slow client. Defined
+//     identically on gRPC and HTTP, so the two surfaces are comparable. It does
+//     NOT include row serialisation, which on a gRPC server stream is
+//     inseparable from the transport write (see WallDuration).
+//   - WallDuration = ServerDuration + DeliverDuration. Everything the server
+//     spent on the request except the caller-requested barrier, including row
+//     serialisation — but on a stream it also absorbs consumer back-pressure.
+//
+// BarrierDuration is excluded from both because it is a wait the caller opted
+// into (Raft ReadIndex quorum, ReadOptions.min_log_sequence catch-up), not work.
+//
+// DeliverDuration is excluded from ServerDuration because on a server stream it
+// contains consumer back-pressure: folding it in would make the headline total
+// move with client behaviour and mislead the reader trying to decide whether the
+// server is slow. It is NOT excluded from the slow-query threshold, which uses
+// WallDuration precisely so that serialisation cost and forwarded-read cost
+// cannot hide from it.
 type QueryProfile struct {
 	IndexDuration      time.Duration
 	EnrichmentDuration time.Duration
@@ -79,19 +90,24 @@ type QueryProfile struct {
 	// response header that must be flushed before the body.
 	DeliverDuration time.Duration
 	// FirstRowDuration is handler entry to the first row accepted by the
-	// transport. Server streams only; zero for unary responses.
+	// transport. Zero means "no row was ever handed to the transport": an empty
+	// result, a unary response, or a failure before the first send. Read it
+	// together with ItemsCollected to tell those apart.
 	FirstRowDuration time.Duration
 	// ServerDuration is the consumer-independent server cost. Computed by
 	// Finish; zero until then.
 	ServerDuration time.Duration
-
-	// detailed is true when the caller explicitly asked for the profile
-	// (gRPC x-query-profile metadata / HTTP X-Query-Profile header). It gates
-	// the only instrumentation whose cost scales with the result size: the
-	// per-row split between production (execute) and delivery in a streaming
-	// send loop. A request that did not ask pays two extra time.Now() calls for
-	// the whole loop instead of two per row.
-	detailed bool
+	// Forwarded is true when the read was routed to another node (an explicit
+	// leader read, or the syncing-follower fallback). On a forwarded read the
+	// remote node runs its own barrier and execution, and that cost lands in
+	// this profile's ExecuteDuration; BarrierDuration therefore reads 0 because
+	// no barrier ran LOCALLY, not because no barrier ran. Without this flag a
+	// zero barrier is ambiguous.
+	Forwarded bool
+	// Anomaly is non-empty when the phase bookkeeping detected a state that is
+	// impossible by contract (see clampPhase). It is surfaced in the log and on
+	// the span so the violation cannot pass unnoticed, per invariant #7.
+	Anomaly string
 
 	// requestStart is the instant the handler began. Zero for a profile built
 	// by hand (tests), which turns Finish and the phase marks into no-ops so a
@@ -145,23 +161,26 @@ type profileKey struct{}
 // request decode, validation and filter compilation — otherwise those phases
 // stay outside the measured window and PrepareDuration is meaningless.
 //
-// detailed must be the transport's "did the caller ask for the profile" answer
-// (gRPC x-query-profile metadata, HTTP X-Query-Profile header). It only enables
-// per-row phase attribution in streaming send loops; every other measurement is
-// O(1) per request and is always collected, because the slow-query log and the
-// OTel span consume the same profile and would otherwise lose the phases that
-// matter most.
-func WithProfile(ctx context.Context, detailed bool) (context.Context, *QueryProfile) {
-	p := &QueryProfile{detailed: detailed, requestStart: time.Now()}
+// The profile is collected in full for every profiled read, whether or not the
+// caller asked to see it: the slow-query log and the OTel span consume the same
+// record, and a measurement regime that depended on the caller having asked
+// would make the two regimes incomparable — the exact defect this timing work
+// exists to remove. The presence of a profile in the context, not the caller's
+// request for one, is what enables instrumentation.
+func WithProfile(ctx context.Context) (context.Context, *QueryProfile) {
+	p := &QueryProfile{requestStart: time.Now()}
 
 	return context.WithValue(ctx, profileKey{}, p), p
 }
 
-// Detailed reports whether the caller explicitly requested the profile, which
-// authorises instrumentation whose cost scales with the number of result rows.
-// Nil-safe.
-func (p *QueryProfile) Detailed() bool {
-	return p != nil && p.detailed
+// MarkForwarded records that the read was served by another node, so a zero
+// BarrierDuration is not misread as "no barrier was needed". Nil-safe.
+func (p *QueryProfile) MarkForwarded() {
+	if p == nil {
+		return
+	}
+
+	p.Forwarded = true
 }
 
 // EnterExecute closes the prepare phase and opens an execution window. Call it
@@ -176,7 +195,7 @@ func (p *QueryProfile) EnterExecute() {
 		p.executeEntered = true
 		// Barrier waits before the executor (min_log_sequence, ReadIndex) are
 		// caller-requested waiting, not preparation work.
-		p.PrepareDuration = nonNegative(time.Since(p.requestStart) - p.BarrierDuration)
+		p.PrepareDuration = p.clampPhase("prepare", time.Since(p.requestStart)-p.BarrierDuration)
 	}
 
 	p.executeStart = time.Now()
@@ -191,7 +210,7 @@ func (p *QueryProfile) LeaveExecute() {
 		return
 	}
 
-	p.ExecuteDuration += nonNegative(time.Since(p.executeStart) - (p.BarrierDuration - p.barrierAtExecuteStart))
+	p.ExecuteDuration += p.clampPhase("execute", time.Since(p.executeStart)-(p.BarrierDuration-p.barrierAtExecuteStart))
 	p.executeStart = time.Time{}
 }
 
@@ -252,7 +271,7 @@ func (p *QueryProfile) Finish() {
 
 	p.LeaveExecute()
 
-	p.ServerDuration = nonNegative(time.Since(p.requestStart) - p.BarrierDuration - p.DeliverDuration)
+	p.ServerDuration = p.clampPhase("server", time.Since(p.requestStart)-p.BarrierDuration-p.DeliverDuration)
 
 	if !p.executeEntered {
 		// The request never reached the executor (validation rejection, missing
@@ -261,16 +280,35 @@ func (p *QueryProfile) Finish() {
 	}
 }
 
-// nonNegative clamps a phase duration at zero. A negative value can only come
-// from an accumulator being credited more than the enclosing window actually
-// lasted (a double-counted barrier wait, say), and publishing a negative
-// duration would be worse than publishing a floor.
-func nonNegative(d time.Duration) time.Duration {
-	if d < 0 {
-		return 0
+// clampPhase floors a computed phase duration at zero.
+//
+// A negative result is impossible by contract: every accumulator is credited
+// from inside the window it is later subtracted from, so it can only exceed that
+// window if a hook double-counted. Per invariant #7 that must not pass silently,
+// but a read request is the wrong place to fail hard over a diagnostic — so the
+// clamp keeps the wire value sane while the violation is made loud: recorded on
+// the profile (and therefore in the slow-query log and the span, where the
+// profile is consumed) and asserted for the fuzzing harness.
+func (p *QueryProfile) clampPhase(phase string, d time.Duration) time.Duration {
+	if d >= 0 {
+		return d
 	}
 
-	return d
+	assert.Unreachable("query profile: phase duration went negative — an accumulator was double-counted", map[string]any{
+		"phase":             phase,
+		"duration_ns":       int64(d),
+		"barrier_ns":        int64(p.BarrierDuration),
+		"deliver_ns":        int64(p.DeliverDuration),
+		"execute_ns":        int64(p.ExecuteDuration),
+		"executeEntered":    p.executeEntered,
+		"executeWindowOpen": !p.executeStart.IsZero(),
+	})
+
+	// assert.Unreachable is a no-op in production builds, so leave a trace the
+	// operator can actually see.
+	p.Anomaly = "negative " + phase + " duration (accumulator double-counted)"
+
+	return 0
 }
 
 // ProfileFromContext extracts the QueryProfile from the context.
@@ -283,9 +321,33 @@ func ProfileFromContext(ctx context.Context) *QueryProfile {
 
 // TotalDuration returns the sum of index and enrichment durations, i.e. the
 // query EXECUTION total. It is a subset of ServerDuration and must not be used
-// as "how long the server took" — use ServerDuration for that.
+// as "how long the server took" — use ServerDuration or WallDuration for that.
 func (p *QueryProfile) TotalDuration() time.Duration {
 	return p.IndexDuration + p.EnrichmentDuration
+}
+
+// WallDuration returns everything the server spent on the request except the
+// caller-requested read barrier: ServerDuration plus the delivery phase.
+//
+// This is the total the slow-query threshold compares against. ServerDuration
+// alone would be blind to two real costs: row serialisation, which grows with
+// page size and is charged to delivery because a gRPC stream.Send() marshals and
+// writes in one inseparable call; and, on a forwarded read, the remote node's
+// entire cost, which arrives through the row-production side of the send loop.
+// A threshold that cannot see either would fail to surface exactly the slow
+// requests it exists for.
+//
+// The price is that on a server stream this total also absorbs consumer
+// back-pressure, so a slow client can trip the threshold. That is accepted
+// deliberately: the logged breakdown (DeliverDuration vs FirstRowDuration vs
+// ServerDuration) tells the reader which side was slow, whereas a threshold that
+// never fires tells them nothing at all.
+func (p *QueryProfile) WallDuration() time.Duration {
+	if p == nil {
+		return 0
+	}
+
+	return p.ServerDuration + p.DeliverDuration
 }
 
 // ToProto converts the profile to its protobuf representation.
@@ -307,6 +369,7 @@ func (p *QueryProfile) ToProto() *servicepb.QueryProfile {
 		BarrierDurationUs:    p.BarrierDuration.Microseconds(),
 		DeliverDurationUs:    p.DeliverDuration.Microseconds(),
 		FirstRowDurationUs:   p.FirstRowDuration.Microseconds(),
+		Forwarded:            p.Forwarded,
 	}
 	if p.Root != nil {
 		pb.RootIterator = p.Root.ToProto()
@@ -360,8 +423,13 @@ func (p *QueryProfile) EmitToSpan(span trace.Span) {
 		attribute.Int64("query.barrier_duration_us", p.BarrierDuration.Microseconds()),
 		attribute.Int64("query.deliver_duration_us", p.DeliverDuration.Microseconds()),
 		attribute.Int64("query.first_row_duration_us", p.FirstRowDuration.Microseconds()),
-		attribute.Bool("query.profile_detailed", p.detailed),
+		attribute.Int64("query.wall_duration_us", p.WallDuration().Microseconds()),
+		attribute.Bool("query.forwarded", p.Forwarded),
 	)
+
+	if p.Anomaly != "" {
+		span.SetAttributes(attribute.String("query.profile_anomaly", p.Anomaly))
+	}
 
 	if p.Root != nil {
 		span.SetAttributes(attribute.String("query.iterator_tree", p.Root.String()))
@@ -388,16 +456,22 @@ func (p *QueryProfile) LogTo(logger logging.Logger) {
 			"barrierDurationUs":    p.BarrierDuration.Microseconds(),
 			"deliverDurationUs":    p.DeliverDuration.Microseconds(),
 			"firstRowDurationUs":   p.FirstRowDuration.Microseconds(),
-			// False means the caller did not ask for the profile, so the
-			// execute/deliver split was not attributed per row: the whole
-			// streaming loop was charged to deliverDurationUs.
-			"profileDetailed": p.detailed,
+			"wallDurationUs":       p.WallDuration().Microseconds(),
+			// True means the read was served by another node, so barrierDurationUs
+			// reads 0 for lack of a LOCAL barrier and the remote node's whole cost
+			// sits inside executeDurationUs.
+			"forwarded": p.Forwarded,
 		}
 		if p.Root != nil {
 			fields["iteratorTree"] = p.Root.String()
 		}
 
-		logger.WithFields(fields).Tracef("Query profile (server=%s, execution=%s)", p.ServerDuration, p.TotalDuration())
+		if p.Anomaly != "" {
+			fields["profileAnomaly"] = p.Anomaly
+		}
+
+		logger.WithFields(fields).Tracef("Query profile (wall=%s, server=%s, execution=%s)",
+			p.WallDuration(), p.ServerDuration, p.TotalDuration())
 	}
 }
 

--- a/internal/query/profile.go
+++ b/internal/query/profile.go
@@ -30,8 +30,9 @@ import (
 // # Phase model
 //
 // The request clock starts when the profile is created — call [WithProfile] as
-// the FIRST statement of a read handler, before any decode or validation — and
-// stops at [QueryProfile.Finish].
+// the FIRST statement of a read handler, before any validation, or
+// [WithProfileStartingAt] from a transport that can stamp an earlier instant —
+// and stops at [QueryProfile.Finish].
 //
 //	|<---------------------- wall clock ---------------------->|
 //	[ prepare ][ barrier ][ execute ][ residual ][   deliver   ]
@@ -69,10 +70,12 @@ type QueryProfile struct {
 	MaterializedItems  int
 	Root               *IteratorStats
 
-	// PrepareDuration covers handler entry to executor invocation:
-	// authentication, request decode/validation, filter parsing/compilation and
-	// checkpoint-store opening. Barrier waits observed in this window are
-	// subtracted out.
+	// PrepareDuration covers request entry to executor invocation:
+	// authentication, request validation, filter parsing/compilation and
+	// checkpoint-store opening, plus query/body decoding on HTTP. gRPC protobuf
+	// decode is outside it — grpc-go unmarshals the request before dispatching to
+	// the handler, so no in-handler clock can reach it. Barrier waits observed in
+	// this window are subtracted out.
 	PrepareDuration time.Duration
 	// ExecuteDuration covers the executor call(s): snapshot setup, ledger and
 	// schema resolution, the index scan (IndexDuration), enrichment
@@ -80,10 +83,11 @@ type QueryProfile struct {
 	// reported through AddProduction. Barrier waits observed inside the window
 	// are subtracted out.
 	ExecuteDuration time.Duration
-	// BarrierDuration is time blocked on a caller-requested read-consistency
-	// barrier, LOCAL to this node. Excluded from ServerDuration. A failed
-	// barrier attempt counts: a syncing follower that burns a quorum wait before
-	// falling back to the leader reports that wait here, with Forwarded true.
+	// BarrierDuration is time blocked on caller-requested read-consistency waits,
+	// LOCAL to this node: the min_log_sequence catch-up and the Raft ReadIndex
+	// quorum. Excluded from ServerDuration. Every local wait counts, including
+	// one that fails or is superseded — a syncing follower burns a quorum wait
+	// before falling back to the leader and reports it here, with Forwarded true.
 	BarrierDuration time.Duration
 	// DeliverDuration is time spent serialising result rows and handing them to
 	// the transport. Excluded from ServerDuration. On a gRPC server stream it is
@@ -104,10 +108,13 @@ type QueryProfile struct {
 	// own barrier and execution, and that whole cost lands in this profile's
 	// ExecuteDuration.
 	//
-	// Forwarded does NOT imply BarrierDuration == 0. An explicit leader read
-	// never attempts a local barrier, so it reports 0 — and this flag exists so
-	// that 0 is not misread as "no barrier was needed". The syncing-follower
-	// fallback does attempt one first, and reports the failed attempt.
+	// Forwarded does NOT imply BarrierDuration == 0, and a non-zero value does
+	// not identify which wait occurred. Two paths produce one: the
+	// syncing-follower fallback attempts a ReadIndex barrier before forwarding,
+	// and waitMinLogSequence charges its catch-up regardless of consistency
+	// level, so an explicit leader read with min_log_sequence set reports a wait
+	// on a healthy cluster. The flag's job is narrower: stop a zero from being
+	// misread as "no barrier was needed".
 	Forwarded bool
 	// Anomaly is non-empty when the phase bookkeeping detected a state that is
 	// impossible by contract (see clampPhase). It is surfaced in the log and on
@@ -163,8 +170,10 @@ type profileKey struct{}
 // returns a context carrying it.
 //
 // Call it as the first statement of a read handler — before authentication,
-// request decode, validation and filter compilation — otherwise those phases
-// stay outside the measured window and PrepareDuration is meaningless.
+// validation and filter compilation — otherwise those phases stay outside the
+// measured window and PrepareDuration is meaningless. Where authentication runs
+// above the handler, as it does in the HTTP router, use
+// [WithProfileStartingAt] with an instant stamped before it instead.
 //
 // The profile is collected in full for every profiled read, whether or not the
 // caller asked to see it: the slow-query log and the OTel span consume the same
@@ -173,7 +182,20 @@ type profileKey struct{}
 // exists to remove. The presence of a profile in the context, not the caller's
 // request for one, is what enables instrumentation.
 func WithProfile(ctx context.Context) (context.Context, *QueryProfile) {
-	p := &QueryProfile{requestStart: time.Now()}
+	return WithProfileStartingAt(ctx, time.Now())
+}
+
+// WithProfileStartingAt is [WithProfile] with an externally captured start
+// instant, for transports where the first instrumentable point sits above the
+// handler.
+//
+// HTTP needs it: authentication runs in a router-wide middleware, so a profile
+// created in the handler would exclude it, while the gRPC handlers call
+// WithProfile before internalauth.Authenticate and include it. Same field name,
+// different span — so the HTTP router stamps the instant just before
+// authenticating and hands it here.
+func WithProfileStartingAt(ctx context.Context, start time.Time) (context.Context, *QueryProfile) {
+	p := &QueryProfile{requestStart: start}
 
 	return context.WithValue(ctx, profileKey{}, p), p
 }
@@ -291,9 +313,14 @@ func (p *QueryProfile) Finish() {
 // from inside the window it is later subtracted from, so it can only exceed that
 // window if a hook double-counted. Per invariant #7 that must not pass silently,
 // but a read request is the wrong place to fail hard over a diagnostic — so the
-// clamp keeps the wire value sane while the violation is made loud: recorded on
-// the profile (and therefore in the slow-query log and the span, where the
-// profile is consumed) and asserted for the fuzzing harness.
+// clamp keeps the wire value sane while the violation is recorded on the profile
+// and asserted for the fuzzing harness.
+//
+// Reaching an operator is best-effort, not guaranteed: the profile is logged only
+// above the slow-query threshold, and clamping ServerDuration to zero is exactly
+// what can pull the compared total below it. The fuzzing assertion is the
+// reliable detector; the recorded string is what makes it legible if a real
+// deployment ever does log one.
 func (p *QueryProfile) clampPhase(phase string, d time.Duration) time.Duration {
 	if d >= 0 {
 		return d

--- a/internal/query/profile.go
+++ b/internal/query/profile.go
@@ -81,7 +81,9 @@ type QueryProfile struct {
 	// are subtracted out.
 	ExecuteDuration time.Duration
 	// BarrierDuration is time blocked on a caller-requested read-consistency
-	// barrier. Excluded from ServerDuration.
+	// barrier, LOCAL to this node. Excluded from ServerDuration. A failed
+	// barrier attempt counts: a syncing follower that burns a quorum wait before
+	// falling back to the leader reports that wait here, with Forwarded true.
 	BarrierDuration time.Duration
 	// DeliverDuration is time spent serialising result rows and handing them to
 	// the transport. Excluded from ServerDuration. On a gRPC server stream it is
@@ -98,11 +100,14 @@ type QueryProfile struct {
 	// Finish; zero until then.
 	ServerDuration time.Duration
 	// Forwarded is true when the read was routed to another node (an explicit
-	// leader read, or the syncing-follower fallback). On a forwarded read the
-	// remote node runs its own barrier and execution, and that cost lands in
-	// this profile's ExecuteDuration; BarrierDuration therefore reads 0 because
-	// no barrier ran LOCALLY, not because no barrier ran. Without this flag a
-	// zero barrier is ambiguous.
+	// leader read, or the syncing-follower fallback). The remote node runs its
+	// own barrier and execution, and that whole cost lands in this profile's
+	// ExecuteDuration.
+	//
+	// Forwarded does NOT imply BarrierDuration == 0. An explicit leader read
+	// never attempts a local barrier, so it reports 0 — and this flag exists so
+	// that 0 is not misread as "no barrier was needed". The syncing-follower
+	// fallback does attempt one first, and reports the failed attempt.
 	Forwarded bool
 	// Anomaly is non-empty when the phase bookkeeping detected a state that is
 	// impossible by contract (see clampPhase). It is surfaced in the log and on
@@ -457,9 +462,10 @@ func (p *QueryProfile) LogTo(logger logging.Logger) {
 			"deliverDurationUs":    p.DeliverDuration.Microseconds(),
 			"firstRowDurationUs":   p.FirstRowDuration.Microseconds(),
 			"wallDurationUs":       p.WallDuration().Microseconds(),
-			// True means the read was served by another node, so barrierDurationUs
-			// reads 0 for lack of a LOCAL barrier and the remote node's whole cost
-			// sits inside executeDurationUs.
+			// True means the read was served by another node, so the remote node's
+			// whole cost sits inside executeDurationUs. barrierDurationUs then
+			// covers the local attempt only: 0 for an explicit leader read, non-zero
+			// when a local barrier failed before the fallback.
 			"forwarded": p.Forwarded,
 		}
 		if p.Root != nil {

--- a/internal/query/profile.go
+++ b/internal/query/profile.go
@@ -17,6 +17,38 @@ import (
 // QueryProfile collects execution statistics for a read query.
 // A single instance is created per query and threaded through the context.
 // All fields are updated synchronously (no concurrency within a single query).
+//
+// # Two families of measurement
+//
+// IndexDuration/EnrichmentDuration and the iterator tree describe query
+// EXECUTION. The Prepare/Execute/Barrier/Deliver/Server durations describe the
+// whole server-side handling of the request, which is strictly larger: request
+// decode, filter compilation, response serialisation and stream writes all live
+// outside execution and used to be invisible (EN-1859).
+//
+// # Phase model
+//
+// The request clock starts when the profile is created — call [WithProfile] as
+// the FIRST statement of a read handler, before any decode or validation — and
+// stops at [QueryProfile.Finish].
+//
+//	|<---------------------- wall clock ---------------------->|
+//	[ prepare ][ barrier ][ execute ][ residual ][   deliver   ]
+//	                 ^                                  ^
+//	                 |                                  |
+//	     caller-requested wait               consumer-dependent
+//	     (excluded from ServerDuration)  (excluded from ServerDuration)
+//
+// ServerDuration is the headline consumer-independent server cost:
+// wall clock - BarrierDuration - DeliverDuration. It is defined identically on
+// gRPC and HTTP, which is what makes the two surfaces comparable, and it is the
+// only field a server-side latency SLO should be written against.
+//
+// BarrierDuration is excluded because it is a wait the caller opted into (Raft
+// ReadIndex quorum, ReadOptions.min_log_sequence catch-up), not work.
+// DeliverDuration is excluded because on a server stream it contains consumer
+// back-pressure: folding it in would make the total move with client behaviour
+// and mislead exactly the reader trying to decide whether the server is slow.
 type QueryProfile struct {
 	IndexDuration      time.Duration
 	EnrichmentDuration time.Duration
@@ -25,6 +57,60 @@ type QueryProfile struct {
 	MaterializedRanges int
 	MaterializedItems  int
 	Root               *IteratorStats
+
+	// PrepareDuration covers handler entry to executor invocation:
+	// authentication, request decode/validation, filter parsing/compilation and
+	// checkpoint-store opening. Barrier waits observed in this window are
+	// subtracted out.
+	PrepareDuration time.Duration
+	// ExecuteDuration covers the executor call(s): snapshot setup, ledger and
+	// schema resolution, the index scan (IndexDuration), enrichment
+	// (EnrichmentDuration) and, for lazily produced rows, the row pulls
+	// reported through AddProduction. Barrier waits observed inside the window
+	// are subtracted out.
+	ExecuteDuration time.Duration
+	// BarrierDuration is time blocked on a caller-requested read-consistency
+	// barrier. Excluded from ServerDuration.
+	BarrierDuration time.Duration
+	// DeliverDuration is time spent serialising result rows and handing them to
+	// the transport. Excluded from ServerDuration. On a gRPC server stream it is
+	// the sum of the stream.Send() calls and therefore includes consumer
+	// back-pressure. Always zero on HTTP, where the profile travels in a
+	// response header that must be flushed before the body.
+	DeliverDuration time.Duration
+	// FirstRowDuration is handler entry to the first row accepted by the
+	// transport. Server streams only; zero for unary responses.
+	FirstRowDuration time.Duration
+	// ServerDuration is the consumer-independent server cost. Computed by
+	// Finish; zero until then.
+	ServerDuration time.Duration
+
+	// detailed is true when the caller explicitly asked for the profile
+	// (gRPC x-query-profile metadata / HTTP X-Query-Profile header). It gates
+	// the only instrumentation whose cost scales with the result size: the
+	// per-row split between production (execute) and delivery in a streaming
+	// send loop. A request that did not ask pays two extra time.Now() calls for
+	// the whole loop instead of two per row.
+	detailed bool
+
+	// requestStart is the instant the handler began. Zero for a profile built
+	// by hand (tests), which turns Finish and the phase marks into no-ops so a
+	// hand-built profile keeps whatever durations were assigned to it.
+	requestStart time.Time
+	// executeStart is non-zero while an execute window is open.
+	executeStart time.Time
+	// barrierAtExecuteStart snapshots BarrierDuration when the current execute
+	// window opened, so a barrier hit inside the executor is not charged to it.
+	barrierAtExecuteStart time.Duration
+	// executeEntered records whether EnterExecute was ever called, so Finish
+	// can attribute an aborted request entirely to the prepare phase.
+	executeEntered bool
+	// firstRowSeen guards FirstRowDuration against later rows.
+	firstRowSeen bool
+	// finished makes Finish idempotent, so a handler that both emits the
+	// profile and falls through to a shared response writer publishes one
+	// stable ServerDuration rather than a second, longer one.
+	finished bool
 }
 
 // IteratorStats holds per-iterator statistics in the query execution tree.
@@ -52,11 +138,139 @@ type IteratorStats struct {
 
 type profileKey struct{}
 
-// WithProfile creates a new QueryProfile and returns a context containing it.
-func WithProfile(ctx context.Context) (context.Context, *QueryProfile) {
-	p := &QueryProfile{}
+// WithProfile creates a new QueryProfile whose request clock starts now, and
+// returns a context carrying it.
+//
+// Call it as the first statement of a read handler — before authentication,
+// request decode, validation and filter compilation — otherwise those phases
+// stay outside the measured window and PrepareDuration is meaningless.
+//
+// detailed must be the transport's "did the caller ask for the profile" answer
+// (gRPC x-query-profile metadata, HTTP X-Query-Profile header). It only enables
+// per-row phase attribution in streaming send loops; every other measurement is
+// O(1) per request and is always collected, because the slow-query log and the
+// OTel span consume the same profile and would otherwise lose the phases that
+// matter most.
+func WithProfile(ctx context.Context, detailed bool) (context.Context, *QueryProfile) {
+	p := &QueryProfile{detailed: detailed, requestStart: time.Now()}
 
 	return context.WithValue(ctx, profileKey{}, p), p
+}
+
+// Detailed reports whether the caller explicitly requested the profile, which
+// authorises instrumentation whose cost scales with the number of result rows.
+// Nil-safe.
+func (p *QueryProfile) Detailed() bool {
+	return p != nil && p.detailed
+}
+
+// EnterExecute closes the prepare phase and opens an execution window. Call it
+// immediately before invoking the query executor. Nil-safe; a no-op on a
+// hand-built profile that has no request clock.
+func (p *QueryProfile) EnterExecute() {
+	if p == nil || p.requestStart.IsZero() {
+		return
+	}
+
+	if !p.executeEntered {
+		p.executeEntered = true
+		// Barrier waits before the executor (min_log_sequence, ReadIndex) are
+		// caller-requested waiting, not preparation work.
+		p.PrepareDuration = nonNegative(time.Since(p.requestStart) - p.BarrierDuration)
+	}
+
+	p.executeStart = time.Now()
+	p.barrierAtExecuteStart = p.BarrierDuration
+}
+
+// LeaveExecute closes the execution window opened by EnterExecute, charging its
+// wall time — minus any barrier wait observed inside it — to ExecuteDuration.
+// Nil-safe and safe to call without a matching EnterExecute.
+func (p *QueryProfile) LeaveExecute() {
+	if p == nil || p.executeStart.IsZero() {
+		return
+	}
+
+	p.ExecuteDuration += nonNegative(time.Since(p.executeStart) - (p.BarrierDuration - p.barrierAtExecuteStart))
+	p.executeStart = time.Time{}
+}
+
+// AddBarrierWait records time blocked on a caller-requested read-consistency
+// barrier: the Raft ReadIndex quorum round-trip or the min_log_sequence
+// read-index catch-up. Nil-safe.
+func (p *QueryProfile) AddBarrierWait(d time.Duration) {
+	if p == nil {
+		return
+	}
+
+	p.BarrierDuration += d
+}
+
+// AddProduction charges row-production time to the execution phase. Used by
+// streaming/drain loops for cursors that produce rows lazily — a follower
+// routing to the leader pulls each row over the wire from inside the send loop,
+// so that cost is execution, not delivery.
+// Nil-safe.
+func (p *QueryProfile) AddProduction(d time.Duration) {
+	if p == nil {
+		return
+	}
+
+	p.ExecuteDuration += d
+}
+
+// AddDelivery charges row serialisation plus transport hand-off to the delivery
+// phase, which is excluded from ServerDuration. Nil-safe.
+func (p *QueryProfile) AddDelivery(d time.Duration) {
+	if p == nil {
+		return
+	}
+
+	p.DeliverDuration += d
+}
+
+// MarkFirstRow records the instant the first result row was accepted by the
+// transport. Subsequent calls are ignored. Nil-safe.
+func (p *QueryProfile) MarkFirstRow() {
+	if p == nil || p.requestStart.IsZero() || p.firstRowSeen {
+		return
+	}
+
+	p.firstRowSeen = true
+	p.FirstRowDuration = time.Since(p.requestStart)
+}
+
+// Finish stops the request clock and computes ServerDuration. Call it once,
+// after the response has been handed to the transport and before the profile is
+// serialised, logged or emitted to a span. Nil-safe and idempotent.
+func (p *QueryProfile) Finish() {
+	if p == nil || p.requestStart.IsZero() || p.finished {
+		return
+	}
+
+	p.finished = true
+
+	p.LeaveExecute()
+
+	p.ServerDuration = nonNegative(time.Since(p.requestStart) - p.BarrierDuration - p.DeliverDuration)
+
+	if !p.executeEntered {
+		// The request never reached the executor (validation rejection, missing
+		// ledger, …): everything measured was preparation.
+		p.PrepareDuration = p.ServerDuration
+	}
+}
+
+// nonNegative clamps a phase duration at zero. A negative value can only come
+// from an accumulator being credited more than the enclosing window actually
+// lasted (a double-counted barrier wait, say), and publishing a negative
+// duration would be worse than publishing a floor.
+func nonNegative(d time.Duration) time.Duration {
+	if d < 0 {
+		return 0
+	}
+
+	return d
 }
 
 // ProfileFromContext extracts the QueryProfile from the context.
@@ -67,7 +281,9 @@ func ProfileFromContext(ctx context.Context) *QueryProfile {
 	return p
 }
 
-// TotalDuration returns the sum of index and enrichment durations.
+// TotalDuration returns the sum of index and enrichment durations, i.e. the
+// query EXECUTION total. It is a subset of ServerDuration and must not be used
+// as "how long the server took" — use ServerDuration for that.
 func (p *QueryProfile) TotalDuration() time.Duration {
 	return p.IndexDuration + p.EnrichmentDuration
 }
@@ -85,6 +301,12 @@ func (p *QueryProfile) ToProto() *servicepb.QueryProfile {
 		EnrichedCount:        int32(p.EnrichedCount),
 		MaterializedRanges:   int32(p.MaterializedRanges),
 		MaterializedItems:    int32(p.MaterializedItems),
+		ServerDurationUs:     p.ServerDuration.Microseconds(),
+		PrepareDurationUs:    p.PrepareDuration.Microseconds(),
+		ExecuteDurationUs:    p.ExecuteDuration.Microseconds(),
+		BarrierDurationUs:    p.BarrierDuration.Microseconds(),
+		DeliverDurationUs:    p.DeliverDuration.Microseconds(),
+		FirstRowDurationUs:   p.FirstRowDuration.Microseconds(),
 	}
 	if p.Root != nil {
 		pb.RootIterator = p.Root.ToProto()
@@ -132,6 +354,13 @@ func (p *QueryProfile) EmitToSpan(span trace.Span) {
 		attribute.Int("query.enriched_count", p.EnrichedCount),
 		attribute.Int("query.materialized_ranges", p.MaterializedRanges),
 		attribute.Int("query.materialized_items", p.MaterializedItems),
+		attribute.Int64("query.server_duration_us", p.ServerDuration.Microseconds()),
+		attribute.Int64("query.prepare_duration_us", p.PrepareDuration.Microseconds()),
+		attribute.Int64("query.execute_duration_us", p.ExecuteDuration.Microseconds()),
+		attribute.Int64("query.barrier_duration_us", p.BarrierDuration.Microseconds()),
+		attribute.Int64("query.deliver_duration_us", p.DeliverDuration.Microseconds()),
+		attribute.Int64("query.first_row_duration_us", p.FirstRowDuration.Microseconds()),
+		attribute.Bool("query.profile_detailed", p.detailed),
 	)
 
 	if p.Root != nil {
@@ -153,12 +382,22 @@ func (p *QueryProfile) LogTo(logger logging.Logger) {
 			"enrichedCount":        p.EnrichedCount,
 			"materializedRanges":   p.MaterializedRanges,
 			"materializedItems":    p.MaterializedItems,
+			"serverDurationUs":     p.ServerDuration.Microseconds(),
+			"prepareDurationUs":    p.PrepareDuration.Microseconds(),
+			"executeDurationUs":    p.ExecuteDuration.Microseconds(),
+			"barrierDurationUs":    p.BarrierDuration.Microseconds(),
+			"deliverDurationUs":    p.DeliverDuration.Microseconds(),
+			"firstRowDurationUs":   p.FirstRowDuration.Microseconds(),
+			// False means the caller did not ask for the profile, so the
+			// execute/deliver split was not attributed per row: the whole
+			// streaming loop was charged to deliverDurationUs.
+			"profileDetailed": p.detailed,
 		}
 		if p.Root != nil {
 			fields["iteratorTree"] = p.Root.String()
 		}
 
-		logger.WithFields(fields).Tracef("Query profile (total=%s)", p.TotalDuration())
+		logger.WithFields(fields).Tracef("Query profile (server=%s, execution=%s)", p.ServerDuration, p.TotalDuration())
 	}
 }
 

--- a/internal/query/profile_test.go
+++ b/internal/query/profile_test.go
@@ -14,26 +14,11 @@ import (
 func TestWithProfile_ContextPropagation(t *testing.T) {
 	t.Parallel()
 
-	ctx, profile := query.WithProfile(context.Background(), true)
+	ctx, profile := query.WithProfile(context.Background())
 	require.NotNil(t, profile)
-	require.True(t, profile.Detailed())
 
 	extracted := query.ProfileFromContext(ctx)
 	require.Same(t, profile, extracted)
-}
-
-func TestWithProfile_NotDetailed(t *testing.T) {
-	t.Parallel()
-
-	_, profile := query.WithProfile(context.Background(), false)
-	require.False(t, profile.Detailed())
-}
-
-func TestQueryProfile_Detailed_NilSafe(t *testing.T) {
-	t.Parallel()
-
-	var p *query.QueryProfile
-	require.False(t, p.Detailed())
 }
 
 func TestProfileFromContext_NilWhenNotSet(t *testing.T) {

--- a/internal/query/profile_test.go
+++ b/internal/query/profile_test.go
@@ -14,11 +14,26 @@ import (
 func TestWithProfile_ContextPropagation(t *testing.T) {
 	t.Parallel()
 
-	ctx, profile := query.WithProfile(context.Background())
+	ctx, profile := query.WithProfile(context.Background(), true)
 	require.NotNil(t, profile)
+	require.True(t, profile.Detailed())
 
 	extracted := query.ProfileFromContext(ctx)
 	require.Same(t, profile, extracted)
+}
+
+func TestWithProfile_NotDetailed(t *testing.T) {
+	t.Parallel()
+
+	_, profile := query.WithProfile(context.Background(), false)
+	require.False(t, profile.Detailed())
+}
+
+func TestQueryProfile_Detailed_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var p *query.QueryProfile
+	require.False(t, p.Detailed())
 }
 
 func TestProfileFromContext_NilWhenNotSet(t *testing.T) {

--- a/internal/query/profile_timing_test.go
+++ b/internal/query/profile_timing_test.go
@@ -1,0 +1,219 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+// The tests below assert the *shape* of the phase model (which window charges
+// which accumulator, what is excluded from the total) rather than absolute
+// wall-clock values. Where an exact number is needed, it comes from an
+// accumulator the test feeds itself (AddBarrierWait / AddDelivery /
+// AddProduction) — never from sleeping, which would make the suite slow and
+// flaky without proving anything the inequalities below do not.
+
+func TestQueryProfile_PhaseDecomposition(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	p.LeaveExecute()
+	p.Finish()
+
+	assert.Positive(t, p.ServerDuration, "the request clock must have advanced")
+	assert.GreaterOrEqual(t, p.ServerDuration, p.PrepareDuration+p.ExecuteDuration,
+		"prepare + execute must fit inside the server total; the difference is unattributed server work")
+}
+
+func TestQueryProfile_BarrierExcludedFromServerDuration(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	p.LeaveExecute()
+	// A barrier wait far larger than anything the test itself spent: if it were
+	// counted as server cost the total would be dominated by it.
+	p.AddBarrierWait(time.Hour)
+	p.Finish()
+
+	assert.Equal(t, time.Hour, p.BarrierDuration, "the wait must still be reported")
+	assert.Zero(t, p.ServerDuration, "but never charged to the server total")
+}
+
+func TestQueryProfile_DeliveryExcludedFromServerDuration(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	p.LeaveExecute()
+	// Stands in for a consumer that stopped draining the stream: the server
+	// total must not move with it.
+	p.AddDelivery(time.Hour)
+	p.Finish()
+
+	assert.Equal(t, time.Hour, p.DeliverDuration)
+	assert.Zero(t, p.ServerDuration)
+}
+
+func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	// A ReadIndex quorum round-trip observed from inside the executor call.
+	p.AddBarrierWait(time.Hour)
+	p.LeaveExecute()
+
+	assert.Zero(t, p.ExecuteDuration, "consensus wait is not execution work")
+	assert.Equal(t, time.Hour, p.BarrierDuration)
+}
+
+func TestQueryProfile_BarrierBeforeExecuteNotChargedToPrepare(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.AddBarrierWait(time.Hour)
+	p.EnterExecute()
+
+	assert.Zero(t, p.PrepareDuration, "min_log_sequence wait is not preparation work")
+}
+
+func TestQueryProfile_AddProductionChargedToExecute(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	p.LeaveExecute()
+
+	before := p.ExecuteDuration
+	// Rows pulled lazily from a routed upstream stream inside the send loop.
+	p.AddProduction(5 * time.Millisecond)
+
+	assert.Equal(t, before+5*time.Millisecond, p.ExecuteDuration)
+}
+
+func TestQueryProfile_AbortedBeforeExecuteIsAllPrepare(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	// Request rejected during validation: it never reached the executor.
+	p.Finish()
+
+	assert.Zero(t, p.ExecuteDuration)
+	assert.Equal(t, p.ServerDuration, p.PrepareDuration)
+}
+
+func TestQueryProfile_FinishClosesOpenExecuteWindow(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	// No LeaveExecute: an early return inside the handler.
+	p.Finish()
+
+	assert.LessOrEqual(t, p.ExecuteDuration, p.ServerDuration)
+	assert.GreaterOrEqual(t, p.ExecuteDuration, time.Duration(0))
+}
+
+func TestQueryProfile_FinishIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.EnterExecute()
+	p.LeaveExecute()
+	p.Finish()
+
+	first := p.ServerDuration
+	p.Finish()
+
+	assert.Equal(t, first, p.ServerDuration, "a second Finish must not extend the total")
+}
+
+func TestQueryProfile_MarkFirstRowRecordsOnlyTheFirst(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background(), true)
+
+	p.MarkFirstRow()
+	first := p.FirstRowDuration
+	require.Positive(t, first)
+
+	p.MarkFirstRow()
+	assert.Equal(t, first, p.FirstRowDuration)
+}
+
+func TestQueryProfile_HandBuiltProfileKeepsAssignedDurations(t *testing.T) {
+	t.Parallel()
+
+	// A profile built by hand (tests, fixtures) has no request clock, so the
+	// phase marks must leave the values it was given alone rather than
+	// overwriting them with meaningless measurements.
+	p := &query.QueryProfile{
+		ServerDuration:  9 * time.Millisecond,
+		PrepareDuration: 4 * time.Millisecond,
+		ExecuteDuration: 5 * time.Millisecond,
+	}
+
+	p.EnterExecute()
+	p.LeaveExecute()
+	p.MarkFirstRow()
+	p.Finish()
+
+	assert.Equal(t, 9*time.Millisecond, p.ServerDuration)
+	assert.Equal(t, 4*time.Millisecond, p.PrepareDuration)
+	assert.Equal(t, 5*time.Millisecond, p.ExecuteDuration)
+	assert.Zero(t, p.FirstRowDuration)
+}
+
+func TestQueryProfile_TimingNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var p *query.QueryProfile
+
+	// Every hook is called from code paths that may run without a profile
+	// (unprofiled RPCs share the same helpers), so none may panic.
+	p.EnterExecute()
+	p.LeaveExecute()
+	p.AddBarrierWait(time.Second)
+	p.AddProduction(time.Second)
+	p.AddDelivery(time.Second)
+	p.MarkFirstRow()
+	p.Finish()
+}
+
+func TestQueryProfile_ToProto_ServerTiming(t *testing.T) {
+	t.Parallel()
+
+	p := &query.QueryProfile{
+		ServerDuration:   56 * time.Millisecond,
+		PrepareDuration:  40 * time.Millisecond,
+		ExecuteDuration:  14 * time.Millisecond,
+		BarrierDuration:  3 * time.Millisecond,
+		DeliverDuration:  7 * time.Millisecond,
+		FirstRowDuration: 55 * time.Millisecond,
+	}
+
+	pb := p.ToProto()
+	require.NotNil(t, pb)
+	assert.Equal(t, int64(56000), pb.GetServerDurationUs())
+	assert.Equal(t, int64(40000), pb.GetPrepareDurationUs())
+	assert.Equal(t, int64(14000), pb.GetExecuteDurationUs())
+	assert.Equal(t, int64(3000), pb.GetBarrierDurationUs())
+	assert.Equal(t, int64(7000), pb.GetDeliverDurationUs())
+	assert.Equal(t, int64(55000), pb.GetFirstRowDurationUs())
+}

--- a/internal/query/profile_timing_test.go
+++ b/internal/query/profile_timing_test.go
@@ -99,6 +99,32 @@ func TestQueryProfile_MarkForwarded(t *testing.T) {
 		"a forwarded read must be flagged so its zero BarrierDuration is not read as 'no barrier needed'")
 }
 
+// Forwarded does NOT imply a zero barrier. RoutedController.readCtrl attempts a
+// local ReadIndex barrier first and only forwards when it fails, so the failed
+// attempt is already recorded when MarkForwarded runs. That combination is the
+// documented contract, not a bookkeeping error: the caller really waited, and a
+// failed quorum wait is no more server work than a successful one. Zeroing it
+// would push consensus latency into PrepareDuration and into the server total.
+func TestQueryProfile_ForwardedKeepsFailedLocalBarrier(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background())
+
+	// The syncing-follower fallback, in order: barrier attempted, barrier fails,
+	// read forwarded, remote cost arrives as row production.
+	p.AddBarrierWait(time.Hour)
+	p.MarkForwarded()
+	p.EnterExecute()
+	p.LeaveExecute()
+	p.Finish()
+
+	assert.True(t, p.Forwarded)
+	assert.Equal(t, time.Hour, p.BarrierDuration,
+		"the failed local attempt must survive MarkForwarded — dropping it hides real caller-visible latency")
+	assert.Zero(t, p.ServerDuration, "and stay excluded from the server total, exactly like a successful barrier")
+	assert.Zero(t, p.PrepareDuration, "in particular it must not leak into prepare, which means request setup work")
+}
+
 func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/query/profile_timing_test.go
+++ b/internal/query/profile_timing_test.go
@@ -21,7 +21,7 @@ import (
 func TestQueryProfile_PhaseDecomposition(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	p.LeaveExecute()
@@ -35,7 +35,7 @@ func TestQueryProfile_PhaseDecomposition(t *testing.T) {
 func TestQueryProfile_BarrierExcludedFromServerDuration(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	p.LeaveExecute()
@@ -46,12 +46,14 @@ func TestQueryProfile_BarrierExcludedFromServerDuration(t *testing.T) {
 
 	assert.Equal(t, time.Hour, p.BarrierDuration, "the wait must still be reported")
 	assert.Zero(t, p.ServerDuration, "but never charged to the server total")
+	assert.Zero(t, p.WallDuration(), "nor to the wall total the slow-query threshold uses")
+	assert.NotEmpty(t, p.Anomaly, "a phase driven negative must be reported, not silently clamped")
 }
 
 func TestQueryProfile_DeliveryExcludedFromServerDuration(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	p.LeaveExecute()
@@ -62,12 +64,45 @@ func TestQueryProfile_DeliveryExcludedFromServerDuration(t *testing.T) {
 
 	assert.Equal(t, time.Hour, p.DeliverDuration)
 	assert.Zero(t, p.ServerDuration)
+
+	// But the slow-query threshold must still see it, otherwise serialisation
+	// cost and forwarded-read cost could hide from the log.
+	assert.GreaterOrEqual(t, p.WallDuration(), time.Hour)
+}
+
+func TestQueryProfile_WallDurationIncludesDelivery(t *testing.T) {
+	t.Parallel()
+
+	p := &query.QueryProfile{
+		ServerDuration:  10 * time.Millisecond,
+		DeliverDuration: 4 * time.Millisecond,
+	}
+
+	assert.Equal(t, 14*time.Millisecond, p.WallDuration())
+}
+
+func TestQueryProfile_WallDuration_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var p *query.QueryProfile
+	assert.Zero(t, p.WallDuration())
+}
+
+func TestQueryProfile_MarkForwarded(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfile(context.Background())
+	assert.False(t, p.Forwarded)
+
+	p.MarkForwarded()
+	assert.True(t, p.Forwarded,
+		"a forwarded read must be flagged so its zero BarrierDuration is not read as 'no barrier needed'")
 }
 
 func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	// A ReadIndex quorum round-trip observed from inside the executor call.
@@ -81,7 +116,7 @@ func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
 func TestQueryProfile_BarrierBeforeExecuteNotChargedToPrepare(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.AddBarrierWait(time.Hour)
 	p.EnterExecute()
@@ -92,7 +127,7 @@ func TestQueryProfile_BarrierBeforeExecuteNotChargedToPrepare(t *testing.T) {
 func TestQueryProfile_AddProductionChargedToExecute(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	p.LeaveExecute()
@@ -107,7 +142,7 @@ func TestQueryProfile_AddProductionChargedToExecute(t *testing.T) {
 func TestQueryProfile_AbortedBeforeExecuteIsAllPrepare(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	// Request rejected during validation: it never reached the executor.
 	p.Finish()
@@ -119,7 +154,7 @@ func TestQueryProfile_AbortedBeforeExecuteIsAllPrepare(t *testing.T) {
 func TestQueryProfile_FinishClosesOpenExecuteWindow(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	// No LeaveExecute: an early return inside the handler.
@@ -132,7 +167,7 @@ func TestQueryProfile_FinishClosesOpenExecuteWindow(t *testing.T) {
 func TestQueryProfile_FinishIsIdempotent(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.EnterExecute()
 	p.LeaveExecute()
@@ -147,7 +182,7 @@ func TestQueryProfile_FinishIsIdempotent(t *testing.T) {
 func TestQueryProfile_MarkFirstRowRecordsOnlyTheFirst(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background(), true)
+	_, p := query.WithProfile(context.Background())
 
 	p.MarkFirstRow()
 	first := p.FirstRowDuration

--- a/internal/query/profile_timing_test.go
+++ b/internal/query/profile_timing_test.go
@@ -99,30 +99,69 @@ func TestQueryProfile_MarkForwarded(t *testing.T) {
 		"a forwarded read must be flagged so its zero BarrierDuration is not read as 'no barrier needed'")
 }
 
-// Forwarded does NOT imply a zero barrier. RoutedController.readCtrl attempts a
-// local ReadIndex barrier first and only forwards when it fails, so the failed
-// attempt is already recorded when MarkForwarded runs. That combination is the
-// documented contract, not a bookkeeping error: the caller really waited, and a
-// failed quorum wait is no more server work than a successful one. Zeroing it
-// would push consensus latency into PrepareDuration and into the server total.
-func TestQueryProfile_ForwardedKeepsFailedLocalBarrier(t *testing.T) {
+// Elapsed/barrier magnitudes for the quantitative tests below. A backdated start
+// is what makes them quantitative: with a live clock the request's wall time is
+// microseconds, so any injected barrier exceeds it, every subtraction floors at
+// zero and the assertions pass on the clamp rather than on the arithmetic.
+const (
+	testElapsed = 2 * time.Hour
+	testBarrier = 30 * time.Minute
+	// Generous next to two hours, and still thousands of times larger than the
+	// microseconds a parallel test actually spends between the two calls.
+	testTolerance = time.Minute
+)
+
+// The exclusion asserted with real numbers rather than a floor: a barrier
+// recorded before the executor — waitMinLogSequence, which runs there on most
+// read paths — must be subtracted from both prepare and the server total, and
+// from nothing else.
+func TestQueryProfile_BarrierBeforeExecuteExcludedFromPrepareAndServer(t *testing.T) {
 	t.Parallel()
 
-	_, p := query.WithProfile(context.Background())
+	_, p := query.WithProfileStartingAt(context.Background(), time.Now().Add(-testElapsed))
 
-	// The syncing-follower fallback, in order: barrier attempted, barrier fails,
-	// read forwarded, remote cost arrives as row production.
-	p.AddBarrierWait(time.Hour)
-	p.MarkForwarded()
+	p.AddBarrierWait(testBarrier)
 	p.EnterExecute()
 	p.LeaveExecute()
 	p.Finish()
 
+	assert.Empty(t, p.Anomaly, "no phase should have been clamped — that would make the numbers below meaningless")
+	assert.InDelta(t, (testElapsed - testBarrier).Seconds(), p.PrepareDuration.Seconds(), testTolerance.Seconds(),
+		"preparation is the elapsed time minus the caller-requested wait")
+	assert.InDelta(t, (testElapsed - testBarrier).Seconds(), p.ServerDuration.Seconds(), testTolerance.Seconds(),
+		"and so is the server total, which subtracts the same wait once")
+}
+
+// Forwarded does NOT imply a zero barrier, and MarkForwarded must not erase one
+// already recorded. RoutedController.readCtrl attempts a local ReadIndex barrier
+// and only forwards when it fails, so on the fallback path the attempt is on the
+// profile before the flag is set. Dropping it would not delete the time: readCtrl
+// runs inside the caller's execute window, so an uncharged wait stays in
+// ExecuteDuration and from there in the server total.
+func TestQueryProfile_ForwardedKeepsFailedLocalBarrier(t *testing.T) {
+	t.Parallel()
+
+	_, p := query.WithProfileStartingAt(context.Background(), time.Now().Add(-testElapsed))
+
+	// The syncing-follower fallback, in the order readCtrl produces it.
+	p.EnterExecute()
+	p.AddBarrierWait(testBarrier)
+	p.MarkForwarded()
+	p.LeaveExecute()
+	p.Finish()
+
 	assert.True(t, p.Forwarded)
-	assert.Equal(t, time.Hour, p.BarrierDuration,
+	assert.Equal(t, testBarrier, p.BarrierDuration,
 		"the failed local attempt must survive MarkForwarded — dropping it hides real caller-visible latency")
-	assert.Zero(t, p.ServerDuration, "and stay excluded from the server total, exactly like a successful barrier")
-	assert.Zero(t, p.PrepareDuration, "in particular it must not leak into prepare, which means request setup work")
+	assert.InDelta(t, (testElapsed - testBarrier).Seconds(), p.ServerDuration.Seconds(), testTolerance.Seconds(),
+		"and stay excluded from the server total, exactly like a successful barrier")
+
+	// The execute window here is the microseconds between EnterExecute and
+	// LeaveExecute, and the barrier subtracted from it is half an hour, so the
+	// floor engages. Asserted rather than left implicit: a clamp that nobody
+	// checks is how a test comes to pass for a reason it does not state.
+	assert.Zero(t, p.ExecuteDuration)
+	assert.NotEmpty(t, p.Anomaly, "flooring a phase must be reported")
 }
 
 func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
@@ -139,6 +178,9 @@ func TestQueryProfile_BarrierInsideExecuteNotChargedToExecute(t *testing.T) {
 	assert.Equal(t, time.Hour, p.BarrierDuration)
 }
 
+// The floor-based counterpart of
+// TestQueryProfile_BarrierBeforeExecuteExcludedFromPrepareAndServer: a wait
+// larger than the request's own lifetime cannot leave preparation positive.
 func TestQueryProfile_BarrierBeforeExecuteNotChargedToPrepare(t *testing.T) {
 	t.Parallel()
 
@@ -148,6 +190,7 @@ func TestQueryProfile_BarrierBeforeExecuteNotChargedToPrepare(t *testing.T) {
 	p.EnterExecute()
 
 	assert.Zero(t, p.PrepareDuration, "min_log_sequence wait is not preparation work")
+	assert.NotEmpty(t, p.Anomaly, "and driving a phase negative must be reported, not silently floored")
 }
 
 func TestQueryProfile_AddProductionChargedToExecute(t *testing.T) {

--- a/misc/operator/api/v1alpha1/cluster_types.go
+++ b/misc/operator/api/v1alpha1/cluster_types.go
@@ -154,7 +154,9 @@ type ClusterSpec struct {
 	// +optional
 	GrpcCompression *bool `json:"grpcCompression,omitempty"`
 
-	// QueryProfileThreshold logs and emits OTel attributes for queries exceeding this duration (0 to disable).
+	// QueryProfileThreshold logs and emits OTel attributes for reads whose total
+	// server-side handling (excluding the caller-requested read barrier) exceeds
+	// this duration. 0 disables the slow-read log.
 	// +optional
 	QueryProfileThreshold string `json:"queryProfileThreshold,omitempty"`
 

--- a/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_clusters.yaml
@@ -2855,8 +2855,10 @@ spec:
                     type: object
                 type: object
               queryProfileThreshold:
-                description: QueryProfileThreshold logs and emits OTel attributes
-                  for queries exceeding this duration (0 to disable).
+                description: |-
+                  QueryProfileThreshold logs and emits OTel attributes for reads whose total
+                  server-side handling (excluding the caller-requested read barrier) exceeds
+                  this duration. 0 disables the slow-read log.
                 type: string
               raft:
                 description: Raft consensus configuration.

--- a/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_clusters.yaml
@@ -2855,8 +2855,10 @@ spec:
                     type: object
                 type: object
               queryProfileThreshold:
-                description: QueryProfileThreshold logs and emits OTel attributes
-                  for queries exceeding this duration (0 to disable).
+                description: |-
+                  QueryProfileThreshold logs and emits OTel attributes for reads whose total
+                  server-side handling (excluding the caller-requested read barrier) exceeds
+                  this duration. 0 disables the slow-read log.
                 type: string
               raft:
                 description: Raft consensus configuration.

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -1281,9 +1281,23 @@ message QueryProfile {
 
   // Consumer-independent server cost: handler entry (before request decode) to
   // the response being ready for delivery, MINUS barrier_duration_us and MINUS
-  // deliver_duration_us. This is the headline number and the only one with an
-  // identical definition on gRPC and HTTP, so the two surfaces are comparable
-  // and it is the right basis for a server-side latency SLO.
+  // deliver_duration_us. It cannot be moved by a slow client, and it is the one
+  // field defined identically on gRPC and HTTP, so the two surfaces compare.
+  //
+  // It does NOT include row serialisation. On a gRPC server stream, marshalling
+  // and the transport write happen inside one inseparable stream.Send() call, so
+  // serialisation is accounted in deliver_duration_us together with consumer
+  // back-pressure. Choose accordingly:
+  //
+  //   - consumer-independent, excludes serialisation:  server_duration_us
+  //   - complete server-side cost, includes serialisation but also absorbs
+  //     back-pressure on a stream:  server_duration_us + deliver_duration_us
+  //
+  // Neither is a clean latency-SLO basis on a streaming read: the first omits a
+  // real cost that grows with page size, the second admits client behaviour into
+  // the signal. Pick the one whose bias is acceptable for the specific SLO and
+  // say which. The server's own slow-query threshold uses the sum, so that
+  // serialisation and forwarded-read cost cannot hide from it.
   //
   // prepare_duration_us + execute_duration_us <= server_duration_us; the
   // difference is server work outside both phases (response assembly,
@@ -1306,6 +1320,11 @@ message QueryProfile {
   // ReadIndex quorum round-trip and the ReadOptions.min_log_sequence read-index
   // catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
   // the request opted into, not server cost.
+  //
+  // Only LOCAL barriers are measured. When `forwarded` is true this reads 0
+  // because no barrier ran on this node, NOT because none ran: the remote node's
+  // barrier is folded into its execution, which arrives here inside
+  // execute_duration_us. Always read this field together with `forwarded`.
   int64 barrier_duration_us = 11;
 
   // Time spent serialising result rows and handing them to the transport.
@@ -1320,11 +1339,25 @@ message QueryProfile {
   // not affect the comparability of the headline number.
   int64 deliver_duration_us = 12;
 
-  // Handler entry to the first row accepted by the transport. Server streams
-  // only (0 for unary responses). Compare against server_duration_us and
-  // deliver_duration_us to separate "the server was slow to produce anything"
-  // from "the consumer was slow to drain the stream".
+  // Handler entry to the first row accepted by the transport. Compare against
+  // server_duration_us and deliver_duration_us to separate "the server was slow
+  // to produce anything" from "the consumer was slow to drain the stream".
+  //
+  // 0 means no row was ever handed to the transport, which covers three distinct
+  // cases: a streaming read that matched nothing, a unary response (HTTP, and
+  // the AggregateVolumes / ExecutePreparedQuery RPCs — these never hand rows to
+  // a stream), and a streaming read that failed before its first send. Use
+  // items_collected and the RPC's own status to tell them apart.
   int64 first_row_duration_us = 13;
+
+  // True when this node did not serve the read itself but forwarded it to
+  // another node — an explicit leader-consistency read, or the fallback taken
+  // when the local replica is still catching up. The remote node's prepare,
+  // barrier and execution all arrive inside execute_duration_us, and
+  // barrier_duration_us reads 0 for lack of a local barrier, so the phase
+  // breakdown describes the local hop only. Its purpose is to stop a zero
+  // barrier from being misread as "no barrier was needed".
+  bool forwarded = 14;
 }
 
 // IteratorProfile describes a single iterator node in the query execution tree.

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -1279,10 +1279,18 @@ message QueryProfile {
   // the whole server-side handling of the request, so a caller can tell a slow
   // network from a slow server.
 
-  // Consumer-independent server cost: handler entry (before request decode) to
-  // the response being ready for delivery, MINUS barrier_duration_us and MINUS
-  // deliver_duration_us. It cannot be moved by a slow client, and it is the one
-  // field defined identically on gRPC and HTTP, so the two surfaces compare.
+  // Consumer-independent server cost: server entry to the response being ready
+  // for delivery, MINUS barrier_duration_us and MINUS deliver_duration_us. It
+  // cannot be moved by a slow client.
+  //
+  // "Server entry" is the earliest instrumentable point on each transport, and
+  // that is not quite the same point: on gRPC it is the handler's first
+  // statement, because grpc-go receives and unmarshals the request message
+  // before dispatching, putting protobuf decode out of reach; on HTTP it is the
+  // router chain just before authentication, so query/body decode inside the
+  // handler is included. Both start before authentication, and both end at the
+  // same place, which is what keeps the field comparable — with the caveat that
+  // gRPC message decode is never counted on either side of the comparison.
   //
   // It does NOT include row serialisation. On a gRPC server stream, marshalling
   // and the transport write happen inside one inseparable stream.Send() call, so
@@ -1305,8 +1313,10 @@ message QueryProfile {
   int64 server_duration_us = 8;
 
   // Portion of server_duration_us spent before the query executor was invoked:
-  // authentication, request decode/validation, filter parsing/compilation and
-  // checkpoint-store opening.
+  // authentication, request validation, filter parsing/compilation and
+  // checkpoint-store opening — plus, on HTTP, query-parameter and body decoding.
+  // gRPC protobuf decode is NOT here: grpc-go unmarshals the request before the
+  // handler runs (see server_duration_us).
   int64 prepare_duration_us = 9;
 
   // Portion of server_duration_us spent inside the query executor. Contains
@@ -1321,20 +1331,25 @@ message QueryProfile {
   // catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
   // the request opted into, not server cost.
   //
-  // Only LOCAL barriers are measured, and only the local one. Always read this
-  // field together with `forwarded`:
+  // Only LOCAL waits are measured, and every local wait is measured: a
+  // min_log_sequence catch-up and a ReadIndex attempt are both counted, whether
+  // or not the attempt succeeds and whether or not the read is then forwarded.
+  // Always read this field together with `forwarded`:
   //
   //   - forwarded=false: the whole barrier this read paid.
-  //   - forwarded=true, 0: no barrier ran HERE (an explicit leader read never
-  //     attempts one). The remote node's barrier is folded into its execution
-  //     and arrives inside execute_duration_us — 0 does NOT mean "no barrier
-  //     was needed".
-  //   - forwarded=true, non-zero: this node ATTEMPTED a local barrier, it
-  //     failed (syncing follower, leadership lost mid-ReadIndex), and the read
-  //     then fell back to the leader. The value is real consensus latency the
-  //     caller paid and is still excluded from server_duration_us — a failed
-  //     quorum wait is not server work — but the leader's own barrier is on top
-  //     of it, inside execute_duration_us.
+  //   - forwarded=true, 0: no local wait happened. The remote node's barrier is
+  //     folded into its execution and arrives inside execute_duration_us — 0
+  //     does NOT mean "no barrier was needed".
+  //   - forwarded=true, non-zero: a local wait happened before the read left
+  //     this node, and the remote node's barrier is on top of it inside
+  //     execute_duration_us. The value does NOT identify which wait: a
+  //     min_log_sequence catch-up does not prevent forwarding, and a failed
+  //     ReadIndex attempt (syncing follower, leadership lost mid-quorum) is
+  //     what triggers the fallback. Do not read cluster health off it.
+  //
+  // A failed or superseded wait is still excluded from server_duration_us: the
+  // caller waited for it, and an abandoned quorum round-trip is no more server
+  // work than a completed one.
   int64 barrier_duration_us = 11;
 
   // Time spent serialising result rows and handing them to the transport.
@@ -1363,10 +1378,11 @@ message QueryProfile {
   // True when this node did not serve the read itself but forwarded it to
   // another node — an explicit leader-consistency read, or the fallback taken
   // when the local replica is still catching up. The remote node's prepare,
-  // barrier and execution all arrive inside execute_duration_us, and
-  // barrier_duration_us reads 0 for lack of a local barrier, so the phase
+  // barrier and execution all arrive inside execute_duration_us, so the phase
   // breakdown describes the local hop only. Its purpose is to stop a zero
-  // barrier from being misread as "no barrier was needed".
+  // barrier_duration_us from being misread as "no barrier was needed"; see that
+  // field for the three cases the pair distinguishes — a forwarded read can
+  // report a non-zero local wait.
   bool forwarded = 14;
 }
 

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -1272,6 +1272,59 @@ message QueryProfile {
   int32 materialized_ranges = 5;
   int32 materialized_items = 6;
   IteratorProfile root_iterator = 7;
+
+  // ---- Server-side request timing ----
+  //
+  // The fields above only cover query EXECUTION. The ones below account for
+  // the whole server-side handling of the request, so a caller can tell a slow
+  // network from a slow server.
+
+  // Consumer-independent server cost: handler entry (before request decode) to
+  // the response being ready for delivery, MINUS barrier_duration_us and MINUS
+  // deliver_duration_us. This is the headline number and the only one with an
+  // identical definition on gRPC and HTTP, so the two surfaces are comparable
+  // and it is the right basis for a server-side latency SLO.
+  //
+  // prepare_duration_us + execute_duration_us <= server_duration_us; the
+  // difference is server work outside both phases (response assembly,
+  // pagination trailer, profile emission).
+  int64 server_duration_us = 8;
+
+  // Portion of server_duration_us spent before the query executor was invoked:
+  // authentication, request decode/validation, filter parsing/compilation and
+  // checkpoint-store opening.
+  int64 prepare_duration_us = 9;
+
+  // Portion of server_duration_us spent inside the query executor. Contains
+  // index_duration_us and enrichment_duration_us as sub-phases, plus snapshot
+  // setup, ledger/schema resolution and — when rows are produced lazily
+  // (a follower routing to the leader) — the time spent pulling rows out of
+  // the cursor.
+  int64 execute_duration_us = 10;
+
+  // Time blocked on a read-consistency barrier the CALLER asked for: the Raft
+  // ReadIndex quorum round-trip and the ReadOptions.min_log_sequence read-index
+  // catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
+  // the request opted into, not server cost.
+  int64 barrier_duration_us = 11;
+
+  // Time spent serialising result rows and handing them to the transport.
+  // EXCLUDED from server_duration_us because on a server stream it also
+  // contains consumer back-pressure, which is client cost, not server cost.
+  //
+  // On a gRPC server stream this is the sum of the stream.Send() calls
+  // (marshal + transport write + flow-control wait). Always 0 on HTTP, where
+  // the profile travels in a response header that must be flushed before the
+  // body, putting response serialisation out of reach. Since row serialisation
+  // is excluded from server_duration_us on both surfaces, that asymmetry does
+  // not affect the comparability of the headline number.
+  int64 deliver_duration_us = 12;
+
+  // Handler entry to the first row accepted by the transport. Server streams
+  // only (0 for unary responses). Compare against server_duration_us and
+  // deliver_duration_us to separate "the server was slow to produce anything"
+  // from "the consumer was slow to drain the stream".
+  int64 first_row_duration_us = 13;
 }
 
 // IteratorProfile describes a single iterator node in the query execution tree.

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -1321,10 +1321,20 @@ message QueryProfile {
   // catch-up wait. Deliberately EXCLUDED from server_duration_us — it is a wait
   // the request opted into, not server cost.
   //
-  // Only LOCAL barriers are measured. When `forwarded` is true this reads 0
-  // because no barrier ran on this node, NOT because none ran: the remote node's
-  // barrier is folded into its execution, which arrives here inside
-  // execute_duration_us. Always read this field together with `forwarded`.
+  // Only LOCAL barriers are measured, and only the local one. Always read this
+  // field together with `forwarded`:
+  //
+  //   - forwarded=false: the whole barrier this read paid.
+  //   - forwarded=true, 0: no barrier ran HERE (an explicit leader read never
+  //     attempts one). The remote node's barrier is folded into its execution
+  //     and arrives inside execute_duration_us — 0 does NOT mean "no barrier
+  //     was needed".
+  //   - forwarded=true, non-zero: this node ATTEMPTED a local barrier, it
+  //     failed (syncing follower, leadership lost mid-ReadIndex), and the read
+  //     then fell back to the leader. The value is real consensus latency the
+  //     caller paid and is still excluded from server_duration_us — a failed
+  //     quorum wait is not server work — but the leader's own barrier is on top
+  //     of it, inside execute_duration_us.
   int64 barrier_duration_us = 11;
 
   // Time spent serialising result rows and handing them to the transport.

--- a/openapi.yml
+++ b/openapi.yml
@@ -725,9 +725,13 @@ paths:
             Filter transactions with timestamp < endDate (exclusive, RFC3339 format).
             Requires the builtin `TX_BUILTIN_INDEX_TIMESTAMP` index to be enabled on the ledger.
         - $ref: '#/components/parameters/ListFilter'
+        - $ref: '#/components/parameters/QueryProfile'
       responses:
         '200':
           description: Transactions retrieved successfully.
+          headers:
+            X-Query-Profile-Result:
+              $ref: '#/components/headers/QueryProfileResult'
           content:
             application/json:
               schema:
@@ -815,9 +819,13 @@ paths:
           schema:
             type: string
         - $ref: '#/components/parameters/ListFilter'
+        - $ref: '#/components/parameters/QueryProfile'
       responses:
         '200':
           description: List of accounts
+          headers:
+            X-Query-Profile-Result:
+              $ref: '#/components/headers/QueryProfileResult'
           content:
             application/json:
               schema:
@@ -924,9 +932,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - $ref: '#/components/parameters/QueryProfile'
       responses:
         '200':
           description: Aggregated volumes retrieved successfully
+          headers:
+            X-Query-Profile-Result:
+              $ref: '#/components/headers/QueryProfileResult'
           content:
             application/json:
               schema:
@@ -2017,6 +2029,7 @@ paths:
           description: Cursor for pagination (overrides body value)
           schema:
             type: string
+        - $ref: '#/components/parameters/QueryProfile'
       requestBody:
         required: false
         content:
@@ -2026,6 +2039,9 @@ paths:
       responses:
         '200':
           description: Query executed successfully
+          headers:
+            X-Query-Profile-Result:
+              $ref: '#/components/headers/QueryProfileResult'
           content:
             application/json:
               schema:
@@ -2925,6 +2941,29 @@ components:
         maxLength: 256
       description: Idempotency key for the request
 
+    QueryProfile:
+      name: X-Query-Profile
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |
+        Set to any non-empty value to receive the query profile in the
+        `X-Query-Profile-Result` response header.
+
+        The profile reports server-side request timing (how long the server spent
+        handling the request, broken down into prepare / execute / read-barrier /
+        deliver phases) plus the query execution plan. Use it to tell a slow
+        network from a slow server: `serverDurationUs` is the
+        consumer-independent server cost, and it excludes both the
+        caller-requested read barrier and response delivery.
+
+        Supported on the transactions list, accounts list, aggregated volumes and
+        prepared-query execution endpoints. The equivalent gRPC opt-in is the
+        `x-query-profile` request metadata, answered in the
+        `x-query-profile-result-bin` trailer; `serverDurationUs` has the same
+        definition on both surfaces, so the two are directly comparable.
+
     ListFilter:
       name: filter
       in: query
@@ -2963,6 +3002,36 @@ components:
         Note: bare audit fields (`outcome`, `ledger`, `seq`, `proposal_id`,
         `timestamp`, `log_seq`, `caller_subject`, `order_type`) have no
         structured JSON form and must be passed in the textual representation.
+
+  headers:
+    QueryProfileResult:
+      description: |
+        Query profile for this request, returned only when the request carried the
+        `X-Query-Profile` header. The value is the base64 (standard alphabet)
+        encoding of a serialized `QueryProfile` protobuf message
+        (`misc/proto/bucket.proto`).
+
+        Key durations, all in microseconds:
+
+          - `serverDurationUs` — consumer-independent server cost: request entry
+            to response-ready, excluding the read barrier and response delivery.
+            This is the number to build a latency SLO on, and it has the same
+            definition over gRPC.
+          - `prepareDurationUs` — request decode, validation and filter
+            compilation.
+          - `executeDurationUs` — query execution (contains
+            `indexDurationUs` + `enrichmentDurationUs`).
+          - `barrierDurationUs` — time blocked on the caller-requested read
+            consistency barrier. Excluded from `serverDurationUs`.
+          - `deliverDurationUs` — response serialization and transport hand-off.
+            Excluded from `serverDurationUs`. Always 0 over HTTP: this header
+            must be flushed before the response body, so the body write is out
+            of reach. It is populated for gRPC server streams.
+          - `firstRowDurationUs` — always 0 over HTTP (the response is
+            buffered); populated for gRPC server streams.
+      schema:
+        type: string
+        format: byte
 
   responses:
     ServiceUnavailable:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3015,20 +3015,31 @@ components:
 
           - `serverDurationUs` — consumer-independent server cost: request entry
             to response-ready, excluding the read barrier and response delivery.
-            This is the number to build a latency SLO on, and it has the same
-            definition over gRPC.
+            Cannot be moved by a slow client, and has the same definition over
+            gRPC. It does NOT include row serialization.
           - `prepareDurationUs` — request decode, validation and filter
             compilation.
           - `executeDurationUs` — query execution (contains
             `indexDurationUs` + `enrichmentDurationUs`).
           - `barrierDurationUs` — time blocked on the caller-requested read
-            consistency barrier. Excluded from `serverDurationUs`.
+            consistency barrier. Excluded from `serverDurationUs`. Measures LOCAL
+            barriers only: see `forwarded`.
           - `deliverDurationUs` — response serialization and transport hand-off.
             Excluded from `serverDurationUs`. Always 0 over HTTP: this header
             must be flushed before the response body, so the body write is out
             of reach. It is populated for gRPC server streams.
           - `firstRowDurationUs` — always 0 over HTTP (the response is
             buffered); populated for gRPC server streams.
+          - `forwarded` — true when another node served the read. Its barrier and
+            execution are then folded into `executeDurationUs` and
+            `barrierDurationUs` reads 0 for lack of a local barrier, so the
+            breakdown describes the local hop only.
+
+        For a latency objective, pick a total and state which: `serverDurationUs`
+        is client-independent but omits serialization, while
+        `serverDurationUs + deliverDurationUs` is the complete server-side cost
+        but absorbs consumer back-pressure on a gRPC stream. Neither is unbiased
+        on a streaming read.
       schema:
         type: string
         format: byte

--- a/openapi.yml
+++ b/openapi.yml
@@ -3031,9 +3031,12 @@ components:
           - `firstRowDurationUs` — always 0 over HTTP (the response is
             buffered); populated for gRPC server streams.
           - `forwarded` — true when another node served the read. Its barrier and
-            execution are then folded into `executeDurationUs` and
-            `barrierDurationUs` reads 0 for lack of a local barrier, so the
-            breakdown describes the local hop only.
+            execution are then folded into `executeDurationUs`, so the breakdown
+            describes the local hop only. `barrierDurationUs` then covers the
+            local attempt only: 0 for an explicit leader read (which never
+            attempts one — so 0 does not mean "no barrier was needed"), non-zero
+            when a local barrier was attempted, failed, and the read fell back to
+            the leader.
 
         For a latency objective, pick a total and state which: `serverDurationUs`
         is client-independent but omits serialization, while

--- a/openapi.yml
+++ b/openapi.yml
@@ -3015,15 +3015,18 @@ components:
 
           - `serverDurationUs` — consumer-independent server cost: request entry
             to response-ready, excluding the read barrier and response delivery.
-            Cannot be moved by a slow client, and has the same definition over
-            gRPC. It does NOT include row serialization.
-          - `prepareDurationUs` — request decode, validation and filter
-            compilation.
+            Cannot be moved by a slow client. Over HTTP, request entry is the
+            router chain just before authentication; over gRPC it is the
+            handler's first statement, because grpc-go unmarshals the request
+            before dispatching. It does NOT include row serialization.
+          - `prepareDurationUs` — authentication, query/body decoding, validation
+            and filter compilation.
           - `executeDurationUs` — query execution (contains
             `indexDurationUs` + `enrichmentDurationUs`).
-          - `barrierDurationUs` — time blocked on the caller-requested read
-            consistency barrier. Excluded from `serverDurationUs`. Measures LOCAL
-            barriers only: see `forwarded`.
+          - `barrierDurationUs` — time blocked on caller-requested read
+            consistency waits. Excluded from `serverDurationUs`. Measures LOCAL
+            waits only, and counts one that fails or is superseded: see
+            `forwarded`.
           - `deliverDurationUs` — response serialization and transport hand-off.
             Excluded from `serverDurationUs`. Always 0 over HTTP: this header
             must be flushed before the response body, so the body write is out
@@ -3033,10 +3036,10 @@ components:
           - `forwarded` — true when another node served the read. Its barrier and
             execution are then folded into `executeDurationUs`, so the breakdown
             describes the local hop only. `barrierDurationUs` then covers the
-            local attempt only: 0 for an explicit leader read (which never
-            attempts one — so 0 does not mean "no barrier was needed"), non-zero
-            when a local barrier was attempted, failed, and the read fell back to
-            the leader.
+            local waits only: 0 means none happened (not "no barrier was
+            needed"), non-zero means one did — a `minLogSequence` catch-up, or a
+            `ReadIndex` attempt that failed and caused the forward. The value
+            does not say which, so do not read cluster health off it.
 
         For a latency objective, pick a total and state which: `serverDurationUs`
         is client-independent but omits serialization, while

--- a/tests/e2e/business/query_profile_test.go
+++ b/tests/e2e/business/query_profile_test.go
@@ -151,8 +151,10 @@ var _ = Describe("QueryProfile", Ordered, func() {
 				// from the consumer-independent server total (EN-1859).
 				g.Expect(profile.ServerDurationUs).To(BeNumerically(">", 0))
 				g.Expect(profile.FirstRowDurationUs).To(BeNumerically(">", 0))
-				g.Expect(profile.DeliverDurationUs).To(BeNumerically(">=", 0),
-					"stream sends are accounted separately and excluded from the server total")
+				g.Expect(profile.ExecuteDurationUs).To(BeNumerically(">", 0),
+					"a real read spends measurable time in the executor")
+				g.Expect(profile.ServerDurationUs).To(BeNumerically(">=", profile.ExecuteDurationUs),
+					"execution is a phase of the server total, not a peer of it")
 			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 		})
 	})

--- a/tests/e2e/business/query_profile_test.go
+++ b/tests/e2e/business/query_profile_test.go
@@ -65,6 +65,20 @@ var _ = Describe("QueryProfile", Ordered, func() {
 
 				// Profile should have meaningful data
 				g.Expect(profile.ItemsCollected).To(BeNumerically(">", 0), "should have collected items")
+
+				// Server-side request timing (EN-1859). The whole handler is
+				// measured, so the total is always populated and is never
+				// smaller than the phases it decomposes into.
+				g.Expect(profile.ServerDurationUs).To(BeNumerically(">", 0),
+					"server duration must be reported for every profiled read")
+				g.Expect(profile.ServerDurationUs).To(BeNumerically(">=",
+					profile.PrepareDurationUs+profile.ExecuteDurationUs),
+					"prepare + execute must fit inside the server total")
+				g.Expect(profile.ExecuteDurationUs).To(BeNumerically(">=",
+					profile.IndexDurationUs+profile.EnrichmentDurationUs),
+					"index + enrichment are sub-phases of execution")
+				g.Expect(profile.FirstRowDurationUs).To(BeNumerically(">", 0),
+					"a stream that emitted rows must report time-to-first-row")
 			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 		})
 
@@ -130,6 +144,15 @@ var _ = Describe("QueryProfile", Ordered, func() {
 				var profile servicepb.QueryProfile
 				g.Expect(proto.Unmarshal([]byte(profileData[0]), &profile)).To(Succeed())
 				g.Expect(profile.ItemsCollected).To(BeNumerically(">", 0), "should have collected items")
+
+				// ListTransactions is server-streaming, so the profile must
+				// separate "the server was slow" from "the consumer was slow":
+				// time-to-first-row and the delivery total are reported apart
+				// from the consumer-independent server total (EN-1859).
+				g.Expect(profile.ServerDurationUs).To(BeNumerically(">", 0))
+				g.Expect(profile.FirstRowDurationUs).To(BeNumerically(">", 0))
+				g.Expect(profile.DeliverDurationUs).To(BeNumerically(">=", 0),
+					"stream sends are accounted separately and excluded from the server total")
 			}).Within(5 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Closes EN-1859.

## Problem

`QueryProfile` reported query **execution** time only — `index_duration_us + enrichment_duration_us` — so a caller could not tell a slow network from a slow server. Measured against a real 87.7M-transaction ledger over an established gRPC connection: **56 ms client-observed against 2.3 ms reported, ~54 ms unaccounted for**. Read-performance work could not be targeted, no server-side latency SLO could be set, and "why is this read slow for us" had no answer beyond "2.3 ms of query execution and 54 ms we cannot account for".

## What this adds

Seven new `QueryProfile` fields (proto 8–14), populated on all four profiled read endpoints of **both** transports:

| Field | Window |
|---|---|
| `server_duration_us` | consumer-independent server cost |
| `prepare_duration_us` | auth, decode, validation, filter compilation |
| `execute_duration_us` | executor call (index + enrichment are sub-phases) |
| `barrier_duration_us` | caller-requested read-consistency wait |
| `deliver_duration_us` | row serialisation + transport hand-off |
| `first_row_duration_us` | entry → first row accepted by the transport |
| `forwarded` | the breakdown is not local (see below) |

The profile clock now starts as the **first statement** of each handler. Previously `WithProfile` ran after auth and filter parsing, which is why `prepare` was structurally invisible — that positioning was the real cause of the unmeasured gap, not a missing field.

Barrier instrumentation sits at two choke points: `waitMinLogSequence` and `RoutedController.readCtrl`.

## Design decisions

**A breakdown, not a single total.** A bare total says "slow" without saying where, which is what makes optimisation untargetable. The phases are attributions inside a directly measured total, so the unattributed residual stays visible (`ledgerctl` renders it as "Other server work") rather than silently vanishing.

**Streaming ambiguity resolved by splitting the send loop.** `cur.Next()` is row *production* and is charged to execute; `stream.Send()` is *delivery* and is excluded from the server total. This matters concretely: on a follower routing to the leader, cursors are lazy, so each `Next()` is an upstream receive — real server cost that would otherwise disappear. Time-to-first-row and total-to-last-row are separate fields, so a slow consumer shows as `deliver >> first_row` with `server_duration_us` unchanged.

**Barrier excluded from the server total** because it is latency the caller opted into; charging it to the server blames the server for the caller's consistency requirement and makes the number track cluster RTT.

**Measurement is unconditional.** An earlier revision gated the per-row split on whether the caller requested the profile, which made *what is measured* depend on *whether someone asked to see it*. Those are different questions, and the gate broke the one consumer that matters — the slow-query log, which runs precisely in the ungated regime. Two `time.Now()` per row is tens of µs across a 1000-row page, against a proto marshal and a transport write per row. Unprofiled handlers still pay nothing (`profile == nil` skips).

**`--query-profile-threshold` now compares `ServerDuration + DeliverDuration`.** This is a behaviour change on an existing operator-facing flag, and it is deliberate: thresholding on execution alone meant the slow requests the log exists to surface were the ones it could not see. This trades in consumer back-pressure, accepted because the logged breakdown says which side was slow, and a threshold that fires with an explanation beats one that never fires. Flag help, the operator CRD and both generated CRDs are updated; `0 to disable` is now actually true.

## What was deliberately not done

**No `PreparedMsg` split to measure marshalling.** It would route the hot streaming path through a different, less-exercised codec and compression path and abandon the generated `Send` every other list handler uses — real behavioural risk for a measurement refinement. Serialisation therefore stays inside `deliver_duration_us`, and the **SLO claim is withdrawn** from the proto, `openapi.yml` and the docs. Both totals are biased on a streaming read: `server_duration_us` omits a cost that grows with page size, `server+deliver` admits client behaviour. The docs now say to pick one and state which, rather than pretending either is clean.

**No nested remote breakdown on forwarded reads.** It means opting every routed read into upstream profiling, plumbing an EOF-only trailer out through `cursor.Cursor`, and deciding how two breakdowns compose. Deferred and documented as deferred; the `forwarded` flag makes "no barrier" distinguishable from "barrier not measured here", which was the load-bearing part.

## Review history

Three rounds, each of which found something real.

**Round 1 (adversarial, pre-PR)** found a **critical** defect: the per-row execute/deliver split was gated on whether the caller requested the profile, so the entire send loop was charged to delivery and excluded from the total — a 2-second forwarded read reported a sub-millisecond `server_duration_us`, in the only configuration that consumes the profile. Its own test asserted the defect. Fixed by removing the gate, which also resolved a separate gRPC/HTTP incomparability (HTTP never had the gate), plus four majors and four minors.

**Round 2 (NumaryBot, on the PR)** found two majors:

- `forwarded=true` with a non-zero `barrier_duration_us` is reachable — `readCtrl` records the local `ReadIndex` attempt before deciding to forward — contradicting the documented "forwarded implies 0". Fixed by correcting the contract rather than zeroing the attempt: the caller really waited for that quorum round-trip, and dropping it would relocate consensus latency into the server total instead of deleting it.
- HTTP started its profile in the handler, so authentication was outside the measured window while gRPC counts it. Fixed at two depths, because the scope guard is chi middleware but JWT validation is router-wide: a `startRequestClock` stamp before `HTTPAuthMiddleware`, adopted by `withQueryProfile` on the four profiled routes via the new `query.WithProfileStartingAt`.

**Round 3 (adversarial, on the pushed branch)** found five more, all fixed in `958902b3`. The two that mattered: the `forwarded` field comment still carried the absolute round 2 had just removed from the barrier field forty lines above, so the wire contract contradicted itself; and a **fourth** forwarded/barrier combination exists that nothing documented — `waitMinLogSequence` charges its catch-up regardless of consistency level and runs before routing, so `--consistency leader --min-log-sequence N` yields a non-zero barrier on a perfectly healthy cluster. Documenting the non-zero case as "an attempt failed" invited reading leadership instability off an ordinary read-your-writes wait. It also caught the round-2 rationale naming the wrong phase (`readCtrl` runs inside the execute bracket, so an uncharged wait lands in `execute_duration_us`, not `prepare_duration_us` — same conclusion, wrong mechanism), a test of mine that passed only because `clampPhase` floored two assertions it never checked, and the fact that `prepare_duration_us` never included gRPC protobuf decode and cannot, since grpc-go unmarshals before dispatching.

## Validation

- `bash scripts/agent-check` — PASS, 0 lint issues across both modules, clean tree after generation
- `go test -race` on `internal/query`, `internal/adapter/grpc`, `internal/adapter/http`, `internal/bootstrap`, `cmd/ledgerctl/...` — PASS
- Full root-module unit suite — PASS
- CI on the branch: `Tests`, `Tests-E2E`, `Tests-Model`, `Tests-Scenarios`, `Tests-Schemathesis`, `Build`, `invariants`, `Dirty`, `Coverage`, codecov — all green

The e2e suite cannot run on this workstation (`ResourceExhausted: writes blocked` — the disk is at 97%, tripping the server's own write guard, reproduced identically on the clean base), so CI is the only e2e signal here. It is green.

## Note for reviewers

The `958902b3` fixes have not themselves been through an adversarial pass. The phase arithmetic, idempotent `Finish`, absence of data races and `Finish` placement were verified clean in round 3 and are unchanged in substance; what is new since then is the HTTP middleware split and the contract wording.

One deliberate non-fix, reported in round 3 and left alone: `clampPhase` records an `Anomaly` whose only emitter is gated on the slow-query threshold, and clamping `ServerDuration` to zero is what can pull the compared total below it — so a clamped profile may never be logged. The comment claiming it "cannot pass unnoticed" has been corrected to say the fuzzing assertion is the reliable detector. No reachable trigger was found; making the anomaly a wire field is a larger change than this PR should carry.

Unrelated pre-existing defect spotted and left alone: `openapi.yml` has a duplicate `'400'` response key around lines 585/591 (`promoteLedger`), which strict YAML parsers reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
