### PR TITLE
fix(EN-1904): stop the index-registry preload serving stale absence

### DIFF
--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -7,7 +7,9 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
 	"github.com/formancehq/ledger/v3/internal/infra/cache"
 	"github.com/formancehq/ledger/v3/internal/infra/preload"
@@ -213,7 +215,14 @@ func resolveCoverage[T interface {
 			// Bloom filter short-circuit: when the key is definitely not
 			// in Pebble, skip the goroutine + Pebble Get and emit Declare
 			// (coverage-only, no value to seed).
-			if bloomFilter != nil && !bloomFilter.MayContain(id) {
+			//
+			// Index registry keys are exempt: they are rare enough that the
+			// Pebble read costs nothing, and a false negative here would make
+			// every replica read an existing index as absent — the removal
+			// then reports nothing dropped while the row sits in Pebble.
+			// The load below both corrects it and proves the filter wrong.
+			bloomAbsent := bloomFilter != nil && !bloomFilter.MayContain(id)
+			if bloomAbsent && attrCode != dal.SubAttrIndex {
 				mu.Lock()
 				plans = append(plans, slab.appendCoverage(id, tag, attrCode))
 				mu.Unlock()
@@ -260,6 +269,17 @@ func resolveCoverage[T interface {
 
 				var zero T
 				hasValue := any(result.Value) != any(zero)
+
+				if hasValue && bloomAbsent {
+					logger.WithFields(map[string]any{
+						"type": typeName,
+						"key":  hex.EncodeToString(canonicalKey),
+					}).Errorf("Bloom filter denied a key Pebble holds")
+					assert.Unreachable("index preload bloom false negative", map[string]any{
+						"type": typeName,
+						"key":  hex.EncodeToString(canonicalKey),
+					})
+				}
 
 				// Track bloom false positives: MayContain said "maybe" but Pebble
 				// had nothing. Only counts loads we actually performed (FromLoad).

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
-	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
-
 	"github.com/formancehq/ledger/v3/internal/infra/bloom"
 	"github.com/formancehq/ledger/v3/internal/infra/cache"
 	"github.com/formancehq/ledger/v3/internal/infra/preload"
@@ -318,9 +318,22 @@ func resolveCoverage[T interface {
 				// cache epoch, so a stale cached absence would poison every
 				// later preload of the key — deterministically, since the
 				// plan is replicated. For index keys, arbitrate an absent
-				// answer against a fresh read before trusting it.
+				// answer against a fresh read before trusting it. A failed
+				// arbitration fails the resolve, exactly like the primary
+				// load and marshal paths: a coverage-only plan carries no
+				// seed, so apply would route back through the very cache
+				// this read exists to distrust.
 				if !hasValue && attrCode == dal.SubAttrIndex {
-					if fresh, freshErr := getValue(store, canonicalKey); freshErr == nil && any(fresh) != any(zero) {
+					fresh, freshErr := getValue(store, canonicalKey)
+					if freshErr != nil {
+						if firstErr == nil {
+							firstErr = freshErr
+						}
+
+						return
+					}
+
+					if any(fresh) != any(zero) {
 						logger.WithFields(map[string]any{
 							"type": typeName,
 							"key":  hex.EncodeToString(canonicalKey),
@@ -330,11 +343,18 @@ func resolveCoverage[T interface {
 							"key":  hex.EncodeToString(canonicalKey),
 						})
 
-						if attrValue, mErr := buildPreloadPayload(attrCode, fresh); mErr == nil {
-							plans = append(plans, slab.appendSeed(id, tag, attrCode, attrValue))
+						attrValue, marshalErr := buildPreloadPayload(attrCode, fresh)
+						if marshalErr != nil {
+							if firstErr == nil {
+								firstErr = marshalErr
+							}
 
 							return
 						}
+
+						plans = append(plans, slab.appendSeed(id, tag, attrCode, attrValue))
+
+						return
 					}
 				}
 

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -302,6 +302,30 @@ func resolveCoverage[T interface {
 					return
 				}
 
+				// The loader dedupes and caches loads keyed by boundary and
+				// cache epoch, so a stale cached absence would poison every
+				// later preload of the key — deterministically, since the
+				// plan is replicated. For index keys, arbitrate an absent
+				// answer against a fresh read before trusting it.
+				if !hasValue && attrCode == dal.SubAttrIndex {
+					if fresh, freshErr := getValue(store, canonicalKey); freshErr == nil && any(fresh) != any(zero) {
+						logger.WithFields(map[string]any{
+							"type": typeName,
+							"key":  hex.EncodeToString(canonicalKey),
+						}).Errorf("Index preload served absence for a row Pebble holds")
+						assert.Unreachable("index preload served stale absence", map[string]any{
+							"type": typeName,
+							"key":  hex.EncodeToString(canonicalKey),
+						})
+
+						if attrValue, mErr := buildPreloadPayload(attrCode, fresh); mErr == nil {
+							plans = append(plans, slab.appendSeed(id, tag, attrCode, attrValue))
+
+							return
+						}
+					}
+				}
+
 				// Pebble had no value either — coverage-only entry. If a
 				// concurrent write populated the cache between admission
 				// and apply, Get's gen0→gen1 fallback will surface it at

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -205,11 +205,23 @@ func resolveCoverage[T interface {
 			// Preload: Get's gen0→gen1 fallback surfaces the value on
 			// read and Del's lazy promote fabricates a gen0 tombstone
 			// on delete. No Pebble read required.
-			mu.Lock()
-			plans = append(plans, slab.appendCoverage(id, tag, attrCode))
-			mu.Unlock()
+			//
+			// Index registry keys never take this shortcut: the classifier
+			// answers hit for any resident under the key's id — tombstoned or
+			// tag-mismatched included — while the apply-path read checks both
+			// and treats them as absent. Loading and seeding below keeps the
+			// plan carrying the durable truth for these rare keys; with the
+			// miss path already arbitrated, a finding that persists past this
+			// pins the divergence to the cache shadowing the seed at apply.
+			if attrCode != dal.SubAttrIndex {
+				mu.Lock()
+				plans = append(plans, slab.appendCoverage(id, tag, attrCode))
+				mu.Unlock()
 
-			continue
+				continue
+			}
+
+			fallthrough
 
 		case cache.CacheMiss:
 			// Bloom filter short-circuit: when the key is definitely not

--- a/internal/infra/plan/resolve.go
+++ b/internal/infra/plan/resolve.go
@@ -295,7 +295,9 @@ func resolveCoverage[T interface {
 
 				// Track bloom false positives: MayContain said "maybe" but Pebble
 				// had nothing. Only counts loads we actually performed (FromLoad).
-				if result.FromLoad && !hasValue && bloomFilter != nil {
+				// A bloom-negative load (an index key exempt from the veto) is a
+				// true negative, not a false positive.
+				if result.FromLoad && !hasValue && bloomFilter != nil && !bloomAbsent {
 					bloomFilter.RecordFalsePositive()
 				}
 

--- a/internal/infra/plan/resolve_arbitration_test.go
+++ b/internal/infra/plan/resolve_arbitration_test.go
@@ -1,0 +1,169 @@
+package plan
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/bloom"
+	"github.com/formancehq/ledger/v3/internal/infra/cache"
+	"github.com/formancehq/ledger/v3/internal/infra/preload"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// arbitrationFixture wires the minimum resolveCoverage needs to drive one
+// index key down the miss path: an empty attribute cache (CheckCache →
+// CacheMiss), a fresh loader, and an injected getValue whose first call is
+// the primary load and whose second call is the stale-absence arbitration
+// read.
+func arbitrationFixture(t *testing.T) (*cache.Cache, *preload.AttributeLoader[*commonpb.Index], map[attributes.U128]CoverageEntry) {
+	t.Helper()
+
+	c, err := cache.New(1000, nil)
+	require.NoError(t, err)
+
+	canonical := []byte("bucket/ledger/meta:account:score")
+	id, tag := attributes.MakeKey(canonical)
+
+	return c, preload.NewAttributeLoader[*commonpb.Index](), map[attributes.U128]CoverageEntry{
+		id: {Canonical: canonical, Tag: tag},
+	}
+}
+
+// TestResolveCoverage_IndexArbitration_FreshReadFailureFailsResolve pins the
+// error contract of the stale-absence arbitration: when the loader serves an
+// absence for an index key and the arbitrating Pebble read fails, the resolve
+// fails — the same contract as the primary load path. Degrading to a
+// coverage-only plan instead would authorize the key with no seed, and apply
+// would route back through the very cache the arbitration exists to distrust.
+func TestResolveCoverage_IndexArbitration_FreshReadFailureFailsResolve(t *testing.T) {
+	t.Parallel()
+
+	c, loader, keys := arbitrationFixture(t)
+
+	readErr := errors.New("injected pebble read failure")
+
+	var calls atomic.Int32
+
+	getValue := func(dal.PebbleGetter, []byte) (*commonpb.Index, error) {
+		if calls.Add(1) == 1 {
+			return nil, nil
+		}
+
+		return nil, readErr
+	}
+
+	_, err := resolveCoverage(
+		keys, 1, 1, 1,
+		c.Indexes, loader, getValue, nil,
+		dal.SubAttrIndex, nil, nil, logging.Testing(), "indexes",
+	)
+	require.ErrorIs(t, err, readErr)
+	require.EqualValues(t, 2, calls.Load(), "the absence must be arbitrated by a second read")
+}
+
+// TestResolveCoverage_IndexArbitration_FreshValueSeedsPlan pins the recovery
+// path: a loader-served absence contradicted by the fresh read yields a
+// seeded plan carrying the durable value.
+func TestResolveCoverage_IndexArbitration_FreshValueSeedsPlan(t *testing.T) {
+	t.Parallel()
+
+	c, loader, keys := arbitrationFixture(t)
+
+	var calls atomic.Int32
+
+	getValue := func(dal.PebbleGetter, []byte) (*commonpb.Index, error) {
+		if calls.Add(1) == 1 {
+			return nil, nil
+		}
+
+		return &commonpb.Index{Ledger: "ledger"}, nil
+	}
+
+	res, err := resolveCoverage(
+		keys, 1, 1, 1,
+		c.Indexes, loader, getValue, nil,
+		dal.SubAttrIndex, nil, nil, logging.Testing(), "indexes",
+	)
+	require.NoError(t, err)
+	require.Len(t, res.attributes, 1)
+	require.NotNil(t, res.attributes[0].GetValue(), "the arbitrated value must seed the plan")
+}
+
+// TestResolveCoverage_IndexKeyExemptFromBloomVeto pins the bloom-veto
+// exemption for index registry keys: a filter that answers "definitely not
+// present" must not short-circuit the Pebble load — the registry can hold a
+// row the filter never learned, and a vetoed load would make every replica
+// read an existing index as absent. The load runs and seeds the plan with
+// the durable row.
+func TestResolveCoverage_IndexKeyExemptFromBloomVeto(t *testing.T) {
+	t.Parallel()
+
+	c, loader, keys := arbitrationFixture(t)
+
+	bfs := bloom.NewFilterSet(&commonpb.ClusterConfig{
+		BloomIndexes: &commonpb.BloomTypeConfig{ExpectedKeys: 1024, FpRate: 0.001},
+	}, nil)
+	require.NotNil(t, bfs)
+
+	filter := bfs.FilterForAttrType(dal.SubAttrIndex)
+	require.NotNil(t, filter)
+
+	var calls atomic.Int32
+
+	getValue := func(dal.PebbleGetter, []byte) (*commonpb.Index, error) {
+		calls.Add(1)
+
+		return &commonpb.Index{Ledger: "ledger"}, nil
+	}
+
+	res, err := resolveCoverage(
+		keys, 1, 1, 1,
+		c.Indexes, loader, getValue, nil,
+		dal.SubAttrIndex, nil, filter, logging.Testing(), "indexes",
+	)
+	require.NoError(t, err)
+	require.NotZero(t, calls.Load(), "the bloom veto must not suppress the index registry load")
+	require.Len(t, res.attributes, 1)
+	require.NotNil(t, res.attributes[0].GetValue(), "the loaded row must seed the plan")
+}
+
+// TestResolveCoverage_IndexKeyCacheHitStillLoads pins the cache-hit
+// fallthrough for index registry keys: the classifier answers hit for any
+// resident under the key's id — tombstoned or tag-mismatched included —
+// while the apply-path read treats those as absent, so a coverage-only
+// shortcut would strand the durable row. Index keys load and seed even on a
+// cache hit.
+func TestResolveCoverage_IndexKeyCacheHitStillLoads(t *testing.T) {
+	t.Parallel()
+
+	c, loader, keys := arbitrationFixture(t)
+
+	for id, entry := range keys {
+		c.Indexes.Put(id, attributes.Entry[*commonpb.Index]{Tag: entry.Tag, Data: &commonpb.Index{Ledger: "stale"}})
+	}
+
+	var calls atomic.Int32
+
+	getValue := func(dal.PebbleGetter, []byte) (*commonpb.Index, error) {
+		calls.Add(1)
+
+		return &commonpb.Index{Ledger: "ledger"}, nil
+	}
+
+	res, err := resolveCoverage(
+		keys, 1, 1, 1,
+		c.Indexes, loader, getValue, nil,
+		dal.SubAttrIndex, nil, nil, logging.Testing(), "indexes",
+	)
+	require.NoError(t, err)
+	require.NotZero(t, calls.Load(), "a cache hit must not skip the index registry load")
+	require.Len(t, res.attributes, 1)
+	require.NotNil(t, res.attributes[0].GetValue(), "the loaded row must seed the plan")
+}


### PR DESCRIPTION
## What changed

Apply-side index-registry preloads no longer trust anything but pebble for index keys: the bloom veto and the cache-hit shortcut are bypassed for `SubAttrIndex`, a loader-cached absence is arbitrated against a fresh pebble read, and a failed arbitration read (or marshal) fails the resolve instead of degrading to a coverage-only plan.

## Why

Jira: EN-1904. Three holes let the apply path read an existing index registry row as absent — deterministically on every replica, since the plan is replicated — driving wrong CreateIndex/DropIndex lifecycle decisions. Found by the EN-1625 model-checking driver hunts (Antithesis assert class "index preload served stale absence").

The error-propagation fix resolves the blocking finding from the automated reviews on the closed bundle PR #1817: both `freshErr` and the arbitration marshal error now land in `firstErr`, matching the primary load and marshal paths — coverage-only authorizes the key with no seed, so apply would route back through the very cache the arbitration exists to distrust.

## Product / operational motivation

N/A (bug fix; index registry keys are rare, so the exempted pebble reads cost nothing)

## Technical decision

N/A

## Risk

**LOW** — scoped to `attrCode == dal.SubAttrIndex`; other attribute types keep the bloom/cache shortcuts unchanged.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `resolve_arbitration_test.go` pins all four behaviors (fresh-read failure fails the resolve, arbitrated value seeds the plan, bloom-veto exemption, cache-hit fallthrough) — every spec verified RED against the pre-fix resolver.
- [x] Full `internal/infra/plan` package suite green.
- No red e2e: these are race-window bugs needing adversarial scheduling (a rotation+restart recipe stays green on old, verified empirically); the windows stay covered continuously by the Antithesis assert class.

## Architecture / behavior impact

Index-key preloads always perform a pebble read on the miss/hit paths; plans for index keys are seeded with the durable row rather than coverage-only whenever pebble holds one.

## Review focus

The arbitration block in `resolve.go` — the error contract must match the primary load path exactly, and the confirmed-absence case must still fall through to coverage-only.

## Known concerns

None
