### PR TITLE
docs(agents): route deep audits through native workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ Critical persisted configuration such as node/cluster identity and storage schem
 
 Do not preload the whole documentation tree. Prefer the smallest authoritative context that covers the change.
 
+## Deep correctness audits
+
+Before a repository-wide/deep correctness audit for latent defects in a reusable domain, check `docs/technical/audits/` for an existing manifest. When one matches, read the native audit contracts and use `bash scripts/ai-audit <domain>` followed by `bash scripts/ai-audit-challenge <audit-result>`; do not replace that domain with an ad-hoc prompt or treat first-pass findings as confirmed defects. If no manifest matches, first decide whether the scope deserves a reusable manifest and review it before running the audit. PR reviews use the PR review workflow; one-off diagnostics, single known bug fixes, and performance/tooling investigations may remain task-specific unless intentionally promoted into a reusable audit domain. Audits and challenges are read-only, and Jira publication is a separate, explicitly authorized downstream step.
+
 <a id="invariants"></a>
 ## Non-negotiable architecture invariants
 

--- a/docs/technical/agent-context.md
+++ b/docs/technical/agent-context.md
@@ -115,6 +115,25 @@ Before adding a flag, environment variable, startup setting, or version-dependen
 
 Decide explicitly whether the value only gates proposal admission or changes the outcome of a committed entry. Node-local configuration may do the former; it must never do the latter. If concurrent admissions can exceed a local operational limit, document whether that soft-limit behavior is intentional rather than silently presenting it as a strict FSM invariant.
 
+### Deep correctness audits
+
+Use the native deep-audit workflow when the request seeks latent correctness defects across an immutable repository state in a reusable domain, such as persistence/restore/replay, Raft membership/leadership, accounting invariants, idempotency/partial failures, read consistency, or concurrency/lifecycle.
+
+1. Check `docs/technical/audits/` for a matching domain manifest.
+2. If a manifest exists, read `docs/technical/contributing/ai-audit.md` and run `bash scripts/ai-audit <domain>`. Keep the manifest as the campaign scope instead of replacing it with an ad-hoc audit prompt.
+3. Qualify the structured result with `bash scripts/ai-audit-challenge <audit-result>` after reading `docs/technical/contributing/ai-audit-challenge.md`. The challenge pass independently tries to disprove every finding; a first-pass finding is not a confirmed engineering defect.
+4. Treat Jira publication as a separate, later step. `scripts/ai-audit-jira` consumes a qualified report, and publication requires explicit authorization; neither the audit nor challenge pass creates issues.
+
+If no manifest matches, first decide whether the requested correctness scope is durable and reusable. If it is, create and review a manifest before running the native audit. If it is not, keep the work as a task-specific investigation rather than mechanically creating a new audit domain.
+
+Do not use `ai-audit` for:
+
+- pull-request review, which follows the AI code review and re-review workflow below;
+- diagnosis or implementation of one concrete known bug;
+- routine performance analysis, benchmark work, CI timing analysis, or diagnosis of one tooling failure, unless the work is intentionally being promoted into a reusable correctness domain.
+
+`ai-audit` runs a read-only, manifest-scoped provider pass and binds its structured report to an exact clean `HEAD`; `ai-audit-challenge` independently qualifies that report at the same clean `HEAD`. Their contracts prohibit code fixes, commits, pushes, comments, issue creation, and GitHub metadata changes; structured reports are their only intended writes.
+
 ### AI code review and re-review
 
 Read `docs/technical/contributing/ai-review.md` before reviewing a pull request or reviewing fixes to previous findings.

--- a/docs/technical/contributing/ai-audit.md
+++ b/docs/technical/contributing/ai-audit.md
@@ -1,9 +1,11 @@
 # AI deep-audit contract
 
-This contract defines repository-wide audit campaigns. It is intentionally separate from the PR review loop:
+This contract defines repository-wide audit campaigns for reusable correctness domains. It is intentionally separate from the PR review loop:
 
 - PR review asks whether a bounded change is safe to integrate;
 - deep audit asks which latent defects may already exist in an immutable repository state.
+
+Routine diagnosis of a known failure, a single bug fix, and performance or tooling investigation remain task-specific unless intentionally promoted into a reusable audit domain.
 
 An audit is read-only. It must never fix code, create commits, push branches, create issues, resolve review threads, or change GitHub metadata.
 
@@ -38,9 +40,11 @@ Audit findings are held to a higher evidence standard than ordinary review sugge
 
 Questions are explicit uncertainties that need human/product/architecture input. They are not findings and must not be counted as defects.
 
-## Duplicate and challenge pass
+## Challenge and downstream publication
 
-A future campaign orchestrator may run independent auditors and challenge findings. The first version deliberately does not auto-deduplicate or auto-fix. A finding becomes a confirmed engineering defect only after reproduction, an independent confirming review, or human validation.
+Every finding emitted by the audit is a hypothesis. Qualify the report with `bash scripts/ai-audit-challenge <audit-result>` according to `docs/technical/contributing/ai-audit-challenge.md`. The challenge pass independently tries to disprove every finding, including by searching for unreachable states, duplicates, and existing protections. A finding is not a confirmed engineering defect merely because the first audit emitted it.
+
+A `CONFIRMED` challenge result is eligible to become a backlog/Jira candidate after human or policy approval. Jira handling is an explicit downstream action through `bash scripts/ai-audit-jira <challenge-result>`; the command previews candidates unless separately invoked with `--publish`. Neither the audit nor challenge pass fixes code, creates issues, or publishes findings automatically.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- route reusable deep correctness audit requests from AGENTS.md through the existing manifest-driven ai-audit workflow
- document the boundary between deep audits, PR review, and task-specific diagnostics
- require independent challenge qualification before treating first-pass findings as confirmed
- clarify that Jira publication is an explicit downstream action
- update the audit contract to describe the already-shipped native challenge stage

## Scope

Documentation and AI-agent process guidance only. No runtime or script changes. No audit was run and no Jira issue was published.

## Validation

- bash scripts/agent-check (fixpoint and after each target rebase)
- git diff --check
- exact read-only Codex review of commit 4f3434d9ad80813d598d2202116dfd1f1bce9023: no actionable findings
