### PR TITLE
test(state): protect primary double-entry guard

### DIFF
--- a/internal/infra/state/write_set_double_entry_test.go
+++ b/internal/infra/state/write_set_double_entry_test.go
@@ -1,0 +1,46 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+// TestWriteSetMergeRejectsUnbalancedVolumeUpdate protects the primary
+// double-entry guard over all volume updates. The production order processors
+// can only build balanced posting pairs; constructing the broken intermediate
+// state directly is intentional fault injection at the guard's boundary.
+func TestWriteSetMergeRejectsUnbalancedVolumeUpdate(t *testing.T) {
+	t.Parallel()
+
+	buf, _, dataStore := newTestBuffer(t)
+	key := domain.NewVolumeKey("test", "destination", "USD", "")
+	buf.Volumes().Put(key, &raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(100),
+		Output: commonpb.NewUint256FromUint64(0),
+	})
+	buf.gatedLedgerTypes = map[string]gatedLedgerType{
+		"test": {found: true},
+	}
+
+	batch := dataStore.OpenWriteSession()
+	err := buf.Merge(batch, nil)
+	require.NoError(t, batch.Cancel())
+
+	var violation *ErrDoubleEntryInvariantViolated
+	require.ErrorAs(t, err, &violation)
+	require.Equal(t, "100", violation.InputSum)
+	require.Equal(t, "0", violation.OutputSum)
+
+	// DerivedKeyStore.Merge updates the cache before this invariant runs. A
+	// Merge error is terminal to the production applier, so cache rollback is
+	// not part of the recoverable contract and is deliberately not asserted.
+	// The rejected update must never cross the Pebble commit boundary.
+	persisted, err := buf.attrs.Volume.Get(dataStore, key.Bytes())
+	require.NoError(t, err)
+	require.Nil(t, persisted)
+}


### PR DESCRIPTION
## Summary

- add a focused WriteSet.Merge regression that injects an actually unbalanced volume update
- require the primary guard to return ErrDoubleEntryInvariantViolated with input 100 / output 0
- prove the rejected update is not persisted to Pebble
- intentionally leave runtime behavior unchanged because the residual cache mutation is on a fatal applier path and no harmful reuse was demonstrated

## Discovery

DISCOVERY: NO_EXISTING_WORK

Searched open and closed PRs, remote branches, and commit history for ErrDoubleEntryInvariantViolated, checkDoubleEntryInvariant, WriteSet.Merge, DerivedKeyStore.Merge, unbalanced updates, and double-entry invariant work. Existing tests only cover error formatting; no equivalent guard regression or cache-semantics fix exists. Unrelated EN-1862, EN-1863, PR #1758, and other campaign work are untouched.

## Exact target

TARGET_BASE_SHA: 2dd21c07668d7fb5861505f92a043aeb9c4e8f26

Effective toolchain: Nix Go 1.26.5 at /nix/store/kdcrss2v61fqb3vz3hm77djhwjd2v010-go-1.26.5/bin/go. Homebrew Go 1.27 contamination was detected and rejected before test evidence was collected.

## Test gap before

TEST_GAP_REPRODUCED

A disposable probe sent input=100/output=0 through the real WriteSet.Merge path and observed ErrDoubleEntryInvariantViolated. On the exact target base, temporarily removing only the primary checkDoubleEntryInvariant(volumeUpdates) call left the pre-existing suite green:

    go test ./internal/infra/state -count=1
    ok github.com/formancehq/ledger/v3/internal/infra/state 37.432s

The mutation was restored and the disposable probe was removed.

## Runtime analysis

FATAL_ERROR_CONTRACT_CONFIRMED; RUNTIME_BUG_NOT_DEMONSTRATED.

The only production volume writers are the direct-posting and Numscript posting processors. A successful posting increments source output and destination input by the same amount; callers cannot submit an arbitrary VolumePair. Reaching the Merge invariant therefore requires broken internal intermediate state or another accounting/cache defect, not an ordinary request shape.

DerivedKeyStore.Merge does mutate the parent cache before the primary check. A disposable observation confirmed that after Merge rejection plus batch cancellation, Pebble is unchanged while the cache contains the unbalanced value. However, Merge errors propagate outside the business-rejection path: PrepareDecodedEntries cancels the batch, Applier.Run returns, the node stops the task pool, and bootstrap panics on Node.Run's error. There is no same-process retry or subsequent apply. Restart rebuilds memory from Pebble and replays the committed entry; it does not reuse the residual cache.

No production-representative reproduction made that residual cache affect later externally observable behavior. This PR therefore does not introduce rollback or change runtime semantics.

## Regression and mutation sensitivity

TEST_SENSITIVITY: PASS

With the permanent test present, temporarily removing only the primary guard made the focused test fail for the intended reason:

    Error: An error is expected but got nil.
    expected: *state.ErrDoubleEntryInvariantViolated

After restoration, the focused test passed and write_set.go matched the target exactly.

The test does not assert cache rollback because that would invent a recoverable contract the runtime does not have. It does assert that the canceled write is absent from Pebble.

## Validation

- focused regression: PASS
- internal/infra/state package: PASS
- focused race test, 20 repetitions: PASS
- bash scripts/agent-check: PASS after final rebase
- trusted pre-commit to fixpoint: PASS, 0 root/operator lint issues
- exact candidate review: one new test file, no runtime or generated changes
- worktree clean
