### PR TITLE
fix(events): add app and version to v3 events

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -54,10 +54,14 @@ message Event {
   common.Timestamp date = 3;         // Event timestamp (HLC)
   fixed64 log_sequence = 4;          // Global log sequence (monotonic, unique)
   common.Log log = 5;                // Full log entry with payload
+  string app = 6;                    // Stable producer identifier: "ledger"
+  string version = 7;                // Event envelope generation: "v3"
 }
 ```
 
 The event carries the full `Log` entry, which contains the typed payload (transaction, metadata change, etc.) in its `LedgerLogPayload` oneof. This avoids duplicating payload definitions and ensures events always carry the complete log data.
+
+`app` and `version` are routing and decoding metadata for broker consumers. Ledger v2's `publish.EventMessage` constructors emitted `app="ledger"` and `version="v2"`; the v3 envelope preserves the producer identity and reports its distinct contract as `version="v3"`. The emitter sets both fields before any sink-specific serialization, so NATS and Kafka publish the same values in JSON and Protobuf formats.
 
 ### JSON Format
 
@@ -65,6 +69,8 @@ When `format=json` in the events config, the event is serialized as JSON via `in
 
 ```json
 {
+  "app": "ledger",
+  "version": "v3",
   "type": "COMMITTED_TRANSACTION",
   "ledger": "orders",
   "date": "2026-02-18T10:30:00.000Z",

--- a/internal/application/events/event.go
+++ b/internal/application/events/event.go
@@ -16,11 +16,18 @@ const (
 	FormatProto Format = "protobuf"
 )
 
+const (
+	EventApp     = "ledger"
+	EventVersion = "v3"
+)
+
 // LogToEvent converts a committed global log entry into a domain event.
 func LogToEvent(log *commonpb.Log) *eventspb.Event {
 	event := &eventspb.Event{
 		LogSequence: log.GetSequence(),
 		Log:         log,
+		App:         EventApp,
+		Version:     EventVersion,
 	}
 
 	switch p := log.GetPayload().GetType().(type) {

--- a/internal/application/events/event_test.go
+++ b/internal/application/events/event_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -199,6 +200,8 @@ func TestLogToEvent(t *testing.T) {
 
 			event := LogToEvent(tc.log)
 
+			require.Equal(t, EventApp, event.GetApp())
+			require.Equal(t, EventVersion, event.GetVersion())
 			require.Equal(t, tc.expectedType, event.GetType())
 			require.Equal(t, tc.expectedName, event.GetLedger())
 			require.Equal(t, tc.log.GetSequence(), event.GetLogSequence())
@@ -211,6 +214,8 @@ func TestSerializeEvent_JSON(t *testing.T) {
 	t.Parallel()
 
 	event := &eventspb.Event{
+		App:         EventApp,
+		Version:     EventVersion,
 		Type:        commonpb.EventType_COMMITTED_TRANSACTION,
 		Ledger:      "orders",
 		LogSequence: 42,
@@ -220,14 +225,21 @@ func TestSerializeEvent_JSON(t *testing.T) {
 	data, err := SerializeEvent(event, FormatJSON)
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
-	require.Contains(t, string(data), "COMMITTED_TRANSACTION")
-	require.Contains(t, string(data), "orders")
+
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, EventApp, decoded["app"])
+	require.Equal(t, EventVersion, decoded["version"])
+	require.Equal(t, "COMMITTED_TRANSACTION", decoded["type"])
+	require.Equal(t, "orders", decoded["ledger"])
 }
 
 func TestSerializeEvent_Proto(t *testing.T) {
 	t.Parallel()
 
 	event := &eventspb.Event{
+		App:         EventApp,
+		Version:     EventVersion,
 		Type:        commonpb.EventType_COMMITTED_TRANSACTION,
 		Ledger:      "orders",
 		LogSequence: 42,
@@ -241,6 +253,8 @@ func TestSerializeEvent_Proto(t *testing.T) {
 	// Verify we can unmarshal back
 	decoded := &eventspb.Event{}
 	require.NoError(t, decoded.UnmarshalVT(data))
+	require.Equal(t, event.GetApp(), decoded.GetApp())
+	require.Equal(t, event.GetVersion(), decoded.GetVersion())
 	require.Equal(t, event.GetType(), decoded.GetType())
 	require.Equal(t, event.GetLedger(), decoded.GetLedger())
 	require.Equal(t, event.GetLogSequence(), decoded.GetLogSequence())

--- a/internal/application/events/sink_kafka_integration_test.go
+++ b/internal/application/events/sink_kafka_integration_test.go
@@ -127,6 +127,8 @@ func TestKafkaSinkIntegration_PublishAndConsume(t *testing.T) {
 	// Verify CREATED_LEDGER event (JSON)
 	var evt1 map[string]any
 	require.NoError(t, json.Unmarshal(msgs[0].Value, &evt1))
+	require.Equal(t, events.EventApp, evt1["app"])
+	require.Equal(t, events.EventVersion, evt1["version"])
 	require.Equal(t, "CREATED_LEDGER", evt1["type"])
 	require.Equal(t, "orders", evt1["ledger"])
 	require.Equal(t, float64(1), evt1["logSequence"])
@@ -134,6 +136,8 @@ func TestKafkaSinkIntegration_PublishAndConsume(t *testing.T) {
 	// Verify COMMITTED_TRANSACTION event (JSON)
 	var evt2 map[string]any
 	require.NoError(t, json.Unmarshal(msgs[1].Value, &evt2))
+	require.Equal(t, events.EventApp, evt2["app"])
+	require.Equal(t, events.EventVersion, evt2["version"])
 	require.Equal(t, "COMMITTED_TRANSACTION", evt2["type"])
 	require.Equal(t, "orders", evt2["ledger"])
 	require.Equal(t, float64(2), evt2["logSequence"])
@@ -270,6 +274,8 @@ func TestKafkaSinkIntegration_ProtobufFormat(t *testing.T) {
 	// Deserialize protobuf and verify
 	var evt eventspb.Event
 	require.NoError(t, evt.UnmarshalVT(msgs[0].Value))
+	require.Equal(t, events.EventApp, evt.GetApp())
+	require.Equal(t, events.EventVersion, evt.GetVersion())
 	require.Equal(t, commonpb.EventType_COMMITTED_TRANSACTION, evt.GetType())
 	require.Equal(t, "payments", evt.GetLedger())
 	require.Equal(t, uint64(1), evt.GetLogSequence())

--- a/internal/application/events/sink_nats_integration_test.go
+++ b/internal/application/events/sink_nats_integration_test.go
@@ -194,6 +194,8 @@ func TestNATSSinkIntegration_PublishAndConsume(t *testing.T) {
 	// Verify CREATED_LEDGER event (JSON)
 	var evt1 map[string]any
 	require.NoError(t, json.Unmarshal(msgs[0].Data(), &evt1))
+	require.Equal(t, events.EventApp, evt1["app"])
+	require.Equal(t, events.EventVersion, evt1["version"])
 	require.Equal(t, "CREATED_LEDGER", evt1["type"])
 	require.Equal(t, "orders", evt1["ledger"])
 	require.Equal(t, float64(1), evt1["logSequence"])
@@ -201,6 +203,8 @@ func TestNATSSinkIntegration_PublishAndConsume(t *testing.T) {
 	// Verify COMMITTED_TRANSACTION event (JSON)
 	var evt2 map[string]any
 	require.NoError(t, json.Unmarshal(msgs[1].Data(), &evt2))
+	require.Equal(t, events.EventApp, evt2["app"])
+	require.Equal(t, events.EventVersion, evt2["version"])
 	require.Equal(t, "COMMITTED_TRANSACTION", evt2["type"])
 	require.Equal(t, "orders", evt2["ledger"])
 	require.Equal(t, float64(2), evt2["logSequence"])
@@ -290,6 +294,8 @@ func TestNATSSinkIntegration_ProtobufFormat(t *testing.T) {
 	// Deserialize protobuf and verify
 	var evt eventspb.Event
 	require.NoError(t, evt.UnmarshalVT(msgs[0].Data()))
+	require.Equal(t, events.EventApp, evt.GetApp())
+	require.Equal(t, events.EventVersion, evt.GetVersion())
 	require.Equal(t, commonpb.EventType_COMMITTED_TRANSACTION, evt.GetType())
 	require.Equal(t, "payments", evt.GetLedger())
 	require.Equal(t, uint64(1), evt.GetLogSequence())

--- a/internal/proto/eventspb/event.go
+++ b/internal/proto/eventspb/event.go
@@ -10,6 +10,8 @@ import (
 // MarshalJSON implements json.Marshaler for Event.
 func (x *Event) MarshalJSON() ([]byte, error) {
 	type Aux struct {
+		App         string        `json:"app"`
+		Version     string        `json:"version"`
 		Type        string        `json:"type"`
 		Ledger      string        `json:"ledger"`
 		Date        *time.Time    `json:"date,omitempty"`
@@ -18,6 +20,8 @@ func (x *Event) MarshalJSON() ([]byte, error) {
 	}
 
 	aux := Aux{
+		App:         x.GetApp(),
+		Version:     x.GetVersion(),
 		Type:        x.GetType().String(),
 		Ledger:      x.GetLedger(),
 		LogSequence: x.GetLogSequence(),

--- a/internal/proto/eventspb/events.pb.go
+++ b/internal/proto/eventspb/events.pb.go
@@ -30,6 +30,8 @@ type Event struct {
 	Date          *commonpb.Timestamp    `protobuf:"bytes,3,opt,name=date,proto3" json:"date,omitempty"`
 	LogSequence   uint64                 `protobuf:"fixed64,4,opt,name=log_sequence,json=logSequence,proto3" json:"log_sequence,omitempty"`
 	Log           *commonpb.Log          `protobuf:"bytes,5,opt,name=log,proto3" json:"log,omitempty"`
+	App           string                 `protobuf:"bytes,6,opt,name=app,proto3" json:"app,omitempty"`         // Stable producer identifier ("ledger").
+	Version       string                 `protobuf:"bytes,7,opt,name=version,proto3" json:"version,omitempty"` // Event envelope generation ("v3").
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -99,17 +101,33 @@ func (x *Event) GetLog() *commonpb.Log {
 	return nil
 }
 
+func (x *Event) GetApp() string {
+	if x != nil {
+		return x.App
+	}
+	return ""
+}
+
+func (x *Event) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 var File_events_proto protoreflect.FileDescriptor
 
 const file_events_proto_rawDesc = "" +
 	"\n" +
-	"\fevents.proto\x12\x06events\x1a\fcommon.proto\"\xaf\x01\n" +
+	"\fevents.proto\x12\x06events\x1a\fcommon.proto\"\xdb\x01\n" +
 	"\x05Event\x12%\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x11.common.EventTypeR\x04type\x12\x16\n" +
 	"\x06ledger\x18\x02 \x01(\tR\x06ledger\x12%\n" +
 	"\x04date\x18\x03 \x01(\v2\x11.common.TimestampR\x04date\x12!\n" +
 	"\flog_sequence\x18\x04 \x01(\x06R\vlogSequence\x12\x1d\n" +
-	"\x03log\x18\x05 \x01(\v2\v.common.LogR\x03logB9Z7github.com/formancehq/ledger/v3/internal/proto/eventspbb\x06proto3"
+	"\x03log\x18\x05 \x01(\v2\v.common.LogR\x03log\x12\x10\n" +
+	"\x03app\x18\x06 \x01(\tR\x03app\x12\x18\n" +
+	"\aversion\x18\a \x01(\tR\aversionB9Z7github.com/formancehq/ledger/v3/internal/proto/eventspbb\x06proto3"
 
 var (
 	file_events_proto_rawDescOnce sync.Once

--- a/internal/proto/eventspb/events_dethash.pb.go
+++ b/internal/proto/eventspb/events_dethash.pb.go
@@ -27,6 +27,20 @@ func (m *Event) MarshalToSizedBufferDeterministicVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Version) > 0 {
+		i -= len(m.Version)
+		copy(dAtA[i:], m.Version)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Version)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.App) > 0 {
+		i -= len(m.App)
+		copy(dAtA[i:], m.App)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.App)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if m.Log != nil {
 		size, _ := m.Log.MarshalToSizedBufferDeterministicVT(dAtA[:i])
 		i -= size

--- a/internal/proto/eventspb/events_reader.pb.go
+++ b/internal/proto/eventspb/events_reader.pb.go
@@ -15,6 +15,8 @@ type EventReader interface {
 	GetDate() commonpb.TimestampReader
 	GetLogSequence() uint64
 	GetLog() commonpb.LogReader
+	GetApp() string
+	GetVersion() string
 	Mutate() *Event
 }
 
@@ -46,6 +48,14 @@ func (r *eventReadonly) GetLog() commonpb.LogReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *eventReadonly) GetApp() string {
+	return (*Event)(r).GetApp()
+}
+
+func (r *eventReadonly) GetVersion() string {
+	return (*Event)(r).GetVersion()
 }
 
 func (r *eventReadonly) Mutate() *Event {

--- a/internal/proto/eventspb/events_vtproto.pb.go
+++ b/internal/proto/eventspb/events_vtproto.pb.go
@@ -31,6 +31,8 @@ func (m *Event) CloneVT() *Event {
 	r.Date = m.Date.CloneVT()
 	r.LogSequence = m.LogSequence
 	r.Log = m.Log.CloneVT()
+	r.App = m.App
+	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -61,6 +63,12 @@ func (this *Event) EqualVT(that *Event) bool {
 		return false
 	}
 	if !this.Log.EqualVT(that.Log) {
+		return false
+	}
+	if this.App != that.App {
+		return false
+	}
+	if this.Version != that.Version {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -102,6 +110,20 @@ func (m *Event) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Version) > 0 {
+		i -= len(m.Version)
+		copy(dAtA[i:], m.Version)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Version)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.App) > 0 {
+		i -= len(m.App)
+		copy(dAtA[i:], m.App)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.App)))
+		i--
+		dAtA[i] = 0x32
 	}
 	if m.Log != nil {
 		size, err := m.Log.MarshalToSizedBufferVT(dAtA[:i])
@@ -166,6 +188,14 @@ func (m *Event) SizeVT() (n int) {
 	}
 	if m.Log != nil {
 		l = m.Log.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.App)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -333,6 +363,70 @@ func (m *Event) UnmarshalVT(dAtA []byte) error {
 			if err := m.Log.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field App", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.App = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/misc/proto/events.proto
+++ b/misc/proto/events.proto
@@ -17,4 +17,6 @@ message Event {
   common.Timestamp date = 3;
   fixed64 log_sequence = 4;
   common.Log log = 5;
+  string app = 6;      // Stable producer identifier ("ledger").
+  string version = 7;  // Event envelope generation ("v3").
 }


### PR DESCRIPTION
## Product / operational motivation

Need: Let broker consumers such as Webhooks identify the event producer and select the correct envelope contract.

Current limitation: Ledger v2 emitted `app="ledger"` and `version="v2"` in every platform event, while the Ledger v3 sink envelope omitted both fields.

Requirement / constraint: Every Ledger v3 event published through NATS or Kafka must carry `app="ledger"` and `version="v3"` in both JSON and Protobuf formats.

Evidence: The Ledger v2 constructors on `main` set both fields, and the v3 sink flow serializes the shared `eventspb.Event` envelope for NATS and Kafka.

Durable repository evidence: `docs/technical/architecture/subsystems/events-mirror/events.md`

## Technical decision

Decision: Add `app` and `version` to the common v3 Event protobuf and populate them once in `LogToEvent` before sink-specific serialization.

Why now / why proportionate: This restores the routing metadata needed by downstream services while keeping one source of truth for all broker transports.

Alternatives considered: Adding transport-specific wrappers in the NATS and Kafka sinks was rejected because it would duplicate the contract and allow the transports to drift.

## Validation

The requirement is satisfied when JSON and Protobuf messages consumed from both brokers expose the expected values.

- `nix develop --command go test ./internal/application/events`
- `nix develop --command go test -tags nats ./internal/application/events -run TestNATSSinkIntegration_... -count=1`
- `nix develop --command go test -tags kafka ./internal/application/events -run TestKafkaSinkIntegration_... -count=1`
- `nix develop --command bash scripts/agent-check`