### PR TITLE
test(startup): cover malformed environment rejection

### DIFF
--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -61,6 +61,15 @@ Options can be provided via:
 - Command line arguments
 - Environment variables (without prefix, with underscores)
 
+Configuration precedence is explicit command-line flag, then environment
+variable, then the flag's default. An environment value selected by that
+precedence is parsed as the flag's declared type before service startup. A
+malformed selected value fails startup with the environment variable and flag
+named in the diagnostic; Ledger does not open its service listeners or report
+readiness. When the same flag is explicitly supplied on the command line, that
+higher-precedence value is used and the lower-precedence environment value is
+ignored.
+
 Example with environment variables:
 ```bash
 export NODE_ID=1

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/service"
+
+	"github.com/formancehq/ledger/v3/cmd/server"
+)
+
+const en1922HelperProcess = "EN1922_HELPER_PROCESS"
+
+// TestMalformedEnvironmentFailsBeforeStartup protects the production
+// main -> service.Execute -> server command boundary reported by the native
+// process-boundary-recovery/malformed-env-falls-back-to-default audit and
+// confirmed as EN-1922.
+func TestMalformedEnvironmentFailsBeforeStartup(t *testing.T) {
+	if os.Getenv(en1922HelperProcess) == "1" {
+		cmd := server.NewRootCommand()
+		cmd.SetArgs([]string{"run"})
+		service.Execute(cmd)
+
+		return
+	}
+
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestMalformedEnvironmentFailsBeforeStartup$")
+	cmd.Env = []string{
+		en1922HelperProcess + "=1",
+		"GRPC_PORT=not-an-integer",
+	}
+	output, err := cmd.CombinedOutput()
+
+	require.Error(t, err)
+	require.Equal(t, 1, cmd.ProcessState.ExitCode())
+	require.Contains(t, string(output), "binding environment variable GRPC_PORT to flag --grpc-port")
+	require.Contains(t, string(output), "not-an-integer")
+	require.NotContains(t, string(output), "Starting application")
+	require.NotContains(t, string(output), "Service gRPC server started successfully")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -14,14 +14,12 @@ import (
 	"github.com/formancehq/ledger/v3/cmd/server"
 )
 
-const en1922HelperProcess = "EN1922_HELPER_PROCESS"
+const malformedEnvironmentHelperProcess = "MALFORMED_ENVIRONMENT_HELPER_PROCESS"
 
-// TestMalformedEnvironmentFailsBeforeStartup protects the production
-// main -> service.Execute -> server command boundary reported by the native
-// process-boundary-recovery/malformed-env-falls-back-to-default audit and
-// confirmed as EN-1922.
+// TestMalformedEnvironmentFailsBeforeStartup verifies that the production
+// command rejects malformed environment configuration before service startup.
 func TestMalformedEnvironmentFailsBeforeStartup(t *testing.T) {
-	if os.Getenv(en1922HelperProcess) == "1" {
+	if os.Getenv(malformedEnvironmentHelperProcess) == "1" {
 		cmd := server.NewRootCommand()
 		cmd.SetArgs([]string{"run"})
 		service.Execute(cmd)
@@ -36,7 +34,7 @@ func TestMalformedEnvironmentFailsBeforeStartup(t *testing.T) {
 
 	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestMalformedEnvironmentFailsBeforeStartup$")
 	cmd.Env = []string{
-		en1922HelperProcess + "=1",
+		malformedEnvironmentHelperProcess + "=1",
 		"GRPC_PORT=not-an-integer",
 	}
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
Reject malformed selected environment configuration before Ledger startup, and preserve explicit CLI flag precedence (EN-1922).

The shared binder fix was merged in formancehq/go-libs#673 and released as `v5.7.2`, which `release/v3.0` already uses. This PR adds the Ledger subprocess regression and documents the deployment contract; no dependency change is required.

The regression calls `service.Execute(server.NewRootCommand())` with `GRPC_PORT=not-an-integer`, checks exit status 1 and the specific environment/flag diagnostic, and rejects application/gRPC startup markers. The shared-library tests cover explicit CLI overrides and malformed values on unselected commands.

Traceability: EN-1922, confirmed native audit finding `process-boundary-recovery/malformed-env-falls-back-to-default`.

Validation of the rebased candidate is recorded in the follow-up comment and GitHub checks.
