### PR TITLE
perf(tooling): make pre-commit input-sensitive

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,24 @@ jobs:
           dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
-      - run: >
-          nix develop --command just pre-commit
+      - name: Run trusted input-sensitive pre-commit
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          if [[ -z "$PR_BASE_SHA" ]]; then
+            nix develop --command just pre-commit
+            exit
+          fi
+          trusted_tools=$(mktemp -d -t ledger-precommit-tools.XXXXXX)
+          cleanup() {
+            git worktree remove --force "$trusted_tools" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          git worktree add --detach "$trusted_tools" "$PR_BASE_SHA"
+          PRECOMMIT_BASE_SHA="$PR_BASE_SHA" \
+            nix develop "path:$trusted_tools" --command \
+            bash "$trusted_tools/scripts/agent-just" pre-commit
       - name: Get changed files
         id: changed-files
         shell: bash

--- a/docs/technical/contributing/ai-review-loop.md
+++ b/docs/technical/contributing/ai-review-loop.md
@@ -416,7 +416,10 @@ fixes or a failed removal — keeps its run directory and its caches.
 Candidate publication normalizes the candidate before assigning its final SHA.
 The trusted base-pinned `just pre-commit` recipe runs in the isolated validation
 environment; any resulting tree changes are logged, checked with `git diff
---check`, committed as normalization, and rechecked. This repeats to a bounded
-fixpoint (three passes by default). Only the converged SHA is reviewed and
-published. A candidate supplied to `ai-pr-adopt-candidate` is immutable: if it
-needs normalization, adoption refuses rather than silently changing the SHA.
+--check`, and committed as normalization. The trusted
+[input-sensitive runner](./pre-commit.md) reaches a bounded component-level
+fixpoint in that invocation and reruns only components invalidated by a later
+normalizer. A clean pass is recorded immediately instead of replaying the full
+recipe. Only the converged SHA is reviewed and published. A candidate supplied
+to `ai-pr-adopt-candidate` is immutable: if it needs normalization, adoption
+refuses rather than silently changing the SHA.

--- a/docs/technical/contributing/conventions.md
+++ b/docs/technical/contributing/conventions.md
@@ -86,10 +86,11 @@ Before completing any task:
 direnv allow && eval "$(direnv export bash)" && GOROOT= just pre-commit
 ```
 
-This runs:
-1. `go generate ./...` - regenerate mocks and protobuf files
-2. `go mod tidy` - clean up dependencies
-3. `golangci-lint run --fix` - lint and auto-fix
+Without a trusted exact-base binding this runs the full component set. PR
+automation may use the fail-closed
+[input-sensitive pre-commit contract](./pre-commit.md); changed Go source still
+runs the applicable lint component, and changed generated output always runs
+its producer.
 
 ## Mock Generation
 

--- a/docs/technical/contributing/getting-started.md
+++ b/docs/technical/contributing/getting-started.md
@@ -88,9 +88,10 @@ just test-e2e
 3. Verify compilation: `go build ./...`
 4. Run tests: `just test`
 
-The pre-commit command runs `go generate ./...` (mocks + proto), `go mod tidy`
-for the root, operator, and Antithesis model-workload modules, and
-`golangci-lint run --fix`.
+Without a trusted exact-base binding, the pre-commit command runs the complete
+generator, dashboard, tidy, and lint set. Trusted PR automation uses the
+[input-sensitive pre-commit contract](./pre-commit.md) to skip only components
+whose complete input/output identity proves them irrelevant.
 
 ## Dependency Injection with fx
 

--- a/docs/technical/contributing/pre-commit.md
+++ b/docs/technical/contributing/pre-commit.md
@@ -1,0 +1,64 @@
+# Input-sensitive pre-commit normalization
+
+`just pre-commit` is a normalization fixpoint, not merely a list of checks. Its
+trusted runner is implemented in `scripts/precommit/`; the `justfile` retains
+the individual recipes that the runner executes.
+
+Local invocations without an exact target SHA deliberately run every component.
+PR automation may skip a component only when it invokes the selector from a
+clean worktree pinned to the exact target commit and supplies that commit as
+`PRECOMMIT_BASE_SHA`. `scripts/agent-just` pins the recipe and selector to that
+trusted worktree. The candidate's `justfile`, selector source, dependency maps,
+and dotenv files are never used to decide what may be skipped.
+
+## Trusted component map
+
+Every current mapping is `COMPLETE`. A partial or unknown mapping must not be
+used for skipping.
+
+| Component | Inputs | Tool identity and configuration | Committed outputs |
+|---|---|---|---|
+| Fuzz inventory | every `*_test.go`, every `go.mod`, `scripts/fuzz-targets.txt` | target SHA; invariant/fuzz scanner source; pinned Go toolchain | none |
+| Mock/code generation | trusted Go packages containing `//go:generate`, any new/changed directive source, generated protobuf Go, root `go.mod`/`go.sum`; the fixpoint fingerprint covers all root Go | target SHA; `go generate` recipe; pinned `mockgen` | `internal/**/*_generated.go`, `internal/**/*_generated_test.go` |
+| Protobuf generation | `misc/proto/*.proto`; every custom `tools/protoc-gen-*` module | target SHA; complete protoc recipe/options; `flake.nix`/`flake.lock` | generated `internal/proto/**/*.pb.go` |
+| Operator generation | operator Go excluding generated outputs; operator module manifests; RBAC sync script | target SHA; controller-gen version/recipe; pinned Go toolchain | deepcopy Go, CRDs, RBAC, copied chart CRDs, chart ClusterRole |
+| Dashboards | dashboard Jsonnet, lockfile and vendor identity; dashboard Go tests/module manifests | target SHA; Jsonnet/JB recipe and pinned tools | `config/dashboards/*.json` |
+| Root tidy | every root-module Go file; root module manifests | target SHA; pinned Go toolchain | root `go.mod`/`go.sum` |
+| Operator tidy | every operator Go file; operator module manifests | target SHA; pinned Go toolchain | operator `go.mod`/`go.sum` |
+| Model-workload tidy | every workload Go file; workload module manifests | target SHA; pinned Go toolchain | workload `go.mod`/`go.sum` |
+| Root lint | every root-module Go file; root module manifests | target SHA; `.golangci.yaml`; pinned linter and build-tag recipe | root-module Go files (`--fix`) |
+| Operator lint | every operator Go file; operator module manifests | target SHA; `.golangci.yaml`; pinned linter recipe | operator Go files (`--fix`) |
+
+The map intentionally errs toward broad inputs. Ordinary root Go changes still
+run root tidy and lint; changes in a package that owns a generation directive
+also run root generation, and test-source changes run the fuzz inventory. This
+change does not implement package-level proportional validation.
+
+## Selection and fail-closed rules
+
+The selector compares the exact candidate workspace—including staged,
+unstaged, and untracked files—with the supplied target commit. A changed input
+or component configuration selects that component. A changed declared output
+also selects its producer, even when no source input changed, so a manually
+edited generated file cannot bypass normalization.
+
+Missing or mismatched target/tool identity, a dirty trusted-tool worktree, a
+non-ancestor base, an unreadable diff, a changed selector/recipe/toolchain, or
+an unclassified path selects the full component set. Documentation and known
+workflow-only paths are explicitly irrelevant to these normalization outputs.
+An existing ignored Jsonnet vendor directory selects dashboard generation
+because its relationship cannot be compared with the Git base.
+
+## Fixpoint proof
+
+One runner process keeps exact SHA-256 fingerprints of the candidate workspace
+and each component's inputs, configuration, and outputs. After a component
+runs, later normalization may invalidate its recorded state. Only invalidated
+components run on the next bounded pass. A clean pass is immediately a
+fixpoint; it is not replayed. If the bounded fixpoint is not reached, pre-commit
+fails with `PRECOMMIT_NON_DETERMINISTIC`.
+
+The fingerprints are in-memory evidence for one invocation only. No candidate-
+writable receipt authorizes later skipping. Candidate publication still runs an
+independent base-pinned pre-commit gate after exact review and refuses any
+mutation of the reviewed SHA.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 set dotenv-load
 
-pre-commit: fuzz-inventory-check generate generate-proto operator-generate test-dashboards tidy lint
+pre-commit:
+    go -C "{{justfile_directory()}}" run ./scripts/precommit --repo "$PWD" --tool-root "{{justfile_directory()}}"
 pc: pre-commit
 
 # Regenerate the Grafana dashboards (otel + prom variants) from Jsonnet
@@ -23,23 +24,39 @@ generate-dashboards:
 test-dashboards: generate-dashboards
     cd misc/devenv/monitoring-dashboards && go test ./...
 
-lint:
+lint: lint-root lint-operator
+
+lint-root:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "==> golangci-lint (.)"
     golangci-lint run --fix --build-tags it,local,{{all_tags}} --timeout 5m
+
+lint-operator:
+    #!/usr/bin/env bash
+    set -euo pipefail
     echo "==> golangci-lint (operator)"
     cd misc/operator && golangci-lint run --fix --timeout 5m
 
-tidy:
+tidy: tidy-root tidy-operator tidy-model-workload
+
+tidy-root:
     #!/usr/bin/env bash
     set -euo pipefail
     echo "==> go mod tidy (.)"
     go mod tidy
+
+tidy-operator:
+    #!/usr/bin/env bash
+    set -euo pipefail
     echo "==> go mod tidy (operator)"
-    (cd misc/operator && go mod tidy)
+    cd misc/operator && go mod tidy
+
+tidy-model-workload:
+    #!/usr/bin/env bash
+    set -euo pipefail
     echo "==> go mod tidy (model workload)"
-    (cd tests/antithesis/workload && go mod tidy)
+    cd tests/antithesis/workload && go mod tidy
 
 # All optional feature build tags
 all_tags := "kafka,nats,clickhouse,databricks,s3,azure,pyroscope"

--- a/scripts/agent-just
+++ b/scripts/agent-just
@@ -9,6 +9,14 @@ WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
 # against a PR worktree. Pin recipe definitions to the wrapper's repository,
 # disable target-controlled dotenv loading, and keep the reviewed tree as cwd.
 case "${1:-}" in
+    pre-commit)
+        trusted_tool_sha=$(git -C "$TOOL_ROOT" rev-parse --verify 'HEAD^{commit}')
+        exec env PRECOMMIT_TRUSTED_TOOL_SHA="$trusted_tool_sha" just \
+            --no-dotenv \
+            --justfile "$TOOL_ROOT/justfile" \
+            --working-directory "$WORKTREE_ROOT" \
+            "$@"
+        ;;
     test-model)
         shift
         exec env \

--- a/scripts/ai-pr-adopt-candidate
+++ b/scripts/ai-pr-adopt-candidate
@@ -211,13 +211,14 @@ printf -v quoted_go_path %q "$validation_run_dir/go-path"
 printf -v quoted_tmp_dir %q "$validation_run_dir/tmp"
 printf -v quoted_cache_home %q "$validation_run_dir/cache"
 printf -v quoted_golangci_cache %q "$validation_run_dir/cache/golangci-lint"
+printf -v quoted_precommit_base %q "$base_sha"
 printf -v quoted_validation_tool %q "$trusted_worktree/scripts/agent-check-pr"
 printf -v quoted_agent_just %q "$trusted_worktree/scripts/agent-just"
 printf -v normalization_program \
-    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s pre-commit' \
+    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s PRECOMMIT_BASE_SHA=%s bash %s pre-commit' \
     "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
     "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
-    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_agent_just"
+    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_precommit_base" "$quoted_agent_just"
 printf -v normalization_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
     "path:$trusted_worktree" "$normalization_program"
 printf -v nix_validation_program \
@@ -239,7 +240,7 @@ git diff --check "$base_sha" "$candidate_sha" || {
 }
 
 # An adopted SHA must already be normalized; never mutate it silently.
-bash -c "$normalization_cmd"
+PRECOMMIT_BASE_SHA="$base_sha" bash -c "$normalization_cmd"
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "CANDIDATE_NEEDS_NORMALIZATION"
     echo "AI_PR_ADOPT_RESULT: REFUSED (candidate is not normalized)"

--- a/scripts/ai-pr-loop
+++ b/scripts/ai-pr-loop
@@ -324,13 +324,14 @@ printf -v quoted_go_path %q "$validation_run_dir/go-path"
 printf -v quoted_tmp_dir %q "$validation_run_dir/tmp"
 printf -v quoted_cache_home %q "$validation_run_dir/cache"
 printf -v quoted_golangci_cache %q "$validation_run_dir/cache/golangci-lint"
+printf -v quoted_precommit_base %q "$base_sha"
 printf -v quoted_validation_tool %q "$trusted_tool_worktree/scripts/agent-check-pr"
 printf -v quoted_agent_just %q "$trusted_tool_worktree/scripts/agent-just"
 printf -v normalization_program \
-    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s bash %s pre-commit' \
+    'mkdir -p %s %s %s %s %s %s && env HOME=%s GOCACHE=%s GOMODCACHE=%s GOPATH=%s TMPDIR=%s XDG_CACHE_HOME=%s GOLANGCI_LINT_CACHE=%s VALIDATION_RUN_ID=%s VALIDATION_RUN_DIR=%s PRECOMMIT_BASE_SHA=%s bash %s pre-commit' \
     "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_golangci_cache" \
     "$quoted_home" "$quoted_go_cache" "$quoted_go_mod_cache" "$quoted_go_path" "$quoted_tmp_dir" "$quoted_cache_home" \
-    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_agent_just"
+    "$quoted_golangci_cache" "$quoted_run_id" "$quoted_run_dir" "$quoted_precommit_base" "$quoted_agent_just"
 printf -v normalization_cmd 'env -u GOROOT nix develop %q --command bash -c %q' \
     "path:$trusted_tool_worktree" "$normalization_program"
 validation_cmd="mkdir -p $quoted_home $quoted_go_cache $quoted_go_mod_cache $quoted_go_path $quoted_tmp_dir $quoted_golangci_cache && env HOME=$quoted_home GOCACHE=$quoted_go_cache GOMODCACHE=$quoted_go_mod_cache GOPATH=$quoted_go_path TMPDIR=$quoted_tmp_dir XDG_CACHE_HOME=$quoted_cache_home GOLANGCI_LINT_CACHE=$quoted_golangci_cache VALIDATION_RUN_ID=$quoted_run_id VALIDATION_RUN_DIR=$quoted_run_dir bash $quoted_validation_tool"
@@ -523,31 +524,9 @@ expected_worktree_head=$candidate_sha
 write_candidate_binding "$expected_worktree_head"
 printf '==> ai-pr-loop: candidate commit %s\n' "$candidate_sha"
 
-normalization_pass=1
-while [[ "$normalization_pass" -le 3 ]]; do
-    bash -c "$normalization_cmd"
-    if [[ -z "$(git status --porcelain)" ]]; then
-        echo "PRECOMMIT_FIXPOINT: PASS"
-        break
-    fi
-    echo "PRECOMMIT_NORMALIZATION: CHANGES_COMMITTED (pass $normalization_pass)"
-    git add -A
-    git diff --cached --check
-    git commit -m "chore: normalize candidate"
-    candidate_sha=$(git rev-parse HEAD)
-    expected_worktree_head=$candidate_sha
-    write_candidate_binding "$expected_worktree_head"
-    normalization_pass=$((normalization_pass + 1))
-done
-# Always perform a final read of the trusted recipe after the last allowed
-# normalization commit. This proves the reviewed SHA is actually converged.
-bash -c "$normalization_cmd"
-if [[ -n "$(git status --porcelain)" ]]; then
-    echo "PRECOMMIT_NON_DETERMINISTIC: refusing candidate publication" >&2
-    keep_worktree=true
-    exit 1
-fi
-echo "PRECOMMIT_FIXPOINT: PASS"
+# The trusted pre-commit runner reaches a bounded component-level fixpoint in
+# one invocation. Its in-memory fingerprints prove which components later
+# normalizers invalidated, so replaying the complete recipe here is redundant.
 
 # Do not spend or trust an exact candidate review against a target that moved
 # during normalization. The synchronized candidate must start a fresh run.
@@ -587,7 +566,7 @@ fi
     # Last-mile publication gate: use only the base-pinned recipe wrapper. The
     # candidate worktree is merely its working directory; generated output is
     # never reset or hidden.
-bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
+PRECOMMIT_BASE_SHA="$base_sha" bash "$trusted_tool_worktree/scripts/agent-just" pre-commit
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "ai-pr-loop: pre-commit left the candidate worktree dirty; refusing push" >&2
     echo "Candidate worktree preserved for inspection: $worktree"

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -26,6 +26,10 @@ func TestPushReviewsCandidateCommitBeforePublishing(t *testing.T) {
 	countBytes, err := os.ReadFile(fixture.reviewCountFile)
 	require.NoError(t, err)
 	require.Equal(t, "2", strings.TrimSpace(string(countBytes)))
+	precommitCountBytes, err := os.ReadFile(fixture.precommitCountFile)
+	require.NoError(t, err)
+	require.Equal(t, "2", strings.TrimSpace(string(precommitCountBytes)),
+		"normalization reaches its own fixpoint; only the independent last-mile gate reruns")
 }
 
 func TestPushRefusesWhenRemoteHeadMoves(t *testing.T) {
@@ -195,16 +199,17 @@ type pushFixtureOptions struct {
 }
 
 type pushFixture struct {
-	root            string
-	remote          string
-	checkout        string
-	fakeBin         string
-	baseSHA         string
-	headSHA         string
-	advancedBaseSHA string
-	divergedBaseSHA string
-	reviewCountFile string
-	options         pushFixtureOptions
+	root               string
+	remote             string
+	checkout           string
+	fakeBin            string
+	baseSHA            string
+	headSHA            string
+	advancedBaseSHA    string
+	divergedBaseSHA    string
+	reviewCountFile    string
+	precommitCountFile string
+	options            pushFixtureOptions
 }
 
 func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
@@ -262,6 +267,11 @@ func newPushFixture(t *testing.T, options pushFixtureOptions) pushFixture {
 		}
 		require.NoError(t, os.WriteFile(filepath.Join(seed, "scripts", "agent-just"), []byte(`#!/usr/bin/env bash
 set -euo pipefail
+count=0
+if [[ -f "$TEST_PRECOMMIT_COUNT_FILE" ]]; then
+    count=$(<"$TEST_PRECOMMIT_COUNT_FILE")
+fi
+printf '%s' "$((count + 1))" > "$TEST_PRECOMMIT_COUNT_FILE"
 if [[ "${TEST_TARGET_MUTATION:-}" == "before-exact-review" && ! -e "$TEST_TARGET_MUTATION_MARKER" ]]; then
     git --git-dir="$TEST_REMOTE" update-ref refs/heads/release/v3.0 "$TEST_ADVANCED_BASE_SHA"
     : > "$TEST_TARGET_MUTATION_MARKER"
@@ -486,16 +496,17 @@ chmod 755 "$output"
 `)
 
 	return pushFixture{
-		root:            root,
-		remote:          remote,
-		checkout:        checkout,
-		fakeBin:         fakeBin,
-		baseSHA:         baseSHA,
-		headSHA:         headSHA,
-		advancedBaseSHA: advancedBaseSHA,
-		divergedBaseSHA: divergedBaseSHA,
-		reviewCountFile: filepath.Join(root, "review-count"),
-		options:         options,
+		root:               root,
+		remote:             remote,
+		checkout:           checkout,
+		fakeBin:            fakeBin,
+		baseSHA:            baseSHA,
+		headSHA:            headSHA,
+		advancedBaseSHA:    advancedBaseSHA,
+		divergedBaseSHA:    divergedBaseSHA,
+		reviewCountFile:    filepath.Join(root, "review-count"),
+		precommitCountFile: filepath.Join(root, "precommit-count"),
+		options:            options,
 	}
 }
 
@@ -509,6 +520,7 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 		"TEST_BASE_SHA="+fixture.baseSHA,
 		"TEST_HEAD_SHA="+fixture.headSHA,
 		"TEST_REVIEW_COUNT_FILE="+fixture.reviewCountFile,
+		"TEST_PRECOMMIT_COUNT_FILE="+fixture.precommitCountFile,
 		"TEST_MOVE_REMOTE="+strconv.FormatBool(fixture.options.moveRemote),
 		"TEST_MOVE_LOCAL_HEAD="+strconv.FormatBool(fixture.options.moveLocalHead),
 		"TEST_REMOTE="+fixture.remote,

--- a/scripts/check-dashboard-test-reachability
+++ b/scripts/check-dashboard-test-reachability
@@ -21,8 +21,11 @@ if ! grep -Eq '(^|/)[^/]+_test\.go$' <<<"$tracked_module_files"; then
 fi
 
 pre_commit_recipe=$(cd "$repository_root" && just --show pre-commit)
-if ! grep -Eq "^pre-commit:.*[[:space:]]${dashboard_recipe}([[:space:]]|$)" <<<"$pre_commit_recipe"; then
-    fail "pre-commit does not depend on $dashboard_recipe"
+if ! grep -Fq 'run ./scripts/precommit' <<<"$pre_commit_recipe"; then
+    fail "pre-commit does not invoke the trusted component selector"
+fi
+if ! grep -Eq 'Recipe:[[:space:]]+"test-dashboards"' "$repository_root/scripts/precommit/components.go"; then
+    fail "pre-commit component map does not reach $dashboard_recipe"
 fi
 
 dashboard_test_recipe=$(cd "$repository_root" && just --show "$dashboard_recipe")

--- a/scripts/precommit/components.go
+++ b/scripts/precommit/components.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const componentMapVersion = "ledger-precommit-components-v1"
+
+type component struct {
+	Name       string
+	Recipe     string
+	Inputs     func(string) bool
+	Outputs    func(string) bool
+	Config     func(string) bool
+	Complete   bool
+	MappingWhy string
+}
+
+func componentMap() []component {
+	return []component{
+		{
+			Name:       "fuzz-inventory",
+			Recipe:     "fuzz-inventory-check",
+			Inputs:     fuzzInventoryInput,
+			Outputs:    noPath,
+			Config:     fuzzInventoryConfig,
+			Complete:   true,
+			MappingWhy: "all test sources, module boundaries, runner inventory, and checker implementation are covered",
+		},
+		{
+			Name:       "mock-code-generation",
+			Recipe:     "generate",
+			Inputs:     mockGenerationInput,
+			Outputs:    mockGenerationOutput,
+			Config:     commonGeneratorConfig,
+			Complete:   true,
+			MappingWhy: "all root-module Go sources that can add directives or affect generated interfaces are covered",
+		},
+		{
+			Name:       "proto-generation",
+			Recipe:     "generate-proto",
+			Inputs:     protoGenerationInput,
+			Outputs:    protoGenerationOutput,
+			Config:     protoGenerationConfig,
+			Complete:   true,
+			MappingWhy: "proto sources, custom plugins, pinned protoc toolchain, recipe, and generated protobuf outputs are covered",
+		},
+		{
+			Name:       "operator-generation",
+			Recipe:     "operator-generate",
+			Inputs:     operatorGenerationInput,
+			Outputs:    operatorGenerationOutput,
+			Config:     operatorGenerationConfig,
+			Complete:   true,
+			MappingWhy: "operator Go annotations, controller-gen identity, RBAC sync script, and every committed output are covered",
+		},
+		{
+			Name:       "dashboards",
+			Recipe:     "test-dashboards",
+			Inputs:     dashboardInput,
+			Outputs:    dashboardOutput,
+			Config:     dashboardConfig,
+			Complete:   true,
+			MappingWhy: "Jsonnet, lockfile/vendor identity, dashboard tests, toolchain, and committed JSON outputs are covered",
+		},
+		{
+			Name:       "tidy-root",
+			Recipe:     "tidy-root",
+			Inputs:     rootTidyInput,
+			Outputs:    rootModuleOutput,
+			Config:     goToolConfig,
+			Complete:   true,
+			MappingWhy: "every root-module Go source and root module manifest is covered",
+		},
+		{
+			Name:       "tidy-operator",
+			Recipe:     "tidy-operator",
+			Inputs:     operatorTidyInput,
+			Outputs:    operatorModuleOutput,
+			Config:     goToolConfig,
+			Complete:   true,
+			MappingWhy: "every operator-module Go source and module manifest is covered",
+		},
+		{
+			Name:       "tidy-model-workload",
+			Recipe:     "tidy-model-workload",
+			Inputs:     workloadTidyInput,
+			Outputs:    workloadModuleOutput,
+			Config:     goToolConfig,
+			Complete:   true,
+			MappingWhy: "every workload-module Go source and module manifest is covered",
+		},
+		{
+			Name:       "lint-root",
+			Recipe:     "lint-root",
+			Inputs:     rootLintInput,
+			Outputs:    rootModuleGo,
+			Config:     lintConfig,
+			Complete:   true,
+			MappingWhy: "all root-module Go, module manifests, lint configuration, and pinned linter identity are covered",
+		},
+		{
+			Name:       "lint-operator",
+			Recipe:     "lint-operator",
+			Inputs:     operatorLintInput,
+			Outputs:    operatorGo,
+			Config:     lintConfig,
+			Complete:   true,
+			MappingWhy: "all operator-module Go, module manifests, lint configuration, and pinned linter identity are covered",
+		},
+	}
+}
+
+func normalizePath(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func noPath(string) bool { return false }
+
+func hasPrefix(path, prefix string) bool {
+	return path == strings.TrimSuffix(prefix, "/") || strings.HasPrefix(path, prefix)
+}
+
+func isGo(path string) bool { return strings.HasSuffix(path, ".go") }
+
+func isModuleManifest(path, directory string) bool {
+	prefix := ""
+	if directory != "" {
+		prefix = strings.TrimSuffix(directory, "/") + "/"
+	}
+
+	return path == prefix+"go.mod" || path == prefix+"go.sum"
+}
+
+func nestedModule(path string) bool {
+	for _, prefix := range []string{
+		"misc/devenv/monitoring-dashboards/",
+		"misc/operator/",
+		"tests/antithesis/workload/",
+		"tests/perf/",
+		"tools/protoc-gen-dethash/",
+		"tools/protoc-gen-queryfilter-validity/",
+		"tools/protoc-gen-reader/",
+		"tools/protoc-gen-skippable/",
+	} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func rootModuleGo(path string) bool { return isGo(path) && !nestedModule(path) }
+func operatorGo(path string) bool   { return strings.HasPrefix(path, "misc/operator/") && isGo(path) }
+
+func fuzzInventoryInput(path string) bool {
+	return strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "/go.mod") || path == "go.mod" ||
+		path == "scripts/fuzz-targets.txt"
+}
+
+func fuzzInventoryConfig(path string) bool {
+	return path == "scripts/check-repo-invariants" || path == "scripts/check-repo-invariants.go" ||
+		path == "scripts/fuzz_inventory.go"
+}
+
+func mockGenerationOutput(path string) bool {
+	if !strings.HasPrefix(path, "internal/") || !isGo(path) {
+		return false
+	}
+	name := filepath.Base(path)
+
+	return strings.Contains(name, "_generated")
+}
+
+func mockGenerationInput(path string) bool {
+	return (rootModuleGo(path) && !mockGenerationOutput(path)) || isModuleManifest(path, "") || protoGenerationOutput(path)
+}
+
+func commonGeneratorConfig(path string) bool {
+	return path == "justfile" || path == "flake.nix" || path == "flake.lock"
+}
+
+func protoGenerationInput(path string) bool {
+	if strings.HasPrefix(path, "misc/proto/") && strings.HasSuffix(path, ".proto") {
+		return true
+	}
+	for _, prefix := range []string{
+		"tools/protoc-gen-dethash/",
+		"tools/protoc-gen-queryfilter-validity/",
+		"tools/protoc-gen-reader/",
+		"tools/protoc-gen-skippable/",
+	} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func protoGenerationOutput(path string) bool {
+	return strings.HasPrefix(path, "internal/proto/") && strings.HasSuffix(path, ".pb.go")
+}
+
+func protoGenerationConfig(path string) bool { return commonGeneratorConfig(path) }
+
+func operatorGenerationOutput(path string) bool {
+	return path == "misc/operator/api/v1alpha1/zz_generated.deepcopy.go" ||
+		hasPrefix(path, "misc/operator/config/crd/bases/") && strings.HasSuffix(path, ".yaml") ||
+		hasPrefix(path, "misc/operator/config/rbac/") && strings.HasSuffix(path, ".yaml") ||
+		hasPrefix(path, "misc/operator/helm/crds/templates/") && strings.HasSuffix(path, ".yaml") ||
+		path == "misc/operator/helm/operator/templates/clusterrole.yaml"
+}
+
+func operatorGenerationInput(path string) bool {
+	return operatorGo(path) && !operatorGenerationOutput(path) ||
+		isModuleManifest(path, "misc/operator") || path == "misc/operator/scripts/sync-chart-rbac.sh"
+}
+
+func operatorGenerationConfig(path string) bool { return commonGeneratorConfig(path) }
+
+func dashboardOutput(path string) bool {
+	return strings.HasPrefix(path, "misc/devenv/monitoring-dashboards/config/dashboards/") &&
+		strings.HasSuffix(path, ".json")
+}
+
+func dashboardInput(path string) bool {
+	return strings.HasPrefix(path, "misc/devenv/monitoring-dashboards/jsonnet/") ||
+		strings.HasPrefix(path, "misc/devenv/monitoring-dashboards/") && isGo(path) ||
+		isModuleManifest(path, "misc/devenv/monitoring-dashboards")
+}
+
+func dashboardConfig(path string) bool { return commonGeneratorConfig(path) }
+
+func rootTidyInput(path string) bool    { return rootModuleGo(path) || isModuleManifest(path, "") }
+func rootModuleOutput(path string) bool { return isModuleManifest(path, "") }
+
+func operatorTidyInput(path string) bool {
+	return operatorGo(path) || isModuleManifest(path, "misc/operator")
+}
+func operatorModuleOutput(path string) bool { return isModuleManifest(path, "misc/operator") }
+
+func workloadTidyInput(path string) bool {
+	return strings.HasPrefix(path, "tests/antithesis/workload/") && isGo(path) ||
+		isModuleManifest(path, "tests/antithesis/workload")
+}
+
+func workloadModuleOutput(path string) bool {
+	return isModuleManifest(path, "tests/antithesis/workload")
+}
+
+func rootLintInput(path string) bool {
+	return rootModuleGo(path) || isModuleManifest(path, "") || path == ".golangci.yaml"
+}
+func operatorLintInput(path string) bool {
+	return operatorGo(path) || isModuleManifest(path, "misc/operator") || path == ".golangci.yaml"
+}
+
+func goToolConfig(path string) bool {
+	return path == "flake.nix" || path == "flake.lock" || path == "justfile"
+}
+
+func lintConfig(path string) bool { return goToolConfig(path) || path == ".golangci.yaml" }
+
+func affectsEveryComponent(path string) bool {
+	return path == "justfile" || path == "flake.nix" || path == "flake.lock" ||
+		hasPrefix(path, "scripts/precommit/")
+}
+
+func knownIrrelevant(path string) bool {
+	return hasPrefix(path, "docs/") || strings.HasSuffix(path, ".md") ||
+		hasPrefix(path, ".github/") || hasPrefix(path, "scripts/")
+}

--- a/scripts/precommit/components_test.go
+++ b/scripts/precommit/components_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInputSensitiveSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		path         string
+		content      string
+		wantSelected []string
+		wantReason   string
+		wantFull     bool
+	}{
+		{
+			name:         "docs only skips expensive components",
+			path:         "docs/guide.md",
+			wantSelected: nil,
+		},
+		{
+			name:         "proto source selects proto generation",
+			path:         "misc/proto/common.proto",
+			wantSelected: []string{"proto-generation"},
+			wantReason:   "input_changed:misc/proto/common.proto",
+		},
+		{
+			name:         "manual generated proto output edit fails closed",
+			path:         "internal/proto/commonpb/common.pb.go",
+			wantSelected: []string{"mock-code-generation", "proto-generation", "tidy-root", "lint-root"},
+			wantReason:   "declared_output_changed:internal/proto/commonpb/common.pb.go",
+		},
+		{
+			name:         "operator API selects operator generator",
+			path:         "misc/operator/api/v1alpha1/cluster_types.go",
+			wantSelected: []string{"operator-generation", "tidy-operator", "lint-operator"},
+			wantReason:   "input_changed:misc/operator/api/v1alpha1/cluster_types.go",
+		},
+		{
+			name:         "dashboard Jsonnet selects dashboard generation",
+			path:         "misc/devenv/monitoring-dashboards/jsonnet/main.jsonnet",
+			wantSelected: []string{"dashboards"},
+			wantReason:   "input_changed:misc/devenv/monitoring-dashboards/jsonnet/main.jsonnet",
+		},
+		{
+			name:         "root Go import selects tidy and lint",
+			path:         "internal/example.go",
+			wantSelected: []string{"tidy-root", "lint-root"},
+		},
+		{
+			name:         "new generator directive selects generation",
+			path:         "scripts/fresh_generator.go",
+			content:      "package main\n//go:generate mockgen -destination generated.go example Interface\n",
+			wantSelected: []string{"mock-code-generation", "tidy-root", "lint-root"},
+			wantReason:   "input_changed:scripts/fresh_generator.go",
+		},
+		{
+			name:         "nested workload change selects its tidy",
+			path:         "tests/antithesis/workload/example.go",
+			wantSelected: []string{"tidy-model-workload"},
+		},
+		{
+			name:         "unknown path forces full fallback",
+			path:         "mystery/input.txt",
+			wantSelected: componentNames(componentMap()),
+			wantFull:     true,
+		},
+		{
+			name:         "lint configuration selects both lint components",
+			path:         ".golangci.yaml",
+			wantSelected: []string{"lint-root", "lint-operator"},
+		},
+		{
+			name:         "candidate selection map change forces trusted full fallback",
+			path:         "scripts/precommit/components.go",
+			wantSelected: componentNames(componentMap()),
+			wantFull:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newSelectionFixture(t)
+			if test.content == "" {
+				fixture.change(t, test.path)
+			} else {
+				writeFixtureFile(t, fixture.candidate, test.path, test.content)
+			}
+			plan := fixture.plan(t)
+			selected := selectedNames(plan, componentMap())
+			require.Equal(t, test.wantSelected, selected)
+			require.Equal(t, test.wantFull, plan.FullFallback)
+			if test.wantReason != "" {
+				var found bool
+				for _, reasons := range plan.Selected {
+					found = found || slices.Contains(reasons, test.wantReason)
+				}
+				require.True(t, found, "selection must retain the exact trusted input/output edge")
+			}
+		})
+	}
+}
+
+func TestToolIdentityMismatchRunsEveryComponent(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSelectionFixture(t)
+	fixture.change(t, "docs/guide.md")
+	r := runner{repo: fixture.candidate, toolRoot: fixture.trusted, components: componentMap()}
+	plan, err := r.selectComponents(fixture.base, strings.Repeat("0", 40))
+	require.NoError(t, err)
+	require.True(t, plan.FullFallback)
+	require.Contains(t, plan.FallbackReasons, "trusted_tool_sha_mismatch")
+	require.Equal(t, componentNames(componentMap()), selectedNames(plan, componentMap()))
+}
+
+func TestUnversionedDashboardVendorCannotBeSkipped(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSelectionFixture(t)
+	fixture.change(t, "docs/guide.md")
+	vendorFile := filepath.Join(fixture.candidate, "misc", "devenv", "monitoring-dashboards", "jsonnet", "vendor", "library.libsonnet")
+	require.NoError(t, os.MkdirAll(filepath.Dir(vendorFile), 0o755))
+	require.NoError(t, os.WriteFile(vendorFile, []byte("vendor\n"), 0o644))
+	plan := fixture.plan(t)
+	require.Contains(t, selectedNames(plan, componentMap()), "dashboards")
+	require.Contains(t, plan.Selected["dashboards"], "untrusted_or_unversioned_jsonnet_vendor")
+}
+
+// These exact reason assertions are the sensitivity proof for the most
+// important edges. Removing the proto input edge changes the selection to an
+// unknown-path fallback; removing the generated-output edge omits the proto
+// generator entirely because other Go mappings still recognize the path.
+func TestSensitivityEdgesRemainExplicit(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSelectionFixture(t)
+	fixture.change(t, "misc/proto/common.proto")
+	protoPlan := fixture.plan(t)
+	require.False(t, protoPlan.FullFallback)
+	require.Equal(t, []string{"input_changed:misc/proto/common.proto"}, protoPlan.Selected["proto-generation"])
+
+	outputFixture := newSelectionFixture(t)
+	outputFixture.change(t, "internal/proto/commonpb/common.pb.go")
+	outputPlan := outputFixture.plan(t)
+	require.False(t, outputPlan.FullFallback)
+	require.Contains(t, outputPlan.Selected["proto-generation"],
+		"declared_output_changed:internal/proto/commonpb/common.pb.go")
+}
+
+type selectionFixture struct {
+	base      string
+	trusted   string
+	candidate string
+}
+
+func newSelectionFixture(t *testing.T) selectionFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	seed := filepath.Join(root, "seed")
+	trusted := filepath.Join(root, "trusted")
+	candidate := filepath.Join(root, "candidate")
+	require.NoError(t, os.MkdirAll(seed, 0o755))
+	runGit(t, seed, "init", "-q")
+	runGit(t, seed, "config", "user.name", "Precommit Test")
+	runGit(t, seed, "config", "user.email", "precommit@example.com")
+	files := map[string]string{
+		"docs/guide.md":                                                      "guide\n",
+		"misc/proto/common.proto":                                            "syntax = \"proto3\";\n",
+		"internal/proto/commonpb/common.pb.go":                               "// Code generated. DO NOT EDIT.\npackage commonpb\n",
+		"misc/operator/api/v1alpha1/cluster_types.go":                        "package v1alpha1\n",
+		"misc/devenv/monitoring-dashboards/jsonnet/main.jsonnet":             "{}\n",
+		"internal/example.go":                                                "package internal\n",
+		"tests/antithesis/workload/example.go":                               "package workload\n",
+		".golangci.yaml":                                                     "version: '2'\n",
+		"mystery/input.txt":                                                  "known at base but relationship unknown\n",
+		"scripts/precommit/components.go":                                    "trusted map\n",
+		"misc/devenv/monitoring-dashboards/jsonnet/.gitignore":               "vendor/\n",
+		"misc/devenv/monitoring-dashboards/config/dashboards/generated.json": "{}\n",
+		"misc/operator/go.mod":                                               "module example/operator\n",
+		"tests/antithesis/workload/go.mod":                                   "module example/workload\n",
+		"go.mod":                                                             "module example/root\n",
+	}
+	for path, content := range files {
+		writeFixtureFile(t, seed, path, content)
+	}
+	runGit(t, seed, "add", ".")
+	runGit(t, seed, "commit", "-qm", "base")
+	base := runGitOutput(t, seed, "rev-parse", "HEAD")
+	runGit(t, root, "clone", "-q", seed, trusted)
+	runGit(t, root, "clone", "-q", seed, candidate)
+
+	return selectionFixture{base: base, trusted: trusted, candidate: candidate}
+}
+
+func (fixture selectionFixture) change(t *testing.T, path string) {
+	t.Helper()
+	fullPath := filepath.Join(fixture.candidate, filepath.FromSlash(path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	file, err := os.OpenFile(fullPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = file.WriteString("changed\n")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+}
+
+func (fixture selectionFixture) plan(t *testing.T) selection {
+	t.Helper()
+	r := runner{repo: fixture.candidate, toolRoot: fixture.trusted, components: componentMap()}
+	plan, err := r.selectComponents(fixture.base, fixture.base)
+	require.NoError(t, err)
+
+	return plan
+}
+
+func componentNames(components []component) []string {
+	names := make([]string, 0, len(components))
+	for _, item := range components {
+		names = append(names, item.Name)
+	}
+
+	return names
+}
+
+func selectedNames(plan selection, components []component) []string {
+	var selected []string
+	for _, item := range components {
+		if _, ok := plan.Selected[item.Name]; ok {
+			selected = append(selected, item.Name)
+		}
+	}
+
+	return selected
+}
+
+func writeFixtureFile(t *testing.T, root, path, content string) {
+	t.Helper()
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o644))
+}
+
+func runGit(t *testing.T, directory string, arguments ...string) {
+	t.Helper()
+	_ = runGitOutput(t, directory, arguments...)
+}
+
+func runGitOutput(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))
+
+	return strings.TrimSpace(string(output))
+}

--- a/scripts/precommit/fixpoint_test.go
+++ b/scripts/precommit/fixpoint_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixpointRerunsOnlyComponentInvalidatedByNormalization(t *testing.T) {
+	t.Parallel()
+
+	repository := newFixpointRepository(t)
+	components := []component{
+		{Name: "consumer", Inputs: exactPath("consumer.in"), Outputs: exactPath("consumer.out"), Config: noPath, Complete: true},
+		{Name: "producer", Inputs: exactPath("producer.in"), Outputs: exactPath("producer.out"), Config: noPath, Complete: true},
+	}
+	counts := map[string]int{}
+	r := runner{repo: repository, toolRoot: repository, components: components}
+	r.execute = func(item component) error {
+		counts[item.Name]++
+		switch item.Name {
+		case "producer":
+			return os.WriteFile(filepath.Join(repository, "consumer.in"), []byte("normalized\n"), 0o644)
+		case "consumer":
+			return os.WriteFile(filepath.Join(repository, "consumer.out"), []byte("generated\n"), 0o644)
+		default:
+			return nil
+		}
+	}
+	plan := fixpointPlan(t, r, map[string][]string{"producer": {"input_changed:producer.in"}})
+	require.NoError(t, r.runFixpoint(plan))
+	require.Equal(t, map[string]int{"producer": 1, "consumer": 1}, counts)
+}
+
+func TestCleanFirstPassDoesNotReplayComponent(t *testing.T) {
+	t.Parallel()
+
+	repository := newFixpointRepository(t)
+	item := component{Name: "clean", Inputs: exactPath("producer.in"), Outputs: noPath, Config: noPath, Complete: true}
+	runs := 0
+	r := runner{repo: repository, toolRoot: repository, components: []component{item}}
+	r.execute = func(component) error {
+		runs++
+
+		return nil
+	}
+	plan := fixpointPlan(t, r, map[string][]string{"clean": {"input_changed:producer.in"}})
+	require.NoError(t, r.runFixpoint(plan))
+	require.Equal(t, 1, runs, "an exact clean pass is already the fixpoint proof")
+}
+
+func TestUnmappedNormalizerEffectForcesFullFallbackPass(t *testing.T) {
+	t.Parallel()
+
+	repository := newFixpointRepository(t)
+	components := []component{
+		{Name: "first", Inputs: exactPath("producer.in"), Outputs: noPath, Config: noPath, Complete: true},
+		{Name: "second", Inputs: exactPath("consumer.in"), Outputs: noPath, Config: noPath, Complete: true},
+	}
+	counts := map[string]int{}
+	r := runner{repo: repository, toolRoot: repository, components: components}
+	r.execute = func(item component) error {
+		counts[item.Name]++
+		if item.Name == "first" && counts[item.Name] == 1 {
+			return os.WriteFile(filepath.Join(repository, "unmapped.output"), []byte("unexpected\n"), 0o644)
+		}
+
+		return nil
+	}
+	plan := fixpointPlan(t, r, map[string][]string{"first": {"input_changed:producer.in"}})
+	require.NoError(t, r.runFixpoint(plan))
+	require.Equal(t, map[string]int{"first": 2, "second": 1}, counts,
+		"an unknown relationship must run the complete component set")
+}
+
+func TestWorkspaceChangeAfterSelectionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	repository := newFixpointRepository(t)
+	item := component{Name: "clean", Inputs: exactPath("producer.in"), Outputs: noPath, Config: noPath, Complete: true}
+	r := runner{repo: repository, toolRoot: repository, components: []component{item}}
+	selectedFingerprint, err := r.workspaceFingerprint()
+	require.NoError(t, err)
+	writeFixtureFile(t, repository, "late-change.go", "package late\n")
+	plan := selection{
+		CandidateFingerprint: selectedFingerprint,
+		Selected:             map[string][]string{"clean": {"input_changed:producer.in"}},
+	}
+	err = r.runFixpoint(plan)
+	require.EqualError(t, err, "candidate workspace changed after component selection")
+}
+
+func newFixpointRepository(t *testing.T) string {
+	t.Helper()
+
+	repository := t.TempDir()
+	runGit(t, repository, "init", "-q")
+	runGit(t, repository, "config", "user.name", "Fixpoint Test")
+	runGit(t, repository, "config", "user.email", "fixpoint@example.com")
+	writeFixtureFile(t, repository, "producer.in", "source\n")
+	writeFixtureFile(t, repository, "consumer.in", "old\n")
+	runGit(t, repository, "add", ".")
+	runGit(t, repository, "commit", "-qm", "base")
+
+	return repository
+}
+
+func exactPath(want string) func(string) bool {
+	return func(path string) bool { return path == want }
+}
+
+func fixpointPlan(t *testing.T, r runner, selected map[string][]string) selection {
+	t.Helper()
+	fingerprint, err := r.workspaceFingerprint()
+	require.NoError(t, err)
+
+	return selection{CandidateFingerprint: fingerprint, Selected: selected}
+}

--- a/scripts/precommit/main.go
+++ b/scripts/precommit/main.go
@@ -1,0 +1,647 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+const maxFixpointPasses = 4
+
+type selection struct {
+	BaseSHA              string              `json:"baseSha"`
+	TrustedToolSHA       string              `json:"trustedToolSha"`
+	CandidateFingerprint string              `json:"candidateFingerprint"`
+	FullFallback         bool                `json:"fullFallback"`
+	FallbackReasons      []string            `json:"fallbackReasons,omitempty"`
+	ChangedPaths         []string            `json:"changedPaths"`
+	Selected             map[string][]string `json:"selected"`
+	Skipped              []string            `json:"skipped"`
+}
+
+type componentState struct {
+	Inputs  string
+	Outputs string
+}
+
+type runner struct {
+	repo           string
+	toolRoot       string
+	trustedToolSHA string
+	components     []component
+	execute        func(component) error
+}
+
+func main() {
+	var repo, toolRoot, baseSHA, trustedToolSHA string
+	var planOnly bool
+	flag.StringVar(&repo, "repo", "", "candidate repository worktree")
+	flag.StringVar(&toolRoot, "tool-root", "", "trusted repository containing the component map and recipes")
+	flag.StringVar(&baseSHA, "base", os.Getenv("PRECOMMIT_BASE_SHA"), "exact target commit")
+	flag.StringVar(&trustedToolSHA, "trusted-tool-sha", os.Getenv("PRECOMMIT_TRUSTED_TOOL_SHA"), "expected trusted tool HEAD")
+	flag.BoolVar(&planOnly, "plan", false, "print the selection without running components")
+	flag.Parse()
+
+	resolvedRepo, err := resolveDirectory(repo)
+	if err != nil {
+		fatal(fmt.Errorf("resolving candidate repository: %w", err))
+	}
+	resolvedToolRoot, err := resolveDirectory(toolRoot)
+	if err != nil {
+		fatal(fmt.Errorf("resolving trusted tool repository: %w", err))
+	}
+
+	r := runner{
+		repo:           resolvedRepo,
+		toolRoot:       resolvedToolRoot,
+		trustedToolSHA: strings.TrimSpace(trustedToolSHA),
+		components:     componentMap(),
+	}
+	selected, err := r.selectComponents(strings.TrimSpace(baseSHA), strings.TrimSpace(trustedToolSHA))
+	if err != nil {
+		fatal(err)
+	}
+	// Identity uncertainty selects the full recipe. Only retain the mutation
+	// guard when this invocation actually started from the expected clean tool
+	// snapshot; otherwise there is no trusted snapshot to compare later.
+	if err := r.verifyTrustedTool(); err != nil {
+		r.trustedToolSHA = ""
+	}
+	r.execute = r.executeComponent
+	encoded, err := json.Marshal(selected)
+	if err != nil {
+		fatal(fmt.Errorf("encoding pre-commit selection: %w", err))
+	}
+	fmt.Printf("PRECOMMIT_SELECTION=%s\n", encoded)
+	if planOnly {
+		return
+	}
+	if err := r.runFixpoint(selected); err != nil {
+		fatal(err)
+	}
+}
+
+func (r runner) selectComponents(baseSHA, trustedToolSHA string) (selection, error) {
+	plan := selection{
+		BaseSHA:        baseSHA,
+		TrustedToolSHA: trustedToolSHA,
+		Selected:       make(map[string][]string),
+	}
+	workspaceFingerprint, err := r.workspaceFingerprint()
+	if err != nil {
+		return selection{}, fmt.Errorf("fingerprinting candidate workspace: %w", err)
+	}
+	plan.CandidateFingerprint = workspaceFingerprint
+
+	if baseSHA == "" {
+		plan.FallbackReasons = append(plan.FallbackReasons, "missing_exact_base_sha")
+	}
+	if trustedToolSHA == "" {
+		plan.FallbackReasons = append(plan.FallbackReasons, "missing_trusted_tool_sha")
+	}
+	for _, item := range r.components {
+		if !item.Complete {
+			plan.FallbackReasons = append(plan.FallbackReasons, "incomplete_component_mapping:"+item.Name)
+		}
+	}
+	actualToolSHA, toolErr := gitText(r.toolRoot, "rev-parse", "--verify", "HEAD^{commit}")
+	if toolErr != nil {
+		plan.FallbackReasons = append(plan.FallbackReasons, "trusted_tool_identity_unavailable")
+	} else if trustedToolSHA != "" && actualToolSHA != trustedToolSHA {
+		plan.FallbackReasons = append(plan.FallbackReasons, "trusted_tool_sha_mismatch")
+	}
+	toolStatus, statusErr := gitOutput(r.toolRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if statusErr != nil || len(toolStatus) != 0 {
+		plan.FallbackReasons = append(plan.FallbackReasons, "trusted_tool_worktree_not_clean")
+	}
+	if baseSHA != "" {
+		if _, err := gitOutput(r.repo, "cat-file", "-e", baseSHA+"^{commit}"); err != nil {
+			plan.FallbackReasons = append(plan.FallbackReasons, "base_commit_unavailable")
+		} else {
+			head, headErr := gitText(r.repo, "rev-parse", "--verify", "HEAD^{commit}")
+			mergeBase, mergeErr := gitText(r.repo, "merge-base", baseSHA, "HEAD")
+			if headErr != nil || mergeErr != nil || (head != baseSHA && mergeBase != baseSHA) {
+				plan.FallbackReasons = append(plan.FallbackReasons, "base_is_not_candidate_ancestor")
+			}
+		}
+	}
+
+	if len(plan.FallbackReasons) == 0 {
+		generatorDirectories, generatorErr := goGenerateDirectories(r.toolRoot)
+		if generatorErr != nil {
+			plan.FallbackReasons = append(plan.FallbackReasons, "generator_input_discovery_failed")
+		}
+		changedPaths, err := changedPaths(r.repo, baseSHA)
+		if err != nil {
+			plan.FallbackReasons = append(plan.FallbackReasons, "candidate_diff_unavailable")
+		} else {
+			plan.ChangedPaths = changedPaths
+			for _, path := range changedPaths {
+				if affectsEveryComponent(path) {
+					plan.FallbackReasons = append(plan.FallbackReasons, "tool_or_map_identity_changed:"+path)
+
+					continue
+				}
+				matched := false
+				for _, item := range r.components {
+					inputChanged := item.Inputs(path)
+					if item.Name == "mock-code-generation" {
+						inputChanged, err = r.mockGenerationTrigger(path, baseSHA, generatorDirectories)
+						if err != nil {
+							plan.FallbackReasons = append(plan.FallbackReasons, "generator_input_identity_unavailable:"+path)
+
+							continue
+						}
+					}
+					switch {
+					case item.Outputs(path):
+						addReason(plan.Selected, item.Name, "declared_output_changed:"+path)
+						matched = true
+					case inputChanged:
+						addReason(plan.Selected, item.Name, "input_changed:"+path)
+						matched = true
+					case item.Config(path):
+						addReason(plan.Selected, item.Name, "config_changed:"+path)
+						matched = true
+					}
+				}
+				if !matched && !knownIrrelevant(path) {
+					plan.FallbackReasons = append(plan.FallbackReasons, "unknown_path:"+path)
+				}
+			}
+		}
+	}
+	if vendorPresent(r.repo) {
+		addReason(plan.Selected, "dashboards", "untrusted_or_unversioned_jsonnet_vendor")
+	}
+
+	if len(plan.FallbackReasons) != 0 {
+		plan.FullFallback = true
+		for _, item := range r.components {
+			addReason(plan.Selected, item.Name, "full_fallback")
+		}
+	}
+	slices.Sort(plan.FallbackReasons)
+	slices.Sort(plan.ChangedPaths)
+	for _, item := range r.components {
+		reasons, ok := plan.Selected[item.Name]
+		if !ok {
+			plan.Skipped = append(plan.Skipped, item.Name)
+
+			continue
+		}
+		slices.Sort(reasons)
+		plan.Selected[item.Name] = slices.Compact(reasons)
+	}
+
+	return plan, nil
+}
+
+func (r runner) mockGenerationTrigger(path, baseSHA string, generatorDirectories map[string]struct{}) (bool, error) {
+	if mockGenerationOutput(path) || protoGenerationOutput(path) || isModuleManifest(path, "") {
+		return true, nil
+	}
+	if !rootModuleGo(path) {
+		return false, nil
+	}
+	if _, ok := generatorDirectories[filepath.ToSlash(filepath.Dir(path))]; ok {
+		return true, nil
+	}
+	workspaceContent, workspaceErr := readLocalFile(r.repo, path)
+	if workspaceErr != nil && !errors.Is(workspaceErr, os.ErrNotExist) {
+		return false, workspaceErr
+	}
+	baseContent, baseErr := gitOutput(r.repo, "show", baseSHA+":"+path)
+	if baseErr != nil {
+		baseContent = nil // A new or untracked path has no base content.
+	}
+
+	return containsGoGenerate(workspaceContent) || containsGoGenerate(baseContent), nil
+}
+
+func goGenerateDirectories(repository string) (map[string]struct{}, error) {
+	output, err := gitOutput(repository, "ls-files", "-z", "--", "*.go")
+	if err != nil {
+		return nil, err
+	}
+	directories := make(map[string]struct{})
+	for _, path := range splitNUL(output) {
+		path = normalizePath(path)
+		if !rootModuleGo(path) {
+			continue
+		}
+		content, err := readLocalFile(repository, path)
+		if err != nil {
+			return nil, err
+		}
+		if containsGoGenerate(content) {
+			directories[filepath.ToSlash(filepath.Dir(path))] = struct{}{}
+		}
+	}
+
+	return directories, nil
+}
+
+func containsGoGenerate(content []byte) bool {
+	return bytes.HasPrefix(content, []byte("//go:generate ")) || bytes.Contains(content, []byte("\n//go:generate "))
+}
+
+func readLocalFile(repository, path string) ([]byte, error) {
+	localPath := filepath.FromSlash(normalizePath(path))
+	if !filepath.IsLocal(localPath) {
+		return nil, fmt.Errorf("path is not local: %q", path)
+	}
+	root, err := os.OpenRoot(repository)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+	file, err := root.Open(localPath)
+	if err != nil {
+		return nil, err
+	}
+	content, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+
+	return content, errors.Join(readErr, closeErr)
+}
+
+func (r runner) runFixpoint(plan selection) error {
+	currentWorkspace, err := r.workspaceFingerprint()
+	if err != nil {
+		return fmt.Errorf("recapturing selected workspace: %w", err)
+	}
+	if currentWorkspace != plan.CandidateFingerprint {
+		return errors.New("candidate workspace changed after component selection")
+	}
+	pending := make(map[string]bool, len(plan.Selected))
+	for name := range plan.Selected {
+		pending[name] = true
+	}
+	if len(pending) == 0 {
+		fmt.Println("PRECOMMIT_FIXPOINT: PASS passes=0 reason=no_relevant_components")
+
+		return nil
+	}
+
+	for pass := 1; pass <= maxFixpointPasses; pass++ {
+		if err := r.verifyTrustedTool(); err != nil {
+			return err
+		}
+		beforeWorkspace, err := r.workspaceFingerprint()
+		if err != nil {
+			return fmt.Errorf("capturing pass %d workspace: %w", pass, err)
+		}
+		beforeStates, err := r.captureStates()
+		if err != nil {
+			return err
+		}
+		postRun := make(map[string]componentState)
+		ran := make(map[string]bool)
+		for _, item := range r.components {
+			if !pending[item.Name] {
+				fmt.Printf("PRECOMMIT_COMPONENT: SKIP name=%s pass=%d reason=not_invalidated\n", item.Name, pass)
+
+				continue
+			}
+			started := time.Now()
+			fmt.Printf("PRECOMMIT_COMPONENT: RUN name=%s pass=%d\n", item.Name, pass)
+			if err := r.execute(item); err != nil {
+				return fmt.Errorf("component %s failed: %w", item.Name, err)
+			}
+			state, err := r.captureState(item)
+			if err != nil {
+				return fmt.Errorf("capturing %s post-run identity: %w", item.Name, err)
+			}
+			postRun[item.Name] = state
+			ran[item.Name] = true
+			fmt.Printf("PRECOMMIT_COMPONENT: PASS name=%s pass=%d duration=%s inputs=%s outputs=%s\n",
+				item.Name, pass, time.Since(started).Round(time.Millisecond), state.Inputs, state.Outputs)
+		}
+
+		afterWorkspace, err := r.workspaceFingerprint()
+		if err != nil {
+			return fmt.Errorf("capturing pass %d final workspace: %w", pass, err)
+		}
+		afterStates, err := r.captureStates()
+		if err != nil {
+			return err
+		}
+		next := make(map[string]bool)
+		mappedEffect := false
+		for _, item := range r.components {
+			if beforeStates[item.Name] != afterStates[item.Name] {
+				mappedEffect = true
+			}
+			if ran[item.Name] {
+				if afterStates[item.Name] != postRun[item.Name] {
+					next[item.Name] = true
+					fmt.Printf("PRECOMMIT_INVALIDATED: name=%s reason=changed_after_component\n", item.Name)
+				}
+
+				continue
+			}
+			if beforeStates[item.Name] != afterStates[item.Name] {
+				next[item.Name] = true
+				fmt.Printf("PRECOMMIT_INVALIDATED: name=%s reason=input_or_output_changed_by_normalization\n", item.Name)
+			}
+		}
+		if beforeWorkspace != afterWorkspace && !mappedEffect {
+			fmt.Println("PRECOMMIT_INVALIDATED: all reason=unmapped_component_effect_full_fallback")
+			for _, item := range r.components {
+				next[item.Name] = true
+			}
+		}
+		if len(next) == 0 {
+			reason := "first_pass_clean"
+			if beforeWorkspace != afterWorkspace {
+				reason = "all_component_identities_stable"
+			}
+			if err := r.verifyTrustedTool(); err != nil {
+				return err
+			}
+			fmt.Printf("PRECOMMIT_FIXPOINT: PASS passes=%d reason=%s candidateFingerprint=%s\n", pass, reason, afterWorkspace)
+
+			return nil
+		}
+		pending = next
+	}
+
+	return fmt.Errorf("PRECOMMIT_NON_DETERMINISTIC: fixpoint not reached after %d passes", maxFixpointPasses)
+}
+
+func (r runner) executeComponent(item component) error {
+	if err := r.verifyTrustedTool(); err != nil {
+		return err
+	}
+	command := exec.Command("just", "--no-dotenv", "--justfile", filepath.Join(r.toolRoot, "justfile"),
+		"--working-directory", r.repo, item.Recipe)
+	command.Dir = r.repo
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Stdin = os.Stdin
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("running trusted recipe %s: %w", item.Recipe, err)
+	}
+
+	return r.verifyTrustedTool()
+}
+
+func (r runner) verifyTrustedTool() error {
+	if r.trustedToolSHA == "" {
+		return nil
+	}
+	head, err := gitText(r.toolRoot, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return fmt.Errorf("TRUSTED_TOOL_MUTATION_DETECTED: resolving HEAD: %w", err)
+	}
+	status, err := gitOutput(r.toolRoot, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		return fmt.Errorf("TRUSTED_TOOL_MUTATION_DETECTED: reading status: %w", err)
+	}
+	if head != r.trustedToolSHA || len(status) != 0 {
+		return fmt.Errorf("TRUSTED_TOOL_MUTATION_DETECTED: expected clean %s, got HEAD %s with status %q",
+			r.trustedToolSHA, head, status)
+	}
+
+	return nil
+}
+
+func (r runner) captureStates() (map[string]componentState, error) {
+	states := make(map[string]componentState, len(r.components))
+	for _, item := range r.components {
+		state, err := r.captureState(item)
+		if err != nil {
+			return nil, fmt.Errorf("capturing %s identity: %w", item.Name, err)
+		}
+		states[item.Name] = state
+	}
+
+	return states, nil
+}
+
+func (r runner) captureState(item component) (componentState, error) {
+	files, err := repositoryFiles(r.repo, item.Name == "dashboards")
+	if err != nil {
+		return componentState{}, err
+	}
+	inputs, err := fingerprintMatching(r.repo, files, func(path string) bool { return item.Inputs(path) || item.Config(path) })
+	if err != nil {
+		return componentState{}, err
+	}
+	outputs, err := fingerprintMatching(r.repo, files, item.Outputs)
+	if err != nil {
+		return componentState{}, err
+	}
+
+	return componentState{Inputs: inputs, Outputs: outputs}, nil
+}
+
+func (r runner) workspaceFingerprint() (string, error) {
+	files, err := repositoryFiles(r.repo, true)
+	if err != nil {
+		return "", err
+	}
+
+	return fingerprintMatching(r.repo, files, func(string) bool { return true })
+}
+
+func repositoryFiles(repository string, includeDashboardVendor bool) ([]string, error) {
+	output, err := gitOutput(repository, "ls-files", "--cached", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return nil, fmt.Errorf("listing repository files: %w", err)
+	}
+	paths := splitNUL(output)
+	if includeDashboardVendor && vendorPresent(repository) {
+		vendorRoot := filepath.Join(repository, "misc", "devenv", "monitoring-dashboards", "jsonnet", "vendor")
+		err := filepath.WalkDir(vendorRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			relative, err := filepath.Rel(repository, path)
+			if err != nil || !filepath.IsLocal(relative) {
+				return fmt.Errorf("dashboard vendor path is not local: %q", path)
+			}
+			paths = append(paths, normalizePath(relative))
+
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("walking dashboard vendor: %w", err)
+		}
+	}
+	slices.Sort(paths)
+
+	return slices.Compact(paths), nil
+}
+
+func fingerprintMatching(repository string, paths []string, matches func(string) bool) (string, error) {
+	root, err := os.OpenRoot(repository)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	hasher := sha256.New()
+	writeField(hasher, []byte(componentMapVersion))
+	for _, rawPath := range paths {
+		path := normalizePath(rawPath)
+		if !matches(path) {
+			continue
+		}
+		if !filepath.IsLocal(filepath.FromSlash(path)) {
+			return "", fmt.Errorf("repository path is not local: %q", path)
+		}
+		info, err := root.Lstat(filepath.FromSlash(path))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("stating %s: %w", path, err)
+		}
+		writeField(hasher, []byte(path))
+		writeField(hasher, []byte(info.Mode().String()))
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := root.Readlink(filepath.FromSlash(path))
+			if err != nil {
+				return "", fmt.Errorf("reading symlink %s: %w", path, err)
+			}
+			writeField(hasher, []byte(target))
+		case info.Mode().IsRegular():
+			file, err := root.Open(filepath.FromSlash(path))
+			if err != nil {
+				return "", fmt.Errorf("opening %s: %w", path, err)
+			}
+			contentHasher := sha256.New()
+			logicalBytes, copyErr := io.Copy(contentHasher, file)
+			openedInfo, statErr := file.Stat()
+			closeErr := file.Close()
+			if copyErr != nil || statErr != nil || closeErr != nil {
+				return "", errors.Join(copyErr, statErr, closeErr)
+			}
+			if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) ||
+				openedInfo.Mode() != info.Mode() || openedInfo.Size() != logicalBytes ||
+				!openedInfo.ModTime().Equal(info.ModTime()) {
+				return "", fmt.Errorf("repository file %s changed while being fingerprinted", path)
+			}
+			writeField(hasher, contentHasher.Sum(nil))
+		default:
+			return "", fmt.Errorf("unsupported repository file type at %s", path)
+		}
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func changedPaths(repository, baseSHA string) ([]string, error) {
+	tracked, err := gitOutput(repository, "diff", "--name-only", "--no-renames", "-z", baseSHA, "--")
+	if err != nil {
+		return nil, err
+	}
+	untracked, err := gitOutput(repository, "ls-files", "--others", "--exclude-standard", "-z")
+	if err != nil {
+		return nil, err
+	}
+	paths := append(splitNUL(tracked), splitNUL(untracked)...)
+	for index := range paths {
+		paths[index] = normalizePath(paths[index])
+		if !filepath.IsLocal(filepath.FromSlash(paths[index])) {
+			return nil, fmt.Errorf("changed path is not local: %q", paths[index])
+		}
+	}
+	slices.Sort(paths)
+
+	return slices.Compact(paths), nil
+}
+
+func vendorPresent(repository string) bool {
+	info, err := os.Stat(filepath.Join(repository, "misc", "devenv", "monitoring-dashboards", "jsonnet", "vendor"))
+
+	return err == nil && info.IsDir()
+}
+
+func splitNUL(content []byte) []string {
+	var values []string
+	for part := range bytes.SplitSeq(content, []byte{0}) {
+		if len(part) != 0 {
+			values = append(values, string(part))
+		}
+	}
+
+	return values
+}
+
+func addReason(selected map[string][]string, name, reason string) {
+	selected[name] = append(selected[name], reason)
+}
+
+func resolveDirectory(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("path is required")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", errors.New("path is not a directory")
+	}
+
+	return resolved, nil
+}
+
+func gitText(directory string, arguments ...string) (string, error) {
+	output, err := gitOutput(directory, arguments...)
+
+	return strings.TrimSpace(string(output)), err
+}
+
+func gitOutput(directory string, arguments ...string) ([]byte, error) {
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return nil, fmt.Errorf("git %s: %s: %w", strings.Join(arguments, " "), strings.TrimSpace(string(exitError.Stderr)), err)
+		}
+
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func writeField(hasher hash.Hash, value []byte) {
+	_, _ = fmt.Fprintf(hasher, "%d:", len(value))
+	_, _ = hasher.Write(value)
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "precommit: %v\n", err)
+	os.Exit(1)
+}


### PR DESCRIPTION
Implements INPUT_SENSITIVE_PRECOMMIT_AND_FIXPOINT.

- selects only normalization components whose complete trusted input/output map intersects the exact candidate diff
- runs the full set for unknown paths or unavailable/mismatched identities
- forces a producer when committed generated output changes without source changes
- keeps changed Go on the applicable tidy/lint paths
- reaches a component-level in-memory fingerprint fixpoint without the duplicate full replay
- base-pins CI and AI normalization selection so candidate dependency maps cannot weaken it

Validation:
- bash scripts/agent-check (isolated lint cache): PASS; full fallback, one clean pass
- targeted race-enabled script suites: PASS
- adversarial selector/fixpoint suite: PASS
- proto input-edge mutation: regression failed as expected, then restored
- generated-proto output-edge mutation: regression failed as expected, then restored
- git diff --check and exact review: PASS

Measured selection/fixpoint totals:
- docs-only: 2.62s, zero components
- tooling-only: 2.09s, zero components
- root Go: selects root tidy and lint
- proto: selects proto generation
- operator API: selects operator generation, operator tidy, operator lint
- unknown: full fallback

Full fallback observed component timings included root lint 4m11s, operator lint 26.8s, mock generation 29.7s, dashboards 12.0s, proto 3.2s, and operator generation 3.5s.

This does not implement proportional validation and does not merge automatically.