### PR TITLE
fix(EN-1724): bind declared metadata types to index versions

### DIFF
--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -90,7 +90,7 @@ flowchart TB
 
 ### Dual-write while a rewrite is in flight
 
-When `IndexVersionState.PendingVersion != 0`, metadata-index handlers go through `dualWriteMetadataIndex` (`builder.go:194-226`) and write the **same encoded value** to **both** `v_current` and `v_pending` keyspaces. The encoding always uses the **current declared type** in `LedgerInfo` — which, during a `SetMetadataFieldType` rewrite, is already the *new* type (the FSM has applied the schema change before the indexer dispatches the log). The two versions differ only by the version embedded in their keys, not by the encoding of the value.
+When `IndexVersionState.PendingVersion != 0`, metadata-index handlers go through `dualWriteMetadataIndex` (`builder.go`) and write to **both** `v_current` and `v_pending` keyspaces, encoding the value once per version under **that version's bound type** (`coerceForVersion`): `v_current` rows keep `CurrentType`'s encoding, `v_pending` rows carry `PendingType` — the retype's target (EN-1724). During a retype the two versions therefore differ both by the version embedded in their keys and by the encoding of the value; the per-version binding is what keeps `v_current`'s view complete and correctly typed until the atomic switch. The `CreatedIndexLog` itself carries the first version's binding (`bound_type`, stamped by the FSM at mint time), so a replica folding it at any replay distance binds the same type.
 
 This is what allows the atomic switch (see below) to flip the served version with zero rebuild cost at the moment of the switch — `v_pending` is already fully consistent with live writes by the time the rewrite cursor reaches the head. See the [Changing a Metadata Key's Type](#changing-a-metadata-keys-type-setmetadatafieldtype) section for the transient query semantics this design produces during the rewrite window.
 
@@ -184,14 +184,14 @@ The two paths use the **same** switch primitive but write **different** batches.
 
 **Index backfill path** (`internal/application/indexbuilder/backfill.go:1197+`, `completeBackfill`). There is no `v_old` keyspace to reclaim — the index has never been served before, the previous "version" is the empty sentinel `v=0`. The batch performs a single operation:
 
-1. `WriteIndexVersionState(batch, ledger, canonicalID, {Current: pending, Pending: 0, RewriteProgress: nil})` — flips the served version.
+1. `WriteIndexVersionState(batch, ledger, canonicalID, {Current: pending, Pending: 0, CurrentType: PendingType, RewriteProgress: nil})` — flips the served version and promotes the pending type binding with it.
 2. `batch.Commit()`.
 
 No `gcVersionAt` call is needed (and none is made — see the explicit comment in `backfill.go:1193-1196`).
 
 **Schema-rewrite path** (in `processSchemaRewrite`, around `backfill.go:855-864` and the deferred-switch path at `backfill.go:931-937`). The batch additionally reclaims the old keyspace:
 
-1. `WriteIndexVersionState(batch, ledger, canonicalID, {Current: pending, Pending: 0, RewriteProgress: nil})`.
+1. `WriteIndexVersionState(batch, ledger, canonicalID, {Current: pending, Pending: 0, CurrentType: PendingType, RewriteProgress: nil})`.
 2. `gcVersionAt(batch, old)` — `DeleteRange` over `MetadataIndexPrefixV(..., old)` and `EntityExistsKey…PrefixV(..., old)`, plus per-key reverse-map cleanup at `gcReverseMapVersion`. Immediate, in-batch, **not deferred**.
 3. `batch.Commit()`.
 
@@ -210,7 +210,7 @@ Re-typing a metadata key (e.g. `category: string → int`) is the most subtle pa
 1. **Admission** receives a `SetMetadataFieldTypeRequest` and emits a `SetMetadataFieldTypeOrder(target, key, type)` (`internal/application/admission/admission.go:1391-1405`). The admission layer preloads the current `MetadataID` (READY or BUILDING) so the FSM can read the prior schema state (`admission.go:995-1002`). **There is no pre-validation of value convertibility** — admission only validates the metadata key shape via `ValidateMetadataKey`.
 2. **FSM apply** updates the per-ledger schema in `LedgerInfo` and emits a `SetMetadataFieldType` audit log. The corresponding `Index.forward_encoding_version` is bumped (cluster-wide).
 3. **Indexer**, on the next tick, sees the log in `processLogs` and dispatches to `addSchemaRewriteTask` (`internal/application/indexbuilder/backfill.go:247+`). Two transitions happen in the same Pebble batch as the indexer's progress write:
-   - `bumpPendingVersion(ledger, indexID)` — sets `IndexVersionState.PendingVersion = max(pending, current) + 1` and persists it. In steady state this is `current + 1`; the `max(pending, …)` only matters when a second `SetMetadataFieldType` lands during an in-flight rewrite, in which case the version keeps climbing rather than being recycled.
+   - `bumpPendingVersion(ledger, indexID)` — sets `IndexVersionState.PendingVersion = max(pending, current) + 1`, binds `PendingType` to the retype's target, and persists it. In steady state this is `current + 1`; the `max(pending, …)` only matters when a second `SetMetadataFieldType` lands during an in-flight rewrite, in which case the version keeps climbing rather than being recycled.
    - A `schemaRewriteTask` is registered in memory with the target type, an empty reverse-map cursor, and `requiredIndexedSeq = 0`. The gate watermark is **not** sampled at task creation — it is sampled per batch later, see [below](#atomic-switch--and-why-it-is-gated).
 
 ### What runs during the rewrite — a state scan, not a log replay
@@ -222,9 +222,9 @@ Re-typing a metadata key (e.g. `category: string → int`) is the most subtle pa
 3. **Write to `v_pending`** via `ReplaceMetadataIndexV` (`backfill.go:781-787`): delete any prior `v_pending` forward-index + existence keys for that entity, write the new ones, update the reverse-map row at the pending version.
 4. **Persist the cursor** in the same batch as the writes, so a crash resumes from exactly the same reverse-map position.
 
-While this loop runs, new `SavedMetadata` / `DeletedMetadata` logs continue to land in `processLogs`. The handlers detect `PendingVersion != 0` and dual-write the **same encoded value** to both `v_current` and `v_pending` — the encoding always uses the current declared type, which by the time the indexer sees these logs is already the *new* type. The rewrite never has to "catch up" to live writes — they keep `v_pending` fresh autonomously.
+While this loop runs, new `SavedMetadata` / `DeletedMetadata` logs continue to land in `processLogs`. The handlers detect `PendingVersion != 0` and dual-write, encoding each value once per version under that version's bound type — `v_current` under `CurrentType` (the old declared type), `v_pending` under `PendingType` (the retype's target). The rewrite never has to "catch up" to live writes — they keep `v_pending` fresh autonomously.
 
-> **Consequence — transient query semantics during a rewrite.** Queries continue to scan `v_current` (the gate `requireIndexReady` at `query/compile.go:1319+` returns `CurrentVersion`), and the query parameter is encoded under the *current* declared type. Pre-existing rows in `v_current` that the rewrite has not yet touched are still encoded under the *old* type, so they are **invisible to queries** during the rewrite window. New writes post-`SetMetadataFieldType` land in `v_current` under the new type (via the dual-write) and remain visible. After the atomic switch, queries land on `v_pending`, which is fully re-encoded under the new type — visibility is restored uniformly. This is the only window where queries can see a degraded view of an index, and it is the price the design pays to avoid log-replay machinery in the rewrite path.
+> **Consequence — query semantics during a rewrite.** Queries continue to scan `v_current` (the gate `requireIndexReady` returns `CurrentVersion`), and the query condition is validated and encoded under `CurrentType` — the type `v_current`'s rows actually carry, which during the window is still the *old* declared type. The old view stays complete and correctly typed for the whole rewrite: pre-existing rows and post-retype live writes alike are served under the old semantics (live writes are dual-written into `v_current` under `CurrentType`). After the atomic switch, queries land on `v_pending`'s keyspace, fully encoded under the retype's target, and the new declared type becomes visible atomically with it (EN-1724).
 
 > **Design note — why not bound the rewrite to the log that triggered it?**
 > A possible alternative design is to bound the scan at the log sequence of the `SetMetadataFieldType` log itself and rely entirely on the dual-write path for everything that comes after. The current code does *not* do that: because step 2 reads the **latest** stored value from the FSM rather than reconstructing the value at the triggering sequence, a row written to `v_pending` may reflect a state newer than the triggering log. This trades off an extra consistency gate at the end (next section) for a much simpler scan loop — no per-row "what was this value at sequence S?" reconstruction, no replay machinery. The gate makes that trade safe.

--- a/docs/technical/architecture/subsystems/indexer/indexes.md
+++ b/docs/technical/architecture/subsystems/indexer/indexes.md
@@ -32,23 +32,40 @@ Build progress is deliberately absent from the registry row: it is a per-replica
 
 ```go
 type IndexVersionState struct {
-    CurrentVersion  uint32 // version actually served by queries; 0 = not built locally
-    PendingVersion  uint32 // target of an in-flight rewrite; 0 = no rewrite running
-    RewriteProgress []byte // opaque cursor for the in-flight rewrite
+    CurrentVersion     uint32 // version actually served by queries; 0 = not built locally
+    PendingVersion     uint32 // target of an in-flight rewrite; 0 = no rewrite running
+    ActivationSequence uint64 // log sequence CurrentVersion's keyspace became complete at; 0 = resolvable at any pin
+    RewriteProgress    []byte // opaque cursor for the in-flight rewrite
+    HighWater          uint32 // highest version ever allocated locally — version numbers are single-use; survives a drop as the tombstone
+
+    CurrentType         commonpb.MetadataType // declared type CurrentVersion's rows are encoded under (EN-1724)
+    CurrentTypeDeclared bool                  // false = bound to no declared type; rows keep each value's natural encoding
+    PendingType         commonpb.MetadataType // the retype's target: the type PendingVersion's rows are encoded under
+    PendingTypeDeclared bool
 }
 ```
 
-Source: `internal/storage/readstore/store.go:339-353`.
+Source: `type IndexVersionState` in `internal/storage/readstore/store.go`.
+
+The type bindings are what keep a retype invisible until the atomic switch: the
+declared schema flips at FSM apply, but a query serves `CurrentVersion` and
+must validate and encode its conditions under the type those rows actually
+carry. The switch promotes `PendingType` into `CurrentType` together with the
+version — binding and keyspace flip as one.
 
 ### Storage encoding
 
-Fixed 4 B big-endian for each version, followed by the variable-length opaque progress cursor:
+Fixed 22 B header, followed by the variable-length opaque progress cursor:
 
 ```
-[ current_version (4B BE) ][ pending_version (4B BE) ][ rewrite_progress … ]
+[ current_version (4B BE) ][ pending_version (4B BE) ][ activation_sequence (8B BE) ][ high_water (4B BE) ][ current_type (1B) ][ pending_type (1B) ][ rewrite_progress … ]
 ```
 
-`encodeIndexVersionState` / `decodeIndexVersionState`: `internal/storage/readstore/store.go:364-391`.
+A type byte holds `0` for "no declared type bound" and `1 + MetadataType`
+otherwise, keeping undeclared distinct from `METADATA_TYPE_STRING` (enum
+value 0).
+
+`encodeIndexVersionState` / `decodeIndexVersionState`: `internal/storage/readstore/store.go`.
 
 ### Versioned keyspace
 

--- a/internal/application/ctrl/list_entities.go
+++ b/internal/application/ctrl/list_entities.go
@@ -39,7 +39,7 @@ type entityListParams[T interface{ ~string | ~uint64 }] struct {
 	indexRegistry indexes.Lookup
 	// indexVersionFor is filled in by listEntities (bound to the
 	// iteration snapshot); leaf compilers should never see a nil here.
-	indexVersionFor func(canonical string) (uint32, bool, error)
+	indexVersionFor readstore.IndexVersionResolver
 	// afterToBytes converts the after cursor to a byte slice for pagination.
 	afterToBytes func(T) []byte
 	// pin is filled in by listEntities: the main handle's applied sequence,

--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -274,7 +274,7 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 			continue
 		}
 
-		if err := b.bumpPendingVersion(ledgerName, indexID); err != nil {
+		if err := b.bumpPendingVersion(ledgerName, indexID, smft.GetType()); err != nil {
 			return fmt.Errorf("bumping pending_version on retype during backfill: %w", err)
 		}
 
@@ -294,6 +294,7 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 			}).Errorf("Deleting persisted backfill cursor on retype reset")
 		}
 
+
 		return nil
 	}
 
@@ -308,7 +309,7 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 	// current batch. The rewrite task will read pending_version from
 	// the cache at processSchemaRewrite time to know its target
 	// keyspace, and the live write path will dual-write into it.
-	if err := b.bumpPendingVersion(ledgerName, indexID); err != nil {
+	if err := b.bumpPendingVersion(ledgerName, indexID, smft.GetType()); err != nil {
 		return fmt.Errorf("bumping pending_version on retype: %w", err)
 	}
 
@@ -357,17 +358,28 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 // Index.ForwardEncodingVersion in processSetMetadataFieldType — each
 // replica derives its own pending the same way, so the two converge as
 // long as every log is seen.
-func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexID) error {
+func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexID, toType commonpb.MetadataType) error {
 	canonical := indexes.Canonical(indexID)
-	current, pending := b.versionFor(ledgerName, canonical)
-
 	prior, _ := b.versionStateFor(ledgerName, canonical)
-	base := max(pending, current, prior.HighWater)
 
+	base := max(prior.PendingVersion, prior.CurrentVersion, prior.HighWater)
+
+	// CurrentVersion keeps everything that describes it: its activation
+	// sequence and its bound type both belong to the version still being
+	// served, and dropping them here would let a stale pin resolve the
+	// promoted keyspace as complete (activation) or re-encode live writes
+	// under the wrong type mid-window (bound type). Only the pending slot
+	// is new: the rewrite's target version, bound to the retype's target
+	// type, with a fresh cursor.
 	newState := readstore.IndexVersionState{
-		CurrentVersion: current,
-		PendingVersion: base + 1,
-		HighWater:      base + 1,
+		CurrentVersion:      prior.CurrentVersion,
+		PendingVersion:      base + 1,
+		ActivationSequence:  prior.ActivationSequence,
+		HighWater:           base + 1,
+		CurrentType:         prior.CurrentType,
+		CurrentTypeDeclared: prior.CurrentTypeDeclared,
+		PendingType:         toType,
+		PendingTypeDeclared: true,
 	}
 
 	batch := b.wb.Batch()
@@ -387,6 +399,7 @@ func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexI
 
 	return nil
 }
+
 
 // removeSchemaRewriteTask removes a schema rewrite task and deletes its persisted progress.
 func (b *Builder) removeSchemaRewriteTask(idx int) {
@@ -869,11 +882,14 @@ scan:
 			// tick via the scanComplete branch at the top of the function.
 			done = false
 		} else {
+			prior, _ := b.versionStateFor(task.ledger, canonical)
 			newState = readstore.IndexVersionState{
-				CurrentVersion:     pendingVersion,
-				PendingVersion:     0,
-				ActivationSequence: task.requiredIndexedSeq,
-				HighWater:          pendingVersion,
+				CurrentVersion:      pendingVersion,
+				PendingVersion:      0,
+				ActivationSequence:  task.requiredIndexedSeq,
+				HighWater:           pendingVersion,
+				CurrentType:         prior.PendingType,
+				CurrentTypeDeclared: prior.PendingTypeDeclared,
 			}
 
 			if err := b.readStore.WriteIndexVersionState(batch, task.ledger, canonical, newState); err != nil {
@@ -947,11 +963,14 @@ func (b *Builder) tryCommitScanCompleteSwitch(
 		}
 	}()
 
+	prior, _ := b.versionStateFor(task.ledger, canonical)
 	newState := readstore.IndexVersionState{
-		CurrentVersion:     pendingVersion,
-		PendingVersion:     0,
-		ActivationSequence: task.requiredIndexedSeq,
-		HighWater:          pendingVersion,
+		CurrentVersion:      pendingVersion,
+		PendingVersion:      0,
+		ActivationSequence:  task.requiredIndexedSeq,
+		HighWater:           pendingVersion,
+		CurrentType:         prior.PendingType,
+		CurrentTypeDeclared: prior.PendingTypeDeclared,
 	}
 
 	if err := b.readStore.WriteIndexVersionState(batch, task.ledger, canonical, newState); err != nil {
@@ -1233,10 +1252,13 @@ func (b *Builder) completeBackfill(task *backfillTask) error {
 			task.ledger, canonical)
 	}
 
+	prior, _ := b.versionStateFor(task.ledger, canonical)
 	newState := readstore.IndexVersionState{
-		CurrentVersion: pending,
-		PendingVersion: 0,
-		HighWater:      pending,
+		CurrentVersion:      pending,
+		PendingVersion:      0,
+		HighWater:           pending,
+		CurrentType:         prior.PendingType,
+		CurrentTypeDeclared: prior.PendingTypeDeclared,
 	}
 
 	batch := b.readStore.NewBatch()

--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -415,9 +415,10 @@ func (b *Builder) removeSchemaRewriteTask(idx int) {
 // reached the atomic switch on this replica when it stopped; the
 // dual-write path was active, and v_pending was being populated. The
 // resumed task carries the same target keyspace (read from the cache),
-// the rmap cursor and the new declared_type (read from the persisted
-// BackfillCursor written at the previous batch), and continues the
-// rmap scan from where it left off.
+// the new declared_type (IndexVersionState.PendingType — the value the
+// atomic switch will promote into CurrentType) and the rmap cursor
+// (read from the persisted BackfillCursor written at the previous
+// batch), and continues the rmap scan from where it left off.
 func (b *Builder) scheduleResumedRewrites() {
 	for ledgerName, inner := range b.indexVersions {
 		cfg := b.ledgerConfig(ledgerName)
@@ -455,28 +456,33 @@ func (b *Builder) scheduleResumedRewrites() {
 
 			rawCursor, hasCursor := b.readStore.ReadBackfillCursor(bbKey)
 
-			var (
-				toType     commonpb.MetadataType
-				rmapCursor []byte
-				haveType   bool
-			)
+			// The persisted IndexVersionState is the authority on the
+			// pending version's bound type: bumpPendingVersion commits
+			// PendingType in the same batch that enqueues the rewrite,
+			// and the atomic switch copies it into CurrentType — so the
+			// rewrite must encode v_pending under exactly this type.
+			toType := state.PendingType
+
+			var rmapCursor []byte
 
 			if hasCursor && len(rawCursor) >= 1 {
-				toType = commonpb.MetadataType(rawCursor[0])
-				haveType = true
-
-				if len(rawCursor) > 1 {
+				// The cursor's leading type byte is a cross-check: it
+				// commits in the same batch as the version state, so a
+				// mismatch means corrupted persisted artifacts. The scan
+				// then restarts from zero under the authoritative type —
+				// resuming would extend a keyspace half-encoded under
+				// another one.
+				if got := commonpb.MetadataType(rawCursor[0]); got != state.PendingType {
+					b.logger.WithFields(map[string]any{
+						"ledger":      ledgerName,
+						"key":         key,
+						"cursorType":  got.String(),
+						"pendingType": state.PendingType.String(),
+					}).Errorf("invariant: resumed rewrite cursor type disagrees with IndexVersionState.PendingType")
+				} else if len(rawCursor) > 1 {
 					rmapCursor = make([]byte, len(rawCursor)-1)
 					copy(rmapCursor, rawCursor[1:])
 				}
-			}
-
-			// If no persisted cursor (the rewrite had been enqueued
-			// but never ran a batch), source toType from the FSM —
-			// the latest SetMetadataFieldType committed it as the
-			// field's declared type before the pending bump landed.
-			if !haveType {
-				toType = b.resolveResumedToType(ledgerName, target, key)
 			}
 
 			b.schemaRewriteTasks = append(b.schemaRewriteTasks, &schemaRewriteTask{
@@ -497,45 +503,6 @@ func (b *Builder) scheduleResumedRewrites() {
 			}).Infof("Resumed in-flight schema rewrite from persisted state")
 		}
 	}
-}
-
-// resolveResumedToType reads the declared_type for a metadata field
-// from the FSM-side LedgerInfo.MetadataSchema. Used at boot when the
-// resumed rewrite has no persisted toType byte (because the task was
-// enqueued but never ran a batch). Falls back to the zero
-// MetadataType (STRING) if the FSM has no entry — pathological but
-// safe: the rewrite will treat existing rmap entries as already at
-// the declared type, run an idempotent re-encode, and reach the
-// atomic switch with no functional damage.
-func (b *Builder) resolveResumedToType(ledgerName string, target commonpb.TargetType, key string) commonpb.MetadataType {
-	handle, err := b.pebbleStore.NewDirectReadHandle()
-	if err != nil {
-		return commonpb.MetadataType_METADATA_TYPE_STRING
-	}
-
-	defer func() { _ = handle.Close() }()
-
-	info, err := query.GetLedgerByName(context.Background(), handle, ledgerName)
-	if err != nil || info == nil || info.GetMetadataSchema() == nil {
-		return commonpb.MetadataType_METADATA_TYPE_STRING
-	}
-
-	var fields map[string]*commonpb.MetadataFieldSchema
-
-	switch target {
-	case commonpb.TargetType_TARGET_TYPE_ACCOUNT:
-		fields = info.GetMetadataSchema().GetAccountFields()
-	case commonpb.TargetType_TARGET_TYPE_TRANSACTION:
-		fields = info.GetMetadataSchema().GetTransactionFields()
-	default:
-		return commonpb.MetadataType_METADATA_TYPE_STRING
-	}
-
-	if schema, ok := fields[key]; ok {
-		return schema.GetType()
-	}
-
-	return commonpb.MetadataType_METADATA_TYPE_STRING
 }
 
 // removeSchemaRewriteTaskByField cancels any in-flight rewrite task matching

--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -294,7 +294,6 @@ func (b *Builder) addSchemaRewriteTask(cfg *ledgerIndexConfig, ledgerName string
 			}).Errorf("Deleting persisted backfill cursor on retype reset")
 		}
 
-
 		return nil
 	}
 
@@ -399,7 +398,6 @@ func (b *Builder) bumpPendingVersion(ledgerName string, indexID *commonpb.IndexI
 
 	return nil
 }
-
 
 // removeSchemaRewriteTask removes a schema rewrite task and deletes its persisted progress.
 func (b *Builder) removeSchemaRewriteTask(idx int) {

--- a/internal/application/indexbuilder/backfill_test.go
+++ b/internal/application/indexbuilder/backfill_test.go
@@ -1949,9 +1949,9 @@ func TestAccountAssetBackfillLifecycle(t *testing.T) {
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
 	b.wb.SetEventSequence(1)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
 		Id: indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET),
-	})
+	}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Len(t, b.backfillTasks, 1, "CreateIndex must schedule one account-asset backfill task")
@@ -2034,9 +2034,9 @@ func TestAccountAssetBackfillWipesDeletedLedgerGeneration(t *testing.T) {
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
 	b.wb.SetEventSequence(1)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
 		Id: indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET),
-	})
+	}))
 	require.NoError(t, b.wb.Flush())
 	require.Len(t, b.backfillTasks, 1, "CreateIndex must schedule one account-asset backfill task")
 
@@ -2174,9 +2174,9 @@ func runAccountAssetBackfill(t *testing.T, b *Builder, ledger string, globalCurs
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
 	b.wb.SetEventSequence(1)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
 		Id: indexes.AccountBuiltinID(commonpb.AccountBuiltinIndex_ACCT_BUILTIN_INDEX_ASSET),
-	})
+	}))
 	require.NoError(t, b.wb.Flush())
 
 	b.backfillBudget = time.Second
@@ -2289,9 +2289,9 @@ func TestMetadataBackfillSkipsForeignLedgerLogs(t *testing.T) {
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
 	b.wb.SetEventSequence(1)
-	b.handleCreatedIndexLog(taskLedger, &commonpb.CreatedIndexLog{
+	require.NoError(t, b.handleCreatedIndexLog(taskLedger, &commonpb.CreatedIndexLog{
 		Id: indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey),
-	})
+	}))
 	require.NoError(t, b.wb.Flush())
 	require.Len(t, b.backfillTasks, 1, "CreateIndex must schedule one metadata backfill task")
 

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -121,6 +121,19 @@ type Builder struct {
 // (0, 0) to "version 1" via effectiveCurrentVersion below because
 // Index.ForwardEncodingVersion is initialised to 1 at CreateIndex /
 // first SetMetadataFieldType apply.
+// versionStateFor returns the full cached per-replica version state for an
+// index, false when this replica has never written one.
+func (b *Builder) versionStateFor(ledgerName, canonicalID string) (readstore.IndexVersionState, bool) {
+	inner, ok := b.indexVersions[ledgerName]
+	if !ok {
+		return readstore.IndexVersionState{}, false
+	}
+
+	state, ok := inner[canonicalID]
+
+	return state, ok
+}
+
 func (b *Builder) versionFor(ledgerName, canonicalID string) (current uint32, pending uint32) {
 	if b.indexVersions == nil {
 		return 0, 0
@@ -184,19 +197,6 @@ func (b *Builder) tombstoneVersionState(ledgerName, canonicalID string) error {
 	b.putVersionState(ledgerName, canonicalID, tomb)
 
 	return nil
-}
-
-// versionStateFor returns the full cached per-replica version state for an
-// index, false when this replica has never written one.
-func (b *Builder) versionStateFor(ledgerName, canonicalID string) (readstore.IndexVersionState, bool) {
-	inner, ok := b.indexVersions[ledgerName]
-	if !ok {
-		return readstore.IndexVersionState{}, false
-	}
-
-	state, ok := inner[canonicalID]
-
-	return state, ok
 }
 
 // effectiveCurrentVersion returns the forward-encoding version live
@@ -264,22 +264,67 @@ func (b *Builder) dualWriteMetadataIndex(
 	kb *dal.KeyBuilder,
 	ledger, ns, metaKey string,
 	target commonpb.TargetType,
-	newEncoded, entityID []byte,
+	value *commonpb.MetadataValue,
+	entityID []byte,
 	rmapKeyAtVersion reverseKeyForVersion,
 ) error {
 	current, pending := b.metadataIndexVersions(ledger, target, metaKey)
 
-	if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, current, newEncoded, entityID, rmapKeyAtVersion(current)); err != nil {
+	if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, target, current, value, entityID, rmapKeyAtVersion(current)); err != nil {
 		return err
 	}
 
 	if pending != 0 && pending != current {
-		if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, pending, newEncoded, entityID, rmapKeyAtVersion(pending)); err != nil {
+		if err := b.writeMetadataIndexAtVersion(kb, ledger, ns, metaKey, target, pending, value, entityID, rmapKeyAtVersion(pending)); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// coerceForVersion coerces a metadata value under the declared type BOUND to
+// the version being written, not the live schema. During a retype's
+// conversion window the two differ, and the difference is the point: rows at
+// v_current must keep the old type's encoding so queries served from it see
+// the complete old-typed index until the atomic switch, while v_pending rows
+// carry the retype's target (EN-1724). A version bound to no declared type
+// encodes each value verbatim, exactly as writes did before any declaration.
+func (b *Builder) coerceForVersion(ledger string, target commonpb.TargetType, key string, version uint32, v *commonpb.MetadataValue) (*commonpb.MetadataValue, error) {
+	canonical := indexes.Canonical(indexes.MetadataID(target, key))
+
+	state, ok := b.versionStateFor(ledger, canonical)
+	if !ok {
+		// No per-replica record: an index served at the promoted v1 that no
+		// rewrite has ever touched. The live declared type is the bound type.
+		return b.coerceForLedger(ledger, target, key, v)
+	}
+
+	switch {
+	case state.PendingVersion != 0 && version == state.PendingVersion:
+		return coerceToBound(v, state.PendingType, state.PendingTypeDeclared), nil
+	case version == state.CurrentVersion,
+		state.CurrentVersion == 0 && version == 1:
+		// The second arm is effectiveCurrentVersion's 0→1 promotion during a
+		// creation backfill whose pending is already past 1 — same binding.
+		return coerceToBound(v, state.CurrentType, state.CurrentTypeDeclared), nil
+	default:
+		// Versions come from the same state the caller consulted, so a write
+		// targeting one the state does not bind is a wiring bug; encoding it
+		// under a guessed type would plant a row no query interprets right.
+		return nil, fmt.Errorf("invariant: write at version %d of %s/%s, which the version state (current=%d pending=%d) does not bind",
+			version, ledger, canonical, state.CurrentVersion, state.PendingVersion)
+	}
+}
+
+// coerceToBound is CoerceToDeclaredType with the version-bound type standing
+// in for the schema lookup.
+func coerceToBound(v *commonpb.MetadataValue, t commonpb.MetadataType, declared bool) *commonpb.MetadataValue {
+	if !declared || v == nil || commonpb.TypeMatches(v, t) {
+		return v
+	}
+
+	return commonpb.ConvertMetadataValue(v, t)
 }
 
 // writeMetadataIndexAtVersion resolves the version-scoped reverse-map
@@ -290,9 +335,18 @@ func (b *Builder) dualWriteMetadataIndex(
 func (b *Builder) writeMetadataIndexAtVersion(
 	kb *dal.KeyBuilder,
 	ledger, ns, metaKey string,
+	target commonpb.TargetType,
 	version uint32,
-	newEncoded, entityID, reverseKey []byte,
+	value *commonpb.MetadataValue,
+	entityID, reverseKey []byte,
 ) error {
+	coerced, err := b.coerceForVersion(ledger, target, metaKey, version, value)
+	if err != nil {
+		return err
+	}
+
+	newEncoded := readstore.EncodeMetadataValue(nil, coerced)
+
 	oldEncoded, err := b.reverseMapValue(reverseKey)
 	if err != nil {
 		return err

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -253,13 +253,17 @@ type reverseKeyForVersion func(version uint32) []byte
 // in flight. rmapKeyAtVersion returns the reverse-map key the namespace
 // uses for a given version.
 //
-// On the encoding side, the value (newEncoded) is identical across
-// versions — the live path always coerces to the *current* declared
-// type. The rmap rows differ only by the version embedded in the key;
-// having distinct rows means a query at v_pending sees only entries
-// that were either backfilled by the rewrite OR mirrored here. Once
-// the rewrite finishes and the atomic switch flips current←pending,
-// the v_pending rows become the authoritative view.
+// Each write coerces the raw value to the type ITS version is bound to
+// (coerceForVersion in writeMetadataIndexAtVersion): v_current encodes
+// under CurrentType, v_pending under PendingType, so the two rows for
+// one value generally differ. That per-version encoding is what keeps
+// v_current's view complete and correctly typed while a retype is in
+// flight — queries serve v_current's semantics until the atomic switch.
+// The rmap rows differ by the version embedded in the key; having
+// distinct rows means a query at v_pending sees only entries that were
+// either backfilled by the rewrite OR mirrored here. Once the rewrite
+// finishes and the atomic switch flips current←pending, the v_pending
+// rows become the authoritative view.
 func (b *Builder) dualWriteMetadataIndex(
 	kb *dal.KeyBuilder,
 	ledger, ns, metaKey string,

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -400,6 +400,30 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // backfill scheduling so the builder does not redo work that has already
 // completed — and, more importantly, does not knock a live index back into
 // ErrIndexBuilding.
+// boundTypeAtCreation resolves the declared type an index's first version is
+// bound to: the schema entry in force when the CreateIndex log folds. Only
+// metadata indexes carry one; for every other kind — and for a key declared
+// after the index — the version is bound to no type and rows keep each
+// value's natural encoding.
+func (b *Builder) boundTypeAtCreation(ledgerName string, id *commonpb.IndexID) (commonpb.MetadataType, bool) {
+	meta, ok := id.GetKind().(*commonpb.IndexID_Metadata)
+	if !ok || meta.Metadata == nil || b.batchSchema == nil {
+		return 0, false
+	}
+
+	schema, err := b.batchSchema.For(ledgerName)
+	if err != nil || schema == nil {
+		return 0, false
+	}
+
+	_, fs := commonpb.SchemaFieldForTarget(schema, meta.Metadata.GetTarget(), meta.Metadata.GetKey())
+	if fs == nil {
+		return 0, false
+	}
+
+	return fs.GetType(), true
+}
+
 func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.CreatedIndexLog) {
 	id := log.GetId()
 	if id == nil {
@@ -442,10 +466,13 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	next := prior.HighWater + 1
 
 	if log.GetInitial() {
+		boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 		state := readstore.IndexVersionState{
-			CurrentVersion: next,
-			PendingVersion: 0,
-			HighWater:      next,
+			CurrentVersion:      next,
+			PendingVersion:      0,
+			HighWater:           next,
+			CurrentType:         boundType,
+			CurrentTypeDeclared: declared,
 		}
 
 		if b.wb != nil && b.readStore != nil {
@@ -473,10 +500,13 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	// boot recovery would otherwise have to guess from cfg.byCanonical
 	// alone, which loses the distinction between "fresh index" and
 	// "stale READY index from a snapshot install".
+	boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 	state := readstore.IndexVersionState{
-		CurrentVersion: 0,
-		PendingVersion: next,
-		HighWater:      next,
+		CurrentVersion:      0,
+		PendingVersion:      next,
+		HighWater:           next,
+		PendingType:         boundType,
+		PendingTypeDeclared: declared,
 	}
 
 	if b.wb != nil && b.readStore != nil {

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -109,9 +109,9 @@ func (b *Builder) initIndexConfig(ctx context.Context) error {
 	// built v_current at some point) gets a schemaRewriteTask. The
 	// atomic switch hasn't fired yet on this replica, so v_current
 	// keeps serving queries while the rewrite catches up and v_pending
-	// receives the new keyspace. Cursor and toType come from the
-	// persisted BackfillCursor — the rewrite resumes mid-rmap-scan
-	// instead of restarting from scratch.
+	// receives the new keyspace. toType comes from the version state's
+	// PendingType, the cursor from the persisted BackfillCursor — the
+	// rewrite resumes mid-rmap-scan instead of restarting from scratch.
 	b.scheduleResumedRewrites()
 
 	// Crash-recovery sweep: the atomic switch GCs v_old in the same
@@ -400,34 +400,10 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // backfill scheduling so the builder does not redo work that has already
 // completed — and, more importantly, does not knock a live index back into
 // ErrIndexBuilding.
-// boundTypeAtCreation resolves the declared type an index's first version is
-// bound to: the schema entry in force when the CreateIndex log folds. Only
-// metadata indexes carry one; for every other kind — and for a key declared
-// after the index — the version is bound to no type and rows keep each
-// value's natural encoding.
-func (b *Builder) boundTypeAtCreation(ledgerName string, id *commonpb.IndexID) (commonpb.MetadataType, bool) {
-	meta, ok := id.GetKind().(*commonpb.IndexID_Metadata)
-	if !ok || meta.Metadata == nil || b.batchSchema == nil {
-		return 0, false
-	}
-
-	schema, err := b.batchSchema.For(ledgerName)
-	if err != nil || schema == nil {
-		return 0, false
-	}
-
-	_, fs := commonpb.SchemaFieldForTarget(schema, meta.Metadata.GetTarget(), meta.Metadata.GetKey())
-	if fs == nil {
-		return 0, false
-	}
-
-	return fs.GetType(), true
-}
-
-func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.CreatedIndexLog) {
+func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.CreatedIndexLog) error {
 	id := log.GetId()
 	if id == nil {
-		return
+		return nil
 	}
 
 	cfg := b.getOrCreateLedgerConfig(ledgerName)
@@ -441,14 +417,14 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	// loadIndexRegistry boot guard and covers both the EN-1564 initial fast
 	// path and the normal post-backfill live state.
 	if current, pending := b.versionFor(ledgerName, indexes.Canonical(id)); current != 0 {
-		return
+		return nil
 	} else if pending != 0 {
 		// A build for this incarnation is already in flight: the running
 		// backfill fills that pending version and will promote it. Allocating
 		// a fresh number here would orphan the half-built keyspace while the
 		// task's caught-up cursor promotes the never-filled replacement — a
 		// permanently empty index. The duplicate create is a no-op.
-		return
+		return nil
 	}
 
 	cfg.byCanonical[indexes.Canonical(id)] = &commonpb.Index{
@@ -465,8 +441,14 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	prior, _ := b.versionStateFor(ledgerName, indexes.Canonical(id))
 	next := prior.HighWater + 1
 
+	// The first version binds to the declared type stamped into the log by
+	// the FSM at mint time — the schema entry in force at exactly this log's
+	// sequence. A local schema read here could not reproduce that: the
+	// readable schema is batch-final at best and arbitrarily far ahead when
+	// the log folds during a backfill or a rebuild replay.
+	boundType, declared := log.GetBoundType(), log.GetBoundTypeDeclared()
+
 	if log.GetInitial() {
-		boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 		state := readstore.IndexVersionState{
 			CurrentVersion:      next,
 			PendingVersion:      0,
@@ -478,18 +460,14 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 		if b.wb != nil && b.readStore != nil {
 			if batch := b.wb.Batch(); batch != nil {
 				if err := b.readStore.WriteIndexVersionState(batch, ledgerName, indexes.Canonical(id), state); err != nil {
-					b.logger.WithFields(map[string]any{
-						"ledger": ledgerName,
-						"index":  indexes.Canonical(id),
-						"error":  err,
-					}).Errorf("Persisting IndexVersionState on initial CreateIndex")
+					return fmt.Errorf("persisting IndexVersionState on initial CreateIndex: %w", err)
 				}
 			}
 		}
 
 		b.putVersionState(ledgerName, indexes.Canonical(id), state)
 
-		return
+		return nil
 	}
 
 	// First time this replica sees the index: target v=1 via the
@@ -500,7 +478,6 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	// boot recovery would otherwise have to guess from cfg.byCanonical
 	// alone, which loses the distinction between "fresh index" and
 	// "stale READY index from a snapshot install".
-	boundType, declared := b.boundTypeAtCreation(ledgerName, id)
 	state := readstore.IndexVersionState{
 		CurrentVersion:      0,
 		PendingVersion:      next,
@@ -512,11 +489,7 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	if b.wb != nil && b.readStore != nil {
 		if batch := b.wb.Batch(); batch != nil {
 			if err := b.readStore.WriteIndexVersionState(batch, ledgerName, indexes.Canonical(id), state); err != nil {
-				b.logger.WithFields(map[string]any{
-					"ledger": ledgerName,
-					"index":  indexes.Canonical(id),
-					"error":  err,
-				}).Errorf("Persisting IndexVersionState on CreateIndex")
+				return fmt.Errorf("persisting IndexVersionState on CreateIndex: %w", err)
 			}
 		}
 	}
@@ -524,6 +497,8 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 	b.putVersionState(ledgerName, indexes.Canonical(id), state)
 
 	b.scheduleBackfillForIndex(ledgerName, id)
+
+	return nil
 }
 
 // handleDroppedIndexLog updates the index config cache when a DropIndex log

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -117,7 +117,7 @@ func TestHandleCreatedIndexLog(t *testing.T) {
 
 			b := &Builder{indexConfig: make(map[string]*ledgerIndexConfig)}
 
-			b.handleCreatedIndexLog("ledger1", &commonpb.CreatedIndexLog{Id: tt.id})
+			require.NoError(t, b.handleCreatedIndexLog("ledger1", &commonpb.CreatedIndexLog{Id: tt.id}))
 
 			cfg := b.indexConfig["ledger1"]
 			require.NotNil(t, cfg)
@@ -144,7 +144,7 @@ func TestHandleDroppedIndexLog(t *testing.T) {
 	defer func() { _ = batch.Cancel() }()
 	b.initBatch(batch)
 
-	b.handleCreatedIndexLog("ledger1", &commonpb.CreatedIndexLog{Id: id})
+	require.NoError(t, b.handleCreatedIndexLog("ledger1", &commonpb.CreatedIndexLog{Id: id}))
 	require.Len(t, b.backfillTasks, 1)
 	assert.True(t, b.indexConfig["ledger1"].isIndexed(id))
 
@@ -962,11 +962,15 @@ func TestInitIndexConfig_ResumesRewriteFromPendingVersion(t *testing.T) {
 	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
 
 	// Persist the in-flight version state: current=1 (serving
-	// queries), pending=2 (rewrite that didn't finish).
+	// queries), pending=2 (rewrite that didn't finish), bound to the
+	// retype's target type — bumpPendingVersion commits PendingType in
+	// the same batch, and the resume path reads the type from here.
 	stateBatch := b.readStore.NewBatch()
 	require.NoError(t, b.readStore.WriteIndexVersionState(stateBatch, ledger, canonical, readstore.IndexVersionState{
-		CurrentVersion: 1,
-		PendingVersion: 2,
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		PendingTypeDeclared: true,
 	}))
 	require.NoError(t, stateBatch.Commit())
 
@@ -1020,6 +1024,111 @@ func TestInitIndexConfig_ResumesRewriteFromPendingVersion(t *testing.T) {
 	current, pending := b.versionFor(ledger, canonical)
 	assert.Equal(t, uint32(1), current)
 	assert.Equal(t, uint32(2), pending)
+}
+
+// TestInitIndexConfig_ResumeBeforeFirstBatch_TypeFromVersionState pins the
+// crash window between the pending-state commit and the rewrite's first
+// batch: no BackfillCursor exists yet, and the resumed task's toType must
+// come from IndexVersionState.PendingType — the value the atomic switch
+// will promote into CurrentType. The FSM schema is deliberately left
+// undeclared: a fallback that guesses from an empty or failed schema read
+// comes back STRING, and the promoted version then advertises a type its
+// rows were never encoded under — every typed row silently out of range.
+func TestInitIndexConfig_ResumeBeforeFirstBatch_TypeFromVersionState(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.logger = noopLogger{}
+
+	const (
+		ledger = "customer"
+		key    = "score"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
+	canonical := indexes.Canonical(id)
+
+	stateBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteIndexVersionState(stateBatch, ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		PendingTypeDeclared: true,
+	}))
+	require.NoError(t, stateBatch.Commit())
+
+	fsmBatch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(fsmBatch, ledger, &commonpb.LedgerInfo{Name: ledger}))
+	indexKey := domain.IndexKey{LedgerName: ledger, Canonical: canonical}.Bytes()
+	_, err := b.attrs.Index.Set(fsmBatch, indexKey, &commonpb.Index{
+		Ledger:                 ledger,
+		Id:                     id,
+		ForwardEncodingVersion: 2,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fsmBatch.Commit())
+
+	require.NoError(t, b.initIndexConfig(context.Background()))
+
+	require.Len(t, b.schemaRewriteTasks, 1)
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, b.schemaRewriteTasks[0].toType)
+	assert.Nil(t, b.schemaRewriteTasks[0].rmapCursor)
+}
+
+// TestInitIndexConfig_ResumeCursorTypeMismatch_RestartsUnderPendingType pins
+// the cross-check on the cursor's leading type byte: it commits in the same
+// batch as the version state, so a disagreement means corrupted persisted
+// artifacts. The resume keeps the authoritative PendingType and drops the
+// cursor — the scan restarts from zero under the type the atomic switch will
+// promote.
+func TestInitIndexConfig_ResumeCursorTypeMismatch_RestartsUnderPendingType(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.logger = noopLogger{}
+
+	const (
+		ledger = "customer"
+		key    = "score"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
+	canonical := indexes.Canonical(id)
+
+	stateBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteIndexVersionState(stateBatch, ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		PendingTypeDeclared: true,
+	}))
+	require.NoError(t, stateBatch.Commit())
+
+	rewriteBBKey := schemaRewriteBBKey(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
+	val := append([]byte{byte(commonpb.MetadataType_METADATA_TYPE_STRING)}, []byte("mid-rewrite-cursor")...)
+
+	cursorBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteBackfillCursor(cursorBatch, rewriteBBKey, val))
+	require.NoError(t, cursorBatch.Commit())
+
+	fsmBatch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(fsmBatch, ledger, &commonpb.LedgerInfo{Name: ledger}))
+	indexKey := domain.IndexKey{LedgerName: ledger, Canonical: canonical}.Bytes()
+	_, err := b.attrs.Index.Set(fsmBatch, indexKey, &commonpb.Index{
+		Ledger:                 ledger,
+		Id:                     id,
+		ForwardEncodingVersion: 2,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fsmBatch.Commit())
+
+	require.NoError(t, b.initIndexConfig(context.Background()))
+
+	require.Len(t, b.schemaRewriteTasks, 1)
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, b.schemaRewriteTasks[0].toType,
+		"IndexVersionState.PendingType is the authority, never the cursor byte")
+	assert.Nil(t, b.schemaRewriteTasks[0].rmapCursor,
+		"a mismatched cursor is discarded so the scan restarts from zero")
 }
 
 // noopLogger implements the logging.Logger interface for tests without output.
@@ -1121,7 +1230,7 @@ func TestHandleCreatedIndexLog_InitialSkipsBackfill(t *testing.T) {
 
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Empty(t, b.backfillTasks, "initial index must not schedule a backfill")
@@ -1144,7 +1253,7 @@ func TestHandleCreatedIndexLog_NonInitialSchedulesBackfill(t *testing.T) {
 
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Len(t, b.backfillTasks, 1, "non-initial index must schedule a backfill")
@@ -1152,6 +1261,62 @@ func TestHandleCreatedIndexLog_NonInitialSchedulesBackfill(t *testing.T) {
 	current, pending := b.versionFor(ledger, canonical)
 	require.Equal(t, uint32(0), current, "non-initial index stays gated until backfill catches up")
 	require.Equal(t, uint32(1), pending)
+}
+
+// TestHandleCreatedIndexLog_BindsStampedType pins the EN-1724 binding source:
+// the version created for a CreateIndex log binds to the type stamped into
+// the log by the FSM at mint time (CreatedIndexLog.bound_type). The schema
+// readable when the log folds plays no part — it is batch-final at best and
+// arbitrarily newer when the log folds during a backfill or rebuild replay,
+// so deriving the binding from it would let a later retype leak into the
+// creation binding.
+func TestHandleCreatedIndexLog_BindsStampedType(t *testing.T) {
+	t.Parallel()
+
+	const ledger = "test"
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "score")
+	canonical := indexes.Canonical(id)
+
+	t.Run("backfilling index binds the stamp to the pending version", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+
+		batch := b.readStore.NewBatch()
+		b.initBatch(batch)
+		require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
+			Id:                id,
+			BoundType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+			BoundTypeDeclared: true,
+		}))
+		require.NoError(t, b.wb.Flush())
+
+		st, ok := b.versionStateFor(ledger, canonical)
+		require.True(t, ok)
+		assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, st.PendingType)
+		assert.True(t, st.PendingTypeDeclared)
+	})
+
+	t.Run("initial index binds the stamp to the live version", func(t *testing.T) {
+		t.Parallel()
+
+		b := newTestBuilderWithStore(t)
+
+		batch := b.readStore.NewBatch()
+		b.initBatch(batch)
+		require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{
+			Id:                id,
+			Initial:           true,
+			BoundType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+			BoundTypeDeclared: true,
+		}))
+		require.NoError(t, b.wb.Flush())
+
+		st, ok := b.versionStateFor(ledger, canonical)
+		require.True(t, ok)
+		assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, st.CurrentType)
+		assert.True(t, st.CurrentTypeDeclared)
+	})
 }
 
 // TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent pins the fix for the
@@ -1172,7 +1337,7 @@ func TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent(t *testing.T) {
 	// First create promotes the index straight to live (current=1, no backfill).
 	first := b.readStore.NewBatch()
 	b.initBatch(first)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: true}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Empty(t, b.backfillTasks)
@@ -1184,7 +1349,7 @@ func TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent(t *testing.T) {
 	// the ledger is no longer born-empty — must be a no-op on this live replica.
 	second := b.readStore.NewBatch()
 	b.initBatch(second)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Empty(t, b.backfillTasks, "duplicate create must not reschedule a backfill")
@@ -1214,7 +1379,7 @@ func TestHandleCreatedIndexLog_DuplicateDuringBackfill_KeepsPending(t *testing.T
 
 	first := b.readStore.NewBatch()
 	b.initBatch(first)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Len(t, b.backfillTasks, 1)
@@ -1224,7 +1389,7 @@ func TestHandleCreatedIndexLog_DuplicateDuringBackfill_KeepsPending(t *testing.T
 
 	second := b.readStore.NewBatch()
 	b.initBatch(second)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Len(t, b.backfillTasks, 1, "duplicate create must not schedule another backfill")
@@ -1287,7 +1452,7 @@ func TestHandleCreatedIndexLog_RecreateAfterDelete_ReseedsBackfill(t *testing.T)
 	// re-seed {current:0, pending:1} and schedule a backfill, not short-circuit.
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))
 	require.NoError(t, b.wb.Flush())
 
 	require.Len(t, b.backfillTasks, 1, "recreated ledger index must schedule a backfill")

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -666,7 +666,8 @@ func TestAddSchemaRewriteTask_ResetsInFlightBackfill(t *testing.T) {
 	}
 
 	// A backfill task always coexists with its version state and runs inside
-	// an active fold batch — CreateIndex writes both in one commit.
+	// an active fold batch — CreateIndex writes both in one commit, and boot
+	// rebuilds the task FROM the persisted state.
 	b.putVersionState("ledger1", indexes.Canonical(id), readstore.IndexVersionState{
 		CurrentVersion: 0,
 		PendingVersion: 1,
@@ -695,6 +696,9 @@ func TestAddSchemaRewriteTask_ResetsInFlightBackfill(t *testing.T) {
 	assert.Equal(t, uint32(2), state.PendingVersion,
 		"the restart must fill a FRESH keyspace — refolding the half-built one re-encodes values at their original sequences, and those retractions lose the same-seq tie forever")
 	assert.Equal(t, uint32(2), state.HighWater)
+	require.True(t, state.PendingTypeDeclared)
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_UINT64, state.PendingType,
+		"the fresh keyspace is bound to the retype's target type")
 }
 
 // TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped pins the
@@ -742,8 +746,9 @@ func TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped(t *testing.T) 
 		},
 	}
 
-	// stripBuildingIndexes hides the index from cfg, but the version state
-	// and the fold batch are untouched by the strip.
+	// stripBuildingIndexes hides the index from cfg, but the version state and
+	// the fold batch are untouched by the strip — both still exist whenever a
+	// backfill task does.
 	b.putVersionState("ledger1", indexes.Canonical(id), readstore.IndexVersionState{
 		CurrentVersion: 0,
 		PendingVersion: 1,
@@ -765,6 +770,13 @@ func TestAddSchemaRewriteTask_ResetsBackfillEvenWhenIndexStripped(t *testing.T) 
 		"stripped index must not block the retype reset — backfill must restart from 0")
 	assert.Equal(t, uint64(0), b.backfillTasks[0].appliedProposalSeq)
 	assert.Empty(t, b.schemaRewriteTasks, "no separate schema rewrite needed; backfill replay covers it")
+
+	state, ok := b.versionStateFor("ledger1", indexes.Canonical(id))
+	require.True(t, ok)
+	require.True(t, state.PendingTypeDeclared)
+	assert.Equal(t, uint32(2), state.PendingVersion,
+		"the restarted backfill fills a fresh keyspace bound to the retype's target type")
+	assert.Equal(t, commonpb.MetadataType_METADATA_TYPE_UINT64, state.PendingType)
 }
 
 // TestAddSchemaRewriteTask_DoesNotResetOtherLedgersBackfill guards against

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -623,17 +623,11 @@ func (b *Builder) indexCreatedTransaction(
 					continue
 				}
 
-				coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, key, value)
-				if err != nil {
-					return err
-				}
-				newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 				if err := b.dualWriteMetadataIndex(
 					kb,
 					ledger, readstore.NamespaceAccount, key,
 					commonpb.TargetType_TARGET_TYPE_ACCOUNT,
-					newEncoded, []byte(account),
+					value, []byte(account),
 					func(version uint32) []byte {
 						return readstore.AccountReverseMapKeyV(kb, ledger, account, key, version)
 					},
@@ -659,17 +653,11 @@ func (b *Builder) indexCreatedTransaction(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},
@@ -753,17 +741,11 @@ func (b *Builder) indexRevertedTransaction(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},
@@ -996,17 +978,11 @@ func (b *Builder) indexSavedMetadata(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_ACCOUNT, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceAccount, key,
 				commonpb.TargetType_TARGET_TYPE_ACCOUNT,
-				newEncoded, []byte(account),
+				value, []byte(account),
 				func(version uint32) []byte {
 					return readstore.AccountReverseMapKeyV(kb, ledger, account, key, version)
 				},
@@ -1024,17 +1000,11 @@ func (b *Builder) indexSavedMetadata(
 				continue
 			}
 
-			coerced, err := b.coerceForLedger(ledger, commonpb.TargetType_TARGET_TYPE_TRANSACTION, key, value)
-			if err != nil {
-				return err
-			}
-			newEncoded := readstore.EncodeMetadataValue(nil, coerced)
-
 			if err := b.dualWriteMetadataIndex(
 				kb,
 				ledger, readstore.NamespaceTransaction, key,
 				commonpb.TargetType_TARGET_TYPE_TRANSACTION,
-				newEncoded, txIDBytes,
+				value, txIDBytes,
 				func(version uint32) []byte {
 					return readstore.TransactionReverseMapKeyV(kb, ledger, txID, key, version)
 				},

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -352,7 +352,7 @@ func (b *Builder) indexPayload(
 	case *commonpb.LedgerLogPayload_RemovedMetadataFieldType:
 		return b.handleRemovedMetadataFieldType(kb, cfg, ledgerName, p.RemovedMetadataFieldType)
 	case *commonpb.LedgerLogPayload_CreateIndex:
-		b.handleCreatedIndexLog(ledgerName, p.CreateIndex)
+		return b.handleCreatedIndexLog(ledgerName, p.CreateIndex)
 	case *commonpb.LedgerLogPayload_DropIndex:
 		if err := b.handleDroppedIndexLog(kb, ledgerName, p.DropIndex); err != nil {
 			return err
@@ -562,7 +562,7 @@ func (b *Builder) indexLogEntry(cfg *ledgerIndexConfig, log *commonpb.Log, propo
 	case *commonpb.LedgerLogPayload_DeletedMetadata:
 		return b.indexDeletedMetadata(b.kb, cfg, ledgerName, p.DeletedMetadata)
 	case *commonpb.LedgerLogPayload_CreateIndex:
-		b.handleCreatedIndexLog(ledgerName, p.CreateIndex)
+		return b.handleCreatedIndexLog(ledgerName, p.CreateIndex)
 	case *commonpb.LedgerLogPayload_DropIndex:
 		if err := b.handleDroppedIndexLog(b.kb, ledgerName, p.DropIndex); err != nil {
 			return err

--- a/internal/application/indexbuilder/resurrection_regression_test.go
+++ b/internal/application/indexbuilder/resurrection_regression_test.go
@@ -163,7 +163,7 @@ func TestDropRecreate_DeletedValueStaysDead(t *testing.T) {
 
 	batch := b.readStore.NewBatch()
 	b.initBatch(batch)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id}))
 	require.NoError(t, b.wb.Flush())
 	driveBackfills(t, b, 1)
 
@@ -198,7 +198,7 @@ func TestDropRecreate_DeletedValueStaysDead(t *testing.T) {
 	// Incarnation 2.
 	batch = b.readStore.NewBatch()
 	b.initBatch(batch)
-	b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id})
+	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id}))
 	require.NoError(t, b.wb.Flush())
 	driveBackfills(t, b, 2)
 

--- a/internal/application/indexbuilder/retype_window_test.go
+++ b/internal/application/indexbuilder/retype_window_test.go
@@ -1,0 +1,148 @@
+package indexbuilder
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// eventGroupExists reports whether the versioned metadata index holds an
+// event group for (encoded value, entity) — i.e. whether a query scanning
+// that value at that version would consider the entity at all.
+func eventGroupExists(t *testing.T, s *readstore.Store, ledger, ns, metaKey string, version uint32, encoded, entity []byte) bool {
+	t.Helper()
+
+	kb := dal.NewKeyBuilder()
+	prefix := append([]byte(nil), readstore.MetadataIndexPrefixV(kb, ledger, ns, metaKey, version)...)
+	prefix = append(prefix, encoded...)
+	prefix = append(prefix, entity...)
+
+	iter, err := s.DB().NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: readstore.IncrementBytes(prefix),
+	})
+	require.NoError(t, err)
+
+	defer func() { _ = iter.Close() }()
+
+	return iter.First()
+}
+
+// A live write during a retype window is coerced once per version: v_current
+// keeps the OLD type's encoding, so the index it serves stays exactly the one
+// the retype never touched, while v_pending carries the retype's target. One
+// shared encoding — the pre-fix behavior — turns v_current into a mixture no
+// declared type describes: -1 under INT64→UINT32 encodes as null in BOTH
+// versions, and the old-typed query loses a row it must still see (EN-1724).
+func TestRetypeWindow_LiveWriteIsCoercedPerVersion(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.seedBatchSchema(t)
+	b.accounts = make(map[string]struct{})
+
+	const (
+		ledger  = "test"
+		metaKey = "k2"
+		account = "acct:1"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)
+	canonical := indexes.Canonical(id)
+
+	cfg := newLedgerIndexConfig()
+	cfg.byCanonical[canonical] = &commonpb.Index{Id: id}
+
+	// Mid-window state: v1 was built under INT64, the retype to UINT32 is
+	// rewriting into v2.
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
+	})
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(1)
+
+	// -1: valid INT64, out of range for UINT32.
+	require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, savedAccountMetadata(account, metaKey, -1)))
+	require.NoError(t, b.wb.Flush())
+
+	oldEncoded := readstore.EncodeMetadataValue(nil, commonpb.NewIntValue(-1))
+	newEncoded := readstore.EncodeMetadataValue(nil, commonpb.ConvertMetadataValue(commonpb.NewIntValue(-1), commonpb.MetadataType_METADATA_TYPE_UINT32))
+
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, oldEncoded, []byte(account)),
+		"v_current must hold the OLD encoding: the window serves the index as if no retype had happened")
+	assert.False(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, newEncoded, []byte(account)),
+		"the new encoding must not leak into v_current — that mixture is the partial-results bug")
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 2, newEncoded, []byte(account)),
+		"v_pending must hold the NEW encoding so the switch promotes a complete new-typed index")
+}
+
+// The reverse direction: the FSM stored the value under the NEW schema (a
+// retype flips the declared type at apply), so what reaches the builder for
+// an out-of-range write is already null-with-original. v_current must still
+// receive the OLD type's faithful encoding, recovered through the null's
+// original representation.
+func TestRetypeWindow_NullOriginalRoundTripsIntoTheOldEncoding(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.seedBatchSchema(t)
+	b.accounts = make(map[string]struct{})
+
+	const (
+		ledger  = "test"
+		metaKey = "k2"
+		account = "acct:2"
+	)
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metaKey)
+	canonical := indexes.Canonical(id)
+
+	cfg := newLedgerIndexConfig()
+	cfg.byCanonical[canonical] = &commonpb.Index{Id: id}
+
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{
+		CurrentVersion:      1,
+		PendingVersion:      2,
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_INT64,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
+	})
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(1)
+
+	// What the FSM stores for a post-retype write of -1 under UINT32.
+	stored := commonpb.ConvertMetadataValue(commonpb.NewIntValue(-1), commonpb.MetadataType_METADATA_TYPE_UINT32)
+	_, isNull := stored.GetType().(*commonpb.MetadataValue_NullValue)
+	require.True(t, isNull, "premise: -1 under UINT32 is stored as null-with-original")
+
+	sm := &commonpb.SavedMetadata{
+		Target: &commonpb.Target{Target: &commonpb.Target_Account{
+			Account: &commonpb.TargetAccount{Addr: account},
+		}},
+		Metadata: map[string]*commonpb.MetadataValue{metaKey: stored},
+	}
+	require.NoError(t, b.indexSavedMetadata(b.kb, cfg, ledger, sm))
+	require.NoError(t, b.wb.Flush())
+
+	oldEncoded := readstore.EncodeMetadataValue(nil, commonpb.NewIntValue(-1))
+
+	assert.True(t, eventGroupExists(t, b.readStore, ledger, readstore.NamespaceAccount, metaKey, 1, oldEncoded, []byte(account)),
+		"v_current recovers int(-1) through the null's original — the write lands exactly where the old world would have put it")
+}

--- a/internal/domain/processing/processor_index.go
+++ b/internal/domain/processing/processor_index.go
@@ -25,6 +25,8 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 	// consistent. A duplicate CreateIndex overwrites the row; the
 	// indexbuilder's handleCreatedIndexLog guards against re-scheduling a
 	// backfill by consulting its per-replica IndexVersionState.
+	boundType, boundTypeDeclared := indexBoundType(info, id)
+
 	indexes.Put(ctx.Scope.Indexes(), ledger, &commonpb.Index{
 		Id:        id,
 		CreatedAt: ctx.Scope.GetDate().Mutate(),
@@ -34,7 +36,7 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 		ForwardEncodingVersion: 1,
 	})
 
-	return buildCreatedIndexLogPayload(id, ctx.isBornEmpty(ledger)), nil
+	return buildCreatedIndexLogPayload(id, ctx.isBornEmpty(ledger), boundType, boundTypeDeclared), nil
 }
 
 func processDropIndex(ledger string, order *raftcmdpb.DropIndexOrder, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
@@ -83,10 +85,34 @@ func validateIndexTarget(info *commonpb.LedgerInfo, id *commonpb.IndexID) domain
 	return nil
 }
 
-func buildCreatedIndexLogPayload(id *commonpb.IndexID, initial bool) *commonpb.LedgerLogPayload {
+// indexBoundType resolves the declared type the index's first version binds
+// to: the schema entry for the indexed metadata field at this point in the
+// order stream. The log carries the binding so replicas folding it at any
+// replay distance bind the same type (see CreatedIndexLog.bound_type).
+// Builtin indexes have no metadata field and carry no binding.
+func indexBoundType(info *commonpb.LedgerInfo, id *commonpb.IndexID) (commonpb.MetadataType, bool) {
+	meta, ok := id.GetKind().(*commonpb.IndexID_Metadata)
+	if !ok || meta.Metadata == nil {
+		return 0, false
+	}
+
+	_, field := commonpb.SchemaFieldForTarget(info.GetMetadataSchema(), meta.Metadata.GetTarget(), meta.Metadata.GetKey())
+	if field == nil {
+		return 0, false
+	}
+
+	return field.GetType(), true
+}
+
+func buildCreatedIndexLogPayload(id *commonpb.IndexID, initial bool, boundType commonpb.MetadataType, boundTypeDeclared bool) *commonpb.LedgerLogPayload {
 	return &commonpb.LedgerLogPayload{
 		Payload: &commonpb.LedgerLogPayload_CreateIndex{
-			CreateIndex: &commonpb.CreatedIndexLog{Id: id, Initial: initial},
+			CreateIndex: &commonpb.CreatedIndexLog{
+				Id:                id,
+				Initial:           initial,
+				BoundType:         boundType,
+				BoundTypeDeclared: boundTypeDeclared,
+			},
 		},
 	}
 }

--- a/internal/domain/processing/processor_index_test.go
+++ b/internal/domain/processing/processor_index_test.go
@@ -162,3 +162,75 @@ func TestProcessCreateIndex_NotInitialWithoutBornEmpty(t *testing.T) {
 	require.Nil(t, derr)
 	require.False(t, payload.GetCreateIndex().GetInitial())
 }
+
+// TestProcessCreateIndex_StampsBoundTypeAtSequence pins the EN-1724 binding
+// contract: the minted CreatedIndexLog carries the metadata field's declared
+// type as it stands when the order applies. Replicas fold the log at
+// arbitrary replay distance — a backfill or a rebuild sees a schema that may
+// be several retypes ahead — so the log itself is the only place the
+// at-sequence binding can live.
+func TestProcessCreateIndex_StampsBoundTypeAtSequence(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+
+	ledgerInfo := &commonpb.LedgerInfo{
+		Name: "test-ledger",
+		Id:   7,
+		MetadataSchema: &commonpb.MetadataSchema{
+			AccountFields: map[string]*commonpb.MetadataFieldSchema{
+				"score": {Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+			},
+		},
+	}
+	indexID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "score")
+	now := &commonpb.Timestamp{Data: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, ledgerInfo.AsReader(), nil)
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+
+	idxStub := setupIndexesStub(mockStore)
+	idxStub.expectGet(domain.IndexKey{LedgerName: "test-ledger", Canonical: indexes.Canonical(indexID)}, nil, domain.ErrNotFound)
+	idxStub.putHook = func(domain.IndexKey, *commonpb.Index) {}
+
+	payload, derr := processCreateIndex("test-ledger", &raftcmdpb.CreateIndexOrder{Id: indexID}, &Context{Scope: mockStore})
+	require.Nil(t, derr)
+
+	log := payload.GetCreateIndex()
+	require.NotNil(t, log)
+	require.True(t, log.GetBoundTypeDeclared())
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, log.GetBoundType())
+}
+
+// TestProcessCreateIndex_BuiltinCarriesNoBinding verifies a builtin index's
+// CreatedIndexLog is stamped with no type binding: there is no metadata
+// field, and its values keep the natural encoding.
+func TestProcessCreateIndex_BuiltinCarriesNoBinding(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+
+	ledgerInfo := &commonpb.LedgerInfo{Name: "test-ledger", Id: 7}
+	indexID := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	now := &commonpb.Timestamp{Data: 1}
+
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "test-ledger"}, ledgerInfo.AsReader(), nil)
+	mockStore.EXPECT().GetDate().Return(now.AsReader())
+
+	idxStub := setupIndexesStub(mockStore)
+	idxStub.expectGet(domain.IndexKey{LedgerName: "test-ledger", Canonical: indexes.Canonical(indexID)}, nil, domain.ErrNotFound)
+	idxStub.putHook = func(domain.IndexKey, *commonpb.Index) {}
+
+	payload, derr := processCreateIndex("test-ledger", &raftcmdpb.CreateIndexOrder{Id: indexID}, &Context{Scope: mockStore})
+	require.Nil(t, derr)
+
+	log := payload.GetCreateIndex()
+	require.NotNil(t, log)
+	require.False(t, log.GetBoundTypeDeclared())
+}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -6334,9 +6334,22 @@ type CreatedIndexLog struct {
 	// (same atomic apply batch as CreateLedger, before any indexable data log).
 	// The read-side indexbuilder promotes such indexes straight to live with no
 	// historical backfill; later indexes (initial=false) keep backfilling. EN-1564.
-	Initial       bool `protobuf:"varint,2,opt,name=initial,proto3" json:"initial,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Initial bool `protobuf:"varint,2,opt,name=initial,proto3" json:"initial,omitempty"`
+	// bound_type is the declared type of the indexed metadata field at this
+	// log's sequence, stamped by the FSM when the log is minted. The index's
+	// first version binds to it: every replica encodes that version's rows —
+	// live folds and backfill replays alike — under this type until a retype's
+	// atomic switch rebinds. Stamping at mint time is what keeps the binding
+	// stable at any replay distance; the schema readable when a replica folds
+	// the log may already be many retypes ahead. EN-1724.
+	BoundType MetadataType `protobuf:"varint,3,opt,name=bound_type,json=boundType,proto3,enum=common.MetadataType" json:"bound_type,omitempty"`
+	// bound_type_declared is false for builtin indexes, which have no metadata
+	// field and therefore no binding: their values keep the natural encoding.
+	// Metadata indexes always carry a binding — CreateIndex validates that the
+	// field is declared in the schema.
+	BoundTypeDeclared bool `protobuf:"varint,4,opt,name=bound_type_declared,json=boundTypeDeclared,proto3" json:"bound_type_declared,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *CreatedIndexLog) Reset() {
@@ -6379,6 +6392,20 @@ func (x *CreatedIndexLog) GetId() *IndexID {
 func (x *CreatedIndexLog) GetInitial() bool {
 	if x != nil {
 		return x.Initial
+	}
+	return false
+}
+
+func (x *CreatedIndexLog) GetBoundType() MetadataType {
+	if x != nil {
+		return x.BoundType
+	}
+	return MetadataType_METADATA_TYPE_STRING
+}
+
+func (x *CreatedIndexLog) GetBoundTypeDeclared() bool {
+	if x != nil {
+		return x.BoundTypeDeclared
 	}
 	return false
 }
@@ -13178,10 +13205,13 @@ const file_common_proto_rawDesc = "" +
 	"\acontext\x18\x02 \x03(\v2$.common.OrderSkippedLog.ContextEntryR\acontext\x1a:\n" +
 	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"L\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb1\x01\n" +
 	"\x0fCreatedIndexLog\x12\x1f\n" +
 	"\x02id\x18\x01 \x01(\v2\x0f.common.IndexIDR\x02id\x12\x18\n" +
-	"\ainitial\x18\x02 \x01(\bR\ainitial\"2\n" +
+	"\ainitial\x18\x02 \x01(\bR\ainitial\x123\n" +
+	"\n" +
+	"bound_type\x18\x03 \x01(\x0e2\x14.common.MetadataTypeR\tboundType\x12.\n" +
+	"\x13bound_type_declared\x18\x04 \x01(\bR\x11boundTypeDeclared\"2\n" +
 	"\x0fDroppedIndexLog\x12\x1f\n" +
 	"\x02id\x18\x01 \x01(\v2\x0f.common.IndexIDR\x02id\"/\n" +
 	"\fFilledGapLog\x12\x1f\n" +
@@ -14118,161 +14148,162 @@ var file_common_proto_depIdxs = []int32{
 	10,  // 120: common.OrderSkippedLog.reason:type_name -> common.ErrorReason
 	186, // 121: common.OrderSkippedLog.context:type_name -> common.OrderSkippedLog.ContextEntry
 	39,  // 122: common.CreatedIndexLog.id:type_name -> common.IndexID
-	39,  // 123: common.DroppedIndexLog.id:type_name -> common.IndexID
-	24,  // 124: common.CreatedTransaction.transaction:type_name -> common.Transaction
-	187, // 125: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
-	24,  // 126: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
-	34,  // 127: common.SavedMetadata.target:type_name -> common.Target
-	188, // 128: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
-	34,  // 129: common.DeletedMetadata.target:type_name -> common.Target
-	0,   // 130: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	1,   // 131: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
-	0,   // 132: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
-	39,  // 133: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
-	17,  // 134: common.Chapter.start:type_name -> common.Timestamp
-	17,  // 135: common.Chapter.end:type_name -> common.Timestamp
-	7,   // 136: common.Chapter.status:type_name -> common.ChapterStatus
-	95,  // 137: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
-	95,  // 138: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
-	95,  // 139: common.SealedChapterLog.chapter:type_name -> common.Chapter
-	95,  // 140: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
-	95,  // 141: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
-	120, // 142: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
-	122, // 143: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
-	101, // 144: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
-	102, // 145: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
-	103, // 146: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
-	104, // 147: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
-	105, // 148: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
-	106, // 149: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
-	107, // 150: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
-	108, // 151: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
-	109, // 152: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
-	110, // 153: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
-	111, // 154: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
-	112, // 155: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	113, // 156: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	114, // 157: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	115, // 158: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
-	116, // 159: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
-	117, // 160: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
-	119, // 161: common.CreatedTransactionAction.drop:type_name -> common.DropAction
-	112, // 162: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
-	113, // 163: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
-	114, // 164: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	119, // 165: common.RevertedTransactionAction.drop:type_name -> common.DropAction
-	112, // 166: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	113, // 167: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
-	114, // 168: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
-	119, // 169: common.SavedMetadataAction.drop:type_name -> common.DropAction
-	112, // 170: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
-	119, // 171: common.DeletedMetadataAction.drop:type_name -> common.DropAction
-	112, // 172: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
-	119, // 173: common.AnyVariantAction.drop:type_name -> common.DropAction
-	118, // 174: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
-	121, // 175: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
-	123, // 176: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
-	17,  // 177: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
-	9,   // 178: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
-	124, // 179: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
-	17,  // 180: common.LedgerInfo.created_at:type_name -> common.Timestamp
-	17,  // 181: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
-	36,  // 182: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
-	8,   // 183: common.LedgerInfo.mode:type_name -> common.LedgerMode
-	100, // 184: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
-	125, // 185: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
-	189, // 186: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
-	11,  // 187: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
-	190, // 188: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
-	34,  // 189: common.SaveMetadataCommand.target:type_name -> common.Target
-	191, // 190: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
-	34,  // 191: common.DeleteMetadataCommand.target:type_name -> common.Target
-	192, // 192: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
-	17,  // 193: common.TransactionState.timestamp:type_name -> common.Timestamp
-	23,  // 194: common.TransactionState.postings:type_name -> common.Posting
-	17,  // 195: common.TransactionState.reverted_at:type_name -> common.Timestamp
-	131, // 196: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
-	10,  // 197: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
-	193, // 198: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
-	135, // 199: common.SegmentType.uuid:type_name -> common.UUIDConstraint
-	136, // 200: common.SegmentType.uint64:type_name -> common.Uint64Constraint
-	137, // 201: common.SegmentType.bytes:type_name -> common.BytesConstraint
-	12,  // 202: common.AccountType.persistence:type_name -> common.AccountTypePersistence
-	194, // 203: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
-	138, // 204: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
-	11,  // 205: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
-	155, // 206: common.QueryFilter.field:type_name -> common.FieldCondition
-	161, // 207: common.QueryFilter.address:type_name -> common.AddressMatch
-	151, // 208: common.QueryFilter.and:type_name -> common.AndFilter
-	152, // 209: common.QueryFilter.or:type_name -> common.OrFilter
-	153, // 210: common.QueryFilter.not:type_name -> common.NotFilter
-	143, // 211: common.QueryFilter.reference:type_name -> common.ReferenceCondition
-	148, // 212: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
-	146, // 213: common.QueryFilter.ledger:type_name -> common.LedgerCondition
-	147, // 214: common.QueryFilter.log_id:type_name -> common.LogIdCondition
-	149, // 215: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
-	150, // 216: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
-	144, // 217: common.QueryFilter.reverted:type_name -> common.RevertedCondition
-	145, // 218: common.QueryFilter.audit:type_name -> common.AuditCondition
-	156, // 219: common.ReferenceCondition.cond:type_name -> common.StringCondition
-	13,  // 220: common.AuditCondition.field:type_name -> common.AuditField
-	156, // 221: common.AuditCondition.string_cond:type_name -> common.StringCondition
-	158, // 222: common.AuditCondition.uint_cond:type_name -> common.UintCondition
-	156, // 223: common.LedgerCondition.cond:type_name -> common.StringCondition
-	158, // 224: common.LogIdCondition.cond:type_name -> common.UintCondition
-	2,   // 225: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
-	158, // 226: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
-	4,   // 227: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
-	158, // 228: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
-	142, // 229: common.AndFilter.filters:type_name -> common.QueryFilter
-	142, // 230: common.OrFilter.filters:type_name -> common.QueryFilter
-	142, // 231: common.NotFilter.filter:type_name -> common.QueryFilter
-	154, // 232: common.FieldCondition.field:type_name -> common.FieldRef
-	156, // 233: common.FieldCondition.string_cond:type_name -> common.StringCondition
-	157, // 234: common.FieldCondition.int_cond:type_name -> common.IntCondition
-	158, // 235: common.FieldCondition.uint_cond:type_name -> common.UintCondition
-	159, // 236: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
-	160, // 237: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
-	14,  // 238: common.AddressMatch.role:type_name -> common.AddressRole
-	142, // 239: common.PreparedQuery.filter:type_name -> common.QueryFilter
-	15,  // 240: common.PreparedQuery.target:type_name -> common.QueryTarget
-	22,  // 241: common.AggregatedVolume.input:type_name -> common.Uint256
-	22,  // 242: common.AggregatedVolume.output:type_name -> common.Uint256
-	163, // 243: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
-	165, // 244: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
-	163, // 245: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
-	32,  // 246: common.PreparedQueryCursor.account_data:type_name -> common.Account
-	24,  // 247: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
-	42,  // 248: common.PreparedQueryCursor.log_data:type_name -> common.Log
-	169, // 249: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
-	171, // 250: common.BackupStorage.s3:type_name -> common.S3StorageConfig
-	172, // 251: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
-	174, // 252: common.ListOptions.read:type_name -> common.ReadOptions
-	142, // 253: common.ListOptions.filter:type_name -> common.QueryFilter
-	19,  // 254: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
-	19,  // 255: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
-	28,  // 256: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
-	19,  // 257: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
-	35,  // 258: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	35,  // 259: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	35,  // 260: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
-	19,  // 261: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
-	138, // 262: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
-	20,  // 263: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
-	19,  // 264: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
-	138, // 265: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
-	19,  // 266: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 267: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
-	19,  // 268: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
-	134, // 269: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
-	196, // 270: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
-	196, // 271: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
-	15,  // 272: common.allowed_query_targets:type_name -> common.QueryTarget
-	273, // [273:273] is the sub-list for method output_type
-	273, // [273:273] is the sub-list for method input_type
-	272, // [272:273] is the sub-list for extension type_name
-	270, // [270:272] is the sub-list for extension extendee
-	0,   // [0:270] is the sub-list for field type_name
+	1,   // 123: common.CreatedIndexLog.bound_type:type_name -> common.MetadataType
+	39,  // 124: common.DroppedIndexLog.id:type_name -> common.IndexID
+	24,  // 125: common.CreatedTransaction.transaction:type_name -> common.Transaction
+	187, // 126: common.CreatedTransaction.account_metadata:type_name -> common.CreatedTransaction.AccountMetadataEntry
+	24,  // 127: common.RevertedTransaction.revert_transaction:type_name -> common.Transaction
+	34,  // 128: common.SavedMetadata.target:type_name -> common.Target
+	188, // 129: common.SavedMetadata.metadata:type_name -> common.SavedMetadata.MetadataEntry
+	34,  // 130: common.DeletedMetadata.target:type_name -> common.Target
+	0,   // 131: common.SetMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	1,   // 132: common.SetMetadataFieldTypeLog.type:type_name -> common.MetadataType
+	0,   // 133: common.RemovedMetadataFieldTypeLog.target_type:type_name -> common.TargetType
+	39,  // 134: common.RemovedMetadataFieldTypeLog.dropped_index:type_name -> common.IndexID
+	17,  // 135: common.Chapter.start:type_name -> common.Timestamp
+	17,  // 136: common.Chapter.end:type_name -> common.Timestamp
+	7,   // 137: common.Chapter.status:type_name -> common.ChapterStatus
+	95,  // 138: common.ClosedChapterLog.closed_chapter:type_name -> common.Chapter
+	95,  // 139: common.ClosedChapterLog.new_chapter:type_name -> common.Chapter
+	95,  // 140: common.SealedChapterLog.chapter:type_name -> common.Chapter
+	95,  // 141: common.ArchivedChapterLog.chapter:type_name -> common.Chapter
+	95,  // 142: common.ConfirmedArchiveChapterLog.chapter:type_name -> common.Chapter
+	120, // 143: common.MirrorSourceConfig.http:type_name -> common.HttpMirrorSourceConfig
+	122, // 144: common.MirrorSourceConfig.postgres:type_name -> common.PostgresMirrorSourceConfig
+	101, // 145: common.MirrorSourceConfig.rewrite_rules:type_name -> common.MirrorRewriteRule
+	102, // 146: common.MirrorRewriteRule.created_transaction:type_name -> common.CreatedTransactionRule
+	103, // 147: common.MirrorRewriteRule.reverted_transaction:type_name -> common.RevertedTransactionRule
+	104, // 148: common.MirrorRewriteRule.saved_metadata:type_name -> common.SavedMetadataRule
+	105, // 149: common.MirrorRewriteRule.deleted_metadata:type_name -> common.DeletedMetadataRule
+	106, // 150: common.MirrorRewriteRule.any_variant:type_name -> common.AnyVariantRule
+	107, // 151: common.CreatedTransactionRule.actions:type_name -> common.CreatedTransactionAction
+	108, // 152: common.RevertedTransactionRule.actions:type_name -> common.RevertedTransactionAction
+	109, // 153: common.SavedMetadataRule.actions:type_name -> common.SavedMetadataAction
+	110, // 154: common.DeletedMetadataRule.actions:type_name -> common.DeletedMetadataAction
+	111, // 155: common.AnyVariantRule.actions:type_name -> common.AnyVariantAction
+	112, // 156: common.CreatedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	113, // 157: common.CreatedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	114, // 158: common.CreatedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	115, // 159: common.CreatedTransactionAction.set_account_metadata:type_name -> common.SetAccountMetadataAction
+	116, // 160: common.CreatedTransactionAction.delete_account_metadata:type_name -> common.DeleteAccountMetadataAction
+	117, // 161: common.CreatedTransactionAction.set_account_metadata_from_address:type_name -> common.SetAccountMetadataFromAddressAction
+	119, // 162: common.CreatedTransactionAction.drop:type_name -> common.DropAction
+	112, // 163: common.RevertedTransactionAction.rewrite_address:type_name -> common.RewriteAddressAction
+	113, // 164: common.RevertedTransactionAction.set_metadata:type_name -> common.SetMetadataAction
+	114, // 165: common.RevertedTransactionAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	119, // 166: common.RevertedTransactionAction.drop:type_name -> common.DropAction
+	112, // 167: common.SavedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	113, // 168: common.SavedMetadataAction.set_metadata:type_name -> common.SetMetadataAction
+	114, // 169: common.SavedMetadataAction.delete_metadata:type_name -> common.DeleteMetadataAction
+	119, // 170: common.SavedMetadataAction.drop:type_name -> common.DropAction
+	112, // 171: common.DeletedMetadataAction.rewrite_address:type_name -> common.RewriteAddressAction
+	119, // 172: common.DeletedMetadataAction.drop:type_name -> common.DropAction
+	112, // 173: common.AnyVariantAction.rewrite_address:type_name -> common.RewriteAddressAction
+	119, // 174: common.AnyVariantAction.drop:type_name -> common.DropAction
+	118, // 175: common.SetAccountMetadataFromAddressAction.replacements:type_name -> common.SetAccountMetadataFromAddressReplacement
+	121, // 176: common.HttpMirrorSourceConfig.oauth2_client_credentials:type_name -> common.OAuth2ClientCredentials
+	123, // 177: common.PostgresMirrorSourceConfig.aws_iam_auth:type_name -> common.PostgresAwsIamAuth
+	17,  // 178: common.MirrorSyncError.occurred_at:type_name -> common.Timestamp
+	9,   // 179: common.MirrorSyncProgress.state:type_name -> common.MirrorSyncState
+	124, // 180: common.MirrorSyncProgress.error:type_name -> common.MirrorSyncError
+	17,  // 181: common.LedgerInfo.created_at:type_name -> common.Timestamp
+	17,  // 182: common.LedgerInfo.deleted_at:type_name -> common.Timestamp
+	36,  // 183: common.LedgerInfo.metadata_schema:type_name -> common.MetadataSchema
+	8,   // 184: common.LedgerInfo.mode:type_name -> common.LedgerMode
+	100, // 185: common.LedgerInfo.mirror_source:type_name -> common.MirrorSourceConfig
+	125, // 186: common.LedgerInfo.mirror_sync_progress:type_name -> common.MirrorSyncProgress
+	189, // 187: common.LedgerInfo.account_types:type_name -> common.LedgerInfo.AccountTypesEntry
+	11,  // 188: common.LedgerInfo.default_enforcement_mode:type_name -> common.ChartEnforcementMode
+	190, // 189: common.LedgerInfo.metadata:type_name -> common.LedgerInfo.MetadataEntry
+	34,  // 190: common.SaveMetadataCommand.target:type_name -> common.Target
+	191, // 191: common.SaveMetadataCommand.metadata:type_name -> common.SaveMetadataCommand.MetadataEntry
+	34,  // 192: common.DeleteMetadataCommand.target:type_name -> common.Target
+	192, // 193: common.TransactionState.metadata:type_name -> common.TransactionState.MetadataEntry
+	17,  // 194: common.TransactionState.timestamp:type_name -> common.Timestamp
+	23,  // 195: common.TransactionState.postings:type_name -> common.Posting
+	17,  // 196: common.TransactionState.reverted_at:type_name -> common.Timestamp
+	131, // 197: common.IdempotencyKeyValue.failure:type_name -> common.IdempotencyFailure
+	10,  // 198: common.IdempotencyFailure.reason:type_name -> common.ErrorReason
+	193, // 199: common.IdempotencyFailure.metadata:type_name -> common.IdempotencyFailure.MetadataEntry
+	135, // 200: common.SegmentType.uuid:type_name -> common.UUIDConstraint
+	136, // 201: common.SegmentType.uint64:type_name -> common.Uint64Constraint
+	137, // 202: common.SegmentType.bytes:type_name -> common.BytesConstraint
+	12,  // 203: common.AccountType.persistence:type_name -> common.AccountTypePersistence
+	194, // 204: common.AccountType.segment_types:type_name -> common.AccountType.SegmentTypesEntry
+	138, // 205: common.AddedAccountTypeLog.account_type:type_name -> common.AccountType
+	11,  // 206: common.UpdatedDefaultEnforcementModeLog.enforcement_mode:type_name -> common.ChartEnforcementMode
+	155, // 207: common.QueryFilter.field:type_name -> common.FieldCondition
+	161, // 208: common.QueryFilter.address:type_name -> common.AddressMatch
+	151, // 209: common.QueryFilter.and:type_name -> common.AndFilter
+	152, // 210: common.QueryFilter.or:type_name -> common.OrFilter
+	153, // 211: common.QueryFilter.not:type_name -> common.NotFilter
+	143, // 212: common.QueryFilter.reference:type_name -> common.ReferenceCondition
+	148, // 213: common.QueryFilter.builtin_uint:type_name -> common.BuiltinUintCondition
+	146, // 214: common.QueryFilter.ledger:type_name -> common.LedgerCondition
+	147, // 215: common.QueryFilter.log_id:type_name -> common.LogIdCondition
+	149, // 216: common.QueryFilter.log_builtin_uint:type_name -> common.LogBuiltinUintCondition
+	150, // 217: common.QueryFilter.account_has_asset:type_name -> common.AccountHasAssetCondition
+	144, // 218: common.QueryFilter.reverted:type_name -> common.RevertedCondition
+	145, // 219: common.QueryFilter.audit:type_name -> common.AuditCondition
+	156, // 220: common.ReferenceCondition.cond:type_name -> common.StringCondition
+	13,  // 221: common.AuditCondition.field:type_name -> common.AuditField
+	156, // 222: common.AuditCondition.string_cond:type_name -> common.StringCondition
+	158, // 223: common.AuditCondition.uint_cond:type_name -> common.UintCondition
+	156, // 224: common.LedgerCondition.cond:type_name -> common.StringCondition
+	158, // 225: common.LogIdCondition.cond:type_name -> common.UintCondition
+	2,   // 226: common.BuiltinUintCondition.field:type_name -> common.TransactionBuiltinIndex
+	158, // 227: common.BuiltinUintCondition.cond:type_name -> common.UintCondition
+	4,   // 228: common.LogBuiltinUintCondition.field:type_name -> common.LogBuiltinIndex
+	158, // 229: common.LogBuiltinUintCondition.cond:type_name -> common.UintCondition
+	142, // 230: common.AndFilter.filters:type_name -> common.QueryFilter
+	142, // 231: common.OrFilter.filters:type_name -> common.QueryFilter
+	142, // 232: common.NotFilter.filter:type_name -> common.QueryFilter
+	154, // 233: common.FieldCondition.field:type_name -> common.FieldRef
+	156, // 234: common.FieldCondition.string_cond:type_name -> common.StringCondition
+	157, // 235: common.FieldCondition.int_cond:type_name -> common.IntCondition
+	158, // 236: common.FieldCondition.uint_cond:type_name -> common.UintCondition
+	159, // 237: common.FieldCondition.bool_cond:type_name -> common.BoolCondition
+	160, // 238: common.FieldCondition.exists_cond:type_name -> common.ExistsCondition
+	14,  // 239: common.AddressMatch.role:type_name -> common.AddressRole
+	142, // 240: common.PreparedQuery.filter:type_name -> common.QueryFilter
+	15,  // 241: common.PreparedQuery.target:type_name -> common.QueryTarget
+	22,  // 242: common.AggregatedVolume.input:type_name -> common.Uint256
+	22,  // 243: common.AggregatedVolume.output:type_name -> common.Uint256
+	163, // 244: common.AggregateResult.volumes:type_name -> common.AggregatedVolume
+	165, // 245: common.AggregateResult.groups:type_name -> common.GroupedAggregateResult
+	163, // 246: common.GroupedAggregateResult.volumes:type_name -> common.AggregatedVolume
+	32,  // 247: common.PreparedQueryCursor.account_data:type_name -> common.Account
+	24,  // 248: common.PreparedQueryCursor.transaction_data:type_name -> common.Transaction
+	42,  // 249: common.PreparedQueryCursor.log_data:type_name -> common.Log
+	169, // 250: common.CallerSnapshot.identity:type_name -> common.CallerIdentity
+	171, // 251: common.BackupStorage.s3:type_name -> common.S3StorageConfig
+	172, // 252: common.BackupStorage.azure:type_name -> common.AzureStorageConfig
+	174, // 253: common.ListOptions.read:type_name -> common.ReadOptions
+	142, // 254: common.ListOptions.filter:type_name -> common.QueryFilter
+	19,  // 255: common.MetadataMap.ValuesEntry.value:type_name -> common.MetadataValue
+	19,  // 256: common.Transaction.MetadataEntry.value:type_name -> common.MetadataValue
+	28,  // 257: common.PostCommitVolumes.VolumesByAccountEntry.value:type_name -> common.VolumesByAssets
+	19,  // 258: common.Account.MetadataEntry.value:type_name -> common.MetadataValue
+	35,  // 259: common.MetadataSchema.AccountFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	35,  // 260: common.MetadataSchema.TransactionFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	35,  // 261: common.MetadataSchema.LedgerFieldsEntry.value:type_name -> common.MetadataFieldSchema
+	19,  // 262: common.SavedLedgerMetadataLog.MetadataEntry.value:type_name -> common.MetadataValue
+	138, // 263: common.CreatedLedgerLog.AccountTypesEntry.value:type_name -> common.AccountType
+	20,  // 264: common.CreatedTransaction.AccountMetadataEntry.value:type_name -> common.MetadataMap
+	19,  // 265: common.SavedMetadata.MetadataEntry.value:type_name -> common.MetadataValue
+	138, // 266: common.LedgerInfo.AccountTypesEntry.value:type_name -> common.AccountType
+	19,  // 267: common.LedgerInfo.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 268: common.SaveMetadataCommand.MetadataEntry.value:type_name -> common.MetadataValue
+	19,  // 269: common.TransactionState.MetadataEntry.value:type_name -> common.MetadataValue
+	134, // 270: common.AccountType.SegmentTypesEntry.value:type_name -> common.SegmentType
+	196, // 271: common.allowed_query_targets:extendee -> google.protobuf.FieldOptions
+	196, // 272: common.valid_on_no_query_target:extendee -> google.protobuf.FieldOptions
+	15,  // 273: common.allowed_query_targets:type_name -> common.QueryTarget
+	274, // [274:274] is the sub-list for method output_type
+	274, // [274:274] is the sub-list for method input_type
+	273, // [273:274] is the sub-list for extension type_name
+	271, // [271:273] is the sub-list for extension extendee
+	0,   // [0:271] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -5696,6 +5696,8 @@ func (m orderSkippedLog_contextMapReadonly) Range(yield func(string, string) boo
 type CreatedIndexLogReader interface {
 	GetId() IndexIDReader
 	GetInitial() bool
+	GetBoundType() MetadataType
+	GetBoundTypeDeclared() bool
 	Mutate() *CreatedIndexLog
 }
 
@@ -5711,6 +5713,14 @@ func (r *createdIndexLogReadonly) GetId() IndexIDReader {
 
 func (r *createdIndexLogReadonly) GetInitial() bool {
 	return (*CreatedIndexLog)(r).GetInitial()
+}
+
+func (r *createdIndexLogReadonly) GetBoundType() MetadataType {
+	return (*CreatedIndexLog)(r).GetBoundType()
+}
+
+func (r *createdIndexLogReadonly) GetBoundTypeDeclared() bool {
+	return (*CreatedIndexLog)(r).GetBoundTypeDeclared()
 }
 
 func (r *createdIndexLogReadonly) Mutate() *CreatedIndexLog {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -2021,6 +2021,8 @@ func (m *CreatedIndexLog) CloneVT() *CreatedIndexLog {
 	r := new(CreatedIndexLog)
 	r.Id = m.Id.CloneVT()
 	r.Initial = m.Initial
+	r.BoundType = m.BoundType
+	r.BoundTypeDeclared = m.BoundTypeDeclared
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -7964,6 +7966,12 @@ func (this *CreatedIndexLog) EqualVT(that *CreatedIndexLog) bool {
 		return false
 	}
 	if this.Initial != that.Initial {
+		return false
+	}
+	if this.BoundType != that.BoundType {
+		return false
+	}
+	if this.BoundTypeDeclared != that.BoundTypeDeclared {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -17164,6 +17172,21 @@ func (m *CreatedIndexLog) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.BoundTypeDeclared {
+		i--
+		if m.BoundTypeDeclared {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.BoundType != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.BoundType))
+		i--
+		dAtA[i] = 0x18
+	}
 	if m.Initial {
 		i--
 		if m.Initial {
@@ -25358,6 +25381,12 @@ func (m *CreatedIndexLog) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Initial {
+		n += 2
+	}
+	if m.BoundType != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.BoundType))
+	}
+	if m.BoundTypeDeclared {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -40110,6 +40139,45 @@ func (m *CreatedIndexLog) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Initial = bool(v != 0)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BoundType", wireType)
+			}
+			m.BoundType = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BoundType |= MetadataType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BoundTypeDeclared", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.BoundTypeDeclared = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/query/compile.go
+++ b/internal/query/compile.go
@@ -57,7 +57,7 @@ type compileCtx struct {
 	// read failure. Compile uses it to pick the right v_n keyspace
 	// and to refuse early with ErrIndexBuilding when no live keyspace
 	// exists yet.
-	indexVersionFor func(canonical string) (uint32, bool, error)
+	indexVersionFor readstore.IndexVersionResolver
 	// pin is the main-store handle's applied sequence: metadata / exists
 	// index leaves resolve their event groups at this sequence, so index
 	// selection observes exactly the state the rest of the query reads
@@ -102,7 +102,7 @@ func Compile(
 	schema map[string]*commonpb.MetadataFieldSchema,
 	info *commonpb.LedgerInfo,
 	indexRegistry indexes.Lookup,
-	indexVersionFor func(canonical string) (uint32, bool, error),
+	indexVersionFor readstore.IndexVersionResolver,
 	profile *QueryProfile,
 	pebbleReader dal.PebbleReader,
 	pin uint64,
@@ -121,7 +121,9 @@ func Compile(
 		// A nil resolver means "every index is at v=1" — only safe in
 		// tests that pre-date EN-1323 versioning. Production wiring
 		// always supplies a resolver backed by readstore.
-		indexVersionFor = func(string) (uint32, bool, error) { return 1, true, nil }
+		indexVersionFor = func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{Version: 1}, true, nil
+		}
 	}
 
 	ctx := &compileCtx{
@@ -483,10 +485,32 @@ func compileFieldCondition(ctx *compileCtx, fc *commonpb.FieldCondition) (readst
 
 	metaID := indexes.MetadataID(targetTypeForQueryTarget(ctx.target), metaKey)
 
-	indexVersion, err := requireIndexReady(ctx, metaID,
+	resolved, err := requireIndexReady(ctx, metaID,
 		fmt.Sprintf("metadata[%q] on %s", metaKey, targetName))
 	if err != nil {
 		return nil, err
+	}
+
+	// The condition is validated and encoded under the type BOUND to the
+	// version being served, not the live schema: a retype flips the schema at
+	// FSM apply but re-encodes rows only when the background rewrite finishes,
+	// so until the atomic switch the served version still carries the old
+	// type. Compiling under the new one would scan its type-tagged byte
+	// ranges over old-encoded rows — partial results (EN-1724). Old-kind
+	// conditions therefore stay valid over the complete old index for the
+	// whole window, and the new kind becomes valid atomically at the switch.
+	switch {
+	case !resolved.BindingKnown:
+		// Pre-versioning resolver (test default): the live schema is all
+		// there is.
+	case !resolved.TypeDeclared:
+		// The served version was built before any type was declared for this
+		// key. Field conditions on an undeclared key were rejected then, and
+		// the window keeps that behavior until the rewrite promotes the
+		// declared-type keyspace.
+		return nil, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: fmt.Sprintf("metadata[%q] on %s", metaKey, targetName)}}
+	default:
+		fieldSchema = &commonpb.MetadataFieldSchema{Type: resolved.Type}
 	}
 
 	fc, err = validateAndCoerceCondition(fc, fieldSchema)
@@ -495,10 +519,10 @@ func compileFieldCondition(ctx *compileCtx, fc *commonpb.FieldCondition) (readst
 	}
 
 	mc := &metadataCtx{
-		prefix:    readstore.MetadataIndexPrefixV(ctx.kb, ctx.ledgerName, ns, metaKey, indexVersion),
+		prefix:    readstore.MetadataIndexPrefixV(ctx.kb, ctx.ledgerName, ns, metaKey, resolved.Version),
 		namespace: ns,
 		metaKey:   metaKey,
-		version:   indexVersion,
+		version:   resolved.Version,
 	}
 
 	switch cond := fc.GetCondition().(type) {
@@ -1524,14 +1548,14 @@ func checkIndexed(ctx *compileCtx, id *commonpb.IndexID, label string) error {
 // which MUST be bound to the iteration snapshot — never the live
 // store — so the gate and the scan observe the same point-in-time
 // view of the atomic-switch state.
-func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (uint32, error) {
+func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (readstore.ResolvedIndexVersion, error) {
 	if err := checkIndexed(ctx, id, label); err != nil {
-		return 0, err
+		return readstore.ResolvedIndexVersion{}, err
 	}
 
-	v, primed, err := ctx.indexVersionFor(indexes.Canonical(id))
+	resolved, primed, err := ctx.indexVersionFor(indexes.Canonical(id))
 	if err != nil {
-		return 0, fmt.Errorf("resolving index version for %s: %w", label, err)
+		return readstore.ResolvedIndexVersion{}, fmt.Errorf("resolving index version for %s: %w", label, err)
 	}
 
 	if !primed {
@@ -1548,14 +1572,14 @@ func requireIndexReady(ctx *compileCtx, id *commonpb.IndexID, label string) (uin
 		// a checkpoint fetched FROM the leader, which moves the node forward,
 		// and an applied index can never exceed the leader's log to begin
 		// with.
-		return 0, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: label}}
+		return readstore.ResolvedIndexVersion{}, &domain.BusinessError{Err: &domain.ErrIndexNotFound{Index: label}}
 	}
 
-	if v == 0 {
-		return 0, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: label}}
+	if resolved.Version == 0 {
+		return readstore.ResolvedIndexVersion{}, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: label}}
 	}
 
-	return v, nil
+	return resolved, nil
 }
 
 // targetTypeForQueryTarget maps a QueryTarget to the matching TargetType used

--- a/internal/query/compile_account_asset_test.go
+++ b/internal/query/compile_account_asset_test.go
@@ -55,7 +55,9 @@ func TestCompile_AccountHasAsset_RequiresReady(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverZero := func(string) (uint32, bool, error) { return 0, true, nil }
+	resolverZero := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{BindingKnown: true}, true, nil
+	}
 
 	_, err := query.Compile(
 		nil, dal.NewKeyBuilder(), accountHasAssetFilter("USD", 2),
@@ -109,7 +111,9 @@ func TestCompile_AccountHasAsset_PrefixScan(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	iter, err := query.Compile(
 		reader, dal.NewKeyBuilder(), accountHasAssetFilter("USD", 2),

--- a/internal/query/compile_account_asset_test.go
+++ b/internal/query/compile_account_asset_test.go
@@ -172,7 +172,9 @@ func TestCompile_AccountHasAsset_PinExcludesLaterFirstTouch(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, assetID): {Ledger: ledgerName, Id: assetID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	scan := func(pin uint64) []string {
 		iter, cErr := query.Compile(
@@ -238,7 +240,9 @@ func TestCompile_RevertedAt_PinExcludesLaterRevert(t *testing.T) {
 	registry := staticIndexLookup{
 		indexes.KeyFor(ledgerName, rvatID): {Ledger: ledgerName, Id: rvatID},
 	}
-	resolverReady := func(string) (uint32, bool, error) { return 1, true, nil }
+	resolverReady := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+	}
 
 	filter := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
 		BuiltinUint: &commonpb.BuiltinUintCondition{

--- a/internal/query/compile_retype_window_test.go
+++ b/internal/query/compile_retype_window_test.go
@@ -1,0 +1,116 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// Field conditions are validated and encoded under the type BOUND to the
+// served index version, never the live schema. During a retype's conversion
+// window the schema already says the new type while the served version still
+// carries the old one — compiling under the schema would scan the new type's
+// tagged byte ranges over old-encoded rows and return partial results
+// (EN-1724). The old kind must stay valid over the complete old index for the
+// whole window, and the new kind must be rejected until the atomic switch —
+// exactly as if the retype had not happened yet.
+func TestCompile_FieldConditionBindsToTheVersionType(t *testing.T) {
+	t.Parallel()
+
+	const ledgerName = "ledger1"
+
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "tier")
+	indexRegistry := staticIndexLookup{
+		indexes.KeyFor(ledgerName, id): {Ledger: ledgerName, Id: id},
+	}
+	info := &commonpb.LedgerInfo{Name: ledgerName}
+
+	// Mid-window: the schema has flipped to INT64, the served version is
+	// still the STRING-encoded one.
+	schema := map[string]*commonpb.MetadataFieldSchema{
+		"tier": {Type: commonpb.MetadataType_METADATA_TYPE_INT64},
+	}
+	boundToString := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{
+			Version:      1,
+			Type:         commonpb.MetadataType_METADATA_TYPE_STRING,
+			TypeDeclared: true,
+			BindingKnown: true,
+		}, true, nil
+	}
+
+	stringCond := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+		Field: &commonpb.FieldCondition{
+			Field: &commonpb.FieldRef{Metadata: "tier"},
+			Condition: &commonpb.FieldCondition_StringCond{StringCond: &commonpb.StringCondition{
+				Value: &commonpb.StringCondition_Hardcoded{Hardcoded: "gold"},
+			}},
+		},
+	}}
+	intCond := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+		Field: &commonpb.FieldCondition{
+			Field:     &commonpb.FieldRef{Metadata: "tier"},
+			Condition: &commonpb.FieldCondition_IntCond{IntCond: &commonpb.IntCondition{}},
+		},
+	}}
+
+	t.Run("old-kind condition stays valid during the window", func(t *testing.T) {
+		t.Parallel()
+
+		// The success path builds its scan, so it needs a real (empty)
+		// readstore to iterate.
+		rs, err := readstore.New(t.TempDir(), logging.NopZap(), readstore.DefaultConfig())
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = rs.Close() })
+
+		iter, err := Compile(
+			rs.DB(), dal.NewKeyBuilder(), stringCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToString, nil, nil, 0)
+		require.NoError(t, err,
+			"a string condition over the still-string-encoded version must compile — rejecting it makes the whole window unqueryable")
+
+		iter.Close()
+	})
+
+	t.Run("new-kind condition is rejected until the switch", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Compile(
+			nil, nil, intCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToString, nil, nil, 0)
+		require.Error(t, err,
+			"an int condition compiled against string-encoded rows scans a disjoint byte range — partial results, must be refused")
+
+		var compileErr *domain.ErrFilterCompilation
+		require.ErrorAs(t, err, &compileErr)
+	})
+
+	t.Run("a version bound to no declared type keeps pre-declaration semantics", func(t *testing.T) {
+		t.Parallel()
+
+		boundToNothing := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{Version: 1, BindingKnown: true}, true, nil
+		}
+
+		_, err := Compile(
+			nil, nil, stringCond,
+			commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
+			nil, schema, info, indexRegistry, boundToNothing, nil, nil, 0)
+		require.Error(t, err)
+
+		var notFound *domain.ErrIndexNotFound
+		require.ErrorAs(t, err, &notFound,
+			"the served version predates any declaration: Field conditions were rejected then, and the window keeps that until the declared-type keyspace is promoted")
+	})
+}

--- a/internal/query/compile_test.go
+++ b/internal/query/compile_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
 // TestCompile_RejectsDeeplyNestedFilter is the regression for #341 /
@@ -786,7 +787,9 @@ func TestBuiltinCompilers_GateOnLocalReadiness(t *testing.T) {
 	// indexResolverZero simulates a replica whose initial backfill
 	// has not yet completed. Real production wiring uses
 	// readstore.SnapshotVersionResolver against the iteration snapshot.
-	indexResolverZero := func(string) (uint32, bool, error) { return 0, true, nil }
+	indexResolverZero := func(string) (readstore.ResolvedIndexVersion, bool, error) {
+		return readstore.ResolvedIndexVersion{BindingKnown: true}, true, nil
+	}
 
 	info := &commonpb.LedgerInfo{Name: ledgerName}
 
@@ -895,11 +898,13 @@ func TestRequireIndexReady_SurfacesPebbleError(t *testing.T) {
 	}
 
 	ctx := &compileCtx{
-		target:          commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
-		indexRegistry:   indexRegistry,
-		ledgerName:      "ledger1",
-		info:            info,
-		indexVersionFor: func(string) (uint32, bool, error) { return 0, false, pebbleErr },
+		target:        commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		indexRegistry: indexRegistry,
+		ledgerName:    "ledger1",
+		info:          info,
+		indexVersionFor: func(string) (readstore.ResolvedIndexVersion, bool, error) {
+			return readstore.ResolvedIndexVersion{}, false, pebbleErr
+		},
 	}
 
 	_, err := requireIndexReady(ctx,
@@ -1053,7 +1058,9 @@ func TestCompile_AbsentVersionRecordIsRemovedNotBuilding(t *testing.T) {
 				nil, nil, filter,
 				commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerName,
 				nil, schema, info, indexRegistry,
-				func(string) (uint32, bool, error) { return 0, tc.primed, nil },
+				func(string) (readstore.ResolvedIndexVersion, bool, error) {
+					return readstore.ResolvedIndexVersion{BindingKnown: true}, tc.primed, nil
+				},
 				nil, nil, 0,
 			)
 			require.Error(t, err)

--- a/internal/storage/readstore/index_version_test.go
+++ b/internal/storage/readstore/index_version_test.go
@@ -10,6 +10,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
@@ -26,6 +27,12 @@ func TestIndexVersionState_RoundTrip(t *testing.T) {
 		CurrentVersion:  3,
 		PendingVersion:  4,
 		RewriteProgress: []byte("cursor-bytes"),
+		// STRING is enum value zero, so it is exactly the value that would
+		// vanish if "declared" were conflated with the type's zero value.
+		CurrentType:         commonpb.MetadataType_METADATA_TYPE_STRING,
+		CurrentTypeDeclared: true,
+		PendingType:         commonpb.MetadataType_METADATA_TYPE_UINT32,
+		PendingTypeDeclared: true,
 	}
 
 	batch := store.NewBatch()
@@ -38,6 +45,10 @@ func TestIndexVersionState_RoundTrip(t *testing.T) {
 	assert.Equal(t, state.CurrentVersion, got.CurrentVersion)
 	assert.Equal(t, state.PendingVersion, got.PendingVersion)
 	assert.Equal(t, state.RewriteProgress, got.RewriteProgress)
+	assert.Equal(t, state.CurrentType, got.CurrentType)
+	assert.True(t, got.CurrentTypeDeclared, "declared STRING must not decode as undeclared")
+	assert.Equal(t, state.PendingType, got.PendingType)
+	assert.True(t, got.PendingTypeDeclared)
 }
 
 func TestIndexVersionState_NoRewriteProgress(t *testing.T) {

--- a/internal/storage/readstore/index_version_test.go
+++ b/internal/storage/readstore/index_version_test.go
@@ -166,7 +166,7 @@ func TestSnapshotVersionResolver_TornReadIsImpossible(t *testing.T) {
 	gotSnap, primed, err := resolveFromSnap(canonical)
 	require.NoError(t, err)
 	require.True(t, primed)
-	assert.Equal(t, uint32(1), gotSnap,
+	assert.Equal(t, uint32(1), gotSnap.Version,
 		"snapshot resolver must hold the pre-switch version — otherwise a query that already iterates a pre-switch keyspace would receive a post-switch version, scanning a half-populated v_new range")
 
 	// Sanity: the live store has of course flipped.
@@ -240,7 +240,7 @@ func TestSnapshotVersionResolver_AbsentReturnsZero(t *testing.T) {
 
 	got, primed, err := readstore.SnapshotVersionResolver(snap, "ledger1")("acct:metadata:never-built")
 	require.NoError(t, err, "absent state must NOT be reported as an error — the query layer decides what an absent record means")
-	assert.Equal(t, uint32(0), got)
+	assert.Equal(t, uint32(0), got.Version)
 	assert.False(t, primed, "absent means no record was ever written for this index on this replica")
 }
 

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -15,6 +15,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/pebblecfg"
 )
@@ -377,6 +378,30 @@ type IndexVersionState struct {
 	// retraction such a pass emits loses the same-sequence tie to the
 	// standing ADD — an immortal row. Reuse is the only way into that state.
 	HighWater uint32
+
+	// CurrentType is the declared metadata type CurrentVersion's rows are
+	// encoded under, bound when the version was built and changed only by
+	// the atomic switch. It is what makes a retype invisible to queries
+	// until the switch: the schema flips at FSM apply, but a query serves
+	// CurrentVersion and must validate and encode its conditions under the
+	// type those rows actually carry — a condition compiled under the new
+	// declared type over old-encoded rows sees only the rows written after
+	// the retype (type-tagged encodings occupy disjoint byte ranges), i.e.
+	// partial results (EN-1724).
+	//
+	// CurrentTypeDeclared distinguishes "bound to no declared type" (the
+	// key had no schema entry when the version was built; rows carry each
+	// value's natural encoding) from METADATA_TYPE_STRING, which is enum
+	// value zero. Only meaningful on metadata indexes.
+	CurrentType         commonpb.MetadataType
+	CurrentTypeDeclared bool
+
+	// PendingType is the declared type PendingVersion's rows are encoded
+	// under: the retype's target, bound when the rewrite starts. Live
+	// dual-writes encode each value once per version, under that version's
+	// bound type.
+	PendingType         commonpb.MetadataType
+	PendingTypeDeclared bool
 }
 
 // Tombstoned reports whether the record marks a dropped index: no servable
@@ -396,19 +421,40 @@ type IndexVersionStateEntry struct {
 }
 
 // encodeIndexVersionState packs the state to a single byte slice.
-// Layout: [current(4B BE)][pending(4B BE)][activation(8B BE)][high_water(4B BE)][rewrite_progress…].
+// Layout: [current(4B BE)][pending(4B BE)][activation(8B BE)][high_water(4B BE)]
+// [current_type(1B)][pending_type(1B)][rewrite_progress…].
+// A type byte holds 0 for "no declared type bound" and 1+MetadataType
+// otherwise, so undeclared stays distinct from METADATA_TYPE_STRING (0).
 func encodeIndexVersionState(s IndexVersionState) []byte {
 	out := make([]byte, indexVersionStateHeaderLen+len(s.RewriteProgress))
 	binary.BigEndian.PutUint32(out[0:4], s.CurrentVersion)
 	binary.BigEndian.PutUint32(out[4:8], s.PendingVersion)
 	binary.BigEndian.PutUint64(out[8:16], s.ActivationSequence)
 	binary.BigEndian.PutUint32(out[16:20], s.HighWater)
+	out[20] = encodeBoundType(s.CurrentType, s.CurrentTypeDeclared)
+	out[21] = encodeBoundType(s.PendingType, s.PendingTypeDeclared)
 	copy(out[indexVersionStateHeaderLen:], s.RewriteProgress)
 
 	return out
 }
 
-const indexVersionStateHeaderLen = 20
+const indexVersionStateHeaderLen = 22
+
+func encodeBoundType(t commonpb.MetadataType, declared bool) byte {
+	if !declared {
+		return 0
+	}
+
+	return byte(t) + 1
+}
+
+func decodeBoundType(b byte) (commonpb.MetadataType, bool) {
+	if b == 0 {
+		return 0, false
+	}
+
+	return commonpb.MetadataType(b - 1), true
+}
 
 // decodeIndexVersionState parses a stored value back to IndexVersionState.
 // Returns (zero, false) on any malformed input — caller treats it as
@@ -421,13 +467,17 @@ func decodeIndexVersionState(v []byte) (IndexVersionState, bool) {
 	progress := make([]byte, len(v)-indexVersionStateHeaderLen)
 	copy(progress, v[indexVersionStateHeaderLen:])
 
-	return IndexVersionState{
+	st := IndexVersionState{
 		CurrentVersion:     binary.BigEndian.Uint32(v[0:4]),
 		PendingVersion:     binary.BigEndian.Uint32(v[4:8]),
 		ActivationSequence: binary.BigEndian.Uint64(v[8:16]),
 		HighWater:          binary.BigEndian.Uint32(v[16:20]),
 		RewriteProgress:    progress,
-	}, true
+	}
+	st.CurrentType, st.CurrentTypeDeclared = decodeBoundType(v[20])
+	st.PendingType, st.PendingTypeDeclared = decodeBoundType(v[21])
+
+	return st, true
 }
 
 // WriteIndexVersionState persists the per-replica version state for an
@@ -488,9 +538,35 @@ func (s *Store) ReadIndexVersionState(ledgerName, canonicalID string) (IndexVers
 // Returns (0, error) on a real Pebble I/O failure; (0, nil) when no
 // version state has been written yet (caller should translate to
 // ErrIndexBuilding at query boundaries).
-func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) func(canonical string) (uint32, bool, error) {
+func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) IndexVersionResolver {
 	return PinnedVersionResolver(reader, ledgerName, 0)
 }
+
+// ResolvedIndexVersion is what a query learns about an index from the
+// version state at its pin: the version to scan and the declared type
+// bound to it. The bound type — not the live schema — is what the
+// version's rows are encoded under, so conditions must be validated and
+// encoded against it (EN-1724); during a retype's conversion window the
+// two legitimately differ.
+type ResolvedIndexVersion struct {
+	Version uint32
+	// Type/TypeDeclared mirror IndexVersionState.CurrentType*: the type
+	// Version's rows carry, or "none was declared when it was built".
+	Type         commonpb.MetadataType
+	TypeDeclared bool
+	// BindingKnown is true for every resolution built from a stored version
+	// state — TypeDeclared=false is then an affirmative "built with no
+	// declared type", not missing information. Only query.Compile's
+	// pre-versioning test default leaves it false, telling the compiler to
+	// fall back to the live schema.
+	BindingKnown bool
+}
+
+// IndexVersionResolver resolves an index's servable version at the pin of
+// the snapshot it was built over. ok=false means no version state exists —
+// the index was removed (callers tell it apart from building via the
+// registry, see requireIndexReady).
+type IndexVersionResolver func(canonical string) (ResolvedIndexVersion, bool, error)
 
 // PinnedVersionResolver is the pin-aware variant: a version promoted by a
 // schema rewrite is only servable at pins at or above its activation
@@ -502,17 +578,17 @@ func SnapshotVersionResolver(reader dal.PebbleGetter, ledgerName string) func(ca
 //
 // A pin of 0 means "no pin" (introspection paths that do not resolve rows
 // at a sequence) and skips the check.
-func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint64) func(canonical string) (uint32, bool, error) {
-	return func(canonical string) (uint32, bool, error) {
+func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint64) IndexVersionResolver {
+	return func(canonical string) (ResolvedIndexVersion, bool, error) {
 		state, present, err := ReadIndexVersionStateFrom(reader, ledgerName, canonical)
 		if err != nil {
-			return 0, false, err
+			return ResolvedIndexVersion{}, false, err
 		}
 
 		if !present {
 			// No record at all. Callers use this to tell a removed index
 			// apart from one still being built — see requireIndexReady.
-			return 0, false, nil
+			return ResolvedIndexVersion{}, false, nil
 		}
 
 		if state.Tombstoned() {
@@ -520,14 +596,19 @@ func PinnedVersionResolver(reader dal.PebbleGetter, ledgerName string, pin uint6
 			// high-water version for the next incarnation; to queries it
 			// must read exactly like the removed index it is, never as one
 			// still building.
-			return 0, false, nil
+			return ResolvedIndexVersion{}, false, nil
 		}
 
 		if pin > 0 && state.ActivationSequence > pin {
-			return 0, true, nil
+			return ResolvedIndexVersion{}, true, nil
 		}
 
-		return state.CurrentVersion, true, nil
+		return ResolvedIndexVersion{
+			Version:      state.CurrentVersion,
+			Type:         state.CurrentType,
+			TypeDeclared: state.CurrentTypeDeclared,
+			BindingKnown: true,
+		}, true, nil
 	}
 }
 

--- a/internal/storage/readstore/version_activation_test.go
+++ b/internal/storage/readstore/version_activation_test.go
@@ -44,7 +44,7 @@ func TestPinnedVersionResolver_HidesAVersionAboveThePin(t *testing.T) {
 			v, primed, err := PinnedVersionResolver(snap, ledger, tc.pin)(canonical)
 			require.NoError(t, err)
 			require.True(t, primed, "the record exists; only the version is withheld")
-			require.Equal(t, tc.want, v)
+			require.Equal(t, tc.want, v.Version)
 		})
 	}
 }
@@ -74,7 +74,7 @@ func TestPinnedVersionResolver_BackfilledVersionServesAtAnyPin(t *testing.T) {
 	v, primed, err := PinnedVersionResolver(snap, ledger, 1)(canonical)
 	require.NoError(t, err)
 	require.True(t, primed)
-	require.Equal(t, uint32(1), v)
+	require.Equal(t, uint32(1), v.Version)
 }
 
 // The activation sequence survives the encode/decode round trip alongside a

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -732,6 +732,19 @@ message CreatedIndexLog {
   // The read-side indexbuilder promotes such indexes straight to live with no
   // historical backfill; later indexes (initial=false) keep backfilling. EN-1564.
   bool initial = 2;
+  // bound_type is the declared type of the indexed metadata field at this
+  // log's sequence, stamped by the FSM when the log is minted. The index's
+  // first version binds to it: every replica encodes that version's rows —
+  // live folds and backfill replays alike — under this type until a retype's
+  // atomic switch rebinds. Stamping at mint time is what keeps the binding
+  // stable at any replay distance; the schema readable when a replica folds
+  // the log may already be many retypes ahead. EN-1724.
+  MetadataType bound_type = 3;
+  // bound_type_declared is false for builtin indexes, which have no metadata
+  // field and therefore no binding: their values keep the natural encoding.
+  // Metadata indexes always carry a binding — CreateIndex validates that the
+  // field is declared in the schema.
+  bool bound_type_declared = 4;
 }
 
 // DroppedIndexLog records the removal of an index.


### PR DESCRIPTION
## What changed

Declared metadata types are bound to index versions instead of read live from the schema:

- `CreatedIndexLog` gains `bound_type` / `bound_type_declared`, stamped by the FSM at mint time — the schema entry in force at exactly the log's sequence. The indexbuilder binds the first version from the stamp; the batch-final schema read (and its silently swallowed error path) is gone from the creation fold.
- `IndexVersionState` carries `CurrentType`/`PendingType` (+ declared flags); live dual-writes encode each value once per version under that version's bound type (`coerceForVersion`), and queries validate/encode conditions under `CurrentType` until the atomic switch promotes `PendingType` with the version.
- Resumed schema rewrites read `toType` from `IndexVersionState.PendingType` (committed in the same batch by `bumpPendingVersion`); the cursor's leading type byte is a cross-check that restarts the scan on mismatch. `resolveResumedToType`, which guessed STRING on any read failure, is deleted.
- `handleCreatedIndexLog` returns an error: a failed version-state persist aborts the indexer batch so the log is re-folded.
- Indexer docs (`indexer.md`, `indexes.md`) rewritten to the per-version binding contract.

## Why

Jira: EN-1724. Mid-rewrite queries mixed encodings: the schema flips at FSM apply, but `v_current`'s rows still carry the old type — a condition compiled under the new declared type over old-encoded rows sees only rows written after the retype (typed encodings occupy disjoint key ranges), i.e. silently partial results. Found by the EN-1625 model-checking driver retype-window oracle.

This PR also resolves the three blocking findings from the automated reviews (NumaryBot + shipfox arbitration) on the closed bundle PR #1817: resume guessing STRING on a read fault, `boundTypeAtCreation` swallowing schema-read errors into a persisted false "not declared", and the creation binding leaking the batch-final schema.

## Product / operational motivation

Need: queries must never silently drop rows during or after a metadata retype.
Current limitation: the binding was derived from whatever schema was readable at fold time — batch-final at best, arbitrarily newer when a log folds during a backfill or rebuild replay.
Requirement / constraint: every replica folding a given CreateIndex log derives the same type binding, at any replay distance; the old view stays complete until the atomic switch.
Evidence: EN-1724; model-driver retype-window oracle; review findings on #1817.
Durable repository evidence: `docs/technical/architecture/subsystems/indexer/indexer.md` + `indexes.md` (updated in this PR), field comments on `CreatedIndexLog.bound_type` and `IndexVersionState`.

## Technical decision

Decision: stamp the binding into the log at FSM mint time (`processCreateIndex` has the at-sequence schema in hand; `validateIndexTarget` already guarantees the field is declared for metadata indexes).
Why now / why proportionate: any fold-time schema read is wrong at replay distance — only the log itself can carry the at-sequence binding. v3 is unreleased, so adding proto fields is free.
Alternatives considered: an in-batch schema overlay in the indexbuilder (fixes only the earlier-in-batch leak, not later-in-batch or replay); propagating the schema-read error without stamping (keeps a read that cannot be made correct, only loud).

## Risk

**MEDIUM** — touches the FSM mint path, the indexer fold path, and persisted per-replica state semantics. Mitigated by: no compat surface (v3 unreleased, wiped per release/v3.0 policy), deterministic stamp (proposal-carried, not re-derived per replica), and the test set below.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: processor stamping (at-sequence binding + builtin-carries-no-binding), fold binding from the stamp (initial + backfilling), resume-before-first-batch from `PendingType`, cursor-type mismatch restart — the two resume specs verified RED on the pre-fix code; retype-window and version-binding suites green.
- [x] Full `internal/domain/processing` + `internal/application/indexbuilder` package suites green.
- The model driver's retype-window oracle covers the serving window continuously in Antithesis runs (no red e2e: the window is transient and needs builder pause control the harness lacks).

## Architecture / behavior impact

New proto fields `CreatedIndexLog.bound_type` / `bound_type_declared` (v3 unreleased — no reservation or compat shim per repo policy). `IndexVersionState` header is 22 bytes with per-version type bindings. The declared-type flip becomes visible to queries atomically at the version switch.

## Review focus

1. The stamp's determinism: it is minted once in `processCreateIndex` and carried by the log — confirm no replica-side re-derivation remains.
2. The idempotent re-create path (READY short-circuit) also stamps at the duplicate's sequence; the fold-side `current != 0 / pending != 0` guards make that stamp inert on replicas that saw the original.
3. The cursor-mismatch restart in `scheduleResumedRewrites` (can't-happen by same-batch commit; restart-from-zero is the safe recovery).

## Known concerns

A pre-existing `IndexVersionState` written before this change carries no binding — irrelevant on release/v3.0 (state wiped every push), noted for completeness.
