### PR TITLE
fix: join reconciliation workers during shutdown

### DIFF
--- a/docs/technical/architecture/subsystems/chapters/README.md
+++ b/docs/technical/architecture/subsystems/chapters/README.md
@@ -2,6 +2,10 @@
 
 Chapters partition a ledger's transaction history into discrete sealed segments. Once sealed, a chapter can be archived to cold storage (S3 or filesystem) — logs and audit entries get exported and purged from Pebble while attributes stay hot. Receipt-based reverts allow undoing archived transactions without rehydrating cold data.
 
+The background Sealer and Archiver own both their request drains and periodic
+reconciliation loops. Shutdown cancels and joins all of that work before the
+chapter runtime releases its stores.
+
 ## Documents
 
 | Document | Description |

--- a/docs/technical/architecture/subsystems/chapters/lifecycle.md
+++ b/docs/technical/architecture/subsystems/chapters/lifecycle.md
@@ -152,6 +152,11 @@ The seal checkpoint exists on disk but the Sealer never proposed the `SealChapte
 
 The Sealer uses exponential backoff (100ms → 10s max) to retry on transient errors. The checkpoint remains on disk until the hash is successfully computed, ensuring no data is lost.
 
+On shutdown, the Sealer cancels both its request drain and reconciliation loop,
+then joins them before its lifecycle hook returns. This keeps reconciliation
+from accessing the chapter state or Pebble after the owning runtime starts
+closing those resources.
+
 ## Transaction Receipts (JWT)
 
 Every transaction created during a chapter includes a JWT receipt that links the transaction to its chapter. The `chapter_id` is captured from the FSM's current open chapter at transaction creation time and stored in the `CreatedTransaction` log entry.
@@ -408,6 +413,11 @@ Crash recovery is deterministic via the `ARCHIVING` state. On leadership gain, t
 - Leader crash during S3 upload
 - Leadership transfer while archiving is in progress
 - Network partition that causes a leader change
+
+On shutdown, the Archiver cancels and joins both the archive-request drain and
+the periodic durable-state reconciliation loop before its lifecycle hook
+returns. Store and cold-storage teardown therefore cannot overlap owned
+archival reconciliation work.
 
 ### Sequence Diagram
 

--- a/internal/infra/state/archiver.go
+++ b/internal/infra/state/archiver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -68,16 +69,18 @@ type ArchiverChapterState interface {
 // It follows the same pattern as Sealer: a background goroutine reads from
 // archiveRequestCh, performs I/O off the Raft critical path, then proposes.
 type Archiver struct {
-	logger           logging.Logger
-	dataStore        dal.ColdStorageScanner
-	coldStorage      coldstorage.ColdStorage
-	archiveRequestCh *worker.Channel[ArchiveRequest]
-	proposeFn        ArchiveProposer
-	isLeader         func() bool
-	chapterState     ArchiverChapterState
-	reconcileFn      func(stop <-chan struct{})
-	w                worker.Worker
-	bucketID         string
+	logger            logging.Logger
+	dataStore         dal.ColdStorageScanner
+	coldStorage       coldstorage.ColdStorage
+	archiveRequestCh  *worker.Channel[ArchiveRequest]
+	proposeFn         ArchiveProposer
+	isLeader          func() bool
+	chapterState      ArchiverChapterState
+	reconcileFn       func(stop <-chan struct{})
+	reconcileInterval time.Duration
+	w                 worker.Worker
+	stopOnce          sync.Once
+	bucketID          string
 }
 
 // archiveReconcileInterval is the interval at which the Archiver re-checks
@@ -98,27 +101,32 @@ func NewArchiver(
 	reconcileFn func(stop <-chan struct{}),
 ) *Archiver {
 	return &Archiver{
-		logger:           logger.WithFields(map[string]any{"cmp": "archiver"}),
-		dataStore:        dataStore,
-		coldStorage:      coldStorage,
-		archiveRequestCh: archiveRequestCh,
-		proposeFn:        proposeFn,
-		isLeader:         isLeader,
-		chapterState:     chapterState,
-		reconcileFn:      reconcileFn,
-		w:                worker.New(),
-		bucketID:         bucketID,
+		logger:            logger.WithFields(map[string]any{"cmp": "archiver"}),
+		dataStore:         dataStore,
+		coldStorage:       coldStorage,
+		archiveRequestCh:  archiveRequestCh,
+		proposeFn:         proposeFn,
+		isLeader:          isLeader,
+		chapterState:      chapterState,
+		reconcileFn:       reconcileFn,
+		reconcileInterval: archiveReconcileInterval,
+		w:                 worker.New(),
+		bucketID:          bucketID,
 	}
 }
 
 // Start launches the background archiving goroutine with periodic reconciliation.
 func (a *Archiver) Start() {
 	a.w.Run(func(stop <-chan struct{}) {
+		var reconciliation sync.WaitGroup
+
 		// Periodic reconciliation: re-scan for ARCHIVING chapters.
-		go worker.RunTicker(stop, archiveReconcileInterval, func() {
-			if a.isLeader() {
-				a.reconcileFn(stop)
-			}
+		reconciliation.Go(func() {
+			worker.RunTicker(stop, a.reconcileInterval, func() {
+				if a.isLeader() {
+					a.reconcileFn(stop)
+				}
+			})
 		})
 
 		// Main drain loop.
@@ -127,12 +135,14 @@ func (a *Archiver) Start() {
 				return a.archive(stop, req)
 			})
 		})
+
+		reconciliation.Wait()
 	})
 }
 
 // Stop signals the background goroutine to stop and waits for it to finish.
 func (a *Archiver) Stop() {
-	a.w.Stop()
+	a.stopOnce.Do(a.w.Stop)
 }
 
 // archive exports chapter data to cold storage and proposes ConfirmArchiveChapter.

--- a/internal/infra/state/reconciliation_shutdown_test.go
+++ b/internal/infra/state/reconciliation_shutdown_test.go
@@ -1,0 +1,185 @@
+package state
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/pkg/worker"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+type blockingSealerChapterState struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingSealerChapterState) ClosingChapters() []*commonpb.Chapter {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+
+	return nil
+}
+
+func (*blockingSealerChapterState) ClosingChapterByID(uint64) (*commonpb.Chapter, bool) {
+	return nil, false
+}
+
+func requireStopJoinsReconciliation(
+	t *testing.T,
+	start func(),
+	stop func(),
+	stopCh <-chan struct{},
+	reconciliationEntered <-chan struct{},
+	releaseReconciliation chan struct{},
+) {
+	t.Helper()
+
+	start()
+	<-reconciliationEntered
+
+	stopReturned := make(chan struct{})
+	go func() {
+		stop()
+		close(stopReturned)
+	}()
+
+	<-stopCh
+
+	select {
+	case <-stopReturned:
+		close(releaseReconciliation)
+		t.Fatal("Stop returned while owned reconciliation work was still active")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseReconciliation)
+	require.Eventually(t, func() bool {
+		select {
+		case <-stopReturned:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond, "Stop did not return after reconciliation completed")
+}
+
+func TestArchiverStopJoinsReconciliation(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.FromContext(logging.TestingContext())
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var reconcileOnce sync.Once
+	archiver := NewArchiver(
+		logger,
+		nil,
+		nil,
+		worker.NewChannel[ArchiveRequest](logger, "test-archive", 1),
+		func(uint64, []byte) error { return nil },
+		func() bool { return true },
+		newArchivingChapterState(t),
+		"test-bucket",
+		func(<-chan struct{}) {
+			reconcileOnce.Do(func() {
+				close(entered)
+				<-release
+			})
+		},
+	)
+	archiver.reconcileInterval = time.Nanosecond
+
+	requireStopJoinsReconciliation(t, archiver.Start, archiver.Stop, archiver.w.StopCh(), entered, release)
+}
+
+func TestSealerStopJoinsReconciliation(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.FromContext(logging.TestingContext())
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	chapterState := &blockingSealerChapterState{entered: entered, release: release}
+	sealer := NewSealer(
+		logger,
+		nil,
+		attributes.New(),
+		worker.NewChannel[SealRequest](logger, "test-seal", 1),
+		func(uint64, []byte, []byte) error { return nil },
+		func() bool { return true },
+		chapterState,
+	)
+
+	requireStopJoinsReconciliation(t, sealer.Start, sealer.Stop, sealer.w.StopCh(), entered, release)
+}
+
+func requireConcurrentStop(t *testing.T, start, stop func()) {
+	t.Helper()
+
+	start()
+
+	var callers sync.WaitGroup
+	callers.Add(2)
+
+	for range 2 {
+		go func() {
+			defer callers.Done()
+			stop()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		callers.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent Stop calls did not return")
+	}
+}
+
+func TestArchiverStopIsConcurrentAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.FromContext(logging.TestingContext())
+	archiver := NewArchiver(
+		logger,
+		nil,
+		nil,
+		worker.NewChannel[ArchiveRequest](logger, "test-archive", 1),
+		func(uint64, []byte) error { return nil },
+		func() bool { return true },
+		newArchivingChapterState(t),
+		"test-bucket",
+		func(<-chan struct{}) {},
+	)
+	archiver.reconcileInterval = time.Hour
+
+	requireConcurrentStop(t, archiver.Start, archiver.Stop)
+}
+
+func TestSealerStopIsConcurrentAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.FromContext(logging.TestingContext())
+	sealer := NewSealer(
+		logger,
+		nil,
+		attributes.New(),
+		worker.NewChannel[SealRequest](logger, "test-seal", 1),
+		func(uint64, []byte, []byte) error { return nil },
+		func() bool { return true },
+		newFixedChapterState(nil),
+	)
+	sealer.reconcileInterval = time.Hour
+
+	requireConcurrentStop(t, sealer.Start, sealer.Stop)
+}

--- a/internal/infra/state/sealer.go
+++ b/internal/infra/state/sealer.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/binary"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -55,6 +56,7 @@ type Sealer struct {
 	chapterState      SealerChapterState
 	reconcileInterval time.Duration
 	w                 worker.Worker
+	stopOnce          sync.Once
 }
 
 // NewSealer creates a new background sealer.
@@ -88,16 +90,18 @@ const sealReconcileInterval = 30 * time.Second
 // seal from a previous crash, and starts periodic reconciliation.
 func (s *Sealer) Start() {
 	s.w.Run(func(stop <-chan struct{}) {
+		var reconciliation sync.WaitGroup
+
 		// Recover on start and periodically in a background goroutine.
 		// Recovery uses blocking sends, so it must run concurrently with
 		// the drain loop to avoid deadlocking when the channel is full.
-		go func() {
+		reconciliation.Go(func() {
 			s.recoverPendingSeal(stop)
 
 			worker.RunTicker(stop, s.reconcileInterval, func() {
 				s.recoverPendingSeal(stop)
 			})
-		}()
+		})
 
 		// Main drain loop.
 		worker.DrainChannel(stop, s.sealRequestCh.Receive(), func(req SealRequest) {
@@ -105,6 +109,8 @@ func (s *Sealer) Start() {
 				return s.seal(req)
 			})
 		})
+
+		reconciliation.Wait()
 	})
 }
 
@@ -135,7 +141,7 @@ func (s *Sealer) recoverPendingSeal(stop <-chan struct{}) {
 
 // Stop signals the background goroutine to stop and waits for it to finish.
 func (s *Sealer) Stop() {
-	s.w.Stop()
+	s.stopOnce.Do(s.w.Stop)
 }
 
 // seal computes the sealing hash for a chapter and proposes a SealChapter order.


### PR DESCRIPTION
Fixes EN-1863.

## Discovery

DISCOVERY: NO_EXISTING_WORK

`NO_EXISTING_WORK`: searches across open/closed PRs, local and remote branches,
GitHub commits, Jira references, and recent Archiver/Sealer shutdown work found
no direct or partial fix to reuse.

## BEFORE_FIX

BEFORE_FIX: BUG_REPRODUCED

- Base: `b327aeaf8a0232c70842ec573e93721f0604e720`
- Evidence: `BACKGROUND_RECONCILIATION_OUTLIVES_OWNER`
- Deterministic channel/barrier tests held the Archiver and Sealer
  reconciliation goroutines active while `Stop` ran.
- Both tests failed because `Stop` returned before the held reconciliation work
  was released.

Invariant: shutdown must not return and release owned resources while
Archiver/Sealer reconciliation work can still mutate or access them.

## Root cause

The lifecycle worker joined only the main request-drain goroutine. Each
component launched its reconciliation loop as an untracked nested goroutine,
so cancellation was signaled but shutdown did not wait for reconciliation to
finish.

## Fix

- Track and join each owned reconciliation goroutine before the main worker
  completes.
- Keep reconciliation on the component-scoped stop channel.
- Make component shutdown safe for concurrent/repeated `Stop` calls.
- Document the shutdown ownership contract for chapters.

## AFTER_FIX

AFTER_FIX: PASS

- Regression tests pass for Archiver and Sealer shutdown while reconciliation
  is blocked.
- Concurrent/double shutdown passes.
- Existing archive/seal retry-error paths remain cancellation-aware and run in
  the joined request drain.
- Targeted package tests pass.

## Test sensitivity

TEST_SENSITIVITY: PASS

`TEST_SENSITIVITY=PASS`: temporarily removing the two reconciliation joins made
both regression tests fail with `Stop returned while owned reconciliation work
was still active`. The mutation was restored and never committed.

## Validation

- Go 1.26.5 from the pinned Nix environment: PASS
- Environment gate and hermetic cache isolation: PASS
- Targeted shutdown tests under race, 50 repetitions: PASS
- `go test -race ./internal/infra/state`: PASS
- `bash scripts/agent-check-full`: PASS
- `go test -race ./... -timeout 20m` (via `agent-check-full`): PASS
- Trusted pre-commit and clean-worktree pre-push gate: PASS
