### PR TITLE
fix: keep agent-check-pr structured stdout clean

### DIFF
--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -58,7 +58,7 @@ if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
             *) echo "LINT_ISOLATION_GATE=FAIL ($var escapes validation run)" >&2; exit 1 ;;
         esac
     done
-    echo "LINT_ISOLATION_GATE=PASS ($lint_root)"
+    echo "LINT_ISOLATION_GATE=PASS ($lint_root)" >&2
 fi
 if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
     echo "agent-check-pr: invalid review base commit: $base_sha" >&2


### PR DESCRIPTION
Keep agent-check-pr machine-readable stdout limited to selected gate names.

The lint isolation diagnostic now goes to stderr, preserving the structured stdout contract consumed by scripts and tests.

No runtime changes.