### PR TITLE
fix(EN-1901): normalize degenerate query range bounds to the empty match

### DIFF
--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -649,6 +649,15 @@ func resolveIntBounds(cond *commonpb.IntCondition, params map[string]*commonpb.P
 		}
 	}
 
+	// max is the exclusive upper, so [min, max) holds nothing once the
+	// adjusted bounds meet or cross — e.g. `(x, x)` resolves to [x+1, x).
+	// Every consumer must see that as the empty match, never as Pebble
+	// iterator bounds: LowerBound above UpperBound is an iterator
+	// invariant violation, not an empty scan.
+	if b.hasMin && b.hasMax && b.min >= b.max {
+		b.empty = true
+	}
+
 	return b, nil
 }
 
@@ -821,6 +830,12 @@ func resolveUintBounds(cond *commonpb.UintCondition, params map[string]*commonpb
 			b.max = nv
 			b.hasMax = true
 		}
+	}
+
+	// See resolveIntBounds: adjusted bounds that meet or cross are the
+	// empty match, and must never reach Pebble as iterator bounds.
+	if b.hasMin && b.hasMax && b.min >= b.max {
+		b.empty = true
 	}
 
 	return b, nil
@@ -1220,6 +1235,10 @@ func compileTxIDCondition(ctx *compileCtx, cond *commonpb.UintCondition) (readst
 		return nil, err
 	}
 
+	if bounds.empty {
+		return &SliceIterator{}, nil
+	}
+
 	// Equality optimization: single txID -> check existence in Pebble and return slice
 	if bounds.isEquality() {
 		exists, pErr := pebbleTxExists(ctx.pebbleReader, ctx.ledgerName, bounds.min)
@@ -1330,6 +1349,10 @@ func compileTimestampRangeCondition(
 		return nil, err
 	}
 
+	if bounds.empty {
+		return &SliceIterator{}, nil
+	}
+
 	// Key layout: [prefix_byte][ledger\x00][timestamp_BE(8B)][entityID_BE(8B)]
 	entityOffset := len(ledgerPrefix) + 8
 	entityLen := 8
@@ -1411,6 +1434,10 @@ func compileLogIdCondition(ctx *compileCtx, cond *commonpb.UintCondition) (reads
 	bounds, err := resolveUintBounds(cond, ctx.params)
 	if err != nil {
 		return nil, err
+	}
+
+	if bounds.empty {
+		return &SliceIterator{}, nil
 	}
 
 	prefix := readstore.LedgerLogPrefix(ctx.kb, ctx.ledgerName)

--- a/internal/query/compile_bounds_test.go
+++ b/internal/query/compile_bounds_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
-func uintCond(min, max uint64, minExcl, maxExcl bool) *commonpb.UintCondition {
-	return &commonpb.UintCondition{Min: &min, Max: &max, MinExclusive: minExcl, MaxExclusive: maxExcl}
+func uintCond(lo, hi uint64, minExcl, maxExcl bool) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Min: &lo, Max: &hi, MinExclusive: minExcl, MaxExclusive: maxExcl}
 }
 
 // TestResolveBounds_DegenerateRangesAreEmpty pins the crossed-bounds rule: max
@@ -46,7 +46,7 @@ func TestResolveBounds_DegenerateRangesAreEmpty(t *testing.T) {
 			require.Equal(t, tc.empty, b.empty)
 
 			ic := &commonpb.IntCondition{
-				Min: int64Ptr(int64(tc.cond.GetMin())), Max: int64Ptr(int64(tc.cond.GetMax())),
+				Min: new(int64(tc.cond.GetMin())), Max: new(int64(tc.cond.GetMax())),
 				MinExclusive: tc.cond.GetMinExclusive(), MaxExclusive: tc.cond.GetMaxExclusive(),
 			}
 			ib, err := resolveIntBounds(ic, nil)
@@ -56,7 +56,8 @@ func TestResolveBounds_DegenerateRangesAreEmpty(t *testing.T) {
 	}
 }
 
-func int64Ptr(v int64) *int64 { return &v }
+//go:fix inline
+func int64Ptr(v int64) *int64 { return new(v) }
 
 // TestCompile_NotOverDegenerateRange_YieldsUniverse pins the composition that
 // panicked under the invariants build: not(logId[(x,x)]) on LOGS. The

--- a/internal/query/compile_bounds_test.go
+++ b/internal/query/compile_bounds_test.go
@@ -1,0 +1,111 @@
+package query
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func uintCond(min, max uint64, minExcl, maxExcl bool) *commonpb.UintCondition {
+	return &commonpb.UintCondition{Min: &min, Max: &max, MinExclusive: minExcl, MaxExclusive: maxExcl}
+}
+
+// TestResolveBounds_DegenerateRangesAreEmpty pins the crossed-bounds rule: max
+// is the exclusive upper, so adjusted bounds that meet or cross resolve to the
+// empty match. They must never reach Pebble as iterator bounds — LowerBound
+// above UpperBound is an iterator invariant violation (mergingIter panics
+// under the invariants/race build tags), not an empty scan.
+func TestResolveBounds_DegenerateRangesAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		cond  *commonpb.UintCondition
+		empty bool
+	}{
+		{"exclusive-exclusive same value", uintCond(7, 7, true, true), true},
+		{"inclusive-exclusive same value", uintCond(7, 7, false, true), true},
+		{"crossed", uintCond(9, 3, false, false), true},
+		{"exclusive min meets inclusive max", uintCond(7, 7, true, false), true},
+		{"single value", uintCond(7, 7, false, false), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, err := resolveUintBounds(tc.cond, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.empty, b.empty)
+
+			ic := &commonpb.IntCondition{
+				Min: int64Ptr(int64(tc.cond.GetMin())), Max: int64Ptr(int64(tc.cond.GetMax())),
+				MinExclusive: tc.cond.GetMinExclusive(), MaxExclusive: tc.cond.GetMaxExclusive(),
+			}
+			ib, err := resolveIntBounds(ic, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.empty, ib.empty, "int resolver must agree")
+		})
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+// TestCompile_NotOverDegenerateRange_YieldsUniverse pins the composition that
+// panicked under the invariants build: not(logId[(x,x)]) on LOGS. The
+// degenerate child resolves to the empty match, and its complement is the
+// whole universe — every log comes back.
+func TestCompile_NotOverDegenerateRange_YieldsUniverse(t *testing.T) {
+	t.Parallel()
+
+	const ledgerName = "ledger1"
+
+	logger := logging.FromContext(logging.TestingContext())
+	store, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = store.Close() })
+
+	kb := dal.NewKeyBuilder()
+	batch := store.NewBatch()
+	for logID := uint64(1); logID <= 3; logID++ {
+		seq := make([]byte, 8)
+		binary.BigEndian.PutUint64(seq, logID+100)
+		require.NoError(t, batch.SetBytes(readstore.LedgerLogKey(kb, ledgerName, logID), seq))
+	}
+	require.NoError(t, batch.Commit())
+
+	reader := store.DB()
+	info := &commonpb.LedgerInfo{Name: ledgerName}
+
+	two := uint64(2)
+	filter := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+		Filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogId{LogId: &commonpb.LogIdCondition{
+			Cond: &commonpb.UintCondition{Min: &two, Max: &two, MinExclusive: true, MaxExclusive: true},
+		}}},
+	}}}
+
+	iter, err := Compile(
+		reader, dal.NewKeyBuilder(), filter,
+		commonpb.QueryTarget_QUERY_TARGET_LOGS, ledgerName,
+		nil, nil, info, nil, nil, nil, reader, 0)
+	require.NoError(t, err)
+
+	t.Cleanup(iter.Close)
+
+	var got []uint64
+	for iter.Next() {
+		got = append(got, binary.BigEndian.Uint64(iter.Current()))
+	}
+	require.NoError(t, iter.Err())
+
+	require.Equal(t, []uint64{1, 2, 3}, got,
+		"not(empty range) must yield the whole universe")
+}

--- a/internal/query/compile_bounds_test.go
+++ b/internal/query/compile_bounds_test.go
@@ -56,9 +56,6 @@ func TestResolveBounds_DegenerateRangesAreEmpty(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func int64Ptr(v int64) *int64 { return new(v) }
-
 // TestCompile_NotOverDegenerateRange_YieldsUniverse pins the composition that
 // panicked under the invariants build: not(logId[(x,x)]) on LOGS. The
 // degenerate child resolves to the empty match, and its complement is the
@@ -109,4 +106,28 @@ func TestCompile_NotOverDegenerateRange_YieldsUniverse(t *testing.T) {
 
 	require.Equal(t, []uint64{1, 2, 3}, got,
 		"not(empty range) must yield the whole universe")
+}
+
+// TestConsumerGuards_DegenerateRangeShortCircuits pins the empty-bounds guard
+// in each range consumer that feeds Pebble iterator bounds: a degenerate
+// condition must come back as the canonical empty iterator before any
+// existence probe or range construction. The zero compileCtx is part of the
+// pin — reaching past the guard would dereference the absent readers.
+func TestConsumerGuards_DegenerateRangeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	ctx := &compileCtx{}
+	cond := uintCond(7, 7, true, true)
+
+	it, err := compileTxIDCondition(ctx, cond)
+	require.NoError(t, err)
+	require.False(t, it.Next(), "txID guard must yield the empty iterator")
+
+	it, err = compileTimestampRangeCondition(ctx, cond, []byte("p"), "tstmp", 0)
+	require.NoError(t, err)
+	require.False(t, it.Next(), "timestamp guard must yield the empty iterator")
+
+	it, err = compileLogIdCondition(ctx, cond)
+	require.NoError(t, err)
+	require.False(t, it.Next(), "logId guard must yield the empty iterator")
 }

--- a/tests/e2e/business/logs_degenerate_bounds_test.go
+++ b/tests/e2e/business/logs_degenerate_bounds_test.go
@@ -1,0 +1,85 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"io"
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// A range condition whose bounds cross — an exclusive interval (x, x) —
+// matches nothing, so its complement is the whole universe: not(logId in
+// (x, x)) must list every log the unfiltered read lists.
+var _ = Describe("Degenerate range bounds resolve to the empty match", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const ledger = "degenerate-bounds"
+
+	BeforeAll(func() {
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
+	})
+
+	countLogs := func(g Gomega, filter *commonpb.QueryFilter) int {
+		stream, err := client.ListLogs(ctx, &servicepb.ListLogsRequest{
+			Ledger:  ledger,
+			Options: &commonpb.ListOptions{Filter: filter},
+		})
+		g.Expect(err).To(Succeed())
+
+		count := 0
+		for {
+			_, re := stream.Recv()
+			if re == io.EOF {
+				break
+			}
+			g.Expect(re).To(Succeed(), "streaming under a degenerate-bounds complement must not error")
+			count++
+		}
+
+		return count
+	}
+
+	It("lists the whole universe under not() of an empty interval", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		for range 3 {
+			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+				actions.CreateForceTransactionAction(ledger, []*commonpb.Posting{
+					actions.NewPosting("world", "acc:1", big.NewInt(10), "USD"),
+				}, nil)))
+			Expect(err).To(Succeed())
+		}
+
+		bound := uint64(2)
+		notEmptyInterval := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+			Filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_LogId{LogId: &commonpb.LogIdCondition{
+				Cond: &commonpb.UintCondition{
+					Min: &bound, MinExclusive: true,
+					Max: &bound, MaxExclusive: true,
+				},
+			}}},
+		}}}
+
+		Eventually(func(g Gomega) {
+			all := countLogs(g, nil)
+			g.Expect(all).To(BeNumerically(">=", 3), "the three committed transactions")
+			g.Expect(countLogs(g, notEmptyInterval)).To(Equal(all),
+				"not(empty interval) must match every log the unfiltered read lists")
+		}).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## What changed

The query compiler normalizes degenerate range bounds — crossed bounds and empty exclusive intervals like `(x, x)` — to the canonical empty match instead of emitting them as pebble iterator bounds. `not()` over such a range now matches the whole universe.

## Why

Jira: EN-1901. An inverted iterator range panics pebble under the invariants build and has undefined matching on the default build. Found by the EN-1625 model-checking driver query hunts.

## Product / operational motivation

N/A (bug fix)

## Technical decision

N/A

## Risk

**LOW** — normalization at compile time; no storage or wire change.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `internal/query/compile_bounds_test.go` (unit); `tests/e2e/business/logs_degenerate_bounds_test.go` — RED on base under `-tags e2e,invariants` (pebble bound panic), green with the fix. On the default build the e2e is green on base too (pebble tolerates the range there); the invariants build is where the panic is observable.
- [x] Full `internal/query` package suite green.

## Architecture / behavior impact

N/A

## Review focus

The bound-comparison logic in `compile.go` — the empty-interval and min>max cases must collapse to the same canonical empty match so the complement stays exact.

## Known concerns

None
