### PR TITLE
test(e2e): prove Raft snapshot restoration

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -129,6 +129,14 @@ BeforeEach(func() {
 `SetupSingleNode` does the same for a one-node cluster. Both accept extra
 instruments for the node under test.
 
+`WithGateway()` places an allocated loopback proxy in front of every Raft and
+snapshot service endpoint. Each node advertises its proxy address, so a gateway
+interceptor observes the real post-admission peer traffic rather than an unused
+side channel. Initial bootstrap discovery starts direct; the proxy also forwards
+the bootstrap unary RPCs required after discovery because the returned peer
+addresses already point at the proxies. The proxy preserves incoming gRPC
+metadata on every backend hop so authenticated peer traffic remains valid.
+
 ### Ports are leased, never chosen
 
 A test node's ports come from `testserver.AllocateNodeLease()`. Do not write a

--- a/pkg/testserver/gateway.go
+++ b/pkg/testserver/gateway.go
@@ -16,6 +16,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/clusterbootstrappb"
 	"github.com/formancehq/ledger/v3/internal/proto/rafttransportpb"
 	"github.com/formancehq/ledger/v3/internal/proto/snapshotpb"
 )
@@ -98,6 +99,19 @@ func (g *Gateway) RemoveInterceptor() {
 	g.interceptor = nil
 }
 
+// Address returns the loopback address allocated for the proxy in front of the
+// node at nodeIndex. Start must have completed before Address is called.
+func (g *Gateway) Address(nodeIndex int) string {
+	if nodeIndex < 0 || nodeIndex >= len(g.ports) {
+		panic(fmt.Sprintf("testserver: gateway node index %d is outside [0, %d)", nodeIndex, len(g.ports)))
+	}
+	if g.ports[nodeIndex] == 0 {
+		panic("testserver: gateway must be started before requesting an address")
+	}
+
+	return fmt.Sprintf("127.0.0.1:%d", g.ports[nodeIndex])
+}
+
 // Start starts the gateway servers on all configured ports.
 func (g *Gateway) Start(ctx context.Context) error {
 	for i, nodeAddr := range g.nodes {
@@ -145,6 +159,10 @@ func (g *Gateway) Start(ctx context.Context) error {
 			client: snapshotpb.NewSnapshotServiceClient(conn),
 		})
 
+		clusterbootstrappb.RegisterClusterBootstrapServiceServer(server, &clusterBootstrapServiceGateway{
+			client: clusterbootstrappb.NewClusterBootstrapServiceClient(conn),
+		})
+
 		g.servers[i] = server
 		g.listeners[i] = lis
 
@@ -180,7 +198,12 @@ func (g *Gateway) Stop(ctx context.Context) error {
 			g.logger.WithFields(map[string]any{
 				"port": g.ports[i],
 			}).Infof("Stopping gateway server on port %d", g.ports[i])
-			server.GracefulStop()
+			// Raft streams are intentionally long-lived. GracefulStop waits for
+			// them to finish, while the streams wait for the proxy to close, so
+			// an exercised gateway can deadlock during test cleanup. Stop cancels
+			// the streams and waits for their handlers; the waitgroup below
+			// verifies that every Serve goroutine returned.
+			server.Stop()
 		}
 
 		if g.listeners[i] != nil {
@@ -380,11 +403,11 @@ type snapshotServiceGateway struct {
 }
 
 func (g *snapshotServiceGateway) PrepareSnapshot(ctx context.Context, req *snapshotpb.PrepareSnapshotRequest) (*snapshotpb.PrepareSnapshotResponse, error) {
-	return g.client.PrepareSnapshot(ctx, req)
+	return g.client.PrepareSnapshot(forwardIncomingMetadata(ctx), req)
 }
 
 func (g *snapshotServiceGateway) FetchFile(req *snapshotpb.FetchFileRequest, stream grpc.ServerStreamingServer[snapshotpb.FetchFileResponse]) error {
-	ctx := stream.Context()
+	ctx := forwardIncomingMetadata(stream.Context())
 
 	clientStream, err := g.client.FetchFile(ctx, req)
 	if err != nil {
@@ -408,5 +431,25 @@ func (g *snapshotServiceGateway) FetchFile(req *snapshotpb.FetchFileRequest, str
 }
 
 func (g *snapshotServiceGateway) CloseSession(ctx context.Context, req *snapshotpb.CloseSessionRequest) (*snapshotpb.CloseSessionResponse, error) {
-	return g.client.CloseSession(ctx, req)
+	return g.client.CloseSession(forwardIncomingMetadata(ctx), req)
+}
+
+type clusterBootstrapServiceGateway struct {
+	clusterbootstrappb.UnimplementedClusterBootstrapServiceServer
+
+	client clusterbootstrappb.ClusterBootstrapServiceClient
+}
+
+func (g *clusterBootstrapServiceGateway) GetPeers(ctx context.Context, req *clusterbootstrappb.GetPeersRequest) (*clusterbootstrappb.GetPeersResponse, error) {
+	return g.client.GetPeers(forwardIncomingMetadata(ctx), req)
+}
+
+func (g *clusterBootstrapServiceGateway) JoinAsLearner(ctx context.Context, req *clusterbootstrappb.JoinAsLearnerRequest) (*clusterbootstrappb.JoinAsLearnerResponse, error) {
+	return g.client.JoinAsLearner(forwardIncomingMetadata(ctx), req)
+}
+
+func forwardIncomingMetadata(ctx context.Context) context.Context {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/pkg/testserver/gateway_test.go
+++ b/pkg/testserver/gateway_test.go
@@ -1,0 +1,24 @@
+package testserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestForwardIncomingMetadata(t *testing.T) {
+	t.Parallel()
+
+	incoming := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"authorization", "Bearer cluster-secret",
+		"cluster-id", "test-cluster",
+	))
+
+	outgoing := forwardIncomingMetadata(incoming)
+	forwarded, ok := metadata.FromOutgoingContext(outgoing)
+	require.True(t, ok)
+	require.Equal(t, []string{"Bearer cluster-secret"}, forwarded.Get("authorization"))
+	require.Equal(t, []string{"test-cluster"}, forwarded.Get("cluster-id"))
+}

--- a/pkg/testserver/testserver.go
+++ b/pkg/testserver/testserver.go
@@ -82,6 +82,14 @@ func WithRaftPort(port int) testservice.InstrumentationFunc {
 	}
 }
 
+func WithRaftAdvertiseAddr(address string) testservice.InstrumentationFunc {
+	return func(ctx context.Context, cfg *testservice.RunConfiguration) error {
+		cfg.AppendArgs("--advertise-addr", address)
+
+		return nil
+	}
+}
+
 func WithWalDir(dir string) testservice.InstrumentationFunc {
 	return func(ctx context.Context, cfg *testservice.RunConfiguration) error {
 		cfg.AppendArgs("--wal-dir", dir)

--- a/tests/e2e/cluster/raft_test.go
+++ b/tests/e2e/cluster/raft_test.go
@@ -6,16 +6,22 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"path/filepath"
 	"time"
 
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	raftwal "github.com/formancehq/ledger/v3/internal/storage/wal"
 	"github.com/formancehq/ledger/v3/pkg/actions"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/grpc/metadata"
 )
 
 var _ = Describe("Simple cluster", func() {
@@ -87,21 +93,34 @@ var _ = Describe("Simple cluster", func() {
 
 	Context("When losing a follower", Ordered, func() {
 		const (
-			ledgerName        = "ledger2"
-			countTransactions = 15
+			ledgerName            = "ledger2"
+			countTransactions     = 3
+			raftCompactionMargin  = uint64(1)
+			maintenanceInterval   = 250 * time.Millisecond
+			offlineAccountAddress = "snapshot-restored"
 		)
 
 		var (
 			ctx        context.Context
 			servers    []*testutil.ServiceWithClient
+			gateway    *testserver.Gateway
 			leaderID   *uint64
 			followerID uint64
 		)
 
 		BeforeAll(func() {
-			ctx, servers, _, leaderID = testutil.SetupMultiNodeCluster(
+			clusterOptions := []testutil.MultiNodeOption{testutil.WithGateway()}
+			for i := range countInstances {
+				clusterOptions = append(clusterOptions, testutil.WithNodeInstruments(
+					i,
+					testserver.WithRaftCompactionMargin(raftCompactionMargin),
+					testserver.WithMaintenanceInterval(maintenanceInterval),
+				))
+			}
+
+			ctx, servers, gateway, leaderID = testutil.SetupMultiNodeCluster(
 				countInstances,
-				testutil.WithGateway(),
+				clusterOptions...,
 			)
 
 			// Find and stop a follower
@@ -155,21 +174,115 @@ var _ = Describe("Simple cluster", func() {
 		})
 
 		It("should restore the state from a snapshot sent by the leader", func() {
+			lid := *leaderID
+
+			By("Capturing the caught-up follower progress before shutdown")
+			var followerLastIndex uint64
+			Eventually(func(g Gomega) {
+				leaderState, err := servers[lid-1].ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{
+					NodeId: uint32(lid),
+				})
+				g.Expect(err).To(Succeed())
+
+				followerState, err := servers[followerID-1].ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{
+					NodeId: uint32(followerID),
+				})
+				g.Expect(err).To(Succeed())
+				g.Expect(followerState.GetState()).To(Equal("Follower"))
+				g.Expect(followerState.GetRaftStatus().GetApplied()).To(BeNumerically(">=", leaderState.GetRaftStatus().GetLastIndex()))
+				g.Expect(followerState.GetRaftStatus().GetLastPersistedIndex()).To(BeNumerically(">=", leaderState.GetRaftStatus().GetLastIndex()))
+
+				followerLastIndex = followerState.GetRaftStatus().GetLastIndex()
+			}).Within(15 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+
 			By("Stopping the follower")
 			testutil.StopNode(ctx, servers[followerID-1])
 
-			By("Creating transactions to trigger background maintenance")
-			lid := *leaderID
+			By("Creating state that cannot be replayed after compaction")
 			for i := 0; i < countTransactions; i++ {
 				_, err := servers[lid-1].Client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-					actions.NewPosting("world", "bank", big.NewInt(100), "USD"),
+					actions.NewPosting("world", offlineAccountAddress, big.NewInt(100), "USD"),
 				}, nil, nil)))
 				Expect(err).To(Succeed())
 			}
 
-			By("Starting the follower")
+			minimumSnapshotIndex := followerLastIndex + raftCompactionMargin + 1
+			var targetIndex uint64
+			Eventually(func(g Gomega) {
+				leaderState, err := servers[lid-1].ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{
+					NodeId: uint32(lid),
+				})
+				g.Expect(err).To(Succeed())
+
+				targetIndex = leaderState.GetRaftStatus().GetLastPersistedIndex()
+				g.Expect(targetIndex).To(BeNumerically(">=", minimumSnapshotIndex),
+					"offline writes must advance beyond the stopped follower's recoverable log range")
+			}).Within(15 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+
+			By("Waiting for leader maintenance to snapshot beyond the follower's retained range")
+			leaderSnapshotter, err := raftwal.NewSnapshotter(
+				filepath.Join(servers[lid-1].WalDir, "snap"),
+				logging.FromContext(ctx),
+			)
+			Expect(err).To(Succeed())
+
+			Eventually(func(g Gomega) uint64 {
+				snapshot, err := leaderSnapshotter.Load()
+				g.Expect(err).To(Succeed())
+				g.Expect(snapshot).NotTo(BeNil())
+
+				return snapshot.GetMetadata().GetIndex()
+			}).Within(15 * time.Second).ProbeEvery(100 * time.Millisecond).Should(BeNumerically(">=", targetIndex))
+
+			By("Allowing only snapshot catch-up while recording the real Raft MsgSnap")
+			snapshotSent := make(chan uint64, 1)
+			gateway.SetInterceptor(testserver.MessageInterceptorFunc(func(msg *raftpb.Message) bool {
+				if msg.GetTo() != followerID {
+					return true
+				}
+
+				if msg.GetType() == raftpb.MsgApp {
+					return false
+				}
+
+				if msg.GetType() == raftpb.MsgSnap {
+					select {
+					case snapshotSent <- msg.GetSnapshot().GetMetadata().GetIndex():
+					default:
+					}
+				}
+
+				return true
+			}))
+			DeferCleanup(gateway.RemoveInterceptor)
+
+			By("Starting the follower and requiring snapshot transfer evidence")
 			testutil.RestartNode(ctx, servers[followerID-1])
-			Eventually(servers[followerID-1], 15*time.Second).Should(BeFollower(), "Timed out waiting for node to become follower")
+
+			var sentSnapshotIndex uint64
+			Eventually(snapshotSent).Within(15 * time.Second).Should(Receive(&sentSnapshotIndex))
+			Expect(sentSnapshotIndex).To(BeNumerically(">=", targetIndex))
+			gateway.RemoveInterceptor()
+
+			By("Waiting for the follower's applied and durable indexes to pass the installed snapshot")
+			Eventually(func(g Gomega) {
+				followerState, err := servers[followerID-1].ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{
+					NodeId: uint32(followerID),
+				})
+				g.Expect(err).To(Succeed())
+				g.Expect(followerState.GetState()).To(Equal("Follower"))
+				g.Expect(followerState.GetRaftStatus().GetApplied()).To(BeNumerically(">=", sentSnapshotIndex))
+				g.Expect(followerState.GetRaftStatus().GetLastPersistedIndex()).To(BeNumerically(">=", sentSnapshotIndex))
+			}).Within(30 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+
+			By("Reading state created while the follower was offline from that follower")
+			staleCtx := metadata.AppendToOutgoingContext(ctx, "x-consistency", "stale")
+			account, err := servers[followerID-1].Client.GetAccount(staleCtx, &servicepb.GetAccountRequest{
+				Ledger:  ledgerName,
+				Address: offlineAccountAddress,
+			})
+			Expect(err).To(Succeed())
+			Expect(account.FindVolume("USD", "").Balance).To(Equal(fmt.Sprintf("%d", countTransactions*100)))
 		})
 
 		It("should restart as expected after a second restart", func() {

--- a/tests/e2e/testutil/server.go
+++ b/tests/e2e/testutil/server.go
@@ -184,6 +184,13 @@ func SetupMultiNodeCluster(
 			testserver.WithRaftCompactionMargin(1),
 			testserver.WithAutoPromoteThreshold(10),
 		)
+		if gw != nil {
+			// Peers must advertise the proxy, not their backend listener;
+			// otherwise WithGateway starts inert servers while Raft silently
+			// continues to use direct connections and no interceptor can
+			// observe or manipulate the real network path.
+			instruments = append(instruments, testserver.WithRaftAdvertiseAddr(gw.Address(i)))
+		}
 		instruments = append(instruments, options.ExtraInstruments...)
 
 		return instruments


### PR DESCRIPTION
## Product / operational motivation

Need: the real-network Raft E2E must prove that an offline follower installs a leader snapshot and restores durable ledger state.
Current limitation: the existing test passed with zero offline writes and asserted only that the restarted node became a follower.
Requirement / constraint: force the follower beyond the retained-log range, observe the real MsgSnap path, require durable/applied progress, and read offline-created state locally from the restarted follower.
Evidence: the zero-write challenge reproduced the gap; `tests/e2e/cluster/raft_test.go` now encodes the observable contract.
Durable repository evidence: `tests/e2e/cluster/raft_test.go` and `docs/technical/contributing/testing.md`.

## Technical decision

Decision: put the existing test gateway on the advertised Raft path, wait on the leader durable WAL snapshot index, deny MsgApp replay during restart, observe MsgSnap, and verify follower indexes plus local account state.
Why now / why proportionate: this uses existing Raft status, WAL snapshot, and gateway primitives without changing runtime behavior or matching log text.
Alternatives considered: keeping the follower-status assertion, using arbitrary sleeps, or relying only on component-level synchronization tests; none proves the real network wiring.

## Validation

The requirement is satisfied when the zero-write mutation fails before restart, while repeated race-enabled focused E2E runs observe MsgSnap and restore the offline account with applied and persisted indexes at or beyond the snapshot.

- zero-write mutation: expected failure (`target 13`, required `>= 15`)
- focused snapshot E2E with race detector: 4/4 passed (three repetitions plus current-base rerun)
- existing gateway and leadership-transfer E2Es with race detector: passed
- `go test ./pkg/testserver ./tests/e2e/testutil`: passed
- `bash scripts/agent-check` with isolated caches: passed

No runtime defect was demonstrated; this fixes the confirmed E2E test gap.