### PR TITLE
chore: add Maxence to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gfyrag @Azorlogh @paul-nicolas
+* @gfyrag @Azorlogh @paul-nicolas @flemzord


### PR DESCRIPTION
Add `@flemzord` as a global CODEOWNER alongside the existing maintainers.

This allows Maxence's approvals to satisfy the repository's required CODEOWNERS review rule.