### PR TITLE
fix: keep active ColdReader databases alive

### DIFF
--- a/docs/technical/architecture/subsystems/chapters/README.md
+++ b/docs/technical/architecture/subsystems/chapters/README.md
@@ -12,6 +12,10 @@ Chapters partition a ledger's transaction history into discrete sealed segments.
 | [backup.md](backup.md) | Full-database backup (Pebble checkpoint + incremental segments) to S3, Azure, or filesystem; restore for disaster recovery. |
 | [incremental-restore-contract.md](incremental-restore-contract.md) | Required parity between live apply and checkpoint-plus-delta restore for persisted state. |
 
+Cold-storage reads use explicit handles: capacity/TTL eviction and shutdown
+must retain an archived chapter's Pebble database until its last active handle
+closes. See [cold-storage.md](cold-storage.md#reading-from-cold-storage).
+
 ## Related
 
 - [Storage](../storage/) — the Pebble zones that hold logs / audit entries before archival.

--- a/docs/technical/architecture/subsystems/chapters/cold-storage.md
+++ b/docs/technical/architecture/subsystems/chapters/cold-storage.md
@@ -59,7 +59,13 @@ Using SST directly (rather than re-encoding into a portable format like Parquet 
 `internal/infra/coldstorage/reader.go` exposes the read side: open an archived chapter, iterate its log + audit ranges, and feed them back into queries that span archived data. Concretely:
 
 - **Audit-chain verification** by the [checker](../checker/checker.md) walks past archive boundaries by joining each chapter's sealed `last_audit_hash` to the start of the next live chain (see [audit-chain.md § Verification](../checker/audit-chain.md#verification)).
-- **Log lookups** by ID across the archived range go through `coldstorage.Reader.Open(chapterID)` and stream the SST.
+- **Log lookups** by ID across the archived range acquire a `ColdReader` read
+  handle and stream the SST. The handle is an explicit lease: callers close it
+  only after their point reads, value closers, and iterators are finished.
+  Capacity and TTL eviction remove an idle chapter immediately, but an active
+  chapter's Pebble database and cache directory stay alive until its last lease
+  closes. `ColdReader.Close` likewise refuses new leases and waits for active
+  handles before releasing the databases it owns.
 - **Reverting an archived transaction** does **not** read cold storage — it uses a [receipt](receipts.md) to skip the round-trip entirely.
 
 ## Configuration

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -5161,7 +5161,11 @@ func (c *Checker) reDeriveArchivedIdempotency(
 
 		last, err := query.ReadLastAuditEntry(coldPebble)
 		if err != nil {
+			closeErr := coldPebble.Close()
 			c.logger.Infof("reading last audit entry of archived chapter %d failed: %v", ch.GetId(), err)
+			if closeErr != nil {
+				c.logger.Infof("closing archived chapter %d after failed idempotency read failed: %v", ch.GetId(), closeErr)
+			}
 
 			return false
 		}
@@ -5169,12 +5173,24 @@ func (c *Checker) reDeriveArchivedIdempotency(
 		// This chapter (and, by audit-sequence order, every older one) is
 		// entirely below the TTL window — nothing here can still be live.
 		if last == nil || last.GetTimestamp().GetData() < ttlCutoff {
+			if err := coldPebble.Close(); err != nil {
+				c.logger.Infof("closing archived chapter %d after idempotency boundary failed: %v", ch.GetId(), err)
+
+				return false
+			}
+
 			break
 		}
 
 		windowStartsHere, err := c.collectChapterIdempotency(ctx, coldPebble, ttlCutoff, expected)
+		closeErr := coldPebble.Close()
 		if err != nil {
 			c.logger.Infof("re-deriving idempotency from archived chapter %d failed: %v", ch.GetId(), err)
+
+			return false
+		}
+		if closeErr != nil {
+			c.logger.Infof("closing archived chapter %d after idempotency scan failed: %v", ch.GetId(), closeErr)
 
 			return false
 		}

--- a/internal/application/check/signing.go
+++ b/internal/application/check/signing.go
@@ -416,8 +416,15 @@ func (v *signingVerifier) foldArchived(
 			return nil
 		}
 
-		if err := v.foldChapter(ctx, coldPebble); err != nil {
-			logger.Infof("folding signing orders from archived chapter %d failed: %v", ch.GetId(), err)
+		foldErr := v.foldChapter(ctx, coldPebble)
+		closeErr := coldPebble.Close()
+		if foldErr != nil {
+			logger.Infof("folding signing orders from archived chapter %d failed: %v", ch.GetId(), foldErr)
+
+			return nil
+		}
+		if closeErr != nil {
+			logger.Infof("closing archived chapter %d after signing verification failed: %v", ch.GetId(), closeErr)
 
 			return nil
 		}

--- a/internal/infra/backup/cold_backfill.go
+++ b/internal/infra/backup/cold_backfill.go
@@ -10,6 +10,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -22,7 +23,7 @@ import (
 // deployments without cold storage; backfillArchivedRanges then fails loudly
 // if an export window overlaps an archived chapter.
 type ColdChapterReader interface {
-	GetReader(ctx context.Context, chapterID uint64) (dal.PebbleReader, error)
+	GetReader(ctx context.Context, chapterID uint64) (coldstorage.ReadHandle, error)
 }
 
 // archivedOverlap is the intersection of one ARCHIVED chapter's sequence
@@ -86,95 +87,122 @@ func backfillArchivedRanges(
 	}
 
 	for _, ov := range overlaps {
-		chapterID := ov.chapter.GetId()
-
-		logger.WithFields(map[string]any{
-			"chapterId": chapterID,
-			"logRange":  fmt.Sprintf("[%d, %d]", ov.logLo, ov.logHi),
-		}).Infof("Backfilling archived chapter range from cold storage")
-
-		cold, err := coldReader.GetReader(ctx, chapterID)
+		chapterSegments, chapterLogCount, chapterAuditCount, err := backfillArchivedOverlap(
+			ctx, logger, storage, coldReader, bucketID, ov, maxSegmentBytes,
+		)
 		if err != nil {
-			return nil, 0, 0, fmt.Errorf("opening cold archive for chapter %d: %w", chapterID, err)
+			return nil, 0, 0, err
 		}
 
-		if ov.logLo <= ov.logHi {
-			segs, count, err := exportEntries(
-				ctx, storage, cold,
-				dal.ZoneCold, dal.SubColdLog, ov.logLo-1, ov.logHi, "log",
-				func(part int) string { return ExportLogSegmentKey(bucketID, ov.logLo, ov.logHi, part) },
-				maxSegmentBytes,
-			)
-			if err != nil {
-				return nil, 0, 0, fmt.Errorf("exporting archived log entries for chapter %d: %w", chapterID, err)
-			}
+		segments = append(segments, chapterSegments...)
+		logCount += chapterLogCount
+		auditCount += chapterAuditCount
+	}
 
-			// The log stream is gap-free (one log per sequence, allocated on
-			// append), so the archive must hold exactly the overlap. Fewer
-			// means the SST is truncated or the chapter registry is wrong —
-			// exporting it would publish a backup missing entries the purge
-			// already deleted from hot.
-			if expected := ov.logHi - ov.logLo + 1; count != expected {
-				return nil, 0, 0, fmt.Errorf(
-					"invariant: cold archive for chapter %d holds %d log entries in [%d, %d], expected %d",
-					chapterID, count, ov.logLo, ov.logHi, expected)
-			}
+	return segments, logCount, auditCount, nil
+}
 
-			segments = append(segments, segs...)
-			logCount += count
+func backfillArchivedOverlap(
+	ctx context.Context,
+	logger logging.Logger,
+	storage Storage,
+	coldReader ColdChapterReader,
+	bucketID string,
+	ov archivedOverlap,
+	maxSegmentBytes int64,
+) (segments []ExportSegment, logCount, auditCount uint64, err error) {
+	chapterID := ov.chapter.GetId()
+	logger.WithFields(map[string]any{
+		"chapterId": chapterID,
+		"logRange":  fmt.Sprintf("[%d, %d]", ov.logLo, ov.logHi),
+	}).Infof("Backfilling archived chapter range from cold storage")
+
+	cold, err := coldReader.GetReader(ctx, chapterID)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("opening cold archive for chapter %d: %w", chapterID, err)
+	}
+	defer func() {
+		if closeErr := cold.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("closing cold archive for chapter %d: %w", chapterID, closeErr))
+		}
+	}()
+
+	if ov.logLo <= ov.logHi {
+		segs, count, exportErr := exportEntries(
+			ctx, storage, cold,
+			dal.ZoneCold, dal.SubColdLog, ov.logLo-1, ov.logHi, "log",
+			func(part int) string { return ExportLogSegmentKey(bucketID, ov.logLo, ov.logHi, part) },
+			maxSegmentBytes,
+		)
+		if exportErr != nil {
+			return nil, 0, 0, fmt.Errorf("exporting archived log entries for chapter %d: %w", chapterID, exportErr)
 		}
 
-		if ov.auditLo <= ov.auditHi {
-			segs, count, err := exportEntries(
-				ctx, storage, cold,
-				dal.ZoneCold, dal.SubColdAudit, ov.auditLo-1, ov.auditHi, "audit",
-				func(part int) string { return ExportAuditSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
-				maxSegmentBytes,
-			)
-			if err != nil {
-				return nil, 0, 0, fmt.Errorf("exporting archived audit entries for chapter %d: %w", chapterID, err)
-			}
-
-			// The audit stream is a hash chain — one entry per sequence, no
-			// gaps — so the same completeness bound applies as for logs.
-			if expected := ov.auditHi - ov.auditLo + 1; count != expected {
-				return nil, 0, 0, fmt.Errorf(
-					"invariant: cold archive for chapter %d holds %d audit entries in [%d, %d], expected %d",
-					chapterID, count, ov.auditLo, ov.auditHi, expected)
-			}
-
-			segments = append(segments, segs...)
-			auditCount += count
-
-			// Audit items and applied proposals share the audit sequence
-			// counter but are legitimately sparse (failures carry no items,
-			// only successes write an AppliedProposal), so no completeness
-			// bound applies and empty results add no segment — same contract
-			// as the hot export.
-			itemSegs, _, err := exportEntries(
-				ctx, storage, cold,
-				dal.ZoneCold, dal.SubColdAuditItem, ov.auditLo-1, ov.auditHi, "auditItem",
-				func(part int) string { return ExportAuditItemSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
-				maxSegmentBytes,
-			)
-			if err != nil {
-				return nil, 0, 0, fmt.Errorf("exporting archived audit items for chapter %d: %w", chapterID, err)
-			}
-
-			segments = append(segments, itemSegs...)
-
-			appliedSegs, _, err := exportEntries(
-				ctx, storage, cold,
-				dal.ZoneCold, dal.SubColdAppliedProposal, ov.auditLo-1, ov.auditHi, "appliedProposal",
-				func(part int) string { return ExportAppliedProposalSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
-				maxSegmentBytes,
-			)
-			if err != nil {
-				return nil, 0, 0, fmt.Errorf("exporting archived applied proposals for chapter %d: %w", chapterID, err)
-			}
-
-			segments = append(segments, appliedSegs...)
+		// The log stream is gap-free (one log per sequence, allocated on
+		// append), so the archive must hold exactly the overlap. Fewer
+		// means the SST is truncated or the chapter registry is wrong —
+		// exporting it would publish a backup missing entries the purge
+		// already deleted from hot.
+		if expected := ov.logHi - ov.logLo + 1; count != expected {
+			return nil, 0, 0, fmt.Errorf(
+				"invariant: cold archive for chapter %d holds %d log entries in [%d, %d], expected %d",
+				chapterID, count, ov.logLo, ov.logHi, expected)
 		}
+
+		segments = append(segments, segs...)
+		logCount += count
+	}
+
+	if ov.auditLo <= ov.auditHi {
+		segs, count, exportErr := exportEntries(
+			ctx, storage, cold,
+			dal.ZoneCold, dal.SubColdAudit, ov.auditLo-1, ov.auditHi, "audit",
+			func(part int) string { return ExportAuditSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
+			maxSegmentBytes,
+		)
+		if exportErr != nil {
+			return nil, 0, 0, fmt.Errorf("exporting archived audit entries for chapter %d: %w", chapterID, exportErr)
+		}
+
+		// The audit stream is a hash chain — one entry per sequence, no
+		// gaps — so the same completeness bound applies as for logs.
+		if expected := ov.auditHi - ov.auditLo + 1; count != expected {
+			return nil, 0, 0, fmt.Errorf(
+				"invariant: cold archive for chapter %d holds %d audit entries in [%d, %d], expected %d",
+				chapterID, count, ov.auditLo, ov.auditHi, expected)
+		}
+
+		segments = append(segments, segs...)
+		auditCount += count
+
+		// Audit items and applied proposals share the audit sequence
+		// counter but are legitimately sparse (failures carry no items,
+		// only successes write an AppliedProposal), so no completeness
+		// bound applies and empty results add no segment — same contract
+		// as the hot export.
+		itemSegs, _, exportErr := exportEntries(
+			ctx, storage, cold,
+			dal.ZoneCold, dal.SubColdAuditItem, ov.auditLo-1, ov.auditHi, "auditItem",
+			func(part int) string { return ExportAuditItemSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
+			maxSegmentBytes,
+		)
+		if exportErr != nil {
+			return nil, 0, 0, fmt.Errorf("exporting archived audit items for chapter %d: %w", chapterID, exportErr)
+		}
+
+		segments = append(segments, itemSegs...)
+
+		appliedSegs, _, exportErr := exportEntries(
+			ctx, storage, cold,
+			dal.ZoneCold, dal.SubColdAppliedProposal, ov.auditLo-1, ov.auditHi, "appliedProposal",
+			func(part int) string { return ExportAppliedProposalSegmentKey(bucketID, ov.auditLo, ov.auditHi, part) },
+			maxSegmentBytes,
+		)
+		if exportErr != nil {
+			return nil, 0, 0, fmt.Errorf("exporting archived applied proposals for chapter %d: %w", chapterID, exportErr)
+		}
+
+		segments = append(segments, appliedSegs...)
 	}
 
 	return segments, logCount, auditCount, nil

--- a/internal/infra/backup/cold_backfill_generated_test.go
+++ b/internal/infra/backup/cold_backfill_generated_test.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	dal "github.com/formancehq/ledger/v3/internal/storage/dal"
+	coldstorage "github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,10 +40,10 @@ func (m *MockColdChapterReader) EXPECT() *MockColdChapterReaderMockRecorder {
 }
 
 // GetReader mocks base method.
-func (m *MockColdChapterReader) GetReader(ctx context.Context, chapterID uint64) (dal.PebbleReader, error) {
+func (m *MockColdChapterReader) GetReader(ctx context.Context, chapterID uint64) (coldstorage.ReadHandle, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReader", ctx, chapterID)
-	ret0, _ := ret[0].(dal.PebbleReader)
+	ret0, _ := ret[0].(coldstorage.ReadHandle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -61,19 +61,19 @@ type MockColdChapterReaderGetReaderCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockColdChapterReaderGetReaderCall) Return(arg0 dal.PebbleReader, arg1 error) *MockColdChapterReaderGetReaderCall {
+func (c *MockColdChapterReaderGetReaderCall) Return(arg0 coldstorage.ReadHandle, arg1 error) *MockColdChapterReaderGetReaderCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockColdChapterReaderGetReaderCall) Do(f func(context.Context, uint64) (dal.PebbleReader, error)) *MockColdChapterReaderGetReaderCall {
+func (c *MockColdChapterReaderGetReaderCall) Do(f func(context.Context, uint64) (coldstorage.ReadHandle, error)) *MockColdChapterReaderGetReaderCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockColdChapterReaderGetReaderCall) DoAndReturn(f func(context.Context, uint64) (dal.PebbleReader, error)) *MockColdChapterReaderGetReaderCall {
+func (c *MockColdChapterReaderGetReaderCall) DoAndReturn(f func(context.Context, uint64) (coldstorage.ReadHandle, error)) *MockColdChapterReaderGetReaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/infra/backup/cold_backfill_test.go
+++ b/internal/infra/backup/cold_backfill_test.go
@@ -11,6 +11,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/infra/coldstorage"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -68,14 +69,12 @@ func purgeChapterRanges(t *testing.T, store *dal.Store, chapter *commonpb.Chapte
 func coldReaderFor(t *testing.T, ctrl *gomock.Controller, chapterID uint64, coldStore *dal.Store) *MockColdChapterReader {
 	t.Helper()
 
-	handle, err := coldStore.NewDirectReadHandle()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = handle.Close() })
-
 	reader := NewMockColdChapterReader(ctrl)
 	reader.EXPECT().
 		GetReader(gomock.Any(), chapterID).
-		Return(handle, nil).
+		DoAndReturn(func(context.Context, uint64) (coldstorage.ReadHandle, error) {
+			return coldStore.NewDirectReadHandle()
+		}).
 		AnyTimes()
 
 	return reader

--- a/internal/infra/coldstorage/reader.go
+++ b/internal/infra/coldstorage/reader.go
@@ -2,6 +2,7 @@ package coldstorage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -36,11 +37,50 @@ type ColdReader struct {
 	lru         []uint64 // eviction order, oldest first
 	logger      logging.Logger
 	stopSweep   chan struct{}
+	sweepDone   chan struct{}
+	stopOnce    sync.Once
+	closed      bool
+	closeCond   *sync.Cond
+	closeErr    error
 }
 
 type cachedChapter struct {
-	db         *pebble.DB
-	lastAccess time.Time
+	db            *pebble.DB
+	lastAccess    time.Time
+	activeReaders int
+	evicted       bool
+}
+
+// ReadHandle is a lease on a cached archived chapter. Callers must close the
+// handle after all point reads, value closers, and iterators are finished.
+// Closing the handle lets cache eviction close the backing Pebble database.
+type ReadHandle interface {
+	dal.PebbleReader
+	io.Closer
+}
+
+type readHandle struct {
+	reader    *ColdReader
+	chapterID uint64
+	cached    *cachedChapter
+	once      sync.Once
+	err       error
+}
+
+func (h *readHandle) Get(key []byte) ([]byte, io.Closer, error) {
+	return h.cached.db.Get(key)
+}
+
+func (h *readHandle) NewIter(opts *pebble.IterOptions) (*pebble.Iterator, error) {
+	return h.cached.db.NewIter(opts)
+}
+
+func (h *readHandle) Close() error {
+	h.once.Do(func() {
+		h.err = h.reader.release(h.chapterID, h.cached)
+	})
+
+	return h.err
 }
 
 // NewColdReader creates a ColdReader that caches up to maxCached opened Pebble DBs.
@@ -63,27 +103,45 @@ func NewColdReader(
 		cache:       make(map[uint64]*cachedChapter),
 		logger:      logger.WithFields(map[string]any{"cmp": "cold-reader"}),
 		stopSweep:   make(chan struct{}),
+		sweepDone:   make(chan struct{}),
 	}
+	r.closeCond = sync.NewCond(&r.mu)
 
 	if ttl > 0 {
 		go r.sweepLoop()
+	} else {
+		close(r.sweepDone)
 	}
 
 	return r
 }
 
-// GetReader returns a PebbleReader for the given archived chapter.
-// It downloads and caches the SST file if not already cached.
-func (r *ColdReader) GetReader(ctx context.Context, chapterID uint64) (dal.PebbleReader, error) {
+// GetReader returns a leased Pebble reader for the given archived chapter.
+// The caller must close the returned handle after all reads and iterators are
+// finished. It downloads and caches the SST file if not already cached.
+func (r *ColdReader) GetReader(ctx context.Context, chapterID uint64) (ReadHandle, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.closed {
+		return nil, errors.New("cold reader is closed")
+	}
 
 	// Cache hit
 	if cached, ok := r.cache[chapterID]; ok {
+		if cached.evicted {
+			if len(r.lru) >= r.maxCached {
+				r.evictOldest()
+			}
+
+			cached.evicted = false
+			r.lru = append(r.lru, chapterID)
+		}
+
 		cached.lastAccess = time.Now()
+		cached.activeReaders++
 		r.touchLRU(chapterID)
 
-		return cached.db, nil
+		return &readHandle{reader: r, chapterID: chapterID, cached: cached}, nil
 	}
 
 	// Cache miss: fetch, ingest, cache
@@ -107,14 +165,15 @@ func (r *ColdReader) GetReader(ctx context.Context, chapterID uint64) (dal.Pebbl
 	}
 
 	// Evict oldest if at capacity
-	if len(r.cache) >= r.maxCached {
+	if len(r.lru) >= r.maxCached {
 		r.evictOldest()
 	}
 
-	r.cache[chapterID] = &cachedChapter{db: db, lastAccess: time.Now()}
+	cached := &cachedChapter{db: db, lastAccess: time.Now(), activeReaders: 1}
+	r.cache[chapterID] = cached
 	r.lru = append(r.lru, chapterID)
 
-	return db, nil
+	return &readHandle{reader: r, chapterID: chapterID, cached: cached}, nil
 }
 
 func (r *ColdReader) downloadSST(ctx context.Context, chapterID uint64, destPath string) error {
@@ -194,17 +253,18 @@ func (r *ColdReader) evictOldest() {
 
 	if cached, ok := r.cache[oldest]; ok {
 		r.logger.WithFields(map[string]any{"chapterId": oldest}).Infof("Evicting cached chapter")
-
-		_ = cached.db.Close()
-		delete(r.cache, oldest)
-
-		chapterDir := filepath.Join(r.cacheDir, "chapter-"+strconv.FormatUint(oldest, 10))
-		_ = os.RemoveAll(chapterDir)
+		cached.evicted = true
+		if cached.activeReaders == 0 {
+			// finalize records cleanup errors for the owning ColdReader.Close.
+			_ = r.finalize(oldest, cached)
+		}
 	}
 }
 
 // sweepLoop periodically evicts cache entries that have not been accessed within the TTL.
 func (r *ColdReader) sweepLoop() {
+	defer close(r.sweepDone)
+
 	ticker := time.NewTicker(r.ttl / 2)
 	defer ticker.Stop()
 
@@ -243,9 +303,7 @@ func (r *ColdReader) evictByID(id uint64) {
 	}
 
 	r.logger.WithFields(map[string]any{"chapterId": id}).Infof("Evicting expired cached chapter")
-
-	_ = cached.db.Close()
-	delete(r.cache, id)
+	cached.evicted = true
 
 	// Remove from LRU slice
 	for i, lruID := range r.lru {
@@ -256,26 +314,86 @@ func (r *ColdReader) evictByID(id uint64) {
 		}
 	}
 
-	chapterDir := filepath.Join(r.cacheDir, "chapter-"+strconv.FormatUint(id, 10))
-	_ = os.RemoveAll(chapterDir)
+	if cached.activeReaders == 0 {
+		// finalize records cleanup errors for the owning ColdReader.Close.
+		_ = r.finalize(id, cached)
+	}
 }
 
-// Close closes all cached Pebble databases and removes the cache directory contents.
-func (r *ColdReader) Close() error {
-	close(r.stopSweep)
-
+func (r *ColdReader) release(id uint64, cached *cachedChapter) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for id, cached := range r.cache {
-		_ = cached.db.Close()
-
-		chapterDir := filepath.Join(r.cacheDir, "chapter-"+strconv.FormatUint(id, 10))
-		_ = os.RemoveAll(chapterDir)
+	if cached.activeReaders <= 0 {
+		return errors.New("cold reader handle released more than once")
 	}
 
-	r.cache = make(map[uint64]*cachedChapter)
+	cached.activeReaders--
+	var err error
+	if cached.activeReaders == 0 && (cached.evicted || r.closed) {
+		err = r.finalize(id, cached)
+	}
+	r.closeCond.Broadcast()
+
+	return err
+}
+
+// finalize closes an idle cached chapter. The caller must hold r.mu.
+func (r *ColdReader) finalize(id uint64, cached *cachedChapter) error {
+	if current, ok := r.cache[id]; !ok || current != cached {
+		return nil
+	}
+
+	err := cached.db.Close()
+	if err != nil {
+		err = fmt.Errorf("closing cached chapter %d: %w", id, err)
+	}
+	delete(r.cache, id)
+
+	chapterDir := filepath.Join(r.cacheDir, "chapter-"+strconv.FormatUint(id, 10))
+	if removeErr := os.RemoveAll(chapterDir); removeErr != nil {
+		err = errors.Join(err, fmt.Errorf("removing cached chapter %d: %w", id, removeErr))
+	}
+	r.closeErr = errors.Join(r.closeErr, err)
+
+	return err
+}
+
+func (r *ColdReader) hasActiveReaders() bool {
+	for _, cached := range r.cache {
+		if cached.activeReaders > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Close stops eviction, refuses new leases, waits for active handles, then
+// closes all cached Pebble databases and removes their cache directories.
+func (r *ColdReader) Close() error {
+	r.mu.Lock()
+	r.closed = true
+	r.mu.Unlock()
+
+	r.stopOnce.Do(func() { close(r.stopSweep) })
+	<-r.sweepDone
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.lru = nil
 
-	return nil
+	for id, cached := range r.cache {
+		cached.evicted = true
+		if cached.activeReaders == 0 {
+			// finalize records cleanup errors for this Close return value.
+			_ = r.finalize(id, cached)
+		}
+	}
+
+	for r.hasActiveReaders() {
+		r.closeCond.Wait()
+	}
+
+	return r.closeErr
 }

--- a/internal/infra/coldstorage/reader_test.go
+++ b/internal/infra/coldstorage/reader_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -172,6 +173,7 @@ func TestColdReaderCacheMiss(t *testing.T) {
 	pebbleReader, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
 	require.NotNil(t, pebbleReader)
+	defer func() { require.NoError(t, pebbleReader.Close()) }()
 
 	// Verify the data is readable
 	val, closer, err := pebbleReader.Get([]byte("key1"))
@@ -210,8 +212,10 @@ func TestColdReaderCacheHit(t *testing.T) {
 	r2, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
 
-	// Both should be the same underlying *pebble.DB
-	require.Equal(t, r1, r2)
+	// Both leases should reference the same cached DB.
+	require.Same(t, r1.(*readHandle).cached, r2.(*readHandle).cached)
+	require.NoError(t, r1.Close())
+	require.NoError(t, r2.Close())
 }
 
 func TestColdReaderEviction(t *testing.T) {
@@ -235,14 +239,17 @@ func TestColdReaderEviction(t *testing.T) {
 	reader := NewColdReader(cs, "bucket", cacheDir, 2, 0, logger)
 	t.Cleanup(func() { _ = reader.Close() })
 
-	_, err := reader.GetReader(ctx, 1)
+	r1, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
-	_, err = reader.GetReader(ctx, 2)
+	require.NoError(t, r1.Close())
+	r2, err := reader.GetReader(ctx, 2)
 	require.NoError(t, err)
+	require.NoError(t, r2.Close())
 
 	// This should evict chapter 1
 	r3, err := reader.GetReader(ctx, 3)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, r3.Close()) }()
 
 	val, closer, err := r3.Get([]byte("key-3"))
 	require.NoError(t, err)
@@ -254,13 +261,195 @@ func TestColdReaderEviction(t *testing.T) {
 	require.True(t, os.IsNotExist(err), "chapter-1 cache directory should have been removed")
 
 	// Chapter 2 should still be cached
-	r2, err := reader.GetReader(ctx, 2)
+	r2, err = reader.GetReader(ctx, 2)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, r2.Close()) }()
 
 	val, closer, err = r2.Get([]byte("key-2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value-2"), val)
 	_ = closer.Close()
+}
+
+func TestColdReaderCapacityEvictionKeepsAcquiredReaderAlive(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+
+	cs := newInMemoryColdStorage()
+	cacheDir := t.TempDir()
+
+	for chapterID := uint64(1); chapterID <= 2; chapterID++ {
+		sstData := buildTestSST(t, [][2][]byte{
+			{fmt.Appendf(nil, "key-%d", chapterID), fmt.Appendf(nil, "value-%d", chapterID)},
+		})
+		require.NoError(t, cs.Archive(ctx, "bucket", chapterID, bytes.NewReader(sstData), ComputeSHA256OrPanic(sstData)))
+	}
+
+	reader := NewColdReader(cs, "bucket", cacheDir, 1, 0, logger)
+	t.Cleanup(func() { _ = reader.Close() })
+
+	acquired := make(chan struct{})
+	evicted := make(chan struct{})
+	readResult := make(chan error, 1)
+
+	go func() {
+		chapter, err := reader.GetReader(ctx, 1)
+		if err != nil {
+			readResult <- err
+
+			return
+		}
+		defer func() { _ = chapter.Close() }()
+
+		close(acquired)
+		<-evicted
+
+		value, closer, err := chapter.Get([]byte("key-1"))
+		if err != nil {
+			readResult <- err
+
+			return
+		}
+		defer func() { _ = closer.Close() }()
+
+		if !bytes.Equal(value, []byte("value-1")) {
+			readResult <- fmt.Errorf("unexpected value: %q", value)
+
+			return
+		}
+
+		readResult <- nil
+	}()
+
+	<-acquired
+	chapter2, err := reader.GetReader(ctx, 2)
+	require.NoError(t, err)
+	require.NoError(t, chapter2.Close())
+	close(evicted)
+
+	require.NoError(t, <-readResult, "an acquired reader must remain usable after cache eviction")
+}
+
+func TestColdReaderTTLEvictionWaitsForLastReader(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	cs := newInMemoryColdStorage()
+	cacheDir := t.TempDir()
+	sstData := buildTestSST(t, [][2][]byte{{[]byte("key"), []byte("value")}})
+	require.NoError(t, cs.Archive(ctx, "bucket", 1, bytes.NewReader(sstData), ComputeSHA256OrPanic(sstData)))
+
+	reader := NewColdReader(cs, "bucket", cacheDir, 4, time.Hour, logger)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	first, err := reader.GetReader(ctx, 1)
+	require.NoError(t, err)
+	second, err := reader.GetReader(ctx, 1)
+	require.NoError(t, err)
+
+	reader.mu.Lock()
+	reader.cache[1].lastAccess = time.Now().Add(-2 * time.Hour)
+	reader.mu.Unlock()
+	reader.sweepExpired()
+
+	_, err = os.Stat(filepath.Join(cacheDir, "chapter-1"))
+	require.NoError(t, err, "an evicted chapter stays resident while readers hold leases")
+	require.NoError(t, first.Close())
+
+	_, err = os.Stat(filepath.Join(cacheDir, "chapter-1"))
+	require.NoError(t, err, "the first of multiple releases must not close the database")
+	value, closer, err := second.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+	require.NoError(t, closer.Close())
+	require.NoError(t, second.Close())
+
+	_, err = os.Stat(filepath.Join(cacheDir, "chapter-1"))
+	require.True(t, os.IsNotExist(err), "the last release must close and remove an evicted chapter")
+}
+
+func TestColdReaderEvictedChapterCanBeReacquired(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	cs := newInMemoryColdStorage()
+	cacheDir := t.TempDir()
+	sstData := buildTestSST(t, [][2][]byte{{[]byte("key"), []byte("value")}})
+	require.NoError(t, cs.Archive(ctx, "bucket", 1, bytes.NewReader(sstData), ComputeSHA256OrPanic(sstData)))
+
+	reader := NewColdReader(cs, "bucket", cacheDir, 1, 0, logger)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	first, err := reader.GetReader(ctx, 1)
+	require.NoError(t, err)
+
+	reader.mu.Lock()
+	reader.evictByID(1)
+	reader.mu.Unlock()
+
+	second, err := reader.GetReader(ctx, 1)
+	require.NoError(t, err)
+	require.Same(t, first.(*readHandle).cached, second.(*readHandle).cached)
+
+	reader.mu.Lock()
+	reader.evictByID(1)
+	reader.evictByID(1)
+	reader.mu.Unlock()
+
+	require.NoError(t, first.Close())
+	value, closer, err := second.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+	require.NoError(t, closer.Close())
+	require.NoError(t, second.Close())
+
+	_, err = os.Stat(filepath.Join(cacheDir, "chapter-1"))
+	require.True(t, os.IsNotExist(err), "repeated eviction must still release the database exactly once")
+}
+
+func TestColdReaderCloseWaitsForActiveReader(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	logger := logging.FromContext(ctx)
+	cs := newInMemoryColdStorage()
+	cacheDir := t.TempDir()
+	sstData := buildTestSST(t, [][2][]byte{{[]byte("key"), []byte("value")}})
+	require.NoError(t, cs.Archive(ctx, "bucket", 1, bytes.NewReader(sstData), ComputeSHA256OrPanic(sstData)))
+
+	reader := NewColdReader(cs, "bucket", cacheDir, 1, 0, logger)
+	handle, err := reader.GetReader(ctx, 1)
+	require.NoError(t, err)
+
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- reader.Close() }()
+	require.Eventually(t, func() bool {
+		reader.mu.Lock()
+		defer reader.mu.Unlock()
+
+		return reader.closed
+	}, time.Second, time.Millisecond, "shutdown must first refuse new leases")
+
+	select {
+	case err := <-closeResult:
+		require.Failf(t, "Close returned with an active reader", "error: %v", err)
+	default:
+	}
+
+	value, closer, err := handle.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+	require.NoError(t, closer.Close())
+	require.NoError(t, handle.Close())
+	require.NoError(t, <-closeResult)
+	require.NoError(t, reader.Close(), "Close must be idempotent")
+
+	_, err = reader.GetReader(ctx, 1)
+	require.EqualError(t, err, "cold reader is closed")
 }
 
 func TestColdReaderLRUTouchOrder(t *testing.T) {
@@ -283,18 +472,22 @@ func TestColdReaderLRUTouchOrder(t *testing.T) {
 	t.Cleanup(func() { _ = reader.Close() })
 
 	// Load chapters 1 and 2
-	_, err := reader.GetReader(ctx, 1)
+	r1, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
-	_, err = reader.GetReader(ctx, 2)
+	require.NoError(t, r1.Close())
+	r2, err := reader.GetReader(ctx, 2)
 	require.NoError(t, err)
+	require.NoError(t, r2.Close())
 
 	// Touch chapter 1 (moves it to end of LRU)
-	_, err = reader.GetReader(ctx, 1)
+	r1, err = reader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	require.NoError(t, r1.Close())
 
 	// Load chapter 3 → should evict chapter 2 (oldest untouched), not chapter 1
-	_, err = reader.GetReader(ctx, 3)
+	r3, err := reader.GetReader(ctx, 3)
 	require.NoError(t, err)
+	require.NoError(t, r3.Close())
 
 	// Chapter 1 should still be cached
 	_, err = os.Stat(cacheDir + "/chapter-1")
@@ -321,8 +514,9 @@ func TestColdReaderClose(t *testing.T) {
 
 	reader := NewColdReader(cs, "bucket", cacheDir, 4, 0, logger)
 
-	_, err := reader.GetReader(ctx, 1)
+	handle, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	require.NoError(t, handle.Close())
 
 	// Close should clean up
 	require.NoError(t, reader.Close())
@@ -372,6 +566,7 @@ func TestColdReaderPebbleQueries(t *testing.T) {
 
 	pebbleReader, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, pebbleReader.Close()) }()
 
 	// Test iterator over prefix 0x01
 	iter, err := pebbleReader.NewIter(&pebble.IterOptions{
@@ -418,8 +613,9 @@ func TestColdReaderTTLEviction(t *testing.T) {
 	reader := NewColdReader(cs, "bucket", cacheDir, 4, 100*time.Millisecond, logger)
 	t.Cleanup(func() { _ = reader.Close() })
 
-	_, err := reader.GetReader(ctx, 1)
+	handle, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	require.NoError(t, handle.Close())
 
 	// Cache directory should exist
 	_, err = os.Stat(cacheDir + "/chapter-1")
@@ -451,8 +647,9 @@ func TestColdReaderTTLRefreshedOnAccess(t *testing.T) {
 	reader := NewColdReader(cs, "bucket", cacheDir, 4, 200*time.Millisecond, logger)
 	t.Cleanup(func() { _ = reader.Close() })
 
-	_, err := reader.GetReader(ctx, 1)
+	handle, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	require.NoError(t, handle.Close())
 
 	cachePath := cacheDir + "/chapter-1"
 
@@ -463,7 +660,10 @@ func TestColdReaderTTLRefreshedOnAccess(t *testing.T) {
 			return true
 		}
 
-		_, getErr := reader.GetReader(ctx, 1)
+		handle, getErr := reader.GetReader(ctx, 1)
+		if getErr == nil {
+			getErr = handle.Close()
+		}
 
 		return getErr != nil
 	}, 400*time.Millisecond, 80*time.Millisecond, "chapter-1 should remain cached while accesses refresh its TTL")

--- a/internal/infra/coldstorage/s3_test.go
+++ b/internal/infra/coldstorage/s3_test.go
@@ -274,6 +274,7 @@ func TestS3Storage_SSTRoundtripWithColdReader(t *testing.T) {
 	pebbleReader, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
 	require.NotNil(t, pebbleReader)
+	defer func() { require.NoError(t, pebbleReader.Close()) }()
 
 	// Verify all keys are readable
 	for i, expected := range []struct {
@@ -312,18 +313,22 @@ func TestS3Storage_ColdReaderCacheEviction(t *testing.T) {
 	t.Cleanup(func() { _ = reader.Close() })
 
 	// Load chapters 1 and 2
-	_, err := reader.GetReader(ctx, 1)
+	r1, err := reader.GetReader(ctx, 1)
 	require.NoError(t, err)
-	_, err = reader.GetReader(ctx, 2)
+	require.NoError(t, r1.Close())
+	r2, err := reader.GetReader(ctx, 2)
 	require.NoError(t, err)
+	require.NoError(t, r2.Close())
 
 	// Load chapter 3 → evicts chapter 1
-	_, err = reader.GetReader(ctx, 3)
-	require.NoError(t, err)
-
-	// Chapter 3 should be readable (re-downloaded if needed)
 	r3, err := reader.GetReader(ctx, 3)
 	require.NoError(t, err)
+	require.NoError(t, r3.Close())
+
+	// Chapter 3 should be readable (re-downloaded if needed)
+	r3, err = reader.GetReader(ctx, 3)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r3.Close()) }()
 
 	val, closer, err := r3.Get([]byte("key"))
 	require.NoError(t, err)

--- a/internal/infra/state/archiver_test.go
+++ b/internal/infra/state/archiver_test.go
@@ -801,6 +801,7 @@ func TestArchiverSSTRoundtrip(t *testing.T) {
 
 	pebbleReader, err := coldReader.GetReader(ctx, 1)
 	require.NoError(t, err)
+	defer func() { require.NoError(t, pebbleReader.Close()) }()
 
 	// Verify the log is readable from the ingested SST
 	log, err := query.ReadLogBySequence(ctx, pebbleReader, 1)

--- a/internal/query/log.go
+++ b/internal/query/log.go
@@ -260,7 +260,16 @@ func ReadLogBySequenceWithCold(
 		return nil, fmt.Errorf("getting cold reader for chapter %d: %w", chapterID, err)
 	}
 
-	return ReadLogBySequence(ctx, coldPebble, sequence)
+	log, readErr := ReadLogBySequence(ctx, coldPebble, sequence)
+	closeErr := coldPebble.Close()
+	if readErr != nil {
+		return nil, errors.Join(readErr, closeErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("closing cold reader for chapter %d: %w", chapterID, closeErr)
+	}
+
+	return log, nil
 }
 
 // findArchivedChapterForSequence iterates chapters to find an archived one containing the given sequence.


### PR DESCRIPTION
Fixes EN-1862.

## Discovery

DISCOVERY: NO_EXISTING_WORK

Exact searches across open/closed PRs, branches, commits, and Jira references found no existing EN-1862 work. PRs #1623, #1633, and #1673 use or extend `ColdReader` for archived queries and backup backfill, but do not change its ownership or eviction lifetime; they are RELATED_BUT_DIFFERENT.

## BEFORE_FIX

BEFORE_FIX: BUG_REPRODUCED

- Base SHA: `b327aeaf8a0232c70842ec573e93721f0604e720`
- Command: `env -u GOROOT nix develop --command go test ./internal/infra/coldstorage -run '^TestColdReaderCapacityEvictionKeepsAcquiredReaderAlive$' -count=1 -v`
- Deterministic interleaving: a goroutine acquires chapter 1, a channel barrier holds its operation, loading chapter 2 at `maxCached=1` evicts chapter 1, then the operation resumes.
- Observed failure: `panic: pebble: closed` in `pebble.(*DB).getInternal`.

Invariant: A ColdReader backing DB must not be closed while an active reader still owns a valid lease/use of it.

## Root cause

`GetReader` returned the cache-owned `*pebble.DB` directly. No refcount, lease, or release operation represented an active user, so LRU/TTL eviction and shutdown could close Pebble while a consumer was still reading.

## Fix

- Return an explicit closeable read-handle lease and count active readers per cached chapter.
- Mark active entries evicted and defer Pebble close/cache-directory removal until the last lease closes.
- Allow a concurrently reacquired immutable chapter to revive the still-live cached DB.
- Make `ColdReader.Close` idempotently refuse new leases, join the TTL sweeper, wait for active handles, and then release owned databases.
- Close leases on every production path. Backup backfill scopes one lease per chapter so close errors can be joined to export errors without retaining all chapter DBs for the whole backup.
- Document the lifetime contract in the chapters subsystem README and cold-storage documentation.

## AFTER_FIX

AFTER_FIX: PASS

- Capacity eviction with an active reader passes.
- Deterministic TTL eviction, multiple readers, last release, concurrent reacquire, repeated eviction, explicit/double shutdown, close ordering, and resource cleanup pass.
- Focused adversarial tests passed normally and for 20 repetitions under the race detector after the final rebase on `1d13a0e82`; an earlier candidate also passed 20 normal repetitions.

TEST_SENSITIVITY: PASS

Temporarily removing the active-reader guard in LRU eviction makes the regression test fail again with `panic: pebble: closed`. The mutation was restored and was never committed.

## Validation

- Go 1.26 environment gate: PASS (`go1.26.5`, Nix store)
- Bugfix evidence gate: PASS
- Targeted package tests: PASS
- Targeted race repetitions: PASS (`-count=20`)
- Hermetic `bash scripts/agent-check-full`: PASS
- Full `go test -race ./...`: PASS (included by `agent-check-full`)
- Trusted `agent-just pre-commit`: PASS
- Pre-commit fixpoint: PASS
- Worktree: clean
- Exact technical review: APPROVE (`e92f3b0e69b9c94332f91b8c0780d0bdd314526a`, findings 0, blockers 0, residual risk LOW)

BASELINE_CLASSIFICATION: ENVIRONMENTAL

An initial non-hermetic lint run saw cache entries from sibling worktrees; the required hermetic-cache rerun was clean. A first manually provisioned module cache under `build/` was also rejected by `go mod tidy` because it was inside the module; moving the writable validation caches outside the worktree resolved it without tooling changes.
