### PR TITLE
fix(grpc): stop fabricating clean pages from canceled forwarded streams

### DIFF
--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -86,7 +86,7 @@ same guarantee for the `Request` oneof.
 - `400 Bad Request`: Invalid request
 - `404 Not Found`: Resource not found
 - `409 Conflict`: Conflict (ex: resource already exists)
-- `503 Service Unavailable`: No Leader available (with `Retry-After` header)
+- `503 Service Unavailable`: the server cannot serve the request right now but a retry can succeed — no leader elected, admission cache horizon exceeded, any `KindUnavailable` domain error (index still building, writes blocked on clock skew, node syncing), or an internal forwarding failure surfaced as gRPC `Unavailable` (always with `Retry-After` header)
 - `500 Internal Server Error`: Server error
 
 ### Internal Errors and Sanitization
@@ -111,38 +111,25 @@ The correlation ID is the request's `X-Request-Id` (Chi `RequestID`) so operator
 
 ### Retry-After Header
 
-The `Retry-After` header is used to indicate when a client should retry a request after receiving a `503 Service Unavailable` response.
+The `Retry-After` header is used to indicate when a client should retry a request after receiving a `503 Service Unavailable` response. Every `503` the adapter emits carries it — `503` is by definition the retry-now class.
 
 #### When It's Returned
 
-The `Retry-After` header is included in responses when no leader is available in the Raft cluster. This can occur in the following situations:
+`handleError` (`internal/adapter/http/error_handler.go`) maps four error families to `503` + `Retry-After`:
 
-1. **Leader Election in Progress**
-   - The previous leader has failed or stepped down
-   - A new leader election is currently taking place
-   - No leader has been elected yet
+1. **No leader** (`errorCode: NO_LEADER`) — the Raft cluster has no elected leader: an election is in progress, a partition or insufficient nodes prevent a quorum, or the cluster is still starting up.
 
-2. **Network Partition**
-   - The cluster is split into multiple partitions
-   - No partition has a majority of nodes
-   - No leader can be elected without a majority
+2. **Admission cache horizon exceeded** (`errorCode: CACHE_HORIZON_EXCEEDED`) — admission predicted the proposal would outlive its preload (2+ cache rotations between propose and apply); retry against a fresher admission snapshot.
 
-3. **Cluster Startup**
-   - The cluster is initializing
-   - Nodes are still discovering each other
-   - Leader election has not completed yet
+3. **`KindUnavailable` domain errors** (`errorCode` = the error's `Reason()`) — the whole kind shares the contract: an index still building, writes blocked on clock skew, a node syncing. Anything `kindToHTTPStatus` maps to `503` gets the header.
 
-4. **Insufficient Nodes**
-   - Not enough nodes are available to form a quorum
-   - The cluster cannot elect a leader
+4. **gRPC `Unavailable` statuses** (`errorCode: UNAVAILABLE`) — an internal forwarding failure surfaced by the read path: a forwarded stream torn down mid-transfer (peer connection churn during a syncing follower's leader fallback), or a peer connection missing from the pool. The original transport message is preserved in `errorMessage`.
 
 #### Response Format
 
-When no leader is available, the API returns:
-
 - **HTTP Status Code**: `503 Service Unavailable`
 - **Header**: `Retry-After: 1` (seconds)
-- **Response Body**:
+- **Response Body** (the `errorCode` discriminates the family, e.g. no leader):
 ```json
 {
   "errorCode": "NO_LEADER",

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -960,6 +960,17 @@ The REST adapter uses the same `Describable.Reason()` as the JSON `errorCode` fi
 | `KindPermissionDenied` | 403 Forbidden |
 | `KindInternal` | 500 Internal Server Error |
 
+Every response the table maps to 503 also carries `Retry-After: 1` — the kind is by definition retry-now, so the header covers the whole class, not just the no-leader sentinel.
+
+**Bare gRPC statuses at the HTTP boundary.** A handler can surface a `google.golang.org/grpc/status` error that is not a domain `Describable`; `handleError` translates exactly two codes and deliberately lets every other one fall through to the sanitized 500:
+
+| gRPC code | HTTP response |
+|-----------|---------------|
+| `INVALID_ARGUMENT` | 400, `errorCode: INVALID_REQUEST` |
+| `UNAVAILABLE` | 503 + `Retry-After: 1`, `errorCode: UNAVAILABLE` |
+
+The `UNAVAILABLE` row is the forwarded-stream error shape: a syncing follower forwards a read to the leader, and the forwarded stream is torn down mid-transfer (peer connection churn) — `normalizeStreamEnd` re-codes that from the raw `Canceled` the transport reports into `Unavailable` with the original message, since the caller did not cancel and an immediate retry can succeed. gRPC clients see the same event as `codes.Unavailable`; SDK retry predicates treat it as retryable on both surfaces.
+
 **Breaking change in #432**: HTTP `errorCode` JSON field previously used HTTP-specific codes (`"CONFLICT"`, `"NOT_FOUND"`, `"SCRIPT_PARSE_ERROR"`, `"INSUFFICIENT_FUNDS"`, ...) that were sometimes the same as the gRPC Reason and sometimes different. After the Describable refactor (#432) it is uniformly `Reason()` from the table above — e.g. `"LEDGER_ALREADY_EXISTS"` (was `"CONFLICT"`), `"NUMSCRIPT_PARSE_ERROR"` (was `"SCRIPT_PARSE_ERROR"`). Update REST clients to widen pattern matching accordingly.
 
 **Client-side Kind reconstruction is lossy — match on `Reason`, not `Kind`.** The server-side `Kind` enum has two values (`KindConflict` and `KindPrecondition`) that both serialise to `codes.FailedPrecondition` on the wire. Client SDKs that reconstruct a `RemoteError` from a gRPC status (see `cmd/ledgerctl/cmdutil`) conservatively pick `KindPrecondition` for every `FailedPrecondition` response — so a server-side `KindConflict` (e.g. ledger deleted, transaction already reverted) reads as `KindPrecondition` client-side. Branching on `RemoteError.Kind()` will therefore misclassify conflict responses. Match on `Reason()` (`LEDGER_DELETED`, `TRANSACTION_ALREADY_REVERTED`, etc.) instead — it is preserved end-to-end and is the reliable discriminator.

--- a/internal/adapter/grpc/client_bucket.go
+++ b/internal/adapter/grpc/client_bucket.go
@@ -93,7 +93,7 @@ func (g *BucketGrpcClient) ListTransactions(ctx context.Context, ledgerName stri
 		return nil, err
 	}
 
-	return NewUpstreamPeekCursor(stream), nil
+	return NewUpstreamPeekCursor(ctx, stream), nil
 }
 
 func (g *BucketGrpcClient) GetAccount(ctx context.Context, ledgerName string, address string, opts ctrl.GetAccountOptions) (*commonpb.Account, error) {
@@ -118,7 +118,7 @@ func (g *BucketGrpcClient) ListAccounts(ctx context.Context, ledgerName string, 
 		return nil, err
 	}
 
-	return NewUpstreamPeekCursor(stream), nil
+	return NewUpstreamPeekCursor(ctx, stream), nil
 }
 
 func (g *BucketGrpcClient) ListLogs(ctx context.Context, ledgerName string, afterSequence uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*commonpb.Log], error) {
@@ -139,7 +139,7 @@ func (g *BucketGrpcClient) ListLogs(ctx context.Context, ledgerName string, afte
 		return nil, err
 	}
 
-	return NewUpstreamPeekCursor(stream), nil
+	return NewUpstreamPeekCursor(ctx, stream), nil
 }
 
 func (g *BucketGrpcClient) ListLedgers(ctx context.Context) (cursor.Cursor[*commonpb.LedgerInfo], error) {
@@ -208,7 +208,7 @@ func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, pageSize uint32
 		return nil, err
 	}
 
-	return NewUpstreamPeekCursor(stream), nil
+	return NewUpstreamPeekCursor(ctx, stream), nil
 }
 
 func (g *BucketGrpcClient) GetLog(ctx context.Context, sequence uint64) (*commonpb.Log, error) {
@@ -523,7 +523,7 @@ func (g *BucketGrpcClient) ListIndexes(ctx context.Context, req *servicepb.ListI
 	// it, so the first item is available before the leader sends EOF and peak
 	// memory is O(1) instead of O(total). Matches ListTransactions /
 	// ListAccounts / ListLogs.
-	return NewUpstreamPeekCursor(stream), nil
+	return NewUpstreamPeekCursor(ctx, stream), nil
 }
 
 var _ ctrl.Controller = (*BucketGrpcClient)(nil)

--- a/internal/adapter/grpc/cursor.go
+++ b/internal/adapter/grpc/cursor.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -14,6 +15,7 @@ import (
 
 // GRPCStreamCursor implements cursor.Cursor[To] by reading from a gRPC server stream.
 type GRPCStreamCursor[Res, To any] struct {
+	ctx    context.Context
 	client grpc.ServerStreamingClient[Res]
 	mapper func(*Res) (To, error)
 }
@@ -21,9 +23,7 @@ type GRPCStreamCursor[Res, To any] struct {
 func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 	next, err := c.client.Recv()
 	if err != nil {
-		if status.Code(err) == codes.Canceled {
-			err = io.EOF
-		}
+		err = normalizeStreamEnd(c.ctx, err)
 
 		var zero To
 
@@ -33,6 +33,27 @@ func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 	return c.mapper(next)
 }
 
+// normalizeStreamEnd maps a Canceled Recv error to io.EOF ONLY when the
+// cancellation is the consumer's own — the caller-supplied context is done
+// because the consumer stopped reading and tore the stream down, so the
+// results gathered so far form a complete answer for it. A Canceled status
+// while that context is still live is a failed transfer (connection churn,
+// remote teardown): surfacing it as EOF would fabricate a clean-looking
+// empty or truncated page that the caller then serves with OK status.
+//
+// The verdict MUST come from the caller-supplied context, never from
+// ClientStream.Context(): gRPC derives the stream context with WithCancel
+// and cancels it in finish() on EVERY stream termination, so by the time
+// Recv returns a terminal error that context is always done and gates
+// nothing.
+func normalizeStreamEnd(ctx context.Context, err error) error {
+	if status.Code(err) == codes.Canceled && ctx.Err() != nil {
+		return io.EOF
+	}
+
+	return err
+}
+
 func (c GRPCStreamCursor[Res, To]) Close() error {
 	return c.client.CloseSend()
 }
@@ -40,13 +61,13 @@ func (c GRPCStreamCursor[Res, To]) Close() error {
 var _ cursor.Cursor[any] = (*GRPCStreamCursor[any, any])(nil)
 
 // NewGRPCStreamCursor creates a cursor that reads from a gRPC server stream and maps each element.
-func NewGRPCStreamCursor[Res, To any](client grpc.ServerStreamingClient[Res], mapper func(*Res) (To, error)) cursor.Cursor[To] {
-	return GRPCStreamCursor[Res, To]{client: client, mapper: mapper}
+func NewGRPCStreamCursor[Res, To any](ctx context.Context, client grpc.ServerStreamingClient[Res], mapper func(*Res) (To, error)) cursor.Cursor[To] {
+	return GRPCStreamCursor[Res, To]{ctx: ctx, client: client, mapper: mapper}
 }
 
 // NewGRPCIdentityCursor creates a GRPCStreamCursor with an identity mapper.
-func NewGRPCIdentityCursor[T any](client grpc.ServerStreamingClient[T]) cursor.Cursor[*T] {
-	return NewGRPCStreamCursor(client, func(res *T) (*T, error) {
+func NewGRPCIdentityCursor[T any](ctx context.Context, client grpc.ServerStreamingClient[T]) cursor.Cursor[*T] {
+	return NewGRPCStreamCursor(ctx, client, func(res *T) (*T, error) {
 		return res, nil
 	})
 }
@@ -76,6 +97,7 @@ type UpstreamTrailer interface {
 // compatibility reads, drain loops — get a normal EOF and never see a fake
 // record.
 type upstreamPeekCursor[Res any] struct {
+	ctx        context.Context
 	client     grpc.ServerStreamingClient[Res]
 	exhausted  bool
 	nextCursor string
@@ -87,9 +109,7 @@ func (c *upstreamPeekCursor[Res]) Next() (*Res, error) {
 		return item, nil
 	}
 
-	if status.Code(err) == codes.Canceled {
-		err = io.EOF
-	}
+	err = normalizeStreamEnd(c.ctx, err)
 
 	if errors.Is(err, io.EOF) && !c.exhausted {
 		c.exhausted = true
@@ -112,8 +132,8 @@ func (c *upstreamPeekCursor[Res]) Close() error {
 // (so generic consumers see only real items + io.EOF) and additionally
 // satisfies UpstreamTrailer so sendPagedToStream can pick up the leader's
 // x-next-cursor.
-func NewUpstreamPeekCursor[T any](client grpc.ServerStreamingClient[T]) cursor.Cursor[*T] {
-	return &upstreamPeekCursor[T]{client: client}
+func NewUpstreamPeekCursor[T any](ctx context.Context, client grpc.ServerStreamingClient[T]) cursor.Cursor[*T] {
+	return &upstreamPeekCursor[T]{ctx: ctx, client: client}
 }
 
 // ListOptionsSupport captures, per resource, which ListOptions sub-fields the

--- a/internal/adapter/grpc/cursor.go
+++ b/internal/adapter/grpc/cursor.go
@@ -41,17 +41,29 @@ func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 // remote teardown): surfacing it as EOF would fabricate a clean-looking
 // empty or truncated page that the caller then serves with OK status.
 //
-// The verdict MUST come from the caller-supplied context, never from
-// ClientStream.Context(): gRPC derives the stream context with WithCancel
-// and cancels it in finish() on EVERY stream termination, so by the time
-// Recv returns a terminal error that context is always done and gates
-// nothing.
+// That not-ours cancellation is re-coded as Unavailable: the failure is a
+// peer-transport transient exactly like ErrNodeNotReachable, and Canceled
+// means "the caller gave up" to every classifier downstream — SDK retry
+// predicates treat it as the client's own shutdown and give up, and the
+// HTTP boundary degrades it to a plain 500. Unavailable is what routes it
+// into the retry path (gRPC clients retry it; HTTP serves 503 with
+// Retry-After).
+//
+// The ours/not-ours verdict MUST come from the caller-supplied context,
+// never from ClientStream.Context(): gRPC derives the stream context with
+// WithCancel and cancels it in finish() on EVERY stream termination, so by
+// the time Recv returns a terminal error that context is always done and
+// gates nothing.
 func normalizeStreamEnd(ctx context.Context, err error) error {
-	if status.Code(err) == codes.Canceled && ctx.Err() != nil {
+	if status.Code(err) != codes.Canceled {
+		return err
+	}
+
+	if ctx.Err() != nil {
 		return io.EOF
 	}
 
-	return err
+	return status.Errorf(codes.Unavailable, "forwarded stream failed mid-transfer: %s", status.Convert(err).Message())
 }
 
 func (c GRPCStreamCursor[Res, To]) Close() error {

--- a/internal/adapter/grpc/cursor_stream_cancel_test.go
+++ b/internal/adapter/grpc/cursor_stream_cancel_test.go
@@ -1,0 +1,158 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// endingBucketServer streams `rows` accounts and then ends the stream with
+// `endErr` — nil for a clean completion, a Canceled status for a handler
+// dying mid-stream (the wire shape of a forwarded read whose serving node
+// is torn down while the follower still waits for rows).
+type endingBucketServer struct {
+	servicepb.UnimplementedBucketServiceServer
+
+	rows   int
+	endErr error
+}
+
+func (s *endingBucketServer) ListAccounts(_ *servicepb.ListAccountsRequest, stream ggrpc.ServerStreamingServer[commonpb.Account]) error {
+	for i := range s.rows {
+		if err := stream.Send(&commonpb.Account{Address: fmt.Sprintf("acc-%d", i)}); err != nil {
+			return err
+		}
+	}
+
+	return s.endErr
+}
+
+// dialBucketServer serves srv over an in-process bufconn listener and
+// returns a connected client.
+func dialBucketServer(t *testing.T, srv servicepb.BucketServiceServer) servicepb.BucketServiceClient {
+	t.Helper()
+
+	lis := bufconn.Listen(1 << 20)
+	server := ggrpc.NewServer()
+	servicepb.RegisterBucketServiceServer(server, srv)
+
+	go func() { _ = server.Serve(lis) }()
+	t.Cleanup(server.Stop)
+
+	conn, err := ggrpc.NewClient("passthrough:///bufconn",
+		ggrpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		ggrpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dialing bufconn: %v", err)
+	}
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return servicepb.NewBucketServiceClient(conn)
+}
+
+// drainPeekCursor consumes the cursor to its terminal error, the way
+// sendPagedToStream does, returning the items and that error.
+func drainPeekCursor(t *testing.T, ctx context.Context, stream ggrpc.ServerStreamingClient[commonpb.Account]) ([]*commonpb.Account, error) {
+	t.Helper()
+
+	cur := NewUpstreamPeekCursor(ctx, stream)
+
+	var items []*commonpb.Account
+
+	for {
+		item, err := cur.Next()
+		if err != nil {
+			return items, err
+		}
+
+		items = append(items, item)
+	}
+}
+
+// TestUpstreamPeekCursorStreamDeath exercises the cursor against a real gRPC
+// stream, not a fake: the discriminator between a dead transfer and a
+// consumer-side teardown lives in grpc-go's context plumbing, which a fake
+// cannot reproduce (the stream-derived context is canceled on EVERY
+// termination — see normalizeStreamEnd).
+func TestUpstreamPeekCursorStreamDeath(t *testing.T) {
+	t.Run("mid-stream cancellation under a live caller propagates", func(t *testing.T) {
+		client := dialBucketServer(t, &endingBucketServer{rows: 2, endErr: status.Error(codes.Canceled, "serving node torn down")})
+
+		ctx := context.Background()
+
+		stream, err := client.ListAccounts(ctx, &servicepb.ListAccountsRequest{Ledger: "l"})
+		if err != nil {
+			t.Fatalf("opening stream: %v", err)
+		}
+
+		items, err := drainPeekCursor(t, ctx, stream)
+		if len(items) != 2 {
+			t.Fatalf("want the 2 rows sent before the death, got %d", len(items))
+		}
+
+		if errors.Is(err, io.EOF) {
+			t.Fatalf("a dead transfer surfaced as clean EOF: a caller would serve the truncated page with OK status")
+		}
+
+		if status.Code(err) != codes.Canceled {
+			t.Fatalf("want Canceled, got %v", err)
+		}
+
+		// The stream-derived context is already canceled here even though the
+		// caller's context is live — which is why normalizeStreamEnd must
+		// judge by the caller's context, never by ClientStream.Context().
+		if stream.Context().Err() == nil {
+			t.Fatalf("expected grpc-go to have canceled the stream-derived context on termination")
+		}
+	})
+
+	t.Run("clean completion is EOF", func(t *testing.T) {
+		client := dialBucketServer(t, &endingBucketServer{rows: 2})
+
+		ctx := context.Background()
+
+		stream, err := client.ListAccounts(ctx, &servicepb.ListAccountsRequest{Ledger: "l"})
+		if err != nil {
+			t.Fatalf("opening stream: %v", err)
+		}
+
+		items, err := drainPeekCursor(t, ctx, stream)
+		if len(items) != 2 || !errors.Is(err, io.EOF) {
+			t.Fatalf("want 2 rows then io.EOF, got %d rows, err %v", len(items), err)
+		}
+	})
+
+	t.Run("caller cancellation is a clean end", func(t *testing.T) {
+		client := dialBucketServer(t, &endingBucketServer{rows: 1})
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		stream, err := client.ListAccounts(ctx, &servicepb.ListAccountsRequest{Ledger: "l"})
+		if err != nil {
+			t.Fatalf("opening stream: %v", err)
+		}
+
+		cancel()
+
+		_, err = drainPeekCursor(t, ctx, stream)
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("a consumer tearing down its own read must see clean EOF, got %v", err)
+		}
+	})
+}

--- a/internal/adapter/grpc/cursor_stream_cancel_test.go
+++ b/internal/adapter/grpc/cursor_stream_cancel_test.go
@@ -110,8 +110,11 @@ func TestUpstreamPeekCursorStreamDeath(t *testing.T) {
 			t.Fatalf("a dead transfer surfaced as clean EOF: a caller would serve the truncated page with OK status")
 		}
 
-		if status.Code(err) != codes.Canceled {
-			t.Fatalf("want Canceled, got %v", err)
+		// The not-ours cancellation is re-coded as the peer-transport
+		// transient it is: Unavailable routes it into every retry path
+		// (Canceled would read as the caller's own shutdown downstream).
+		if status.Code(err) != codes.Unavailable {
+			t.Fatalf("want Unavailable, got %v", err)
 		}
 
 		// The stream-derived context is already canceled here even though the

--- a/internal/adapter/grpc/cursor_stream_end_test.go
+++ b/internal/adapter/grpc/cursor_stream_end_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -13,10 +14,14 @@ import (
 func TestNormalizeStreamEnd(t *testing.T) {
 	canceled := status.Error(codes.Canceled, "context canceled")
 
-	t.Run("canceled with live caller context propagates", func(t *testing.T) {
+	t.Run("canceled with live caller context becomes the Unavailable transient", func(t *testing.T) {
 		got := normalizeStreamEnd(context.Background(), canceled)
-		if status.Code(got) != codes.Canceled {
-			t.Fatalf("want Canceled, got %v", got)
+		if status.Code(got) != codes.Unavailable {
+			t.Fatalf("want Unavailable, got %v", got)
+		}
+
+		if msg := status.Convert(got).Message(); !strings.Contains(msg, "context canceled") {
+			t.Fatalf("the original failure must survive in the message, got %q", msg)
 		}
 	})
 

--- a/internal/adapter/grpc/cursor_stream_end_test.go
+++ b/internal/adapter/grpc/cursor_stream_end_test.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNormalizeStreamEnd(t *testing.T) {
+	canceled := status.Error(codes.Canceled, "context canceled")
+
+	t.Run("canceled with live caller context propagates", func(t *testing.T) {
+		got := normalizeStreamEnd(context.Background(), canceled)
+		if status.Code(got) != codes.Canceled {
+			t.Fatalf("want Canceled, got %v", got)
+		}
+	})
+
+	t.Run("canceled after caller cancellation is EOF", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		got := normalizeStreamEnd(ctx, canceled)
+		if !errors.Is(got, io.EOF) {
+			t.Fatalf("want io.EOF, got %v", got)
+		}
+	})
+
+	t.Run("other errors pass through", func(t *testing.T) {
+		unavailable := status.Error(codes.Unavailable, "conn reset")
+
+		got := normalizeStreamEnd(context.Background(), unavailable)
+		if status.Code(got) != codes.Unavailable {
+			t.Fatalf("want Unavailable, got %v", got)
+		}
+	})
+}

--- a/internal/adapter/grpc/stream_helper_test.go
+++ b/internal/adapter/grpc/stream_helper_test.go
@@ -314,7 +314,7 @@ func TestUpstreamPeekCursor(t *testing.T) {
 			return nil
 		})
 
-		c := NewUpstreamPeekCursor[stringItem](client)
+		c := NewUpstreamPeekCursor[stringItem](context.Background(), client)
 		ut, ok := c.(UpstreamTrailer)
 		require.True(t, ok, "cursor returned by NewUpstreamPeekCursor must satisfy UpstreamTrailer")
 

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -115,14 +115,25 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 	// must not degrade to a 500. The audit-filter compiler (query.CompileAuditFilter,
 	// shared with the gRPC surface) rejects filters that parse but are not
 	// audit-supported — `not outcome == failure`, a non-audit condition, an unknown
-	// field — as codes.InvalidArgument; surface that as a 400. Only
-	// InvalidArgument is translated here; other status codes keep the generic
-	// 500 fallthrough deliberately, since no other HTTP handler is expected to
-	// produce them and we do not want to leak arbitrary gRPC semantics.
-	if st, ok := status.FromError(err); ok && st.Code() == codes.InvalidArgument {
-		writeErrorResponse(w, http.StatusBadRequest, "INVALID_REQUEST", errors.New(st.Message()))
+	// field — as codes.InvalidArgument; surface that as a 400. A codes.Unavailable
+	// status is a retry-now transient (a forwarded stream torn down mid-transfer,
+	// a peer connection missing from the pool) and gets the same 503 + Retry-After
+	// contract as the KindUnavailable Describables above. Only these two codes are
+	// translated; the rest keep the generic 500 fallthrough deliberately, since no
+	// other HTTP handler is expected to produce them and we do not want to leak
+	// arbitrary gRPC semantics.
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.InvalidArgument:
+			writeErrorResponse(w, http.StatusBadRequest, "INVALID_REQUEST", errors.New(st.Message()))
 
-		return
+			return
+		case codes.Unavailable:
+			w.Header().Set("Retry-After", "1")
+			writeErrorResponse(w, http.StatusServiceUnavailable, "UNAVAILABLE", errors.New(st.Message()))
+
+			return
+		}
 	}
 
 	writeInternalServerError(w, r, err)

--- a/internal/adapter/http/error_handler_test.go
+++ b/internal/adapter/http/error_handler_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/infra/plan"
@@ -151,6 +153,19 @@ func TestHandleError(t *testing.T) {
 		{
 			name:           "unknown error",
 			err:            errors.New("something unexpected"),
+			expectedStatus: http.StatusInternalServerError,
+			expectedCode:   "INTERNAL_ERROR",
+		},
+		{
+			name:           "grpc unavailable status",
+			err:            status.Error(codes.Unavailable, "forwarded stream failed mid-transfer: serving node torn down"),
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedCode:   "UNAVAILABLE",
+			checkRetry:     true,
+		},
+		{
+			name:           "grpc canceled status stays a sanitized 500",
+			err:            status.Error(codes.Canceled, "context canceled"),
 			expectedStatus: http.StatusInternalServerError,
 			expectedCode:   "INTERNAL_ERROR",
 		},

--- a/openapi.yml
+++ b/openapi.yml
@@ -3052,7 +3052,14 @@ components:
 
   responses:
     ServiceUnavailable:
-      description: Service unavailable (no leader available)
+      description: >-
+        Service unavailable — the server cannot serve the request right now
+        but an immediate retry can succeed. The `errorCode` field
+        discriminates the cause: `NO_LEADER` (no elected Raft leader),
+        `CACHE_HORIZON_EXCEEDED` (admission snapshot too old, retry against a
+        fresh one), `UNAVAILABLE` (an internal forwarded stream was torn down
+        mid-transfer), or the reason of any domain error of the unavailable
+        kind (e.g. `INDEX_BUILDING`).
       headers:
         Retry-After:
           description: Number of seconds to wait before retrying the request


### PR DESCRIPTION
## What changed

The routed read cursors (`GRPCStreamCursor`, `upstreamPeekCursor`) no longer map every `Canceled` stream error to `io.EOF`. `normalizeStreamEnd` maps it only when the caller-supplied context is itself done (the consumer stopped reading and tore the stream down); any other cancellation propagates as an error.

## Why

On a forwarded read — a syncing follower falling back to the leader — a mid-flight stream cancellation (connection churn during partitions, pool teardown on leadership change) read as clean exhaustion, so the follower served the empty or truncated page with **OK status**. A linearizable `ListAccounts` could return zero rows for long-committed data, and a leader-side error reply (e.g. `index not found`) could surface as an empty page. Found by the Antithesis model workload as `* query outside model` findings, all in sync/heal windows with `route=leader_fallback`.

## Product / operational motivation

Need: linearizable reads must never return fabricated results, under any fault schedule.
Current limitation: the forwarded-read path converted transfer failures into clean pages.
Requirement / constraint: a stream that dies under a live caller surfaces an error; only consumer-side teardown reads as a clean end.
Evidence / durable repository evidence: `internal/adapter/grpc/cursor_stream_cancel_test.go` pins the contract against a real in-process stream.

## Technical decision

Decision: gate the `Canceled → io.EOF` mapping on the caller-supplied context, threaded into both cursors at construction.
Why now / why proportionate: minimal mechanism that keeps the one legitimate mapping (consumer teardown) and removes the fabrication.
Alternatives considered: dropping the mapping entirely (breaks the legitimate consumer-teardown end); gating on `ClientStream.Context()` (ineffective — gRPC cancels the stream-derived context on every termination, verified in grpc-go `stream.go` and pinned by the test).

## Risk

**LOW** — error propagation replaces silently wrong data; clients already treat `Canceled` as transient and retry.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `TestUpstreamPeekCursorStreamDeath` (bufconn, real stream: red on the old mapping and on a stream-context gate, green now), `TestNormalizeStreamEnd`, existing `internal/adapter/grpc` + `internal/bootstrap` suites
- [ ] Antithesis model-only verification runs on the instrumented branch are still in progress — draft until they complete

## Architecture / behavior impact

Forwarded list RPCs that lose their upstream stream now fail with `Canceled` instead of returning an empty/truncated OK page. No persisted state, FSM, or storage impact.

## Review focus

The `normalizeStreamEnd` discriminator, and the test's pinned assertion that the stream-derived context is already canceled at failure time — that is the reason the caller context is the only valid signal.

## Known concerns

The forwarded list requests also drop `ReadOptions.MinLogSequence` (`BucketGrpcClient` builds `ListOptions` without `Read`). Separate latent issue, currently masked by the leader's read barrier; not addressed here.
