### PR TITLE
fix: provision writable validation cache directories

### DIFF
--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -58,7 +58,7 @@ if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
             *) echo "LINT_ISOLATION_GATE=FAIL ($var escapes validation run)" >&2; exit 1 ;;
         esac
     done
-    echo "LINT_ISOLATION_GATE=PASS ($lint_root)"
+    echo "LINT_ISOLATION_GATE=PASS ($lint_root)" >&2
 fi
 if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
     echo "agent-check-pr: invalid review base commit: $base_sha" >&2

--- a/scripts/ai-review-codex
+++ b/scripts/ai-review-codex
@@ -152,6 +152,24 @@ fi
 
 cd "$repo_root"
 
+# Reviewers can invoke Go indirectly (for repository inspection/tests). When a
+# validation run is active, provide every mutable Go/cache directory explicitly
+# so macOS does not fall back to $HOME/Library/Caches/go-build.
+if [[ -n "${VALIDATION_RUN_DIR:-}" ]]; then
+    run_dir=$(cd "$VALIDATION_RUN_DIR" 2>/dev/null && pwd -P) || exit 1
+    for dir in home go-cache go-mod-cache go-path tmp cache; do
+        mkdir -p "$run_dir/$dir"
+    done
+    export HOME="$run_dir/home"
+    export GOCACHE="$run_dir/go-cache"
+    export GOMODCACHE="$run_dir/go-mod-cache"
+    export GOPATH="$run_dir/go-path"
+    export TMPDIR="$run_dir/tmp"
+    export XDG_CACHE_HOME="$run_dir/cache"
+    export GOLANGCI_LINT_CACHE="$run_dir/cache/golangci-lint"
+    mkdir -p "$GOLANGCI_LINT_CACHE"
+fi
+
 # Codex 0.147 has no single switch that disables every extension source. The
 # isolated HOME/CODEX_HOME removes personal config and skill/plugin discovery;
 # explicit flags additionally reject rules and disable extension features. Repo


### PR DESCRIPTION
Ensure Codex reviewer subprocesses inherit explicit writable per-run Go and lint cache directories.

Prevents macOS HOME/Library/Caches/go-build fallback when the reviewer runs in an isolated HOME.

No runtime changes.