### PR TITLE
fix(EN-1854): preserve mirror source ingestion dates

### DIFF
--- a/docs/technical/architecture/audit-vs-technical-state.md
+++ b/docs/technical/architecture/audit-vs-technical-state.md
@@ -66,6 +66,13 @@ projections were exactly that kind of gap and no longer are: `signingVerifier`
 Maintenance mode has the identical shape and is deliberately deferred, so it is
 the governance gap that remains.
 
+The transaction pass has a narrower, field-level gap: it re-derives
+`TransactionState`, but that projection does not contain the `inserted_at` and
+`updated_at` fields stored in ledger-log `Transaction` payloads. Mirror orders
+hash-bind their source date as of EN-1854, yet no checker pass currently compares
+those two derived log fields against it. This is an existing primary-store
+projection gap, not an exemption created by the mirror-date change.
+
 ### Technical execution metadata is excluded from the audit business-intent hash (EN-1558)
 
 `AuditItem.serialized_order` stores the *business-intent* bytes of the order — the

--- a/docs/technical/architecture/subsystems/checker/checker.md
+++ b/docs/technical/architecture/subsystems/checker/checker.md
@@ -212,6 +212,13 @@ Adding a new persisted projection requires adding a new pass *and* a new error t
 
 A short list, because it matters for the threat model:
 
+- **Transaction `inserted_at` / `updated_at` in ledger-log payloads**: the
+  transaction pass verifies `TransactionState`, which deliberately does not
+  contain these read-model fields. For mirror ingests the source date is
+  hash-bound in `MirrorLogEntry`, but no checker pass currently re-derives the
+  two persisted `Transaction` fields from that order and compares them with the
+  ledger log. This is an existing primary-store projection gap; EN-1854 changes
+  the authoritative source value without claiming to close that checker gap.
 - **`IndexVersionState`** (per-replica): legitimately diverges during a rewrite — see [indexer / indexes.md](../indexer/indexes.md).
 - **`Index.BuildStatus`**: informational and per-replica.
 - **Bloom filters**: a probabilistic cache; correctness is a function of the underlying attribute store, which the checker *does* verify.

--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -48,7 +48,7 @@ Both adapters return v2 log entries in their native shape; translation to v3 ord
 
 ## The translation layer
 
-`internal/application/mirror/translator.go` (`TranslateBatch`) walks the fetched v2 logs, fills gaps if the source jumped log IDs (e.g. due to deletions or filtered logs on the v2 side), and produces a sequence of v3 `MirrorLogEntry` payloads. Each entry carries the v2 log ID plus a oneof:
+`internal/adapter/v2/translator.go` (`TranslateBatch`) walks the fetched v2 logs, fills gaps if the source jumped log IDs (e.g. due to deletions or filtered logs on the v2 side), and produces a sequence of v3 `MirrorLogEntry` payloads. Each entry carries the v2 log ID plus a oneof:
 
 ```
 oneof payload {
@@ -59,6 +59,20 @@ oneof payload {
     FillGap            // synthesised when a v2 log ID is missing
 }
 ```
+
+When `V2Log.Date` is present, the translated entry carries that parsed source
+log `date`. Created and reverted transactions require it: the FSM uses the
+chain-bound value for the resulting transaction's `insertedAt` and `updatedAt`
+and does not substitute the v3 apply time. This preserves the source insertion
+chronology during a long-running migration while keeping the transaction's
+business `timestamp` as a distinct field. A created or reverted transaction
+without a source date is rejected before mutation. Synthetic `FillGap` entries
+created for missing source log IDs carry no date because no source row exists.
+
+The resulting transaction, including these dates, is embedded in the persisted
+ledger log. Incremental backup exports that log row and `RebuildDelta` replays
+it into the restored transaction projection, so a post-checkpoint mirror ingest
+keeps the same `insertedAt` and `updatedAt` across a cross-cluster restore.
 
 `FillGap` is the explicit "we know there's a v2 log here but we have no payload for it" marker — it lets the v3 ledger advance its own logical sequence even when the source skipped one.
 

--- a/docs/technical/contributing/protobuf.md
+++ b/docs/technical/contributing/protobuf.md
@@ -142,7 +142,7 @@ Mirror mode introduces several protobuf types across multiple files:
 
 **`raft_cmd.proto`:**
 - `MirrorIngestOrder` — Raft command to ingest a translated v2 log entry
-- `MirrorLogEntry` — Wrapper for a single v2 log entry (oneof: `CreatedTransaction`, `SavedMetadata`, `DeletedMetadata`, `RevertedTransaction`, `FillGap`)
+- `MirrorLogEntry` — Wrapper for a single v2 log entry, including its source date (oneof: `CreatedTransaction`, `SavedMetadata`, `DeletedMetadata`, `RevertedTransaction`, `FillGap`)
 - `PromoteLedgerOrder` — Raft command to promote a mirror ledger to normal mode
 - `MirrorSyncUpdate` — Streaming update from the mirror worker (progress reporting)
 

--- a/internal/adapter/v2/source_postgres.go
+++ b/internal/adapter/v2/source_postgres.go
@@ -76,10 +76,7 @@ func (s *PostgresSource) FetchLogs(ctx context.Context, afterID uint64, pageSize
 	// Fetch pageSize+1 rows to determine if there are more.
 	// COALESCE on hash: v2 ledgers with LEDGER_FEATURE_HASH_LOGS disabled leave
 	// logs.hash NULL, which would fail the scan into V2Log.Hash (string).
-	query := fmt.Sprintf(
-		`SELECT id, type, date::text, data, COALESCE(encode(hash, 'hex'), '') FROM %q.logs WHERE ledger = $1 AND id > $2 ORDER BY id ASC LIMIT $3`,
-		s.bucket,
-	)
+	query := postgresFetchLogsQuery(s.bucket)
 
 	rows, err := s.pool.Query(ctx, query, s.ledgerName, afterID, pageSize+1)
 	if err != nil {
@@ -91,15 +88,20 @@ func (s *PostgresSource) FetchLogs(ctx context.Context, afterID uint64, pageSize
 
 	for rows.Next() {
 		var (
-			l    V2Log
-			data []byte
+			l       V2Log
+			logDate time.Time
+			data    []byte
 		)
 
-		err := rows.Scan(&l.ID, &l.Type, &l.Date, &data, &l.Hash)
+		err := rows.Scan(&l.ID, &l.Type, &logDate, &data, &l.Hash)
 		if err != nil {
 			return nil, false, fmt.Errorf("scanning log row: %w", err)
 		}
 
+		// Keep PostgreSQL DateStyle out of the mirror protocol: pgx decodes the
+		// typed timestamp, then the adapter emits the same RFC3339 shape as the
+		// HTTP v2 API.
+		l.Date = formatPostgresLogDate(logDate)
 		l.Data = json.RawMessage(data)
 		logs = append(logs, l)
 	}
@@ -114,6 +116,17 @@ func (s *PostgresSource) FetchLogs(ctx context.Context, afterID uint64, pageSize
 	}
 
 	return logs, hasMore, nil
+}
+
+func postgresFetchLogsQuery(bucket string) string {
+	return fmt.Sprintf(
+		`SELECT id, type, date, data, COALESCE(encode(hash, 'hex'), '') FROM %q.logs WHERE ledger = $1 AND id > $2 ORDER BY id ASC LIMIT $3`,
+		bucket,
+	)
+}
+
+func formatPostgresLogDate(date time.Time) string {
+	return date.UTC().Format(time.RFC3339Nano)
 }
 
 // GetLatestLogID returns the highest log ID from the v2 PostgreSQL log table.

--- a/internal/adapter/v2/source_postgres_test.go
+++ b/internal/adapter/v2/source_postgres_test.go
@@ -4,11 +4,30 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
+
+func TestPostgresFetchLogs_DateIsDateStyleIndependent(t *testing.T) {
+	t.Parallel()
+
+	query := postgresFetchLogsQuery("bucket")
+	require.Contains(t, query, "SELECT id, type, date, data")
+	require.NotContains(t, query, "date::text")
+
+	// pgx decodes the typed timestamp before formatting, so the output is
+	// independent of SQL/DMY, Postgres/MDY, or any other textual DateStyle.
+	logDate := time.Date(2023, 11, 14, 23, 13, 20, 123456000, time.FixedZone("UTC+1", 3600))
+	formatted := formatPostgresLogDate(logDate)
+	require.Equal(t, "2023-11-14T22:13:20.123456Z", formatted)
+
+	translated, err := translateV2LogDate(formatted)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1700000000123456), translated.GetData())
+}
 
 func TestBuildPgxPoolConfig_NoIAMLeavesBeforeConnectNil(t *testing.T) {
 	t.Parallel()

--- a/internal/adapter/v2/translator.go
+++ b/internal/adapter/v2/translator.go
@@ -60,6 +60,12 @@ func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNe
 		expectedNextTxID = newNextTxID
 
 		if entry != nil {
+			date, err := translateV2LogDate(v2Log.Date)
+			if err != nil {
+				return nil, 0, 0, fmt.Errorf("translating v2 log %d (type=%s): %w", v2Log.ID, v2Log.Type, err)
+			}
+			entry.Date = date
+
 			// Apply the mirror's CEL rewrite rules to the translated entry. This
 			// runs on the leader and its output is baked into the proposed order,
 			// so followers apply identical bytes. A rule may drop the entry, in
@@ -76,6 +82,42 @@ func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNe
 	}
 
 	return orders, expectedNextLogID, expectedNextTxID, nil
+}
+
+func translateV2LogDate(value string) (*commonpb.Timestamp, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	// HTTP sources expose RFC3339 while the direct PostgreSQL source selects
+	// date::text, whose timestamptz representation uses a space separator and
+	// may emit either an hour-only or hour/minute UTC offset.
+	formats := [...]string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999Z07",
+	}
+
+	var (
+		date time.Time
+		err  error
+	)
+	for _, format := range formats {
+		date, err = time.Parse(format, value)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("parsing v2 log date %q: %w", value, err)
+	}
+
+	microseconds := date.UnixMicro()
+	if microseconds < 0 {
+		return nil, fmt.Errorf("parsing v2 log date %q: date is before the Unix epoch", value)
+	}
+
+	return &commonpb.Timestamp{Data: uint64(microseconds)}, nil
 }
 
 func makeMirrorOrder(ledger string, entry *raftcmdpb.MirrorLogEntry) *raftcmdpb.Order {

--- a/internal/adapter/v2/translator.go
+++ b/internal/adapter/v2/translator.go
@@ -89,25 +89,10 @@ func translateV2LogDate(value string) (*commonpb.Timestamp, error) {
 		return nil, nil
 	}
 
-	// HTTP sources expose RFC3339 while the direct PostgreSQL source selects
-	// date::text, whose timestamptz representation uses a space separator and
-	// may emit either an hour-only or hour/minute UTC offset.
-	formats := [...]string{
-		time.RFC3339Nano,
-		"2006-01-02 15:04:05.999999999Z07:00",
-		"2006-01-02 15:04:05.999999999Z07",
-	}
-
-	var (
-		date time.Time
-		err  error
-	)
-	for _, format := range formats {
-		date, err = time.Parse(format, value)
-		if err == nil {
-			break
-		}
-	}
+	// HTTP sources expose RFC3339 directly. The PostgreSQL adapter scans the
+	// typed timestamp and normalizes it to the same form, independent of the
+	// server's DateStyle setting.
+	date, err := time.Parse(time.RFC3339Nano, value)
 	if err != nil {
 		return nil, fmt.Errorf("parsing v2 log date %q: %w", value, err)
 	}

--- a/internal/adapter/v2/translator_rewrite_test.go
+++ b/internal/adapter/v2/translator_rewrite_test.go
@@ -55,6 +55,7 @@ func TestTranslateBatch_Rewrite_CreatedTransaction(t *testing.T) {
 	v2Logs := []V2Log{{
 		ID:   1,
 		Type: "NEW_TRANSACTION",
+		Date: "2023-11-14T22:13:20.123456Z",
 		Data: mustMarshal(t, V2NewTransactionData{
 			Transaction: V2Transaction{
 				ID: 0,
@@ -75,7 +76,10 @@ func TestTranslateBatch_Rewrite_CreatedTransaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, orders, 1)
 
-	ct := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetCreatedTransaction()
+	entry := orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry()
+	require.Equal(t, uint64(1700000000123456), entry.GetDate().GetData())
+
+	ct := entry.GetCreatedTransaction()
 	require.NotNil(t, ct)
 	require.Equal(t, "world", ct.GetPostings()[0].GetSource())
 	require.Equal(t, "payments:acme:main", ct.GetPostings()[0].GetDestination())

--- a/internal/adapter/v2/translator_test.go
+++ b/internal/adapter/v2/translator_test.go
@@ -204,6 +204,15 @@ func TestTranslateBatch_InvalidLogDate(t *testing.T) {
 	require.Contains(t, err.Error(), "parsing v2 log date")
 }
 
+func TestTranslateV2LogDate_BeforeUnixEpochRejected(t *testing.T) {
+	t.Parallel()
+
+	date, err := translateV2LogDate("1969-12-31T23:59:59.999999Z")
+	require.Error(t, err)
+	require.Nil(t, date)
+	require.Contains(t, err.Error(), "before the Unix epoch")
+}
+
 func TestTranslateBatch_DeleteMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/v2/translator_test.go
+++ b/internal/adapter/v2/translator_test.go
@@ -15,6 +15,7 @@ func TestTranslateBatch_NewTransaction(t *testing.T) {
 	v2Logs := []V2Log{{
 		ID:   1,
 		Type: "NEW_TRANSACTION",
+		Date: "2023-11-14T22:13:20.123456Z",
 		Data: mustMarshal(t, V2NewTransactionData{
 			Transaction: V2Transaction{
 				ID: 0,
@@ -51,6 +52,7 @@ func TestTranslateBatch_NewTransaction(t *testing.T) {
 	require.Equal(t, "world", ct.GetPostings()[0].GetSource())
 	require.Equal(t, "users:001", ct.GetPostings()[0].GetDestination())
 	require.Equal(t, "USD/2", ct.GetPostings()[0].GetAsset())
+	require.Equal(t, uint64(1700000000123456), ingest.GetEntry().GetDate().GetData())
 }
 
 func TestTranslateBatch_SetMetadata_Account(t *testing.T) {
@@ -155,6 +157,7 @@ func TestTranslateBatch_RevertedTransaction(t *testing.T) {
 	v2Logs := []V2Log{{
 		ID:   3,
 		Type: "REVERTED_TRANSACTION",
+		Date: "2023-11-14T22:14:00Z",
 		Data: mustMarshal(t, V2RevertedTransactionData{
 			RevertedTransactionID: 1,
 			RevertTransaction: V2Transaction{
@@ -180,6 +183,33 @@ func TestTranslateBatch_RevertedTransaction(t *testing.T) {
 	require.Equal(t, uint64(1), rt.GetRevertedTransactionId())
 	require.Equal(t, uint64(5), rt.GetNewTransactionId())
 	require.Len(t, rt.GetReversePostings(), 1)
+	require.Equal(t, uint64(1700000040000000), orders[0].GetLedgerScoped().GetMirrorIngest().GetEntry().GetDate().GetData())
+}
+
+func TestTranslateBatch_InvalidLogDate(t *testing.T) {
+	t.Parallel()
+
+	v2Logs := []V2Log{{
+		ID:   1,
+		Type: "NEW_TRANSACTION",
+		Date: "not-a-date",
+		Data: mustMarshal(t, V2NewTransactionData{
+			Transaction: V2Transaction{ID: 1},
+		}),
+	}}
+
+	orders, _, _, err := TranslateBatch("default", v2Logs, 1, 1, nil)
+	require.Error(t, err)
+	require.Nil(t, orders)
+	require.Contains(t, err.Error(), "parsing v2 log date")
+}
+
+func TestTranslateV2LogDate_PostgresTextFormat(t *testing.T) {
+	t.Parallel()
+
+	date, err := translateV2LogDate("2023-11-14 23:13:20.123456+01")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1700000000123456), date.GetData())
 }
 
 func TestTranslateBatch_DeleteMetadata(t *testing.T) {

--- a/internal/adapter/v2/translator_test.go
+++ b/internal/adapter/v2/translator_test.go
@@ -204,14 +204,6 @@ func TestTranslateBatch_InvalidLogDate(t *testing.T) {
 	require.Contains(t, err.Error(), "parsing v2 log date")
 }
 
-func TestTranslateV2LogDate_PostgresTextFormat(t *testing.T) {
-	t.Parallel()
-
-	date, err := translateV2LogDate("2023-11-14 23:13:20.123456+01")
-	require.NoError(t, err)
-	require.Equal(t, uint64(1700000000123456), date.GetData())
-}
-
 func TestTranslateBatch_DeleteMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/processing/processor_mirror.go
+++ b/internal/domain/processing/processor_mirror.go
@@ -89,6 +89,16 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 		return nil, &domain.ErrMirrorV2LogIDGap{Name: ledger, Got: v2LogID, Expected: last + 1}
 	}
 
+	// Created and reverted transactions must carry the source v2 log date.
+	// The mirror translator owns this declaration; accepting a missing date
+	// would silently fall back to the v3 apply time and corrupt insertedAt / updatedAt.
+	switch entry.GetData().(type) {
+	case *raftcmdpb.MirrorLogEntry_CreatedTransaction, *raftcmdpb.MirrorLogEntry_RevertedTransaction:
+		if entry.GetDate() == nil {
+			return nil, &domain.ErrInvalidExecutionPlan{Reason_: "mirror transaction is missing its source v2 log date"}
+		}
+	}
+
 	// Re-touch ledger info so it enters the Merge buffer and gets propagated
 	// back to Gen0 on commit. Without this, ledger info is evicted after two
 	// cache rotations because mirror proposals bypass the admission preloader.
@@ -107,7 +117,7 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 	case *raftcmdpb.MirrorLogEntry_CreatedTransaction:
 		var err domain.Describable
 
-		logPayload, err = processMirrorCreatedTransaction(ledger, data.CreatedTransaction, ctx)
+		logPayload, err = processMirrorCreatedTransaction(ledger, data.CreatedTransaction, entry.GetDate(), ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +141,7 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 	case *raftcmdpb.MirrorLogEntry_RevertedTransaction:
 		var err domain.Describable
 
-		logPayload, err = processMirrorRevertedTransaction(ledger, data.RevertedTransaction, ctx)
+		logPayload, err = processMirrorRevertedTransaction(ledger, data.RevertedTransaction, entry.GetDate(), ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -196,8 +206,9 @@ func processMirrorFillGap(gap *raftcmdpb.MirrorFillGap, v2LogID uint64, ctx *Con
 
 // processMirrorCreatedTransaction creates a transaction from mirror data.
 // It applies postings with force=true (no balance checks) and assigns the exact transaction ID from v2.
+// insertedAt and updatedAt preserve the source v2 log date rather than the v3 apply time.
 // Missing volumes are auto-initialized to zero so postings are never silently skipped.
-func processMirrorCreatedTransaction(ledger string, ct *raftcmdpb.MirrorCreatedTransaction, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
+func processMirrorCreatedTransaction(ledger string, ct *raftcmdpb.MirrorCreatedTransaction, sourceDate *commonpb.Timestamp, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
 	boundaries := ctx.Boundaries
 	s := ctx.Scope
 
@@ -280,8 +291,8 @@ func processMirrorCreatedTransaction(ledger string, ct *raftcmdpb.MirrorCreatedT
 					Timestamp:         timestamp,
 					Reference:         ct.GetReference(),
 					Id:                txID,
-					InsertedAt:        s.GetDate().Mutate(),
-					UpdatedAt:         s.GetDate().Mutate(),
+					InsertedAt:        sourceDate.CloneVT(),
+					UpdatedAt:         sourceDate.CloneVT(),
 					PostCommitVolumes: postCommitVolumes,
 				},
 				AccountMetadata: accountMetadata,
@@ -388,8 +399,9 @@ func processMirrorDeletedMetadata(ledger string, dm *raftcmdpb.MirrorDeletedMeta
 }
 
 // processMirrorRevertedTransaction processes a v2 REVERTED_TRANSACTION log.
+// insertedAt and updatedAt preserve the source v2 log date rather than the v3 apply time.
 // Missing volumes are auto-initialized to zero so reverse postings are never silently skipped.
-func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorRevertedTransaction, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
+func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorRevertedTransaction, sourceDate *commonpb.Timestamp, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
 	boundaries := ctx.Boundaries
 	s := ctx.Scope
 
@@ -461,8 +473,8 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 					Metadata:           rt.GetMetadata(),
 					Timestamp:          timestamp,
 					Id:                 revertTxID,
-					InsertedAt:         s.GetDate().Mutate(),
-					UpdatedAt:          s.GetDate().Mutate(),
+					InsertedAt:         sourceDate.CloneVT(),
+					UpdatedAt:          sourceDate.CloneVT(),
 					RevertsTransaction: rt.GetRevertedTransactionId(),
 					PostCommitVolumes:  postCommitVolumes,
 				},

--- a/internal/domain/processing/processor_mirror_test.go
+++ b/internal/domain/processing/processor_mirror_test.go
@@ -88,6 +88,7 @@ func TestMirrorIngest_CreatedTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	now := &commonpb.Timestamp{Data: 1234567890}
+	sourceDate := &commonpb.Timestamp{Data: 1699990000}
 	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 1, NextLogId: 1}
 	ledgerInfo := &commonpb.LedgerInfo{
 		Name: "mirror-ledger",
@@ -137,6 +138,7 @@ func TestMirrorIngest_CreatedTransaction(t *testing.T) {
 				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
 					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
 						V2LogId: 1,
+						Date:    sourceDate,
 						Data: &raftcmdpb.MirrorLogEntry_CreatedTransaction{
 							CreatedTransaction: &raftcmdpb.MirrorCreatedTransaction{
 								TransactionId: 42,
@@ -163,6 +165,8 @@ func TestMirrorIngest_CreatedTransaction(t *testing.T) {
 	require.NotNil(t, createdTx)
 	require.Equal(t, uint64(42), createdTx.GetTransaction().GetId())
 	require.Equal(t, "tx-ref-v2", createdTx.GetTransaction().GetReference())
+	require.Equal(t, sourceDate, createdTx.GetTransaction().GetInsertedAt())
+	require.Equal(t, sourceDate, createdTx.GetTransaction().GetUpdatedAt())
 
 	// Post-commit volumes are part of every transaction, mirrored ones
 	// included: the snapshot must carry a row for each touched account.
@@ -187,6 +191,7 @@ func mirrorCreatedTxOrder(ledger string, v2LogID, txID uint64) *raftcmdpb.Order 
 				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
 					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
 						V2LogId: v2LogID,
+						Date:    &commonpb.Timestamp{Data: 1},
 						Data: &raftcmdpb.MirrorLogEntry_CreatedTransaction{
 							CreatedTransaction: &raftcmdpb.MirrorCreatedTransaction{
 								TransactionId: txID,
@@ -429,6 +434,42 @@ func TestMirrorIngest_ZeroV2LogIdRejected(t *testing.T) {
 	// same way — the reject is a pure function of the order, mutating nothing.
 	assertRejected()
 	assertRejected()
+}
+
+func TestMirrorIngest_TransactionWithoutSourceDateRejected(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	ledgerInfo := &commonpb.LedgerInfo{Name: "mirror-ledger", Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR}
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 1, NextLogId: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil).AnyTimes()
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+
+	ledgers := setupLedgersStub(mockStore)
+	ledgers.onPut(func(_ domain.LedgerKey, _ *commonpb.LedgerInfo) {
+		t.Errorf("Ledgers().Put must not be called when the source date is missing")
+	})
+	boundariesStub.onPut(func(_ domain.LedgerKey, _ *raftcmdpb.LedgerBoundaries) {
+		t.Errorf("Boundaries().Put must not be called when the source date is missing")
+	})
+
+	order := mirrorCreatedTxOrder("mirror-ledger", 1, 42)
+	order.GetLedgerScoped().GetMirrorIngest().GetEntry().Date = nil
+
+	result, err := processor.ProcessOrder(order, mockStore)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	var invalid *domain.ErrInvalidExecutionPlan
+	require.ErrorAs(t, err, &invalid)
 }
 
 func TestMirrorIngest_NotMirrorMode(t *testing.T) {
@@ -690,6 +731,7 @@ func TestMirrorIngest_CreatedTransaction_AbsentVolumes(t *testing.T) {
 				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
 					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
 						V2LogId: 1,
+						Date:    now,
 						Data: &raftcmdpb.MirrorLogEntry_CreatedTransaction{
 							CreatedTransaction: &raftcmdpb.MirrorCreatedTransaction{
 								TransactionId: 42,
@@ -761,6 +803,7 @@ func TestMirrorIngest_RevertedTransaction_AbsentVolumes(t *testing.T) {
 				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
 					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
 						V2LogId: 2,
+						Date:    now,
 						Data: &raftcmdpb.MirrorLogEntry_RevertedTransaction{
 							RevertedTransaction: &raftcmdpb.MirrorRevertedTransaction{
 								RevertedTransactionId: 5,
@@ -804,6 +847,7 @@ func TestMirrorIngest_RevertedTransaction_LinksOriginal(t *testing.T) {
 	expectGetBoundaries(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
 
 	revertTimestamp := &commonpb.Timestamp{Data: 1234567890}
+	sourceDate := &commonpb.Timestamp{Data: 1200000000}
 
 	origKey := domain.TransactionKey{LedgerName: "mirror-ledger", ID: 5}
 
@@ -837,6 +881,7 @@ func TestMirrorIngest_RevertedTransaction_LinksOriginal(t *testing.T) {
 				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
 					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
 						V2LogId: 2,
+						Date:    sourceDate,
 						Data: &raftcmdpb.MirrorLogEntry_RevertedTransaction{
 							RevertedTransaction: &raftcmdpb.MirrorRevertedTransaction{
 								RevertedTransactionId: 5,
@@ -857,6 +902,8 @@ func TestMirrorIngest_RevertedTransaction_LinksOriginal(t *testing.T) {
 	revertedTx := result.GetApply().GetLog().GetData().GetRevertedTransaction()
 	require.Equal(t, uint64(5), revertedTx.GetRevertedTransactionId())
 	require.Equal(t, uint64(5), revertedTx.GetRevertTransaction().GetRevertsTransaction())
+	require.Equal(t, sourceDate, revertedTx.GetRevertTransaction().GetInsertedAt())
+	require.Equal(t, sourceDate, revertedTx.GetRevertTransaction().GetUpdatedAt())
 
 	// The compensating mirror transaction carries its own post-revert snapshot.
 	pcv := revertedTx.GetRevertTransaction().GetPostCommitVolumes()

--- a/internal/proto/raftcmdpb/raft_cmd.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd.pb.go
@@ -1996,6 +1996,7 @@ func (x *MirrorIngestOrder) GetEntry() *MirrorLogEntry {
 type MirrorLogEntry struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	V2LogId uint64                 `protobuf:"fixed64,1,opt,name=v2_log_id,json=v2LogId,proto3" json:"v2_log_id,omitempty"`
+	Date    *commonpb.Timestamp    `protobuf:"bytes,2,opt,name=date,proto3" json:"date,omitempty"`
 	// Types that are valid to be assigned to Data:
 	//
 	//	*MirrorLogEntry_CreatedTransaction
@@ -2043,6 +2044,13 @@ func (x *MirrorLogEntry) GetV2LogId() uint64 {
 		return x.V2LogId
 	}
 	return 0
+}
+
+func (x *MirrorLogEntry) GetDate() *commonpb.Timestamp {
+	if x != nil {
+		return x.Date
+	}
+	return nil
 }
 
 func (x *MirrorLogEntry) GetData() isMirrorLogEntry_Data {
@@ -2102,23 +2110,23 @@ type isMirrorLogEntry_Data interface {
 }
 
 type MirrorLogEntry_CreatedTransaction struct {
-	CreatedTransaction *MirrorCreatedTransaction `protobuf:"bytes,2,opt,name=created_transaction,json=createdTransaction,proto3,oneof"`
+	CreatedTransaction *MirrorCreatedTransaction `protobuf:"bytes,3,opt,name=created_transaction,json=createdTransaction,proto3,oneof"`
 }
 
 type MirrorLogEntry_SavedMetadata struct {
-	SavedMetadata *MirrorSavedMetadata `protobuf:"bytes,3,opt,name=saved_metadata,json=savedMetadata,proto3,oneof"`
+	SavedMetadata *MirrorSavedMetadata `protobuf:"bytes,4,opt,name=saved_metadata,json=savedMetadata,proto3,oneof"`
 }
 
 type MirrorLogEntry_RevertedTransaction struct {
-	RevertedTransaction *MirrorRevertedTransaction `protobuf:"bytes,4,opt,name=reverted_transaction,json=revertedTransaction,proto3,oneof"`
+	RevertedTransaction *MirrorRevertedTransaction `protobuf:"bytes,5,opt,name=reverted_transaction,json=revertedTransaction,proto3,oneof"`
 }
 
 type MirrorLogEntry_DeletedMetadata struct {
-	DeletedMetadata *MirrorDeletedMetadata `protobuf:"bytes,5,opt,name=deleted_metadata,json=deletedMetadata,proto3,oneof"`
+	DeletedMetadata *MirrorDeletedMetadata `protobuf:"bytes,6,opt,name=deleted_metadata,json=deletedMetadata,proto3,oneof"`
 }
 
 type MirrorLogEntry_FillGap struct {
-	FillGap *MirrorFillGap `protobuf:"bytes,6,opt,name=fill_gap,json=fillGap,proto3,oneof"`
+	FillGap *MirrorFillGap `protobuf:"bytes,7,opt,name=fill_gap,json=fillGap,proto3,oneof"`
 }
 
 func (*MirrorLogEntry_CreatedTransaction) isMirrorLogEntry_Data() {}
@@ -5723,14 +5731,15 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
 	"\x05value\x18\x02 \x01(\v2\x13.common.AccountTypeR\x05value:\x028\x01\"?\n" +
 	"\x11MirrorIngestOrder\x12*\n" +
-	"\x05entry\x18\x01 \x01(\v2\x14.raft.MirrorLogEntryR\x05entry\"\x9d\x03\n" +
+	"\x05entry\x18\x01 \x01(\v2\x14.raft.MirrorLogEntryR\x05entry\"\xc4\x03\n" +
 	"\x0eMirrorLogEntry\x12\x1a\n" +
-	"\tv2_log_id\x18\x01 \x01(\x06R\av2LogId\x12Q\n" +
-	"\x13created_transaction\x18\x02 \x01(\v2\x1e.raft.MirrorCreatedTransactionH\x00R\x12createdTransaction\x12B\n" +
-	"\x0esaved_metadata\x18\x03 \x01(\v2\x19.raft.MirrorSavedMetadataH\x00R\rsavedMetadata\x12T\n" +
-	"\x14reverted_transaction\x18\x04 \x01(\v2\x1f.raft.MirrorRevertedTransactionH\x00R\x13revertedTransaction\x12H\n" +
-	"\x10deleted_metadata\x18\x05 \x01(\v2\x1b.raft.MirrorDeletedMetadataH\x00R\x0fdeletedMetadata\x120\n" +
-	"\bfill_gap\x18\x06 \x01(\v2\x13.raft.MirrorFillGapH\x00R\afillGapB\x06\n" +
+	"\tv2_log_id\x18\x01 \x01(\x06R\av2LogId\x12%\n" +
+	"\x04date\x18\x02 \x01(\v2\x11.common.TimestampR\x04date\x12Q\n" +
+	"\x13created_transaction\x18\x03 \x01(\v2\x1e.raft.MirrorCreatedTransactionH\x00R\x12createdTransaction\x12B\n" +
+	"\x0esaved_metadata\x18\x04 \x01(\v2\x19.raft.MirrorSavedMetadataH\x00R\rsavedMetadata\x12T\n" +
+	"\x14reverted_transaction\x18\x05 \x01(\v2\x1f.raft.MirrorRevertedTransactionH\x00R\x13revertedTransaction\x12H\n" +
+	"\x10deleted_metadata\x18\x06 \x01(\v2\x1b.raft.MirrorDeletedMetadataH\x00R\x0fdeletedMetadata\x120\n" +
+	"\bfill_gap\x18\a \x01(\v2\x13.raft.MirrorFillGapH\x00R\afillGapB\x06\n" +
 	"\x04data\"G\n" +
 	"\rMirrorFillGap\x126\n" +
 	"\x17skipped_transaction_ids\x18\x01 \x03(\x06R\x15skippedTransactionIds\"\x94\x04\n" +
@@ -6175,102 +6184,103 @@ var file_raft_cmd_proto_depIdxs = []int32{
 	78,  // 37: raft.CreateLedgerOrder.account_types:type_name -> raft.CreateLedgerOrder.AccountTypesEntry
 	96,  // 38: raft.CreateLedgerOrder.default_enforcement_mode:type_name -> common.ChartEnforcementMode
 	29,  // 39: raft.MirrorIngestOrder.entry:type_name -> raft.MirrorLogEntry
-	31,  // 40: raft.MirrorLogEntry.created_transaction:type_name -> raft.MirrorCreatedTransaction
-	32,  // 41: raft.MirrorLogEntry.saved_metadata:type_name -> raft.MirrorSavedMetadata
-	33,  // 42: raft.MirrorLogEntry.reverted_transaction:type_name -> raft.MirrorRevertedTransaction
-	34,  // 43: raft.MirrorLogEntry.deleted_metadata:type_name -> raft.MirrorDeletedMetadata
-	30,  // 44: raft.MirrorLogEntry.fill_gap:type_name -> raft.MirrorFillGap
-	97,  // 45: raft.MirrorCreatedTransaction.postings:type_name -> common.Posting
-	79,  // 46: raft.MirrorCreatedTransaction.metadata:type_name -> raft.MirrorCreatedTransaction.MetadataEntry
-	92,  // 47: raft.MirrorCreatedTransaction.timestamp:type_name -> common.Timestamp
-	80,  // 48: raft.MirrorCreatedTransaction.account_metadata:type_name -> raft.MirrorCreatedTransaction.AccountMetadataEntry
-	98,  // 49: raft.MirrorSavedMetadata.target:type_name -> common.Target
-	81,  // 50: raft.MirrorSavedMetadata.metadata:type_name -> raft.MirrorSavedMetadata.MetadataEntry
-	97,  // 51: raft.MirrorRevertedTransaction.reverse_postings:type_name -> common.Posting
-	82,  // 52: raft.MirrorRevertedTransaction.metadata:type_name -> raft.MirrorRevertedTransaction.MetadataEntry
-	92,  // 53: raft.MirrorRevertedTransaction.timestamp:type_name -> common.Timestamp
-	98,  // 54: raft.MirrorDeletedMetadata.target:type_name -> common.Target
-	45,  // 55: raft.LedgerApplyOrder.create_transaction:type_name -> raft.CreateTransactionOrder
-	47,  // 56: raft.LedgerApplyOrder.add_metadata:type_name -> raft.SaveMetadataOrder
-	48,  // 57: raft.LedgerApplyOrder.revert_transaction:type_name -> raft.RevertTransactionOrder
-	49,  // 58: raft.LedgerApplyOrder.delete_metadata:type_name -> raft.DeleteMetadataOrder
-	43,  // 59: raft.LedgerApplyOrder.set_metadata_field_type:type_name -> raft.SetMetadataFieldTypeOrder
-	44,  // 60: raft.LedgerApplyOrder.remove_metadata_field_type:type_name -> raft.RemoveMetadataFieldTypeOrder
-	38,  // 61: raft.LedgerApplyOrder.create_index:type_name -> raft.CreateIndexOrder
-	39,  // 62: raft.LedgerApplyOrder.drop_index:type_name -> raft.DropIndexOrder
-	40,  // 63: raft.LedgerApplyOrder.add_account_type:type_name -> raft.AddAccountTypeOrder
-	41,  // 64: raft.LedgerApplyOrder.remove_account_type:type_name -> raft.RemoveAccountTypeOrder
-	42,  // 65: raft.LedgerApplyOrder.update_default_enforcement_mode:type_name -> raft.UpdateDefaultEnforcementModeOrder
-	99,  // 66: raft.LedgerApplyOrder.skippable_reasons:type_name -> common.ErrorReason
-	100, // 67: raft.CreateIndexOrder.id:type_name -> common.IndexID
-	100, // 68: raft.DropIndexOrder.id:type_name -> common.IndexID
-	101, // 69: raft.AddAccountTypeOrder.account_type:type_name -> common.AccountType
-	96,  // 70: raft.UpdateDefaultEnforcementModeOrder.enforcement_mode:type_name -> common.ChartEnforcementMode
-	102, // 71: raft.SetMetadataFieldTypeOrder.target_type:type_name -> common.TargetType
-	103, // 72: raft.SetMetadataFieldTypeOrder.type:type_name -> common.MetadataType
-	102, // 73: raft.RemoveMetadataFieldTypeOrder.target_type:type_name -> common.TargetType
-	97,  // 74: raft.CreateTransactionOrder.postings:type_name -> common.Posting
-	104, // 75: raft.CreateTransactionOrder.script:type_name -> common.Script
-	92,  // 76: raft.CreateTransactionOrder.timestamp:type_name -> common.Timestamp
-	83,  // 77: raft.CreateTransactionOrder.metadata:type_name -> raft.CreateTransactionOrder.MetadataEntry
-	84,  // 78: raft.CreateTransactionOrder.account_metadata:type_name -> raft.CreateTransactionOrder.AccountMetadataEntry
-	46,  // 79: raft.CreateTransactionOrder.numscript_reference:type_name -> raft.NumscriptReference
-	85,  // 80: raft.NumscriptReference.vars:type_name -> raft.NumscriptReference.VarsEntry
-	98,  // 81: raft.SaveMetadataOrder.target:type_name -> common.Target
-	86,  // 82: raft.SaveMetadataOrder.metadata:type_name -> raft.SaveMetadataOrder.MetadataEntry
-	87,  // 83: raft.RevertTransactionOrder.metadata:type_name -> raft.RevertTransactionOrder.MetadataEntry
-	98,  // 84: raft.DeleteMetadataOrder.target:type_name -> common.Target
-	88,  // 85: raft.SaveLedgerMetadataOrder.metadata:type_name -> raft.SaveLedgerMetadataOrder.MetadataEntry
-	2,   // 86: raft.Proposal.orders:type_name -> raft.Order
-	92,  // 87: raft.Proposal.date:type_name -> common.Timestamp
-	69,  // 88: raft.Proposal.execution_plan:type_name -> raft.ExecutionPlan
-	105, // 89: raft.Proposal.caller_snapshot:type_name -> common.CallerSnapshot
-	106, // 90: raft.Proposal.idempotency:type_name -> common.Idempotency
-	107, // 91: raft.Proposal.signature:type_name -> signature.SignedApplyBatch
-	53,  // 92: raft.Proposal.technical_updates:type_name -> raft.TechnicalUpdate
-	64,  // 93: raft.TechnicalUpdate.mirror_sync:type_name -> raft.MirrorSyncUpdate
-	65,  // 94: raft.TechnicalUpdate.events_sink:type_name -> raft.EventsSinkUpdate
-	63,  // 95: raft.TechnicalUpdate.idempotency_eviction:type_name -> raft.IdempotencyEviction
-	108, // 96: raft.TechnicalUpdate.cluster_config:type_name -> common.ClusterConfig
-	58,  // 97: raft.TechnicalUpdate.backup_order:type_name -> raft.BackupOrder
-	59,  // 98: raft.TechnicalUpdate.incremental_backup_order:type_name -> raft.IncrementalBackupOrder
-	55,  // 99: raft.BackupDestination.s3:type_name -> raft.S3BackupTarget
-	56,  // 100: raft.BackupDestination.azure:type_name -> raft.AzureBackupTarget
-	0,   // 101: raft.BackupJob.kind:type_name -> raft.BackupKind
-	1,   // 102: raft.BackupJob.status:type_name -> raft.BackupJobStatus
-	54,  // 103: raft.BackupJob.destination:type_name -> raft.BackupDestination
-	60,  // 104: raft.BackupOrder.start:type_name -> raft.BackupOrderStart
-	61,  // 105: raft.BackupOrder.complete:type_name -> raft.BackupOrderComplete
-	62,  // 106: raft.BackupOrder.fail:type_name -> raft.BackupOrderFail
-	60,  // 107: raft.IncrementalBackupOrder.start:type_name -> raft.BackupOrderStart
-	61,  // 108: raft.IncrementalBackupOrder.complete:type_name -> raft.BackupOrderComplete
-	62,  // 109: raft.IncrementalBackupOrder.fail:type_name -> raft.BackupOrderFail
-	54,  // 110: raft.BackupOrderStart.destination:type_name -> raft.BackupDestination
-	109, // 111: raft.MirrorSyncUpdate.error:type_name -> common.MirrorSyncError
-	110, // 112: raft.EventsSinkUpdate.error:type_name -> common.SinkError
-	111, // 113: raft.CreatedLogOrReference.created_log:type_name -> common.Log
-	112, // 114: raft.VolumePair.input:type_name -> common.Uint256
-	112, // 115: raft.VolumePair.output:type_name -> common.Uint256
-	70,  // 116: raft.ExecutionPlan.attributes:type_name -> raft.AttributeCoverage
-	72,  // 117: raft.ExecutionPlan.idempotency_keys:type_name -> raft.ReloadIdempotencyKey
-	77,  // 118: raft.AttributeCoverage.id:type_name -> raft.AttributeID
-	71,  // 119: raft.AttributeCoverage.value:type_name -> raft.AttributeValue
-	113, // 120: raft.ReloadIdempotencyKey.value:type_name -> common.IdempotencyKeyValue
-	101, // 121: raft.CreateLedgerOrder.AccountTypesEntry.value:type_name -> common.AccountType
-	114, // 122: raft.MirrorCreatedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
-	115, // 123: raft.MirrorCreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	114, // 124: raft.MirrorSavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	114, // 125: raft.MirrorRevertedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
-	114, // 126: raft.CreateTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	115, // 127: raft.CreateTransactionOrder.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	114, // 128: raft.SaveMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	114, // 129: raft.RevertTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	114, // 130: raft.SaveLedgerMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
-	131, // [131:131] is the sub-list for method output_type
-	131, // [131:131] is the sub-list for method input_type
-	131, // [131:131] is the sub-list for extension type_name
-	131, // [131:131] is the sub-list for extension extendee
-	0,   // [0:131] is the sub-list for field type_name
+	92,  // 40: raft.MirrorLogEntry.date:type_name -> common.Timestamp
+	31,  // 41: raft.MirrorLogEntry.created_transaction:type_name -> raft.MirrorCreatedTransaction
+	32,  // 42: raft.MirrorLogEntry.saved_metadata:type_name -> raft.MirrorSavedMetadata
+	33,  // 43: raft.MirrorLogEntry.reverted_transaction:type_name -> raft.MirrorRevertedTransaction
+	34,  // 44: raft.MirrorLogEntry.deleted_metadata:type_name -> raft.MirrorDeletedMetadata
+	30,  // 45: raft.MirrorLogEntry.fill_gap:type_name -> raft.MirrorFillGap
+	97,  // 46: raft.MirrorCreatedTransaction.postings:type_name -> common.Posting
+	79,  // 47: raft.MirrorCreatedTransaction.metadata:type_name -> raft.MirrorCreatedTransaction.MetadataEntry
+	92,  // 48: raft.MirrorCreatedTransaction.timestamp:type_name -> common.Timestamp
+	80,  // 49: raft.MirrorCreatedTransaction.account_metadata:type_name -> raft.MirrorCreatedTransaction.AccountMetadataEntry
+	98,  // 50: raft.MirrorSavedMetadata.target:type_name -> common.Target
+	81,  // 51: raft.MirrorSavedMetadata.metadata:type_name -> raft.MirrorSavedMetadata.MetadataEntry
+	97,  // 52: raft.MirrorRevertedTransaction.reverse_postings:type_name -> common.Posting
+	82,  // 53: raft.MirrorRevertedTransaction.metadata:type_name -> raft.MirrorRevertedTransaction.MetadataEntry
+	92,  // 54: raft.MirrorRevertedTransaction.timestamp:type_name -> common.Timestamp
+	98,  // 55: raft.MirrorDeletedMetadata.target:type_name -> common.Target
+	45,  // 56: raft.LedgerApplyOrder.create_transaction:type_name -> raft.CreateTransactionOrder
+	47,  // 57: raft.LedgerApplyOrder.add_metadata:type_name -> raft.SaveMetadataOrder
+	48,  // 58: raft.LedgerApplyOrder.revert_transaction:type_name -> raft.RevertTransactionOrder
+	49,  // 59: raft.LedgerApplyOrder.delete_metadata:type_name -> raft.DeleteMetadataOrder
+	43,  // 60: raft.LedgerApplyOrder.set_metadata_field_type:type_name -> raft.SetMetadataFieldTypeOrder
+	44,  // 61: raft.LedgerApplyOrder.remove_metadata_field_type:type_name -> raft.RemoveMetadataFieldTypeOrder
+	38,  // 62: raft.LedgerApplyOrder.create_index:type_name -> raft.CreateIndexOrder
+	39,  // 63: raft.LedgerApplyOrder.drop_index:type_name -> raft.DropIndexOrder
+	40,  // 64: raft.LedgerApplyOrder.add_account_type:type_name -> raft.AddAccountTypeOrder
+	41,  // 65: raft.LedgerApplyOrder.remove_account_type:type_name -> raft.RemoveAccountTypeOrder
+	42,  // 66: raft.LedgerApplyOrder.update_default_enforcement_mode:type_name -> raft.UpdateDefaultEnforcementModeOrder
+	99,  // 67: raft.LedgerApplyOrder.skippable_reasons:type_name -> common.ErrorReason
+	100, // 68: raft.CreateIndexOrder.id:type_name -> common.IndexID
+	100, // 69: raft.DropIndexOrder.id:type_name -> common.IndexID
+	101, // 70: raft.AddAccountTypeOrder.account_type:type_name -> common.AccountType
+	96,  // 71: raft.UpdateDefaultEnforcementModeOrder.enforcement_mode:type_name -> common.ChartEnforcementMode
+	102, // 72: raft.SetMetadataFieldTypeOrder.target_type:type_name -> common.TargetType
+	103, // 73: raft.SetMetadataFieldTypeOrder.type:type_name -> common.MetadataType
+	102, // 74: raft.RemoveMetadataFieldTypeOrder.target_type:type_name -> common.TargetType
+	97,  // 75: raft.CreateTransactionOrder.postings:type_name -> common.Posting
+	104, // 76: raft.CreateTransactionOrder.script:type_name -> common.Script
+	92,  // 77: raft.CreateTransactionOrder.timestamp:type_name -> common.Timestamp
+	83,  // 78: raft.CreateTransactionOrder.metadata:type_name -> raft.CreateTransactionOrder.MetadataEntry
+	84,  // 79: raft.CreateTransactionOrder.account_metadata:type_name -> raft.CreateTransactionOrder.AccountMetadataEntry
+	46,  // 80: raft.CreateTransactionOrder.numscript_reference:type_name -> raft.NumscriptReference
+	85,  // 81: raft.NumscriptReference.vars:type_name -> raft.NumscriptReference.VarsEntry
+	98,  // 82: raft.SaveMetadataOrder.target:type_name -> common.Target
+	86,  // 83: raft.SaveMetadataOrder.metadata:type_name -> raft.SaveMetadataOrder.MetadataEntry
+	87,  // 84: raft.RevertTransactionOrder.metadata:type_name -> raft.RevertTransactionOrder.MetadataEntry
+	98,  // 85: raft.DeleteMetadataOrder.target:type_name -> common.Target
+	88,  // 86: raft.SaveLedgerMetadataOrder.metadata:type_name -> raft.SaveLedgerMetadataOrder.MetadataEntry
+	2,   // 87: raft.Proposal.orders:type_name -> raft.Order
+	92,  // 88: raft.Proposal.date:type_name -> common.Timestamp
+	69,  // 89: raft.Proposal.execution_plan:type_name -> raft.ExecutionPlan
+	105, // 90: raft.Proposal.caller_snapshot:type_name -> common.CallerSnapshot
+	106, // 91: raft.Proposal.idempotency:type_name -> common.Idempotency
+	107, // 92: raft.Proposal.signature:type_name -> signature.SignedApplyBatch
+	53,  // 93: raft.Proposal.technical_updates:type_name -> raft.TechnicalUpdate
+	64,  // 94: raft.TechnicalUpdate.mirror_sync:type_name -> raft.MirrorSyncUpdate
+	65,  // 95: raft.TechnicalUpdate.events_sink:type_name -> raft.EventsSinkUpdate
+	63,  // 96: raft.TechnicalUpdate.idempotency_eviction:type_name -> raft.IdempotencyEviction
+	108, // 97: raft.TechnicalUpdate.cluster_config:type_name -> common.ClusterConfig
+	58,  // 98: raft.TechnicalUpdate.backup_order:type_name -> raft.BackupOrder
+	59,  // 99: raft.TechnicalUpdate.incremental_backup_order:type_name -> raft.IncrementalBackupOrder
+	55,  // 100: raft.BackupDestination.s3:type_name -> raft.S3BackupTarget
+	56,  // 101: raft.BackupDestination.azure:type_name -> raft.AzureBackupTarget
+	0,   // 102: raft.BackupJob.kind:type_name -> raft.BackupKind
+	1,   // 103: raft.BackupJob.status:type_name -> raft.BackupJobStatus
+	54,  // 104: raft.BackupJob.destination:type_name -> raft.BackupDestination
+	60,  // 105: raft.BackupOrder.start:type_name -> raft.BackupOrderStart
+	61,  // 106: raft.BackupOrder.complete:type_name -> raft.BackupOrderComplete
+	62,  // 107: raft.BackupOrder.fail:type_name -> raft.BackupOrderFail
+	60,  // 108: raft.IncrementalBackupOrder.start:type_name -> raft.BackupOrderStart
+	61,  // 109: raft.IncrementalBackupOrder.complete:type_name -> raft.BackupOrderComplete
+	62,  // 110: raft.IncrementalBackupOrder.fail:type_name -> raft.BackupOrderFail
+	54,  // 111: raft.BackupOrderStart.destination:type_name -> raft.BackupDestination
+	109, // 112: raft.MirrorSyncUpdate.error:type_name -> common.MirrorSyncError
+	110, // 113: raft.EventsSinkUpdate.error:type_name -> common.SinkError
+	111, // 114: raft.CreatedLogOrReference.created_log:type_name -> common.Log
+	112, // 115: raft.VolumePair.input:type_name -> common.Uint256
+	112, // 116: raft.VolumePair.output:type_name -> common.Uint256
+	70,  // 117: raft.ExecutionPlan.attributes:type_name -> raft.AttributeCoverage
+	72,  // 118: raft.ExecutionPlan.idempotency_keys:type_name -> raft.ReloadIdempotencyKey
+	77,  // 119: raft.AttributeCoverage.id:type_name -> raft.AttributeID
+	71,  // 120: raft.AttributeCoverage.value:type_name -> raft.AttributeValue
+	113, // 121: raft.ReloadIdempotencyKey.value:type_name -> common.IdempotencyKeyValue
+	101, // 122: raft.CreateLedgerOrder.AccountTypesEntry.value:type_name -> common.AccountType
+	114, // 123: raft.MirrorCreatedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
+	115, // 124: raft.MirrorCreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	114, // 125: raft.MirrorSavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	114, // 126: raft.MirrorRevertedTransaction.MetadataEntry.value:type_name -> common.MetadataValue
+	114, // 127: raft.CreateTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	115, // 128: raft.CreateTransactionOrder.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	114, // 129: raft.SaveMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	114, // 130: raft.RevertTransactionOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	114, // 131: raft.SaveLedgerMetadataOrder.MetadataEntry.value:type_name -> common.MetadataValue
+	132, // [132:132] is the sub-list for method output_type
+	132, // [132:132] is the sub-list for method input_type
+	132, // [132:132] is the sub-list for extension type_name
+	132, // [132:132] is the sub-list for extension extendee
+	0,   // [0:132] is the sub-list for field type_name
 }
 
 func init() { file_raft_cmd_proto_init() }

--- a/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_dethash.pb.go
@@ -565,6 +565,13 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Date != nil {
+		size, _ := m.Date.MarshalToSizedBufferVT(dAtA[:i])
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
 	if m.V2LogId != 0 {
 		i -= 8
 		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.V2LogId))
@@ -578,7 +585,7 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x12
+			dAtA[i] = 0x1a
 		}
 	case *MirrorLogEntry_SavedMetadata:
 		if v.SavedMetadata != nil {
@@ -586,7 +593,7 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x1a
+			dAtA[i] = 0x22
 		}
 	case *MirrorLogEntry_RevertedTransaction:
 		if v.RevertedTransaction != nil {
@@ -594,7 +601,7 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x22
+			dAtA[i] = 0x2a
 		}
 	case *MirrorLogEntry_DeletedMetadata:
 		if v.DeletedMetadata != nil {
@@ -602,7 +609,7 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x2a
+			dAtA[i] = 0x32
 		}
 	case *MirrorLogEntry_FillGap:
 		if v.FillGap != nil {
@@ -610,7 +617,7 @@ func (m *MirrorLogEntry) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, 
 			i -= size
 			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
-			dAtA[i] = 0x32
+			dAtA[i] = 0x3a
 		}
 	}
 	return len(dAtA) - i, nil

--- a/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
@@ -1955,6 +1955,7 @@ func NewMirrorIngestOrderListReader(s []*MirrorIngestOrder) MirrorIngestOrderLis
 // Call Mutate() to obtain a mutable clone.
 type MirrorLogEntryReader interface {
 	GetV2LogId() uint64
+	GetDate() commonpb.TimestampReader
 	GetData() isMirrorLogEntry_Data
 	Mutate() *MirrorLogEntry
 }
@@ -1963,6 +1964,14 @@ type mirrorLogEntryReadonly MirrorLogEntry
 
 func (r *mirrorLogEntryReadonly) GetV2LogId() uint64 {
 	return (*MirrorLogEntry)(r).GetV2LogId()
+}
+
+func (r *mirrorLogEntryReadonly) GetDate() commonpb.TimestampReader {
+	v := (*MirrorLogEntry)(r).GetDate()
+	if v == nil {
+		return nil
+	}
+	return v.AsReader()
 }
 
 func (r *mirrorLogEntryReadonly) GetData() isMirrorLogEntry_Data {

--- a/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
@@ -810,6 +810,7 @@ func (m *MirrorLogEntry) CloneVT() *MirrorLogEntry {
 	}
 	r := new(MirrorLogEntry)
 	r.V2LogId = m.V2LogId
+	r.Date = m.Date.CloneVT()
 	if m.Data != nil {
 		r.Data = m.Data.(interface{ CloneVT() isMirrorLogEntry_Data }).CloneVT()
 	}
@@ -3539,6 +3540,9 @@ func (this *MirrorLogEntry) EqualVT(that *MirrorLogEntry) bool {
 		}
 	}
 	if this.V2LogId != that.V2LogId {
+		return false
+	}
+	if !this.Date.EqualVT(that.Date) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -7672,6 +7676,16 @@ func (m *MirrorLogEntry) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if m.Date != nil {
+		size, err := m.Date.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
 	if m.V2LogId != 0 {
 		i -= 8
 		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.V2LogId))
@@ -7696,7 +7710,7 @@ func (m *MirrorLogEntry_CreatedTransaction) MarshalToSizedBufferVT(dAtA []byte) 
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x1a
 	}
 	return len(dAtA) - i, nil
 }
@@ -7715,7 +7729,7 @@ func (m *MirrorLogEntry_SavedMetadata) MarshalToSizedBufferVT(dAtA []byte) (int,
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
 	}
 	return len(dAtA) - i, nil
 }
@@ -7734,7 +7748,7 @@ func (m *MirrorLogEntry_RevertedTransaction) MarshalToSizedBufferVT(dAtA []byte)
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x22
+		dAtA[i] = 0x2a
 	}
 	return len(dAtA) - i, nil
 }
@@ -7753,7 +7767,7 @@ func (m *MirrorLogEntry_DeletedMetadata) MarshalToSizedBufferVT(dAtA []byte) (in
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x32
 	}
 	return len(dAtA) - i, nil
 }
@@ -7772,7 +7786,7 @@ func (m *MirrorLogEntry_FillGap) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x32
+		dAtA[i] = 0x3a
 	}
 	return len(dAtA) - i, nil
 }
@@ -12015,6 +12029,10 @@ func (m *MirrorLogEntry) SizeVT() (n int) {
 	_ = l
 	if m.V2LogId != 0 {
 		n += 9
+	}
+	if m.Date != nil {
+		l = m.Date.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if vtmsg, ok := m.Data.(interface{ SizeVT() int }); ok {
 		n += vtmsg.SizeVT()
@@ -17259,6 +17277,42 @@ func (m *MirrorLogEntry) UnmarshalVT(dAtA []byte) error {
 			iNdEx += 8
 		case 2:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Date", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Date == nil {
+				m.Date = &commonpb.Timestamp{}
+			}
+			if err := m.Date.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field CreatedTransaction", wireType)
 			}
 			var msglen int
@@ -17298,7 +17352,7 @@ func (m *MirrorLogEntry) UnmarshalVT(dAtA []byte) error {
 				m.Data = &MirrorLogEntry_CreatedTransaction{CreatedTransaction: v}
 			}
 			iNdEx = postIndex
-		case 3:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SavedMetadata", wireType)
 			}
@@ -17339,7 +17393,7 @@ func (m *MirrorLogEntry) UnmarshalVT(dAtA []byte) error {
 				m.Data = &MirrorLogEntry_SavedMetadata{SavedMetadata: v}
 			}
 			iNdEx = postIndex
-		case 4:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RevertedTransaction", wireType)
 			}
@@ -17380,7 +17434,7 @@ func (m *MirrorLogEntry) UnmarshalVT(dAtA []byte) error {
 				m.Data = &MirrorLogEntry_RevertedTransaction{RevertedTransaction: v}
 			}
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field DeletedMetadata", wireType)
 			}
@@ -17421,7 +17475,7 @@ func (m *MirrorLogEntry) UnmarshalVT(dAtA []byte) error {
 				m.Data = &MirrorLogEntry_DeletedMetadata{DeletedMetadata: v}
 			}
 			iNdEx = postIndex
-		case 6:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field FillGap", wireType)
 			}

--- a/misc/proto/raft_cmd.proto
+++ b/misc/proto/raft_cmd.proto
@@ -231,12 +231,13 @@ message MirrorIngestOrder {
 
 message MirrorLogEntry {
   fixed64 v2_log_id = 1;
+  common.Timestamp date = 2;
   oneof data {
-    MirrorCreatedTransaction created_transaction = 2;
-    MirrorSavedMetadata saved_metadata = 3;
-    MirrorRevertedTransaction reverted_transaction = 4;
-    MirrorDeletedMetadata deleted_metadata = 5;
-    MirrorFillGap fill_gap = 6;
+    MirrorCreatedTransaction created_transaction = 3;
+    MirrorSavedMetadata saved_metadata = 4;
+    MirrorRevertedTransaction reverted_transaction = 5;
+    MirrorDeletedMetadata deleted_metadata = 6;
+    MirrorFillGap fill_gap = 7;
   }
 }
 
@@ -805,4 +806,3 @@ message AttributeID {
   bytes id = 1;           // 16-byte U128 identifier
   fixed64 tag = 2;
 }
-

--- a/tests/e2e/cluster/mirror_test.go
+++ b/tests/e2e/cluster/mirror_test.go
@@ -361,8 +361,12 @@ var _ = Describe("Mirror", Ordered, func() {
 			DeferCleanup(mockV2.Close)
 
 			// Seed v2 logs before creating the mirror
-			mockV2.addLog(newV2TransactionLog(1, 0, "world", "users:001", "100", "USD/2"))
-			mockV2.addLog(newV2TransactionLog(2, 1, "world", "users:002", "200", "EUR/2"))
+			first := newV2TransactionLog(1, 0, "world", "users:001", "100", "USD/2")
+			first.Date = "2023-11-14T22:13:20.123456Z"
+			mockV2.addLog(first)
+			second := newV2TransactionLog(2, 1, "world", "users:002", "200", "EUR/2")
+			second.Date = "2023-11-14T22:14:00Z"
+			mockV2.addLog(second)
 			mockV2.addLog(newV2SetMetadataLog(3, "ACCOUNT", "users:001", map[string]string{"role": "admin"}))
 
 			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
@@ -390,9 +394,50 @@ var _ = Describe("Mirror", Ordered, func() {
 				txs, err := listAllTransactions(ctx, client, "mirror-sync", 10, 0)
 				g.Expect(err).To(Succeed())
 
-				// We expect at least 2 transactions from the v2 logs
+				// We expect at least 2 transactions from the v2 logs, with their
+				// original v2 insertion chronology preserved end-to-end.
 				g.Expect(len(txs)).To(BeNumerically(">=", 2))
+
+				insertedAtByID := make(map[uint64]uint64, len(txs))
+				for _, tx := range txs {
+					insertedAtByID[tx.GetId()] = tx.GetInsertedAt().GetData()
+				}
+				g.Expect(insertedAtByID).To(HaveKeyWithValue(uint64(0), uint64(1700000000123456)))
+				g.Expect(insertedAtByID).To(HaveKeyWithValue(uint64(1), uint64(1700000040000000)))
 			}).Within(15 * time.Second).ProbeEvery(500 * time.Millisecond).Should(Succeed())
+		})
+
+		It("Should query the source insertion chronology through the inserted_at index", func() {
+			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateBuiltinTxIndexAction(
+				"mirror-sync",
+				commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT,
+			)))
+			Expect(err).To(Succeed())
+			Expect(actions.WaitForBuiltinIndexReady(
+				ctx,
+				client,
+				"mirror-sync",
+				commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_INSERTED_AT,
+			)).To(Succeed())
+
+			_, err = client.CreatePreparedQuery(ctx, &servicepb.CreatePreparedQueryRequest{
+				Ledger: "mirror-sync",
+				Query: &commonpb.PreparedQuery{
+					Name:   "first-source-ingestion-window",
+					Target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+					Filter: actions.InsertedAtRangeFilter(1700000000000000, 1700000000500000),
+				},
+			})
+			Expect(err).To(Succeed())
+
+			result, err := client.ExecutePreparedQuery(ctx, &servicepb.ExecutePreparedQueryRequest{
+				Ledger:    "mirror-sync",
+				QueryName: "first-source-ingestion-window",
+				Mode:      commonpb.QueryMode_QUERY_MODE_LIST,
+			})
+			Expect(err).To(Succeed())
+			Expect(result.GetCursor().GetTransactionData()).To(HaveLen(1))
+			Expect(result.GetCursor().GetTransactionData()[0].GetId()).To(Equal(uint64(0)))
 		})
 
 		It("Should sync account metadata from v2", func() {
@@ -455,7 +500,7 @@ var _ = Describe("Mirror", Ordered, func() {
 											Key:    "mirrored",
 											Source: &commonpb.SetMetadataAction_Value{Value: "true"},
 										},
-										},
+									},
 									}},
 								}}},
 								// Never mirror transactions flagged skip=yes.

--- a/tests/e2e/cluster/restore_mirror_test.go
+++ b/tests/e2e/cluster/restore_mirror_test.go
@@ -93,6 +93,10 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		// Recorded rather than hard-coded so the comparison pins "unchanged by
 		// the restore" instead of a particular amount encoding.
 		preBackupInput string
+		// The transaction projection is rebuilt from the exported ledger-log
+		// delta. Keep an independent source-date oracle so the restore cannot
+		// silently replace that field with its own apply time.
+		sourceDateMicrosByTxID map[uint64]uint64
 
 		// Read on the restored node as early as the gRPC surface answers.
 		restoredCursor uint64
@@ -128,6 +132,12 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		txs, err := listAllTransactions(ctx, client, ledgerName, 100, 0)
 		g.Expect(err).To(Succeed())
 		g.Expect(txs).To(HaveLen(preBackupTxCount), "%s: mirrored transaction count", phase)
+		for _, tx := range txs {
+			sourceDate, ok := sourceDateMicrosByTxID[tx.GetId()]
+			g.Expect(ok).To(BeTrue(), "%s: missing source-date oracle for transaction %d", phase, tx.GetId())
+			g.Expect(tx.GetInsertedAt().GetData()).To(Equal(sourceDate), "%s: transaction %d insertedAt", phase, tx.GetId())
+			g.Expect(tx.GetUpdatedAt().GetData()).To(Equal(sourceDate), "%s: transaction %d updatedAt", phase, tx.GetId())
+		}
 
 		acct, err := actions.GetAccount(ctx, client, ledgerName, account)
 		g.Expect(err).To(Succeed())
@@ -142,11 +152,17 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 
 		mockV2 = newMockV2Server()
 		DeferCleanup(mockV2.Close)
+		sourceDateMicrosByTxID = make(map[uint64]uint64, sourceLogCount)
 
 		for i := 1; i <= sourceLogCount; i++ {
 			// Source log ids are 1-based; the transactions they carry are
 			// 0-based, matching a real v2 ledger.
-			mockV2.addLog(newV2TransactionLog(uint64(i), uint64(i-1), "world", account, perTxAmount, asset))
+			txID := uint64(i - 1)
+			sourceDate := time.Date(2023, 11, 14, 22, 13+i, 0, i*1000, time.UTC)
+			log := newV2TransactionLog(uint64(i), txID, "world", account, perTxAmount, asset)
+			log.Date = sourceDate.Format(time.RFC3339Nano)
+			mockV2.addLog(log)
+			sourceDateMicrosByTxID[txID] = uint64(sourceDate.UnixMicro())
 		}
 
 		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
@@ -476,6 +492,13 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 			Consistently(func(g Gomega) {
 				expectSingleIngestion(g, client, "restored")
 			}, 12*time.Second, 1*time.Second).Should(Succeed())
+		})
+
+		It("passes the integrity checker after restoring the non-empty mirror delta", func() {
+			result, err := actions.CollectCheckStoreEvents(ctx, client)
+			Expect(err).To(Succeed())
+			Expect(result.Errors).To(BeEmpty())
+			Expect(result.Progress).ToNot(BeEmpty())
 		})
 
 		It("ingests new source logs and keeps transaction ids aligned", func() {

--- a/tests/e2e/cluster/restore_mirror_test.go
+++ b/tests/e2e/cluster/restore_mirror_test.go
@@ -65,8 +65,9 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		// Source logs 1..4 carry transactions 0..3, each crediting `account`
 		// with 100. sourceLogCount is therefore the cursor the mirror must hold
 		// when the delta is exported.
-		sourceLogCount = 4
-		perTxAmount    = "100"
+		sourceLogCount           = 4
+		checkpointSourceLogCount = 1
+		perTxAmount              = "100"
 
 		// Appended after the restore to prove ingestion resumes rather than
 		// merely stopping in a correct-looking state.
@@ -124,6 +125,17 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		return info.GetMirrorSyncProgress()
 	}
 
+	addSourceTransaction := func(logID int) {
+		// Source log ids are 1-based; the transactions they carry are 0-based,
+		// matching a real v2 ledger.
+		txID := uint64(logID - 1)
+		sourceDate := time.Date(2023, 11, 14, 22, 13+logID, 0, logID*1000, time.UTC)
+		log := newV2TransactionLog(uint64(logID), txID, "world", account, perTxAmount, asset)
+		log.Date = sourceDate.Format(time.RFC3339Nano)
+		mockV2.addLog(log)
+		sourceDateMicrosByTxID[txID] = uint64(sourceDate.UnixMicro())
+	}
+
 	// expectSingleIngestion asserts the two observables a second ingestion of
 	// the same source logs moves differently: the mirrored transaction count
 	// (unchanged, because a re-apply reuses the source transaction ids) and the
@@ -153,17 +165,7 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		mockV2 = newMockV2Server()
 		DeferCleanup(mockV2.Close)
 		sourceDateMicrosByTxID = make(map[uint64]uint64, sourceLogCount)
-
-		for i := 1; i <= sourceLogCount; i++ {
-			// Source log ids are 1-based; the transactions they carry are
-			// 0-based, matching a real v2 ledger.
-			txID := uint64(i - 1)
-			sourceDate := time.Date(2023, 11, 14, 22, 13+i, 0, i*1000, time.UTC)
-			log := newV2TransactionLog(uint64(i), txID, "world", account, perTxAmount, asset)
-			log.Date = sourceDate.Format(time.RFC3339Nano)
-			mockV2.addLog(log)
-			sourceDateMicrosByTxID[txID] = uint64(sourceDate.UnixMicro())
-		}
+		addSourceTransaction(1)
 
 		container, err := testcontainers.Run(context.Background(), "minio/minio:latest",
 			testcontainers.WithEnv(map[string]string{
@@ -206,7 +208,7 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 		Expect(err).To(Succeed())
 	})
 
-	Describe("Phase 1: a fully synced mirror ledger in the exported delta", Ordered, func() {
+	Describe("Phase 1: a mirror checkpoint prefix followed by an exported delta", Ordered, func() {
 		var (
 			sourceServer  *testservice.Service
 			client        servicepb.BucketServiceClient
@@ -238,14 +240,6 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 				g.Expect(err).To(Succeed())
 				return state.Leader != 0
 			}).Within(10 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeTrue())
-
-			// Full checkpoint on the EMPTY store: the mirror ledger and every
-			// ingest land in the incremental delta, so the restore has to
-			// reconstruct last_mirror_v2_log_id by replaying the exported log
-			// instead of copying a checkpoint that already holds it.
-			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
-			Expect(err).To(Succeed())
-			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
 		})
 
 		AfterAll(func() {
@@ -275,7 +269,33 @@ var _ = Describe("Restore mirror resume position", Ordered, func() {
 			Expect(err).To(Succeed())
 		})
 
-		It("syncs every source log before the delta is exported", func() {
+		It("syncs a source-dated transaction into the checkpoint prefix", func() {
+			Eventually(func(g Gomega) {
+				progress := syncProgress(g, client)
+				g.Expect(progress.GetError().GetMessage()).To(BeEmpty())
+				g.Expect(progress.GetCursor()).To(Equal(uint64(checkpointSourceLogCount)))
+				g.Expect(progress.GetSourceLogCount()).To(Equal(uint64(checkpointSourceLogCount)))
+				g.Expect(progress.GetState()).To(Equal(commonpb.MirrorSyncState_MIRROR_SYNC_STATE_FOLLOWING))
+
+				txs, err := listAllTransactions(ctx, client, ledgerName, 100, 0)
+				g.Expect(err).To(Succeed())
+				g.Expect(txs).To(HaveLen(checkpointSourceLogCount))
+				g.Expect(txs[0].GetInsertedAt().GetData()).To(Equal(sourceDateMicrosByTxID[0]))
+				g.Expect(txs[0].GetUpdatedAt().GetData()).To(Equal(sourceDateMicrosByTxID[0]))
+			}).Within(60 * time.Second).ProbeEvery(500 * time.Millisecond).Should(Succeed())
+		})
+
+		It("creates a full checkpoint with meaningful mirror state", func() {
+			backupResp, err := clusterClient.Backup(ctx, &clusterpb.BackupRequest{Storage: storage()})
+			Expect(err).To(Succeed())
+			Expect(backupResp.GetTotalFiles()).To(BeNumerically(">", 0))
+		})
+
+		It("syncs source-dated transactions into the post-checkpoint delta", func() {
+			for logID := checkpointSourceLogCount + 1; logID <= sourceLogCount; logID++ {
+				addSourceTransaction(logID)
+			}
+
 			// FOLLOWING requires cursor >= source head, so it pins both that the
 			// worker consumed the whole source and that the FSM advanced the
 			// high-water mark for each ingest.


### PR DESCRIPTION
## What changed

Mirror ingestion now carries the source v2 log date in `MirrorLogEntry` and uses it for created and reverted transactions' `insertedAt` / `updatedAt` fields.
The HTTP source supplies RFC3339 directly, while the PostgreSQL adapter scans a typed timestamp and normalizes it to the same form independently of server `DateStyle`; the FSM rejects mirror transaction commands that omit the source date.
Regression coverage includes CEL rewriting, the `inserted_at` index, and incremental-restore preservation.

## Why

Fixes [EN-1854](https://formance-team.atlassian.net/browse/EN-1854). Long-running v2 migrations currently collapse the source insertion chronology into the much shorter v3 ingestion window, making `inserted_at` range queries and indexes semantically incorrect.

## Product / operational motivation

Need: migrated ledgers must preserve the source transaction insertion chronology used by reconciliation workloads.

Current limitation: mirror-created transactions use the v3 Raft apply date for `insertedAt` and `updatedAt`, so months of source history can appear to have been inserted in a few hours.

Requirement / constraint: created and reverted mirror transactions must expose the corresponding v2 log date through both fields, retain it through CEL rewriting and incremental restore, and keep the business `timestamp` distinct.

Evidence: [EN-1854](https://formance-team.atlassian.net/browse/EN-1854) and the end-to-end `inserted_at` index regression in `tests/e2e/cluster/mirror_test.go`.

Durable repository evidence: `docs/technical/architecture/subsystems/events-mirror/mirror.md`.

## Technical decision

Decision: add a chain-bound `date` to `MirrorLogEntry`, populate it from `V2Log.Date`, and clone it into the resulting transaction log payload. Transaction variants without the date fail before any FSM mutation; synthetic gaps remain dateless. Because v3 is unreleased, the oneof field numbers are realigned sequentially without compatibility shims or reserved fields.

Why now / why proportionate: the v2 log row already carries the only source value that is transactionally aligned with the original v2 insertion time, so propagating it through the existing mirror command is a narrow change with no new subsystem or dependency.

Alternatives considered: keeping the v3 apply time preserves the defect; using the business transaction timestamp changes semantics and is not a proxy for insertion time; silently falling back to apply time on a missing source date would reintroduce corrupt chronology.

## Risk

**MEDIUM** — this changes the pre-GA Raft order wire shape and persisted transaction-log values in the deterministic FSM path. The new field is audit-bound, protobuf fields are sequentially realigned per the v3 policy, and targeted unit/E2E coverage exercises both transaction variants and the query behavior.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `go test ./internal/adapter/v2/... ./internal/domain/processing/... -count=1`
- [x] Affected secondary packages: mirror, checker, usage builder, replay, backup, and raft command protobuf packages
- [x] Focused E2E: 7/7 specs under `When syncing from a v2 source`
- [x] S3 restore regression compiles with `-tags 'e2e s3'`
- [ ] S3 restore regression runtime: unavailable locally because testcontainers found no Docker daemon

Observable evidence: API reads expose the original source microseconds; an `inserted_at` index window returns only the matching source transaction; the restore regression ingests one dated transaction before the full checkpoint and three afterward, restores the non-empty delta, compares every live/restored `insertedAt` / `updatedAt`, and invokes `CheckStore`.

## Architecture / behavior impact

- Changes `MirrorLogEntry`'s pre-GA protobuf wire layout and regenerated bindings.
- Moves mirror transaction insertion/update dates from the v3 apply timestamp to a source-supplied, audit-bound value.
- Preserves the new value through the existing raw ledger-log incremental export and `RebuildDelta` replay.
- No HTTP/gRPC API shape change and no migration or compatibility path, per the unreleased-v3 policy.

## Review focus

- Sequential protobuf field numbering and generated bindings.
- Typed PostgreSQL timestamp scanning, DateStyle-independent normalization, and RFC3339 parsing.
- Deterministic missing-date rejection before mutation and preservation through CEL rewriting.
- Whether the restore and `inserted_at` index regressions observe the intended customer-visible behavior.

## Known concerns

- The tagged S3 restore test could not run locally because no Docker daemon was available; it compiled successfully and should run in an environment with testcontainers support.
- `inserted_at` / `updated_at` ledger-log fields are not currently re-derived by a checker pass. This pre-existing primary-store projection gap is documented by this change but not expanded into EN-1854's scope.


[EN-1854]: https://formance-team.atlassian.net/browse/EN-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1854]: https://formance-team.atlassian.net/browse/EN-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ