### PR TITLE
fix: preserve state for atomic bulks after import (v2.3 backport)

### DIFF
--- a/internal/controller/ledger/controller_with_events.go
+++ b/internal/controller/ledger/controller_with_events.go
@@ -10,11 +10,18 @@ import (
 
 type ControllerWithEvents struct {
 	Controller
-	ledger   ledger.Ledger
-	listener Listener
-	atCommit []func()
-	parent   *ControllerWithEvents
-	hasTx    bool
+	ledger      ledger.Ledger
+	listener    Listener
+	eventBuffer *transactionalEventBuffer
+}
+
+// transactionalEventBuffer follows transaction boundaries independently from
+// the controller wrappers created by BeginTX and LockLedger. A nested commit
+// promotes its events to the enclosing transaction; only the root commit
+// publishes them.
+type transactionalEventBuffer struct {
+	parent    *transactionalEventBuffer
+	callbacks []func()
 }
 
 func NewControllerWithEvents(ledger ledger.Ledger, underlying Controller, listener Listener) *ControllerWithEvents {
@@ -26,16 +33,31 @@ func NewControllerWithEvents(ledger ledger.Ledger, underlying Controller, listen
 }
 
 func (c *ControllerWithEvents) handleEvent(ctx context.Context, fn func()) {
-	if !c.hasTx {
+	if c.eventBuffer == nil {
 		fn()
 		return
 	}
-	if c.parent != nil && c.parent.hasTx {
-		c.parent.handleEvent(ctx, fn)
-		return
-	}
 
-	c.atCommit = append(c.atCommit, fn)
+	c.eventBuffer.add(fn)
+}
+
+func (b *transactionalEventBuffer) add(fn func()) {
+	b.callbacks = append(b.callbacks, fn)
+}
+
+func (b *transactionalEventBuffer) commit() {
+	if b.parent != nil {
+		b.parent.callbacks = append(b.parent.callbacks, b.callbacks...)
+	} else {
+		for _, callback := range b.callbacks {
+			callback()
+		}
+	}
+	b.callbacks = nil
+}
+
+func (b *transactionalEventBuffer) rollback() {
+	b.callbacks = nil
 }
 
 func (c *ControllerWithEvents) CreateTransaction(ctx context.Context, parameters Parameters[CreateTransaction]) (*ledger.Log, *ledger.CreatedTransaction, bool, error) {
@@ -161,8 +183,9 @@ func (c *ControllerWithEvents) BeginTX(ctx context.Context, options *sql.TxOptio
 		ledger:     c.ledger,
 		Controller: ctrl,
 		listener:   c.listener,
-		parent:     c,
-		hasTx:      true,
+		eventBuffer: &transactionalEventBuffer{
+			parent: c.eventBuffer,
+		},
 	}, tx, nil
 }
 
@@ -172,11 +195,13 @@ func (c *ControllerWithEvents) LockLedger(ctx context.Context) (Controller, bun.
 		return nil, nil, nil, err
 	}
 
+	// Locking swaps the underlying controller but does not create a transaction
+	// boundary, so both wrappers share the same event buffer.
 	return &ControllerWithEvents{
-		ledger:     c.ledger,
-		Controller: ctrl,
-		listener:   c.listener,
-		parent:     c,
+		ledger:      c.ledger,
+		Controller:  ctrl,
+		listener:    c.listener,
+		eventBuffer: c.eventBuffer,
 	}, db, release, nil
 }
 
@@ -186,15 +211,19 @@ func (c *ControllerWithEvents) Commit(ctx context.Context) error {
 		return err
 	}
 
-	for _, f := range c.atCommit {
-		f()
+	if c.eventBuffer != nil {
+		c.eventBuffer.commit()
+		c.eventBuffer = nil
 	}
 
 	return nil
 }
 
 func (c *ControllerWithEvents) Rollback(ctx context.Context) error {
-	c.atCommit = nil
+	if c.eventBuffer != nil {
+		c.eventBuffer.rollback()
+		c.eventBuffer = nil
+	}
 
 	return c.Controller.Rollback(ctx)
 }

--- a/internal/controller/ledger/controller_with_events_test.go
+++ b/internal/controller/ledger/controller_with_events_test.go
@@ -1,0 +1,164 @@
+package ledger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"go.uber.org/mock/gomock"
+
+	ledger "github.com/formancehq/ledger/internal"
+)
+
+func TestControllerWithEventsLockLedgerPreservesTransaction(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name   string
+		commit bool
+	}{
+		{name: "commit publishes the event", commit: true},
+		{name: "rollback discards the event", commit: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockController := gomock.NewController(t)
+			root := NewMockController(mockController)
+			transaction := NewMockController(mockController)
+			locked := NewMockController(mockController)
+			listener := NewMockListener(mockController)
+			ctx := context.Background()
+			parameters := Parameters[CreateTransaction]{}
+			created := &ledger.CreatedTransaction{
+				Transaction: ledger.NewTransaction(),
+			}
+			eventPublished := false
+
+			root.EXPECT().
+				BeginTX(ctx, nil).
+				Return(transaction, &bun.Tx{}, nil)
+			transaction.EXPECT().
+				LockLedger(ctx).
+				Return(locked, nil, func() error { return nil }, nil)
+			locked.EXPECT().
+				CreateTransaction(ctx, parameters).
+				Return(&ledger.Log{}, created, false, nil)
+
+			if testCase.commit {
+				transaction.EXPECT().Commit(ctx).Return(nil)
+				listener.EXPECT().
+					CommittedTransactions(ctx, "foo", created.Transaction, created.AccountMetadata).
+					Do(func(context.Context, string, ledger.Transaction, ledger.AccountMetadata) {
+						eventPublished = true
+					})
+			} else {
+				transaction.EXPECT().Rollback(ctx).Return(nil)
+			}
+
+			controller := NewControllerWithEvents(ledger.Ledger{Name: "foo"}, root, listener)
+			transactionController, _, err := controller.BeginTX(ctx, nil)
+			require.NoError(t, err)
+
+			lockedController, _, release, err := transactionController.LockLedger(ctx)
+			require.NoError(t, err)
+
+			_, _, _, err = lockedController.CreateTransaction(ctx, parameters)
+			require.NoError(t, err)
+			require.NoError(t, release())
+			require.False(t, eventPublished)
+
+			if testCase.commit {
+				require.NoError(t, transactionController.Commit(ctx))
+				require.True(t, eventPublished)
+			} else {
+				require.NoError(t, transactionController.Rollback(ctx))
+				require.False(t, eventPublished)
+			}
+		})
+	}
+}
+
+func TestControllerWithEventsNestedTransactions(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name         string
+		commitNested bool
+		commitOuter  bool
+		publishEvent bool
+	}{
+		{name: "committing both transactions publishes the event", commitNested: true, commitOuter: true, publishEvent: true},
+		{name: "rolling back the nested transaction discards the event", commitNested: false, commitOuter: true},
+		{name: "rolling back the outer transaction discards a committed nested event", commitNested: true, commitOuter: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockController := gomock.NewController(t)
+			root := NewMockController(mockController)
+			outer := NewMockController(mockController)
+			nested := NewMockController(mockController)
+			listener := NewMockListener(mockController)
+			ctx := context.Background()
+			parameters := Parameters[CreateTransaction]{}
+			created := &ledger.CreatedTransaction{
+				Transaction: ledger.NewTransaction(),
+			}
+			eventPublished := false
+
+			root.EXPECT().
+				BeginTX(ctx, nil).
+				Return(outer, &bun.Tx{}, nil)
+			outer.EXPECT().
+				BeginTX(ctx, nil).
+				Return(nested, &bun.Tx{}, nil)
+			nested.EXPECT().
+				CreateTransaction(ctx, parameters).
+				Return(&ledger.Log{}, created, false, nil)
+
+			if testCase.commitNested {
+				nested.EXPECT().Commit(ctx).Return(nil)
+			} else {
+				nested.EXPECT().Rollback(ctx).Return(nil)
+			}
+			if testCase.commitOuter {
+				outer.EXPECT().Commit(ctx).Return(nil)
+			} else {
+				outer.EXPECT().Rollback(ctx).Return(nil)
+			}
+			if testCase.publishEvent {
+				listener.EXPECT().
+					CommittedTransactions(ctx, "foo", created.Transaction, created.AccountMetadata).
+					Do(func(context.Context, string, ledger.Transaction, ledger.AccountMetadata) {
+						eventPublished = true
+					})
+			}
+
+			controller := NewControllerWithEvents(ledger.Ledger{Name: "foo"}, root, listener)
+			outerController, _, err := controller.BeginTX(ctx, nil)
+			require.NoError(t, err)
+			nestedController, _, err := outerController.BeginTX(ctx, nil)
+			require.NoError(t, err)
+
+			_, _, _, err = nestedController.CreateTransaction(ctx, parameters)
+			require.NoError(t, err)
+			require.False(t, eventPublished)
+
+			if testCase.commitNested {
+				require.NoError(t, nestedController.Commit(ctx))
+			} else {
+				require.NoError(t, nestedController.Rollback(ctx))
+			}
+			require.False(t, eventPublished)
+
+			if testCase.commitOuter {
+				require.NoError(t, outerController.Commit(ctx))
+			} else {
+				require.NoError(t, outerController.Rollback(ctx))
+			}
+			require.Equal(t, testCase.publishEvent, eventPublished)
+		})
+	}
+}

--- a/internal/controller/system/state_tracker.go
+++ b/internal/controller/system/state_tracker.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"github.com/formancehq/go-libs/v3/logging"
@@ -14,20 +15,34 @@ import (
 
 type controllerFacade struct {
 	ledgercontroller.Controller
+	state             *ledgerState
+	tx                *bun.Tx
+	parent            *controllerFacade
+	stateTransitioned bool
+}
+
+type ledgerState struct {
 	mu     sync.RWMutex
 	ledger ledger.Ledger
 }
 
 func (c *controllerFacade) handleState(ctx context.Context, dryRun bool, fn func(ctrl ledgercontroller.Controller) error) error {
-	c.mu.RLock()
-	l := c.ledger
-	c.mu.RUnlock()
+	c.state.mu.RLock()
+	l := c.state.ledger
+	c.state.mu.RUnlock()
 
 	if l.State == ledger.StateInUse {
 		return fn(c.Controller)
 	}
 
-	ctrl, tx, err := c.BeginTX(ctx, nil)
+	if c.tx != nil && !dryRun {
+		return c.handleStateInTransaction(ctx, l, fn)
+	}
+
+	// Dry runs still need the post-import sequence reset. Use a dedicated
+	// transaction (or a nested savepoint) so the state transition is rolled back
+	// while PostgreSQL keeps the non-transactional sequence update.
+	ctrl, _, err := c.beginTX(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -35,10 +50,32 @@ func (c *controllerFacade) handleState(ctx context.Context, dryRun bool, fn func
 		_ = ctrl.Rollback(ctx)
 	}()
 
-	if err := withLock(ctx, ctrl, func(ctrl ledgercontroller.Controller, conn bun.IDB) error {
+	if err := ctrl.handleStateInTransaction(ctx, l, fn); err != nil {
+		return err
+	}
+
+	if !dryRun {
+		if err := ctrl.Commit(ctx); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+	} else {
+		if err := ctrl.Rollback(ctx); err != nil {
+			return fmt.Errorf("failed to rollback transaction: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *controllerFacade) handleStateInTransaction(ctx context.Context, l ledger.Ledger, fn func(ctrl ledgercontroller.Controller) error) error {
+	if c.stateTransitioned {
+		return fn(c.Controller)
+	}
+
+	return withLock(ctx, c.Controller, func(ctrl ledgercontroller.Controller, conn bun.IDB) error {
 
 		// todo: remove that in a later version
-		ret, err := tx.NewUpdate().
+		ret, err := c.tx.NewUpdate().
 			Model(&l).
 			Set("state = ?", ledger.StateInUse).
 			Where("id = ? and state = ?", l.ID, ledger.StateInitializing).
@@ -53,13 +90,14 @@ func (c *controllerFacade) handleState(ctx context.Context, dryRun bool, fn func
 		}
 
 		if rowsAffected > 0 {
-			_, err := tx.NewRaw(
+			_, err := c.tx.NewRaw(
 				fmt.Sprintf(`
 					select setval(
-						'"%s"."transaction_id_%d"', 
-						(
-							select max(id) from "%s".transactions where ledger = '%s'
-						)::bigint
+						'"%s"."transaction_id_%d"',
+						coalesce((
+							select max(id) + 1 from "%s".transactions where ledger = '%s'
+						), 1)::bigint,
+						false
 					)
 				`, l.Bucket, l.ID, l.Bucket, l.Name),
 			).Exec(ctx)
@@ -67,13 +105,14 @@ func (c *controllerFacade) handleState(ctx context.Context, dryRun bool, fn func
 				return fmt.Errorf("failed to update transactions sequence value: %w", err)
 			}
 
-			_, err = tx.NewRaw(
+			_, err = c.tx.NewRaw(
 				fmt.Sprintf(`
 					select setval(
-						'"%s"."log_id_%d"', 
-						(
-							select max(id) from "%s".logs where ledger = '%s'
-						)::bigint
+						'"%s"."log_id_%d"',
+						coalesce((
+							select max(id) + 1 from "%s".logs where ledger = '%s'
+						), 1)::bigint,
+						false
 					)
 				`, l.Bucket, l.ID, l.Bucket, l.Name),
 			).Exec(ctx)
@@ -86,27 +125,55 @@ func (c *controllerFacade) handleState(ctx context.Context, dryRun bool, fn func
 			return err
 		}
 
+		c.stateTransitioned = true
 		return nil
-	}); err != nil {
+	})
+}
+
+func (c *controllerFacade) beginTX(ctx context.Context, options *sql.TxOptions) (*controllerFacade, *bun.Tx, error) {
+	ctrl, tx, err := c.Controller.BeginTX(ctx, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &controllerFacade{
+		Controller:        ctrl,
+		state:             c.state,
+		tx:                tx,
+		parent:            c,
+		stateTransitioned: c.stateTransitioned,
+	}, tx, nil
+}
+
+func (c *controllerFacade) BeginTX(ctx context.Context, options *sql.TxOptions) (ledgercontroller.Controller, *bun.Tx, error) {
+	// Keep the state tracker around the transactional controller so atomic bulks
+	// cannot bypass the initializing-to-in-use transition and sequence reset.
+	return c.beginTX(ctx, options)
+}
+
+func (c *controllerFacade) Commit(ctx context.Context) error {
+	if err := c.Controller.Commit(ctx); err != nil {
 		return err
 	}
 
-	if !dryRun {
-		if err := ctrl.Commit(ctx); err != nil {
-			return fmt.Errorf("failed to commit transaction: %w", err)
-		}
-
-		c.mu.Lock()
-		c.ledger.State = ledger.StateInUse
-		c.mu.Unlock()
-	} else {
-		if err := ctrl.Rollback(ctx); err != nil {
-			return fmt.Errorf("failed to rollback transaction: %w", err)
+	if c.stateTransitioned {
+		if c.parent != nil && c.parent.tx != nil {
+			// Committing a nested transaction only releases its savepoint. Defer
+			// publishing the state transition until the root transaction commits.
+			c.parent.stateTransitioned = true
+		} else {
+			c.state.mu.Lock()
+			c.state.ledger.State = ledger.StateInUse
+			c.state.mu.Unlock()
 		}
 	}
 
 
 	return nil
+}
+
+func (c *controllerFacade) Rollback(ctx context.Context) error {
+	return c.Controller.Rollback(ctx)
 }
 
 func (c *controllerFacade) CreateTransaction(ctx context.Context, parameters ledgercontroller.Parameters[ledgercontroller.CreateTransaction]) (*ledger.Log, *ledger.CreatedTransaction, bool, error) {
@@ -195,15 +262,19 @@ func (c *controllerFacade) DeleteAccountMetadata(ctx context.Context, parameters
 }
 
 func (c *controllerFacade) Import(ctx context.Context, stream chan ledger.Log) error {
+	c.state.mu.RLock()
+	l := c.state.ledger
+	c.state.mu.RUnlock()
+
 	return withLock(ctx, c.Controller, func(ctrl ledgercontroller.Controller, conn bun.IDB) error {
 		// todo: remove that in a later version
-		if err := conn.NewSelect().Model(&c.ledger).
-			Where("id = ?", c.ledger.ID).
+		if err := conn.NewSelect().Model(&l).
+			Where("id = ?", l.ID).
 			Scan(ctx); err != nil {
 			return err
 		}
 
-		if c.ledger.State != ledger.StateInitializing {
+		if l.State != ledger.StateInitializing {
 			return ledgercontroller.NewErrImport(errors.New("ledger is not in initializing state"))
 		}
 
@@ -216,7 +287,9 @@ var _ ledgercontroller.Controller = (*controllerFacade)(nil)
 func newLedgerStateTracker(ctrl ledgercontroller.Controller, ledger ledger.Ledger) ledgercontroller.Controller {
 	return &controllerFacade{
 		Controller: ctrl,
-		ledger:     ledger,
+		state: &ledgerState{
+			ledger: ledger,
+		},
 	}
 }
 

--- a/internal/storage/ledger/logs.go
+++ b/internal/storage/ledger/logs.go
@@ -98,6 +98,7 @@ func (store *Store) InsertLog(ctx context.Context, log *ledger.Log) error {
 					if err.(postgres.ErrConstraintsFailed).GetConstraint() == "logs_idempotency_key" {
 						return NewErrIdempotencyKeyConflict(log.IdempotencyKey)
 					}
+					return fmt.Errorf("inserting log: %w", err)
 				default:
 					return fmt.Errorf("inserting log: %w", err)
 				}

--- a/internal/storage/ledger/logs_test.go
+++ b/internal/storage/ledger/logs_test.go
@@ -29,6 +29,28 @@ func TestLogsInsert(t *testing.T) {
 
 	ctx := logging.TestingContext()
 
+	t.Run("generated id collision returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		store := newLedgerStore(t)
+		imported := ledger.NewLog(ledger.CreatedTransaction{
+			Transaction:     ledger.NewTransaction().WithID(1),
+			AccountMetadata: ledger.AccountMetadata{},
+		}).WithID(1)
+		require.NoError(t, store.InsertLog(ctx, &imported))
+
+		generated := ledger.NewLog(ledger.CreatedTransaction{
+			Transaction:     ledger.NewTransaction().WithID(2),
+			AccountMetadata: ledger.AccountMetadata{},
+		})
+		var err error
+		require.NotPanics(t, func() {
+			err = store.InsertLog(ctx, &generated)
+		})
+		require.Error(t, err)
+		require.Nil(t, generated.ID)
+	})
+
 	t.Run("check hash against core", func(t *testing.T) {
 		// Insert a first tx (we don't have any previous hash to use at this moment)
 		store := newLedgerStore(t)

--- a/internal/storage/ledger/transactions.go
+++ b/internal/storage/ledger/transactions.go
@@ -155,6 +155,9 @@ func (store *Store) InsertTransaction(ctx context.Context, tx *ledger.Transactio
 						return nil, NewErrTransactionReferenceConflict(tx.Reference)
 					}
 					if err.(postgres.ErrConstraintsFailed).GetConstraint() == "transactions_ledger" {
+						if tx.ID == nil {
+							return nil, fmt.Errorf("invariant: generated transaction ID conflicts with an existing transaction: %w", err)
+						}
 						return nil, NewErrConcurrentTransaction(*tx.ID)
 					}
 

--- a/internal/storage/ledger/transactions_test.go
+++ b/internal/storage/ledger/transactions_test.go
@@ -227,6 +227,24 @@ func TestTransactionsCommit(t *testing.T) {
 
 	ctx := logging.TestingContext()
 
+	t.Run("generated id collision returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		store := newLedgerStore(t)
+		imported := ledger.NewTransaction().
+			WithID(1).
+			WithPostings(ledger.NewPosting("world", "bank", "USD", big.NewInt(100)))
+		require.NoError(t, store.InsertTransaction(ctx, &imported))
+
+		generated := ledger.NewTransaction().
+			WithPostings(ledger.NewPosting("world", "bank", "USD", big.NewInt(100)))
+		var err error
+		require.NotPanics(t, func() {
+			err = store.InsertTransaction(ctx, &generated)
+		})
+		require.ErrorContains(t, err, "invariant: generated transaction ID conflicts with an existing transaction")
+	})
+
 	t.Run("inserting some transactions", func(t *testing.T) {
 		t.Parallel()
 

--- a/test/e2e/api_bulk_test.go
+++ b/test/e2e/api_bulk_test.go
@@ -365,7 +365,7 @@ var _ = Context("Ledger engine tests", func() {
 					Transactions:    []ledger.Transaction{ConvertSDKTxToCoreTX(&bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultCreateTransaction.Data)},
 					AccountMetadata: ledger.AccountMetadata{},
 				}))))
-				Eventually(events).ShouldNot(Receive())
+				Consistently(events).ShouldNot(Receive(Event(ledgerevents.EventTypeCommittedTransactions)))
 			})
 		})
 		Context("with atomic", func() {
@@ -382,7 +382,7 @@ var _ = Context("Ledger engine tests", func() {
 				Expect(txs.V2TransactionsCursorResponse.Cursor.Data).To(HaveLen(0))
 
 				By("Should not have sent any event", func() {
-					Eventually(events).ShouldNot(Receive())
+					Consistently(events, time.Second).ShouldNot(Receive(Event(ledgerevents.EventTypeCommittedTransactions)))
 				})
 			})
 		})

--- a/test/e2e/api_ledgers_import_test.go
+++ b/test/e2e/api_ledgers_import_test.go
@@ -65,6 +65,56 @@ var _ = Context("Ledger engine tests", func() {
 				})
 				Expect(err).To(BeNil())
 
+				By("dry running a transaction after the partial import", func() {
+					transaction, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+						Ledger: createLedgerRequest.Ledger,
+						DryRun: pointer.For(true),
+						V2PostTransaction: components.V2PostTransaction{
+							Postings: []components.V2Posting{{
+								Source:      "world",
+								Destination: "dry-run",
+								Asset:       "USD",
+								Amount:      big.NewInt(1),
+							}},
+						},
+					})
+					Expect(err).To(Succeed())
+					Expect(transaction.V2CreateTransactionResponse.Data.ID).To(Equal(big.NewInt(2)))
+				})
+
+				By("keeping the ledger initializing when an atomic bulk rolls back", func() {
+					bulkResponse, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+						Atomic: pointer.For(true),
+						Ledger: createLedgerRequest.Ledger,
+						RequestBody: []components.V2BulkElement{
+							components.CreateV2BulkElementCreateTransaction(components.V2BulkElementCreateTransaction{
+								Data: &components.V2PostTransaction{
+									Postings: []components.V2Posting{{
+										Source:      "world",
+										Destination: "bank",
+										Asset:       "EUR/2",
+										Amount:      big.NewInt(100),
+									}},
+								},
+							}),
+							components.CreateV2BulkElementCreateTransaction(components.V2BulkElementCreateTransaction{
+								Data: &components.V2PostTransaction{
+									Postings: []components.V2Posting{{
+										Source:      "bank",
+										Destination: "merchant",
+										Asset:       "EUR/2",
+										Amount:      big.NewInt(200),
+									}},
+								},
+							}),
+						},
+					})
+					Expect(err).To(Succeed())
+					Expect(bulkResponse.V2BulkResponse.Data).To(HaveLen(2))
+					Expect(bulkResponse.V2BulkResponse.Data[0].Type).To(Equal(components.V2BulkElementResultTypeCreateTransaction))
+					Expect(bulkResponse.V2BulkResponse.Data[1].V2BulkElementResultError.ErrorCode).To(Equal(string(components.V2ErrorsEnumInsufficientFund)))
+				})
+
 				secondBatch := `{"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"merchants:777","destination":"payouts:987","amount":8500,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:08:24.955784Z","id":2,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:08:24.985834Z","idempotencyKey":"","id":2,"hash":"WgOIXsh8x0pGSi//jHjQ78RF9YnFRslsbp2aOHiG43U="}
 {"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"platform","destination":"refunds:4567","amount":5000,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:08:39.301709Z","id":3,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:08:39.330919Z","idempotencyKey":"","id":3,"hash":"JblhzL91s+DTcd53YTV2laC4QBRe5oDDoz9CzsX5Pro="}
 {"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"refunds:4567","destination":"world","amount":5000,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:11:02.413499Z","id":4,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:11:02.434078Z","idempotencyKey":"","id":4,"hash":"Y8TBz5GhxTWW9D/wRXHPcIlrYFPQjroiIBWX1q6SJJo="}`
@@ -80,6 +130,53 @@ var _ = Context("Ledger engine tests", func() {
 				})
 				Expect(err).To(Succeed())
 				Expect(logsFromOriginalLedger.V2LogsCursorResponse.Cursor.Data).To(HaveLen(5))
+
+				By("creating an atomic bulk after the import", func() {
+					bulkResponse, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+						Atomic: pointer.For(true),
+						Ledger: createLedgerRequest.Ledger,
+						RequestBody: []components.V2BulkElement{
+							components.CreateV2BulkElementCreateTransaction(components.V2BulkElementCreateTransaction{
+								Data: &components.V2PostTransaction{
+									Postings: []components.V2Posting{{
+										Source:      "world",
+										Destination: "bank",
+										Asset:       "USD",
+										Amount:      big.NewInt(100),
+									}},
+								},
+							}),
+						},
+					})
+					Expect(err).To(Succeed())
+					Expect(bulkResponse.V2BulkResponse.Data).To(HaveLen(1))
+					Expect(bulkResponse.V2BulkResponse.Data[0].V2BulkElementResultCreateTransaction.Data.ID).To(Equal(big.NewInt(5)))
+				})
+			})
+		})
+		When("importing only an id zero log", func() {
+			It("starts generated ids at one", func(specContext SpecContext) {
+				importedLog := `{"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"world","destination":"payments:1234","amount":10000,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:07:41.522336Z","id":0,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:07:41.534898Z","idempotencyKey":"","id":0,"hash":"g489GFReBqquboEjkB95X3OU6mheMzgiu63PdSTfMuM="}`
+
+				_, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.ImportLogs(ctx, operations.V2ImportLogsRequest{
+					Ledger:              createLedgerRequest.Ledger,
+					V2ImportLogsRequest: []byte(importedLog),
+				})
+				Expect(err).To(Succeed())
+
+				transaction, err := Wait(specContext, DeferClient(testServer)).Ledger.V2.CreateTransaction(ctx, operations.V2CreateTransactionRequest{
+					Ledger: createLedgerRequest.Ledger,
+					V2PostTransaction: components.V2PostTransaction{
+						Postings: []components.V2Posting{{
+							Source:      "world",
+							Destination: "bank",
+							Asset:       "USD",
+							Amount:      big.NewInt(1),
+						}},
+					},
+				})
+				Expect(err).To(Succeed())
+				Expect(transaction.V2CreateTransactionResponse.Data.ID).To(Equal(big.NewInt(1)))
 			})
 		})
 		When("importing data from 2.1", func() {

--- a/test/e2e/app_multiple_instance_test.go
+++ b/test/e2e/app_multiple_instance_test.go
@@ -3,15 +3,24 @@
 package test_suite
 
 import (
+	"context"
+	"fmt"
+	"math/big"
+	"slices"
+	"sync"
+	"time"
+
 	"github.com/formancehq/go-libs/v3/logging"
+	"github.com/formancehq/go-libs/v3/pointer"
 	"github.com/formancehq/go-libs/v3/testing/deferred"
 	"github.com/formancehq/go-libs/v3/testing/platform/pgtesting"
 	"github.com/formancehq/go-libs/v3/testing/testservice"
 	"github.com/formancehq/ledger/cmd"
+	"github.com/formancehq/ledger/pkg/client/models/components"
+	"github.com/formancehq/ledger/pkg/client/models/operations"
 	. "github.com/formancehq/ledger/pkg/testserver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"sync"
 )
 
 var _ = Context("Ledger application multiple instance tests", func() {
@@ -25,6 +34,16 @@ var _ = Context("Ledger application multiple instance tests", func() {
 	When("starting multiple instances of the service", func() {
 		var allServers []*testservice.Service
 		BeforeEach(func() {
+			allServers = make([]*testservice.Service, 0, nbServer)
+			DeferCleanup(func() {
+				for _, server := range allServers {
+					stopContext, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					err := server.Stop(stopContext)
+					cancel()
+					Expect(err).To(Succeed())
+				}
+			})
+
 			servers := make(chan *testservice.Service, nbServer)
 			wg := sync.WaitGroup{}
 			wg.Add(nbServer)
@@ -66,6 +85,80 @@ var _ = Context("Ledger application multiple instance tests", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.V2ConfigInfoResponse.Version).To(Equal("develop"))
 			}
+		})
+
+		It("serializes post-import atomic bulks across instances", func() {
+			const ledgerName = "multi-instance-import"
+
+			_, err := Client(allServers[0]).Ledger.V2.CreateLedger(ctx, operations.V2CreateLedgerRequest{
+				Ledger: ledgerName,
+			})
+			Expect(err).To(Succeed())
+
+			importedLogs := `{"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"world","destination":"payments:1234","amount":10000,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:07:41.522336Z","id":0,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:07:41.534898Z","idempotencyKey":"","id":0,"hash":"g489GFReBqquboEjkB95X3OU6mheMzgiu63PdSTfMuM="}
+{"type":"NEW_TRANSACTION","data":{"transaction":{"postings":[{"source":"payments:1234","destination":"platform","amount":1500,"asset":"EUR/2"},{"source":"payments:1234","destination":"merchants:777","amount":8500,"asset":"EUR/2"}],"metadata":{},"timestamp":"2025-02-17T12:07:55.145802Z","id":1,"reverted":false},"accountMetadata":{}},"date":"2025-02-17T12:07:55.170731Z","idempotencyKey":"","id":1,"hash":"T+2SGiCeC8tagt1tf5E/L7r98wB8tm6EbNd+OJ7ZvCI="}`
+			_, err = Client(allServers[0]).Ledger.V2.ImportLogs(ctx, operations.V2ImportLogsRequest{
+				Ledger:              ledgerName,
+				V2ImportLogsRequest: []byte(importedLogs),
+			})
+			Expect(err).To(Succeed())
+
+			type result struct {
+				id  uint64
+				err error
+			}
+			results := make(chan result, len(allServers))
+			start := make(chan struct{})
+			for index, server := range allServers {
+				go func() {
+					result := result{}
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							result.err = fmt.Errorf("atomic bulk panicked: %v", recovered)
+						}
+						results <- result
+					}()
+					<-start
+
+					response, err := Client(server).Ledger.V2.CreateBulk(ctx, operations.V2CreateBulkRequest{
+						Atomic: pointer.For(true),
+						Ledger: ledgerName,
+						RequestBody: []components.V2BulkElement{
+							components.CreateV2BulkElementCreateTransaction(components.V2BulkElementCreateTransaction{
+								Data: &components.V2PostTransaction{
+									Postings: []components.V2Posting{{
+										Source:      "world",
+										Destination: fmt.Sprintf("instance:%d", index),
+										Asset:       "USD",
+										Amount:      big.NewInt(1),
+									}},
+								},
+							}),
+						},
+					})
+					if err != nil {
+						result.err = err
+						return
+					}
+					if len(response.V2BulkResponse.Data) != 1 ||
+						response.V2BulkResponse.Data[0].V2BulkElementResultCreateTransaction == nil ||
+						response.V2BulkResponse.Data[0].V2BulkElementResultCreateTransaction.Data.ID == nil {
+						result.err = fmt.Errorf("unexpected bulk response: %+v", response.V2BulkResponse.Data)
+						return
+					}
+					result.id = response.V2BulkResponse.Data[0].V2BulkElementResultCreateTransaction.Data.ID.Uint64()
+				}()
+			}
+			close(start)
+
+			ids := make([]uint64, 0, len(allServers))
+			for range allServers {
+				result := <-results
+				Expect(result.err).To(Succeed())
+				ids = append(ids, result.id)
+			}
+			slices.Sort(ids)
+			Expect(ids).To(Equal([]uint64{2, 3, 4}))
 		})
 	})
 })


### PR DESCRIPTION
## Backport

Backport of #1781 to `release/v2.3`.

Cherry-picked from `448ffe2253d1334d6d4c8260043dc8873725a4da`. The only conflict was mechanical: the multi-instance E2E test keeps the `go-libs/v3` import paths used by this release branch.

## Validation

- `GOROOT= go build ./...`
- controller unit tests with `-race`
- focused import, atomic rollback, and three-instance E2E scenarios with `-race`
- `nix develop --command bash -c "just pre-commit"`
- GitNexus comparison against `origin/release/v2.3`: LOW risk, no affected process
