### PR TITLE
test(processing): assert transaction ID boundaries

### DIFF
--- a/internal/domain/processing/processor_revert_transaction_test.go
+++ b/internal/domain/processing/processor_revert_transaction_test.go
@@ -75,7 +75,9 @@ func TestProcessRevertTransaction_Success(t *testing.T) {
 	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "test-ledger", ID: 5}, nil, func(_ domain.TransactionKey, st *commonpb.TransactionState) {
 		require.Equal(t, uint64(3), st.GetRevertsTransaction())
 	})
-	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
+	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil, func(_ string, persisted *raftcmdpb.LedgerBoundaries) {
+		require.Equal(t, uint64(6), persisted.GetNextTransactionId())
+	})
 
 	order := &raftcmdpb.Order{
 		Type: &raftcmdpb.Order_LedgerScoped{

--- a/internal/domain/processing/processor_transaction_test.go
+++ b/internal/domain/processing/processor_transaction_test.go
@@ -44,7 +44,9 @@ func TestProcessCreateTransaction(t *testing.T) {
 	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, (&commonpb.LedgerInfo{Name: "test-ledger", Id: 1}).AsReader(), nil).AnyTimes()
 	mockStore.EXPECT().GetDate().Return(now.AsReader()).Times(4) // Called for: ledger log date, timestamp fallback, InsertedAt, UpdatedAt
 	mockStore.EXPECT().GetCurrentOpenChapter().Return(nil, false)
-	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
+	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil, func(_ string, persisted *raftcmdpb.LedgerBoundaries) {
+		require.Equal(t, uint64(2), persisted.GetNextTransactionId())
+	})
 	expectGetVolume(mockStore, sourceKey, sourceVolume.AsReader(), nil)
 	expectPutVolume(t, mockStore, sourceKey, nil, func(key domain.VolumeKey, value *raftcmdpb.VolumePair) {
 		// Output should increase by 100


### PR DESCRIPTION
## Summary

- Assert that a successful transaction creation persists `LedgerBoundaries.NextTransactionId` from 1 to 2.
- Assert that a successful transaction reversion persists `LedgerBoundaries.NextTransactionId` from 5 to 6.
- Keep the regression coverage focused on the existing happy-path `Put` hooks; production semantics are unchanged.

## Mutation evidence

- With `nextTransactionID + 1` temporarily changed to subtraction, `TestProcessCreateTransaction` failed with expected `2`, actual `0`.
- With `revertTxID + 1` temporarily changed to subtraction, `TestProcessRevertTransaction_Success` failed with expected `6`, actual `4`.
- Both production expressions were restored to addition before commit.

## Validation

- `nix develop -c go test -race ./internal/domain/processing -run '^(TestProcessCreateTransaction|TestProcessRevertTransaction_Success)$' -count=1`
- `GOMAXPROCS=2 bash scripts/agent-check`
- Final diff inspection: only the two intended `NextTransactionId` assertions are present.