### PR TITLE
fix(test): isolate nested AI tooling fixtures

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -35,6 +35,19 @@ example that reaches nearby code.
   bypassing the guarded production call and confirming that the focused test
   fails. Never keep the mutation in the worktree.
 
+#### Nested AI-tooling fixtures
+
+Tests that launch AI workflow scripts or operate on synthetic Git repositories
+must start from `scripts/internal/testenv.Environment` (or
+`testenv.Command` when resolving Git itself). The helper removes an enclosing
+AI run's worktree/review/validation identity and every `git-guard-bin` PATH
+entry. A fixture then adds only its own synthetic identity explicitly.
+
+Concurrent subprocess fixtures must use bounded, blocking synchronization and
+supervise process exit. A peer that fails before reaching a barrier must abort
+its siblings and report every peer's combined stdout/stderr; shell spin loops
+and unbounded marker waits are not permitted.
+
 **Example**:
 ```go
 func TestValidateBucketConfig(t *testing.T) {

--- a/scripts/agentcheckpr/selector_test.go
+++ b/scripts/agentcheckpr/selector_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestSelectorEnvironmentDropsParentReviewBinding(t *testing.T) {
@@ -32,7 +34,7 @@ func TestSelectorEnvironmentDropsParentReviewBinding(t *testing.T) {
 	}
 
 	environment := map[string]string{}
-	for _, value := range selectorEnvironment() {
+	for _, value := range testenv.Environment() {
 		name, contents, _ := strings.Cut(value, "=")
 		environment[name] = contents
 	}
@@ -123,7 +125,7 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 				runGit(t, repository, "-c", "user.name=Agent Check PR Test", "-c", "user.email=agent-check-pr@example.com", "commit", "-m", "changes")
 			}
 
-			stdout, _ := runSelectorList(t, repository, selectorEnvironment("AI_REVIEW_BASE_SHA="+baseSHA))
+			stdout, _ := runSelectorList(t, repository, testenv.Environment("AI_REVIEW_BASE_SHA="+baseSHA))
 			require.Equal(t, testCase.expected, strings.Fields(stdout))
 		})
 	}
@@ -152,7 +154,7 @@ func TestSelectorListKeepsDiagnosticsOutOfStructuredStdout(t *testing.T) {
 		"XDG_CACHE_HOME":      "cache",
 		"GOLANGCI_LINT_CACHE": "cache/golangci-lint",
 	}
-	environment := selectorEnvironment(
+	environment := testenv.Environment(
 		"AI_REVIEW_BASE_SHA="+baseSHA,
 		"VALIDATION_RUN_DIR="+runDirectory,
 		"VALIDATION_RUN_ID=selector-test",
@@ -166,46 +168,6 @@ func TestSelectorListKeepsDiagnosticsOutOfStructuredStdout(t *testing.T) {
 	stdout, stderr := runSelectorList(t, repository, environment)
 	require.Equal(t, "agent-check-full\ntest-operator\n", stdout, "stdout must contain structured gates only")
 	require.Contains(t, stderr, "LINT_ISOLATION_GATE=PASS (", "stderr may contain validation diagnostics")
-}
-
-// The selector runs against a synthetic repository in these tests. A parent
-// review loop may bind its own candidate worktree through these variables and
-// prepend a Git guard that depends on that binding. Carrying either into the
-// child process would reject the synthetic repository before exercising the
-// test case.
-func selectorEnvironment(overrides ...string) []string {
-	parentGitGuard := ""
-	if validationRunDirectory := os.Getenv("VALIDATION_RUN_DIR"); validationRunDirectory != "" {
-		parentGitGuard = filepath.Join(validationRunDirectory, "git-guard-bin")
-	}
-
-	environment := make([]string, 0, len(os.Environ())+len(overrides))
-	for _, value := range os.Environ() {
-		name, contents, _ := strings.Cut(value, "=")
-		switch name {
-		case "EXPECTED_PR_NUMBER",
-			"EXPECTED_WORKTREE",
-			"EXPECTED_HEAD",
-			"AI_WORKTREE_PR",
-			"AI_WORKTREE_PATH",
-			"AI_WORKTREE_EXPECTED_HEAD",
-			"TRUSTED_ROOT_CHECKOUT":
-			continue
-		case "PATH":
-			paths := strings.Split(contents, string(os.PathListSeparator))
-			filteredPaths := paths[:0]
-			for _, path := range paths {
-				if parentGitGuard != "" && filepath.Clean(path) == filepath.Clean(parentGitGuard) {
-					continue
-				}
-				filteredPaths = append(filteredPaths, path)
-			}
-			value = name + "=" + strings.Join(filteredPaths, string(os.PathListSeparator))
-		}
-		environment = append(environment, value)
-	}
-
-	return append(environment, overrides...)
 }
 
 func runSelectorList(t *testing.T, repository string, environment []string) (string, string) {
@@ -250,7 +212,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	var stderr bytes.Buffer
 	command.Stderr = &stderr

--- a/scripts/agentjust/wrapper_test.go
+++ b/scripts/agentjust/wrapper_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestWrapperPinsJustfileAndUsesReviewedWorktree(t *testing.T) {
@@ -34,7 +36,7 @@ func TestWrapperPinsJustfileAndUsesReviewedWorktree(t *testing.T) {
 	workingDirectoryPath := filepath.Join(root, "working-directory")
 	command := exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "trusted")
 	command.Dir = worktree
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"TEST_RESULT="+resultPath,
 		"TEST_WORKING_DIRECTORY="+workingDirectoryPath,
 	)
@@ -85,7 +87,7 @@ printf 'trusted-schemathesis\n%s\n%s\n' "$REPO_ROOT" "$SCHEMATHESIS_OPENAPI_PATH
 	resultPath := filepath.Join(root, "result")
 	command := exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "test-model-cluster", "180")
 	command.Dir = worktree
-	command.Env = append(os.Environ(), "TEST_RESULT="+resultPath)
+	command.Env = testenv.Environment("TEST_RESULT=" + resultPath)
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))
 	result, err := os.ReadFile(resultPath)
@@ -99,7 +101,7 @@ printf 'trusted-schemathesis\n%s\n%s\n' "$REPO_ROOT" "$SCHEMATHESIS_OPENAPI_PATH
 
 	command = exec.Command("bash", filepath.Join(toolRoot, "scripts", "agent-just"), "test-schemathesis")
 	command.Dir = worktree
-	command.Env = append(os.Environ(), "TEST_RESULT="+resultPath)
+	command.Env = testenv.Environment("TEST_RESULT=" + resultPath)
 	output, err = command.CombinedOutput()
 	require.NoError(t, err, string(output))
 	result, err = os.ReadFile(resultPath)
@@ -123,7 +125,7 @@ func wrapperPath(t *testing.T) string {
 func runGit(t *testing.T, directory string, arguments ...string) {
 	t.Helper()
 
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))

--- a/scripts/aiaudit/runner_test.go
+++ b/scripts/aiaudit/runner_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -125,7 +127,7 @@ cp "$FAKE_CODEX_RESULT" "$output"
 	outputPath := filepath.Join(t.TempDir(), "report.json")
 	command := exec.Command("bash", filepath.Join(checkout, "scripts", "ai-audit"), testAuditID, "--output", outputPath)
 	command.Dir = checkout
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"FAKE_CODEX_RESULT="+resultPath,
 		"HOME="+t.TempDir(),
 		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
@@ -179,7 +181,7 @@ func copyFile(t *testing.T, source, destination string) {
 
 func runGit(t *testing.T, directory string, args ...string) {
 	t.Helper()
-	command := exec.Command("git", args...)
+	command := testenv.Command(t, "git", args...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -187,7 +189,7 @@ func runGit(t *testing.T, directory string, args ...string) {
 
 func gitOutput(t *testing.T, directory string, args ...string) string {
 	t.Helper()
-	command := exec.Command("git", args...)
+	command := testenv.Command(t, "git", args...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))

--- a/scripts/aiauditchallenge/runner_test.go
+++ b/scripts/aiauditchallenge/runner_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -404,16 +406,17 @@ func (f *fixture) run(t *testing.T, result map[string]any) (string, error) {
 	writeJSON(t, f.providerResult, result)
 	command := exec.Command("bash", filepath.Join(f.checkout, "scripts", "ai-audit-challenge"), f.sourceReport, "--output", f.outputPath)
 	command.Dir = f.checkout
-	command.Env = append(os.Environ(),
-		"FAKE_CODEX_RESULT="+f.providerResult,
-		"FAKE_CODEX_DIRTY_FILE="+f.dirtyFile,
-		"FAKE_CODEX_SOURCE_REPORT="+f.sourceReport,
-		"FAKE_CODEX_REPLACEMENT_REPORT="+f.replacementReport,
-		"HOME="+t.TempDir(),
+	environment := []string{
+		"FAKE_CODEX_RESULT=" + f.providerResult,
+		"FAKE_CODEX_DIRTY_FILE=" + f.dirtyFile,
+		"FAKE_CODEX_SOURCE_REPORT=" + f.sourceReport,
+		"FAKE_CODEX_REPLACEMENT_REPORT=" + f.replacementReport,
+		"HOME=" + t.TempDir(),
 		"CODEX_HOME=",
-		"PATH="+f.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
-	)
-	command.Env = append(command.Env, goCaches(t)...)
+		"PATH=" + f.fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	environment = append(environment, goCaches(t)...)
+	command.Env = testenv.Environment(environment...)
 	output, err := command.CombinedOutput()
 
 	return string(output), err
@@ -507,7 +510,7 @@ func fileDigest(t *testing.T, path string) string {
 // network.
 func goCaches(t *testing.T) []string {
 	t.Helper()
-	command := exec.Command("go", "env", "GOCACHE", "GOMODCACHE")
+	command := testenv.Command(t, "go", "env", "GOCACHE", "GOMODCACHE")
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))
 	values := strings.Split(strings.TrimSpace(string(output)), "\n")
@@ -576,7 +579,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 
 func gitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))

--- a/scripts/aiauditjira/runner_test.go
+++ b/scripts/aiauditjira/runner_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -318,7 +320,7 @@ func (f *fixture) run(t *testing.T, result map[string]any, arguments ...string) 
 		[]string{filepath.Join(repositoryRoot(t), "scripts", "ai-audit-jira"), f.inputPath},
 		arguments...,
 	)...)
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"FAKE_ACLI_LOG="+f.logPath,
 		"FAKE_ACLI_SEARCH_JSON="+f.searchJSON,
 		`FAKE_ACLI_CREATE_JSON={"key":"`+createdKey+`"}`,

--- a/scripts/aicampaign/claim_test.go
+++ b/scripts/aicampaign/claim_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,12 +14,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
 	testClaimantA = "agent@machine#session-a"
 	testClaimantB = "agent@machine#session-b"
 )
+
+func TestMain(testingMain *testing.M) {
+	if err := testenv.SanitizeProcess(); err != nil {
+		panic(err)
+	}
+	os.Exit(testingMain.Run())
+}
 
 func TestClaimRefIsDeterministicAndDigestIndependent(t *testing.T) {
 	t.Parallel()
@@ -529,7 +537,7 @@ func inspectAgainstRemoteTarget(
 
 func remoteRefSHA(t *testing.T, remote, ref string) string {
 	t.Helper()
-	command := exec.Command("git", "ls-remote", "--heads", remote, ref)
+	command := testenv.Command(t, "git", "ls-remote", "--heads", remote, ref)
 	output, err := command.Output()
 	require.NoError(t, err)
 	fields := strings.Fields(string(output))
@@ -570,9 +578,9 @@ func runGit(t *testing.T, directory string, arguments ...string) string {
 
 func runGitInput(t *testing.T, input []byte, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.invalid",
 		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.invalid",
 	)

--- a/scripts/aifixclaude/adapter_test.go
+++ b/scripts/aifixclaude/adapter_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 type adapterFixture struct {
@@ -142,7 +144,7 @@ func runAdapter(t *testing.T, fixture adapterFixture, extraEnvironment map[strin
 
 	cmd := exec.Command("bash", fixture.adapterPath)
 	cmd.Dir = fixture.repositoryRoot
-	cmd.Env = replaceEnvironment(os.Environ(), replacements)
+	cmd.Env = testenv.EnvironmentMap(replacements)
 	output, err := cmd.CombinedOutput()
 
 	return string(output), err
@@ -151,7 +153,7 @@ func runAdapter(t *testing.T, fixture adapterFixture, extraEnvironment map[strin
 func runCommand(t *testing.T, name string, arguments ...string) string {
 	t.Helper()
 
-	output, err := exec.Command(name, arguments...).CombinedOutput()
+	output, err := testenv.Command(t, name, arguments...).CombinedOutput()
 	require.NoError(t, err, string(output))
 
 	return string(output)
@@ -182,20 +184,4 @@ func argumentValue(t *testing.T, arguments []string, name string) string {
 	require.FailNow(t, "missing argument", name)
 
 	return ""
-}
-
-func replaceEnvironment(current []string, replacements map[string]string) []string {
-	result := make([]string, 0, len(current)+len(replacements))
-	for _, item := range current {
-		key, _, found := strings.Cut(item, "=")
-		if _, replaced := replacements[key]; found && replaced {
-			continue
-		}
-		result = append(result, item)
-	}
-	for key, value := range replacements {
-		result = append(result, key+"="+value)
-	}
-
-	return result
 }

--- a/scripts/aipradoptcandidate/launcher_test.go
+++ b/scripts/aipradoptcandidate/launcher_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestAdoptCandidateAcceptsLegitimateNonBugfix(t *testing.T) {
@@ -511,7 +513,7 @@ func (fixture adoptionFixture) run(t *testing.T, options adoptionRun) (string, i
 	}
 	command := exec.Command("bash", arguments...)
 	command.Dir = fixture.checkout
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"TEST_PR_JSON="+string(metadataJSON),
 		"TEST_TRIAGE_DECISION="+options.triageDecision,
@@ -523,7 +525,7 @@ func (fixture adoptionFixture) run(t *testing.T, options adoptionRun) (string, i
 		"TEST_TARGET_MUTATION="+options.targetMutation,
 	)
 	if options.validationFailure {
-		command.Env = append(command.Env, "VALIDATION_FAILURE=1")
+		command.Env = testenv.Environment(append(command.Env, "VALIDATION_FAILURE=1")...)
 	}
 	output, runErr := command.CombinedOutput()
 	if runErr == nil {
@@ -597,7 +599,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))

--- a/scripts/aiprknownfindings/runner_test.go
+++ b/scripts/aiprknownfindings/runner_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -169,7 +171,7 @@ func (fixture fixture) run(t *testing.T, moveHead bool, mode string) (string, er
 
 	command := exec.Command("bash", fixture.runner, "123", "--head", testHead, "--output", fixture.output)
 	command.Dir = fixture.root
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"TEST_HEAD="+testHead,
 		"TEST_MOVED_HEAD="+testMovedHead,

--- a/scripts/aiprloop/launcher_test.go
+++ b/scripts/aiprloop/launcher_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestHelpDoesNotRequirePRMetadata(t *testing.T) {
@@ -19,7 +21,7 @@ func TestHelpDoesNotRequirePRMetadata(t *testing.T) {
 	writeExecutable(t, filepath.Join(fakeBin, "gh"), "#!/usr/bin/env bash\nexit 97\n")
 
 	command := exec.Command("bash", launcherPath(t), "--help")
-	command.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	command.Env = testenv.Environment("PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"))
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))
 	require.Contains(t, string(output), "Usage: bash scripts/ai-pr-loop")
@@ -461,19 +463,20 @@ func runLauncherWithFlags(
 	arguments := append([]string{filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123"}, flags...)
 	command := exec.Command("bash", arguments...)
 	command.Dir = fixture.checkout
-	command.Env = append(os.Environ(),
-		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"TEST_BASE_SHA="+fixture.baseSHA,
-		"TEST_HEAD_SHA="+fixture.headSHA,
-		"TEST_REMOTE="+fixture.remote,
-		"TEST_ADVANCED_BASE_SHA="+fixture.advancedBaseSHA,
-		"TEST_CAPTURE_FILE="+capturePath,
-		"TEST_TRIAGE_DECISION="+triage.decision,
-		"TEST_TRIAGE_BASE_SHA="+triage.baseSHA,
-		"TEST_TRIAGE_HEAD_SHA="+triage.headSHA,
+	environment := []string{
+		"PATH=" + fixture.fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_BASE_SHA=" + fixture.baseSHA,
+		"TEST_HEAD_SHA=" + fixture.headSHA,
+		"TEST_REMOTE=" + fixture.remote,
+		"TEST_ADVANCED_BASE_SHA=" + fixture.advancedBaseSHA,
+		"TEST_CAPTURE_FILE=" + capturePath,
+		"TEST_TRIAGE_DECISION=" + triage.decision,
+		"TEST_TRIAGE_BASE_SHA=" + triage.baseSHA,
+		"TEST_TRIAGE_HEAD_SHA=" + triage.headSHA,
 		fmt.Sprintf("TEST_TRIAGE_EXIT_CODE=%d", triage.exitCode),
-	)
-	command.Env = append(command.Env, extraEnv...)
+	}
+	environment = append(environment, extraEnv...)
+	command.Env = testenv.Environment(environment...)
 	output, err := command.CombinedOutput()
 
 	return string(output), err
@@ -534,7 +537,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))

--- a/scripts/aiprloop/push_test.go
+++ b/scripts/aiprloop/push_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestPushReviewsCandidateCommitBeforePublishing(t *testing.T) {
@@ -504,7 +506,7 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 
 	command := exec.Command("bash", filepath.Join(fixture.checkout, "scripts", "ai-pr-loop"), "123", "--push", "--keep-worktree")
 	command.Dir = fixture.checkout
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"PATH="+fixture.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"TEST_BASE_SHA="+fixture.baseSHA,
 		"TEST_HEAD_SHA="+fixture.headSHA,
@@ -529,8 +531,8 @@ func (fixture pushFixture) run(t *testing.T) (string, int) {
 
 func createCommitObject(t *testing.T, gitDirectory, tree, message string) string {
 	t.Helper()
-	command := exec.Command("git", "--git-dir", gitDirectory, "commit-tree", tree, "-m", message)
-	command.Env = append(os.Environ(),
+	command := testenv.Command(t, "git", "--git-dir", gitDirectory, "commit-tree", tree, "-m", message)
+	command.Env = testenv.Environment(
 		"GIT_AUTHOR_NAME=Target Rewrite",
 		"GIT_AUTHOR_EMAIL=target-rewrite@example.com",
 		"GIT_COMMITTER_NAME=Target Rewrite",

--- a/scripts/aiprtriage/runner_test.go
+++ b/scripts/aiprtriage/runner_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestRunnerPinsPolicyToBaseAndExposesExactPRHeadAsEvidence(t *testing.T) {
@@ -229,7 +231,7 @@ func (f fixture) run(t *testing.T) (string, error) {
 
 	command := exec.Command("bash", filepath.Join(f.checkout, "scripts", "ai-pr-triage"), "123", "--output", f.resultPath)
 	command.Dir = f.checkout
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"PATH="+f.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"HOME="+t.TempDir(),
 		"TEST_BASE_SHA="+f.baseSHA,
@@ -304,7 +306,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 
 func gitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))

--- a/scripts/aireviewcodex/adapter_test.go
+++ b/scripts/aireviewcodex/adapter_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -262,26 +264,10 @@ func runAdapter(t *testing.T, fixture adapterFixture, extraEnvironment map[strin
 
 	cmd := exec.Command("bash", fixture.adapterPath)
 	cmd.Dir = fixture.repositoryRoot
-	cmd.Env = replaceEnvironment(os.Environ(), environment)
+	cmd.Env = testenv.EnvironmentMap(environment)
 	output, err := cmd.CombinedOutput()
 
 	return string(output), err
-}
-
-func replaceEnvironment(current []string, replacements map[string]string) []string {
-	result := make([]string, 0, len(current)+len(replacements))
-	for _, item := range current {
-		key, _, found := strings.Cut(item, "=")
-		if _, replaced := replacements[key]; found && replaced {
-			continue
-		}
-		result = append(result, item)
-	}
-	for key, value := range replacements {
-		result = append(result, key+"="+value)
-	}
-
-	return result
 }
 
 func writeFile(t *testing.T, path, content string, mode os.FileMode) {
@@ -299,7 +285,7 @@ func readFile(t *testing.T, path string) string {
 
 func runCommand(t *testing.T, directory, name string, arguments ...string) string {
 	t.Helper()
-	cmd := exec.Command(name, arguments...)
+	cmd := testenv.Command(t, name, arguments...)
 	if directory != "" {
 		cmd.Dir = directory
 	}

--- a/scripts/aireviewknownfindings/adapter_test.go
+++ b/scripts/aireviewknownfindings/adapter_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 const (
@@ -402,7 +404,7 @@ func (fixture adapterFixture) run(t *testing.T, extra map[string]string) (string
 
 	command := exec.Command("bash", fixture.adapter)
 	command.Dir = fixture.repository
-	command.Env = replaceEnvironment(os.Environ(), environment)
+	command.Env = testenv.EnvironmentMap(environment)
 	output, err := command.CombinedOutput()
 
 	return string(output), err
@@ -547,33 +549,11 @@ func readFile(t *testing.T, path string) string {
 }
 
 func runCommand(t *testing.T, directory, name string, arguments ...string) string {
-	if t != nil {
-		t.Helper()
-	}
-	command := exec.Command(name, arguments...)
+	t.Helper()
+	command := testenv.Command(t, name, arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
-	if t != nil {
-		require.NoError(t, err, string(output))
-	} else if err != nil {
-		panic(string(output))
-	}
+	require.NoError(t, err, string(output))
 
 	return string(output)
-}
-
-func replaceEnvironment(current []string, replacements map[string]string) []string {
-	result := make([]string, 0, len(current)+len(replacements))
-	for _, item := range current {
-		key, _, found := strings.Cut(item, "=")
-		if _, replaced := replacements[key]; found && replaced {
-			continue
-		}
-		result = append(result, item)
-	}
-	for key, value := range replacements {
-		result = append(result, key+"="+value)
-	}
-
-	return result
 }

--- a/scripts/internal/rootguard/rootguard_test.go
+++ b/scripts/internal/rootguard/rootguard_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -12,9 +11,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestMain(testingMain *testing.M) {
+	if err := testenv.SanitizeProcess(); err != nil {
+		panic(err)
+	}
 	if err := os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull); err != nil {
 		panic(err)
 	}
@@ -387,7 +391,7 @@ func capture(t *testing.T, root string) Snapshot {
 
 func runGit(t *testing.T, directory string, arguments ...string) {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, "git %s:\n%s", strings.Join(arguments, " "), output)

--- a/scripts/internal/testenv/environment.go
+++ b/scripts/internal/testenv/environment.go
@@ -1,0 +1,183 @@
+// Package testenv provides hermetic process environments for AI-tooling tests.
+package testenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const gitGuardDirectory = "git-guard-bin"
+
+var exactOuterIdentityVariables = map[string]struct{}{
+	"CANDIDATE_SHA":         {},
+	"CANDIDATE_WORKTREE":    {},
+	"PR_HEAD_SHA":           {},
+	"TARGET_BASE_SHA":       {},
+	"TRUSTED_ROOT_CHECKOUT": {},
+}
+
+var outerIdentityPrefixes = []string{
+	"EXPECTED_",
+	"AI_WORKTREE_",
+	"AI_GIT_",
+	"AI_PR_TRIAGE_",
+	"AI_REVIEW_",
+	"VALIDATION_RUN_",
+}
+
+// Environment returns the current environment without an enclosing AI run's
+// worktree identity or Git guard. Overrides are applied last, so a fixture can
+// explicitly install its own synthetic identity.
+func Environment(overrides ...string) []string {
+	values := make(map[string]string, len(os.Environ())+len(overrides))
+	for _, item := range append(os.Environ(), overrides...) {
+		name, value, found := strings.Cut(item, "=")
+		if found {
+			values[name] = value
+		}
+	}
+
+	for name := range values {
+		if isOuterIdentityVariable(name) {
+			delete(values, name)
+		}
+	}
+	if path, found := values["PATH"]; found {
+		values["PATH"] = sanitizePath(path)
+	}
+
+	// Explicit fixture values are trusted only after the inherited environment
+	// has been removed. This makes re-injection deliberate and visible.
+	for _, item := range overrides {
+		name, value, found := strings.Cut(item, "=")
+		if found {
+			values[name] = value
+		}
+	}
+	if path, found := values["PATH"]; found {
+		values["PATH"] = sanitizePath(path)
+	}
+
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	environment := make([]string, 0, len(names))
+	for _, name := range names {
+		environment = append(environment, name+"="+values[name])
+	}
+
+	return environment
+}
+
+// EnvironmentMap is Environment with map-shaped fixture overrides.
+func EnvironmentMap(overrides map[string]string) []string {
+	names := make([]string, 0, len(overrides))
+	for name := range overrides {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	values := make([]string, 0, len(names))
+	for _, name := range names {
+		values = append(values, name+"="+overrides[name])
+	}
+
+	return Environment(values...)
+}
+
+// SanitizeProcess removes outer AI identity from the test binary itself. Use
+// it from TestMain when production code called in-process resolves Git before a
+// per-command fixture environment can be supplied.
+func SanitizeProcess() error {
+	environment := Environment()
+	os.Clearenv()
+	for _, item := range environment {
+		name, value, found := strings.Cut(item, "=")
+		if !found {
+			continue
+		}
+		if err := os.Setenv(name, value); err != nil {
+			return fmt.Errorf("restore sanitized environment variable %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// Command resolves a test tool through the sanitized PATH and gives it the
+// sanitized environment. This matters for Git because exec.Command otherwise
+// resolves the executable through the enclosing AI run's PATH before Cmd.Env
+// can take effect.
+func Command(t testing.TB, name string, arguments ...string) *exec.Cmd {
+	t.Helper()
+	environment := Environment()
+	executable, err := lookPath(name, environmentValue(environment, "PATH"))
+	if err != nil {
+		t.Fatalf("resolve %s in sanitized test PATH: %v", name, err)
+	}
+	command := exec.Command(executable, arguments...)
+	command.Env = environment
+
+	return command
+}
+
+func isOuterIdentityVariable(name string) bool {
+	if _, found := exactOuterIdentityVariables[name]; found {
+		return true
+	}
+	for _, prefix := range outerIdentityPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func sanitizePath(path string) string {
+	entries := strings.Split(path, string(os.PathListSeparator))
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if filepath.Base(filepath.Clean(entry)) == gitGuardDirectory {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	return strings.Join(filtered, string(os.PathListSeparator))
+}
+
+func environmentValue(environment []string, name string) string {
+	for _, item := range environment {
+		key, value, found := strings.Cut(item, "=")
+		if found && key == name {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func lookPath(name, path string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		return name, nil
+	}
+	for _, directory := range filepath.SplitList(path) {
+		if directory == "" {
+			directory = "."
+		}
+		candidate := filepath.Join(directory, name)
+		info, err := os.Stat(candidate)
+		if err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", exec.ErrNotFound, name)
+}

--- a/scripts/internal/testenv/environment_test.go
+++ b/scripts/internal/testenv/environment_test.go
@@ -1,0 +1,81 @@
+package testenv
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnvironmentDropsCurrentAndFutureOuterIdentity(t *testing.T) {
+	guardOne := filepath.Join(t.TempDir(), gitGuardDirectory)
+	guardTwo := filepath.Join(t.TempDir(), gitGuardDirectory)
+	cleanBin := t.TempDir()
+	t.Setenv("PATH", strings.Join([]string{guardOne, cleanBin, guardTwo}, string(os.PathListSeparator)))
+	outerVariables := []string{
+		"EXPECTED_PR_NUMBER",
+		"EXPECTED_WORKTREE",
+		"EXPECTED_HEAD",
+		"EXPECTED_FUTURE_BINDING",
+		"AI_WORKTREE_PR",
+		"AI_WORKTREE_PATH",
+		"AI_WORKTREE_EXPECTED_HEAD",
+		"AI_WORKTREE_BINDING_FILE",
+		"AI_WORKTREE_FUTURE_BINDING",
+		"TRUSTED_ROOT_CHECKOUT",
+		"AI_GIT_REAL_PATH",
+		"AI_GIT_ORIGINAL_PATH",
+		"AI_GIT_FUTURE_BINDING",
+		"AI_PR_TRIAGE_EXPECT_BASE_SHA",
+		"AI_REVIEW_HEAD",
+		"AI_REVIEW_FUTURE_IDENTITY",
+		"TARGET_BASE_SHA",
+		"PR_HEAD_SHA",
+		"CANDIDATE_SHA",
+		"CANDIDATE_WORKTREE",
+		"VALIDATION_RUN_DIR",
+		"VALIDATION_RUN_ID",
+		"VALIDATION_RUN_FUTURE_IDENTITY",
+	}
+	for _, name := range outerVariables {
+		t.Setenv(name, "inherited-parent-value")
+	}
+
+	environment := environmentMap(Environment())
+	for _, name := range outerVariables {
+		if _, found := environment[name]; found {
+			t.Errorf("%s escaped into the synthetic environment", name)
+		}
+	}
+	if got := environment["PATH"]; got != cleanBin {
+		t.Errorf("sanitized PATH = %q, want %q", got, cleanBin)
+	}
+}
+
+func TestEnvironmentOnlyRestoresExplicitSyntheticIdentity(t *testing.T) {
+	t.Setenv("EXPECTED_HEAD", "outer-head")
+	t.Setenv("AI_WORKTREE_PATH", "/outer/worktree")
+
+	environment := environmentMap(Environment(
+		"EXPECTED_HEAD=synthetic-head",
+		"AI_WORKTREE_PATH=/synthetic/worktree",
+	))
+	if got := environment["EXPECTED_HEAD"]; got != "synthetic-head" {
+		t.Errorf("EXPECTED_HEAD = %q, want synthetic-head", got)
+	}
+	if got := environment["AI_WORKTREE_PATH"]; got != "/synthetic/worktree" {
+		t.Errorf("AI_WORKTREE_PATH = %q, want /synthetic/worktree", got)
+	}
+}
+
+func environmentMap(environment []string) map[string]string {
+	values := make(map[string]string, len(environment))
+	for _, item := range environment {
+		name, value, found := strings.Cut(item, "=")
+		if found {
+			values[name] = value
+		}
+	}
+
+	return values
+}

--- a/scripts/internal/testenv/synchronize.go
+++ b/scripts/internal/testenv/synchronize.go
@@ -1,0 +1,238 @@
+package testenv
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// SynchronizedCommand is a subprocess whose fixture command writes one line to
+// file descriptor 3, then blocks reading file descriptor 4. RunSynchronized
+// releases all commands only after every command has reported ready.
+type SynchronizedCommand struct {
+	Name    string
+	Command *exec.Cmd
+}
+
+// SynchronizedResult contains the combined stdout/stderr and exit error for
+// every named subprocess.
+type SynchronizedResult struct {
+	Output   map[string]string
+	Exit     map[string]error
+	Duration time.Duration
+}
+
+type synchronizedProcess struct {
+	name          string
+	command       *exec.Cmd
+	output        bytes.Buffer
+	readyReader   *os.File
+	readyWriter   *os.File
+	releaseReader *os.File
+	releaseWriter *os.File
+	started       bool
+	exited        bool
+}
+
+type processEvent struct {
+	index int
+	err   error
+}
+
+// RunSynchronized supervises a bounded fixture barrier. A process that exits
+// before ready aborts its siblings, and every error reports both subprocesses'
+// output. Each command runs in its own process group so aborting it also stops
+// reviewer or validator children.
+func RunSynchronized(t testing.TB, timeout time.Duration, commands ...SynchronizedCommand) (SynchronizedResult, error) {
+	t.Helper()
+	startedAt := time.Now()
+	result := SynchronizedResult{
+		Output: make(map[string]string, len(commands)),
+		Exit:   make(map[string]error, len(commands)),
+	}
+	if len(commands) == 0 {
+		result.Duration = time.Since(startedAt)
+
+		return result, nil
+	}
+
+	processes := make([]synchronizedProcess, len(commands))
+	for index, item := range commands {
+		if item.Name == "" || item.Command == nil {
+			return result, errors.New("synchronized command requires a name and command")
+		}
+		if len(item.Command.ExtraFiles) != 0 {
+			return result, fmt.Errorf("%s already has extra files", item.Name)
+		}
+		readyReader, readyWriter, err := os.Pipe()
+		if err != nil {
+			return result, fmt.Errorf("create %s ready pipe: %w", item.Name, err)
+		}
+		releaseReader, releaseWriter, err := os.Pipe()
+		if err != nil {
+			_ = readyReader.Close()
+			_ = readyWriter.Close()
+
+			return result, fmt.Errorf("create %s release pipe: %w", item.Name, err)
+		}
+		processes[index] = synchronizedProcess{
+			name:          item.Name,
+			command:       item.Command,
+			readyReader:   readyReader,
+			readyWriter:   readyWriter,
+			releaseReader: releaseReader,
+			releaseWriter: releaseWriter,
+		}
+		processes[index].command.ExtraFiles = []*os.File{readyWriter, releaseReader}
+		processes[index].command.Stdout = &processes[index].output
+		processes[index].command.Stderr = &processes[index].output
+		processes[index].command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
+
+	readyEvents := make(chan processEvent, len(processes))
+	exitEvents := make(chan processEvent, len(processes))
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	failure := error(nil)
+	for index := range processes {
+		process := &processes[index]
+		if err := process.command.Start(); err != nil {
+			failure = fmt.Errorf("start %s: %w", process.name, err)
+
+			break
+		}
+		process.started = true
+		_ = process.readyWriter.Close()
+		_ = process.releaseReader.Close()
+		go func(index int, reader *os.File) {
+			_, err := bufio.NewReader(reader).ReadString('\n')
+			_ = reader.Close()
+			readyEvents <- processEvent{index: index, err: err}
+		}(index, process.readyReader)
+		go func(index int, command *exec.Cmd) {
+			exitEvents <- processEvent{index: index, err: command.Wait()}
+		}(index, process.command)
+	}
+
+	ready := make([]bool, len(processes))
+	readyCount := 0
+	for failure == nil && readyCount < len(processes) {
+		select {
+		case event := <-readyEvents:
+			process := &processes[event.index]
+			switch {
+			case event.err != nil:
+				failure = fmt.Errorf("%s failed before all peers were ready: ready signal: %w", process.name, event.err)
+			case ready[event.index]:
+				failure = fmt.Errorf("unexpected duplicate ready signal from %s", process.name)
+			default:
+				ready[event.index] = true
+				readyCount++
+			}
+		case event := <-exitEvents:
+			process := &processes[event.index]
+			process.exited = true
+			result.Exit[process.name] = event.err
+			if event.err == nil {
+				failure = fmt.Errorf("%s failed before all peers were ready: process exited successfully", process.name)
+			} else {
+				failure = fmt.Errorf("%s failed before all peers were ready: process exit: %w", process.name, event.err)
+			}
+		case <-deadline.C:
+			failure = fmt.Errorf("fixture synchronization exceeded %s", timeout)
+		}
+	}
+
+	if failure == nil {
+		for index := range processes {
+			if _, err := processes[index].releaseWriter.WriteString("release\n"); err != nil {
+				failure = fmt.Errorf("release %s: %w", processes[index].name, err)
+
+				break
+			}
+			_ = processes[index].releaseWriter.Close()
+		}
+	}
+
+	if failure != nil {
+		for index := range processes {
+			_ = processes[index].releaseWriter.Close() // Wake a blocked fixture before the kill fallback.
+			if processes[index].started && !processes[index].exited {
+				terminateProcessGroup(processes[index].command)
+			}
+		}
+	}
+
+	remaining := 0
+	for index := range processes {
+		if processes[index].started && !processes[index].exited {
+			remaining++
+		}
+	}
+	for remaining > 0 {
+		select {
+		case event := <-exitEvents:
+			if !processes[event.index].exited {
+				processes[event.index].exited = true
+				result.Exit[processes[event.index].name] = event.err
+				remaining--
+			}
+		case <-deadline.C:
+			if failure == nil {
+				failure = fmt.Errorf("fixture processes exceeded %s", timeout)
+			}
+			for index := range processes {
+				if processes[index].started && !processes[index].exited {
+					terminateProcessGroup(processes[index].command)
+				}
+			}
+		}
+	}
+
+	for index := range processes {
+		process := &processes[index]
+		_ = process.readyReader.Close()
+		_ = process.readyWriter.Close()
+		_ = process.releaseReader.Close()
+		_ = process.releaseWriter.Close()
+		result.Output[process.name] = process.output.String()
+		if failure == nil && result.Exit[process.name] != nil {
+			failure = fmt.Errorf("%s failed: %w", process.name, result.Exit[process.name])
+		}
+	}
+	result.Duration = time.Since(startedAt)
+	if failure != nil {
+		return result, fmt.Errorf("%w\n%s", failure, synchronizedDiagnostics(processes))
+	}
+
+	return result, nil
+}
+
+func terminateProcessGroup(command *exec.Cmd) {
+	if command.Process == nil {
+		return
+	}
+	if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		_ = command.Process.Kill()
+	}
+}
+
+func synchronizedDiagnostics(processes []synchronizedProcess) string {
+	var diagnostics strings.Builder
+	for index := range processes {
+		if index > 0 {
+			diagnostics.WriteByte('\n')
+		}
+		fmt.Fprintf(&diagnostics, "%s stdout/stderr:\n%s", processes[index].name, processes[index].output.String())
+	}
+
+	return diagnostics.String()
+}

--- a/scripts/internal/testenv/synchronize_test.go
+++ b/scripts/internal/testenv/synchronize_test.go
@@ -1,0 +1,28 @@
+package testenv
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer(t *testing.T) {
+	first := exec.Command("/bin/sh", "-c", "echo first-peer-output >&2; printf 'ready\\n' >&3; IFS= read -r _ <&4")
+	second := exec.Command("/bin/sh", "-c", "echo second-peer-output >&2; sleep 60")
+
+	result, err := RunSynchronized(t, 200*time.Millisecond,
+		SynchronizedCommand{Name: "first peer", Command: first},
+		SynchronizedCommand{Name: "second peer", Command: second},
+	)
+	require.Error(t, err)
+	require.Less(t, result.Duration, 2*time.Second, err.Error())
+	require.Contains(t, err.Error(), "fixture synchronization exceeded 200ms")
+	require.Contains(t, err.Error(), "first peer stdout/stderr:\nfirst-peer-output")
+	require.Contains(t, err.Error(), "second peer stdout/stderr:\nsecond-peer-output")
+	_, firstReaped := result.Exit["first peer"]
+	_, secondReaped := result.Exit["second peer"]
+	require.True(t, firstReaped, "first peer was not reaped: %v", err)
+	require.True(t, secondReaped, "second peer was not reaped: %v", err)
+}

--- a/scripts/reviewloop/main_test.go
+++ b/scripts/reviewloop/main_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestDecideApprove(t *testing.T) {
@@ -453,7 +455,7 @@ func TestStageCandidateAgentInputsRejectsSymlinkEscape(t *testing.T) {
 
 func TestValidationReceiptReviewLoopFlows(t *testing.T) {
 	binary := filepath.Join(t.TempDir(), "review-loop")
-	build := exec.Command("go", "build", "-o", binary, ".")
+	build := testenv.Command(t, "go", "build", "-o", binary, ".")
 	build.Dir = "."
 	output, err := build.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -673,7 +675,7 @@ fi
 		"--state-dir", filepath.Join(fixtureRoot, "review-state"),
 	)
 	command.Dir = candidate
-	command.Env = append(os.Environ(),
+	command.Env = testenv.Environment(
 		"TEST_REVIEW_MUTATION="+options.reviewMutation,
 		"TEST_SECOND_FIX="+strconv.FormatBool(options.secondFix),
 		"TEST_VALIDATION_EXIT="+options.validationExit,
@@ -722,7 +724,7 @@ exit 42
 `), 0o755))
 
 	binary := filepath.Join(t.TempDir(), "review-loop")
-	build := exec.Command("go", "build", "-o", binary, ".")
+	build := testenv.Command(t, "go", "build", "-o", binary, ".")
 	build.Dir = "."
 	output, err := build.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -741,7 +743,7 @@ exit 42
 		"--state-dir", filepath.Join(candidate, ".review-state"),
 	)
 	command.Dir = candidate
-	command.Env = append(os.Environ(), "TEST_VALIDATION_BASE="+validationBase)
+	command.Env = testenv.Environment("TEST_VALIDATION_BASE=" + validationBase)
 	output, err = command.CombinedOutput()
 	require.Error(t, err, string(output))
 	require.Contains(t, string(output), "local validation before readiness")
@@ -768,6 +770,7 @@ printf 'changed by validation\n' > base.txt
 		"--state-dir", filepath.Join(candidate, ".review-state"),
 	)
 	command.Dir = candidate
+	command.Env = testenv.Environment()
 	output, err = command.CombinedOutput()
 	require.Error(t, err, string(output))
 	require.Contains(t, string(output), "local validation changed the approved workspace")
@@ -785,7 +788,7 @@ func writeReviewResult(t *testing.T, content string) string {
 func runGit(t *testing.T, directory string, arguments ...string) {
 	t.Helper()
 
-	cmd := exec.Command("git", arguments...)
+	cmd := testenv.Command(t, "git", arguments...)
 	cmd.Dir = directory
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -794,7 +797,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 
-	cmd := exec.Command("git", arguments...)
+	cmd := testenv.Command(t, "git", arguments...)
 	cmd.Dir = directory
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))

--- a/scripts/reviewloop/testmain_test.go
+++ b/scripts/reviewloop/testmain_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
+)
+
+func TestMain(testingMain *testing.M) {
+	if err := testenv.SanitizeProcess(); err != nil {
+		panic(err)
+	}
+	os.Exit(testingMain.Run())
+}

--- a/scripts/reviewloop/worktree_binding_test.go
+++ b/scripts/reviewloop/worktree_binding_test.go
@@ -1,15 +1,20 @@
 package main
 
 import (
-	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 type worktreeBindingFixture struct {
@@ -22,6 +27,8 @@ type worktreeBindingFixture struct {
 	reviewer      string
 	guard         string
 }
+
+const reviewLoopFixtureTimeout = 45 * time.Second
 
 func TestReviewOnlyFlowBindsAgentToDedicatedCandidate(t *testing.T) {
 	fixture := newWorktreeBindingFixture(t)
@@ -237,8 +244,7 @@ func TestGuardDoesNotExposeUnguardedGitEnvironment(t *testing.T) {
 
 func TestDirectGitBypassStillTriggersRootMutationDetection(t *testing.T) {
 	fixture := newWorktreeBindingFixture(t)
-	unguardedGit, err := exec.LookPath("git")
-	require.NoError(t, err)
+	unguardedGit := testenv.Command(t, "git").Path
 	execPathOutput, execPathErr := exec.Command(unguardedGit, "--exec-path").Output()
 	if execPathErr == nil {
 		gitBesideExecPath := filepath.Join(filepath.Dir(filepath.Dir(strings.TrimSpace(string(execPathOutput)))), "bin", "git")
@@ -272,14 +278,13 @@ func TestGitMutationGuardRunsWithoutTempfilesUnderSystemBash(t *testing.T) {
 	guardContent, err := os.ReadFile(fixture.guard)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(guardCopy, guardContent, 0o700))
-	realGit, err := exec.LookPath("git")
-	require.NoError(t, err)
+	realGit := testenv.Command(t, "git").Path
 	readOnlyTemp := filepath.Join(fixture.validationDir, "read-only-tmp")
 	require.NoError(t, os.Mkdir(readOnlyTemp, 0o500))
 
 	command := exec.Command("/bin/bash", guardCopy, "status", "--short")
 	command.Dir = fixture.candidate
-	command.Env = replaceEnvironment(os.Environ(), map[string]string{
+	command.Env = testenv.EnvironmentMap(map[string]string{
 		"PATH":                  filepath.Dir(guardCopy) + string(os.PathListSeparator) + os.Getenv("PATH"),
 		"TMPDIR":                readOnlyTemp,
 		"TRUSTED_ROOT_CHECKOUT": fixture.root,
@@ -289,6 +294,34 @@ func TestGitMutationGuardRunsWithoutTempfilesUnderSystemBash(t *testing.T) {
 }
 
 func TestConcurrentPRRunsUseDistinctWorktreesAndValidationDirs(t *testing.T) {
+	outerGuardDirectory := filepath.Join(t.TempDir(), "git-guard-bin")
+	require.NoError(t, os.Mkdir(outerGuardDirectory, 0o755))
+	outerGuardMarker := filepath.Join(t.TempDir(), "outer-guard-used")
+	require.NoError(t, os.WriteFile(filepath.Join(outerGuardDirectory, "git"), fmt.Appendf(nil,
+		"#!/bin/sh\nprintf 'outer guard used\\n' >> %s\nexit 99\n",
+		shellQuote(outerGuardMarker),
+	), 0o755))
+	t.Setenv("PATH", outerGuardDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
+	for name, value := range map[string]string{
+		"EXPECTED_PR_NUMBER":         "999999",
+		"EXPECTED_WORKTREE":          "/inherited/outer/candidate",
+		"EXPECTED_HEAD":              strings.Repeat("f", 40),
+		"EXPECTED_FUTURE_BINDING":    "must-not-leak",
+		"AI_WORKTREE_PR":             "999999",
+		"AI_WORKTREE_PATH":           "/inherited/outer/candidate",
+		"AI_WORKTREE_EXPECTED_HEAD":  strings.Repeat("e", 40),
+		"AI_WORKTREE_BINDING_FILE":   "/inherited/outer/binding.json",
+		"AI_WORKTREE_FUTURE_BINDING": "must-not-leak",
+		"TRUSTED_ROOT_CHECKOUT":      "/inherited/outer/root",
+		"AI_GIT_REAL_PATH":           "/inherited/outer/git",
+		"AI_GIT_ORIGINAL_PATH":       "/inherited/outer/original-git",
+		"AI_REVIEW_HEAD":             strings.Repeat("d", 40),
+		"VALIDATION_RUN_DIR":         "/inherited/outer/validation",
+		"VALIDATION_RUN_ID":          "inherited-outer-run",
+	} {
+		t.Setenv(name, value)
+	}
+
 	fixture := newWorktreeBindingFixture(t)
 	parent := filepath.Dir(fixture.candidate)
 	secondCandidate := filepath.Join(parent, "candidate-456")
@@ -298,27 +331,21 @@ func TestConcurrentPRRunsUseDistinctWorktreesAndValidationDirs(t *testing.T) {
 	secondBinding := filepath.Join(parent, "binding-456.json")
 	writeBindingFile(t, secondBinding, 456, secondCandidate, fixture.head, fixture.root)
 
-	firstReady := filepath.Join(parent, "ready-123")
-	secondReady := filepath.Join(parent, "ready-456")
 	firstCWD := filepath.Join(parent, "cwd-123")
 	secondCWD := filepath.Join(parent, "cwd-456")
 	first := fixture.command(123, fixture.candidate, fixture.validationDir, fixture.bindingFile, map[string]string{
-		"TEST_AGENT_CWD":   firstCWD,
-		"TEST_READY":       firstReady,
-		"TEST_OTHER_READY": secondReady,
+		"TEST_AGENT_CWD": firstCWD,
+		"TEST_SYNC_FDS":  "1",
 	})
 	second := fixture.command(456, secondCandidate, secondValidation, secondBinding, map[string]string{
-		"TEST_AGENT_CWD":   secondCWD,
-		"TEST_READY":       secondReady,
-		"TEST_OTHER_READY": firstReady,
+		"TEST_AGENT_CWD": secondCWD,
+		"TEST_SYNC_FDS":  "1",
 	})
-	var firstOutput, secondOutput bytes.Buffer
-	first.Stdout, first.Stderr = &firstOutput, &firstOutput
-	second.Stdout, second.Stderr = &secondOutput, &secondOutput
-	require.NoError(t, first.Start())
-	require.NoError(t, second.Start())
-	require.NoError(t, first.Wait(), firstOutput.String())
-	require.NoError(t, second.Wait(), secondOutput.String())
+	result, err := testenv.RunSynchronized(t, reviewLoopFixtureTimeout,
+		testenv.SynchronizedCommand{Name: "PR 123", Command: first},
+		testenv.SynchronizedCommand{Name: "PR 456", Command: second},
+	)
+	require.NoError(t, err)
 
 	require.NotEqual(t, fixture.candidate, secondCandidate)
 	require.NotEqual(t, fixture.validationDir, secondValidation)
@@ -326,10 +353,50 @@ func TestConcurrentPRRunsUseDistinctWorktreesAndValidationDirs(t *testing.T) {
 	require.NotEqual(t, secondCandidate, secondValidation)
 	require.Equal(t, canonicalTestPath(t, fixture.candidate), strings.TrimSpace(readTestFile(t, firstCWD)))
 	require.Equal(t, canonicalTestPath(t, secondCandidate), strings.TrimSpace(readTestFile(t, secondCWD)))
-	require.Contains(t, firstOutput.String(), "VALIDATION_EXECUTED reason=no_successful_receipt")
-	require.Contains(t, secondOutput.String(), "VALIDATION_EXECUTED reason=no_successful_receipt")
-	require.NotContains(t, firstOutput.String(), "VALIDATION_REUSED_EXACT_STATE")
-	require.NotContains(t, secondOutput.String(), "VALIDATION_REUSED_EXACT_STATE")
+	require.Contains(t, result.Output["PR 123"], "VALIDATION_EXECUTED reason=no_successful_receipt")
+	require.Contains(t, result.Output["PR 456"], "VALIDATION_EXECUTED reason=no_successful_receipt")
+	require.NotContains(t, result.Output["PR 123"], "VALIDATION_REUSED_EXACT_STATE")
+	require.NotContains(t, result.Output["PR 456"], "VALIDATION_REUSED_EXACT_STATE")
+	require.NoFileExists(t, outerGuardMarker, "the enclosing AI run's Git guard must never execute")
+}
+
+func TestConcurrentPRRunAbortsSiblingWhenPeerFailsBeforeReady(t *testing.T) {
+	fixture := newWorktreeBindingFixture(t)
+	parent := filepath.Dir(fixture.candidate)
+	secondCandidate := filepath.Join(parent, "candidate-456")
+	runGit(t, fixture.root, "worktree", "add", "--detach", secondCandidate, fixture.head)
+	secondValidation := filepath.Join(parent, "validation-456")
+	require.NoError(t, os.MkdirAll(secondValidation, 0o755))
+	secondBinding := filepath.Join(parent, "binding-456.json")
+	writeBindingFile(t, secondBinding, 456, secondCandidate, fixture.head, fixture.root)
+	firstPID := filepath.Join(parent, "reviewer-123.pid")
+	secondPID := filepath.Join(parent, "reviewer-456.pid")
+
+	first := fixture.command(123, fixture.candidate, fixture.validationDir, fixture.bindingFile, map[string]string{
+		"TEST_REVIEWER_PID": firstPID,
+		"TEST_SYNC_FDS":     "1",
+	})
+	second := fixture.command(456, secondCandidate, secondValidation, secondBinding, map[string]string{
+		"TEST_FAIL_BEFORE_READY": "forced peer failure before ready",
+		"TEST_REVIEWER_PID":      secondPID,
+		"TEST_SYNC_FDS":          "1",
+	})
+	result, err := testenv.RunSynchronized(t, reviewLoopFixtureTimeout,
+		testenv.SynchronizedCommand{Name: "waiting peer", Command: first},
+		testenv.SynchronizedCommand{Name: "failed peer", Command: second},
+	)
+	require.Error(t, err)
+	require.Less(t, result.Duration, 30*time.Second, err.Error())
+	t.Logf("bounded peer failure completed in %s", result.Duration)
+	require.Error(t, result.Exit["waiting peer"])
+	_, failedPeerExited := result.Exit["failed peer"]
+	require.True(t, failedPeerExited, "the failed review-loop process must be reaped: %v", err)
+	require.Contains(t, err.Error(), "failed peer failed before all peers were ready")
+	require.Contains(t, err.Error(), "forced peer failure before ready")
+	require.Contains(t, err.Error(), "waiting peer stdout/stderr:")
+	require.Contains(t, err.Error(), "failed peer stdout/stderr:")
+	requireProcessGone(t, firstPID)
+	requireProcessGone(t, secondPID)
 }
 
 func newWorktreeBindingFixture(t *testing.T) worktreeBindingFixture {
@@ -355,9 +422,16 @@ func newWorktreeBindingFixture(t *testing.T) worktreeBindingFixture {
 	reviewer := filepath.Join(parent, "reviewer.sh")
 	require.NoError(t, os.WriteFile(reviewer, []byte(`#!/usr/bin/env bash
 set -euo pipefail
-if [[ -n "${TEST_READY:-}" ]]; then
-    : > "$TEST_READY"
-    while [[ ! -e "$TEST_OTHER_READY" ]]; do :; done
+if [[ -n "${TEST_REVIEWER_PID:-}" ]]; then
+    printf '%s\n' "$$" > "$TEST_REVIEWER_PID"
+fi
+if [[ -n "${TEST_FAIL_BEFORE_READY:-}" ]]; then
+    printf '%s\n' "$TEST_FAIL_BEFORE_READY" >&2
+    exit 77
+fi
+if [[ "${TEST_SYNC_FDS:-}" == 1 ]]; then
+    printf 'ready\n' >&3
+    IFS= read -r _ <&4
 fi
 if [[ -n "${TEST_AGENT_CWD:-}" ]]; then pwd > "$TEST_AGENT_CWD"; fi
 case "${TEST_ROOT_MUTATION:-}" in
@@ -402,7 +476,7 @@ printf '{"decision":"APPROVE","head":"%s","worktree_fingerprint":"%s","previous_
 `), 0o755))
 
 	binary := filepath.Join(parent, "review-loop")
-	build := exec.Command("go", "build", "-o", binary, ".")
+	build := testenv.Command(t, "go", "build", "-o", binary, ".")
 	build.Dir = filepath.Join(repositoryRootForTests(t), "scripts", "reviewloop")
 	output, err := build.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -458,9 +532,33 @@ func (fixture worktreeBindingFixture) command(
 	}
 	command := exec.Command(fixture.binary, arguments...)
 	command.Dir = candidate
-	command.Env = replaceEnvironment(os.Environ(), extraEnvironment)
+	command.Env = testenv.EnvironmentMap(extraEnvironment)
 
 	return command
+}
+
+func requireProcessGone(t *testing.T, pidFile string) {
+	t.Helper()
+	pidText := strings.TrimSpace(readTestFile(t, pidFile))
+	pid, err := strconv.Atoi(pidText)
+	require.NoError(t, err)
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		err = syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		select {
+		case <-deadline.C:
+			require.ErrorIs(t, err, syscall.ESRCH, "reviewer process %d is still alive", pid)
+
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func readTestFile(t *testing.T, path string) string {

--- a/scripts/rootguard/main_test.go
+++ b/scripts/rootguard/main_test.go
@@ -8,11 +8,17 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestMain(testingMain *testing.M) {
+	if err := testenv.SanitizeProcess(); err != nil {
+		panic(err)
+	}
 	if err := os.Setenv("GIT_CONFIG_GLOBAL", os.DevNull); err != nil {
 		panic(err)
 	}
@@ -62,17 +68,8 @@ func TestConcurrentResidentRunnersProtectSameUnchangedRoot(t *testing.T) {
 
 	root := newRunnerTestRepository(t)
 	binary := buildRunner(t)
-	coordination := t.TempDir()
-	firstReady := filepath.Join(coordination, "first-ready")
-	secondReady := filepath.Join(coordination, "second-ready")
-	first := guardedCommand(binary, root, fmt.Sprintf(
-		": > %s; while [ ! -e %s ]; do :; done",
-		shellQuote(firstReady), shellQuote(secondReady),
-	))
-	second := guardedCommand(binary, root, fmt.Sprintf(
-		": > %s; while [ ! -e %s ]; do :; done",
-		shellQuote(secondReady), shellQuote(firstReady),
-	))
+	first := guardedCommand(binary, root, "printf 'ready\\n' >&3; IFS= read -r _ <&4")
+	second := guardedCommand(binary, root, "printf 'ready\\n' >&3; IFS= read -r _ <&4")
 	firstOutput, secondOutput := runConcurrently(t, first, second)
 	require.Contains(t, firstOutput, "ROOT_UNCHANGED=PASS")
 	require.Contains(t, secondOutput, "ROOT_UNCHANGED=PASS")
@@ -84,16 +81,11 @@ func TestConcurrentResidentRunnersBothDetectOverlappingMutation(t *testing.T) {
 	root := newRunnerTestRepository(t)
 	binary := buildRunner(t)
 	coordination := t.TempDir()
-	firstReady := filepath.Join(coordination, "first-ready")
-	secondReady := filepath.Join(coordination, "second-ready")
 	mutated := filepath.Join(coordination, "mutated")
-	first := guardedCommand(binary, root, fmt.Sprintf(
-		": > %s; while [ ! -e %s ]; do :; done; printf changed > ignored/value; : > %s",
-		shellQuote(firstReady), shellQuote(secondReady), shellQuote(mutated),
-	))
+	first := guardedCommand(binary, root, "printf 'ready\\n' >&3; IFS= read -r _ <&4; printf changed > ignored/value; : > "+shellQuote(mutated))
 	second := guardedCommand(binary, root, fmt.Sprintf(
-		": > %s; while [ ! -e %s ]; do :; done; while [ ! -e %s ]; do :; done",
-		shellQuote(secondReady), shellQuote(firstReady), shellQuote(mutated),
+		"printf 'ready\\n' >&3; IFS= read -r _ <&4; for attempt in $(seq 1 100); do [ -e %s ] && exit 0; sleep 0.01; done; echo 'mutation marker timeout' >&2; exit 78",
+		shellQuote(mutated),
 	))
 	firstOutput, secondOutput := runConcurrentlyExpectingFailure(t, first, second)
 	require.Contains(t, firstOutput, "ROOT_MUTATION_DETECTED")
@@ -103,45 +95,39 @@ func TestConcurrentResidentRunnersBothDetectOverlappingMutation(t *testing.T) {
 func guardedCommand(binary, root, script string) *exec.Cmd {
 	command := exec.Command(binary, "--root", root, "--", "/bin/sh", "-c", script)
 	command.Dir = root
+	command.Env = testenv.Environment("TEST_SYNC_FDS=1")
 
 	return command
 }
 
 func runConcurrently(t *testing.T, commands ...*exec.Cmd) (string, string) {
 	t.Helper()
-	outputs := make([]bytes.Buffer, len(commands))
-	for index, command := range commands {
-		command.Stdout = &outputs[index]
-		command.Stderr = &outputs[index]
-		require.NoError(t, command.Start())
-	}
-	for index, command := range commands {
-		require.NoError(t, command.Wait(), outputs[index].String())
-	}
+	result, err := testenv.RunSynchronized(t, 30*time.Second,
+		testenv.SynchronizedCommand{Name: "first", Command: commands[0]},
+		testenv.SynchronizedCommand{Name: "second", Command: commands[1]},
+	)
+	require.NoError(t, err)
 
-	return outputs[0].String(), outputs[1].String()
+	return result.Output["first"], result.Output["second"]
 }
 
 func runConcurrentlyExpectingFailure(t *testing.T, commands ...*exec.Cmd) (string, string) {
 	t.Helper()
-	outputs := make([]bytes.Buffer, len(commands))
-	for index, command := range commands {
-		command.Stdout = &outputs[index]
-		command.Stderr = &outputs[index]
-		require.NoError(t, command.Start())
-	}
-	for index, command := range commands {
-		require.Error(t, command.Wait(), outputs[index].String())
-		require.Equal(t, exitError, command.ProcessState.ExitCode(), outputs[index].String())
-	}
+	result, err := testenv.RunSynchronized(t, 30*time.Second,
+		testenv.SynchronizedCommand{Name: "first", Command: commands[0]},
+		testenv.SynchronizedCommand{Name: "second", Command: commands[1]},
+	)
+	require.Error(t, err)
+	require.Equal(t, exitError, commands[0].ProcessState.ExitCode(), result.Output["first"])
+	require.Equal(t, exitError, commands[1].ProcessState.ExitCode(), result.Output["second"])
 
-	return outputs[0].String(), outputs[1].String()
+	return result.Output["first"], result.Output["second"]
 }
 
 func buildRunner(t *testing.T) string {
 	t.Helper()
 	binary := filepath.Join(t.TempDir(), "rootguard")
-	command := exec.Command("go", "build", "-o", binary, ".")
+	command := testenv.Command(t, "go", "build", "-o", binary, ".")
 	command.Dir = packageRoot(t)
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, string(output))
@@ -168,7 +154,7 @@ func newRunnerTestRepository(t *testing.T) string {
 
 func runRunnerGit(t *testing.T, directory string, arguments ...string) {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, "git %s:\n%s", strings.Join(arguments, " "), output)

--- a/scripts/targetbaserevalidation/revalidation_test.go
+++ b/scripts/targetbaserevalidation/revalidation_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/scripts/internal/testenv"
 )
 
 func TestTargetBaseRevalidationClassifications(t *testing.T) {
@@ -57,6 +59,7 @@ func TestTargetBaseRevalidationClassifications(t *testing.T) {
 			}
 			command := exec.Command("bash", revalidatorPath(t), "origin", "release/v3.0", fixture.baseSHA)
 			command.Dir = fixture.checkout
+			command.Env = testenv.Environment()
 			output, err := command.CombinedOutput()
 			exitCode := 0
 			if err != nil {
@@ -115,7 +118,7 @@ func runGit(t *testing.T, directory string, arguments ...string) {
 
 func runGitOutput(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
-	command := exec.Command("git", arguments...)
+	command := testenv.Command(t, "git", arguments...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	require.NoError(t, err, fmt.Sprintf("git %s:\n%s", strings.Join(arguments, " "), output))


### PR DESCRIPTION
## Summary

- sanitize synthetic AI-tooling subprocess environments so accidentally inherited outer worktree bindings and git-guard-bin PATH entries cannot leak into fixtures
- replace marker spin loops with a supervised, bounded pipe barrier that terminates and reaps sibling process groups on failure
- cover conflicting inherited outer bindings, pre-barrier peer failure, timeout diagnostics, and sibling fixture adoption

## Root cause

Nested synthetic review-loop processes accidentally inherited the enclosing ai-pr-loop Git guard and candidate identity. If one peer failed before creating its marker, the other peer busy-waited until the global 20-minute Go test timeout.

The regression models accidental parent/child environment contamination. It does not treat agents or the parent loop as hostile; CI is responsible for catching this isolation failure.

## Validation

- pinned Nix Go: focused reviewloop package under -race
- pinned Nix Go: focused agentcheckpr package under -race
- inherited-environment regression: 5 consecutive -race runs
- peer failure regression: 3 consecutive -race runs, 1.69-1.79s
- timeout/reaping helper regression: 10 consecutive -race runs
- bash scripts/agent-check: PASS with isolated per-run lint cache after shared-cache contamination was identified
- pinned Nix Go: go test -race ./scripts/...: PASS

Production Git guard, rootguard, candidate binding, cache policy, validation policy, and product code are unchanged.