### PR TITLE
test: cover transaction state metadata persistence

### DIFF
--- a/internal/domain/processing/processor_transaction_test.go
+++ b/internal/domain/processing/processor_transaction_test.go
@@ -727,7 +727,11 @@ func TestProcessCreateTransaction_Numscript_SetTxMeta(t *testing.T) {
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
 	setupNumscriptVolumeMocks(mockStore)
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
-	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 1}, nil)
+	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 1}, nil, func(_ domain.TransactionKey, state *commonpb.TransactionState) {
+		metadata := commonpb.MetadataToGoMap(state.GetMetadata())
+		require.Equal(t, "payment", metadata["type"])
+		require.Equal(t, "purchase", metadata["category"])
+	})
 
 	// Test set_tx_meta
 	request := &servicepb.Request{


### PR DESCRIPTION
## Summary

- assert Numscript-produced transaction metadata is present in the `TransactionState` passed to `Put`
- keep the existing CreatedTransaction log assertions, covering both persisted state and returned log
- leave production behavior unchanged

## Mutation evidence

Temporarily inverted the production gate from `len(finalMetadata) > 0` to `len(finalMetadata) == 0`.

The focused race test failed at the new persisted-state assertion with `expected: "payment"` and `actual: ""`, while the existing log-only coverage would still have observed metadata. Restoring the original gate made the test pass.

## Validation

- `go test -race ./internal/domain/processing -run '^TestProcessCreateTransaction_Numscript_SetTxMeta$' -count=1`
- `go test -race ./internal/domain/processing -count=1`
- `bash scripts/agent-check`
