### PR TITLE
fix(EN-1902): recover WAL snapshotting after the snapshot directory vanishes

### DIFF
--- a/internal/storage/wal/snapshotter.go
+++ b/internal/storage/wal/snapshotter.go
@@ -47,6 +47,14 @@ func (s *Snapshotter) Save(snap *raftpb.Snapshot) error {
 	path := filepath.Join(s.dir, name)
 	tmpPath := path + ".tmp"
 
+	// The directory is created in NewSnapshotter, so reaching here without it
+	// means it went away underneath a running node. Recreate it: the snapshot
+	// this call is persisting is how a follower catches up, and failing the
+	// save propagates as a task-pool panic that takes the node down.
+	if err := os.MkdirAll(s.dir, 0755); err != nil {
+		return fmt.Errorf("recreating snapshot directory: %w", err)
+	}
+
 	f, err := os.Create(tmpPath)
 	if err != nil {
 		return fmt.Errorf("creating temp snap file: %w", err)

--- a/internal/storage/wal/snapshotter.go
+++ b/internal/storage/wal/snapshotter.go
@@ -55,6 +55,14 @@ func (s *Snapshotter) Save(snap *raftpb.Snapshot) error {
 		return fmt.Errorf("recreating snapshot directory: %w", err)
 	}
 
+	// The rename below is made durable by fsyncing s.dir, which says nothing
+	// about s.dir's own entry in its parent. A crash after Save returns and the
+	// WAL snapshot record is written would then leave the WAL pointing at a
+	// directory that recovery cannot find, so fsync the parent too.
+	if err := syncDir(filepath.Dir(s.dir)); err != nil {
+		return fmt.Errorf("syncing snapshot directory parent: %w", err)
+	}
+
 	f, err := os.Create(tmpPath)
 	if err != nil {
 		return fmt.Errorf("creating temp snap file: %w", err)

--- a/internal/storage/wal/snapshotter_missing_dir_test.go
+++ b/internal/storage/wal/snapshotter_missing_dir_test.go
@@ -1,0 +1,33 @@
+package wal
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+// A follower catching up on a leader snapshot persists it through Save, and the
+// failure propagates as a task-pool panic that takes the node down. Losing the
+// directory underneath a running node is not a reason to lose the node.
+func TestSnapshotterSaveRecreatesAMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir() + "/snap"
+	s, err := NewSnapshotter(dir, logging.Testing())
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(dir))
+
+	require.NoError(t, s.Save(&raftpb.Snapshot{
+		Metadata: &raftpb.SnapshotMetadata{Index: proto.Uint64(9000), Term: proto.Uint64(7)},
+	}))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the snapshot is on disk")
+}

--- a/internal/storage/wal/wal_default_test.go
+++ b/internal/storage/wal/wal_default_test.go
@@ -918,7 +918,13 @@ func TestApplySnapshotUnlocksOnSnapshotSaveFailure(t *testing.T) {
 	t.Parallel()
 
 	w := newTestWAL(t)
-	w.snapshotter.dir = filepath.Join(t.TempDir(), "missing", "snap")
+
+	// A vanished snapshot directory is recreated by Save, so the failure has
+	// to sit deeper: occupy the parent with a regular file so the recreation
+	// itself cannot succeed.
+	parent := filepath.Join(t.TempDir(), "occupied")
+	require.NoError(t, os.WriteFile(parent, nil, 0o600))
+	w.snapshotter.dir = filepath.Join(parent, "snap")
 
 	err := w.ApplySnapshot(&raftpb.Snapshot{
 		Metadata: snapshotMeta(10, 2, &raftpb.ConfState{Voters: []uint64{1}}),

--- a/tests/e2e/business/wal_snapshot_dir_recovery_test.go
+++ b/tests/e2e/business/wal_snapshot_dir_recovery_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// The WAL snapshot directory can vanish under a running node (operator
+// mistake, cleanup job). Persisting the next snapshot must recreate it and
+// carry on; failing the save instead propagates as a task-pool panic that
+// takes the node down.
+var _ = Describe("WAL snapshot directory recovery", Ordered, func() {
+	var (
+		ctx     context.Context
+		node    *testutil.ServiceWithClient
+		client  servicepb.BucketServiceClient
+		snapDir string
+	)
+
+	const ledger = "wal-snapdir"
+
+	BeforeAll(func() {
+		ctx, node = testutil.SetupSingleNode()
+		client = node.Client
+		snapDir = filepath.Join(node.WalDir, "snap")
+	})
+
+	apply := func(g Gomega) {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.CreateForceTransactionAction(ledger, []*commonpb.Posting{
+				actions.NewPosting("world", "acc:1", big.NewInt(10), "USD"),
+			}, nil)))
+		g.Expect(err).To(Succeed())
+	}
+
+	It("survives the snapshot directory vanishing", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		Eventually(func(g Gomega) { apply(g) }).Should(Succeed())
+
+		Expect(os.RemoveAll(snapDir)).To(Succeed(), "simulate the directory vanishing under the node")
+
+		// Background maintenance persists WAL snapshots as entries accumulate.
+		// With the directory gone, every save must recreate it and succeed;
+		// the node keeps accepting writes throughout.
+		Eventually(func(g Gomega) {
+			apply(g)
+
+			entries, err := os.ReadDir(snapDir)
+			g.Expect(err).To(Succeed(), "the snapshot directory must be recreated by the next save")
+			g.Expect(entries).ToNot(BeEmpty(), "a snapshot file must be persisted into the recreated directory")
+		}).WithTimeout(30 * time.Second).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## What changed

WAL snapshot saves recreate the snapshot directory when it has vanished under a live node, and fsync the parent directory before the rename so the directory entry is durable before any WAL record references it.

## Why

Jira: EN-1902. Once the snapshot directory disappeared (operator mistake, cleanup job), every subsequent save failed permanently — no snapshot ever persisted again, and the follower-sync save path propagated the failure as a task-pool panic that took the node down.

## Product / operational motivation

N/A (bug fix)

## Technical decision

N/A

## Risk

**LOW** — one extra parent fsync per save; the new error path only fires on a genuine durability failure, where failing the save is correct. (An automated arbitration pass on the closed bundle PR #1817 challenged the unconditional parent fsync and ruled it correct-as-written: `NewSnapshotter` creates the directory without fsyncing its parent, and `Save` promises crash-safe durability.)

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `snapshotter_missing_dir_test.go` (unit, incl. save-failure injection via a file-occupied parent); `tests/e2e/business/wal_snapshot_dir_recovery_test.go` — RED on base (directory never recreated within 30s), green with the fix.
- [x] Full `internal/storage/wal` package suite green.

## Architecture / behavior impact

Snapshot `Save` gains a parent-directory fsync; no format or wire change.

## Review focus

The recreate-then-rename ordering in `snapshotter.go` — the parent must be synced before a WAL record can reference the directory.

## Known concerns

None
