### PR TITLE
feat(tooling): add atomic finding claims

### DIFF
--- a/docs/technical/agent-context.md
+++ b/docs/technical/agent-context.md
@@ -43,6 +43,7 @@ When current code and authoritative documentation disagree, stop treating the do
 | `internal/bootstrap/**` | `docs/technical/architecture/overview.md`, relevant subsystem docs, and `docs/ops/deployment.md` for persisted/config behavior |
 | tests only | `docs/technical/contributing/testing.md` plus the subsystem documentation for the behavior under test |
 | contributor/build tooling | `docs/technical/contributing/getting-started.md`, `docs/technical/contributing/development.md`, `docs/technical/contributing/conventions.md` as relevant |
+| `scripts/aicampaign/**`, `scripts/ai-campaign*` | `docs/technical/contributing/ai-campaign.md`, `docs/technical/contributing/testing.md`; also `docs/technical/contributing/product-technical-traceability.md` for distributed coordination semantics |
 
 If a touched production area has no matching row, do not assume that no subsystem rules apply. Identify its callers/callees or owning subsystem first, then load that subsystem's documentation before editing.
 

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -2,10 +2,11 @@
 
 `scripts/ai-campaign` is a deterministic coordination and projection layer over
 qualified native audit results. It preserves immutable audit provenance, caches
-external observations, and reports the mechanically next valid workflow
-transition. It does not perform engineering reasoning, choose product priority,
-fix findings, publish issues, dispatch agents, mutate pull-request bindings, or
-merge pull requests.
+external observations, reports the mechanically next valid workflow transition,
+and coordinates exclusive finding ownership through remote Git claim leases. It
+does not perform engineering reasoning, choose product priority, fix findings,
+publish issues, dispatch agents, mutate pull-request bindings, or merge pull
+requests.
 
 ## Motivation and boundary
 
@@ -14,19 +15,26 @@ optionally, independently published Jira issues. That does not give an
 interrupted agent or operator one durable, machine-readable view of every
 qualification and its current external bindings.
 
-The campaign artifact provides that local coordination view. It is
+The campaign artifact provides that local projection view. It is
 operational/informational state, not Ledger product state or a source of business
 truth. GitHub, Jira, Git, and the native audit/challenge artifacts remain
 authoritative. A campaign can derive and cache observations from them; it cannot
 override them or manually advance externally derived state.
+
+The remote claim ref is the exclusivity authority. Campaign JSON is only a local
+cache and never proves ownership. A session may begin or continue engineering
+work only after it has successfully acquired or renewed the corresponding remote
+claim. Claims coordinate ownership; they do not qualify findings, prove a branch
+or PR correct, authorize merge, or override GitHub, Jira, Git ancestry, or review
+and validation results.
 
 The v1 storage model is one JSON file. By default it is written below ignored
 `build/ai-campaign/`, so it survives an agent session without entering a
 candidate/product commit. An explicit destination outside the repository is also
 allowed. Repository-local destinations outside ignored `build/` are rejected.
 Writes use a directory-anchored temporary file, file sync, atomic rename, and
-directory sync. This is proportionate local durability and a human-inspectable
-base for later distributed claims without implementing a claim protocol now.
+directory sync. This is proportionate local durability, but it is not a
+distributed lock and is never used as an ownership fallback.
 
 ## Import
 
@@ -71,18 +79,110 @@ The artifact separates:
   artifacts, and per-finding/source-set identity digests;
 - `observations` (`DERIVED_OBSERVATION`): refresh time, provider freshness,
   target SHA, exact bindings, projected states, blockers, and next actions;
-- local/imported bindings: none in v1. There is deliberately no binding mutation
-  command. A future explicit binding must use a distinct
-  `LOCAL_IMPORTED_BINDING` class rather than masquerading as external truth.
+- claim observations: cached remote ownership, lease, and optional work-branch
+  binding. They remain derived observations rather than imported facts.
 
 Stable digest-plus-JSON-pointer references preserve original invariant and
 challenge-summary identity without copying arbitrary prose into campaign state.
 The native artifacts remain the content source.
 
+## Remote claim backend
+
+One finding maps deterministically to:
+
+```text
+refs/heads/ai-claims/v1/<sha256("ai-claim-ref/v1" NUL auditId NUL findingId)>
+```
+
+The `refs/heads` namespace is used because GitHub reliably advertises and accepts
+atomic updates to branch refs. Arbitrary top-level namespaces such as
+`refs/ai-claims/*` are not a portable GitHub coordination interface. The fixed
+`ai-claims/v1/` prefix is reserved for coordination; it must never be used for a
+product or work branch, and claim refs are not intended for pull requests or
+merge. The hash input comes only from validated campaign identity fields, never
+from a candidate-provided ref name. It intentionally excludes source digests:
+re-importing the same human finding ID with changed qualified evidence reaches
+the same ref and is rejected as an identity conflict rather than creating a
+second ownership lane.
+
+Each ref points to a Git commit whose tree contains only `claim.json`. Initial
+claims are parentless. Renewal and takeover commits have the exact prior claim
+commit as their sole parent, leaving an inspectable object history. The record
+schema is [`scripts/ai-claim.schema.json`](../../../scripts/ai-claim.schema.json)
+and binds the campaign, audit and finding IDs, per-finding and qualified-result
+digests, audited SHA, `CONFIRMED` qualification, claimant, lease times, target
+branch/SHA, optional work branch, renewal metadata, and takeover predecessor.
+Unknown fields, duplicate JSON keys, malformed trees, multiple parents,
+unsupported versions, and identity mismatches fail closed.
+Renewal/takeover transitions are checked against their parent record, and a
+cached previously observed SHA must remain an ancestor of a changed live ref;
+an external history rewrite becomes `CLAIM_HISTORY_REWRITTEN` / `AMBIGUOUS`.
+
+Create pushes use `--force-with-lease=<ref>:`: the empty expected value requires
+the ref not to exist. Renewal and takeover use
+`--force-with-lease=<ref>:<observed-sha>`, and release uses the same exact lease
+for deletion. A preliminary `ls-remote` is observation only; exclusivity comes
+from the push compare-and-swap. Two clones may both observe absence, but only one
+can create the ref. No local lock or remote-tracking ref is authoritative.
+
+## Claim, renew, release, and takeover
+
+```sh
+bash scripts/ai-campaign claim <campaign> --finding <audit-id/finding-id> \
+  [--claimant <session-id>] [--lease 24h] [--work-branch <branch>]
+
+bash scripts/ai-campaign renew <campaign> --finding <audit-id/finding-id> \
+  --claimant <session-id> [--lease 24h] [--work-branch <branch>] \
+  [--expected-claim-sha <sha>]
+
+bash scripts/ai-campaign release <campaign> --finding <audit-id/finding-id> \
+  --claimant <session-id> [--expected-claim-sha <sha>]
+
+bash scripts/ai-campaign takeover <campaign> --finding <audit-id/finding-id> \
+  [--claimant <new-session-id>] [--lease 24h] \
+  [--expected-claim-sha <sha>]
+```
+
+Only an immutable imported `CONFIRMED` finding is claimable. Claim also requires
+the freshly observed target branch SHA to equal the campaign's audited SHA. A
+`LIKELY`, `QUESTION`, or `REJECTED` finding is refused even when Jira or PR
+evidence exists. The optional work branch is a claim binding only; these commands
+never create a branch or mutate a PR binding. `renew --work-branch` can add or
+replace that binding through the same exact-SHA CAS.
+
+The default lease is 24 hours. Explicit leases must be from one hour through
+seven days. Times are client-observed UTC values. Inspection and takeover treat
+a claim as expired only after `expiresAt` plus a five-minute skew allowance; the
+allowance can delay takeover but cannot make a live claim stealable. A clock that
+appears to precede claim creation fails conservatively. Expiry never steals or
+deletes a claim automatically. The owner must explicitly renew/release it, or a
+new session must explicitly take it over. Takeover preserves the prior SHA,
+claimant, creation/expiry times, and `EXPIRED_TAKEOVER` reason in `predecessor`.
+
+When `--claimant` is omitted for claim/takeover, the tool generates a
+human-readable non-secret value from sanitized user and machine labels plus 128
+random bits. Set `AI_CAMPAIGN_CLAIMANT` once per task or pass the emitted claimant
+to subsequent commands. Renew and release require an exact claimant match. A
+recovered session may assume the same textual claimant and renew the exact claim;
+this is operational recovery, not cryptographic identity proof. Repository write
+authentication remains the security boundary, and remote commit/ref audit data
+is the evidence of who performed an update. Do not put tokens, email addresses,
+or other secrets in claimant IDs.
+
+Structured mutation outcomes include `CLAIMED`, `ALREADY_CLAIMED`,
+`CLAIM_EXPIRED`, `CLAIM_CONFLICT`, `FINDING_NOT_CLAIMABLE`,
+`BROKEN_CAMPAIGN_BINDING`, `RENEWED`, `RELEASED`, `TAKEN_OVER`, `NOT_OWNER`,
+`CLAIM_CHANGED`, `CLAIM_MISSING`, `HUMAN_DECISION_REQUIRED`, and
+`REMOTE_UNAVAILABLE`. An ambiguous push response is re-observed when possible;
+the tool does not claim success unless it can prove the outcome. If the remote
+cannot be reached, claim, renew, release, and takeover perform no local fallback
+and report `REMOTE_UNAVAILABLE`.
+
 ## Inspect
 
 ```sh
 bash scripts/ai-campaign inspect build/ai-campaign/<campaign-id>.json
+bash scripts/ai-campaign inspect build/ai-campaign/<campaign-id>.json --claimant "$AI_CAMPAIGN_CLAIMANT"
 bash scripts/ai-campaign inspect build/ai-campaign/<campaign-id>.json --offline
 ```
 
@@ -91,23 +191,36 @@ Live inspection queries:
 - GitHub for PR state, current head, base, merge state, current review decision,
   and check summary;
 - Jira for issue existence, status, and assignee;
-- Git for the current `release/v3.0` target and same-repository PR branch refs.
+- Git for remote claim records, the current `release/v3.0` target,
+  same-repository PR branches, and claim-bound work branches.
 
 The defaults are `formancehq/ledger`, `EN`, `origin`, and `release/v3.0`; the
-command exposes read-only overrides. The campaign never treats current reviews
+command exposes read-only overrides. `--claimant` (or
+`AI_CAMPAIGN_CLAIMANT`) lets inspection distinguish this session from another
+live claimant. The campaign never treats current reviews
 or checks as an exact-current readiness verdict. It does not recreate the
 publication/readiness engine.
 
 Every provider records `FRESH`, `STALE`, or `UNAVAILABLE` plus its observation
 time and a concise failure. Campaign/finding freshness is `FRESH`, `PARTIAL`,
 `STALE`, or `UNAVAILABLE`. When a live provider fails, cached values remain
-visible but the affected binding status becomes `UNKNOWN`. `--offline` performs
+visible but the affected binding/claim status becomes `UNKNOWN`. `--offline` performs
 no external calls and marks cached observations stale. A confirmed finding never
 reports a readiness-like next action from partial, stale, or unavailable
 external truth; its next action is `REFRESH_REQUIRED`.
 
 `refreshedAt` is the last time at least one external provider refreshed data. It
 is not advanced by a wholly offline/unavailable inspection.
+
+Every finding exposes `claim.state`, `claimant`, `createdAt`, `expiresAt`,
+`remoteRef`, `workBranch`, `observedClaimSha`, `freshness`,
+`ownedBySession`, and a concise integrity problem when applicable. A missing ref
+is unassigned only after a successful remote refresh. When refresh fails, cached
+claim information is retained as stale/unknown and the finding requires refresh.
+A previously observed claim that disappears outside the explicit local release
+path becomes `CLAIM_HISTORY_MISSING`; it is not silently projected as safe to
+claim. A missing bound work branch becomes `BROKEN_BINDING` and never releases
+the claim.
 
 ## Exact binding markers
 
@@ -138,11 +251,13 @@ the audit finding is fixed.
 | `NON_DISPATCHABLE` | Qualification is `LIKELY`, `QUESTION`, or `REJECTED`. |
 | `CONFIRMED_UNASSIGNED` | Confirmed, current audit target, no Jira or PR binding. |
 | `TRACKED` | Confirmed, current audit target, exactly one Jira issue, no PR. |
+| `CLAIMED` | One valid live remote claim exists; ownership may be this session or another. |
+| `CLAIM_EXPIRED` | The valid remote claim is beyond expiry plus the skew allowance and needs explicit disposition. |
 | `PR_OPEN` | Exactly one bound PR is open and its branch/head binding is intact. |
 | `PR_CLOSED` | Exactly one bound PR is closed without merge. |
 | `MERGED` | Exactly one bound PR is merged; resolution still needs verification. |
-| `AMBIGUOUS` | Multiple exact Jira or PR bindings exist. |
-| `BROKEN_BINDING` | A bound unmerged PR has an unknown state or missing branch/head ref. |
+| `AMBIGUOUS` | Multiple exact Jira/PR bindings, a malformed/conflicting claim, or missing prior claim history prevents a safe projection. |
+| `BROKEN_BINDING` | A bound unmerged PR or claim work branch is missing/unknown. |
 | `BLOCKED` | Current target identity is unavailable or advanced without a bound PR. |
 | `SUPERSEDED` | Reserved for a future externally evidenced supersession contract. |
 
@@ -168,8 +283,10 @@ mechanically safe workflow transition per finding from cached state:
 
 | Condition | `nextAction` |
 |---|---|
-| Confirmed, no Jira or PR | `PUBLISH_JIRA_OR_REVIEW_POLICY` |
-| Confirmed, Jira, no PR | `READY_FOR_CLAIM_OR_DISPATCH` |
+| Confirmed and freshly unclaimed | `CLAIM` |
+| Live claim owned by current session | `CONTINUE_CLAIMED_WORK` |
+| Live claim owned by another session | `WAIT_OR_COORDINATE` |
+| Expired claim | `REVIEW_EXPIRED_CLAIM` |
 | Open PR | `CONTINUE_PR` |
 | Merged PR | `VERIFY_RESOLUTION` |
 | Closed unmerged PR | `REVIEW_CLOSED_PR` |
@@ -180,9 +297,9 @@ mechanically safe workflow transition per finding from cached state:
 | `QUESTION` | `HUMAN_DECISION_REQUIRED` |
 | `LIKELY` or `REJECTED` | `NO_ACTION` |
 
-`READY_FOR_CLAIM_OR_DISPATCH` is a label for the next future workflow phase, not
-a claim, dispatch, priority decision, or authorization to write. The command
-does not rank unrelated findings.
+`CLAIM` is an instruction to attempt the remote compare-and-swap, not proof that
+ownership was acquired. The command does not dispatch or rank unrelated
+findings.
 
 ## Output contract
 
@@ -190,12 +307,48 @@ Every command writes a concise human summary to stderr and stable structured
 JSON to stdout. This keeps interactive use readable while letting future agents
 consume stdout without scraping prose. Inspection JSON includes campaign/audit
 identity, source digests, refresh/freshness data, provider status, and structured
-finding identity, severity, qualification, state, Jira/PR details, observed
+finding identity, severity, qualification, state, Jira/PR/claim details, observed
 candidate/target SHAs, blockers, next action, freshness, and confidence.
+
+## Failure, cleanup, and trust boundaries
+
+Network partitions are conservative. Inspection may show cached claim data, but
+it never turns an unavailable claim provider into `UNCLAIMED`. Mutations fail
+with `REMOTE_UNAVAILABLE` or, when a concurrent/ambiguous update is observed,
+`CLAIM_CHANGED`. Operators must refresh and inspect the exact remote SHA before
+retrying. No unpublished work done before claim acquisition, or in a disconnected
+clone that never acquired a claim, can be discovered perfectly. Claims prevent
+duplicate work only after successful acquisition.
+
+Explicit release deletes the ref by exact-SHA CAS and is sufficient cleanup for
+this milestone. The local campaign cache is cleared after proven release when it
+can be written safely. A merged PR does not automatically release a claim, and
+abandoned claims remain visible until explicit release or expired takeover.
+Later reconciliation may clean terminal claims, but no such automation exists
+here.
+
+Claim mutation tooling is policy code. Invoke `scripts/ai-campaign` from a clean,
+base-pinned trusted-tool worktree, even when the campaign file or candidate work
+branch is elsewhere. The launcher resolves its Go package relative to the script
+itself so an absolute base-pinned invocation does not silently switch to the
+candidate's package. Candidate comments, campaign prose, work branch contents,
+and arbitrary remote JSON are untrusted data and must not choose mutation code or
+ref names.
+
+CAS prevents two conforming clients from both winning, but it cannot stop a
+repository administrator or another writer from force-updating the namespace.
+External rewrites are detected on the next exact observation; malformed or
+identity-conflicting content fails closed. Claimant strings are diagnostic and
+can be spoofed by a writer with repository permission, so repository Git
+authentication and audit logs remain authoritative. The design relies on
+SHA-256 collision resistance for the finding lane and on Git object-hash
+collision resistance for exact CAS. No branch-protection or ruleset changes are
+made by this tooling.
 
 ## Explicit non-goals
 
-This milestone does not implement distributed claims, claim leases, dispatch,
-PR-binding mutation, publication resume/events, merge, Jira mutation, composite
-exact-SHA readiness, or a shared structured failure envelope. Those require
-separate contracts and trust reviews.
+This milestone does not implement confirmed-finding dispatch, automatic
+branch/worktree creation, PR-binding mutation, publication resume/events,
+automatic merge, Jira mutation, composite exact-SHA readiness, a shared
+structured failure envelope, or automatic terminal reconciliation. Those
+require separate contracts and trust reviews.

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -129,23 +129,28 @@ can create the ref. No local lock or remote-tracking ref is authoritative.
 
 ```sh
 bash scripts/ai-campaign claim <campaign> --finding <audit-id/finding-id> \
-  [--claimant <session-id>] [--lease 24h] [--work-branch <branch>]
+  [--claimant <session-id>] [--lease 24h] [--work-branch <branch>] \
+  [--target release/v3.0]
 
 bash scripts/ai-campaign renew <campaign> --finding <audit-id/finding-id> \
   --claimant <session-id> [--lease 24h] [--work-branch <branch>] \
-  [--expected-claim-sha <sha>]
+  [--expected-claim-sha <sha>] [--target release/v3.0]
 
 bash scripts/ai-campaign release <campaign> --finding <audit-id/finding-id> \
-  --claimant <session-id> [--expected-claim-sha <sha>]
+  --claimant <session-id> [--expected-claim-sha <sha>] \
+  [--target release/v3.0]
 
 bash scripts/ai-campaign takeover <campaign> --finding <audit-id/finding-id> \
   [--claimant <new-session-id>] [--lease 24h] \
-  [--expected-claim-sha <sha>]
+  [--expected-claim-sha <sha>] [--target release/v3.0]
 ```
 
 Only an immutable imported `CONFIRMED` finding is claimable. Claim also requires
-the freshly observed target branch SHA to equal the campaign's audited SHA. A
-`LIKELY`, `QUESTION`, or `REJECTED` finding is refused even when Jira or PR
+the freshly observed target branch SHA to equal the campaign's audited SHA.
+Every read and mutation requires the record's target branch and SHA to match the
+active `--target` and campaign audited SHA; another branch pointing at the same
+commit is still a distinct claim binding. A `LIKELY`, `QUESTION`, or `REJECTED`
+finding is refused even when Jira or PR
 evidence exists. The optional work branch is a claim binding only; these commands
 never create a branch or mutate a PR binding. `renew --work-branch` can add or
 replace that binding through the same exact-SHA CAS.

--- a/scripts/ai-campaign
+++ b/scripts/ai-campaign
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root=$(git rev-parse --show-toplevel)
+script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+repo_root=$(git -C "$script_root" rev-parse --show-toplevel)
 exec env -u GOROOT go run "$repo_root/scripts/aicampaign" "$@"

--- a/scripts/ai-campaign.schema.json
+++ b/scripts/ai-campaign.schema.json
@@ -108,11 +108,12 @@
     "providers": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["github", "jira", "git"],
+      "required": ["github", "jira", "git", "claims"],
       "properties": {
         "github": { "$ref": "#/$defs/provider" },
         "jira": { "$ref": "#/$defs/provider" },
-        "git": { "$ref": "#/$defs/provider" }
+        "git": { "$ref": "#/$defs/provider" },
+        "claims": { "$ref": "#/$defs/provider" }
       }
     },
     "jiraIssue": {
@@ -189,6 +190,7 @@
         "state",
         "jira",
         "pr",
+        "claim",
         "observedCandidateSha",
         "observedTargetSha",
         "blockers",
@@ -210,18 +212,23 @@
             "SUPERSEDED",
             "AMBIGUOUS",
             "BROKEN_BINDING",
+            "CLAIMED",
+            "CLAIM_EXPIRED",
             "NON_DISPATCHABLE"
           ]
         },
         "jira": { "$ref": "#/$defs/jira" },
         "pr": { "$ref": "#/$defs/pr" },
+        "claim": { "$ref": "#/$defs/claim" },
         "observedCandidateSha": { "type": "string" },
         "observedTargetSha": { "type": "string" },
         "blockers": { "type": "array", "items": { "type": "string", "minLength": 1 } },
         "nextAction": {
           "enum": [
-            "PUBLISH_JIRA_OR_REVIEW_POLICY",
-            "READY_FOR_CLAIM_OR_DISPATCH",
+            "CLAIM",
+            "CONTINUE_CLAIMED_WORK",
+            "WAIT_OR_COORDINATE",
+            "REVIEW_EXPIRED_CLAIM",
             "CONTINUE_PR",
             "VERIFY_RESOLUTION",
             "NO_ACTION",
@@ -235,6 +242,45 @@
         },
         "freshness": { "$ref": "#/$defs/freshness" },
         "confidence": { "enum": ["HIGH", "MEDIUM", "LOW"] }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "claimant",
+        "createdAt",
+        "expiresAt",
+        "remoteRef",
+        "workBranch",
+        "observedClaimSha",
+        "freshness",
+        "ownedBySession",
+        "problem"
+      ],
+      "properties": {
+        "state": {
+          "enum": [
+            "UNCLAIMED",
+            "CLAIMED",
+            "CLAIM_EXPIRED",
+            "BROKEN_BINDING",
+            "AMBIGUOUS",
+            "CLAIM_HISTORY_MISSING",
+            "UNKNOWN",
+            "NON_CLAIMABLE"
+          ]
+        },
+        "claimant": { "type": "string" },
+        "createdAt": { "$ref": "#/$defs/nullableTime" },
+        "expiresAt": { "$ref": "#/$defs/nullableTime" },
+        "remoteRef": { "type": "string", "pattern": "^refs/heads/ai-claims/v1/[0-9a-f]{64}$" },
+        "workBranch": { "type": "string" },
+        "observedClaimSha": { "type": "string" },
+        "freshness": { "enum": ["FRESH", "STALE", "UNAVAILABLE"] },
+        "ownedBySession": { "type": "boolean" },
+        "problem": { "type": "string" }
       }
     },
     "observations": {

--- a/scripts/ai-claim.schema.json
+++ b/scripts/ai-claim.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://formance.com/schemas/ai-claim/v1",
+  "title": "Ledger AI finding claim v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "campaignId",
+    "auditId",
+    "findingId",
+    "findingIdentityDigest",
+    "sourceQualifiedDigest",
+    "auditedSha",
+    "qualification",
+    "claimant",
+    "createdAt",
+    "expiresAt",
+    "targetBranch",
+    "targetSha",
+    "workBranch",
+    "renewedAt",
+    "renewalCount",
+    "predecessor"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "ai-claim/v1" },
+    "campaignId": { "type": "string", "pattern": "^campaign-[0-9a-f]{64}$" },
+    "auditId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+    "findingId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*/[a-z0-9]+(-[a-z0-9]+)*$" },
+    "findingIdentityDigest": { "$ref": "#/$defs/digest" },
+    "sourceQualifiedDigest": { "$ref": "#/$defs/digest" },
+    "auditedSha": { "$ref": "#/$defs/sha" },
+    "qualification": { "const": "CONFIRMED" },
+    "claimant": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._@:/+#=-]{2,159}$" },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "expiresAt": { "type": "string", "format": "date-time" },
+    "targetBranch": { "type": "string", "minLength": 1 },
+    "targetSha": { "$ref": "#/$defs/sha" },
+    "workBranch": { "type": "string" },
+    "renewedAt": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "format": "date-time" }
+      ]
+    },
+    "renewalCount": { "type": "integer", "minimum": 0 },
+    "predecessor": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/predecessor" }
+      ]
+    }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "predecessor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["claimSha", "claimant", "createdAt", "expiresAt", "reason"],
+      "properties": {
+        "claimSha": { "$ref": "#/$defs/sha" },
+        "claimant": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._@:/+#=-]{2,159}$" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "expiresAt": { "type": "string", "format": "date-time" },
+        "reason": { "const": "EXPIRED_TAKEOVER" }
+      }
+    }
+  }
+}

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -218,6 +218,34 @@ func TestInspectOfflineGitHubNeverReportsReady(t *testing.T) {
 	require.NotEqual(t, "READY_FOR_CLAIM_OR_DISPATCH", inspection.Findings[0].NextAction)
 }
 
+func TestClaimedFindingStillHonorsFreshnessAndTargetGates(t *testing.T) {
+	t.Parallel()
+
+	campaign := testCampaign("CONFIRMED")
+	source := campaign.SourceFacts.Findings[0]
+	createdAt := testNow.Add(-time.Hour)
+	expiresAt := testNow.Add(defaultClaimLease)
+	claim := ClaimObservation{
+		State: "CLAIMED", Claimant: testClaimantA, CreatedAt: &createdAt, ExpiresAt: &expiresAt,
+		RemoteRef: claimRef(campaign.AuditID, source.ID), ObservedClaimSHA: strings.Repeat("c", 40),
+		Freshness: "FRESH", OwnedBySession: true,
+	}
+	providerUnavailable := runFakeInspection(campaign, fakeObservations{
+		claims: map[string]ClaimObservation{source.ID: claim}, githubError: errors.New("offline"),
+	})
+	require.Equal(t, "CLAIMED", providerUnavailable.Findings[0].State)
+	require.Equal(t, "REFRESH_REQUIRED", providerUnavailable.Findings[0].NextAction)
+
+	campaign = testCampaign("CONFIRMED")
+	source = campaign.SourceFacts.Findings[0]
+	claim.RemoteRef = claimRef(campaign.AuditID, source.ID)
+	targetAdvanced := runFakeInspection(campaign, fakeObservations{
+		claims: map[string]ClaimObservation{source.ID: claim}, targetSHA: strings.Repeat("a", 40),
+	})
+	require.Equal(t, "BLOCKED", targetAdvanced.Findings[0].State)
+	require.Equal(t, "REQUALIFY_ON_CURRENT_TARGET", targetAdvanced.Findings[0].NextAction)
+}
+
 func TestInspectOfflineJiraMarksStatusUnknown(t *testing.T) {
 	t.Parallel()
 
@@ -420,6 +448,8 @@ type fakeObservations struct {
 	jiraError       error
 	githubError     error
 	gitError        error
+	claimError      error
+	claims          map[string]ClaimObservation
 	targetSHA       string
 	missingBranches bool
 }
@@ -440,7 +470,7 @@ func runFakeInspection(campaign *Campaign, observations fakeObservations) *Inspe
 		jira:   fakeJiraProvider{issues: observations.jira, err: observations.jiraError},
 		github: fakeGitHubProvider{pullRequests: observations.pullRequests, err: observations.githubError},
 		git:    fakeGitProvider{refs: refs, err: observations.gitError},
-		claims: fakeClaimProvider{},
+		claims: fakeClaimProvider{values: observations.claims, err: observations.claimError},
 	}
 
 	return runner.run(context.Background(), campaign, inspectOptions{

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -232,7 +232,7 @@ func TestOfflineInspectUsesStaleCache(t *testing.T) {
 
 	campaign := testCampaign("CONFIRMED")
 	first := runFakeInspection(campaign, fakeObservations{jira: []JiraIssue{{Key: "EN-41", Status: "Open"}}})
-	require.Equal(t, "READY_FOR_CLAIM_OR_DISPATCH", first.Findings[0].NextAction)
+	require.Equal(t, "CLAIM", first.Findings[0].NextAction)
 	stale := (inspector{}).run(context.Background(), campaign, inspectOptions{target: testTarget, offline: true})
 	require.Equal(t, "STALE", stale.Freshness)
 	require.Equal(t, "EN-41", stale.Findings[0].Jira.Issues[0].Key)
@@ -440,6 +440,7 @@ func runFakeInspection(campaign *Campaign, observations fakeObservations) *Inspe
 		jira:   fakeJiraProvider{issues: observations.jira, err: observations.jiraError},
 		github: fakeGitHubProvider{pullRequests: observations.pullRequests, err: observations.githubError},
 		git:    fakeGitProvider{refs: refs, err: observations.gitError},
+		claims: fakeClaimProvider{},
 	}
 
 	return runner.run(context.Background(), campaign, inspectOptions{
@@ -486,6 +487,38 @@ func (provider fakeGitHubProvider) Observe(
 type fakeGitProvider struct {
 	refs map[string]string
 	err  error
+}
+
+type fakeClaimProvider struct {
+	values map[string]ClaimObservation
+	err    error
+}
+
+func (provider fakeClaimProvider) Observe(
+	_ context.Context,
+	_ string,
+	campaign *Campaign,
+	_ time.Time,
+	_ string,
+	_ map[string]string,
+) (map[string]ClaimObservation, error) {
+	if provider.err != nil {
+		return nil, provider.err
+	}
+	values := make(map[string]ClaimObservation, len(campaign.SourceFacts.Findings))
+	for _, finding := range campaign.SourceFacts.Findings {
+		if observation, ok := provider.values[finding.ID]; ok {
+			values[finding.ID] = observation
+		} else if finding.Qualification == "CONFIRMED" {
+			values[finding.ID] = emptyClaimObservation(campaign.AuditID, finding.ID, "FRESH")
+		} else {
+			observation := emptyClaimObservation(campaign.AuditID, finding.ID, "FRESH")
+			observation.State = "NON_CLAIMABLE"
+			values[finding.ID] = observation
+		}
+	}
+
+	return values, nil
 }
 
 func (provider fakeGitProvider) ObserveRefs(context.Context, string, []string) (map[string]string, error) {

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -528,6 +528,7 @@ func (provider fakeClaimProvider) Observe(
 	_ context.Context,
 	_ string,
 	campaign *Campaign,
+	_ string,
 	_ time.Time,
 	_ string,
 	_ map[string]string,

--- a/scripts/aicampaign/claim_command.go
+++ b/scripts/aicampaign/claim_command.go
@@ -88,7 +88,7 @@ func createClaim(
 		return result
 	}
 	if observedSHA := refs[result.RemoteRef]; observedSHA != "" {
-		return classifyExistingClaim(ctx, repository, result, campaign, finding, observedSHA, now().UTC())
+		return classifyExistingClaim(ctx, repository, result, campaign, finding, target, observedSHA, now().UTC())
 	}
 	createdAt := now().UTC()
 	record := ClaimRecord{
@@ -105,7 +105,7 @@ func createClaim(
 			return remoteUnavailable(result, refreshErr)
 		}
 		if observedSHA := refs[result.RemoteRef]; observedSHA != "" {
-			return classifyExistingClaim(ctx, repository, result, campaign, finding, observedSHA, now().UTC())
+			return classifyExistingClaim(ctx, repository, result, campaign, finding, target, observedSHA, now().UTC())
 		}
 
 		return remoteUnavailable(result, err)
@@ -124,6 +124,7 @@ func classifyExistingClaim(
 	result ClaimResult,
 	campaign *Campaign,
 	finding SourceFinding,
+	targetBranch string,
 	observedSHA string,
 	now time.Time,
 ) ClaimResult {
@@ -136,7 +137,7 @@ func classifyExistingClaim(
 		return result
 	}
 	result.Claim = &observed.Record
-	if !observed.Record.matches(campaign, finding) {
+	if !observed.Record.matches(campaign, finding, targetBranch) {
 		result.Status = "CLAIM_CONFLICT"
 		result.Reason = "remote claim identity does not match campaign finding"
 

--- a/scripts/aicampaign/claim_command.go
+++ b/scripts/aicampaign/claim_command.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func runClaim(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--finding": true, "--claimant": true, "--lease": true, "--remote": true, "--target": true,
+		"--work-branch": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--finding"] == "" {
+		return errors.New("usage: ai-campaign claim <campaign> --finding <id> [--claimant <id>] [--lease <duration>] [--work-branch <branch>] [--remote <name>] [--target <branch>]")
+	}
+	lease, err := validateClaimLease(flags["--lease"])
+	if err != nil {
+		return err
+	}
+	if err := validateWorkBranch(flags["--work-branch"]); err != nil {
+		return err
+	}
+	claimant, err := resolveClaimant(flags["--claimant"], true)
+	if err != nil {
+		return err
+	}
+	campaign, finding, err := loadClaimInput(values[0], flags["--finding"])
+	if err != nil {
+		return err
+	}
+	remote := valueOr(flags["--remote"], "origin")
+	target := valueOr(flags["--target"], "release/v3.0")
+	if err := validateClaimCommandOptions(remote, target); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := createClaim(ctx, campaign, finding, claimant, lease, remote, target, flags["--work-branch"], time.Now)
+
+	return emitClaimResult(stdout, stderr, result)
+}
+
+func createClaim(
+	ctx context.Context,
+	campaign *Campaign,
+	finding SourceFinding,
+	claimant string,
+	lease time.Duration,
+	remote string,
+	target string,
+	workBranch string,
+	now func() time.Time,
+) ClaimResult {
+	result := baseClaimResult(campaign, finding)
+	if finding.Qualification != "CONFIRMED" || !finding.Dispatchable {
+		result.Status = "FINDING_NOT_CLAIMABLE"
+		result.Reason = "qualification is " + finding.Qualification
+
+		return result
+	}
+	if workBranch == target {
+		result.Status = "BROKEN_CAMPAIGN_BINDING"
+		result.Reason = "work branch cannot equal target branch"
+
+		return result
+	}
+	repository, err := openClaimRepository(ctx, remote)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	defer repository.close()
+	refs, err := repository.listRefs(ctx, result.RemoteRef, "refs/heads/"+target)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	targetSHA := refs["refs/heads/"+target]
+	if targetSHA == "" || targetSHA != campaign.AuditedSHA {
+		result.Status = "BROKEN_CAMPAIGN_BINDING"
+		result.Reason = "target branch is missing or no longer equals audited SHA"
+
+		return result
+	}
+	if observedSHA := refs[result.RemoteRef]; observedSHA != "" {
+		return classifyExistingClaim(ctx, repository, result, campaign, finding, observedSHA, now().UTC())
+	}
+	createdAt := now().UTC()
+	record := ClaimRecord{
+		SchemaVersion: claimSchemaVersion, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
+		FindingID: finding.ID, FindingIdentityDigest: finding.IdentityDigest,
+		SourceQualifiedDigest: campaign.SourceDigests.Qualified, AuditedSHA: campaign.AuditedSHA,
+		Qualification: finding.Qualification, Claimant: claimant, CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(lease), TargetBranch: target, TargetSHA: targetSHA, WorkBranch: workBranch,
+	}
+	claimSHA, err := repository.writeClaim(ctx, result.RemoteRef, "", record)
+	if err != nil {
+		refs, refreshErr := repository.listRefs(ctx, result.RemoteRef)
+		if refreshErr != nil {
+			return remoteUnavailable(result, refreshErr)
+		}
+		if observedSHA := refs[result.RemoteRef]; observedSHA != "" {
+			return classifyExistingClaim(ctx, repository, result, campaign, finding, observedSHA, now().UTC())
+		}
+
+		return remoteUnavailable(result, err)
+	}
+	result.Status = "CLAIMED"
+	result.ClaimSHA = claimSHA
+	result.ObservedClaimSHA = claimSHA
+	result.Claim = &record
+
+	return result
+}
+
+func classifyExistingClaim(
+	ctx context.Context,
+	repository *claimRepository,
+	result ClaimResult,
+	campaign *Campaign,
+	finding SourceFinding,
+	observedSHA string,
+	now time.Time,
+) ClaimResult {
+	result.ObservedClaimSHA = observedSHA
+	observed, err := repository.readClaim(ctx, result.RemoteRef, observedSHA)
+	if err != nil {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = conciseError(err)
+
+		return result
+	}
+	result.Claim = &observed.Record
+	if !observed.Record.matches(campaign, finding) {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "remote claim identity does not match campaign finding"
+
+		return result
+	}
+	if isExpired(observed.Record, now) {
+		result.Status = "CLAIM_EXPIRED"
+		result.Reason = "expired claim requires explicit renew, release, or takeover"
+
+		return result
+	}
+	result.Status = "ALREADY_CLAIMED"
+	result.Reason = "finding has a live remote claim"
+
+	return result
+}
+
+func loadClaimInput(path, findingID string) (*Campaign, SourceFinding, error) {
+	campaign, err := loadCampaign(path)
+	if err != nil {
+		return nil, SourceFinding{}, err
+	}
+	finding, err := findingByID(campaign, findingID)
+	if err != nil {
+		return nil, SourceFinding{}, err
+	}
+
+	return campaign, finding, nil
+}
+
+func validateClaimCommandOptions(remote, target string) error {
+	if !gitRemotePattern.MatchString(remote) {
+		return errors.New("invalid Git remote")
+	}
+	if target == "" || execCheckBranch(target) != nil || strings.HasPrefix(target, "ai-claims/") {
+		return errors.New("invalid target branch")
+	}
+
+	return nil
+}
+
+func execCheckBranch(branch string) error {
+	return exec.Command("git", "check-ref-format", "refs/heads/"+branch).Run()
+}
+
+func baseClaimResult(campaign *Campaign, finding SourceFinding) ClaimResult {
+	return ClaimResult{
+		SchemaVersion: "ai-campaign-claim-result/v1", CampaignID: campaign.CampaignID,
+		FindingID: finding.ID, RemoteRef: claimRef(campaign.AuditID, finding.ID),
+	}
+}
+
+func remoteUnavailable(result ClaimResult, err error) ClaimResult {
+	result.Status = "REMOTE_UNAVAILABLE"
+	result.Reason = conciseError(err)
+
+	return result
+}
+
+func emitClaimResult(stdout, stderr io.Writer, result ClaimResult) error {
+	if err := writeHuman(stderr, "%s %s ref=%s", result.Status, result.FindingID, result.RemoteRef); err != nil {
+		return err
+	}
+	if result.ObservedClaimSHA != "" {
+		if err := writeHuman(stderr, " observed=%s", result.ObservedClaimSHA); err != nil {
+			return err
+		}
+	}
+	if result.Reason != "" {
+		if err := writeHuman(stderr, " reason=%s", result.Reason); err != nil {
+			return err
+		}
+	}
+	if err := writeHuman(stderr, "\n"); err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, result)
+}
+
+func claimResultChanged(result ClaimResult, reason string) ClaimResult {
+	result.Status = "CLAIM_CHANGED"
+	result.Reason = reason
+
+	return result
+}
+
+func expectedClaimMatches(expected, observed string) bool {
+	return expected == "" || expected == observed
+}
+
+func requireClaimOwner(result ClaimResult, record ClaimRecord, claimant string) (ClaimResult, bool) {
+	if record.Claimant != claimant {
+		result.Status = "NOT_OWNER"
+		result.Reason = "remote claim belongs to " + record.Claimant
+
+		return result, false
+	}
+
+	return result, true
+}

--- a/scripts/aicampaign/claim_external.go
+++ b/scripts/aicampaign/claim_external.go
@@ -6,7 +6,7 @@ import (
 )
 
 type claimProvider interface {
-	Observe(context.Context, string, *Campaign, time.Time, string, map[string]string) (map[string]ClaimObservation, error)
+	Observe(context.Context, string, *Campaign, string, time.Time, string, map[string]string) (map[string]ClaimObservation, error)
 }
 
 type commandClaimProvider struct{}
@@ -15,6 +15,7 @@ func (commandClaimProvider) Observe(
 	ctx context.Context,
 	remote string,
 	campaign *Campaign,
+	targetBranch string,
 	now time.Time,
 	currentClaimant string,
 	previousClaimSHAs map[string]string,
@@ -57,7 +58,7 @@ func (commandClaimProvider) Observe(
 
 			continue
 		}
-		if !claim.Record.matches(campaign, finding) {
+		if !claim.Record.matches(campaign, finding, targetBranch) {
 			observation.State = "AMBIGUOUS"
 			observation.Problem = "CLAIM_IDENTITY_CONFLICT"
 			observations[finding.ID] = observation

--- a/scripts/aicampaign/claim_external.go
+++ b/scripts/aicampaign/claim_external.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+type claimProvider interface {
+	Observe(context.Context, string, *Campaign, time.Time, string, map[string]string) (map[string]ClaimObservation, error)
+}
+
+type commandClaimProvider struct{}
+
+func (commandClaimProvider) Observe(
+	ctx context.Context,
+	remote string,
+	campaign *Campaign,
+	now time.Time,
+	currentClaimant string,
+	previousClaimSHAs map[string]string,
+) (map[string]ClaimObservation, error) {
+	repository, err := openClaimRepository(ctx, remote)
+	if err != nil {
+		return nil, err
+	}
+	defer repository.close()
+	refs := make([]string, 0, len(campaign.SourceFacts.Findings))
+	for _, finding := range campaign.SourceFacts.Findings {
+		refs = append(refs, claimRef(campaign.AuditID, finding.ID))
+	}
+	remoteRefs, err := repository.listRefs(ctx, refs...)
+	if err != nil {
+		return nil, err
+	}
+	observations := make(map[string]ClaimObservation, len(campaign.SourceFacts.Findings))
+	for _, finding := range campaign.SourceFacts.Findings {
+		ref := claimRef(campaign.AuditID, finding.ID)
+		observation := emptyClaimObservation(campaign.AuditID, finding.ID, "FRESH")
+		if finding.Qualification != "CONFIRMED" {
+			observation.State = "NON_CLAIMABLE"
+			observations[finding.ID] = observation
+
+			continue
+		}
+		observedSHA := remoteRefs[ref]
+		if observedSHA == "" {
+			observations[finding.ID] = observation
+
+			continue
+		}
+		observation.ObservedClaimSHA = observedSHA
+		claim, readErr := repository.readClaim(ctx, ref, observedSHA)
+		if readErr != nil {
+			observation.State = "AMBIGUOUS"
+			observation.Problem = "INVALID_CLAIM_RECORD: " + conciseError(readErr)
+			observations[finding.ID] = observation
+
+			continue
+		}
+		if !claim.Record.matches(campaign, finding) {
+			observation.State = "AMBIGUOUS"
+			observation.Problem = "CLAIM_IDENTITY_CONFLICT"
+			observations[finding.ID] = observation
+
+			continue
+		}
+		if previousSHA := previousClaimSHAs[finding.ID]; previousSHA != "" && previousSHA != observedSHA &&
+			!repository.isAncestor(ctx, previousSHA, observedSHA) {
+			observation.State = "AMBIGUOUS"
+			observation.Problem = "CLAIM_HISTORY_REWRITTEN"
+			observations[finding.ID] = observation
+
+			continue
+		}
+		observation.Claimant = claim.Record.Claimant
+		observation.CreatedAt = timePointer(claim.Record.CreatedAt)
+		observation.ExpiresAt = timePointer(claim.Record.ExpiresAt)
+		observation.WorkBranch = claim.Record.WorkBranch
+		observation.OwnedBySession = currentClaimant != "" && currentClaimant == claim.Record.Claimant
+		if isExpired(claim.Record, now) {
+			observation.State = "CLAIM_EXPIRED"
+		} else {
+			observation.State = "CLAIMED"
+		}
+		observations[finding.ID] = observation
+	}
+
+	return observations, nil
+}
+
+func emptyClaimObservation(auditID, findingID, freshness string) ClaimObservation {
+	return ClaimObservation{
+		State: "UNCLAIMED", RemoteRef: claimRef(auditID, findingID), Freshness: freshness,
+	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	valueCopy := value
+
+	return &valueCopy
+}
+
+func unavailableClaimObservation(
+	campaign *Campaign,
+	finding SourceFinding,
+	previous ClaimObservation,
+	reason error,
+) ClaimObservation {
+	hadPreviousObservation := previous.RemoteRef != ""
+	if previous.RemoteRef == "" {
+		previous = emptyClaimObservation(campaign.AuditID, finding.ID, "UNAVAILABLE")
+	}
+	previous.State = "UNKNOWN"
+	previous.OwnedBySession = false
+	previous.Problem = "REMOTE_UNAVAILABLE: " + conciseError(reason)
+	if hadPreviousObservation {
+		previous.Freshness = "STALE"
+	} else {
+		previous.Freshness = "UNAVAILABLE"
+	}
+
+	return previous
+}

--- a/scripts/aicampaign/claim_model.go
+++ b/scripts/aicampaign/claim_model.go
@@ -117,7 +117,7 @@ func (claim ClaimRecord) matches(campaign *Campaign, finding SourceFinding) bool
 	return claim.CampaignID == campaign.CampaignID && claim.AuditID == campaign.AuditID &&
 		claim.FindingID == finding.ID && claim.FindingIdentityDigest == finding.IdentityDigest &&
 		claim.SourceQualifiedDigest == campaign.SourceDigests.Qualified && claim.AuditedSHA == campaign.AuditedSHA &&
-		claim.Qualification == finding.Qualification
+		claim.Qualification == finding.Qualification && claim.TargetSHA == campaign.AuditedSHA
 }
 
 func claimRef(auditID, findingID string) string {

--- a/scripts/aicampaign/claim_model.go
+++ b/scripts/aicampaign/claim_model.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	claimRefPrefix    = "refs/heads/ai-claims/v1/"
+	defaultClaimLease = 24 * time.Hour
+	minimumClaimLease = time.Hour
+	maximumClaimLease = 7 * 24 * time.Hour
+	claimClockSkew    = 5 * time.Minute
+)
+
+type ClaimRecord struct {
+	SchemaVersion         string            `json:"schemaVersion"`
+	CampaignID            string            `json:"campaignId"`
+	AuditID               string            `json:"auditId"`
+	FindingID             string            `json:"findingId"`
+	FindingIdentityDigest string            `json:"findingIdentityDigest"`
+	SourceQualifiedDigest string            `json:"sourceQualifiedDigest"`
+	AuditedSHA            string            `json:"auditedSha"`
+	Qualification         string            `json:"qualification"`
+	Claimant              string            `json:"claimant"`
+	CreatedAt             time.Time         `json:"createdAt"`
+	ExpiresAt             time.Time         `json:"expiresAt"`
+	TargetBranch          string            `json:"targetBranch"`
+	TargetSHA             string            `json:"targetSha"`
+	WorkBranch            string            `json:"workBranch"`
+	RenewedAt             *time.Time        `json:"renewedAt"`
+	RenewalCount          int               `json:"renewalCount"`
+	Predecessor           *ClaimPredecessor `json:"predecessor"`
+}
+
+type ClaimPredecessor struct {
+	ClaimSHA  string    `json:"claimSha"`
+	Claimant  string    `json:"claimant"`
+	CreatedAt time.Time `json:"createdAt"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	Reason    string    `json:"reason"`
+}
+
+type ClaimResult struct {
+	SchemaVersion    string       `json:"schemaVersion"`
+	Status           string       `json:"status"`
+	CampaignID       string       `json:"campaignId"`
+	FindingID        string       `json:"findingId"`
+	RemoteRef        string       `json:"remoteRef"`
+	ObservedClaimSHA string       `json:"observedClaimSha"`
+	ClaimSHA         string       `json:"claimSha"`
+	Claim            *ClaimRecord `json:"claim"`
+	Reason           string       `json:"reason"`
+}
+
+func (claim ClaimRecord) validate() error {
+	if claim.SchemaVersion != claimSchemaVersion {
+		return fmt.Errorf("unsupported claim schema version %q", claim.SchemaVersion)
+	}
+	if !auditIDPattern.MatchString(claim.AuditID) || !findingIDPattern.MatchString(claim.FindingID) ||
+		!strings.HasPrefix(claim.FindingID, claim.AuditID+"/") || !digestPattern.MatchString(claim.FindingIdentityDigest) ||
+		!digestPattern.MatchString(claim.SourceQualifiedDigest) || !shaPattern.MatchString(claim.AuditedSHA) ||
+		claim.Qualification != "CONFIRMED" || !claimantPattern.MatchString(claim.Claimant) {
+		return errors.New("invalid claim identity")
+	}
+	if !campaignIDPattern.MatchString(claim.CampaignID) {
+		return errors.New("invalid campaign identity")
+	}
+	if claim.CreatedAt.IsZero() || claim.ExpiresAt.IsZero() || !claim.ExpiresAt.After(claim.CreatedAt) ||
+		claim.CreatedAt.Location() != time.UTC || claim.ExpiresAt.Location() != time.UTC {
+		return errors.New("invalid claim lease")
+	}
+	if claim.RenewalCount < 0 || claim.RenewalCount == 0 && claim.RenewedAt != nil ||
+		claim.RenewalCount > 0 && claim.RenewedAt == nil {
+		return errors.New("invalid claim renewal metadata")
+	}
+	if claim.RenewedAt != nil && (claim.RenewedAt.IsZero() || claim.RenewedAt.Location() != time.UTC ||
+		claim.RenewedAt.Before(claim.CreatedAt) || claim.RenewedAt.After(claim.ExpiresAt)) {
+		return errors.New("invalid claim renewal time")
+	}
+	leaseStart := claim.CreatedAt
+	if claim.RenewedAt != nil {
+		leaseStart = *claim.RenewedAt
+	}
+	if lease := claim.ExpiresAt.Sub(leaseStart); lease < minimumClaimLease || lease > maximumClaimLease {
+		return errors.New("claim lease is outside policy bounds")
+	}
+	if claim.TargetBranch == "" || exec.Command("git", "check-ref-format", "refs/heads/"+claim.TargetBranch).Run() != nil ||
+		strings.HasPrefix("refs/heads/"+claim.TargetBranch, claimRefPrefix) || !shaPattern.MatchString(claim.TargetSHA) {
+		return errors.New("invalid claim target")
+	}
+	if claim.WorkBranch != "" && (exec.Command("git", "check-ref-format", "refs/heads/"+claim.WorkBranch).Run() != nil ||
+		strings.HasPrefix("refs/heads/"+claim.WorkBranch, claimRefPrefix) || claim.WorkBranch == claim.TargetBranch) {
+		return errors.New("invalid claim work branch")
+	}
+	if claim.Predecessor != nil {
+		predecessor := claim.Predecessor
+		if !shaPattern.MatchString(predecessor.ClaimSHA) || !claimantPattern.MatchString(predecessor.Claimant) ||
+			predecessor.CreatedAt.IsZero() || predecessor.ExpiresAt.IsZero() ||
+			predecessor.CreatedAt.Location() != time.UTC || predecessor.ExpiresAt.Location() != time.UTC ||
+			!predecessor.ExpiresAt.After(predecessor.CreatedAt) || predecessor.Reason != "EXPIRED_TAKEOVER" {
+			return errors.New("invalid claim predecessor")
+		}
+	}
+
+	return nil
+}
+
+func (claim ClaimRecord) matches(campaign *Campaign, finding SourceFinding) bool {
+	return claim.CampaignID == campaign.CampaignID && claim.AuditID == campaign.AuditID &&
+		claim.FindingID == finding.ID && claim.FindingIdentityDigest == finding.IdentityDigest &&
+		claim.SourceQualifiedDigest == campaign.SourceDigests.Qualified && claim.AuditedSHA == campaign.AuditedSHA &&
+		claim.Qualification == finding.Qualification
+}
+
+func claimRef(auditID, findingID string) string {
+	payload := strings.Join([]string{"ai-claim-ref/v1", auditID, findingID}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+
+	return claimRefPrefix + hex.EncodeToString(sum[:])
+}
+
+func findingByID(campaign *Campaign, findingID string) (SourceFinding, error) {
+	for _, finding := range campaign.SourceFacts.Findings {
+		if finding.ID == findingID {
+			return finding, nil
+		}
+	}
+
+	return SourceFinding{}, fmt.Errorf("finding %q is not in campaign", findingID)
+}
+
+func validateClaimLease(value string) (time.Duration, error) {
+	if value == "" {
+		return defaultClaimLease, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid lease duration: %w", err)
+	}
+	if duration < minimumClaimLease || duration > maximumClaimLease {
+		return 0, fmt.Errorf("lease duration must be between %s and %s", minimumClaimLease, maximumClaimLease)
+	}
+
+	return duration, nil
+}
+
+func validateWorkBranch(branch string) error {
+	if branch == "" {
+		return nil
+	}
+	if exec.Command("git", "check-ref-format", "refs/heads/"+branch).Run() != nil || strings.HasPrefix(branch, "ai-claims/") {
+		return errors.New("invalid work branch")
+	}
+
+	return nil
+}
+
+func resolveClaimant(explicit string, generate bool) (string, error) {
+	claimant := explicit
+	if claimant == "" {
+		claimant = os.Getenv("AI_CAMPAIGN_CLAIMANT")
+	}
+	if claimant == "" && !generate {
+		return "", errors.New("claimant is required (--claimant or AI_CAMPAIGN_CLAIMANT)")
+	}
+	if claimant == "" {
+		random := make([]byte, 16)
+		if _, err := rand.Read(random); err != nil {
+			return "", fmt.Errorf("generate claimant identity: %w", err)
+		}
+		user := sanitizeIdentityComponent(os.Getenv("USER"), "agent")
+		host, err := os.Hostname()
+		if err != nil {
+			host = "machine"
+		}
+		claimant = fmt.Sprintf("%s@%s#%s", user, sanitizeIdentityComponent(host, "machine"), hex.EncodeToString(random))
+	}
+	if !claimantPattern.MatchString(claimant) {
+		return "", errors.New("claimant must be 3-160 non-sensitive ref-safe characters")
+	}
+
+	return claimant, nil
+}
+
+func sanitizeIdentityComponent(value, fallback string) string {
+	var builder strings.Builder
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || strings.ContainsRune("._-", character) {
+			builder.WriteRune(character)
+		}
+	}
+	if builder.Len() == 0 {
+		return fallback
+	}
+
+	return builder.String()
+}
+
+func isExpired(claim ClaimRecord, now time.Time) bool {
+	return !now.UTC().Before(claim.ExpiresAt.Add(claimClockSkew))
+}

--- a/scripts/aicampaign/claim_model.go
+++ b/scripts/aicampaign/claim_model.go
@@ -113,11 +113,12 @@ func (claim ClaimRecord) validate() error {
 	return nil
 }
 
-func (claim ClaimRecord) matches(campaign *Campaign, finding SourceFinding) bool {
+func (claim ClaimRecord) matches(campaign *Campaign, finding SourceFinding, targetBranch string) bool {
 	return claim.CampaignID == campaign.CampaignID && claim.AuditID == campaign.AuditID &&
 		claim.FindingID == finding.ID && claim.FindingIdentityDigest == finding.IdentityDigest &&
 		claim.SourceQualifiedDigest == campaign.SourceDigests.Qualified && claim.AuditedSHA == campaign.AuditedSHA &&
-		claim.Qualification == finding.Qualification && claim.TargetSHA == campaign.AuditedSHA
+		claim.Qualification == finding.Qualification && claim.TargetBranch == targetBranch &&
+		claim.TargetSHA == campaign.AuditedSHA
 }
 
 func claimRef(auditID, findingID string) string {

--- a/scripts/aicampaign/claim_store.go
+++ b/scripts/aicampaign/claim_store.go
@@ -70,6 +70,9 @@ func (repository *claimRepository) close() {
 }
 
 func (repository *claimRepository) listRefs(ctx context.Context, refs ...string) (map[string]string, error) {
+	if len(refs) == 0 {
+		return map[string]string{}, nil
+	}
 	arguments := []string{"ls-remote", "--heads", repository.remoteURL}
 	arguments = append(arguments, refs...)
 	output, err := repository.git(ctx, nil, arguments...)

--- a/scripts/aicampaign/claim_store.go
+++ b/scripts/aicampaign/claim_store.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+var (
+	errClaimChanged   = errors.New("remote claim changed during observation")
+	errRemoteMutation = errors.New("remote compare-and-swap rejected")
+)
+
+type observedClaim struct {
+	Record ClaimRecord
+	SHA    string
+	Ref    string
+}
+
+type claimRepository struct {
+	directory string
+	remoteURL string
+}
+
+func openClaimRepository(ctx context.Context, remote string) (*claimRepository, error) {
+	remoteURL := remote
+	if !filepath.IsAbs(remote) && !strings.Contains(remote, "://") {
+		var output []byte
+		for _, suffix := range []string{"pushurl", "url"} {
+			command := exec.CommandContext(ctx, "git", "config", "--get", "remote."+remote+"."+suffix)
+			value, err := command.Output()
+			if err == nil && strings.TrimSpace(string(value)) != "" {
+				output = value
+
+				break
+			}
+		}
+		if len(output) == 0 {
+			return nil, fmt.Errorf("resolve Git remote: remote %q has no URL", remote)
+		}
+		remoteURL = strings.TrimSpace(string(output))
+	}
+	if remoteURL == "" {
+		return nil, errors.New("git remote has no push URL")
+	}
+	directory, err := os.MkdirTemp("", "ai-campaign-claim-git-")
+	if err != nil {
+		return nil, fmt.Errorf("create claim Git directory: %w", err)
+	}
+	repository := &claimRepository{directory: directory, remoteURL: remoteURL}
+	if _, err := repository.git(ctx, nil, "init", "--bare", "--quiet", directory); err != nil {
+		repository.close()
+
+		return nil, fmt.Errorf("initialize claim Git directory: %w", err)
+	}
+
+	return repository, nil
+}
+
+func (repository *claimRepository) close() {
+	_ = os.RemoveAll(repository.directory) // Private best-effort temporary object cleanup.
+}
+
+func (repository *claimRepository) listRefs(ctx context.Context, refs ...string) (map[string]string, error) {
+	arguments := []string{"ls-remote", "--heads", repository.remoteURL}
+	arguments = append(arguments, refs...)
+	output, err := repository.git(ctx, nil, arguments...)
+	if err != nil {
+		return nil, fmt.Errorf("query remote claims: %w", err)
+	}
+	result := make(map[string]string, len(refs))
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) != 2 || !shaPattern.MatchString(fields[0]) || !slices.Contains(refs, fields[1]) {
+			return nil, errors.New("malformed remote claim ref response")
+		}
+		result[fields[1]] = fields[0]
+	}
+
+	return result, nil
+}
+
+func (repository *claimRepository) readClaim(ctx context.Context, ref, expectedSHA string) (*observedClaim, error) {
+	localRef := "refs/ai-claim-cache/" + strings.TrimPrefix(ref, claimRefPrefix)
+	if _, err := repository.git(ctx, nil, "fetch", "--quiet", "--no-tags", "--no-write-fetch-head",
+		repository.remoteURL, "+"+ref+":"+localRef); err != nil {
+		return nil, fmt.Errorf("fetch remote claim: %w", err)
+	}
+	output, err := repository.git(ctx, nil, "rev-parse", "--verify", localRef)
+	if err != nil {
+		return nil, fmt.Errorf("resolve fetched claim: %w", err)
+	}
+	actualSHA := strings.TrimSpace(string(output))
+	if expectedSHA != "" && actualSHA != expectedSHA {
+		return nil, errClaimChanged
+	}
+	tree, err := repository.git(ctx, nil, "ls-tree", "--name-only", actualSHA)
+	if err != nil {
+		return nil, fmt.Errorf("inspect claim tree: %w", err)
+	}
+	if string(tree) != "claim.json\n" {
+		return nil, errors.New("claim commit must contain only claim.json")
+	}
+	parents, err := repository.git(ctx, nil, "show", "-s", "--format=%P", actualSHA)
+	if err != nil {
+		return nil, fmt.Errorf("inspect claim parents: %w", err)
+	}
+	parentSHAs := strings.Fields(string(parents))
+	if len(parentSHAs) > 1 {
+		return nil, errors.New("claim commit has multiple parents")
+	}
+	content, err := repository.git(ctx, nil, "show", actualSHA+":claim.json")
+	if err != nil {
+		return nil, fmt.Errorf("read claim record: %w", err)
+	}
+	var record ClaimRecord
+	if err := decodeStrictJSON(content, &record); err != nil {
+		return nil, fmt.Errorf("decode claim record: %w", err)
+	}
+	if err := record.validate(); err != nil {
+		return nil, fmt.Errorf("validate claim record: %w", err)
+	}
+	if record.RenewalCount == 0 && record.Predecessor == nil && len(parentSHAs) != 0 {
+		return nil, errors.New("initial claim commit must be parentless")
+	}
+	if (record.RenewalCount > 0 || record.Predecessor != nil) && len(parentSHAs) != 1 {
+		return nil, errors.New("updated claim commit must have one parent")
+	}
+	if record.RenewalCount == 0 && record.Predecessor != nil && parentSHAs[0] != record.Predecessor.ClaimSHA {
+		return nil, errors.New("takeover predecessor does not match claim parent")
+	}
+	if len(parentSHAs) == 1 {
+		parentContent, err := repository.git(ctx, nil, "show", parentSHAs[0]+":claim.json")
+		if err != nil {
+			return nil, fmt.Errorf("read parent claim record: %w", err)
+		}
+		var parentRecord ClaimRecord
+		if err := decodeStrictJSON(parentContent, &parentRecord); err != nil {
+			return nil, fmt.Errorf("decode parent claim record: %w", err)
+		}
+		if err := parentRecord.validate(); err != nil {
+			return nil, fmt.Errorf("validate parent claim record: %w", err)
+		}
+		if err := validateClaimTransition(record, parentRecord, parentSHAs[0]); err != nil {
+			return nil, err
+		}
+	}
+
+	return &observedClaim{Record: record, SHA: actualSHA, Ref: ref}, nil
+}
+
+func validateClaimTransition(current, previous ClaimRecord, previousSHA string) error {
+	if current.CampaignID != previous.CampaignID || current.AuditID != previous.AuditID ||
+		current.FindingID != previous.FindingID || current.FindingIdentityDigest != previous.FindingIdentityDigest ||
+		current.SourceQualifiedDigest != previous.SourceQualifiedDigest || current.AuditedSHA != previous.AuditedSHA ||
+		current.Qualification != previous.Qualification || current.TargetBranch != previous.TargetBranch ||
+		current.TargetSHA != previous.TargetSHA {
+		return errors.New("claim transition changed immutable identity")
+	}
+	if current.RenewalCount > 0 {
+		if current.Claimant != previous.Claimant || !current.CreatedAt.Equal(previous.CreatedAt) ||
+			current.RenewalCount != previous.RenewalCount+1 ||
+			!samePredecessor(current.Predecessor, previous.Predecessor) {
+			return errors.New("invalid claim renewal transition")
+		}
+		previousMutation := previous.CreatedAt
+		if previous.RenewedAt != nil {
+			previousMutation = *previous.RenewedAt
+		}
+		if current.RenewedAt == nil || current.RenewedAt.Before(previousMutation) {
+			return errors.New("claim renewal time moved backwards")
+		}
+
+		return nil
+	}
+	if current.Predecessor == nil || current.Predecessor.ClaimSHA != previousSHA ||
+		current.Predecessor.Claimant != previous.Claimant ||
+		!current.Predecessor.CreatedAt.Equal(previous.CreatedAt) ||
+		!current.Predecessor.ExpiresAt.Equal(previous.ExpiresAt) ||
+		current.CreatedAt.Before(previous.ExpiresAt.Add(claimClockSkew)) {
+		return errors.New("invalid expired-claim takeover transition")
+	}
+
+	return nil
+}
+
+func samePredecessor(left, right *ClaimPredecessor) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.ClaimSHA == right.ClaimSHA && left.Claimant == right.Claimant &&
+		left.CreatedAt.Equal(right.CreatedAt) && left.ExpiresAt.Equal(right.ExpiresAt) && left.Reason == right.Reason
+}
+
+func (repository *claimRepository) writeClaim(
+	ctx context.Context,
+	ref string,
+	expectedSHA string,
+	record ClaimRecord,
+) (string, error) {
+	if err := record.validate(); err != nil {
+		return "", fmt.Errorf("refusing invalid claim record: %w", err)
+	}
+	content, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal claim record: %w", err)
+	}
+	content = append(content, '\n')
+	blob, err := repository.git(ctx, content, "hash-object", "-w", "--stdin")
+	if err != nil {
+		return "", fmt.Errorf("write claim blob: %w", err)
+	}
+	treeInput := []byte("100644 blob " + strings.TrimSpace(string(blob)) + "\tclaim.json\n")
+	tree, err := repository.git(ctx, treeInput, "mktree")
+	if err != nil {
+		return "", fmt.Errorf("write claim tree: %w", err)
+	}
+	arguments := []string{"commit-tree", strings.TrimSpace(string(tree)), "-m", "ai-campaign claim " + record.FindingID}
+	if expectedSHA != "" {
+		arguments = append(arguments, "-p", expectedSHA)
+	}
+	commitTime := record.CreatedAt
+	if record.RenewedAt != nil {
+		commitTime = *record.RenewedAt
+	}
+	environment := []string{
+		"GIT_AUTHOR_NAME=ai-campaign", "GIT_AUTHOR_EMAIL=ai-campaign@formance.invalid",
+		"GIT_COMMITTER_NAME=ai-campaign", "GIT_COMMITTER_EMAIL=ai-campaign@formance.invalid",
+		"GIT_AUTHOR_DATE=" + commitTime.Format(time.RFC3339Nano),
+		"GIT_COMMITTER_DATE=" + commitTime.Format(time.RFC3339Nano),
+	}
+	commit, err := repository.gitWithEnvironment(ctx, nil, environment, arguments...)
+	if err != nil {
+		return "", fmt.Errorf("write claim commit: %w", err)
+	}
+	claimSHA := strings.TrimSpace(string(commit))
+	lease := "--force-with-lease=" + ref + ":" + expectedSHA
+	if _, err := repository.git(ctx, nil, "push", "--porcelain", lease, repository.remoteURL, claimSHA+":"+ref); err != nil {
+		return claimSHA, fmt.Errorf("%w: %w", errRemoteMutation, err)
+	}
+
+	return claimSHA, nil
+}
+
+func (repository *claimRepository) deleteClaim(ctx context.Context, ref, expectedSHA string) error {
+	if expectedSHA == "" || !shaPattern.MatchString(expectedSHA) {
+		return errors.New("exact observed claim SHA is required for deletion")
+	}
+	lease := "--force-with-lease=" + ref + ":" + expectedSHA
+	if _, err := repository.git(ctx, nil, "push", "--porcelain", lease, repository.remoteURL, ":"+ref); err != nil {
+		return fmt.Errorf("%w: %w", errRemoteMutation, err)
+	}
+
+	return nil
+}
+
+func (repository *claimRepository) isAncestor(ctx context.Context, ancestor, descendant string) bool {
+	if !shaPattern.MatchString(ancestor) || !shaPattern.MatchString(descendant) {
+		return false
+	}
+	_, err := repository.git(ctx, nil, "merge-base", "--is-ancestor", ancestor, descendant)
+
+	return err == nil
+}
+
+func (repository *claimRepository) git(ctx context.Context, input []byte, arguments ...string) ([]byte, error) {
+	return repository.gitWithEnvironment(ctx, input, nil, arguments...)
+}
+
+func (repository *claimRepository) gitWithEnvironment(
+	ctx context.Context,
+	input []byte,
+	environment []string,
+	arguments ...string,
+) ([]byte, error) {
+	if arguments[0] != "init" {
+		arguments = append([]string{"--git-dir", repository.directory}, arguments...)
+	}
+	command := exec.CommandContext(ctx, "git", arguments...)
+	command.Env = append(os.Environ(), environment...)
+	if input != nil {
+		command.Stdin = bytes.NewReader(input)
+	}
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return nil, errors.New(conciseGitError(message, repository.remoteURL))
+		}
+
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func conciseGitError(message, remoteURL string) string {
+	message = strings.ReplaceAll(message, remoteURL, "<remote>")
+	message = strings.ReplaceAll(message, filepath.Base(remoteURL), "<remote>")
+
+	return conciseError(errors.New(message))
+}

--- a/scripts/aicampaign/claim_store.go
+++ b/scripts/aicampaign/claim_store.go
@@ -108,59 +108,76 @@ func (repository *claimRepository) readClaim(ctx context.Context, ref, expectedS
 	if expectedSHA != "" && actualSHA != expectedSHA {
 		return nil, errClaimChanged
 	}
-	tree, err := repository.git(ctx, nil, "ls-tree", "--name-only", actualSHA)
+	record, err := repository.validateClaimLineage(ctx, actualSHA)
 	if err != nil {
-		return nil, fmt.Errorf("inspect claim tree: %w", err)
-	}
-	if string(tree) != "claim.json\n" {
-		return nil, errors.New("claim commit must contain only claim.json")
-	}
-	parents, err := repository.git(ctx, nil, "show", "-s", "--format=%P", actualSHA)
-	if err != nil {
-		return nil, fmt.Errorf("inspect claim parents: %w", err)
-	}
-	parentSHAs := strings.Fields(string(parents))
-	if len(parentSHAs) > 1 {
-		return nil, errors.New("claim commit has multiple parents")
-	}
-	content, err := repository.git(ctx, nil, "show", actualSHA+":claim.json")
-	if err != nil {
-		return nil, fmt.Errorf("read claim record: %w", err)
-	}
-	var record ClaimRecord
-	if err := decodeStrictJSON(content, &record); err != nil {
-		return nil, fmt.Errorf("decode claim record: %w", err)
-	}
-	if err := record.validate(); err != nil {
-		return nil, fmt.Errorf("validate claim record: %w", err)
-	}
-	if record.RenewalCount == 0 && record.Predecessor == nil && len(parentSHAs) != 0 {
-		return nil, errors.New("initial claim commit must be parentless")
-	}
-	if (record.RenewalCount > 0 || record.Predecessor != nil) && len(parentSHAs) != 1 {
-		return nil, errors.New("updated claim commit must have one parent")
-	}
-	if record.RenewalCount == 0 && record.Predecessor != nil && parentSHAs[0] != record.Predecessor.ClaimSHA {
-		return nil, errors.New("takeover predecessor does not match claim parent")
-	}
-	if len(parentSHAs) == 1 {
-		parentContent, err := repository.git(ctx, nil, "show", parentSHAs[0]+":claim.json")
-		if err != nil {
-			return nil, fmt.Errorf("read parent claim record: %w", err)
-		}
-		var parentRecord ClaimRecord
-		if err := decodeStrictJSON(parentContent, &parentRecord); err != nil {
-			return nil, fmt.Errorf("decode parent claim record: %w", err)
-		}
-		if err := parentRecord.validate(); err != nil {
-			return nil, fmt.Errorf("validate parent claim record: %w", err)
-		}
-		if err := validateClaimTransition(record, parentRecord, parentSHAs[0]); err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	return &observedClaim{Record: record, SHA: actualSHA, Ref: ref}, nil
+}
+
+func (repository *claimRepository) validateClaimLineage(ctx context.Context, tipSHA string) (ClaimRecord, error) {
+	currentRecord, parentSHA, err := repository.readClaimCommit(ctx, tipSHA)
+	if err != nil {
+		return ClaimRecord{}, err
+	}
+	tipRecord := currentRecord
+	for parentSHA != "" {
+		parentRecord, nextParentSHA, err := repository.readClaimCommit(ctx, parentSHA)
+		if err != nil {
+			return ClaimRecord{}, err
+		}
+		if err := validateClaimTransition(currentRecord, parentRecord, parentSHA); err != nil {
+			return ClaimRecord{}, err
+		}
+		currentRecord = parentRecord
+		parentSHA = nextParentSHA
+	}
+
+	return tipRecord, nil
+}
+
+func (repository *claimRepository) readClaimCommit(ctx context.Context, claimSHA string) (ClaimRecord, string, error) {
+	tree, err := repository.git(ctx, nil, "ls-tree", "--name-only", claimSHA)
+	if err != nil {
+		return ClaimRecord{}, "", fmt.Errorf("inspect claim tree: %w", err)
+	}
+	if string(tree) != "claim.json\n" {
+		return ClaimRecord{}, "", errors.New("claim commit must contain only claim.json")
+	}
+	parents, err := repository.git(ctx, nil, "show", "-s", "--format=%P", claimSHA)
+	if err != nil {
+		return ClaimRecord{}, "", fmt.Errorf("inspect claim parents: %w", err)
+	}
+	parentSHAs := strings.Fields(string(parents))
+	if len(parentSHAs) > 1 {
+		return ClaimRecord{}, "", errors.New("claim commit has multiple parents")
+	}
+	content, err := repository.git(ctx, nil, "show", claimSHA+":claim.json")
+	if err != nil {
+		return ClaimRecord{}, "", fmt.Errorf("read claim record: %w", err)
+	}
+	var record ClaimRecord
+	if err := decodeStrictJSON(content, &record); err != nil {
+		return ClaimRecord{}, "", fmt.Errorf("decode claim record: %w", err)
+	}
+	if err := record.validate(); err != nil {
+		return ClaimRecord{}, "", fmt.Errorf("validate claim record: %w", err)
+	}
+	if record.RenewalCount == 0 && record.Predecessor == nil && len(parentSHAs) != 0 {
+		return ClaimRecord{}, "", errors.New("initial claim commit must be parentless")
+	}
+	if (record.RenewalCount > 0 || record.Predecessor != nil) && len(parentSHAs) != 1 {
+		return ClaimRecord{}, "", errors.New("updated claim commit must have one parent")
+	}
+	if record.RenewalCount == 0 && record.Predecessor != nil && parentSHAs[0] != record.Predecessor.ClaimSHA {
+		return ClaimRecord{}, "", errors.New("takeover predecessor does not match claim parent")
+	}
+	if len(parentSHAs) == 0 {
+		return record, "", nil
+	}
+
+	return record, parentSHAs[0], nil
 }
 
 func validateClaimTransition(current, previous ClaimRecord, previousSHA string) error {

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -264,6 +264,35 @@ func TestMalformedClaimRecordFailsClosed(t *testing.T) {
 	require.Contains(t, inspection.Findings[0].Claim.Problem, "INVALID_CLAIM_RECORD")
 }
 
+func TestClaimReadValidatesEveryLineageGeneration(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+
+	forgedParent := *claimed.Claim
+	firstRenewedAt := testNow.Add(time.Hour)
+	forgedParent.RenewedAt = &firstRenewedAt
+	forgedParent.RenewalCount = 1
+	forgedParent.ExpiresAt = firstRenewedAt.Add(defaultClaimLease)
+	forgedParentSHA := writeRemoteClaimRecord(t, remote, forgedParent, "")
+
+	forgedTip := forgedParent
+	secondRenewedAt := testNow.Add(2 * time.Hour)
+	forgedTip.RenewedAt = &secondRenewedAt
+	forgedTip.RenewalCount = 2
+	forgedTip.ExpiresAt = secondRenewedAt.Add(defaultClaimLease)
+	forgedTipSHA := writeRemoteClaimRecord(t, remote, forgedTip, forgedParentSHA)
+	runGit(t, "", "--git-dir", remote, "update-ref", claimed.RemoteRef, forgedTipSHA, claimed.ClaimSHA)
+
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, secondRenewedAt)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].Claim.State)
+	require.Contains(t, inspection.Findings[0].Claim.Problem, "INVALID_CLAIM_RECORD")
+}
+
 func TestValidButForceRewrittenClaimHistoryFailsClosed(t *testing.T) {
 	remote, targetSHA := newClaimRemote(t)
 	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
@@ -444,6 +473,14 @@ func writeRemoteClaimContent(t *testing.T, remote string, content []byte, parent
 	}
 
 	return strings.TrimSpace(runGitInput(t, nil, "", arguments...))
+}
+
+func writeRemoteClaimRecord(t *testing.T, remote string, record ClaimRecord, parent string) string {
+	t.Helper()
+	content, err := json.MarshalIndent(record, "", "  ")
+	require.NoError(t, err)
+
+	return writeRemoteClaimContent(t, remote, append(content, '\n'), parent)
 }
 
 func runGit(t *testing.T, directory string, arguments ...string) string {

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -123,7 +123,7 @@ func TestRenewRaceRejectsTheStaleObservedSHA(t *testing.T) {
 			<-start
 			renewedAt := testNow.Add(time.Duration(index+1) * time.Minute)
 			results <- renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
-				remote, "", claimed.ClaimSHA, func() time.Time { return renewedAt })
+				remote, testTarget, "", claimed.ClaimSHA, func() time.Time { return renewedAt })
 		})
 	}
 	close(start)
@@ -144,10 +144,10 @@ func TestReleaseRaceDoesNotDeleteChangedClaim(t *testing.T) {
 	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
 		remote, testTarget, "", func() time.Time { return testNow })
 	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
-		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+		remote, testTarget, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
 	require.Equal(t, "RENEWED", renewed.Status)
 
-	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, claimed.ClaimSHA)
+	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, testTarget, claimed.ClaimSHA)
 	require.Equal(t, "CLAIM_CHANGED", released.Status)
 	require.Equal(t, renewed.ClaimSHA, remoteRefSHA(t, remote, claimed.RemoteRef))
 }
@@ -162,7 +162,7 @@ func TestExpiredClaimTakeoverUsesExactCASAndPreservesPredecessor(t *testing.T) {
 	require.Equal(t, "CLAIMED", claimed.Status)
 
 	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
-		remote, "", claimed.ClaimSHA, func() time.Time { return testNow })
+		remote, testTarget, "", claimed.ClaimSHA, func() time.Time { return testNow })
 	require.Equal(t, "TAKEN_OVER", taken.Status)
 	require.NotNil(t, taken.Claim.Predecessor)
 	require.Equal(t, claimed.ClaimSHA, taken.Claim.Predecessor.ClaimSHA)
@@ -178,7 +178,7 @@ func TestLiveClaimTakeoverIsRefused(t *testing.T) {
 		remote, testTarget, "", func() time.Time { return testNow })
 
 	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
-		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+		remote, testTarget, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
 	require.Equal(t, "CLAIM_CONFLICT", taken.Status)
 	require.Contains(t, taken.Reason, "live claims cannot be taken over")
 }
@@ -195,9 +195,10 @@ func TestClaimExpiryAndOwnershipStatuses(t *testing.T) {
 		remote, testTarget, "", func() time.Time { return testNow.Add(defaultClaimLease + claimClockSkew) })
 	require.Equal(t, "CLAIM_EXPIRED", alreadyExpired.Status)
 	notRenewOwner := renewClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
-		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+		remote, testTarget, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
 	require.Equal(t, "NOT_OWNER", notRenewOwner.Status)
-	notReleaseOwner := releaseClaim(context.Background(), campaign, finding, testClaimantB, remote, claimed.ClaimSHA)
+	notReleaseOwner := releaseClaim(context.Background(), campaign, finding, testClaimantB,
+		remote, testTarget, claimed.ClaimSHA)
 	require.Equal(t, "NOT_OWNER", notReleaseOwner.Status)
 
 	inspection := inspectAgainstRemote(campaign, remote, testClaimantB, testNow.Add(time.Hour))
@@ -223,10 +224,10 @@ func TestRemoteUnavailableAllowsNoClaimMutation(t *testing.T) {
 	claim := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
 		remote, testTarget, "", func() time.Time { return testNow })
 	renew := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
-		remote, "", "", func() time.Time { return testNow })
-	release := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, "")
+		remote, testTarget, "", "", func() time.Time { return testNow })
+	release := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, testTarget, "")
 	takeover := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
-		remote, "", "", func() time.Time { return testNow })
+		remote, testTarget, "", "", func() time.Time { return testNow })
 	for _, result := range []ClaimResult{claim, renew, release, takeover} {
 		require.Equal(t, "REMOTE_UNAVAILABLE", result.Status)
 	}
@@ -362,16 +363,44 @@ func TestClaimBoundToDifferentTargetSHAFailsClosed(t *testing.T) {
 	claimed := createClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
 		remote, testTarget, "", func() time.Time { return testNow })
 	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
-		remote, "", forgedSHA, func() time.Time { return testNow.Add(time.Hour) })
-	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, forgedSHA)
+		remote, testTarget, "", forgedSHA, func() time.Time { return testNow.Add(time.Hour) })
+	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, testTarget, forgedSHA)
 	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
-		remote, "", forgedSHA, func() time.Time { return testNow.Add(defaultClaimLease + claimClockSkew) })
+		remote, testTarget, "", forgedSHA, func() time.Time { return testNow.Add(defaultClaimLease + claimClockSkew) })
 	require.Equal(t, "CLAIM_CONFLICT", claimed.Status)
 	require.Equal(t, "CLAIM_CONFLICT", renewed.Status)
 	require.Equal(t, "CLAIM_CHANGED", released.Status)
 	require.Equal(t, "CLAIM_CONFLICT", taken.Status)
 
 	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
+	require.Equal(t, "CLAIM_IDENTITY_CONFLICT", inspection.Findings[0].Claim.Problem)
+}
+
+func TestClaimBoundToDifferentTargetBranchFailsClosed(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	const otherTarget = "release/other"
+	runGit(t, "", "--git-dir", remote, "update-ref", "refs/heads/"+otherTarget, targetSHA)
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+
+	otherClaim := createClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, otherTarget, "", func() time.Time { return testNow })
+	otherRenew := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, otherTarget, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	otherRelease := releaseClaim(context.Background(), campaign, finding, testClaimantA,
+		remote, otherTarget, claimed.ClaimSHA)
+	otherTakeover := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, otherTarget, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	require.Equal(t, "CLAIM_CONFLICT", otherClaim.Status)
+	require.Equal(t, "CLAIM_CONFLICT", otherRenew.Status)
+	require.Equal(t, "CLAIM_CHANGED", otherRelease.Status)
+	require.Equal(t, "CLAIM_CONFLICT", otherTakeover.Status)
+
+	inspection := inspectAgainstRemoteTarget(campaign, remote, otherTarget, testClaimantA, testNow)
 	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
 	require.Equal(t, "CLAIM_IDENTITY_CONFLICT", inspection.Findings[0].Claim.Problem)
 }
@@ -395,7 +424,7 @@ func TestRenewCanBindWorkBranchAndInspectDetectsItsDeletion(t *testing.T) {
 		remote, testTarget, "", func() time.Time { return testNow })
 	runGit(t, "", "--git-dir", remote, "update-ref", "refs/heads/work/finding", targetSHA)
 	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
-		remote, "work/finding", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+		remote, testTarget, "work/finding", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
 	require.Equal(t, "RENEWED", renewed.Status)
 	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Hour))
 	require.Equal(t, "CLAIMED", inspection.Findings[0].State)
@@ -480,11 +509,21 @@ func cloneCampaignWithQualifiedDigest(source *Campaign, digest string) *Campaign
 }
 
 func inspectAgainstRemote(campaign *Campaign, remote, claimant string, now time.Time) *Inspection {
+	return inspectAgainstRemoteTarget(campaign, remote, testTarget, claimant, now)
+}
+
+func inspectAgainstRemoteTarget(
+	campaign *Campaign,
+	remote string,
+	target string,
+	claimant string,
+	now time.Time,
+) *Inspection {
 	return (inspector{
 		now: func() time.Time { return now }, jira: fakeJiraProvider{}, github: fakeGitHubProvider{},
 		git: commandGitProvider{}, claims: commandClaimProvider{},
 	}).run(context.Background(), campaign, inspectOptions{
-		repository: "formancehq/ledger", jiraProject: "EN", remote: remote, target: testTarget, claimant: claimant,
+		repository: "formancehq/ledger", jiraProject: "EN", remote: remote, target: target, claimant: claimant,
 	})
 }
 

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -347,6 +347,14 @@ func TestClaimProviderUnavailableFailsClosed(t *testing.T) {
 	require.NotEqual(t, "CONFIRMED_UNASSIGNED", inspection.Findings[0].State)
 }
 
+func TestLiveInspectSupportsZeroFindingCampaign(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA)
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "FRESH", inspection.Freshness)
+	require.Empty(t, inspection.Findings)
+}
+
 func newClaimRemote(t *testing.T) (string, string) {
 	t.Helper()
 	remote := filepath.Join(t.TempDir(), "remote.git")

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -246,8 +246,15 @@ func TestManuallyDeletedClaimIsNotSilentlyUnassigned(t *testing.T) {
 
 	second := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Minute))
 	require.Equal(t, "CLAIM_HISTORY_MISSING", second.Findings[0].Claim.State)
+	require.Equal(t, claimed.ClaimSHA, second.Findings[0].Claim.ObservedClaimSHA)
 	require.Equal(t, "AMBIGUOUS", second.Findings[0].State)
 	require.Equal(t, "REFRESH_REQUIRED", second.Findings[0].NextAction)
+
+	third := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(2*time.Minute))
+	require.Equal(t, "CLAIM_HISTORY_MISSING", third.Findings[0].Claim.State)
+	require.Equal(t, claimed.ClaimSHA, third.Findings[0].Claim.ObservedClaimSHA)
+	require.Equal(t, "AMBIGUOUS", third.Findings[0].State)
+	require.Equal(t, "REFRESH_REQUIRED", third.Findings[0].NextAction)
 }
 
 func TestMalformedClaimRecordFailsClosed(t *testing.T) {

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -343,6 +343,39 @@ func TestSameFindingIDDifferentQualifiedDigestConflicts(t *testing.T) {
 	require.Contains(t, conflict.Reason, "identity does not match")
 }
 
+func TestClaimBoundToDifferentTargetSHAFailsClosed(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	forged := ClaimRecord{
+		SchemaVersion: claimSchemaVersion, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
+		FindingID: finding.ID, FindingIdentityDigest: finding.IdentityDigest,
+		SourceQualifiedDigest: campaign.SourceDigests.Qualified, AuditedSHA: campaign.AuditedSHA,
+		Qualification: "CONFIRMED", Claimant: testClaimantA, CreatedAt: testNow,
+		ExpiresAt: testNow.Add(defaultClaimLease), TargetBranch: testTarget,
+		TargetSHA: strings.Repeat("e", 40),
+	}
+	ref := claimRef(campaign.AuditID, finding.ID)
+	forgedSHA := writeRemoteClaimRecord(t, remote, forged, "")
+	runGit(t, "", "--git-dir", remote, "update-ref", ref, forgedSHA)
+
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, "", forgedSHA, func() time.Time { return testNow.Add(time.Hour) })
+	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, forgedSHA)
+	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, "", forgedSHA, func() time.Time { return testNow.Add(defaultClaimLease + claimClockSkew) })
+	require.Equal(t, "CLAIM_CONFLICT", claimed.Status)
+	require.Equal(t, "CLAIM_CONFLICT", renewed.Status)
+	require.Equal(t, "CLAIM_CHANGED", released.Status)
+	require.Equal(t, "CLAIM_CONFLICT", taken.Status)
+
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
+	require.Equal(t, "CLAIM_IDENTITY_CONFLICT", inspection.Findings[0].Claim.Problem)
+}
+
 func TestNonConfirmedAndRejectedFindingsCannotBeClaimed(t *testing.T) {
 	remote, targetSHA := newClaimRemote(t)
 	campaign := claimCampaignAt(targetSHA, "LIKELY", "QUESTION", "REJECTED")

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testClaimantA = "agent@machine#session-a"
+	testClaimantB = "agent@machine#session-b"
+)
+
+func TestClaimRefIsDeterministicAndDigestIndependent(t *testing.T) {
+	t.Parallel()
+
+	first := claimRef("audit-domain", "audit-domain/finding-one")
+	second := claimRef("audit-domain", "audit-domain/finding-one")
+	require.Equal(t, first, second)
+	require.Regexp(t, `^refs/heads/ai-claims/v1/[0-9a-f]{64}$`, first)
+	require.NotEqual(t, first, claimRef("audit-domain", "audit-domain/finding-two"))
+}
+
+func TestClaimCommandsEmitStructuredStatuses(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	path := filepath.Join(t.TempDir(), "campaign.json")
+	require.NoError(t, writeCampaign(path, campaign))
+	config := filepath.Join(t.TempDir(), "gitconfig")
+	require.NoError(t, os.WriteFile(config, []byte("[remote \"claimtest\"]\n\turl = "+remote+"\n"), 0o600))
+	t.Setenv("GIT_CONFIG_GLOBAL", config)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	require.NoError(t, run([]string{
+		"claim", path, "--finding", campaign.SourceFacts.Findings[0].ID,
+		"--claimant", testClaimantA, "--remote", "claimtest",
+	}, &stdout, &stderr))
+	var claimed ClaimResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &claimed))
+	require.Equal(t, "CLAIMED", claimed.Status, claimed.Reason)
+	require.Contains(t, stderr.String(), "CLAIMED")
+
+	stdout.Reset()
+	stderr.Reset()
+	require.NoError(t, run([]string{
+		"release", path, "--finding", campaign.SourceFacts.Findings[0].ID,
+		"--claimant", testClaimantA, "--remote", "claimtest", "--expected-claim-sha", claimed.ClaimSHA,
+	}, &stdout, &stderr))
+	var released ClaimResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &released))
+	require.Equal(t, "RELEASED", released.Status)
+}
+
+func TestTwoSimultaneousClaimersExactlyOneWins(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	start := make(chan struct{})
+	results := make(chan ClaimResult, 2)
+	var wait sync.WaitGroup
+	for _, claimant := range []string{testClaimantA, testClaimantB} {
+		wait.Go(func() {
+			<-start
+			results <- createClaim(context.Background(), campaign, finding, claimant, defaultClaimLease,
+				remote, testTarget, "", func() time.Time { return testNow })
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	statuses := []string{}
+	for result := range results {
+		statuses = append(statuses, result.Status)
+	}
+	sort.Strings(statuses)
+	require.Equal(t, []string{"ALREADY_CLAIMED", "CLAIMED"}, statuses)
+}
+
+func TestDifferentFindingsCanBeClaimedConcurrently(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED", "CONFIRMED")
+	results := make(chan ClaimResult, 2)
+	var wait sync.WaitGroup
+	for index, finding := range campaign.SourceFacts.Findings {
+		wait.Go(func() {
+			claimant := []string{testClaimantA, testClaimantB}[index]
+			results <- createClaim(context.Background(), campaign, finding, claimant, defaultClaimLease,
+				remote, testTarget, "", func() time.Time { return testNow })
+		})
+	}
+	wait.Wait()
+	close(results)
+	for result := range results {
+		require.Equal(t, "CLAIMED", result.Status)
+	}
+}
+
+func TestRenewRaceRejectsTheStaleObservedSHA(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+
+	start := make(chan struct{})
+	results := make(chan ClaimResult, 2)
+	var wait sync.WaitGroup
+	for index := range 2 {
+		wait.Go(func() {
+			<-start
+			renewedAt := testNow.Add(time.Duration(index+1) * time.Minute)
+			results <- renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+				remote, "", claimed.ClaimSHA, func() time.Time { return renewedAt })
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	statuses := []string{}
+	for result := range results {
+		statuses = append(statuses, result.Status)
+	}
+	sort.Strings(statuses)
+	require.Equal(t, []string{"CLAIM_CHANGED", "RENEWED"}, statuses)
+}
+
+func TestReleaseRaceDoesNotDeleteChangedClaim(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	require.Equal(t, "RENEWED", renewed.Status)
+
+	released := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, claimed.ClaimSHA)
+	require.Equal(t, "CLAIM_CHANGED", released.Status)
+	require.Equal(t, renewed.ClaimSHA, remoteRefSHA(t, remote, claimed.RemoteRef))
+}
+
+func TestExpiredClaimTakeoverUsesExactCASAndPreservesPredecessor(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	createdAt := testNow.Add(-2 * time.Hour)
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, time.Hour,
+		remote, testTarget, "work/old", func() time.Time { return createdAt })
+	require.Equal(t, "CLAIMED", claimed.Status)
+
+	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, "", claimed.ClaimSHA, func() time.Time { return testNow })
+	require.Equal(t, "TAKEN_OVER", taken.Status)
+	require.NotNil(t, taken.Claim.Predecessor)
+	require.Equal(t, claimed.ClaimSHA, taken.Claim.Predecessor.ClaimSHA)
+	require.Equal(t, testClaimantA, taken.Claim.Predecessor.Claimant)
+	require.Equal(t, "work/old", taken.Claim.WorkBranch)
+}
+
+func TestLiveClaimTakeoverIsRefused(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+
+	taken := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	require.Equal(t, "CLAIM_CONFLICT", taken.Status)
+	require.Contains(t, taken.Reason, "live claims cannot be taken over")
+}
+
+func TestClaimExpiryAndOwnershipStatuses(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+
+	alreadyExpired := createClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow.Add(defaultClaimLease + claimClockSkew) })
+	require.Equal(t, "CLAIM_EXPIRED", alreadyExpired.Status)
+	notRenewOwner := renewClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, "", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	require.Equal(t, "NOT_OWNER", notRenewOwner.Status)
+	notReleaseOwner := releaseClaim(context.Background(), campaign, finding, testClaimantB, remote, claimed.ClaimSHA)
+	require.Equal(t, "NOT_OWNER", notReleaseOwner.Status)
+
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantB, testNow.Add(time.Hour))
+	require.Equal(t, "WAIT_OR_COORDINATE", inspection.Findings[0].NextAction)
+}
+
+func TestClaimRefusesAdvancedTarget(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	advancedSHA := writeRemoteClaimContent(t, remote, []byte("advanced\n"), "")
+	runGit(t, "", "--git-dir", remote, "update-ref", "refs/heads/"+testTarget, advancedSHA)
+
+	result := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "BROKEN_CAMPAIGN_BINDING", result.Status)
+}
+
+func TestRemoteUnavailableAllowsNoClaimMutation(t *testing.T) {
+	campaign := claimCampaignAt(testHead, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	remote := filepath.Join(t.TempDir(), "missing.git")
+	claim := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	renew := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, "", "", func() time.Time { return testNow })
+	release := releaseClaim(context.Background(), campaign, finding, testClaimantA, remote, "")
+	takeover := takeoverClaim(context.Background(), campaign, finding, testClaimantB, defaultClaimLease,
+		remote, "", "", func() time.Time { return testNow })
+	for _, result := range []ClaimResult{claim, renew, release, takeover} {
+		require.Equal(t, "REMOTE_UNAVAILABLE", result.Status)
+	}
+}
+
+func TestManuallyDeletedClaimIsNotSilentlyUnassigned(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "work/in-progress", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+	runGit(t, "", "--git-dir", remote, "update-ref", "refs/heads/work/in-progress", targetSHA)
+	first := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "CLAIMED", first.Findings[0].State)
+	runGit(t, "", "--git-dir", remote, "update-ref", "-d", claimed.RemoteRef)
+
+	second := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Minute))
+	require.Equal(t, "CLAIM_HISTORY_MISSING", second.Findings[0].Claim.State)
+	require.Equal(t, "AMBIGUOUS", second.Findings[0].State)
+	require.Equal(t, "REFRESH_REQUIRED", second.Findings[0].NextAction)
+}
+
+func TestMalformedClaimRecordFailsClosed(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	ref := claimRef(campaign.AuditID, finding.ID)
+	malformedSHA := writeRemoteClaimContent(t, remote, []byte(`{"schemaVersion":"ai-claim/v1","claimant":"spoof"}`+"\n"), "")
+	runGit(t, "", "--git-dir", remote, "update-ref", ref, malformedSHA)
+
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].Claim.State)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
+	require.Contains(t, inspection.Findings[0].Claim.Problem, "INVALID_CLAIM_RECORD")
+}
+
+func TestValidButForceRewrittenClaimHistoryFailsClosed(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+	first := inspectAgainstRemote(campaign, remote, testClaimantA, testNow)
+	require.Equal(t, "CLAIMED", first.Findings[0].State)
+	createdAt := testNow.Add(time.Hour)
+	forged := ClaimRecord{
+		SchemaVersion: claimSchemaVersion, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
+		FindingID: finding.ID, FindingIdentityDigest: finding.IdentityDigest,
+		SourceQualifiedDigest: campaign.SourceDigests.Qualified, AuditedSHA: campaign.AuditedSHA,
+		Qualification: "CONFIRMED", Claimant: testClaimantB, CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(defaultClaimLease), TargetBranch: testTarget, TargetSHA: targetSHA,
+	}
+	content, err := json.MarshalIndent(forged, "", "  ")
+	require.NoError(t, err)
+	content = append(content, '\n')
+	forgedSHA := writeRemoteClaimContent(t, remote, content, "")
+	runGit(t, "", "--git-dir", remote, "update-ref", claimed.RemoteRef, forgedSHA, claimed.ClaimSHA)
+
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, createdAt)
+	require.Equal(t, "AMBIGUOUS", inspection.Findings[0].State)
+	require.Equal(t, "CLAIM_HISTORY_REWRITTEN", inspection.Findings[0].Claim.Problem)
+}
+
+func TestSameFindingIDDifferentQualifiedDigestConflicts(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	first := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := first.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), first, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	require.Equal(t, "CLAIMED", claimed.Status)
+	second := cloneCampaignWithQualifiedDigest(first, "sha256:"+strings.Repeat("c", 64))
+
+	conflict := createClaim(context.Background(), second, second.SourceFacts.Findings[0], testClaimantB,
+		defaultClaimLease, remote, testTarget, "", func() time.Time { return testNow.Add(time.Minute) })
+	require.Equal(t, "CLAIM_CONFLICT", conflict.Status)
+	require.Contains(t, conflict.Reason, "identity does not match")
+}
+
+func TestNonConfirmedAndRejectedFindingsCannotBeClaimed(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "LIKELY", "QUESTION", "REJECTED")
+	for _, finding := range campaign.SourceFacts.Findings {
+		result := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+			remote, testTarget, "", func() time.Time { return testNow })
+		require.Equal(t, "FINDING_NOT_CLAIMABLE", result.Status)
+		require.Empty(t, remoteRefSHA(t, remote, claimRef(campaign.AuditID, finding.ID)))
+	}
+}
+
+func TestRenewCanBindWorkBranchAndInspectDetectsItsDeletion(t *testing.T) {
+	remote, targetSHA := newClaimRemote(t)
+	campaign := claimCampaignAt(targetSHA, "CONFIRMED")
+	finding := campaign.SourceFacts.Findings[0]
+	claimed := createClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, testTarget, "", func() time.Time { return testNow })
+	runGit(t, "", "--git-dir", remote, "update-ref", "refs/heads/work/finding", targetSHA)
+	renewed := renewClaim(context.Background(), campaign, finding, testClaimantA, defaultClaimLease,
+		remote, "work/finding", claimed.ClaimSHA, func() time.Time { return testNow.Add(time.Hour) })
+	require.Equal(t, "RENEWED", renewed.Status)
+	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Hour))
+	require.Equal(t, "CLAIMED", inspection.Findings[0].State)
+	require.Equal(t, "CONTINUE_CLAIMED_WORK", inspection.Findings[0].NextAction)
+	runGit(t, "", "--git-dir", remote, "update-ref", "-d", "refs/heads/work/finding")
+
+	inspection = inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Hour))
+	require.Equal(t, "BROKEN_BINDING", inspection.Findings[0].Claim.State)
+	require.Equal(t, "REPAIR_BINDING", inspection.Findings[0].NextAction)
+}
+
+func TestClaimProviderUnavailableFailsClosed(t *testing.T) {
+	campaign := claimCampaignAt(testHead, "CONFIRMED")
+	missing := filepath.Join(t.TempDir(), "missing.git")
+	inspection := inspectAgainstRemote(campaign, missing, testClaimantA, testNow)
+	require.Equal(t, "UNKNOWN", inspection.Findings[0].Claim.State)
+	require.Equal(t, "REFRESH_REQUIRED", inspection.Findings[0].NextAction)
+	require.NotEqual(t, "CONFIRMED_UNASSIGNED", inspection.Findings[0].State)
+}
+
+func newClaimRemote(t *testing.T) (string, string) {
+	t.Helper()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "", "init", "--bare", "--quiet", remote)
+	seed := filepath.Join(t.TempDir(), "seed")
+	runGit(t, "", "init", "--quiet", seed)
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "README"), []byte("seed\n"), 0o600))
+	runGit(t, seed, "add", "README")
+	runGit(t, seed, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "--quiet", "-m", "seed")
+	targetSHA := strings.TrimSpace(runGit(t, seed, "rev-parse", "HEAD"))
+	runGit(t, seed, "push", "--quiet", remote, targetSHA+":refs/heads/"+testTarget)
+
+	return remote, targetSHA
+}
+
+func claimCampaignAt(targetSHA string, qualifications ...string) *Campaign {
+	campaign := testCampaign(qualifications...)
+	campaign.AuditedSHA = targetSHA
+	seen := map[string]int{}
+	for index := range campaign.SourceFacts.Findings {
+		id := campaign.SourceFacts.Findings[index].ID
+		seen[id]++
+		if seen[id] > 1 {
+			campaign.SourceFacts.Findings[index].ID += fmt.Sprintf("-%d", seen[id])
+		}
+	}
+	for index := range campaign.SourceFacts.Findings {
+		campaign.SourceFacts.Findings[index].IdentityDigest = sourceFindingDigest(campaign, campaign.SourceFacts.Findings[index])
+	}
+	campaign.SourceFacts.IdentityDigest = sourceFactsDigest(campaign)
+	campaign.CampaignID = campaignID(campaign)
+
+	return campaign
+}
+
+func cloneCampaignWithQualifiedDigest(source *Campaign, digest string) *Campaign {
+	content, err := json.Marshal(source)
+	if err != nil {
+		panic(err)
+	}
+	var clone Campaign
+	if err := json.Unmarshal(content, &clone); err != nil {
+		panic(err)
+	}
+	clone.Observations = nil
+	clone.SourceDigests.Qualified = digest
+	for index := range clone.SourceFacts.Findings {
+		clone.SourceFacts.Findings[index].IdentityDigest = sourceFindingDigest(&clone, clone.SourceFacts.Findings[index])
+	}
+	clone.SourceFacts.IdentityDigest = sourceFactsDigest(&clone)
+	clone.CampaignID = campaignID(&clone)
+
+	return &clone
+}
+
+func inspectAgainstRemote(campaign *Campaign, remote, claimant string, now time.Time) *Inspection {
+	return (inspector{
+		now: func() time.Time { return now }, jira: fakeJiraProvider{}, github: fakeGitHubProvider{},
+		git: commandGitProvider{}, claims: commandClaimProvider{},
+	}).run(context.Background(), campaign, inspectOptions{
+		repository: "formancehq/ledger", jiraProject: "EN", remote: remote, target: testTarget, claimant: claimant,
+	})
+}
+
+func remoteRefSHA(t *testing.T, remote, ref string) string {
+	t.Helper()
+	command := exec.Command("git", "ls-remote", "--heads", remote, ref)
+	output, err := command.Output()
+	require.NoError(t, err)
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return ""
+	}
+	require.Len(t, fields, 2)
+
+	return fields[0]
+}
+
+func writeRemoteClaimContent(t *testing.T, remote string, content []byte, parent string) string {
+	t.Helper()
+	blob := strings.TrimSpace(runGitInput(t, content, "", "--git-dir", remote, "hash-object", "-w", "--stdin"))
+	tree := strings.TrimSpace(runGitInput(t, []byte("100644 blob "+blob+"\tclaim.json\n"), "",
+		"--git-dir", remote, "mktree"))
+	arguments := []string{"--git-dir", remote, "commit-tree", tree, "-m", "tampered claim"}
+	if parent != "" {
+		arguments = append(arguments, "-p", parent)
+	}
+
+	return strings.TrimSpace(runGitInput(t, nil, "", arguments...))
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+
+	return runGitInput(t, nil, directory, arguments...)
+}
+
+func runGitInput(t *testing.T, input []byte, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	command.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.invalid",
+	)
+	command.Stdin = bytes.NewReader(input)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+
+	return string(output)
+}

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -56,7 +56,7 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 		previousClaimSHAs[source.ID] = previous.claim(source.ID).ObservedClaimSHA
 	}
 	claimValues, claimError := runner.claims.Observe(
-		ctx, options.remote, campaign, now, options.claimant, previousClaimSHAs,
+		ctx, options.remote, campaign, options.target, now, options.claimant, previousClaimSHAs,
 	)
 	claimProviderObservation := freshProvider(now)
 	if claimError != nil {

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ type inspectOptions struct {
 	remote      string
 	target      string
 	offline     bool
+	claimant    string
 }
 
 type inspector struct {
@@ -20,6 +22,7 @@ type inspector struct {
 	jira   jiraProvider
 	github githubProvider
 	git    gitProvider
+	claims claimProvider
 }
 
 func (runner inspector) run(ctx context.Context, campaign *Campaign, options inspectOptions) *Inspection {
@@ -48,6 +51,32 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 		githubProviderObservation = unavailableProvider(previous.provider("github"), githubError)
 	}
 
+	previousClaimSHAs := make(map[string]string, len(campaign.SourceFacts.Findings))
+	for _, source := range campaign.SourceFacts.Findings {
+		previousClaimSHAs[source.ID] = previous.claim(source.ID).ObservedClaimSHA
+	}
+	claimValues, claimError := runner.claims.Observe(
+		ctx, options.remote, campaign, now, options.claimant, previousClaimSHAs,
+	)
+	claimProviderObservation := freshProvider(now)
+	if claimError != nil {
+		claimProviderObservation = unavailableProvider(previous.provider("claims"), claimError)
+		claimValues = make(map[string]ClaimObservation, len(campaign.SourceFacts.Findings))
+		for _, source := range campaign.SourceFacts.Findings {
+			claimValues[source.ID] = unavailableClaimObservation(campaign, source, previous.claim(source.ID), claimError)
+		}
+	} else {
+		for _, source := range campaign.SourceFacts.Findings {
+			current := claimValues[source.ID]
+			prior := previous.claim(source.ID)
+			if current.State == "UNCLAIMED" && prior.ObservedClaimSHA != "" && prior.State != "UNCLAIMED" {
+				current.State = "CLAIM_HISTORY_MISSING"
+				current.Problem = "previously observed remote claim ref is missing"
+				claimValues[source.ID] = current
+			}
+		}
+	}
+
 	refs := []string{"refs/heads/" + options.target}
 	prValuesForRefs := githubValues
 	if githubError != nil {
@@ -58,6 +87,11 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 			if !match.CrossRepository && match.HeadRef != "" {
 				refs = append(refs, "refs/heads/"+match.HeadRef)
 			}
+		}
+	}
+	for _, claim := range claimValues {
+		if claim.WorkBranch != "" {
+			refs = append(refs, "refs/heads/"+claim.WorkBranch)
 		}
 	}
 	slices.Sort(refs)
@@ -72,6 +106,7 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 		GitHub: githubProviderObservation,
 		Jira:   jiraProviderObservation,
 		Git:    gitProviderObservation,
+		Claims: claimProviderObservation,
 	}
 	freshness := combinedFreshness(providers)
 	var refreshedAt *time.Time
@@ -137,9 +172,16 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 				}
 			}
 		}
+		claimObservation := claimValues[source.ID]
+		if claimObservation.WorkBranch != "" && gitError == nil &&
+			gitValues["refs/heads/"+claimObservation.WorkBranch] == "" &&
+			(claimObservation.State == "CLAIMED" || claimObservation.State == "CLAIM_EXPIRED") {
+			claimObservation.State = "BROKEN_BINDING"
+			claimObservation.Problem = "CLAIM_WORK_BRANCH_MISSING"
+		}
 
 		projection := projectFinding(source, jiraObservation, prObservation,
-			campaign.AuditedSHA, options.target, observations.Target.ObservedSHA, freshness)
+			campaign.AuditedSHA, options.target, observations.Target.ObservedSHA, freshness, claimObservation)
 		observations.Findings = append(observations.Findings, projection)
 	}
 	campaign.Observations = observations
@@ -166,9 +208,19 @@ func (previous priorObservationSet) provider(name string) ProviderObservation {
 		return previous.set.Providers.Jira
 	case "git":
 		return previous.set.Providers.Git
+	case "claims":
+		return previous.set.Providers.Claims
 	default:
 		panic("unknown provider " + name)
 	}
+}
+
+func (previous priorObservationSet) claim(id string) ClaimObservation {
+	if finding, ok := previous.finding(id); ok && finding.Claim.RemoteRef != "" {
+		return finding.Claim
+	}
+
+	return ClaimObservation{}
 }
 
 func (previous priorObservationSet) finding(id string) (FindingObservation, bool) {
@@ -239,6 +291,7 @@ func staleObservations(campaign *Campaign, previous priorObservationSet, target 
 		GitHub: staleProvider(previous.provider("github"), "offline inspection"),
 		Jira:   staleProvider(previous.provider("jira"), "offline inspection"),
 		Git:    staleProvider(previous.provider("git"), "offline inspection"),
+		Claims: staleProvider(previous.provider("claims"), "offline inspection"),
 	}
 	freshness := combinedFreshness(providers)
 	observations := &ObservationSet{
@@ -260,8 +313,9 @@ func staleObservations(campaign *Campaign, previous priorObservationSet, target 
 		jira.Status = "UNKNOWN"
 		pr := previous.pr(source.ID)
 		pr.Status = "UNKNOWN"
+		claim := unavailableClaimObservation(campaign, source, previous.claim(source.ID), errors.New("offline inspection"))
 		observations.Findings = append(observations.Findings,
-			projectFinding(source, jira, pr, campaign.AuditedSHA, target, observations.Target.ObservedSHA, freshness))
+			projectFinding(source, jira, pr, campaign.AuditedSHA, target, observations.Target.ObservedSHA, freshness, claim))
 	}
 
 	return observations
@@ -275,12 +329,14 @@ func projectFinding(
 	targetBranch string,
 	targetSHA string,
 	freshness string,
+	claim ClaimObservation,
 ) FindingObservation {
 	projection := FindingObservation{
 		FactType:          observationFactType,
 		ID:                source.ID,
 		Jira:              jira,
 		PR:                pr,
+		Claim:             claim,
 		ObservedTargetSHA: targetSHA,
 		Blockers:          []string{},
 		Freshness:         freshness,
@@ -301,6 +357,39 @@ func projectFinding(
 			projection.NextAction = "HUMAN_DECISION_REQUIRED"
 		default:
 			projection.NextAction = "NO_ACTION"
+		}
+
+		return projection
+	}
+	if claim.State == "AMBIGUOUS" || claim.State == "CLAIM_HISTORY_MISSING" {
+		projection.State = "AMBIGUOUS"
+		projection.Blockers = append(projection.Blockers, claim.State)
+		if claim.Problem != "" {
+			projection.Blockers = append(projection.Blockers, claim.Problem)
+		}
+		projection.NextAction = "REFRESH_REQUIRED"
+
+		return projection
+	}
+	if claim.State == "BROKEN_BINDING" {
+		projection.State = "BROKEN_BINDING"
+		projection.Blockers = append(projection.Blockers, claim.Problem)
+		projection.NextAction = "REPAIR_BINDING"
+
+		return projection
+	}
+	if claim.State == "CLAIM_EXPIRED" {
+		projection.State = "CLAIM_EXPIRED"
+		projection.NextAction = "REVIEW_EXPIRED_CLAIM"
+
+		return projection
+	}
+	if claim.State == "CLAIMED" {
+		projection.State = "CLAIMED"
+		if claim.OwnedBySession {
+			projection.NextAction = "CONTINUE_CLAIMED_WORK"
+		} else {
+			projection.NextAction = "WAIT_OR_COORDINATE"
 		}
 
 		return projection
@@ -358,10 +447,10 @@ func projectFinding(
 		projection.NextAction = "REQUALIFY_ON_CURRENT_TARGET"
 	case len(jira.Issues) == 1:
 		projection.State = "TRACKED"
-		projection.NextAction = "READY_FOR_CLAIM_OR_DISPATCH"
+		projection.NextAction = "CLAIM"
 	default:
 		projection.State = "CONFIRMED_UNASSIGNED"
-		projection.NextAction = "PUBLISH_JIRA_OR_REVIEW_POLICY"
+		projection.NextAction = "CLAIM"
 	}
 
 	if freshness != "FRESH" {
@@ -402,6 +491,7 @@ func buildInspection(campaign *Campaign) *Inspection {
 			State:                observation.State,
 			Jira:                 observation.Jira,
 			PR:                   observation.PR,
+			Claim:                observation.Claim,
 			ObservedCandidateSHA: observation.ObservedCandidateSHA,
 			ObservedTargetSHA:    observation.ObservedTargetSHA,
 			Blockers:             nonNilStrings(observation.Blockers),
@@ -448,7 +538,7 @@ func staleProvider(previous ProviderObservation, reason string) ProviderObservat
 }
 
 func combinedFreshness(providers ProviderObservations) string {
-	statuses := []string{providers.GitHub.Status, providers.Jira.Status, providers.Git.Status}
+	statuses := []string{providers.GitHub.Status, providers.Jira.Status, providers.Git.Status, providers.Claims.Status}
 	fresh := 0
 	stale := 0
 	for _, status := range statuses {

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -361,39 +361,6 @@ func projectFinding(
 
 		return projection
 	}
-	if claim.State == "AMBIGUOUS" || claim.State == "CLAIM_HISTORY_MISSING" {
-		projection.State = "AMBIGUOUS"
-		projection.Blockers = append(projection.Blockers, claim.State)
-		if claim.Problem != "" {
-			projection.Blockers = append(projection.Blockers, claim.Problem)
-		}
-		projection.NextAction = "REFRESH_REQUIRED"
-
-		return projection
-	}
-	if claim.State == "BROKEN_BINDING" {
-		projection.State = "BROKEN_BINDING"
-		projection.Blockers = append(projection.Blockers, claim.Problem)
-		projection.NextAction = "REPAIR_BINDING"
-
-		return projection
-	}
-	if claim.State == "CLAIM_EXPIRED" {
-		projection.State = "CLAIM_EXPIRED"
-		projection.NextAction = "REVIEW_EXPIRED_CLAIM"
-
-		return projection
-	}
-	if claim.State == "CLAIMED" {
-		projection.State = "CLAIMED"
-		if claim.OwnedBySession {
-			projection.NextAction = "CONTINUE_CLAIMED_WORK"
-		} else {
-			projection.NextAction = "WAIT_OR_COORDINATE"
-		}
-
-		return projection
-	}
 
 	switch {
 	case jira.Status == "AMBIGUOUS":
@@ -404,6 +371,17 @@ func projectFinding(
 		projection.State = "AMBIGUOUS"
 		projection.Blockers = append(projection.Blockers, "AMBIGUOUS_PR_BINDING")
 		projection.NextAction = "RESOLVE_BINDING"
+	case claim.State == "AMBIGUOUS" || claim.State == "CLAIM_HISTORY_MISSING":
+		projection.State = "AMBIGUOUS"
+		projection.Blockers = append(projection.Blockers, claim.State)
+		if claim.Problem != "" {
+			projection.Blockers = append(projection.Blockers, claim.Problem)
+		}
+		projection.NextAction = "REFRESH_REQUIRED"
+	case claim.State == "BROKEN_BINDING":
+		projection.State = "BROKEN_BINDING"
+		projection.Blockers = append(projection.Blockers, claim.Problem)
+		projection.NextAction = "REPAIR_BINDING"
 	case len(pr.Matches) == 1:
 		match := pr.Matches[0]
 		switch {
@@ -445,6 +423,16 @@ func projectFinding(
 		projection.State = "BLOCKED"
 		projection.Blockers = append(projection.Blockers, "TARGET_ADVANCED")
 		projection.NextAction = "REQUALIFY_ON_CURRENT_TARGET"
+	case claim.State == "CLAIM_EXPIRED":
+		projection.State = "CLAIM_EXPIRED"
+		projection.NextAction = "REVIEW_EXPIRED_CLAIM"
+	case claim.State == "CLAIMED":
+		projection.State = "CLAIMED"
+		if claim.OwnedBySession {
+			projection.NextAction = "CONTINUE_CLAIMED_WORK"
+		} else {
+			projection.NextAction = "WAIT_OR_COORDINATE"
+		}
 	case len(jira.Issues) == 1:
 		projection.State = "TRACKED"
 		projection.NextAction = "CLAIM"

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -70,7 +70,10 @@ func (runner inspector) run(ctx context.Context, campaign *Campaign, options ins
 			current := claimValues[source.ID]
 			prior := previous.claim(source.ID)
 			if current.State == "UNCLAIMED" && prior.ObservedClaimSHA != "" && prior.State != "UNCLAIMED" {
+				current = prior
 				current.State = "CLAIM_HISTORY_MISSING"
+				current.Freshness = "FRESH"
+				current.OwnedBySession = current.Claimant != "" && current.Claimant == options.claimant
 				current.Problem = "previously observed remote claim ref is missing"
 				claimValues[source.ID] = current
 			}

--- a/scripts/aicampaign/main.go
+++ b/scripts/aicampaign/main.go
@@ -38,6 +38,14 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		return runInspect(arguments[1:], stdout, stderr)
 	case "next":
 		return runNext(arguments[1:], stdout, stderr)
+	case "claim":
+		return runClaim(arguments[1:], stdout, stderr)
+	case "renew":
+		return runRenew(arguments[1:], stdout, stderr)
+	case "release":
+		return runRelease(arguments[1:], stdout, stderr)
+	case "takeover":
+		return runTakeover(arguments[1:], stdout, stderr)
 	default:
 		if err := usage(stderr); err != nil {
 			return err
@@ -101,12 +109,13 @@ func runImport(arguments []string, stdout, stderr io.Writer) error {
 func runInspect(arguments []string, stdout, stderr io.Writer) error {
 	values, flags, err := parseArguments(arguments, map[string]bool{
 		"--offline": false, "--repo": true, "--jira-project": true, "--remote": true, "--target": true,
+		"--claimant": true,
 	})
 	if err != nil {
 		return err
 	}
 	if len(values) != 1 {
-		return errors.New("usage: ai-campaign inspect <campaign> [--offline] [--repo <owner/name>] [--jira-project <key>] [--remote <name>] [--target <branch>]")
+		return errors.New("usage: ai-campaign inspect <campaign> [--offline] [--claimant <id>] [--repo <owner/name>] [--jira-project <key>] [--remote <name>] [--target <branch>]")
 	}
 	repoRoot, err := repositoryRoot()
 	if err != nil {
@@ -126,6 +135,7 @@ func runInspect(arguments []string, stdout, stderr io.Writer) error {
 		remote:      valueOr(flags["--remote"], "origin"),
 		target:      valueOr(flags["--target"], "release/v3.0"),
 		offline:     flags["--offline"] == "true",
+		claimant:    valueOr(flags["--claimant"], os.Getenv("AI_CAMPAIGN_CLAIMANT")),
 	}
 	if err := validateInspectOptions(options); err != nil {
 		return err
@@ -134,6 +144,7 @@ func runInspect(arguments []string, stdout, stderr io.Writer) error {
 	defer cancel()
 	result := (inspector{
 		now: time.Now, jira: commandJiraProvider{}, github: commandGitHubProvider{}, git: commandGitProvider{},
+		claims: commandClaimProvider{},
 	}).run(ctx, campaign, options)
 	if err := writeCampaign(campaignPath, campaign); err != nil {
 		return err
@@ -220,6 +231,9 @@ func validateInspectOptions(options inspectOptions) error {
 	if options.target == "" || exec.Command("git", "check-ref-format", "refs/heads/"+options.target).Run() != nil {
 		return errors.New("invalid target branch")
 	}
+	if options.claimant != "" && !claimantPattern.MatchString(options.claimant) {
+		return errors.New("invalid claimant")
+	}
 
 	return nil
 }
@@ -263,8 +277,12 @@ func writeInspectionHuman(destination io.Writer, inspection *Inspection) error {
 		if len(finding.Blockers) > 0 {
 			blockers = strings.Join(finding.Blockers, ",")
 		}
-		if err := writeHuman(destination, "  %s [%s] %s jira=%s pr=%s freshness=%s blockers=%s next=%s\n",
-			finding.ID, finding.Qualification, finding.State, jira, pullRequest, finding.Freshness, blockers,
+		claim := finding.Claim.State
+		if finding.Claim.Claimant != "" {
+			claim += "/" + finding.Claim.Claimant
+		}
+		if err := writeHuman(destination, "  %s [%s] %s claim=%s jira=%s pr=%s freshness=%s blockers=%s next=%s\n",
+			finding.ID, finding.Qualification, finding.State, claim, jira, pullRequest, finding.Freshness, blockers,
 			finding.NextAction); err != nil {
 			return err
 		}
@@ -286,6 +304,10 @@ func usage(destination io.Writer) error {
   scripts/ai-campaign import <qualified-result> --audit <source-audit> [--output <path>]
   scripts/ai-campaign inspect <campaign> [--offline]
   scripts/ai-campaign next <campaign>
+  scripts/ai-campaign claim <campaign> --finding <id> [--claimant <id>]
+  scripts/ai-campaign renew <campaign> --finding <id> --claimant <id>
+  scripts/ai-campaign release <campaign> --finding <id> --claimant <id>
+  scripts/ai-campaign takeover <campaign> --finding <id> [--claimant <id>]
 
 Human summaries are written to stderr; stable JSON is written to stdout.
 `)

--- a/scripts/aicampaign/model.go
+++ b/scripts/aicampaign/model.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"slices"
 	"strings"
@@ -14,8 +15,9 @@ import (
 
 const (
 	campaignSchemaVersion   = "ai-campaign/v1"
-	inspectionSchemaVersion = "ai-campaign-inspection/v1"
-	nextSchemaVersion       = "ai-campaign-next/v1"
+	inspectionSchemaVersion = "ai-campaign-inspection/v2"
+	nextSchemaVersion       = "ai-campaign-next/v2"
+	claimSchemaVersion      = "ai-claim/v1"
 	sourceFactType          = "SOURCE_FACT"
 	observationFactType     = "DERIVED_OBSERVATION"
 )
@@ -29,6 +31,8 @@ var (
 	jiraProjectPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
 	githubRepoPattern  = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 	gitRemotePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+	claimantPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._@:/+#=-]{2,159}$`)
+	campaignIDPattern  = regexp.MustCompile(`^campaign-[0-9a-f]{64}$`)
 )
 
 type Campaign struct {
@@ -84,6 +88,7 @@ type ProviderObservations struct {
 	GitHub ProviderObservation `json:"github"`
 	Jira   ProviderObservation `json:"jira"`
 	Git    ProviderObservation `json:"git"`
+	Claims ProviderObservation `json:"claims"`
 }
 
 type ProviderObservation struct {
@@ -99,17 +104,18 @@ type TargetObservation struct {
 }
 
 type FindingObservation struct {
-	FactType             string          `json:"factType"`
-	ID                   string          `json:"id"`
-	State                string          `json:"state"`
-	Jira                 JiraObservation `json:"jira"`
-	PR                   PRObservation   `json:"pr"`
-	ObservedCandidateSHA string          `json:"observedCandidateSha"`
-	ObservedTargetSHA    string          `json:"observedTargetSha"`
-	Blockers             []string        `json:"blockers"`
-	NextAction           string          `json:"nextAction"`
-	Freshness            string          `json:"freshness"`
-	Confidence           string          `json:"confidence"`
+	FactType             string           `json:"factType"`
+	ID                   string           `json:"id"`
+	State                string           `json:"state"`
+	Jira                 JiraObservation  `json:"jira"`
+	PR                   PRObservation    `json:"pr"`
+	Claim                ClaimObservation `json:"claim"`
+	ObservedCandidateSHA string           `json:"observedCandidateSha"`
+	ObservedTargetSHA    string           `json:"observedTargetSha"`
+	Blockers             []string         `json:"blockers"`
+	NextAction           string           `json:"nextAction"`
+	Freshness            string           `json:"freshness"`
+	Confidence           string           `json:"confidence"`
 }
 
 type JiraObservation struct {
@@ -160,20 +166,21 @@ type Inspection struct {
 }
 
 type InspectionFinding struct {
-	ID                   string          `json:"id"`
-	Title                string          `json:"title"`
-	Severity             string          `json:"severity"`
-	Qualification        string          `json:"qualification"`
-	Dispatchable         bool            `json:"dispatchable"`
-	State                string          `json:"state"`
-	Jira                 JiraObservation `json:"jira"`
-	PR                   PRObservation   `json:"pr"`
-	ObservedCandidateSHA string          `json:"observedCandidateSha"`
-	ObservedTargetSHA    string          `json:"observedTargetSha"`
-	Blockers             []string        `json:"blockers"`
-	NextAction           string          `json:"nextAction"`
-	Freshness            string          `json:"freshness"`
-	Confidence           string          `json:"confidence"`
+	ID                   string           `json:"id"`
+	Title                string           `json:"title"`
+	Severity             string           `json:"severity"`
+	Qualification        string           `json:"qualification"`
+	Dispatchable         bool             `json:"dispatchable"`
+	State                string           `json:"state"`
+	Jira                 JiraObservation  `json:"jira"`
+	PR                   PRObservation    `json:"pr"`
+	Claim                ClaimObservation `json:"claim"`
+	ObservedCandidateSHA string           `json:"observedCandidateSha"`
+	ObservedTargetSHA    string           `json:"observedTargetSha"`
+	Blockers             []string         `json:"blockers"`
+	NextAction           string           `json:"nextAction"`
+	Freshness            string           `json:"freshness"`
+	Confidence           string           `json:"confidence"`
 }
 
 type NextResult struct {
@@ -193,6 +200,19 @@ type NextFinding struct {
 	NextAction    string   `json:"nextAction"`
 	Blockers      []string `json:"blockers"`
 	Freshness     string   `json:"freshness"`
+}
+
+type ClaimObservation struct {
+	State            string     `json:"state"`
+	Claimant         string     `json:"claimant"`
+	CreatedAt        *time.Time `json:"createdAt"`
+	ExpiresAt        *time.Time `json:"expiresAt"`
+	RemoteRef        string     `json:"remoteRef"`
+	WorkBranch       string     `json:"workBranch"`
+	ObservedClaimSHA string     `json:"observedClaimSha"`
+	Freshness        string     `json:"freshness"`
+	OwnedBySession   bool       `json:"ownedBySession"`
+	Problem          string     `json:"problem"`
 }
 
 func (campaign *Campaign) validate() error {
@@ -263,6 +283,7 @@ func (campaign *Campaign) validateObservations(sourceFindings map[string]SourceF
 		"github": observations.Providers.GitHub,
 		"jira":   observations.Providers.Jira,
 		"git":    observations.Providers.Git,
+		"claims": observations.Providers.Claims,
 	} {
 		if !validProviderStatus(provider.Status) ||
 			(provider.Status != "UNAVAILABLE" && provider.ObservedAt == nil) ||
@@ -311,8 +332,11 @@ func (campaign *Campaign) validateObservations(sourceFindings map[string]SourceF
 		if err := validatePRObservation(finding.PR); err != nil {
 			return fmt.Errorf("invalid PR observation for %q: %w", finding.ID, err)
 		}
+		if err := validateClaimObservation(finding.Claim); err != nil {
+			return fmt.Errorf("invalid claim observation for %q: %w", finding.ID, err)
+		}
 		expected := projectFinding(source, finding.Jira, finding.PR, campaign.AuditedSHA,
-			observations.Target.Branch, observations.Target.ObservedSHA, observations.Freshness)
+			observations.Target.Branch, observations.Target.ObservedSHA, observations.Freshness, finding.Claim)
 		if finding.State != expected.State || finding.ObservedCandidateSHA != expected.ObservedCandidateSHA ||
 			finding.NextAction != expected.NextAction || finding.Confidence != expected.Confidence ||
 			!slices.Equal(finding.Blockers, expected.Blockers) {
@@ -321,6 +345,47 @@ func (campaign *Campaign) validateObservations(sourceFindings map[string]SourceF
 	}
 	if len(seen) != len(sourceFindings) {
 		return errors.New("incomplete finding observations")
+	}
+
+	return nil
+}
+
+func validateClaimObservation(observation ClaimObservation) error {
+	if !slices.Contains([]string{
+		"UNCLAIMED", "CLAIMED", "CLAIM_EXPIRED", "BROKEN_BINDING", "AMBIGUOUS",
+		"CLAIM_HISTORY_MISSING", "UNKNOWN", "NON_CLAIMABLE",
+	}, observation.State) {
+		return errors.New("invalid claim state")
+	}
+	if !slices.Contains([]string{"FRESH", "STALE", "UNAVAILABLE"}, observation.Freshness) {
+		return errors.New("invalid claim freshness")
+	}
+	if observation.State == "UNKNOWN" && observation.Freshness == "FRESH" ||
+		observation.State != "UNKNOWN" && observation.Freshness != "FRESH" {
+		return errors.New("claim state does not match freshness")
+	}
+	if observation.RemoteRef == "" || execCheckRef(observation.RemoteRef) != nil {
+		return errors.New("invalid claim remote ref")
+	}
+	if observation.ObservedClaimSHA != "" && !shaPattern.MatchString(observation.ObservedClaimSHA) {
+		return errors.New("invalid observed claim SHA")
+	}
+	if observation.Claimant != "" && !claimantPattern.MatchString(observation.Claimant) {
+		return errors.New("invalid claimant")
+	}
+	if observation.CreatedAt != nil && observation.CreatedAt.IsZero() ||
+		observation.ExpiresAt != nil && observation.ExpiresAt.IsZero() {
+		return errors.New("invalid claim time")
+	}
+	if observation.State == "CLAIMED" || observation.State == "CLAIM_EXPIRED" || observation.State == "BROKEN_BINDING" {
+		if observation.Claimant == "" || observation.CreatedAt == nil || observation.ExpiresAt == nil ||
+			observation.ObservedClaimSHA == "" {
+			return errors.New("incomplete claim")
+		}
+	}
+	if observation.OwnedBySession && observation.State != "CLAIMED" && observation.State != "CLAIM_EXPIRED" &&
+		observation.State != "BROKEN_BINDING" {
+		return errors.New("invalid current-session ownership")
 	}
 
 	return nil
@@ -405,16 +470,24 @@ func validProviderStatus(value string) bool {
 func validState(value string) bool {
 	return slices.Contains([]string{
 		"CONFIRMED_UNASSIGNED", "TRACKED", "PR_OPEN", "PR_CLOSED", "MERGED", "BLOCKED",
-		"SUPERSEDED", "AMBIGUOUS", "BROKEN_BINDING", "NON_DISPATCHABLE",
+		"SUPERSEDED", "AMBIGUOUS", "BROKEN_BINDING", "NON_DISPATCHABLE", "CLAIMED", "CLAIM_EXPIRED",
 	}, value)
 }
 
 func validNextAction(value string) bool {
 	return slices.Contains([]string{
-		"PUBLISH_JIRA_OR_REVIEW_POLICY", "READY_FOR_CLAIM_OR_DISPATCH", "CONTINUE_PR", "VERIFY_RESOLUTION",
+		"CLAIM", "CONTINUE_CLAIMED_WORK", "WAIT_OR_COORDINATE", "REVIEW_EXPIRED_CLAIM", "CONTINUE_PR", "VERIFY_RESOLUTION",
 		"NO_ACTION", "HUMAN_DECISION_REQUIRED", "RESOLVE_BINDING", "REFRESH_REQUIRED", "REPAIR_BINDING",
 		"REVIEW_CLOSED_PR", "REQUALIFY_ON_CURRENT_TARGET",
 	}, value)
+}
+
+func execCheckRef(ref string) error {
+	if !strings.HasPrefix(ref, claimRefPrefix) {
+		return errors.New("outside claim namespace")
+	}
+
+	return exec.Command("git", "check-ref-format", ref).Run()
 }
 
 func validSeverity(value string) bool {

--- a/scripts/aicampaign/release_command.go
+++ b/scripts/aicampaign/release_command.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+func runRelease(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--finding": true, "--claimant": true, "--remote": true, "--expected-claim-sha": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--finding"] == "" {
+		return errors.New("usage: ai-campaign release <campaign> --finding <id> --claimant <id> [--expected-claim-sha <sha>] [--remote <name>]")
+	}
+	claimant, err := resolveClaimant(flags["--claimant"], false)
+	if err != nil {
+		return err
+	}
+	campaign, finding, err := loadClaimInput(values[0], flags["--finding"])
+	if err != nil {
+		return err
+	}
+	remote := valueOr(flags["--remote"], "origin")
+	if !gitRemotePattern.MatchString(remote) {
+		return errors.New("invalid Git remote")
+	}
+	expectedSHA := flags["--expected-claim-sha"]
+	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
+		return errors.New("invalid expected claim SHA")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := releaseClaim(ctx, campaign, finding, claimant, remote, expectedSHA)
+	if result.Status == "RELEASED" && clearCachedClaim(campaign, finding.ID) {
+		if writeErr := writeCampaign(values[0], campaign); writeErr != nil {
+			result.Reason = "remote released; local campaign cache update failed: " + conciseError(writeErr)
+		}
+	}
+
+	return emitClaimResult(stdout, stderr, result)
+}
+
+func releaseClaim(
+	ctx context.Context,
+	campaign *Campaign,
+	finding SourceFinding,
+	claimant string,
+	remote string,
+	expectedSHA string,
+) ClaimResult {
+	result := baseClaimResult(campaign, finding)
+	repository, err := openClaimRepository(ctx, remote)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	defer repository.close()
+	refs, err := repository.listRefs(ctx, result.RemoteRef)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	observedSHA := refs[result.RemoteRef]
+	if observedSHA == "" {
+		result.Status = "CLAIM_MISSING"
+		result.Reason = "remote claim ref does not exist"
+
+		return result
+	}
+	result.ObservedClaimSHA = observedSHA
+	if !expectedClaimMatches(expectedSHA, observedSHA) {
+		return claimResultChanged(result, "remote claim does not equal expected SHA")
+	}
+	observed, err := repository.readClaim(ctx, result.RemoteRef, observedSHA)
+	if err != nil {
+		return claimResultChanged(result, conciseError(err))
+	}
+	result.Claim = &observed.Record
+	if !observed.Record.matches(campaign, finding) {
+		result.Status = "CLAIM_CHANGED"
+		result.Reason = "remote claim identity does not match campaign finding"
+
+		return result
+	}
+	if ownerResult, ok := requireClaimOwner(result, observed.Record, claimant); !ok {
+		return ownerResult
+	}
+	if err := repository.deleteClaim(ctx, result.RemoteRef, observedSHA); err != nil {
+		return classifyMutationFailure(ctx, repository, result, observedSHA, err)
+	}
+	result.Status = "RELEASED"
+
+	return result
+}
+
+func clearCachedClaim(campaign *Campaign, findingID string) bool {
+	if campaign.Observations == nil {
+		return false
+	}
+	for index := range campaign.Observations.Findings {
+		finding := &campaign.Observations.Findings[index]
+		if finding.ID != findingID {
+			continue
+		}
+		source, err := findingByID(campaign, findingID)
+		if err != nil {
+			return false
+		}
+		claim := emptyClaimObservation(campaign.AuditID, findingID, "FRESH")
+		*finding = projectFinding(source, finding.Jira, finding.PR, campaign.AuditedSHA,
+			campaign.Observations.Target.Branch, campaign.Observations.Target.ObservedSHA,
+			campaign.Observations.Freshness, claim)
+
+		return true
+	}
+
+	return false
+}

--- a/scripts/aicampaign/release_command.go
+++ b/scripts/aicampaign/release_command.go
@@ -9,13 +9,13 @@ import (
 
 func runRelease(arguments []string, stdout, stderr io.Writer) error {
 	values, flags, err := parseArguments(arguments, map[string]bool{
-		"--finding": true, "--claimant": true, "--remote": true, "--expected-claim-sha": true,
+		"--finding": true, "--claimant": true, "--remote": true, "--target": true, "--expected-claim-sha": true,
 	})
 	if err != nil {
 		return err
 	}
 	if len(values) != 1 || flags["--finding"] == "" {
-		return errors.New("usage: ai-campaign release <campaign> --finding <id> --claimant <id> [--expected-claim-sha <sha>] [--remote <name>]")
+		return errors.New("usage: ai-campaign release <campaign> --finding <id> --claimant <id> [--expected-claim-sha <sha>] [--remote <name>] [--target <branch>]")
 	}
 	claimant, err := resolveClaimant(flags["--claimant"], false)
 	if err != nil {
@@ -26,8 +26,9 @@ func runRelease(arguments []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	remote := valueOr(flags["--remote"], "origin")
-	if !gitRemotePattern.MatchString(remote) {
-		return errors.New("invalid Git remote")
+	target := valueOr(flags["--target"], "release/v3.0")
+	if err := validateClaimCommandOptions(remote, target); err != nil {
+		return err
 	}
 	expectedSHA := flags["--expected-claim-sha"]
 	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
@@ -35,7 +36,7 @@ func runRelease(arguments []string, stdout, stderr io.Writer) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	result := releaseClaim(ctx, campaign, finding, claimant, remote, expectedSHA)
+	result := releaseClaim(ctx, campaign, finding, claimant, remote, target, expectedSHA)
 	if result.Status == "RELEASED" && clearCachedClaim(campaign, finding.ID) {
 		if writeErr := writeCampaign(values[0], campaign); writeErr != nil {
 			result.Reason = "remote released; local campaign cache update failed: " + conciseError(writeErr)
@@ -51,6 +52,7 @@ func releaseClaim(
 	finding SourceFinding,
 	claimant string,
 	remote string,
+	targetBranch string,
 	expectedSHA string,
 ) ClaimResult {
 	result := baseClaimResult(campaign, finding)
@@ -79,7 +81,7 @@ func releaseClaim(
 		return claimResultChanged(result, conciseError(err))
 	}
 	result.Claim = &observed.Record
-	if !observed.Record.matches(campaign, finding) {
+	if !observed.Record.matches(campaign, finding, targetBranch) {
 		result.Status = "CLAIM_CHANGED"
 		result.Reason = "remote claim identity does not match campaign finding"
 

--- a/scripts/aicampaign/renew_command.go
+++ b/scripts/aicampaign/renew_command.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+func runRenew(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--finding": true, "--claimant": true, "--lease": true, "--remote": true,
+		"--work-branch": true, "--expected-claim-sha": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--finding"] == "" {
+		return errors.New("usage: ai-campaign renew <campaign> --finding <id> --claimant <id> [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>]")
+	}
+	lease, err := validateClaimLease(flags["--lease"])
+	if err != nil {
+		return err
+	}
+	if err := validateWorkBranch(flags["--work-branch"]); err != nil {
+		return err
+	}
+	claimant, err := resolveClaimant(flags["--claimant"], false)
+	if err != nil {
+		return err
+	}
+	campaign, finding, err := loadClaimInput(values[0], flags["--finding"])
+	if err != nil {
+		return err
+	}
+	remote := valueOr(flags["--remote"], "origin")
+	if !gitRemotePattern.MatchString(remote) {
+		return errors.New("invalid Git remote")
+	}
+	expectedSHA := flags["--expected-claim-sha"]
+	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
+		return errors.New("invalid expected claim SHA")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := renewClaim(ctx, campaign, finding, claimant, lease, remote, flags["--work-branch"], expectedSHA, time.Now)
+
+	return emitClaimResult(stdout, stderr, result)
+}
+
+func renewClaim(
+	ctx context.Context,
+	campaign *Campaign,
+	finding SourceFinding,
+	claimant string,
+	lease time.Duration,
+	remote string,
+	workBranch string,
+	expectedSHA string,
+	now func() time.Time,
+) ClaimResult {
+	result := baseClaimResult(campaign, finding)
+	repository, err := openClaimRepository(ctx, remote)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	defer repository.close()
+	refs, err := repository.listRefs(ctx, result.RemoteRef)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	observedSHA := refs[result.RemoteRef]
+	if observedSHA == "" {
+		result.Status = "CLAIM_MISSING"
+		result.Reason = "remote claim ref does not exist"
+
+		return result
+	}
+	result.ObservedClaimSHA = observedSHA
+	if !expectedClaimMatches(expectedSHA, observedSHA) {
+		return claimResultChanged(result, "remote claim does not equal expected SHA")
+	}
+	observed, err := repository.readClaim(ctx, result.RemoteRef, observedSHA)
+	if err != nil {
+		return claimResultChanged(result, conciseError(err))
+	}
+	result.Claim = &observed.Record
+	if !observed.Record.matches(campaign, finding) {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "remote claim identity does not match campaign finding"
+
+		return result
+	}
+	if ownerResult, ok := requireClaimOwner(result, observed.Record, claimant); !ok {
+		return ownerResult
+	}
+	if workBranch == observed.Record.TargetBranch {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "work branch cannot equal target branch"
+
+		return result
+	}
+	renewedAt := now().UTC()
+	if renewedAt.Before(observed.Record.CreatedAt) {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "local clock precedes claim creation time"
+
+		return result
+	}
+	record := observed.Record
+	record.RenewedAt = &renewedAt
+	record.RenewalCount++
+	record.ExpiresAt = renewedAt.Add(lease)
+	if workBranch != "" {
+		record.WorkBranch = workBranch
+	}
+	claimSHA, err := repository.writeClaim(ctx, result.RemoteRef, observedSHA, record)
+	if err != nil {
+		return classifyMutationFailure(ctx, repository, result, observedSHA, err)
+	}
+	result.Status = "RENEWED"
+	result.ClaimSHA = claimSHA
+	result.ObservedClaimSHA = claimSHA
+	result.Claim = &record
+
+	return result
+}
+
+func classifyMutationFailure(
+	ctx context.Context,
+	repository *claimRepository,
+	result ClaimResult,
+	previousSHA string,
+	mutationError error,
+) ClaimResult {
+	refs, err := repository.listRefs(ctx, result.RemoteRef)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	currentSHA := refs[result.RemoteRef]
+	result.ObservedClaimSHA = currentSHA
+	if currentSHA != previousSHA {
+		return claimResultChanged(result, "remote claim changed during compare-and-swap")
+	}
+
+	return remoteUnavailable(result, mutationError)
+}

--- a/scripts/aicampaign/renew_command.go
+++ b/scripts/aicampaign/renew_command.go
@@ -10,13 +10,13 @@ import (
 func runRenew(arguments []string, stdout, stderr io.Writer) error {
 	values, flags, err := parseArguments(arguments, map[string]bool{
 		"--finding": true, "--claimant": true, "--lease": true, "--remote": true,
-		"--work-branch": true, "--expected-claim-sha": true,
+		"--target": true, "--work-branch": true, "--expected-claim-sha": true,
 	})
 	if err != nil {
 		return err
 	}
 	if len(values) != 1 || flags["--finding"] == "" {
-		return errors.New("usage: ai-campaign renew <campaign> --finding <id> --claimant <id> [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>]")
+		return errors.New("usage: ai-campaign renew <campaign> --finding <id> --claimant <id> [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>] [--target <branch>]")
 	}
 	lease, err := validateClaimLease(flags["--lease"])
 	if err != nil {
@@ -34,8 +34,9 @@ func runRenew(arguments []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	remote := valueOr(flags["--remote"], "origin")
-	if !gitRemotePattern.MatchString(remote) {
-		return errors.New("invalid Git remote")
+	target := valueOr(flags["--target"], "release/v3.0")
+	if err := validateClaimCommandOptions(remote, target); err != nil {
+		return err
 	}
 	expectedSHA := flags["--expected-claim-sha"]
 	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
@@ -43,7 +44,8 @@ func runRenew(arguments []string, stdout, stderr io.Writer) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	result := renewClaim(ctx, campaign, finding, claimant, lease, remote, flags["--work-branch"], expectedSHA, time.Now)
+	result := renewClaim(ctx, campaign, finding, claimant, lease, remote, target,
+		flags["--work-branch"], expectedSHA, time.Now)
 
 	return emitClaimResult(stdout, stderr, result)
 }
@@ -55,6 +57,7 @@ func renewClaim(
 	claimant string,
 	lease time.Duration,
 	remote string,
+	targetBranch string,
 	workBranch string,
 	expectedSHA string,
 	now func() time.Time,
@@ -85,7 +88,7 @@ func renewClaim(
 		return claimResultChanged(result, conciseError(err))
 	}
 	result.Claim = &observed.Record
-	if !observed.Record.matches(campaign, finding) {
+	if !observed.Record.matches(campaign, finding, targetBranch) {
 		result.Status = "CLAIM_CONFLICT"
 		result.Reason = "remote claim identity does not match campaign finding"
 

--- a/scripts/aicampaign/storage.go
+++ b/scripts/aicampaign/storage.go
@@ -26,20 +26,28 @@ func readStrictJSON(path string, destination any) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	if err := rejectDuplicateObjectKeys(content); err != nil {
+	if err := decodeStrictJSON(content, destination); err != nil {
 		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+
+	return content, nil
+}
+
+func decodeStrictJSON(content []byte, destination any) error {
+	if err := rejectDuplicateObjectKeys(content); err != nil {
+		return err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(content))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
-		return nil, fmt.Errorf("decode %s: %w", path, err)
+		return err
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("decode %s: trailing JSON value", path)
+		return errors.New("trailing JSON value")
 	}
 
-	return content, nil
+	return nil
 }
 
 func rejectDuplicateObjectKeys(content []byte) error {

--- a/scripts/aicampaign/takeover_command.go
+++ b/scripts/aicampaign/takeover_command.go
@@ -10,13 +10,13 @@ import (
 func runTakeover(arguments []string, stdout, stderr io.Writer) error {
 	values, flags, err := parseArguments(arguments, map[string]bool{
 		"--finding": true, "--claimant": true, "--lease": true, "--remote": true,
-		"--work-branch": true, "--expected-claim-sha": true,
+		"--target": true, "--work-branch": true, "--expected-claim-sha": true,
 	})
 	if err != nil {
 		return err
 	}
 	if len(values) != 1 || flags["--finding"] == "" {
-		return errors.New("usage: ai-campaign takeover <campaign> --finding <id> [--claimant <id>] [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>]")
+		return errors.New("usage: ai-campaign takeover <campaign> --finding <id> [--claimant <id>] [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>] [--target <branch>]")
 	}
 	lease, err := validateClaimLease(flags["--lease"])
 	if err != nil {
@@ -34,8 +34,9 @@ func runTakeover(arguments []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	remote := valueOr(flags["--remote"], "origin")
-	if !gitRemotePattern.MatchString(remote) {
-		return errors.New("invalid Git remote")
+	target := valueOr(flags["--target"], "release/v3.0")
+	if err := validateClaimCommandOptions(remote, target); err != nil {
+		return err
 	}
 	expectedSHA := flags["--expected-claim-sha"]
 	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
@@ -43,7 +44,8 @@ func runTakeover(arguments []string, stdout, stderr io.Writer) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	result := takeoverClaim(ctx, campaign, finding, claimant, lease, remote, flags["--work-branch"], expectedSHA, time.Now)
+	result := takeoverClaim(ctx, campaign, finding, claimant, lease, remote, target,
+		flags["--work-branch"], expectedSHA, time.Now)
 
 	return emitClaimResult(stdout, stderr, result)
 }
@@ -55,6 +57,7 @@ func takeoverClaim(
 	claimant string,
 	lease time.Duration,
 	remote string,
+	targetBranch string,
 	workBranch string,
 	expectedSHA string,
 	now func() time.Time,
@@ -88,7 +91,7 @@ func takeoverClaim(
 		return result
 	}
 	result.Claim = &observed.Record
-	if !observed.Record.matches(campaign, finding) {
+	if !observed.Record.matches(campaign, finding, targetBranch) {
 		result.Status = "CLAIM_CONFLICT"
 		result.Reason = "remote claim identity does not match campaign finding"
 

--- a/scripts/aicampaign/takeover_command.go
+++ b/scripts/aicampaign/takeover_command.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+func runTakeover(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--finding": true, "--claimant": true, "--lease": true, "--remote": true,
+		"--work-branch": true, "--expected-claim-sha": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--finding"] == "" {
+		return errors.New("usage: ai-campaign takeover <campaign> --finding <id> [--claimant <id>] [--lease <duration>] [--work-branch <branch>] [--expected-claim-sha <sha>] [--remote <name>]")
+	}
+	lease, err := validateClaimLease(flags["--lease"])
+	if err != nil {
+		return err
+	}
+	if err := validateWorkBranch(flags["--work-branch"]); err != nil {
+		return err
+	}
+	claimant, err := resolveClaimant(flags["--claimant"], true)
+	if err != nil {
+		return err
+	}
+	campaign, finding, err := loadClaimInput(values[0], flags["--finding"])
+	if err != nil {
+		return err
+	}
+	remote := valueOr(flags["--remote"], "origin")
+	if !gitRemotePattern.MatchString(remote) {
+		return errors.New("invalid Git remote")
+	}
+	expectedSHA := flags["--expected-claim-sha"]
+	if expectedSHA != "" && !shaPattern.MatchString(expectedSHA) {
+		return errors.New("invalid expected claim SHA")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result := takeoverClaim(ctx, campaign, finding, claimant, lease, remote, flags["--work-branch"], expectedSHA, time.Now)
+
+	return emitClaimResult(stdout, stderr, result)
+}
+
+func takeoverClaim(
+	ctx context.Context,
+	campaign *Campaign,
+	finding SourceFinding,
+	claimant string,
+	lease time.Duration,
+	remote string,
+	workBranch string,
+	expectedSHA string,
+	now func() time.Time,
+) ClaimResult {
+	result := baseClaimResult(campaign, finding)
+	repository, err := openClaimRepository(ctx, remote)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	defer repository.close()
+	refs, err := repository.listRefs(ctx, result.RemoteRef)
+	if err != nil {
+		return remoteUnavailable(result, err)
+	}
+	observedSHA := refs[result.RemoteRef]
+	if observedSHA == "" {
+		result.Status = "CLAIM_MISSING"
+		result.Reason = "takeover requires an existing expired claim"
+
+		return result
+	}
+	result.ObservedClaimSHA = observedSHA
+	if !expectedClaimMatches(expectedSHA, observedSHA) {
+		return claimResultChanged(result, "remote claim does not equal expected SHA")
+	}
+	observed, err := repository.readClaim(ctx, result.RemoteRef, observedSHA)
+	if err != nil {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = conciseError(err)
+
+		return result
+	}
+	result.Claim = &observed.Record
+	if !observed.Record.matches(campaign, finding) {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "remote claim identity does not match campaign finding"
+
+		return result
+	}
+	if workBranch == observed.Record.TargetBranch {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "work branch cannot equal target branch"
+
+		return result
+	}
+	createdAt := now().UTC()
+	if createdAt.Before(observed.Record.CreatedAt) {
+		result.Status = "HUMAN_DECISION_REQUIRED"
+		result.Reason = "local clock precedes claim creation time"
+
+		return result
+	}
+	if !isExpired(observed.Record, createdAt) {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "live claims cannot be taken over"
+
+		return result
+	}
+	if workBranch == "" {
+		workBranch = observed.Record.WorkBranch
+	}
+	record := ClaimRecord{
+		SchemaVersion: claimSchemaVersion, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
+		FindingID: finding.ID, FindingIdentityDigest: finding.IdentityDigest,
+		SourceQualifiedDigest: campaign.SourceDigests.Qualified, AuditedSHA: campaign.AuditedSHA,
+		Qualification: finding.Qualification, Claimant: claimant, CreatedAt: createdAt,
+		ExpiresAt: createdAt.Add(lease), TargetBranch: observed.Record.TargetBranch,
+		TargetSHA: observed.Record.TargetSHA, WorkBranch: workBranch,
+		Predecessor: &ClaimPredecessor{
+			ClaimSHA: observedSHA, Claimant: observed.Record.Claimant,
+			CreatedAt: observed.Record.CreatedAt, ExpiresAt: observed.Record.ExpiresAt, Reason: "EXPIRED_TAKEOVER",
+		},
+	}
+	claimSHA, err := repository.writeClaim(ctx, result.RemoteRef, observedSHA, record)
+	if err != nil {
+		return classifyMutationFailure(ctx, repository, result, observedSHA, err)
+	}
+	result.Status = "TAKEN_OVER"
+	result.ClaimSHA = claimSHA
+	result.ObservedClaimSHA = claimSHA
+	result.Claim = &record
+
+	return result
+}


### PR DESCRIPTION
## Summary

- add remote Git ref claim leases for confirmed campaign findings
- enforce create, renew, release, and expired takeover with exact compare-and-swap
- integrate claim state, expiry, ownership, and work-branch health into campaign inspect/next
- add strict claim schema, lineage validation, and bare-remote adversarial tests

## Backend

Claims use orphan/history commits at `refs/heads/ai-claims/v1/<stable-finding-hash>`. The remote ref is authoritative; campaign JSON remains a local observation cache.

## Validation

- `go test ./scripts/aicampaign -count=1` (Nix Go 1.26.5, hermetic caches)
- focused `go test -race` for claim/renew/release concurrency
- `go test ./scripts/... -count=1`
- `bash scripts/check-repo-invariants`
- `bash scripts/agent-check`
- create-only CAS mutation challenge: regression failed with two winners, then passed after restoring force-with-lease

## Non-goals

No automatic bug fixing, dispatch, branch/worktree creation, PR binding mutation, merge, resume/events, composite readiness, structured failure envelope, terminal reconciliation, or ruleset changes.