### PR TITLE
fix(check): bind the checker baseline to the archived boundary

### DIFF
--- a/docs/technical/architecture/subsystems/checker/checker.md
+++ b/docs/technical/architecture/subsystems/checker/checker.md
@@ -136,6 +136,32 @@ Replay reads from a Pebble-backed `replayStore` with merge operators so a multi-
 
 The transaction merge operator is associative. On a partial merge — Pebble compacting operands without the base value, `includesBase=false` — it defers the ordered ops as a `txOpBatch` instead of collapsing them into a finalized snapshot: a metadata delete has no snapshot representation, so collapsing would silently drop it and a later fold with the base could not undo it. Only a base-inclusive fold (at read, or the LSM bottom) resolves to a finalized `TransactionState`. Under archiving, each transaction's pre-archive baseline state is seeded lazily on the first post-archive delta that touches it (`newLazyTxSeedWriter`), so the delta merges onto the full state whose create log has been purged; untouched transactions carry no replay entry and fall back to the baseline in `compareTransactions`.
 
+### The baseline snapshot and the archived boundary
+
+Every baseline-seeded pass computes `expected = baseline + replay(boundary..now)`,
+where the boundary is the newest **archived** chapter's close. That arithmetic is
+only sound when the baseline is the state at exactly that close, so the baseline's
+lifecycle is bound to the archival confirm, not to the close:
+
+- the applier **stages** a compact attribute-only snapshot per closing chapter,
+  inside the seal-checkpoint maintenance gate (`StagedBaselineDir`) — state at
+  exactly that chapter's close;
+- the FSM **promotes** the staged snapshot to the live baseline
+  (`checker-<chapterID>`) in the post-commit hook of the proposal whose archival
+  confirm moved the boundary onto it (`PromoteStagedBaseline`); the applier runs
+  the same reconciliation once at boot for the crash window between the commit
+  and the rename;
+- `Check()` **refuses** a live baseline whose chapter id differs from the
+  snapshot's archived boundary — a promotion racing the check, or one whose
+  staging failed — and degrades to skipping entry-by-entry verification, exactly
+  as it does when no baseline exists.
+
+Promoting at close instead — the earlier behavior — double-counts every
+transaction between the boundary and the newest close: with a chapter closed but
+not yet archived — the lifecycle's normal intermediate state — those transactions
+sit in the baseline *and* in the replay window, and `Check()` reported a healthy
+store as corrupt with one `VOLUME_MISMATCH` per touched account.
+
 ## Pass-by-pass derivation flow
 
 ```mermaid

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -213,6 +213,7 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	var (
 		hasArchivedChapters  bool
 		archiveEndSeq        uint64 // max close_sequence among archived chapters
+		archivedMaxID        uint64 // max chapter id among archived chapters
 		archiveLastAuditHash []byte // last_audit_hash from the latest archived chapter
 	)
 
@@ -231,6 +232,10 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			if p.GetCloseSequence() > archiveEndSeq {
 				archiveEndSeq = p.GetCloseSequence()
 				archiveLastAuditHash = p.GetLastAuditHash()
+			}
+
+			if p.GetId() > archivedMaxID {
+				archivedMaxID = p.GetId()
 			}
 		}
 	}
@@ -271,7 +276,21 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 	var baselineDB *pebble.DB
 
 	if hasArchivedChapters {
-		baselinePath, exists := c.store.BaselineCheckpointPath()
+		baselinePath, baselineChapterID, exists := c.store.BaselineCheckpointPath()
+
+		// The arithmetic below assumes the baseline is the state at exactly the
+		// archived boundary: expected = baseline + replay(boundary..now). A
+		// baseline from any other close double-counts or drops the difference and
+		// reports a healthy store as corrupt, so a mismatched one — a promotion
+		// racing this snapshot, or one lost to a crash — is refused the same way
+		// a missing one is: entry-by-entry verification degrades honestly.
+		if exists && baselineChapterID != archivedMaxID {
+			c.logger.Infof("baseline checkpoint is for chapter %d but the snapshot's archived boundary is chapter %d (skipping entry-by-entry comparison)",
+				baselineChapterID, archivedMaxID)
+
+			exists = false
+		}
+
 		if exists {
 			db, openErr := pebble.Open(baselinePath, &pebble.Options{
 				Logger:   dal.NewPebbleLogger(c.logger),

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -2126,7 +2126,7 @@ func TestFoldBaselineIndexes_SeedSilencesArchivedEntry(t *testing.T) {
 	reader, err := store.NewReadHandle()
 	require.NoError(t, err)
 
-	dest, err := store.BaselineSnapshotDir()
+	dest, err := store.StagedBaselineDir(1)
 	require.NoError(t, err)
 	require.NoError(t, attributes.CreateBaselineSnapshot(reader, dest))
 	_ = reader.Close()
@@ -2515,7 +2515,7 @@ func TestSeedExpectedFromBaseline(t *testing.T) {
 	reader, err := store.NewReadHandle()
 	require.NoError(t, err)
 
-	dest, err := store.BaselineSnapshotDir()
+	dest, err := store.StagedBaselineDir(1)
 	require.NoError(t, err)
 	require.NoError(t, attributes.CreateBaselineSnapshot(reader, dest))
 	_ = reader.Close()

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -423,7 +423,7 @@ func Module() fx.Option {
 					logger,
 					registry,
 					snapshotter,
-					store, // QueryCheckpoints
+					store, // FSMFileArtifacts
 					dal.NewSentinelFactory(store, cfg.SentinelMode),
 					meterProvider,
 					ks,

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -589,6 +589,17 @@ func (a *Applier) RecoverAndReplay(ctx context.Context) (bool, error) {
 		}
 	}
 
+	// Reconcile the checker baseline with the archived prefix. Promotion
+	// normally rides the confirm's post-commit hook, but a crash between that
+	// commit and the rename loses it, and nothing re-applies the confirm on
+	// restart. Idempotent; replayed confirms below promote through the same
+	// hook. Non-fatal: the checker refuses a baseline whose chapter does not
+	// match the boundary, so a missed promotion degrades rather than misleads.
+	if err := a.store.PromoteStagedBaseline(a.fsm.Chapters.ArchivedThroughID()); err != nil {
+		a.logger.WithFields(map[string]any{"error": err}).
+			Errorf("Failed to reconcile staged checker baselines at boot (checker will degrade gracefully)")
+	}
+
 	storeLastAppliedIndex, err := query.ReadLastAppliedIndex(a.store)
 	if err != nil {
 		return false, fmt.Errorf("getting store last applied index: %w", err)
@@ -1683,8 +1694,8 @@ func (a *Applier) handleCheckpointRequired(
 				applyResult.OnCheckpointDone(path)
 			}
 
-			// Create compact baseline snapshot for the checker (non-fatal on error).
-			if err := a.createBaselineSnapshot(); err != nil {
+			// Stage the checker baseline for this close (non-fatal on error).
+			if err := a.createBaselineSnapshot(applyResult.CheckpointChapterID); err != nil {
 				a.logger.WithFields(map[string]any{"error": err}).
 					Errorf("Failed to create baseline snapshot (checker will degrade gracefully)")
 			}
@@ -2062,9 +2073,9 @@ func (a *Applier) createReplayCheckpoint(result *state.ApplyEntriesResult) error
 		result.OnCheckpointDone(checkpointPath)
 	}
 
-	if err := a.createBaselineSnapshot(); err != nil {
+	if err := a.createBaselineSnapshot(result.CheckpointChapterID); err != nil {
 		a.logger.WithFields(map[string]any{"error": err}).
-			Errorf("Failed to create baseline snapshot during replay (checker will degrade gracefully)")
+			Errorf("Failed to stage baseline snapshot during replay (checker will degrade gracefully)")
 	}
 
 	if lastResult, deferred := a.extractDeferredFuture(result); deferred != nil {
@@ -2092,11 +2103,19 @@ func (a *Applier) createMainStoreCheckpoint(checkpointID uint64) error {
 	return nil
 }
 
-// createBaselineSnapshot creates a compact attribute-only snapshot for the checker.
-// Unlike a full Pebble checkpoint, this contains only computed attribute values
-// (volumes, metadata, transactions), making it orders of magnitude smaller.
-func (a *Applier) createBaselineSnapshot() error {
-	destPath, err := a.store.BaselineSnapshotDir()
+// createBaselineSnapshot stages a compact attribute-only snapshot for the
+// checker. Unlike a full Pebble checkpoint, this contains only computed
+// attribute values (volumes, metadata, transactions), making it orders of
+// magnitude smaller.
+//
+// It runs inside the seal-checkpoint maintenance gate, so what it captures is
+// the state at exactly this chapter's close. It stays staged until the
+// chapter's archival is confirmed: the checker replays everything above the
+// archived boundary and seeds the sums with the baseline, so making this live
+// at close time double-counts every transaction between the boundary and the
+// close — the FSM promotes it on the confirm instead (PromoteStagedBaseline).
+func (a *Applier) createBaselineSnapshot(chapterID uint64) error {
+	destPath, err := a.store.StagedBaselineDir(chapterID)
 	if err != nil {
 		return err
 	}

--- a/internal/infra/node/applier.go
+++ b/internal/infra/node/applier.go
@@ -586,6 +586,19 @@ func (a *Applier) RecoverAndReplay(ctx context.Context) (bool, error) {
 
 			// The checkpoint is now on disk. The Sealer's recoverPendingSeal
 			// and periodic reconciliation will pick it up once started.
+
+			// A missing seal checkpoint is the proof that nothing after the close
+			// was applied — Pebble is at the close boundary, which is what makes
+			// the checkpoint above valid. The same proof makes staging the
+			// checker's baseline valid here, so the crash window between the
+			// close's commit and its staging closes too. When the checkpoint
+			// already exists that proof is gone, and a chapter whose staging
+			// failed stays unstaged: its promotion degrades rather than serves
+			// state captured at the wrong boundary.
+			if err := a.createBaselineSnapshot(chapter.GetId()); err != nil {
+				a.logger.WithFields(map[string]any{"error": err}).
+					Errorf("Failed to stage recovery baseline snapshot (checker will degrade gracefully)")
+			}
 		}
 	}
 

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -51,11 +51,12 @@ type Machine struct {
 	// WriteSessionFactory as a parameter to PrepareEntries / ApplyEntries, not
 	// as a field.
 
-	// queryCheckpoints lets the FSM delete query-checkpoint files when an
-	// apply removes their metadata. Two methods only: create + delete. The
-	// surface is not a read capability and does not give access to Pebble
-	// contents.
-	queryCheckpoints dal.QueryCheckpoints
+	// fileArtifacts lets the FSM drive the node-local file lifecycles bound to
+	// applied orders: deleting query-checkpoint files when an order removes
+	// their metadata, and promoting the checker's staged baseline when an
+	// archival confirm advances the archived prefix. The surface is not a read
+	// capability and does not give access to Pebble contents.
+	fileArtifacts dal.FSMFileArtifacts
 
 	// sentinel runs scoped post-commit reader-based checks in debug mode.
 	// The Reader never escapes the callback, so even in sentinelMode the
@@ -184,7 +185,7 @@ type Machine struct {
 // confChangeHandler is invoked from PrepareEntries for every
 // EntryConfChange* in the in-flight batch (see the field comment on
 // Machine). Must be non-nil.
-func NewMachine(logger logging.Logger, registry *StateRegistry, cacheSnapshotter *CacheSnapshotter, queryCheckpoints dal.QueryCheckpoints, sentinel dal.SentinelFactory, meterProvider metric.MeterProvider, ks *keystore.KeyStore, sharedState *SharedState, notifier Notifier, bloomFilters *bloom.FilterSet, clusterID string, numscriptCacheSize int, confChangeHandler func(entry *raftpb.Entry, session *dal.WriteSession) error) (*Machine, error) {
+func NewMachine(logger logging.Logger, registry *StateRegistry, cacheSnapshotter *CacheSnapshotter, fileArtifacts dal.FSMFileArtifacts, sentinel dal.SentinelFactory, meterProvider metric.MeterProvider, ks *keystore.KeyStore, sharedState *SharedState, notifier Notifier, bloomFilters *bloom.FilterSet, clusterID string, numscriptCacheSize int, confChangeHandler func(entry *raftpb.Entry, session *dal.WriteSession) error) (*Machine, error) {
 	sentinelMode := sentinel.IsEnabled()
 	// raft.* metrics describe the consensus engine and follow the
 	// upstream etcd-raft naming convention; numscript.* metrics are
@@ -241,7 +242,7 @@ func NewMachine(logger logging.Logger, registry *StateRegistry, cacheSnapshotter
 
 	fsm := &Machine{
 		logger:                         logger,
-		queryCheckpoints:               queryCheckpoints,
+		fileArtifacts:                  fileArtifacts,
 		sentinel:                       sentinel,
 		BloomFilters:                   bloomFilters,
 		sentinelMode:                   sentinelMode,
@@ -897,6 +898,17 @@ func (fsm *Machine) CommitPreparedBatch(ctx context.Context, pb *PreparedBatch) 
 		default:
 			// Coalescent signal — safe to drop, next purge will re-signal.
 		}
+
+		// A purge means an archival confirm advanced the archived prefix, so the
+		// staged baseline of the newly archived close becomes the checker's live
+		// one. Node-local file bookkeeping like the query-checkpoint deletes
+		// above; non-fatal, because the checker degrades honestly without a
+		// baseline while a stale one makes it report a healthy store as corrupt —
+		// which is also why promotion happens here and not when a chapter closes.
+		if err := fsm.fileArtifacts.PromoteStagedBaseline(fsm.Chapters.ArchivedThroughID()); err != nil {
+			fsm.logger.WithFields(map[string]any{"error": err}).
+				Errorf("Failed to promote staged checker baseline (checker will degrade gracefully)")
+		}
 	}
 
 	fsm.notifier.NotifyLogsCommitted(pb.lastSequenceID)
@@ -931,7 +943,7 @@ func (fsm *Machine) ApplyEntries(ctx context.Context, sessions dal.WriteSessionF
 // deleteQueryCheckpointFiles removes the physical files for a deleted checkpoint.
 // Called after the batch containing the DeleteQueryCheckpoint metadata removal is committed.
 func (fsm *Machine) deleteQueryCheckpointFiles(checkpointID uint64) {
-	if err := fsm.queryCheckpoints.DeleteQueryCheckpointFiles(checkpointID); err != nil {
+	if err := fsm.fileArtifacts.DeleteQueryCheckpointFiles(checkpointID); err != nil {
 		if fsm.logger.Enabled(logging.DebugLevel) {
 			fsm.logger.WithFields(map[string]any{
 				"error":        err,

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -758,6 +758,7 @@ func (fsm *Machine) PrepareDecodedEntries(ctx context.Context, sessions dal.Writ
 		lastSequenceID:       fsm.State.NextSequenceID - 1,
 		needsArchiveDispatch: needsArchiveDispatch,
 		needsColdCompaction:  needsColdCompaction,
+		archivedThrough:      fsm.Chapters.ArchivedThroughID(),
 		sinkConfigChanged:    sinkConfigChanged,
 		mirrorConfigChanged:  mirrorConfigChanged,
 		entryCount:           len(decoded),
@@ -905,7 +906,7 @@ func (fsm *Machine) CommitPreparedBatch(ctx context.Context, pb *PreparedBatch) 
 		// above; non-fatal, because the checker degrades honestly without a
 		// baseline while a stale one makes it report a healthy store as corrupt —
 		// which is also why promotion happens here and not when a chapter closes.
-		if err := fsm.fileArtifacts.PromoteStagedBaseline(fsm.Chapters.ArchivedThroughID()); err != nil {
+		if err := fsm.fileArtifacts.PromoteStagedBaseline(pb.archivedThrough); err != nil {
 			fsm.logger.WithFields(map[string]any{"error": err}).
 				Errorf("Failed to promote staged checker baseline (checker will degrade gracefully)")
 		}
@@ -2024,9 +2025,15 @@ type PreparedBatch struct {
 	lastSequenceID       uint64
 	needsArchiveDispatch bool
 	needsColdCompaction  bool
-	sinkConfigChanged    bool
-	mirrorConfigChanged  bool
-	checkpointDeletes    []uint64
+	// archivedThrough is the archived boundary as THIS batch's confirms left it,
+	// captured at prepare like every other post-commit input: preparation is
+	// pipelined, so by the time this batch's post-commit hook runs the live
+	// tracker may already carry a later batch's advance, and promoting to that
+	// boundary would consume a staged baseline whose confirm is not yet durable.
+	archivedThrough     uint64
+	sinkConfigChanged   bool
+	mirrorConfigChanged bool
+	checkpointDeletes   []uint64
 
 	// Sentinel data (captured during prepare, validated after commit).
 	sentinelMode        bool

--- a/internal/storage/dal/baseline_promote_test.go
+++ b/internal/storage/dal/baseline_promote_test.go
@@ -154,3 +154,65 @@ func TestPromoteStagedBaseline_NothingArchivedIsANoOp(t *testing.T) {
 	require.False(t, ok)
 	require.ElementsMatch(t, []string{"staged-00000000000000000001"}, baselineNames(t, store))
 }
+
+// A hard crash between CreateBaselineSnapshot's temp write and its rename leaves
+// a "staged-<id>.tmp-<pid>-<ns>" sibling. It must never pass for the snapshot it
+// was meant to become — fmt.Sscanf's %d would accept it — and it is swept.
+func TestPromoteStagedBaseline_IgnoresAndSweepsInterruptedWrites(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+
+	// Chapter 2's staging crashed mid-write: only the temp sibling exists.
+	dir := filepath.Join(store.dataDir, baselineCheckpointsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "staged-00000000000000000002.tmp-1234-5678"), 0755))
+
+	require.NoError(t, store.PromoteStagedBaseline(2))
+
+	// The temp must not have been promoted as chapter 2's snapshot; with no real
+	// snapshot for the boundary, the stale live baseline goes and the checker
+	// degrades. The interrupted write is swept either way.
+	_, _, ok := store.BaselineCheckpointPath()
+	require.False(t, ok, "an interrupted write must not serve as the boundary snapshot")
+	require.Empty(t, baselineNames(t, store))
+}
+
+// BaselineCheckpointPath applies the same anchored parse: an interrupted write
+// next to the live baseline must not shadow or impersonate it.
+func TestBaselineCheckpointPath_IgnoresInterruptedWrites(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 3)
+	require.NoError(t, store.PromoteStagedBaseline(3))
+
+	dir := filepath.Join(store.dataDir, baselineCheckpointsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "checker-00000000000000000009.tmp-1-1"), 0755))
+
+	_, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 3, id)
+}
+
+// The clean snapshot must win over a leftover temp for the same chapter — the
+// crash-then-retry case where staging eventually succeeded.
+func TestPromoteStagedBaseline_PromotesTheCleanSnapshotPastItsTemp(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	dir := filepath.Join(store.dataDir, baselineCheckpointsDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "staged-00000000000000000001.tmp-9-9"), 0755))
+
+	require.NoError(t, store.PromoteStagedBaseline(1))
+
+	_, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 1, id)
+	require.ElementsMatch(t, []string{"checker-00000000000000000001"}, baselineNames(t, store))
+}

--- a/internal/storage/dal/baseline_promote_test.go
+++ b/internal/storage/dal/baseline_promote_test.go
@@ -1,0 +1,156 @@
+package dal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func newBaselineTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	store, err := NewStore(t.TempDir(), logging.Testing(), noop.NewMeterProvider().Meter("t"), DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store
+}
+
+func stageBaseline(t *testing.T, store *Store, chapterID uint64) {
+	t.Helper()
+
+	path, err := store.StagedBaselineDir(chapterID)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path, 0755))
+}
+
+func baselineNames(t *testing.T, store *Store) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(store.dataDir, baselineCheckpointsDir))
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	require.NoError(t, err)
+
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+
+	return names
+}
+
+// The checker's arithmetic is expected = baseline + replay(boundary..now), so
+// the live baseline must be the staged snapshot of exactly the boundary close —
+// promoted when the confirm advances the boundary, never when a chapter merely
+// closes.
+func TestPromoteStagedBaseline_PromotesTheBoundaryClose(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	stageBaseline(t, store, 2)
+
+	require.NoError(t, store.PromoteStagedBaseline(1))
+
+	path, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 1, id)
+	require.DirExists(t, path)
+	require.ElementsMatch(t, []string{"checker-00000000000000000001", "staged-00000000000000000002"}, baselineNames(t, store),
+		"chapter 2 is closed but not archived: its staged snapshot must survive, unpromoted")
+}
+
+// Confirms can land several chapters ahead in one batch; only the boundary's
+// snapshot becomes live, and everything staged at or below is consumed.
+func TestPromoteStagedBaseline_ConsumesEverythingAtOrBelowTheBoundary(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	stageBaseline(t, store, 2)
+	stageBaseline(t, store, 3)
+
+	require.NoError(t, store.PromoteStagedBaseline(3))
+
+	_, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 3, id)
+	require.ElementsMatch(t, []string{"checker-00000000000000000003"}, baselineNames(t, store))
+}
+
+// Re-running with nothing new staged must keep the live baseline: this is every
+// boot after a clean shutdown, and every confirm-free batch.
+func TestPromoteStagedBaseline_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+	require.NoError(t, store.PromoteStagedBaseline(1))
+
+	_, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 1, id)
+}
+
+// A boundary whose own staging failed cannot be caught up by anything: an older
+// staged snapshot is just as stale as the live one. Both go, and the checker
+// degrades honestly on the missing baseline instead of comparing against the
+// wrong state.
+func TestPromoteStagedBaseline_RemovesWhatCannotReachTheBoundary(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+
+	// Chapter 2's close failed to stage; chapter 2 is then confirmed.
+	require.NoError(t, store.PromoteStagedBaseline(2))
+
+	_, _, ok := store.BaselineCheckpointPath()
+	require.False(t, ok, "a baseline for chapter 1 must not serve a boundary at chapter 2")
+}
+
+// The crash window the boot reconcile exists for: the confirm committed, the
+// rename did not happen, and the confirm is never re-applied.
+func TestPromoteStagedBaseline_RecoversALostPromotion(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+	stageBaseline(t, store, 2)
+
+	// Crash here: confirm of 2 was applied, promotion lost. Boot reconciles.
+	require.NoError(t, store.PromoteStagedBaseline(2))
+
+	_, id, ok := store.BaselineCheckpointPath()
+	require.True(t, ok)
+	require.EqualValues(t, 2, id)
+}
+
+func TestPromoteStagedBaseline_NothingArchivedIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(0))
+
+	_, _, ok := store.BaselineCheckpointPath()
+	require.False(t, ok)
+	require.ElementsMatch(t, []string{"staged-00000000000000000001"}, baselineNames(t, store))
+}

--- a/internal/storage/dal/baseline_promote_test.go
+++ b/internal/storage/dal/baseline_promote_test.go
@@ -1,6 +1,7 @@
 package dal
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -275,4 +276,45 @@ func TestNewStore_AdoptingACheckpointClearsBaselines(t *testing.T) {
 
 	_, _, ok := reopened.BaselineCheckpointPath()
 	require.False(t, ok, "baselines from before the adoption must not survive it")
+}
+
+// A cleanup failure at the publish boundary must roll back like every other
+// pre-publish failure: the original database stays installed and open. The
+// failure is injected through the clearBaselines seam — os.RemoveAll cannot be
+// made to fail deterministically across environments.
+func TestRestoreCheckpoint_BaselineCleanupFailureRollsBack(t *testing.T) {
+	store := newBaselineTestStore(t)
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte("seed"), []byte("value")))
+	require.NoError(t, batch.Commit())
+
+	checkpointID, err := store.CreateSnapshot()
+	require.NoError(t, err)
+
+	stageBaseline(t, store, 1)
+
+	original := clearBaselines
+	clearBaselines = func(string) error { return errors.New("injected cleanup failure") }
+	t.Cleanup(func() { clearBaselines = original })
+
+	err = store.RestoreCheckpoint(checkpointID)
+	require.ErrorContains(t, err, "clearing baselines")
+
+	// The rollback restored the original live database and reopened it: the
+	// pre-restore bytes are still served.
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	value, closer, err := handle.Get([]byte("seed"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+	require.NoError(t, closer.Close())
+	// The handle pins dbMu; RestoreCheckpoint takes it exclusively.
+	require.NoError(t, handle.Close())
+
+	// And the failure is recoverable in place: with the injection gone the same
+	// restore succeeds.
+	clearBaselines = original
+	require.NoError(t, store.RestoreCheckpoint(checkpointID))
 }

--- a/internal/storage/dal/baseline_promote_test.go
+++ b/internal/storage/dal/baseline_promote_test.go
@@ -216,3 +216,63 @@ func TestPromoteStagedBaseline_PromotesTheCleanSnapshotPastItsTemp(t *testing.T)
 	require.EqualValues(t, 1, id)
 	require.ElementsMatch(t, []string{"checker-00000000000000000001"}, baselineNames(t, store))
 }
+
+// A checkpoint restore replaces live/ with content that did not produce the
+// baselines sitting next to it. A previous incarnation's snapshot can share a
+// chapter id with the installed store's boundary while holding different state —
+// the id-guard cannot tell them apart — so every baseline artifact goes with the
+// old live/, and the checker degrades until the installed store mints its own.
+func TestRestoreCheckpoint_ClearsBaselines(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte("seed"), []byte("value")))
+	require.NoError(t, batch.Commit())
+
+	checkpointID, err := store.CreateSnapshot()
+	require.NoError(t, err)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+	stageBaseline(t, store, 2)
+
+	require.NoError(t, store.RestoreCheckpoint(checkpointID))
+
+	_, _, ok := store.BaselineCheckpointPath()
+	require.False(t, ok, "the previous incarnation's live baseline must not survive the restore")
+	require.Empty(t, baselineNames(t, store), "staged snapshots are the previous incarnation's too")
+}
+
+// Boot adoption of a checkpoint (no live/ present) is the same situation one
+// step earlier: whatever baselines sit in the data directory were not produced
+// by the checkpoint being adopted.
+func TestNewStore_AdoptingACheckpointClearsBaselines(t *testing.T) {
+	t.Parallel()
+
+	store := newBaselineTestStore(t)
+	dataDir := store.dataDir
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, batch.SetBytes([]byte("seed"), []byte("value")))
+	require.NoError(t, batch.Commit())
+
+	_, err := store.CreateSnapshot()
+	require.NoError(t, err)
+
+	stageBaseline(t, store, 1)
+	require.NoError(t, store.PromoteStagedBaseline(1))
+	require.NoError(t, store.Close())
+
+	// No live/, checkpoints present, stale baselines present: the boot path
+	// adopts the checkpoint and must discard the baselines with the old live/.
+	require.NoError(t, os.RemoveAll(filepath.Join(dataDir, "live")))
+
+	reopened, err := NewStore(dataDir, logging.Testing(), noop.NewMeterProvider().Meter("t"), DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	_, _, ok := reopened.BaselineCheckpointPath()
+	require.False(t, ok, "baselines from before the adoption must not survive it")
+}

--- a/internal/storage/dal/capabilities.go
+++ b/internal/storage/dal/capabilities.go
@@ -106,6 +106,25 @@ type QueryCheckpoints interface {
 	DeleteQueryCheckpointFiles(id uint64) error
 }
 
+// CheckerBaselines is the FSM's handle on the checker's baseline snapshot.
+// A baseline is staged per chapter when that chapter closes (the applier writes
+// it at the seal-checkpoint boundary) and promoted to the live baseline when the
+// chapter's archival is confirmed — the promotion is what keeps the baseline
+// equal to the state at the archived boundary the checker replays from.
+//
+// Intended consumer: the FSM's post-commit hook, next to the query-checkpoint
+// file deletes.
+type CheckerBaselines interface {
+	PromoteStagedBaseline(archivedThrough uint64) error
+}
+
+// FSMFileArtifacts groups the node-local file lifecycles the FSM drives from
+// post-commit hooks: query-checkpoint files and the checker's baseline.
+type FSMFileArtifacts interface {
+	QueryCheckpoints
+	CheckerBaselines
+}
+
 // ColdStorageScanner exposes the cold-storage iteration primitive used to
 // export an archived chapter's data.
 //

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -1572,7 +1572,7 @@ func (s *Store) RestoreCheckpoint(checkpointID uint64) error {
 	// between this and the rename, the rollback comes back with no baselines and
 	// the checker degrades honestly; after, the foreign live/ starts clean.
 	if err := clearBaselines(s.dataDir); err != nil {
-		return err
+		return rollback(fmt.Errorf("clearing baselines before publish: %w", err))
 	}
 
 	if err := os.Rename(stagingDirectory, liveDirectory); err != nil {

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -971,11 +971,19 @@ func (s *Store) QueryCheckpointMainDir(id uint64) string {
 	return filepath.Join(s.dataDir, queryCheckpointsDir, strconv.FormatUint(id, 10), "main")
 }
 
-// BaselineSnapshotDir returns the path where the baseline attribute snapshot
-// should be written and ensures its parent directory exists.
-// Callers (e.g. the applier) use this path with attributes.CreateBaselineSnapshot.
-func (s *Store) BaselineSnapshotDir() (string, error) {
-	path := filepath.Join(s.dataDir, baselineCheckpointsDir, "checker")
+// StagedBaselineDir returns the path where the baseline attribute snapshot for
+// one closing chapter should be written, and ensures its parent directory
+// exists. Callers (the applier) use this path with
+// attributes.CreateBaselineSnapshot at the seal-checkpoint boundary, so the
+// staged snapshot is the state at exactly that chapter's close.
+//
+// The snapshot stays staged until the chapter's archival is confirmed —
+// PromoteStagedBaseline then makes it the checker's live baseline. Promotion is
+// what the checker's arithmetic depends on: it seeds expected volumes with the
+// baseline and replays everything above the archived boundary, so a baseline
+// from any other close double-counts or drops the difference.
+func (s *Store) StagedBaselineDir(chapterID uint64) (string, error) {
+	path := filepath.Join(s.dataDir, baselineCheckpointsDir, fmt.Sprintf("staged-%020d", chapterID))
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return "", fmt.Errorf("creating baseline snapshot directory: %w", err)
@@ -984,14 +992,110 @@ func (s *Store) BaselineSnapshotDir() (string, error) {
 	return path, nil
 }
 
-// BaselineCheckpointPath returns the path to the baseline checker checkpoint and whether it exists.
-func (s *Store) BaselineCheckpointPath() (string, bool) {
-	path := filepath.Join(s.dataDir, baselineCheckpointsDir, "checker")
-	if _, err := os.Stat(path); err != nil {
-		return "", false
+// PromoteStagedBaseline aligns the checker's live baseline with the archived
+// prefix: the staged snapshot of the newest archived close becomes
+// checker-<id>, consuming it, and staged snapshots at or below the boundary are
+// deleted. Idempotent, and safe to call again after a crash anywhere in the
+// sequence — every step is an atomic rename or a remove of something already
+// consumed.
+//
+// A live baseline that no staged snapshot can bring up to the boundary is
+// removed rather than kept: the checker degrades honestly on a missing baseline
+// (it skips entry-by-entry verification), while a stale one makes it report a
+// healthy store as corrupt.
+func (s *Store) PromoteStagedBaseline(archivedThrough uint64) error {
+	dir := filepath.Join(s.dataDir, baselineCheckpointsDir)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("reading baseline snapshot directory: %w", err)
 	}
 
-	return path, true
+	var (
+		bestStaged  uint64
+		currentID   uint64
+		currentPath string
+		stagedBelow []string
+	)
+
+	for _, entry := range entries {
+		var id uint64
+		if n, _ := fmt.Sscanf(entry.Name(), "staged-%d", &id); n == 1 {
+			if id <= archivedThrough {
+				stagedBelow = append(stagedBelow, entry.Name())
+				if id > bestStaged {
+					bestStaged = id
+				}
+			}
+
+			continue
+		}
+
+		if n, _ := fmt.Sscanf(entry.Name(), "checker-%d", &id); n == 1 {
+			currentID = id
+			currentPath = filepath.Join(dir, entry.Name())
+		}
+	}
+
+	switch {
+	case bestStaged == archivedThrough && bestStaged > 0 && bestStaged != currentID:
+		// The staged snapshot of the boundary close exists: make it live.
+		if currentPath != "" {
+			if err := os.RemoveAll(currentPath); err != nil {
+				return fmt.Errorf("removing superseded baseline: %w", err)
+			}
+		}
+
+		from := filepath.Join(dir, fmt.Sprintf("staged-%020d", bestStaged))
+		to := filepath.Join(dir, fmt.Sprintf("checker-%020d", bestStaged))
+
+		if err := os.Rename(from, to); err != nil {
+			return fmt.Errorf("promoting staged baseline %d: %w", bestStaged, err)
+		}
+
+	case currentID != archivedThrough && currentPath != "":
+		// The boundary moved past the live baseline and no staged snapshot of the
+		// boundary close exists (its staging failed at close time, which is
+		// non-fatal there). A lower staged snapshot would be just as stale, so
+		// nothing is promoted and the live baseline is removed.
+		if err := os.RemoveAll(currentPath); err != nil {
+			return fmt.Errorf("removing stale baseline: %w", err)
+		}
+	}
+
+	for _, name := range stagedBelow {
+		if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
+			return fmt.Errorf("removing consumed staged baseline: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// BaselineCheckpointPath returns the path to the checker's live baseline, the
+// chapter whose close it captures, and whether one exists. The chapter id lets
+// the checker refuse a baseline that does not match the archived boundary of
+// the snapshot it is verifying.
+func (s *Store) BaselineCheckpointPath() (string, uint64, bool) {
+	dir := filepath.Join(s.dataDir, baselineCheckpointsDir)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", 0, false
+	}
+
+	for _, entry := range entries {
+		var id uint64
+		if n, _ := fmt.Sscanf(entry.Name(), "checker-%d", &id); n == 1 {
+			return filepath.Join(dir, entry.Name()), id, true
+		}
+	}
+
+	return "", 0, false
 }
 
 // cleanupTemporaryCheckpoints removes the entire tmp/ directory on startup.

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -496,6 +496,12 @@ func NewStore(
 
 			logger.Infof("No live directory found, restoring from checkpoint %d", latestCheckpointID)
 
+			// The adopted checkpoint did not produce whatever baselines sit in
+			// this data directory.
+			if err = clearBaselines(dataDir); err != nil {
+				return nil, err
+			}
+
 			if err = HardLink(checkpointPath, liveDir); err != nil {
 				return nil, fmt.Errorf("hard linking checkpoint to live directory: %w", err)
 			}
@@ -1108,6 +1114,22 @@ func (s *Store) BaselineCheckpointPath() (string, uint64, bool) {
 	return "", 0, false
 }
 
+// ClearBaselines removes every baseline artifact — the live checker baseline
+// and all staged snapshots. Called whenever live/ is replaced with content that
+// did not produce them (a checkpoint restore, follower sync's publish, boot
+// adoption of a checkpoint): a baseline describes the store it was captured
+// from, and a previous incarnation's snapshot can share a chapter id with the
+// installed store's boundary while holding different state — the id-guard
+// cannot tell them apart, so the artifacts must go. The checker degrades until
+// the next close/confirm cycle mints a baseline from the installed store.
+func clearBaselines(dataDir string) error {
+	if err := os.RemoveAll(filepath.Join(dataDir, baselineCheckpointsDir)); err != nil {
+		return fmt.Errorf("clearing baseline snapshots: %w", err)
+	}
+
+	return nil
+}
+
 // parseBaselineName reads a baseline directory name of the form
 // <prefix><zero-padded id>, refusing anything with a remainder — an interrupted
 // write's ".tmp-<pid>-<ns>" sibling must never pass as the snapshot it was
@@ -1544,6 +1566,14 @@ func (s *Store) RestoreCheckpoint(checkpointID uint64) error {
 	}
 
 	s.db = nil
+
+	// Before the publish rename, so every crash window is safe: before this,
+	// the rollback restores the original live/ whose baselines still match it;
+	// between this and the rename, the rollback comes back with no baselines and
+	// the checker degrades honestly; after, the foreign live/ starts clean.
+	if err := clearBaselines(s.dataDir); err != nil {
+		return err
+	}
 
 	if err := os.Rename(stagingDirectory, liveDirectory); err != nil {
 		return rollback(fmt.Errorf("publishing live.staging to live: %w", err))

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -1122,7 +1122,10 @@ func (s *Store) BaselineCheckpointPath() (string, uint64, bool) {
 // installed store's boundary while holding different state — the id-guard
 // cannot tell them apart, so the artifacts must go. The checker degrades until
 // the next close/confirm cycle mints a baseline from the installed store.
-func clearBaselines(dataDir string) error {
+// A function variable so the failure branch is reachable from a test:
+// os.RemoveAll cannot be made to fail deterministically across environments
+// (permission tricks do not bind as root).
+var clearBaselines = func(dataDir string) error {
 	if err := os.RemoveAll(filepath.Join(dataDir, baselineCheckpointsDir)); err != nil {
 		return fmt.Errorf("clearing baseline snapshots: %w", err)
 	}

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1023,8 +1024,7 @@ func (s *Store) PromoteStagedBaseline(archivedThrough uint64) error {
 	)
 
 	for _, entry := range entries {
-		var id uint64
-		if n, _ := fmt.Sscanf(entry.Name(), "staged-%d", &id); n == 1 {
+		if id, ok := parseBaselineName(entry.Name(), "staged-"); ok {
 			if id <= archivedThrough {
 				stagedBelow = append(stagedBelow, entry.Name())
 				if id > bestStaged {
@@ -1035,9 +1035,20 @@ func (s *Store) PromoteStagedBaseline(archivedThrough uint64) error {
 			continue
 		}
 
-		if n, _ := fmt.Sscanf(entry.Name(), "checker-%d", &id); n == 1 {
+		if id, ok := parseBaselineName(entry.Name(), "checker-"); ok {
 			currentID = id
 			currentPath = filepath.Join(dir, entry.Name())
+
+			continue
+		}
+
+		// CreateBaselineSnapshot writes through a sibling ".tmp-<pid>-<ns>"
+		// directory, so a hard crash mid-write leaves one here. It is not a
+		// snapshot — sweep it. Nothing else writes into this directory.
+		if strings.Contains(entry.Name(), ".tmp-") {
+			if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+				return fmt.Errorf("removing interrupted baseline write %s: %w", entry.Name(), err)
+			}
 		}
 	}
 
@@ -1089,13 +1100,31 @@ func (s *Store) BaselineCheckpointPath() (string, uint64, bool) {
 	}
 
 	for _, entry := range entries {
-		var id uint64
-		if n, _ := fmt.Sscanf(entry.Name(), "checker-%d", &id); n == 1 {
+		if id, ok := parseBaselineName(entry.Name(), "checker-"); ok {
 			return filepath.Join(dir, entry.Name()), id, true
 		}
 	}
 
 	return "", 0, false
+}
+
+// parseBaselineName reads a baseline directory name of the form
+// <prefix><zero-padded id>, refusing anything with a remainder — an interrupted
+// write's ".tmp-<pid>-<ns>" sibling must never pass as the snapshot it was
+// meant to become (fmt.Sscanf would accept it: %d stops at the first non-digit
+// and trailing input is ignored).
+func parseBaselineName(name, prefix string) (uint64, bool) {
+	rest, found := strings.CutPrefix(name, prefix)
+	if !found {
+		return 0, false
+	}
+
+	id, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return id, true
 }
 
 // cleanupTemporaryCheckpoints removes the entire tmp/ directory on startup.

--- a/tests/e2e/business/check_store_baseline_boundary_test.go
+++ b/tests/e2e/business/check_store_baseline_boundary_test.go
@@ -1,0 +1,154 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+)
+
+// store check seeds expected volumes with the baseline snapshot and replays
+// everything above the archived boundary, so the baseline must be the state at
+// exactly that boundary. It used to be overwritten at every chapter close: on any
+// store with a closed-but-unarchived chapter — the lifecycle's normal
+// intermediate state — every transaction between the boundary and the newest
+// close was counted twice, and a healthy store was reported corrupt with one
+// VOLUME_MISMATCH per touched account. The baseline is now staged per close and
+// only promoted when the chapter's archival confirm moves the boundary onto it.
+//
+// The three phases walk the store through the alignments: boundary behind the
+// newest close, boundary on it, and behind again.
+var _ = Describe("CheckStoreBaselineBoundary", Ordered, func() {
+	var (
+		ctx    context.Context
+		client servicepb.BucketServiceClient
+	)
+
+	const ledger = "baseline-boundary"
+
+	BeforeAll(func() {
+		var node *testutil.ServiceWithClient
+		ctx, node = testutil.SetupSingleNode(
+			testserver.WithColdStorageDriver("filesystem"),
+		)
+		client = node.Client
+	})
+
+	commitTx := func(dest string) {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("",
+			actions.CreateTransactionAction(ledger, []*commonpb.Posting{
+				actions.NewPosting("world", dest, big.NewInt(10), "USD"),
+			}, nil, nil)))
+		Expect(err).To(Succeed())
+	}
+
+	closeAndAwaitSealed := func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CloseChapterAction()))
+		Expect(err).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			chapters, err := actions.ListAllChapters(ctx, client)
+			g.Expect(err).To(Succeed())
+
+			for _, chapter := range chapters {
+				if chapter.GetStatus() == commonpb.ChapterStatus_CHAPTER_CLOSED {
+					return
+				}
+			}
+
+			g.Expect(false).To(BeTrue(), "no sealed chapter yet")
+		}).Should(Succeed())
+	}
+
+	expectCleanCheck := func(label string) {
+		result, err := actions.CollectCheckStoreEvents(ctx, client)
+		Expect(err).To(Succeed())
+
+		// Zero errors alone would also accept the degrade path: on a baseline that
+		// does not match the archived boundary the checker skips entry-by-entry
+		// verification and reports nothing. A healthy store in any boundary/close
+		// alignment must get the full pass — the baseline must be present AND
+		// aligned, which is exactly what promoting at the confirm provides.
+		var checked uint64
+		for _, progress := range result.Progress {
+			if progress.GetLogsChecked() > checked {
+				checked = progress.GetLogsChecked()
+			}
+		}
+		Expect(checked).To(BeNumerically(">", 0),
+			"%s: store check must have verified logs, not degraded on a missing or misaligned baseline", label)
+
+		var messages []string
+		for _, checkErr := range result.Errors {
+			messages = append(messages, fmt.Sprintf("%v %s", checkErr.GetErrorType(), checkErr.GetMessage()))
+		}
+
+		Expect(messages).To(BeEmpty(), "%s: a healthy store must verify whatever the boundary/close alignment", label)
+	}
+
+	It("verifies cleanly with a closed chapter waiting above the archived boundary", func() {
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		commitTx("acc:pre")
+		archiveChapterFull(ctx, client)
+
+		// The lifecycle's normal intermediate state: transactions past the
+		// boundary, then a close that is sealed but not archived. The baseline
+		// staged at this close must NOT serve a boundary one chapter back.
+		commitTx("acc:post")
+		closeAndAwaitSealed()
+
+		expectCleanCheck("closed chapter above the boundary")
+	})
+
+	It("verifies cleanly once the archival confirm promotes that close onto the boundary", func() {
+		var closedID uint64
+
+		chapters, err := actions.ListAllChapters(ctx, client)
+		Expect(err).To(Succeed())
+		for _, chapter := range chapters {
+			if chapter.GetStatus() == commonpb.ChapterStatus_CHAPTER_CLOSED {
+				closedID = chapter.GetId()
+			}
+		}
+		Expect(closedID).NotTo(BeZero())
+
+		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.ArchiveChapterAction(closedID)))
+		Expect(err).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			chapters, err := actions.ListAllChapters(ctx, client)
+			g.Expect(err).To(Succeed())
+
+			for _, chapter := range chapters {
+				if chapter.GetId() == closedID {
+					g.Expect(chapter.GetStatus()).To(Equal(commonpb.ChapterStatus_CHAPTER_ARCHIVED))
+
+					return
+				}
+			}
+
+			g.Expect(false).To(BeTrue())
+		}).Should(Succeed())
+
+		expectCleanCheck("boundary on the newest close")
+	})
+
+	It("verifies cleanly when another close lands above the moved boundary", func() {
+		commitTx("acc:post2")
+		closeAndAwaitSealed()
+
+		expectCleanCheck("second closed chapter above the boundary")
+	})
+})


### PR DESCRIPTION
Independent of #1850 (verified: the repro fires identically on clean
`release/v3.0`), found while writing its restore e2e.

## What changed

The checker's baseline snapshot is staged per closing chapter and promoted to
live only when that chapter's archival confirm moves the archived boundary onto
it. `Check()` refuses a baseline whose chapter does not match the boundary it is
verifying.

## Why

`store check` seeds expected volumes with the baseline and replays everything
above the archived boundary: `expected = baseline + replay(boundary..now)`. That
is only sound when the baseline is the state at exactly the boundary — and it was
overwritten at **every** chapter close with the state at that close.

So on a store with a closed-but-unarchived chapter — the lifecycle's normal
intermediate state between any close and its archival — every transaction between
the boundary and the newest close sat in the baseline *and* in the replay window,
and was counted twice. Result: a healthy store reported corrupt, one
`VOLUME_MISMATCH` per touched account, replay side exactly one transaction high.
Repro is three requests on a live single node:

```
tx → archive chapter 1 → tx → close chapter 2 → store check
  VOLUME_MISMATCH | input mismatch for acc:post/USD: expected 20, got 10
  VOLUME_MISMATCH | output mismatch for world/USD:   expected 30, got 20
```

Archive chapter 2 and the same check is clean; close chapter 3 over a new
transaction and it fires again. Whether a given run reports a healthy store as
corrupt is purely whether it lands in the aligned window — which is why the model
runs' teardown checks pass or fail by pacing luck, and why the 210
`VOLUME_MISMATCH` errors in the run that surfaced EN-1888 began at exactly the
first closed-unarchived chapter's start sequence: they were this bug, not that
one.

## Technical decision

- **Stage at close, promote at confirm.** The state at a chapter's close can only
  be captured at its close (the applier stages it inside the seal-checkpoint
  maintenance gate, as before); whether it is the boundary is only known at its
  confirm. The FSM's post-commit hook promotes it (`PromoteStagedBaseline`),
  next to the query-checkpoint file deletes — the established home for
  node-local file lifecycles bound to applied orders, wired through the same
  capability-interface pattern (`dal.FSMFileArtifacts`) so the Machine still
  holds no raw `*dal.Store`.
- **Boot reconcile** covers the crash window between the confirm's commit and the
  rename; replayed confirms promote through the hook itself.
- **Refuse, never serve stale.** A boundary whose own staging failed (staging
  stays non-fatal) cannot be caught up by any older snapshot, so promotion
  removes the stale live baseline; `Check()` independently refuses a baseline
  whose chapter id differs from the snapshot's boundary (promotion racing the
  check). Both degrade to the existing skip of entry-by-entry verification —
  the checker already treats a missing baseline that way.
- **Alternatives considered:** recomputing the boundary state at confirm time
  (impossible from the live store — later transactions are already folded in);
  having the checker pick among per-close baselines at check time (keeps every
  close's snapshot forever, and still needs the staleness rules).

## Risk

**MEDIUM.** The promotion is a new FSM post-commit step — node-local file
bookkeeping like the query-checkpoint deletes beside it, nothing in the applied
row, non-fatal on error. Coverage narrows in one honest way: between a confirm
whose close failed to stage and the next full cycle, the checker skips
entry-by-entry verification instead of comparing against wrong state.

## Validation

- [x] `bash scripts/agent-check`; `go vet` with CI's full tag set over `./tests/...`
- [x] `internal/storage/dal`, `internal/infra/state`, `internal/infra/node`,
      `internal/application/check`
- [x] `TestPromoteStagedBaseline_*` — the promote rule: boundary close promoted,
      multi-confirm batches, idempotency, lost-promotion recovery, and the
      stale-removal when the boundary's staging failed
- [x] `CheckStoreBaselineBoundary` e2e — a healthy store verifies cleanly in all
      three alignments (closed chapter above the boundary, boundary on the newest
      close, and again above). It asserts the full pass **ran**, not merely that
      no errors came back: the id refusal turns the old misalignment into a
      silent skip, so a zero-error assertion cannot tell the fix from the guard.
      Red-checked by restoring promote-at-close — fails on the degrade guard.

## Architecture / behavior impact

Baseline layout changes from a single `checker` directory to
`staged-<chapterID>` / `checker-<chapterID>` (v3 unreleased, no migration).
`BaselineCheckpointPath` now returns the chapter id; `BaselineSnapshotDir` is
replaced by `StagedBaselineDir(chapterID)`. Documented in `checker.md` ("The
baseline snapshot and the archived boundary").

## Review focus

The promote rule's refusal cases in `PromoteStagedBaseline` — the crash
interleavings are enumerated in its tests, and the dangerous one (promoting an
older staged snapshot when the boundary's own staging failed) is refused rather
than approximated. Second opinion welcome on degrading instead: it trades checker
coverage for never comparing against wrong state.

## Known concerns

A restored store has no staged snapshots (they are not part of the backup), so
the checker degrades there until the first close-and-confirm cycle after the
restore. Before this change it compared against a wrong baseline instead; #1850's
restore e2e keeps its own scoped assertions until both PRs land, after which its
store-check assertion can be widened to `result.Errors` empty.
