### PR TITLE
fix: server correctness fixes surfaced by the model-checking driver

### DIFF
--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -213,6 +213,7 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	var (
 		hasArchivedChapters  bool
 		archiveEndSeq        uint64 // max close_sequence among archived chapters
+		archiveAuditEndSeq   uint64 // max close_audit_sequence among archived chapters
 		archiveLastAuditHash []byte // last_audit_hash from the latest archived chapter
 	)
 
@@ -231,6 +232,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			if p.GetCloseSequence() > archiveEndSeq {
 				archiveEndSeq = p.GetCloseSequence()
 				archiveLastAuditHash = p.GetLastAuditHash()
+			}
+
+			if p.GetCloseAuditSequence() > archiveAuditEndSeq {
+				archiveAuditEndSeq = p.GetCloseAuditSequence()
 			}
 		}
 	}
@@ -783,7 +788,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	// projection. Combined with the LedgerLog.PurgedVolumes already
 	// accumulated above, `stored` now represents the full per-ledger
 	// exclusion set the index builder will consume.
-	if err := c.collectStoredTransientVolumes(ctx, snap, addStored); err != nil {
+	//
+	// The scan starts strictly above the archived audit boundary, mirroring
+	// the replay loop's `seq <= archiveEndSeq` skip on the log side: the
+	// derived set only covers post-boundary history, and rows at or below the
+	// boundary can legitimately sit in hot storage — a restore re-ingests the
+	// backfilled archived ranges and never re-purges them, and out-of-order
+	// archiving leaves an un-archived chapter's rows below the max archived
+	// close — so comparing them against a replay that skipped their logs
+	// reports a healthy store as corrupt. Same trade-off as the log-side
+	// skip: retained sub-boundary rows go unverified.
+	if err := c.collectStoredTransientVolumes(ctx, snap, archiveAuditEndSeq, addStored); err != nil {
 		return fmt.Errorf("reading applied proposals for exclusion check: %w", err)
 	}
 
@@ -887,9 +902,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 func (c *Checker) collectStoredTransientVolumes(
 	ctx context.Context,
 	reader dal.PebbleReader,
+	archiveAuditEndSeq uint64,
 	addStored func(ledger, account, asset, color string),
 ) error {
-	proposals, err := query.ReadAppliedProposals(ctx, reader, nil)
+	// Proposals at or below the archived audit boundary are outside the
+	// replay's derivation window (see the call site) — start above it.
+	var afterSeq *uint64
+	if archiveAuditEndSeq > 0 {
+		afterSeq = &archiveAuditEndSeq
+	}
+
+	proposals, err := query.ReadAppliedProposals(ctx, reader, afterSeq)
 	if err != nil {
 		return fmt.Errorf("reading applied proposals: %w", err)
 	}

--- a/internal/application/check/checker_exclusion_archived_test.go
+++ b/internal/application/check/checker_exclusion_archived_test.go
@@ -1,0 +1,136 @@
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/proposalpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// writeAppliedProposal persists an AppliedProposal row at the given audit
+// sequence, byte-for-byte as the FSM (and a restore's raw segment ingest)
+// would store it.
+func writeAppliedProposal(t *testing.T, store *dal.Store, entry *proposalpb.AppliedProposal) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	key := dal.NewKeyBuilder().
+		PutZonePrefix(dal.ZoneCold, dal.SubColdAppliedProposal).
+		PutUint64(entry.GetSequence()).
+		Build()
+	require.NoError(t, batch.SetProto(key, entry))
+	require.NoError(t, batch.Commit())
+}
+
+func transientProposal(seq uint64, ledger, account, asset string) *proposalpb.AppliedProposal {
+	return &proposalpb.AppliedProposal{
+		Sequence: seq,
+		TransientVolumes: map[string]*proposalpb.TouchedVolumeList{
+			ledger: {Volumes: []*commonpb.TouchedVolume{{Account: account, Asset: asset}}},
+		},
+	}
+}
+
+// TestCollectStoredTransientVolumes_SkipsArchivedAuditRange pins the scan's
+// lower bound: proposals at or below the archived audit boundary are outside
+// the replay's derivation window and must not enter the stored exclusion set.
+func TestCollectStoredTransientVolumes_SkipsArchivedAuditRange(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeAppliedProposal(t, store, transientProposal(1, "L", "t:below", "USD"))
+	writeAppliedProposal(t, store, transientProposal(2, "L", "t:boundary", "USD"))
+	writeAppliedProposal(t, store, transientProposal(3, "L", "t:above", "USD"))
+
+	checker := NewChecker(store, nil, "test-cluster", nil, nil, nil, logging.Testing())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	var got []string
+
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 2,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:above"}, got,
+		"rows at or below the archived audit boundary must be skipped")
+
+	got = nil
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 0,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:below", "t:boundary", "t:above"}, got,
+		"without archived chapters the scan stays unbounded")
+}
+
+// TestCheck_RetainedTransientRecordsBelowArchiveBoundary is the model-test
+// regression: a restore re-ingests the backfilled archived ranges — including
+// AppliedProposal rows carrying TransientVolumes — and never re-purges them.
+// The replay skips the matching logs (seq <= archiveEndSeq), so deriving
+// nothing for them is correct; the stored side must skip the same window or a
+// healthy restored store reports EXCLUSION_RECORD_MISMATCH for every
+// transient account used before the archival.
+func TestCheck_RetainedTransientRecordsBelowArchiveBoundary(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestEngine(t)
+	engine.processAndCommit(createLedgerOrder("test"))
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "alice", "USD", 100)))
+
+	handle, err := engine.store.NewReadHandle()
+	require.NoError(t, err)
+
+	lastLog, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+
+	lastAudit, err := query.ReadLastAuditSequence(handle)
+	require.NoError(t, err)
+
+	// The boundary-time baseline snapshot, as chapter close writes it — without
+	// it Check() skips entry-by-entry verification entirely under archiving.
+	baselinePath, err := engine.store.BaselineSnapshotDir()
+	require.NoError(t, err)
+	require.NoError(t, attributes.CreateBaselineSnapshot(handle, baselinePath))
+	require.NoError(t, handle.Close())
+
+	// The transient record lives in the range about to be marked archived,
+	// exactly as a backfilled restore retains it.
+	writeAppliedProposal(t, engine.store, transientProposal(1, "test", "t:42", "USD"))
+
+	// Post-boundary activity so the replay window is non-empty.
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "bob", "USD", 5)))
+
+	batch := engine.store.OpenWriteSession()
+	require.NoError(t, state.StoreChapter(batch, &commonpb.Chapter{
+		Id:                 1,
+		Status:             commonpb.ChapterStatus_CHAPTER_ARCHIVED,
+		StartSequence:      1,
+		CloseSequence:      lastLog.GetSequence(),
+		StartAuditSequence: 1,
+		CloseAuditSequence: lastAudit,
+	}))
+	require.NoError(t, batch.Commit())
+
+	for _, e := range collectCheckErrors(t, engine.store, engine.attrs) {
+		require.NotEqual(t,
+			servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_EXCLUSION_RECORD_MISMATCH,
+			e.GetErrorType(),
+			"retained sub-boundary exclusion records must not be reported: %s", e.GetMessage())
+	}
+}

--- a/internal/application/ctrl/list_entities.go
+++ b/internal/application/ctrl/list_entities.go
@@ -39,7 +39,7 @@ type entityListParams[T interface{ ~string | ~uint64 }] struct {
 	indexRegistry indexes.Lookup
 	// indexVersionFor is filled in by listEntities (bound to the
 	// iteration snapshot); leaf compilers should never see a nil here.
-	indexVersionFor func(canonical string) (uint32, bool, error)
+	indexVersionFor readstore.IndexVersionResolver
 	// afterToBytes converts the after cursor to a byte slice for pagination.
 	afterToBytes func(T) []byte
 	// pin is filled in by listEntities: the main handle's applied sequence,

--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -274,7 +274,7 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 			continue
 		}
 
-		if err := b.bumpPendingVersion(ledgerName, indexID); err != nil {
+		if err := b.bumpPendingVersion(ledgerName, indexID, smft.GetType()); err != nil {
 			return fmt.Errorf("bumping pending_version on retype during backfill: %w", err)
 		}
 
@@ -308,7 +308,7 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 	// current batch. The rewrite task will read pending_version from
 	// the cache at processSchemaRewrite time to know its target
 	// keyspace, and the live write path will dual-write into it.
-	if err := b.bumpPendingVersion(ledgerName, indexID); err != nil {
+	if err := b.bumpPendingVersion(ledgerName, indexID, smft.GetType()); err != nil {
 		return fmt.Errorf("bumping pending_version on retype: %w", err)
 	}
 
@@ -357,17 +357,28 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 // Index.ForwardEncodingVersion in processSetMetadataFieldType — each
 // replica derives its own pending the same way, so the two converge as
 // long as every log is seen.
-func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexID) error {
+func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexID, toType commonpb.MetadataType) error {
 	canonical := indexes.Canonical(indexID)
-	current, pending := b.versionFor(ledgerName, canonical)
-
 	prior, _ := b.versionStateFor(ledgerName, canonical)
-	base := max(pending, current, prior.HighWater)
 
+	base := max(prior.PendingVersion, prior.CurrentVersion, prior.HighWater)
+
+	// CurrentVersion keeps everything that describes it: its activation
+	// sequence and its bound type both belong to the version still being
+	// served, and dropping them here would let a stale pin resolve the
+	// promoted keyspace as complete (activation) or re-encode live writes
+	// under the wrong type mid-window (bound type). Only the pending slot
+	// is new: the rewrite's target version, bound to the retype's target
+	// type, with a fresh cursor.
 	newState := readstore.IndexVersionState{
-		CurrentVersion: current,
-		PendingVersion: base + 1,
-		HighWater:      base + 1,
+		CurrentVersion:      prior.CurrentVersion,
+		PendingVersion:      base + 1,
+		ActivationSequence:  prior.ActivationSequence,
+		HighWater:           base + 1,
+		CurrentType:         prior.CurrentType,
+		CurrentTypeDeclared: prior.CurrentTypeDeclared,
+		PendingType:         toType,
+		PendingTypeDeclared: true,
 	}
 
 	batch := b.wb.Batch()
@@ -874,11 +885,14 @@ scan:
 			// tick via the scanComplete branch at the top of the function.
 			done = false
 		} else {
+			prior, _ := b.versionStateFor(task.ledger, canonical)
 			newState = readstore.IndexVersionState{
-				CurrentVersion:     pendingVersion,
-				PendingVersion:     0,
-				ActivationSequence: task.requiredIndexedSeq,
-				HighWater:          pendingVersion,
+				CurrentVersion:      pendingVersion,
+				PendingVersion:      0,
+				ActivationSequence:  task.requiredIndexedSeq,
+				HighWater:           pendingVersion,
+				CurrentType:         prior.PendingType,
+				CurrentTypeDeclared: prior.PendingTypeDeclared,
 			}
 
 			if err := b.readStore.WriteIndexVersionState(batch, task.ledger, canonical, newState); err != nil {
@@ -952,11 +966,14 @@ func (b *Builder) tryCommitScanCompleteSwitch(
 		}
 	}()
 
+	prior, _ := b.versionStateFor(task.ledger, canonical)
 	newState := readstore.IndexVersionState{
-		CurrentVersion:     pendingVersion,
-		PendingVersion:     0,
-		ActivationSequence: task.requiredIndexedSeq,
-		HighWater:          pendingVersion,
+		CurrentVersion:      pendingVersion,
+		PendingVersion:      0,
+		ActivationSequence:  task.requiredIndexedSeq,
+		HighWater:           pendingVersion,
+		CurrentType:         prior.PendingType,
+		CurrentTypeDeclared: prior.PendingTypeDeclared,
 	}
 
 	if err := b.readStore.WriteIndexVersionState(batch, task.ledger, canonical, newState); err != nil {
@@ -1239,10 +1256,13 @@ func (b *Builder) completeBackfill(task *backfillTask) error {
 			task.ledger, canonical)
 	}
 
+	prior, _ := b.versionStateFor(task.ledger, canonical)
 	newState := readstore.IndexVersionState{
-		CurrentVersion: pending,
-		PendingVersion: 0,
-		HighWater:      pending,
+		CurrentVersion:      pending,
+		PendingVersion:      0,
+		HighWater:           pending,
+		CurrentType:         prior.PendingType,
+		CurrentTypeDeclared: prior.PendingTypeDeclared,
 	}
 
 	batch := b.readStore.NewBatch()

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -121,6 +121,19 @@ type Builder struct {
 // (0, 0) to "version 1" via effectiveCurrentVersion below because
 // Index.ForwardEncodingVersion is initialised to 1 at CreateIndex /
 // first SetMetadataFieldType apply.
+// versionStateFor returns the full cached per-replica version state for an
+// index, false when this replica has never written one.
+func (b *Builder) versionStateFor(ledgerName, canonicalID string) (readstore.IndexVersionState, bool) {
+	inner, ok := b.indexVersions[ledgerName]
+	if !ok {
+		return readstore.IndexVersionState{}, false
+	}
+
+	state, ok := inner[canonicalID]
+
+	return state, ok
+}
+
 func (b *Builder) versionFor(ledgerName, canonicalID string) (current uint32, pending uint32) {
 	if b.indexVersions == nil {
 		return 0, 0
@@ -184,19 +197,6 @@ func (b *Builder) tombstoneVersionState(ledgerName, canonicalID string) error {
 	b.putVersionState(ledgerName, canonicalID, tomb)
 
 	return nil
-}
-
-// versionStateFor returns the full cached per-replica version state for an
-// index, false when this replica has never written one.
-func (b *Builder) versionStateFor(ledgerName, canonicalID string) (readstore.IndexVersionState, bool) {
-	inner, ok := b.indexVersions[ledgerName]
-	if !ok {
-		return readstore.IndexVersionState{}, false
-	}
-
-	state, ok := inner[canonicalID]
-
-	return state, ok
 }
 
 // effectiveCurrentVersion returns the forward-encoding version live
@@ -264,22 +264,67 @@ func (b *Builder) dualWriteMetadataIndex(
 	kb *dal.KeyBuilder,
 	ledger, ns, metaKey string,
 	target commonpb.TargetType,
-	newEncoded, entityID []byte,
+	value *commonpb.MetadataValue,
+	entityID []byte,
 	rmapKeyAtVersion reverseKeyForVersion,
 ) error {
 	current, pending := b.metadataIndexVersions(ledger, target, metaKey)
 
-	if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, current, newEncoded, entityID, rmapKeyAtVersion(current)); err != nil {
+	if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, target, current, value, entityID, rmapKeyAtVersion(current)); err != nil {
 		return err
 	}
 
 	if pending != 0 && pending != current {
-		if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, pending, newEncoded, entityID, rmapKeyAtVersion(pending)); err != nil {
+		if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, target, pending, value, entityID, rmapKeyAtVersion(pending)); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// coerceForVersion coerces a metadata value under the declared type BOUND to
+// the version being written, not the live schema. During a retype's
+// conversion window the two differ, and the difference is the point: rows at
+// v_current must keep the old type's encoding so queries served from it see
+// the complete old-typed index until the atomic switch, while v_pending rows
+// carry the retype's target (EN-1724). A version bound to no declared type
+// encodes each value verbatim, exactly as writes did before any declaration.
+func (b *Builder) coerceForVersion(ledger string, target commonpb.TargetType, key string, version uint32, v *commonpb.MetadataValue) (*commonpb.MetadataValue, error) {
+	canonical := indexes.Canonical(indexes.MetadataID(target, key))
+
+	state, ok := b.versionStateFor(ledger, canonical)
+	if !ok {
+		// No per-replica record: an index served at the promoted v1 that no
+		// rewrite has ever touched. The live declared type is the bound type.
+		return b.coerceForLedger(ledger, target, key, v)
+	}
+
+	switch {
+	case state.PendingVersion != 0 && version == state.PendingVersion:
+		return coerceToBound(v, state.PendingType, state.PendingTypeDeclared), nil
+	case version == state.CurrentVersion,
+		state.CurrentVersion == 0 && version == 1:
+		// The second arm is effectiveCurrentVersion's 0→1 promotion during a
+		// creation backfill whose pending is already past 1 — same binding.
+		return coerceToBound(v, state.CurrentType, state.CurrentTypeDeclared), nil
+	default:
+		// Versions come from the same state the caller consulted, so a write
+		// targeting one the state does not bind is a wiring bug; encoding it
+		// under a guessed type would plant a row no query interprets right.
+		return nil, fmt.Errorf("invariant: write at version %d of %s/%s, which the version state (current=%d pending=%d) does not bind",
+			version, ledger, canonical, state.CurrentVersion, state.PendingVersion)
+	}
+}
+
+// coerceToBound is CoerceToDeclaredType with the version-bound type standing
+// in for the schema lookup.
+func coerceToBound(v *commonpb.MetadataValue, t commonpb.MetadataType, declared bool) *commonpb.MetadataValue {
+	if !declared || v == nil || commonpb.TypeMatches(v, t) {
+		return v
+	}
+
+	return commonpb.ConvertMetadataValue(v, t)
 }
 
 // writeMetadataIndexAtVersion resolves the version-scoped reverse-map
@@ -290,9 +335,18 @@ func (b *Builder) dualWriteMetadataIndex(
 func (b *Builder) writeMetadataIndexAtVersion(
 	kb *dal.KeyBuilder,
 	ledger, ns, metaKey string,
+	target commonpb.TargetType,
 	version uint32,
-	newEncoded, entityID, reverseKey []byte,
+	value *commonpb.MetadataValue,
+	entityID, reverseKey []byte,
 ) error {
+	coerced, err := b.coerceForVersion(ledger, target, metaKey, version, value)
+	if err != nil {
+		return err
+	}
+
+	newEncoded := readstore.EncodeMetadataValue(nil, coerced)
+
 	oldEncoded, err := b.reverseMapValue(reverseKey)
 	if err != nil {
 		return err

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -408,6 +408,30 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // backfill scheduling so the builder does not redo work that has already
 // completed — and, more importantly, does not knock a live index back into
 // ErrIndexBuilding.
+// boundTypeAtCreation resolves the declared type an index's first version is
+// bound to: the schema entry in force when the CreateIndex log folds. Only
+// metadata indexes carry one; for every other kind — and for a key declared
+// after the index — the version is bound to no type and rows keep each
+// value's natural encoding.
+func (b *Builder) boundTypeAtCreation(ledgerName string, id *commonpb.IndexID) (commonpb.MetadataType, bool) {
+	meta, ok := id.GetKind().(*commonpb.IndexID_Metadata)
+	if !ok || meta.Metadata == nil || b.batchSchema == nil {
+		return 0, false
+	}
+
+	schema, err := b.batchSchema.For(ledgerName)
+	if err != nil || schema == nil {
+		return 0, false
+	}
+
+	_, fs := commonpb.SchemaFieldForTarget(schema, meta.Metadata.GetTarget(), meta.Metadata.GetKey())
+	if fs == nil {
+		return 0, false
+	}
+
+	return fs.GetType(), true
+}
+
 func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.CreatedIndexLog) {
 	id := log.GetId()
 	if id == nil {
@@ -453,10 +477,13 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	next := prior.HighWater + 1
 
 	if log.GetInitial() {
+		boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 		state := readstore.IndexVersionState{
-			CurrentVersion: next,
-			PendingVersion: 0,
-			HighWater:      next,
+			CurrentVersion:      next,
+			PendingVersion:      0,
+			HighWater:           next,
+			CurrentType:         boundType,
+			CurrentTypeDeclared: declared,
 		}
 
 		if b.wb != nil && b.readStore != nil {
@@ -484,10 +511,13 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	// boot recovery would otherwise have to guess from cfg.byCanonical
 	// alone, which loses the distinction between "fresh index" and
 	// "stale READY index from a snapshot install".
+	boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 	state := readstore.IndexVersionState{
-		CurrentVersion: 0,
-		PendingVersion: next,
-		HighWater:      next,
+		CurrentVersion:      0,
+		PendingVersion:      next,
+		HighWater:           next,
+		PendingType:         boundType,
+		PendingTypeDeclared: declared,
 	}
 
 	if b.wb != nil && b.readStore != nil {

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -677,7 +677,8 @@ func TestAddSchemaRewriteTask_ResetsInFlightBackfill(t *testing.T) {
 	}
 
 	// A backfill task always coexists with its version state and runs inside
-	// an active fold batch — CreateIndex writes both in one commit.
+	// an active fold batch — CreateIndex writes both in one commit, and boot
+	// rebuilds the task FROM the persisted state.
 	b.putVersionState("ledger1", indexes.Canonical(id), readstore.IndexVersionState{
 		CurrentVersion: 0,
 		PendingVersion: 1,
@@ -706,6 +707,9 @@ func TestAddSchemaRewriteTask_ResetsInFlightBackfill(t *testing.T) {
 	assert.Equal(t, uint32(2), state.PendingVersion,
 		"the restart must fill a FRESH keyspace — refolding the half-built one re-encodes values at their original sequences, and those retractions lose the same-seq tie forever")
 	assert.Equal(t, uint32(2), state.HighWater)
+	require.True(t, state.PendingTypeDeclared)
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_UINT64, state.PendingType,
+		"the fresh keyspace is bound to the retype's target type")
 }
 
 // TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped pins the
@@ -753,8 +757,9 @@ func TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped(t *testing.T) 
 		},
 	}
 
-	// stripBuildingIndexes hides the index from cfg, but the version state
-	// and the fold batch are untouched by the strip.
+	// stripBuildingIndexes hides the index from cfg, but the version state and
+	// the fold batch are untouched by the strip — both still exist whenever a
+	// backfill task does.
 	b.putVersionState("ledger1", indexes.Canonical(id), readstore.IndexVersionState{
 		CurrentVersion: 0,
 		PendingVersion: 1,
@@ -776,6 +781,13 @@ func TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped(t *testing.T) 
 		"stripped index must not block the retype reset — backfill must restart from 0")
 	assert.Equal(t, uint64(0), b.backfillTasks[0].appliedProposalSeq)
 	assert.Empty(t, b.schemaRewriteTasks, "no separate schema rewrite needed; backfill replay covers it")
+
+	state, ok := b.versionStateFor("ledger1", indexes.Canonical(id))
+	require.True(t, ok)
+	require.True(t, state.PendingTypeDeclared)
+	assert.Equal(t, uint32(2), state.PendingVersion,
+		"the restarted backfill fills a fresh keyspace bound to the retype's target type")
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_UINT64, state.PendingType)
 }
 
 // TestAddSchemaRewriteTask_DoesNotResetOtherLedgersBackfill guards against

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -540,18 +540,6 @@ func (b *Builder) indexLogEntry(cfg *ledgerIndexConfig, log *commonpb.Log, propo
 		}
 	}
 
-	// Schema logs are deliberately absent from this switch. The only caller,
-	// processBackfill, gates on isDataLog, which admits exactly
-	// CreatedTransaction / RevertedTransaction / SavedMetadata / DeletedMetadata
-	// / OrderSkipped and switches on the same discriminator used here — so a
-	// SetMetadataFieldType or RemovedMetadataFieldType log can never arrive.
-	// Schema handling belongs to the live path (indexPayload), where
-	// SetMetadataFieldType defers to addSchemaRewriteTask / processSchemaRewrite
-	// and RemovedMetadataFieldType to handleRemovedMetadataFieldType. A retype
-	// that lands mid-backfill is handled by addSchemaRewriteTask resetting the
-	// in-flight cursor, not by replaying the schema log here. Do NOT add a case
-	// for them without also changing isDataLog: an unreachable second
-	// implementation of the schema rewrite is what this replaced.
 	switch p := ledgerLog.GetData().GetPayload().(type) {
 	case *commonpb.LedgerLogPayload_CreatedTransaction:
 		return b.indexCreatedTransaction(b.kb, cfg, ledgerName, p.CreatedTransaction, excludedVolumes)
@@ -623,17 +611,11 @@ func (b *Builder) indexCreatedTransaction(
 					continue
 				}
 
-				coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, key, value)
-				if err != nil {
-					return err
-				}
-				newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 				if err := b.dualWriteMetadataIndex(
 					kb,
 					ledger, readstore.NamespaceAccount, key,
 					commonpb.TargetType_TARGET_TYPE_ACCOUNT,
-					newEncoded, []byte(account),
+					value, []byte(account),
 					func(version uint32) []byte {
 						return readstore.AccountReverseMapKeyV(kb, ledger, account, key, version)
 					},
@@ -659,17 +641,11 @@ func (b *Builder) indexCreatedTransaction(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},
@@ -753,17 +729,11 @@ func (b *Builder) indexRevertedTransaction(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},
@@ -814,6 +784,18 @@ func (b *Builder) indexPostingAddressMappings(
 	wb := b.wb
 	sourceExcluded := isExcluded(excludedVolumes, source, asset, color)
 	destinationExcluded := isExcluded(excludedVolumes, destination, asset, color)
+
+	// Exclusion skips are rare (a purged/transient touch) and each one silently
+	// shapes the posting-derived indexes, so log every decision for diagnosis.
+	if (sourceExcluded || destinationExcluded) && b.logger != nil {
+		b.logger.WithFields(map[string]any{
+			"ledger": ledger,
+			"txID":   txID,
+			"source": source, "sourceExcluded": sourceExcluded,
+			"destination": destination, "destinationExcluded": destinationExcluded,
+			"asset": asset,
+		}).Infof("Posting-index exclusion skip")
+	}
 
 	// Account has-asset index: record every (account, assetBase, precision) a
 	// posting touches, for both source and destination, skipping excluded
@@ -996,17 +978,11 @@ func (b *Builder) indexSavedMetadata(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceAccount, key,
 				commonpb.TargetType_TARGET_TYPE_ACCOUNT,
-				newEncoded, []byte(account),
+				value, []byte(account),
 				func(version uint32) []byte {
 					return readstore.AccountReverseMapKeyV(kb, ledger, account, key, version)
 				},
@@ -1024,17 +1000,11 @@ func (b *Builder) indexSavedMetadata(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},
@@ -1108,6 +1078,12 @@ func cloneBytes(b []byte) []byte {
 	return c
 }
 
+// extractMetadataKeyFromReverseMap extracts the metadata key name from a
+// reverse map key, given the prefix up to the namespace.
+// For accounts:     [ledger\x00][a:][account\x00][version:4B BE][metadataKey]
+// For transactions: [ledger\x00][t:][txID(8B)][version:4B BE][metadataKey].
+//
+
 // isExcluded returns true if the (account, asset, color) tuple is in the
 // excluded set (transient or purged ephemeral). All three dimensions matter
 // — a multi-bucket account may have one (asset, color) purged while another
@@ -1122,3 +1098,16 @@ func isExcluded(excluded map[domain.AccountAssetKey]struct{}, account, asset, co
 
 	return ok
 }
+
+// parseReverseMapKey parses a full reverse-map key (including the
+// PrefixReverseMap discriminator byte) and returns the (entityID,
+// metaKey, version) tuple it encodes. ok=false when the key shape is
+// incompatible with the namespace (corrupt key, scanning past a fresh
+// version frontier with truncated tails).
+//
+
+// extractVersionFromReverseMap returns the 4-byte big-endian
+// forward-encoding version embedded in a reverse map key suffix.
+// Returns (0, false) when the suffix is too short or malformed —
+// callers treat that as "skip this entry" rather than crash.
+//

--- a/internal/application/indexbuilder/retype_window_test.go
+++ b/internal/application/indexbuilder/retype_window_test.go
@@ -1,0 +1,148 @@
+package indexbuilder
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// eventGroupExists reports whether the versioned metadata index holds an
+// event group for (encoded value, entity) — i.e. whether a query scanning
+// that value at that version would consider the entity at all.
+func eventGroupExists(t *testing.T, s *readstore.Store, ledger, ns, metaKey string, version uint32, encoded, entity []byte) bool {
+	t.Helper()
+
+	kb := dal.NewKeyBuilder()
+	prefix := append([]byte(nil), readstore.MetadataIndexPrefixV(kb, ledger, ns, metaKey, version)...)
+	prefix = append(prefix, encoded...)
+	prefix = append(prefix, entity...)
+
+	iter, err := s.DB().NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: readstore.IncrementBytes(prefix),
+	})
+	require.NoError(t, err)
+
+	defer func() { _ = iter.Close() }()
+
+	return iter.First()
+}
+
+// A live write during a retype window is coerced once per version: v_current
+// keeps the OLD type's encoding, so the index it serves stays exactly the one
+// the retype never touched, while v_pending carries the retype's target. One
+// shared encoding — the pre-fix behavior — turns v_current into a mixture no
+// declared type describes: -1 under INT64→UINT32 encodes as null in BOTH
+// versions, and the old-typed query loses a row it must still see (EN-1724).
+func TestRetypeWindow_LiveWriteIsCoercedPerVersion(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.seedBatchSchema(t)
+	b.accounts = make(map[string]struct{})
+
+	const (
+		ledger  = "test"
+		metaKey = "k2"
+		account = "acct:1"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)
+	canonical := indexes.Canonical(id)
+
+	cfg := newLedgerIndexConfig()
+	cfg.byCanonical[canonical] = &commonpb.Index{Id: id}
+
+	// Mid-window state: v1 was built under INT64, the retype to UINT32 is
+	// rewriting into v2.
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
+	})
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(1)
+
+	// -1: valid INT64, out of range for UINT32.
+	require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(account, metaKey, -1)))
+	require.NoError(t, b.wb.Flush())
+
+	oldEncoded := readstore.EncodeMetadataValue(nil, commonpb.NewIntValue(-1))
+	newEncoded := readstore.EncodeMetadataValue(nil, commonpb.ConvertMetadataValue(commonpb.NewIntValue(-1), commonpb.MetadataType_METADATA_TYPE_UINT32))
+
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, oldEncoded, []byte(account)),
+		"v_current must hold the OLD encoding: the window serves the index as if no retype had happened")
+	assert.False(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, newEncoded, []byte(account)),
+		"the new encoding must not leak into v_current — that mixture is the partial-results bug")
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 2, newEncoded, []byte(account)),
+		"v_pending must hold the NEW encoding so the switch promotes a complete new-typed index")
+}
+
+// The reverse direction: the FSM stored the value under the NEW schema (a
+// retype flips the declared type at apply), so what reaches the builder for
+// an out-of-range write is already null-with-original. v_current must still
+// receive the OLD type's faithful encoding, recovered through the null's
+// original representation.
+func TestRetypeWindow_NullOriginalRoundTripsIntoTheOldEncoding(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.seedBatchSchema(t)
+	b.accounts = make(map[string]struct{})
+
+	const (
+		ledger  = "test"
+		metaKey = "k2"
+		account = "acct:2"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)
+	canonical := indexes.Canonical(id)
+
+	cfg := newLedgerIndexConfig()
+	cfg.byCanonical[canonical] = &commonpb.Index{Id: id}
+
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
+	})
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(1)
+
+	// What the FSM stores for a post-retype write of -1 under UINT32.
+	stored := commonpb.ConvertMetadataValue(commonpb.NewIntValue(-1), commonpb.MetadataType_METADATA_TYPE_UINT32)
+	_, isNull := stored.GetType().(*commonpb.MetadataValue_NullValue)
+	require.True(t, isNull, "premise: -1 under UINT32 is stored as null-with-original")
+
+	sm := &commonpb.SavedMetadata{
+		Target: &commonpb.Target{Target: &commonpb.Target_Account{
+			Account: &commonpb.TargetAccount{Addr: account},
+		}},
+		Metadata: map[string]*commonpb.MetadataValue{metaKey: stored},
+	}
+	require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, sm))
+	require.NoError(t, b.wb.Flush())
+
+	oldEncoded := readstore.EncodeMetadataValue(nil, commonpb.NewIntValue(-1))
+
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, oldEncoded, []byte(account)),
+		"v_current recovers int(-1) through the null's original — the write lands exactly where the old world would have put it")
+}

--- a/internal/domain/processing/processor_index.go
+++ b/internal/domain/processing/processor_index.go
@@ -1,6 +1,8 @@
 package processing
 
 import (
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -50,6 +52,14 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 		ForwardEncodingVersion: 1,
 	})
 
+	// Registry mutation trace: paired with the removal probes below, the
+	// event stream carries the FSM's own view of when an entry was written
+	// and when a later lookup no longer found it.
+	assert.Reachable("index registry entry written", map[string]any{
+		"ledger":    ledger,
+		"canonical": indexes.Canonical(id),
+	})
+
 	return buildCreatedIndexLogPayload(id, ctx.isBornEmpty(ledger)), nil
 }
 
@@ -66,6 +76,11 @@ func processDropIndex(ledger string, order *raftcmdpb.DropIndexOrder, ctx *Conte
 	if err := indexes.Remove(ctx.Scope.Indexes(), ledger, id); err != nil {
 		return nil, domain.StoreFailure("dropping index", err)
 	}
+
+	assert.Reachable("index registry entry removed", map[string]any{
+		"ledger":    ledger,
+		"canonical": indexes.Canonical(id),
+	})
 
 	return &commonpb.LedgerLogPayload{
 		Payload: &commonpb.LedgerLogPayload_DropIndex{

--- a/internal/domain/processing/processor_metadata_schema.go
+++ b/internal/domain/processing/processor_metadata_schema.go
@@ -1,6 +1,8 @@
 package processing
 
 import (
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
@@ -82,6 +84,15 @@ func processSetMetadataFieldType(ledger string, order *raftcmdpb.SetMetadataFiel
 		updated.BuildStatus = commonpb.IndexBuildStatus_INDEX_BUILD_STATUS_BUILDING
 		updated.ForwardEncodingVersion++
 		indexes.Put(s.Indexes(), ledger, updated)
+
+		// The bump is observable downstream (it drives each replica's rewrite),
+		// so this event dates the last moment the registry is known to hold
+		// the entry.
+		assert.Reachable("field type change bumped its index", map[string]any{
+			"ledger":     ledger,
+			"canonical":  indexes.Canonical(id),
+			"fwdVersion": updated.GetForwardEncodingVersion(),
+		})
 	}
 
 	return &commonpb.LedgerLogPayload{
@@ -112,6 +123,9 @@ func processRemoveMetadataFieldType(ledger string, order *raftcmdpb.RemoveMetada
 	if info.GetMetadataSchema() == nil {
 		info.MetadataSchema = &commonpb.MetadataSchema{}
 	}
+
+	_, priorField := commonpb.SchemaFieldForTarget(info.GetMetadataSchema(), order.GetTargetType(), order.GetKey())
+	hadDeclaration := priorField != nil
 
 	switch order.GetTargetType() {
 	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
@@ -144,6 +158,21 @@ func processRemoveMetadataFieldType(ledger string, order *raftcmdpb.RemoveMetada
 			return nil, domain.StoreFailure("removing metadata field index", err)
 		}
 		droppedIndex = id
+
+		assert.Reachable("field removal dropped its index", map[string]any{
+			"ledger":    ledger,
+			"canonical": indexes.Canonical(id),
+		})
+	} else {
+		// A field can be declared without ever being indexed, so an absent
+		// entry is legitimate on its own. hadDeclaration separates "no such
+		// field" from "declared field whose registry entry is missing", which
+		// is what the indexbuilder cross-checks against its own config.
+		assert.Reachable("field removal found no index", map[string]any{
+			"ledger":         ledger,
+			"canonical":      indexes.Canonical(id),
+			"hadDeclaration": hadDeclaration,
+		})
 	}
 
 	return &commonpb.LedgerLogPayload{

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
@@ -203,17 +205,36 @@ func resolveCoverage[T interface {
 			// Preload: Get's gen0→gen1 fallback surfaces the value on
 			// read and Del's lazy promote fabricates a gen0 tombstone
 			// on delete. No Pebble read required.
-			mu.Lock()
-			plans = append(plans, slab.appendCoverage(id, tag, attrCode))
-			mu.Unlock()
+			//
+			// Index registry keys never take this shortcut: the classifier
+			// answers hit for any resident under the key's id — tombstoned or
+			// tag-mismatched included — while the apply-path read checks both
+			// and treats them as absent. Loading and seeding below keeps the
+			// plan carrying the durable truth for these rare keys; with the
+			// miss path already arbitrated, a finding that persists past this
+			// pins the divergence to the cache shadowing the seed at apply.
+			if attrCode != dal.SubAttrIndex {
+				mu.Lock()
+				plans = append(plans, slab.appendCoverage(id, tag, attrCode))
+				mu.Unlock()
 
-			continue
+				continue
+			}
+
+			fallthrough
 
 		case cache.CacheMiss:
 			// Bloom filter short-circuit: when the key is definitely not
 			// in Pebble, skip the goroutine + Pebble Get and emit Declare
 			// (coverage-only, no value to seed).
-			if bloomFilter != nil && !bloomFilter.MayContain(id) {
+			//
+			// Index registry keys are exempt: they are rare enough that the
+			// Pebble read costs nothing, and a false negative here would make
+			// every replica read an existing index as absent — the removal
+			// then reports nothing dropped while the row sits in Pebble.
+			// The load below both corrects it and proves the filter wrong.
+			bloomAbsent := bloomFilter != nil && !bloomFilter.MayContain(id)
+			if bloomAbsent && attrCode != dal.SubAttrIndex {
 				mu.Lock()
 				plans = append(plans, slab.appendCoverage(id, tag, attrCode))
 				mu.Unlock()
@@ -261,6 +282,17 @@ func resolveCoverage[T interface {
 				var zero T
 				hasValue := any(result.Value) != any(zero)
 
+				if hasValue && bloomAbsent {
+					logger.WithFields(map[string]any{
+						"type": typeName,
+						"key":  hex.EncodeToString(canonicalKey),
+					}).Errorf("Bloom filter denied a key Pebble holds")
+					assert.Unreachable("index preload bloom false negative", map[string]any{
+						"type": typeName,
+						"key":  hex.EncodeToString(canonicalKey),
+					})
+				}
+
 				// Track bloom false positives: MayContain said "maybe" but Pebble
 				// had nothing. Only counts loads we actually performed (FromLoad).
 				if result.FromLoad && !hasValue && bloomFilter != nil {
@@ -280,6 +312,30 @@ func resolveCoverage[T interface {
 					plans = append(plans, slab.appendSeed(id, tag, attrCode, attrValue))
 
 					return
+				}
+
+				// The loader dedupes and caches loads keyed by boundary and
+				// cache epoch, so a stale cached absence would poison every
+				// later preload of the key — deterministically, since the
+				// plan is replicated. For index keys, arbitrate an absent
+				// answer against a fresh read before trusting it.
+				if !hasValue && attrCode == dal.SubAttrIndex {
+					if fresh, freshErr := getValue(store, canonicalKey); freshErr == nil && any(fresh) != any(zero) {
+						logger.WithFields(map[string]any{
+							"type": typeName,
+							"key":  hex.EncodeToString(canonicalKey),
+						}).Errorf("Index preload served absence for a row Pebble holds")
+						assert.Unreachable("index preload served stale absence", map[string]any{
+							"type": typeName,
+							"key":  hex.EncodeToString(canonicalKey),
+						})
+
+						if attrValue, mErr := buildPreloadPayload(attrCode, fresh); mErr == nil {
+							plans = append(plans, slab.appendSeed(id, tag, attrCode, attrValue))
+
+							return
+						}
+					}
 				}
 
 				// Pebble had no value either — coverage-only entry. If a

--- a/internal/infra/state/cache_snapshotter.go
+++ b/internal/infra/state/cache_snapshotter.go
@@ -14,6 +14,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
 	"github.com/formancehq/ledger/v3/internal/infra/cache"
@@ -178,10 +179,14 @@ func (s *protoSnapshotSlot[V]) MirrorPreload(
 	// U128 id. With the tag check, only a tombstone for THIS key
 	// short-circuits.
 	if existing, ok := s.ac.Gen1().Get(id); ok && existing.Deleted && existing.Tag == tag {
+		reportSuppressedIndexSeed(s.cacheType, "gen1", rawValue)
+
 		return nil
 	}
 
 	if existing, ok := s.ac.Gen0().Get(id); ok && existing.Deleted && existing.Tag == tag {
+		reportSuppressedIndexSeed(s.cacheType, "gen0", rawValue)
+
 		return nil
 	}
 
@@ -1007,4 +1012,25 @@ func (s *CacheSnapshotter) Stop() {
 	s.bloomPopulateReason = ""
 	s.bloomExecutor.Interrupt()
 	s.bloomMu.Unlock()
+}
+
+// reportSuppressedIndexSeed fires when a cache tombstone discards a seeded
+// index registry value. Admission now loads and seeds these keys on every
+// path, so a suppression here is the only remaining way an index durably in
+// Pebble reads as absent at apply — a tombstone outliving the row it was
+// paired with.
+func reportSuppressedIndexSeed(cacheType byte, gen string, rawValue []byte) {
+	if cacheType != dal.SubAttrIndex {
+		return
+	}
+
+	details := map[string]any{"gen": gen}
+
+	idx := &commonpb.Index{}
+	if err := idx.UnmarshalVT(rawValue); err == nil {
+		details["ledger"] = idx.GetLedger()
+		details["canonical"] = indexes.Canonical(idx.GetId())
+	}
+
+	assert.Unreachable("index seed suppressed by cache tombstone", details)
 }

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -597,6 +597,37 @@ func (b *WriteSet) Merge(batch *dal.WriteSession, logsOrRefs []*raftcmdpb.Create
 		return err
 	}
 
+	// Registry rows go missing from storage with nothing accounting for it, and
+	// the indexbuilder only notices later, when a removal finds nothing to drop.
+	// Recording the row's creation and its deletion here dates both ends: a
+	// canonical that was written, never deleted, and is gone from Pebble was
+	// lost by something other than a delete.
+	for _, u := range indexUpdates {
+		if u.Old.IsDefined() {
+			continue
+		}
+
+		var k domain.IndexKey
+		if err := k.Unmarshal(u.CanonicalKey); err == nil {
+			b.fsm.logger.WithFields(map[string]any{
+				"cmp":       "index-registry",
+				"ledger":    k.LedgerName,
+				"canonical": k.Canonical,
+			}).Infof("Index registry row written")
+		}
+	}
+
+	for _, d := range indexDeletions {
+		var k domain.IndexKey
+		if err := k.Unmarshal(d.CanonicalKey); err == nil {
+			b.fsm.logger.WithFields(map[string]any{
+				"cmp":       "index-registry",
+				"ledger":    k.LedgerName,
+				"canonical": k.Canonical,
+			}).Infof("Index registry row deleted")
+		}
+	}
+
 	// SubAttrIndex (0x0C) — bucket-scoped index registry (per-ledger or bucket).
 	if err := flushAttributeAndCache(b.attrs.Index, batch, genByte, dal.SubAttrIndex, indexUpdates, indexDeletions, &b.bloomUpdates.Indexes, "indexes"); err != nil {
 		return err

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -57,7 +57,7 @@ type compileCtx struct {
 	// read failure. Compile uses it to pick the right v_n keyspace
 	// and to refuse early with ErrIndexBuilding when no live keyspace
 	// exists yet.
-	indexVersionFor func(canonical string) (uint32, bool, error)
+	indexVersionFor readstore.IndexVersionResolver
 	// pin is the main-store handle's applied sequence: metadata / exists
 	// index leaves resolve their event groups at this sequence, so index
 	// selection observes exactly the state the rest of the query reads
@@ -102,7 +102,7 @@ func Compile(
 	schema map[string]*commonpb.MetadataFieldSchema,
 	info *commonpb.LedgerInfo,
 	indexRegistry indexes.Lookup,
-	indexVersionFor func(canonical string) (uint32, bool, error),
+	indexVersionFor readstore.IndexVersionResolver,
 	profile *QueryProfile,
 	pebbleReader dal.PebbleReader,
 	pin uint64,
@@ -121,7 +121,9 @@ func Compile(
 		// A nil resolver means "every index is at v=1" — only safe in
 		// tests that pre-date EN-1323 versioning. Production wiring
 		// always supplies a resolver backed by readstore.
-		indexVersionFor = func(string) (uint32, bool, error) { return 1, true, nil }
+		indexVersionFor = func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{Version: 1}, true, nil
+		}
 	}
 
 	ctx := &compileCtx{
@@ -483,10 +485,32 @@ func compileFieldCondition(ctx *compileCtx, fc *commonpb.FieldCondition) (readst
 
 	metaID := indexes.MetadataID(targetTypeForQueryTarget(ctx.target), metaKey)
 
-	indexVersion, err := requireIndexReady(ctx, metaID,
+	resolved, err := requireIndexReady(ctx, metaID,
 		fmt.Sprintf("metadata[%q] on %s", metaKey, targetName))
 	if err != nil {
 		return nil, err
+	}
+
+	// The condition is validated and encoded under the type BOUND to the
+	// version being served, not the live schema: a retype flips the schema at
+	// FSM apply but re-encodes rows only when the background rewrite finishes,
+	// so until the atomic switch the served version still carries the old
+	// type. Compiling under the new one would scan its type-tagged byte
+	// ranges over old-encoded rows — partial results (EN-1724). Old-kind
+	// conditions therefore stay valid over the complete old index for the
+	// whole window, and the new kind becomes valid atomically at the switch.
+	switch {
+	case !resolved.BindingKnown:
+		// Pre-versioning resolver (test default): the live schema is all
+		// there is.
+	case !resolved.TypeDeclared:
+		// The served version was built before any type was declared for this
+		// key. Field conditions on an undeclared key were rejected then, and
+		// the window keeps that behavior until the rewrite promotes the
+		// declared-type keyspace.
+		return nil, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: fmt.Sprintf("metadata[%q] on %s", metaKey, targetName)}}
+	default:
+		fieldSchema = &commonpb.MetadataFieldSchema{Type: resolved.Type}
 	}
 
 	fc, err = validateAndCoerceCondition(fc, fieldSchema)
@@ -495,10 +519,10 @@ func compileFieldCondition(ctx *compileCtx, fc *commonpb.FieldCondition) (readst
 	}
 
 	mc := &metadataCtx{
-		prefix:    readstore.MetadataIndexPrefixV(ctx.kb, ctx.ledgerName, ns, metaKey, indexVersion),
+		prefix:    readstore.MetadataIndexPrefixV(ctx.kb, ctx.ledgerName, ns, metaKey, resolved.Version),
 		namespace: ns,
 		metaKey:   metaKey,
-		version:   indexVersion,
+		version:   resolved.Version,
 	}
 
 	switch cond := fc.GetCondition().(type) {
@@ -647,6 +671,15 @@ func resolveIntBounds(cond *commonpb.IntCondition, params map[string]*commonpb.P
 			b.max = nv
 			b.hasMax = true
 		}
+	}
+
+	// max is the exclusive upper, so [min, max) holds nothing once the
+	// adjusted bounds meet or cross — e.g. `(x, x)` resolves to [x+1, x).
+	// Every consumer must see that as the empty match, never as Pebble
+	// iterator bounds: LowerBound above UpperBound is an iterator
+	// invariant violation, not an empty scan.
+	if b.hasMin && b.hasMax && b.min >= b.max {
+		b.empty = true
 	}
 
 	return b, nil
@@ -821,6 +854,12 @@ func resolveUintBounds(cond *commonpb.UintCondition, params map[string]*commonpb
 			b.max = nv
 			b.hasMax = true
 		}
+	}
+
+	// See resolveIntBounds: adjusted bounds that meet or cross are the
+	// empty match, and must never reach Pebble as iterator bounds.
+	if b.hasMin && b.hasMax && b.min >= b.max {
+		b.empty = true
 	}
 
 	return b, nil
@@ -1220,6 +1259,10 @@ func compileTxIDCondition(ctx *compileCtx, cond *commonpb.UintCondition) (readst
 		return nil, err
 	}
 
+	if bounds.empty {
+		return &SliceIterator{}, nil
+	}
+
 	// Equality optimization: single txID -> check existence in Pebble and return slice
 	if bounds.isEquality() {
 		exists, pErr := pebbleTxExists(ctx.pebbleReader, ctx.ledgerName, bounds.min)
@@ -1330,6 +1373,10 @@ func compileTimestampRangeCondition(
 		return nil, err
 	}
 
+	if bounds.empty {
+		return &SliceIterator{}, nil
+	}
+
 	// Key layout: [prefix_byte][ledger\x00][timestamp_BE(8B)][entityID_BE(8B)]
 	entityOffset := len(ledgerPrefix) + 8
 	entityLen := 8
@@ -1411,6 +1458,10 @@ func compileLogIdCondition(ctx *compileCtx, cond *commonpb.UintCondition) (reads
 	bounds, err := resolveUintBounds(cond, ctx.params)
 	if err != nil {
 		return nil, err
+	}
+
+	if bounds.empty {
+		return &SliceIterator{}, nil
 	}
 
 	prefix := readstore.LedgerLogPrefix(ctx.kb, ctx.ledgerName)
@@ -1525,14 +1576,14 @@ func checkIndexed(ctx *compileCtx, id *commonpb.IndexID, label string) error {
 // which MUST be bound to the iteration snapshot — never the live
 // store — so the gate and the scan observe the same point-in-time
 // view of the atomic-switch state.
-func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (uint32, error) {
+func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (readstore.ResolvedIndexVersion, error) {
 	if err := checkIndexed(ctx, id, label); err != nil {
-		return 0, err
+		return readstore.ResolvedIndexVersion{}, err
 	}
 
-	v, primed, err := ctx.indexVersionFor(indexes.Canonical(id))
+	resolved, primed, err := ctx.indexVersionFor(indexes.Canonical(id))
 	if err != nil {
-		return 0, fmt.Errorf("resolving index version for %s: %w", label, err)
+		return readstore.ResolvedIndexVersion{}, fmt.Errorf("resolving index version for %s: %w", label, err)
 	}
 
 	if !primed {
@@ -1549,14 +1600,14 @@ func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (uin
 		// a checkpoint fetched FROM the leader, which moves the node forward,
 		// and an applied index can never exceed the leader's log to begin
 		// with.
-		return 0, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: label}}
+		return readstore.ResolvedIndexVersion{}, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: label}}
 	}
 
-	if v == 0 {
-		return 0, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: label}}
+	if resolved.Version == 0 {
+		return readstore.ResolvedIndexVersion{}, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: label}}
 	}
 
-	return v, nil
+	return resolved, nil
 }
 
 // targetTypeForQueryTarget maps a QueryTarget to the matching TargetType used

--- a/internal/query/compile_account_asset_test.go
+++ b/internal/query/compile_account_asset_test.go
@@ -55,7 +55,9 @@ func TestCompile_AccountHasAsset_RequiresReady(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverZero := func(string) (uint32, bool, error) { return 0, true, nil }
+	resolverZero := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{BindingKnown: true}, true, nil
+	}
 
 	_, err := query.Compile(
 		nil, dal.NewKeyBuilder(), accountHasAssetFilter("USD", 2),
@@ -109,7 +111,9 @@ func TestCompile_AccountHasAsset_PrefixScan(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	iter, err := query.Compile(
 		reader, dal.NewKeyBuilder(), accountHasAssetFilter("USD", 2),
@@ -168,7 +172,9 @@ func TestCompile_AccountHasAsset_PinExcludesLaterFirstTouch(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	scan := func(pin uint64) []string {
 		iter, cErr := query.Compile(
@@ -234,7 +240,9 @@ func TestCompile_RevertedAt_PinExcludesLaterRevert(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, rvatID): {Ledger: ledgerName, Id: rvatID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	filter := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
 		BuiltinUint: &commonpb.BuiltinUintCondition{

--- a/internal/query/compile_bounds_test.go
+++ b/internal/query/compile_bounds_test.go
@@ -1,0 +1,109 @@
+package query
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func uintCond(lo, hi uint64, minExcl, maxExcl bool) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Min: &lo, Max: &hi, MinExclusive: minExcl, MaxExclusive: maxExcl}
+}
+
+// TestResolveBounds_DegenerateRangesAreEmpty pins the crossed-bounds rule: max
+// is the exclusive upper, so adjusted bounds that meet or cross resolve to the
+// empty match. They must never reach Pebble as iterator bounds — LowerBound
+// above UpperBound is an iterator invariant violation (mergingIter panics
+// under the invariants/race build tags), not an empty scan.
+func TestResolveBounds_DegenerateRangesAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cond  *commonpb.UintCondition
+		empty bool
+	}{
+		{"exclusive-exclusive same value", uintCond(7, 7, true, true), true},
+		{"inclusive-exclusive same value", uintCond(7, 7, false, true), true},
+		{"crossed", uintCond(9, 3, false, false), true},
+		{"exclusive min meets inclusive max", uintCond(7, 7, true, false), true},
+		{"single value", uintCond(7, 7, false, false), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := resolveUintBounds(tc.cond, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.empty, b.empty)
+
+			ic := &commonpb.IntCondition{
+				Min: new(int64(tc.cond.GetMin())), Max: new(int64(tc.cond.GetMax())),
+				MinExclusive: tc.cond.GetMinExclusive(), MaxExclusive: tc.cond.GetMaxExclusive(),
+			}
+			ib, err := resolveIntBounds(ic, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.empty, ib.empty, "int resolver must agree")
+		})
+	}
+}
+
+// TestCompile_NotOverDegenerateRange_YieldsUniverse pins the composition that
+// panicked under the invariants build: not(logId[(x,x)]) on LOGS. The
+// degenerate child resolves to the empty match, and its complement is the
+// whole universe — every log comes back.
+func TestCompile_NotOverDegenerateRange_YieldsUniverse(t *testing.T) {
+	t.Parallel()
+
+	const ledgerName = "ledger1"
+
+	logger := logging.FromContext(logging.TestingContext())
+	store, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = store.Close() })
+
+	kb := dal.NewKeyBuilder()
+	batch := store.NewBatch()
+	for logID := uint64(1); logID <= 3; logID++ {
+		seq := make([]byte, 8)
+		binary.BigEndian.PutUint64(seq, logID+100)
+		require.NoError(t, batch.SetBytes(readstore.LedgerLogKey(kb, ledgerName, logID), seq))
+	}
+	require.NoError(t, batch.Commit())
+
+	reader := store.DB()
+	info := &commonpb.LedgerInfo{Name: ledgerName}
+
+	two := uint64(2)
+	filter := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+		Filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogId{LogId: &commonpb.LogIdCondition{
+			Cond: &commonpb.UintCondition{Min: &two, Max: &two, MinExclusive: true, MaxExclusive: true},
+		}}},
+	}}}
+
+	iter, err := Compile(
+		reader, dal.NewKeyBuilder(), filter,
+		commonpb.QueryTarget_QUERY_TARGET_LOGS, ledgerName,
+		nil, nil, info, nil, nil, nil, reader, 0)
+	require.NoError(t, err)
+
+	t.Cleanup(iter.Close)
+
+	var got []uint64
+	for iter.Next() {
+		got = append(got, binary.BigEndian.Uint64(iter.Current()))
+	}
+	require.NoError(t, iter.Err())
+
+	require.Equal(t, []uint64{1, 2, 3}, got,
+		"not(empty range) must yield the whole universe")
+}

--- a/internal/query/compile_retype_window_test.go
+++ b/internal/query/compile_retype_window_test.go
@@ -1,0 +1,116 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// Field conditions are validated and encoded under the type BOUND to the
+// served index version, never the live schema. During a retype's conversion
+// window the schema already says the new type while the served version still
+// carries the old one — compiling under the schema would scan the new type's
+// tagged byte ranges over old-encoded rows and return partial results
+// (EN-1724). The old kind must stay valid over the complete old index for the
+// whole window, and the new kind must be rejected until the atomic switch —
+// exactly as if the retype had not happened yet.
+func TestCompile_FieldConditionBindsToTheVersionType(t *testing.T) {
+	t.Parallel()
+
+	const ledgerName = "ledger1"
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier")
+	indexRegistry := staticIndexLookup{
+		indexes.KeyFor(ledgerName, id): {Ledger: ledgerName, Id: id},
+	}
+	info := &commonpb.LedgerInfo{Name: ledgerName}
+
+	// Mid-window: the schema has flipped to INT64, the served version is
+	// still the STRING-encoded one.
+	schema := map[string]*commonpb.MetadataFieldSchema{
+		"tier": {Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+	}
+	boundToString := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{
+			Version:      1,
+			Type:         commonpb.MetadataType_METADATA_TYPE_STRING,
+			TypeDeclared: true,
+			BindingKnown: true,
+		}, true, nil
+	}
+
+	stringCond := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+		Field: &commonpb.FieldCondition{
+			Field: &commonpb.FieldRef{Metadata: "tier"},
+			Condition: &commonpb.FieldCondition_StringCond{StringCond: &commonpb.StringCondition{
+				Value: &commonpb.StringCondition_Hardcoded{Hardcoded: "gold"},
+			}},
+		},
+	}}
+	intCond := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+		Field: &commonpb.FieldCondition{
+			Field:     &commonpb.FieldRef{Metadata: "tier"},
+			Condition: &commonpb.FieldCondition_IntCond{IntCond: &commonpb.IntCondition{}},
+		},
+	}}
+
+	t.Run("old-kind condition stays valid during the window", func(t *testing.T) {
+		t.Parallel()
+
+		// The success path builds its scan, so it needs a real (empty)
+		// readstore to iterate.
+		rs, err := readstore.New(t.TempDir(), logging.NopZap(), readstore.DefaultConfig())
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = rs.Close() })
+
+		iter, err := Compile(
+			rs.DB(), dal.NewKeyBuilder(), stringCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToString, nil, nil, 0)
+		require.NoError(t, err,
+			"a string condition over the still-string-encoded version must compile — rejecting it makes the whole window unqueryable")
+
+		iter.Close()
+	})
+
+	t.Run("new-kind condition is rejected until the switch", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Compile(
+			nil, nil, intCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToString, nil, nil, 0)
+		require.Error(t, err,
+			"an int condition compiled against string-encoded rows scans a disjoint byte range — partial results, must be refused")
+
+		var compileErr *domain.ErrFilterCompilation
+		require.ErrorAs(t, err, &compileErr)
+	})
+
+	t.Run("a version bound to no declared type keeps pre-declaration semantics", func(t *testing.T) {
+		t.Parallel()
+
+		boundToNothing := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+		}
+
+		_, err := Compile(
+			nil, nil, stringCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToNothing, nil, nil, 0)
+		require.Error(t, err)
+
+		var notFound *domain.ErrIndexNotFound
+		require.ErrorAs(t, err, &notFound,
+			"the served version predates any declaration: Field conditions were rejected then, and the window keeps that until the declared-type keyspace is promoted")
+	})
+}

--- a/internal/query/compile_test.go
+++ b/internal/query/compile_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
 // TestCompile_RejectsDeeplyNestedFilter is the regression for #341 /
@@ -786,7 +787,9 @@ func TestBuiltinCompilers_GateOnLocalReadiness(t *testing.T) {
 	// indexResolverZero simulates a replica whose initial backfill
 	// has not yet completed. Real production wiring uses
 	// readstore.SnapshotVersionResolver against the iteration snapshot.
-	indexResolverZero := func(string) (uint32, bool, error) { return 0, true, nil }
+	indexResolverZero := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{BindingKnown: true}, true, nil
+	}
 
 	info := &commonpb.LedgerInfo{Name: ledgerName}
 
@@ -895,11 +898,13 @@ func TestRequireIndexReady_SurfacesPebbleError(t *testing.T) {
 	}
 
 	ctx := &compileCtx{
-		target:          commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
-		indexRegistry:   indexRegistry,
-		ledgerName:      "ledger1",
-		info:            info,
-		indexVersionFor: func(string) (uint32, bool, error) { return 0, false, pebbleErr },
+		target:        commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		indexRegistry: indexRegistry,
+		ledgerName:    "ledger1",
+		info:          info,
+		indexVersionFor: func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{}, false, pebbleErr
+		},
 	}
 
 	_, err := requireIndexReady(ctx,
@@ -1053,7 +1058,9 @@ func TestCompile_AbsentVersionRecordIsRemovedNotBuilding(t *testing.T) {
 				nil, nil, filter,
 				commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
 				nil, schema, info, indexRegistry,
-				func(string) (uint32, bool, error) { return 0, tc.primed, nil },
+				func(string) (readstore.ResolvedIndexVersion, bool, error) {
+					return readstore.ResolvedIndexVersion{BindingKnown: true}, tc.primed, nil
+				},
 				nil, nil, 0,
 			)
 			require.Error(t, err)

--- a/internal/storage/readstore/index_version_test.go
+++ b/internal/storage/readstore/index_version_test.go
@@ -10,6 +10,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
@@ -26,6 +27,12 @@ func TestIndexVersionState_RoundTrip(t *testing.T) {
 		CurrentVersion:  3,
 		PendingVersion:  4,
 		RewriteProgress: []byte("cursor-bytes"),
+		// STRING is enum value zero, so it is exactly the value that would
+		// vanish if "declared" were conflated with the type's zero value.
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_STRING,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
 	}
 
 	batch := store.NewBatch()
@@ -38,6 +45,10 @@ func TestIndexVersionState_RoundTrip(t *testing.T) {
 	assert.Equal(t, state.CurrentVersion, got.CurrentVersion)
 	assert.Equal(t, state.PendingVersion, got.PendingVersion)
 	assert.Equal(t, state.RewriteProgress, got.RewriteProgress)
+	assert.Equal(t, state.CurrentType, got.CurrentType)
+	assert.True(t, got.CurrentTypeDeclared, "declared STRING must not decode as undeclared")
+	assert.Equal(t, state.PendingType, got.PendingType)
+	assert.True(t, got.PendingTypeDeclared)
 }
 
 func TestIndexVersionState_NoRewriteProgress(t *testing.T) {
@@ -166,7 +177,7 @@ func TestSnapshotVersionResolver_TornReadIsImpossible(t *testing.T) {
 	gotSnap, primed, err := resolveFromSnap(canonical)
 	require.NoError(t, err)
 	require.True(t, primed)
-	assert.Equal(t, uint32(1), gotSnap,
+	assert.Equal(t, uint32(1), gotSnap.Version,
 		"snapshot resolver must hold the pre-switch version — otherwise a query that already iterates a pre-switch keyspace would receive a post-switch version, scanning a half-populated v_new range")
 
 	// Sanity: the live store has of course flipped.
@@ -240,7 +251,7 @@ func TestSnapshotVersionResolver_AbsentReturnsZero(t *testing.T) {
 
 	got, primed, err := readstore.SnapshotVersionResolver(snap, "ledger1")("acct:metadata:never-built")
 	require.NoError(t, err, "absent state must NOT be reported as an error — the query layer decides what an absent record means")
-	assert.Equal(t, uint32(0), got)
+	assert.Equal(t, uint32(0), got.Version)
 	assert.False(t, primed, "absent means no record was ever written for this index on this replica")
 }
 

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -15,6 +15,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/pebblecfg"
 )
@@ -377,6 +378,30 @@ type IndexVersionState struct {
 	// retraction such a pass emits loses the same-sequence tie to the
 	// standing ADD — an immortal row. Reuse is the only way into that state.
 	HighWater uint32
+
+	// CurrentType is the declared metadata type CurrentVersion's rows are
+	// encoded under, bound when the version was built and changed only by
+	// the atomic switch. It is what makes a retype invisible to queries
+	// until the switch: the schema flips at FSM apply, but a query serves
+	// CurrentVersion and must validate and encode its conditions under the
+	// type those rows actually carry — a condition compiled under the new
+	// declared type over old-encoded rows sees only the rows written after
+	// the retype (type-tagged encodings occupy disjoint byte ranges), i.e.
+	// partial results (EN-1724).
+	//
+	// CurrentTypeDeclared distinguishes "bound to no declared type" (the
+	// key had no schema entry when the version was built; rows carry each
+	// value's natural encoding) from METADATA_TYPE_STRING, which is enum
+	// value zero. Only meaningful on metadata indexes.
+	CurrentType         commonpb.MetadataType
+	CurrentTypeDeclared bool
+
+	// PendingType is the declared type PendingVersion's rows are encoded
+	// under: the retype's target, bound when the rewrite starts. Live
+	// dual-writes encode each value once per version, under that version's
+	// bound type.
+	PendingType         commonpb.MetadataType
+	PendingTypeDeclared bool
 }
 
 // Tombstoned reports whether the record marks a dropped index: no servable
@@ -396,19 +421,40 @@ type IndexVersionStateEntry struct {
 }
 
 // encodeIndexVersionState packs the state to a single byte slice.
-// Layout: [current(4B BE)][pending(4B BE)][activation(8B BE)][high_water(4B BE)][rewrite_progress…].
+// Layout: [current(4B BE)][pending(4B BE)][activation(8B BE)][high_water(4B BE)]
+// [current_type(1B)][pending_type(1B)][rewrite_progress…].
+// A type byte holds 0 for "no declared type bound" and 1+MetadataType
+// otherwise, so undeclared stays distinct from METADATA_TYPE_STRING (0).
 func encodeIndexVersionState(s IndexVersionState) []byte {
 	out := make([]byte, indexVersionStateHeaderLen+len(s.RewriteProgress))
 	binary.BigEndian.PutUint32(out[0:4], s.CurrentVersion)
 	binary.BigEndian.PutUint32(out[4:8], s.PendingVersion)
 	binary.BigEndian.PutUint64(out[8:16], s.ActivationSequence)
 	binary.BigEndian.PutUint32(out[16:20], s.HighWater)
+	out[20] = encodeBoundType(s.CurrentType, s.CurrentTypeDeclared)
+	out[21] = encodeBoundType(s.PendingType, s.PendingTypeDeclared)
 	copy(out[indexVersionStateHeaderLen:], s.RewriteProgress)
 
 	return out
 }
 
-const indexVersionStateHeaderLen = 20
+const indexVersionStateHeaderLen = 22
+
+func encodeBoundType(t commonpb.MetadataType, declared bool) byte {
+	if !declared {
+		return 0
+	}
+
+	return byte(t) + 1
+}
+
+func decodeBoundType(b byte) (commonpb.MetadataType, bool) {
+	if b == 0 {
+		return 0, false
+	}
+
+	return commonpb.MetadataType(b - 1), true
+}
 
 // decodeIndexVersionState parses a stored value back to IndexVersionState.
 // Returns (zero, false) on any malformed input — caller treats it as
@@ -421,13 +467,17 @@ func decodeIndexVersionState(v []byte) (IndexVersionState, bool) {
 	progress := make([]byte, len(v)-indexVersionStateHeaderLen)
 	copy(progress, v[indexVersionStateHeaderLen:])
 
-	return IndexVersionState{
+	st := IndexVersionState{
 		CurrentVersion:     binary.BigEndian.Uint32(v[0:4]),
 		PendingVersion:     binary.BigEndian.Uint32(v[4:8]),
 		ActivationSequence: binary.BigEndian.Uint64(v[8:16]),
 		HighWater:          binary.BigEndian.Uint32(v[16:20]),
 		RewriteProgress:    progress,
-	}, true
+	}
+	st.CurrentType, st.CurrentTypeDeclared = decodeBoundType(v[20])
+	st.PendingType, st.PendingTypeDeclared = decodeBoundType(v[21])
+
+	return st, true
 }
 
 // WriteIndexVersionState persists the per-replica version state for an
@@ -488,9 +538,35 @@ func (s *Store) ReadIndexVersionState(ledgerName, canonicalID string) (IndexVers
 // Returns (0, error) on a real Pebble I/O failure; (0, nil) when no
 // version state has been written yet (caller should translate to
 // ErrIndexBuilding at query boundaries).
-func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) func(canonical string) (uint32, bool, error) {
+func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) IndexVersionResolver {
 	return PinnedVersionResolver(reader, ledgerName, 0)
 }
+
+// ResolvedIndexVersion is what a query learns about an index from the
+// version state at its pin: the version to scan and the declared type
+// bound to it. The bound type — not the live schema — is what the
+// version's rows are encoded under, so conditions must be validated and
+// encoded against it (EN-1724); during a retype's conversion window the
+// two legitimately differ.
+type ResolvedIndexVersion struct {
+	Version uint32
+	// Type/TypeDeclared mirror IndexVersionState.CurrentType*: the type
+	// Version's rows carry, or "none was declared when it was built".
+	Type         commonpb.MetadataType
+	TypeDeclared bool
+	// BindingKnown is true for every resolution built from a stored version
+	// state — TypeDeclared=false is then an affirmative "built with no
+	// declared type", not missing information. Only query.Compile's
+	// pre-versioning test default leaves it false, telling the compiler to
+	// fall back to the live schema.
+	BindingKnown bool
+}
+
+// IndexVersionResolver resolves an index's servable version at the pin of
+// the snapshot it was built over. ok=false means no version state exists —
+// the index was removed (callers tell it apart from building via the
+// registry, see requireIndexReady).
+type IndexVersionResolver func(canonical string) (ResolvedIndexVersion, bool, error)
 
 // PinnedVersionResolver is the pin-aware variant: a version promoted by a
 // schema rewrite is only servable at pins at or above its activation
@@ -502,17 +578,17 @@ func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) func(ca
 //
 // A pin of 0 means "no pin" (introspection paths that do not resolve rows
 // at a sequence) and skips the check.
-func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint64) func(canonical string) (uint32, bool, error) {
-	return func(canonical string) (uint32, bool, error) {
+func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint64) IndexVersionResolver {
+	return func(canonical string) (ResolvedIndexVersion, bool, error) {
 		state, present, err := ReadIndexVersionStateFrom(reader, ledgerName, canonical)
 		if err != nil {
-			return 0, false, err
+			return ResolvedIndexVersion{}, false, err
 		}
 
 		if !present {
 			// No record at all. Callers use this to tell a removed index
 			// apart from one still being built — see requireIndexReady.
-			return 0, false, nil
+			return ResolvedIndexVersion{}, false, nil
 		}
 
 		if state.Tombstoned() {
@@ -520,14 +596,19 @@ func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint6
 			// high-water version for the next incarnation; to queries it
 			// must read exactly like the removed index it is, never as one
 			// still building.
-			return 0, false, nil
+			return ResolvedIndexVersion{}, false, nil
 		}
 
 		if pin > 0 && state.ActivationSequence > pin {
-			return 0, true, nil
+			return ResolvedIndexVersion{}, true, nil
 		}
 
-		return state.CurrentVersion, true, nil
+		return ResolvedIndexVersion{
+			Version:      state.CurrentVersion,
+			Type:         state.CurrentType,
+			TypeDeclared: state.CurrentTypeDeclared,
+			BindingKnown: true,
+		}, true, nil
 	}
 }
 

--- a/internal/storage/readstore/version_activation_test.go
+++ b/internal/storage/readstore/version_activation_test.go
@@ -44,7 +44,7 @@ func TestPinnedVersionResolver_HidesAVersionAboveThePin(t *testing.T) {
 			v, primed, err := PinnedVersionResolver(snap, ledger, tc.pin)(canonical)
 			require.NoError(t, err)
 			require.True(t, primed, "the record exists; only the version is withheld")
-			require.Equal(t, tc.want, v)
+			require.Equal(t, tc.want, v.Version)
 		})
 	}
 }
@@ -74,7 +74,7 @@ func TestPinnedVersionResolver_BackfilledVersionServesAtAnyPin(t *testing.T) {
 	v, primed, err := PinnedVersionResolver(snap, ledger, 1)(canonical)
 	require.NoError(t, err)
 	require.True(t, primed)
-	require.Equal(t, uint32(1), v)
+	require.Equal(t, uint32(1), v.Version)
 }
 
 // The activation sequence survives the encode/decode round trip alongside a

--- a/internal/storage/wal/snapshotter.go
+++ b/internal/storage/wal/snapshotter.go
@@ -47,6 +47,22 @@ func (s *Snapshotter) Save(snap *raftpb.Snapshot) error {
 	path := filepath.Join(s.dir, name)
 	tmpPath := path + ".tmp"
 
+	// The directory is created in NewSnapshotter, so reaching here without it
+	// means it went away underneath a running node. Recreate it: the snapshot
+	// this call is persisting is how a follower catches up, and failing the
+	// save propagates as a task-pool panic that takes the node down.
+	if err := os.MkdirAll(s.dir, 0755); err != nil {
+		return fmt.Errorf("recreating snapshot directory: %w", err)
+	}
+
+	// The rename below is made durable by fsyncing s.dir, which says nothing
+	// about s.dir's own entry in its parent. A crash after Save returns and the
+	// WAL snapshot record is written would then leave the WAL pointing at a
+	// directory that recovery cannot find, so fsync the parent too.
+	if err := syncDir(filepath.Dir(s.dir)); err != nil {
+		return fmt.Errorf("syncing snapshot directory parent: %w", err)
+	}
+
 	f, err := os.Create(tmpPath)
 	if err != nil {
 		return fmt.Errorf("creating temp snap file: %w", err)

--- a/internal/storage/wal/snapshotter_missing_dir_test.go
+++ b/internal/storage/wal/snapshotter_missing_dir_test.go
@@ -1,0 +1,33 @@
+package wal
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// A follower catching up on a leader snapshot persists it through Save, and the
+// failure propagates as a task-pool panic that takes the node down. Losing the
+// directory underneath a running node is not a reason to lose the node.
+func TestSnapshotterSaveRecreatesAMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir() + "/snap"
+	s, err := NewSnapshotter(dir, logging.Testing())
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(dir))
+
+	require.NoError(t, s.Save(&raftpb.Snapshot{
+		Metadata: &raftpb.SnapshotMetadata{Index: proto.Uint64(9000), Term: proto.Uint64(7)},
+	}))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the snapshot is on disk")
+}

--- a/internal/storage/wal/wal_default_test.go
+++ b/internal/storage/wal/wal_default_test.go
@@ -918,7 +918,13 @@ func TestApplySnapshotUnlocksOnSnapshotSaveFailure(t *testing.T) {
 	t.Parallel()
 
 	w := newTestWAL(t)
-	w.snapshotter.dir = filepath.Join(t.TempDir(), "missing", "snap")
+
+	// A vanished snapshot directory is recreated by Save, so the failure has
+	// to sit deeper: occupy the parent with a regular file so the recreation
+	// itself cannot succeed.
+	parent := filepath.Join(t.TempDir(), "occupied")
+	require.NoError(t, os.WriteFile(parent, nil, 0o600))
+	w.snapshotter.dir = filepath.Join(parent, "snap")
 
 	err := w.ApplySnapshot(&raftpb.Snapshot{
 		Metadata: snapshotMeta(10, 2, &raftpb.ConfState{Voters: []uint64{1}}),

--- a/tests/e2e/business/address_index_purged_retouch_test.go
+++ b/tests/e2e/business/address_index_purged_retouch_test.go
@@ -1,0 +1,91 @@
+//go:build e2e
+
+package business
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// An ephemeral account whose volume cell was purged (drained to zero) and then
+// re-touched by a later transaction must be reachable through the address
+// indexes for that later transaction: its cell survives the second commit
+// (non-zero via force), so the posting is not in the exclusion projection and
+// the account→tx mapping row must exist (EN-1625, found by
+// singleton_driver_model: source-role window missing exactly the post-purge
+// transaction).
+var _ = Describe("Address index after ephemeral purge and re-touch", Ordered, func() {
+	const ledgerName = "idx-src-purged-retouch"
+
+	roleFilter := func(addr string, role commonpb.AddressRole) *commonpb.QueryFilter {
+		f := actions.AddressExactFilter(addr)
+		f.GetAddress().Role = role
+
+		return f
+	}
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateLedgerAction(ledgerName, nil),
+			actions.AddEphemeralAccountTypeAction(ledgerName, "e", "e:{id}"),
+			actions.CreateAddressIndexAction(ledgerName, commonpb.AddressRole_ADDRESS_ROLE_SOURCE),
+			actions.CreateAddressIndexAction(ledgerName, commonpb.AddressRole_ADDRESS_ROLE_ANY),
+		))
+		Expect(err).To(Succeed())
+
+		// tx 1: fund e:1 (kept non-zero). tx 2: drain to zero — the cell is
+		// purged, so tx 2's e:1 rows are excluded. tx 3: force-drain the purged
+		// cell into a non-zero (negative) balance — kept, so tx 3's e:1 rows
+		// must be written. Separate bulks, adjacent logs, mirroring the driver
+		// sequence that surfaced the miss.
+		for _, req := range []*servicepb.Request{
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "e:1", big.NewInt(5), "USD"),
+			}, nil, nil),
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("e:1", "world", big.NewInt(5), "USD"),
+			}, nil, nil),
+			actions.CreateForceTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("e:1", "world", big.NewInt(5), "USD"),
+			}, nil),
+		} {
+			_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", req))
+			Expect(err).To(Succeed())
+		}
+	})
+
+	It("source filter reaches the post-purge transaction", func() {
+		Eventually(func(g Gomega) {
+			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0,
+				roleFilter("e:1", commonpb.AddressRole_ADDRESS_ROLE_SOURCE))
+			g.Expect(err).To(Succeed())
+
+			ids := make([]uint64, len(txs))
+			for i, tx := range txs {
+				ids[i] = tx.GetId()
+			}
+			// tx 2's rows are excluded (purged); tx 3's must exist.
+			g.Expect(ids).To(ConsistOf(uint64(3)))
+		}).Within(10 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+	})
+
+	It("any-role filter sees the funding and the post-purge transaction", func() {
+		Eventually(func(g Gomega) {
+			txs, err := actions.ListTransactionsFiltered(sharedCtx, sharedClient, ledgerName, 0, 0,
+				roleFilter("e:1", commonpb.AddressRole_ADDRESS_ROLE_ANY))
+			g.Expect(err).To(Succeed())
+
+			ids := make([]uint64, len(txs))
+			for i, tx := range txs {
+				ids[i] = tx.GetId()
+			}
+			g.Expect(ids).To(ConsistOf(uint64(1), uint64(3)))
+		}).Within(10 * time.Second).ProbeEvery(200 * time.Millisecond).Should(Succeed())
+	})
+})

--- a/tests/e2e/business/asset_index_backfill_exclusion_test.go
+++ b/tests/e2e/business/asset_index_backfill_exclusion_test.go
@@ -1,0 +1,67 @@
+//go:build e2e
+
+package business
+
+import (
+	"math/big"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// A transient account whose asset cell was
+// washed to zero and purged BEFORE the asset index exists must stay excluded
+// when the index is later created and BACKFILLED — mirroring the live fold's
+// exclusion of transient touches.
+var _ = Describe("Asset-index backfill exclusion", Ordered, func() {
+	const ledgerName = "asset-backfill-exclusion-ledger"
+
+	hasEUR := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_AccountHasAsset{
+			AccountHasAsset: &commonpb.AccountHasAssetCondition{AssetBase: "EUR"},
+		},
+	}
+
+	BeforeAll(func() {
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.AddAccountTypeWithPersistenceAction(ledgerName, "t", "t:{id}", commonpb.AccountTypePersistence_ACCOUNT_TYPE_TRANSIENT),
+			actions.AddAccountTypeWithPersistenceAction(ledgerName, "keep", "keep:{id}", commonpb.AccountTypePersistence_ACCOUNT_TYPE_NORMAL)))
+		Expect(err).To(Succeed())
+
+		// Washed transient EUR touch (excluded), plus a durable EUR toucher.
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("",
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "t:1", big.NewInt(5), "EUR"),
+			}, nil, nil),
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("t:1", "world", big.NewInt(5), "EUR"),
+			}, nil, nil),
+			actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
+				actions.NewPosting("world", "keep:1", big.NewInt(5), "EUR"),
+			}, nil, nil)))
+		Expect(err).To(Succeed())
+
+		// Index created AFTER the wash: the rows come from the backfill.
+		_, err = sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateAccountAssetIndexAction(ledgerName)))
+		Expect(err).To(Succeed())
+		Expect(actions.WaitForAccountAssetIndexReady(sharedCtx, sharedClient, ledgerName)).To(Succeed())
+	})
+
+	It("backfill excludes the washed transient touch", func() {
+		accts, err := actions.ListAccountsFiltered(sharedCtx, sharedClient, ledgerName, 0, "", hasEUR)
+		Expect(err).To(Succeed())
+
+		addrs := make([]string, len(accts))
+		for i, a := range accts {
+			addrs[i] = a.GetAddress()
+		}
+
+		Expect(addrs).To(ConsistOf("world", "keep:1"), "t:1's washed touch must stay excluded")
+	})
+})

--- a/tests/e2e/business/index_registry_cache_rotation_test.go
+++ b/tests/e2e/business/index_registry_cache_rotation_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The FSM reads the index registry from its in-memory cache, and a cache entry
+// that goes untouched across two rotations is dropped from both generations —
+// the entry survives in Pebble, so nothing was deleted and no log records a
+// removal. Whatever a proposal needs after that must be preloaded back by
+// admission; a path that declares coverage for a key without preloading its
+// value reads the evicted entry as absent.
+//
+// removeFieldType is such a path. It probes the registry to report the index it
+// cascade-drops, so an evicted entry makes it drop nothing and report nothing:
+// the index outlives the field declaration it was attached to, keeps serving a
+// keyspace nothing will purge, and every replica agrees because rotation rides
+// the replicated Raft index.
+var _ = Describe("Index registry survives cache rotation", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const (
+		rotationThreshold = uint64(10)
+		// Enough no-op proposals to push the registry entry past gen1. Each
+		// Barrier preloads nothing, so none of them refresh it.
+		barrierCount = 50
+		ledgerName   = "idx-registry-rotation"
+		metaKey      = "k3"
+	)
+
+	BeforeAll(func() {
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode(
+			testserver.WithCacheRotationThreshold(rotationThreshold),
+		)
+		client = node.Client
+
+		// Declare the field and index it: the registry entry lands in Pebble
+		// and in the current cache generation.
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.CreateLedgerWithSchemaAction(ledgerName, nil, []*commonpb.SetMetadataFieldTypeCommand{
+				{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: metaKey, Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+			})))
+		Expect(err).To(Succeed())
+
+		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.CreateAccountMetadataIndexAction(ledgerName, metaKey)))
+		Expect(err).To(Succeed())
+		Expect(actions.WaitForMetadataIndexReady(ctx, client, ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)).To(Succeed())
+
+		// Age the entry out of both generations without touching it.
+		for range barrierCount {
+			_, err := client.Barrier(ctx, &servicepb.BarrierRequest{})
+			Expect(err).To(Succeed())
+		}
+	})
+
+	It("reports the dropped index after the entry is evicted from cache", func() {
+		resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.RemoveMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)))
+		Expect(err).To(Succeed())
+
+		logs := resp.GetLogs()
+		Expect(logs).To(HaveLen(1))
+
+		removed := logs[0].GetPayload().GetApply().GetLog().GetData().GetRemovedMetadataFieldType()
+		Expect(removed).NotTo(BeNil())
+
+		want := indexes.Canonical(indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey))
+		Expect(removed.GetDroppedIndex()).NotTo(BeNil(),
+			"the index was created and never dropped, so the removal must cascade-drop it — "+
+				"an empty dropped_index means the evicted registry entry read as absent, leaving "+
+				"the index alive with its declaration gone")
+		Expect(indexes.Canonical(removed.GetDroppedIndex())).To(Equal(want))
+	})
+})

--- a/tests/e2e/business/index_registry_survives_churn_test.go
+++ b/tests/e2e/business/index_registry_survives_churn_test.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// An index lives in the bucket-scoped registry until something drops it, and
+// removeFieldType reports the index it cascade-dropped on its log. The model
+// checker catches that report coming back empty for indexes it watched get
+// created and never dropped: the entry is gone from the registry while the
+// indexbuilder still holds it, so the index outlives the field declaration it
+// was attached to and keeps serving a keyspace nothing will purge.
+//
+// Each case drives the registry the way the observed traffic did — retypes that
+// rewrite the entry, index lifecycle on a neighbouring ledger in the same
+// bucket, and both inside one multi-ledger batch — and asserts the removal
+// still names the index it dropped.
+var _ = Describe("Index registry survives schema churn", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const metaKey = "k3"
+
+	BeforeAll(func() {
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
+	})
+
+	apply := func(reqs ...*servicepb.Request) *servicepb.ApplyResponse {
+		GinkgoHelper()
+
+		resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", reqs...))
+		Expect(err).To(Succeed())
+
+		return resp
+	}
+
+	// indexedLedger creates a ledger declaring metaKey on accounts and indexes
+	// it, returning once the index is READY on every replica.
+	indexedLedger := func(ledger string) {
+		GinkgoHelper()
+
+		apply(actions.CreateLedgerWithSchemaAction(ledger, nil, []*commonpb.SetMetadataFieldTypeCommand{
+			{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: metaKey, Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+		}))
+
+		apply(actions.CreateAccountMetadataIndexAction(ledger, metaKey))
+		Expect(actions.WaitForMetadataIndexReady(ctx, client, ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)).To(Succeed())
+	}
+
+	// expectRemovalDropsIndex removes the field declaration and requires the log
+	// to name the index that went with it.
+	expectRemovalDropsIndex := func(ledger, label string) {
+		GinkgoHelper()
+
+		resp := apply(actions.RemoveMetadataFieldTypeAction(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey))
+
+		logs := resp.GetLogs()
+		Expect(logs).To(HaveLen(1), "%s: the removal commits exactly one log", label)
+
+		removed := logs[0].GetPayload().GetApply().GetLog().GetData().GetRemovedMetadataFieldType()
+		Expect(removed).NotTo(BeNil(), "%s: the log must be a field removal", label)
+
+		want := indexes.Canonical(indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey))
+		Expect(removed.GetDroppedIndex()).NotTo(BeNil(),
+			"%s: the index was created and never dropped, so the removal must cascade-drop it — "+
+				"an empty dropped_index leaves the index outliving its declaration", label)
+		Expect(indexes.Canonical(removed.GetDroppedIndex())).To(Equal(want), "%s: dropped the wrong index", label)
+	}
+
+	It("drops the index after the field type is rewritten repeatedly", func() {
+		const ledger = "idx-registry-retype"
+
+		indexedLedger(ledger)
+
+		// Every retype rewrites the registry entry (the bump is what drives
+		// each replica's rewrite), so this is the path that keeps touching it.
+		types := []commonpb.MetadataType{
+			commonpb.MetadataType_METADATA_TYPE_INT32,
+			commonpb.MetadataType_METADATA_TYPE_UINT64,
+			commonpb.MetadataType_METADATA_TYPE_INT8,
+			commonpb.MetadataType_METADATA_TYPE_INT64,
+		}
+		for range 6 {
+			for _, t := range types {
+				apply(actions.SetMetadataFieldTypeAction(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey, t))
+			}
+		}
+
+		expectRemovalDropsIndex(ledger, "after retype churn")
+	})
+
+	It("drops the index while a neighbouring ledger churns its own indexes", func() {
+		const (
+			ledger    = "idx-registry-neighbour"
+			neighbour = "idx-registry-neighbour-other"
+		)
+
+		indexedLedger(ledger)
+		indexedLedger(neighbour)
+
+		// The registry is bucket-scoped: the neighbour's lifecycle must not
+		// reach this ledger's entry.
+		for range 4 {
+			apply(actions.RemoveMetadataFieldTypeAction(neighbour, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey))
+			apply(actions.SetMetadataFieldTypeAction(neighbour, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey, commonpb.MetadataType_METADATA_TYPE_INT64))
+			apply(actions.CreateAccountMetadataIndexAction(neighbour, metaKey))
+		}
+
+		expectRemovalDropsIndex(ledger, "beside a churning neighbour")
+	})
+
+	It("drops the index when the batch also touches another ledger's registry", func() {
+		const (
+			ledger    = "idx-registry-batched"
+			neighbour = "idx-registry-batched-other"
+		)
+
+		indexedLedger(ledger)
+		indexedLedger(neighbour)
+
+		// One batch spanning both ledgers, mixing a retype of the target field
+		// with registry writes for the neighbour — the shape the failing
+		// sequences committed in.
+		apply(
+			actions.SetMetadataFieldTypeAction(neighbour, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey, commonpb.MetadataType_METADATA_TYPE_INT32),
+			actions.SetMetadataFieldTypeAction(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey, commonpb.MetadataType_METADATA_TYPE_INT32),
+			actions.RemoveMetadataFieldTypeAction(neighbour, commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey),
+		)
+
+		expectRemovalDropsIndex(ledger, "after a shared batch")
+	})
+})


### PR DESCRIPTION
## What changed

The server-side correctness fixes the model-checking driver (EN-1625, #1659) surfaced, peeled out of the test-coverage branch so that PR stays test-only. Each fix ships with the test that pins it (unit + the four e2e index-registry specs).

## Why

The model workload found these as `outside model` classes; they were fixed on the coverage branch during the hunts and now need to land independently. #1659's model runs are red without them.

## Product / operational motivation

Need: reads and index lifecycle must match a serializable state under churn.
Current limitation: retypes could serve mixed semantics, duplicate CreateIndex orphaned keyspaces, degenerate bounds mis-resolved, the abya scan admitted future members, a vanished WAL snapshot dir killed the node.
Requirement / constraint: every fix is pinned by a committed test.
Evidence / durable repository evidence: the tests in this PR; the model driver in #1659 exercises them continuously.

## Technical decision

Decision: land the accumulated fixes as one reviewable unit, tests included.
Why now / why proportionate: they block #1659 (test-only) from validating green.
Alternatives considered: one PR per fix (more churn, the fixes interlock through the index-version machinery); keeping them inside #1659 (mixes product and test changes).

## Risk

**MEDIUM** — touches the index-version machinery (EN-1724), query compile bounds/stamps, checker, and WAL snapshot recovery. Mitigated by the pinned tests and continuous model-run coverage.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: indexbuilder, query compile (bounds/asset/retype), checker, WAL, readstore version-activation; e2e specs included
- [x] Continuous: the model workload (#1659) exercises all of these; a 3h model-only Antithesis run from the combined branch is in flight

## Architecture / behavior impact

Index retypes bind declared types to versions (per-replica `IndexVersionState`); degenerate query ranges resolve to the empty match; the account-by-asset index rows carry first-touch stamps; WAL snapshot saves recreate a missing directory.

## Review focus

The EN-1724 version-binding semantics (`index_config.go`, `backfill.go`) and the abya stamp-gating in `compile.go`.

## Known concerns

Ordering: #1659 (test-only) validates green only with these fixes present; merge this first or together.
