### PR TITLE
fix(bloom): replay deferred population after follower sync

### DIFF
--- a/docs/technical/architecture/subsystems/attributes/bloom.md
+++ b/docs/technical/architecture/subsystems/attributes/bloom.md
@@ -4,7 +4,7 @@
 
 A bloom filter sits in front of each attribute cache. Its job is to **short-circuit "key absent" lookups** during preload: when `MayContain(k) == false`, the loader knows the key is *certainly* missing and can skip the Pebble `Get` entirely. When `MayContain(k) == true`, the key *might* be present and the loader proceeds normally — a false-positive costs one Pebble read.
 
-The bloom filter is not a correctness primitive — it does not gate the FSM apply path and the system is correct without it. It is a **preload-time performance optimisation** that materially reduces the load on Pebble for workloads dominated by writes to fresh accounts (the common case).
+The bloom filter is a **preload-time performance optimisation** that materially reduces the load on Pebble for workloads dominated by writes to fresh accounts (the common case). The system is correct without consulting it, but a filter published as ready must be a superset of the installed attribute store: admission trusts a negative result and skips the Pebble read. Lifecycle transitions therefore keep readiness false whenever completeness is uncertain.
 
 Source: `internal/infra/bloom/bloom.go`.
 
@@ -62,12 +62,24 @@ Dirty blocks are flushed to Pebble at every batch commit:
 
 ### Boot path — populate from the attribute store
 
-`PopulateFromStore()` (`bloom.go:536`) scans the attribute zones at boot and re-adds every key to the relevant filter. This handles two cases:
+`PopulateFromStore()` (`bloom.go:536`) scans the attribute zones at boot and re-adds every key to the relevant filter. This handles three cases:
 
 1. The node has never run before (no persisted bloom rows).
 2. A snapshot was installed — the bloom rows from the donor node may not match this node's view.
+3. Persisted rows exist for a known attribute type disabled by the current configuration, so the enabled filters require a full rescan.
 
-The populate runs **asynchronously** after boot (`StartAsyncBloomPopulate` in `cache_snapshotter.go:602-667`). Until it completes, the bloom is in a "not-ready" state and `MayContain` conservatively returns `true` for every key — meaning preload behaves as if the bloom didn't exist (every lookup hits Pebble). `SetReadyIfEpoch()` (`bloom.go:414`) closes the window via an epoch number, preventing a stale rebuild from publishing over a fresh one.
+The populate runs **asynchronously** after boot (`StartAsyncBloomPopulate` in `cache_snapshotter.go`). Until it completes, the bloom is in a "not-ready" state and the plan builder ignores it — meaning preload behaves as if the bloom didn't exist and every cache miss reaches Pebble. `SetReadyIfEpoch()` (`bloom.go`) closes the window via an epoch number, preventing a stale rebuild from publishing over a fresh one.
+
+### Follower checkpoint synchronization
+
+Follower synchronization pauses Bloom background work before replacing Pebble so no iterator survives the close/reopen boundary. If it interrupts a not-ready population, the request is kept pending so an early sync failure can resume it against the unchanged store. Once replacement succeeds, `RestoreFromStore()` publishes the current filter snapshot as not-ready before its first fallible restore step: the incoming checkpoint may contain keys the follower's previous ready filter never observed. A fetch failure leaves an already-ready filter for the untouched store unchanged.
+
+`RestoreFromStore()` then chooses one of two paths while the snapshotter is paused:
+
+- persisted compatible blocks are restored synchronously and cache generations are replayed before readiness is republished;
+- missing blocks or configuration drift request a full population. The request is recorded without retaining a Pebble reader on `CacheSnapshotter`.
+
+`Synchronizer` always resumes through `Recovery`, including on error paths. On success, `Recovery` supplies its reader and starts any deferred full population. Until that scan completes, readiness stays false and admission falls back to Pebble, preventing a ready-but-stale follower filter from producing false negatives.
 
 ### Cache rotation interaction
 
@@ -96,5 +108,5 @@ A rising `false_positives / lookups` ratio (above ~1%) is the usual operator tri
 ## What the bloom does not do
 
 - **It is not a tombstone source.** `MayContain == false` means "never inserted", which for a monotone bloom is equivalent to "key has never been written". It cannot represent "key was deleted" because the filter doesn't support deletion.
-- **It does not gate the FSM.** The coverage gate (`Scope.GetX`) is the structural guarantee — the bloom only optimises the preload-time loader. A bug in the bloom can never cause divergence between replicas; it can only cause one of them to be slower than the others.
+- **It does not gate the FSM.** The coverage gate (`Scope.GetX`) is the structural apply-time guarantee, while the bloom only optimises the preload-time loader. This does not make Bloom readiness optional: publishing an incomplete filter as ready can suppress a required Pebble preload and produce an incorrect business result. A not-ready filter is always safe because admission ignores it.
 - **It is not consulted on the apply path.** The FSM holds a `*dal.WriteSession` with no read methods — see [invariant #3](../../../../../AGENTS.md). Bloom is preload-only.

--- a/internal/infra/state/cache_snapshotter.go
+++ b/internal/infra/state/cache_snapshotter.go
@@ -288,13 +288,15 @@ func newProtoSnapshotSlot[V interface {
 // the reader as a parameter and are only called from non-hot-path contexts
 // (Recovery, bootstrap).
 type CacheSnapshotter struct {
-	bloomMu      sync.Mutex
-	bloomStopped bool
-	bloomPaused  bool
-	logger       logging.Logger
-	registry     *StateRegistry
-	bloomFilters *bloom.FilterSet
-	slots        []cacheSnapshotSlot
+	bloomMu              sync.Mutex
+	bloomStopped         bool
+	bloomPaused          bool
+	bloomPopulatePending bool
+	bloomPopulateReason  string
+	logger               logging.Logger
+	registry             *StateRegistry
+	bloomFilters         *bloom.FilterSet
+	slots                []cacheSnapshotSlot
 	// slotByAttrCode maps attribute code bytes to the corresponding slot,
 	// for the FSM apply path's MirrorPreload dispatch.
 	slotByAttrCode map[byte]cacheSnapshotSlot
@@ -407,6 +409,13 @@ func persistLeanProtoEntries[V interface {
 // rather than gating restoration on the meta sentinel.
 func (s *CacheSnapshotter) RestoreFromStore(store dal.RecoveryReader) error {
 	restoreStart := time.Now()
+	if s.bloomFilters != nil {
+		// Restore may follow a checkpoint replacement whose key set the current
+		// filter never observed. Fail closed before the first fallible restore
+		// step; successful synchronous restore or async population republishes
+		// readiness after completeness is re-established.
+		s.bloomFilters.SetReady(false)
+	}
 
 	s.registry.Cache.Reset()
 	s.registry.Idempotency.Reset()
@@ -780,7 +789,16 @@ func (s *CacheSnapshotter) restoreBloomFilters(store dal.RecoveryReader) error {
 func (s *CacheSnapshotter) StartAsyncBloomPopulate(store dal.RecoveryReader, reason string) {
 	s.bloomMu.Lock()
 	defer s.bloomMu.Unlock()
-	if s.bloomStopped || s.bloomPaused {
+	if s.bloomStopped {
+		return
+	}
+	if s.bloomPaused {
+		// Do not retain store on the snapshotter: Recovery remains the sole
+		// owner of Pebble read capability. One pending full population is enough
+		// regardless of how many rebuild signals arrive while paused.
+		s.bloomPopulatePending = true
+		s.bloomPopulateReason = reason
+
 		return
 	}
 	s.runBloomTask(store, reason, s.bloomFilters.PopulateFromStore)
@@ -948,21 +966,45 @@ func (s *CacheSnapshotter) replayBloomFromCache(ctx context.Context) error {
 func (s *CacheSnapshotter) Pause() {
 	s.bloomMu.Lock()
 	s.bloomPaused = true
+	if s.bloomFilters != nil && !s.bloomFilters.IsReady() {
+		// A not-ready filter may have an active population that Interrupt stops.
+		// Preserve the work request so an early sync failure can resume it against
+		// the still-current store instead of leaving acceleration disabled.
+		s.bloomPopulatePending = true
+		s.bloomPopulateReason = "resume Bloom population interrupted by follower sync"
+	}
 	s.bloomExecutor.Interrupt()
 	s.bloomMu.Unlock()
 }
 
-// Resume reopens a snapshotter paused for checkpoint replacement.
-func (s *CacheSnapshotter) Resume() {
+// Resume reopens a snapshotter paused for checkpoint replacement and starts
+// one full population when RestoreFromStore requested it during the pause.
+// The reader is supplied by Recovery and is captured only by the task.
+func (s *CacheSnapshotter) Resume(store dal.RecoveryReader) {
 	s.bloomMu.Lock()
+	defer s.bloomMu.Unlock()
+
+	if s.bloomStopped {
+		return
+	}
+
 	s.bloomPaused = false
-	s.bloomMu.Unlock()
+	if !s.bloomPopulatePending {
+		return
+	}
+
+	reason := s.bloomPopulateReason
+	s.bloomPopulatePending = false
+	s.bloomPopulateReason = ""
+	s.runBloomTask(store, reason, s.bloomFilters.PopulateFromStore)
 }
 
 // Stop permanently closes the snapshotter's background-work ownership.
 func (s *CacheSnapshotter) Stop() {
 	s.bloomMu.Lock()
 	s.bloomStopped = true
+	s.bloomPopulatePending = false
+	s.bloomPopulateReason = ""
 	s.bloomExecutor.Interrupt()
 	s.bloomMu.Unlock()
 }

--- a/internal/infra/state/cache_snapshotter_test.go
+++ b/internal/infra/state/cache_snapshotter_test.go
@@ -1,8 +1,10 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -39,7 +41,7 @@ func TestCacheSnapshotter_StopPreventsBloomRestart(t *testing.T) {
 	snapshotter.StartAsyncBloomPopulate(nil, "late dispatcher signal")
 }
 
-func TestCacheSnapshotter_PauseResumeAllowsCheckpointRepopulation(t *testing.T) {
+func TestCacheSnapshotter_StopWaitsForAdmittedBloomTask(t *testing.T) {
 	t.Parallel()
 
 	meter := noop.NewMeterProvider().Meter("test")
@@ -47,16 +49,76 @@ func TestCacheSnapshotter_PauseResumeAllowsCheckpointRepopulation(t *testing.T) 
 		BloomVolumes: &commonpb.BloomTypeConfig{ExpectedKeys: 1000, FpRate: 0.01},
 	}, meter)
 	snapshotter, dataStore, _ := newTestCacheSnapshotter(t, bloomFilters)
+	taskStarted := make(chan struct{})
+	taskExited := make(chan struct{})
 
-	bloomFilters.SetReady(false)
-	snapshotter.Pause()
-	snapshotter.StartAsyncBloomPopulate(dataStore, "suppressed during checkpoint replacement")
-	require.False(t, bloomFilters.IsReady())
+	// Admit a task before Stop. The task exits only after its context is
+	// cancelled, so Stop returning proves that it cancelled and drained the
+	// already-admitted work rather than merely closing future admission.
+	snapshotter.bloomMu.Lock()
+	snapshotter.runBloomTask(dataStore, "admitted before stop", func(ctx context.Context, _ dal.PebbleReader) error {
+		close(taskStarted)
+		<-ctx.Done()
+		close(taskExited)
 
-	snapshotter.Resume()
-	snapshotter.StartAsyncBloomPopulate(dataStore, "repopulate after checkpoint replacement")
+		return ctx.Err()
+	})
+	snapshotter.bloomMu.Unlock()
+
+	<-taskStarted
 	snapshotter.Stop()
+
+	select {
+	case <-taskExited:
+	default:
+		t.Fatal("Stop returned before the admitted Bloom task exited")
+	}
+
+	// A dispatcher signal delivered after the drain must still be rejected.
+	snapshotter.StartAsyncBloomPopulate(nil, "late dispatcher signal")
+}
+
+func TestCacheSnapshotter_PausedRestoreDefersBloomPopulationUntilResume(t *testing.T) {
+	t.Parallel()
+
+	meter := noop.NewMeterProvider().Meter("test")
+	bloomFilters := bloom.NewFilterSet(&commonpb.ClusterConfig{
+		BloomVolumes: &commonpb.BloomTypeConfig{ExpectedKeys: 1000, FpRate: 0.01},
+	}, meter)
+	snapshotter, dataStore, registry := newTestCacheSnapshotter(t, bloomFilters)
+	t.Cleanup(snapshotter.Stop)
+
+	volumeKey := newVolumeKey(domain.AccountKey{LedgerName: "leader", Account: "destination"}, "USD/2")
+	volumeID := attributes.HashU128(volumeKey.Bytes())
+	pair := &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(100),
+		Output: commonpb.NewUint256FromUint64(0),
+	}
+
+	batch := dataStore.OpenWriteSession()
+	_, err := registry.Attrs.Volume.Set(batch, volumeKey.Bytes(), pair)
+	require.NoError(t, err)
+	require.NoError(t, batch.Commit())
+
+	volumeFilter := bloomFilters.FilterForAttrType(dal.SubAttrVolume)
+	require.NotNil(t, volumeFilter)
+	require.False(t, volumeFilter.MayContain(volumeID))
+	bloomFilters.SetReady(true) // Model the follower's ready pre-sync filter.
+
+	snapshotter.Pause()
 	require.True(t, bloomFilters.IsReady())
+
+	// With no persisted Bloom blocks, RestoreFromStore requests a full scan.
+	// While paused that request must remain pending and readiness must remain
+	// conservative rather than exposing the follower's stale filter.
+	require.NoError(t, snapshotter.RestoreFromStore(dataStore))
+	require.False(t, bloomFilters.IsReady())
+	require.False(t, volumeFilter.MayContain(volumeID))
+
+	snapshotter.Resume(dataStore)
+	require.Eventually(t, func() bool {
+		return bloomFilters.IsReady() && volumeFilter.MayContain(volumeID)
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func newVolumeKey(ak domain.AccountKey, asset string) domain.VolumeKey {

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1786,10 +1786,6 @@ func (fsm *Machine) PauseBackgroundTasks() {
 	fsm.cacheSnapshotter.Pause()
 }
 
-func (fsm *Machine) ResumeBackgroundTasks() {
-	fsm.cacheSnapshotter.Resume()
-}
-
 // DrainBackgroundChannels empties every background-request channel without
 // blocking. Called by Synchronizer.SynchronizeWithLeader before the leader's
 // checkpoint is installed: messages enqueued by the FSM hot path pre-sync

--- a/internal/infra/state/machine_sync_test.go
+++ b/internal/infra/state/machine_sync_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
@@ -21,6 +22,22 @@ import (
 // the target directory provided by the machine (simulating a real peer fetch).
 type copyDirFetcher struct {
 	srcDir string
+}
+
+type errorSnapshotFetcher struct {
+	err error
+}
+
+func (f *errorSnapshotFetcher) FetchSnapshot(_ context.Context, _ string, _ *SyncProgress, _ uint64) (uint64, error) {
+	return 0, f.err
+}
+
+func requireBloomBackgroundTasksResumed(t *testing.T, machine *Machine) {
+	t.Helper()
+
+	machine.cacheSnapshotter.bloomMu.Lock()
+	defer machine.cacheSnapshotter.bloomMu.Unlock()
+	require.False(t, machine.cacheSnapshotter.bloomPaused)
 }
 
 func (f *copyDirFetcher) FetchSnapshot(_ context.Context, targetDir string, _ *SyncProgress, _ uint64) (uint64, error) {
@@ -87,6 +104,45 @@ func TestSynchronizeWithLeader(t *testing.T) {
 
 	_, err = query.GetLedgerByName(ctx, followerStore, "follower-ledger")
 	require.ErrorIs(t, err, domain.ErrNotFound, "stale follower-ledger must be gone after sync")
+}
+
+func TestSynchronizeWithLeaderResumesBloomAfterFetchError(t *testing.T) {
+	t.Parallel()
+
+	machine, store, _ := newTestMachine(t)
+	recovery := NewRecovery(machine, store)
+	synchronizer := NewSynchronizer(machine, recovery, dal.NewIncomingRestoreFactory(store))
+
+	_, err := synchronizer.SynchronizeWithLeader(t.Context(), &errorSnapshotFetcher{err: errors.New("fetch failed")}, nil)
+	require.ErrorContains(t, err, "fetch failed")
+	requireBloomBackgroundTasksResumed(t, machine)
+}
+
+func TestSynchronizeWithLeaderResumesBloomAfterCacheRestoreError(t *testing.T) {
+	t.Parallel()
+
+	meter := noop.NewMeterProvider().Meter("test")
+	logger := logging.FromContext(logging.TestingContext())
+	leaderStore, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = leaderStore.Close() })
+
+	batch := leaderStore.OpenWriteSession()
+	require.NoError(t, batch.Set([]byte{dal.ZoneCache, 0x7F}, []byte("invalid cache row"), nil))
+	require.NoError(t, batch.Commit())
+
+	_, err = leaderStore.CreateSnapshot()
+	require.NoError(t, err)
+	leaderCheckpointPath, err := leaderStore.GetCheckpointPath(1)
+	require.NoError(t, err)
+
+	machine, followerStore, _ := newTestMachine(t)
+	recovery := NewRecovery(machine, followerStore)
+	synchronizer := NewSynchronizer(machine, recovery, dal.NewIncomingRestoreFactory(followerStore))
+
+	_, err = synchronizer.SynchronizeWithLeader(t.Context(), &copyDirFetcher{srcDir: leaderCheckpointPath}, nil)
+	require.ErrorContains(t, err, "validating cache namespace")
+	requireBloomBackgroundTasksResumed(t, machine)
 }
 
 // TestSynchronizeWithLeaderDrainsBackgroundChannels asserts that

--- a/internal/infra/state/recovery.go
+++ b/internal/infra/state/recovery.go
@@ -233,6 +233,13 @@ func (r *Recovery) RestoreCacheFromStore() error {
 	return nil
 }
 
+// ResumeBackgroundTasks reopens background work after follower checkpoint
+// replacement. Recovery supplies the reader required by any Bloom population
+// that RestoreCacheFromStore deferred while the snapshotter was paused.
+func (r *Recovery) ResumeBackgroundTasks() {
+	r.apply.cacheSnapshotter.Resume(r.reader)
+}
+
 // OnLeadershipAcquired is called when this node becomes the Raft leader. It
 // re-dispatches archive requests from durable state, allowing the new leader
 // to retry work that may have been in flight when the previous leader

--- a/internal/infra/state/synchronizer.go
+++ b/internal/infra/state/synchronizer.go
@@ -44,6 +44,7 @@ func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetche
 	// Stop background tasks (bloom restore, etc.) that may hold Pebble iterators.
 	// RestoreCheckpoint closes and reopens the DB — outstanding references cause a panic.
 	s.apply.PauseBackgroundTasks()
+	defer s.recovery.ResumeBackgroundTasks()
 
 	// Drop any background-request messages enqueued by the FSM hot path
 	// pre-sync: their payloads reference chapter IDs / sequence ranges /
@@ -63,10 +64,6 @@ func (s *Synchronizer) SynchronizeWithLeader(ctx context.Context, snapshotFetche
 	if err := s.recovery.RestoreCacheFromStore(); err != nil {
 		return 0, fmt.Errorf("restoring cache after sync: %w", err)
 	}
-	// Pebble replacement and synchronous cache restoration are complete; only
-	// now may the Bloom dispatcher resume work for the installed checkpoint.
-	s.apply.ResumeBackgroundTasks()
-
 	// Reload all FSM state from Pebble (the checkpoint contains the leader's state).
 	// This also recovers lastAppliedIndex from the restored Pebble — the fresh
 	// checkpoint is at an index >= snapshotIndex, so spool replay correctly


### PR DESCRIPTION
Follow-up to #1771. This addresses the automated-review findings that arrived after that PR was merged.

## What changed

- publish Bloom readiness as conservative before restoring cache state from an installed checkpoint;
- retain one pending full-population request while Bloom work is paused, without retaining a Pebble reader on `CacheSnapshotter`;
- resume deferred population through `Recovery`, which remains the sole owner of the recovery reader;
- pair every follower-sync pause with a deferred resume, including checkpoint-fetch and cache-restore failures;
- replace the empty-store Pause/Resume test with a non-empty restore regression that proves eventual membership for an installed key;
- add deterministic coverage for an admitted Bloom task being cancelled and drained by terminal `Stop`;
- document the follower-sync readiness contract and the correctness impact of publishing an incomplete filter as ready.

## Findings from #1771

- ready-but-stale Bloom after follower sync: fixed;
- Pause not paired with Resume on errors: fixed;
- production restore path not covered by the Pause/Resume test: fixed;
- Stop test did not cover already-admitted work: fixed.

## Validation

- `bash scripts/agent-check-full`
- `bash scripts/agent-check` after rebasing on the latest `release/v3.0`
- `go test -race ./internal/infra/state -run 'TestCacheSnapshotter_(StopPreventsBloomRestart|StopWaitsForAdmittedBloomTask|PausedRestoreDefersBloomPopulationUntilResume)$|TestSynchronizeWithLeader(ResumesBloomAfterFetchError|ResumesBloomAfterCacheRestoreError)?$' -count=3`
- the same targeted race suite once more after the final rebase
