### PR TITLE
perf(tooling): share verified module downloads

### DIFF
--- a/docs/technical/agent-context.md
+++ b/docs/technical/agent-context.md
@@ -44,6 +44,7 @@ When current code and authoritative documentation disagree, stop treating the do
 | tests only | `docs/technical/contributing/testing.md` plus the subsystem documentation for the behavior under test |
 | contributor/build tooling | `docs/technical/contributing/getting-started.md`, `docs/technical/contributing/development.md`, `docs/technical/contributing/conventions.md` as relevant |
 | `scripts/aicampaign/**`, `scripts/ai-campaign*` | `docs/technical/contributing/ai-campaign.md`, `docs/technical/contributing/testing.md`; also `docs/technical/contributing/product-technical-traceability.md` for distributed coordination semantics |
+| agent Go cache / validation isolation tooling | `docs/technical/contributing/agent-module-download-cache.md`, `docs/technical/contributing/ai-worktree-isolation.md`, `docs/technical/contributing/testing.md` |
 
 If a touched production area has no matching row, do not assume that no subsystem rules apply. Identify its callers/callees or owning subsystem first, then load that subsystem's documentation before editing.
 

--- a/docs/technical/contributing/agent-module-download-cache.md
+++ b/docs/technical/contributing/agent-module-download-cache.md
@@ -1,0 +1,196 @@
+# Agent module download cache
+
+## Operational requirement
+
+Candidate validation needs to reuse verified Go module downloads without
+giving two candidates a shared extracted module tree. A cold isolated module
+setup is material to PR-loop latency, but ordinary `go build` and `go test`
+trust an extracted tree already present in `GOMODCACHE`. Sharing that tree lets
+one candidate change dependency source consumed by another candidate without a
+checksum failure.
+
+The required boundary is therefore:
+
+```text
+base-pinned trusted module graph
+        -> shared .zip/.mod seed
+        -> copy/reflink by value
+        -> unique run-local GOMODCACHE
+        -> Go checksum verification
+        -> run-local extracted trees
+```
+
+`GOCACHE` remains unique per validation run. Local `replace` targets remain in
+their worktrees and never enter the module download seed.
+
+## Alternatives evaluated
+
+### A. Direct `file://` module proxy
+
+- **TRUST:** Go verifies proxy archives, but the candidate receives the shared
+  filesystem path in `GOPROXY`. Under the same UID it can mutate version lists,
+  metadata, or artifacts while another run resolves modules.
+- **PORTABILITY:** Go-native and supported on every repository platform.
+- **SETUP_COST:** Low; no seed copy.
+- **COPY_COST:** None.
+- **DISK_COST:** One shared archive set plus each run's extracted cache.
+- **CONCURRENT_BEHAVIOR:** Concurrent readers are simple, but candidate writes
+  cross the authority boundary.
+- **PRIVATE_MODULE_FUTURE_COMPATIBILITY:** Would need separate credentials and
+  no-sumdb policy; unsafe as an automatic shared path.
+- **COMPLEXITY:** Low mechanically, unacceptable authority boundary.
+
+### B. Copy verified downloads into each run (selected)
+
+- **TRUST:** The shared generation is never a `GOMODCACHE`. Only `.zip` and
+  `.mod` files are copied. `.ziphash`, proxy lists, checksum-database tiles,
+  locks, temporary files, and extracted directories are excluded. The trusted
+  base graph then runs `go mod download` in the run-local cache. Missing
+  `.ziphash` files force Go to hash archives and check `go.sum` / `GOSUMDB`
+  before extraction. Seed entries not verified by that graph are removed.
+- **PORTABILITY:** Uses pinned Go, GNU coreutils, findutils, and Bash from the
+  existing Nix shell on Linux and macOS.
+- **SETUP_COST:** A cold generation costs the ordinary trusted download once;
+  repeated runs retain only hashing and extraction.
+- **COPY_COST:** `cp --reflink=auto` uses copy-on-write where supported and a
+  normal byte copy elsewhere.
+- **DISK_COST:** One content-addressed download generation plus one complete
+  run-local module cache per active validation. Reflink-capable filesystems
+  reduce physical duplication but are not required for correctness.
+- **CONCURRENT_BEHAVIOR:** Cold runs may download in parallel. A complete
+  run-local publication is atomically renamed into place; no run waits for or
+  consumes a partial generation.
+- **PRIVATE_MODULE_FUTURE_COMPATIBILITY:** Sharing disables completely when
+  `GOPRIVATE`, `GONOSUMDB`, or `GONOPROXY` is non-empty, or when `GOSUMDB` is
+  empty/off. Such runs retain fully isolated module resolution.
+- **COMPLEXITY:** One focused preparation helper and the existing validation
+  wrapper; no daemon, mount, or new service.
+
+### C. Immutable prepopulation in the Nix store
+
+- **TRUST:** Strong filesystem immutability and no candidate write authority.
+- **PORTABILITY:** Supported by the repository's Nix environments.
+- **SETUP_COST:** Good after realization, but every module-graph change needs a
+  new fixed-output derivation and hash.
+- **COPY_COST:** Still requires a run-local extraction or module cache.
+- **DISK_COST:** Nix generations plus run-local caches.
+- **CONCURRENT_BEHAVIOR:** Nix realizes derivations safely.
+- **PRIVATE_MODULE_FUTURE_COMPATIBILITY:** Fixed-output fetching and credentials
+  would require a separate design.
+- **COMPLEXITY:** Disproportionate maintenance for frequently changing root and
+  nested module graphs, so rejected.
+
+### D. Shared raw download subtree, overlay, or cache daemon
+
+- **TRUST:** A symlink or bind-mounted `GOMODCACHE/cache/download` also shares
+  `.ziphash` state and lets `go clean -modcache` affect peers. A daemon could
+  enforce read-only serving but creates a new service boundary.
+- **PORTABILITY:** Overlay/mount behavior varies by host; a daemon adds process
+  lifecycle and networking requirements.
+- **SETUP_COST:** Potentially low.
+- **COPY_COST:** None for overlays/daemon serving.
+- **DISK_COST:** Low shared storage, at the cost of the stronger coupling.
+- **CONCURRENT_BEHAVIOR:** Requires mount or service coordination and crash
+  handling.
+- **PRIVATE_MODULE_FUTURE_COMPATIBILITY:** Requires credential, tenant, and
+  checksum-exemption policy.
+- **COMPLEXITY:** Exceeds the saved setup time and violates the no-service
+  constraint, so rejected.
+
+## Authority and verification boundary
+
+`ai-pr-loop` and `ai-pr-adopt-candidate` invoke the base-pinned
+`agent-validation-env` before any candidate process. The wrapper consumes
+`SHARE_DOWNLOAD_CACHE_ONLY=1`, unsets it before executing the requested
+command, and never exports the shared generation path. The helper derives the
+shared root from the trusted worktree's Git common directory; candidate input
+does not select it.
+
+Filesystem secrecy or same-UID permissions are not treated as integrity. A
+candidate that deliberately locates and edits the shared directory can cause a
+cache miss or validation failure, but cannot authorize bytes for another run:
+
+1. reuse copies regular `.zip` and `.mod` files by value into a unique run;
+2. no shared `.ziphash` is copied;
+3. the trusted base's root and every tracked nested module execute `go mod
+   download` before candidate execution;
+4. Go recreates `.ziphash` only after the archive matches the trusted
+   `go.sum`, consulting `GOSUMDB` for sums not already recorded;
+5. copied entries without a freshly created run-local `.ziphash` are removed;
+6. newly introduced candidate dependencies are absent from the allowlisted
+   run-local seed and use the unchanged `GOPROXY` chain.
+
+Wrong archives, same-size/same-mtime changes, changed module files, and
+candidate-injected entries therefore fail or are discarded before reuse. A
+candidate's later changes to its own extracted tree, archive cache, or
+`.ziphash` remain confined to that run.
+
+## State and lifecycle
+
+Shared generations live at:
+
+```text
+<git-common-dir>/ledger-agent-module-download-cache/v1/<go-version>/<manifest-fingerprint>/
+```
+
+The fingerprint covers pinned Go version, `GOPROXY`, `GOSUMDB`, and every
+tracked root/nested `go.mod` and `go.sum` blob. Source-only changes reuse the
+same generation; dependency, proxy, checksum-database, or toolchain changes
+select a new generation.
+
+Cold preparation downloads through the existing Go configuration into the
+current run's private `GOMODCACHE`, then publishes only verified `.zip`/`.mod`
+pairs. Publication uses an atomic no-clobber rename. Concurrent cold runs may
+duplicate the initial network work, which is cheaper and safer than a lock or
+daemon; one complete generation wins. A crash before rename leaves no visible
+generation because staging lives inside the disposable run directory.
+
+Run cleanup continues to remove the complete validation directory, including
+all extracted modules. Shared generations are deliberately outside that tree.
+They are content-addressed and may be removed as a whole for garbage
+collection; active runs already hold private copies. An unexpected incomplete
+or corrupt generation is never repaired in place: remove that generation and
+the next trusted preparation recreates it.
+
+## Private and no-sumdb policy
+
+The optimization is fail-closed. Any effective non-empty `GOPRIVATE`,
+`GONOSUMDB`, or `GONOPROXY`, or an empty/off `GOSUMDB`, disables all shared
+reuse for the run. This conservative policy avoids leaking private archives or
+silently extending shared trust to modules without the current checksum
+database contract. Public and private dependencies can be split later only
+with a separately reviewed classification mechanism; this helper does not try
+to infer privacy from module names.
+
+## Measured behavior
+
+Measurements used two clean worktrees at the same target commit, pinned Go
+1.26.5, all tracked root and nested modules, and a distinct empty `GOCACHE` for
+every run. Times vary with network and filesystem state, so they describe the
+observed envelope rather than a fixed budget:
+
+| Scenario | Module setup wall time |
+| --- | ---: |
+| Fully isolated baseline | 45.18 s |
+| Cold shared-generation creation | 31.19 s |
+| Repeated reuse, sample 1 | 31.49 s |
+| Repeated reuse, sample 2 | 23.32 s |
+| Two concurrent isolated runs | 49.36 s |
+| Two concurrent reuse runs | 50.38 s |
+
+Repeated single-run setup improved by 1.43-1.94x (13.69-21.86 seconds).
+Concurrent wall time was neutral within observed variance because both runs
+still perform independent hashing and extraction. Copy/reflink setup took
+0.79 seconds for 354 MiB of shared downloads. Each complete run-local cache
+was approximately 1.51 GiB; the shared download-only generation added 355 MiB.
+A source-only candidate reused the generation and its subsequent `go mod
+download` took 0.13 seconds. A candidate with a new public dependency fetched
+that dependency into its own cache in 0.34 seconds. No measurement reused or
+changed `GOCACHE`.
+
+Uncontrolled post-rebase spot checks ranged from 32.30 to 63.83 seconds for
+reuse against a 41.21-second isolated sample. The wide range coincided with
+heavy temporary-cache cleanup and is retained here as a caution: the cache
+removes repeated network transfer and showed a material controlled-worktree
+improvement, but it does not eliminate local hashing/extraction cost or
+guarantee lower latency under host I/O contention.

--- a/docs/technical/contributing/agent-module-download-cache.md
+++ b/docs/technical/contributing/agent-module-download-cache.md
@@ -136,7 +136,9 @@ Shared generations live at:
 The fingerprint covers pinned Go version, `GOPROXY`, `GOSUMDB`, and every
 tracked root/nested `go.mod` and `go.sum` blob. Source-only changes reuse the
 same generation; dependency, proxy, checksum-database, or toolchain changes
-select a new generation.
+select a new generation. `GOPROXY` is used only as input to that opaque digest;
+the shared generation metadata never persists its raw value because proxy URLs
+may contain credentials.
 
 Cold preparation downloads through the existing Go configuration into the
 current run's private `GOMODCACHE`, then publishes only verified `.zip`/`.mod`

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -347,8 +347,17 @@ run must use a unique temporary validation directory and isolate `HOME`,
 `GOCACHE`, `GOMODCACHE`, `GOPATH`, `TMPDIR`, `XDG_CACHE_HOME`, and the
 `golangci-lint` cache. The canonical `agent-validation-env` wrapper creates
 these directories and records `VALIDATION_RUN_ID`; `ai-pr-loop` and
-`ai-pr-adopt-candidate` invoke validation through it. This keeps generated
-files and absolute paths from one concurrent run out of another run's caches.
+`ai-pr-adopt-candidate` invoke it from the base-pinned trusted worktree before
+candidate execution, then pass the same paths to every validation phase. This
+keeps generated files and absolute paths from one concurrent run out of
+another run's caches.
+
+The wrapper also prepares the
+[agent module download cache](agent-module-download-cache.md). Reuse is limited
+to copied `.zip`/`.mod` downloads that Go re-verifies against the trusted base
+module graph before extraction. `GOMODCACHE` itself, including extracted
+module trees and `.ziphash` state, remains unique and writable only by its
+owning run. `GOCACHE` isolation is unchanged.
 
 Those caches live inside the run's dedicated `validation/` directory, disjoint
 from both Git worktrees, so `ai-pr-loop` reclaims the whole

--- a/docs/technical/contributing/ai-worktree-isolation.md
+++ b/docs/technical/contributing/ai-worktree-isolation.md
@@ -17,8 +17,11 @@ The workflow keeps three directory roles separate:
   expected HEAD. Reviewers, fixers, and PR validation run there. It must never
   equal `TRUSTED_ROOT_CHECKOUT`.
 - `VALIDATION_RUN_DIR` is a unique non-worktree directory for `HOME`, Go caches,
-  `TMPDIR`, the golangci-lint cache, and the Git guard wrapper. It must neither
-  equal nor contain either checkout, and neither checkout may contain it.
+  `TMPDIR`, the golangci-lint cache, the Git guard wrapper, and run-local module
+  download preparation state. It must neither equal nor contain either
+  checkout, and neither checkout may contain it. Extracted Go module trees and
+  `.ziphash` files never leave this directory; only the separately documented
+  verified `.zip`/`.mod` seed is shared.
 
 `ai-pr-loop` uses
 `.<repo>-ai-worktrees/pr-<pr>.<run>/{worktree,trusted-tools,validation}`.

--- a/scripts/agent-module-download-cache
+++ b/scripts/agent-module-download-cache
@@ -187,8 +187,11 @@ if [[ ! -f "$generation_ready" ]]; then
         find . -type f \( -name '*.zip' -o -name '*.mod' \) -print0 |
             xargs -0 -r cp --parents --reflink=auto --no-dereference -t "$publish_dir/download"
     )
-    printf 'version=1\nkey=%s\ngo=%s\ngoproxy=%s\ngosumdb=%s\n' \
-        "$fingerprint" "$go_version" "$goproxy" "$gosumdb" >"$publish_dir/READY"
+    # GOPROXY may contain embedded credentials. Its complete value influences
+    # the opaque fingerprint above but must never be persisted in shared
+    # metadata.
+    printf 'version=1\nkey=%s\ngo=%s\n' \
+        "$fingerprint" "$go_version" >"$publish_dir/READY"
     mv -T -n -- "$publish_dir" "$generation"
     if [[ -d "$publish_dir" ]]; then
         rm -rf -- "$publish_dir"

--- a/scripts/agent-module-download-cache
+++ b/scripts/agent-module-download-cache
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: agent-module-download-cache RUN_DIR" >&2
+    exit 2
+fi
+
+run_dir=$(cd "$1" 2>/dev/null && pwd -P) || {
+    echo "agent-module-download-cache: invalid run directory: $1" >&2
+    exit 1
+}
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+trusted_root=$(cd "$script_dir/.." && pwd -P)
+
+gomodcache=$(cd "${GOMODCACHE:-}" 2>/dev/null && pwd -P) || {
+    echo "agent-module-download-cache: GOMODCACHE is not configured" >&2
+    exit 1
+}
+case "$gomodcache/" in
+    "$run_dir/"*) ;;
+    *)
+        echo "agent-module-download-cache: GOMODCACHE escapes the validation run" >&2
+        exit 1
+        ;;
+esac
+
+gosumdb=$(go env GOSUMDB)
+goprivate=$(go env GOPRIVATE)
+gonosumdb=$(go env GONOSUMDB)
+gonoproxy=$(go env GONOPROXY)
+if [[ -z "$gosumdb" || "$gosumdb" == "off" || -n "$goprivate" || -n "$gonosumdb" || -n "$gonoproxy" ]]; then
+    echo "MODULE_DOWNLOAD_CACHE=DISABLED_PRIVATE_OR_NOSUMDB_POLICY" >&2
+    exit 0
+fi
+
+module_files=()
+manifest_files=()
+while IFS= read -r -d '' tracked_file; do
+    case "$tracked_file" in
+        go.mod|*/go.mod)
+            module_files+=("$tracked_file")
+            manifest_files+=("$tracked_file")
+            ;;
+        go.sum|*/go.sum)
+            manifest_files+=("$tracked_file")
+            ;;
+    esac
+done < <(git -C "$trusted_root" ls-files -z)
+
+if (( ${#module_files[@]} == 0 )); then
+    echo "MODULE_DOWNLOAD_CACHE=DISABLED_NO_MODULES" >&2
+    exit 0
+fi
+
+for manifest_file in "${manifest_files[@]}"; do
+    if [[ -L "$trusted_root/$manifest_file" || ! -f "$trusted_root/$manifest_file" ]]; then
+        echo "agent-module-download-cache: invalid tracked module manifest: $manifest_file" >&2
+        exit 1
+    fi
+done
+if ! git -C "$trusted_root" diff --quiet HEAD -- "${manifest_files[@]}" ||
+    ! git -C "$trusted_root" diff --cached --quiet HEAD -- "${manifest_files[@]}"; then
+    echo "agent-module-download-cache: trusted module manifests are dirty" >&2
+    exit 1
+fi
+
+go_version=$(go env GOVERSION)
+goproxy=$(go env GOPROXY)
+fingerprint=$(
+    {
+        printf 'version=1\ngo=%s\ngoproxy=%s\ngosumdb=%s\n' "$go_version" "$goproxy" "$gosumdb"
+        for manifest_file in "${manifest_files[@]}"; do
+            printf '%s ' "$manifest_file"
+            git -C "$trusted_root" hash-object -- "$manifest_file"
+        done
+    } | sha256sum | awk '{print $1}'
+)
+
+marker_dir="$run_dir/module-download-cache"
+marker="$marker_dir/$fingerprint.ready"
+if [[ -f "$marker" && ! -L "$marker" ]]; then
+    echo "MODULE_DOWNLOAD_CACHE=RUN_LOCAL_READY key=$fingerprint" >&2
+    exit 0
+fi
+
+common_dir=$(git -C "$trusted_root" rev-parse --path-format=absolute --git-common-dir)
+common_dir=$(cd "$common_dir" && pwd -P)
+cache_root="$common_dir/ledger-agent-module-download-cache/v1"
+if [[ -L "$common_dir/ledger-agent-module-download-cache" ]]; then
+    echo "agent-module-download-cache: shared cache root must not be a symlink" >&2
+    exit 1
+fi
+version_root="$cache_root/$go_version"
+if [[ -L "$version_root" ]]; then
+    echo "agent-module-download-cache: toolchain cache root must not be a symlink" >&2
+    exit 1
+fi
+mkdir -p "$version_root"
+resolved_cache_root=$(cd "$cache_root" && pwd -P)
+case "$resolved_cache_root/" in
+    "$common_dir/"*) ;;
+    *)
+        echo "agent-module-download-cache: shared cache root escapes the Git common directory" >&2
+        exit 1
+        ;;
+esac
+resolved_version_root=$(cd "$version_root" && pwd -P)
+case "$resolved_version_root/" in
+    "$resolved_cache_root/"*) ;;
+    *)
+        echo "agent-module-download-cache: toolchain cache root escapes the shared cache" >&2
+        exit 1
+        ;;
+esac
+
+generation="$version_root/$fingerprint"
+generation_ready="$generation/READY"
+download_dir="$gomodcache/cache/download"
+mkdir -p "$download_dir" "$marker_dir"
+
+seeded_files="$run_dir/module-download-cache/$fingerprint.seeded-files"
+: >"$seeded_files"
+reused=false
+if [[ -d "$generation" && ! -L "$generation" && -f "$generation_ready" && ! -L "$generation_ready" && -d "$generation/download" && ! -L "$generation/download" ]]; then
+    (
+        cd "$generation/download"
+        find . -type f \( -name '*.zip' -o -name '*.mod' \) -print0 |
+            xargs -0 -r cp --parents --reflink=auto --no-dereference -t "$download_dir"
+    )
+    if [[ -n "$(find "$download_dir" -type l -print -quit)" ]]; then
+        echo "agent-module-download-cache: shared seed contained a symlink" >&2
+        exit 1
+    fi
+    find "$download_dir" -type f \( -name '*.zip' -o -name '*.mod' \) -print0 >"$seeded_files"
+    reused=true
+fi
+
+# Run the trusted dependency graph through the ordinary Go downloader. The
+# shared seed deliberately has no .ziphash files, so Go re-hashes every reused
+# archive and checks it against the trusted go.sum / checksum database before
+# extracting it into this run's private GOMODCACHE.
+for module_file in "${module_files[@]}"; do
+    module_dir=$(dirname "$module_file")
+    if [[ "$module_dir" == "." ]]; then
+        module_dir="$trusted_root"
+    else
+        module_dir="$trusted_root/$module_dir"
+    fi
+    env GOFLAGS= GOWORK=off go -C "$module_dir" mod download
+done
+if ! git -C "$trusted_root" diff --quiet HEAD -- "${manifest_files[@]}" ||
+    ! git -C "$trusted_root" diff --cached --quiet HEAD -- "${manifest_files[@]}"; then
+    echo "agent-module-download-cache: trusted module download changed a manifest" >&2
+    exit 1
+fi
+
+if [[ "$reused" == true ]]; then
+    while IFS= read -r -d '' seeded_file; do
+        case "$seeded_file" in
+            *.zip)
+                ziphash_file="${seeded_file}hash"
+                if [[ ! -f "$ziphash_file" || -L "$ziphash_file" ]]; then
+                    rm -f -- "$seeded_file" "${seeded_file%.zip}.mod"
+                fi
+                ;;
+            *.mod)
+                ziphash_file="${seeded_file%.mod}.ziphash"
+                if [[ ! -f "$ziphash_file" || -L "$ziphash_file" ]]; then
+                    rm -f -- "$seeded_file"
+                fi
+                ;;
+        esac
+    done <"$seeded_files"
+fi
+rm -f -- "$seeded_files"
+
+# A cold run publishes only content that Go just verified. The generation is
+# built in the run directory and renamed atomically; concurrent cold runs may
+# duplicate downloads, but they never observe a partial shared generation.
+if [[ ! -f "$generation_ready" ]]; then
+    publish_dir="$run_dir/module-download-cache/publish-$fingerprint"
+    rm -rf -- "$publish_dir"
+    mkdir -p "$publish_dir/download"
+    (
+        cd "$download_dir"
+        find . -type f \( -name '*.zip' -o -name '*.mod' \) -print0 |
+            xargs -0 -r cp --parents --reflink=auto --no-dereference -t "$publish_dir/download"
+    )
+    printf 'version=1\nkey=%s\ngo=%s\ngoproxy=%s\ngosumdb=%s\n' \
+        "$fingerprint" "$go_version" "$goproxy" "$gosumdb" >"$publish_dir/READY"
+    mv -T -n -- "$publish_dir" "$generation"
+    if [[ -d "$publish_dir" ]]; then
+        rm -rf -- "$publish_dir"
+    fi
+fi
+
+printf 'key=%s\n' "$fingerprint" >"$marker"
+if [[ "$reused" == true ]]; then
+    echo "MODULE_DOWNLOAD_CACHE=REUSED key=$fingerprint" >&2
+else
+    echo "MODULE_DOWNLOAD_CACHE=POPULATED key=$fingerprint" >&2
+fi

--- a/scripts/agent-validation-env
+++ b/scripts/agent-validation-env
@@ -33,4 +33,14 @@ case "$PWD/" in
         ;;
 esac
 
+share_download_cache=${SHARE_DOWNLOAD_CACHE_ONLY:-0}
+unset SHARE_DOWNLOAD_CACHE_ONLY
+if [[ "$share_download_cache" == "1" ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+    bash "$script_dir/agent-module-download-cache" "$run_dir"
+elif [[ "$share_download_cache" != "0" ]]; then
+    echo "agent-validation-env: SHARE_DOWNLOAD_CACHE_ONLY must be 0 or 1" >&2
+    exit 2
+fi
+
 exec "$@"

--- a/scripts/agentvalidationenv/cache_test.go
+++ b/scripts/agentvalidationenv/cache_test.go
@@ -1,0 +1,468 @@
+package agentvalidationenv
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testModulePath    = "github.com/stretchr/testify"
+	testModuleVersion = "v1.11.1"
+	testModuleSum     = "h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U="
+	testGoModSum      = "h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U="
+)
+
+type cacheFixture struct {
+	trustedRoot string
+	upstream    string
+	helper      string
+	wrapper     string
+}
+
+func TestDownloadSeedKeepsExtractedModulesRunLocal(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runA := fixture.newRun(t)
+	output, err := fixture.prepare(runA, nil)
+	require.NoError(t, err, output)
+	require.Contains(t, output, "MODULE_DOWNLOAD_CACHE=POPULATED")
+
+	generation := fixture.generation(t)
+	requireSeedContainsDownloadsOnly(t, generation)
+	runB := fixture.newRun(t)
+	output, err = fixture.prepare(runB, nil)
+	require.NoError(t, err, output)
+	require.Contains(t, output, "MODULE_DOWNLOAD_CACHE=REUSED")
+
+	extractedA := extractedAssertionPath(runA)
+	extractedB := extractedAssertionPath(runB)
+	require.FileExists(t, extractedA)
+	require.FileExists(t, extractedB)
+	infoA, err := os.Stat(extractedA)
+	require.NoError(t, err)
+	originalA, err := os.ReadFile(extractedA)
+	require.NoError(t, err)
+	originalB, err := os.ReadFile(extractedB)
+	require.NoError(t, err)
+	require.NotEmpty(t, originalA)
+	poisonedA := append([]byte(nil), originalA...)
+	poisonedA[len(poisonedA)/2] ^= 0xff
+	require.NoError(t, os.Chmod(extractedA, 0o644))
+	require.NoError(t, os.WriteFile(extractedA, poisonedA, 0o644))
+	require.NoError(t, os.Chtimes(extractedA, infoA.ModTime(), infoA.ModTime()))
+	afterB, err := os.ReadFile(extractedB)
+	require.NoError(t, err)
+	require.Equal(t, originalB, afterB, "one run's extracted tree must not affect another run")
+
+	sharedZip := filepath.Join(generation, "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".zip")
+	require.FileExists(t, sharedZip)
+	sharedBefore, err := os.ReadFile(sharedZip)
+	require.NoError(t, err)
+	localZipA := filepath.Join(runA, "go-mod-cache", "cache", "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".zip")
+	localZipB := filepath.Join(runB, "go-mod-cache", "cache", "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".zip")
+	localB, err := os.ReadFile(localZipB)
+	require.NoError(t, err)
+	localA, err := os.ReadFile(localZipA)
+	require.NoError(t, err)
+	localA[len(localA)/3] ^= 0xff
+	require.NoError(t, os.Chmod(localZipA, 0o644))
+	require.NoError(t, os.WriteFile(localZipA, localA, 0o644))
+	localBAfter, err := os.ReadFile(localZipB)
+	require.NoError(t, err)
+	require.Equal(t, localB, localBAfter, "one run's downloaded archive must not affect another run")
+
+	makeWritable(t, filepath.Join(runA, "go-mod-cache"))
+	require.NoError(t, os.RemoveAll(filepath.Join(runA, "go-mod-cache")))
+	require.FileExists(t, extractedB)
+	runC := fixture.newRun(t)
+	output, err = fixture.prepare(runC, nil)
+	require.NoError(t, err, output)
+	require.FileExists(t, extractedAssertionPath(runC), "same-size/same-mtime poisoning in run A must not reach run C")
+	require.NoError(t, runGo(runC, "clean", "-modcache"))
+	require.FileExists(t, extractedB)
+	sharedAfter, err := os.ReadFile(sharedZip)
+	require.NoError(t, err)
+	require.Equal(t, sharedBefore, sharedAfter, "go clean -modcache must not touch the shared download seed")
+}
+
+func TestPoisonedSharedArchiveFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runA := fixture.newRun(t)
+	output, err := fixture.prepare(runA, nil)
+	require.NoError(t, err, output)
+	sharedZip := filepath.Join(fixture.generation(t), "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".zip")
+	info, err := os.Stat(sharedZip)
+	require.NoError(t, err)
+	archive, err := os.ReadFile(sharedZip)
+	require.NoError(t, err)
+	require.NotEmpty(t, archive)
+	archive[len(archive)/2] ^= 0xff
+	require.NoError(t, os.Chmod(sharedZip, 0o644))
+	require.NoError(t, os.WriteFile(sharedZip, archive, 0o644))
+	require.NoError(t, os.Chtimes(sharedZip, info.ModTime(), info.ModTime()))
+
+	runB := fixture.newRun(t)
+	output, err = fixture.prepare(runB, nil)
+	require.Error(t, err, output)
+	require.True(t,
+		strings.Contains(output, "checksum mismatch") || strings.Contains(output, "not a valid zip file"),
+		"poisoned same-size archive must fail validation: %s", output)
+	require.NoFileExists(t, extractedAssertionPath(runB))
+}
+
+func TestPoisonedSharedGoModFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runA := fixture.newRun(t)
+	output, err := fixture.prepare(runA, nil)
+	require.NoError(t, err, output)
+	sharedGoMod := filepath.Join(fixture.generation(t), "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".mod")
+	moduleFile, err := os.ReadFile(sharedGoMod)
+	require.NoError(t, err)
+	require.NotEmpty(t, moduleFile)
+	moduleFile[len(moduleFile)/2] ^= 0xff
+	require.NoError(t, os.Chmod(sharedGoMod, 0o644))
+	require.NoError(t, os.WriteFile(sharedGoMod, moduleFile, 0o644))
+
+	runB := fixture.newRun(t)
+	output, err = fixture.prepare(runB, nil)
+	require.Error(t, err, output)
+	require.Contains(t, output, "checksum mismatch")
+	require.NoFileExists(t, extractedAssertionPath(runB))
+}
+
+func TestSharedZiphashAndUnlistedArtifactsAreNeverReused(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runA := fixture.newRun(t)
+	output, err := fixture.prepare(runA, nil)
+	require.NoError(t, err, output)
+	generation := fixture.generation(t)
+	versionDir := filepath.Join(generation, "download", "github.com", "stretchr", "testify", "@v")
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, testModuleVersion+".ziphash"), []byte("h1:poison\n"), 0o644))
+	extraDir := filepath.Join(generation, "download", "example.com", "unlisted", "@v")
+	require.NoError(t, os.MkdirAll(extraDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(extraDir, "v1.0.0.zip"), []byte("not a module zip"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(extraDir, "v1.0.0.mod"), []byte("module example.com/unlisted\n"), 0o644))
+
+	runB := fixture.newRun(t)
+	output, err = fixture.prepare(runB, nil)
+	require.NoError(t, err, output)
+	localVersionDir := filepath.Join(runB, "go-mod-cache", "cache", "download", "github.com", "stretchr", "testify", "@v")
+	localHash, err := os.ReadFile(filepath.Join(localVersionDir, testModuleVersion+".ziphash"))
+	require.NoError(t, err)
+	require.Equal(t, testModuleSum, strings.TrimSpace(string(localHash)))
+	require.NoFileExists(t, filepath.Join(runB, "go-mod-cache", "cache", "download", "example.com", "unlisted", "@v", "v1.0.0.zip"))
+}
+
+func TestDifferentGoSumRejectsVerifiedRunCache(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runDir := fixture.newRun(t)
+	output, err := fixture.prepare(runDir, nil)
+	require.NoError(t, err, output)
+
+	candidate := t.TempDir()
+	writeModuleFiles(t, candidate, "h1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+	command := exec.Command("go", "mod", "download")
+	command.Dir = candidate
+	command.Env = fixture.environment(runDir, "GOPROXY=off")
+	outputBytes, err := command.CombinedOutput()
+	require.Error(t, err, string(outputBytes))
+	require.Contains(t, string(outputBytes), "checksum mismatch")
+}
+
+func TestPrivateOrNoSumDBPolicyDisablesSharing(t *testing.T) {
+	t.Parallel()
+
+	for _, policy := range []string{"GOPRIVATE=github.com/*", "GONOSUMDB=github.com/*", "GONOPROXY=github.com/*", "GOSUMDB=off"} {
+		t.Run(policy, func(t *testing.T) {
+			fixture := newCacheFixture(t)
+			runDir := fixture.newRun(t)
+			output, err := fixture.prepare(runDir, []string{policy})
+			require.NoError(t, err, output)
+			require.Contains(t, output, "MODULE_DOWNLOAD_CACHE=DISABLED_PRIVATE_OR_NOSUMDB_POLICY")
+			require.NoDirExists(t, filepath.Join(fixture.trustedRoot, ".git", "ledger-agent-module-download-cache"))
+			require.NoFileExists(t, extractedAssertionPath(runDir))
+		})
+	}
+}
+
+func TestNewCandidateDependencyIsNotInventedByTheSharedSeed(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runDir := fixture.newRun(t)
+	output, err := fixture.prepare(runDir, nil)
+	require.NoError(t, err, output)
+
+	candidate := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(candidate, "go.mod"), []byte(
+		"module example.com/candidate\n\ngo 1.26.0\n\nrequire rsc.io/quote v1.5.2\n"), 0o644))
+	command := exec.Command("go", "mod", "download")
+	command.Dir = candidate
+	command.Env = fixture.environment(runDir, "GOPROXY=off")
+	outputBytes, err := command.CombinedOutput()
+	require.Error(t, err, string(outputBytes))
+	require.Contains(t, string(outputBytes), "module lookup disabled by GOPROXY=off")
+	require.NotContains(t, string(outputBytes), "checksum mismatch")
+}
+
+func TestConcurrentPreparationProducesIndependentRuns(t *testing.T) {
+	fixture := newCacheFixture(t)
+	runs := []string{fixture.newRun(t), fixture.newRun(t)}
+	outputs := make([]string, len(runs))
+	errors := make([]error, len(runs))
+	var waitGroup sync.WaitGroup
+	for index := range runs {
+		waitGroup.Go(func() {
+			outputs[index], errors[index] = fixture.prepare(runs[index], nil)
+		})
+	}
+	waitGroup.Wait()
+	for index := range runs {
+		require.NoError(t, errors[index], outputs[index])
+		require.FileExists(t, extractedAssertionPath(runs[index]))
+	}
+	require.NotEqual(t, extractedAssertionPath(runs[0]), extractedAssertionPath(runs[1]))
+	requireSeedContainsDownloadsOnly(t, fixture.generation(t))
+}
+
+func TestValidationWrapperDoesNotExposeSharedCacheAuthority(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runDir := fixture.newRun(t)
+	command := exec.Command("bash", fixture.wrapper, runDir, "env")
+	command.Dir = runDir
+	command.Env = fixture.environment(runDir, "SHARE_DOWNLOAD_CACHE_ONLY=1")
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+	require.NotContains(t, string(output), "SHARE_DOWNLOAD_CACHE_ONLY=")
+	require.NotContains(t, string(output), "ledger-agent-module-download-cache")
+	require.Contains(t, string(output), "GOMODCACHE="+filepath.Join(runDir, "go-mod-cache"))
+}
+
+func newCacheFixture(t *testing.T) cacheFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	trustedRoot := filepath.Join(root, "trusted")
+	require.NoError(t, os.MkdirAll(filepath.Join(trustedRoot, "scripts"), 0o755))
+	helperSource, err := filepath.Abs(filepath.Join("..", "agent-module-download-cache"))
+	require.NoError(t, err)
+	wrapperSource, err := filepath.Abs(filepath.Join("..", "agent-validation-env"))
+	require.NoError(t, err)
+	helper := filepath.Join(trustedRoot, "scripts", "agent-module-download-cache")
+	wrapper := filepath.Join(trustedRoot, "scripts", "agent-validation-env")
+	copyFile(t, helperSource, helper, 0o755)
+	copyFile(t, wrapperSource, wrapper, 0o755)
+	writeModuleFiles(t, trustedRoot, testModuleSum)
+	runGit(t, trustedRoot, "init")
+	runGit(t, trustedRoot, "config", "user.name", "Module Cache Test")
+	runGit(t, trustedRoot, "config", "user.email", "module-cache@example.com")
+	runGit(t, trustedRoot, "add", ".")
+	runGit(t, trustedRoot, "commit", "-m", "trusted base")
+
+	upstream := filepath.Join(root, "upstream")
+	versionDir := filepath.Join(upstream, "github.com", "stretchr", "testify", "@v")
+	require.NoError(t, os.MkdirAll(versionDir, 0o755))
+	goModCache := strings.TrimSpace(runCommand(t, "", nil, "go", "env", "GOMODCACHE"))
+	sourceVersionDir := filepath.Join(goModCache, "cache", "download", "github.com", "stretchr", "testify", "@v")
+	for _, suffix := range []string{".info", ".mod", ".zip"} {
+		copyFile(t, filepath.Join(sourceVersionDir, testModuleVersion+suffix), filepath.Join(versionDir, testModuleVersion+suffix), 0o644)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(versionDir, "list"), []byte(testModuleVersion+"\n"), 0o644))
+
+	return cacheFixture{trustedRoot: trustedRoot, upstream: upstream, helper: helper, wrapper: wrapper}
+}
+
+func (fixture cacheFixture) newRun(t *testing.T) string {
+	t.Helper()
+
+	runDir := t.TempDir()
+	physicalRunDir, err := filepath.EvalSymlinks(runDir)
+	require.NoError(t, err)
+	for _, directory := range []string{"home", "go-cache", "go-mod-cache", "go-path", "tmp", "cache"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(physicalRunDir, directory), 0o755))
+	}
+	t.Cleanup(func() {
+		require.NoError(t, filepath.WalkDir(physicalRunDir, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+
+			return os.Chmod(walkPath, 0o755)
+		}))
+	})
+
+	return physicalRunDir
+}
+
+func (fixture cacheFixture) prepare(runDir string, extraEnvironment []string) (string, error) {
+	command := exec.Command("bash", fixture.helper, runDir)
+	command.Dir = runDir
+	command.Env = fixture.environment(runDir, extraEnvironment...)
+	output, err := command.CombinedOutput()
+
+	return string(output), err
+}
+
+func (fixture cacheFixture) environment(runDir string, extraEnvironment ...string) []string {
+	proxyURL := (&url.URL{Scheme: "file", Path: fixture.upstream}).String()
+	values := []string{
+		"HOME=" + filepath.Join(runDir, "home"),
+		"GOCACHE=" + filepath.Join(runDir, "go-cache"),
+		"GOMODCACHE=" + filepath.Join(runDir, "go-mod-cache"),
+		"GOPATH=" + filepath.Join(runDir, "go-path"),
+		"TMPDIR=" + filepath.Join(runDir, "tmp"),
+		"XDG_CACHE_HOME=" + filepath.Join(runDir, "cache"),
+		"GOPROXY=" + proxyURL,
+		"GOSUMDB=sum.golang.org",
+		"GOPRIVATE=",
+		"GONOSUMDB=",
+		"GONOPROXY=",
+		"GOENV=off",
+		"GOTOOLCHAIN=local",
+	}
+	values = append(values, extraEnvironment...)
+
+	return replaceEnvironment(os.Environ(), values)
+}
+
+func (fixture cacheFixture) generation(t *testing.T) string {
+	t.Helper()
+
+	cacheRoot := filepath.Join(fixture.trustedRoot, ".git", "ledger-agent-module-download-cache")
+	var generations []string
+	require.NoError(t, filepath.WalkDir(cacheRoot, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Name() == "READY" {
+			generations = append(generations, filepath.Dir(walkPath))
+		}
+
+		return nil
+	}))
+	require.Len(t, generations, 1)
+
+	return generations[0]
+}
+
+func requireSeedContainsDownloadsOnly(t *testing.T, generation string) {
+	t.Helper()
+
+	require.NoDirExists(t, filepath.Join(generation, "github.com"), "extracted module trees must not be shared")
+	require.NoError(t, filepath.WalkDir(generation, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		require.False(t, entry.Type()&os.ModeSymlink != 0, walkPath)
+		if entry.IsDir() || entry.Name() == "READY" {
+			return nil
+		}
+		require.True(t, strings.HasSuffix(entry.Name(), ".zip") || strings.HasSuffix(entry.Name(), ".mod"), walkPath)
+
+		return nil
+	}))
+	require.NoFileExists(t, filepath.Join(generation, "download", "github.com", "stretchr", "testify", "@v", testModuleVersion+".ziphash"))
+}
+
+func extractedAssertionPath(runDir string) string {
+	return filepath.Join(runDir, "go-mod-cache", "github.com", "stretchr", "testify@"+testModuleVersion, "assert", "assertions.go")
+}
+
+func runGo(runDir string, arguments ...string) error {
+	command := exec.Command("go", arguments...)
+	command.Env = replaceEnvironment(os.Environ(), []string{
+		"HOME=" + filepath.Join(runDir, "home"),
+		"GOCACHE=" + filepath.Join(runDir, "go-cache"),
+		"GOMODCACHE=" + filepath.Join(runDir, "go-mod-cache"),
+		"GOPATH=" + filepath.Join(runDir, "go-path"),
+		"TMPDIR=" + filepath.Join(runDir, "tmp"),
+		"GOENV=off",
+	})
+
+	return command.Run()
+}
+
+func makeWritable(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, filepath.WalkDir(root, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		return os.Chmod(walkPath, 0o755)
+	}))
+}
+
+func writeModuleFiles(t *testing.T, directory, moduleSum string) {
+	t.Helper()
+
+	goMod := fmt.Sprintf("module example.com/trusted\n\ngo 1.26.0\n\nrequire %s %s\n", testModulePath, testModuleVersion)
+	goSum := fmt.Sprintf("%s %s %s\n%s %s/go.mod %s\n", testModulePath, testModuleVersion, moduleSum, testModulePath, testModuleVersion, testGoModSum)
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "go.mod"), []byte(goMod), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "go.sum"), []byte(goSum), 0o644))
+}
+
+func copyFile(t *testing.T, source, destination string, mode fs.FileMode) {
+	t.Helper()
+
+	content, err := os.ReadFile(source)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(destination, content, mode))
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	runCommand(t, directory, nil, "git", arguments...)
+}
+
+func runCommand(t *testing.T, directory string, environment []string, name string, arguments ...string) string {
+	t.Helper()
+
+	command := exec.Command(name, arguments...)
+	command.Dir = directory
+	if environment != nil {
+		command.Env = environment
+	}
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	return string(bytes.TrimSpace(output))
+}
+
+func replaceEnvironment(base, replacements []string) []string {
+	names := make(map[string]struct{}, len(replacements))
+	for _, replacement := range replacements {
+		name, _, _ := strings.Cut(replacement, "=")
+		names[name] = struct{}{}
+	}
+	result := make([]string, 0, len(base)+len(replacements))
+	for _, value := range base {
+		name, _, _ := strings.Cut(value, "=")
+		if _, replaced := names[name]; !replaced {
+			result = append(result, value)
+		}
+	}
+
+	return append(result, replacements...)
+}

--- a/scripts/agentvalidationenv/cache_test.go
+++ b/scripts/agentvalidationenv/cache_test.go
@@ -204,6 +204,39 @@ func TestPrivateOrNoSumDBPolicyDisablesSharing(t *testing.T) {
 	}
 }
 
+func TestSharedMetadataDoesNotPersistProxyCredentials(t *testing.T) {
+	t.Parallel()
+
+	fixture := newCacheFixture(t)
+	runDir := fixture.newRun(t)
+	output, err := fixture.prepare(runDir, nil)
+	require.NoError(t, err, output)
+
+	// The already-verified run-local cache keeps this hermetic: Go has no reason
+	// to contact the deliberately unreachable authenticated proxy.
+	output, err = fixture.prepare(runDir, []string{"GOPROXY=https://cache-user:cache-secret@example.invalid"})
+	require.NoError(t, err, output)
+	readyFiles := 0
+	cacheRoot := filepath.Join(fixture.trustedRoot, ".git", "ledger-agent-module-download-cache")
+	require.NoError(t, filepath.WalkDir(cacheRoot, func(walkPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Name() != "READY" {
+			return nil
+		}
+		readyFiles++
+		metadata, readErr := os.ReadFile(walkPath)
+		require.NoError(t, readErr)
+		require.NotContains(t, string(metadata), "cache-user")
+		require.NotContains(t, string(metadata), "cache-secret")
+		require.NotContains(t, string(metadata), "goproxy=")
+
+		return nil
+	}))
+	require.Equal(t, 2, readyFiles, "proxy configuration must select a distinct generation")
+}
+
 func TestNewCandidateDependencyIsNotInventedByTheSharedSeed(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -196,6 +196,11 @@ known_findings_digest=$(git hash-object -- "$known_findings")
 for trusted_tool in ai-review-codex ai-review-known-findings agent-check-pr agent-just ai-git-guard; do
     [[ -x "$trusted_worktree/scripts/$trusted_tool" ]] || { echo "ai-pr-adopt-candidate: trusted base lacks executable scripts/$trusted_tool" >&2; exit 1; }
 done
+if [[ -f "$trusted_worktree/go.mod" ]]; then
+    env -u GOROOT nix develop "path:$trusted_worktree" --command \
+        env -C "$validation_run_dir" SHARE_DOWNLOAD_CACHE_ONLY=1 \
+        bash "$trusted_worktree/scripts/agent-validation-env" "$validation_run_dir" true
+fi
 nix develop "path:$trusted_worktree" --command env -u GOROOT go -C "$trusted_worktree" build -o "$review_loop_binary" ./scripts/reviewloop
 printf -v review_cmd 'bash %q' "$trusted_worktree/scripts/ai-review-known-findings"
 # The run directory derives from the repository location, which may contain

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -293,6 +293,11 @@ if ! command -v nix >/dev/null 2>&1; then
     echo "ai-pr-loop: required command not found in PATH: nix" >&2
     exit 1
 fi
+if [[ -f "$trusted_tool_worktree/go.mod" ]]; then
+    env -u GOROOT nix develop "path:$trusted_tool_worktree" --command \
+        env -C "$validation_run_dir" SHARE_DOWNLOAD_CACHE_ONLY=1 \
+        bash "$trusted_tool_worktree/scripts/agent-validation-env" "$validation_run_dir" true
+fi
 
 # READY_FOR_HUMAN_REVIEW is itself a policy decision, even without publication.
 # Build its orchestrator from the verified base and use the base-pinned reviewer


### PR DESCRIPTION
## Summary

- keep GOMODCACHE and extracted module trees unique per validation run
- reuse only copied zip/mod download artifacts, with Go verification against the trusted base before candidate execution
- disable reuse for private, no-sumdb, or no-proxy configurations
- add poisoning, concurrency, cleanup, and sensitivity coverage plus lifecycle/performance documentation

## Validation

- bash scripts/agent-check
- bash scripts/agent-check-full
- focused agent validation / PR-loop tooling tests
- operator, Antithesis workload, dashboard, perf, and tools module tests
- TEST_SENSITIVITY=PASS

No GOCACHE, rootguard, lint-cache, or campaign-orchestration changes.