### PR TITLE
perf(tooling): use resident root guard for PR triage

### DIFF
--- a/docs/technical/contributing/ai-pr-triage-loop.md
+++ b/docs/technical/contributing/ai-pr-triage-loop.md
@@ -29,5 +29,7 @@ checks the trusted top-level and base HEAD. `EXPECTED_WORKTREE` and
 `AI_WORKTREE_PATH` and `AI_WORKTREE_EXPECTED_HEAD` independently bind the
 provider cwd to the trusted worktree and target-base HEAD. `TARGET_BASE_SHA` and
 `PR_HEAD_SHA` expose those identities without overloading either one. The
-adapter snapshots primary-checkout HEAD, branch, and status around Codex and
-reports `ROOT_MUTATION_DETECTED` on any change.
+adapter uses the shared, resident full-content rootguard around Codex and
+reports `ROOT_MUTATION_DETECTED` on any change. The same process owns both
+snapshots; scope and observation frequency match the technical review
+root-protection contract.

--- a/docs/technical/contributing/ai-pr-triage.md
+++ b/docs/technical/contributing/ai-pr-triage.md
@@ -29,7 +29,12 @@ actual PR head. The separate `AI_WORKTREE_PATH` and
 `AI_WORKTREE_EXPECTED_HEAD` values bind the provider cwd to the trusted target
 worktree and target-base HEAD. The process is surrounded by the same
 primary-checkout mutation detection described in
-[AI PR worktree isolation](ai-worktree-isolation.md).
+[AI PR worktree isolation](ai-worktree-isolation.md). A base-pinned, Nix-built
+resident rootguard process captures the full-content state before launching the
+provider, waits for it, and captures and compares the state again in that same
+process. The provider cannot replace an on-disk post-snapshot helper, and the
+guard uses a bounded number of Git enumeration processes rather than one `git
+hash-object` process per ignored file.
 
 ## Decisions
 

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -43,8 +43,8 @@ A full PR URL is accepted as well. The launcher:
 - runs repository validation locally before accepting any approval; no GitHub
   Actions status participates in the decision;
 - never checks out or edits the primary checkout, and fails with
-  `ROOT_MUTATION_DETECTED` if its HEAD, branch, or status changes while a
-  subprocess runs;
+  `ROOT_MUTATION_DETECTED` if its HEAD, branch, status, workspace content, or
+  ignored configuration changes while a subprocess runs;
 - preserves the isolated worktree automatically when fixes remain so the resulting diff can be inspected manually;
 - removes a clean temporary worktree after the loop unless `--keep-worktree` is supplied, together with the run directory that holds its triage result, known-findings ledger, and isolated validation caches.
 

--- a/docs/technical/contributing/ai-worktree-isolation.md
+++ b/docs/technical/contributing/ai-worktree-isolation.md
@@ -99,6 +99,43 @@ difference emits `ROOT_MUTATION_DETECTED` and stops without reset, clean,
 checkout, or other automatic recovery. An already-dirty root is supported
 because equality, not cleanliness, is the invariant.
 
+`scripts/internal/rootguard` is the single trusted implementation used by both
+`review-loop` and legitimacy triage. Each snapshot has the following exact
+semantics:
+
+- `HEAD`, the current branch, and NUL-delimited porcelain v1 status are captured
+  independently;
+- staged and unstaged state use binary, full-index diffs;
+- non-ignored untracked and ignored paths come from separate NUL-delimited Git
+  enumerations, are sorted by their raw path bytes, and are opened relative to
+  the trusted root;
+- every Git-reported path uses `Lstat`; its mode/type is hashed, regular-file
+  bytes are streamed through SHA-256 in-process, and a symlink contributes its
+  target text without following the link;
+- the repository `info/exclude` file and every configured `core.excludesFile`
+  are content-aware snapshot inputs, including semantically inert mutations
+  that happen not to change the enumerated path set; and
+- enumeration, stat, open, read, and post-read identity errors fail closed.
+
+The implementation launches exactly nine Git processes per snapshot for Git
+state and path enumeration, independent of the number of regular ignored or
+untracked files. It never launches Git once per file. Ignored nested Git
+repositories/worktrees remain a single directory entry in their parent's Git
+enumeration and are therefore explicit separate protection roots.
+
+This consolidates two former algorithms. The old triage shell implementation
+hashed regular files by invoking `git hash-object --no-filters` once per file
+and used Git's object hash (SHA-1 in this repository). The former Go
+review-loop implementation already used in-process SHA-256 and included
+ignored-path mode/type. The consolidated
+contract keeps the stronger Go semantics and intentionally strengthens both
+callers with raw-byte sorting, NUL-delimited status/path handling, root-scoped
+opens, and direct ignored-configuration capture.
+
+Snapshots are repeated at the same existing process boundaries. They are not
+continuous filesystem monitoring: a complete mutation and restoration wholly
+between two observation boundaries remains outside this contract.
+
 The validation directory contains a defense-in-depth `git` wrapper at the
 front of agent `PATH`. Within that wrapper, `TRUSTED_ROOT_CHECKOUT` is
 deny-by-default: only an enumerated set of read-only inspection commands is
@@ -115,7 +152,7 @@ not receive dedicated variables exposing the real Git path or original `PATH`.
 
 The wrapper is not an OS filesystem sandbox: a subprocess with host access can
 deliberately locate an absolute Git executable or write a root file without
-using Git. The authoritative enforcement for that threat is the before/after
+using Git. The authoritative enforcement for that threat is the resident before/after
 root snapshot, which emits `ROOT_MUTATION_DETECTED` and stops the workflow. It
 does not claim to prevent or roll back a hostile same-user process. Tests cover
 both wrapper refusal and detection of a deliberate direct-Git bypass.
@@ -125,8 +162,11 @@ Detached worktrees for baseline comparison, read-only experiments, and
 triage adapter is the model: it creates and owns separate trusted-policy and
 untrusted-head worktrees, explicitly binds the read-only Codex cwd to the
 trusted one, applies the same content-aware root snapshot, and removes both on
-exit. An agent cannot silently replace its
-primary candidate worktree with another worktree.
+exit. Triage builds its resident runner from the base-pinned trusted tooling
+worktree with the pinned Nix Go toolchain before starting the provider. The
+same in-memory process owns both snapshots, so replacing an on-disk helper while
+the provider runs cannot select the post-snapshot implementation. An agent
+cannot silently replace its primary candidate worktree with another worktree.
 
 ## Launcher inventory
 

--- a/scripts/ai-pr-triage
+++ b/scripts/ai-pr-triage
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
         *) echo "ai-pr-triage: unknown argument: $1" >&2; exit 1 ;;
     esac
 done
-for command in codex git gh jq; do command -v "$command" >/dev/null 2>&1 || { echo "ai-pr-triage: required command not found: $command" >&2; exit 1; }; done
+for command in codex git gh jq nix; do command -v "$command" >/dev/null 2>&1 || { echo "ai-pr-triage: required command not found: $command" >&2; exit 1; }; done
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -92,6 +92,10 @@ agent_context="$trusted_worktree/docs/technical/agent-context.md"
 for trusted_file in "$trusted_worktree/AGENTS.md" "$agent_context" "$contract" "$traceability" "$schema"; do
     [[ -f "$trusted_file" ]] || { echo "ai-pr-triage: trusted base is missing $trusted_file" >&2; exit 1; }
 done
+rootguard_binary="$isolation_root/rootguard"
+env -u GOROOT nix develop "path:$trusted_worktree" --command \
+    go -C "$trusted_worktree" build -o "$rootguard_binary" ./scripts/rootguard
+[[ -x "$rootguard_binary" ]] || { echo "ai-pr-triage: trusted rootguard build produced no executable" >&2; exit 1; }
 
 cat > "$prompt" <<'EOF'
 You are performing advisory PR legitimacy triage for Ledger before technical code review.
@@ -143,42 +147,6 @@ repo_root=$(cd "$repo_root" && pwd -P)
     exit 1
 }
 
-root_workspace_fingerprint() (
-  cd "$1"
-  {
-    printf 'head\0'
-    git rev-parse HEAD
-    printf 'staged\0'
-    git diff --cached --binary --full-index HEAD --
-    printf 'unstaged\0'
-    git diff --binary --full-index --
-    for ignored in false true; do
-      printf 'untracked-ignored=%s\0' "$ignored"
-      list_args=(ls-files --others --exclude-standard -z)
-      if [[ "$ignored" == true ]]; then
-        list_args=(ls-files --others --ignored --exclude-standard -z)
-      fi
-      git "${list_args[@]}" | while IFS= read -r -d '' path; do
-        printf 'path\0%s\0' "$path"
-        if [[ -d "$path" && ! -L "$path" ]]; then
-          printf 'directory\0'
-        elif [[ -L "$path" ]]; then
-          printf 'symlink\0%s\0' "$(readlink "$path")"
-        elif [[ -f "$path" ]]; then
-          printf 'file\0'
-          git hash-object --no-filters -- "$path"
-        else
-          printf 'special\0'
-        fi
-      done
-    done
-  } | git hash-object --stdin
-)
-
-root_head=$(git -C "$repo_root" rev-parse HEAD)
-root_branch=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)
-root_status=$(git -C "$repo_root" status --porcelain=v1 --untracked-files=all)
-root_fingerprint=$(root_workspace_fingerprint "$repo_root")
 echo "WORKTREE_BINDING_GATE=PASS role=trusted-triage pr=$pr_number path=$trusted_worktree head=$base_sha"
 set +e
 EXPECTED_PR_NUMBER="$pr_number" \
@@ -189,22 +157,14 @@ AI_WORKTREE_PATH="$trusted_worktree" \
 AI_WORKTREE_EXPECTED_HEAD="$base_sha" \
 TARGET_BASE_SHA="$base_sha" \
 PR_HEAD_SHA="$head_sha" \
-  env -C "$trusted_worktree" HOME="$isolation_root/home" CODEX_HOME="$isolation_root/home/.codex" codex exec \
+  "$rootguard_binary" --root "$repo_root" -- \
+    env -C "$trusted_worktree" HOME="$isolation_root/home" CODEX_HOME="$isolation_root/home/.codex" codex exec \
     --ephemeral --ignore-user-config --ignore-rules \
     --disable hooks --disable plugins --disable apps --disable memories --disable multi_agent --disable skill_search \
     --sandbox read-only --output-schema "$schema" -o "$result" - < "$prompt"
-codex_status=$?
+guard_status=$?
 set -e
-current_root_head=$(git -C "$repo_root" rev-parse HEAD)
-current_root_branch=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)
-current_root_status=$(git -C "$repo_root" status --porcelain=v1 --untracked-files=all)
-current_root_fingerprint=$(root_workspace_fingerprint "$repo_root")
-if [[ "$current_root_head" != "$root_head" || "$current_root_branch" != "$root_branch" || "$current_root_status" != "$root_status" || "$current_root_fingerprint" != "$root_fingerprint" ]]; then
-    echo "ROOT_MUTATION_DETECTED" >&2
-    exit 1
-fi
-echo "ROOT_UNCHANGED=PASS"
-[[ $codex_status -eq 0 ]] || exit "$codex_status"
+[[ $guard_status -eq 0 ]] || exit "$guard_status"
 [[ -s "$result" ]] || { echo "ai-pr-triage: provider produced no result" >&2; exit 1; }
 jq -e --arg base "$base_sha" --arg head "$head_sha" '.base_sha == $base and .head == $head' "$result" >/dev/null || { echo "ai-pr-triage: result target mismatch" >&2; exit 1; }
 cp "$result" "$output"

--- a/scripts/aiprtriage/runner_test.go
+++ b/scripts/aiprtriage/runner_test.go
@@ -89,7 +89,8 @@ func newFixture(t *testing.T, headRepository string) fixture {
 	remote := filepath.Join(testRoot, "remote.git")
 	seed := filepath.Join(testRoot, "seed")
 	checkout := filepath.Join(testRoot, "checkout")
-	require.NoError(t, os.MkdirAll(filepath.Join(seed, "scripts"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "scripts", "rootguard"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(seed, "scripts", "internal", "rootguard"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(seed, "docs", "technical", "contributing"), 0o755))
 
 	runGit(t, testRoot, "init", "--bare", remote)
@@ -98,6 +99,13 @@ func newFixture(t *testing.T, headRepository string) fixture {
 	runGit(t, seed, "config", "user.email", "ai-pr-triage@example.com")
 	copyFile(t, runnerPath(t), filepath.Join(seed, "scripts", "ai-pr-triage"), 0o755)
 	copyFile(t, schemaPath(t), filepath.Join(seed, "scripts", "codex-pr-triage.schema.json"), 0o644)
+	copyFile(t, rootguardMainPath(t), filepath.Join(seed, "scripts", "rootguard", "main.go"), 0o644)
+	copyFile(t, rootguardPackagePath(t), filepath.Join(seed, "scripts", "internal", "rootguard", "rootguard.go"), 0o644)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(seed, "go.mod"),
+		[]byte("module github.com/formancehq/ledger/v3\n\ngo 1.26.0\n"),
+		0o644,
+	))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(seed, "docs", "technical", "contributing", "ai-pr-triage.md"),
 		[]byte("# AI PR triage contract\n"),
@@ -125,7 +133,12 @@ func newFixture(t *testing.T, headRepository string) fixture {
 	runGit(t, seed, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "AGENTS.md"), []byte("untrusted head instruction\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(seed, "head.txt"), []byte("head\n"), 0o644))
-	runGit(t, seed, "add", "--", "AGENTS.md", "head.txt")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(seed, "scripts", "rootguard", "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"),
+		0o644,
+	))
+	runGit(t, seed, "add", "--", "AGENTS.md", "head.txt", "scripts/rootguard/main.go")
 	runGit(t, seed, "commit", "-m", "feature")
 	headSHA := gitOutput(t, seed, "rev-parse", "HEAD")
 	runGit(t, seed, "push", "-u", "origin", "feature")
@@ -183,6 +196,12 @@ if [[ "${TEST_ROOT_MUTATION:-}" == dirty-content ]]; then
   printf 'different caller content\n' >"$TEST_CALLER_CHECKOUT/caller-only.txt"
 fi
 printf '{"decision":"KEEP","base_sha":"%s","head":"%s","problem_statement":"test","documented_needs":[],"technical_decisions":[],"existing_alternatives":[],"cost_assessment":"test","consequence_of_doing_nothing":"test","questions_for_author":[],"summary":"test"}\n' "$TEST_BASE_SHA" "$TEST_HEAD_SHA" >"$output"
+`)
+	writeExecutable(t, filepath.Join(fakeBin, "nix"), `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == develop && "$3" == --command ]]
+shift 3
+exec "$@"
 `)
 
 	return fixture{
@@ -248,6 +267,22 @@ func schemaPath(t *testing.T) string {
 	require.True(t, ok)
 
 	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "codex-pr-triage.schema.json"))
+}
+
+func rootguardMainPath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "rootguard", "main.go"))
+}
+
+func rootguardPackagePath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "internal", "rootguard", "rootguard.go"))
 }
 
 func copyFile(t *testing.T, source, destination string, mode os.FileMode) {

--- a/scripts/internal/rootguard/rootguard.go
+++ b/scripts/internal/rootguard/rootguard.go
@@ -1,0 +1,408 @@
+// Package rootguard captures content-aware snapshots of a trusted Git worktree.
+package rootguard
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const gitProcessesPerSnapshot = 9
+
+// Metrics describes the full-content worktree scope captured in a snapshot.
+type Metrics struct {
+	GitProcesses          int
+	Entries               int
+	RegularFiles          int
+	LogicalBytes          int64
+	UntrackedEntries      int
+	UntrackedRegularFiles int
+	UntrackedLogicalBytes int64
+	IgnoredEntries        int
+	IgnoredRegularFiles   int
+	IgnoredLogicalBytes   int64
+}
+
+// Snapshot is the trusted state compared at guard observation boundaries.
+type Snapshot struct {
+	Head                 string
+	Branch               string
+	Status               []byte
+	WorkspaceFingerprint string
+	Metrics              Metrics
+}
+
+type gitCommand func(directory string, arguments ...string) ([]byte, error)
+
+type rootedFile interface {
+	io.Reader
+	Stat() (os.FileInfo, error)
+	Close() error
+}
+
+type rootedFilesystem interface {
+	Lstat(name string) (os.FileInfo, error)
+	Open(name string) (rootedFile, error)
+	Readlink(name string) (string, error)
+	Close() error
+}
+
+type osRoot struct {
+	root *os.Root
+}
+
+func (root osRoot) Lstat(name string) (os.FileInfo, error) {
+	return root.root.Lstat(name)
+}
+
+func (root osRoot) Open(name string) (rootedFile, error) {
+	return root.root.Open(name)
+}
+
+func (root osRoot) Readlink(name string) (string, error) {
+	return root.root.Readlink(name)
+}
+
+func (root osRoot) Close() error {
+	return root.root.Close()
+}
+
+type snapshotter struct {
+	git      gitCommand
+	openRoot func(string) (rootedFilesystem, error)
+	metrics  Metrics
+}
+
+// Capture takes one deterministic, full-content snapshot of root.
+func Capture(root string) (Snapshot, error) {
+	worker := snapshotter{
+		git: gitOutput,
+		openRoot: func(path string) (rootedFilesystem, error) {
+			opened, err := os.OpenRoot(path)
+			if err != nil {
+				return nil, err
+			}
+
+			return osRoot{root: opened}, nil
+		},
+	}
+
+	return worker.capture(root)
+}
+
+// Compare verifies that two observation boundaries describe the same trusted
+// worktree state.
+func Compare(expected, current Snapshot) error {
+	if current.Head != expected.Head {
+		return fmt.Errorf("root HEAD changed: got %s, expected %s", current.Head, expected.Head)
+	}
+	if current.Branch != expected.Branch {
+		return fmt.Errorf("root branch changed: got %s, expected %s", current.Branch, expected.Branch)
+	}
+	if !bytes.Equal(current.Status, expected.Status) {
+		return errors.New("root status changed")
+	}
+	if current.WorkspaceFingerprint != expected.WorkspaceFingerprint {
+		return errors.New("root workspace content changed")
+	}
+
+	return nil
+}
+
+// StatusSHA256 returns a display-safe digest of the NUL-delimited porcelain
+// status captured in the snapshot.
+func (snapshot Snapshot) StatusSHA256() string {
+	digest := sha256.Sum256(snapshot.Status)
+
+	return hex.EncodeToString(digest[:])
+}
+
+func (worker *snapshotter) capture(root string) (Snapshot, error) {
+	if !filepath.IsAbs(root) {
+		return Snapshot{}, errors.New("trusted root path is not absolute")
+	}
+	rootFS, err := worker.openRoot(root)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("opening trusted root: %w", err)
+	}
+	defer func() {
+		_ = rootFS.Close() // Capture errors take precedence over best-effort descriptor cleanup.
+	}()
+
+	head, err := worker.runGit(root, "rev-parse", "HEAD")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("capturing ROOT_HEAD: %w", err)
+	}
+	branch, err := worker.runGit(root, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("capturing ROOT_BRANCH: %w", err)
+	}
+	status, err := worker.runGit(root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("capturing ROOT_STATUS: %w", err)
+	}
+	stagedDiff, err := worker.runGit(root, "diff", "--cached", "--binary", "--full-index", "HEAD", "--")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("reading staged root diff: %w", err)
+	}
+	unstagedDiff, err := worker.runGit(root, "diff", "--binary", "--full-index", "--")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("reading unstaged root diff: %w", err)
+	}
+	untracked, err := worker.runGit(root, "ls-files", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("listing untracked root paths: %w", err)
+	}
+	ignored, err := worker.runGit(root, "ls-files", "--others", "--ignored", "--exclude-standard", "-z")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("listing ignored root paths: %w", err)
+	}
+	infoExclude, err := worker.runGit(root, "rev-parse", "--path-format=absolute", "--git-path", "info/exclude")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("resolving repository exclude file: %w", err)
+	}
+	globalExcludes, err := worker.runOptionalGit(root, "config", "--null", "--path", "--get-all", "core.excludesFile")
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("resolving configured exclude files: %w", err)
+	}
+
+	hasher := sha256.New()
+	writeHashField(hasher, []byte("ledger-rootguard-v1"))
+	writeHashField(hasher, bytes.TrimSpace(head))
+	writeHashField(hasher, stagedDiff)
+	writeHashField(hasher, unstagedDiff)
+	if err := worker.hashGitPaths(hasher, rootFS, "untracked", untracked); err != nil {
+		return Snapshot{}, err
+	}
+	if err := worker.hashGitPaths(hasher, rootFS, "ignored", ignored); err != nil {
+		return Snapshot{}, err
+	}
+	writeHashField(hasher, []byte("ignore-configuration"))
+	infoExcludePath := strings.TrimSuffix(string(infoExclude), "\n")
+	if err := worker.hashExternalPath(hasher, root, infoExcludePath); err != nil {
+		return Snapshot{}, fmt.Errorf("hashing repository exclude file: %w", err)
+	}
+	configuredPaths, err := splitNUL(globalExcludes)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("parsing configured exclude files: %w", err)
+	}
+	slices.SortFunc(configuredPaths, bytes.Compare)
+	for _, configuredPath := range configuredPaths {
+		if err := worker.hashExternalPath(hasher, root, string(configuredPath)); err != nil {
+			return Snapshot{}, fmt.Errorf("hashing configured exclude file %q: %w", configuredPath, err)
+		}
+	}
+
+	return Snapshot{
+		Head:                 strings.TrimSpace(string(head)),
+		Branch:               strings.TrimSpace(string(branch)),
+		Status:               status,
+		WorkspaceFingerprint: hex.EncodeToString(hasher.Sum(nil)),
+		Metrics:              worker.metrics,
+	}, nil
+}
+
+func (worker *snapshotter) hashGitPaths(hasher hash.Hash, root rootedFilesystem, class string, output []byte) error {
+	paths, err := splitNUL(output)
+	if err != nil {
+		return fmt.Errorf("parsing %s root paths: %w", class, err)
+	}
+	slices.SortFunc(paths, bytes.Compare)
+	writeHashField(hasher, []byte(class))
+	for _, rawPath := range paths {
+		path := filepath.FromSlash(string(rawPath))
+		if !filepath.IsLocal(path) || path == "." {
+			return fmt.Errorf("%s path is not local: %q", class, rawPath)
+		}
+		if err := worker.hashPath(hasher, root, path, rawPath, class); err != nil {
+			return fmt.Errorf("hashing %s path %q: %w", class, rawPath, err)
+		}
+	}
+
+	return nil
+}
+
+func (worker *snapshotter) hashExternalPath(hasher hash.Hash, repositoryRoot, path string) error {
+	writeHashField(hasher, []byte(path))
+	if path == "" {
+		writeHashField(hasher, []byte("missing"))
+
+		return nil
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repositoryRoot, path)
+	}
+	directory, name := filepath.Split(filepath.Clean(path))
+	if !filepath.IsLocal(name) || name == "." {
+		return fmt.Errorf("exclude path has invalid final component: %q", path)
+	}
+	root, err := worker.openRoot(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		writeHashField(hasher, []byte("missing"))
+
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = root.Close() // Hashing errors take precedence over best-effort descriptor cleanup.
+	}()
+
+	return worker.hashPath(hasher, root, name, []byte(name), "")
+}
+
+func (worker *snapshotter) hashPath(
+	hasher hash.Hash,
+	root rootedFilesystem,
+	path string,
+	rawPath []byte,
+	metricsClass string,
+) error {
+	info, err := root.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) && metricsClass == "" {
+		writeHashField(hasher, []byte("missing"))
+
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading path metadata: %w", err)
+	}
+	writeHashField(hasher, rawPath)
+	writeHashField(hasher, []byte(info.Mode().String()))
+	if metricsClass != "" {
+		worker.metrics.Entries++
+		switch metricsClass {
+		case "untracked":
+			worker.metrics.UntrackedEntries++
+		case "ignored":
+			worker.metrics.IgnoredEntries++
+		}
+	}
+
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		writeHashField(hasher, []byte("symlink"))
+		target, err := root.Readlink(path)
+		if err != nil {
+			return fmt.Errorf("reading symlink target: %w", err)
+		}
+		writeHashField(hasher, []byte(target))
+	case info.Mode().IsRegular():
+		writeHashField(hasher, []byte("regular"))
+		file, err := root.Open(path)
+		if err != nil {
+			return fmt.Errorf("opening regular file: %w", err)
+		}
+		contentHasher := sha256.New()
+		logicalBytes, copyErr := io.Copy(contentHasher, file)
+		openedInfo, statErr := file.Stat()
+		closeErr := file.Close()
+		if copyErr != nil {
+			return fmt.Errorf("reading regular file: %w", copyErr)
+		}
+		if statErr != nil {
+			return fmt.Errorf("checking regular file after read: %w", statErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("closing regular file after read: %w", closeErr)
+		}
+		if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) || openedInfo.Mode() != info.Mode() || openedInfo.Size() != logicalBytes {
+			return errors.New("regular file changed type or identity while being read")
+		}
+		writeHashField(hasher, contentHasher.Sum(nil))
+		if metricsClass != "" {
+			worker.metrics.RegularFiles++
+			worker.metrics.LogicalBytes += logicalBytes
+			switch metricsClass {
+			case "untracked":
+				worker.metrics.UntrackedRegularFiles++
+				worker.metrics.UntrackedLogicalBytes += logicalBytes
+			case "ignored":
+				worker.metrics.IgnoredRegularFiles++
+				worker.metrics.IgnoredLogicalBytes += logicalBytes
+			}
+		}
+	case info.IsDir():
+		writeHashField(hasher, []byte("directory"))
+	default:
+		writeHashField(hasher, []byte("special"))
+	}
+
+	return nil
+}
+
+func (worker *snapshotter) runGit(directory string, arguments ...string) ([]byte, error) {
+	worker.metrics.GitProcesses++
+
+	return worker.git(directory, arguments...)
+}
+
+func (worker *snapshotter) runOptionalGit(directory string, arguments ...string) ([]byte, error) {
+	output, err := worker.runGit(directory, arguments...)
+	if err == nil {
+		return output, nil
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return nil, nil
+	}
+
+	return nil, err
+}
+
+func splitNUL(output []byte) ([][]byte, error) {
+	if len(output) == 0 {
+		return nil, nil
+	}
+	if output[len(output)-1] != 0 {
+		return nil, errors.New("NUL-delimited Git output lacks final delimiter")
+	}
+	parts := bytes.Split(output[:len(output)-1], []byte{0})
+	for _, part := range parts {
+		if len(part) == 0 {
+			return nil, errors.New("NUL-delimited Git output contains an empty path")
+		}
+	}
+
+	return parts, nil
+}
+
+func writeHashField(hasher hash.Hash, value []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	// hash.Hash.Write is specified to never return an error.
+	_, _ = hasher.Write(length[:])
+	_, _ = hasher.Write(value)
+}
+
+func gitOutput(directory string, arguments ...string) ([]byte, error) {
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return nil, fmt.Errorf("git %s: %w: %s", strings.Join(arguments, " "), err, strings.TrimSpace(string(exitError.Stderr)))
+		}
+
+		return nil, fmt.Errorf("git %s: %w", strings.Join(arguments, " "), err)
+	}
+
+	return output, nil
+}
+
+// GitProcessesPerSnapshot returns the fixed upper bound used by Capture.
+func GitProcessesPerSnapshot() int {
+	return gitProcessesPerSnapshot
+}

--- a/scripts/internal/rootguard/rootguard_test.go
+++ b/scripts/internal/rootguard/rootguard_test.go
@@ -1,0 +1,394 @@
+package rootguard
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(testingMain *testing.M) {
+	if err := os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull); err != nil {
+		panic(err)
+	}
+	os.Exit(testingMain.Run())
+}
+
+func TestSnapshotDetectsGitAndWorkspaceStateChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "HEAD",
+			mutate: func(t *testing.T, root string) {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "committed.txt"), []byte("committed\n"), 0o644))
+				runGit(t, root, "add", "committed.txt")
+				runGit(t, root, "commit", "-m", "advance HEAD")
+			},
+		},
+		{
+			name: "branch",
+			mutate: func(t *testing.T, root string) {
+				runGit(t, root, "switch", "-c", "other-branch")
+			},
+		},
+		{
+			name: "staged diff",
+			mutate: func(t *testing.T, root string) {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "base.txt"), []byte("staged\n"), 0o644))
+				runGit(t, root, "add", "base.txt")
+			},
+		},
+		{
+			name: "unstaged diff",
+			mutate: func(t *testing.T, root string) {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "base.txt"), []byte("unstaged\n"), 0o644))
+			},
+		},
+		{
+			name: "non-ignored untracked file",
+			mutate: func(t *testing.T, root string) {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("untracked\n"), 0o644))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := newTestRepository(t)
+			before := capture(t, root)
+			test.mutate(t, root)
+			after := capture(t, root)
+			require.Error(t, Compare(before, after))
+		})
+	}
+}
+
+func TestSnapshotDetectsAdversarialIgnoredPathChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prepare func(*testing.T, string) string
+		mutate  func(*testing.T, string, string)
+	}{
+		{
+			name: "same-size content with restored mtime",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "same-size")
+				require.NoError(t, os.WriteFile(path, []byte("before"), 0o644))
+
+				return path
+			},
+			mutate: func(t *testing.T, _ string, path string) {
+				info, err := os.Stat(path)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, []byte("after!"), 0o644))
+				require.NoError(t, os.Chtimes(path, info.ModTime(), info.ModTime()))
+			},
+		},
+		{
+			name:    "addition",
+			prepare: func(*testing.T, string) string { return "" },
+			mutate: func(t *testing.T, root, _ string) {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "ignored", "added"), []byte("added"), 0o644))
+			},
+		},
+		{
+			name: "deletion",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "deleted")
+				require.NoError(t, os.WriteFile(path, []byte("deleted"), 0o644))
+
+				return path
+			},
+			mutate: func(t *testing.T, _ string, path string) {
+				require.NoError(t, os.Remove(path))
+			},
+		},
+		{
+			name: "rename",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "old-name")
+				require.NoError(t, os.WriteFile(path, []byte("renamed"), 0o644))
+
+				return path
+			},
+			mutate: func(t *testing.T, root, path string) {
+				require.NoError(t, os.Rename(path, filepath.Join(root, "ignored", "new-name")))
+			},
+		},
+		{
+			name: "regular file to symlink",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "node")
+				require.NoError(t, os.WriteFile(path, []byte("target"), 0o644))
+
+				return path
+			},
+			mutate: func(t *testing.T, _ string, path string) {
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Symlink("target", path))
+			},
+		},
+		{
+			name: "symlink target",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "link")
+				require.NoError(t, os.Symlink("before", path))
+
+				return path
+			},
+			mutate: func(t *testing.T, _ string, path string) {
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Symlink("after", path))
+			},
+		},
+		{
+			name: "directory to regular file",
+			prepare: func(t *testing.T, root string) string {
+				path := filepath.Join(root, "ignored", "directory")
+				require.NoError(t, os.Mkdir(path, 0o755))
+				runGit(t, path, "init")
+
+				return path
+			},
+			mutate: func(t *testing.T, _ string, path string) {
+				require.NoError(t, os.RemoveAll(path))
+				require.NoError(t, os.WriteFile(path, []byte("file"), 0o644))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := newTestRepository(t)
+			path := test.prepare(t, root)
+			before := capture(t, root)
+			test.mutate(t, root, path)
+			after := capture(t, root)
+			require.ErrorContains(t, Compare(before, after), "root workspace content changed")
+		})
+	}
+}
+
+func TestSnapshotHandlesUnusualFilenameBytes(t *testing.T) {
+	t.Parallel()
+
+	root := newTestRepository(t)
+	path := filepath.Join(root, "ignored", "space and\nnewline")
+	require.NoError(t, os.WriteFile(path, []byte("before"), 0o644))
+	before := capture(t, root)
+	require.NoError(t, os.WriteFile(path, []byte("after!"), 0o644))
+	after := capture(t, root)
+	require.ErrorContains(t, Compare(before, after), "root workspace content changed")
+}
+
+func TestSnapshotHandlesNonUTF8FilenameBytesWhereSupported(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("os.Root rejects non-UTF-8 path bytes on this platform")
+	}
+	root := newTestRepository(t)
+	path := filepath.Join(root, "ignored", string([]byte{'n', 'o', 'n', '-', 0xff, '-', 'u', 't', 'f', '8'}))
+	require.NoError(t, os.WriteFile(path, []byte("before"), 0o644))
+	before := capture(t, root)
+	require.NoError(t, os.WriteFile(path, []byte("after!"), 0o644))
+	after := capture(t, root)
+	require.ErrorContains(t, Compare(before, after), "root workspace content changed")
+}
+
+func TestSnapshotPreservesIgnoredNestedRepositoryBoundary(t *testing.T) {
+	t.Parallel()
+
+	root := newTestRepository(t)
+	nested := filepath.Join(root, "ignored", "nested-repository")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+	runGit(t, nested, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "inside"), []byte("before"), 0o644))
+
+	before := capture(t, root)
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "inside"), []byte("after!"), 0o644))
+	after := capture(t, root)
+	require.NoError(t, Compare(before, after), "the parent guard intentionally treats an ignored nested repository as a separate root")
+}
+
+func TestSnapshotDetectsTrustedIgnoreConfigurationMutation(t *testing.T) {
+	t.Parallel()
+
+	root := newTestRepository(t)
+	before := capture(t, root)
+	excludePath := filepath.Join(root, ".git", "info", "exclude")
+	require.NoError(t, os.WriteFile(excludePath, []byte("# semantically inert mutation\n"), 0o644))
+	after := capture(t, root)
+	require.ErrorContains(t, Compare(before, after), "root workspace content changed")
+}
+
+func TestSnapshotFailsClosedOnEnumerationStatAndReadErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enumeration", func(t *testing.T) {
+		root := newTestRepository(t)
+		worker := newTestSnapshotter()
+		worker.git = func(directory string, arguments ...string) ([]byte, error) {
+			if slices.Equal(arguments, []string{"ls-files", "--others", "--ignored", "--exclude-standard", "-z"}) {
+				return nil, errors.New("injected enumeration failure")
+			}
+
+			return gitOutput(directory, arguments...)
+		}
+		_, err := worker.capture(root)
+		require.ErrorContains(t, err, "injected enumeration failure")
+	})
+
+	for _, test := range []struct {
+		name     string
+		failOpen bool
+	}{
+		{name: "stat"},
+		{name: "read", failOpen: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := newTestRepository(t)
+			path := filepath.Join(root, "ignored", "unreadable")
+			require.NoError(t, os.WriteFile(path, []byte("content"), 0o644))
+			worker := newTestSnapshotter()
+			baseOpenRoot := worker.openRoot
+			worker.openRoot = func(path string) (rootedFilesystem, error) {
+				opened, err := baseOpenRoot(path)
+				if err != nil || path != root {
+					return opened, err
+				}
+
+				return errorFilesystem{
+					rootedFilesystem: opened,
+					path:             filepath.Join("ignored", "unreadable"),
+					failOpen:         test.failOpen,
+				}, nil
+			}
+			_, err := worker.capture(root)
+			require.ErrorContains(t, err, "injected "+test.name+" failure")
+		})
+	}
+}
+
+func TestSnapshotUsesBoundedGitProcessesIndependentOfEntryCount(t *testing.T) {
+	t.Parallel()
+
+	root := newTestRepository(t)
+	for index := range 200 {
+		path := filepath.Join(root, "ignored", fmt.Sprintf("file-%03d", index))
+		require.NoError(t, os.WriteFile(path, []byte("content"), 0o644))
+	}
+
+	snapshot := capture(t, root)
+	require.Equal(t, 200, snapshot.Metrics.Entries)
+	require.Equal(t, 200, snapshot.Metrics.RegularFiles)
+	require.Equal(t, int64(1400), snapshot.Metrics.LogicalBytes)
+	require.Equal(t, 200, snapshot.Metrics.IgnoredEntries)
+	require.Equal(t, 200, snapshot.Metrics.IgnoredRegularFiles)
+	require.Equal(t, int64(1400), snapshot.Metrics.IgnoredLogicalBytes)
+	require.Equal(t, GitProcessesPerSnapshot(), snapshot.Metrics.GitProcesses)
+	require.Equal(t, 9, snapshot.Metrics.GitProcesses)
+}
+
+func BenchmarkCapture(b *testing.B) {
+	root := os.Getenv("ROOTGUARD_BENCH_ROOT")
+	if root == "" {
+		b.Skip("set ROOTGUARD_BENCH_ROOT to benchmark a representative trusted root")
+	}
+	snapshot, err := Capture(root)
+	require.NoError(b, err)
+	b.ReportMetric(float64(snapshot.Metrics.IgnoredEntries), "ignored-entries")
+	b.ReportMetric(float64(snapshot.Metrics.IgnoredRegularFiles), "ignored-regular-files")
+	b.ReportMetric(float64(snapshot.Metrics.IgnoredLogicalBytes), "ignored-logical-bytes")
+	b.ReportMetric(float64(snapshot.Metrics.GitProcesses), "git-processes/snapshot")
+	b.ResetTimer()
+	for range b.N {
+		_, err := Capture(root)
+		require.NoError(b, err)
+	}
+}
+
+type errorFilesystem struct {
+	rootedFilesystem
+
+	path     string
+	failOpen bool
+}
+
+func (filesystem errorFilesystem) Lstat(name string) (os.FileInfo, error) {
+	if name == filesystem.path && !filesystem.failOpen {
+		return nil, errors.New("injected stat failure")
+	}
+
+	return filesystem.rootedFilesystem.Lstat(name)
+}
+
+func (filesystem errorFilesystem) Open(name string) (rootedFile, error) {
+	if name == filesystem.path && filesystem.failOpen {
+		return nil, errors.New("injected read failure")
+	}
+
+	return filesystem.rootedFilesystem.Open(name)
+}
+
+func newTestSnapshotter() snapshotter {
+	return snapshotter{
+		git: gitOutput,
+		openRoot: func(path string) (rootedFilesystem, error) {
+			opened, err := os.OpenRoot(path)
+			if err != nil {
+				return nil, err
+			}
+
+			return osRoot{root: opened}, nil
+		},
+	}
+}
+
+func newTestRepository(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(t, os.Mkdir(root, 0o755))
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Root Guard Test")
+	runGit(t, root, "config", "user.email", "rootguard@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored/\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "base.txt"), []byte("base\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "ignored"), 0o755))
+	runGit(t, root, "add", ".gitignore", "base.txt")
+	runGit(t, root, "commit", "-m", "base")
+
+	return root
+}
+
+func capture(t *testing.T, root string) Snapshot {
+	t.Helper()
+	snapshot, err := Capture(root)
+	require.NoError(t, err)
+
+	return snapshot
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "git %s:\n%s", strings.Join(arguments, " "), output)
+}

--- a/scripts/reviewloop/worktree_binding.go
+++ b/scripts/reviewloop/worktree_binding.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/rootguard"
 )
 
 type worktreeBindingFile struct {
@@ -22,13 +22,6 @@ type worktreeBindingFile struct {
 	CandidateWorktree   string `json:"candidateWorktree"`
 	ExpectedHead        string `json:"expectedHead"`
 	TrustedRootCheckout string `json:"trustedRootCheckout"`
-}
-
-type rootCheckoutSnapshot struct {
-	Head                 string
-	Branch               string
-	Status               []byte
-	WorkspaceFingerprint string
 }
 
 type boundCommandRunner struct {
@@ -40,7 +33,7 @@ type boundCommandRunner struct {
 	bindingFile         string
 	bindingFileContent  []byte
 	gitGuardBin         string
-	rootSnapshot        rootCheckoutSnapshot
+	rootSnapshot        rootguard.Snapshot
 }
 
 func newBoundCommandRunner(
@@ -130,17 +123,23 @@ func newBoundCommandRunner(
 	if err := runner.verifyWorktreeBinding(); err != nil {
 		return nil, err
 	}
-	runner.rootSnapshot, err = captureRootCheckoutSnapshot(trustedRoot)
+	runner.rootSnapshot, err = rootguard.Capture(trustedRoot)
 	if err != nil {
 		return nil, err
 	}
-	statusDigest := sha256.Sum256(runner.rootSnapshot.Status)
 	fmt.Printf(
-		"ROOT_PROTECTION_ARMED head=%s branch=%s statusSha256=%s workspaceFingerprint=%s\n",
+		"ROOT_PROTECTION_ARMED head=%s branch=%s statusSha256=%s workspaceFingerprint=%s entries=%d regularFiles=%d logicalBytes=%d ignoredEntries=%d ignoredRegularFiles=%d ignoredLogicalBytes=%d gitProcesses=%d\n",
 		runner.rootSnapshot.Head,
 		runner.rootSnapshot.Branch,
-		hex.EncodeToString(statusDigest[:]),
+		runner.rootSnapshot.StatusSHA256(),
 		runner.rootSnapshot.WorkspaceFingerprint,
+		runner.rootSnapshot.Metrics.Entries,
+		runner.rootSnapshot.Metrics.RegularFiles,
+		runner.rootSnapshot.Metrics.LogicalBytes,
+		runner.rootSnapshot.Metrics.IgnoredEntries,
+		runner.rootSnapshot.Metrics.IgnoredRegularFiles,
+		runner.rootSnapshot.Metrics.IgnoredLogicalBytes,
+		runner.rootSnapshot.Metrics.GitProcesses,
 	)
 
 	return runner, nil
@@ -312,95 +311,12 @@ func (runner *boundCommandRunner) verifyWorktreeBinding() error {
 }
 
 func (runner *boundCommandRunner) verifyRootUnchanged() error {
-	current, err := captureRootCheckoutSnapshot(runner.trustedRootCheckout)
+	current, err := rootguard.Capture(runner.trustedRootCheckout)
 	if err != nil {
 		return err
 	}
-	if current.Head != runner.rootSnapshot.Head {
-		return fmt.Errorf("root HEAD changed: got %s, expected %s", current.Head, runner.rootSnapshot.Head)
-	}
-	if current.Branch != runner.rootSnapshot.Branch {
-		return fmt.Errorf("root branch changed: got %s, expected %s", current.Branch, runner.rootSnapshot.Branch)
-	}
-	if !bytes.Equal(current.Status, runner.rootSnapshot.Status) {
-		return errors.New("root status changed")
-	}
-	if current.WorkspaceFingerprint != runner.rootSnapshot.WorkspaceFingerprint {
-		return errors.New("root workspace content changed")
-	}
 
-	return nil
-}
-
-func captureRootCheckoutSnapshot(root string) (rootCheckoutSnapshot, error) {
-	head, err := gitOutput(root, "rev-parse", "HEAD")
-	if err != nil {
-		return rootCheckoutSnapshot{}, fmt.Errorf("capturing ROOT_HEAD: %w", err)
-	}
-	branch, err := gitOutput(root, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		return rootCheckoutSnapshot{}, fmt.Errorf("capturing ROOT_BRANCH: %w", err)
-	}
-	status, err := gitOutput(root, "status", "--porcelain=v1", "--untracked-files=all")
-	if err != nil {
-		return rootCheckoutSnapshot{}, fmt.Errorf("capturing ROOT_STATUS: %w", err)
-	}
-	workspaceFingerprint, err := captureRootWorkspaceFingerprint(root)
-	if err != nil {
-		return rootCheckoutSnapshot{}, fmt.Errorf("capturing ROOT_STATUS content fingerprint: %w", err)
-	}
-
-	return rootCheckoutSnapshot{
-		Head:                 strings.TrimSpace(string(head)),
-		Branch:               strings.TrimSpace(string(branch)),
-		Status:               status,
-		WorkspaceFingerprint: workspaceFingerprint,
-	}, nil
-}
-
-func captureRootWorkspaceFingerprint(root string) (string, error) {
-	workspace, err := captureWorkspaceState(root)
-	if err != nil {
-		return "", err
-	}
-	ignoredOutput, err := gitOutput(root, "ls-files", "--others", "--ignored", "--exclude-standard", "-z")
-	if err != nil {
-		return "", fmt.Errorf("listing ignored workspace files: %w", err)
-	}
-
-	hasher := sha256.New()
-	writeHashField(hasher, []byte(workspace.Fingerprint))
-	for rawPath := range bytes.SplitSeq(ignoredOutput, []byte{0}) {
-		if len(rawPath) == 0 {
-			continue
-		}
-		path := string(rawPath)
-		absolutePath := filepath.Join(root, filepath.FromSlash(path))
-		info, err := os.Lstat(absolutePath)
-		if err != nil {
-			return "", fmt.Errorf("reading ignored path metadata %s: %w", path, err)
-		}
-		writeHashField(hasher, rawPath)
-		writeHashField(hasher, []byte(info.Mode().String()))
-
-		var content []byte
-		switch {
-		case info.Mode()&os.ModeSymlink != 0:
-			target, err := os.Readlink(absolutePath)
-			if err != nil {
-				return "", fmt.Errorf("reading ignored symlink %s: %w", path, err)
-			}
-			content = []byte(target)
-		case info.Mode().IsRegular():
-			content, err = os.ReadFile(absolutePath)
-			if err != nil {
-				return "", fmt.Errorf("reading ignored file %s: %w", path, err)
-			}
-		}
-		writeHashField(hasher, content)
-	}
-
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+	return rootguard.Compare(runner.rootSnapshot, current)
 }
 
 func gitCommonDirectory(worktree string) (string, error) {

--- a/scripts/rootguard/main.go
+++ b/scripts/rootguard/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/rootguard"
+)
+
+const exitError = 1
+
+type options struct {
+	root string
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(arguments []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	settings := options{}
+	flags := flag.NewFlagSet("rootguard", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.StringVar(&settings.root, "root", "", "absolute trusted Git worktree root")
+	if err := flags.Parse(arguments); err != nil {
+		return exitError
+	}
+	if strings.TrimSpace(settings.root) == "" {
+		if _, err := fmt.Fprintln(stderr, "rootguard: --root is required"); err != nil {
+			return exitError
+		}
+
+		return exitError
+	}
+	commandArguments := flags.Args()
+	if len(commandArguments) == 0 {
+		if _, err := fmt.Fprintln(stderr, "rootguard: a child command is required after --"); err != nil {
+			return exitError
+		}
+
+		return exitError
+	}
+
+	started := time.Now()
+	before, err := rootguard.Capture(settings.root)
+	if err != nil {
+		if _, writeErr := fmt.Fprintf(stderr, "ROOT_PROTECTION_ARMING_FAILED (%v)\n", err); writeErr != nil {
+			return exitError
+		}
+
+		return exitError
+	}
+	if _, err := fmt.Fprintf(
+		stdout,
+		"ROOT_PROTECTION_ARMED head=%s branch=%s statusSha256=%s workspaceFingerprint=%s entries=%d regularFiles=%d logicalBytes=%d ignoredEntries=%d ignoredRegularFiles=%d ignoredLogicalBytes=%d gitProcesses=%d snapshotMillis=%d\n",
+		before.Head,
+		before.Branch,
+		before.StatusSHA256(),
+		before.WorkspaceFingerprint,
+		before.Metrics.Entries,
+		before.Metrics.RegularFiles,
+		before.Metrics.LogicalBytes,
+		before.Metrics.IgnoredEntries,
+		before.Metrics.IgnoredRegularFiles,
+		before.Metrics.IgnoredLogicalBytes,
+		before.Metrics.GitProcesses,
+		time.Since(started).Milliseconds(),
+	); err != nil {
+		return exitError
+	}
+
+	command := exec.Command(commandArguments[0], commandArguments[1:]...)
+	command.Stdin = stdin
+	command.Stdout = stdout
+	command.Stderr = stderr
+	childErr := command.Run()
+
+	after, snapshotErr := rootguard.Capture(settings.root)
+	if snapshotErr != nil {
+		if _, err := fmt.Fprintf(stderr, "ROOT_MUTATION_DETECTED (post-snapshot failed closed: %v)\n", snapshotErr); err != nil {
+			return exitError
+		}
+
+		return exitError
+	}
+	if err := rootguard.Compare(before, after); err != nil {
+		if _, writeErr := fmt.Fprintf(stderr, "ROOT_MUTATION_DETECTED (%v)\n", err); writeErr != nil {
+			return exitError
+		}
+
+		return exitError
+	}
+	if _, err := fmt.Fprintln(stdout, "ROOT_UNCHANGED=PASS"); err != nil {
+		return exitError
+	}
+	if childErr == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(childErr, &exitErr) && exitErr.ExitCode() >= 0 {
+		return exitErr.ExitCode()
+	}
+	if _, err := fmt.Fprintf(stderr, "rootguard: child command failed: %v\n", childErr); err != nil {
+		return exitError
+	}
+
+	return exitError
+}

--- a/scripts/rootguard/main_test.go
+++ b/scripts/rootguard/main_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(testingMain *testing.M) {
+	if err := os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GIT_CONFIG_SYSTEM", os.DevNull); err != nil {
+		panic(err)
+	}
+	os.Exit(testingMain.Run())
+}
+
+func TestProviderMutationWinsOverNonZeroExit(t *testing.T) {
+	t.Parallel()
+
+	root := newRunnerTestRepository(t)
+	var output bytes.Buffer
+	status := run([]string{
+		"--root", root, "--", "/bin/sh", "-c",
+		"printf changed > " + shellQuote(filepath.Join(root, "ignored", "value")) + "; exit 7",
+	}, strings.NewReader(""), &output, &output)
+	require.Equal(t, exitError, status, output.String())
+	require.Contains(t, output.String(), "ROOT_MUTATION_DETECTED")
+	require.NotContains(t, output.String(), "ROOT_UNCHANGED=PASS")
+}
+
+func TestResidentRunnerDetectsMutationAfterItsOnDiskBinaryIsReplaced(t *testing.T) {
+	t.Parallel()
+
+	root := newRunnerTestRepository(t)
+	binary := buildRunner(t)
+	replacement := binary + ".replacement"
+	script := fmt.Sprintf(
+		"printf '#!/bin/sh\\nexit 0\\n' > %s; chmod 700 %s; mv %s %s; printf changed > ignored/value",
+		shellQuote(replacement),
+		shellQuote(replacement),
+		shellQuote(replacement),
+		shellQuote(binary),
+	)
+	command := exec.Command(binary, "--root", root, "--", "/bin/sh", "-c", script)
+	command.Dir = root
+	output, err := command.CombinedOutput()
+	require.Error(t, err, string(output))
+	require.Equal(t, exitError, command.ProcessState.ExitCode(), string(output))
+	require.Contains(t, string(output), "ROOT_MUTATION_DETECTED")
+}
+
+func TestConcurrentResidentRunnersProtectSameUnchangedRoot(t *testing.T) {
+	t.Parallel()
+
+	root := newRunnerTestRepository(t)
+	binary := buildRunner(t)
+	coordination := t.TempDir()
+	firstReady := filepath.Join(coordination, "first-ready")
+	secondReady := filepath.Join(coordination, "second-ready")
+	first := guardedCommand(binary, root, fmt.Sprintf(
+		": > %s; while [ ! -e %s ]; do :; done",
+		shellQuote(firstReady), shellQuote(secondReady),
+	))
+	second := guardedCommand(binary, root, fmt.Sprintf(
+		": > %s; while [ ! -e %s ]; do :; done",
+		shellQuote(secondReady), shellQuote(firstReady),
+	))
+	firstOutput, secondOutput := runConcurrently(t, first, second)
+	require.Contains(t, firstOutput, "ROOT_UNCHANGED=PASS")
+	require.Contains(t, secondOutput, "ROOT_UNCHANGED=PASS")
+}
+
+func TestConcurrentResidentRunnersBothDetectOverlappingMutation(t *testing.T) {
+	t.Parallel()
+
+	root := newRunnerTestRepository(t)
+	binary := buildRunner(t)
+	coordination := t.TempDir()
+	firstReady := filepath.Join(coordination, "first-ready")
+	secondReady := filepath.Join(coordination, "second-ready")
+	mutated := filepath.Join(coordination, "mutated")
+	first := guardedCommand(binary, root, fmt.Sprintf(
+		": > %s; while [ ! -e %s ]; do :; done; printf changed > ignored/value; : > %s",
+		shellQuote(firstReady), shellQuote(secondReady), shellQuote(mutated),
+	))
+	second := guardedCommand(binary, root, fmt.Sprintf(
+		": > %s; while [ ! -e %s ]; do :; done; while [ ! -e %s ]; do :; done",
+		shellQuote(secondReady), shellQuote(firstReady), shellQuote(mutated),
+	))
+	firstOutput, secondOutput := runConcurrentlyExpectingFailure(t, first, second)
+	require.Contains(t, firstOutput, "ROOT_MUTATION_DETECTED")
+	require.Contains(t, secondOutput, "ROOT_MUTATION_DETECTED")
+}
+
+func guardedCommand(binary, root, script string) *exec.Cmd {
+	command := exec.Command(binary, "--root", root, "--", "/bin/sh", "-c", script)
+	command.Dir = root
+
+	return command
+}
+
+func runConcurrently(t *testing.T, commands ...*exec.Cmd) (string, string) {
+	t.Helper()
+	outputs := make([]bytes.Buffer, len(commands))
+	for index, command := range commands {
+		command.Stdout = &outputs[index]
+		command.Stderr = &outputs[index]
+		require.NoError(t, command.Start())
+	}
+	for index, command := range commands {
+		require.NoError(t, command.Wait(), outputs[index].String())
+	}
+
+	return outputs[0].String(), outputs[1].String()
+}
+
+func runConcurrentlyExpectingFailure(t *testing.T, commands ...*exec.Cmd) (string, string) {
+	t.Helper()
+	outputs := make([]bytes.Buffer, len(commands))
+	for index, command := range commands {
+		command.Stdout = &outputs[index]
+		command.Stderr = &outputs[index]
+		require.NoError(t, command.Start())
+	}
+	for index, command := range commands {
+		require.Error(t, command.Wait(), outputs[index].String())
+		require.Equal(t, exitError, command.ProcessState.ExitCode(), outputs[index].String())
+	}
+
+	return outputs[0].String(), outputs[1].String()
+}
+
+func buildRunner(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "rootguard")
+	command := exec.Command("go", "build", "-o", binary, ".")
+	command.Dir = packageRoot(t)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	return binary
+}
+
+func newRunnerTestRepository(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(t, os.Mkdir(root, 0o755))
+	runRunnerGit(t, root, "init")
+	runRunnerGit(t, root, "config", "user.name", "Root Guard Runner Test")
+	runRunnerGit(t, root, "config", "user.email", "rootguard-runner@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("ignored/\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "base.txt"), []byte("base\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(root, "ignored"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored", "value"), []byte("before"), 0o644))
+	runRunnerGit(t, root, "add", ".gitignore", "base.txt")
+	runRunnerGit(t, root, "commit", "-m", "base")
+
+	return root
+}
+
+func runRunnerGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "git %s:\n%s", strings.Join(arguments, " "), output)
+}
+
+func packageRoot(t *testing.T) string {
+	t.Helper()
+	directory, err := os.Getwd()
+	require.NoError(t, err)
+
+	return directory
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}


### PR DESCRIPTION
## Summary

- replace ai-pr-triage's per-file `git hash-object` guard with a base-pinned resident Go runner
- share one full-content SHA-256 root snapshot implementation with review-loop
- preserve Git-reported ignored scope and observation frequency while strengthening NUL/path, mode/type, symlink, and ignore-configuration coverage
- add adversarial, fail-closed, helper-replacement, concurrency, and bounded-process regressions

## Equal-scope performance

192 ignored entries, 84 regular files, 1,641,383,391 logical bytes:

- old production Bash median: 21.252 s (21.252 / 19.058 / 25.681)
- new in-process median: 2.240 s (2.240 / 2.317 / 1.911)
- speedup: 9.49x
- Git processes: 93 -> 9 for this tree; new count is constant per snapshot

## Validation

- pinned Nix Go 1.26.5 `go test ./scripts/...`
- targeted `-race` for rootguard, runner, review-loop, and triage
- sensitivity mutations for ignored content and mutable post-helper designs
- `bash scripts/agent-check`
- guarded pre-commit fixpoint with `ROOT_UNCHANGED=PASS`

No product code changes. No snapshot-scope reduction or metadata-only shortcut.