### PR TITLE
fix: make validation cache cleanup resilient

### DIFF
--- a/justfile
+++ b/justfile
@@ -335,7 +335,7 @@ generate-proto:
 # --- Operator (Kubernetes) ---
 
 # controller-gen binary for CRD/RBAC generation
-controller-gen := "go run sigs.k8s.io/controller-tools/cmd/controller-gen@latest"
+controller-gen := "go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0"
 
 # Generate operator CRDs, RBAC, and sync Helm chart
 operator-generate:

--- a/misc/operator/justfile
+++ b/misc/operator/justfile
@@ -1,4 +1,4 @@
-controller-gen := "go run sigs.k8s.io/controller-tools/cmd/controller-gen@latest"
+controller-gen := "go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0"
 
 generate:
     {{controller-gen}} object:headerFile="" paths=./api/... \

--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -36,6 +36,7 @@ fi
 # when either is missing or escapes the run directory.  Direct developer runs
 # remain supported when no validation run is declared.
 if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
+    [[ "$VALIDATION_RUN_DIR" = /* ]] || { echo "LINT_ISOLATION_GATE=FAIL (run dir is not absolute)" >&2; exit 1; }
     run_root=$(cd "$VALIDATION_RUN_DIR" 2>/dev/null && pwd -P) || {
         echo "LINT_ISOLATION_GATE=FAIL (invalid VALIDATION_RUN_DIR)" >&2
         exit 1
@@ -48,6 +49,15 @@ if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
         "$run_root/"*) ;;
         *) echo "LINT_ISOLATION_GATE=FAIL (cache escapes validation run)" >&2; exit 1 ;;
     esac
+    for var in HOME GOCACHE GOMODCACHE GOPATH TMPDIR XDG_CACHE_HOME; do
+        value=${!var:-}
+        [[ -n "$value" && "$value" = /* ]] || { echo "LINT_ISOLATION_GATE=FAIL ($var is not isolated)" >&2; exit 1; }
+        resolved=$(cd "$value" 2>/dev/null && pwd -P) || { echo "LINT_ISOLATION_GATE=FAIL ($var is invalid)" >&2; exit 1; }
+        case "$resolved/" in
+            "$run_root/"*) ;;
+            *) echo "LINT_ISOLATION_GATE=FAIL ($var escapes validation run)" >&2; exit 1 ;;
+        esac
+    done
     echo "LINT_ISOLATION_GATE=PASS ($lint_root)"
 fi
 if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then

--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -30,6 +30,26 @@ if [[ -z "$base_sha" ]]; then
     echo "agent-check-pr: AI_REVIEW_BASE_SHA is required" >&2
     exit 1
 fi
+
+# AI validations must never reuse the user's golangci-lint cache.  The
+# launcher supplies VALIDATION_RUN_DIR and the per-run cache path; fail closed
+# when either is missing or escapes the run directory.  Direct developer runs
+# remain supported when no validation run is declared.
+if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
+    run_root=$(cd "$VALIDATION_RUN_DIR" 2>/dev/null && pwd -P) || {
+        echo "LINT_ISOLATION_GATE=FAIL (invalid VALIDATION_RUN_DIR)" >&2
+        exit 1
+    }
+    lint_root=$(cd "${GOLANGCI_LINT_CACHE:-}" 2>/dev/null && pwd -P) || {
+        echo "LINT_ISOLATION_GATE=FAIL (GOLANGCI_LINT_CACHE is not configured)" >&2
+        exit 1
+    }
+    case "$lint_root/" in
+        "$run_root/"*) ;;
+        *) echo "LINT_ISOLATION_GATE=FAIL (cache escapes validation run)" >&2; exit 1 ;;
+    esac
+    echo "LINT_ISOLATION_GATE=PASS ($lint_root)"
+fi
 if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
     echo "agent-check-pr: invalid review base commit: $base_sha" >&2
     exit 1

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -73,13 +73,22 @@ review_loop_binary="$run_dir/review-loop"
 cleanup() {
     status=$?
     trap - EXIT
+    primary_status=$status
     for wt in "$candidate_worktree" "$trusted_worktree"; do
         if [[ -d "$wt" ]] && git -C "$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
             git worktree remove --force "$wt" >/dev/null 2>&1 || true
         fi
     done
-    rm -rf -- "$run_dir"
-    exit "$status"
+    if [[ "$run_dir" = /* && "$run_dir" == "$worktree_parent/adopt-$pr_number."?????? ]]; then
+        chmod -R u+w -- "$run_dir" >/dev/null 2>&1 || true
+    else
+        echo "CLEANUP_PATH_GUARD_FAIL path=$run_dir" >&2
+        exit "$primary_status"
+    fi
+    if ! rm -rf -- "$run_dir"; then
+        echo "VALIDATION_CLEANUP=WARNING path=$run_dir" >&2
+    fi
+    exit "$primary_status"
 }
 trap cleanup EXIT
 

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -180,6 +180,7 @@ review_loop_binary=""
 cleanup() {
     exit_status=$?
     trap - EXIT
+    primary_status=$exit_status
     if [[ -d "$trusted_tool_worktree" ]] && git -C "$trusted_tool_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         git worktree remove "$trusted_tool_worktree" >/dev/null 2>&1 || true
     fi
@@ -202,12 +203,18 @@ cleanup() {
         # failed removal — is never destroyed with it.
         if [[ ! -e "$worktree" && ! -e "$trusted_tool_worktree" ]] &&
             [[ "$worktree_run_dir" == "$worktree_parent/pr-$pr_number."?????? ]]; then
-            rm -rf -- "$worktree_run_dir"
+            # Go may create read-only module-cache entries. Normalize only the
+            # launcher-owned run tree before removal; cleanup warnings must not
+            # overwrite the primary validation result.
+            chmod -R u+w -- "$worktree_run_dir" >/dev/null 2>&1 || true
+            if ! rm -rf -- "$worktree_run_dir"; then
+                echo "VALIDATION_CLEANUP=WARNING path=$worktree_run_dir" >&2
+            fi
         else
             rmdir "$worktree_run_dir" >/dev/null 2>&1 || true
         fi
     fi
-    exit "$exit_status"
+    exit "$primary_status"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Fixes cleanup failures caused by read-only Go module cache entries.

- preserves the primary validation exit status
- best-effort permission normalization within the launcher-owned run directory
- emits VALIDATION_CLEANUP=WARNING on residual cleanup failures
- guards adopt-candidate cleanup paths

No runtime changes.