### PR TITLE
ci: run monitoring dashboard tests

### DIFF
--- a/docs/technical/architecture/README.md
+++ b/docs/technical/architecture/README.md
@@ -41,7 +41,7 @@ Cross-cutting concerns (overall design, data flows shared across subsystems, the
 | [data-model.md](data-model.md) | Ledgers, transactions, postings — the core domain shape. |
 | [data-model/color-of-money.md](data-model/color-of-money.md) | Per-bucket "color of money" balance segregation — key encoding, numscript contract, collapse modes. |
 | [audit-vs-technical-state.md](audit-vs-technical-state.md) | Boundary between business truth, governance truth, operational state, and rebuildable projections. |
-| [repository-invariant-gates.md](repository-invariant-gates.md) | Deterministic repository checks that turn selected contributor and FSM rules into executable gates. |
+| [repository-invariant-gates.md](repository-invariant-gates.md) | Deterministic source and CI-topology checks that turn selected contributor and FSM rules into executable gates. |
 | [primitives/uint256-wire-format.md](primitives/uint256-wire-format.md) | Fixed-size monetary-amount wire format used everywhere on the boundary. |
 
 ## Conventions

--- a/docs/technical/architecture/repository-invariant-gates.md
+++ b/docs/technical/architecture/repository-invariant-gates.md
@@ -22,6 +22,10 @@ The current rules are:
    gate admission but cannot affect how a committed entry is applied.
 3. Protocol definitions under `misc/proto` must not declare `reserved` fields
    while Ledger v3 remains unreleased and field numbers are kept sequential.
+4. The nested monitoring-dashboard Go tests must remain reachable from the
+   Default CI workflow. The dashboard test recipe regenerates the committed
+   dashboards before testing them, and `pre-commit` must continue to invoke
+   that recipe.
 
 The FSM boundary is recursive and consists of:
 
@@ -40,6 +44,11 @@ are parsed independently, so build tags do not remove a file from the check.
 The protobuf check masks comments and quoted strings before detecting the
 `reserved` keyword. Declarations remain detectable when the keyword and its
 field numbers are split across lines.
+
+The dashboard reachability check inspects the tracked nested module, Just
+recipe metadata, and the Default workflow. It fails if the module loses its
+tracked tests, generation no longer precedes the tests, the nested
+`go test ./...` command disappears, or CI stops invoking `pre-commit`.
 
 ## Extending the gate
 

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set dotenv-load
 
-pre-commit: generate generate-proto operator-generate generate-dashboards tidy lint
+pre-commit: generate generate-proto operator-generate test-dashboards tidy lint
 pc: pre-commit
 
 # Regenerate the Grafana dashboards (otel + prom variants) from Jsonnet
@@ -18,6 +18,10 @@ generate-dashboards:
     echo "==> jsonnet -m config/dashboards jsonnet/main.jsonnet"
     rm -f config/dashboards/ledger-metrics*.json
     jsonnet -m config/dashboards -J jsonnet/vendor jsonnet/main.jsonnet
+
+# Regenerate and validate the committed Grafana dashboard variants.
+test-dashboards: generate-dashboards
+    cd misc/devenv/monitoring-dashboards && go test ./...
 
 lint:
     #!/usr/bin/env bash

--- a/misc/devenv/monitoring-dashboards/README.md
+++ b/misc/devenv/monitoring-dashboards/README.md
@@ -60,7 +60,9 @@ JSON files under `config/dashboards/`. All seven are committed so Pulumi
 can deploy without invoking Jsonnet.
 
 `generate-dashboards` is part of `just pre-commit`; CI fails if the
-generated files have drifted from the source.
+generated files have drifted from the source. `just test-dashboards`
+regenerates those files and then runs the nested Go module's semantic tests;
+it is also part of `pre-commit` and therefore runs in the Default CI workflow.
 
 ## Seven variants
 

--- a/scripts/check-dashboard-test-reachability
+++ b/scripts/check-dashboard-test-reachability
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root=$(git rev-parse --show-toplevel)
+dashboard_module=misc/devenv/monitoring-dashboards
+dashboard_recipe=test-dashboards
+default_workflow=.github/workflows/main.yml
+
+fail() {
+    echo "DASHBOARD_TEST_REACHABILITY: $*" >&2
+    exit 1
+}
+
+if [[ ! -f "$repository_root/$dashboard_module/go.mod" ]]; then
+    fail "missing nested module: $dashboard_module/go.mod"
+fi
+
+tracked_module_files=$(git -C "$repository_root" ls-files -- "$dashboard_module")
+if ! grep -Eq '(^|/)[^/]+_test\.go$' <<<"$tracked_module_files"; then
+    fail "nested module has no tracked Go tests: $dashboard_module"
+fi
+
+pre_commit_recipe=$(cd "$repository_root" && just --show pre-commit)
+if ! grep -Eq "^pre-commit:.*[[:space:]]${dashboard_recipe}([[:space:]]|$)" <<<"$pre_commit_recipe"; then
+    fail "pre-commit does not depend on $dashboard_recipe"
+fi
+
+dashboard_test_recipe=$(cd "$repository_root" && just --show "$dashboard_recipe")
+if ! grep -Eq "^${dashboard_recipe}:[[:space:]]+generate-dashboards([[:space:]]|$)" <<<"$dashboard_test_recipe"; then
+    fail "$dashboard_recipe must depend on generate-dashboards"
+fi
+dashboard_test_plan=$(cd "$repository_root" && just --dry-run "$dashboard_recipe" 2>&1)
+if ! grep -Fxq "cd $dashboard_module && go test ./..." <<<"$dashboard_test_plan"; then
+    fail "$dashboard_recipe does not run the nested module tests"
+fi
+
+if ! grep -Eq '^[[:space:]]+nix[[:space:]]+develop[[:space:]]+--command[[:space:]]+just[[:space:]]+pre-commit[[:space:]]*$' \
+    "$repository_root/$default_workflow"; then
+    fail "Default CI does not execute just pre-commit"
+fi
+
+echo "dashboard-test-reachability: PASS"

--- a/scripts/check-repo-invariants
+++ b/scripts/check-repo-invariants
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$SCRIPT_DIR/check-dashboard-test-reachability"
 exec go run ./scripts


### PR DESCRIPTION
## Summary

- make `just pre-commit` run the nested monitoring-dashboard Go tests
- regenerate dashboard artifacts before the semantic tests execute
- fail closed through the repository invariant gate if the module/tests/recipe/CI reachability chain is removed
- document the executable reachability contract

## Reproduction

- target base: `ae5346f1d183e22b498b6d429c37178370a80fa1`
- root `go list -test ./...`: 337 package entries, zero dashboard-module matches
- dashboard module discovery: `TestGeneratedDashboards`
- baseline uncached module run: PASS (`15.846s` package runtime, `37.10s` wall)
- GitHub workflows/actions had zero dashboard-module or dashboard-test references

## Required CI compatibility

The open Required CI implementation (#1835) already aggregates both `Dirty` and `Repository-Invariants`. This change adds the test to the existing `Dirty` producer via `pre-commit` and extends the existing invariant entry point, so it creates no unaggregated producer.

## Validation

- `just test-dashboards`
- uncached `go test -count=1 ./...` in `misc/devenv/monitoring-dashboards`
- fail-closed mutation: removing `test-dashboards` from `pre-commit` is rejected
- `bash scripts/check-repo-invariants`
- `bash scripts/agent-check`
- base-pinned trusted `scripts/agent-just pre-commit`
- repeated candidate pre-commit: identical before/after fingerprint (`cbf6b962fed0f5fa141a9c5dc303adb57c2a8400f83a6f7286836fc6638d44f0`)
- `git diff --check`

Finding: `test-reachability-enforcement/dashboard-tests-never-collected` (P2).

No automatic merge requested.