### PR TITLE
ci: run E2E suites on isolated runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  Tests-E2E:
+  Tests-E2E-Business:
     runs-on: namespace-profile-linux-amd64-4vcpu
     env:
       GOPATH: /tmp/go
@@ -90,17 +90,40 @@ jobs:
           dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
-      - name: Run E2E tests with coverage
+      - name: Run Business E2E tests with coverage
         run: >
-          nix develop --command just test-e2e-coverage
-      - name: Upload coverage profile
+          nix develop --command just test-e2e-coverage './tests/e2e/business/...' e2e-business.out
+      - name: Upload Business coverage profile
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-e2e
-          path: build/coverage/e2e.out
+          name: coverage-e2e-business
+          path: build/coverage/e2e-business.out
           retention-days: 7
-          if-no-files-found: ignore
+          if-no-files-found: error
+
+  Tests-E2E-Cluster:
+    runs-on: namespace-profile-linux-amd64-4vcpu
+    env:
+      GOPATH: /tmp/go
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
+        with:
+          fetch-depth: 0
+          dissociate: true
+      - name: Setup Env
+        uses: ./.github/actions/default
+      - name: Run Cluster E2E tests with coverage
+        run: >
+          nix develop --command just test-e2e-coverage './tests/e2e/cluster/...' e2e-cluster.out
+      - name: Upload Cluster coverage profile
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-e2e-cluster
+          path: build/coverage/e2e-cluster.out
+          retention-days: 7
+          if-no-files-found: error
 
   Tests-Scenarios:
     runs-on: namespace-profile-linux-amd64-4vcpu
@@ -142,7 +165,7 @@ jobs:
 
   Coverage:
     if: always()
-    needs: [Tests, Tests-E2E, Tests-Scenarios]
+    needs: [Tests, Tests-E2E-Business, Tests-E2E-Cluster, Tests-Scenarios]
     runs-on: namespace-profile-linux-amd64-4vcpu
     env:
       GOPATH: /tmp/go
@@ -163,6 +186,13 @@ jobs:
         run: |
           nix develop --command bash -c '
             cd build/coverage
+            required_profiles=(e2e-business.out e2e-cluster.out)
+            for f in "${required_profiles[@]}"; do
+              if [ ! -s "$f" ]; then
+                echo "Missing required coverage profile: $f"
+                exit 1
+              fi
+            done
             profiles=()
             for f in *.out; do
               [ -f "$f" ] && profiles+=("$f")
@@ -239,7 +269,8 @@ jobs:
       [
         Dirty,
         Tests,
-        Tests-E2E,
+        Tests-E2E-Business,
+        Tests-E2E-Cluster,
         Tests-Scenarios,
         Tests-Model,
         Tests-Schemathesis,
@@ -294,7 +325,8 @@ jobs:
       [
         Dirty,
         Tests,
-        Tests-E2E,
+        Tests-E2E-Business,
+        Tests-E2E-Cluster,
         Tests-Scenarios,
         Tests-Model,
         Tests-Schemathesis,

--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -612,8 +612,10 @@ plain `-tags e2e` run neither builds nor runs them:
 | `databricks` | Databricks event sink | real workspace credentials; skips itself when unset |
 
 `just test-e2e` runs the light set for a fast local loop. **CI runs the full tag
-set** through `just test-e2e-coverage`, so a green `just test-e2e` does not
-guarantee a green pipeline. Reproduce the CI set locally with:
+set** through separate isolated Business and Cluster invocations of
+`just test-e2e-coverage`, so a green `just test-e2e` does not guarantee a green
+pipeline. The recipe's no-argument form retains the combined package selection
+for local coverage. Reproduce the CI set locally with:
 
 ```bash
 just test-e2e-full

--- a/justfile
+++ b/justfile
@@ -180,18 +180,20 @@ test-coverage:
     GOTOOLCHAIN=$(go env GOVERSION) go test -race -coverprofile={{coverage_dir}}/unit.out -coverpkg={{coverage_pkgs}} ./... -timeout 20m
     echo "Coverage profile: {{coverage_dir}}/unit.out"
 
-# Run E2E tests with coverage. This is the CI gate, so it runs the full tag
-# set: the feature-gated suites (s3, azure, clickhouse, nats, ...) are only
-# compiled when their tag is present, and running them here is what stops
-# them rotting unnoticed. Suites needing external credentials, such as
-# databricks, skip themselves when the environment is not configured.
-test-e2e-coverage:
+# Run E2E tests with coverage. The CI gates invoke this recipe once for each
+# isolated Business/Cluster job. Every invocation uses the full tag set: the
+# feature-gated suites (s3, azure, clickhouse, nats, ...) are only compiled
+# when their tag is present, and running them here is what stops them rotting
+# unnoticed. Suites needing external credentials, such as databricks, skip
+# themselves when the environment is not configured. With no arguments the
+# recipe retains the combined, serial local coverage run.
+test-e2e-coverage packages="./tests/e2e/business/... ./tests/e2e/cluster/..." profile="e2e.out":
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p {{coverage_dir}}
     echo "==> E2E tests with coverage..."
-    GOTOOLCHAIN=$(go env GOVERSION) go test -race -tags "e2e,{{all_tags}}" -p 1 -coverprofile={{coverage_dir}}/e2e.out -coverpkg={{coverage_pkgs}} ./tests/e2e/business/... ./tests/e2e/cluster/... -timeout 20m
-    echo "Coverage profile: {{coverage_dir}}/e2e.out"
+    GOTOOLCHAIN=$(go env GOVERSION) go test -race -tags "e2e,{{all_tags}}" -p 1 -coverprofile={{coverage_dir}}/{{profile}} -coverpkg={{coverage_pkgs}} {{packages}} -timeout 20m
+    echo "Coverage profile: {{coverage_dir}}/{{profile}}"
 
 # Run scenario tests with coverage
 test-scenarios-coverage:


### PR DESCRIPTION
## Summary

- run the existing Business and Cluster E2E packages in separate GitHub Actions jobs/runners
- retain the full build-tag set, race detector, package serialization, timeout, and coverage instrumentation
- upload distinct E2E coverage fragments and fail Coverage when either fragment is absent

## Validation

- canonical isolated `bash scripts/agent-check` passed twice at a stable normalization fixpoint
- rendered Just commands preserve the original flags and partition only the two existing package paths
- empirical GitHub Actions timing will be recorded from this PR; no performance claim is inferred from YAML alone

Do not merge automatically.