### PR TITLE
test(processing): cover revert boundary equality

### DIFF
--- a/internal/domain/processing/processor_revert_transaction_test.go
+++ b/internal/domain/processing/processor_revert_transaction_test.go
@@ -318,6 +318,48 @@ func TestProcessRevertTransaction_NotFound(t *testing.T) {
 	require.Equal(t, uint64(99), txNotFound.TransactionID)
 }
 
+func TestProcessRevertTransaction_NextTransactionIDNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 5, NextLogId: 10}
+
+	expectGetBoundaries(mockStore, domain.LedgerKey{Name: "test-ledger"}, boundaries.AsReader(), nil)
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, (&commonpb.LedgerInfo{Name: "test-ledger", Id: 1}).AsReader(), nil).AnyTimes()
+	// No reverted-status or transaction-state expectations are registered: any
+	// lookup after the boundary check makes gomock fail the test.
+
+	order := &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: "test-ledger",
+				Payload: &raftcmdpb.LedgerScopedOrder_Apply{
+					Apply: &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_RevertTransaction{
+						RevertTransaction: &raftcmdpb.RevertTransactionOrder{
+							TransactionId: boundaries.GetNextTransactionId(),
+						},
+					},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := processor.ProcessOrder(order, mockStore)
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	var txNotFound *domain.ErrTransactionNotFound
+	require.ErrorAs(t, err, &txNotFound)
+	require.Equal(t, boundaries.GetNextTransactionId(), txNotFound.TransactionID)
+}
+
 // An allocated tx id (below NextTransactionId, so it passes the boundary
 // check) whose TransactionState is absent is an inconsistent projection, not a
 // routine "not found": chapter archival never evicts TransactionState and tx


### PR DESCRIPTION
## Summary

- Add focused coverage for a revert request whose transaction ID equals LedgerBoundaries.NextTransactionId.
- Assert the unallocated ID returns ErrTransactionNotFound.
- Leave reverted-status and transaction-state access unconfigured so any read after the boundary guard fails the test.

## Mutation evidence

Temporarily changed the production guard from >= to >. The focused race test failed on an unexpected MockScope.GetReverted call for transaction ID 5, proving the equality case reaches state access under the mutation. Restored >= before commit; the final tree is test-only.

## Checks

- GOMAXPROCS=2 bash scripts/agent-check
- GOMAXPROCS=2 env -u GOROOT nix develop --command go test -race ./internal/domain/processing -run ^TestProcessRevertTransaction_ -count=1