### PR TITLE
fix: revalidate target at publication boundaries

### DIFF
--- a/docs/technical/contributing/ai-bugfix-workflow.md
+++ b/docs/technical/contributing/ai-bugfix-workflow.md
@@ -27,3 +27,7 @@ of the effective toolchain.
 Immediately before a guarded push, the loop runs `just pre-commit` and checks
 `git status --porcelain`. If pre-commit changes files, the candidate must be
 updated and re-reviewed; the workflow never resets those changes to hide them.
+After final pre-commit and exact review, the launcher re-fetches the target and
+requires it to remain at the run's immutable base before guarded publication.
+Any target advance requires explicit synchronization and a fresh trust pipeline,
+regardless of whether the changed paths overlap the candidate.

--- a/docs/technical/contributing/ai-pr-adopt-candidate.md
+++ b/docs/technical/contributing/ai-pr-adopt-candidate.md
@@ -18,7 +18,9 @@ never runs a fixer.
 - the candidate commit exists locally;
 - the candidate is a strict descendant of that PR head.
 
-If the target advanced, return `BASE_UPDATE_REQUIRED`. If the PR head moved or the candidate is not a descendant, refuse adoption.
+If the target advanced, return `BASE_UPDATE_REQUIRED`. This rule applies even
+when the target and candidate changed disjoint paths. If the PR head moved or
+the candidate is not a descendant, refuse adoption.
 
 After those identity checks, adoption runs the same base-pinned publication
 precondition helper as `ai-pr-loop`. The helper:
@@ -80,6 +82,13 @@ loaded/built from a detached worktree at the exact verified PR base SHA.
 
 The candidate is reviewed in a detached clean worktree. The review pass has no fixer. Local validation runs only after approval, through the base-pinned `agent-check-pr` path.
 
+The startup base comparison cannot authorize a long-running adoption by itself.
+Adoption re-fetches and compares the exact target again after normalization and
+before exact review, after review before that evidence can authorize approval,
+and after the final trusted pre-commit immediately before a guarded push. These
+checks all compare with the immutable base established at startup; they never
+move that expected base forward.
+
 Adoption uses the same immutable PR/worktree manifest, explicit `env -C`
 process cwd, root snapshot, cross-PR guard, Git mutation guard, and disjoint
 validation directory described in
@@ -92,15 +101,25 @@ Without `--push`, a successful run ends with `APPROVED_NOT_PUSHED`.
 
 With `--push`, publication is allowed only if:
 
-1. the exact candidate SHA was approved and validated;
-2. review/validation left its worktree clean and did not change HEAD;
-3. the base-pinned pre-commit recipe is rerun after review and leaves the exact
+1. the target still equals the startup base immediately before exact review;
+2. the exact candidate SHA was approved and validated;
+3. the target still equals the startup base before that exact review becomes
+   publication-authorizing evidence;
+4. review/validation left its worktree clean and did not change HEAD;
+5. the base-pinned pre-commit recipe is rerun after review and leaves the exact
    candidate clean and unchanged;
-4. the remote PR head still equals the original verified head;
-5. the candidate still descends from that original head;
-6. `git push --force-with-lease=<head-ref>:<original-head>` succeeds.
+6. the remote PR head still equals the original verified head;
+7. the candidate still descends from that original head;
+8. the target still equals the startup base immediately before push;
+9. `git push --force-with-lease=<head-ref>:<original-head>` succeeds.
 
 The force-with-lease is only a compare-and-swap guard. The candidate itself must be a normal descendant of the existing PR head.
+
+If any last-mile target check observes an advance, adoption reports the
+expected base, observed base, and candidate SHA, preserves the candidate
+worktree, and returns `BASE_UPDATE_REQUIRED` without approving or pushing.
+Synchronization is manual and must be followed by a fresh trust run. A review
+of the pre-synchronization candidate is never reused.
 
 ## Non-goals
 

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -29,6 +29,9 @@ A full PR URL is accepted as well. The launcher:
 - resolves the current repository and PR metadata through `gh`;
 - requires an open same-repository PR and currently rejects fork/cross-repository heads;
 - fetches the current target-branch tip and the PR head ref, requires the fetched head to equal the GitHub-reported head SHA, and requires the fetched target tip to still equal the GitHub-reported base SHA before running agents;
+- treats that base SHA as immutable for the run and re-fetches the exact target
+  before reporting local readiness, before and after an exact-candidate review,
+  and immediately before a guarded push;
 - creates a detached linked worktree outside the primary checkout, under a unique sibling `.<repo>-ai-worktrees/pr-<number>.<run>/worktree` directory;
 - writes an immutable PR/worktree binding outside that candidate, starts the
   orchestrator with `env -C` in the candidate, and requires the mechanical
@@ -62,6 +65,17 @@ When the checkout is shallow and the first ancestry check is negative, the launc
 
 Only the first case reaches an agent; every other case stops before triage, so no legitimacy triage, technical review, fix, or validation runs.
 
+The startup comparison is necessary but is not sufficient for a long-running
+review. The launcher uses the same exact-fetch classifier again at publication
+boundaries. Any target advance after startup invalidates the current readiness
+and any exact-candidate approval, including when the changed paths are
+disjoint. The launcher reports the expected and observed base SHAs, the current
+candidate SHA when available, preserves the useful worktree, and returns
+`BASE_UPDATE_REQUIRED` without pushing or silently restarting triage.
+Synchronization remains an explicit manual action. After synchronizing the PR,
+rerun the complete trust pipeline; an exact review made against the old base
+cannot authorize the synchronized candidate.
+
 ### Guarded publish mode
 
 Publishing reviewed fixes is explicit and opt-in:
@@ -74,13 +88,18 @@ bash scripts/ai-pr-loop 1732 --push
 
 1. creates a second detached worktree at the exact verified base SHA, builds the policy engine in that base's pinned Nix environment, and uses only the base-pinned reviewer, fixer, and validation tools; the PR under review cannot supply the tooling that authorizes its own publication;
 2. stages the complete isolated fix set and creates one local `fix: address AI review findings` candidate commit;
-3. runs a second **review-only** pass on that exact clean commit, with no fixer configured;
-4. refuses publication unless that candidate commit is approved as-is, `HEAD` still equals its immutable SHA, and the worktree remains clean;
+3. re-fetches the target, then runs a second **review-only** pass on that exact
+   clean commit, with no fixer configured;
+4. refuses publication unless that candidate commit is approved as-is, the
+   target remains unchanged after review, `HEAD` still equals its immutable SHA,
+   and the worktree remains clean;
 5. verifies that the remote PR branch still points to the exact head SHA observed before any agent ran;
 6. checks that the candidate is a descendant of that original head;
-7. pushes the candidate SHA, rather than the mutable `HEAD` name, to the PR branch with an explicit lease on the original head SHA.
+7. re-fetches the target immediately before pushing, then pushes the candidate
+   SHA, rather than the mutable `HEAD` name, to the PR branch with an explicit
+   lease on the original head SHA.
 
-The lease acts as an atomic compare-and-swap guard. The candidate update is still a normal fast-forward, but the push is rejected if another actor updates or rewrites the PR branch between the initial metadata lookup and publication. A failed candidate review, moved remote head, dirty post-review worktree, or failed push preserves the candidate worktree for inspection and never overwrites the remote branch.
+The lease acts as an atomic compare-and-swap guard. The candidate update is still a normal fast-forward, but the push is rejected if another actor updates or rewrites the PR branch between the initial metadata lookup and publication. A target update, failed candidate review, moved remote head, dirty post-review worktree, or failed push preserves the candidate worktree for inspection and never overwrites the remote branch. `READY_FOR_HUMAN_REVIEW` is not emitted in publish mode until these last-mile checks and publication succeed.
 
 If the bounded loop produces no fixes, `--push` reports `NO_CHANGES` and does not create a commit. The launcher never comments on GitHub, resolves review threads, marks a PR ready, or merges it.
 

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -38,6 +38,11 @@ trusted_root_checkout=$(git -C "$invocation_checkout" worktree list --porcelain 
 trusted_root_checkout=$(cd "$trusted_root_checkout" && pwd -P)
 repo_root=$trusted_root_checkout
 cd "$trusted_root_checkout"
+base_revalidator="$repo_root/scripts/ai-target-base-revalidate"
+if [[ -L "$base_revalidator" || ! -f "$base_revalidator" || ! -r "$base_revalidator" ]]; then
+    echo "ai-pr-adopt-candidate: trusted root does not provide scripts/ai-target-base-revalidate" >&2
+    exit 1
+fi
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 pr_json=$(gh pr view "$pr" --repo "$repo" --json number,url,state,title,body,labels,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository)
 pr_number=$(jq -r .number <<<"$pr_json")
@@ -53,16 +58,52 @@ head_repo=$(jq -r '.headRepository.name // empty' <<<"$pr_json")
 
 remote=origin
 git remote get-url "$remote" >/dev/null 2>&1 || { echo "ai-pr-adopt-candidate: required git remote origin is missing" >&2; exit 1; }
-git fetch --no-tags "$remote" "+refs/heads/$base_ref:refs/remotes/$remote/$base_ref" "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
-current_base=$(git rev-parse "refs/remotes/$remote/$base_ref")
-current_head=$(git rev-parse "refs/remotes/$remote/$head_ref")
-[[ "$current_head" == "$head_sha" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (remote PR head differs from GitHub snapshot)"; exit 2; }
-if [[ "$current_base" != "$base_sha" ]]; then
-    echo "AI_PR_ADOPT_RESULT: BASE_UPDATE_REQUIRED"
-    exit 3
-fi
+keep_candidate=false
+
+revalidate_target_or_exit() {
+    local revalidation_output
+    local revalidation_status
+    set +e
+    revalidation_output=$(bash "$base_revalidator" "$remote" "$base_ref" "$base_sha" 2>&1)
+    revalidation_status=$?
+    set -e
+    printf '%s\n' "$revalidation_output"
+    case "$revalidation_status" in
+        0)
+            return 0
+            ;;
+        3)
+            printf 'CURRENT_CANDIDATE_SHA=%s\n' "$candidate_sha"
+            if [[ -n "${candidate_worktree:-}" && -d "${candidate_worktree:-}" ]]; then
+                printf 'CANDIDATE_WORKTREE=%s\n' "$candidate_worktree"
+                keep_candidate=true
+            fi
+            echo "REQUIRED_NEXT_ACTION=synchronize the PR with the target branch, then rerun candidate adoption from scratch"
+            echo "AI_PR_ADOPT_RESULT: BASE_UPDATE_REQUIRED"
+            exit 3
+            ;;
+        4)
+            if [[ -n "${candidate_worktree:-}" && -d "${candidate_worktree:-}" ]]; then
+                keep_candidate=true
+            fi
+            echo "AI_PR_ADOPT_RESULT: ERROR (target base rewritten or diverged)"
+            exit 1
+            ;;
+        *)
+            if [[ -n "${candidate_worktree:-}" && -d "${candidate_worktree:-}" ]]; then
+                keep_candidate=true
+            fi
+            echo "AI_PR_ADOPT_RESULT: ERROR (target base fetch failed)"
+            exit 1
+            ;;
+    esac
+}
 
 git cat-file -e "${candidate_sha}^{commit}" 2>/dev/null || { echo "ai-pr-adopt-candidate: candidate commit is not available locally: $candidate_sha" >&2; exit 1; }
+git fetch --no-tags "$remote" "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
+current_head=$(git rev-parse "refs/remotes/$remote/$head_ref")
+[[ "$current_head" == "$head_sha" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (remote PR head differs from GitHub snapshot)"; exit 2; }
+revalidate_target_or_exit
 git merge-base --is-ancestor "$head_sha" "$candidate_sha" || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate is not a descendant of PR head)"; exit 2; }
 [[ "$candidate_sha" != "$head_sha" ]] || { echo "AI_PR_ADOPT_RESULT: NO_CHANGES"; exit 0; }
 
@@ -81,11 +122,16 @@ cleanup() {
     status=$?
     trap - EXIT
     primary_status=$status
-    for wt in "$candidate_worktree" "$trusted_worktree"; do
-        if [[ -d "$wt" ]] && git -C "$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            git worktree remove --force "$wt" >/dev/null 2>&1 || true
-        fi
-    done
+    if [[ "$keep_candidate" == "false" ]] && [[ -d "$candidate_worktree" ]] && git -C "$candidate_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git worktree remove --force "$candidate_worktree" >/dev/null 2>&1 || true
+    fi
+    if [[ -d "$trusted_worktree" ]] && git -C "$trusted_worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        git worktree remove --force "$trusted_worktree" >/dev/null 2>&1 || true
+    fi
+    if [[ "$keep_candidate" == "true" ]]; then
+        printf 'Candidate worktree preserved for inspection: %s\n' "$candidate_worktree"
+        exit "$primary_status"
+    fi
     if [[ "$run_dir" = /* && "$run_dir" == "$worktree_parent/adopt-$pr_number."?????? ]]; then
         chmod -R u+w -- "$run_dir" >/dev/null 2>&1 || true
     else
@@ -199,6 +245,10 @@ if [[ -n "$(git status --porcelain)" ]]; then
     exit 1
 fi
 
+# Normalization and its validation environment can be long-running. Re-fetch
+# before asking the exact-candidate reviewer to authorize this SHA.
+revalidate_target_or_exit
+
 set +e
 env -C "$candidate_worktree" "$review_loop_binary" \
     --base "$base_sha" \
@@ -232,6 +282,10 @@ read -r remote_head _ < <(git ls-remote --exit-code "$remote" "refs/heads/$head_
 
 git merge-base --is-ancestor "$head_sha" "$candidate_sha" || { echo "AI_PR_ADOPT_RESULT: REFUSED (candidate ancestry changed)"; exit 1; }
 
+# Do not authorize the exact review if the immutable target snapshot moved
+# while review or validation was running.
+revalidate_target_or_exit
+
 if [[ "$push_changes" == "false" ]]; then
     echo "AI_PR_ADOPT_RESULT: APPROVED_NOT_PUSHED $candidate_sha"
     exit 0
@@ -253,6 +307,10 @@ remote_head=""
 read -r remote_head _ < <(git ls-remote --exit-code "$remote" "refs/heads/$head_ref") || true
 [[ -n "$remote_head" ]] || { echo "ai-pr-adopt-candidate: could not re-resolve remote PR head before push" >&2; exit 1; }
 [[ "$remote_head" == "$head_sha" ]] || { echo "AI_PR_ADOPT_RESULT: REFUSED (remote PR head moved before push)"; exit 2; }
+
+# Target movement during the last trusted pre-commit pass must still prevent
+# the guarded push. This check intentionally remains adjacent to publication.
+revalidate_target_or_exit
 
 if ! git push --force-with-lease="refs/heads/$head_ref:$head_sha" "$remote" "$candidate_sha:refs/heads/$head_ref"; then
     echo "AI_PR_ADOPT_RESULT: REFUSED (remote changed during push or push failed)"

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -72,6 +72,12 @@ trusted_root_checkout=$(cd "$trusted_root_checkout" && pwd -P)
 repo_root=$trusted_root_checkout
 cd "$trusted_root_checkout"
 
+base_revalidator="$repo_root/scripts/ai-target-base-revalidate"
+if [[ -L "$base_revalidator" || ! -f "$base_revalidator" || ! -r "$base_revalidator" ]]; then
+    echo "ai-pr-loop: trusted root does not provide scripts/ai-target-base-revalidate" >&2
+    exit 1
+fi
+
 repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 pr_json=$(gh pr view "$pr" --repo "$repo" --json number,url,state,isDraft,title,body,labels,baseRefName,baseRefOid,headRefName,headRefOid,headRepositoryOwner,headRepository)
 
@@ -105,59 +111,60 @@ if ! git remote get-url "$remote" >/dev/null 2>&1; then
     exit 1
 fi
 
-# Fetch the current target/head refs. GitHub's baseRefOid describes the PR
-# snapshot and may legitimately lag behind the current target branch.
-git fetch --no-tags "$remote" \
-    "+refs/heads/$base_ref:refs/remotes/$remote/$base_ref" \
-    "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
+revalidate_target_or_exit() {
+    local candidate_sha=${1:-}
+    local revalidation_output
+    local revalidation_status
+    set +e
+    revalidation_output=$(bash "$base_revalidator" "$remote" "$base_ref" "$base_sha" 2>&1)
+    revalidation_status=$?
+    set -e
+    printf '%s\n' "$revalidation_output"
+    case "$revalidation_status" in
+        0)
+            return 0
+            ;;
+        3)
+            printf 'ai-pr-loop: target branch %s advanced during this run\n' "$base_ref" >&2
+            if [[ -n "$candidate_sha" ]]; then
+                printf 'CURRENT_CANDIDATE_SHA=%s\n' "$candidate_sha"
+            else
+                echo "CURRENT_CANDIDATE_SHA=UNAVAILABLE"
+            fi
+            if [[ -n "${worktree:-}" && -d "${worktree:-}" ]]; then
+                printf 'CANDIDATE_WORKTREE=%s\n' "$worktree"
+                keep_worktree=true
+            fi
+            echo "REQUIRED_NEXT_ACTION=synchronize the PR with the target branch, then rerun the full trust pipeline"
+            echo "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED"
+            exit 3
+            ;;
+        4)
+            echo "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)"
+            if [[ -n "${worktree:-}" && -d "${worktree:-}" ]]; then
+                keep_worktree=true
+            fi
+            exit 1
+            ;;
+        *)
+            echo "AI_PR_LOOP_RESULT: ERROR (target base fetch failed)"
+            if [[ -n "${worktree:-}" && -d "${worktree:-}" ]]; then
+                keep_worktree=true
+            fi
+            exit 1
+            ;;
+    esac
+}
 
-current_base=$(git rev-parse "refs/remotes/$remote/$base_ref")
+# Fetch the current head, then establish the immutable target-base trust anchor
+# through the same classifier used at every later publication boundary.
+git fetch --no-tags "$remote" "+refs/heads/$head_ref:refs/remotes/$remote/$head_ref"
 fetched_head=$(git rev-parse "refs/remotes/$remote/$head_ref")
 if [[ "$fetched_head" != "$head_sha" ]]; then
     echo "ai-pr-loop: fetched head SHA does not match GitHub: got $fetched_head expected $head_sha" >&2
     exit 1
 fi
-
-# Keep the review target synchronized with the branch that will eventually
-# receive the PR. Reviewing against a historical base can miss semantic
-# conflicts introduced since the PR was opened. Fail closed, but report this as
-# an actionable synchronization state rather than a generic orchestration error.
-if [[ "$current_base" != "$base_sha" ]]; then
-    if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
-        git fetch --no-tags "$remote" "$base_sha" >/dev/null 2>&1 || true
-    fi
-    if ! git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
-        echo "ai-pr-loop: GitHub-reported PR base commit is unavailable locally: $base_sha" >&2
-        exit 1
-    fi
-    base_is_ancestor=false
-    if git merge-base --is-ancestor "$base_sha" "$current_base"; then
-        base_is_ancestor=true
-    elif [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-        # A shallow repository can contain both commits without their connecting
-        # history. Restore ancestry for the exact fetched target before treating
-        # a negative merge-base result as evidence of a rewrite or divergence.
-        if ! git fetch --no-tags --unshallow "$remote" "$current_base" >/dev/null 2>&1; then
-            echo "ai-pr-loop: could not deepen shallow history for target base classification" >&2
-            exit 1
-        fi
-        if git merge-base --is-ancestor "$base_sha" "$current_base"; then
-            base_is_ancestor=true
-        fi
-    fi
-    if [[ "$base_is_ancestor" == "true" ]]; then
-        printf 'ai-pr-loop: target branch %s advanced since this PR snapshot\n' "$base_ref" >&2
-        printf 'ai-pr-loop: PR base:      %s\n' "$base_sha" >&2
-        printf 'ai-pr-loop: current base: %s\n' "$current_base" >&2
-        echo "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED"
-        exit 3
-    fi
-    echo "ai-pr-loop: target branch no longer descends from the GitHub-reported PR base" >&2
-    printf 'ai-pr-loop: PR base:      %s\n' "$base_sha" >&2
-    printf 'ai-pr-loop: current base: %s\n' "$current_base" >&2
-    echo "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)"
-    exit 1
-fi
+revalidate_target_or_exit
 
 repo_parent=$(dirname "$repo_root")
 repo_name=$(basename "$repo_root")
@@ -442,7 +449,17 @@ fi
 
 echo
 case "$loop_status" in
-    0) echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW" ;;
+    0)
+        # A startup check cannot authorize a readiness decision after a long
+        # review/validation pass. In publish mode this is only an intermediate
+        # approval; final readiness is deferred until publication completes.
+        revalidate_target_or_exit
+        if [[ "$push_changes" == "false" ]]; then
+            echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
+        else
+            echo "AI_PR_LOOP_REVIEW_RESULT: APPROVED_FOR_CANDIDATE_CREATION"
+        fi
+        ;;
     2) echo "AI_PR_LOOP_RESULT: HUMAN_DECISION_REQUIRED" ;;
     *) echo "AI_PR_LOOP_RESULT: ERROR (review-loop exit $loop_status)" ;;
 esac
@@ -467,6 +484,7 @@ fi
 
 if [[ -z "$(git status --porcelain)" ]]; then
     echo "No local fixes to publish; remote PR branch is unchanged."
+    echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
     echo "AI_PR_LOOP_PUSH_RESULT: NO_CHANGES"
     exit 0
 fi
@@ -478,6 +496,8 @@ if [[ -n "$(git status --porcelain)" ]]; then
     echo "PRECOMMIT_NORMALIZATION: CHANGES"
 else
     echo "PRECOMMIT_NORMALIZATION: NO_CHANGES"
+    revalidate_target_or_exit
+    echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
     echo "AI_PR_LOOP_PUSH_RESULT: NO_CHANGES"
     exit 0
 fi
@@ -522,6 +542,10 @@ if [[ -n "$(git status --porcelain)" ]]; then
 fi
 echo "PRECOMMIT_FIXPOINT: PASS"
 
+# Do not spend or trust an exact candidate review against a target that moved
+# during normalization. The synchronized candidate must start a fresh run.
+revalidate_target_or_exit "$candidate_sha"
+
 set +e
 run_commit_review
 commit_review_status=$?
@@ -540,6 +564,11 @@ if [[ "$commit_review_status" -ne 0 ]]; then
     keep_worktree=true
     exit "$commit_review_status"
 fi
+
+# An exact review only becomes publication-authorizing evidence while the
+# immutable target snapshot is still current. The final pre-push check below
+# separately covers target movement during the last trusted pre-commit pass.
+revalidate_target_or_exit "$candidate_sha"
 
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "ai-pr-loop: candidate review left the worktree dirty; refusing push" >&2
@@ -591,6 +620,10 @@ if ! git merge-base --is-ancestor "$head_sha" "$candidate_sha"; then
     exit 1
 fi
 
+# Keep the last target fetch immediately adjacent to the guarded push. The PR
+# head lease remains the atomic guard for the independently mutable head ref.
+revalidate_target_or_exit "$candidate_sha"
+
 if ! git push \
     --force-with-lease="refs/heads/$head_ref:$head_sha" \
     "$remote" \
@@ -601,5 +634,6 @@ if ! git push \
     exit 2
 fi
 
+echo "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW"
 echo "AI_PR_LOOP_PUSH_RESULT: PUSHED $candidate_sha"
 exit 0

--- a/scripts/ai-target-base-revalidate
+++ b/scripts/ai-target-base-revalidate
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/ai-target-base-revalidate <remote> <target-ref> <expected-sha>
+
+Fetches the exact remote target branch and classifies it against an immutable
+expected commit. Exit 0 is reserved for UNCHANGED; ADVANCED exits 3,
+REWRITTEN_OR_DIVERGED exits 4, and FETCH_ERROR exits 1.
+EOF
+}
+
+if [[ $# -ne 3 ]]; then
+    usage >&2
+    exit 1
+fi
+
+remote=$1
+target_ref=$2
+expected_sha=$3
+
+if ! git check-ref-format --branch "$target_ref" >/dev/null 2>&1; then
+    echo "ai-target-base-revalidate: invalid target branch: $target_ref" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    exit 1
+fi
+if [[ ! "$expected_sha" =~ ^[0-9a-f]{40,64}$ ]]; then
+    echo "ai-target-base-revalidate: expected SHA must be a full lowercase commit SHA" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    exit 1
+fi
+if ! git remote get-url "$remote" >/dev/null 2>&1; then
+    echo "ai-target-base-revalidate: remote is unavailable: $remote" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    exit 1
+fi
+
+remote_ref="refs/remotes/$remote/$target_ref"
+if ! git fetch --no-tags "$remote" "+refs/heads/$target_ref:$remote_ref"; then
+    echo "ai-target-base-revalidate: failed to fetch $remote/$target_ref" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    printf 'EXPECTED_BASE_SHA=%s\n' "$expected_sha"
+    exit 1
+fi
+if ! observed_sha=$(git rev-parse --verify "${remote_ref}^{commit}" 2>/dev/null); then
+    echo "ai-target-base-revalidate: fetched target does not resolve to a commit" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    printf 'EXPECTED_BASE_SHA=%s\n' "$expected_sha"
+    exit 1
+fi
+
+printf 'EXPECTED_BASE_SHA=%s\n' "$expected_sha"
+printf 'OBSERVED_BASE_SHA=%s\n' "$observed_sha"
+if [[ "$observed_sha" == "$expected_sha" ]]; then
+    echo "BASE_REVALIDATION_CLASSIFICATION=UNCHANGED"
+    exit 0
+fi
+
+if ! git cat-file -e "${expected_sha}^{commit}" 2>/dev/null; then
+    if ! git fetch --no-tags "$remote" "$expected_sha"; then
+        echo "ai-target-base-revalidate: expected base commit is unavailable: $expected_sha" >&2
+        echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+        exit 1
+    fi
+fi
+if ! git cat-file -e "${expected_sha}^{commit}" 2>/dev/null; then
+    echo "ai-target-base-revalidate: expected base does not resolve to a commit: $expected_sha" >&2
+    echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+    exit 1
+fi
+
+expected_is_ancestor=false
+if git merge-base --is-ancestor "$expected_sha" "$observed_sha"; then
+    expected_is_ancestor=true
+elif [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+    # Both endpoints may exist without their connecting history. Restore the
+    # exact fetched target's ancestry before classifying a rewrite/divergence.
+    if ! git fetch --no-tags --unshallow "$remote" "$observed_sha"; then
+        echo "ai-target-base-revalidate: could not deepen target history" >&2
+        echo "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR"
+        exit 1
+    fi
+    if git merge-base --is-ancestor "$expected_sha" "$observed_sha"; then
+        expected_is_ancestor=true
+    fi
+fi
+
+if [[ "$expected_is_ancestor" == "true" ]]; then
+    echo "BASE_REVALIDATION_CLASSIFICATION=ADVANCED"
+    exit 3
+fi
+
+echo "BASE_REVALIDATION_CLASSIFICATION=REWRITTEN_OR_DIVERGED"
+exit 4

--- a/scripts/aipradoptcandidate/launcher_test.go
+++ b/scripts/aipradoptcandidate/launcher_test.go
@@ -234,6 +234,38 @@ func TestAdoptCandidateRerunsPreCommitImmediatelyBeforePush(t *testing.T) {
 	require.Equal(t, fixture.candidateSHA, remoteHead)
 }
 
+func TestAdoptCandidateRevalidatesBeforeAndAfterExactReview(t *testing.T) {
+	t.Parallel()
+
+	for _, stage := range []string{"before-exact-review", "after-exact-review"} {
+		t.Run(stage, func(t *testing.T) {
+			fixture := newAdoptionFixture(t, adoptionFixtureOptions{})
+			output, exitCode := fixture.run(t, adoptionRun{targetMutation: stage})
+			require.Equal(t, 3, exitCode, output)
+			require.Contains(t, output, "BASE_REVALIDATION_CLASSIFICATION=ADVANCED")
+			require.Contains(t, output, "AI_PR_ADOPT_RESULT: BASE_UPDATE_REQUIRED")
+			require.NotContains(t, output, "AI_PR_ADOPT_RESULT: APPROVED_NOT_PUSHED")
+			require.Contains(t, output, "CURRENT_CANDIDATE_SHA="+fixture.candidateSHA)
+			require.Contains(t, output, "EXPECTED_BASE_SHA="+fixture.baseSHA)
+			require.Contains(t, output, "OBSERVED_BASE_SHA="+fixture.advancedBaseSHA)
+			candidateWorktree := preservedAdoptionWorktree(t, output)
+			require.Equal(t, fixture.candidateSHA, runGitOutput(t, candidateWorktree, "rev-parse", "HEAD"))
+		})
+	}
+}
+
+func TestAdoptCandidateRevalidatesAfterLastPreCommitBeforePush(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAdoptionFixture(t, adoptionFixtureOptions{})
+	output, exitCode := fixture.run(t, adoptionRun{push: true, targetMutation: "during-final-precommit"})
+	require.Equal(t, 3, exitCode, output)
+	require.Contains(t, output, "AI_PR_ADOPT_RESULT: BASE_UPDATE_REQUIRED")
+	require.NotContains(t, output, "AI_PR_ADOPT_RESULT: PUSHED")
+	require.Equal(t, fixture.headSHA, runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature"))
+	require.Equal(t, fixture.candidateSHA, runGitOutput(t, preservedAdoptionWorktree(t, output), "rev-parse", "HEAD"))
+}
+
 type adoptionRun struct {
 	title             string
 	body              string
@@ -243,19 +275,21 @@ type adoptionRun struct {
 	candidateSHA      string
 	push              bool
 	validationFailure bool
+	targetMutation    string
 }
 
 type adoptionFixture struct {
-	root         string
-	remote       string
-	seed         string
-	checkout     string
-	fakeBin      string
-	baseSHA      string
-	headSHA      string
-	candidateSHA string
-	capture      string
-	countsDir    string
+	root            string
+	remote          string
+	seed            string
+	checkout        string
+	fakeBin         string
+	baseSHA         string
+	headSHA         string
+	candidateSHA    string
+	advancedBaseSHA string
+	capture         string
+	countsDir       string
 }
 
 type adoptionFixtureOptions struct {
@@ -276,7 +310,7 @@ func newAdoptionFixture(t *testing.T, options adoptionFixtureOptions) adoptionFi
 	runGit(t, seed, "config", "user.name", "Adoption Test")
 	runGit(t, seed, "config", "user.email", "adoption@example.com")
 
-	baseScripts := []string{"ai-pr-adopt-candidate", "ai-bugfix-gate", "ai-git-guard"}
+	baseScripts := []string{"ai-pr-adopt-candidate", "ai-target-base-revalidate", "ai-bugfix-gate", "ai-git-guard"}
 	if !options.omitPreconditions {
 		baseScripts = append(baseScripts, "ai-pr-publication-preconditions")
 	}
@@ -327,6 +361,11 @@ increment "$TEST_COUNTS_DIR/validation"
 	writeExecutable(t, filepath.Join(seed, "scripts", "agent-just"), `#!/usr/bin/env bash
 set -euo pipefail
 increment "$TEST_COUNTS_DIR/pre-commit"
+precommit_count=$(<"$TEST_COUNTS_DIR/pre-commit")
+if [[ "${TEST_TARGET_MUTATION:-}" == "before-exact-review" && "$precommit_count" == "1" ]] ||
+   [[ "${TEST_TARGET_MUTATION:-}" == "during-final-precommit" && "$precommit_count" == "2" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
+fi
 `)
 	writeExecutable(t, filepath.Join(seed, "scripts", "review-loop"), `#!/usr/bin/env bash
 set -euo pipefail
@@ -344,6 +383,9 @@ while [[ $# -gt 0 ]]; do
 done
 bash -c "$review_cmd"
 bash -c "$validation_cmd"
+if [[ "${TEST_TARGET_MUTATION:-}" == "after-exact-review" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
+fi
 `)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644))
 	runGit(t, seed, "add", ".")
@@ -352,6 +394,13 @@ bash -c "$validation_cmd"
 	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
 	runGit(t, seed, "remote", "add", "origin", remote)
 	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "advanced-base.txt"), []byte("advanced base\n"), 0o644))
+	runGit(t, seed, "add", "advanced-base.txt")
+	runGit(t, seed, "commit", "-m", "advance target fixture")
+	advancedBaseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "push", "origin", "release/v3.0")
+	runGit(t, seed, "reset", "--hard", baseSHA)
+	runGit(t, seed, "push", "--force", "origin", "release/v3.0")
 
 	runGit(t, seed, "switch", "-c", "feature")
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
@@ -419,7 +468,7 @@ chmod 755 "$output"
 
 	return adoptionFixture{
 		root: root, remote: remote, seed: seed, checkout: checkout, fakeBin: fakeBin,
-		baseSHA: baseSHA, headSHA: headSHA, candidateSHA: candidateSHA,
+		baseSHA: baseSHA, headSHA: headSHA, candidateSHA: candidateSHA, advancedBaseSHA: advancedBaseSHA,
 		capture: filepath.Join(root, "review-args"), countsDir: countsDir,
 	}
 }
@@ -466,6 +515,9 @@ func (fixture adoptionFixture) run(t *testing.T, options adoptionRun) (string, i
 		"TEST_KNOWN_FINDINGS_JSON="+options.knownFindings,
 		"TEST_COUNTS_DIR="+fixture.countsDir,
 		"TEST_CAPTURE="+fixture.capture,
+		"TEST_REMOTE="+fixture.remote,
+		"TEST_ADVANCED_BASE_SHA="+fixture.advancedBaseSHA,
+		"TEST_TARGET_MUTATION="+options.targetMutation,
 	)
 	if options.validationFailure {
 		command.Env = append(command.Env, "VALIDATION_FAILURE=1")
@@ -494,11 +546,20 @@ func (fixture adoptionFixture) count(t *testing.T, name string) string {
 func (fixture adoptionFixture) advanceBase(t *testing.T) {
 	t.Helper()
 
-	runGit(t, fixture.seed, "switch", "release/v3.0")
-	require.NoError(t, os.WriteFile(filepath.Join(fixture.seed, "advanced.txt"), []byte("advanced\n"), 0o644))
-	runGit(t, fixture.seed, "add", "advanced.txt")
-	runGit(t, fixture.seed, "commit", "-m", "advance base")
-	runGit(t, fixture.seed, "push", "origin", "release/v3.0")
+	runGit(t, fixture.root, "--git-dir", fixture.remote, "update-ref", "refs/heads/release/v3.0", fixture.advancedBaseSHA)
+}
+
+func preservedAdoptionWorktree(t *testing.T, output string) string {
+	t.Helper()
+
+	for line := range strings.SplitSeq(output, "\n") {
+		if worktree, found := strings.CutPrefix(line, "CANDIDATE_WORKTREE="); found {
+			return worktree
+		}
+	}
+	require.FailNow(t, "preserved candidate worktree not reported", output)
+
+	return ""
 }
 
 func sourceScriptPath(t *testing.T, name string) string {

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -251,11 +251,13 @@ func TestLauncherClassifiesGenuinelyMissingSharedPolicyAsToolingError(t *testing
 }
 
 type launcherFixture struct {
-	root     string
-	checkout string
-	fakeBin  string
-	baseSHA  string
-	headSHA  string
+	root            string
+	remote          string
+	checkout        string
+	fakeBin         string
+	baseSHA         string
+	advancedBaseSHA string
+	headSHA         string
 }
 
 func newLauncherFixture(t *testing.T) launcherFixture {
@@ -275,6 +277,9 @@ func newLauncherFixture(t *testing.T) launcherFixture {
 	launcher, err := os.ReadFile(launcherPath(t))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	revalidator, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "ai-target-base-revalidate"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-target-base-revalidate"), revalidator, 0o755))
 	guard, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "ai-git-guard"))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-git-guard"), guard, 0o755))
@@ -305,6 +310,9 @@ if [[ -n "${TEST_RUN_VALIDATION_CMD:-}" ]]; then
     # then invokes the trusted validator, which this fixture does not provide.
     bash -lc "$validation_cmd" >/dev/null 2>&1 || true
     ls -1 "$validation_run_dir" > "$TEST_CAPTURE_FILE.rundir"
+fi
+if [[ "${TEST_ADVANCE_TARGET_AFTER_REVIEW:-false}" == "true" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
 fi
 `)
 	writeExecutable(t, filepath.Join(seed, "scripts", "ai-review-codex"), "#!/usr/bin/env bash\nexit 0\n")
@@ -351,6 +359,13 @@ printf '{"decision":"%s","base_sha":"%s","head":"%s"}\n' \
 	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
 	runGit(t, seed, "remote", "add", "origin", remote)
 	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "advanced-base.txt"), []byte("advanced base\n"), 0o644))
+	runGit(t, seed, "add", "advanced-base.txt")
+	runGit(t, seed, "commit", "-m", "advance target fixture")
+	advancedBaseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "push", "origin", "release/v3.0")
+	runGit(t, seed, "reset", "--hard", baseSHA)
+	runGit(t, seed, "push", "--force", "origin", "release/v3.0")
 
 	runGit(t, seed, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
@@ -398,7 +413,7 @@ cp "$source_root/scripts/review-loop" "$output"
 chmod 755 "$output"
 `)
 
-	return launcherFixture{root: testRoot, checkout: checkout, fakeBin: fakeBin, baseSHA: baseSHA, headSHA: headSHA}
+	return launcherFixture{root: testRoot, remote: remote, checkout: checkout, fakeBin: fakeBin, baseSHA: baseSHA, advancedBaseSHA: advancedBaseSHA, headSHA: headSHA}
 }
 
 func launcherPath(t *testing.T) string {
@@ -446,6 +461,8 @@ func runLauncherWithFlags(
 		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"TEST_BASE_SHA="+fixture.baseSHA,
 		"TEST_HEAD_SHA="+fixture.headSHA,
+		"TEST_REMOTE="+fixture.remote,
+		"TEST_ADVANCED_BASE_SHA="+fixture.advancedBaseSHA,
 		"TEST_CAPTURE_FILE="+capturePath,
 		"TEST_TRIAGE_DECISION="+triage.decision,
 		"TEST_TRIAGE_BASE_SHA="+triage.baseSHA,

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -129,6 +129,55 @@ func TestPushQuotesValidationPathsContainingAnApostrophe(t *testing.T) {
 	require.Contains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
 }
 
+func TestPushRevalidatesTargetAtEveryPublicationBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		stage string
+	}{
+		{name: "after initial review before readiness", stage: "after-initial-review"},
+		{name: "during normalization before exact review", stage: "before-exact-review"},
+		{name: "during exact review before authorization", stage: "after-exact-review"},
+		{name: "during final pre-commit before push", stage: "during-final-precommit"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newPushFixture(t, pushFixtureOptions{targetMutation: test.stage})
+			output, exitCode := fixture.run(t)
+			require.Equal(t, 3, exitCode, output)
+			require.Contains(t, output, "BASE_REVALIDATION_CLASSIFICATION=ADVANCED")
+			require.Contains(t, output, "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED")
+			require.NotContains(t, output, "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW")
+			require.NotContains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+			require.Contains(t, output, "EXPECTED_BASE_SHA="+fixture.baseSHA)
+			require.Contains(t, output, "OBSERVED_BASE_SHA="+fixture.advancedBaseSHA)
+			require.Contains(t, output, "REQUIRED_NEXT_ACTION=")
+			worktree := worktreeFromOutput(t, output)
+			require.DirExists(t, worktree, "stale-base work must remain inspectable")
+			require.Equal(t, fixture.headSHA, runGitOutput(t, fixture.root, "--git-dir", fixture.remote, "rev-parse", "refs/heads/feature"))
+		})
+	}
+}
+
+func TestPushFailsClosedWhenTargetIsRewrittenMidRun(t *testing.T) {
+	fixture := newPushFixture(t, pushFixtureOptions{targetMutation: "rewrite-after-initial-review"})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 1, exitCode, output)
+	require.Contains(t, output, "BASE_REVALIDATION_CLASSIFICATION=REWRITTEN_OR_DIVERGED")
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)")
+	require.NotContains(t, output, "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW")
+	require.NotContains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+}
+
+func TestPushFailsClosedWhenLastMileTargetFetchFails(t *testing.T) {
+	fixture := newPushFixture(t, pushFixtureOptions{targetMutation: "fetch-error-after-initial-review"})
+	output, exitCode := fixture.run(t)
+	require.Equal(t, 1, exitCode, output)
+	require.Contains(t, output, "BASE_REVALIDATION_CLASSIFICATION=FETCH_ERROR")
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (target base fetch failed)")
+	require.NotContains(t, output, "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW")
+	require.NotContains(t, output, "AI_PR_LOOP_PUSH_RESULT: PUSHED")
+	require.DirExists(t, worktreeFromOutput(t, output), "candidate work must survive a fetch failure")
+}
+
 type pushFixtureOptions struct {
 	moveRemote                           bool
 	moveLocalHead                        bool
@@ -138,6 +187,7 @@ type pushFixtureOptions struct {
 	trustedValidatorDirectory            bool
 	trustedValidatorSymlink              bool
 	trustedDirectToolNonExecutable       bool
+	targetMutation                       string
 
 	// quotedRepositoryParent nests the repository under a parent directory whose
 	// name contains an apostrophe, which the run directory inherits.
@@ -151,6 +201,8 @@ type pushFixture struct {
 	fakeBin         string
 	baseSHA         string
 	headSHA         string
+	advancedBaseSHA string
+	divergedBaseSHA string
 	reviewCountFile string
 	options         pushFixtureOptions
 }
@@ -177,6 +229,9 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 	launcher, err := os.ReadFile(launcherPath(t))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-pr-loop"), launcher, 0o755))
+	revalidator, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "ai-target-base-revalidate"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-target-base-revalidate"), revalidator, 0o755))
 	guard, err := os.ReadFile(filepath.Join(filepath.Dir(launcherPath(t)), "ai-git-guard"))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "ai-git-guard"), guard, 0o755))
@@ -205,7 +260,18 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 			require.NoError(t, err)
 			require.NoError(t, os.WriteFile(validatorPath, validator, publicationToolMode))
 		}
-		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-just"), []byte("#!/usr/bin/env bash\nexit 0\n"), publicationToolMode))
+		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-just"), []byte(`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${TEST_TARGET_MUTATION:-}" == "before-exact-review" && ! -e "$TEST_TARGET_MUTATION_MARKER" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
+    : > "$TEST_TARGET_MUTATION_MARKER"
+fi
+if [[ "${TEST_TARGET_MUTATION:-}" == "during-final-precommit" && -f "$TEST_REVIEW_COUNT_FILE" ]] &&
+   [[ "$(<"$TEST_REVIEW_COUNT_FILE")" == "2" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
+fi
+exit 0
+`), publicationToolMode))
 	}
 	directToolMode := os.FileMode(0o755)
 	if options.trustedDirectToolNonExecutable {
@@ -312,12 +378,25 @@ count=$((count + 1))
 printf '%s' "$count" > "$TEST_REVIEW_COUNT_FILE"
 if [[ "$count" -eq 1 ]]; then
     printf 'review fix\n' >> feature.txt
+    case "${TEST_TARGET_MUTATION:-}" in
+        after-initial-review)
+            git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
+            ;;
+        rewrite-after-initial-review)
+            git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_DIVERGED_BASE_SHA"
+            ;;
+        fetch-error-after-initial-review)
+            mv "$TEST_REMOTE" "$TEST_REMOTE.unavailable"
+            ;;
+    esac
 elif [[ "$count" -eq 2 && "${TEST_MOVE_REMOTE:-false}" == "true" ]]; then
     git --git-dir="$TEST_REMOTE" update-ref refs/heads/feature "$TEST_BASE_SHA"
 elif [[ "$count" -eq 2 && "${TEST_MOVE_LOCAL_HEAD:-false}" == "true" ]]; then
     printf 'unreviewed commit\n' > unreviewed.txt
     git add unreviewed.txt
     git commit -m 'test: move reviewed candidate head'
+elif [[ "$count" -eq 2 && "${TEST_TARGET_MUTATION:-}" == "after-exact-review" ]]; then
+    git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
 fi
 exit 0
 `)
@@ -329,6 +408,14 @@ exit 0
 	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
 	runGit(t, seed, "remote", "add", "origin", remote)
 	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "advanced-base.txt"), []byte("advanced base\n"), 0o644))
+	runGit(t, seed, "add", "advanced-base.txt")
+	runGit(t, seed, "commit", "-m", "advance target fixture")
+	advancedBaseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "push", "origin", "release/v3.0")
+	runGit(t, seed, "reset", "--hard", baseSHA)
+	runGit(t, seed, "push", "--force", "origin", "release/v3.0")
+	divergedBaseSHA := createCommitObject(t, remote, baseSHA+"^{tree}", "diverged target fixture")
 
 	runGit(t, seed, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "feature.txt"), []byte("feature\n"), 0o644))
@@ -405,6 +492,8 @@ chmod 755 "$output"
 		fakeBin:         fakeBin,
 		baseSHA:         baseSHA,
 		headSHA:         headSHA,
+		advancedBaseSHA: advancedBaseSHA,
+		divergedBaseSHA: divergedBaseSHA,
 		reviewCountFile: filepath.Join(root, "review-count"),
 		options:         options,
 	}
@@ -423,6 +512,10 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 		"TEST_MOVE_REMOTE="+strconv.FormatBool(fixture.options.moveRemote),
 		"TEST_MOVE_LOCAL_HEAD="+strconv.FormatBool(fixture.options.moveLocalHead),
 		"TEST_REMOTE="+fixture.remote,
+		"TEST_ADVANCED_BASE_SHA="+fixture.advancedBaseSHA,
+		"TEST_DIVERGED_BASE_SHA="+fixture.divergedBaseSHA,
+		"TEST_TARGET_MUTATION="+fixture.options.targetMutation,
+		"TEST_TARGET_MUTATION_MARKER="+filepath.Join(fixture.root, "target-mutation-marker"),
 	)
 	output, err := command.CombinedOutput()
 	if err == nil {
@@ -432,4 +525,19 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 	require.ErrorAs(t, err, &exitError, string(output))
 
 	return string(output), exitError.ExitCode()
+}
+
+func createCommitObject(t *testing.T, gitDirectory, tree, message string) string {
+	t.Helper()
+	command := exec.Command("git", "--git-dir", gitDirectory, "commit-tree", tree, "-m", message)
+	command.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Target Rewrite",
+		"GIT_AUTHOR_EMAIL=target-rewrite@example.com",
+		"GIT_COMMITTER_NAME=Target Rewrite",
+		"GIT_COMMITTER_EMAIL=target-rewrite@example.com",
+	)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	return strings.TrimSpace(string(output))
 }

--- a/scripts/aiprloop/stale_base_test.go
+++ b/scripts/aiprloop/stale_base_test.go
@@ -85,3 +85,20 @@ func TestLauncherTreatsRewrittenTargetAsError(t *testing.T) {
 	require.Contains(t, output, "AI_PR_LOOP_RESULT: ERROR (target base rewritten or diverged)")
 	require.NoFileExists(t, capture, "technical review must not run")
 }
+
+func TestLauncherDoesNotEmitReadinessWhenTargetAdvancesAfterTriage(t *testing.T) {
+	fixture := newLauncherFixture(t)
+	capture := filepath.Join(fixture.root, "review-args")
+	output, err := runLauncher(t, fixture, capture, triageResult{decision: "KEEP"}, "TEST_ADVANCE_TARGET_AFTER_REVIEW=true")
+
+	require.Error(t, err, output)
+	var exitError *exec.ExitError
+	require.ErrorAs(t, err, &exitError)
+	require.Equal(t, 3, exitError.ExitCode(), output)
+	require.FileExists(t, capture, "the target must advance after review, not at startup")
+	require.Contains(t, output, "AI_PR_LOOP_RESULT: BASE_UPDATE_REQUIRED")
+	require.NotContains(t, output, "AI_PR_LOOP_RESULT: READY_FOR_HUMAN_REVIEW")
+	require.Contains(t, output, "EXPECTED_BASE_SHA="+fixture.baseSHA)
+	require.Contains(t, output, "OBSERVED_BASE_SHA="+fixture.advancedBaseSHA)
+	require.DirExists(t, worktreeFromOutput(t, output), "reviewed worktree must be preserved")
+}

--- a/scripts/targetbaserevalidation/revalidation_test.go
+++ b/scripts/targetbaserevalidation/revalidation_test.go
@@ -1,0 +1,132 @@
+package targetbaserevalidation
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetBaseRevalidationClassifications(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		mutate         func(*testing.T, revalidationFixture)
+		expectedCode   int
+		classification string
+	}{
+		{name: "unchanged", expectedCode: 0, classification: "UNCHANGED"},
+		{
+			name: "advanced",
+			mutate: func(t *testing.T, fixture revalidationFixture) {
+				writeAndCommit(t, fixture.seed, "advanced.txt", "advanced\n", "advance target")
+				runGit(t, fixture.seed, "push", "origin", "release/v3.0")
+			},
+			expectedCode:   3,
+			classification: "ADVANCED",
+		},
+		{
+			name: "rewritten or diverged",
+			mutate: func(t *testing.T, fixture revalidationFixture) {
+				runGit(t, fixture.seed, "switch", "--orphan", "replacement")
+				writeAndCommit(t, fixture.seed, "replacement.txt", "replacement\n", "replace target")
+				runGit(t, fixture.seed, "push", "--force", "origin", "HEAD:release/v3.0")
+			},
+			expectedCode:   4,
+			classification: "REWRITTEN_OR_DIVERGED",
+		},
+		{
+			name: "fetch error",
+			mutate: func(t *testing.T, fixture revalidationFixture) {
+				runGit(t, fixture.checkout, "remote", "set-url", "origin", filepath.Join(fixture.root, "missing.git"))
+			},
+			expectedCode:   1,
+			classification: "FETCH_ERROR",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRevalidationFixture(t)
+			if test.mutate != nil {
+				test.mutate(t, fixture)
+			}
+			command := exec.Command("bash", revalidatorPath(t), "origin", "release/v3.0", fixture.baseSHA)
+			command.Dir = fixture.checkout
+			output, err := command.CombinedOutput()
+			exitCode := 0
+			if err != nil {
+				var exitError *exec.ExitError
+				require.ErrorAs(t, err, &exitError, string(output))
+				exitCode = exitError.ExitCode()
+			}
+			require.Equal(t, test.expectedCode, exitCode, string(output))
+			require.Contains(t, string(output), "BASE_REVALIDATION_CLASSIFICATION="+test.classification)
+			require.Contains(t, string(output), "EXPECTED_BASE_SHA="+fixture.baseSHA)
+			if test.classification != "FETCH_ERROR" {
+				require.Contains(t, string(output), "OBSERVED_BASE_SHA=")
+			}
+		})
+	}
+}
+
+type revalidationFixture struct {
+	root     string
+	seed     string
+	checkout string
+	baseSHA  string
+}
+
+func newRevalidationFixture(t *testing.T) revalidationFixture {
+	t.Helper()
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	seed := filepath.Join(root, "seed")
+	checkout := filepath.Join(root, "checkout")
+	runGit(t, root, "init", "--bare", remote)
+	runGit(t, root, "init", seed)
+	runGit(t, seed, "config", "user.name", "Base Revalidation Test")
+	runGit(t, seed, "config", "user.email", "base-revalidation@example.com")
+	writeAndCommit(t, seed, "base.txt", "base\n", "base")
+	runGit(t, seed, "branch", "-M", "release/v3.0")
+	baseSHA := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, seed, "remote", "add", "origin", remote)
+	runGit(t, seed, "push", "-u", "origin", "release/v3.0")
+	runGit(t, root, "clone", "--branch", "release/v3.0", remote, checkout)
+
+	return revalidationFixture{root: root, seed: seed, checkout: checkout, baseSHA: baseSHA}
+}
+
+func writeAndCommit(t *testing.T, repository, name, content, message string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(repository, name), []byte(content), 0o644))
+	runGit(t, repository, "add", name)
+	runGit(t, repository, "commit", "-m", message)
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	_ = runGitOutput(t, directory, arguments...)
+}
+
+func runGitOutput(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+
+	return strings.TrimSpace(string(output))
+}
+
+func revalidatorPath(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("..", "ai-target-base-revalidate"))
+	require.NoError(t, err)
+
+	return path
+}


### PR DESCRIPTION
Implements tooling-audit P1 `MID_RUN_BASE_INVALIDATION` / `LAST_MILE_BASE_REVALIDATION`.

`DISCOVERY: PARTIAL_EXISTING_WORK`  
`BEFORE_FIX: BUG_REPRODUCED`  
`AFTER_FIX: PASS`

- centralizes exact target fetch and `UNCHANGED` / `ADVANCED` / `REWRITTEN_OR_DIVERGED` / `FETCH_ERROR` classification;
- revalidates before readiness, before and after exact candidate review authorization, and immediately before guarded push;
- applies equivalent checks to candidate adoption while reusing #1848's shared publication preconditions and complete base-pinned tooling graph;
- preserves #1853's identity contract: `EXPECTED_HEAD` is the reviewed PR/candidate SHA, never `TARGET_BASE_SHA` or trusted-tool identity;
- preserves candidate work and reports `BASE_UPDATE_REQUIRED` with expected/observed target and candidate information when available;
- adds deterministic local bare-remote adversarial regressions, including historical-base/helper and absent-helper policy cases.

This intentionally does not auto-rebase, infer safety from disjoint paths, add campaign orchestration, or modify GitHub rulesets.

Recovery synchronization:

- current base: `cad987d804a571fef78c8f98e5411755611f9cc4`;
- exact candidate: `9f15095e2cad35fb8e5b316b5fe64f58815dbb5d`;
- target advancement during recovery correctly stopped the first publication attempt and forced explicit synchronization plus a fresh validation/review pipeline.

Validation was rerun from scratch on the synchronized candidate with pinned Nix Go 1.26.5: focused and full script suites, targeted race tests, repository invariants, `scripts/agent-check`, trusted base-pinned pre-commit normalization to fixpoint, `git diff --check`, and exact candidate review.

`TEST_SENSITIVITY: PASS`
