### PR TITLE
feat(tooling): add audit campaign inspection

### DIFF
--- a/docs/technical/agent-context.md
+++ b/docs/technical/agent-context.md
@@ -123,6 +123,10 @@ Use the native deep-audit workflow when the request seeks latent correctness def
 2. If a manifest exists, read `docs/technical/contributing/ai-audit.md` and run `bash scripts/ai-audit <domain>`. Keep the manifest as the campaign scope instead of replacing it with an ad-hoc audit prompt.
 3. Qualify the structured result with `bash scripts/ai-audit-challenge <audit-result>` after reading `docs/technical/contributing/ai-audit-challenge.md`. The challenge pass independently tries to disprove every finding; a first-pass finding is not a confirmed engineering defect.
 4. Treat Jira publication as a separate, later step. `scripts/ai-audit-jira` consumes a qualified report, and publication requires explicit authorization; neither the audit nor challenge pass creates issues.
+5. For cross-session coordination, read
+   `docs/technical/contributing/ai-campaign.md` and use
+   `scripts/ai-campaign`. Campaign state is a local projection; it never
+   replaces GitHub, Jira, Git, or native audit provenance.
 
 If no manifest matches, first decide whether the requested correctness scope is durable and reusable. If it is, create and review a manifest before running the native audit. If it is not, keep the work as a task-specific investigation rather than mechanically creating a new audit domain.
 

--- a/docs/technical/contributing/ai-audit-challenge.md
+++ b/docs/technical/contributing/ai-audit-challenge.md
@@ -33,6 +33,11 @@ Challenge runs are bound to the exact `head` recorded in the source audit report
 
 The source report itself is caller-owned and may live outside the worktree, where the repository cleanliness check cannot observe it. A run therefore snapshots it once, before validation, and binds everything to that snapshot: the trusted `audit_id`/`head`, the evidence handed to the challenger, and the final id/severity/title comparisons. Editing or replacing the external report while a challenge runs cannot retarget or alter the published qualification.
 
+The trusted runner also records `sourceAuditDigest`, the SHA-256 identity of that
+private source snapshot, in the published qualified report. Downstream campaign
+import uses this field to reject a different or subsequently modified source
+audit artifact. The reasoning provider does not mint this provenance value.
+
 ## Mutation policy
 
 The challenge pass is read-only. It must not edit code, add a reproducer, create issues, commit, push, comment, or resolve anything. Reproducer implementation is a separate later phase.

--- a/docs/technical/contributing/ai-audit-jira.md
+++ b/docs/technical/contributing/ai-audit-jira.md
@@ -60,3 +60,7 @@ The challenge result is caller-owned and may live outside the worktree, so it ca
 ## Failure behavior
 
 Publishing is fail-closed per finding. Search failure, malformed challenge input, unsupported qualification status, or creation failure stops the command. Successfully created issues are reported so a retry can deduplicate them by stable marker.
+
+`scripts/ai-campaign inspect` reuses this exact description-line marker for
+read-only Jira discovery. It does not weaken the publisher's exact-match rule or
+mutate the discovered issue.

--- a/docs/technical/contributing/ai-audit.md
+++ b/docs/technical/contributing/ai-audit.md
@@ -46,6 +46,10 @@ Every finding emitted by the audit is a hypothesis. Qualify the report with `bas
 
 A `CONFIRMED` challenge result is eligible to become a backlog/Jira candidate after human or policy approval. Jira handling is an explicit downstream action through `bash scripts/ai-audit-jira <challenge-result>`; the command previews candidates unless separately invoked with `--publish`. Neither the audit nor challenge pass fixes code, creates issues, or publishes findings automatically.
 
+For durable read-only coordination across every qualification status, import the
+source and qualified artifacts with `scripts/ai-campaign`; see
+`ai-campaign.md`. Campaign import and inspection do not publish or fix findings.
+
 ## Output
 
 `bash scripts/ai-audit <domain>` writes a structured JSON report. The report records the audited HEAD, manifest id, findings, questions, inspected areas, and residual risk.

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -59,7 +59,9 @@ All `CONFIRMED`, `LIKELY`, `QUESTION`, and `REJECTED` findings are retained.
 Only `CONFIRMED` has `dispatchable: true`. Import sorts findings by stable ID and
 derives `campaignId` from the schema version, audit identity, audited SHA, and
 both artifact digests. Import time is recorded separately and does not enter the
-logical identity.
+logical identity. A qualified clean audit with empty `findings` and `results`
+arrays imports as a valid zero-finding campaign; those arrays remain explicit
+empty JSON arrays in campaign, inspection, and next-action output.
 
 The schema is [`scripts/ai-campaign.schema.json`](../../../scripts/ai-campaign.schema.json).
 The artifact separates:

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -148,7 +148,12 @@ State is recomputed from immutable qualification plus the latest observation;
 there is no manual state-transition command. Target advancement does not reuse
 an older `READY` interpretation. A confirmed finding with no PR becomes
 `BLOCKED` / `REQUALIFY_ON_CURRENT_TARGET` until qualification is established on
-the current target.
+the current target. For same-repository PRs, `branchExists` is true only when
+the configured Git remote contains the exact observed head ref and SHA. Version
+1 does not query a fork's remote directly, so an unmerged cross-repository PR is
+conservatively `BROKEN_BINDING` with
+`CROSS_REPOSITORY_BRANCH_UNVERIFIED`; its retained GitHub head OID is not treated
+as proof that the source branch still exists.
 
 ## Next action
 

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -1,0 +1,194 @@
+# Audit campaign coordination and inspection
+
+`scripts/ai-campaign` is a deterministic coordination and projection layer over
+qualified native audit results. It preserves immutable audit provenance, caches
+external observations, and reports the mechanically next valid workflow
+transition. It does not perform engineering reasoning, choose product priority,
+fix findings, publish issues, dispatch agents, mutate pull-request bindings, or
+merge pull requests.
+
+## Motivation and boundary
+
+Qualified audit findings currently survive as native JSON artifacts and,
+optionally, independently published Jira issues. That does not give an
+interrupted agent or operator one durable, machine-readable view of every
+qualification and its current external bindings.
+
+The campaign artifact provides that local coordination view. It is
+operational/informational state, not Ledger product state or a source of business
+truth. GitHub, Jira, Git, and the native audit/challenge artifacts remain
+authoritative. A campaign can derive and cache observations from them; it cannot
+override them or manually advance externally derived state.
+
+The v1 storage model is one JSON file. By default it is written below ignored
+`build/ai-campaign/`, so it survives an agent session without entering a
+candidate/product commit. An explicit destination outside the repository is also
+allowed. Repository-local destinations outside ignored `build/` are rejected.
+Writes use a directory-anchored temporary file, file sync, atomic rename, and
+directory sync. This is proportionate local durability and a human-inspectable
+base for later distributed claims without implementing a claim protocol now.
+
+## Import
+
+```sh
+bash scripts/ai-campaign import qualified.json --audit audit.json
+```
+
+Use `--output <path>` to select another campaign artifact. Reimporting the same
+campaign at the same path is idempotent and preserves its original import time
+and cached observations. Replacing a different or malformed campaign is refused.
+
+Import requires both artifacts because the qualified result contains the
+qualification set while the source audit contains the original finding set and
+metadata. `ai-audit-challenge` records `sourceAuditDigest` from its private audit
+snapshot in every newly published qualified result. Import recomputes that
+SHA-256 digest and rejects a different or modified source report.
+
+The importer fails closed on:
+
+- unknown or malformed source/challenge fields;
+- an unsupported campaign schema version;
+- duplicate finding IDs;
+- an invented or omitted qualification result;
+- changed severity or title;
+- mismatched audit ID or audited SHA;
+- a mismatched source audit digest;
+- a non-canonical finding ID or unsupported qualification.
+
+All `CONFIRMED`, `LIKELY`, `QUESTION`, and `REJECTED` findings are retained.
+Only `CONFIRMED` has `dispatchable: true`. Import sorts findings by stable ID and
+derives `campaignId` from the schema version, audit identity, audited SHA, and
+both artifact digests. Import time is recorded separately and does not enter the
+logical identity.
+
+The schema is [`scripts/ai-campaign.schema.json`](../../../scripts/ai-campaign.schema.json).
+The artifact separates:
+
+- `sourceFacts` (`SOURCE_FACT`): immutable imported identity, minimal finding
+  metadata, qualification, digest-bound JSON references into the two source
+  artifacts, and per-finding/source-set identity digests;
+- `observations` (`DERIVED_OBSERVATION`): refresh time, provider freshness,
+  target SHA, exact bindings, projected states, blockers, and next actions;
+- local/imported bindings: none in v1. There is deliberately no binding mutation
+  command. A future explicit binding must use a distinct
+  `LOCAL_IMPORTED_BINDING` class rather than masquerading as external truth.
+
+Stable digest-plus-JSON-pointer references preserve original invariant and
+challenge-summary identity without copying arbitrary prose into campaign state.
+The native artifacts remain the content source.
+
+## Inspect
+
+```sh
+bash scripts/ai-campaign inspect build/ai-campaign/<campaign-id>.json
+bash scripts/ai-campaign inspect build/ai-campaign/<campaign-id>.json --offline
+```
+
+Live inspection queries:
+
+- GitHub for PR state, current head, base, merge state, current review decision,
+  and check summary;
+- Jira for issue existence, status, and assignee;
+- Git for the current `release/v3.0` target and same-repository PR branch refs.
+
+The defaults are `formancehq/ledger`, `EN`, `origin`, and `release/v3.0`; the
+command exposes read-only overrides. The campaign never treats current reviews
+or checks as an exact-current readiness verdict. It does not recreate the
+publication/readiness engine.
+
+Every provider records `FRESH`, `STALE`, or `UNAVAILABLE` plus its observation
+time and a concise failure. Campaign/finding freshness is `FRESH`, `PARTIAL`,
+`STALE`, or `UNAVAILABLE`. When a live provider fails, cached values remain
+visible but the affected binding status becomes `UNKNOWN`. `--offline` performs
+no external calls and marks cached observations stale. A confirmed finding never
+reports a readiness-like next action from partial, stale, or unavailable
+external truth; its next action is `REFRESH_REQUIRED`.
+
+`refreshedAt` is the last time at least one external provider refreshed data. It
+is not advanced by a wholly offline/unavailable inspection.
+
+## Exact binding markers
+
+Jira discovery reuses the publisher marker exactly as written in issue
+descriptions:
+
+```text
+AI-AUDIT:<finding-id>
+```
+
+Jira search is only a prefilter. An issue binds only when its description
+contains a trimmed line exactly equal to the marker. Prefix matches, summary-only
+matches, and fuzzy text do not bind.
+
+A PR carrying that same exact body line is an explicit audit binding. When no PR
+has the audit marker, inspect may retain a weaker historical binding through one
+exact known Jira reference line (`Jira: EN-123`, `Fixes EN-123`, or the existing
+linked-key form). An explicit audit-marker match takes precedence over Jira-only
+references. Multiple matches at the selected exactness level produce an
+ambiguous binding; inspect never chooses one. A merged Jira-only PR remains
+`VERIFY_RESOLUTION` with `MERGED_WITHOUT_EXACT_AUDIT_MARKER`; it is not proof that
+the audit finding is fixed.
+
+## Derived finding states
+
+| State | Mechanical meaning |
+|---|---|
+| `NON_DISPATCHABLE` | Qualification is `LIKELY`, `QUESTION`, or `REJECTED`. |
+| `CONFIRMED_UNASSIGNED` | Confirmed, current audit target, no Jira or PR binding. |
+| `TRACKED` | Confirmed, current audit target, exactly one Jira issue, no PR. |
+| `PR_OPEN` | Exactly one bound PR is open and its branch/head binding is intact. |
+| `PR_CLOSED` | Exactly one bound PR is closed without merge. |
+| `MERGED` | Exactly one bound PR is merged; resolution still needs verification. |
+| `AMBIGUOUS` | Multiple exact Jira or PR bindings exist. |
+| `BROKEN_BINDING` | A bound unmerged PR has an unknown state or missing branch/head ref. |
+| `BLOCKED` | Current target identity is unavailable or advanced without a bound PR. |
+| `SUPERSEDED` | Reserved for a future externally evidenced supersession contract. |
+
+State is recomputed from immutable qualification plus the latest observation;
+there is no manual state-transition command. Target advancement does not reuse
+an older `READY` interpretation. A confirmed finding with no PR becomes
+`BLOCKED` / `REQUALIFY_ON_CURRENT_TARGET` until qualification is established on
+the current target.
+
+## Next action
+
+```sh
+bash scripts/ai-campaign next build/ai-campaign/<campaign-id>.json
+```
+
+`next` does not contact external systems or mutate the artifact. It projects one
+mechanically safe workflow transition per finding from cached state:
+
+| Condition | `nextAction` |
+|---|---|
+| Confirmed, no Jira or PR | `PUBLISH_JIRA_OR_REVIEW_POLICY` |
+| Confirmed, Jira, no PR | `READY_FOR_CLAIM_OR_DISPATCH` |
+| Open PR | `CONTINUE_PR` |
+| Merged PR | `VERIFY_RESOLUTION` |
+| Closed unmerged PR | `REVIEW_CLOSED_PR` |
+| Broken binding | `REPAIR_BINDING` |
+| Ambiguous binding | `RESOLVE_BINDING` |
+| Advanced target without PR | `REQUALIFY_ON_CURRENT_TARGET` |
+| Stale/incomplete external truth | `REFRESH_REQUIRED` |
+| `QUESTION` | `HUMAN_DECISION_REQUIRED` |
+| `LIKELY` or `REJECTED` | `NO_ACTION` |
+
+`READY_FOR_CLAIM_OR_DISPATCH` is a label for the next future workflow phase, not
+a claim, dispatch, priority decision, or authorization to write. The command
+does not rank unrelated findings.
+
+## Output contract
+
+Every command writes a concise human summary to stderr and stable structured
+JSON to stdout. This keeps interactive use readable while letting future agents
+consume stdout without scraping prose. Inspection JSON includes campaign/audit
+identity, source digests, refresh/freshness data, provider status, and structured
+finding identity, severity, qualification, state, Jira/PR details, observed
+candidate/target SHAs, blockers, next action, freshness, and confidence.
+
+## Explicit non-goals
+
+This milestone does not implement distributed claims, claim leases, dispatch,
+PR-binding mutation, publication resume/events, merge, Jira mutation, composite
+exact-SHA readiness, or a shared structured failure envelope. Those require
+separate contracts and trust reviews.

--- a/scripts/ai-audit-challenge
+++ b/scripts/ai-audit-challenge
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
         *) echo "ai-audit-challenge: unknown argument: $1" >&2; usage >&2; exit 1 ;;
     esac
 done
-for command in codex git go jq; do command -v "$command" >/dev/null 2>&1 || { echo "ai-audit-challenge: required command not found: $command" >&2; exit 1; }; done
+for command in codex git go jq sha256sum; do command -v "$command" >/dev/null 2>&1 || { echo "ai-audit-challenge: required command not found: $command" >&2; exit 1; }; done
 
 repo_root=$(git rev-parse --show-toplevel)
 repo_root=$(cd -- "$repo_root" && pwd -P)
@@ -42,6 +42,7 @@ trap cleanup EXIT
 source_snapshot="$isolation_root/source-audit.json"
 cp -- "$source_report" "$source_snapshot"
 chmod 400 "$source_snapshot"
+source_audit_digest="sha256:$(sha256sum "$source_snapshot" | cut -d' ' -f1)"
 
 # The audit_id is untrusted report content that is interpolated into the default
 # destination path, so it must be a single safe path component. Finding ids must
@@ -167,6 +168,7 @@ run_challenge() {
     if [[ -f "$original_codex_home/auth.json" ]]; then cp "$original_codex_home/auth.json" "$isolation_root/home/.codex/auth.json"; chmod 600 "$isolation_root/home/.codex/auth.json"; fi
     prompt="$isolation_root/prompt.txt"
     result="$isolation_root/result.json"
+    qualified_result="$isolation_root/qualified-result.json"
     publisher_binary="$isolation_root/audit-publish"
     (cd "$repo_root" && env -u GOROOT go build -o "$publisher_binary" ./scripts/auditpublish) || { echo "ai-audit-challenge: failed to build the trusted output publisher" >&2; exit 1; }
 
@@ -221,7 +223,13 @@ EOF
     # challenge. The helper uses rename(2) with basename-only paths from that
     # anchored directory, so publication cannot follow a substituted parent,
     # destination symlink, or hard link into tracked repository content.
-    "$publisher_binary" "$result" "$output_basename"
+    # Provenance is added by the trusted runner after the provider result has
+    # passed its semantic checks. It binds the native qualification artifact to
+    # the exact caller-owned audit snapshot challenged above without asking the
+    # reasoning provider to establish its own source identity.
+    jq --arg digest "$source_audit_digest" '. + {sourceAuditDigest: $digest}' \
+        "$result" >"$qualified_result"
+    "$publisher_binary" "$qualified_result" "$output_basename"
 
     printf 'AI_AUDIT_CHALLENGE_RESULT: %s\n' "$output"
     printf 'AI_AUDIT_CHALLENGE_CONFIRMED: %s\n' "$(jq '[.results[] | select(.status == "CONFIRMED")] | length' "$result")"

--- a/scripts/ai-campaign
+++ b/scripts/ai-campaign
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+exec env -u GOROOT go run "$repo_root/scripts/aicampaign" "$@"

--- a/scripts/ai-campaign.schema.json
+++ b/scripts/ai-campaign.schema.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://formance.com/schemas/ai-campaign/v1",
+  "title": "Ledger AI audit campaign state v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "campaignId",
+    "auditId",
+    "auditedSha",
+    "importedAt",
+    "sourceDigests",
+    "sourceFacts",
+    "observations"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "ai-campaign/v1" },
+    "campaignId": { "type": "string", "pattern": "^campaign-[0-9a-f]{64}$" },
+    "auditId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+    "auditedSha": { "$ref": "#/$defs/sha" },
+    "importedAt": { "type": "string", "format": "date-time" },
+    "sourceDigests": { "$ref": "#/$defs/sourceDigests" },
+    "sourceFacts": { "$ref": "#/$defs/sourceFacts" },
+    "observations": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/observations" }
+      ]
+    }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "nullableTime": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "format": "date-time" }
+      ]
+    },
+    "freshness": { "enum": ["FRESH", "PARTIAL", "STALE", "UNAVAILABLE"] },
+    "sourceDigests": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audit", "qualified"],
+      "properties": {
+        "audit": { "$ref": "#/$defs/digest" },
+        "qualified": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "sourceFacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["factType", "identityDigest", "findings"],
+      "properties": {
+        "factType": { "const": "SOURCE_FACT" },
+        "identityDigest": { "$ref": "#/$defs/digest" },
+        "findings": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/sourceFinding" }
+        }
+      }
+    },
+    "sourceFinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "factType",
+        "id",
+        "title",
+        "severity",
+        "qualification",
+        "dispatchable",
+        "references",
+        "identityDigest"
+      ],
+      "properties": {
+        "factType": { "const": "SOURCE_FACT" },
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*/[a-z0-9]+(-[a-z0-9]+)*$" },
+        "title": { "type": "string", "minLength": 1 },
+        "severity": { "enum": ["P0", "P1", "P2", "P3"] },
+        "qualification": { "enum": ["CONFIRMED", "LIKELY", "QUESTION", "REJECTED"] },
+        "dispatchable": { "type": "boolean" },
+        "references": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["auditFinding", "invariant", "qualificationResult", "challengeSummary"],
+          "properties": {
+            "auditFinding": { "type": "string", "minLength": 1 },
+            "invariant": { "type": "string", "minLength": 1 },
+            "qualificationResult": { "type": "string", "minLength": 1 },
+            "challengeSummary": { "type": "string", "minLength": 1 }
+          }
+        },
+        "identityDigest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "observedAt", "error"],
+      "properties": {
+        "status": { "enum": ["FRESH", "STALE", "UNAVAILABLE"] },
+        "observedAt": { "$ref": "#/$defs/nullableTime" },
+        "error": { "type": "string" }
+      }
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["github", "jira", "git"],
+      "properties": {
+        "github": { "$ref": "#/$defs/provider" },
+        "jira": { "$ref": "#/$defs/provider" },
+        "git": { "$ref": "#/$defs/provider" }
+      }
+    },
+    "jiraIssue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "url", "status", "assignee"],
+      "properties": {
+        "key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*-[1-9][0-9]*$" },
+        "url": { "type": "string" },
+        "status": { "type": "string" },
+        "assignee": { "type": "string" }
+      }
+    },
+    "jira": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "bindingBasis", "issues"],
+      "properties": {
+        "status": { "enum": ["UNBOUND", "BOUND", "AMBIGUOUS", "UNKNOWN"] },
+        "bindingBasis": { "enum": ["", "AI_AUDIT_MARKER"] },
+        "issues": { "type": "array", "items": { "$ref": "#/$defs/jiraIssue" } }
+      }
+    },
+    "prMatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "url",
+        "state",
+        "headRef",
+        "headSha",
+        "baseRef",
+        "baseSha",
+        "merged",
+        "branchExists",
+        "crossRepository",
+        "reviewDecision",
+        "checks",
+        "bindingBasis"
+      ],
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "url": { "type": "string" },
+        "state": { "type": "string" },
+        "headRef": { "type": "string" },
+        "headSha": { "type": "string" },
+        "baseRef": { "type": "string" },
+        "baseSha": { "type": "string" },
+        "merged": { "type": "boolean" },
+        "branchExists": { "type": "boolean" },
+        "crossRepository": { "type": "boolean" },
+        "reviewDecision": { "type": "string" },
+        "checks": { "type": "string" },
+        "bindingBasis": { "enum": ["AI_AUDIT_MARKER", "JIRA_KEY"] }
+      }
+    },
+    "pr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "bindingBasis", "matches"],
+      "properties": {
+        "status": { "enum": ["UNBOUND", "BOUND", "AMBIGUOUS", "UNKNOWN"] },
+        "bindingBasis": { "enum": ["", "AI_AUDIT_MARKER", "JIRA_KEY"] },
+        "matches": { "type": "array", "items": { "$ref": "#/$defs/prMatch" } }
+      }
+    },
+    "findingObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "factType",
+        "id",
+        "state",
+        "jira",
+        "pr",
+        "observedCandidateSha",
+        "observedTargetSha",
+        "blockers",
+        "nextAction",
+        "freshness",
+        "confidence"
+      ],
+      "properties": {
+        "factType": { "const": "DERIVED_OBSERVATION" },
+        "id": { "type": "string" },
+        "state": {
+          "enum": [
+            "CONFIRMED_UNASSIGNED",
+            "TRACKED",
+            "PR_OPEN",
+            "PR_CLOSED",
+            "MERGED",
+            "BLOCKED",
+            "SUPERSEDED",
+            "AMBIGUOUS",
+            "BROKEN_BINDING",
+            "NON_DISPATCHABLE"
+          ]
+        },
+        "jira": { "$ref": "#/$defs/jira" },
+        "pr": { "$ref": "#/$defs/pr" },
+        "observedCandidateSha": { "type": "string" },
+        "observedTargetSha": { "type": "string" },
+        "blockers": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "nextAction": {
+          "enum": [
+            "PUBLISH_JIRA_OR_REVIEW_POLICY",
+            "READY_FOR_CLAIM_OR_DISPATCH",
+            "CONTINUE_PR",
+            "VERIFY_RESOLUTION",
+            "NO_ACTION",
+            "HUMAN_DECISION_REQUIRED",
+            "RESOLVE_BINDING",
+            "REFRESH_REQUIRED",
+            "REPAIR_BINDING",
+            "REVIEW_CLOSED_PR",
+            "REQUALIFY_ON_CURRENT_TARGET"
+          ]
+        },
+        "freshness": { "$ref": "#/$defs/freshness" },
+        "confidence": { "enum": ["HIGH", "MEDIUM", "LOW"] }
+      }
+    },
+    "observations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["factType", "refreshedAt", "freshness", "providers", "target", "findings"],
+      "properties": {
+        "factType": { "const": "DERIVED_OBSERVATION" },
+        "refreshedAt": { "$ref": "#/$defs/nullableTime" },
+        "freshness": { "$ref": "#/$defs/freshness" },
+        "providers": { "$ref": "#/$defs/providers" },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["factType", "branch", "observedSha"],
+          "properties": {
+            "factType": { "const": "DERIVED_OBSERVATION" },
+            "branch": { "type": "string", "minLength": 1 },
+            "observedSha": { "type": "string" }
+          }
+        },
+        "findings": { "type": "array", "items": { "$ref": "#/$defs/findingObservation" } }
+      }
+    }
+  }
+}

--- a/scripts/ai-campaign.schema.json
+++ b/scripts/ai-campaign.schema.json
@@ -57,7 +57,6 @@
         "identityDigest": { "$ref": "#/$defs/digest" },
         "findings": {
           "type": "array",
-          "minItems": 1,
           "items": { "$ref": "#/$defs/sourceFinding" }
         }
       }

--- a/scripts/aiauditchallenge/runner_test.go
+++ b/scripts/aiauditchallenge/runner_test.go
@@ -1,7 +1,9 @@
 package aiauditchallenge
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,6 +61,7 @@ func TestRunnerPublishesOneQualifiedResultPerOriginalFinding(t *testing.T) {
 	published := readJSON(t, fixture.outputPath)
 	require.Equal(t, testAuditID, published["audit_id"])
 	require.Equal(t, fixture.head, published["head"])
+	require.Equal(t, fileDigest(t, fixture.sourceReport), published["sourceAuditDigest"])
 	require.Equal(t, []string{firstFindingID, secondFindingID}, resultIDs(t, published))
 }
 
@@ -487,6 +490,15 @@ func resultIDs(t *testing.T, report map[string]any) []string {
 	}
 
 	return ids
+}
+
+func fileDigest(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(content))
 }
 
 // The runner builds the trusted publisher from the fixture checkout with an

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAuditID = "tooling-integrity"
+	testHead    = "0123456789abcdef0123456789abcdef01234567"
+	testTarget  = "release/v3.0"
+)
+
+var testNow = time.Date(2026, time.September, 1, 14, 0, 0, 0, time.UTC)
+
+func TestImportValidQualifiedAudit(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t,
+		[]fixtureFinding{{"confirmed", "CONFIRMED"}, {"likely", "LIKELY"}, {"question", "QUESTION"}, {"rejected", "REJECTED"}})
+	campaign, err := (importer{now: func() time.Time { return testNow }}).run(sourcePath, qualifiedPath)
+	require.NoError(t, err)
+	require.Equal(t, campaignSchemaVersion, campaign.SchemaVersion)
+	require.Equal(t, testAuditID, campaign.AuditID)
+	require.Equal(t, testHead, campaign.AuditedSHA)
+	require.Len(t, campaign.SourceFacts.Findings, 4)
+	require.True(t, digestPattern.MatchString(campaign.SourceDigests.Audit))
+	require.True(t, digestPattern.MatchString(campaign.SourceDigests.Qualified))
+	require.NoError(t, campaign.validate())
+}
+
+func TestImportRetainsNonConfirmedFindingsAsNonDispatchable(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t,
+		[]fixtureFinding{{"confirmed", "CONFIRMED"}, {"likely", "LIKELY"}, {"question", "QUESTION"}, {"rejected", "REJECTED"}})
+	campaign, err := (importer{now: func() time.Time { return testNow }}).run(sourcePath, qualifiedPath)
+	require.NoError(t, err)
+
+	qualifications := map[string]SourceFinding{}
+	for _, finding := range campaign.SourceFacts.Findings {
+		qualifications[finding.Qualification] = finding
+	}
+	require.True(t, qualifications["CONFIRMED"].Dispatchable)
+	for _, status := range []string{"LIKELY", "QUESTION", "REJECTED"} {
+		require.False(t, qualifications[status].Dispatchable, status)
+	}
+
+	next := buildNextResult(campaign)
+	actions := nextActions(next)
+	require.Equal(t, "REFRESH_REQUIRED", actions[testAuditID+"/confirmed"])
+	require.Equal(t, "NO_ACTION", actions[testAuditID+"/likely"])
+	require.Equal(t, "HUMAN_DECISION_REQUIRED", actions[testAuditID+"/question"])
+	require.Equal(t, "NO_ACTION", actions[testAuditID+"/rejected"])
+}
+
+func TestImportRejectsDuplicateFindingIDs(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t,
+		[]fixtureFinding{{"duplicate", "CONFIRMED"}, {"duplicate", "REJECTED"}})
+	_, err := (importer{now: time.Now}).run(sourcePath, qualifiedPath)
+	require.ErrorContains(t, err, "duplicate finding id")
+}
+
+func TestImportRejectsDigestAndProvenanceMismatch(t *testing.T) {
+	t.Parallel()
+
+	for name, mutate := range map[string]func(map[string]any){
+		"source digest": func(qualified map[string]any) {
+			qualified["sourceAuditDigest"] = "sha256:" + strings.Repeat("f", 64)
+		},
+		"audit id": func(qualified map[string]any) { qualified["audit_id"] = "another-audit" },
+		"head":     func(qualified map[string]any) { qualified["head"] = strings.Repeat("1", 40) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sourcePath, qualifiedPath := writeImportFixture(t, []fixtureFinding{{"finding", "CONFIRMED"}})
+			qualified := readObject(t, qualifiedPath)
+			mutate(qualified)
+			writeObject(t, qualifiedPath, qualified)
+			_, err := (importer{now: time.Now}).run(sourcePath, qualifiedPath)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestImportRejectsIncompleteQualificationSet(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t,
+		[]fixtureFinding{{"first", "CONFIRMED"}, {"second", "LIKELY"}})
+	qualified := readObject(t, qualifiedPath)
+	qualified["results"] = qualified["results"].([]any)[:1]
+	writeObject(t, qualifiedPath, qualified)
+	_, err := (importer{now: time.Now}).run(sourcePath, qualifiedPath)
+	require.ErrorContains(t, err, "incomplete qualification set")
+}
+
+func TestExactJiraMarkerDiscovery(t *testing.T) {
+	t.Parallel()
+
+	marker := "AI-AUDIT:" + testAuditID + "/finding"
+	response := map[string]any{"issues": []any{
+		map[string]any{"key": "EN-41", "fields": map[string]any{
+			"description": "Context\n" + marker + "\n", "status": map[string]any{"name": "In Progress"},
+			"assignee": map[string]any{"displayName": "Ledger Agent"},
+		}},
+		map[string]any{"key": "EN-42", "fields": map[string]any{"description": marker + "-extended"}},
+		map[string]any{"key": "EN-43", "fields": map[string]any{"summary": marker, "description": "no marker"}},
+	}}
+	content, err := json.Marshal(response)
+	require.NoError(t, err)
+	issues, err := parseJiraIssues(content, marker)
+	require.NoError(t, err)
+	require.Equal(t, []JiraIssue{{Key: "EN-41", Status: "In Progress", Assignee: "Ledger Agent"}}, issues)
+}
+
+func TestExactPRBindingDiscovery(t *testing.T) {
+	t.Parallel()
+
+	marker := "AI-AUDIT:" + testAuditID + "/finding"
+	require.True(t, exactLine("Context\n"+marker+"\n", marker))
+	require.False(t, exactLine("Context\n"+marker+"-extended\n", marker))
+	require.True(t, exactJiraReference("Fixes EN-4242", "EN-4242"))
+	require.True(t, exactJiraReference("Fixes [EN-4242](https://example.test/EN-4242).", "EN-4242"))
+	require.False(t, exactJiraReference("Possibly related: EN-4242", "EN-4242"))
+}
+
+func TestInspectMarksMultiplePRsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	inspection := runFakeInspection(campaign, fakeObservations{
+		pullRequests: []PRMatch{
+			openPR(41, "first", "AI_AUDIT_MARKER"),
+			openPR(42, "second", "AI_AUDIT_MARKER"),
+		},
+	})
+	finding := inspection.Findings[0]
+	require.Equal(t, "AMBIGUOUS", finding.State)
+	require.Equal(t, "RESOLVE_BINDING", finding.NextAction)
+	require.Contains(t, finding.Blockers, "AMBIGUOUS_PR_BINDING")
+}
+
+func TestInspectClosedUnmergedPR(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	closed := openPR(41, "closed", "AI_AUDIT_MARKER")
+	closed.State = "CLOSED"
+	inspection := runFakeInspection(campaign, fakeObservations{pullRequests: []PRMatch{closed}})
+	require.Equal(t, "PR_CLOSED", inspection.Findings[0].State)
+	require.Equal(t, "REVIEW_CLOSED_PR", inspection.Findings[0].NextAction)
+	require.Contains(t, inspection.Findings[0].Blockers, "PR_CLOSED_UNMERGED")
+}
+
+func TestInspectMergedPRRequiresResolutionVerification(t *testing.T) {
+	t.Parallel()
+
+	for name, basis := range map[string]string{"exact marker": "AI_AUDIT_MARKER", "jira key only": "JIRA_KEY"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			campaign := testCampaign("CONFIRMED")
+			merged := openPR(41, "merged", basis)
+			merged.State = "MERGED"
+			merged.Merged = true
+			inspection := runFakeInspection(campaign, fakeObservations{pullRequests: []PRMatch{merged}})
+			require.Equal(t, "MERGED", inspection.Findings[0].State)
+			require.Equal(t, "VERIFY_RESOLUTION", inspection.Findings[0].NextAction)
+			if basis == "JIRA_KEY" {
+				require.Contains(t, inspection.Findings[0].Blockers, "MERGED_WITHOUT_EXACT_AUDIT_MARKER")
+			}
+		})
+	}
+}
+
+func TestInspectOfflineGitHubNeverReportsReady(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	inspection := runFakeInspection(campaign, fakeObservations{
+		jira: []JiraIssue{{Key: "EN-41", Status: "Open"}}, githubError: errors.New("offline"),
+	})
+	require.Equal(t, "UNKNOWN", inspection.Findings[0].PR.Status)
+	require.Equal(t, "REFRESH_REQUIRED", inspection.Findings[0].NextAction)
+	require.NotEqual(t, "READY_FOR_CLAIM_OR_DISPATCH", inspection.Findings[0].NextAction)
+}
+
+func TestInspectOfflineJiraMarksStatusUnknown(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	inspection := runFakeInspection(campaign, fakeObservations{jiraError: errors.New("offline")})
+	require.Equal(t, "UNKNOWN", inspection.Findings[0].Jira.Status)
+	require.Equal(t, "REFRESH_REQUIRED", inspection.Findings[0].NextAction)
+}
+
+func TestOfflineInspectUsesStaleCache(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	first := runFakeInspection(campaign, fakeObservations{jira: []JiraIssue{{Key: "EN-41", Status: "Open"}}})
+	require.Equal(t, "READY_FOR_CLAIM_OR_DISPATCH", first.Findings[0].NextAction)
+	stale := (inspector{}).run(context.Background(), campaign, inspectOptions{target: testTarget, offline: true})
+	require.Equal(t, "STALE", stale.Freshness)
+	require.Equal(t, "EN-41", stale.Findings[0].Jira.Issues[0].Key)
+	require.Equal(t, "UNKNOWN", stale.Findings[0].Jira.Status)
+	require.Equal(t, "REFRESH_REQUIRED", stale.Findings[0].NextAction)
+}
+
+func TestNextActionIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED", "LIKELY", "QUESTION", "REJECTED")
+	runFakeInspection(campaign, fakeObservations{})
+	first, err := json.Marshal(buildNextResult(campaign))
+	require.NoError(t, err)
+	second, err := json.Marshal(buildNextResult(campaign))
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestMalformedCampaignStateFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	path := filepath.Join(t.TempDir(), "campaign.json")
+	require.NoError(t, writeCampaign(path, campaign))
+	content := readObject(t, path)
+	sourceFacts := content["sourceFacts"].(map[string]any)
+	findings := sourceFacts["findings"].([]any)
+	findings[0].(map[string]any)["qualification"] = "REJECTED"
+	writeObject(t, path, content)
+	_, err := loadCampaign(path)
+	require.ErrorContains(t, err, "invalid campaign state")
+}
+
+func TestHistoricalCampaignWithoutBindingsRequiresRequalification(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	inspection := runFakeInspection(campaign, fakeObservations{targetSHA: strings.Repeat("a", 40)})
+	require.Equal(t, "BLOCKED", inspection.Findings[0].State)
+	require.Equal(t, "REQUALIFY_ON_CURRENT_TARGET", inspection.Findings[0].NextAction)
+	require.Contains(t, inspection.Findings[0].Blockers, "TARGET_ADVANCED")
+}
+
+func TestCommandsEmitHumanAndStructuredJSON(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t, []fixtureFinding{{"finding", "CONFIRMED"}})
+	campaignPath := filepath.Join(t.TempDir(), "campaign.json")
+	var importJSON bytes.Buffer
+	var importHuman bytes.Buffer
+	require.NoError(t, run([]string{
+		"import", qualifiedPath, "--audit", sourcePath, "--output", campaignPath,
+	}, &importJSON, &importHuman))
+	require.Contains(t, importHuman.String(), "Imported campaign-")
+	var imported Campaign
+	require.NoError(t, json.Unmarshal(importJSON.Bytes(), &imported))
+	require.Equal(t, testAuditID, imported.AuditID)
+
+	var inspectJSON bytes.Buffer
+	var inspectHuman bytes.Buffer
+	require.NoError(t, run([]string{"inspect", campaignPath, "--offline"}, &inspectJSON, &inspectHuman))
+	require.Contains(t, inspectHuman.String(), imported.CampaignID)
+	var inspection Inspection
+	require.NoError(t, json.Unmarshal(inspectJSON.Bytes(), &inspection))
+	require.Equal(t, "UNAVAILABLE", inspection.Freshness)
+	require.Equal(t, "REFRESH_REQUIRED", inspection.Findings[0].NextAction)
+
+	var nextJSON bytes.Buffer
+	var nextHuman bytes.Buffer
+	require.NoError(t, run([]string{"next", campaignPath}, &nextJSON, &nextHuman))
+	require.Contains(t, nextHuman.String(), "next actions")
+	var next NextResult
+	require.NoError(t, json.Unmarshal(nextJSON.Bytes(), &next))
+	require.Equal(t, "REFRESH_REQUIRED", next.Findings[0].NextAction)
+}
+
+func TestMissingPRBranchIsBrokenBinding(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	pullRequest := openPR(41, "deleted", "AI_AUDIT_MARKER")
+	inspection := runFakeInspection(campaign, fakeObservations{
+		pullRequests: pullRequestSlice(pullRequest), missingBranches: true,
+	})
+	require.Equal(t, "BROKEN_BINDING", inspection.Findings[0].State)
+	require.Equal(t, "REPAIR_BINDING", inspection.Findings[0].NextAction)
+}
+
+type fixtureFinding struct {
+	name   string
+	status string
+}
+
+func writeImportFixture(t *testing.T, findings []fixtureFinding) (string, string) {
+	t.Helper()
+
+	sourceFindings := make([]any, 0, len(findings))
+	qualifiedFindings := make([]any, 0, len(findings))
+	for _, finding := range findings {
+		id := testAuditID + "/" + finding.name
+		sourceFindings = append(sourceFindings, map[string]any{
+			"id": id, "severity": "P2", "title": "Title " + finding.name, "location": "scripts/example:1",
+			"violated_invariant": "Invariant " + finding.name, "failure_path": "Failure path", "impact": "Impact",
+			"evidence": "Evidence", "reproduction_plan": "Reproduce", "test_gap": "Gap", "confidence": "HIGH",
+		})
+		qualifiedFindings = append(qualifiedFindings, map[string]any{
+			"id": id, "severity": "P2", "title": "Title " + finding.name, "status": finding.status,
+			"challenge_summary": "Challenge", "evidence_for": []any{"Evidence"}, "evidence_against": []any{},
+			"invariant_assessment": "Established", "reachability_assessment": "Reachable", "existing_tests": []any{},
+			"reproduction_plan": "Reproduce", "recommended_next_action": "Next",
+		})
+	}
+	source := map[string]any{
+		"audit_id": testAuditID, "head": testHead, "summary": "Audit", "inspected_areas": []any{"scripts"},
+		"findings": sourceFindings, "questions": []any{}, "residual_risk": "LOW",
+	}
+	directory := t.TempDir()
+	sourcePath := filepath.Join(directory, "audit.json")
+	qualifiedPath := filepath.Join(directory, "qualified.json")
+	writeObject(t, sourcePath, source)
+	sourceContent, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+	qualified := map[string]any{
+		"audit_id": testAuditID, "head": testHead, "sourceAuditDigest": digestBytes(sourceContent), "summary": "Challenge",
+		"results": qualifiedFindings, "questions": []any{}, "residual_risk": "LOW",
+	}
+	writeObject(t, qualifiedPath, qualified)
+
+	return sourcePath, qualifiedPath
+}
+
+func testCampaign(qualifications ...string) *Campaign {
+	campaign := &Campaign{
+		SchemaVersion: campaignSchemaVersion,
+		AuditID:       testAuditID,
+		AuditedSHA:    testHead,
+		ImportedAt:    testNow,
+		SourceDigests: SourceDigests{
+			Audit: "sha256:" + strings.Repeat("a", 64), Qualified: "sha256:" + strings.Repeat("b", 64),
+		},
+		SourceFacts: SourceFacts{FactType: sourceFactType},
+	}
+	for _, qualification := range qualifications {
+		id := testAuditID + "/finding"
+		if len(qualifications) > 1 {
+			id += "-" + strings.ToLower(qualification)
+		}
+		finding := SourceFinding{
+			FactType: sourceFactType, ID: id, Title: "Finding", Severity: "P2", Qualification: qualification,
+			Dispatchable: qualification == "CONFIRMED",
+			References: FindingReferences{
+				AuditFinding: "audit:#/findings", Invariant: "audit:#/invariant",
+				QualificationResult: "qualified:#/results", ChallengeSummary: "qualified:#/summary",
+			},
+		}
+		campaign.SourceFacts.Findings = append(campaign.SourceFacts.Findings, finding)
+	}
+	for index := range campaign.SourceFacts.Findings {
+		campaign.SourceFacts.Findings[index].IdentityDigest = sourceFindingDigest(campaign, campaign.SourceFacts.Findings[index])
+	}
+	campaign.SourceFacts.IdentityDigest = sourceFactsDigest(campaign)
+	campaign.CampaignID = campaignID(campaign)
+
+	return campaign
+}
+
+type fakeObservations struct {
+	jira            []JiraIssue
+	pullRequests    []PRMatch
+	jiraError       error
+	githubError     error
+	gitError        error
+	targetSHA       string
+	missingBranches bool
+}
+
+func runFakeInspection(campaign *Campaign, observations fakeObservations) *Inspection {
+	targetSHA := observations.targetSHA
+	if targetSHA == "" {
+		targetSHA = testHead
+	}
+	refs := map[string]string{"refs/heads/" + testTarget: targetSHA}
+	if !observations.missingBranches {
+		for _, pullRequest := range observations.pullRequests {
+			refs["refs/heads/"+pullRequest.HeadRef] = pullRequest.HeadSHA
+		}
+	}
+	runner := inspector{
+		now:    func() time.Time { return testNow },
+		jira:   fakeJiraProvider{issues: observations.jira, err: observations.jiraError},
+		github: fakeGitHubProvider{pullRequests: observations.pullRequests, err: observations.githubError},
+		git:    fakeGitProvider{refs: refs, err: observations.gitError},
+	}
+
+	return runner.run(context.Background(), campaign, inspectOptions{
+		repository: "formancehq/ledger", jiraProject: "EN", remote: "origin", target: testTarget,
+	})
+}
+
+type fakeJiraProvider struct {
+	issues []JiraIssue
+	err    error
+}
+
+func (provider fakeJiraProvider) Observe(_ context.Context, _ string, findings []SourceFinding) (map[string][]JiraIssue, error) {
+	if provider.err != nil {
+		return nil, provider.err
+	}
+	result := map[string][]JiraIssue{}
+	for _, finding := range findings {
+		result[finding.ID] = provider.issues
+	}
+
+	return result, nil
+}
+
+type fakeGitHubProvider struct {
+	pullRequests []PRMatch
+	err          error
+}
+
+func (provider fakeGitHubProvider) Observe(
+	_ context.Context, _ string, findings []SourceFinding, _ map[string][]JiraIssue,
+) (map[string][]PRMatch, error) {
+	if provider.err != nil {
+		return nil, provider.err
+	}
+	result := map[string][]PRMatch{}
+	for _, finding := range findings {
+		result[finding.ID] = provider.pullRequests
+	}
+
+	return result, nil
+}
+
+type fakeGitProvider struct {
+	refs map[string]string
+	err  error
+}
+
+func (provider fakeGitProvider) ObserveRefs(context.Context, string, []string) (map[string]string, error) {
+	return provider.refs, provider.err
+}
+
+func openPR(number int, branch, basis string) PRMatch {
+	return PRMatch{
+		Number: number, URL: "https://example.test/pr", State: "OPEN", HeadRef: branch,
+		HeadSHA: strings.Repeat(string(rune('a'+number%20)), 40), BaseRef: testTarget, BaseSHA: testHead,
+		ReviewDecision: "APPROVED", Checks: "SUCCESS", BindingBasis: basis,
+	}
+}
+
+func pullRequestSlice(values ...PRMatch) []PRMatch { return values }
+
+func nextActions(result *NextResult) map[string]string {
+	actions := map[string]string{}
+	for _, finding := range result.Findings {
+		actions[finding.ID] = finding.NextAction
+	}
+
+	return actions
+}
+
+func writeObject(t *testing.T, path string, object map[string]any) {
+	t.Helper()
+	content, err := json.MarshalIndent(object, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, append(content, '\n'), 0o600))
+}
+
+func readObject(t *testing.T, path string) map[string]any {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(content, &object))
+
+	return object
+}

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -38,6 +38,28 @@ func TestImportValidQualifiedAudit(t *testing.T) {
 	require.NoError(t, campaign.validate())
 }
 
+func TestImportAllowsQualifiedAuditWithNoFindings(t *testing.T) {
+	t.Parallel()
+
+	sourcePath, qualifiedPath := writeImportFixture(t, []fixtureFinding{})
+	campaign, err := (importer{now: func() time.Time { return testNow }}).run(sourcePath, qualifiedPath)
+	require.NoError(t, err)
+	require.Empty(t, campaign.SourceFacts.Findings)
+	require.NotNil(t, campaign.SourceFacts.Findings)
+	require.NoError(t, campaign.validate())
+
+	inspection := runFakeInspection(campaign, fakeObservations{})
+	require.Empty(t, inspection.Findings)
+	require.NotNil(t, inspection.Findings)
+	next := buildNextResult(campaign)
+	require.Empty(t, next.Findings)
+	require.NotNil(t, next.Findings)
+
+	encoded, err := json.Marshal(campaign)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"findings":[]`)
+}
+
 func TestImportRetainsNonConfirmedFindingsAsNonDispatchable(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -300,6 +300,20 @@ func TestMissingPRBranchIsBrokenBinding(t *testing.T) {
 	require.Equal(t, "REPAIR_BINDING", inspection.Findings[0].NextAction)
 }
 
+func TestCrossRepositoryPRHeadOIDDoesNotProveBranchExists(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	pullRequest := openPR(41, "fork-branch", "AI_AUDIT_MARKER")
+	pullRequest.CrossRepository = true
+	inspection := runFakeInspection(campaign, fakeObservations{
+		pullRequests: pullRequestSlice(pullRequest),
+	})
+	require.Equal(t, "BROKEN_BINDING", inspection.Findings[0].State)
+	require.Equal(t, "REPAIR_BINDING", inspection.Findings[0].NextAction)
+	require.Contains(t, inspection.Findings[0].Blockers, "CROSS_REPOSITORY_BRANCH_UNVERIFIED")
+}
+
 type fixtureFinding struct {
 	name   string
 	status string

--- a/scripts/aicampaign/external.go
+++ b/scripts/aicampaign/external.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type jiraProvider interface {
+	Observe(context.Context, string, []SourceFinding) (map[string][]JiraIssue, error)
+}
+
+type githubProvider interface {
+	Observe(context.Context, string, []SourceFinding, map[string][]JiraIssue) (map[string][]PRMatch, error)
+}
+
+type gitProvider interface {
+	ObserveRefs(context.Context, string, []string) (map[string]string, error)
+}
+
+type commandJiraProvider struct{}
+
+func (commandJiraProvider) Observe(ctx context.Context, project string, findings []SourceFinding) (map[string][]JiraIssue, error) {
+	observed := make(map[string][]JiraIssue, len(findings))
+	for _, finding := range findings {
+		marker := "AI-AUDIT:" + finding.ID
+		command := exec.CommandContext(ctx, "acli", "jira", "workitem", "search",
+			"--jql", fmt.Sprintf(`project = %s AND text ~ '"%s"'`, project, marker),
+			"--fields", "key,status,assignee,description", "--paginate", "--json")
+		output, err := command.Output()
+		if err != nil {
+			return nil, fmt.Errorf("jira lookup for %s: %w", finding.ID, commandError(err))
+		}
+		issues, err := parseJiraIssues(output, marker)
+		if err != nil {
+			return nil, fmt.Errorf("jira lookup for %s: %w", finding.ID, err)
+		}
+		observed[finding.ID] = issues
+	}
+
+	return observed, nil
+}
+
+type commandGitHubProvider struct{}
+
+type githubPR struct {
+	Number            int             `json:"number"`
+	Body              string          `json:"body"`
+	URL               string          `json:"url"`
+	State             string          `json:"state"`
+	HeadRefName       string          `json:"headRefName"`
+	HeadRefOID        string          `json:"headRefOid"`
+	BaseRefName       string          `json:"baseRefName"`
+	BaseRefOID        string          `json:"baseRefOid"`
+	IsCrossRepository bool            `json:"isCrossRepository"`
+	MergedAt          *string         `json:"mergedAt"`
+	ReviewDecision    string          `json:"reviewDecision"`
+	StatusCheckRollup json.RawMessage `json:"statusCheckRollup"`
+}
+
+func (commandGitHubProvider) Observe(
+	ctx context.Context,
+	repository string,
+	findings []SourceFinding,
+	jira map[string][]JiraIssue,
+) (map[string][]PRMatch, error) {
+	observed := make(map[string][]PRMatch, len(findings))
+	for _, finding := range findings {
+		marker := "AI-AUDIT:" + finding.ID
+		markerPRs, err := searchPullRequests(ctx, repository, marker)
+		if err != nil {
+			return nil, fmt.Errorf("GitHub lookup for %s: %w", finding.ID, err)
+		}
+		matches := map[int]PRMatch{}
+		for _, candidate := range markerPRs {
+			if exactLine(candidate.Body, marker) {
+				match := candidate.toMatch("AI_AUDIT_MARKER")
+				matches[match.Number] = match
+			}
+		}
+		// An explicit audit marker is the strongest available binding. Jira-key
+		// references are considered only when no PR carries that marker, so a
+		// weaker historical reference cannot make an explicit binding ambiguous.
+		if len(matches) == 0 {
+			for _, issue := range jira[finding.ID] {
+				jiraPRs, err := searchPullRequests(ctx, repository, issue.Key)
+				if err != nil {
+					return nil, fmt.Errorf("GitHub Jira-key lookup for %s: %w", finding.ID, err)
+				}
+				for _, candidate := range jiraPRs {
+					if exactJiraReference(candidate.Body, issue.Key) {
+						match := candidate.toMatch("JIRA_KEY")
+						matches[match.Number] = match
+					}
+				}
+			}
+		}
+		for _, match := range matches {
+			observed[finding.ID] = append(observed[finding.ID], match)
+		}
+		slices.SortFunc(observed[finding.ID], func(left, right PRMatch) int { return left.Number - right.Number })
+	}
+
+	return observed, nil
+}
+
+func searchPullRequests(ctx context.Context, repository, query string) ([]githubPR, error) {
+	const fields = "number,body,url,state,headRefName,headRefOid,baseRefName,baseRefOid,isCrossRepository,mergedAt,reviewDecision,statusCheckRollup"
+	command := exec.CommandContext(ctx, "gh", "pr", "list", "--repo", repository,
+		"--state", "all", "--limit", "1000", "--search", `"`+query+`"`, "--json", fields)
+	output, err := command.Output()
+	if err != nil {
+		return nil, commandError(err)
+	}
+	var pullRequests []githubPR
+	if err := json.Unmarshal(output, &pullRequests); err != nil {
+		return nil, fmt.Errorf("decode GitHub response: %w", err)
+	}
+
+	return pullRequests, nil
+}
+
+func (pullRequest githubPR) toMatch(bindingBasis string) PRMatch {
+	return PRMatch{
+		Number:          pullRequest.Number,
+		URL:             pullRequest.URL,
+		State:           pullRequest.State,
+		HeadRef:         pullRequest.HeadRefName,
+		HeadSHA:         pullRequest.HeadRefOID,
+		BaseRef:         pullRequest.BaseRefName,
+		BaseSHA:         pullRequest.BaseRefOID,
+		Merged:          pullRequest.MergedAt != nil || strings.EqualFold(pullRequest.State, "MERGED"),
+		CrossRepository: pullRequest.IsCrossRepository,
+		ReviewDecision:  pullRequest.ReviewDecision,
+		Checks:          summarizeChecks(pullRequest.StatusCheckRollup),
+		BindingBasis:    bindingBasis,
+	}
+}
+
+type commandGitProvider struct{}
+
+func (commandGitProvider) ObserveRefs(ctx context.Context, remote string, refs []string) (map[string]string, error) {
+	arguments := []string{"ls-remote", "--heads", remote}
+	arguments = append(arguments, refs...)
+	command := exec.CommandContext(ctx, "git", arguments...)
+	output, err := command.Output()
+	if err != nil {
+		return nil, commandError(err)
+	}
+	observed := make(map[string]string, len(refs))
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 || !shaPattern.MatchString(fields[0]) {
+			return nil, errors.New("malformed git ls-remote response")
+		}
+		observed[fields[1]] = fields[0]
+	}
+
+	return observed, nil
+}
+
+func parseJiraIssues(content []byte, marker string) ([]JiraIssue, error) {
+	var document any
+	if err := json.Unmarshal(content, &document); err != nil {
+		return nil, fmt.Errorf("decode Jira response: %w", err)
+	}
+	objects := collectObjects(document)
+	byKey := map[string]JiraIssue{}
+	for _, object := range objects {
+		key, _ := object["key"].(string)
+		fields, _ := object["fields"].(map[string]any)
+		if !jiraKeyPattern.MatchString(key) || fields == nil || !containsExactLine(fields["description"], marker) {
+			continue
+		}
+		issue := JiraIssue{Key: key}
+		issue.URL, _ = object["url"].(string)
+		if issue.URL == "" {
+			issue.URL, _ = object["self"].(string)
+		}
+		if status, ok := fields["status"].(map[string]any); ok {
+			issue.Status, _ = status["name"].(string)
+		} else {
+			issue.Status, _ = fields["status"].(string)
+		}
+		if assignee, ok := fields["assignee"].(map[string]any); ok {
+			for _, field := range []string{"displayName", "emailAddress", "accountId"} {
+				if value, ok := assignee[field].(string); ok && value != "" {
+					issue.Assignee = value
+
+					break
+				}
+			}
+		} else {
+			issue.Assignee, _ = fields["assignee"].(string)
+		}
+		byKey[key] = issue
+	}
+	issues := make([]JiraIssue, 0, len(byKey))
+	for _, issue := range byKey {
+		issues = append(issues, issue)
+	}
+	slices.SortFunc(issues, func(left, right JiraIssue) int { return strings.Compare(left.Key, right.Key) })
+
+	return issues, nil
+}
+
+func collectObjects(value any) []map[string]any {
+	var collected []map[string]any
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			collected = append(collected, typed)
+			for _, child := range typed {
+				walk(child)
+			}
+		case []any:
+			for _, child := range typed {
+				walk(child)
+			}
+		}
+	}
+	walk(value)
+
+	return collected
+}
+
+func containsExactLine(value any, marker string) bool {
+	switch typed := value.(type) {
+	case string:
+		return exactLine(typed, marker)
+	case map[string]any:
+		for _, child := range typed {
+			if containsExactLine(child, marker) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if containsExactLine(child, marker) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func exactLine(value, marker string) bool {
+	for line := range strings.SplitSeq(value, "\n") {
+		if strings.TrimSpace(line) == marker {
+			return true
+		}
+	}
+
+	return false
+}
+
+func exactJiraReference(body, key string) bool {
+	escaped := regexp.QuoteMeta(key)
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)^\s*` + escaped + `\s*[.]?\s*$`),
+		regexp.MustCompile(`(?i)^\s*(?:jira|fixes|fix|resolves|closes):?\s+` + escaped + `\s*[.]?\s*$`),
+		regexp.MustCompile(`(?i)^\s*(?:fixes|fix|resolves|closes)\s+\[` + escaped + `\]\([^\s)]+\)\s*[.]?\s*$`),
+	}
+	for line := range strings.SplitSeq(body, "\n") {
+		for _, pattern := range patterns {
+			if pattern.MatchString(line) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func summarizeChecks(content json.RawMessage) string {
+	if len(content) == 0 || string(content) == "null" {
+		return "UNKNOWN"
+	}
+	var checks []map[string]any
+	if err := json.Unmarshal(content, &checks); err != nil || len(checks) == 0 {
+		return "UNKNOWN"
+	}
+	result := "SUCCESS"
+	for _, check := range checks {
+		conclusion := strings.ToUpper(stringField(check, "conclusion"))
+		status := strings.ToUpper(stringField(check, "status"))
+		state := strings.ToUpper(stringField(check, "state"))
+		if slices.Contains([]string{"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}, conclusion) ||
+			slices.Contains([]string{"FAILURE", "ERROR"}, state) {
+			return "FAILURE"
+		}
+		if conclusion == "" || slices.Contains([]string{"PENDING", "QUEUED", "IN_PROGRESS", "EXPECTED"}, status) ||
+			slices.Contains([]string{"PENDING", "EXPECTED"}, state) {
+			result = "PENDING"
+		}
+	}
+
+	return result
+}
+
+func stringField(object map[string]any, key string) string {
+	value, _ := object[key].(string)
+
+	return value
+}
+
+func commandError(err error) error {
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		message := strings.TrimSpace(string(exitError.Stderr))
+		if message != "" {
+			return errors.New(message)
+		}
+	}
+
+	return err
+}

--- a/scripts/aicampaign/import.go
+++ b/scripts/aicampaign/import.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+type auditReport struct {
+	AuditID        string          `json:"audit_id"`
+	Head           string          `json:"head"`
+	Summary        string          `json:"summary"`
+	InspectedAreas []string        `json:"inspected_areas"`
+	Findings       []auditFinding  `json:"findings"`
+	Questions      []auditQuestion `json:"questions"`
+	ResidualRisk   string          `json:"residual_risk"`
+}
+
+type auditFinding struct {
+	ID                string `json:"id"`
+	Severity          string `json:"severity"`
+	Title             string `json:"title"`
+	Location          string `json:"location"`
+	ViolatedInvariant string `json:"violated_invariant"`
+	FailurePath       string `json:"failure_path"`
+	Impact            string `json:"impact"`
+	Evidence          string `json:"evidence"`
+	ReproductionPlan  string `json:"reproduction_plan"`
+	TestGap           string `json:"test_gap"`
+	Confidence        string `json:"confidence"`
+}
+
+type auditQuestion struct {
+	Location     string `json:"location"`
+	Question     string `json:"question"`
+	WhyItMatters string `json:"why_it_matters"`
+}
+
+type challengeReport struct {
+	AuditID           string            `json:"audit_id"`
+	Head              string            `json:"head"`
+	SourceAuditDigest string            `json:"sourceAuditDigest"`
+	Summary           string            `json:"summary"`
+	Results           []challengeResult `json:"results"`
+	Questions         []auditQuestion   `json:"questions"`
+	ResidualRisk      string            `json:"residual_risk"`
+}
+
+type challengeResult struct {
+	ID                     string   `json:"id"`
+	Severity               string   `json:"severity"`
+	Title                  string   `json:"title"`
+	Status                 string   `json:"status"`
+	ChallengeSummary       string   `json:"challenge_summary"`
+	EvidenceFor            []string `json:"evidence_for"`
+	EvidenceAgainst        []string `json:"evidence_against"`
+	InvariantAssessment    string   `json:"invariant_assessment"`
+	ReachabilityAssessment string   `json:"reachability_assessment"`
+	ExistingTests          []string `json:"existing_tests"`
+	ReproductionPlan       string   `json:"reproduction_plan"`
+	RecommendedNextAction  string   `json:"recommended_next_action"`
+}
+
+type importer struct {
+	now func() time.Time
+}
+
+func (runner importer) run(auditPath, qualifiedPath string) (*Campaign, error) {
+	var source auditReport
+	auditContent, err := readStrictJSON(auditPath, &source)
+	if err != nil {
+		return nil, fmt.Errorf("invalid source audit result: %w", err)
+	}
+	var qualified challengeReport
+	qualifiedContent, err := readStrictJSON(qualifiedPath, &qualified)
+	if err != nil {
+		return nil, fmt.Errorf("invalid qualified result: %w", err)
+	}
+	if err := validateImportReports(&source, &qualified, auditContent); err != nil {
+		return nil, err
+	}
+
+	campaign := &Campaign{
+		SchemaVersion: campaignSchemaVersion,
+		AuditID:       source.AuditID,
+		AuditedSHA:    source.Head,
+		ImportedAt:    runner.now().UTC(),
+		SourceDigests: SourceDigests{
+			Audit:     digestBytes(auditContent),
+			Qualified: digestBytes(qualifiedContent),
+		},
+		SourceFacts: SourceFacts{FactType: sourceFactType},
+	}
+	sourceIndexes := make(map[string]int, len(source.Findings))
+	for index, finding := range source.Findings {
+		sourceIndexes[finding.ID] = index
+	}
+	qualifiedIndexes := make(map[string]int, len(qualified.Results))
+	qualifiedByID := make(map[string]challengeResult, len(qualified.Results))
+	for index, finding := range qualified.Results {
+		qualifiedIndexes[finding.ID] = index
+		qualifiedByID[finding.ID] = finding
+	}
+	for _, original := range source.Findings {
+		qualification := qualifiedByID[original.ID]
+		finding := SourceFinding{
+			FactType:      sourceFactType,
+			ID:            original.ID,
+			Title:         original.Title,
+			Severity:      original.Severity,
+			Qualification: qualification.Status,
+			Dispatchable:  qualification.Status == "CONFIRMED",
+			References: FindingReferences{
+				AuditFinding:        fmt.Sprintf("audit:%s#/findings/%d", campaign.SourceDigests.Audit, sourceIndexes[original.ID]),
+				Invariant:           fmt.Sprintf("audit:%s#/findings/%d/violated_invariant", campaign.SourceDigests.Audit, sourceIndexes[original.ID]),
+				QualificationResult: fmt.Sprintf("qualified:%s#/results/%d", campaign.SourceDigests.Qualified, qualifiedIndexes[original.ID]),
+				ChallengeSummary:    fmt.Sprintf("qualified:%s#/results/%d/challenge_summary", campaign.SourceDigests.Qualified, qualifiedIndexes[original.ID]),
+			},
+		}
+		campaign.SourceFacts.Findings = append(campaign.SourceFacts.Findings, finding)
+	}
+	slices.SortFunc(campaign.SourceFacts.Findings, func(left, right SourceFinding) int {
+		return strings.Compare(left.ID, right.ID)
+	})
+	for index := range campaign.SourceFacts.Findings {
+		campaign.SourceFacts.Findings[index].IdentityDigest = sourceFindingDigest(campaign, campaign.SourceFacts.Findings[index])
+	}
+	campaign.SourceFacts.IdentityDigest = sourceFactsDigest(campaign)
+	campaign.CampaignID = campaignID(campaign)
+	if err := campaign.validate(); err != nil {
+		return nil, fmt.Errorf("constructed invalid campaign: %w", err)
+	}
+
+	return campaign, nil
+}
+
+func validateImportReports(source *auditReport, qualified *challengeReport, auditContent []byte) error {
+	if !auditIDPattern.MatchString(source.AuditID) || !shaPattern.MatchString(source.Head) ||
+		len(source.Findings) == 0 || source.InspectedAreas == nil || source.Questions == nil ||
+		!validResidualRisk(source.ResidualRisk) || !nonEmptyStrings(source.InspectedAreas) ||
+		!validQuestions(source.Questions) {
+		return errors.New("malformed source audit schema")
+	}
+	if qualified.AuditID != source.AuditID || qualified.Head != source.Head {
+		return errors.New("mismatched audit/challenge provenance")
+	}
+	if !digestPattern.MatchString(qualified.SourceAuditDigest) || qualified.SourceAuditDigest != digestBytes(auditContent) {
+		return errors.New("source audit digest mismatch")
+	}
+	if !validResidualRisk(qualified.ResidualRisk) || len(qualified.Results) == 0 || qualified.Questions == nil ||
+		!validQuestions(qualified.Questions) {
+		return errors.New("malformed qualification schema")
+	}
+	originals := make(map[string]auditFinding, len(source.Findings))
+	for _, finding := range source.Findings {
+		if !findingIDPattern.MatchString(finding.ID) || !strings.HasPrefix(finding.ID, source.AuditID+"/") ||
+			!validSeverity(finding.Severity) || finding.Title == "" || finding.ViolatedInvariant == "" ||
+			finding.FailurePath == "" || finding.Impact == "" || finding.Evidence == "" ||
+			finding.ReproductionPlan == "" || !validConfidence(finding.Confidence) {
+			return fmt.Errorf("malformed source finding %q", finding.ID)
+		}
+		if _, exists := originals[finding.ID]; exists {
+			return fmt.Errorf("duplicate finding id %q", finding.ID)
+		}
+		originals[finding.ID] = finding
+	}
+	qualifiedIDs := make(map[string]struct{}, len(qualified.Results))
+	for _, finding := range qualified.Results {
+		if _, exists := qualifiedIDs[finding.ID]; exists {
+			return fmt.Errorf("duplicate finding id %q", finding.ID)
+		}
+		qualifiedIDs[finding.ID] = struct{}{}
+		original, exists := originals[finding.ID]
+		if !exists {
+			return fmt.Errorf("qualification contains unknown finding %q", finding.ID)
+		}
+		if finding.Severity != original.Severity || finding.Title != original.Title {
+			return fmt.Errorf("qualification mismatch for %q", finding.ID)
+		}
+		if !validQualification(finding.Status) || finding.ChallengeSummary == "" ||
+			finding.InvariantAssessment == "" || finding.ReachabilityAssessment == "" ||
+			finding.ReproductionPlan == "" || finding.RecommendedNextAction == "" ||
+			finding.EvidenceFor == nil || finding.EvidenceAgainst == nil || finding.ExistingTests == nil {
+			return fmt.Errorf("malformed qualification for %q", finding.ID)
+		}
+	}
+	if len(qualifiedIDs) != len(originals) {
+		return errors.New("incomplete qualification set")
+	}
+
+	return nil
+}
+
+func nonEmptyStrings(values []string) bool {
+	return !slices.Contains(values, "")
+}
+
+func validQuestions(questions []auditQuestion) bool {
+	for _, question := range questions {
+		if question.Question == "" || question.WhyItMatters == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validConfidence(value string) bool {
+	return value == "HIGH" || value == "MEDIUM" || value == "LOW"
+}
+
+func validResidualRisk(value string) bool {
+	return value == "HIGH" || value == "MEDIUM" || value == "LOW"
+}
+
+func digestBytes(content []byte) string {
+	sum := sha256.Sum256(content)
+
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func defaultCampaignPath(repoRoot string, campaign *Campaign) string {
+	return filepath.Join(repoRoot, "build", "ai-campaign", campaign.CampaignID+".json")
+}

--- a/scripts/aicampaign/import.go
+++ b/scripts/aicampaign/import.go
@@ -94,7 +94,7 @@ func (runner importer) run(auditPath, qualifiedPath string) (*Campaign, error) {
 			Audit:     digestBytes(auditContent),
 			Qualified: digestBytes(qualifiedContent),
 		},
-		SourceFacts: SourceFacts{FactType: sourceFactType},
+		SourceFacts: SourceFacts{FactType: sourceFactType, Findings: []SourceFinding{}},
 	}
 	sourceIndexes := make(map[string]int, len(source.Findings))
 	for index, finding := range source.Findings {
@@ -141,7 +141,7 @@ func (runner importer) run(auditPath, qualifiedPath string) (*Campaign, error) {
 
 func validateImportReports(source *auditReport, qualified *challengeReport, auditContent []byte) error {
 	if !auditIDPattern.MatchString(source.AuditID) || !shaPattern.MatchString(source.Head) ||
-		len(source.Findings) == 0 || source.InspectedAreas == nil || source.Questions == nil ||
+		source.Findings == nil || source.InspectedAreas == nil || source.Questions == nil ||
 		!validResidualRisk(source.ResidualRisk) || !nonEmptyStrings(source.InspectedAreas) ||
 		!validQuestions(source.Questions) {
 		return errors.New("malformed source audit schema")
@@ -152,7 +152,7 @@ func validateImportReports(source *auditReport, qualified *challengeReport, audi
 	if !digestPattern.MatchString(qualified.SourceAuditDigest) || qualified.SourceAuditDigest != digestBytes(auditContent) {
 		return errors.New("source audit digest mismatch")
 	}
-	if !validResidualRisk(qualified.ResidualRisk) || len(qualified.Results) == 0 || qualified.Questions == nil ||
+	if !validResidualRisk(qualified.ResidualRisk) || qualified.Results == nil || qualified.Questions == nil ||
 		!validQuestions(qualified.Questions) {
 		return errors.New("malformed qualification schema")
 	}

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -85,6 +85,7 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 		RefreshedAt: refreshedAt,
 		Freshness:   freshness,
 		Providers:   providers,
+		Findings:    []FindingObservation{},
 		Target: TargetObservation{
 			FactType: observationFactType,
 			Branch:   options.target,
@@ -244,6 +245,7 @@ func staleObservations(campaign *Campaign, previous priorObservationSet, target 
 		FactType:  observationFactType,
 		Freshness: freshness,
 		Providers: providers,
+		Findings:  []FindingObservation{},
 		Target: TargetObservation{
 			FactType:    observationFactType,
 			Branch:      target,
@@ -383,6 +385,7 @@ func buildInspection(campaign *Campaign) *Inspection {
 		RefreshedAt:   observations.RefreshedAt,
 		Freshness:     observations.Freshness,
 		Providers:     observations.Providers,
+		Findings:      []InspectionFinding{},
 	}
 	byID := make(map[string]FindingObservation, len(observations.Findings))
 	for _, finding := range observations.Findings {

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -1,0 +1,517 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+)
+
+type inspectOptions struct {
+	repository  string
+	jiraProject string
+	remote      string
+	target      string
+	offline     bool
+}
+
+type inspector struct {
+	now    func() time.Time
+	jira   jiraProvider
+	github githubProvider
+	git    gitProvider
+}
+
+func (runner inspector) run(ctx context.Context, campaign *Campaign, options inspectOptions) *Inspection {
+	previous := previousObservations(campaign)
+	if options.offline {
+		observations := staleObservations(campaign, previous, options.target)
+		campaign.Observations = observations
+
+		return buildInspection(campaign)
+	}
+	now := runner.now().UTC()
+
+	jiraValues, jiraError := runner.jira.Observe(ctx, options.jiraProject, campaign.SourceFacts.Findings)
+	jiraProviderObservation := freshProvider(now)
+	if jiraError != nil {
+		jiraProviderObservation = unavailableProvider(previous.provider("jira"), jiraError)
+	}
+	jiraForGitHub := jiraValues
+	if jiraError != nil {
+		jiraForGitHub = previous.jiraValues()
+	}
+
+	githubValues, githubError := runner.github.Observe(ctx, options.repository, campaign.SourceFacts.Findings, jiraForGitHub)
+	githubProviderObservation := freshProvider(now)
+	if githubError != nil {
+		githubProviderObservation = unavailableProvider(previous.provider("github"), githubError)
+	}
+
+	refs := []string{"refs/heads/" + options.target}
+	prValuesForRefs := githubValues
+	if githubError != nil {
+		prValuesForRefs = previous.prValues()
+	}
+	for _, matches := range prValuesForRefs {
+		for _, match := range matches {
+			if !match.CrossRepository && match.HeadRef != "" {
+				refs = append(refs, "refs/heads/"+match.HeadRef)
+			}
+		}
+	}
+	slices.Sort(refs)
+	refs = slices.Compact(refs)
+	gitValues, gitError := runner.git.ObserveRefs(ctx, options.remote, refs)
+	gitProviderObservation := freshProvider(now)
+	if gitError != nil {
+		gitProviderObservation = unavailableProvider(previous.provider("git"), gitError)
+	}
+
+	providers := ProviderObservations{
+		GitHub: githubProviderObservation,
+		Jira:   jiraProviderObservation,
+		Git:    gitProviderObservation,
+	}
+	freshness := combinedFreshness(providers)
+	var refreshedAt *time.Time
+	if freshness == "FRESH" || freshness == "PARTIAL" {
+		refreshedAt = &now
+	} else if previous.set != nil {
+		refreshedAt = previous.set.RefreshedAt
+	}
+	observations := &ObservationSet{
+		FactType:    observationFactType,
+		RefreshedAt: refreshedAt,
+		Freshness:   freshness,
+		Providers:   providers,
+		Target: TargetObservation{
+			FactType: observationFactType,
+			Branch:   options.target,
+		},
+	}
+	if gitError == nil {
+		observations.Target.ObservedSHA = gitValues["refs/heads/"+options.target]
+	} else {
+		observations.Target.ObservedSHA = previous.targetSHA()
+	}
+
+	for _, source := range campaign.SourceFacts.Findings {
+		jiraObservation := JiraObservation{Status: "UNBOUND", BindingBasis: "AI_AUDIT_MARKER", Issues: []JiraIssue{}}
+		if jiraError == nil {
+			jiraObservation.Issues = nonNilJiraIssues(jiraValues[source.ID])
+			jiraObservation.Status = bindingStatus(len(jiraObservation.Issues))
+		} else {
+			jiraObservation = previous.jira(source.ID)
+			jiraObservation.Status = "UNKNOWN"
+		}
+
+		prObservation := PRObservation{Status: "UNBOUND", Matches: []PRMatch{}}
+		if githubError == nil {
+			prObservation.Matches = nonNilPRMatches(githubValues[source.ID])
+			prObservation.Status = bindingStatus(len(prObservation.Matches))
+			if len(prObservation.Matches) > 0 {
+				prObservation.BindingBasis = prObservation.Matches[0].BindingBasis
+			}
+		} else {
+			prObservation = previous.pr(source.ID)
+			prObservation.Status = "UNKNOWN"
+		}
+
+		for index := range prObservation.Matches {
+			match := &prObservation.Matches[index]
+			if match.Merged {
+				match.BranchExists = true
+
+				continue
+			}
+			if gitError == nil {
+				if match.CrossRepository {
+					match.BranchExists = match.HeadSHA != ""
+				} else {
+					match.BranchExists = gitValues["refs/heads/"+match.HeadRef] == match.HeadSHA && match.HeadSHA != ""
+				}
+			}
+		}
+
+		projection := projectFinding(source, jiraObservation, prObservation,
+			campaign.AuditedSHA, options.target, observations.Target.ObservedSHA, freshness)
+		observations.Findings = append(observations.Findings, projection)
+	}
+	campaign.Observations = observations
+
+	return buildInspection(campaign)
+}
+
+type priorObservationSet struct {
+	set *ObservationSet
+}
+
+func previousObservations(campaign *Campaign) priorObservationSet {
+	return priorObservationSet{set: campaign.Observations}
+}
+
+func (previous priorObservationSet) provider(name string) ProviderObservation {
+	if previous.set == nil {
+		return ProviderObservation{}
+	}
+	switch name {
+	case "github":
+		return previous.set.Providers.GitHub
+	case "jira":
+		return previous.set.Providers.Jira
+	case "git":
+		return previous.set.Providers.Git
+	default:
+		panic("unknown provider " + name)
+	}
+}
+
+func (previous priorObservationSet) finding(id string) (FindingObservation, bool) {
+	if previous.set == nil {
+		return FindingObservation{}, false
+	}
+	for _, finding := range previous.set.Findings {
+		if finding.ID == id {
+			return finding, true
+		}
+	}
+
+	return FindingObservation{}, false
+}
+
+func (previous priorObservationSet) jira(id string) JiraObservation {
+	if finding, ok := previous.finding(id); ok {
+		finding.Jira.Issues = nonNilJiraIssues(finding.Jira.Issues)
+
+		return finding.Jira
+	}
+
+	return JiraObservation{Status: "UNKNOWN", BindingBasis: "AI_AUDIT_MARKER", Issues: []JiraIssue{}}
+}
+
+func (previous priorObservationSet) pr(id string) PRObservation {
+	if finding, ok := previous.finding(id); ok {
+		finding.PR.Matches = nonNilPRMatches(finding.PR.Matches)
+
+		return finding.PR
+	}
+
+	return PRObservation{Status: "UNKNOWN", Matches: []PRMatch{}}
+}
+
+func (previous priorObservationSet) jiraValues() map[string][]JiraIssue {
+	values := map[string][]JiraIssue{}
+	if previous.set != nil {
+		for _, finding := range previous.set.Findings {
+			values[finding.ID] = finding.Jira.Issues
+		}
+	}
+
+	return values
+}
+
+func (previous priorObservationSet) prValues() map[string][]PRMatch {
+	values := map[string][]PRMatch{}
+	if previous.set != nil {
+		for _, finding := range previous.set.Findings {
+			values[finding.ID] = finding.PR.Matches
+		}
+	}
+
+	return values
+}
+
+func (previous priorObservationSet) targetSHA() string {
+	if previous.set == nil {
+		return ""
+	}
+
+	return previous.set.Target.ObservedSHA
+}
+
+func staleObservations(campaign *Campaign, previous priorObservationSet, target string) *ObservationSet {
+	providers := ProviderObservations{
+		GitHub: staleProvider(previous.provider("github"), "offline inspection"),
+		Jira:   staleProvider(previous.provider("jira"), "offline inspection"),
+		Git:    staleProvider(previous.provider("git"), "offline inspection"),
+	}
+	freshness := combinedFreshness(providers)
+	observations := &ObservationSet{
+		FactType:  observationFactType,
+		Freshness: freshness,
+		Providers: providers,
+		Target: TargetObservation{
+			FactType:    observationFactType,
+			Branch:      target,
+			ObservedSHA: previous.targetSHA(),
+		},
+	}
+	if previous.set != nil {
+		observations.RefreshedAt = previous.set.RefreshedAt
+	}
+	for _, source := range campaign.SourceFacts.Findings {
+		jira := previous.jira(source.ID)
+		jira.Status = "UNKNOWN"
+		pr := previous.pr(source.ID)
+		pr.Status = "UNKNOWN"
+		observations.Findings = append(observations.Findings,
+			projectFinding(source, jira, pr, campaign.AuditedSHA, target, observations.Target.ObservedSHA, freshness))
+	}
+
+	return observations
+}
+
+func projectFinding(
+	source SourceFinding,
+	jira JiraObservation,
+	pr PRObservation,
+	auditedSHA string,
+	targetBranch string,
+	targetSHA string,
+	freshness string,
+) FindingObservation {
+	projection := FindingObservation{
+		FactType:          observationFactType,
+		ID:                source.ID,
+		Jira:              jira,
+		PR:                pr,
+		ObservedTargetSHA: targetSHA,
+		Blockers:          []string{},
+		Freshness:         freshness,
+		Confidence:        "HIGH",
+	}
+	if len(pr.Matches) == 1 {
+		projection.ObservedCandidateSHA = pr.Matches[0].HeadSHA
+		if pr.Matches[0].BindingBasis == "JIRA_KEY" {
+			projection.Confidence = "MEDIUM"
+		}
+	}
+
+	if source.Qualification != "CONFIRMED" {
+		projection.State = "NON_DISPATCHABLE"
+		projection.Blockers = append(projection.Blockers, "QUALIFICATION_"+source.Qualification)
+		switch source.Qualification {
+		case "QUESTION":
+			projection.NextAction = "HUMAN_DECISION_REQUIRED"
+		default:
+			projection.NextAction = "NO_ACTION"
+		}
+
+		return projection
+	}
+
+	switch {
+	case jira.Status == "AMBIGUOUS":
+		projection.State = "AMBIGUOUS"
+		projection.Blockers = append(projection.Blockers, "AMBIGUOUS_JIRA_BINDING")
+		projection.NextAction = "RESOLVE_BINDING"
+	case pr.Status == "AMBIGUOUS":
+		projection.State = "AMBIGUOUS"
+		projection.Blockers = append(projection.Blockers, "AMBIGUOUS_PR_BINDING")
+		projection.NextAction = "RESOLVE_BINDING"
+	case len(pr.Matches) == 1:
+		match := pr.Matches[0]
+		switch {
+		case match.BaseRef != targetBranch:
+			projection.State = "BROKEN_BINDING"
+			projection.Blockers = append(projection.Blockers, "PR_TARGET_MISMATCH")
+			projection.NextAction = "REPAIR_BINDING"
+		case match.Merged:
+			projection.State = "MERGED"
+			projection.NextAction = "VERIFY_RESOLUTION"
+			if match.BindingBasis != "AI_AUDIT_MARKER" {
+				projection.Blockers = append(projection.Blockers, "MERGED_WITHOUT_EXACT_AUDIT_MARKER")
+			}
+		case !match.BranchExists:
+			projection.State = "BROKEN_BINDING"
+			projection.Blockers = append(projection.Blockers, "PR_BRANCH_MISSING")
+			projection.NextAction = "REPAIR_BINDING"
+		case strings.EqualFold(match.State, "OPEN"):
+			projection.State = "PR_OPEN"
+			projection.NextAction = "CONTINUE_PR"
+		case strings.EqualFold(match.State, "CLOSED"):
+			projection.State = "PR_CLOSED"
+			projection.Blockers = append(projection.Blockers, "PR_CLOSED_UNMERGED")
+			projection.NextAction = "REVIEW_CLOSED_PR"
+		default:
+			projection.State = "BROKEN_BINDING"
+			projection.Blockers = append(projection.Blockers, "PR_STATE_UNKNOWN")
+			projection.NextAction = "REPAIR_BINDING"
+		}
+	case targetSHA == "":
+		projection.State = "BLOCKED"
+		projection.Blockers = append(projection.Blockers, "TARGET_SHA_UNKNOWN")
+		projection.NextAction = "REFRESH_REQUIRED"
+	case targetSHA != "" && targetSHA != auditedSHA:
+		projection.State = "BLOCKED"
+		projection.Blockers = append(projection.Blockers, "TARGET_ADVANCED")
+		projection.NextAction = "REQUALIFY_ON_CURRENT_TARGET"
+	case len(jira.Issues) == 1:
+		projection.State = "TRACKED"
+		projection.NextAction = "READY_FOR_CLAIM_OR_DISPATCH"
+	default:
+		projection.State = "CONFIRMED_UNASSIGNED"
+		projection.NextAction = "PUBLISH_JIRA_OR_REVIEW_POLICY"
+	}
+
+	if freshness != "FRESH" {
+		projection.Freshness = freshness
+		projection.Confidence = "LOW"
+		projection.Blockers = appendUnique(projection.Blockers, "STALE_EXTERNAL_TRUTH")
+		projection.NextAction = "REFRESH_REQUIRED"
+	}
+
+	return projection
+}
+
+func buildInspection(campaign *Campaign) *Inspection {
+	observations := campaign.Observations
+	inspection := &Inspection{
+		SchemaVersion: inspectionSchemaVersion,
+		CampaignID:    campaign.CampaignID,
+		AuditID:       campaign.AuditID,
+		AuditedSHA:    campaign.AuditedSHA,
+		SourceDigests: campaign.SourceDigests,
+		RefreshedAt:   observations.RefreshedAt,
+		Freshness:     observations.Freshness,
+		Providers:     observations.Providers,
+	}
+	byID := make(map[string]FindingObservation, len(observations.Findings))
+	for _, finding := range observations.Findings {
+		byID[finding.ID] = finding
+	}
+	for _, source := range campaign.SourceFacts.Findings {
+		observation := byID[source.ID]
+		inspection.Findings = append(inspection.Findings, InspectionFinding{
+			ID:                   source.ID,
+			Title:                source.Title,
+			Severity:             source.Severity,
+			Qualification:        source.Qualification,
+			Dispatchable:         source.Dispatchable,
+			State:                observation.State,
+			Jira:                 observation.Jira,
+			PR:                   observation.PR,
+			ObservedCandidateSHA: observation.ObservedCandidateSHA,
+			ObservedTargetSHA:    observation.ObservedTargetSHA,
+			Blockers:             nonNilStrings(observation.Blockers),
+			NextAction:           observation.NextAction,
+			Freshness:            observation.Freshness,
+			Confidence:           observation.Confidence,
+		})
+	}
+	// Persist the same final projection that inspect emits; next therefore never
+	// reinterprets a different state from the cached campaign artifact.
+	observationIndexes := make(map[string]int, len(observations.Findings))
+	for index, observation := range observations.Findings {
+		observationIndexes[observation.ID] = index
+	}
+	for _, projected := range inspection.Findings {
+		index := observationIndexes[projected.ID]
+		observations.Findings[index].State = projected.State
+		observations.Findings[index].Blockers = projected.Blockers
+		observations.Findings[index].NextAction = projected.NextAction
+	}
+
+	return inspection
+}
+
+func freshProvider(now time.Time) ProviderObservation {
+	return ProviderObservation{Status: "FRESH", ObservedAt: &now}
+}
+
+func unavailableProvider(previous ProviderObservation, err error) ProviderObservation {
+	if previous.ObservedAt != nil {
+		return ProviderObservation{Status: "STALE", ObservedAt: previous.ObservedAt, Error: conciseError(err)}
+	}
+
+	return ProviderObservation{Status: "UNAVAILABLE", Error: conciseError(err)}
+}
+
+func staleProvider(previous ProviderObservation, reason string) ProviderObservation {
+	status := "UNAVAILABLE"
+	if previous.ObservedAt != nil {
+		status = "STALE"
+	}
+
+	return ProviderObservation{Status: status, ObservedAt: previous.ObservedAt, Error: reason}
+}
+
+func combinedFreshness(providers ProviderObservations) string {
+	statuses := []string{providers.GitHub.Status, providers.Jira.Status, providers.Git.Status}
+	fresh := 0
+	stale := 0
+	for _, status := range statuses {
+		switch status {
+		case "FRESH":
+			fresh++
+		case "STALE":
+			stale++
+		}
+	}
+	switch {
+	case fresh == len(statuses):
+		return "FRESH"
+	case fresh > 0:
+		return "PARTIAL"
+	case stale > 0:
+		return "STALE"
+	default:
+		return "UNAVAILABLE"
+	}
+}
+
+func bindingStatus(count int) string {
+	switch count {
+	case 0:
+		return "UNBOUND"
+	case 1:
+		return "BOUND"
+	default:
+		return "AMBIGUOUS"
+	}
+}
+
+func appendUnique(values []string, value string) []string {
+	if !slices.Contains(values, value) {
+		return append(values, value)
+	}
+
+	return values
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+
+	return values
+}
+
+func nonNilJiraIssues(values []JiraIssue) []JiraIssue {
+	if values == nil {
+		return []JiraIssue{}
+	}
+
+	return values
+}
+
+func nonNilPRMatches(values []PRMatch) []PRMatch {
+	if values == nil {
+		return []PRMatch{}
+	}
+
+	return values
+}
+
+func conciseError(err error) string {
+	message := strings.TrimSpace(err.Error())
+	if newline := strings.IndexByte(message, '\n'); newline >= 0 {
+		message = message[:newline]
+	}
+	if len(message) > 240 {
+		message = message[:240]
+	}
+
+	return message
+}

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -127,7 +127,10 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 			}
 			if gitError == nil {
 				if match.CrossRepository {
-					match.BranchExists = match.HeadSHA != ""
+					// GitHub retains a pull request's head commit after a fork or
+					// source branch is deleted. Without an authoritative lookup
+					// against that fork, the branch is not proven to exist.
+					match.BranchExists = false
 				} else {
 					match.BranchExists = gitValues["refs/heads/"+match.HeadRef] == match.HeadSHA && match.HeadSHA != ""
 				}
@@ -325,7 +328,11 @@ func projectFinding(
 			}
 		case !match.BranchExists:
 			projection.State = "BROKEN_BINDING"
-			projection.Blockers = append(projection.Blockers, "PR_BRANCH_MISSING")
+			if match.CrossRepository {
+				projection.Blockers = append(projection.Blockers, "CROSS_REPOSITORY_BRANCH_UNVERIFIED")
+			} else {
+				projection.Blockers = append(projection.Blockers, "PR_BRANCH_MISSING")
+			}
 			projection.NextAction = "REPAIR_BINDING"
 		case strings.EqualFold(match.State, "OPEN"):
 			projection.State = "PR_OPEN"

--- a/scripts/aicampaign/main.go
+++ b/scripts/aicampaign/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if _, writeErr := fmt.Fprintf(os.Stderr, "ai-campaign: %v\n", err); writeErr != nil {
+			os.Exit(1)
+		}
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string, stdout, stderr io.Writer) error {
+	if len(arguments) == 0 {
+		if err := usage(stderr); err != nil {
+			return err
+		}
+
+		return errors.New("command is required")
+	}
+	switch arguments[0] {
+	case "-h", "--help", "help":
+		return usage(stdout)
+	case "import":
+		return runImport(arguments[1:], stdout, stderr)
+	case "inspect":
+		return runInspect(arguments[1:], stdout, stderr)
+	case "next":
+		return runNext(arguments[1:], stdout, stderr)
+	default:
+		if err := usage(stderr); err != nil {
+			return err
+		}
+
+		return fmt.Errorf("unknown command %q", arguments[0])
+	}
+}
+
+func runImport(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{"--audit": true, "--output": true})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--audit"] == "" {
+		return errors.New("usage: ai-campaign import <qualified-result> --audit <source-audit> [--output <path>]")
+	}
+	repoRoot, err := repositoryRoot()
+	if err != nil {
+		return err
+	}
+	campaign, err := (importer{now: time.Now}).run(flags["--audit"], values[0])
+	if err != nil {
+		return err
+	}
+	output := flags["--output"]
+	if output == "" {
+		output = defaultCampaignPath(repoRoot, campaign)
+	}
+	output, err = validateCampaignDestination(repoRoot, output, true)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(output); err == nil {
+		existing, loadErr := loadCampaign(output)
+		if loadErr != nil {
+			return fmt.Errorf("refusing to replace existing state: %w", loadErr)
+		}
+		if existing.CampaignID != campaign.CampaignID {
+			return fmt.Errorf("refusing to replace campaign %s with %s", existing.CampaignID, campaign.CampaignID)
+		}
+		if err := writeHuman(stderr, "Campaign %s already imported at %s\n", existing.CampaignID, output); err != nil {
+			return err
+		}
+
+		return writeJSON(stdout, existing)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect campaign output: %w", err)
+	}
+	if err := writeCampaign(output, campaign); err != nil {
+		return err
+	}
+	if err := writeHuman(stderr, "Imported %s (%d findings) -> %s\n", campaign.CampaignID,
+		len(campaign.SourceFacts.Findings), output); err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, campaign)
+}
+
+func runInspect(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--offline": false, "--repo": true, "--jira-project": true, "--remote": true, "--target": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 {
+		return errors.New("usage: ai-campaign inspect <campaign> [--offline] [--repo <owner/name>] [--jira-project <key>] [--remote <name>] [--target <branch>]")
+	}
+	repoRoot, err := repositoryRoot()
+	if err != nil {
+		return err
+	}
+	campaignPath, err := validateCampaignDestination(repoRoot, values[0], false)
+	if err != nil {
+		return err
+	}
+	campaign, err := loadCampaign(campaignPath)
+	if err != nil {
+		return err
+	}
+	options := inspectOptions{
+		repository:  valueOr(flags["--repo"], "formancehq/ledger"),
+		jiraProject: valueOr(flags["--jira-project"], "EN"),
+		remote:      valueOr(flags["--remote"], "origin"),
+		target:      valueOr(flags["--target"], "release/v3.0"),
+		offline:     flags["--offline"] == "true",
+	}
+	if err := validateInspectOptions(options); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := (inspector{
+		now: time.Now, jira: commandJiraProvider{}, github: commandGitHubProvider{}, git: commandGitProvider{},
+	}).run(ctx, campaign, options)
+	if err := writeCampaign(campaignPath, campaign); err != nil {
+		return err
+	}
+	if err := writeInspectionHuman(stderr, result); err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, result)
+}
+
+func runNext(arguments []string, stdout, stderr io.Writer) error {
+	values, _, err := parseArguments(arguments, map[string]bool{})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 {
+		return errors.New("usage: ai-campaign next <campaign>")
+	}
+	campaign, err := loadCampaign(values[0])
+	if err != nil {
+		return err
+	}
+	result := buildNextResult(campaign)
+	if err := writeHuman(stderr, "Campaign %s next actions (%s external truth):\n", result.CampaignID, result.Freshness); err != nil {
+		return err
+	}
+	for _, finding := range result.Findings {
+		if err := writeHuman(stderr, "  %s: %s\n", finding.ID, finding.NextAction); err != nil {
+			return err
+		}
+	}
+
+	return writeJSON(stdout, result)
+}
+
+func parseArguments(arguments []string, specification map[string]bool) ([]string, map[string]string, error) {
+	values := []string{}
+	flags := map[string]string{}
+	for index := 0; index < len(arguments); index++ {
+		argument := arguments[index]
+		requiresValue, known := specification[argument]
+		if !known {
+			if strings.HasPrefix(argument, "-") {
+				return nil, nil, fmt.Errorf("unknown option %q", argument)
+			}
+			values = append(values, argument)
+
+			continue
+		}
+		if !requiresValue {
+			flags[argument] = "true"
+
+			continue
+		}
+		if index+1 >= len(arguments) || strings.HasPrefix(arguments[index+1], "-") {
+			return nil, nil, fmt.Errorf("%s requires a value", argument)
+		}
+		index++
+		flags[argument] = arguments[index]
+	}
+
+	return values, flags, nil
+}
+
+func valueOr(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}
+
+func validateInspectOptions(options inspectOptions) error {
+	if !jiraProjectPattern.MatchString(options.jiraProject) {
+		return errors.New("invalid Jira project")
+	}
+	if !githubRepoPattern.MatchString(options.repository) {
+		return errors.New("invalid GitHub repository")
+	}
+	if !gitRemotePattern.MatchString(options.remote) {
+		return errors.New("invalid Git remote")
+	}
+	if options.target == "" || exec.Command("git", "check-ref-format", "refs/heads/"+options.target).Run() != nil {
+		return errors.New("invalid target branch")
+	}
+
+	return nil
+}
+
+func writeJSON(destination io.Writer, value any) error {
+	encoder := json.NewEncoder(destination)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("write JSON output: %w", err)
+	}
+
+	return nil
+}
+
+func writeInspectionHuman(destination io.Writer, inspection *Inspection) error {
+	if err := writeHuman(destination, "Campaign %s: %s external truth\n", inspection.CampaignID, inspection.Freshness); err != nil {
+		return err
+	}
+	for _, finding := range inspection.Findings {
+		jira := finding.Jira.Status
+		if len(finding.Jira.Issues) == 1 {
+			jira = finding.Jira.Issues[0].Key + "/" + valueOr(finding.Jira.Issues[0].Status, "UNKNOWN")
+			if finding.Jira.Status == "UNKNOWN" {
+				jira = "UNKNOWN(cached " + jira + ")"
+			}
+		}
+		pullRequest := finding.PR.Status
+		if len(finding.PR.Matches) == 1 {
+			match := finding.PR.Matches[0]
+			head := match.HeadSHA
+			if len(head) > 12 {
+				head = head[:12]
+			}
+			pullRequest = fmt.Sprintf("#%d/%s@%s", match.Number, match.State, valueOr(head, "UNKNOWN"))
+			if finding.PR.Status == "UNKNOWN" {
+				pullRequest = "UNKNOWN(cached " + pullRequest + ")"
+			}
+		}
+		blockers := "-"
+		if len(finding.Blockers) > 0 {
+			blockers = strings.Join(finding.Blockers, ",")
+		}
+		if err := writeHuman(destination, "  %s [%s] %s jira=%s pr=%s freshness=%s blockers=%s next=%s\n",
+			finding.ID, finding.Qualification, finding.State, jira, pullRequest, finding.Freshness, blockers,
+			finding.NextAction); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeHuman(destination io.Writer, format string, arguments ...any) error {
+	if _, err := fmt.Fprintf(destination, format, arguments...); err != nil {
+		return fmt.Errorf("write human output: %w", err)
+	}
+
+	return nil
+}
+
+func usage(destination io.Writer) error {
+	return writeHuman(destination, `%s`, `Usage:
+  scripts/ai-campaign import <qualified-result> --audit <source-audit> [--output <path>]
+  scripts/ai-campaign inspect <campaign> [--offline]
+  scripts/ai-campaign next <campaign>
+
+Human summaries are written to stderr; stable JSON is written to stdout.
+`)
+}

--- a/scripts/aicampaign/model.go
+++ b/scripts/aicampaign/model.go
@@ -1,0 +1,479 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	campaignSchemaVersion   = "ai-campaign/v1"
+	inspectionSchemaVersion = "ai-campaign-inspection/v1"
+	nextSchemaVersion       = "ai-campaign-next/v1"
+	sourceFactType          = "SOURCE_FACT"
+	observationFactType     = "DERIVED_OBSERVATION"
+)
+
+var (
+	auditIDPattern     = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	findingIDPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*/[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	shaPattern         = regexp.MustCompile(`^[0-9a-f]{40,64}$`)
+	digestPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	jiraKeyPattern     = regexp.MustCompile(`^[A-Z][A-Z0-9_]*-[1-9][0-9]*$`)
+	jiraProjectPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	githubRepoPattern  = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	gitRemotePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+)
+
+type Campaign struct {
+	SchemaVersion string          `json:"schemaVersion"`
+	CampaignID    string          `json:"campaignId"`
+	AuditID       string          `json:"auditId"`
+	AuditedSHA    string          `json:"auditedSha"`
+	ImportedAt    time.Time       `json:"importedAt"`
+	SourceDigests SourceDigests   `json:"sourceDigests"`
+	SourceFacts   SourceFacts     `json:"sourceFacts"`
+	Observations  *ObservationSet `json:"observations"`
+}
+
+type SourceDigests struct {
+	Audit     string `json:"audit"`
+	Qualified string `json:"qualified"`
+}
+
+type SourceFacts struct {
+	FactType       string          `json:"factType"`
+	IdentityDigest string          `json:"identityDigest"`
+	Findings       []SourceFinding `json:"findings"`
+}
+
+type SourceFinding struct {
+	FactType       string            `json:"factType"`
+	ID             string            `json:"id"`
+	Title          string            `json:"title"`
+	Severity       string            `json:"severity"`
+	Qualification  string            `json:"qualification"`
+	Dispatchable   bool              `json:"dispatchable"`
+	References     FindingReferences `json:"references"`
+	IdentityDigest string            `json:"identityDigest"`
+}
+
+type FindingReferences struct {
+	AuditFinding        string `json:"auditFinding"`
+	Invariant           string `json:"invariant"`
+	QualificationResult string `json:"qualificationResult"`
+	ChallengeSummary    string `json:"challengeSummary"`
+}
+
+type ObservationSet struct {
+	FactType    string               `json:"factType"`
+	RefreshedAt *time.Time           `json:"refreshedAt"`
+	Freshness   string               `json:"freshness"`
+	Providers   ProviderObservations `json:"providers"`
+	Target      TargetObservation    `json:"target"`
+	Findings    []FindingObservation `json:"findings"`
+}
+
+type ProviderObservations struct {
+	GitHub ProviderObservation `json:"github"`
+	Jira   ProviderObservation `json:"jira"`
+	Git    ProviderObservation `json:"git"`
+}
+
+type ProviderObservation struct {
+	Status     string     `json:"status"`
+	ObservedAt *time.Time `json:"observedAt"`
+	Error      string     `json:"error"`
+}
+
+type TargetObservation struct {
+	FactType    string `json:"factType"`
+	Branch      string `json:"branch"`
+	ObservedSHA string `json:"observedSha"`
+}
+
+type FindingObservation struct {
+	FactType             string          `json:"factType"`
+	ID                   string          `json:"id"`
+	State                string          `json:"state"`
+	Jira                 JiraObservation `json:"jira"`
+	PR                   PRObservation   `json:"pr"`
+	ObservedCandidateSHA string          `json:"observedCandidateSha"`
+	ObservedTargetSHA    string          `json:"observedTargetSha"`
+	Blockers             []string        `json:"blockers"`
+	NextAction           string          `json:"nextAction"`
+	Freshness            string          `json:"freshness"`
+	Confidence           string          `json:"confidence"`
+}
+
+type JiraObservation struct {
+	Status       string      `json:"status"`
+	BindingBasis string      `json:"bindingBasis"`
+	Issues       []JiraIssue `json:"issues"`
+}
+
+type JiraIssue struct {
+	Key      string `json:"key"`
+	URL      string `json:"url"`
+	Status   string `json:"status"`
+	Assignee string `json:"assignee"`
+}
+
+type PRObservation struct {
+	Status       string    `json:"status"`
+	BindingBasis string    `json:"bindingBasis"`
+	Matches      []PRMatch `json:"matches"`
+}
+
+type PRMatch struct {
+	Number          int    `json:"number"`
+	URL             string `json:"url"`
+	State           string `json:"state"`
+	HeadRef         string `json:"headRef"`
+	HeadSHA         string `json:"headSha"`
+	BaseRef         string `json:"baseRef"`
+	BaseSHA         string `json:"baseSha"`
+	Merged          bool   `json:"merged"`
+	BranchExists    bool   `json:"branchExists"`
+	CrossRepository bool   `json:"crossRepository"`
+	ReviewDecision  string `json:"reviewDecision"`
+	Checks          string `json:"checks"`
+	BindingBasis    string `json:"bindingBasis"`
+}
+
+type Inspection struct {
+	SchemaVersion string               `json:"schemaVersion"`
+	CampaignID    string               `json:"campaignId"`
+	AuditID       string               `json:"auditId"`
+	AuditedSHA    string               `json:"auditedSha"`
+	SourceDigests SourceDigests        `json:"sourceDigests"`
+	RefreshedAt   *time.Time           `json:"refreshedAt"`
+	Freshness     string               `json:"freshness"`
+	Providers     ProviderObservations `json:"providers"`
+	Findings      []InspectionFinding  `json:"findings"`
+}
+
+type InspectionFinding struct {
+	ID                   string          `json:"id"`
+	Title                string          `json:"title"`
+	Severity             string          `json:"severity"`
+	Qualification        string          `json:"qualification"`
+	Dispatchable         bool            `json:"dispatchable"`
+	State                string          `json:"state"`
+	Jira                 JiraObservation `json:"jira"`
+	PR                   PRObservation   `json:"pr"`
+	ObservedCandidateSHA string          `json:"observedCandidateSha"`
+	ObservedTargetSHA    string          `json:"observedTargetSha"`
+	Blockers             []string        `json:"blockers"`
+	NextAction           string          `json:"nextAction"`
+	Freshness            string          `json:"freshness"`
+	Confidence           string          `json:"confidence"`
+}
+
+type NextResult struct {
+	SchemaVersion      string        `json:"schemaVersion"`
+	CampaignID         string        `json:"campaignId"`
+	AuditID            string        `json:"auditId"`
+	AuditedSHA         string        `json:"auditedSha"`
+	BasedOnRefreshedAt *time.Time    `json:"basedOnRefreshedAt"`
+	Freshness          string        `json:"freshness"`
+	Findings           []NextFinding `json:"findings"`
+}
+
+type NextFinding struct {
+	ID            string   `json:"id"`
+	Qualification string   `json:"qualification"`
+	State         string   `json:"state"`
+	NextAction    string   `json:"nextAction"`
+	Blockers      []string `json:"blockers"`
+	Freshness     string   `json:"freshness"`
+}
+
+func (campaign *Campaign) validate() error {
+	if campaign.SchemaVersion != campaignSchemaVersion {
+		return fmt.Errorf("unsupported schema version %q", campaign.SchemaVersion)
+	}
+	if !auditIDPattern.MatchString(campaign.AuditID) || !shaPattern.MatchString(campaign.AuditedSHA) {
+		return errors.New("invalid campaign audit identity")
+	}
+	if campaign.ImportedAt.IsZero() || !digestPattern.MatchString(campaign.SourceDigests.Audit) ||
+		!digestPattern.MatchString(campaign.SourceDigests.Qualified) {
+		return errors.New("invalid campaign provenance")
+	}
+	if campaign.SourceFacts.FactType != sourceFactType || len(campaign.SourceFacts.Findings) == 0 {
+		return errors.New("invalid source facts")
+	}
+	ids := make(map[string]SourceFinding, len(campaign.SourceFacts.Findings))
+	for index := range campaign.SourceFacts.Findings {
+		finding := &campaign.SourceFacts.Findings[index]
+		if finding.FactType != sourceFactType || !findingIDPattern.MatchString(finding.ID) ||
+			!strings.HasPrefix(finding.ID, campaign.AuditID+"/") || finding.Title == "" ||
+			!validSeverity(finding.Severity) || !validQualification(finding.Qualification) ||
+			finding.Dispatchable != (finding.Qualification == "CONFIRMED") {
+			return fmt.Errorf("invalid source finding %q", finding.ID)
+		}
+		if _, exists := ids[finding.ID]; exists {
+			return fmt.Errorf("duplicate finding id %q", finding.ID)
+		}
+		ids[finding.ID] = *finding
+		if finding.References.AuditFinding == "" || finding.References.Invariant == "" ||
+			finding.References.QualificationResult == "" || finding.References.ChallengeSummary == "" {
+			return fmt.Errorf("incomplete source references for %q", finding.ID)
+		}
+		if finding.IdentityDigest != sourceFindingDigest(campaign, *finding) {
+			return fmt.Errorf("source identity digest mismatch for %q", finding.ID)
+		}
+	}
+	if !slices.IsSortedFunc(campaign.SourceFacts.Findings, func(left, right SourceFinding) int {
+		return strings.Compare(left.ID, right.ID)
+	}) {
+		return errors.New("source findings are not in deterministic id order")
+	}
+	if campaign.SourceFacts.IdentityDigest != sourceFactsDigest(campaign) {
+		return errors.New("source facts digest mismatch")
+	}
+	if campaign.CampaignID != campaignID(campaign) {
+		return errors.New("campaign id mismatch")
+	}
+	if campaign.Observations != nil {
+		if err := campaign.validateObservations(ids); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (campaign *Campaign) validateObservations(sourceFindings map[string]SourceFinding) error {
+	observations := campaign.Observations
+	if observations.FactType != observationFactType || !validFreshness(observations.Freshness) {
+		return errors.New("invalid observation envelope")
+	}
+	if observations.Freshness != combinedFreshness(observations.Providers) {
+		return errors.New("observation freshness does not match provider freshness")
+	}
+	for name, provider := range map[string]ProviderObservation{
+		"github": observations.Providers.GitHub,
+		"jira":   observations.Providers.Jira,
+		"git":    observations.Providers.Git,
+	} {
+		if !validProviderStatus(provider.Status) ||
+			(provider.Status != "UNAVAILABLE" && provider.ObservedAt == nil) ||
+			(provider.ObservedAt != nil && provider.ObservedAt.IsZero()) {
+			return fmt.Errorf("invalid %s provider observation", name)
+		}
+	}
+	if (observations.Freshness == "FRESH" || observations.Freshness == "PARTIAL") && observations.RefreshedAt == nil {
+		return errors.New("refreshed observations require refreshedAt")
+	}
+	if observations.RefreshedAt != nil && observations.RefreshedAt.IsZero() {
+		return errors.New("invalid refreshedAt")
+	}
+	if observations.Target.FactType != observationFactType || observations.Target.Branch == "" ||
+		(observations.Target.ObservedSHA != "" && !shaPattern.MatchString(observations.Target.ObservedSHA)) {
+		return errors.New("invalid target observation")
+	}
+	if len(observations.Findings) != len(sourceFindings) {
+		return errors.New("incomplete finding observations")
+	}
+	seen := make(map[string]struct{}, len(observations.Findings))
+	for index, finding := range observations.Findings {
+		if finding.FactType != observationFactType {
+			return fmt.Errorf("invalid observation for %q", finding.ID)
+		}
+		source, exists := sourceFindings[finding.ID]
+		if !exists {
+			return fmt.Errorf("observation for unknown finding %q", finding.ID)
+		}
+		if campaign.SourceFacts.Findings[index].ID != finding.ID {
+			return errors.New("finding observations are not in deterministic source order")
+		}
+		if _, exists := seen[finding.ID]; exists {
+			return fmt.Errorf("duplicate finding observation %q", finding.ID)
+		}
+		seen[finding.ID] = struct{}{}
+		if !validFreshness(finding.Freshness) || finding.Freshness != observations.Freshness ||
+			!validState(finding.State) || !validNextAction(finding.NextAction) || !validConfidence(finding.Confidence) ||
+			(finding.ObservedCandidateSHA != "" && !shaPattern.MatchString(finding.ObservedCandidateSHA)) ||
+			finding.ObservedTargetSHA != observations.Target.ObservedSHA || !uniqueNonEmpty(finding.Blockers) {
+			return fmt.Errorf("incomplete finding observation %q", finding.ID)
+		}
+		if err := validateJiraObservation(finding.Jira); err != nil {
+			return fmt.Errorf("invalid Jira observation for %q: %w", finding.ID, err)
+		}
+		if err := validatePRObservation(finding.PR); err != nil {
+			return fmt.Errorf("invalid PR observation for %q: %w", finding.ID, err)
+		}
+		expected := projectFinding(source, finding.Jira, finding.PR, campaign.AuditedSHA,
+			observations.Target.Branch, observations.Target.ObservedSHA, observations.Freshness)
+		if finding.State != expected.State || finding.ObservedCandidateSHA != expected.ObservedCandidateSHA ||
+			finding.NextAction != expected.NextAction || finding.Confidence != expected.Confidence ||
+			!slices.Equal(finding.Blockers, expected.Blockers) {
+			return fmt.Errorf("derived projection mismatch for %q", finding.ID)
+		}
+	}
+	if len(seen) != len(sourceFindings) {
+		return errors.New("incomplete finding observations")
+	}
+
+	return nil
+}
+
+func validateJiraObservation(observation JiraObservation) error {
+	if !validBindingStatus(observation.Status, len(observation.Issues)) || observation.BindingBasis != "AI_AUDIT_MARKER" {
+		return errors.New("invalid binding envelope")
+	}
+	seen := map[string]struct{}{}
+	for _, issue := range observation.Issues {
+		if !jiraKeyPattern.MatchString(issue.Key) {
+			return fmt.Errorf("invalid Jira key %q", issue.Key)
+		}
+		if _, exists := seen[issue.Key]; exists {
+			return fmt.Errorf("duplicate Jira issue %q", issue.Key)
+		}
+		seen[issue.Key] = struct{}{}
+	}
+
+	return nil
+}
+
+func validatePRObservation(observation PRObservation) error {
+	if !validBindingStatus(observation.Status, len(observation.Matches)) {
+		return errors.New("invalid binding envelope")
+	}
+	if len(observation.Matches) == 0 && observation.BindingBasis != "" {
+		return errors.New("unbound PR observation has a binding basis")
+	}
+	seen := map[int]struct{}{}
+	for _, match := range observation.Matches {
+		if match.Number <= 0 || match.BindingBasis != "AI_AUDIT_MARKER" && match.BindingBasis != "JIRA_KEY" ||
+			observation.BindingBasis != match.BindingBasis || match.HeadRef == "" || match.BaseRef == "" ||
+			(match.HeadSHA != "" && !shaPattern.MatchString(match.HeadSHA)) ||
+			(match.BaseSHA != "" && !shaPattern.MatchString(match.BaseSHA)) {
+			return fmt.Errorf("invalid PR match #%d", match.Number)
+		}
+		if _, exists := seen[match.Number]; exists {
+			return fmt.Errorf("duplicate PR #%d", match.Number)
+		}
+		seen[match.Number] = struct{}{}
+	}
+
+	return nil
+}
+
+func validBindingStatus(status string, count int) bool {
+	switch status {
+	case "UNKNOWN":
+		return true
+	case "UNBOUND":
+		return count == 0
+	case "BOUND":
+		return count == 1
+	case "AMBIGUOUS":
+		return count > 1
+	default:
+		return false
+	}
+}
+
+func uniqueNonEmpty(values []string) bool {
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			return false
+		}
+		if _, exists := seen[value]; exists {
+			return false
+		}
+		seen[value] = struct{}{}
+	}
+
+	return true
+}
+
+func validProviderStatus(value string) bool {
+	return value == "FRESH" || value == "STALE" || value == "UNAVAILABLE"
+}
+
+func validState(value string) bool {
+	return slices.Contains([]string{
+		"CONFIRMED_UNASSIGNED", "TRACKED", "PR_OPEN", "PR_CLOSED", "MERGED", "BLOCKED",
+		"SUPERSEDED", "AMBIGUOUS", "BROKEN_BINDING", "NON_DISPATCHABLE",
+	}, value)
+}
+
+func validNextAction(value string) bool {
+	return slices.Contains([]string{
+		"PUBLISH_JIRA_OR_REVIEW_POLICY", "READY_FOR_CLAIM_OR_DISPATCH", "CONTINUE_PR", "VERIFY_RESOLUTION",
+		"NO_ACTION", "HUMAN_DECISION_REQUIRED", "RESOLVE_BINDING", "REFRESH_REQUIRED", "REPAIR_BINDING",
+		"REVIEW_CLOSED_PR", "REQUALIFY_ON_CURRENT_TARGET",
+	}, value)
+}
+
+func validSeverity(value string) bool {
+	return value == "P0" || value == "P1" || value == "P2" || value == "P3"
+}
+
+func validQualification(value string) bool {
+	return value == "CONFIRMED" || value == "LIKELY" || value == "QUESTION" || value == "REJECTED"
+}
+
+func validFreshness(value string) bool {
+	return value == "FRESH" || value == "PARTIAL" || value == "STALE" || value == "UNAVAILABLE"
+}
+
+func campaignID(campaign *Campaign) string {
+	payload := strings.Join([]string{
+		campaignSchemaVersion,
+		campaign.AuditID,
+		campaign.AuditedSHA,
+		campaign.SourceDigests.Audit,
+		campaign.SourceDigests.Qualified,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+
+	return "campaign-" + hex.EncodeToString(sum[:])
+}
+
+func sourceFindingDigest(campaign *Campaign, finding SourceFinding) string {
+	payload := struct {
+		AuditID       string            `json:"auditId"`
+		AuditedSHA    string            `json:"auditedSha"`
+		SourceDigests SourceDigests     `json:"sourceDigests"`
+		ID            string            `json:"id"`
+		Title         string            `json:"title"`
+		Severity      string            `json:"severity"`
+		Qualification string            `json:"qualification"`
+		References    FindingReferences `json:"references"`
+	}{campaign.AuditID, campaign.AuditedSHA, campaign.SourceDigests, finding.ID, finding.Title,
+		finding.Severity, finding.Qualification, finding.References}
+
+	return digestJSON(payload)
+}
+
+func sourceFactsDigest(campaign *Campaign) string {
+	payload := struct {
+		AuditID       string          `json:"auditId"`
+		AuditedSHA    string          `json:"auditedSha"`
+		SourceDigests SourceDigests   `json:"sourceDigests"`
+		Findings      []SourceFinding `json:"findings"`
+	}{campaign.AuditID, campaign.AuditedSHA, campaign.SourceDigests, campaign.SourceFacts.Findings}
+
+	return digestJSON(payload)
+}
+
+func digestJSON(value any) string {
+	content, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("marshal deterministic digest input: %v", err))
+	}
+	sum := sha256.Sum256(content)
+
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/scripts/aicampaign/model.go
+++ b/scripts/aicampaign/model.go
@@ -206,7 +206,7 @@ func (campaign *Campaign) validate() error {
 		!digestPattern.MatchString(campaign.SourceDigests.Qualified) {
 		return errors.New("invalid campaign provenance")
 	}
-	if campaign.SourceFacts.FactType != sourceFactType || len(campaign.SourceFacts.Findings) == 0 {
+	if campaign.SourceFacts.FactType != sourceFactType || campaign.SourceFacts.Findings == nil {
 		return errors.New("invalid source facts")
 	}
 	ids := make(map[string]SourceFinding, len(campaign.SourceFacts.Findings))
@@ -252,7 +252,8 @@ func (campaign *Campaign) validate() error {
 
 func (campaign *Campaign) validateObservations(sourceFindings map[string]SourceFinding) error {
 	observations := campaign.Observations
-	if observations.FactType != observationFactType || !validFreshness(observations.Freshness) {
+	if observations.FactType != observationFactType || observations.Findings == nil ||
+		!validFreshness(observations.Freshness) {
 		return errors.New("invalid observation envelope")
 	}
 	if observations.Freshness != combinedFreshness(observations.Providers) {

--- a/scripts/aicampaign/next.go
+++ b/scripts/aicampaign/next.go
@@ -1,0 +1,28 @@
+package main
+
+func buildNextResult(campaign *Campaign) *NextResult {
+	if campaign.Observations == nil {
+		campaign.Observations = staleObservations(campaign, previousObservations(campaign), "release/v3.0")
+	}
+	inspection := buildInspection(campaign)
+	result := &NextResult{
+		SchemaVersion:      nextSchemaVersion,
+		CampaignID:         campaign.CampaignID,
+		AuditID:            campaign.AuditID,
+		AuditedSHA:         campaign.AuditedSHA,
+		BasedOnRefreshedAt: inspection.RefreshedAt,
+		Freshness:          inspection.Freshness,
+	}
+	for _, finding := range inspection.Findings {
+		result.Findings = append(result.Findings, NextFinding{
+			ID:            finding.ID,
+			Qualification: finding.Qualification,
+			State:         finding.State,
+			NextAction:    finding.NextAction,
+			Blockers:      finding.Blockers,
+			Freshness:     finding.Freshness,
+		})
+	}
+
+	return result
+}

--- a/scripts/aicampaign/next.go
+++ b/scripts/aicampaign/next.go
@@ -12,6 +12,7 @@ func buildNextResult(campaign *Campaign) *NextResult {
 		AuditedSHA:         campaign.AuditedSHA,
 		BasedOnRefreshedAt: inspection.RefreshedAt,
 		Freshness:          inspection.Freshness,
+		Findings:           []NextFinding{},
 	}
 	for _, finding := range inspection.Findings {
 		result.Findings = append(result.Findings, NextFinding{

--- a/scripts/aicampaign/storage.go
+++ b/scripts/aicampaign/storage.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func readStrictJSON(path string, destination any) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a non-symlink regular file", path)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := rejectDuplicateObjectKeys(content); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("decode %s: trailing JSON value", path)
+	}
+
+	return content, nil
+}
+
+func rejectDuplicateObjectKeys(content []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	var walk func() error
+	walk = func() error {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		delimiter, ok := token.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch delimiter {
+		case '{':
+			keys := map[string]struct{}{}
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("object key is not a string")
+				}
+				if _, exists := keys[key]; exists {
+					return fmt.Errorf("duplicate object key %q", key)
+				}
+				keys[key] = struct{}{}
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+
+			return err
+		case '[':
+			for decoder.More() {
+				if err := walk(); err != nil {
+					return err
+				}
+			}
+			_, err = decoder.Token()
+
+			return err
+		default:
+			return fmt.Errorf("unexpected delimiter %q", delimiter)
+		}
+	}
+	if err := walk(); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("trailing JSON value")
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func loadCampaign(path string) (*Campaign, error) {
+	var campaign Campaign
+	if _, err := readStrictJSON(path, &campaign); err != nil {
+		return nil, err
+	}
+	if err := campaign.validate(); err != nil {
+		return nil, fmt.Errorf("invalid campaign state: %w", err)
+	}
+
+	return &campaign, nil
+}
+
+func writeCampaign(path string, campaign *Campaign) error {
+	if err := campaign.validate(); err != nil {
+		return fmt.Errorf("refusing malformed campaign state: %w", err)
+	}
+	content, err := json.MarshalIndent(campaign, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal campaign: %w", err)
+	}
+	content = append(content, '\n')
+
+	return atomicWrite(path, content)
+}
+
+func atomicWrite(path string, content []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return fmt.Errorf("create campaign directory: %w", err)
+	}
+	parent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return fmt.Errorf("resolve campaign directory: %w", err)
+	}
+	base := filepath.Base(path)
+	if !filepath.IsLocal(base) || base == "." {
+		return errors.New("campaign filename must be local to its destination directory")
+	}
+	if info, err := os.Lstat(filepath.Join(parent, base)); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return errors.New("campaign destination must be a non-symlink regular file")
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect campaign destination: %w", err)
+	}
+	root, err := os.OpenRoot(parent)
+	if err != nil {
+		return fmt.Errorf("anchor campaign directory: %w", err)
+	}
+	defer func() {
+		_ = root.Close() // Best effort after the result has already been determined.
+	}()
+	temporary, temporaryName, err := createTemporary(root)
+	if err != nil {
+		return fmt.Errorf("create campaign temporary file: %w", err)
+	}
+	cleanup := func() {
+		_ = temporary.Close()          // Best effort cleanup.
+		_ = root.Remove(temporaryName) // Best effort cleanup.
+	}
+	if err := temporary.Chmod(0o600); err != nil {
+		cleanup()
+
+		return fmt.Errorf("set campaign file mode: %w", err)
+	}
+	if _, err := temporary.Write(content); err != nil {
+		cleanup()
+
+		return fmt.Errorf("write campaign: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		cleanup()
+
+		return fmt.Errorf("sync campaign: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		_ = root.Remove(temporaryName) // Best effort cleanup.
+
+		return fmt.Errorf("close campaign: %w", err)
+	}
+	if err := root.Rename(temporaryName, base); err != nil {
+		_ = root.Remove(temporaryName) // Best effort cleanup.
+
+		return fmt.Errorf("publish campaign: %w", err)
+	}
+	directory, err := os.Open(parent)
+	if err != nil {
+		return fmt.Errorf("open campaign directory for sync: %w", err)
+	}
+	defer func() {
+		_ = directory.Close() // Best effort after the result has already been determined.
+	}()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync campaign directory: %w", err)
+	}
+
+	return nil
+}
+
+func createTemporary(root *os.Root) (*os.File, string, error) {
+	for range 100 {
+		random := make([]byte, 16)
+		if _, err := rand.Read(random); err != nil {
+			return nil, "", fmt.Errorf("generate temporary filename: %w", err)
+		}
+		name := ".ai-campaign-" + hex.EncodeToString(random) + ".tmp"
+		file, err := root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return file, name, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, "", err
+		}
+	}
+
+	return nil, "", errors.New("could not allocate a unique temporary filename")
+}
+
+func repositoryRoot() (string, error) {
+	command := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	return filepath.EvalSymlinks(strings.TrimSpace(string(output)))
+}
+
+func validateCampaignDestination(repoRoot, path string, createParent bool) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve output path: %w", err)
+	}
+	parent := filepath.Dir(absolute)
+	buildRoot := filepath.Join(repoRoot, "build")
+	if pathWithin(absolute, repoRoot) && !pathWithin(absolute, buildRoot) {
+		return "", errors.New("repository-local campaign state must be stored under build/")
+	}
+
+	probe := parent
+	missing := []string{}
+	for {
+		info, statErr := os.Stat(probe)
+		if statErr == nil && info.IsDir() {
+			break
+		}
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("inspect output ancestor: %w", statErr)
+		}
+		next := filepath.Dir(probe)
+		if next == probe {
+			return "", errors.New("output path has no existing ancestor")
+		}
+		missing = append([]string{filepath.Base(probe)}, missing...)
+		probe = next
+	}
+	physicalProbe, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		return "", fmt.Errorf("resolve output ancestor: %w", err)
+	}
+	physicalParentCandidate := physicalProbe
+	for _, component := range missing {
+		physicalParentCandidate = filepath.Join(physicalParentCandidate, component)
+	}
+	physicalCandidate := filepath.Join(physicalParentCandidate, filepath.Base(absolute))
+	if pathWithin(physicalCandidate, repoRoot) && !pathWithin(physicalCandidate, buildRoot) {
+		return "", errors.New("repository-local campaign state must be stored under build/")
+	}
+	if !createParent && len(missing) > 0 {
+		return "", errors.New("campaign directory does not exist")
+	}
+
+	if createParent {
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			return "", fmt.Errorf("create output directory: %w", err)
+		}
+	}
+	physicalParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", fmt.Errorf("resolve output directory: %w", err)
+	}
+	physical := filepath.Join(physicalParent, filepath.Base(absolute))
+	insideRepository := pathWithin(physical, repoRoot)
+	if !insideRepository {
+		return physical, nil
+	}
+	if !pathWithin(physical, buildRoot) {
+		return "", errors.New("repository-local campaign state must be stored under build/")
+	}
+	command := exec.Command("git", "-C", repoRoot, "check-ignore", "-q", "--", physical)
+	if err := command.Run(); err != nil {
+		return "", errors.New("repository-local campaign state must be ignored by Git")
+	}
+
+	return physical, nil
+}
+
+func pathWithin(path, root string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+
+	return relative == "." || (filepath.IsLocal(relative) && relative != "..")
+}

--- a/scripts/codex-audit-challenge.schema.json
+++ b/scripts/codex-audit-challenge.schema.json
@@ -6,6 +6,7 @@
   "properties": {
     "audit_id": {"type": "string", "minLength": 1},
     "head": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},
+    "sourceAuditDigest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
     "summary": {"type": "string"},
     "results": {
       "type": "array",


### PR DESCRIPTION
## Summary

- add strict `ai-campaign/v1` import for native audit and qualified challenge artifacts
- preserve every qualification status while limiting dispatch eligibility to `CONFIRMED`
- cache read-only GitHub, Jira, and Git observations with explicit freshness
- project conservative finding states and mechanically safe next actions
- emit concise human output on stderr and stable JSON on stdout

## Product / operational motivation

Need: qualified audit work must remain coordinatable across interrupted agent sessions without making a local cache authoritative over GitHub, Jira, Git, or native audit artifacts.

Current limitation: the audit/challenge/Jira tools operate on individual artifacts, with no durable per-finding projection or safe next-transition view.

Requirement / constraint: import must be provenance-bound and complete; external state must be refreshed or marked stale; ambiguous bindings must remain ambiguous; non-confirmed findings must never become fix-ready.

Evidence: CAMPAIGN_SCHEMA_AND_INSPECT milestone and the current native audit, challenge, Jira marker, review binding, and target-revalidation contracts.

Durable repository evidence: `docs/technical/contributing/ai-campaign.md` and `scripts/ai-campaign.schema.json`.

## Technical decision

Decision: store one atomic, ignored/local JSON campaign artifact that separates immutable source facts from derived observations. Reuse the exact `AI-AUDIT:<finding-id>` marker and allow only conservative exact Jira-key fallback for historical PRs.

Why proportionate: this is the smallest inspectable state layer that survives session loss and remains suitable for later claims without introducing a service, remote refs, mutation commands, or a readiness engine.

Alternatives considered: infer state on every run without storage, which loses offline history; store state in candidate commits, which mixes coordination with product history; add remote claims now, which is explicitly deferred.

## Validation

- pinned Nix Go 1.26.5
- focused campaign, audit schema, challenge, and Jira marker suites
- complete `go test ./scripts/...`
- complete `go test -race ./... -timeout 20m`
- repository invariants
- clean `bash scripts/agent-check` runs with hermetic writable caches after each final fix
- ambiguity mutation sensitivity: PASS
- exact Codex review: APPROVE, zero findings, LOW residual risk at `c291a6c7394a68d85f7b2c0287a4d6cb2e3026e7`
- NumaryBot: no findings at the same exact head
- fresh CI: 15 successful, 2 intentionally skipped, 0 pending/failing
- target base revalidation: UNCHANGED at `c3139990c13108e0d1a4339323ca16a5cca209ab`

## Non-goals

No distributed claims, leases, dispatch, PR-binding mutation, publication resume/events, merge, Jira mutation, composite readiness, or shared structured failure envelope.

This PR must not be merged automatically.
