### PR TITLE
fix: separate review target from trusted tool head

### DIFF
--- a/docs/technical/contributing/ai-pr-known-findings.md
+++ b/docs/technical/contributing/ai-pr-known-findings.md
@@ -60,6 +60,13 @@ Structured splitting is syntax-only. The collector does not trust severity label
 
 The launcher snapshots findings before the technical loop and binds the snapshot to the PR number/head. It does not resolve threads, edit comments, or infer that a GitHub thread being marked resolved proves the underlying defect is fixed.
 
+During reconciliation, `EXPECTED_HEAD` always means the exact reviewed
+candidate SHA. `PR_HEAD_SHA` is the PR head to which the known-findings ledger
+was bound, and `TARGET_BASE_SHA` is the base-pinned policy/tool identity. An
+adopted candidate may differ from `PR_HEAD_SHA`; the provider cwd is therefore
+bound separately with `AI_WORKTREE_PATH` and `AI_WORKTREE_EXPECTED_HEAD` rather
+than reusing `EXPECTED_HEAD` for the trusted-tool worktree.
+
 ## Trusted-tool rollout
 
 Run `ai-pr-loop` from an up-to-date checkout of the target branch, never from
@@ -67,7 +74,10 @@ the PR worktree it is reviewing. A change that introduces or updates a
 base-pinned collector, reviewer, schema, or policy is reviewed and published by
 the preceding target-branch toolchain; it cannot authorize itself. The new
 toolchain becomes available atomically when all of those files land on the
-target branch. Until then, directly running the candidate launcher correctly
-fails closed when its historical target base does not contain the tools it
-requires. Do not add a fallback to the PR-head copies to bootstrap such a
-change.
+target branch. Until then, use the complete preceding target-branch launcher
+and dependency graph. A newer launcher must not resolve a newly introduced
+dependency from a historical base that predates it: it must require target-base
+synchronization with `BASE_UPDATE_REQUIRED` before dependency lookup. A missing
+tool that should genuinely exist in the selected complete base-pinned graph is
+a tooling error, never `HUMAN_DECISION_REQUIRED`. Do not add a fallback to the
+PR-head copies to bootstrap such a change.

--- a/docs/technical/contributing/ai-pr-triage-loop.md
+++ b/docs/technical/contributing/ai-pr-triage-loop.md
@@ -24,7 +24,10 @@ The base-pinned triage adapter may predate that binding, so `ai-pr-loop` does no
 
 The triage provider itself starts with `env -C` in the workflow-created trusted
 worktree, never in the primary checkout. Immediately before launch, the adapter
-checks the trusted top-level and base HEAD and binds `EXPECTED_PR_NUMBER`,
-`EXPECTED_WORKTREE`, and `EXPECTED_HEAD`. It snapshots primary-checkout HEAD,
-branch, and status around Codex and reports `ROOT_MUTATION_DETECTED` on any
-change. The separate PR-head worktree remains read-only evidence.
+checks the trusted top-level and base HEAD. `EXPECTED_WORKTREE` and
+`EXPECTED_HEAD` identify the read-only PR evidence worktree and actual PR head;
+`AI_WORKTREE_PATH` and `AI_WORKTREE_EXPECTED_HEAD` independently bind the
+provider cwd to the trusted worktree and target-base HEAD. `TARGET_BASE_SHA` and
+`PR_HEAD_SHA` expose those identities without overloading either one. The
+adapter snapshots primary-checkout HEAD, branch, and status around Codex and
+reports `ROOT_MUTATION_DETECTED` on any change.

--- a/docs/technical/contributing/ai-pr-triage.md
+++ b/docs/technical/contributing/ai-pr-triage.md
@@ -23,8 +23,11 @@ available only after it reaches the target branch; its bootstrap review uses the
 normal technical review workflow.
 
 Both detached worktrees are workflow-owned child worktrees. The provider
-process uses an explicit process cwd (`env -C`) in the trusted target worktree,
-receives the expected PR/worktree/HEAD values, and is surrounded by the same
+process uses an explicit process cwd (`env -C`) in the trusted target worktree.
+`EXPECTED_WORKTREE` and `EXPECTED_HEAD` identify the PR evidence worktree and
+actual PR head. The separate `AI_WORKTREE_PATH` and
+`AI_WORKTREE_EXPECTED_HEAD` values bind the provider cwd to the trusted target
+worktree and target-base HEAD. The process is surrounded by the same
 primary-checkout mutation detection described in
 [AI PR worktree isolation](ai-worktree-isolation.md).
 

--- a/docs/technical/contributing/ai-worktree-isolation.md
+++ b/docs/technical/contributing/ai-worktree-isolation.md
@@ -76,6 +76,15 @@ Codex and Claude adapters re-check them, add the expected values to the trusted
 prompt, and use `env -C "$EXPECTED_WORKTREE"` for the provider process. An
 agent's `pwd` self-check is defense in depth, not the authorization mechanism.
 
+For the ordinary technical review/fix/validation path, the reviewed candidate
+is also the provider cwd, so both pairs are equal. Trusted-policy passes such as
+legitimacy triage and known-finding reconciliation intentionally execute from a
+base-pinned worktree while inspecting a separate PR/candidate worktree. In
+those passes, `EXPECTED_WORKTREE` / `EXPECTED_HEAD` retain target semantics,
+while `AI_WORKTREE_PATH` / `AI_WORKTREE_EXPECTED_HEAD` bind the provider cwd and
+trusted-tool HEAD. `EXPECTED_HEAD` must never carry the target-base SHA merely
+because the provider executes from the base-pinned worktree.
+
 ## Root protection and Git guard
 
 Before the first subprocess, `review-loop` captures `ROOT_HEAD`, `ROOT_BRANCH`,

--- a/scripts/ai-pr-triage
+++ b/scripts/ai-pr-triage
@@ -116,8 +116,11 @@ REJECT is advisory and requires positive repository evidence that the change is 
 Copy base_sha and head exactly. Output only JSON matching the schema.
 
 At the start, verify `pwd` and `git rev-parse --show-toplevel`. Both must equal
-the expected trusted worktree supplied below. `EXPECTED_PR_NUMBER` and
-`EXPECTED_HEAD` bind this read-only triage to the exact PR state.
+the trusted worktree supplied below. `EXPECTED_PR_NUMBER`, `EXPECTED_WORKTREE`,
+and `EXPECTED_HEAD` identify the exact PR evidence target. `AI_WORKTREE_PATH`
+and `AI_WORKTREE_EXPECTED_HEAD` separately bind this provider process to the
+base-pinned trusted worktree; never compare the PR head to the trusted-tool
+HEAD as though they were the same identity.
 EOF
 {
   printf '\nTRUSTED POLICY FILES\n- AGENTS: `%s`\n- agent context: `%s`\n- triage contract: `%s`\n- traceability contract: `%s`\n' \
@@ -179,11 +182,13 @@ root_fingerprint=$(root_workspace_fingerprint "$repo_root")
 echo "WORKTREE_BINDING_GATE=PASS role=trusted-triage pr=$pr_number path=$trusted_worktree head=$base_sha"
 set +e
 EXPECTED_PR_NUMBER="$pr_number" \
-EXPECTED_WORKTREE="$trusted_worktree" \
-EXPECTED_HEAD="$base_sha" \
+EXPECTED_WORKTREE="$head_worktree" \
+EXPECTED_HEAD="$head_sha" \
 AI_WORKTREE_PR="$pr_number" \
 AI_WORKTREE_PATH="$trusted_worktree" \
 AI_WORKTREE_EXPECTED_HEAD="$base_sha" \
+TARGET_BASE_SHA="$base_sha" \
+PR_HEAD_SHA="$head_sha" \
   env -C "$trusted_worktree" HOME="$isolation_root/home" CODEX_HOME="$isolation_root/home/.codex" codex exec \
     --ephemeral --ignore-user-config --ignore-rules \
     --disable hooks --disable plugins --disable apps --disable memories --disable multi_agent --disable skill_search \

--- a/scripts/ai-review-known-findings
+++ b/scripts/ai-review-known-findings
@@ -105,6 +105,12 @@ Copy head and worktree_fingerprint exactly. Output only JSON matching the schema
 
 At the start, verify `pwd` and `git rev-parse --show-toplevel` against the
 base-pinned trusted worktree supplied below. Stop if either differs.
+
+`EXPECTED_WORKTREE` and `EXPECTED_HEAD` identify the exact candidate being
+reviewed. `AI_WORKTREE_PATH` and `AI_WORKTREE_EXPECTED_HEAD` separately bind
+this reconciliation process to its base-pinned trusted-tool worktree. The PR
+head recorded by the known-findings ledger can differ from the candidate head
+during adoption; do not collapse any of those identities.
 EOF
 printf '\nUNTRUSTED INPUT FILES\n- base_review: `%s`\n- known_findings: `%s`\n- candidate_worktree: `%s`\n' \
   "$base_result" "$AI_REVIEW_KNOWN_FINDINGS" "$repo_root" >> "$prompt"
@@ -112,10 +118,13 @@ printf '\nTRUSTED TARGET\n- head: %s\n- worktree_fingerprint: %s\n- trusted_work
   "$AI_REVIEW_HEAD" "$AI_REVIEW_WORKTREE_FINGERPRINT" "$trusted_root" >> "$prompt"
 
 trusted_head=$(jq -r '.base_sha' "$AI_REVIEW_CHANGE_TARGET")
-EXPECTED_WORKTREE="$trusted_root" \
-EXPECTED_HEAD="$trusted_head" \
+EXPECTED_WORKTREE="$repo_root" \
+EXPECTED_HEAD="$AI_REVIEW_HEAD" \
 AI_WORKTREE_PATH="$trusted_root" \
 AI_WORKTREE_EXPECTED_HEAD="$trusted_head" \
+TARGET_BASE_SHA="$trusted_head" \
+PR_HEAD_SHA="$AI_REVIEW_KNOWN_FINDINGS_HEAD" \
+CANDIDATE_SHA="$AI_REVIEW_HEAD" \
   env -C "$trusted_root" HOME="$isolation_root/home" CODEX_HOME="$isolation_root/home/.codex" codex exec \
     --ephemeral --ignore-user-config --ignore-rules \
     --disable hooks --disable plugins --disable apps --disable memories --disable multi_agent --disable skill_search \

--- a/scripts/aiprtriage/runner_test.go
+++ b/scripts/aiprtriage/runner_test.go
@@ -19,6 +19,9 @@ func TestRunnerPinsPolicyToBaseAndExposesExactPRHeadAsEvidence(t *testing.T) {
 	require.NoError(t, err, output)
 	require.Equal(t, fixture.baseSHA, strings.TrimSpace(readFile(t, fixture.codexHeadCapture)))
 	require.Equal(t, fixture.headSHA, strings.TrimSpace(readFile(t, fixture.evidenceHeadCapture)))
+	require.Equal(t, fixture.headSHA, strings.TrimSpace(readFile(t, fixture.expectedHeadCapture)))
+	require.Equal(t, fixture.baseSHA, strings.TrimSpace(readFile(t, fixture.trustedHeadCapture)))
+	require.Equal(t, fixture.baseSHA+" "+fixture.headSHA+" ", strings.TrimSuffix(readFile(t, fixture.identityCapture), "\n"))
 	require.Equal(t, "trusted", strings.TrimSpace(readFile(t, fixture.trustedInstructionsCapture)))
 	require.Equal(t, "false", strings.TrimSpace(readFile(t, fixture.callerMarkerCapture)))
 	require.Contains(t, readFile(t, fixture.promptCapture), "product-technical-traceability.md")
@@ -73,6 +76,9 @@ type fixture struct {
 	callerMarkerCapture        string
 	promptCapture              string
 	trustedInstructionsCapture string
+	expectedHeadCapture        string
+	trustedHeadCapture         string
+	identityCapture            string
 	rootMutation               string
 }
 
@@ -164,6 +170,9 @@ cat >"$TEST_PROMPT_CAPTURE"
 pwd >"$TEST_CODEX_DIRECTORY_CAPTURE"
 git rev-parse HEAD >"$TEST_CODEX_HEAD_CAPTURE"
 git -C ../head-worktree rev-parse HEAD >"$TEST_EVIDENCE_HEAD_CAPTURE"
+printf '%s\n' "$EXPECTED_HEAD" >"$TEST_EXPECTED_HEAD_CAPTURE"
+printf '%s\n' "$AI_WORKTREE_EXPECTED_HEAD" >"$TEST_TRUSTED_HEAD_CAPTURE"
+printf '%s %s %s\n' "$TARGET_BASE_SHA" "$PR_HEAD_SHA" "${CANDIDATE_SHA:-}" >"$TEST_IDENTITY_CAPTURE"
 if grep -qx 'trusted base instruction' AGENTS.md && grep -qx 'untrusted head instruction' ../head-worktree/AGENTS.md; then
   printf 'trusted\n' >"$TEST_TRUSTED_INSTRUCTIONS_CAPTURE"
 else
@@ -190,6 +199,9 @@ printf '{"decision":"KEEP","base_sha":"%s","head":"%s","problem_statement":"test
 		callerMarkerCapture:        filepath.Join(testRoot, "caller-marker"),
 		promptCapture:              filepath.Join(testRoot, "prompt"),
 		trustedInstructionsCapture: filepath.Join(testRoot, "trusted-instructions"),
+		expectedHeadCapture:        filepath.Join(testRoot, "expected-head"),
+		trustedHeadCapture:         filepath.Join(testRoot, "trusted-head"),
+		identityCapture:            filepath.Join(testRoot, "identities"),
 	}
 }
 
@@ -210,6 +222,9 @@ func (f fixture) run(t *testing.T) (string, error) {
 		"TEST_CALLER_MARKER_CAPTURE="+f.callerMarkerCapture,
 		"TEST_PROMPT_CAPTURE="+f.promptCapture,
 		"TEST_TRUSTED_INSTRUCTIONS_CAPTURE="+f.trustedInstructionsCapture,
+		"TEST_EXPECTED_HEAD_CAPTURE="+f.expectedHeadCapture,
+		"TEST_TRUSTED_HEAD_CAPTURE="+f.trustedHeadCapture,
+		"TEST_IDENTITY_CAPTURE="+f.identityCapture,
 		"TEST_CALLER_CHECKOUT="+f.checkout,
 		"TEST_ROOT_MUTATION="+f.rootMutation,
 	)

--- a/scripts/aireviewknownfindings/adapter_test.go
+++ b/scripts/aireviewknownfindings/adapter_test.go
@@ -18,6 +18,7 @@ const (
 	testReviewedHead = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	testLedgerHead   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	testFingerprint  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	testTrustedHead  = "dddddddddddddddddddddddddddddddddddddddd"
 )
 
 func TestNoKnownFindingsPreservesBaseResultByteForByte(t *testing.T) {
@@ -229,6 +230,27 @@ func TestReconcilerUsesBasePinnedInstructions(t *testing.T) {
 	require.Contains(t, prompt, fixture.repository)
 }
 
+func TestReconcilerBindsCandidateHeadSeparatelyFromTrustedToolHead(t *testing.T) {
+	t.Parallel()
+
+	fixture := newAdapterFixture(t)
+	known := newKnownFinding(114)
+	base := newReview("APPROVE", "LOW")
+	fixture.writeInputs(t, base, newLedger(known), combined(base, classification(known, "FIXED")))
+
+	output, err := fixture.run(t, nil)
+	require.NoError(t, err, output)
+	repository, err := filepath.EvalSymlinks(fixture.repository)
+	require.NoError(t, err)
+	trustedRoot, err := filepath.EvalSymlinks(fixture.trustedRoot)
+	require.NoError(t, err)
+	require.Equal(t, testReviewedHead, strings.TrimSpace(readFile(t, fixture.expectedHeadCapture)))
+	require.Equal(t, repository, strings.TrimSpace(readFile(t, fixture.expectedWorktreeCapture)))
+	require.Equal(t, testTrustedHead, strings.TrimSpace(readFile(t, fixture.trustedHeadCapture)))
+	require.Equal(t, trustedRoot, strings.TrimSpace(readFile(t, fixture.trustedWorktreeCapture)))
+	require.Equal(t, testTrustedHead+" "+testLedgerHead+" "+testReviewedHead, strings.TrimSpace(readFile(t, fixture.identityCapture)))
+}
+
 func assertResolvedKnownFindingLeavesBaseUnchanged(t *testing.T, status string) {
 	t.Helper()
 
@@ -243,18 +265,23 @@ func assertResolvedKnownFindingLeavesBaseUnchanged(t *testing.T, status string) 
 }
 
 type adapterFixture struct {
-	repository  string
-	trustedRoot string
-	adapter     string
-	fakeBin     string
-	home        string
-	result      string
-	baseResult  string
-	combined    string
-	ledger      string
-	target      string
-	prompt      string
-	cwdCapture  string
+	repository              string
+	trustedRoot             string
+	adapter                 string
+	fakeBin                 string
+	home                    string
+	result                  string
+	baseResult              string
+	combined                string
+	ledger                  string
+	target                  string
+	prompt                  string
+	cwdCapture              string
+	expectedHeadCapture     string
+	expectedWorktreeCapture string
+	trustedHeadCapture      string
+	trustedWorktreeCapture  string
+	identityCapture         string
 }
 
 func newAdapterFixture(t *testing.T) adapterFixture {
@@ -297,6 +324,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 pwd > "$TEST_CWD_CAPTURE"
+printf '%s\n' "$EXPECTED_HEAD" > "$TEST_EXPECTED_HEAD_CAPTURE"
+printf '%s\n' "$EXPECTED_WORKTREE" > "$TEST_EXPECTED_WORKTREE_CAPTURE"
+printf '%s\n' "$AI_WORKTREE_EXPECTED_HEAD" > "$TEST_TRUSTED_HEAD_CAPTURE"
+printf '%s\n' "$AI_WORKTREE_PATH" > "$TEST_TRUSTED_WORKTREE_CAPTURE"
+printf '%s %s %s\n' "$TARGET_BASE_SHA" "$PR_HEAD_SHA" "$CANDIDATE_SHA" > "$TEST_IDENTITY_CAPTURE"
 cat > "$TEST_PROMPT_CAPTURE"
 [[ -n "$output" ]]
 cp "$TEST_COMBINED_RESULT" "$output"
@@ -307,21 +339,26 @@ cp "$TEST_COMBINED_RESULT" "$output"
 	tmp := filepath.Join(root, "tmp")
 	require.NoError(t, os.MkdirAll(tmp, 0o755))
 	target := filepath.Join(root, "target.json")
-	writeFile(t, target, "{}\n", 0o644)
+	writeFile(t, target, `{"base_sha":"`+testTrustedHead+`"}`+"\n", 0o644)
 
 	return adapterFixture{
-		repository:  repository,
-		trustedRoot: trustedRoot,
-		adapter:     filepath.Join(trustedRoot, "scripts", "ai-review-known-findings"),
-		fakeBin:     fakeBin,
-		home:        home,
-		result:      filepath.Join(root, "result.json"),
-		baseResult:  filepath.Join(root, "base.json"),
-		combined:    filepath.Join(root, "combined.json"),
-		ledger:      filepath.Join(root, "ledger.json"),
-		target:      target,
-		prompt:      filepath.Join(root, "prompt.txt"),
-		cwdCapture:  filepath.Join(root, "codex-cwd.txt"),
+		repository:              repository,
+		trustedRoot:             trustedRoot,
+		adapter:                 filepath.Join(trustedRoot, "scripts", "ai-review-known-findings"),
+		fakeBin:                 fakeBin,
+		home:                    home,
+		result:                  filepath.Join(root, "result.json"),
+		baseResult:              filepath.Join(root, "base.json"),
+		combined:                filepath.Join(root, "combined.json"),
+		ledger:                  filepath.Join(root, "ledger.json"),
+		target:                  target,
+		prompt:                  filepath.Join(root, "prompt.txt"),
+		cwdCapture:              filepath.Join(root, "codex-cwd.txt"),
+		expectedHeadCapture:     filepath.Join(root, "expected-head.txt"),
+		expectedWorktreeCapture: filepath.Join(root, "expected-worktree.txt"),
+		trustedHeadCapture:      filepath.Join(root, "trusted-head.txt"),
+		trustedWorktreeCapture:  filepath.Join(root, "trusted-worktree.txt"),
+		identityCapture:         filepath.Join(root, "identities.txt"),
 	}
 }
 
@@ -355,6 +392,11 @@ func (fixture adapterFixture) run(t *testing.T, extra map[string]string) (string
 		"TEST_COMBINED_RESULT":           fixture.combined,
 		"TEST_PROMPT_CAPTURE":            fixture.prompt,
 		"TEST_CWD_CAPTURE":               fixture.cwdCapture,
+		"TEST_EXPECTED_HEAD_CAPTURE":     fixture.expectedHeadCapture,
+		"TEST_EXPECTED_WORKTREE_CAPTURE": fixture.expectedWorktreeCapture,
+		"TEST_TRUSTED_HEAD_CAPTURE":      fixture.trustedHeadCapture,
+		"TEST_TRUSTED_WORKTREE_CAPTURE":  fixture.trustedWorktreeCapture,
+		"TEST_IDENTITY_CAPTURE":          fixture.identityCapture,
 	}
 	maps.Copy(environment, extra)
 


### PR DESCRIPTION
## Summary

- keep `EXPECTED_HEAD` bound to the actual PR/candidate review target in legitimacy triage and known-finding reconciliation
- bind the base-pinned provider cwd independently through `AI_WORKTREE_PATH` / `AI_WORKTREE_EXPECTED_HEAD`
- document the complete base-pinned tool-graph rollout contract exposed by #1848 without duplicating its publication-precondition extraction

## Diagnosis

Issue A is not reachable on current `release/v3.0`; it is introduced by active #1848, whose newer launcher resolves its newly added helper from an older base that cannot contain it. The contract remains a complete graph pinned to the verified target base; use the preceding target toolchain until the new graph lands, and classify incompatible newer-launcher use as `BASE_UPDATE_REQUIRED`, never a generic missing tool.

Issue B remained present on current `release/v3.0`: trusted-policy provider passes overwrote `EXPECTED_HEAD` with the target-base/tool SHA. This could make the provider compare the review target against the base. `EXPECTED_HEAD` now always identifies the actual PR/candidate head.

#1849 remains orthogonal: target-base freshness is still checked separately from PR-head/candidate binding.

## Bugfix evidence

DISCOVERY: PARTIAL_FIX
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

The pre-fix regressions observed the base SHA in `EXPECTED_HEAD` for both ordinary triage (`PR_HEAD_SHA != TARGET_BASE_SHA`) and candidate reconciliation (`CANDIDATE_SHA != PR_HEAD_SHA`). Both pass after the identity split. Mutating the candidate wiring back to the base SHA makes the candidate-binding regression fail.

## Validation

- Nix Go 1.26.5 with isolated HOME/Go/lint caches
- `go test -count=1 ./scripts/...`
- focused triage, known-findings, ai-pr-loop, and adoption packages after final rebase
- `bash scripts/check-repo-invariants --fuzz-inventory`
- `bash scripts/agent-check`
- base-pinned trusted pre-commit normalization, two-pass fixpoint
- `git diff --check`

Target base: `16ede24ce93a5be56934716c3f88684591a5ed46`
Candidate: `142ae8b2391891e2a2b2f727d16653f7203bc804`

No product or WAL changes are included.