### PR TITLE
docs(consensus): clarify partition safety and read guarantees

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -80,18 +80,38 @@ repeated on every invocation.
 
 ### Read Consistency
 
-By default, all read operations use **linearizable** consistency: the node performs a ReadIndex barrier to ensure it has applied all committed entries before reading from the local store. This guarantees that reads always reflect the latest committed state, but it can block during maintenance windows (e.g. mirror sync, snapshot creation) when the FSM is frozen.
+Most live business reads default to **linearizable** consistency: reads routed
+through `RoutedController.readCtrl` perform a ReadIndex barrier before reading
+from the local store. This establishes a quorum-confirmed applied-state horizon
+for FSM-backed data and secondary indexes aligned to that horizon. It does not
+make independently asynchronous projections linearizable; endpoint sections
+document those exceptions. The barrier can block during maintenance windows
+(e.g. mirror sync or snapshot creation) when the FSM is frozen.
 
 Two alternative consistency levels are available:
 
-- **`stale`** — Skip the ReadIndex barrier and read directly from the local store. Data may lag behind the latest committed index, but reads never block. Useful for monitoring, dashboards, and non-critical queries.
-- **`leader`** — Forward the read to the leader node. The leader always has the most up-to-date data and its ReadIndex barrier is fast (no round-trip needed). Useful when you need fresh data but the local node may be lagging.
+- **`stale`** — Skip the Raft ReadIndex barrier and read from local state, which
+  may lag behind the latest committed index. A read can still wait for an
+  explicitly requested `--min-log-sequence` or for mandatory secondary-index
+  alignment. Useful for monitoring, dashboards, and non-critical queries where
+  quorum-confirmed freshness is unnecessary.
+- **`leader`** — Route the read to the node currently considered leader. When
+  the request is forwarded, the remote node applies its default ReadIndex
+  barrier. When the receiving node already considers itself leader, it serves
+  the read locally without a barrier. Because `CheckQuorum` is disabled, an
+  isolated former leader can therefore return stale state in this mode; use the
+  default `linearizable` mode when quorum-confirmed freshness is required.
+
+`chapters list` is leader-routed independently of this selector and does not
+perform a ReadIndex barrier. If it reaches an isolated node that still considers
+itself leader, it can return stale chapter rows. Filtered `audit list` also has
+an endpoint-specific asynchronous-index caveat; see its consistency note below.
 
 ```bash
-# Stale read (instant, may lag)
+# Stale read (no Raft barrier; may lag)
 ledgerctl --consistency stale ledgers get my-ledger
 
-# Leader read (fresh, forwarded to leader)
+# Leader-routed read (may be stale from an isolated former leader)
 ledgerctl --consistency leader ledgers list
 
 # Default linearizable read
@@ -419,7 +439,18 @@ ledgerctl ledgers promote
 
 #### ledgers stats
 
-Get aggregate statistics (account count, transaction count) for a ledger.
+Get FSM-backed transaction/log counts and asynchronous usage counters for a
+ledger.
+
+On a default live read, `transactionCount` and `logCount` come from FSM-backed
+ledger boundaries and share the request's applied-state horizon. Other
+consistency modes follow the global contract above. `postingCount`, `revertCount`,
+`numscriptExecutionCount`, `referenceCount`, `ephemeralEvictedCount`,
+`transientUsedCount`, and `volumeCount` come from the per-node asynchronous
+usagestore projection. Those seven fields can lag committed state even after a
+default ReadIndex barrier; they are a mutually consistent usagestore snapshot,
+not a projection aligned to the barrier. See the
+[usagebuilder pipeline](../technical/architecture/subsystems/usage/usagebuilder.md).
 
 **Aliases:** `st`
 
@@ -2328,20 +2359,25 @@ reads first-class with every other list endpoint while never degrading to a
 full-chain scan.
 
 > **Consistency note.** The audit secondary index is maintained by an
-> asynchronous per-node worker, so any *filtered* audit read (including an
-> `ledger` or `outcome` filter) is eventually consistent — a
-> just-applied entry may take up to ~200 ms to appear. `--min-log-sequence`
-> gates the read-side log index, not the audit index. An *unfiltered* read
-> (plain `audit list`, optionally with `--reverse` / `seq` bounds) reads
-> the audit zone directly and is strongly consistent.
+> asynchronous per-node worker, so a filter that contains any field other than
+> `seq` (for example `ledger` or `outcome`) is eventually consistent when
+> `--min-log-sequence` is zero. With a non-zero bound, every node that receives
+> or forwards the live request first waits for its log index to reach that
+> sequence, samples its live audit head, and waits for its own audit index to
+> reach that head. This preserves the bound when the request is routed to
+> another node. An unfiltered live read, or a conjunction made only of `seq`
+> bounds, scans the audit zone directly. With a non-zero bound, every gRPC node
+> traversed by the routed request waits for its own log-index progress before
+> routing or serving, but does not wait for audit-index progress.
 >
-> **Checkpoint + filter caveat.** A query checkpoint snapshots the audit index
+> **Checkpoint + indexed-filter caveat.** A query checkpoint snapshots the audit index
 > at creation time; checkpoint creation waits for the log index but not yet for
-> the audit indexer, so a *filtered* read against `--checkpoint-id` may omit
-> entries whose audit-zone rows exist in the checkpoint but were not indexed
-> when it was taken (a frozen checkpoint never catches up). Unfiltered checkpoint
-> reads scan the zone directly and are unaffected. Making the audit indexer catch
-> up before the checkpoint snapshot is a tracked follow-up.
+> the audit indexer, so a read whose filter contains a field other than `seq`
+> may omit entries whose audit-zone rows exist in the checkpoint but were not
+> indexed when it was taken (a frozen checkpoint never catches up). Unfiltered
+> and `seq`-only checkpoint reads scan the zone directly and are unaffected.
+> Making the audit indexer catch up before the checkpoint snapshot is a tracked
+> follow-up.
 
 **Behavior:**
 - Streams audit entries from the server, oldest first by default / chronological (`--reverse` for newest first)
@@ -4087,7 +4123,17 @@ ledger run --read-index-dir /ssd/read-indexes [other flags...]
 ledger run --read-index-cache-size 128Mi [other flags...]
 ```
 
-The index builder runs on ALL nodes (not just the leader), so follower nodes can also serve prepared query reads. Listings are eventually consistent (the read index may lag behind the latest Raft commits).
+The index builder runs on ALL nodes (not just the leader), so follower nodes can
+also serve prepared-query and indexed-list reads. The builder itself is
+asynchronous. A live query waits for its read-index snapshot to cover the
+request's pinned main-store horizon only when it actually consults an index
+leaf: filtered account/transaction lists, every log list, and prepared queries
+with a non-nil filter or a LOGS target. Unfiltered account/transaction lists and
+matching unfiltered prepared queries use one main-store handle without an index
+catch-up wait; point reads do not use the read index. Frozen checkpoint pairs do
+not catch up, while `stale` skips only the Raft barrier and can still wait for
+alignment on an indexed shape. The separately maintained audit index has the
+filtered-read contract documented under `audit list`.
 
 Offline read-index rebuild is not available in Ledger v3.0. A generic projection-rebuild mechanism is planned for a later release.
 

--- a/docs/technical/architecture/data-flows.md
+++ b/docs/technical/architecture/data-flows.md
@@ -548,11 +548,18 @@ config:
 - Larger margins use more disk but allow slower followers to catch up
 - Smaller margins save disk but may force more snapshot transfers
 
-## Request Forwarding (Writes Only)
+## Request Forwarding
 
 ### Overview
 
-Only **write requests** (`Apply`) and **`ListChapters`** are forwarded to the leader. All other reads use the ReadIndex mechanism (see below).
+**Write requests** (`Apply`) and **`ListChapters`** are always routed to the
+node currently considered leader. `ListChapters` bypasses the normal read
+consistency selector and does not perform a ReadIndex barrier; a node that still
+considers itself leader serves its persisted chapter rows locally. Other live
+reads normally use the ReadIndex mechanism (see below), but callers can
+explicitly select `x-consistency: leader`. That mode also routes the read to the
+perceived leader; if the receiving node already considers itself leader, the
+local shortcut does not perform a ReadIndex barrier.
 
 ### Forwarding Flow
 
@@ -594,7 +601,12 @@ If the leader is not available:
 
 ### Overview
 
-All read operations use the Raft **ReadIndex** mechanism to provide linearizable reads on any node (leader or follower) without forwarding to the leader. This distributes read load across the cluster while guaranteeing consistency.
+Live reads routed through `RoutedController.readCtrl` in the default consistency
+mode use the Raft **ReadIndex** mechanism. For FSM-backed data and secondary
+indexes aligned to the applied-state horizon, this provides linearizable reads
+on any quorum-connected node without forwarding data to the leader. Explicit
+consistency modes and endpoint-specific paths are documented under
+[consensus exceptions](subsystems/consensus/raft-consensus.md#linearizable-reads-via-readindex).
 
 ### ReadIndex Flow
 
@@ -629,9 +641,12 @@ sequenceDiagram
 
 ### Key Properties
 
-- **Linearizable**: The read reflects all writes committed before the ReadIndex call
+- **Linearizable for aligned state**: The read reflects all writes committed
+  before the ReadIndex call when its serving data and indexes share the applied
+  horizon
 - **Distributed**: Any node can serve reads, not just the leader
-- **Efficient**: No data forwarding via gRPC, only a lightweight heartbeat round-trip
+- **Efficient normal path**: No data forwarding via gRPC, only a lightweight
+  heartbeat round-trip
 - **Context-aware**: Respects deadlines and cancellation throughout
 
 ## Bulk Operations

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -653,8 +653,13 @@ List audit trail entries (success and failure):
 
 ```go
 stream, err := client.ListAuditEntries(ctx, &servicepb.ListAuditEntriesRequest{
-    Ledger:       "my-ledger",      // Optional: filter by ledger
-    FailuresOnly: true,              // Optional: only failures
+	Options: &commonpb.ListOptions{
+		PageSize: 100,
+		Filter: auditFilter, // Bare audit fields, e.g. ledger/outcome.
+		Read: &commonpb.ReadOptions{
+			MinLogSequence: lastWrittenSequence,
+		},
+	},
 })
 if err != nil {
     return err
@@ -671,6 +676,14 @@ for {
     fmt.Printf("Audit #%d: proposal=%d\n", entry.Sequence, entry.ProposalId)
 }
 ```
+
+For a live request whose filter contains any field other than `seq`, a non-zero
+`MinLogSequence` makes every gRPC node that receives or serves the routed
+request wait for its log index to reach the bound and for its local audit index
+to reach the live audit head sampled afterward. With a zero bound, those
+index-backed results are best-effort. Unfiltered and `seq`-only conjunctions
+scan the audit zone directly and need only the log-sequence wait. Checkpoint
+reads ignore the bound.
 
 ## Store Metrics
 

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -401,9 +401,12 @@ Query parameters:
   to the audit condition only on the audit target, which is why audit fields are
   valid on this endpoint alone. This is the shared `filterexpr` DSL — **not** the
   JSON `QueryFilter` DSL used by prepared queries, which cannot represent audit
-  conditions. Filtered reads are served by
-  the asynchronous audit index; the consistency guarantee matches the gRPC
-  surface.
+  conditions. A filter containing any field other than `seq` is served by the
+  asynchronous audit index; unfiltered and `seq`-only conjunctions scan the
+  audit zone directly. This HTTP endpoint exposes no `minLogSequence` bound, so
+  index-backed reads are best-effort and may omit entries not yet indexed; gRPC
+  callers can request a consistency-bound wait that is preserved across routing
+  hops.
 
 **Response**: `{ "data": [ AuditEntry, ... ] }` (list omits per-order `items`).
 

--- a/docs/technical/architecture/subsystems/consensus/README.md
+++ b/docs/technical/architecture/subsystems/consensus/README.md
@@ -6,7 +6,7 @@ The replication and ordering layer (`internal/infra/node`, `internal/infra/trans
 
 | Document | Description |
 |----------|-------------|
-| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, leader election, retained-log catch-up, and snapshot transfer. |
+| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, and snapshot transfer. |
 | [global-log.md](global-log.md) | Two-level log architecture enabling system-level atomic bulk operations. |
 | [hybrid-logical-clock.md](hybrid-logical-clock.md) | Monotonic HLC timestamps across leader changes and clock skew. |
 | [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted. |

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -27,7 +27,6 @@ stateDiagram-v2
     Candidate --> Leader: Majority Votes
     Candidate --> Follower: Another Leader Elected
     Leader --> Follower: Higher Term Detected
-    Leader --> Follower: Network Partition
 ```
 
 ## Single Raft Architecture
@@ -251,9 +250,107 @@ If two nodes become candidates simultaneously, neither can obtain a majority. Th
 
 ### Consistency Guarantees
 
-- **Linearizability**: All operations are seen in the same order by all nodes
+- **Linearizability**: Committed mutations are seen in the same order by all
+  nodes; default live reads routed through `RoutedController.readCtrl` use the
+  quorum-backed `ReadIndex` barrier described below
 - **Durability**: Once committed, an entry is guaranteed to be persisted
 - **Consistency**: All nodes see the same data once synchronized
+
+## Safety and Availability During Partitions
+
+Under normal Raft consensus operations, Ledger v3 is **CP rather than AP** in
+the CAP sense. During a network partition, only a partition containing a
+majority of the configured voters can elect a leader, commit writes, or
+complete the quorum barrier required by a default live read routed through
+`RoutedController.readCtrl`. A minority partition does not accept a divergent
+committed history; requests that require consensus wait or fail instead.
+Availability is therefore preserved on the majority side and deliberately
+sacrificed on every side that cannot form a quorum. Endpoint-specific reads
+that bypass that controller path are exceptions described below.
+
+The emergency [`remove-node --force`](../../../../ops/cluster-operations.md#force-removing-a-down-node)
+path is deliberately outside that guarantee: it changes one node's membership
+locally without consensus. Use it only when every removed member is permanently
+unreachable and its old state cannot run or rejoin. If an isolated former
+leader force-removes voters that remain live, the reduced local configuration
+and the original majority can both commit, creating divergent histories.
+
+For normal consensus operations, the guarantee applies to committed state,
+which is the boundary visible to a successful write response. A request that
+times out while consensus is being lost has an unknown outcome from the
+client's perspective. Retrying without duplication is safe only when the
+original request carried an idempotency key, the retry uses the same key and
+content, and the key has not passed its configured TTL (`0` means no
+expiration). Without those preconditions, a retry is a new operation and may
+duplicate the original; the client must determine the original outcome before
+resubmitting. See [Idempotency Keys](../admission/idempotency.md).
+
+### Why a Partition Cannot Commit Two Histories
+
+A voter grants at most one vote per term, a candidate needs a majority to
+become leader, and a log entry needs majority replication to commit. Any two
+majorities intersect in at least one voter. Raft's voting and log-matching rules
+therefore prevent two conflicting entries at the same log position from both
+becoming committed, even if nodes on different sides of a partition temporarily
+disagree about who the leader is.
+
+Ledger v3 enables Raft `PreVote` but does not enable `CheckQuorum`. Consequently,
+an isolated former leader may continue to report its local role as leader until
+it hears from a higher term. It still cannot commit or acknowledge new writes,
+and a `ReadOnlySafe` `ReadIndex` cannot complete without quorum confirmation.
+That temporary role disagreement is not a split brain at the committed-state
+level. Explicit `stale` reads intentionally bypass the quorum barrier and may
+return an older local view. An explicit `leader` read can do the same when it
+reaches a node that still considers itself leader: the local-leader routing
+shortcut serves local state without `ReadIndex`. Neither mode should be used
+when quorum-confirmed freshness is required during a partition.
+
+### Quorum and Failure Tolerance
+
+For `N` voters, quorum is `floor(N/2) + 1` and the cluster tolerates at most
+`floor((N-1)/2)` unavailable voters while continuing to write:
+
+| Voters | Quorum | Unavailable voters tolerated |
+|--------|--------|------------------------------|
+| 1 | 1 | 0 |
+| 2 | 2 | 0 |
+| 3 | 2 | 1 |
+| 4 | 3 | 1 |
+| 5 | 3 | 2 |
+
+An odd voter count is recommended because adding a voter to move from an odd to
+the next even number does not increase failure tolerance. A two-voter cluster
+does not create split brain; it simply loses write availability as soon as
+either voter is unavailable.
+
+Learners replicate the log but do not vote and cannot become leader. Nodes join
+as learners and, by default, are promoted automatically once caught up. A
+topology with one voter and two permanent learners can be maintained only by
+disabling automatic promotion; it has a fixed writer in practice, but no write
+availability after that voter fails. The normal three-node steady state is one
+leader plus two follower voters, any caught-up voter being eligible to replace
+the leader after a failure.
+
+### Implementation Evidence
+
+- The independent protocol references are the
+  [Raft paper](https://raft.github.io/raft.pdf), which defines election safety,
+  leader completeness, and state-machine safety, and its
+  [TLA+ specification](https://github.com/ongardie/raft.tla).
+- Ledger v3 uses [`go.etcd.io/raft/v3`](https://github.com/etcd-io/raft/tree/v3.7.0),
+  with its safety properties and deterministic state-machine contract described
+  in the [library README](https://github.com/etcd-io/raft/blob/v3.7.0/README.md).
+- The [routed controller](../../../../../internal/bootstrap/controller_routed.go)
+  sends writes to the current leader. The
+  [Raft node configuration](../../../../../internal/infra/node/node.go) enables
+  `PreVote` and leaves `CheckQuorum` disabled.
+- Default live reads routed through `RoutedController.readCtrl` use
+  `ReadOnlySafe` `ReadIndex`, wait for the returned commit index to be applied
+  locally, and only then read Pebble. See
+  [Linearizable Reads via ReadIndex](#linearizable-reads-via-readindex).
+- Cluster bootstrap, learner registration, automatic voter promotion, and the
+  safeguards preventing a syncing node from becoming leader are detailed in
+  [Cluster Lifecycle](../../../../ops/cluster-operations.md).
 
 ## Snapshots
 
@@ -418,9 +515,12 @@ See [Follower Synchronization](../../data-flows.md#follower-synchronization) for
 #### Network Partition
 
 If the cluster is partitioned:
-- The partition with the majority continues to function
-- The minority partition cannot elect a leader
+- Under normal consensus membership, the partition with the majority continues to function
+- Under normal consensus membership, the minority partition cannot elect a leader
 - When the partition is resolved, nodes synchronize
+
+Emergency force-removal bypasses this model; see
+[Safety and Availability During Partitions](#safety-and-availability-during-partitions).
 
 ### Recovery
 
@@ -446,27 +546,76 @@ The system can pipeline requests:
 
 ### Linearizable Reads via ReadIndex
 
-All reads use the etcd/raft **ReadIndex** mechanism to provide linearizable consistency on every node:
+Default live reads routed through `RoutedController.readCtrl` use the etcd/raft
+**ReadIndex** mechanism to establish a linearizable applied-state horizon on any
+node that can reach a quorum. Reads served directly from the FSM-backed Pebble
+state are linearizable at that horizon; independently asynchronous secondary
+indexes need their own progress barrier:
 
 1. The caller invokes `Node.ReadIndexAndWait(ctx)`.
 2. `ReadIndex` sends a `ReadIndex` request through the Raft orchestrate loop. The leader confirms it is still the leader by exchanging heartbeats with a quorum of peers (the `ReadOnlySafe` mode, which is the default).
 3. The leader responds with the current **commit index** via `rd.ReadStates`.
 4. `WaitForApplied` blocks until the local FSM has applied entries up to that commit index (using a `sync.Cond` that broadcasts after each `lastPersistedIndex.Store()`).
-5. The caller reads from the local Pebble store, which is now guaranteed to reflect all writes committed before the ReadIndex call.
+5. The caller reads from the local Pebble store, which is now guaranteed to
+   reflect all writes committed before the ReadIndex call. This does not by
+   itself advance independently asynchronous secondary indexes.
 
 **Benefits**:
-- **Linearizable reads on all nodes** (leader and followers)
-- **Read load distributed** across the cluster instead of concentrated on the leader
-- **No gRPC forwarding** for reads (lower latency than routing to the leader)
-- **No stale reads** (unlike plain local reads which could return outdated data)
+- **Linearizable reads on leaders, followers, and caught-up learners** that can reach quorum
+- **Read load distributed** across the cluster in the normal local path
+- **No gRPC forwarding in the normal local path** (lower latency than routing to the leader)
+- **No stale FSM-backed results in linearizable mode** for reads whose serving
+  data and indexes are aligned with the applied-state horizon
 
-**Exceptions**:
-- `Apply` (writes) are still forwarded to the leader via gRPC, since writes must go through Raft consensus.
-- `ListChapters` is forwarded to the leader because chapter state is kept in-memory only on the leader.
+**Consistency and routing exceptions**:
+- `x-consistency: stale` bypasses `ReadIndex` and reads the local store directly;
+  it may return an older view.
+- `x-consistency: leader` routes the read to the node currently considered
+  leader. A call forwarded to a remote node does not propagate the consistency
+  metadata, so the remote call defaults to linearizable mode and performs its
+  quorum barrier. However, if the receiving node already considers itself
+  leader, `getLeaderCtrl` returns the local controller directly and skips
+  `ReadIndex`. Because `CheckQuorum` is disabled, an isolated former leader can
+  therefore serve stale local state in this mode.
+- If a non-leader node is syncing or cannot complete its local barrier,
+  `RoutedController` can transparently retry the read against the leader. The
+  forwarded attempt can still fail when the leader is unavailable. If
+  leadership moves local between the failed barrier and leader resolution, the
+  router returns the barrier failure rather than serving the newly local
+  controller without a successful `ReadIndex`.
+- A `ListAuditEntries` filter that contains any field other than `seq` resolves
+  through the independently asynchronous audit index. With the default
+  `minLogSequence = 0`, its handler does not wait for audit-index progress, so
+  it can temporarily omit entries that are already committed even though the
+  ReadIndex barrier completed. A non-zero `minLogSequence` makes each gRPC node
+  that receives the live request wait for that log sequence, sample its live
+  audit head, and wait for its own audit index to reach that head. The bound is
+  propagated when routing selects another node, so the node that actually
+  serves the indexed query repeats the wait against its own independently
+  maintained index. Unfiltered listings and conjunctions made only of `seq`
+  bounds scan the audit zone directly and do not have this secondary-index lag;
+  they still honor a non-zero log-sequence wait. Checkpoint reads ignore the
+  bound, and an index-backed checkpoint filter can retain audit-index lag frozen
+  at checkpoint creation.
+- `GetLedgerStats` has mixed provenance. `transactionCount` and `logCount` are
+  FSM-backed, while `postingCount`, `revertCount`,
+  `numscriptExecutionCount`, `referenceCount`, `ephemeralEvictedCount`,
+  `transientUsedCount`, and `volumeCount` come from the per-replica asynchronous
+  usagestore. `GetTemplateUsage` is entirely usagestore-backed. A completed
+  ReadIndex does not advance either usage projection, so those values may lag;
+  see the [usagebuilder pipeline](../usage/usagebuilder.md).
+- `ListChapters` bypasses `readCtrl` and the consistency selector. It is routed
+  to the node currently considered leader, where it reads persisted chapter
+  rows without a ReadIndex barrier. An isolated former leader can therefore
+  return an older chapter view even for a request using the default consistency
+  setting.
+- `Apply` is a write rather than a read and is always routed to the node
+  currently considered leader; successful completion still requires Raft
+  consensus.
 
 **Fallback during sync**:
 - If the node is still syncing (restoring a snapshot or replaying spool), `ReadIndexAndWait` returns `ErrNodeSyncing`.
-- The `RoutedController` catches this and transparently forwards the read to the leader via gRPC, so the client always gets an answer without having to retry.
+- The `RoutedController` catches this and transparently forwards the read to the leader via gRPC; if the leader cannot be reached, the request returns an error.
 
 **Error handling**:
 - On leadership loss, all pending ReadIndex requests are failed immediately.

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -1,6 +1,15 @@
 # Read Path
 
-The CQRS read side (`internal/application/ctrl` reads, `internal/query`, `internal/storage/readstore`). Default live reads go through a `ReadIndex` quorum check (linearizability barrier). Indexed entity-list reads then iterate over the inverted index in the read store, enriching candidate entity IDs with volumes and metadata from the main store. Point reads and main-store-only queries use the same barrier but their own main-store read path; they do not iterate the inverted index. Explicit stale and checkpoint reads have the exceptions documented in the pipeline pages.
+The CQRS read side (`internal/application/ctrl` reads, `internal/query`,
+`internal/storage/readstore`). Default live reads routed through `readCtrl` use
+a `ReadIndex` quorum barrier to establish an applied-state horizon. Point reads
+and unfiltered account/transaction queries then use the main store only.
+Filtered account/transaction queries and every log query additionally wait for
+the read index to align with that horizon before iterating it. `stale` removes
+only the Raft barrier, checkpoint pairs are already frozen, and leader-local,
+chapter, audit-index, and usagestore exceptions are documented in the
+[consensus matrix](../consensus/raft-consensus.md#linearizable-reads-via-readindex)
+and the pipeline pages.
 
 ## Documents
 

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -71,7 +71,11 @@ A compile error at FSM time is hash-bound as an `AuditFailure`, so a checker run
 
 1. Reads the prepared query via `ReadPreparedQuery` (`internal/query/executor.go:67`).
 2. Verifies the requested mode is compatible with the query's `target` (e.g. `AGGREGATE_VOLUMES` only makes sense for accounts).
-3. Calls the standard pipeline: `ReadIndexAndWait`, Pebble snapshot, `Compile(indexSnap, kb, pq.GetFilter(), ...)`, iterator execution.
+3. Enters the standard read route. Default live consistency establishes a
+   `ReadIndexAndWait` horizon; `stale`, leader-local, and checkpoint reads have
+   the documented exceptions. The executor waits for read-index alignment only
+   when `AlignmentOwed` is true — a non-nil filter or a LOGS target — then calls
+   `Compile(indexSnap, kb, pq.GetFilter(), ...)` and executes the iterator.
 4. For `LIST`, streams the matching entities through the standard cursor pipeline (see [query-pipeline.md](query-pipeline.md)).
 5. For `AGGREGATE_VOLUMES`, loops over the candidate account set and sums per-asset volumes from the main store. The aggregation is **computed at request time** — there is no materialised aggregate table.
 

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -2,9 +2,22 @@
 
 ## Overview
 
-Indexed entity-list reads go through four stages: a **Raft `ReadIndex`** barrier for linearizability, an optional **`min_log_sequence`** wait for read-side freshness, coordinated **Pebble snapshots** for the main and read stores, and a **composable iterator pipeline** over the read store. The result is streamed back through gRPC with cursor-based pagination. Point reads and main-store-only queries use their own single main-store handle and do not enter this indexed-list pipeline. The indexed-list snapshots are aligned but distinct; their per-target consistency exceptions are described below.
+Entity-list reads can pass through four distinct mechanisms: a Raft
+**`ReadIndex`** barrier for default live consistency, an optional
+**`min_log_sequence`** wait for read-side freshness, Pebble snapshots, and a
+composable iterator pipeline. A query waits for cross-store alignment only when
+`query.AlignmentOwed` says its shape actually consults an index leaf: filtered
+account/transaction queries and every log query. Unfiltered account/transaction
+queries use only the main-store handle and do not wait for the read index. Point
+reads likewise use their own main-store path. `stale` skips only the Raft
+barrier, while the leader-local and checkpoint exceptions are described below
+and in the [consensus contract](../consensus/raft-consensus.md#linearizable-reads-via-readindex).
 
-The indexed-list pipeline is deliberately uniform across `ListAccounts`, `ListTransactions`, and `ListLogs`. Point reads such as `GetAccount` and `GetTransaction`, plus main-store-only queries such as `ListLedgers`, use the controller layer but not the read-store iterator algebra. The differences between indexed lists are which read-store prefix is scanned and how iterators are composed.
+The list dispatcher is shared across `ListAccounts`, `ListTransactions`, and
+`ListLogs`, but the selected execution path depends on the query shape. Point
+reads such as `GetAccount` and `GetTransaction`, plus main-store-only queries
+such as `ListLedgers`, use the controller layer but not the read-store iterator
+algebra.
 
 ```mermaid
 sequenceDiagram
@@ -74,13 +87,27 @@ was used.
 1. Call `node.ReadIndex(ctx)` — Raft sends a heartbeat round-trip to confirm quorum and returns the current commit index.
 2. `fsm.WaitForApplied(commitIndex)` — block until the local FSM has applied every entry up to that commit index.
 
-Once both succeed, the local Pebble snapshot reflects state at least as fresh as the moment the request reached the cluster. This guarantees **linearizable reads on any node**: a read started after a successful write returns at least that write's effects, regardless of which node serves the read.
+For a default live request, once both steps succeed the local main-store snapshot
+reflects state at least as fresh as the moment the request reached the cluster.
+FSM-backed results served from that snapshot inherit this linearizable horizon;
+secondary-index results do so only after their separate alignment wait. The
+barrier alone does not advance independently asynchronous projections such as
+the audit index or usagestore.
 
-If the node is syncing or otherwise unable to confirm `ReadIndex`, the call fails — callers either retry or forward to the leader.
+If the node is syncing or otherwise unable to confirm `ReadIndex`, the call
+fails. The router may resolve a remote leader and forward; if leadership moved
+local after the failed barrier, it returns the failure rather than serving the
+local store without a fresh barrier. Explicit `stale` skips this barrier, an
+explicit leader-local read does not perform it, and checkpoint reads use their
+frozen snapshot instead.
 
 ## Freshness — `min_log_sequence`
 
-The client can pass `min_log_sequence` in gRPC metadata to demand a *read-side* freshness guarantee. `ReadIndex` only guarantees the **FSM** has caught up; `min_log_sequence` additionally waits for the **read store** to have indexed up to that log sequence.
+The client can pass `min_log_sequence` in the request's `ReadOptions` to demand
+a *read-side* freshness guarantee. `ReadIndex` only guarantees the **FSM** has
+caught up; `min_log_sequence` additionally waits for the **read store** to have
+indexed up to that log sequence. This wait is independent of consistency mode
+and can therefore also block a `stale` read.
 
 `waitMinLogSequence()` (`server_bucket.go:434`) calls `readStore.WaitForSequence(ctx, minLogSequence)`, which blocks until the indexer's persisted progress cursor (see [indexer / Progress Cursors](../indexer/indexer.md#progress-cursors)) has caught up.
 
@@ -90,7 +117,7 @@ Checkpoint reads (see below) ignore `min_log_sequence` — a frozen checkpoint i
 
 ## Pebble snapshot
 
-`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, main-store leaves and enrichment (volumes, metadata, transaction bodies) all read through the **one** main-store handle `query.OpenQueryHandle` opened. The read-store iterators (inverted index) run against a **separate** Pebble snapshot of the read store: `readStore.NewSnapshot()` when the read consults no index leaf, and otherwise `query.AlignedIndexSnapshot`, which returns an index snapshot whose fold cursor covers the main handle's sequence. The two are therefore *coordinated*, not identical — the index view may be **ahead** of the main handle, and `query.MainHorizonKeep` trims that excess back to the main-store horizon for TRANSACTIONS and LOGS (ACCOUNTS are served as folded). The contract and its per-target exceptions live in [read-snapshot-consistency.md](read-snapshot-consistency.md#cross-store-alignment-en-1748). The main handle — with the reclaim hold taken alongside it — is owned by the returned cursor and closed when that cursor is closed; the index snapshot and its read lease are released once the page's index iteration ends, before enrichment reads the handle. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore fresh snapshot state.
+`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, main-store leaves and enrichment (volumes, metadata, transaction bodies) all read through the **one** main-store handle `query.OpenQueryHandle` opened. A query for which `AlignmentOwed` is false uses `readStore.NewSnapshot()` only as an implementation handle and executes `listWithoutIndex`; it does not wait for the read-store fold. A query that actually consults an index uses `query.AlignedIndexSnapshot`, which returns a separate index snapshot whose fold cursor covers the main handle's sequence. The two aligned snapshots are therefore *coordinated*, not identical — the index view may be **ahead** of the main handle, and `query.MainHorizonKeep` trims that excess back to the main-store horizon for TRANSACTIONS and LOGS (ACCOUNTS are served as folded). The contract and its per-target exceptions live in [read-snapshot-consistency.md](read-snapshot-consistency.md#cross-store-alignment-en-1748). The main handle — with the reclaim hold taken alongside it — is owned by the returned cursor and closed when that cursor is closed; the index snapshot and its read lease are released once the page's index iteration ends, before enrichment reads the handle. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore fresh snapshot state.
 
 The cursor carries only the exclusive resume position (for example, an account address or transaction ID); it does not identify or retain the Pebble snapshot. Within one request/page, results are served under the coordinated consistency contract described above: main-store leaves and enrichment reflect that request's single pin, subject to the per-target cross-store exceptions — ACCOUNTS membership is served as folded, so a page may include index members absent from the pinned main store. Because the cursor does not retain that snapshot state, there is no general snapshot-consistency guarantee across separate pages. Inserts, deletes, or updates committed between requests may therefore affect later pages according to the documented cursor ordering and filtering semantics. Duplications or omissions across pages under concurrent writes are not, by themselves, evidence of a product defect unless an API contract explicitly promises a cross-page snapshot.
 
@@ -140,7 +167,7 @@ The cursor is sent back as an `x-next-cursor` gRPC trailer.
 
 ## Special read paths
 
-**Query checkpoints.** When the request carries a `checkpoint_id > 0`, the controller resolves the checkpoint to its frozen main-store + read-store snapshot pair, ignores `min_log_sequence` entirely, and runs the same iterator pipeline against the frozen views. Useful for reconciliation and auditing. See [query-checkpoints.md](query-checkpoints.md).
+**Query checkpoints.** When the request carries a `checkpoint_id > 0`, the controller resolves the checkpoint to its frozen main-store + read-store snapshot pair, ignores `min_log_sequence` entirely, and runs the same iterator pipeline against the frozen views. The pair is already frozen, so `AlignedIndexSnapshot` performs no catch-up wait. Useful for reconciliation and auditing. See [query-checkpoints.md](query-checkpoints.md).
 
 **Aggregate volumes.** `ExecutePreparedQuery` with the `AGGREGATE_VOLUMES` mode runs the same compiled filter to obtain a candidate account set, then loops over per-account asset volumes in the main store and sums per asset. The aggregation is computed at request time — there is no precomputed aggregate table.
 

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -110,10 +110,12 @@ which:
   routing — so `--consistency leader --min-log-sequence N` yields a non-zero
   barrier on a perfectly healthy cluster, with no failed attempt anywhere.
 - **A failed `ReadIndex` attempt.** The syncing-follower fallback in
-  `RoutedController.readCtrl` records the attempt and *then* forwards. Magnitude
-  differs sharply by cause: `ErrNodeSyncing` returns before any wait, so it costs
-  nanoseconds, whereas leadership lost mid-`ReadIndex` resolves a pending future
-  and can account for the whole quorum attempt.
+  `RoutedController.readCtrl` records the attempt and may then forward after it
+  resolves a remote leader. If leadership moved local in the meantime, the
+  router returns the failed barrier rather than serving locally. Magnitude
+  differs sharply by cause: `ErrNodeSyncing` returns before any wait, so it
+  costs nanoseconds, whereas leadership lost mid-`ReadIndex` resolves a pending
+  future and can account for the whole quorum attempt.
 
 So do not read cluster health off a non-zero forwarded barrier — the common cause
 is a caller asking for read-your-writes.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -397,7 +397,7 @@ When referencing a numscript from a transaction (`scriptReference` on `POST /v3/
 
 **Usage tracking (`GET /v3/{ledgerName}/numscripts/{name}/usage`):**
 
-Returns per-template invocation counters and the timestamp of the most recent invocation. Populated asynchronously by the `usagebuilder` subsystem, which tails the FSM audit chain and writes to a dedicated secondary Pebble store (`<data-dir>/usage/`). Values are eventually consistent with the FSM and may lag by up to one usagebuilder tick interval (~100 ms).
+Returns per-template invocation counters and the timestamp of the most recent invocation. Populated asynchronously by the `usagebuilder` subsystem, which tails the FSM audit chain and writes to a dedicated secondary Pebble store (`<data-dir>/usage/`). Values are eventually consistent with the FSM and may lag while the worker drains pending batches.
 
 A never-invoked template returns a zero-valued response (not 404), so clients handle "never used" uniformly:
 - `count` (uint64): Number of times the template has been invoked. `0` means not yet invoked (or the usagebuilder has not caught up).

--- a/openapi.yml
+++ b/openapi.yml
@@ -292,6 +292,11 @@ paths:
         Returns aggregate usage statistics (transaction, volume, reference, posting, log, revert
         and Numscript-execution counts, plus ephemeral-evicted and transient-used volume tallies)
         for a ledger. Requires `ledger:read` scope.
+        On live reads, `transactionCount` and `logCount` are FSM-backed. The seven
+        usage-derived counters (`postingCount`, `revertCount`, `numscriptExecutionCount`,
+        `referenceCount`, `ephemeralEvictedCount`, `transientUsedCount`, `volumeCount`)
+        are materialised asynchronously in the serving replica's usagestore and may lag
+        committed state even after the request's ReadIndex barrier.
         Note: for checkpoint-scoped (historical) reads, only `transactionCount` and `logCount` are
         checkpoint-consistent; the usage-derived counters (`postingCount`, `revertCount`,
         `numscriptExecutionCount`, `referenceCount`, `ephemeralEvictedCount`, `transientUsedCount`,
@@ -426,10 +431,12 @@ paths:
         This endpoint always performs a live, best-effort read. Unlike the gRPC
         `ListAuditEntries` surface, it does not expose the read-consistency
         options (pinned checkpoint reads, or a consistency-bound wait on the
-        audit index): filtered reads are served by an asynchronous secondary
-        index and may transiently omit very recent entries that are not yet
-        indexed. A client that needs a pinned or consistency-bounded audit read
-        must use the gRPC surface.
+        audit index): filters containing a field other than `seq` are served by
+        an asynchronous secondary index and may transiently omit very recent
+        entries that are not yet indexed. Unfiltered reads and conjunctions
+        made only of `seq` bounds scan the audit zone directly. A client that
+        needs a pinned or consistency-bounded audit read must use the gRPC
+        surface.
 
         Requires `ledger:AuditRead` scope.
       operationId: listAuditEntries
@@ -1714,9 +1721,9 @@ paths:
       summary: Get template usage
       description: |
         Returns the invocation counter and last-used timestamp for a Numscript template. Values are
-        materialised asynchronously by the `usagebuilder` subsystem from the FSM audit chain — expect
-        up to one usagebuilder tick interval (~100 ms) of lag behind the live FSM. A never-invoked
-        template returns a zero-valued response (not 404), so clients handle "never used" uniformly.
+        materialised asynchronously by the `usagebuilder` subsystem from the FSM audit chain and may
+        lag the live FSM while the worker drains pending batches. A never-invoked template returns a
+        zero-valued response (not 404), so clients handle "never used" uniformly.
 
         On existing ledgers whose audit chain has been partially archived to cold storage, only
         invocations still reachable in Pebble are counted.


### PR DESCRIPTION
## Summary

- document Ledger v3 as CP under normal Raft membership and explain partition, quorum, retry, and force-removal boundaries
- scope read guarantees to the actual consistency mode and serving data, including leader-local, stale, chapter, audit-index, and usagestore exceptions
- document conditional read-index alignment, query-profile semantics, and mixed-provenance ledger statistics
- update the HTTP/OpenAPI descriptions for audit filtering and asynchronous usage projections

## Stack

This documentation-only PR is stacked on #1876, which contains the runtime fixes and regression tests. Merge #1876 first, then retarget this PR to `release/v3.0`.

## Validation

- `git diff --check fix/routed-read-consistency...HEAD`
- final diff contains only `docs/**` and `openapi.yml`