### PR TITLE
fix(storage): date the account-metadata delete's history revision (EN-1872) (v2.4 backport)

### DIFF
--- a/internal/controller/ledger/controller_default.go
+++ b/internal/controller/ledger/controller_default.go
@@ -348,7 +348,7 @@ func (ctrl *DefaultController) importLog(ctx context.Context, store Store, log l
 					}
 				case ledger.MetaTargetTypeAccount:
 					logging.FromContext(ctx).Debugf("Deleting metadata of account %s", payload.TargetID)
-					if err := store.DeleteAccountMetadata(ctx, payload.TargetID.(string), payload.Key); err != nil {
+					if err := store.DeleteAccountMetadata(ctx, payload.TargetID.(string), payload.Key, log.Date); err != nil {
 						return nil, fmt.Errorf("failed to delete account metadata: %w", err)
 					}
 				}
@@ -662,7 +662,7 @@ func (ctrl *DefaultController) DeleteTransactionMetadata(ctx context.Context, pa
 }
 
 func (ctrl *DefaultController) deleteAccountMetadata(ctx context.Context, store Store, schema *ledger.Schema, parameters Parameters[DeleteAccountMetadata]) (*ledger.DeletedMetadata, error) {
-	err := store.DeleteAccountMetadata(ctx, parameters.Input.Address, parameters.Input.Key)
+	err := store.DeleteAccountMetadata(ctx, parameters.Input.Address, parameters.Input.Key, time.Time{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/ledger/store.go
+++ b/internal/controller/ledger/store.go
@@ -45,7 +45,7 @@ type Store interface {
 	UpdateAccountsMetadata(ctx context.Context, m map[string]metadata.Metadata, at time.Time) error
 	// UpsertAccount returns a boolean indicating if the account was upserted
 	UpsertAccounts(ctx context.Context, accounts ...ledger.AccountWithDefaultMetadata) error
-	DeleteAccountMetadata(ctx context.Context, address, key string) error
+	DeleteAccountMetadata(ctx context.Context, address, key string, at time.Time) error
 	InsertSchema(ctx context.Context, data *ledger.Schema) error
 	FindSchema(ctx context.Context, version string) (*ledger.Schema, error)
 	FindSchemas(ctx context.Context, query common.PaginatedQuery[any]) (*paginate.Cursor[ledger.Schema], error)

--- a/internal/controller/ledger/store_generated_test.go
+++ b/internal/controller/ledger/store_generated_test.go
@@ -120,17 +120,17 @@ func (mr *MockStoreMockRecorder) CommitTransaction(ctx, transaction any) *gomock
 }
 
 // DeleteAccountMetadata mocks base method.
-func (m *MockStore) DeleteAccountMetadata(ctx context.Context, address, key string) error {
+func (m *MockStore) DeleteAccountMetadata(ctx context.Context, address, key string, at time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAccountMetadata", ctx, address, key)
+	ret := m.ctrl.Call(m, "DeleteAccountMetadata", ctx, address, key, at)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAccountMetadata indicates an expected call of DeleteAccountMetadata.
-func (mr *MockStoreMockRecorder) DeleteAccountMetadata(ctx, address, key any) *gomock.Call {
+func (mr *MockStoreMockRecorder) DeleteAccountMetadata(ctx, address, key, at any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountMetadata", reflect.TypeOf((*MockStore)(nil).DeleteAccountMetadata), ctx, address, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountMetadata", reflect.TypeOf((*MockStore)(nil).DeleteAccountMetadata), ctx, address, key, at)
 }
 
 // DeleteTransactionMetadata mocks base method.

--- a/internal/storage/ledger/accounts.go
+++ b/internal/storage/ledger/accounts.go
@@ -81,19 +81,32 @@ func (store *Store) UpdateAccountsMetadata(ctx context.Context, m map[string]met
 	return err
 }
 
-func (store *Store) DeleteAccountMetadata(ctx context.Context, account, key string) error {
+func (store *Store) DeleteAccountMetadata(ctx context.Context, account, key string, at time.Time) error {
 	_, err := tracing.TraceWithMetric(
 		ctx,
 		"DeleteAccountMetadata",
 		store.tracer,
 		store.deleteAccountMetadataHistogram,
 		tracing.NoResult(func(ctx context.Context) error {
-			_, err := store.db.NewUpdate().
+			query := store.db.NewUpdate().
 				ModelTableExpr(store.GetPrefixedRelationName("accounts")).
 				Set("metadata = metadata - ?", key).
 				Where("address = ?", account).
 				Where("ledger = ?", store.ledger.Name).
-				Exec(ctx)
+				// An absent key leaves the row untouched: no updated_at bump and no
+				// history revision for a request that changes nothing, matching the
+				// no-op set (whose upsert is guarded the same way).
+				Where("metadata -> ? is not null", key)
+			// The metadata-history trigger dates the delete's revision at updated_at,
+			// so the delete must carry its own instant: left stale, the revision is
+			// dated at the previous write's and erases the key from every pit at or
+			// after it.
+			if at.IsZero() {
+				query = query.Set("updated_at = " + store.GetPrefixedRelationName("transaction_date") + "()")
+			} else {
+				query = query.Set("updated_at = ?", at)
+			}
+			_, err := query.Exec(ctx)
 			return postgres.ResolveError(err)
 		}),
 	)

--- a/internal/storage/ledger/balances_test.go
+++ b/internal/storage/ledger/balances_test.go
@@ -198,7 +198,7 @@ func TestBalancesAggregates(t *testing.T) {
 		},
 	}, time.Time{}))
 
-	require.NoError(t, store.DeleteAccountMetadata(ctx, "users:2", "category"))
+	require.NoError(t, store.DeleteAccountMetadata(ctx, "users:2", "category", time.Time{}))
 
 	require.NoError(t, store.UpdateAccountsMetadata(ctx, map[string]metadata.Metadata{
 		"users:1": {

--- a/test/e2e/api_pit_metadata_delete_test.go
+++ b/test/e2e/api_pit_metadata_delete_test.go
@@ -1,0 +1,216 @@
+//go:build it
+
+package test_suite
+
+import (
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	. "github.com/formancehq/go-libs/v5/pkg/testing/deferred/ginkgo"
+	"github.com/formancehq/go-libs/v5/pkg/testing/platform/pgtesting"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
+	. "github.com/formancehq/ledger/pkg/testserver"
+	"github.com/formancehq/ledger/pkg/testserver/ginkgo"
+)
+
+// Deleting a metadata key must not touch history: as of an instant at which the
+// key was set and not yet deleted, reads still see it. Each revision of an
+// account's metadata is dated when it is written, and a pit read resolves to the
+// newest revision at or before the pit — so the delete has to carry its own
+// date. A delete dated at the previous write's instant instead erases the key
+// from every pit at or after the set, as if it had never existed.
+var _ = Context("Ledger account metadata deleted after a pit", func() {
+	var (
+		db         = UseTemplatedDatabase()
+		ctx        = logging.TestingContext()
+		testServer = ginkgo.DeferTestServer(
+			DeferMap(db, (*pgtesting.Database).ConnectionOptions),
+			testservice.WithInstruments(
+				testservice.DebugInstrumentation(debug),
+				testservice.OutputInstrumentation(GinkgoWriter),
+			),
+			testservice.WithLogger(GinkgoT()),
+		)
+
+		// The set's own instant, read back from its log entry. A pit placed exactly
+		// there is the earliest instant at which the key is visible, with no clock
+		// assumptions in the test.
+		pit time.Time
+	)
+
+	BeforeEach(func(specContext SpecContext) {
+		client := Wait(specContext, DeferClient(testServer))
+
+		_, err := client.Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		_, err = client.Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+			Ledger: "default",
+			V2PostTransaction: components.V2PostTransaction{
+				Postings: []components.V2Posting{{
+					Amount:      big.NewInt(100),
+					Asset:       "USD/2",
+					Source:      "world",
+					Destination: "bank1",
+				}},
+			},
+		})
+		Expect(err).To(BeNil())
+
+		_, err = client.Ledger.V2.AddMetadataToAccount(ctx, operations.V2AddMetadataToAccountRequest{
+			Ledger:      "default",
+			Address:     "bank1",
+			RequestBody: map[string]string{"category": "premium"},
+		})
+		Expect(err).To(BeNil())
+
+		logs, err := client.Ledger.V2.ListLogs(ctx, operations.V2ListLogsRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+		Expect(logs.V2LogsCursorResponse.Cursor.Data).ToNot(BeEmpty())
+		// Newest first: the head is the metadata write just made.
+		pit = logs.V2LogsCursorResponse.Cursor.Data[0].Date
+
+		_, err = client.Ledger.V2.DeleteAccountMetadata(ctx, operations.V2DeleteAccountMetadataRequest{
+			Ledger:  "default",
+			Address: "bank1",
+			Key:     "category",
+		})
+		Expect(err).To(BeNil())
+	})
+
+	It("should still read the key as of the pit", func(specContext SpecContext) {
+		response, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger: "default",
+			Pit:    &pit,
+		})
+		Expect(err).To(BeNil())
+
+		metadata := map[string]map[string]string{}
+		for _, account := range response.V2AccountsCursorResponse.Cursor.Data {
+			metadata[account.Address] = account.Metadata
+		}
+		Expect(metadata["bank1"]).To(Equal(map[string]string{"category": "premium"}))
+	})
+
+	It("should leave the account untouched when deleting an absent key", func(specContext SpecContext) {
+		client := Wait(specContext, DeferClient(testServer))
+
+		before, err := client.Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+			Ledger:  "default",
+			Address: "bank1",
+		})
+		Expect(err).To(BeNil())
+
+		_, err = client.Ledger.V2.DeleteAccountMetadata(ctx, operations.V2DeleteAccountMetadataRequest{
+			Ledger:  "default",
+			Address: "bank1",
+			Key:     "never-set",
+		})
+		Expect(err).To(BeNil())
+
+		after, err := client.Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+			Ledger:  "default",
+			Address: "bank1",
+		})
+		Expect(err).To(BeNil())
+		Expect(after.V2AccountResponse.Data.UpdatedAt).To(Equal(before.V2AccountResponse.Data.UpdatedAt))
+	})
+
+	It("should preserve both instants through an export and import", func(specContext SpecContext) {
+		// The replay path dates the revisions from the imported logs' own dates
+		// (importLog passes log.Date), where the live path lets the store stamp
+		// them — so a replica must answer the same pit reads as the original.
+		client := Wait(specContext, DeferClient(testServer))
+
+		export, err := client.Ledger.V2.ExportLogs(ctx, operations.V2ExportLogsRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+
+		_, err = client.Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+			Ledger: "replica",
+		})
+		Expect(err).To(BeNil())
+
+		_, err = client.Ledger.V2.ImportLogs(ctx, operations.V2ImportLogsRequest{
+			Ledger:              "replica",
+			V2ImportLogsRequest: export.HTTPMeta.Response.Body,
+		})
+		Expect(err).To(BeNil())
+
+		atPit, err := client.Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger: "replica",
+			Pit:    &pit,
+		})
+		Expect(err).To(BeNil())
+		metadata := map[string]map[string]string{}
+		for _, account := range atPit.V2AccountsCursorResponse.Cursor.Data {
+			metadata[account.Address] = account.Metadata
+		}
+		Expect(metadata["bank1"]).To(Equal(map[string]string{"category": "premium"}))
+
+		now, err := client.Ledger.V2.GetAccount(ctx, operations.V2GetAccountRequest{
+			Ledger:  "replica",
+			Address: "bank1",
+		})
+		Expect(err).To(BeNil())
+		Expect(now.V2AccountResponse.Data.Metadata).To(BeEmpty())
+
+		// The discriminating instant: as of the delete's own original date the key
+		// is already gone. A replay dating the delete at import time instead of the
+		// log's date would still show it here, since the import happened later.
+		logs, err := client.Ledger.V2.ListLogs(ctx, operations.V2ListLogsRequest{
+			Ledger: "default",
+		})
+		Expect(err).To(BeNil())
+		deleteDate := logs.V2LogsCursorResponse.Cursor.Data[0].Date
+
+		atDelete, err := client.Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger: "replica",
+			Pit:    &deleteDate,
+		})
+		Expect(err).To(BeNil())
+		for _, account := range atDelete.V2AccountsCursorResponse.Cursor.Data {
+			if account.Address == "bank1" {
+				Expect(account.Metadata).To(BeEmpty())
+			}
+		}
+	})
+
+	It("should still select the key's account as of the pit, and none now", func(specContext SpecContext) {
+		client := Wait(specContext, DeferClient(testServer))
+		hasCategory := map[string]any{
+			"$exists": map[string]any{"metadata": "category"},
+		}
+
+		response, err := client.Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger:      "default",
+			Pit:         &pit,
+			RequestBody: hasCategory,
+		})
+		Expect(err).To(BeNil())
+		addresses := make([]string, 0, len(response.V2AccountsCursorResponse.Cursor.Data))
+		for _, account := range response.V2AccountsCursorResponse.Cursor.Data {
+			addresses = append(addresses, account.Address)
+		}
+		Expect(addresses).To(ConsistOf("bank1"))
+
+		now, err := client.Ledger.V2.ListAccounts(ctx, operations.V2ListAccountsRequest{
+			Ledger:      "default",
+			RequestBody: hasCategory,
+		})
+		Expect(err).To(BeNil())
+		Expect(now.V2AccountsCursorResponse.Cursor.Data).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Backport of #1779 to release/v2.4, without the main-only dependency sync.

## What changed

`DeleteAccountMetadata` now stamps `updated_at` on the account row — the log date on the replay path, `transaction_date()` when none is given — so the metadata-history revision the trigger writes for a delete carries the delete's own instant. Deleting an absent key now leaves the row untouched entirely (no `updated_at` bump, no history revision), matching the guard the no-op set already has. New e2e test covering metadata reads and filters as of a pit between a set and its delete, and the no-op delete.

## Why

Deleting an account metadata key erased it retroactively: the history trigger dates each revision at `updated_at`, which the delete left untouched, so the delete's revision inherited the previous write's date. Any point-in-time read at or after the set then resolved to the delete's revision — on `/accounts`, account counts, aggregated balances and `/volumes`. `DeleteTransactionMetadata` already handles this correctly; the account variant was the omission. [EN-1872](https://formance-team.atlassian.net/browse/EN-1872)

## Risk

**LOW** — one store method gains a date parameter; its two callers pass the same values the transaction-metadata delete already passes; no schema change. Only the bugged behavior changes observably.

## Validation

- [x] Targeted tests: the e2e specs are red without the fix on main, green with it; a third spec pins that a no-op delete leaves `updatedAt` untouched
- [x] Baseline validation on this branch: `internal/storage/ledger`, `internal/controller/ledger` and the new e2e suite green

## Architecture / behavior impact

`accounts_metadata` revisions written by future deletes are dated correctly; revisions already written by past deletes remain misdated — this fixes the write path, not existing history. Replayed `DELETED_METADATA` logs (`importLog`) date the revision at the log's date, so an import reconstructs the same history.

## Review focus

The absent-key guard (`metadata -> ? is not null`): it must not change anything a client can observe. The controller ignores the row count, so the HTTP status stays 2xx.

## Known concerns

None

[EN-1872]: https://formance-team.atlassian.net/browse/EN-1872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ