### PR TITLE
fix(EN-1903): bound the checker's stored-exclusion scan to the archived audit boundary

### DIFF
--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -213,6 +213,7 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	var (
 		hasArchivedChapters  bool
 		archiveEndSeq        uint64 // max close_sequence among archived chapters
+		archiveAuditEndSeq   uint64 // max close_audit_sequence among archived chapters
 		archiveLastAuditHash []byte // last_audit_hash from the latest archived chapter
 	)
 
@@ -231,6 +232,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			if p.GetCloseSequence() > archiveEndSeq {
 				archiveEndSeq = p.GetCloseSequence()
 				archiveLastAuditHash = p.GetLastAuditHash()
+			}
+
+			if p.GetCloseAuditSequence() > archiveAuditEndSeq {
+				archiveAuditEndSeq = p.GetCloseAuditSequence()
 			}
 		}
 	}
@@ -783,7 +788,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	// projection. Combined with the LedgerLog.PurgedVolumes already
 	// accumulated above, `stored` now represents the full per-ledger
 	// exclusion set the index builder will consume.
-	if err := c.collectStoredTransientVolumes(ctx, snap, addStored); err != nil {
+	//
+	// The scan starts strictly above the archived audit boundary, mirroring
+	// the replay loop's `seq <= archiveEndSeq` skip on the log side: the
+	// derived set only covers post-boundary history, and rows at or below the
+	// boundary can legitimately sit in hot storage — a restore re-ingests the
+	// backfilled archived ranges and never re-purges them, and out-of-order
+	// archiving leaves an un-archived chapter's rows below the max archived
+	// close — so comparing them against a replay that skipped their logs
+	// reports a healthy store as corrupt. Same trade-off as the log-side
+	// skip: retained sub-boundary rows go unverified.
+	if err := c.collectStoredTransientVolumes(ctx, snap, archiveAuditEndSeq, addStored); err != nil {
 		return fmt.Errorf("reading applied proposals for exclusion check: %w", err)
 	}
 
@@ -887,9 +902,17 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 func (c *Checker) collectStoredTransientVolumes(
 	ctx context.Context,
 	reader dal.PebbleReader,
+	archiveAuditEndSeq uint64,
 	addStored func(ledger, account, asset, color string),
 ) error {
-	proposals, err := query.ReadAppliedProposals(ctx, reader, nil)
+	// Proposals at or below the archived audit boundary are outside the
+	// replay's derivation window (see the call site) — start above it.
+	var afterSeq *uint64
+	if archiveAuditEndSeq > 0 {
+		afterSeq = &archiveAuditEndSeq
+	}
+
+	proposals, err := query.ReadAppliedProposals(ctx, reader, afterSeq)
 	if err != nil {
 		return fmt.Errorf("reading applied proposals: %w", err)
 	}

--- a/internal/application/check/checker_exclusion_archived_test.go
+++ b/internal/application/check/checker_exclusion_archived_test.go
@@ -1,0 +1,136 @@
+package check
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/proposalpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// writeAppliedProposal persists an AppliedProposal row at the given audit
+// sequence, byte-for-byte as the FSM (and a restore's raw segment ingest)
+// would store it.
+func writeAppliedProposal(t *testing.T, store *dal.Store, entry *proposalpb.AppliedProposal) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	key := dal.NewKeyBuilder().
+		PutZonePrefix(dal.ZoneCold, dal.SubColdAppliedProposal).
+		PutUint64(entry.GetSequence()).
+		Build()
+	require.NoError(t, batch.SetProto(key, entry))
+	require.NoError(t, batch.Commit())
+}
+
+func transientProposal(seq uint64, ledger, account, asset string) *proposalpb.AppliedProposal {
+	return &proposalpb.AppliedProposal{
+		Sequence: seq,
+		TransientVolumes: map[string]*proposalpb.TouchedVolumeList{
+			ledger: {Volumes: []*commonpb.TouchedVolume{{Account: account, Asset: asset}}},
+		},
+	}
+}
+
+// TestCollectStoredTransientVolumes_SkipsArchivedAuditRange pins the scan's
+// lower bound: proposals at or below the archived audit boundary are outside
+// the replay's derivation window and must not enter the stored exclusion set.
+func TestCollectStoredTransientVolumes_SkipsArchivedAuditRange(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeAppliedProposal(t, store, transientProposal(1, "L", "t:below", "USD"))
+	writeAppliedProposal(t, store, transientProposal(2, "L", "t:boundary", "USD"))
+	writeAppliedProposal(t, store, transientProposal(3, "L", "t:above", "USD"))
+
+	checker := NewChecker(store, nil, "test-cluster", nil, nil, nil, logging.Testing())
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = handle.Close() }()
+
+	var got []string
+
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 2,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:above"}, got,
+		"rows at or below the archived audit boundary must be skipped")
+
+	got = nil
+	require.NoError(t, checker.collectStoredTransientVolumes(context.Background(), handle, 0,
+		func(_, account, _, _ string) {
+			got = append(got, account)
+		}))
+	require.Equal(t, []string{"t:below", "t:boundary", "t:above"}, got,
+		"without archived chapters the scan stays unbounded")
+}
+
+// TestCheck_RetainedTransientRecordsBelowArchiveBoundary is the model-test
+// regression: a restore re-ingests the backfilled archived ranges — including
+// AppliedProposal rows carrying TransientVolumes — and never re-purges them.
+// The replay skips the matching logs (seq <= archiveEndSeq), so deriving
+// nothing for them is correct; the stored side must skip the same window or a
+// healthy restored store reports EXCLUSION_RECORD_MISMATCH for every
+// transient account used before the archival.
+func TestCheck_RetainedTransientRecordsBelowArchiveBoundary(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestEngine(t)
+	engine.processAndCommit(createLedgerOrder("test"))
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "alice", "USD", 100)))
+
+	handle, err := engine.store.NewReadHandle()
+	require.NoError(t, err)
+
+	lastLog, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+
+	lastAudit, err := query.ReadLastAuditSequence(handle)
+	require.NoError(t, err)
+
+	// The boundary-time baseline snapshot, as chapter close writes it — without
+	// it Check() skips entry-by-entry verification entirely under archiving.
+	baselinePath, err := engine.store.BaselineSnapshotDir()
+	require.NoError(t, err)
+	require.NoError(t, attributes.CreateBaselineSnapshot(handle, baselinePath))
+	require.NoError(t, handle.Close())
+
+	// The transient record lives in the range about to be marked archived,
+	// exactly as a backfilled restore retains it.
+	writeAppliedProposal(t, engine.store, transientProposal(1, "test", "t:42", "USD"))
+
+	// Post-boundary activity so the replay window is non-empty.
+	engine.processAndCommit(createTransactionOrder("test", false,
+		newPosting("world", "bob", "USD", 5)))
+
+	batch := engine.store.OpenWriteSession()
+	require.NoError(t, state.StoreChapter(batch, &commonpb.Chapter{
+		Id:                 1,
+		Status:             commonpb.ChapterStatus_CHAPTER_ARCHIVED,
+		StartSequence:      1,
+		CloseSequence:      lastLog.GetSequence(),
+		StartAuditSequence: 1,
+		CloseAuditSequence: lastAudit,
+	}))
+	require.NoError(t, batch.Commit())
+
+	for _, e := range collectCheckErrors(t, engine.store, engine.attrs) {
+		require.NotEqual(t,
+			servicepb.CheckStoreErrorType_CHECK_STORE_ERROR_TYPE_EXCLUSION_RECORD_MISMATCH,
+			e.GetErrorType(),
+			"retained sub-boundary exclusion records must not be reported: %s", e.GetMessage())
+	}
+}


### PR DESCRIPTION
## What changed

The checker's stored-exclusion scan is bounded to the archived audit boundary: AppliedProposal transient/purged rows at or below the boundary no longer enter the stored exclusion set.

## Why

Jira: EN-1903 (possibly related: EN-1329). The replay side derives exclusions only past the archive, so a store with pre-archive transient traffic could fail its own consistency check after a segment-level restore — a checker false positive, not data corruption.

## Product / operational motivation

N/A (bug fix)

## Technical decision

N/A

## Risk

**LOW** — checker-only change; no server write path touched.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `checker_exclusion_archived_test.go` pins the boundary (the pre-fix code does not compile against it).
- [x] Full `internal/application/check` package suite green.
- No red e2e is possible: a live node keeps both exclusion derivations consistent (verified empirically green-on-old); the divergence needs a raw-segment restore the e2e harness cannot stage.

## Architecture / behavior impact

N/A

## Review focus

That the boundary comparison matches the replay side's archive cutoff exactly — off-by-one here would just move the false positive.

## Known concerns

None
