### PR TITLE
fix: isolate AI validation caches per run

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -37,7 +37,7 @@ A full PR URL is accepted as well. The launcher:
   Actions status participates in the decision;
 - never checks out or edits the primary checkout;
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
-- removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied.
+- removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied, together with the run directory that holds its triage result, known-findings ledger, and isolated validation caches.
 
 Each invocation owns a unique worktree and never reuses or removes another invocation's directory. Without `--push`, the launcher performs no commit or push and only reports `READY_FOR_HUMAN_REVIEW`, `HUMAN_DECISION_REQUIRED`, `LEGITIMACY_REJECTED`, `BASE_UPDATE_REQUIRED`, or an orchestration error.
 
@@ -296,3 +296,8 @@ run must use a unique temporary validation directory and isolate `HOME`,
 these directories and records `VALIDATION_RUN_ID`; `ai-pr-loop` and
 `ai-pr-adopt-candidate` invoke validation through it. This keeps generated
 files and absolute paths from one concurrent run out of another run's caches.
+
+Those caches live inside the run directory, so `ai-pr-loop` reclaims the whole
+run directory recursively when the run ends without `--keep-worktree`. It does
+so only after both owned worktrees are gone: a preserved worktree — inspectable
+fixes or a failed removal — keeps its run directory and its caches.

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -287,3 +287,12 @@ Because one launcher exit code can cover several outcomes, automation must key o
 ## Safety boundary
 
 `review-loop` itself never posts comments, resolves threads, pushes commits, or merges pull requests. The higher-level `ai-pr-loop` also remains read-only with respect to GitHub by default. Its explicit `--push` mode may create a local candidate commit and update only the existing same-repository PR head branch under the verified lease described above; it still never comments, resolves threads, changes PR metadata, or merges.
+### Hermetic validation environments
+
+Git worktree isolation alone is insufficient for candidate validation. Each
+run must use a unique temporary validation directory and isolate `HOME`,
+`GOCACHE`, `GOMODCACHE`, `GOPATH`, `TMPDIR`, `XDG_CACHE_HOME`, and the
+`golangci-lint` cache. The canonical `agent-validation-env` wrapper creates
+these directories and records `VALIDATION_RUN_ID`; `ai-pr-loop` and
+`ai-pr-adopt-candidate` invoke validation through it. This keeps generated
+files and absolute paths from one concurrent run out of another run's caches.

--- a/scripts/agent-validation-env
+++ b/scripts/agent-validation-env
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: agent-validation-env RUN_DIR COMMAND [ARGS...]" >&2
+    exit 2
+fi
+
+run_dir=$1
+shift
+run_id=${VALIDATION_RUN_ID:-$(basename "$run_dir")}
+
+for name in home go-cache go-mod-cache go-path tmp cache; do
+    mkdir -p "$run_dir/$name"
+done
+
+export VALIDATION_RUN_ID="$run_id"
+export VALIDATION_RUN_DIR="$run_dir"
+export HOME="$run_dir/home"
+export GOCACHE="$run_dir/go-cache"
+export GOMODCACHE="$run_dir/go-mod-cache"
+export GOPATH="$run_dir/go-path"
+export TMPDIR="$run_dir/tmp"
+export XDG_CACHE_HOME="$run_dir/cache"
+export GOLANGCI_LINT_CACHE="$run_dir/cache/golangci-lint"
+mkdir -p "$GOLANGCI_LINT_CACHE"
+
+case "$PWD/" in
+    "$run_dir"/*) ;;
+    *)
+        echo "agent-validation-env: command must run from the isolated run directory" >&2
+        exit 1
+        ;;
+esac
+
+exec "$@"

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -90,9 +90,28 @@ for trusted_tool in ai-review-codex agent-check-pr; do
 done
 nix develop "path:$trusted_worktree" --command env -u GOROOT go -C "$trusted_worktree" build -o "$review_loop_binary" ./scripts/reviewloop
 printf -v review_cmd 'bash %q' "$trusted_worktree/scripts/ai-review-codex"
+# The run directory derives from the repository location, which may contain
+# whitespace or quoting characters such as an apostrophe, and the nested
+# `bash -c` program is shell input too. Quote every interpolated path so the
+# recipe reaches the validator intact.
+printf -v quoted_run_dir %q "$run_dir"
+printf -v quoted_run_id %q "$(basename "$run_dir")"
+printf -v quoted_home %q "$run_dir/home"
+printf -v quoted_go_cache %q "$run_dir/go-cache"
+printf -v quoted_go_mod_cache %q "$run_dir/go-mod-cache"
+printf -v quoted_go_path %q "$run_dir/go-path"
+printf -v quoted_tmp_dir %q "$run_dir/tmp"
+printf -v quoted_cache_home %q "$run_dir/cache"
+printf -v quoted_golangci_cache %q "$run_dir/cache/golangci-lint"
+printf -v quoted_validation_tool %q "$trusted_worktree/scripts/agent-check-pr"
+printf -v nix_validation_program \
+    'mkdir -p %s %s %s %s %s %s && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s' \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
+    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_validation_tool"
 printf -v validation_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
     "path:$trusted_worktree" \
-    "mkdir -p '$run_dir'/home '$run_dir'/go-cache '$run_dir'/go-mod-cache '$run_dir'/go-path '$run_dir'/tmp '$run_dir'/cache/golangci-lint && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME='$run_dir/home' GOCACHE='$run_dir/go-cache' GOMODCACHE='$run_dir/go-mod-cache' GOPATH='$run_dir/go-path' TMPDIR='$run_dir/tmp' XDG_CACHE_HOME='$run_dir/cache' GOLANGCI_LINT_CACHE='$run_dir/cache/golangci-lint' VALIDATION_RUN_ID='$(basename "$run_dir")' VALIDATION_RUN_DIR='$run_dir' bash '$trusted_worktree/scripts/agent-check-pr'"
+    "$nix_validation_program"
 
 cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -90,7 +90,10 @@ for trusted_tool in ai-review-codex agent-check-pr; do
 done
 nix develop "path:$trusted_worktree" --command env -u GOROOT go -C "$trusted_worktree" build -o "$review_loop_binary" ./scripts/reviewloop
 printf -v review_cmd 'bash %q' "$trusted_worktree/scripts/ai-review-codex"
-printf -v validation_cmd 'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q' "path:$trusted_worktree" "$trusted_worktree/scripts/agent-check-pr"
+validation_env_script="$candidate_worktree/scripts/agent-validation-env"
+[[ -x "$trusted_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_worktree/scripts/agent-validation-env"
+printf -v validation_cmd 'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q %q bash %q' \
+    "path:$trusted_worktree" "$validation_env_script" "$run_dir" "$trusted_worktree/scripts/agent-check-pr"
 
 cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -90,10 +90,9 @@ for trusted_tool in ai-review-codex agent-check-pr; do
 done
 nix develop "path:$trusted_worktree" --command env -u GOROOT go -C "$trusted_worktree" build -o "$review_loop_binary" ./scripts/reviewloop
 printf -v review_cmd 'bash %q' "$trusted_worktree/scripts/ai-review-codex"
-validation_env_script="$candidate_worktree/scripts/agent-validation-env"
-[[ -x "$trusted_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_worktree/scripts/agent-validation-env"
-printf -v validation_cmd 'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q %q bash %q' \
-    "path:$trusted_worktree" "$validation_env_script" "$run_dir" "$trusted_worktree/scripts/agent-check-pr"
+printf -v validation_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
+    "path:$trusted_worktree" \
+    "mkdir -p '$run_dir'/home '$run_dir'/go-cache '$run_dir'/go-mod-cache '$run_dir'/go-path '$run_dir'/tmp '$run_dir'/cache/golangci-lint && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME='$run_dir/home' GOCACHE='$run_dir/go-cache' GOMODCACHE='$run_dir/go-mod-cache' GOPATH='$run_dir/go-path' TMPDIR='$run_dir/tmp' XDG_CACHE_HOME='$run_dir/cache' GOLANGCI_LINT_CACHE='$run_dir/cache/golangci-lint' VALIDATION_RUN_ID='$(basename "$run_dir")' VALIDATION_RUN_DIR='$run_dir' bash '$trusted_worktree/scripts/agent-check-pr'"
 
 cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -332,8 +332,9 @@ review_loop=("$review_loop_binary")
 printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-known-findings"
 fix_cmd='bash scripts/ai-fix-claude'
 # review-loop executes the validation command through `bash -lc`, and the run
-# directory derives from the repository location, which may contain whitespace.
-# Quote every interpolated path so the recipe reaches the validator intact.
+# directory derives from the repository location, which may contain whitespace or
+# quoting characters such as an apostrophe. Quote every interpolated path so the
+# recipe reaches the validator intact.
 printf -v quoted_run_dir %q "$worktree_run_dir"
 printf -v quoted_run_id %q "$(basename "$worktree_run_dir")"
 printf -v quoted_home %q "$worktree_run_dir/home"
@@ -355,10 +356,17 @@ if [[ "$push_changes" == "true" ]]; then
         fi
     done
     printf -v fix_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-fix-claude"
+    # The nested `bash -c` program is shell input too, so it must be assembled
+    # from the same shell-safe values rather than from literal single quotes.
+    printf -v nix_validation_program \
+        'mkdir -p %s %s %s %s %s %s && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s' \
+        "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
+        "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
+        "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_validation_tool"
     printf -v validation_cmd \
         'env -u GOROOT nix develop %q --command bash -c %q' \
         "path:$trusted_tool_worktree" \
-        "mkdir -p '$worktree_run_dir'/home '$worktree_run_dir'/go-cache '$worktree_run_dir'/go-mod-cache '$worktree_run_dir'/go-path '$worktree_run_dir'/tmp '$worktree_run_dir'/cache/golangci-lint && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME='$worktree_run_dir/home' GOCACHE='$worktree_run_dir/go-cache' GOMODCACHE='$worktree_run_dir/go-mod-cache' GOPATH='$worktree_run_dir/go-path' TMPDIR='$worktree_run_dir/tmp' XDG_CACHE_HOME='$worktree_run_dir/cache' GOLANGCI_LINT_CACHE='$worktree_run_dir/cache/golangci-lint' VALIDATION_RUN_ID='$(basename "$worktree_run_dir")' VALIDATION_RUN_DIR='$worktree_run_dir' bash '$trusted_tool_worktree/scripts/agent-check-pr'"
+        "$nix_validation_program"
 fi
 
 if [[ "$bugfix_intent" == bugfix ]]; then

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -187,12 +187,25 @@ cleanup() {
         rm -f -- "$review_loop_binary"
     fi
     if [[ "$keep_worktree" == false ]]; then
+        # The loop runs from inside the worktree that is about to be removed;
+        # leave it first so removal never operates on the current directory.
+        cd "$repo_root" || true
         if [[ -d "$worktree" ]] && git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             if [[ -z "$(git -C "$worktree" status --porcelain 2>/dev/null || true)" ]]; then
                 git worktree remove "$worktree" >/dev/null 2>&1 || true
             fi
         fi
-        rmdir "$worktree_run_dir" >/dev/null 2>&1 || true
+        # Validation isolates HOME, the Go caches, and TMPDIR inside the run
+        # directory, so a clean run cannot be reclaimed by an empty-directory
+        # rmdir. Remove the launcher-created tree recursively, but only once both
+        # owned worktrees are gone, so a preserved worktree — dirty fixes or a
+        # failed removal — is never destroyed with it.
+        if [[ ! -e "$worktree" && ! -e "$trusted_tool_worktree" ]] &&
+            [[ "$worktree_run_dir" == "$worktree_parent/pr-$pr_number."?????? ]]; then
+            rm -rf -- "$worktree_run_dir"
+        else
+            rmdir "$worktree_run_dir" >/dev/null 2>&1 || true
+        fi
     fi
     exit "$exit_status"
 }

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -331,9 +331,7 @@ nix develop "path:$trusted_tool_worktree" --command \
 review_loop=("$review_loop_binary")
 printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-known-findings"
 fix_cmd='bash scripts/ai-fix-claude'
-    validation_env_script="$worktree/scripts/agent-validation-env"
-    [[ -x "$trusted_tool_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_tool_worktree/scripts/agent-validation-env"
-    validation_cmd="bash $validation_env_script $worktree_run_dir bash $trusted_tool_worktree/scripts/agent-check-pr"
+    validation_cmd="mkdir -p $worktree_run_dir/home $worktree_run_dir/go-cache $worktree_run_dir/go-mod-cache $worktree_run_dir/go-path $worktree_run_dir/tmp $worktree_run_dir/cache/golangci-lint && env HOME=$worktree_run_dir/home GOCACHE=$worktree_run_dir/go-cache GOMODCACHE=$worktree_run_dir/go-mod-cache GOPATH=$worktree_run_dir/go-path TMPDIR=$worktree_run_dir/tmp XDG_CACHE_HOME=$worktree_run_dir/cache GOLANGCI_LINT_CACHE=$worktree_run_dir/cache/golangci-lint VALIDATION_RUN_ID=$(basename $worktree_run_dir) VALIDATION_RUN_DIR=$worktree_run_dir bash $trusted_tool_worktree/scripts/agent-check-pr"
 if [[ "$push_changes" == "true" ]]; then
     # Publication additionally base-pins the mutating fixer and validator.
     for trusted_tool in ai-fix-claude agent-check-pr agent-just; do
@@ -344,14 +342,10 @@ if [[ "$push_changes" == "true" ]]; then
         fi
     done
     printf -v fix_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-fix-claude"
-    validation_env_script="$worktree/scripts/agent-validation-env"
-    [[ -x "$trusted_tool_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_tool_worktree/scripts/agent-validation-env"
     printf -v validation_cmd \
-        'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q %q bash %q' \
+        'env -u GOROOT nix develop %q --command bash -c %q' \
         "path:$trusted_tool_worktree" \
-        "$validation_env_script" \
-        "$worktree_run_dir" \
-        "$trusted_tool_worktree/scripts/agent-check-pr"
+        "mkdir -p '$worktree_run_dir'/home '$worktree_run_dir'/go-cache '$worktree_run_dir'/go-mod-cache '$worktree_run_dir'/go-path '$worktree_run_dir'/tmp '$worktree_run_dir'/cache/golangci-lint && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME='$worktree_run_dir/home' GOCACHE='$worktree_run_dir/go-cache' GOMODCACHE='$worktree_run_dir/go-mod-cache' GOPATH='$worktree_run_dir/go-path' TMPDIR='$worktree_run_dir/tmp' XDG_CACHE_HOME='$worktree_run_dir/cache' GOLANGCI_LINT_CACHE='$worktree_run_dir/cache/golangci-lint' VALIDATION_RUN_ID='$(basename "$worktree_run_dir")' VALIDATION_RUN_DIR='$worktree_run_dir' bash '$trusted_tool_worktree/scripts/agent-check-pr'"
 fi
 
 if [[ "$bugfix_intent" == bugfix ]]; then

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -331,7 +331,20 @@ nix develop "path:$trusted_tool_worktree" --command \
 review_loop=("$review_loop_binary")
 printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-known-findings"
 fix_cmd='bash scripts/ai-fix-claude'
-    validation_cmd="mkdir -p $worktree_run_dir/home $worktree_run_dir/go-cache $worktree_run_dir/go-mod-cache $worktree_run_dir/go-path $worktree_run_dir/tmp $worktree_run_dir/cache/golangci-lint && env HOME=$worktree_run_dir/home GOCACHE=$worktree_run_dir/go-cache GOMODCACHE=$worktree_run_dir/go-mod-cache GOPATH=$worktree_run_dir/go-path TMPDIR=$worktree_run_dir/tmp XDG_CACHE_HOME=$worktree_run_dir/cache GOLANGCI_LINT_CACHE=$worktree_run_dir/cache/golangci-lint VALIDATION_RUN_ID=$(basename $worktree_run_dir) VALIDATION_RUN_DIR=$worktree_run_dir bash $trusted_tool_worktree/scripts/agent-check-pr"
+# review-loop executes the validation command through `bash -lc`, and the run
+# directory derives from the repository location, which may contain whitespace.
+# Quote every interpolated path so the recipe reaches the validator intact.
+printf -v quoted_run_dir %q "$worktree_run_dir"
+printf -v quoted_run_id %q "$(basename "$worktree_run_dir")"
+printf -v quoted_home %q "$worktree_run_dir/home"
+printf -v quoted_go_cache %q "$worktree_run_dir/go-cache"
+printf -v quoted_go_mod_cache %q "$worktree_run_dir/go-mod-cache"
+printf -v quoted_go_path %q "$worktree_run_dir/go-path"
+printf -v quoted_tmp_dir %q "$worktree_run_dir/tmp"
+printf -v quoted_cache_home %q "$worktree_run_dir/cache"
+printf -v quoted_golangci_cache %q "$worktree_run_dir/cache/golangci-lint"
+printf -v quoted_validation_tool %q "$trusted_tool_worktree/scripts/agent-check-pr"
+validation_cmd="mkdir -p $quoted_home $quoted_go_cache $quoted_go_mod_cache $quoted_go_path $quoted_tmp_dir $quoted_golangci_cache && env HOME=$quoted_home GOCACHE=$quoted_go_cache GOMODCACHE=$quoted_go_mod_cache GOPATH=$quoted_go_path TMPDIR=$quoted_tmp_dir XDG_CACHE_HOME=$quoted_cache_home GOLANGCI_LINT_CACHE=$quoted_golangci_cache VALIDATION_RUN_ID=$quoted_run_id VALIDATION_RUN_DIR=$quoted_run_dir bash $quoted_validation_tool"
 if [[ "$push_changes" == "true" ]]; then
     # Publication additionally base-pins the mutating fixer and validator.
     for trusted_tool in ai-fix-claude agent-check-pr agent-just; do

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -331,7 +331,9 @@ nix develop "path:$trusted_tool_worktree" --command \
 review_loop=("$review_loop_binary")
 printf -v review_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-review-known-findings"
 fix_cmd='bash scripts/ai-fix-claude'
-validation_cmd='bash scripts/agent-check-pr'
+    validation_env_script="$worktree/scripts/agent-validation-env"
+    [[ -x "$trusted_tool_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_tool_worktree/scripts/agent-validation-env"
+    validation_cmd="bash $validation_env_script $worktree_run_dir bash $trusted_tool_worktree/scripts/agent-check-pr"
 if [[ "$push_changes" == "true" ]]; then
     # Publication additionally base-pins the mutating fixer and validator.
     for trusted_tool in ai-fix-claude agent-check-pr agent-just; do
@@ -342,9 +344,13 @@ if [[ "$push_changes" == "true" ]]; then
         fi
     done
     printf -v fix_cmd 'bash %q' "$trusted_tool_worktree/scripts/ai-fix-claude"
+    validation_env_script="$worktree/scripts/agent-validation-env"
+    [[ -x "$trusted_tool_worktree/scripts/agent-validation-env" ]] && validation_env_script="$trusted_tool_worktree/scripts/agent-validation-env"
     printf -v validation_cmd \
-        'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q' \
+        'env -u GOROOT nix develop %q --command env LEDGER_AGENT_CHECK_IN_NIX=1 bash %q %q bash %q' \
         "path:$trusted_tool_worktree" \
+        "$validation_env_script" \
+        "$worktree_run_dir" \
         "$trusted_tool_worktree/scripts/agent-check-pr"
 fi
 

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -170,6 +170,26 @@ func TestLauncherRefusesKnownFindingsForAnotherTarget(t *testing.T) {
 	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (known findings target mismatch)")
 }
 
+func TestLauncherRemovesTheRunDirectoryOfACleanRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newLauncherFixture(t)
+	capture := filepath.Join(fixture.root, "review-args")
+	// Validation isolates HOME and the Go caches inside the run directory, so a
+	// completed run without --keep-worktree must reclaim that whole directory.
+	output, err := runLauncherWithFlags(t, fixture, capture, triageResult{decision: "KEEP"}, nil,
+		[]string{"TEST_RUN_VALIDATION_CMD=1"})
+	require.NoError(t, err, output)
+	require.Contains(t, output, "Worktree is clean.")
+
+	isolatedCaches := readCapturedFile(t, capture+".rundir")
+	for _, cache := range []string{"home", "go-cache", "go-mod-cache", "go-path", "tmp", "cache"} {
+		require.Contains(t, strings.Split(isolatedCaches, "\n"), cache,
+			"validation must have populated the run directory")
+	}
+	require.NoDirExists(t, filepath.Dir(worktreeFromOutput(t, output)))
+}
+
 func TestLauncherTreatsTriageFailureAsOrchestrationError(t *testing.T) {
 	fixture := newLauncherFixture(t)
 	capture := filepath.Join(fixture.root, "review-args")
@@ -212,6 +232,20 @@ set -euo pipefail
 printf '%s\n' "$@" > "$TEST_CAPTURE_FILE"
 printf '%s\n' "${AI_REVIEW_KNOWN_FINDINGS:-}" > "$TEST_CAPTURE_FILE.known"
 printf '%s|%s\n' "${AI_REVIEW_KNOWN_FINDINGS_PR:-}" "${AI_REVIEW_KNOWN_FINDINGS_HEAD:-}" > "$TEST_CAPTURE_FILE.binding"
+if [[ -n "${TEST_RUN_VALIDATION_CMD:-}" ]]; then
+    validation_cmd=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --validation-cmd) validation_cmd=$2; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    # review-loop runs the validation recipe through bash -lc from the worktree.
+    # The recipe first creates the isolated caches in the parent run directory,
+    # then invokes the trusted validator, which this fixture does not provide.
+    bash -lc "$validation_cmd" >/dev/null 2>&1 || true
+    ls -1 "$(dirname "$PWD")" > "$TEST_CAPTURE_FILE.rundir"
+fi
 `)
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-known-findings"), "#!/usr/bin/env bash\nexit 0\n")
@@ -326,13 +360,27 @@ type triageResult struct {
 
 func runLauncher(t *testing.T, fixture launcherFixture, capturePath string, triage triageResult, extraEnv ...string) (string, error) {
 	t.Helper()
+
+	return runLauncherWithFlags(t, fixture, capturePath, triage, []string{"--keep-worktree"}, extraEnv)
+}
+
+func runLauncherWithFlags(
+	t *testing.T,
+	fixture launcherFixture,
+	capturePath string,
+	triage triageResult,
+	flags []string,
+	extraEnv []string,
+) (string, error) {
+	t.Helper()
 	if triage.baseSHA == "" {
 		triage.baseSHA = fixture.baseSHA
 	}
 	if triage.headSHA == "" {
 		triage.headSHA = fixture.headSHA
 	}
-	command := exec.Command("bash", filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123", "--keep-worktree")
+	arguments := append([]string{filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123"}, flags...)
+	command := exec.Command("bash", arguments...)
 	command.Dir = fixture.checkout
 	command.Env = append(os.Environ(),
 		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -73,11 +73,26 @@ func TestPushRefusesBaseWithoutTrustedValidator(t *testing.T) {
 	require.Equal(t, fixture.headSHA, remoteHead)
 }
 
+func TestPushQuotesValidationPathsContainingAnApostrophe(t *testing.T) {
+	t.Parallel()
+
+	// The run directory inherits the repository parent path, so the guarded
+	// validation recipe must survive a checkout such as `/tmp/user's repo`.
+	fixture := newPushFixture(t, pushFixtureOptions{quotedRepositoryParent: true})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 0, exitCode, output)
+	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+}
+
 type pushFixtureOptions struct {
 	moveRemote            bool
 	moveLocalHead         bool
 	tamperTargetToolchain bool
 	omitTrustedValidator  bool
+
+	// quotedRepositoryParent nests the repository under a parent directory whose
+	// name contains an apostrophe, which the run directory inherits.
+	quotedRepositoryParent bool
 }
 
 type pushFixture struct {
@@ -95,6 +110,10 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	t.Helper()
 
 	root := t.TempDir()
+	if options.quotedRepositoryParent {
+		root = filepath.Join(root, "ai loop's fixtures")
+		require.NoError(t, os.MkdirAll(root, 0o755))
+	}
 	remote := filepath.Join(root, "remote.git")
 	seed := filepath.Join(root, "seed")
 	checkout := filepath.Join(root, "checkout")
@@ -188,7 +207,7 @@ case "$review_cmd" in
     *trusted-tools/scripts/ai-review-known-findings) ;;
     *) exit 95 ;;
 esac
-review_script=${review_cmd#bash }
+eval "review_script=${review_cmd#bash }"
 trusted_root=$(git -C "$(dirname "$review_script")" rev-parse --show-toplevel)
 grep -qx 'trusted known-findings contract' "$trusted_root/docs/technical/contributing/ai-pr-known-findings.md" || exit 91
 [[ -n "${AI_REVIEW_KNOWN_FINDINGS:-}" && -f "$AI_REVIEW_KNOWN_FINDINGS" ]] || exit 92
@@ -198,7 +217,13 @@ if [[ -n "$fix_cmd" ]]; then
         *) exit 94 ;;
     esac
 fi
-case "$validation_cmd" in
+# The guarded validation recipe nests a program inside bash -c, so that
+# program must itself be valid shell input for any repository path.
+validation_words=()
+eval "validation_words=($validation_cmd)"
+validation_program=${validation_words[$((${#validation_words[@]} - 1))]}
+bash -n -c "$validation_program" || exit 90
+case "$validation_program" in
     *trusted-tools/scripts/agent-check-pr) ;;
     *) exit 93 ;;
 esac


### PR DESCRIPTION
Hardens candidate validation against cross-run cache contamination.

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
BASELINE_CLASSIFICATION: ENVIRONMENTAL

This PR intentionally carries the trusted bugfix workflow gates required by release/v3.0 before the isolation change: discovery and BEFORE/AFTER evidence gates, baseline classification, Nix toolchain gate, pre-commit/clean-worktree gate, and exact-candidate binding. These policies are required by the real EN-1861/#1771 and EN-1865/#1772 remediation failures (Go 1.27 swiss mismatch, Dirty import formatting, and cross-worktree lint/protobuf cache contamination). The new change adds per-run HOME, GOCACHE, GOMODCACHE, GOPATH, TMPDIR, XDG_CACHE_HOME, and GOLANGCI_LINT_CACHE isolation.

Validation: shell isolation test and diff checks under Go 1.26.5 Nix.