### PR TITLE
fix: normalize AI candidates before exact review

### DIFF
--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -301,3 +301,13 @@ Those caches live inside the run directory, so `ai-pr-loop` reclaims the whole
 run directory recursively when the run ends without `--keep-worktree`. It does
 so only after both owned worktrees are gone: a preserved worktree — inspectable
 fixes or a failed removal — keeps its run directory and its caches.
+
+### Candidate normalization
+
+Candidate publication normalizes the candidate before assigning its final SHA.
+The trusted base-pinned `just pre-commit` recipe runs in the isolated validation
+environment; any resulting tree changes are logged, checked with `git diff
+--check`, committed as normalization, and rechecked. This repeats to a bounded
+fixpoint (three passes by default). Only the converged SHA is reviewed and
+published. A candidate supplied to `ai-pr-adopt-candidate` is immutable: if it
+needs normalization, adoption refuses rather than silently changing the SHA.

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -116,6 +116,14 @@ printf -v validation_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
 cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }
 
+# An adopted SHA must already be normalized; never mutate it silently.
+bash "$trusted_worktree/scripts/agent-just" pre-commit
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "CANDIDATE_NEEDS_NORMALIZATION"
+    echo "AI_PR_ADOPT_RESULT: REFUSED (candidate is not normalized)"
+    exit 1
+fi
+
 set +e
 "$review_loop_binary" --base "$base_sha" --review-cmd "$review_cmd" --validation-cmd "$validation_cmd"
 review_status=$?

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -104,6 +104,14 @@ printf -v quoted_tmp_dir %q "$run_dir/tmp"
 printf -v quoted_cache_home %q "$run_dir/cache"
 printf -v quoted_golangci_cache %q "$run_dir/cache/golangci-lint"
 printf -v quoted_validation_tool %q "$trusted_worktree/scripts/agent-check-pr"
+printf -v quoted_agent_just %q "$trusted_worktree/scripts/agent-just"
+printf -v normalization_program \
+    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s pre-commit' \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
+    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_agent_just"
+printf -v normalization_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
+    "path:$trusted_worktree" "$normalization_program"
 printf -v nix_validation_program \
     'mkdir -p %s %s %s %s %s %s && env LEDGER_AGENT_CHECK_IN_NIX=1 HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s' \
     "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
@@ -117,7 +125,7 @@ cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }
 
 # An adopted SHA must already be normalized; never mutate it silently.
-bash "$trusted_worktree/scripts/agent-just" pre-commit
+bash -c "$normalization_cmd"
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "CANDIDATE_NEEDS_NORMALIZATION"
     echo "AI_PR_ADOPT_RESULT: REFUSED (candidate is not normalized)"

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -123,6 +123,11 @@ printf -v validation_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
 
 cd "$candidate_worktree"
 [[ -z "$(git status --porcelain)" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate worktree is dirty before review)"; exit 1; }
+git diff --check "$base_sha" "$candidate_sha" || {
+    echo "CANDIDATE_NEEDS_NORMALIZATION"
+    echo "AI_PR_ADOPT_RESULT: REFUSED (candidate contains whitespace errors)"
+    exit 1
+}
 
 # An adopted SHA must already be normalized; never mutate it silently.
 bash -c "$normalization_cmd"

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -522,6 +522,15 @@ if [[ -z "$(git status --porcelain)" ]]; then
     exit 0
 fi
 
+# Normalize deterministic changes before creating the candidate SHA.
+echo "==> ai-pr-loop: pre-commit normalization"
+bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "PRECOMMIT_NORMALIZATION: CHANGES"
+else
+    echo "PRECOMMIT_NORMALIZATION: NO_CHANGES"
+fi
+
 git add -A
 if git diff --cached --quiet; then
     echo "ai-pr-loop: worktree reported changes but nothing is staged" >&2

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -542,6 +542,26 @@ git commit -m "fix: address AI review findings"
 candidate_sha=$(git rev-parse HEAD)
 printf '==> ai-pr-loop: candidate commit %s\n' "$candidate_sha"
 
+normalization_pass=1
+while [[ "$normalization_pass" -le 3 ]]; do
+    bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+    if [[ -z "$(git status --porcelain)" ]]; then
+        echo "PRECOMMIT_FIXPOINT: PASS"
+        break
+    fi
+    echo "PRECOMMIT_NORMALIZATION: CHANGES_COMMITTED (pass $normalization_pass)"
+    git add -A
+    git diff --cached --check
+    git commit -m "chore: normalize candidate"
+    candidate_sha=$(git rev-parse HEAD)
+    normalization_pass=$((normalization_pass + 1))
+done
+if [[ "$normalization_pass" -gt 3 && -n "$(git status --porcelain)" ]]; then
+    echo "PRECOMMIT_NON_DETERMINISTIC: refusing candidate publication" >&2
+    keep_worktree=true
+    exit 1
+fi
+
 set +e
 run_commit_review
 commit_review_status=$?

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -537,6 +537,8 @@ if [[ -n "$(git status --porcelain)" ]]; then
     echo "PRECOMMIT_NORMALIZATION: CHANGES"
 else
     echo "PRECOMMIT_NORMALIZATION: NO_CHANGES"
+    echo "AI_PR_LOOP_PUSH_RESULT: NO_CHANGES"
+    exit 0
 fi
 
 git add -A

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -358,6 +358,14 @@ printf -v quoted_tmp_dir %q "$worktree_run_dir/tmp"
 printf -v quoted_cache_home %q "$worktree_run_dir/cache"
 printf -v quoted_golangci_cache %q "$worktree_run_dir/cache/golangci-lint"
 printf -v quoted_validation_tool %q "$trusted_tool_worktree/scripts/agent-check-pr"
+printf -v quoted_agent_just %q "$trusted_tool_worktree/scripts/agent-just"
+printf -v normalization_program \
+    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s pre-commit' \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
+    "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
+    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_agent_just"
+printf -v normalization_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
+    "path:$trusted_tool_worktree" "$normalization_program"
 validation_cmd="mkdir -p $quoted_home $quoted_go_cache $quoted_go_mod_cache $quoted_go_path $quoted_tmp_dir $quoted_golangci_cache && env HOME=$quoted_home GOCACHE=$quoted_go_cache GOMODCACHE=$quoted_go_mod_cache GOPATH=$quoted_go_path TMPDIR=$quoted_tmp_dir XDG_CACHE_HOME=$quoted_cache_home GOLANGCI_LINT_CACHE=$quoted_golangci_cache VALIDATION_RUN_ID=$quoted_run_id VALIDATION_RUN_DIR=$quoted_run_dir bash $quoted_validation_tool"
 if [[ "$push_changes" == "true" ]]; then
     # Publication additionally base-pins the mutating fixer and validator.
@@ -524,7 +532,7 @@ fi
 
 # Normalize deterministic changes before creating the candidate SHA.
 echo "==> ai-pr-loop: pre-commit normalization"
-bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+bash -c "$normalization_cmd"
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "PRECOMMIT_NORMALIZATION: CHANGES"
 else
@@ -544,7 +552,7 @@ printf '==> ai-pr-loop: candidate commit %s\n' "$candidate_sha"
 
 normalization_pass=1
 while [[ "$normalization_pass" -le 3 ]]; do
-    bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+    bash -c "$normalization_cmd"
     if [[ -z "$(git status --porcelain)" ]]; then
         echo "PRECOMMIT_FIXPOINT: PASS"
         break
@@ -558,7 +566,7 @@ while [[ "$normalization_pass" -le 3 ]]; do
 done
 # Always perform a final read of the trusted recipe after the last allowed
 # normalization commit. This proves the reviewed SHA is actually converged.
-bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+bash -c "$normalization_cmd"
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "PRECOMMIT_NON_DETERMINISTIC: refusing candidate publication" >&2
     keep_worktree=true

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -545,6 +545,7 @@ if git diff --cached --quiet; then
     keep_worktree=true
     exit 1
 fi
+git diff --cached --check
 
 git commit -m "fix: address AI review findings"
 candidate_sha=$(git rev-parse HEAD)

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -556,11 +556,15 @@ while [[ "$normalization_pass" -le 3 ]]; do
     candidate_sha=$(git rev-parse HEAD)
     normalization_pass=$((normalization_pass + 1))
 done
-if [[ "$normalization_pass" -gt 3 && -n "$(git status --porcelain)" ]]; then
+# Always perform a final read of the trusted recipe after the last allowed
+# normalization commit. This proves the reviewed SHA is actually converged.
+bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+if [[ -n "$(git status --porcelain)" ]]; then
     echo "PRECOMMIT_NON_DETERMINISTIC: refusing candidate publication" >&2
     keep_worktree=true
     exit 1
 fi
+echo "PRECOMMIT_FIXPOINT: PASS"
 
 set +e
 run_commit_review

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -291,10 +291,14 @@ case "$1 $2" in
         ;;
 esac
 `)
-	writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
+writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
 set -euo pipefail
 source_root=""
 output=""
+if [[ " $* " == *" --command bash -c "* ]]; then
+    eval "${@: -1}"
+    exit $?
+fi
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -C)

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -291,7 +291,7 @@ case "$1 $2" in
         ;;
 esac
 `)
-writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
+	writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
 set -euo pipefail
 source_root=""
 output=""


### PR DESCRIPTION
## Scope
Move trusted pre-commit normalization before candidate SHA creation and exact review. Adopted SHAs are rejected as CANDIDATE_NEEDS_NORMALIZATION rather than mutated.

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
BASELINE_CLASSIFICATION: ENVIRONMENTAL

This is workflow tooling only; no runtime behavior changes.