### PR TITLE
feat(tooling): dispatch confirmed campaign findings

### DIFF
--- a/docs/technical/contributing/ai-audit-jira.md
+++ b/docs/technical/contributing/ai-audit-jira.md
@@ -7,6 +7,11 @@ Deep-audit findings become durable work only after independent qualification. Ji
 Only `CONFIRMED` findings are Jira candidates by default. `LIKELY`, `QUESTION`, and `REJECTED` are never published by this command. A human may handle them separately.
 
 Publication does not implement a fix and does not create a pull request. The resulting Jira bug is the durable handoff into the normal engineering workflow.
+Accordingly, `ai-campaign dispatch --workflow BUGFIX` requires one exact Jira
+binding and returns `JIRA_REQUIRED` when none exists. Dispatch never supplies the
+explicit publication authorization on the operator's behalf. Non-runtime
+`TEST_GAP`, `TOOLING_FIX`, and `DOCUMENTATION` dispatches may omit Jira under the
+campaign workflow contract.
 
 ## Stable identity and deduplication
 

--- a/docs/technical/contributing/ai-campaign.md
+++ b/docs/technical/contributing/ai-campaign.md
@@ -4,9 +4,10 @@
 qualified native audit results. It preserves immutable audit provenance, caches
 external observations, reports the mechanically next valid workflow transition,
 and coordinates exclusive finding ownership through remote Git claim leases. It
-does not perform engineering reasoning, choose product priority, fix findings,
-publish issues, dispatch agents, mutate pull-request bindings, or merge pull
-requests.
+can mechanically dispatch an owned confirmed finding into an isolated branch,
+worktree, and reconstructable work-item contract. It does not invoke an agent,
+perform engineering reasoning, choose product priority, fix findings, publish
+issues, open or merge pull requests, or decide readiness.
 
 ## Motivation and boundary
 
@@ -28,8 +29,16 @@ claim. Claims coordinate ownership; they do not qualify findings, prove a branch
 or PR correct, authorize merge, or override GitHub, Jira, Git ancestry, or review
 and validation results.
 
-The v1 storage model is one JSON file. By default it is written below ignored
-`build/ai-campaign/`, so it survives an agent session without entering a
+A claim is not a dispatch. Dispatch is the one-time mechanical binding of an
+already-owned claim to a canonical work identity, branch, initial SHA, and
+workflow contract. Dispatch is not engineering work, PR readiness, publication,
+or permission to merge. The engineering agent remains responsible for
+reproduction, root cause, implementation, regression design, mutation
+sensitivity, validation, and review findings.
+
+The campaign projection is one JSON file; dispatch adds one work-item JSON file
+per canonical work identity. By default both live below ignored
+`build/ai-campaign/`, so they survive an agent session without entering a
 candidate/product commit. An explicit destination outside the repository is also
 allowed. Repository-local destinations outside ignored `build/` are rejected.
 Writes use a directory-anchored temporary file, file sync, atomic rename, and
@@ -183,6 +192,165 @@ the tool does not claim success unless it can prove the outcome. If the remote
 cannot be reached, claim, renew, release, and takeover perform no local fallback
 and report `REMOTE_UNAVAILABLE`.
 
+## Confirmed-finding dispatch
+
+Run dispatch from a clean worktree pinned to the verified target implementation:
+
+```sh
+bash scripts/ai-campaign dispatch build/ai-campaign/<campaign-id>.json \
+  --finding <audit-id/finding-id> \
+  --audit <source-audit.json> \
+  --qualified <qualified-result.json> \
+  --claimant "$AI_CAMPAIGN_CLAIMANT" \
+  --workflow BUGFIX
+```
+
+The source and qualified files are required because the campaign deliberately
+stores digest-bound JSON references instead of copying arbitrary evidence prose.
+Dispatch strictly reloads both files, validates their native schemas, recomputes
+both campaign digests, and extracts the invariant and qualification evidence for
+the work item. A changed, substituted, or incomplete artifact is rejected before
+remote mutation.
+
+Dispatch refreshes GitHub, Jira, Git, the target ref, and the claim ref before it
+creates anything, then performs a last-mile exact campaign-work-marker PR search
+after deriving the stable work identity and repeats that search immediately
+before the claim CAS. It requires one `CONFIRMED` campaign
+finding, fully fresh external truth, no ambiguous or existing PR ownership, the
+exact current audited target SHA, and a live claim owned by the supplied
+claimant. It then:
+
+1. derives the work identity and canonical branch;
+2. creates the remote branch at the immutable target SHA with an empty-value
+   `--force-with-lease`;
+3. creates or discovers a dedicated attached worktree outside the trusted
+   checkout and review validation directories, validating the discovered
+   physical path and rejecting dirty discovered state before an initial claim
+   binding;
+4. revalidates the claim, target, and branch;
+5. appends the dispatch binding to the existing claim lineage by exact claim-SHA
+   CAS; and
+6. writes the local work item atomically.
+
+It never runs Codex or another provider. The resulting worktree is clean at the
+initial work SHA; no engineering modification is made by dispatch.
+
+### Workflow and Jira policy
+
+The native audit and challenge schemas do not contain an authoritative
+engineering workflow type. The caller must therefore select one of `BUGFIX`,
+`TEST_GAP`, `TOOLING_FIX`, or `DOCUMENTATION`. Omitting it returns
+`HUMAN_DECISION_REQUIRED`; dispatch never guesses from severity, title, or prose.
+
+`BUGFIX` means a runtime product defect and requires one exact Jira binding before
+dispatch. If none exists, dispatch returns `JIRA_REQUIRED`. The tool does not call
+`ai-audit-jira` or create the issue: Jira publication remains dry-run by default
+and requires the operator's explicit `--publish` authorization. `TEST_GAP`,
+`TOOLING_FIX`, and `DOCUMENTATION` may proceed without Jira because the native
+bugfix publication contract does not require runtime bug evidence for those
+classes. If an exact Jira issue already exists for any class, its key and URL are
+preserved in the durable binding and work item. Multiple exact Jira issues are
+always ambiguous; dispatch never creates a second issue.
+
+### Work identity and branch contract
+
+The work identity is:
+
+```text
+work-<sha256("ai-campaign-work/v1" NUL campaignId NUL findingId
+             NUL qualifiedDigest NUL jiraKey-if-present)>
+```
+
+Title text is not an identity input. The branch is a human-readable
+`fix/`, `test/`, or `docs/` name containing the Jira key when present, the stable
+finding slug, and the first twelve work-identity hex characters. The full digest
+remains authoritative in the claim and work item. Dispatch searches the exact
+remote branch, claim binding, and PR binding before creation. An exact branch at
+the expected initial SHA is recoverable `EXPECTED_EXISTING_WORK`; a different SHA
+is `CONFLICTING_BRANCH`. Dispatch never force-updates an existing engineering
+branch.
+
+The branch always begins at `targetBaseSha`, and `initialWorkSha` records that
+same immutable commit. A final target observation occurs after claim binding. If
+the target advances before the binding precheck, dispatch stops with
+`BASE_UPDATE_REQUIRED` and does not bind the claim. If it advances in the narrow
+interval after the precheck and the exact claim CAS succeeds, the work item is
+written as `STALE_AT_DISPATCH` with `BASE_UPDATE_REQUIRED`. The work branch is
+never silently moved.
+
+### Durable binding and work item
+
+The existing claim commit is not replaced. Its next exact-CAS child adds:
+
+- `workIdentity`, `workBranch`, and `workflowClassification`;
+- `targetBaseSha` and `initialWorkSha`;
+- the exact Jira key when one exists; and
+- `dispatchedAt`.
+
+Renewal and expired takeover preserve these fields. A dispatched claim's work
+branch is immutable. `CLAIM_CHANGED` means another mutation won after the
+eligibility observation; the caller must refresh instead of continuing with a
+possibly renewed or stolen claim.
+
+The local artifact uses
+[`ai-campaign-work/v1`](../../../scripts/ai-campaign-work.schema.json). Its
+`remoteIdentity` section contains campaign/audit/finding digests, Jira, current
+claim SHA and lease, target/base, branch/initial SHA, and future PR markers.
+`localState` contains the ephemeral absolute worktree and artifact paths. It also
+contains exact audit/challenge provenance, workflow-specific gates, and a
+deterministic `engineeringTask`. That task contains mechanically known facts and
+the repository engineering sequence; it is context, not proof of the finding or
+of completed validation.
+
+Future PR creation must include exact trimmed body lines:
+
+```text
+AI-AUDIT:<finding-id>
+AI-CAMPAIGN-WORK:<work-identity>
+Jira: <key>                       # when present
+```
+
+The audit marker remains the current discovery key. The campaign-work marker is
+the exact work-item binding and must not be replaced by branch-name inference.
+Dispatch does not open a draft or non-draft PR.
+
+### Idempotency and crash recovery
+
+Remote claim/branch state is authoritative; the local work item is a
+reconstructable projection. Repeating dispatch with the same campaign, claim
+binding, workflow, branch, and target lineage discovers the existing worktree or
+creates the missing local one, rewrites a missing or malformed artifact from
+remote truth, and returns `ALREADY_DISPATCHED`. When the target has advanced, the
+reconstructed artifact is `STALE_AT_DISPATCH` and the next action remains
+`BASE_UPDATE_REQUIRED`; idempotency does not conceal the stale base. Any
+different binding returns `CONFLICTING_DISPATCH` or a narrower broken/ambiguous
+classification.
+
+Recovery by boundary is:
+
+| Observed state | Recovery |
+|---|---|
+| Claim only, no branch | Retry dispatch; create the exact branch. |
+| Exact branch at initial SHA, claim unbound | Reconcile `EXPECTED_EXISTING_WORK`, create/discover the worktree, then CAS-bind. |
+| Branch and worktree, claim unbound | Discover both and retry the same claim CAS. |
+| Claim bound, worktree missing | Verify branch lineage and recreate the local worktree. |
+| Claim bound, work item missing/malformed | Reconstruct it from claim, branch, campaign, and digest-verified evidence. |
+| Complete work item, session lost | Repeat dispatch; `ALREADY_DISPATCHED` returns the inherited task. |
+
+Claim binding occurs only after successful worktree creation, so a dispatch
+cannot create a new state in which it bound the claim and then failed its initial
+worktree creation. A bound claim with no local worktree means the path was lost
+or removed after binding and is recovered by the rule above.
+
+Dispatch does not blindly roll back a remote branch after an ambiguous failure.
+It only reports mutations it can prove. No retry deletes a claim or work branch.
+
+Structured stops include `FINDING_NOT_CONFIRMED`, `CLAIM_REQUIRED`,
+`CLAIM_NOT_OWNER`, `CLAIM_EXPIRED`, `JIRA_REQUIRED`, `AMBIGUOUS_BINDING`,
+`EXISTING_PR`, `ALREADY_MERGED`, `BROKEN_BINDING`, `CONFLICTING_BRANCH`,
+`CONFLICTING_DISPATCH`, `CLAIM_CHANGED`, `STALE_CAMPAIGN`,
+`REMOTE_UNAVAILABLE`, `BASE_UPDATE_REQUIRED`, and `STALE_AT_DISPATCH`.
+
 ## Inspect
 
 ```sh
@@ -258,6 +426,8 @@ the audit finding is fixed.
 | `TRACKED` | Confirmed, current audit target, exactly one Jira issue, no PR. |
 | `CLAIMED` | One valid live remote claim exists; ownership may be this session or another. |
 | `CLAIM_EXPIRED` | The valid remote claim is beyond expiry plus the skew allowance and needs explicit disposition. |
+| `DISPATCHED` | The live claim has a complete immutable dispatch binding and its remote work branch exists. |
+| `STALE_AT_DISPATCH` | A dispatched work item retains its immutable base, but the target has advanced. |
 | `PR_OPEN` | Exactly one bound PR is open and its branch/head binding is intact. |
 | `PR_CLOSED` | Exactly one bound PR is closed without merge. |
 | `MERGED` | Exactly one bound PR is merged; resolution still needs verification. |
@@ -289,7 +459,8 @@ mechanically safe workflow transition per finding from cached state:
 | Condition | `nextAction` |
 |---|---|
 | Confirmed and freshly unclaimed | `CLAIM` |
-| Live claim owned by current session | `CONTINUE_CLAIMED_WORK` |
+| Live unbound claim owned by current session | `DISPATCH` |
+| Complete dispatch owned by current session | `START_ENGINEERING_AGENT` |
 | Live claim owned by another session | `WAIT_OR_COORDINATE` |
 | Expired claim | `REVIEW_EXPIRED_CLAIM` |
 | Open PR | `CONTINUE_PR` |
@@ -297,7 +468,8 @@ mechanically safe workflow transition per finding from cached state:
 | Closed unmerged PR | `REVIEW_CLOSED_PR` |
 | Broken binding | `REPAIR_BINDING` |
 | Ambiguous binding | `RESOLVE_BINDING` |
-| Advanced target without PR | `REQUALIFY_ON_CURRENT_TARGET` |
+| Advanced target without dispatch/PR | `REQUALIFY_ON_CURRENT_TARGET` |
+| Advanced target after dispatch | `BASE_UPDATE_REQUIRED` |
 | Stale/incomplete external truth | `REFRESH_REQUIRED` |
 | `QUESTION` | `HUMAN_DECISION_REQUIRED` |
 | `LIKELY` or `REJECTED` | `NO_ACTION` |
@@ -352,8 +524,8 @@ made by this tooling.
 
 ## Explicit non-goals
 
-This milestone does not implement confirmed-finding dispatch, automatic
-branch/worktree creation, PR-binding mutation, publication resume/events,
-automatic merge, Jira mutation, composite exact-SHA readiness, a shared
-structured failure envelope, or automatic terminal reconciliation. Those
+This milestone does not implement automatic PR creation/publication,
+publication resume/events, automatic merge, Jira mutation, composite exact-SHA
+readiness, a shared structured failure envelope, automatic terminal
+reconciliation/claim cleanup, or a higher-level multi-finding scheduler. Those
 require separate contracts and trust reviews.

--- a/scripts/ai-campaign
+++ b/scripts/ai-campaign
@@ -3,4 +3,4 @@ set -euo pipefail
 
 script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 repo_root=$(git -C "$script_root" rev-parse --show-toplevel)
-exec env -u GOROOT go run "$repo_root/scripts/aicampaign" "$@"
+exec env -u GOROOT go -C "$repo_root" run ./scripts/aicampaign "$@"

--- a/scripts/ai-campaign-work.schema.json
+++ b/scripts/ai-campaign-work.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://formance.com/schemas/ai-campaign-work/v1",
+  "title": "Ledger AI campaign engineering work item v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "status",
+    "createdAt",
+    "workflowClassification",
+    "remoteIdentity",
+    "finding",
+    "localState",
+    "requiredGates",
+    "canonicalNextAction",
+    "engineeringTask"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "ai-campaign-work/v1" },
+    "status": { "enum": ["DISPATCHED", "STALE_AT_DISPATCH"] },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "workflowClassification": { "$ref": "#/$defs/workflow" },
+    "remoteIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository", "campaignId", "auditId", "findingId", "workIdentity",
+        "findingIdentityDigest", "sourceAuditDigest", "qualifiedDigest", "sourceAuditSha",
+        "jiraKey", "jiraUrl", "claimRef", "claimSha", "claimant", "leaseExpiry",
+        "targetBranch", "targetBaseSha", "workBranch", "initialWorkSha", "prMarkers"
+      ],
+      "properties": {
+        "repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "campaignId": { "type": "string", "pattern": "^campaign-[0-9a-f]{64}$" },
+        "auditId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "findingId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*/[a-z0-9]+(-[a-z0-9]+)*$" },
+        "workIdentity": { "type": "string", "pattern": "^work-[0-9a-f]{64}$" },
+        "findingIdentityDigest": { "$ref": "#/$defs/digest" },
+        "sourceAuditDigest": { "$ref": "#/$defs/digest" },
+        "qualifiedDigest": { "$ref": "#/$defs/digest" },
+        "sourceAuditSha": { "$ref": "#/$defs/sha" },
+        "jiraKey": { "type": "string", "pattern": "^$|^[A-Z][A-Z0-9_]*-[1-9][0-9]*$" },
+        "jiraUrl": { "type": "string" },
+        "claimRef": { "type": "string", "pattern": "^refs/heads/ai-claims/v1/[0-9a-f]{64}$" },
+        "claimSha": { "$ref": "#/$defs/sha" },
+        "claimant": { "type": "string", "minLength": 3 },
+        "leaseExpiry": { "type": "string", "format": "date-time" },
+        "targetBranch": { "type": "string", "minLength": 1 },
+        "targetBaseSha": { "$ref": "#/$defs/sha" },
+        "workBranch": { "type": "string", "minLength": 1 },
+        "initialWorkSha": { "$ref": "#/$defs/sha" },
+        "prMarkers": {
+          "type": "array",
+          "minItems": 2,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "qualification", "severity", "title", "invariant", "challengeSummary",
+        "auditFindingReference", "qualificationReference", "evidenceFor", "evidenceAgainst",
+        "reproductionPlan"
+      ],
+      "properties": {
+        "qualification": { "const": "CONFIRMED" },
+        "severity": { "enum": ["P0", "P1", "P2", "P3"] },
+        "title": { "type": "string", "minLength": 1 },
+        "invariant": { "type": "string", "minLength": 1 },
+        "challengeSummary": { "type": "string", "minLength": 1 },
+        "auditFindingReference": { "type": "string", "minLength": 1 },
+        "qualificationReference": { "type": "string", "minLength": 1 },
+        "evidenceFor": { "type": "array", "items": { "type": "string" } },
+        "evidenceAgainst": { "type": "array", "items": { "type": "string" } },
+        "reproductionPlan": { "type": "string", "minLength": 1 }
+      }
+    },
+    "localState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["worktreePath", "workItemPath"],
+      "properties": {
+        "worktreePath": { "type": "string", "minLength": 1 },
+        "workItemPath": { "type": "string", "minLength": 1 }
+      }
+    },
+    "requiredGates": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "canonicalNextAction": { "enum": ["START_ENGINEERING_AGENT", "BASE_UPDATE_REQUIRED"] },
+    "engineeringTask": { "type": "string", "minLength": 1 }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
+    "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "workflow": { "enum": ["BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"] }
+  }
+}

--- a/scripts/ai-campaign.schema.json
+++ b/scripts/ai-campaign.schema.json
@@ -214,6 +214,8 @@
             "BROKEN_BINDING",
             "CLAIMED",
             "CLAIM_EXPIRED",
+            "DISPATCHED",
+            "STALE_AT_DISPATCH",
             "NON_DISPATCHABLE"
           ]
         },
@@ -226,6 +228,11 @@
         "nextAction": {
           "enum": [
             "CLAIM",
+            "DISPATCH",
+            "RESUME_DISPATCH",
+            "START_ENGINEERING_AGENT",
+            "CONTINUE_WORK",
+            "BASE_UPDATE_REQUIRED",
             "CONTINUE_CLAIMED_WORK",
             "WAIT_OR_COORDINATE",
             "REVIEW_EXPIRED_CLAIM",
@@ -254,6 +261,12 @@
         "expiresAt",
         "remoteRef",
         "workBranch",
+        "workIdentity",
+        "initialWorkSha",
+        "targetBaseSha",
+        "workflowClassification",
+        "jiraKey",
+        "dispatchedAt",
         "observedClaimSha",
         "freshness",
         "ownedBySession",
@@ -277,11 +290,40 @@
         "expiresAt": { "$ref": "#/$defs/nullableTime" },
         "remoteRef": { "type": "string", "pattern": "^refs/heads/ai-claims/v1/[0-9a-f]{64}$" },
         "workBranch": { "type": "string" },
+        "workIdentity": { "type": "string", "pattern": "^$|^work-[0-9a-f]{64}$" },
+        "initialWorkSha": { "type": "string", "pattern": "^$|^[0-9a-f]{40,64}$" },
+        "targetBaseSha": { "type": "string", "pattern": "^$|^[0-9a-f]{40,64}$" },
+        "workflowClassification": { "enum": ["", "BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"] },
+        "jiraKey": { "type": "string", "pattern": "^$|^[A-Z][A-Z0-9_]*-[1-9][0-9]*$" },
+        "dispatchedAt": { "$ref": "#/$defs/nullableTime" },
         "observedClaimSha": { "type": "string" },
         "freshness": { "enum": ["FRESH", "STALE", "UNAVAILABLE"] },
         "ownedBySession": { "type": "boolean" },
         "problem": { "type": "string" }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "workIdentity": { "const": "" } } },
+          "then": {
+            "properties": {
+              "initialWorkSha": { "const": "" },
+              "targetBaseSha": { "const": "" },
+              "workflowClassification": { "const": "" },
+              "jiraKey": { "const": "" },
+              "dispatchedAt": { "type": "null" }
+            }
+          },
+          "else": {
+            "properties": {
+              "workBranch": { "type": "string", "minLength": 1 },
+              "initialWorkSha": { "$ref": "#/$defs/sha" },
+              "targetBaseSha": { "$ref": "#/$defs/sha" },
+              "workflowClassification": { "enum": ["BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"] },
+              "dispatchedAt": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      ]
     },
     "observations": {
       "type": "object",

--- a/scripts/ai-claim.schema.json
+++ b/scripts/ai-claim.schema.json
@@ -19,6 +19,12 @@
     "targetBranch",
     "targetSha",
     "workBranch",
+    "workIdentity",
+    "initialWorkSha",
+    "targetBaseSha",
+    "workflowClassification",
+    "jiraKey",
+    "dispatchedAt",
     "renewedAt",
     "renewalCount",
     "predecessor"
@@ -38,6 +44,17 @@
     "targetBranch": { "type": "string", "minLength": 1 },
     "targetSha": { "$ref": "#/$defs/sha" },
     "workBranch": { "type": "string" },
+    "workIdentity": { "type": "string", "pattern": "^$|^work-[0-9a-f]{64}$" },
+    "initialWorkSha": { "type": "string", "pattern": "^$|^[0-9a-f]{40,64}$" },
+    "targetBaseSha": { "type": "string", "pattern": "^$|^[0-9a-f]{40,64}$" },
+    "workflowClassification": { "enum": ["", "BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"] },
+    "jiraKey": { "type": "string", "pattern": "^$|^[A-Z][A-Z0-9_]*-[1-9][0-9]*$" },
+    "dispatchedAt": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "format": "date-time" }
+      ]
+    },
     "renewedAt": {
       "oneOf": [
         { "type": "null" },
@@ -52,6 +69,29 @@
       ]
     }
   },
+  "allOf": [
+    {
+      "if": { "properties": { "workIdentity": { "const": "" } } },
+      "then": {
+        "properties": {
+          "initialWorkSha": { "const": "" },
+          "targetBaseSha": { "const": "" },
+          "workflowClassification": { "const": "" },
+          "jiraKey": { "const": "" },
+          "dispatchedAt": { "type": "null" }
+        }
+      },
+      "else": {
+        "properties": {
+          "workBranch": { "type": "string", "minLength": 1 },
+          "initialWorkSha": { "$ref": "#/$defs/sha" },
+          "targetBaseSha": { "$ref": "#/$defs/sha" },
+          "workflowClassification": { "enum": ["BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"] },
+          "dispatchedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  ],
   "$defs": {
     "sha": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
     "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },

--- a/scripts/aicampaign/campaign_test.go
+++ b/scripts/aicampaign/campaign_test.go
@@ -560,7 +560,7 @@ func openPR(number int, branch, basis string) PRMatch {
 	return PRMatch{
 		Number: number, URL: "https://example.test/pr", State: "OPEN", HeadRef: branch,
 		HeadSHA: strings.Repeat(string(rune('a'+number%20)), 40), BaseRef: testTarget, BaseSHA: testHead,
-		ReviewDecision: "APPROVED", Checks: "SUCCESS", BindingBasis: basis,
+		BranchExists: true, ReviewDecision: "APPROVED", Checks: "SUCCESS", BindingBasis: basis,
 	}
 }
 

--- a/scripts/aicampaign/claim_external.go
+++ b/scripts/aicampaign/claim_external.go
@@ -77,6 +77,12 @@ func (commandClaimProvider) Observe(
 		observation.CreatedAt = timePointer(claim.Record.CreatedAt)
 		observation.ExpiresAt = timePointer(claim.Record.ExpiresAt)
 		observation.WorkBranch = claim.Record.WorkBranch
+		observation.WorkIdentity = claim.Record.WorkIdentity
+		observation.InitialWorkSHA = claim.Record.InitialWorkSHA
+		observation.TargetBaseSHA = claim.Record.TargetBaseSHA
+		observation.Workflow = claim.Record.Workflow
+		observation.JiraKey = claim.Record.JiraKey
+		observation.DispatchedAt = claim.Record.DispatchedAt
 		observation.OwnedBySession = currentClaimant != "" && currentClaimant == claim.Record.Claimant
 		if isExpired(claim.Record, now) {
 			observation.State = "CLAIM_EXPIRED"

--- a/scripts/aicampaign/claim_model.go
+++ b/scripts/aicampaign/claim_model.go
@@ -35,6 +35,12 @@ type ClaimRecord struct {
 	TargetBranch          string            `json:"targetBranch"`
 	TargetSHA             string            `json:"targetSha"`
 	WorkBranch            string            `json:"workBranch"`
+	WorkIdentity          string            `json:"workIdentity"`
+	InitialWorkSHA        string            `json:"initialWorkSha"`
+	TargetBaseSHA         string            `json:"targetBaseSha"`
+	Workflow              string            `json:"workflowClassification"`
+	JiraKey               string            `json:"jiraKey"`
+	DispatchedAt          *time.Time        `json:"dispatchedAt"`
 	RenewedAt             *time.Time        `json:"renewedAt"`
 	RenewalCount          int               `json:"renewalCount"`
 	Predecessor           *ClaimPredecessor `json:"predecessor"`
@@ -100,6 +106,13 @@ func (claim ClaimRecord) validate() error {
 		strings.HasPrefix("refs/heads/"+claim.WorkBranch, claimRefPrefix) || claim.WorkBranch == claim.TargetBranch) {
 		return errors.New("invalid claim work branch")
 	}
+	if err := validateDispatchBinding(claim.WorkIdentity, claim.WorkBranch, claim.InitialWorkSHA, claim.TargetBaseSHA,
+		claim.Workflow, claim.JiraKey, claim.DispatchedAt); err != nil {
+		return fmt.Errorf("invalid claim dispatch binding: %w", err)
+	}
+	if claim.WorkIdentity != "" && claim.TargetBaseSHA != claim.TargetSHA {
+		return errors.New("claim dispatch base does not match immutable target SHA")
+	}
 	if claim.Predecessor != nil {
 		predecessor := claim.Predecessor
 		if !shaPattern.MatchString(predecessor.ClaimSHA) || !claimantPattern.MatchString(predecessor.Claimant) ||
@@ -108,6 +121,35 @@ func (claim ClaimRecord) validate() error {
 			!predecessor.ExpiresAt.After(predecessor.CreatedAt) || predecessor.Reason != "EXPIRED_TAKEOVER" {
 			return errors.New("invalid claim predecessor")
 		}
+	}
+
+	return nil
+}
+
+func validateDispatchBinding(
+	workIdentity string,
+	workBranch string,
+	initialWorkSHA string,
+	targetBaseSHA string,
+	workflow string,
+	jiraKey string,
+	dispatchedAt *time.Time,
+) error {
+	valuesPresent := workIdentity != "" || initialWorkSHA != "" || targetBaseSHA != "" || workflow != "" ||
+		jiraKey != "" || dispatchedAt != nil
+	if !valuesPresent {
+		return nil
+	}
+	if !workIdentityPattern.MatchString(workIdentity) || workBranch == "" || !shaPattern.MatchString(initialWorkSHA) ||
+		!shaPattern.MatchString(targetBaseSHA) || !validWorkflow(workflow) || dispatchedAt == nil ||
+		dispatchedAt.IsZero() || dispatchedAt.Location() != time.UTC {
+		return errors.New("partial or malformed dispatch binding")
+	}
+	if initialWorkSHA != targetBaseSHA {
+		return errors.New("initial work SHA does not match target base SHA")
+	}
+	if jiraKey != "" && !jiraKeyPattern.MatchString(jiraKey) {
+		return errors.New("invalid dispatch Jira key")
 	}
 
 	return nil

--- a/scripts/aicampaign/claim_store.go
+++ b/scripts/aicampaign/claim_store.go
@@ -31,11 +31,19 @@ type claimRepository struct {
 }
 
 func openClaimRepository(ctx context.Context, remote string) (*claimRepository, error) {
+	return openClaimRepositoryAt(ctx, remote, "")
+}
+
+func openClaimRepositoryAt(ctx context.Context, remote, repoRoot string) (*claimRepository, error) {
 	remoteURL := remote
 	if !filepath.IsAbs(remote) && !strings.Contains(remote, "://") {
 		var output []byte
 		for _, suffix := range []string{"pushurl", "url"} {
-			command := exec.CommandContext(ctx, "git", "config", "--get", "remote."+remote+"."+suffix)
+			arguments := []string{"config", "--get", "remote." + remote + "." + suffix}
+			if repoRoot != "" {
+				arguments = append([]string{"-C", repoRoot}, arguments...)
+			}
+			command := exec.CommandContext(ctx, "git", arguments...)
 			value, err := command.Output()
 			if err == nil && strings.TrimSpace(string(value)) != "" {
 				output = value
@@ -164,10 +172,10 @@ func (repository *claimRepository) readClaimCommit(ctx context.Context, claimSHA
 	if err := record.validate(); err != nil {
 		return ClaimRecord{}, "", fmt.Errorf("validate claim record: %w", err)
 	}
-	if record.RenewalCount == 0 && record.Predecessor == nil && len(parentSHAs) != 0 {
+	if record.RenewalCount == 0 && record.Predecessor == nil && record.DispatchedAt == nil && len(parentSHAs) != 0 {
 		return ClaimRecord{}, "", errors.New("initial claim commit must be parentless")
 	}
-	if (record.RenewalCount > 0 || record.Predecessor != nil) && len(parentSHAs) != 1 {
+	if (record.RenewalCount > 0 || record.Predecessor != nil || record.DispatchedAt != nil) && len(parentSHAs) != 1 {
 		return ClaimRecord{}, "", errors.New("updated claim commit must have one parent")
 	}
 	if record.RenewalCount == 0 && record.Predecessor != nil && parentSHAs[0] != record.Predecessor.ClaimSHA {
@@ -188,6 +196,23 @@ func validateClaimTransition(current, previous ClaimRecord, previousSHA string) 
 		current.TargetSHA != previous.TargetSHA {
 		return errors.New("claim transition changed immutable identity")
 	}
+	if current.DispatchedAt != nil && previous.DispatchedAt == nil {
+		previousMutation := previous.CreatedAt
+		if previous.RenewedAt != nil {
+			previousMutation = *previous.RenewedAt
+		}
+		if current.Claimant != previous.Claimant || !current.CreatedAt.Equal(previous.CreatedAt) ||
+			!current.ExpiresAt.Equal(previous.ExpiresAt) || current.RenewalCount != previous.RenewalCount ||
+			!sameTime(current.RenewedAt, previous.RenewedAt) ||
+			!samePredecessor(current.Predecessor, previous.Predecessor) ||
+			(previous.WorkBranch != "" && previous.WorkBranch != current.WorkBranch) ||
+			current.DispatchedAt.Before(previousMutation) ||
+			current.DispatchedAt.After(previous.ExpiresAt.Add(claimClockSkew)) {
+			return errors.New("invalid dispatch binding transition")
+		}
+
+		return nil
+	}
 	if current.RenewalCount > 0 {
 		if current.Claimant != previous.Claimant || !current.CreatedAt.Equal(previous.CreatedAt) ||
 			current.RenewalCount != previous.RenewalCount+1 ||
@@ -201,6 +226,12 @@ func validateClaimTransition(current, previous ClaimRecord, previousSHA string) 
 		if current.RenewedAt == nil || current.RenewedAt.Before(previousMutation) {
 			return errors.New("claim renewal time moved backwards")
 		}
+		if previous.DispatchedAt != nil && (current.WorkIdentity != previous.WorkIdentity ||
+			current.WorkBranch != previous.WorkBranch || current.InitialWorkSHA != previous.InitialWorkSHA ||
+			current.TargetBaseSHA != previous.TargetBaseSHA || current.Workflow != previous.Workflow ||
+			current.JiraKey != previous.JiraKey || !sameTime(current.DispatchedAt, previous.DispatchedAt)) {
+			return errors.New("claim renewal changed dispatch binding")
+		}
 
 		return nil
 	}
@@ -211,8 +242,22 @@ func validateClaimTransition(current, previous ClaimRecord, previousSHA string) 
 		current.CreatedAt.Before(previous.ExpiresAt.Add(claimClockSkew)) {
 		return errors.New("invalid expired-claim takeover transition")
 	}
+	if current.WorkIdentity != previous.WorkIdentity || current.WorkBranch != previous.WorkBranch ||
+		current.InitialWorkSHA != previous.InitialWorkSHA || current.TargetBaseSHA != previous.TargetBaseSHA ||
+		current.Workflow != previous.Workflow || current.JiraKey != previous.JiraKey ||
+		!sameTime(current.DispatchedAt, previous.DispatchedAt) {
+		return errors.New("claim takeover changed dispatch binding")
+	}
 
 	return nil
+}
+
+func sameTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return left.Equal(*right)
 }
 
 func samePredecessor(left, right *ClaimPredecessor) bool {
@@ -232,6 +277,15 @@ func (repository *claimRepository) writeClaim(
 ) (string, error) {
 	if err := record.validate(); err != nil {
 		return "", fmt.Errorf("refusing invalid claim record: %w", err)
+	}
+	if expectedSHA != "" {
+		previous, _, err := repository.readClaimCommit(ctx, expectedSHA)
+		if err != nil {
+			return "", fmt.Errorf("read claim transition parent: %w", err)
+		}
+		if err := validateClaimTransition(record, previous, expectedSHA); err != nil {
+			return "", fmt.Errorf("refusing invalid claim transition: %w", err)
+		}
 	}
 	content, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
@@ -254,6 +308,9 @@ func (repository *claimRepository) writeClaim(
 	commitTime := record.CreatedAt
 	if record.RenewedAt != nil {
 		commitTime = *record.RenewedAt
+	}
+	if record.DispatchedAt != nil && record.DispatchedAt.After(commitTime) {
+		commitTime = *record.DispatchedAt
 	}
 	environment := []string{
 		"GIT_AUTHOR_NAME=ai-campaign", "GIT_AUTHOR_EMAIL=ai-campaign@formance.invalid",
@@ -284,6 +341,73 @@ func (repository *claimRepository) deleteClaim(ctx context.Context, ref, expecte
 	}
 
 	return nil
+}
+
+func (repository *claimRepository) createBranch(
+	ctx context.Context,
+	targetRef string,
+	expectedTargetSHA string,
+	workRef string,
+) (string, error) {
+	if !strings.HasPrefix(targetRef, "refs/heads/") || !strings.HasPrefix(workRef, "refs/heads/") ||
+		strings.HasPrefix(workRef, claimRefPrefix) || !shaPattern.MatchString(expectedTargetSHA) {
+		return "BROKEN_BINDING", errors.New("invalid branch creation contract")
+	}
+	refs, err := repository.listRefs(ctx, targetRef, workRef)
+	if err != nil {
+		return "REMOTE_UNAVAILABLE", err
+	}
+	if refs[targetRef] != expectedTargetSHA {
+		return "BASE_UPDATE_REQUIRED", errors.New("target branch does not equal the expected dispatch base")
+	}
+	if workSHA := refs[workRef]; workSHA != "" {
+		if workSHA == expectedTargetSHA {
+			return "EXPECTED_EXISTING_WORK", nil
+		}
+
+		return "CONFLICTING_BRANCH", errors.New("work branch already exists at another SHA")
+	}
+	localRef := "refs/ai-campaign-target/" + strings.TrimPrefix(workRef, "refs/heads/")
+	if _, err := repository.git(ctx, nil, "fetch", "--quiet", "--no-tags", "--no-write-fetch-head",
+		repository.remoteURL, "+"+targetRef+":"+localRef); err != nil {
+		return "REMOTE_UNAVAILABLE", fmt.Errorf("fetch exact target for branch creation: %w", err)
+	}
+	resolved, err := repository.git(ctx, nil, "rev-parse", "--verify", localRef)
+	if err != nil || strings.TrimSpace(string(resolved)) != expectedTargetSHA {
+		return "BASE_UPDATE_REQUIRED", errors.New("fetched target changed before branch creation")
+	}
+	lease := "--force-with-lease=" + workRef + ":"
+	if _, err := repository.git(ctx, nil, "push", "--porcelain", lease, repository.remoteURL,
+		expectedTargetSHA+":"+workRef); err != nil {
+		refreshed, refreshErr := repository.listRefs(ctx, targetRef, workRef)
+		if refreshErr != nil {
+			return "REMOTE_UNAVAILABLE", refreshErr
+		}
+		if refreshed[targetRef] != expectedTargetSHA {
+			return "BASE_UPDATE_REQUIRED", errors.New("target advanced during work branch creation")
+		}
+		if refreshed[workRef] == expectedTargetSHA {
+			return "EXPECTED_EXISTING_WORK", nil
+		}
+		if refreshed[workRef] != "" {
+			return "CONFLICTING_BRANCH", errors.New("concurrent writer created a conflicting work branch")
+		}
+
+		return "REMOTE_UNAVAILABLE", err
+	}
+
+	return "CREATED", nil
+}
+
+func (repository *claimRepository) fetchBranch(ctx context.Context, ref string) error {
+	if !strings.HasPrefix(ref, "refs/heads/") || strings.HasPrefix(ref, claimRefPrefix) {
+		return errors.New("invalid work branch ref")
+	}
+	localRef := "refs/ai-campaign-work/" + strings.TrimPrefix(ref, "refs/heads/")
+	_, err := repository.git(ctx, nil, "fetch", "--quiet", "--no-tags", "--no-write-fetch-head",
+		repository.remoteURL, "+"+ref+":"+localRef)
+
+	return err
 }
 
 func (repository *claimRepository) isAncestor(ctx context.Context, ancestor, descendant string) bool {

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -436,7 +436,7 @@ func TestRenewCanBindWorkBranchAndInspectDetectsItsDeletion(t *testing.T) {
 	require.Equal(t, "RENEWED", renewed.Status)
 	inspection := inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Hour))
 	require.Equal(t, "CLAIMED", inspection.Findings[0].State)
-	require.Equal(t, "CONTINUE_CLAIMED_WORK", inspection.Findings[0].NextAction)
+	require.Equal(t, "DISPATCH", inspection.Findings[0].NextAction)
 	runGit(t, "", "--git-dir", remote, "update-ref", "-d", "refs/heads/work/finding")
 
 	inspection = inspectAgainstRemote(campaign, remote, testClaimantA, testNow.Add(time.Hour))

--- a/scripts/aicampaign/dispatch.go
+++ b/scripts/aicampaign/dispatch.go
@@ -1,0 +1,988 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+type dispatchOptions struct {
+	repository         string
+	remote             string
+	target             string
+	claimant           string
+	workflow           string
+	repoRoot           string
+	campaignPath       string
+	worktreePath       string
+	workItemPath       string
+	beforeClaimBinding func()
+	afterClaimBinding  func()
+	writeWorkItem      func(string, *CampaignWork) error
+	findWorkPRs        func(context.Context, string, string) ([]PRMatch, error)
+}
+
+type dispatchEvidence struct {
+	Audit     auditFinding
+	Qualified challengeResult
+}
+
+type DispatchResult struct {
+	SchemaVersion string        `json:"schemaVersion"`
+	Status        string        `json:"status"`
+	CampaignID    string        `json:"campaignId"`
+	FindingID     string        `json:"findingId"`
+	Workflow      string        `json:"workflowClassification"`
+	Reason        string        `json:"reason"`
+	NextAction    string        `json:"nextAction"`
+	ExistingPR    *PRMatch      `json:"existingPr"`
+	Resources     WorkResources `json:"resources"`
+	WorkItem      *CampaignWork `json:"workItem"`
+}
+
+type WorkResources struct {
+	WorkIdentity     string `json:"workIdentity"`
+	WorkBranch       string `json:"workBranch"`
+	WorktreePath     string `json:"worktreePath"`
+	WorkItemPath     string `json:"workItemPath"`
+	TargetBaseSHA    string `json:"targetBaseSha"`
+	InitialWorkSHA   string `json:"initialWorkSha"`
+	ClaimRef         string `json:"claimRef"`
+	ObservedClaimSHA string `json:"observedClaimSha"`
+	BoundClaimSHA    string `json:"boundClaimSha"`
+	BranchState      string `json:"branchState"`
+	WorktreeState    string `json:"worktreeState"`
+}
+
+type CampaignWork struct {
+	SchemaVersion          string             `json:"schemaVersion"`
+	Status                 string             `json:"status"`
+	CreatedAt              time.Time          `json:"createdAt"`
+	WorkflowClassification string             `json:"workflowClassification"`
+	RemoteIdentity         WorkRemoteIdentity `json:"remoteIdentity"`
+	Finding                WorkFinding        `json:"finding"`
+	LocalState             WorkLocalState     `json:"localState"`
+	RequiredGates          []string           `json:"requiredGates"`
+	CanonicalNextAction    string             `json:"canonicalNextAction"`
+	EngineeringTask        string             `json:"engineeringTask"`
+}
+
+type WorkRemoteIdentity struct {
+	Repository            string    `json:"repository"`
+	CampaignID            string    `json:"campaignId"`
+	AuditID               string    `json:"auditId"`
+	FindingID             string    `json:"findingId"`
+	WorkIdentity          string    `json:"workIdentity"`
+	FindingIdentityDigest string    `json:"findingIdentityDigest"`
+	SourceAuditDigest     string    `json:"sourceAuditDigest"`
+	QualifiedDigest       string    `json:"qualifiedDigest"`
+	SourceAuditSHA        string    `json:"sourceAuditSha"`
+	JiraKey               string    `json:"jiraKey"`
+	JiraURL               string    `json:"jiraUrl"`
+	ClaimRef              string    `json:"claimRef"`
+	ClaimSHA              string    `json:"claimSha"`
+	Claimant              string    `json:"claimant"`
+	LeaseExpiry           time.Time `json:"leaseExpiry"`
+	TargetBranch          string    `json:"targetBranch"`
+	TargetBaseSHA         string    `json:"targetBaseSha"`
+	WorkBranch            string    `json:"workBranch"`
+	InitialWorkSHA        string    `json:"initialWorkSha"`
+	PRMarkers             []string  `json:"prMarkers"`
+}
+
+type WorkFinding struct {
+	Qualification          string   `json:"qualification"`
+	Severity               string   `json:"severity"`
+	Title                  string   `json:"title"`
+	Invariant              string   `json:"invariant"`
+	ChallengeSummary       string   `json:"challengeSummary"`
+	AuditFindingReference  string   `json:"auditFindingReference"`
+	QualificationReference string   `json:"qualificationReference"`
+	EvidenceFor            []string `json:"evidenceFor"`
+	EvidenceAgainst        []string `json:"evidenceAgainst"`
+	ReproductionPlan       string   `json:"reproductionPlan"`
+}
+
+type WorkLocalState struct {
+	WorktreePath string `json:"worktreePath"`
+	WorkItemPath string `json:"workItemPath"`
+}
+
+func loadDispatchEvidence(auditPath, qualifiedPath string, campaign *Campaign, findingID string) (dispatchEvidence, error) {
+	var source auditReport
+	auditContent, err := readStrictJSON(auditPath, &source)
+	if err != nil {
+		return dispatchEvidence{}, fmt.Errorf("invalid source audit result: %w", err)
+	}
+	var qualified challengeReport
+	qualifiedContent, err := readStrictJSON(qualifiedPath, &qualified)
+	if err != nil {
+		return dispatchEvidence{}, fmt.Errorf("invalid qualified result: %w", err)
+	}
+	if err := validateImportReports(&source, &qualified, auditContent); err != nil {
+		return dispatchEvidence{}, err
+	}
+	if source.AuditID != campaign.AuditID || source.Head != campaign.AuditedSHA ||
+		digestBytes(auditContent) != campaign.SourceDigests.Audit ||
+		digestBytes(qualifiedContent) != campaign.SourceDigests.Qualified {
+		return dispatchEvidence{}, errors.New("dispatch evidence does not match campaign provenance")
+	}
+	var evidence dispatchEvidence
+	for _, finding := range source.Findings {
+		if finding.ID == findingID {
+			evidence.Audit = finding
+		}
+	}
+	for _, result := range qualified.Results {
+		if result.ID == findingID {
+			evidence.Qualified = result
+		}
+	}
+	if evidence.Audit.ID == "" || evidence.Qualified.ID == "" {
+		return dispatchEvidence{}, fmt.Errorf("finding %q is not present exactly once in dispatch evidence", findingID)
+	}
+
+	return evidence, nil
+}
+
+func baseDispatchResult(campaign *Campaign, finding SourceFinding, options dispatchOptions) DispatchResult {
+	return DispatchResult{
+		SchemaVersion: dispatchSchemaVersion,
+		CampaignID:    campaign.CampaignID,
+		FindingID:     finding.ID,
+		Workflow:      options.workflow,
+		Resources: WorkResources{
+			ClaimRef:       claimRef(campaign.AuditID, finding.ID),
+			TargetBaseSHA:  campaign.AuditedSHA,
+			InitialWorkSHA: campaign.AuditedSHA,
+		},
+	}
+}
+
+func dispatchFinding(
+	ctx context.Context,
+	campaign *Campaign,
+	finding SourceFinding,
+	observed InspectionFinding,
+	evidence dispatchEvidence,
+	options dispatchOptions,
+	now func() time.Time,
+) DispatchResult {
+	result := baseDispatchResult(campaign, finding, options)
+	if finding.Qualification != "CONFIRMED" || !finding.Dispatchable {
+		return dispatchStopped(result, "FINDING_NOT_CONFIRMED", "qualification is "+finding.Qualification, "NO_ACTION")
+	}
+	if observed.Freshness != "FRESH" {
+		status := "STALE_CAMPAIGN"
+		if observed.Freshness == "UNAVAILABLE" || campaign.Observations != nil && (campaign.Observations.Providers.Git.Status == "UNAVAILABLE" ||
+			campaign.Observations.Providers.Claims.Status == "UNAVAILABLE") {
+			status = "REMOTE_UNAVAILABLE"
+		}
+
+		return dispatchStopped(result, status, "dispatch requires fresh GitHub, Jira, Git, and claim observations", "REFRESH_REQUIRED")
+	}
+	if observed.Jira.Status == "AMBIGUOUS" || observed.PR.Status == "AMBIGUOUS" {
+		return dispatchStopped(result, "AMBIGUOUS_BINDING", "multiple exact Jira or PR bindings exist", "RESOLVE_BINDING")
+	}
+	if len(observed.PR.Matches) == 1 {
+		match := observed.PR.Matches[0]
+		result.ExistingPR = &match
+		if match.BaseRef != options.target {
+			return dispatchStopped(result, "BROKEN_BINDING", "the existing PR targets another branch", "REPAIR_BINDING")
+		}
+		if match.Merged && match.BindingBasis == "AI_AUDIT_MARKER" {
+			return dispatchStopped(result, "ALREADY_MERGED", "an exact-marker PR already merged this finding", "VERIFY_RESOLUTION")
+		}
+		if match.Merged {
+			return dispatchStopped(result, "BROKEN_BINDING", "the merged Jira-only PR is not exact resolution proof", "VERIFY_RESOLUTION")
+		}
+		if !match.BranchExists {
+			return dispatchStopped(result, "BROKEN_BINDING", "the existing PR branch or target binding is broken", "REPAIR_BINDING")
+		}
+		switch {
+		case strings.EqualFold(match.State, "OPEN"):
+			return dispatchStopped(result, "EXISTING_PR", "an exact active PR binding already exists", "CONTINUE_PR")
+		case strings.EqualFold(match.State, "CLOSED"):
+			return dispatchStopped(result, "EXISTING_PR", "an exact closed PR binding already exists", "REVIEW_CLOSED_PR")
+		default:
+			return dispatchStopped(result, "BROKEN_BINDING", "the existing PR state is unknown", "REPAIR_BINDING")
+		}
+	}
+	if observed.ObservedTargetSHA == "" {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", "target branch could not be resolved", "REFRESH_REQUIRED")
+	}
+	if observed.ObservedTargetSHA != campaign.AuditedSHA {
+		return dispatchStopped(result, "BASE_UPDATE_REQUIRED", "target branch advanced beyond the qualified audit SHA", "BASE_UPDATE_REQUIRED")
+	}
+	if options.workflow == "" || !validWorkflow(options.workflow) {
+		return dispatchStopped(result, "HUMAN_DECISION_REQUIRED", "workflow classification must be selected explicitly", "HUMAN_DECISION_REQUIRED")
+	}
+	if observed.Jira.Status == "UNKNOWN" || observed.PR.Status == "UNKNOWN" {
+		return dispatchStopped(result, "STALE_CAMPAIGN", "exact external bindings are not fresh", "REFRESH_REQUIRED")
+	}
+	var jira JiraIssue
+	if len(observed.Jira.Issues) == 1 {
+		jira = observed.Jira.Issues[0]
+	}
+	if options.workflow == "BUGFIX" && jira.Key == "" {
+		return dispatchStopped(result, "JIRA_REQUIRED", "runtime bugfix dispatch requires the explicitly published Jira handoff", "PUBLISH_JIRA_WITH_AUTHORIZATION")
+	}
+	identity := workIdentity(campaign, finding, jira.Key)
+	branch := workBranch(options.workflow, finding.ID, jira.Key, identity)
+	result.Resources.WorkIdentity = identity
+	result.Resources.WorkBranch = branch
+	if stopped, stop := stopForCampaignWorkPR(ctx, result, options, identity); stop {
+		return stopped
+	}
+	if options.worktreePath == "" {
+		options.worktreePath = defaultDispatchWorktree(options.repoRoot, identity)
+	}
+	if options.workItemPath == "" {
+		options.workItemPath = defaultWorkItemPath(options.campaignPath, identity)
+	}
+	validatedWorkItemPath, err := validateCampaignDestination(options.repoRoot, options.workItemPath, true)
+	if err != nil {
+		return dispatchStopped(result, "BROKEN_BINDING", conciseError(err), "REPAIR_BINDING")
+	}
+	options.workItemPath = validatedWorkItemPath
+	result.Resources.WorktreePath = options.worktreePath
+	result.Resources.WorkItemPath = options.workItemPath
+
+	switch observed.Claim.State {
+	case "UNCLAIMED", "NON_CLAIMABLE":
+		return dispatchStopped(result, "CLAIM_REQUIRED", "dispatch requires an active remote claim", "CLAIM")
+	case "CLAIM_EXPIRED":
+		return dispatchStopped(result, "CLAIM_EXPIRED", "remote claim lease is expired", "REVIEW_EXPIRED_CLAIM")
+	case "BROKEN_BINDING", "AMBIGUOUS", "CLAIM_HISTORY_MISSING":
+		return dispatchStopped(result, "BROKEN_BINDING", "remote claim binding is not mechanically safe", "REPAIR_BINDING")
+	case "UNKNOWN":
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", "remote claim could not be verified", "REFRESH_REQUIRED")
+	}
+	if !observed.Claim.OwnedBySession || observed.Claim.Claimant != options.claimant {
+		return dispatchStopped(result, "CLAIM_NOT_OWNER", "remote claim belongs to another claimant", "WAIT_OR_COORDINATE")
+	}
+	if observed.Claim.ExpiresAt == nil || isObservationExpired(*observed.Claim.ExpiresAt, now().UTC()) {
+		return dispatchStopped(result, "CLAIM_EXPIRED", "remote claim lease is expired", "REVIEW_EXPIRED_CLAIM")
+	}
+	result.Resources.ObservedClaimSHA = observed.Claim.ObservedClaimSHA
+
+	repository, err := openClaimRepositoryAt(ctx, options.remote, options.repoRoot)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED")
+	}
+	defer repository.close()
+	refs, err := repository.listRefs(ctx, result.Resources.ClaimRef, "refs/heads/"+options.target, "refs/heads/"+branch)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED")
+	}
+	claimSHA := refs[result.Resources.ClaimRef]
+	if claimSHA == "" {
+		return dispatchStopped(result, "CLAIM_REQUIRED", "remote claim disappeared during dispatch", "CLAIM")
+	}
+	if claimSHA != observed.Claim.ObservedClaimSHA {
+		return dispatchStopped(result, "CLAIM_CHANGED", "remote claim changed after eligibility observation", "REFRESH_REQUIRED")
+	}
+	claimed, err := repository.readClaim(ctx, result.Resources.ClaimRef, claimSHA)
+	if err != nil {
+		return dispatchStopped(result, "CLAIM_CHANGED", conciseError(err), "REFRESH_REQUIRED")
+	}
+	if !claimed.Record.matches(campaign, finding, options.target) {
+		return dispatchStopped(result, "BROKEN_BINDING", "claim source identity does not match the campaign finding", "REPAIR_BINDING")
+	}
+	if claimed.Record.Claimant != options.claimant {
+		return dispatchStopped(result, "CLAIM_NOT_OWNER", "remote claim belongs to another claimant", "WAIT_OR_COORDINATE")
+	}
+	if isExpired(claimed.Record, now().UTC()) {
+		return dispatchStopped(result, "CLAIM_EXPIRED", "remote claim expired during dispatch", "REVIEW_EXPIRED_CLAIM")
+	}
+
+	if claimed.Record.DispatchedAt != nil {
+		if !sameDispatchBinding(claimed.Record, identity, branch, campaign.AuditedSHA, options.workflow, jira.Key) {
+			return dispatchStopped(result, "CONFLICTING_DISPATCH", "claim is bound to a different canonical work item", "REPAIR_BINDING")
+		}
+
+		return resumeDispatched(ctx, repository, result, campaign, finding, evidence, jira, claimed.Record,
+			claimSHA, refs["refs/heads/"+branch], options)
+	}
+	if refs["refs/heads/"+options.target] != campaign.AuditedSHA {
+		return dispatchStopped(result, "BASE_UPDATE_REQUIRED", "target advanced during dispatch", "BASE_UPDATE_REQUIRED")
+	}
+	if claimed.Record.WorkBranch != "" && claimed.Record.WorkBranch != branch {
+		return dispatchStopped(result, "CONFLICTING_BRANCH", "claim carries a different work-branch binding", "REPAIR_BINDING")
+	}
+
+	branchSHA := refs["refs/heads/"+branch]
+	switch {
+	case branchSHA == "":
+		created, createErr := repository.createBranch(ctx, "refs/heads/"+options.target, campaign.AuditedSHA, "refs/heads/"+branch)
+		if createErr != nil {
+			return dispatchStopped(result, created, conciseError(createErr), "REFRESH_REQUIRED")
+		}
+		result.Resources.BranchState = created
+		branchSHA = campaign.AuditedSHA
+	case branchSHA != campaign.AuditedSHA:
+		result.Resources.BranchState = "CONFLICTING_BRANCH"
+
+		return dispatchStopped(result, "CONFLICTING_BRANCH", "canonical work branch exists at a different SHA", "REPAIR_BINDING")
+	default:
+		result.Resources.BranchState = "EXPECTED_EXISTING_WORK"
+	}
+
+	worktreePath, worktreeState, err := ensureDispatchWorktree(options.repoRoot, options.remote, branch, branchSHA,
+		options.worktreePath, false)
+	if err != nil {
+		result.Resources.WorktreeState = worktreeState
+
+		return dispatchStopped(result, "WORKTREE_CREATION_FAILED", conciseError(err), "RESUME_DISPATCH")
+	}
+	result.Resources.WorktreePath = worktreePath
+	result.Resources.WorktreeState = worktreeState
+	if options.beforeClaimBinding != nil {
+		options.beforeClaimBinding()
+	}
+
+	refs, err = repository.listRefs(ctx, result.Resources.ClaimRef, "refs/heads/"+options.target, "refs/heads/"+branch)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED")
+	}
+	if refs[result.Resources.ClaimRef] != claimSHA {
+		return dispatchStopped(result, "CLAIM_CHANGED", "claim changed between worktree creation and binding", "REFRESH_REQUIRED")
+	}
+	if refs["refs/heads/"+options.target] != campaign.AuditedSHA {
+		return dispatchStopped(result, "BASE_UPDATE_REQUIRED", "target advanced before claim binding", "BASE_UPDATE_REQUIRED")
+	}
+	if refs["refs/heads/"+branch] != campaign.AuditedSHA {
+		return dispatchStopped(result, "CONFLICTING_BRANCH", "work branch changed before claim binding", "REPAIR_BINDING")
+	}
+
+	dispatchedAt := now().UTC()
+	if isExpired(claimed.Record, dispatchedAt) {
+		return dispatchStopped(result, "CLAIM_EXPIRED", "remote claim expired before binding", "REVIEW_EXPIRED_CLAIM")
+	}
+	if stopped, stop := stopForCampaignWorkPR(ctx, result, options, identity); stop {
+		return stopped
+	}
+	record := claimed.Record
+	record.WorkBranch = branch
+	record.WorkIdentity = identity
+	record.InitialWorkSHA = campaign.AuditedSHA
+	record.TargetBaseSHA = campaign.AuditedSHA
+	record.Workflow = options.workflow
+	record.JiraKey = jira.Key
+	record.DispatchedAt = &dispatchedAt
+	boundSHA, err := repository.writeClaim(ctx, result.Resources.ClaimRef, claimSHA, record)
+	if err != nil {
+		current, refreshErr := repository.listRefs(ctx, result.Resources.ClaimRef)
+		if refreshErr != nil {
+			return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(refreshErr), "REFRESH_REQUIRED")
+		}
+		result.Resources.ObservedClaimSHA = current[result.Resources.ClaimRef]
+
+		return dispatchStopped(result, "CLAIM_CHANGED", "claim binding compare-and-swap failed", "REFRESH_REQUIRED")
+	}
+	result.Resources.BoundClaimSHA = boundSHA
+	result.Resources.ObservedClaimSHA = boundSHA
+	if options.afterClaimBinding != nil {
+		options.afterClaimBinding()
+	}
+
+	status := "DISPATCHED"
+	nextAction := "START_ENGINEERING_AGENT"
+	refs, err = repository.listRefs(ctx, "refs/heads/"+options.target, "refs/heads/"+branch)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", "claim was bound but final remote state is unavailable", "REFRESH_REQUIRED")
+	}
+	if refs["refs/heads/"+branch] != campaign.AuditedSHA {
+		return dispatchStopped(result, "BROKEN_BINDING", "work branch changed while dispatch completed", "REPAIR_BINDING")
+	}
+	if refs["refs/heads/"+options.target] != campaign.AuditedSHA {
+		status = "STALE_AT_DISPATCH"
+		nextAction = "BASE_UPDATE_REQUIRED"
+	}
+	work := buildCampaignWork(status, campaign, finding, evidence, jira, record, boundSHA,
+		options.repository, worktreePath, options.workItemPath)
+	writer := options.writeWorkItem
+	if writer == nil {
+		writer = writeWorkItem
+	}
+	if err := writer(options.workItemPath, work); err != nil {
+		return dispatchStopped(result, "WORK_ITEM_WRITE_FAILED", conciseError(err), "RESUME_DISPATCH")
+	}
+	result.Status = status
+	result.NextAction = nextAction
+	result.WorkItem = work
+
+	return result
+}
+
+func resumeDispatched(
+	ctx context.Context,
+	repository *claimRepository,
+	result DispatchResult,
+	campaign *Campaign,
+	finding SourceFinding,
+	evidence dispatchEvidence,
+	jira JiraIssue,
+	record ClaimRecord,
+	claimSHA string,
+	branchSHA string,
+	options dispatchOptions,
+) DispatchResult {
+	if branchSHA == "" {
+		return dispatchStopped(result, "BROKEN_BINDING", "claim-bound work branch is missing", "REPAIR_BINDING")
+	}
+	if err := repository.fetchBranch(ctx, "refs/heads/"+record.WorkBranch); err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED")
+	}
+	if !repository.isAncestor(ctx, record.InitialWorkSHA, branchSHA) {
+		return dispatchStopped(result, "BROKEN_BINDING", "work branch no longer descends from the immutable initial work SHA", "REPAIR_BINDING")
+	}
+	worktreePath, worktreeState, err := ensureDispatchWorktree(options.repoRoot, options.remote, record.WorkBranch,
+		branchSHA, options.worktreePath, true)
+	if err != nil {
+		result.Resources.WorktreeState = worktreeState
+
+		return dispatchStopped(result, "CONFLICTING_DISPATCH", conciseError(err), "REPAIR_BINDING")
+	}
+	result.Resources.WorktreePath = worktreePath
+	result.Resources.WorktreeState = worktreeState
+	result.Resources.BranchState = "EXPECTED_EXISTING_WORK"
+	result.Resources.BoundClaimSHA = claimSHA
+	result.Resources.ObservedClaimSHA = claimSHA
+	refs, err := repository.listRefs(ctx, result.Resources.ClaimRef, "refs/heads/"+options.target,
+		"refs/heads/"+record.WorkBranch)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED")
+	}
+	if refs[result.Resources.ClaimRef] != claimSHA {
+		return dispatchStopped(result, "CLAIM_CHANGED", "claim changed while reconstructing dispatch", "REFRESH_REQUIRED")
+	}
+	if refs["refs/heads/"+record.WorkBranch] != branchSHA {
+		return dispatchStopped(result, "BROKEN_BINDING", "work branch changed while reconstructing dispatch", "REPAIR_BINDING")
+	}
+	workStatus := "DISPATCHED"
+	resultStatus := "ALREADY_DISPATCHED"
+	nextAction := "START_ENGINEERING_AGENT"
+	if refs["refs/heads/"+options.target] != record.TargetBaseSHA {
+		workStatus = "STALE_AT_DISPATCH"
+		nextAction = "BASE_UPDATE_REQUIRED"
+	}
+	work := buildCampaignWork(workStatus, campaign, finding, evidence, jira, record, claimSHA,
+		options.repository, worktreePath, options.workItemPath)
+	writer := options.writeWorkItem
+	if writer == nil {
+		writer = writeWorkItem
+	}
+	if err := writer(options.workItemPath, work); err != nil {
+		return dispatchStopped(result, "WORK_ITEM_WRITE_FAILED", conciseError(err), "RESUME_DISPATCH")
+	}
+	result.Status = resultStatus
+	result.NextAction = nextAction
+	result.WorkItem = work
+
+	return result
+}
+
+func dispatchStopped(result DispatchResult, status, reason, nextAction string) DispatchResult {
+	result.Status = status
+	result.Reason = reason
+	result.NextAction = nextAction
+
+	return result
+}
+
+func stopForCampaignWorkPR(
+	ctx context.Context,
+	result DispatchResult,
+	options dispatchOptions,
+	identity string,
+) (DispatchResult, bool) {
+	if options.findWorkPRs == nil {
+		return result, false
+	}
+	matches, err := options.findWorkPRs(ctx, options.repository, "AI-CAMPAIGN-WORK:"+identity)
+	if err != nil {
+		return dispatchStopped(result, "REMOTE_UNAVAILABLE", conciseError(err), "REFRESH_REQUIRED"), true
+	}
+	if len(matches) > 1 {
+		return dispatchStopped(result, "AMBIGUOUS_BINDING", "multiple exact campaign-work PR bindings exist", "RESOLVE_BINDING"), true
+	}
+	if len(matches) == 0 {
+		return result, false
+	}
+	match := matches[0]
+	result.ExistingPR = &match
+	if match.BaseRef != options.target {
+		return dispatchStopped(result, "BROKEN_BINDING", "the campaign-work PR targets another branch", "REPAIR_BINDING"), true
+	}
+	if match.Merged {
+		return dispatchStopped(result, "ALREADY_MERGED", "an exact campaign-work PR already merged this work identity", "VERIFY_RESOLUTION"), true
+	}
+	switch {
+	case strings.EqualFold(match.State, "OPEN"):
+		return dispatchStopped(result, "EXISTING_PR", "an exact campaign-work PR binding already exists", "CONTINUE_PR"), true
+	case strings.EqualFold(match.State, "CLOSED"):
+		return dispatchStopped(result, "EXISTING_PR", "an exact closed campaign-work PR binding already exists", "REVIEW_CLOSED_PR"), true
+	default:
+		return dispatchStopped(result, "BROKEN_BINDING", "the campaign-work PR state is unknown", "REPAIR_BINDING"), true
+	}
+}
+
+func workIdentity(campaign *Campaign, finding SourceFinding, jiraKey string) string {
+	payload := strings.Join([]string{
+		workSchemaVersion,
+		campaign.CampaignID,
+		finding.ID,
+		campaign.SourceDigests.Qualified,
+		jiraKey,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+
+	return "work-" + hex.EncodeToString(sum[:])
+}
+
+func workBranch(workflow, findingID, jiraKey, identity string) string {
+	prefix := map[string]string{
+		"BUGFIX":        "fix/",
+		"TEST_GAP":      "test/",
+		"TOOLING_FIX":   "fix/",
+		"DOCUMENTATION": "docs/",
+	}[workflow]
+	slug := strings.TrimPrefix(findingID, strings.SplitN(findingID, "/", 2)[0]+"/")
+	if jiraKey != "" {
+		slug = strings.ToLower(jiraKey) + "-" + slug
+	}
+	if workflow == "TOOLING_FIX" {
+		slug = "tooling-" + slug
+	}
+
+	return prefix + slug + "-" + strings.TrimPrefix(identity, "work-")[:12]
+}
+
+func sameDispatchBinding(record ClaimRecord, identity, branch, baseSHA, workflow, jiraKey string) bool {
+	return record.WorkIdentity == identity && record.WorkBranch == branch && record.InitialWorkSHA == baseSHA &&
+		record.TargetBaseSHA == baseSHA && record.Workflow == workflow && record.JiraKey == jiraKey
+}
+
+func isObservationExpired(expiresAt, now time.Time) bool {
+	return !now.Before(expiresAt.Add(claimClockSkew))
+}
+
+func defaultDispatchWorktree(repoRoot, identity string) string {
+	common := gitOutput(repoRoot, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	mainRoot := repoRoot
+	if common != "" && filepath.Base(common) == ".git" {
+		mainRoot = filepath.Dir(common)
+	}
+
+	return filepath.Join(filepath.Dir(mainRoot), "."+filepath.Base(mainRoot)+"-ai-worktrees",
+		"campaign-"+strings.TrimPrefix(identity, "work-")[:16], "worktree")
+}
+
+func defaultWorkItemPath(campaignPath, identity string) string {
+	return filepath.Join(filepath.Dir(campaignPath), "work-items", identity+".json")
+}
+
+func buildCampaignWork(
+	status string,
+	campaign *Campaign,
+	finding SourceFinding,
+	evidence dispatchEvidence,
+	jira JiraIssue,
+	record ClaimRecord,
+	claimSHA string,
+	repository string,
+	worktreePath string,
+	workItemPath string,
+) *CampaignWork {
+	markers := []string{"AI-AUDIT:" + finding.ID, "AI-CAMPAIGN-WORK:" + record.WorkIdentity}
+	if jira.Key != "" {
+		markers = append(markers, "Jira: "+jira.Key)
+	}
+	work := &CampaignWork{
+		SchemaVersion:          workSchemaVersion,
+		Status:                 status,
+		CreatedAt:              *record.DispatchedAt,
+		WorkflowClassification: record.Workflow,
+		RemoteIdentity: WorkRemoteIdentity{
+			Repository: repository, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
+			FindingID: finding.ID, WorkIdentity: record.WorkIdentity,
+			FindingIdentityDigest: finding.IdentityDigest, SourceAuditDigest: campaign.SourceDigests.Audit,
+			QualifiedDigest: campaign.SourceDigests.Qualified, SourceAuditSHA: campaign.AuditedSHA,
+			JiraKey: jira.Key, JiraURL: jira.URL, ClaimRef: claimRef(campaign.AuditID, finding.ID),
+			ClaimSHA: claimSHA, Claimant: record.Claimant, LeaseExpiry: record.ExpiresAt,
+			TargetBranch: record.TargetBranch, TargetBaseSHA: record.TargetBaseSHA,
+			WorkBranch: record.WorkBranch, InitialWorkSHA: record.InitialWorkSHA, PRMarkers: markers,
+		},
+		Finding: WorkFinding{
+			Qualification: finding.Qualification, Severity: finding.Severity, Title: finding.Title,
+			Invariant: evidence.Audit.ViolatedInvariant, ChallengeSummary: evidence.Qualified.ChallengeSummary,
+			AuditFindingReference:  finding.References.AuditFinding,
+			QualificationReference: finding.References.QualificationResult,
+			EvidenceFor:            nonNilStrings(evidence.Qualified.EvidenceFor),
+			EvidenceAgainst:        nonNilStrings(evidence.Qualified.EvidenceAgainst),
+			ReproductionPlan:       evidence.Qualified.ReproductionPlan,
+		},
+		LocalState:          WorkLocalState{WorktreePath: worktreePath, WorkItemPath: workItemPath},
+		RequiredGates:       requiredGates(record.Workflow),
+		CanonicalNextAction: "START_ENGINEERING_AGENT",
+	}
+	if status == "STALE_AT_DISPATCH" {
+		work.CanonicalNextAction = "BASE_UPDATE_REQUIRED"
+	}
+	work.EngineeringTask = engineeringTask(work)
+
+	return work
+}
+
+func requiredGates(workflow string) []string {
+	common := []string{"SEARCH_AND_RECONCILE_EXISTING_WORK", "EFFECTIVE_NIX_TOOLCHAIN", "NORMALIZE_TO_FIXPOINT", "EXACT_REVIEW", "GUARDED_PUBLICATION"}
+	switch workflow {
+	case "BUGFIX":
+		return append([]string{"DISCOVERY", "BEFORE_FIX", "AFTER_FIX", "REGRESSION_SENSITIVITY"}, common...)
+	case "TEST_GAP":
+		return append([]string{"TEST_GAP_EVIDENCE", "REGRESSION_SENSITIVITY"}, common...)
+	case "TOOLING_FIX":
+		return append([]string{"TOOLING_FAILURE_BEFORE_FIX", "TOOLING_AFTER_FIX", "REGRESSION_SENSITIVITY"}, common...)
+	case "DOCUMENTATION":
+		return append([]string{"DOCUMENTATION_VALIDATION"}, common...)
+	default:
+		return common
+	}
+}
+
+func engineeringTask(work *CampaignWork) string {
+	remote := work.RemoteIdentity
+	finding := work.Finding
+	jira := "none (optional for this workflow)"
+	if remote.JiraKey != "" {
+		jira = remote.JiraKey
+	}
+
+	return fmt.Sprintf(`Work only in the bound candidate worktree below. This task is orchestration context, not proof of a defect or permission to merge.
+
+Repository: %s
+Target branch: %s
+Exact dispatch base SHA: %s
+Finding: %s
+Jira: %s
+Severity: %s
+Qualification: %s
+Workflow: %s
+Invariant: %s
+Audit provenance: %s at %s
+Qualified provenance: %s
+Work identity: %s
+Work branch: %s
+Worktree: %s
+Claim: %s at %s, claimant %s, lease expiry %s
+Required future PR body lines:
+%s
+
+Engineering sequence:
+1. Search and reconcile existing work; record the repository discovery classification.
+2. Produce the workflow-appropriate BEFORE_FIX evidence before changing production or test behavior. Runtime BUGFIX work must use the native bugfix evidence contract; TEST_GAP and TOOLING_FIX work must use their own evidence semantics without fabricating a runtime reproduction.
+3. Preserve the evidence and determine the root cause; do not treat the qualified finding as an implementation prescription.
+4. Implement the minimum justified fix.
+5. Add regression coverage and challenge its sensitivity with a meaningful temporary mutation, then restore the correct implementation.
+6. Validate using the effective pinned Nix toolchain and hermetic writable caches outside trusted/candidate worktrees.
+7. Run normalization to a fixpoint and keep the worktree clean.
+8. Obtain an exact review of the final candidate SHA.
+9. Use guarded publication with last-mile target and remote-head revalidation. Do not merge automatically.
+
+The work branch started at the immutable dispatch base. If the target has advanced, stop with BASE_UPDATE_REQUIRED; never silently move this branch. Invoke orchestration/review policy from a clean base-pinned trusted-tool worktree, not from candidate-modified tooling.
+`, remote.Repository, remote.TargetBranch, remote.TargetBaseSHA, remote.FindingID, jira, finding.Severity,
+		finding.Qualification, work.WorkflowClassification, finding.Invariant, remote.SourceAuditDigest,
+		remote.SourceAuditSHA, remote.QualifiedDigest, remote.WorkIdentity, remote.WorkBranch,
+		work.LocalState.WorktreePath, remote.ClaimRef, remote.ClaimSHA, remote.Claimant,
+		remote.LeaseExpiry.Format(time.RFC3339Nano), strings.Join(remote.PRMarkers, "\n"))
+}
+
+func writeWorkItem(path string, work *CampaignWork) error {
+	if err := validateCampaignWork(work); err != nil {
+		return fmt.Errorf("refusing malformed work item: %w", err)
+	}
+	content, err := json.MarshalIndent(work, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal work item: %w", err)
+	}
+
+	return atomicWrite(path, append(content, '\n'))
+}
+
+func validateCampaignWork(work *CampaignWork) error {
+	if work == nil || work.SchemaVersion != workSchemaVersion || !workIdentityPattern.MatchString(work.RemoteIdentity.WorkIdentity) ||
+		!validWorkflow(work.WorkflowClassification) || work.CreatedAt.IsZero() ||
+		work.RemoteIdentity.CampaignID == "" || work.RemoteIdentity.FindingID == "" ||
+		work.RemoteIdentity.ClaimRef == "" || !shaPattern.MatchString(work.RemoteIdentity.ClaimSHA) ||
+		!shaPattern.MatchString(work.RemoteIdentity.TargetBaseSHA) || !shaPattern.MatchString(work.RemoteIdentity.InitialWorkSHA) ||
+		work.RemoteIdentity.WorkBranch == "" || work.LocalState.WorktreePath == "" || work.LocalState.WorkItemPath == "" ||
+		work.Finding.Qualification != "CONFIRMED" || work.Finding.Invariant == "" || work.EngineeringTask == "" {
+		return errors.New("incomplete canonical work item")
+	}
+	if len(work.RemoteIdentity.PRMarkers) < 2 || !slices.Equal(work.RemoteIdentity.PRMarkers[:2], []string{
+		"AI-AUDIT:" + work.RemoteIdentity.FindingID,
+		"AI-CAMPAIGN-WORK:" + work.RemoteIdentity.WorkIdentity,
+	}) {
+		return errors.New("invalid PR marker contract")
+	}
+
+	return nil
+}
+
+func ensureDispatchWorktree(
+	repoRoot string,
+	remote string,
+	branch string,
+	expectedSHA string,
+	requestedPath string,
+	allowLocalAhead bool,
+) (string, string, error) {
+	if !shaPattern.MatchString(expectedSHA) || execCheckBranch(branch) != nil || strings.HasPrefix(branch, "ai-claims/") {
+		return requestedPath, "INVALID", errors.New("invalid worktree branch binding")
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		return requestedPath, "INVALID", fmt.Errorf("resolve repository root: %w", err)
+	}
+	absolutePath, err := filepath.Abs(requestedPath)
+	if err != nil {
+		return requestedPath, "INVALID", fmt.Errorf("resolve worktree path: %w", err)
+	}
+	absolutePath, err = resolvePhysicalCandidate(absolutePath)
+	if err != nil {
+		return requestedPath, "INVALID", err
+	}
+	if pathWithin(absolutePath, canonicalRoot) {
+		return absolutePath, "FORBIDDEN", errors.New("candidate worktree must be outside the trusted checkout")
+	}
+	entries, err := listWorktrees(repoRoot)
+	if err != nil {
+		return absolutePath, "UNKNOWN", err
+	}
+	for _, entry := range entries {
+		if entry.Branch == "refs/heads/"+branch {
+			physicalEntry, physicalErr := filepath.EvalSymlinks(entry.Path)
+			if physicalErr != nil {
+				return absolutePath, "UNKNOWN", fmt.Errorf("resolve discovered worktree: %w", physicalErr)
+			}
+			if pathWithin(physicalEntry, canonicalRoot) || looksLikeValidationPath(physicalEntry) {
+				return physicalEntry, "FORBIDDEN", errors.New("discovered worktree violates the isolation boundary")
+			}
+			localAhead := allowLocalAhead && gitExitSuccess(repoRoot, "merge-base", "--is-ancestor", expectedSHA, entry.Head)
+			if entry.Head != expectedSHA && !localAhead {
+				return absolutePath, "CONFLICT", errors.New("existing worktree HEAD does not match remote work branch")
+			}
+			if !allowLocalAhead {
+				clean, cleanErr := worktreeIsClean(entry.Path)
+				if cleanErr != nil {
+					return absolutePath, "UNKNOWN", cleanErr
+				}
+				if !clean {
+					return entry.Path, "CONFLICT", errors.New("existing initial-dispatch worktree is dirty")
+				}
+			}
+
+			return entry.Path, "DISCOVERED", nil
+		}
+	}
+	for _, entry := range entries {
+		if samePath(entry.Path, absolutePath) || pathWithin(absolutePath, entry.Path) || pathWithin(entry.Path, absolutePath) {
+			return absolutePath, "CONFLICT", errors.New("candidate path overlaps another registered worktree")
+		}
+	}
+	if looksLikeValidationPath(absolutePath) {
+		return absolutePath, "FORBIDDEN", errors.New("candidate worktree cannot overlap a validation run directory")
+	}
+	if output := gitOutput(repoRoot, "fetch", "--quiet", "--no-tags", remote,
+		"+refs/heads/"+branch+":refs/remotes/"+remote+"/"+branch); output == "" {
+		if gitOutput(repoRoot, "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch) != expectedSHA {
+			return absolutePath, "REMOTE_UNAVAILABLE", errors.New("fetch work branch failed")
+		}
+	}
+	localSHA := gitOutput(repoRoot, "show-ref", "--verify", "--hash", "refs/heads/"+branch)
+	if localSHA != "" && localSHA != expectedSHA {
+		switch {
+		case allowLocalAhead && gitExitSuccess(repoRoot, "merge-base", "--is-ancestor", expectedSHA, localSHA):
+			// Preserve useful unpushed local engineering commits.
+		case allowLocalAhead && gitExitSuccess(repoRoot, "merge-base", "--is-ancestor", localSHA, expectedSHA):
+			command := exec.Command("git", "-C", repoRoot, "update-ref", "refs/heads/"+branch, expectedSHA, localSHA)
+			if output, updateErr := command.CombinedOutput(); updateErr != nil {
+				return absolutePath, "CONFLICT", fmt.Errorf("fast-forward local work branch: %s",
+					conciseError(errors.New(string(output))))
+			}
+			localSHA = expectedSHA
+		default:
+			return absolutePath, "CONFLICT", errors.New("local work branch differs from remote work branch")
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o700); err != nil {
+		return absolutePath, "CREATE_FAILED", fmt.Errorf("create worktree parent: %w", err)
+	}
+	arguments := []string{"-C", repoRoot, "worktree", "add"}
+	if localSHA == "" {
+		arguments = append(arguments, "-b", branch, absolutePath, expectedSHA)
+	} else {
+		arguments = append(arguments, absolutePath, branch)
+	}
+	command := exec.Command("git", arguments...)
+	if output, commandErr := command.CombinedOutput(); commandErr != nil {
+		return absolutePath, "CREATE_FAILED", fmt.Errorf("create candidate worktree: %s", conciseError(errors.New(string(output))))
+	}
+	entries, err = listWorktrees(repoRoot)
+	if err != nil {
+		return absolutePath, "CREATE_FAILED", err
+	}
+	for _, entry := range entries {
+		localAhead := allowLocalAhead && gitExitSuccess(repoRoot, "merge-base", "--is-ancestor", expectedSHA, entry.Head)
+		if samePath(entry.Path, absolutePath) && entry.Branch == "refs/heads/"+branch &&
+			(entry.Head == expectedSHA || localAhead) {
+			if !allowLocalAhead {
+				clean, cleanErr := worktreeIsClean(entry.Path)
+				if cleanErr != nil {
+					return absolutePath, "CREATE_FAILED", cleanErr
+				}
+				if !clean {
+					return entry.Path, "CONFLICT", errors.New("created initial-dispatch worktree is dirty")
+				}
+			}
+
+			return entry.Path, "CREATED", nil
+		}
+	}
+
+	return absolutePath, "CREATE_FAILED", errors.New("created worktree failed exact binding verification")
+}
+
+func worktreeIsClean(path string) (bool, error) {
+	command := exec.Command("git", "-C", path, "status", "--porcelain=v1", "--untracked-files=all")
+	output, err := command.Output()
+	if err != nil {
+		return false, fmt.Errorf("inspect worktree cleanliness: %w", err)
+	}
+
+	return len(output) == 0, nil
+}
+
+func resolvePhysicalCandidate(path string) (string, error) {
+	probe := filepath.Clean(path)
+	missing := []string{}
+	for {
+		info, err := os.Stat(probe)
+		if err == nil {
+			if !info.IsDir() {
+				return "", errors.New("worktree path has a non-directory ancestor")
+			}
+
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("inspect worktree ancestor: %w", err)
+		}
+		next := filepath.Dir(probe)
+		if next == probe {
+			return "", errors.New("worktree path has no existing ancestor")
+		}
+		missing = append([]string{filepath.Base(probe)}, missing...)
+		probe = next
+	}
+	physical, err := filepath.EvalSymlinks(probe)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree ancestor: %w", err)
+	}
+	for _, component := range missing {
+		physical = filepath.Join(physical, component)
+	}
+
+	return physical, nil
+}
+
+func gitExitSuccess(directory string, arguments ...string) bool {
+	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
+
+	return command.Run() == nil
+}
+
+func looksLikeValidationPath(path string) bool {
+	components := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	seenWorktreeRoot := false
+	for _, component := range components {
+		if strings.HasSuffix(component, "-ai-worktrees") {
+			seenWorktreeRoot = true
+		}
+		if seenWorktreeRoot && component == "validation" {
+			return true
+		}
+	}
+
+	return false
+}
+
+type worktreeEntry struct {
+	Path   string
+	Head   string
+	Branch string
+}
+
+func listWorktrees(repoRoot string) ([]worktreeEntry, error) {
+	command := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain")
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list worktrees: %w", err)
+	}
+	var entries []worktreeEntry
+	var current worktreeEntry
+	for line := range strings.SplitSeq(string(output), "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			if current.Path != "" {
+				entries = append(entries, current)
+			}
+			current = worktreeEntry{Path: strings.TrimPrefix(line, "worktree ")}
+		case strings.HasPrefix(line, "HEAD "):
+			current.Head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			current.Branch = strings.TrimPrefix(line, "branch ")
+		}
+	}
+	if current.Path != "" {
+		entries = append(entries, current)
+	}
+
+	return entries, nil
+}
+
+func samePath(left, right string) bool {
+	leftAbsolute, leftErr := filepath.Abs(left)
+	rightAbsolute, rightErr := filepath.Abs(right)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	if physical, err := filepath.EvalSymlinks(leftAbsolute); err == nil {
+		leftAbsolute = physical
+	}
+	if physical, err := filepath.EvalSymlinks(rightAbsolute); err == nil {
+		rightAbsolute = physical
+	}
+
+	return filepath.Clean(leftAbsolute) == filepath.Clean(rightAbsolute)
+}
+
+func gitOutput(directory string, arguments ...string) string {
+	command := exec.Command("git", append([]string{"-C", directory}, arguments...)...)
+	output, err := command.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(output))
+}

--- a/scripts/aicampaign/dispatch_command.go
+++ b/scripts/aicampaign/dispatch_command.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+func runDispatch(arguments []string, stdout, stderr io.Writer) error {
+	values, flags, err := parseArguments(arguments, map[string]bool{
+		"--finding": true, "--audit": true, "--qualified": true, "--claimant": true, "--workflow": true,
+		"--repo": true, "--jira-project": true, "--remote": true, "--target": true,
+		"--worktree": true, "--output": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(values) != 1 || flags["--finding"] == "" || flags["--audit"] == "" || flags["--qualified"] == "" {
+		return errors.New("usage: ai-campaign dispatch <campaign> --finding <id> --audit <source-audit> --qualified <qualified-result> [--claimant <id>] [--workflow <classification>] [--worktree <path>] [--output <path>] [--repo <owner/name>] [--jira-project <key>] [--remote <name>] [--target <branch>]")
+	}
+	repoRoot, err := repositoryRoot()
+	if err != nil {
+		return err
+	}
+	campaignPath, err := validateCampaignDestination(repoRoot, values[0], false)
+	if err != nil {
+		return err
+	}
+	campaign, err := loadCampaign(campaignPath)
+	if err != nil {
+		return err
+	}
+	finding, err := findingByID(campaign, flags["--finding"])
+	if err != nil {
+		return err
+	}
+	evidence, err := loadDispatchEvidence(flags["--audit"], flags["--qualified"], campaign, finding.ID)
+	if err != nil {
+		return err
+	}
+	claimant, err := resolveClaimant(flags["--claimant"], false)
+	if err != nil {
+		return err
+	}
+	inspectOptions := inspectOptions{
+		repository:  valueOr(flags["--repo"], "formancehq/ledger"),
+		jiraProject: valueOr(flags["--jira-project"], "EN"), remote: valueOr(flags["--remote"], "origin"),
+		target: valueOr(flags["--target"], "release/v3.0"), claimant: claimant,
+	}
+	if err := validateInspectOptions(inspectOptions); err != nil {
+		return err
+	}
+	if flags["--workflow"] != "" && !validWorkflow(flags["--workflow"]) {
+		return errors.New("workflow must be BUGFIX, TEST_GAP, TOOLING_FIX, or DOCUMENTATION")
+	}
+	inspectContext, cancelInspection := context.WithTimeout(context.Background(), 2*time.Minute)
+	runner := inspector{now: time.Now, jira: commandJiraProvider{}, github: commandGitHubProvider{},
+		git: commandGitProvider{}, claims: commandClaimProvider{}}
+	inspection := runner.run(inspectContext, campaign, inspectOptions)
+	cancelInspection()
+	if err := writeCampaign(campaignPath, campaign); err != nil {
+		return err
+	}
+	var observed InspectionFinding
+	for _, candidate := range inspection.Findings {
+		if candidate.ID == finding.ID {
+			observed = candidate
+
+			break
+		}
+	}
+	if observed.ID == "" {
+		return errors.New("fresh inspection omitted dispatch finding")
+	}
+	dispatchContext, cancelDispatch := context.WithTimeout(context.Background(), 2*time.Minute)
+	result := dispatchFinding(dispatchContext, campaign, finding, observed, evidence, dispatchOptions{
+		repository: inspectOptions.repository, remote: inspectOptions.remote, target: inspectOptions.target,
+		claimant: claimant, workflow: flags["--workflow"], repoRoot: repoRoot, campaignPath: campaignPath,
+		worktreePath: flags["--worktree"], workItemPath: flags["--output"], findWorkPRs: findCampaignWorkPRs,
+	}, time.Now)
+	cancelDispatch()
+	if result.Status == "DISPATCHED" || result.Status == "STALE_AT_DISPATCH" ||
+		result.Status == "ALREADY_DISPATCHED" || result.Resources.BoundClaimSHA != "" {
+		postContext, cancelPostInspection := context.WithTimeout(context.Background(), 2*time.Minute)
+		_ = runner.run(postContext, campaign, inspectOptions)
+		cancelPostInspection()
+		if err := writeCampaign(campaignPath, campaign); err != nil {
+			return err
+		}
+	}
+	if err := writeHuman(stderr, "%s %s", result.Status, finding.ID); err != nil {
+		return err
+	}
+	if result.Resources.WorkBranch != "" {
+		if err := writeHuman(stderr, " branch=%s", result.Resources.WorkBranch); err != nil {
+			return err
+		}
+	}
+	if result.Reason != "" {
+		if err := writeHuman(stderr, " reason=%s", result.Reason); err != nil {
+			return err
+		}
+	}
+	if err := writeHuman(stderr, " next=%s\n", result.NextAction); err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, result)
+}

--- a/scripts/aicampaign/dispatch_test.go
+++ b/scripts/aicampaign/dispatch_test.go
@@ -1,0 +1,638 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dispatchFixture struct {
+	remote       string
+	repo         string
+	campaign     *Campaign
+	finding      SourceFinding
+	evidence     dispatchEvidence
+	claim        ClaimResult
+	observed     InspectionFinding
+	options      dispatchOptions
+	dispatchTime time.Time
+}
+
+func TestConfirmedOwnedClaimDispatchesCanonicalWork(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	require.Equal(t, "START_ENGINEERING_AGENT", result.NextAction)
+	require.Equal(t, fixture.campaign.AuditedSHA, remoteRefSHA(t, fixture.remote,
+		"refs/heads/"+result.Resources.WorkBranch))
+	require.Equal(t, fixture.campaign.AuditedSHA, strings.TrimSpace(runGit(t, result.Resources.WorktreePath, "rev-parse", "HEAD")))
+	require.Equal(t, result.Resources.WorkBranch, strings.TrimSpace(runGit(t, result.Resources.WorktreePath,
+		"branch", "--show-current")))
+	require.FileExists(t, result.Resources.WorkItemPath)
+	require.NotNil(t, result.WorkItem)
+	require.Equal(t, result.Resources.WorkIdentity, result.WorkItem.RemoteIdentity.WorkIdentity)
+	require.Equal(t, []string{
+		"AI-AUDIT:" + fixture.finding.ID,
+		"AI-CAMPAIGN-WORK:" + result.Resources.WorkIdentity,
+		"Jira: EN-42",
+	}, result.WorkItem.RemoteIdentity.PRMarkers)
+	require.Contains(t, result.WorkItem.EngineeringTask, "BEFORE_FIX")
+	require.Contains(t, result.WorkItem.EngineeringTask, fixture.evidence.Audit.ViolatedInvariant)
+
+	claim := readRemoteClaim(t, fixture.remote, result.Resources.ClaimRef)
+	require.Equal(t, result.Resources.WorkIdentity, claim.Record.WorkIdentity)
+	require.Equal(t, result.Resources.WorkBranch, claim.Record.WorkBranch)
+	require.Equal(t, fixture.campaign.AuditedSHA, claim.Record.InitialWorkSHA)
+	require.Equal(t, fixture.campaign.AuditedSHA, claim.Record.TargetBaseSHA)
+	require.Equal(t, "BUGFIX", claim.Record.Workflow)
+	require.Equal(t, "EN-42", claim.Record.JiraKey)
+	require.Equal(t, fixture.claim.ClaimSHA, claimParent(t, fixture.remote, claim.SHA))
+}
+
+func TestDispatchEligibilityRefusals(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*dispatchFixture)
+		status    string
+	}{
+		{
+			name: "no claim", status: "CLAIM_REQUIRED",
+			configure: func(fixture *dispatchFixture) {
+				runGit(t, "", "--git-dir", fixture.remote, "update-ref", "-d", fixture.claim.RemoteRef)
+				fixture.observed.Claim = emptyClaimObservation(fixture.campaign.AuditID, fixture.finding.ID, "FRESH")
+			},
+		},
+		{
+			name: "another owner", status: "CLAIM_NOT_OWNER",
+			configure: func(fixture *dispatchFixture) {
+				runGit(t, "", "--git-dir", fixture.remote, "update-ref", "-d", fixture.claim.RemoteRef)
+				other := createClaim(context.Background(), fixture.campaign, fixture.finding, testClaimantB,
+					defaultClaimLease, fixture.remote, testTarget, "", func() time.Time { return testNow })
+				require.Equal(t, "CLAIMED", other.Status, other.Reason)
+				fixture.observed.Claim = observationFromClaim(&observedClaim{
+					Record: *other.Claim, SHA: other.ClaimSHA, Ref: other.RemoteRef,
+				}, testClaimantA)
+			},
+		},
+		{
+			name: "expired claim", status: "CLAIM_EXPIRED",
+			configure: func(fixture *dispatchFixture) {
+				expired := fixture.dispatchTime.Add(-claimClockSkew)
+				fixture.observed.Claim.ExpiresAt = &expired
+				fixture.observed.Claim.State = "CLAIM_EXPIRED"
+			},
+		},
+		{
+			name: "workflow unknown", status: "HUMAN_DECISION_REQUIRED",
+			configure: func(fixture *dispatchFixture) { fixture.options.workflow = "" },
+		},
+		{
+			name: "runtime bugfix without Jira", status: "JIRA_REQUIRED",
+			configure: func(fixture *dispatchFixture) {
+				fixture.observed.Jira = JiraObservation{Status: "UNBOUND", BindingBasis: "AI_AUDIT_MARKER", Issues: []JiraIssue{}}
+			},
+		},
+		{
+			name: "remote unavailable", status: "REMOTE_UNAVAILABLE",
+			configure: func(fixture *dispatchFixture) { fixture.observed.Freshness = "UNAVAILABLE" },
+		},
+		{
+			name: "target already advanced", status: "BASE_UPDATE_REQUIRED",
+			configure: func(fixture *dispatchFixture) { fixture.observed.ObservedTargetSHA = testHead },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+			test.configure(&fixture)
+			result := runFixtureDispatch(fixture)
+			require.Equal(t, test.status, result.Status, result.Reason)
+			if result.Resources.WorkBranch != "" {
+				require.Empty(t, remoteRefSHA(t, fixture.remote, "refs/heads/"+result.Resources.WorkBranch))
+			}
+		})
+	}
+}
+
+func TestNonConfirmedFindingsAreNeverDispatched(t *testing.T) {
+	for _, qualification := range []string{"LIKELY", "QUESTION", "REJECTED"} {
+		t.Run(qualification, func(t *testing.T) {
+			fixture := newDispatchFixture(t, qualification, "", "TEST_GAP", false)
+			result := runFixtureDispatch(fixture)
+			require.Equal(t, "FINDING_NOT_CONFIRMED", result.Status)
+		})
+	}
+}
+
+func TestTestGapDoesNotRequireJiraOrRuntimeBugEvidence(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "TEST_GAP", false)
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	require.NotContains(t, result.WorkItem.RequiredGates, "BEFORE_FIX")
+	require.Contains(t, result.WorkItem.RequiredGates, "TEST_GAP_EVIDENCE")
+	require.Empty(t, result.WorkItem.RemoteIdentity.JiraKey)
+}
+
+func TestExistingAndAmbiguousPRBindingsStopBeforeBranchCreation(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.observed.PR = PRObservation{Status: "BOUND", BindingBasis: "AI_AUDIT_MARKER", Matches: []PRMatch{
+		openPR(42, "existing", "AI_AUDIT_MARKER"),
+	}}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "EXISTING_PR", result.Status)
+	require.Equal(t, "CONTINUE_PR", result.NextAction)
+	require.NotNil(t, result.ExistingPR)
+
+	ambiguous := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	ambiguous.observed.PR = PRObservation{Status: "AMBIGUOUS", BindingBasis: "AI_AUDIT_MARKER", Matches: []PRMatch{
+		openPR(42, "first", "AI_AUDIT_MARKER"), openPR(43, "second", "AI_AUDIT_MARKER"),
+	}}
+	result = runFixtureDispatch(ambiguous)
+	require.Equal(t, "AMBIGUOUS_BINDING", result.Status)
+}
+
+func TestLastMileCampaignWorkPRBindingStopsDispatch(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.options.findWorkPRs = func(_ context.Context, _ string, marker string) ([]PRMatch, error) {
+		require.Equal(t, "AI-CAMPAIGN-WORK:"+workIdentity(fixture.campaign, fixture.finding, "EN-42"), marker)
+
+		return []PRMatch{openPR(44, "last-mile", "AI_CAMPAIGN_WORK_MARKER")}, nil
+	}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "EXISTING_PR", result.Status, result.Reason)
+	require.Equal(t, "CONTINUE_PR", result.NextAction)
+	require.Empty(t, remoteRefSHA(t, fixture.remote, "refs/heads/"+result.Resources.WorkBranch))
+
+	ambiguous := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	ambiguous.options.findWorkPRs = func(context.Context, string, string) ([]PRMatch, error) {
+		return []PRMatch{
+			openPR(44, "first", "AI_CAMPAIGN_WORK_MARKER"),
+			openPR(45, "second", "AI_CAMPAIGN_WORK_MARKER"),
+		}, nil
+	}
+	result = runFixtureDispatch(ambiguous)
+	require.Equal(t, "AMBIGUOUS_BINDING", result.Status, result.Reason)
+}
+
+func TestCampaignWorkPRCreatedBeforeClaimCASStopsDispatch(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	searches := 0
+	fixture.options.findWorkPRs = func(_ context.Context, _ string, marker string) ([]PRMatch, error) {
+		require.Equal(t, "AI-CAMPAIGN-WORK:"+workIdentity(fixture.campaign, fixture.finding, "EN-42"), marker)
+		searches++
+		if searches == 1 {
+			return []PRMatch{}, nil
+		}
+
+		return []PRMatch{openPR(46, "raced", "AI_CAMPAIGN_WORK_MARKER")}, nil
+	}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "EXISTING_PR", result.Status, result.Reason)
+	require.Equal(t, "CONTINUE_PR", result.NextAction)
+	require.Equal(t, 2, searches)
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+	require.Equal(t, fixture.campaign.AuditedSHA, remoteRefSHA(t, fixture.remote,
+		"refs/heads/"+result.Resources.WorkBranch))
+}
+
+func TestMergedExactPRIsAlreadyResolvedButJiraOnlyIsNotProof(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	merged := openPR(42, "merged", "AI_AUDIT_MARKER")
+	merged.Merged = true
+	merged.State = "MERGED"
+	fixture.observed.PR = PRObservation{Status: "BOUND", BindingBasis: merged.BindingBasis, Matches: []PRMatch{merged}}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "ALREADY_MERGED", result.Status)
+
+	jiraOnly := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	merged.BindingBasis = "JIRA_KEY"
+	jiraOnly.observed.PR = PRObservation{Status: "BOUND", BindingBasis: merged.BindingBasis, Matches: []PRMatch{merged}}
+	result = runFixtureDispatch(jiraOnly)
+	require.Equal(t, "BROKEN_BINDING", result.Status)
+}
+
+func TestUnrelatedCanonicalBranchCollisionIsRefused(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	identity := workIdentity(fixture.campaign, fixture.finding, "EN-42")
+	branch := workBranch("BUGFIX", fixture.finding.ID, "EN-42", identity)
+	require.NoError(t, os.WriteFile(filepath.Join(fixture.repo, "collision"), []byte("unrelated\n"), 0o600))
+	runGit(t, fixture.repo, "add", "collision")
+	runGit(t, fixture.repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+		"commit", "--quiet", "-m", "unrelated")
+	runGit(t, fixture.repo, "push", "--quiet", "origin", "HEAD:refs/heads/"+branch)
+
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "CONFLICTING_BRANCH", result.Status, result.Reason)
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestTargetAdvanceDuringDispatchStopsBeforeClaimBinding(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.options.beforeClaimBinding = func() {
+		require.NoError(t, os.WriteFile(filepath.Join(fixture.repo, "advance"), []byte("advance\n"), 0o600))
+		runGit(t, fixture.repo, "add", "advance")
+		runGit(t, fixture.repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+			"commit", "--quiet", "-m", "advance target")
+		runGit(t, fixture.repo, "push", "--quiet", "origin", "HEAD:refs/heads/"+testTarget)
+	}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "BASE_UPDATE_REQUIRED", result.Status, result.Reason)
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestTargetAdvanceAfterClaimCASProducesStaleWorkItem(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.options.afterClaimBinding = func() {
+		require.NoError(t, os.WriteFile(filepath.Join(fixture.repo, "advance-after-cas"), []byte("advance\n"), 0o600))
+		runGit(t, fixture.repo, "add", "advance-after-cas")
+		runGit(t, fixture.repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+			"commit", "--quiet", "-m", "advance after claim CAS")
+		runGit(t, fixture.repo, "push", "--quiet", "origin", "HEAD:refs/heads/"+testTarget)
+	}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "STALE_AT_DISPATCH", result.Status, result.Reason)
+	require.Equal(t, "BASE_UPDATE_REQUIRED", result.NextAction)
+	require.NotNil(t, result.WorkItem)
+	require.Equal(t, "STALE_AT_DISPATCH", result.WorkItem.Status)
+	require.Equal(t, "BASE_UPDATE_REQUIRED", result.WorkItem.CanonicalNextAction)
+	require.NotEmpty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestClaimChangeBetweenWorktreeAndBindingFailsCAS(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.options.beforeClaimBinding = func() {
+		renewed := renewClaim(context.Background(), fixture.campaign, fixture.finding, testClaimantA,
+			defaultClaimLease, fixture.remote, testTarget, "", fixture.claim.ClaimSHA,
+			func() time.Time { return fixture.dispatchTime.Add(time.Minute) })
+		require.Equal(t, "RENEWED", renewed.Status, renewed.Reason)
+	}
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "CLAIM_CHANGED", result.Status, result.Reason)
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestCrashAfterBranchCreationReconcilesExpectedBranch(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	identity := workIdentity(fixture.campaign, fixture.finding, "EN-42")
+	branch := workBranch("BUGFIX", fixture.finding.ID, "EN-42", identity)
+	runGit(t, fixture.repo, "push", "--quiet", "--force-with-lease=refs/heads/"+branch+":", "origin",
+		fixture.campaign.AuditedSHA+":refs/heads/"+branch)
+
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	require.Equal(t, "EXPECTED_EXISTING_WORK", result.Resources.BranchState)
+}
+
+func TestDirtyDiscoveredInitialWorktreeRefusesClaimBinding(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	identity := workIdentity(fixture.campaign, fixture.finding, "EN-42")
+	branch := workBranch("BUGFIX", fixture.finding.ID, "EN-42", identity)
+	runGit(t, fixture.repo, "push", "--quiet", "--force-with-lease=refs/heads/"+branch+":", "origin",
+		fixture.campaign.AuditedSHA+":refs/heads/"+branch)
+	dirtyWorktree := filepath.Join(t.TempDir(), "dirty-worktree")
+	runGit(t, fixture.repo, "worktree", "add", "--quiet", "-b", branch, dirtyWorktree, fixture.campaign.AuditedSHA)
+	require.NoError(t, os.WriteFile(filepath.Join(dirtyWorktree, "untracked"), []byte("contamination\n"), 0o600))
+
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "WORKTREE_CREATION_FAILED", result.Status, result.Reason)
+	require.Equal(t, "CONFLICT", result.Resources.WorktreeState)
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestDiscoveredTrustedRootWorktreeRefusesClaimBinding(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	identity := workIdentity(fixture.campaign, fixture.finding, "EN-42")
+	branch := workBranch("BUGFIX", fixture.finding.ID, "EN-42", identity)
+	runGit(t, fixture.repo, "push", "--quiet", "--force-with-lease=refs/heads/"+branch+":", "origin",
+		fixture.campaign.AuditedSHA+":refs/heads/"+branch)
+	runGit(t, fixture.repo, "checkout", "--quiet", "-b", branch, fixture.campaign.AuditedSHA)
+
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "WORKTREE_CREATION_FAILED", result.Status, result.Reason)
+	require.Equal(t, "FORBIDDEN", result.Resources.WorktreeState)
+	require.Contains(t, result.Reason, "isolation boundary")
+	require.Empty(t, readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef).Record.WorkIdentity)
+}
+
+func TestCrashAfterClaimBindingReconstructsArtifact(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.options.writeWorkItem = func(string, *CampaignWork) error { return errors.New("simulated crash") }
+	first := runFixtureDispatch(fixture)
+	require.Equal(t, "WORK_ITEM_WRITE_FAILED", first.Status, first.Reason)
+	bound := readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef)
+	require.NotEmpty(t, bound.Record.WorkIdentity)
+	runGit(t, fixture.repo, "worktree", "remove", first.Resources.WorktreePath)
+
+	fixture.options.writeWorkItem = nil
+	fixture.observed.Claim = observationFromClaim(bound, testClaimantA)
+	second := runFixtureDispatch(fixture)
+	require.Equal(t, "ALREADY_DISPATCHED", second.Status, second.Reason)
+	require.FileExists(t, second.Resources.WorkItemPath)
+}
+
+func TestRepeatedDispatchAndMalformedArtifactAreIdempotent(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	first := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", first.Status, first.Reason)
+	require.NoError(t, os.WriteFile(first.Resources.WorkItemPath, []byte("not json\n"), 0o600))
+	bound := readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef)
+	fixture.observed.Claim = observationFromClaim(bound, testClaimantA)
+	fixture.options.worktreePath = filepath.Join(t.TempDir(), "would-be-duplicate")
+	second := runFixtureDispatch(fixture)
+	require.Equal(t, "ALREADY_DISPATCHED", second.Status, second.Reason)
+	require.Equal(t, first.Resources.WorkBranch, second.Resources.WorkBranch)
+	require.Equal(t, first.Resources.WorktreePath, second.Resources.WorktreePath)
+	var reconstructed CampaignWork
+	_, err := readStrictJSON(second.Resources.WorkItemPath, &reconstructed)
+	require.NoError(t, err)
+	require.Equal(t, first.Resources.WorkIdentity, reconstructed.RemoteIdentity.WorkIdentity)
+}
+
+func TestRepeatedStaleDispatchRemainsIdempotent(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	first := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", first.Status, first.Reason)
+
+	require.NoError(t, os.WriteFile(filepath.Join(fixture.repo, "advance-before-repeat"), []byte("advance\n"), 0o600))
+	runGit(t, fixture.repo, "add", "advance-before-repeat")
+	runGit(t, fixture.repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+		"commit", "--quiet", "-m", "advance before repeated dispatch")
+	runGit(t, fixture.repo, "push", "--quiet", "origin", "HEAD:refs/heads/"+testTarget)
+
+	bound := readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef)
+	fixture.observed.Claim = observationFromClaim(bound, testClaimantA)
+	second := runFixtureDispatch(fixture)
+	require.Equal(t, "ALREADY_DISPATCHED", second.Status, second.Reason)
+	require.Equal(t, "BASE_UPDATE_REQUIRED", second.NextAction)
+	require.NotNil(t, second.WorkItem)
+	require.Equal(t, "STALE_AT_DISPATCH", second.WorkItem.Status)
+}
+
+func TestInspectAndNextProjectDispatchedAndStaleStates(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	runner := inspector{
+		now:  func() time.Time { return fixture.dispatchTime.Add(time.Minute) },
+		jira: fakeJiraProvider{issues: fixture.observed.Jira.Issues}, github: fakeGitHubProvider{},
+		git: commandGitProvider{}, claims: commandClaimProvider{},
+	}
+	inspection := runner.run(context.Background(), fixture.campaign, inspectOptions{
+		repository: "formancehq/ledger", jiraProject: "EN", remote: fixture.remote,
+		target: testTarget, claimant: testClaimantA,
+	})
+	require.Equal(t, "DISPATCHED", inspection.Findings[0].State)
+	require.Equal(t, "START_ENGINEERING_AGENT", inspection.Findings[0].NextAction)
+	next := buildNextResult(fixture.campaign)
+	require.Equal(t, "START_ENGINEERING_AGENT", next.Findings[0].NextAction)
+
+	require.NoError(t, os.WriteFile(filepath.Join(fixture.repo, "advance-after"), []byte("advance\n"), 0o600))
+	runGit(t, fixture.repo, "add", "advance-after")
+	runGit(t, fixture.repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+		"commit", "--quiet", "-m", "advance after dispatch")
+	runGit(t, fixture.repo, "push", "--quiet", "origin", "HEAD:refs/heads/"+testTarget)
+	inspection = runner.run(context.Background(), fixture.campaign, inspectOptions{
+		repository: "formancehq/ledger", jiraProject: "EN", remote: fixture.remote,
+		target: testTarget, claimant: testClaimantA,
+	})
+	require.Equal(t, "STALE_AT_DISPATCH", inspection.Findings[0].State)
+	require.Equal(t, "BASE_UPDATE_REQUIRED", inspection.Findings[0].NextAction)
+}
+
+func TestTrustedAbsoluteLauncherIgnoresCandidateToolingChanges(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+	candidate := t.TempDir()
+	runGit(t, candidate, "init", "--quiet")
+	for _, name := range []string{"go.mod", "go.sum"} {
+		content, err := os.ReadFile(filepath.Join(repoRoot, name))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(candidate, name), content, 0o600))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(candidate, "scripts", "aicampaign"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(candidate, "scripts", "aicampaign", "main.go"),
+		[]byte("this is deliberately invalid candidate tooling\n"), 0o600))
+	command := exec.Command("bash", filepath.Join(repoRoot, "scripts", "ai-campaign"), "--help")
+	command.Dir = candidate
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	require.Contains(t, string(output), "scripts/ai-campaign dispatch")
+}
+
+func TestDispatchWorktreeRejectsTrustedAndValidationPaths(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	identity := workIdentity(fixture.campaign, fixture.finding, "EN-42")
+	branch := workBranch("BUGFIX", fixture.finding.ID, "EN-42", identity)
+	_, state, err := ensureDispatchWorktree(fixture.repo, "origin", branch, fixture.campaign.AuditedSHA,
+		filepath.Join(fixture.repo, "candidate"), false)
+	require.ErrorContains(t, err, "outside the trusted checkout")
+	require.Equal(t, "FORBIDDEN", state)
+
+	validationPath := filepath.Join(filepath.Dir(fixture.repo), ".repo-ai-worktrees", "pr-42", "validation", "worktree")
+	_, state, err = ensureDispatchWorktree(fixture.repo, "origin", branch, fixture.campaign.AuditedSHA,
+		validationPath, false)
+	require.ErrorContains(t, err, "validation run directory")
+	require.Equal(t, "FORBIDDEN", state)
+}
+
+func TestSameFindingChangedQualifiedDigestConflictsWithClaimLane(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	fixture.campaign = cloneCampaignWithQualifiedDigest(fixture.campaign,
+		"sha256:"+fmt.Sprintf("%064x", 42))
+	fixture.finding = fixture.campaign.SourceFacts.Findings[0]
+	fixture.observed.ID = fixture.finding.ID
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "BROKEN_BINDING", result.Status, result.Reason)
+}
+
+func TestTwoSimultaneousDispatchAttemptsAtMostOneBindsClaim(t *testing.T) {
+	first := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	secondRepo := filepath.Join(t.TempDir(), "second")
+	runGit(t, "", "clone", "--quiet", first.remote, secondRepo)
+	runGit(t, secondRepo, "checkout", "--quiet", "-b", testTarget, "origin/"+testTarget)
+	second := first
+	second.repo = secondRepo
+	second.options.repoRoot = secondRepo
+	second.options.worktreePath = filepath.Join(t.TempDir(), "worktree")
+	second.options.workItemPath = filepath.Join(t.TempDir(), "work.json")
+	second.options.campaignPath = filepath.Join(t.TempDir(), "campaign.json")
+	require.NoError(t, writeCampaign(second.options.campaignPath, second.campaign))
+
+	start := make(chan struct{})
+	results := make(chan DispatchResult, 2)
+	var wait sync.WaitGroup
+	for _, fixture := range []dispatchFixture{first, second} {
+		wait.Go(func() {
+			<-start
+			results <- runFixtureDispatch(fixture)
+		})
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	statuses := []string{}
+	for result := range results {
+		statuses = append(statuses, result.Status)
+	}
+	sort.Strings(statuses)
+	require.Contains(t, statuses, "DISPATCHED")
+	require.NotContains(t, statuses, "CONFLICTING_BRANCH")
+	bound := readRemoteClaim(t, first.remote, first.claim.RemoteRef)
+	require.NotEmpty(t, bound.Record.WorkIdentity)
+}
+
+func TestDispatchClaimBindingTransitionRejectsMutation(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	bound := readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef)
+	mutated := bound.Record
+	mutated.InitialWorkSHA = testHead
+	renewedAt := fixture.dispatchTime.Add(time.Minute)
+	mutated.RenewedAt = &renewedAt
+	mutated.RenewalCount++
+	mutated.ExpiresAt = renewedAt.Add(defaultClaimLease)
+	require.ErrorContains(t, validateClaimTransition(mutated, bound.Record, bound.SHA), "renewal changed dispatch binding")
+}
+
+func TestClaimDispatchBindingRequiresExactTargetLineage(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	record := *fixture.claim.Claim
+	dispatchedAt := fixture.dispatchTime
+	record.WorkIdentity = "work-" + strings.Repeat("a", 64)
+	record.WorkBranch = "fix/audit-finding-aaaaaaaaaaaa"
+	record.InitialWorkSHA = testHead
+	record.TargetBaseSHA = record.TargetSHA
+	record.Workflow = "BUGFIX"
+	record.JiraKey = "EN-42"
+	record.DispatchedAt = &dispatchedAt
+	require.ErrorContains(t, record.validate(), "initial work SHA does not match target base SHA")
+
+	record.InitialWorkSHA = testHead
+	record.TargetBaseSHA = testHead
+	require.ErrorContains(t, record.validate(), "dispatch base does not match immutable target SHA")
+}
+
+func TestRenewAndTakeoverCannotRetargetDispatchedClaim(t *testing.T) {
+	fixture := newDispatchFixture(t, "CONFIRMED", testClaimantA, "BUGFIX", true)
+	result := runFixtureDispatch(fixture)
+	require.Equal(t, "DISPATCHED", result.Status, result.Reason)
+	bound := readRemoteClaim(t, fixture.remote, fixture.claim.RemoteRef)
+	renewed := renewClaim(context.Background(), fixture.campaign, fixture.finding, testClaimantA,
+		defaultClaimLease, fixture.remote, testTarget, "fix/other", bound.SHA,
+		func() time.Time { return fixture.dispatchTime.Add(time.Hour) })
+	require.Equal(t, "CLAIM_CONFLICT", renewed.Status)
+	taken := takeoverClaim(context.Background(), fixture.campaign, fixture.finding, testClaimantB,
+		defaultClaimLease, fixture.remote, testTarget, "fix/other", bound.SHA,
+		func() time.Time { return bound.Record.ExpiresAt.Add(claimClockSkew) })
+	require.Equal(t, "CLAIM_CONFLICT", taken.Status)
+	require.Equal(t, bound.SHA, remoteRefSHA(t, fixture.remote, fixture.claim.RemoteRef))
+}
+
+func newDispatchFixture(
+	t *testing.T,
+	qualification string,
+	claimant string,
+	workflow string,
+	withJira bool,
+) dispatchFixture {
+	t.Helper()
+	remote, targetSHA := newClaimRemote(t)
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGit(t, "", "clone", "--quiet", remote, repo)
+	runGit(t, repo, "checkout", "--quiet", "-b", testTarget, "origin/"+testTarget)
+	campaign := claimCampaignAt(targetSHA, qualification)
+	finding := campaign.SourceFacts.Findings[0]
+	evidence := dispatchEvidence{
+		Audit: auditFinding{ID: finding.ID, Severity: finding.Severity, Title: finding.Title,
+			ViolatedInvariant: "Every dispatched finding retains exact provenance", ReproductionPlan: "Reproduce first"},
+		Qualified: challengeResult{ID: finding.ID, Severity: finding.Severity, Title: finding.Title,
+			Status: qualification, ChallengeSummary: "Independently confirmed", EvidenceFor: []string{"evidence"},
+			EvidenceAgainst: []string{}, ReproductionPlan: "Reproduce first"},
+	}
+	dispatchTime := testNow.Add(time.Minute)
+	var claimed ClaimResult
+	var claimObservation ClaimObservation
+	if claimant != "" && qualification == "CONFIRMED" {
+		claimed = createClaim(context.Background(), campaign, finding, claimant, defaultClaimLease,
+			remote, testTarget, "", func() time.Time { return testNow })
+		require.Equal(t, "CLAIMED", claimed.Status, claimed.Reason)
+		claimObservation = observationFromClaim(&observedClaim{
+			Record: *claimed.Claim, SHA: claimed.ClaimSHA, Ref: claimed.RemoteRef,
+		}, claimant)
+	} else {
+		claimObservation = emptyClaimObservation(campaign.AuditID, finding.ID, "FRESH")
+		if qualification != "CONFIRMED" {
+			claimObservation.State = "NON_CLAIMABLE"
+		}
+	}
+	jira := JiraObservation{Status: "UNBOUND", BindingBasis: "AI_AUDIT_MARKER", Issues: []JiraIssue{}}
+	if withJira {
+		jira.Status = "BOUND"
+		jira.Issues = []JiraIssue{{Key: "EN-42", URL: "https://jira.example/EN-42", Status: "Open"}}
+	}
+	campaignPath := filepath.Join(t.TempDir(), "campaign.json")
+	require.NoError(t, writeCampaign(campaignPath, campaign))
+
+	return dispatchFixture{
+		remote: remote, repo: repo, campaign: campaign, finding: finding, evidence: evidence, claim: claimed,
+		observed: InspectionFinding{
+			ID: finding.ID, Qualification: qualification, Dispatchable: qualification == "CONFIRMED",
+			Freshness: "FRESH", Jira: jira, PR: PRObservation{Status: "UNBOUND", Matches: []PRMatch{}},
+			Claim: claimObservation, ObservedTargetSHA: targetSHA,
+		},
+		options: dispatchOptions{
+			repository: "formancehq/ledger", remote: "origin", target: testTarget, claimant: claimant,
+			workflow: workflow, repoRoot: repo, campaignPath: campaignPath,
+			worktreePath: filepath.Join(t.TempDir(), "worktree"), workItemPath: filepath.Join(t.TempDir(), "work.json"),
+		},
+		dispatchTime: dispatchTime,
+	}
+}
+
+func runFixtureDispatch(fixture dispatchFixture) DispatchResult {
+	return dispatchFinding(context.Background(), fixture.campaign, fixture.finding, fixture.observed,
+		fixture.evidence, fixture.options, func() time.Time { return fixture.dispatchTime })
+}
+
+func observationFromClaim(claim *observedClaim, claimant string) ClaimObservation {
+	return ClaimObservation{
+		State: "CLAIMED", Claimant: claim.Record.Claimant, CreatedAt: &claim.Record.CreatedAt,
+		ExpiresAt: &claim.Record.ExpiresAt, RemoteRef: claim.Ref, WorkBranch: claim.Record.WorkBranch,
+		WorkIdentity: claim.Record.WorkIdentity, InitialWorkSHA: claim.Record.InitialWorkSHA,
+		TargetBaseSHA: claim.Record.TargetBaseSHA, Workflow: claim.Record.Workflow, JiraKey: claim.Record.JiraKey,
+		DispatchedAt: claim.Record.DispatchedAt, ObservedClaimSHA: claim.SHA, Freshness: "FRESH",
+		OwnedBySession: claim.Record.Claimant == claimant,
+	}
+}
+
+func readRemoteClaim(t *testing.T, remote, ref string) *observedClaim {
+	t.Helper()
+	repository, err := openClaimRepository(context.Background(), remote)
+	require.NoError(t, err)
+	t.Cleanup(repository.close)
+	sha := remoteRefSHA(t, remote, ref)
+	require.NotEmpty(t, sha)
+	claim, err := repository.readClaim(context.Background(), ref, sha)
+	require.NoError(t, err)
+
+	return claim
+}
+
+func claimParent(t *testing.T, remote, sha string) string {
+	t.Helper()
+
+	return strings.TrimSpace(runGit(t, "", "--git-dir", remote, "show", "-s", "--format=%P", sha))
+}

--- a/scripts/aicampaign/external.go
+++ b/scripts/aicampaign/external.go
@@ -125,6 +125,22 @@ func searchPullRequests(ctx context.Context, repository, query string) ([]github
 	return pullRequests, nil
 }
 
+func findCampaignWorkPRs(ctx context.Context, repository, marker string) ([]PRMatch, error) {
+	pullRequests, err := searchPullRequests(ctx, repository, marker)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]PRMatch, 0, len(pullRequests))
+	for _, pullRequest := range pullRequests {
+		if exactLine(pullRequest.Body, marker) {
+			matches = append(matches, pullRequest.toMatch("AI_CAMPAIGN_WORK_MARKER"))
+		}
+	}
+	slices.SortFunc(matches, func(left, right PRMatch) int { return left.Number - right.Number })
+
+	return matches, nil
+}
+
 func (pullRequest githubPR) toMatch(bindingBasis string) PRMatch {
 	return PRMatch{
 		Number:          pullRequest.Number,

--- a/scripts/aicampaign/inspect.go
+++ b/scripts/aicampaign/inspect.go
@@ -423,18 +423,32 @@ func projectFinding(
 		projection.Blockers = append(projection.Blockers, "TARGET_SHA_UNKNOWN")
 		projection.NextAction = "REFRESH_REQUIRED"
 	case targetSHA != "" && targetSHA != auditedSHA:
-		projection.State = "BLOCKED"
+		if claim.WorkIdentity != "" {
+			projection.State = "STALE_AT_DISPATCH"
+			projection.NextAction = "BASE_UPDATE_REQUIRED"
+		} else {
+			projection.State = "BLOCKED"
+			projection.NextAction = "REQUALIFY_ON_CURRENT_TARGET"
+		}
 		projection.Blockers = append(projection.Blockers, "TARGET_ADVANCED")
-		projection.NextAction = "REQUALIFY_ON_CURRENT_TARGET"
 	case claim.State == "CLAIM_EXPIRED":
 		projection.State = "CLAIM_EXPIRED"
 		projection.NextAction = "REVIEW_EXPIRED_CLAIM"
 	case claim.State == "CLAIMED":
-		projection.State = "CLAIMED"
-		if claim.OwnedBySession {
-			projection.NextAction = "CONTINUE_CLAIMED_WORK"
+		if claim.WorkIdentity != "" {
+			projection.State = "DISPATCHED"
+			if claim.OwnedBySession {
+				projection.NextAction = "START_ENGINEERING_AGENT"
+			} else {
+				projection.NextAction = "WAIT_OR_COORDINATE"
+			}
 		} else {
-			projection.NextAction = "WAIT_OR_COORDINATE"
+			projection.State = "CLAIMED"
+			if claim.OwnedBySession {
+				projection.NextAction = "DISPATCH"
+			} else {
+				projection.NextAction = "WAIT_OR_COORDINATE"
+			}
 		}
 	case len(jira.Issues) == 1:
 		projection.State = "TRACKED"

--- a/scripts/aicampaign/main.go
+++ b/scripts/aicampaign/main.go
@@ -46,6 +46,8 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		return runRelease(arguments[1:], stdout, stderr)
 	case "takeover":
 		return runTakeover(arguments[1:], stdout, stderr)
+	case "dispatch":
+		return runDispatch(arguments[1:], stdout, stderr)
 	default:
 		if err := usage(stderr); err != nil {
 			return err
@@ -308,6 +310,7 @@ func usage(destination io.Writer) error {
   scripts/ai-campaign renew <campaign> --finding <id> --claimant <id>
   scripts/ai-campaign release <campaign> --finding <id> --claimant <id>
   scripts/ai-campaign takeover <campaign> --finding <id> [--claimant <id>]
+  scripts/ai-campaign dispatch <campaign> --finding <id> --audit <source-audit> --qualified <qualified-result> [--workflow <classification>]
 
 Human summaries are written to stderr; stable JSON is written to stdout.
 `)

--- a/scripts/aicampaign/model.go
+++ b/scripts/aicampaign/model.go
@@ -18,22 +18,29 @@ const (
 	inspectionSchemaVersion = "ai-campaign-inspection/v2"
 	nextSchemaVersion       = "ai-campaign-next/v2"
 	claimSchemaVersion      = "ai-claim/v1"
+	workSchemaVersion       = "ai-campaign-work/v1"
+	dispatchSchemaVersion   = "ai-campaign-dispatch-result/v1"
 	sourceFactType          = "SOURCE_FACT"
 	observationFactType     = "DERIVED_OBSERVATION"
 )
 
 var (
-	auditIDPattern     = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
-	findingIDPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*/[a-z0-9]+(?:-[a-z0-9]+)*$`)
-	shaPattern         = regexp.MustCompile(`^[0-9a-f]{40,64}$`)
-	digestPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-	jiraKeyPattern     = regexp.MustCompile(`^[A-Z][A-Z0-9_]*-[1-9][0-9]*$`)
-	jiraProjectPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
-	githubRepoPattern  = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
-	gitRemotePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
-	claimantPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._@:/+#=-]{2,159}$`)
-	campaignIDPattern  = regexp.MustCompile(`^campaign-[0-9a-f]{64}$`)
+	auditIDPattern      = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	findingIDPattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*/[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	shaPattern          = regexp.MustCompile(`^[0-9a-f]{40,64}$`)
+	digestPattern       = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	jiraKeyPattern      = regexp.MustCompile(`^[A-Z][A-Z0-9_]*-[1-9][0-9]*$`)
+	jiraProjectPattern  = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	githubRepoPattern   = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	gitRemotePattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+	claimantPattern     = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._@:/+#=-]{2,159}$`)
+	campaignIDPattern   = regexp.MustCompile(`^campaign-[0-9a-f]{64}$`)
+	workIdentityPattern = regexp.MustCompile(`^work-[0-9a-f]{64}$`)
 )
+
+func validWorkflow(value string) bool {
+	return slices.Contains([]string{"BUGFIX", "TEST_GAP", "TOOLING_FIX", "DOCUMENTATION"}, value)
+}
 
 type Campaign struct {
 	SchemaVersion string          `json:"schemaVersion"`
@@ -209,6 +216,12 @@ type ClaimObservation struct {
 	ExpiresAt        *time.Time `json:"expiresAt"`
 	RemoteRef        string     `json:"remoteRef"`
 	WorkBranch       string     `json:"workBranch"`
+	WorkIdentity     string     `json:"workIdentity"`
+	InitialWorkSHA   string     `json:"initialWorkSha"`
+	TargetBaseSHA    string     `json:"targetBaseSha"`
+	Workflow         string     `json:"workflowClassification"`
+	JiraKey          string     `json:"jiraKey"`
+	DispatchedAt     *time.Time `json:"dispatchedAt"`
 	ObservedClaimSHA string     `json:"observedClaimSha"`
 	Freshness        string     `json:"freshness"`
 	OwnedBySession   bool       `json:"ownedBySession"`
@@ -383,6 +396,10 @@ func validateClaimObservation(observation ClaimObservation) error {
 			return errors.New("incomplete claim")
 		}
 	}
+	if err := validateDispatchBinding(observation.WorkIdentity, observation.WorkBranch, observation.InitialWorkSHA,
+		observation.TargetBaseSHA, observation.Workflow, observation.JiraKey, observation.DispatchedAt); err != nil {
+		return fmt.Errorf("invalid dispatch binding: %w", err)
+	}
 	if observation.OwnedBySession && observation.State != "CLAIMED" && observation.State != "CLAIM_EXPIRED" &&
 		observation.State != "BROKEN_BINDING" {
 		return errors.New("invalid current-session ownership")
@@ -418,7 +435,8 @@ func validatePRObservation(observation PRObservation) error {
 	}
 	seen := map[int]struct{}{}
 	for _, match := range observation.Matches {
-		if match.Number <= 0 || match.BindingBasis != "AI_AUDIT_MARKER" && match.BindingBasis != "JIRA_KEY" ||
+		if match.Number <= 0 || match.BindingBasis != "AI_AUDIT_MARKER" && match.BindingBasis != "JIRA_KEY" &&
+			match.BindingBasis != "AI_CAMPAIGN_WORK_MARKER" ||
 			observation.BindingBasis != match.BindingBasis || match.HeadRef == "" || match.BaseRef == "" ||
 			(match.HeadSHA != "" && !shaPattern.MatchString(match.HeadSHA)) ||
 			(match.BaseSHA != "" && !shaPattern.MatchString(match.BaseSHA)) {
@@ -471,12 +489,14 @@ func validState(value string) bool {
 	return slices.Contains([]string{
 		"CONFIRMED_UNASSIGNED", "TRACKED", "PR_OPEN", "PR_CLOSED", "MERGED", "BLOCKED",
 		"SUPERSEDED", "AMBIGUOUS", "BROKEN_BINDING", "NON_DISPATCHABLE", "CLAIMED", "CLAIM_EXPIRED",
+		"DISPATCHED", "STALE_AT_DISPATCH",
 	}, value)
 }
 
 func validNextAction(value string) bool {
 	return slices.Contains([]string{
-		"CLAIM", "CONTINUE_CLAIMED_WORK", "WAIT_OR_COORDINATE", "REVIEW_EXPIRED_CLAIM", "CONTINUE_PR", "VERIFY_RESOLUTION",
+		"CLAIM", "DISPATCH", "RESUME_DISPATCH", "START_ENGINEERING_AGENT", "CONTINUE_WORK", "BASE_UPDATE_REQUIRED",
+		"CONTINUE_CLAIMED_WORK", "WAIT_OR_COORDINATE", "REVIEW_EXPIRED_CLAIM", "CONTINUE_PR", "VERIFY_RESOLUTION",
 		"NO_ACTION", "HUMAN_DECISION_REQUIRED", "RESOLVE_BINDING", "REFRESH_REQUIRED", "REPAIR_BINDING",
 		"REVIEW_CLOSED_PR", "REQUALIFY_ON_CURRENT_TARGET",
 	}, value)

--- a/scripts/aicampaign/renew_command.go
+++ b/scripts/aicampaign/renew_command.go
@@ -111,6 +111,12 @@ func renewClaim(
 		return result
 	}
 	record := observed.Record
+	if record.DispatchedAt != nil && workBranch != "" && workBranch != record.WorkBranch {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "a dispatched claim's work branch is immutable"
+
+		return result
+	}
 	record.RenewedAt = &renewedAt
 	record.RenewalCount++
 	record.ExpiresAt = renewedAt.Add(lease)

--- a/scripts/aicampaign/takeover_command.go
+++ b/scripts/aicampaign/takeover_command.go
@@ -119,6 +119,12 @@ func takeoverClaim(
 	if workBranch == "" {
 		workBranch = observed.Record.WorkBranch
 	}
+	if observed.Record.DispatchedAt != nil && workBranch != observed.Record.WorkBranch {
+		result.Status = "CLAIM_CONFLICT"
+		result.Reason = "a dispatched claim's work branch is immutable"
+
+		return result
+	}
 	record := ClaimRecord{
 		SchemaVersion: claimSchemaVersion, CampaignID: campaign.CampaignID, AuditID: campaign.AuditID,
 		FindingID: finding.ID, FindingIdentityDigest: finding.IdentityDigest,
@@ -126,6 +132,9 @@ func takeoverClaim(
 		Qualification: finding.Qualification, Claimant: claimant, CreatedAt: createdAt,
 		ExpiresAt: createdAt.Add(lease), TargetBranch: observed.Record.TargetBranch,
 		TargetSHA: observed.Record.TargetSHA, WorkBranch: workBranch,
+		WorkIdentity: observed.Record.WorkIdentity, InitialWorkSHA: observed.Record.InitialWorkSHA,
+		TargetBaseSHA: observed.Record.TargetBaseSHA, Workflow: observed.Record.Workflow,
+		JiraKey: observed.Record.JiraKey, DispatchedAt: observed.Record.DispatchedAt,
 		Predecessor: &ClaimPredecessor{
 			ClaimSHA: observedSHA, Claimant: observed.Record.Claimant,
 			CreatedAt: observed.Record.CreatedAt, ExpiresAt: observed.Record.ExpiresAt, Reason: "EXPIRED_TAKEOVER",


### PR DESCRIPTION
## What changed

Adds `ai-campaign dispatch` to bind an owned confirmed finding to a deterministic work identity, exact-base branch, isolated worktree, immutable claim lineage, and reconstructable `ai-campaign-work/v1` artifact.
Extends inspect/next projection, exact PR-marker discovery, claim renewal/takeover preservation, crash recovery, and adversarial bare-remote coverage.
Dispatch does not create Jira issues or PRs, invoke an engineering agent, implement a finding, decide readiness, or merge.

## Why

Atomic claims coordinate ownership but do not provide a durable, recoverable engineering-work binding. Starting or resuming confirmed-finding work currently depends on conversation context and manual branch/worktree reconstruction.

## Product / operational motivation

Need: A confirmed finding with an owned live claim can be handed to an engineering agent deterministically and recovered after session loss.
Current limitation: Campaign state stops at claim ownership; branch, worktree, Jira, provenance, and future PR identity are not durably bound as one exact work item.
Requirement / constraint: Dispatch must fail closed on stale, ambiguous, expired, conflicting, or raced state; create no product fix; and preserve exact campaign/claim/base/branch identity through remote CAS.
Evidence: Campaign orchestration milestone `CONFIRMED_FINDING_DISPATCH_AND_BINDING`; adversarial tests in `scripts/aicampaign/dispatch_test.go`.
Durable repository evidence: `docs/technical/contributing/ai-campaign.md`, `docs/technical/contributing/ai-audit-jira.md`, and `scripts/ai-campaign-work.schema.json`.

## Technical decision

Decision: Derive a digest-backed work identity from campaign/finding/qualified-result/Jira identity; create the exact remote work branch with an empty-value lease; attach an isolated worktree; then append the binding to the existing claim through exact CAS and write a reconstructable local artifact.
Why now / why proportionate: The preceding campaign schema, freshness, adoption, and atomic-claim milestones now provide the authoritative inputs needed for deterministic dispatch without expanding into engineering or readiness automation.
Alternatives considered: Conversation-only handoff is not recoverable; branch-name-only binding is ambiguous; automatic Jira/PR/agent invocation would cross explicit authorization and workflow boundaries; replacing the claim backend would duplicate established CAS semantics.

## Risk

**MEDIUM** — this changes distributed orchestration and claim schemas, but not Ledger runtime/product behavior. Exact-CAS transitions, empty-value branch leases, fail-closed classifications, and bare-remote race/crash tests bound the risk.

## Validation

- [x] `bash scripts/agent-check`
- [x] Pinned Nix Go 1.26.5: `go test ./scripts/aicampaign -count=1`
- [x] Pinned Nix Go 1.26.5 race tests for concurrent dispatch/claim/renew
- [x] `go test ./scripts/... -count=1` during candidate validation
- [x] Dispatch, claim concurrency, worktree/branch, PR-marker, crash recovery, idempotency, stale-base, and local bare-remote integration tests
- [x] Mutation challenge: disabling the existing-PR stop made the duplicate-dispatch regression fail; restored implementation passed
- [x] Trusted pre-commit normalization reached a byte-identical fixpoint

The requirement is satisfied when one owned live confirmed finding yields at most one exact branch/claim binding and another clean session can reconstruct the work item without duplicate Jira, branch, worktree, claim, or PR creation.

## Architecture / behavior impact

Tooling only. Extends unreleased `ai-claim/v1` and campaign observation schemas with immutable dispatch binding fields and adds local `ai-campaign-work/v1`. No product storage, API, protobuf, FSM, checker, or compatibility behavior changes.

## Review focus

Please focus on CAS transition invariants, last-mile target/PR races, worktree isolation, idempotent crash recovery, and whether structured stop classifications fail closed.

## Known concerns

None. Automatic PR creation/publication, resume/event journal, composite readiness, structured failure envelopes, terminal claim cleanup, and multi-finding scheduling remain intentionally deferred.
