### PR TITLE
fix(operator): configure ledgerctl in cluster pods

### DIFF
--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -343,7 +343,7 @@ Once a learner has caught up with the leader's log (within the threshold configu
 The operator configures the `ledgerctl` binary shipped in every ledger pod with
 the pod's own headless DNS address and the transport credentials matching the
 current TLS mode. After entering a pod, commands therefore work without
-connection flags:
+connection flags when the operator-managed headless Service is enabled:
 
 ```bash
 ledgerctl cluster status
@@ -352,10 +352,13 @@ ledgerctl ledgers list
 
 The injected `LEDGERCTL_SERVER` uses the pod DNS name covered by the TLS
 certificate rather than `localhost` or `127.0.0.1`. For TLS clusters the
-operator also injects `LEDGERCTL_TLS_CA_CERT` and `LEDGERCTL_AUTH_TOKEN`; for a
-plaintext cluster it injects `LEDGERCTL_INSECURE=true`. These values follow TLS
-mode transitions through StatefulSet rollouts. `spec.extraEnv` can override an
-injected `LEDGERCTL_*` value when a deployment needs custom client behavior.
+operator injects `LEDGERCTL_AUTH_TOKEN` and, when `tls.caSecretKey` is
+configured, `LEDGERCTL_TLS_CA_CERT`; for a plaintext cluster it injects
+`LEDGERCTL_INSECURE=true`. These values follow TLS mode transitions through
+StatefulSet rollouts. If `headlessService.enabled` is `false`, `spec.extraEnv`
+must override `LEDGERCTL_SERVER` with a resolvable address. `spec.extraEnv` can
+also override any other injected `LEDGERCTL_*` value when a deployment needs
+custom client behavior.
 
 ### Disk Space Limiting
 

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -338,6 +338,25 @@ Pod 0 uses the `--bootstrap` flag to create a new single-node cluster. All subse
 
 Once a learner has caught up with the leader's log (within the threshold configured by `--learner-promotion-threshold`, default: 100 entries), it is automatically promoted to a full voting member.
 
+### Using ledgerctl inside a cluster pod
+
+The operator configures the `ledgerctl` binary shipped in every ledger pod with
+the pod's own headless DNS address and the transport credentials matching the
+current TLS mode. After entering a pod, commands therefore work without
+connection flags:
+
+```bash
+ledgerctl cluster status
+ledgerctl ledgers list
+```
+
+The injected `LEDGERCTL_SERVER` uses the pod DNS name covered by the TLS
+certificate rather than `localhost` or `127.0.0.1`. For TLS clusters the
+operator also injects `LEDGERCTL_TLS_CA_CERT` and `LEDGERCTL_AUTH_TOKEN`; for a
+plaintext cluster it injects `LEDGERCTL_INSECURE=true`. These values follow TLS
+mode transitions through StatefulSet rollouts. `spec.extraEnv` can override an
+injected `LEDGERCTL_*` value when a deployment needs custom client behavior.
+
 ### Disk Space Limiting
 
 The cluster monitors disk usage across all nodes and rejects write operations when usage exceeds configurable thresholds. See [Disk Space Limiting](./disk-space.md) for detailed architecture documentation.

--- a/misc/operator/internal/controller/envvars.go
+++ b/misc/operator/internal/controller/envvars.go
@@ -39,6 +39,18 @@ func boolEnv(name string, value bool) corev1.EnvVar {
 	return corev1.EnvVar{Name: name, Value: strconv.FormatBool(value)}
 }
 
+func secretKeyEnv(name, secretName, secretKey string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+				Key:                  secretKey,
+			},
+		},
+	}
+}
+
 // appendIfStr appends an env var if the string value is non-empty.
 func appendIfStr(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
 	if value != "" {
@@ -266,6 +278,25 @@ func buildEnvVars(ledger *ledgerv1alpha1.Cluster, targetTLSMode string, credenti
 		if spec.TLS != nil && spec.TLS.CASecretKey != "" {
 			envs = append(envs, strEnv("TLS_CA_CERT_FILE", "/tls/"+spec.TLS.CASecretKey))
 		}
+	}
+
+	// Make the ledgerctl binary shipped in the ledger image immediately usable
+	// from an interactive pod shell. The pod's headless DNS is covered by the
+	// cluster certificate, unlike localhost/127.0.0.1, and avoids the
+	// IPv6 localhost resolution mismatch when the server listens on IPv4 only.
+	ledgerctlServer := fmt.Sprintf("$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:%d", hlsSvcName, spec.GrpcPort)
+	envs = append(envs, strEnv("LEDGERCTL_SERVER", ledgerctlServer))
+	if targetTLSMode == tlsModeDisabled {
+		envs = append(envs, boolEnv("LEDGERCTL_INSECURE", true))
+	} else {
+		if spec.TLS != nil && spec.TLS.CASecretKey != "" {
+			envs = append(envs, strEnv("LEDGERCTL_TLS_CA_CERT", "/tls/"+spec.TLS.CASecretKey))
+		}
+		envs = append(envs, secretKeyEnv(
+			"LEDGERCTL_AUTH_TOKEN",
+			clusterSecretName(ledger.Name),
+			clusterSecretKey,
+		))
 	}
 
 	// GOMEMLIMIT: set to a percentage of memory limit if available.

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -1378,6 +1378,46 @@ func TestBuildEnvVars_AdvertiseAddr_UsesRaftPort(t *testing.T) {
 	})
 }
 
+func TestBuildEnvVars_LedgerctlConnection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plaintext cluster", func(t *testing.T) {
+		t.Parallel()
+		ls := newMinimalCluster()
+		ls.Spec.GrpcPort = 18888
+
+		envs := buildEnvVars(ls, tlsModeDisabled, nil)
+
+		assertEnv(t, envs, "LEDGERCTL_SERVER",
+			"$(POD_NAME).ledger-test-headless.$(POD_NAMESPACE).svc.cluster.local:18888")
+		assertEnv(t, envs, "LEDGERCTL_INSECURE", "true")
+		assertNoEnv(t, envs, "LEDGERCTL_TLS_CA_CERT")
+		assertNoEnv(t, envs, "LEDGERCTL_AUTH_TOKEN")
+	})
+
+	for _, tlsMode := range []string{tlsModeOptional, tlsModeRequired} {
+		t.Run(tlsMode+" TLS cluster", func(t *testing.T) {
+			t.Parallel()
+			ls := newMinimalCluster()
+			ls.Spec.TLS = &ledgerv1alpha1.TLSConfig{CASecretKey: "ca.crt"}
+
+			envs := buildEnvVars(ls, tlsMode, nil)
+
+			assertEnv(t, envs, "LEDGERCTL_SERVER",
+				"$(POD_NAME).ledger-test-headless.$(POD_NAMESPACE).svc.cluster.local:8888")
+			assertNoEnv(t, envs, "LEDGERCTL_INSECURE")
+			assertEnv(t, envs, "LEDGERCTL_TLS_CA_CERT", "/tls/ca.crt")
+
+			authToken := findEnv(envs, "LEDGERCTL_AUTH_TOKEN")
+			require.NotNil(t, authToken)
+			require.NotNil(t, authToken.ValueFrom)
+			require.NotNil(t, authToken.ValueFrom.SecretKeyRef)
+			require.Equal(t, clusterSecretName(ls.Name), authToken.ValueFrom.SecretKeyRef.Name)
+			require.Equal(t, clusterSecretKey, authToken.ValueFrom.SecretKeyRef.Key)
+		})
+	}
+}
+
 func TestRaftPortFromBindAddr(t *testing.T) {
 	t.Parallel()
 

--- a/misc/operator/internal/controller/envvars_test.go
+++ b/misc/operator/internal/controller/envvars_test.go
@@ -1416,6 +1416,26 @@ func TestBuildEnvVars_LedgerctlConnection(t *testing.T) {
 			require.Equal(t, clusterSecretKey, authToken.ValueFrom.SecretKeyRef.Key)
 		})
 	}
+
+	t.Run("TLS cluster without configured CA", func(t *testing.T) {
+		t.Parallel()
+		ls := newMinimalCluster()
+		ls.Spec.TLS = &ledgerv1alpha1.TLSConfig{}
+
+		envs := buildEnvVars(ls, tlsModeRequired, nil)
+
+		assertEnv(t, envs, "LEDGERCTL_SERVER",
+			"$(POD_NAME).ledger-test-headless.$(POD_NAMESPACE).svc.cluster.local:8888")
+		assertNoEnv(t, envs, "LEDGERCTL_INSECURE")
+		assertNoEnv(t, envs, "LEDGERCTL_TLS_CA_CERT")
+
+		authToken := findEnv(envs, "LEDGERCTL_AUTH_TOKEN")
+		require.NotNil(t, authToken)
+		require.NotNil(t, authToken.ValueFrom)
+		require.NotNil(t, authToken.ValueFrom.SecretKeyRef)
+		require.Equal(t, clusterSecretName(ls.Name), authToken.ValueFrom.SecretKeyRef.Name)
+		require.Equal(t, clusterSecretKey, authToken.ValueFrom.SecretKeyRef.Key)
+	})
 }
 
 func TestRaftPortFromBindAddr(t *testing.T) {

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -415,17 +415,11 @@ func buildPodTemplate(ledger *ledgerv1alpha1.Cluster, specHash string, credentia
 	// optional mode (rolling update phase 1), so pods on either side of
 	// the rollout see consistent behavior.
 	if shouldInjectClusterSecret(targetTLSMode) {
-		envVars = append(envVars, corev1.EnvVar{
-			Name: "CLUSTER_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: clusterSecretName(ledger.Name),
-					},
-					Key: clusterSecretKey,
-				},
-			},
-		})
+		envVars = append(envVars, secretKeyEnv(
+			"CLUSTER_SECRET",
+			clusterSecretName(ledger.Name),
+			clusterSecretKey,
+		))
 	}
 
 	container := corev1.Container{


### PR DESCRIPTION
## Summary

- inject pod-local `LEDGERCTL_SERVER` using the headless DNS name covered by cluster certificates
- configure `ledgerctl` automatically for plaintext and TLS modes, including the cluster authentication token
- document flagless in-pod usage and cover disabled, optional, required, and custom gRPC port cases

## Validation

- `go test ./internal/controller` (from `misc/operator`)
- `GOLANGCI_LINT_CACHE=<isolated> bash scripts/agent-check`