### PR TITLE
fix: route snapshot fetcher and gRPC auth logs through the app logger

### DIFF
--- a/internal/adapter/grpc/logger_interceptor.go
+++ b/internal/adapter/grpc/logger_interceptor.go
@@ -1,0 +1,40 @@
+package grpc
+
+import (
+	"context"
+
+	ggrpc "google.golang.org/grpc"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// loggerInterceptor injects the configured logger into every unary call
+// context so downstream code (auth failure logging, error sanitization) can
+// resolve it via logging.FromContext. Without this, FromContext degrades to
+// go-libs' bare logrus stderr fallback and emits lines in a different format
+// than the rest of the process. This mirrors the HTTP loggerMiddleware.
+func loggerInterceptor(logger logging.Logger) ggrpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *ggrpc.UnaryServerInfo, handler ggrpc.UnaryHandler) (any, error) {
+		return handler(logging.ContextWithLogger(ctx, logger), req)
+	}
+}
+
+// loggerStreamInterceptor is the streaming counterpart of loggerInterceptor.
+func loggerStreamInterceptor(logger logging.Logger) ggrpc.StreamServerInterceptor {
+	return func(srv any, ss ggrpc.ServerStream, info *ggrpc.StreamServerInfo, handler ggrpc.StreamHandler) error {
+		ctx := logging.ContextWithLogger(ss.Context(), logger)
+
+		return handler(srv, &loggerServerStream{ServerStream: ss, ctx: ctx})
+	}
+}
+
+// loggerServerStream wraps a ServerStream to override its Context.
+type loggerServerStream struct {
+	ggrpc.ServerStream
+
+	ctx context.Context
+}
+
+func (s *loggerServerStream) Context() context.Context {
+	return s.ctx
+}

--- a/internal/adapter/grpc/logger_interceptor_test.go
+++ b/internal/adapter/grpc/logger_interceptor_test.go
@@ -1,0 +1,118 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+const (
+	unaryLogMarker  = "logger-interceptor-unary-marker"
+	streamLogMarker = "logger-interceptor-stream-marker"
+)
+
+// contextLoggingHealth logs through logging.FromContext on every RPC so the
+// test can prove the request context carries the injected app logger rather
+// than degrading to go-libs' bare stderr fallback.
+type contextLoggingHealth struct {
+	healthpb.UnimplementedHealthServer
+}
+
+func (contextLoggingHealth) Check(ctx context.Context, _ *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	logging.FromContext(ctx).Infof(unaryLogMarker)
+
+	return &healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING}, nil
+}
+
+func (contextLoggingHealth) Watch(_ *healthpb.HealthCheckRequest, stream ggrpc.ServerStreamingServer[healthpb.HealthCheckResponse]) error {
+	logging.FromContext(stream.Context()).Infof(streamLogMarker)
+
+	return stream.Send(&healthpb.HealthCheckResponse{Status: healthpb.HealthCheckResponse_SERVING})
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer: the server logs from RPC
+// goroutines while the test reads the captured output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
+}
+
+// TestNewServiceServer_InjectsLoggerIntoRequestContexts drives the real
+// NewServiceServer interceptor chain (not the interceptors in isolation) and
+// asserts that a handler resolving logging.FromContext on both a unary and a
+// streaming call writes to the configured app logger. Removing
+// loggerInterceptor/loggerStreamInterceptor from the chain keeps the RPCs
+// succeeding but fails this test, because the lines would land on the
+// process stderr instead of the injected writer.
+func TestNewServiceServer_InjectsLoggerIntoRequestContexts(t *testing.T) {
+	t.Parallel()
+
+	logs := &syncBuffer{}
+	logger := logging.NewDefaultLogger(logs, false, false, false)
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv, err := NewServiceServer("", 0, logger, false, time.Second, nil, true, WithListener(listener))
+	require.NoError(t, err)
+
+	healthpb.RegisterHealthServer(srv.GetServer(), contextLoggingHealth{})
+
+	require.NoError(t, srv.Listen())
+
+	go func() {
+		_ = srv.Serve()
+	}()
+
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	conn, err := ggrpc.NewClient(listener.Addr().String(), ggrpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	client := healthpb.NewHealthClient(conn)
+
+	_, err = client.Check(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	watch, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	_, err = watch.Recv()
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		logged := logs.String()
+
+		return strings.Contains(logged, unaryLogMarker) &&
+			strings.Contains(logged, streamLogMarker)
+	}, 5*time.Second, 10*time.Millisecond, "handler logs must reach the injected app logger; got: %q", logs.String())
+}

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -840,12 +840,14 @@ func NewServiceServer(host string, port int, logger logging.Logger, debug bool, 
 	// proper gRPC status code instead of "Unknown" for domain errors.
 	unaryInterceptors := []ggrpc.UnaryServerInterceptor{
 		recoveryInterceptor(logger),
+		loggerInterceptor(logger),
 		consistencyInterceptor(),
 		loggingInterceptor(logger, slowThreshold),
 		errorConversionInterceptor(logger),
 	}
 	streamInterceptors := []ggrpc.StreamServerInterceptor{
 		recoveryStreamInterceptor(logger),
+		loggerStreamInterceptor(logger),
 		consistencyStreamInterceptor(),
 		loggingStreamInterceptor(logger, slowThreshold),
 		errorConversionStreamInterceptor(logger),

--- a/internal/application/ctrl/snapshot_fetcher.go
+++ b/internal/application/ctrl/snapshot_fetcher.go
@@ -36,6 +36,7 @@ const (
 // grpcSnapshotFetcher implements state.SnapshotFetcher using the session-based gRPC protocol.
 type grpcSnapshotFetcher struct {
 	client         snapshotpb.SnapshotServiceClient
+	logger         logging.Logger
 	parallelism    int
 	retryCount     int
 	fileRetryCount int
@@ -75,7 +76,7 @@ func isSessionExpired(err error) bool {
 }
 
 func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
-	logger := logging.FromContext(ctx)
+	logger := f.logger.WithContext(ctx)
 
 	for attempt := range f.retryCount {
 		if attempt > 0 {
@@ -128,7 +129,7 @@ func (f *grpcSnapshotFetcher) FetchSnapshot(ctx context.Context, targetDir strin
 // briefly outlive the call while it drains gRPC internals; that is a
 // bounded leak, and the caller is unblocked to retry a fresh session.
 func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, minAppliedIndex uint64) (*snapshotpb.PrepareSnapshotResponse, error) {
-	logger := logging.FromContext(ctx)
+	logger := f.logger.WithContext(ctx)
 
 	callCtx, cancel := context.WithTimeout(ctx, prepareSnapshotTimeout)
 	defer cancel()
@@ -168,7 +169,7 @@ func (f *grpcSnapshotFetcher) prepareSnapshotWithHeartbeat(ctx context.Context, 
 }
 
 func (f *grpcSnapshotFetcher) fetchWithSession(ctx context.Context, targetDir string, progress *state.SyncProgress, minAppliedIndex uint64) (uint64, error) {
-	logger := logging.FromContext(ctx)
+	logger := f.logger.WithContext(ctx)
 
 	logger.WithFields(map[string]any{
 		"minAppliedIndex": minAppliedIndex,
@@ -284,6 +285,7 @@ func sessionBackoffWait(ctx context.Context, attempt int) error {
 // grpcSnapshotFetcherProvider provides snapshot fetchers for peers.
 type grpcSnapshotFetcherProvider struct {
 	transport      *node.DefaultTransport
+	logger         logging.Logger
 	parallelism    int
 	retryCount     int
 	fileRetryCount int
@@ -297,6 +299,7 @@ func (p *grpcSnapshotFetcherProvider) GetForPeer(id uint64) (state.SnapshotFetch
 
 	return &grpcSnapshotFetcher{
 		client:         snapshotpb.NewSnapshotServiceClient(conn),
+		logger:         p.logger,
 		parallelism:    p.parallelism,
 		retryCount:     p.retryCount,
 		fileRetryCount: p.fileRetryCount,
@@ -304,9 +307,16 @@ func (p *grpcSnapshotFetcherProvider) GetForPeer(id uint64) (state.SnapshotFetch
 }
 
 // GRPCSnapshotFetcherProvider creates a new snapshot fetcher provider using gRPC.
-func GRPCSnapshotFetcherProvider(transport *node.DefaultTransport, parallelism, retryCount, fileRetryCount int) state.SnapshotFetcherProvider {
+//
+// The logger is injected explicitly rather than resolved through
+// logging.FromContext: the sync context originates in the applier and never
+// carries a logger, so FromContext would degrade to go-libs' bare logrus
+// stderr fallback and emit lines in a different format than the rest of the
+// process.
+func GRPCSnapshotFetcherProvider(transport *node.DefaultTransport, logger logging.Logger, parallelism, retryCount, fileRetryCount int) state.SnapshotFetcherProvider {
 	return &grpcSnapshotFetcherProvider{
 		transport:      transport,
+		logger:         logger.WithFields(map[string]any{"cmp": "snapshot-fetcher"}),
 		parallelism:    parallelism,
 		retryCount:     retryCount,
 		fileRetryCount: fileRetryCount,

--- a/internal/application/ctrl/snapshot_fetcher_test.go
+++ b/internal/application/ctrl/snapshot_fetcher_test.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -592,4 +593,31 @@ func TestGRPCSnapshotFetcher_CloseSessionAlwaysCalled(t *testing.T) {
 	_, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
 	require.Error(t, err)
 	require.GreaterOrEqual(t, csState.closeCalled.Load(), int32(1))
+}
+
+// TestGRPCSnapshotFetcher_LogsThroughInjectedLogger pins the logging wiring:
+// the fetcher must write through the logger it was constructed with, not
+// through logging.FromContext on a context that carries no logger (which
+// degrades to go-libs' bare logrus stderr fallback and produced mixed log
+// formats in production). Reverting to FromContext keeps every other fetcher
+// test green but fails this one, because the context passed here is bare.
+func TestGRPCSnapshotFetcher_LogsThroughInjectedLogger(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	files := map[string][]byte{"a.txt": []byte("aaa")}
+
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+
+	client, _ := buildMockClient(t, files)
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logger, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+
+	_, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
+	require.NoError(t, err)
+
+	logged := logs.String()
+	require.Contains(t, logged, "Requesting snapshot session from leader")
+	require.Contains(t, logged, "Downloading snapshot file")
+	require.Contains(t, logged, "Snapshot file downloaded")
 }

--- a/internal/application/ctrl/snapshot_fetcher_test.go
+++ b/internal/application/ctrl/snapshot_fetcher_test.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/proto/snapshotpb"
 )
@@ -152,7 +154,7 @@ func TestGRPCSnapshotFetcher_HappyPath(t *testing.T) {
 	}
 
 	client, csState := buildMockClient(t, files)
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 2, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 2, retryCount: 5, fileRetryCount: 3}
 
 	size, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
 	require.NoError(t, err)
@@ -179,7 +181,7 @@ func TestGRPCSnapshotFetcher_ParallelFetch(t *testing.T) {
 	}
 
 	client, csState := buildMockClient(t, files)
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 4, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 4, retryCount: 5, fileRetryCount: 3}
 
 	size, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
 	require.NoError(t, err)
@@ -217,7 +219,7 @@ func TestGRPCSnapshotFetcher_HashMismatch(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 5, fileRetryCount: 3}
 	_, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "hash mismatch")
@@ -242,7 +244,7 @@ func TestGRPCSnapshotFetcher_RejectsNonLocalManifestPath(t *testing.T) {
 		nil,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 1}
 	_, err = fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.ErrorContains(t, err, "invalid snapshot path")
 	require.Zero(t, clientState.fetchFileCalls.Load())
@@ -273,7 +275,7 @@ func TestGRPCSnapshotFetcher_RejectsStagingPathCollision(t *testing.T) {
 		nil,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 4, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 4, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.ErrorContains(t, err, "collides with the staging path")
 	require.Zero(t, clientState.fetchFileCalls.Load())
@@ -302,7 +304,7 @@ func TestGRPCSnapshotFetcher_RejectsDuplicateManifestPath(t *testing.T) {
 		nil,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 4, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 4, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.ErrorContains(t, err, "duplicate snapshot path")
 	require.Zero(t, clientState.fetchFileCalls.Load())
@@ -338,7 +340,7 @@ func TestGRPCSnapshotFetcher_RejectsSymlinkEscape(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.ErrorContains(t, err, "creating parent directory")
 	require.Equal(t, int32(1), clientState.fetchFileCalls.Load())
@@ -368,7 +370,7 @@ func TestGRPCSnapshotFetcher_MissingDigest(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid or missing SHA-256 digest")
@@ -397,7 +399,7 @@ func TestGRPCSnapshotFetcher_SizeMismatch(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "size mismatch")
@@ -429,7 +431,7 @@ func TestGRPCSnapshotFetcher_RejectsExcessBytes(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 1}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 1}
 	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "got at least 5")
@@ -463,7 +465,7 @@ func TestGRPCSnapshotFetcher_RetryRewritesPartialFile(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 1, fileRetryCount: 2}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 1, fileRetryCount: 2}
 	_, err := fetcher.FetchSnapshot(t.Context(), targetDir, nil, 0)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), csState.fetchFileCalls.Load())
@@ -483,7 +485,7 @@ func TestGRPCSnapshotFetcher_UnavailableWrapsErrNotAvailable(t *testing.T) {
 		nil,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 5, fileRetryCount: 3}
 	_, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
 	require.Error(t, err)
 	require.ErrorIs(t, err, state.ErrNotAvailable)
@@ -500,7 +502,7 @@ func TestGRPCSnapshotFetcher_ProgressTracking(t *testing.T) {
 
 	client, _ := buildMockClient(t, files)
 	progress := state.NewSyncProgress()
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 2, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 2, retryCount: 5, fileRetryCount: 3}
 
 	_, err := fetcher.FetchSnapshot(t.Context(), dir, progress, 0)
 	require.NoError(t, err)
@@ -550,7 +552,7 @@ func TestGRPCSnapshotFetcher_RedownloadsCompletedFiles(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 2, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 2, retryCount: 5, fileRetryCount: 3}
 	_, err := fetcher.FetchSnapshot(t.Context(), dir, nil, 0)
 	require.NoError(t, err)
 
@@ -586,7 +588,7 @@ func TestGRPCSnapshotFetcher_CloseSessionAlwaysCalled(t *testing.T) {
 		streams,
 	)
 
-	fetcher := &grpcSnapshotFetcher{client: client, parallelism: 1, retryCount: 5, fileRetryCount: 3}
+	fetcher := &grpcSnapshotFetcher{client: client, logger: logging.Testing(), parallelism: 1, retryCount: 5, fileRetryCount: 3}
 	_, err := fetcher.FetchSnapshot(t.Context(), t.TempDir(), nil, 0)
 	require.Error(t, err)
 	require.GreaterOrEqual(t, csState.closeCalled.Load(), int32(1))

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -294,9 +294,10 @@ func Module() fx.Option {
 					}),
 				})
 			},
-			func(cfg Config, transport *node.DefaultTransport) state.SnapshotFetcherProvider {
+			func(cfg Config, transport *node.DefaultTransport, logger logging.Logger) state.SnapshotFetcherProvider {
 				return ctrl.GRPCSnapshotFetcherProvider(
 					transport,
+					logger,
 					cfg.SnapshotSyncConfig.Parallelism,
 					cfg.SnapshotSyncConfig.RetryCount,
 					cfg.SnapshotSyncConfig.FileRetryCount,


### PR DESCRIPTION
## Problem

Process output mixed two log formats:

```
time="2026-08-27T16:15:11Z" level=info msg="Downloading snapshot file" path=001424.sst size=33523537
2026-08-27T16:15:12.603Z    INFO    IndexTracker updated in finishReady    {"node-id": 2, ...}
```

Both call sites use the same `logging.Logger` interface, but go-libs' `logging.FromContext(ctx)` silently falls back to a fresh **logrus text logger on stderr** when the context carries no logger. The snapshot fetcher resolved its logger from the applier's sync context (never has one attached), and gRPC auth failures (`logAuthFailure`) from the raw request context.

## Fix

- `internal/application/ctrl/snapshot_fetcher.go`: provider/fetcher take an injected `logging.Logger` (tagged `cmp=snapshot-fetcher`) and use `logger.WithContext(ctx)` instead of `FromContext`.
- `internal/bootstrap/module.go`: pass the app logger into `GRPCSnapshotFetcherProvider`.
- `internal/adapter/grpc/logger_interceptor.go` (new) + `server.go`: unary/stream interceptors inject the logger into service gRPC request contexts, mirroring the existing HTTP `loggerMiddleware`. Fixes the same leak for gRPC auth-failure logs.
- Test fixtures set `logger: logging.Testing()`.

Remaining `FromContext` callers (HTTP handlers/middleware, e2e testutil) already run under a context with the logger attached.

## Validation

- `GOROOT= go build ./...`, `golangci-lint` on touched packages (0 issues), `git diff --check`
- `go test ./internal/application/ctrl/ ./internal/adapter/grpc/ ./internal/adapter/auth/ ./internal/bootstrap/` — pass
- `scripts/agent-check` lint stage reports pre-existing issues in generated `*.pb.go` files only; nothing in touched files.