### PR TITLE
ci: run operator unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,22 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  Tests-Operator:
+    runs-on: namespace-profile-linux-amd64-4vcpu
+    env:
+      GOPATH: /tmp/go
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
+        with:
+          fetch-depth: 0
+          dissociate: true
+      - name: Setup Env
+        uses: ./.github/actions/default
+      - name: Run operator unit tests
+        run: >
+          nix develop --command bash -c "unset GOROOT;
+          cd misc/operator && go test ./..."
+
   Tests-E2E-Business:
     runs-on: namespace-profile-linux-amd64-4vcpu
     env:
@@ -269,6 +285,7 @@ jobs:
       [
         Dirty,
         Tests,
+        Tests-Operator,
         Tests-E2E-Business,
         Tests-E2E-Cluster,
         Tests-Scenarios,
@@ -325,6 +342,7 @@ jobs:
       [
         Dirty,
         Tests,
+        Tests-Operator,
         Tests-E2E-Business,
         Tests-E2E-Cluster,
         Tests-Scenarios,

--- a/docs/technical/architecture/repository-invariant-gates.md
+++ b/docs/technical/architecture/repository-invariant-gates.md
@@ -26,6 +26,10 @@ The current rules are:
    Default CI workflow. The dashboard test recipe regenerates the committed
    dashboards before testing them, and `pre-commit` must continue to invoke
    that recipe.
+5. The `Default` GitHub Actions workflow must retain an unconditional
+   `Tests-Operator` job that runs the full default-tag `misc/operator` unit
+   suite through the pinned Nix toolchain. The command is kept explicit so
+   the nested Go module cannot silently fall outside root-module `./...` tests.
 
 The FSM boundary is recursive and consists of:
 
@@ -49,6 +53,11 @@ The dashboard reachability check inspects the tracked nested module, Just
 recipe metadata, and the Default workflow. It fails if the module loses its
 tracked tests, generation no longer precedes the tests, the nested
 `go test ./...` command disappears, or CI stops invoking `pre-commit`.
+
+The operator-test reachability check parses the workflow as YAML and requires
+the exact argument-free unit-test command. It rejects job or step conditions,
+allowed failures, non-Nix execution, and added build tags; integration/envtest
+and Chainsaw coverage remain separate suites.
 
 ## Extending the gate
 

--- a/scripts/check-repo-invariants
+++ b/scripts/check-repo-invariants
@@ -4,4 +4,5 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 bash "$SCRIPT_DIR/check-dashboard-test-reachability"
-exec go run ./scripts
+go run ./scripts
+go run ./scripts/checkoperatorci

--- a/scripts/checkoperatorci/main.go
+++ b/scripts/checkoperatorci/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	operatorTestsWorkflowPath = ".github/workflows/main.yml"
+	operatorTestsJobID        = "Tests-Operator"
+	operatorTestsCommand      = `nix develop --command bash -c "unset GOROOT; cd misc/operator && go test ./..."`
+)
+
+func main() {
+	source, err := os.ReadFile(operatorTestsWorkflowPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "check-operator-tests-reachability: reading %s: %v\n", operatorTestsWorkflowPath, err)
+		os.Exit(1)
+	}
+
+	if err := checkOperatorTestsWorkflow(source); err != nil {
+		fmt.Fprintf(os.Stderr, "%s:1:1: ERROR: %v\n", operatorTestsWorkflowPath, err)
+		fmt.Fprintln(os.Stderr, "check-operator-tests-reachability: FAIL")
+		os.Exit(1)
+	}
+
+	fmt.Println("check-operator-tests-reachability: PASS")
+}
+
+func checkOperatorTestsWorkflow(source []byte) error {
+	var workflow struct {
+		Jobs map[string]struct {
+			If              any `yaml:"if"`
+			ContinueOnError any `yaml:"continue-on-error"`
+			Steps           []struct {
+				If              any    `yaml:"if"`
+				ContinueOnError any    `yaml:"continue-on-error"`
+				Run             string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+
+	if err := yaml.Unmarshal(source, &workflow); err != nil {
+		return fmt.Errorf("parse workflow YAML: %w", err)
+	}
+
+	job, ok := workflow.Jobs[operatorTestsJobID]
+	if ok && job.If == nil && job.ContinueOnError == nil {
+		for _, step := range job.Steps {
+			if step.If == nil && step.ContinueOnError == nil && normalizeWorkflowCommand(step.Run) == operatorTestsCommand {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf(
+		"operator unit tests must remain reachable from the unconditional %q job through the pinned command %q",
+		operatorTestsJobID,
+		operatorTestsCommand,
+	)
+}
+
+func normalizeWorkflowCommand(command string) string {
+	return strings.Join(strings.Fields(command), " ")
+}

--- a/scripts/checkoperatorci/main_test.go
+++ b/scripts/checkoperatorci/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOperatorTestsWorkflowAcceptsPinnedDefaultSuite(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`jobs:
+  Tests-Operator:
+    steps:
+      - run: >
+          nix develop --command bash -c "unset GOROOT;
+          cd misc/operator && go test ./..."
+`)
+
+	require.NoError(t, checkOperatorTestsWorkflow(source))
+}
+
+func TestCheckOperatorTestsWorkflowRejectsMissingOrWeakenedRunner(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"missing job": `jobs:
+  Build:
+    steps:
+      - run: go build ./...
+`,
+		"outside pinned Nix": `jobs:
+  Tests-Operator:
+    steps:
+      - run: cd misc/operator && go test ./...
+`,
+		"integration tags": `jobs:
+  Tests-Operator:
+    steps:
+      - run: nix develop --command bash -c "unset GOROOT; cd misc/operator && go test -tags integration ./..."
+`,
+		"conditional job": `jobs:
+  Tests-Operator:
+    if: github.event_name == 'push'
+    steps:
+      - run: nix develop --command bash -c "unset GOROOT; cd misc/operator && go test ./..."
+`,
+		"allowed failure": `jobs:
+  Tests-Operator:
+    continue-on-error: true
+    steps:
+      - run: nix develop --command bash -c "unset GOROOT; cd misc/operator && go test ./..."
+`,
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkOperatorTestsWorkflow([]byte(source))
+			require.ErrorContains(t, err, "operator unit tests must remain reachable")
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- add a distinct Tests-Operator job to the Default workflow
- run the full default-tag misc/operator module suite through pinned Nix Go
- make release and opt-in PR image publication wait for operator tests
- add a narrow fail-closed workflow reachability invariant

## Reproduction

Target base: ae5346f1d183e22b498b6d429c37178370a80fa1

Default-tag test-bearing packages existed in misc/operator, while GitHub Actions only generated, linted, and built that module. No PR job ran its unit tests.

Pinned Go 1.26.5 baseline:
- go test ./...: PASS
- cold-cache runtime: 58.17s
- warm candidate runtime: 8.48s
- go test -race -count=2 ./...: PASS in 38.24s

The initial local attempts failed before repository compilation because an ambient Homebrew Go 1.27 GOROOT overrode the Nix Go 1.26.5 binary. Clearing GOROOT resolved the environment; this PR explicitly clears it in the job command.

## Scope

No integration/envtest tags and no Chainsaw coverage are added or changed.

## Required CI integration

PR #1835 is still open and owns the in-flight Required CI aggregate. This PR intentionally does not duplicate or edit that aggregate. If #1835 merges first, this branch must be synchronized and Tests-Operator added to Required-CI.needs under its documented contract.

## Validation

- operator go test ./...
- operator go test -race -count=2 ./...
- go test -count=1 ./scripts/checkoperatorci
- bash scripts/check-repo-invariants
- trusted just pre-commit to fixpoint
- bash scripts/agent-check
- exact target-base diff review: APPROVE, 0 findings

## Risk

LOW: CI and repository-invariant tooling only; production and operator runtime code are unchanged.