### PR TITLE
test: isolate Schemathesis from host disk occupancy

### DIFF
--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -40,10 +40,13 @@ cd "$REPO_ROOT"
 go build -o "$TMPDIR/ledger-server" .
 
 echo "==> Starting server (single-node, bootstrap, no auth)..."
+# This disposable store shares the host filesystem. Keep conformance results
+# independent from the host's production disk-pressure threshold.
 "$TMPDIR/ledger-server" run \
     --node-id 1 --cluster-id schemathesis-test --bootstrap \
     --bind-addr "127.0.0.1:$RAFT_PORT" \
     --wal-dir "$TMPDIR/wal" --data-dir "$TMPDIR/data" \
+    --health-wal-threshold 1 --health-data-threshold 1 \
     --http-port "$HTTP_PORT" --grpc-port "$GRPC_PORT" \
     > "$TMPDIR/server.log" 2>&1 &
 SERVER_PID=$!


### PR DESCRIPTION
## Summary

- set the disposable Schemathesis server disk-health thresholds to 100%
- keep API conformance independent from incidental host filesystem occupancy
- leave production defaults and product disk-health tests unchanged

Split from #1758. This PR intentionally contains no AI tooling, historical balances, transient history retry, or Python test changes.

## Validation

- BEFORE_FIX on isolated APFS image: `429 WRITES_BLOCKED_DISK_FULL`
- AFTER_FIX with `--health-wal-threshold 1 --health-data-threshold 1`: `201`
- Schemathesis: 64/64 endpoints passed
- `bash scripts/agent-check-full`
- `go test -race ./...`
- trusted base-pinned `just pre-commit` fixpoint
- exact review: APPROVE, blockers 0