### PR TITLE
test: cover posting validation guards

### DIFF
--- a/internal/domain/processing/processor_transaction_test.go
+++ b/internal/domain/processing/processor_transaction_test.go
@@ -12,6 +12,81 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
+func TestValidatePostings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		posting *commonpb.Posting
+		wantErr error
+	}{
+		{
+			name: "valid posting",
+			posting: &commonpb.Posting{
+				Source:      "bank",
+				Destination: "users:alice",
+				Asset:       "USD",
+				Color:       "BLUE",
+			},
+		},
+		{
+			name: "invalid source",
+			posting: &commonpb.Posting{
+				Source:      "invalid source",
+				Destination: "users:alice",
+				Asset:       "USD",
+				Color:       "BLUE",
+			},
+			wantErr: domain.ErrAccountAddressInvalidChar,
+		},
+		{
+			name: "invalid destination",
+			posting: &commonpb.Posting{
+				Source:      "bank",
+				Destination: "invalid destination",
+				Asset:       "USD",
+				Color:       "BLUE",
+			},
+			wantErr: domain.ErrAccountAddressInvalidChar,
+		},
+		{
+			name: "invalid asset",
+			posting: &commonpb.Posting{
+				Source:      "bank",
+				Destination: "users:alice",
+				Asset:       "usd",
+				Color:       "BLUE",
+			},
+			wantErr: domain.ErrAssetInvalid,
+		},
+		{
+			name: "invalid color",
+			posting: &commonpb.Posting{
+				Source:      "bank",
+				Destination: "users:alice",
+				Asset:       "USD",
+				Color:       "blue",
+			},
+			wantErr: domain.ErrColorInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validatePostings([]*commonpb.Posting{tt.posting})
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestProcessCreateTransaction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add focused table-driven coverage for `validatePostings`
- exercise one valid posting plus invalid source, destination, asset, and color cases
- keep production code unchanged because no independent defect was found

## Mutation evidence

After adding the test, each `err != nil` validation guard was inverted independently and the focused test was rerun. Every mutation was killed: the invalid source, destination, asset, and color cases failed for their respective guard inversion. All temporary mutations were then restored, and `processor_transaction.go` has no diff.

## Validation

- `go test -race ./internal/domain/processing -count=1`
- `GOMAXPROCS=2 bash scripts/agent-check`
- final diff inspection: one test file only; no generated or dashboard drift