### PR TITLE
ci: run nested model workload race tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,21 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  Tests-Antithesis-Workload:
+    runs-on: namespace-profile-linux-amd64-4vcpu
+    env:
+      GOPATH: /tmp/go
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9
+        with:
+          fetch-depth: 0
+          dissociate: true
+      - name: Setup Env
+        uses: ./.github/actions/default
+      - name: Run deterministic model workload tests with race detection
+        run: >
+          nix develop --command go -C tests/antithesis/workload test -race ./...
+
   Tests-Model:
     runs-on: namespace-profile-linux-amd64-4vcpu
     env:
@@ -289,6 +304,7 @@ jobs:
         Tests-E2E-Business,
         Tests-E2E-Cluster,
         Tests-Scenarios,
+        Tests-Antithesis-Workload,
         Tests-Model,
         Tests-Schemathesis,
         Build,
@@ -346,6 +362,7 @@ jobs:
         Tests-E2E-Business,
         Tests-E2E-Cluster,
         Tests-Scenarios,
+        Tests-Antithesis-Workload,
         Tests-Model,
         Tests-Schemathesis,
         Build,

--- a/docs/technical/architecture/repository-invariant-gates.md
+++ b/docs/technical/architecture/repository-invariant-gates.md
@@ -74,3 +74,17 @@ nix develop --command bash scripts/check-repo-invariants
 
 The full definition of done remains `scripts/agent-check` (or
 `scripts/agent-check-full` when the full unit suite is required).
+
+## Model workload test reachability
+
+Root-module `go test ./...` does not cross the nested module boundary at
+`tests/antithesis/workload`. The default CI workflow must therefore run that
+module's deterministic test suite with the race detector in the dedicated
+`Tests-Antithesis-Workload` job. The existing runtime campaign remains in the
+separate `Tests-Model` job.
+
+The reachability check parses the workflow YAML and verifies both commands
+structurally within their respective jobs; the same command elsewhere in the
+workflow does not satisfy the invariant. Both jobs and commands must be
+unconditional, neither command can ignore failures, and the runtime campaign
+remains required alongside the deterministic suite.

--- a/scripts/check-repo-invariants.go
+++ b/scripts/check-repo-invariants.go
@@ -95,6 +95,8 @@ func checkFile(path string) ([]finding, error) {
 	}
 
 	switch {
+	case path == defaultCIWorkflowPath:
+		return checkModelWorkloadTestReachability(path, source)
 	case strings.HasSuffix(path, ".go"):
 		return checkGoSource(path, source)
 	case isProtoPath(path):

--- a/scripts/check_model_workload_reachability.go
+++ b/scripts/check_model_workload_reachability.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	defaultCIWorkflowPath = ".github/workflows/main.yml"
+	modelWorkloadTestJob  = "Tests-Antithesis-Workload"
+	modelCampaignJob      = "Tests-Model"
+	modelUnitTestCommand  = "nix develop --command go -C tests/antithesis/workload test -race ./..."
+	modelCampaignCommand  = "nix develop --command just test-model-cluster 180"
+)
+
+type workflowReachability struct {
+	Jobs map[string]workflowReachabilityJob `yaml:"jobs"`
+}
+
+type workflowReachabilityJob struct {
+	If    any                        `yaml:"if"`
+	Steps []workflowReachabilityStep `yaml:"steps"`
+}
+
+type workflowReachabilityStep struct {
+	Run             string `yaml:"run"`
+	If              any    `yaml:"if"`
+	ContinueOnError any    `yaml:"continue-on-error"`
+}
+
+func checkModelWorkloadTestReachability(path string, source []byte) ([]finding, error) {
+	var workflow workflowReachability
+	if err := yaml.Unmarshal(source, &workflow); err != nil {
+		return nil, fmt.Errorf("parsing workflow YAML: %w", err)
+	}
+
+	job, ok := workflow.Jobs[modelWorkloadTestJob]
+	if !ok {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf("MODEL_WORKLOAD_TESTS_UNREACHABLE: missing %s job", modelWorkloadTestJob),
+		)}, nil
+	}
+	if workflowConditionSet(job.If) {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf("MODEL_WORKLOAD_TESTS_CONDITIONAL: %s must not have a job-level if condition", modelWorkloadTestJob),
+		)}, nil
+	}
+
+	testStep := -1
+	for index, step := range job.Steps {
+		command := strings.Join(strings.Fields(step.Run), " ")
+		if command == modelUnitTestCommand {
+			if !workflowConditionSet(step.If) &&
+				!workflowFailureIgnored(step.ContinueOnError) &&
+				testStep < 0 {
+				testStep = index
+			}
+		}
+	}
+
+	if testStep < 0 {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf(
+				"MODEL_WORKLOAD_TESTS_UNREACHABLE: %s must run %q",
+				modelWorkloadTestJob,
+				modelUnitTestCommand,
+			),
+		)}, nil
+	}
+
+	campaign, ok := workflow.Jobs[modelCampaignJob]
+	if !ok {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf("MODEL_CAMPAIGN_UNREACHABLE: missing %s job", modelCampaignJob),
+		)}, nil
+	}
+	if workflowConditionSet(campaign.If) {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf("MODEL_CAMPAIGN_CONDITIONAL: %s must not have a job-level if condition", modelCampaignJob),
+		)}, nil
+	}
+
+	campaignStep := -1
+	for index, step := range campaign.Steps {
+		command := strings.Join(strings.Fields(step.Run), " ")
+		if command == modelCampaignCommand &&
+			!workflowConditionSet(step.If) &&
+			!workflowFailureIgnored(step.ContinueOnError) &&
+			campaignStep < 0 {
+			campaignStep = index
+		}
+	}
+	if campaignStep < 0 {
+		return []finding{workflowFinding(
+			path,
+			fmt.Sprintf(
+				"MODEL_CAMPAIGN_UNREACHABLE: %s must run %q",
+				modelCampaignJob,
+				modelCampaignCommand,
+			),
+		)}, nil
+	}
+
+	return nil, nil
+}
+
+func workflowFailureIgnored(value any) bool {
+	if value == nil {
+		return false
+	}
+
+	ignored, ok := value.(bool)
+
+	return !ok || ignored
+}
+
+func workflowConditionSet(value any) bool {
+	if value == nil {
+		return false
+	}
+
+	if condition, ok := value.(string); ok {
+		return strings.TrimSpace(condition) != ""
+	}
+
+	return true
+}
+
+func workflowFinding(path, message string) finding {
+	return finding{
+		path:    path,
+		line:    1,
+		column:  1,
+		message: message,
+	}
+}

--- a/scripts/check_model_workload_reachability_test.go
+++ b/scripts/check_model_workload_reachability_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelWorkloadTestReachabilityAcceptsDedicatedRaceJob(t *testing.T) {
+	t.Parallel()
+
+	findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, validModelWorkflow())
+	require.NoError(t, err)
+	require.Empty(t, findings)
+}
+
+func TestModelWorkloadTestReachabilityRejectsMissingRaceTest(t *testing.T) {
+	t.Parallel()
+
+	source := strings.ReplaceAll(
+		string(validModelWorkflow()),
+		modelUnitTestCommand,
+		"nix develop --command go -C tests/antithesis/workload test ./...",
+	)
+
+	findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, []byte(source))
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].message, "MODEL_WORKLOAD_TESTS_UNREACHABLE")
+}
+
+func TestModelWorkloadTestReachabilityRejectsNonMandatoryRaceJob(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string][]byte{
+		"conditional job": []byte(`jobs:
+  Tests-Antithesis-Workload:
+    if: false
+    steps:
+      - run: nix develop --command go -C tests/antithesis/workload test -race ./...
+`),
+		"conditional step": []byte(`jobs:
+  Tests-Antithesis-Workload:
+    steps:
+      - if: false
+        run: nix develop --command go -C tests/antithesis/workload test -race ./...
+`),
+		"ignored failure": []byte(`jobs:
+  Tests-Antithesis-Workload:
+    steps:
+      - continue-on-error: true
+        run: nix develop --command go -C tests/antithesis/workload test -race ./...
+`),
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, source)
+			require.NoError(t, err)
+			require.NotEmpty(t, findings)
+		})
+	}
+}
+
+func TestModelCampaignReachabilityRejectsNonMandatoryCampaign(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"conditional job": strings.Replace(
+			string(validModelWorkflow()),
+			"  Tests-Model:\n",
+			"  Tests-Model:\n    if: false\n",
+			1,
+		),
+		"ignored failure": strings.Replace(
+			string(validModelWorkflow()),
+			"      - run: "+modelCampaignCommand+"\n",
+			"      - continue-on-error: true\n        run: "+modelCampaignCommand+"\n",
+			1,
+		),
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, []byte(source))
+			require.NoError(t, err)
+			require.NotEmpty(t, findings)
+			require.Contains(t, findings[0].message, "MODEL_CAMPAIGN")
+		})
+	}
+}
+
+func TestModelWorkloadTestReachabilityRejectsTestInAnotherJob(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`jobs:
+  Tests-Antithesis-Workload:
+    steps:
+      - run: echo no workload tests here
+  Tests-Model:
+    steps:
+      - run: nix develop --command just test-model-cluster 180
+  Other:
+    steps:
+      - run: nix develop --command go -C tests/antithesis/workload test -race ./...
+`)
+
+	findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, source)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].message, "MODEL_WORKLOAD_TESTS_UNREACHABLE")
+}
+
+func TestModelWorkloadTestReachabilityRejectsMissingRuntimeCampaign(t *testing.T) {
+	t.Parallel()
+
+	source := strings.ReplaceAll(
+		string(validModelWorkflow()),
+		modelCampaignCommand,
+		"nix develop --command just test-model 180",
+	)
+
+	findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, []byte(source))
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].message, "MODEL_CAMPAIGN_UNREACHABLE")
+}
+
+func TestModelWorkloadTestReachabilityRejectsCombinedModelJob(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`jobs:
+  Tests-Model:
+    steps:
+      - run: nix develop --command just test-model-cluster 180
+      - run: nix develop --command go -C tests/antithesis/workload test -race ./...
+`)
+
+	findings, err := checkModelWorkloadTestReachability(defaultCIWorkflowPath, source)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].message, "missing Tests-Antithesis-Workload job")
+}
+
+func validModelWorkflow() []byte {
+	return []byte(`jobs:
+  Tests-Antithesis-Workload:
+    steps:
+      - run: nix develop --command go -C tests/antithesis/workload test -race ./...
+  Tests-Model:
+    steps:
+      - run: nix develop --command just test-model-cluster 180
+`)
+}


### PR DESCRIPTION
## Summary

- run the `tests/antithesis/workload` nested module's deterministic suite with `-race` in a dedicated mandatory `Tests-Antithesis-Workload` job
- preserve the existing 180-second three-node runtime `Tests-Model` campaign unchanged
- add a repository invariant that structurally enforces both distinct jobs and their mandatory failure behavior

## Discovery and reproduction

- recorded target base: `ae5346f1d183e22b498b6d429c37178370a80fa1`
- rebased integration base: `7c88752e1afacb9afdfe11635ebdbee79aa93686`
- root `go test ./...` passed in 256s and did not enumerate any `tests/antithesis/workload` package
- the existing runtime harness builds `singleton_driver_model` but does not invoke `go test`
- pinned Nix Go 1.26.5: `go -C tests/antithesis/workload test -race ./...` passed with no failures in 50.92s cold
- inspected open model/query PR #1659 and Required CI PR #1835; no workload driver sources are changed or absorbed

## Placement

The deterministic suite has its own `Tests-Antithesis-Workload` job. This separates deterministic unit/race failures from the long runtime model campaign, lets both jobs run in parallel, and provides a dedicated required status. The additional checkout/Nix setup is acceptable for a roughly 51-second cold suite.

`Release-Latest` and `Build-PR-Image` depend on both jobs. When pending Required CI PR #1835 rebases after this PR lands, it must add `Tests-Antithesis-Workload` to `Required-CI.needs`; its fail-closed topology invariant will enforce that update.

## Validation

- dedicated nested module race command: PASS
- unchanged `just test-model-cluster 180`: PASS with four rolling restart cycles and no findings (local 95% disk required documented `HEALTH_THRESHOLD=0.99` accommodation)
- focused reachability tests: PASS
- repository invariants, including dashboard/operator/workload reachability: PASS
- `AI_REVIEW_BASE_SHA=7c88752e... bash scripts/agent-check-pr`: PASS (`agent-check-full`, including root `go test -race ./...`)
- trusted pre-push fixpoint: `PRE_COMMIT=PASS`, `WORKTREE_CLEAN=YES`
- exact review: APPROVE, 0 blocking / 0 non-blocking findings

No branch-protection bypass requested. Merge only after all mandatory CI and review requirements are green.
